### PR TITLE
fix(mcp): harden ChatGPT review contract

### DIFF
--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -65,5 +65,5 @@ Read before editing. Full list in `docs/GOTCHAS.md`; these bite most often here:
 - Slackbot is an MCP client. A Slack app exposes tools/resources only with `mcp:connect` bot scope plus an `mcp_servers` manifest block; after scope changes, reinstall the app.
 - Manifest template: `config/slack-app-manifest.self-install.json`. Manage it with `scripts/slack-manifest.ts` (`print|validate|update`) and Slack config credentials.
 - `/mcp` is mounted at app root, not under `/lobu`. Manifest MCP URL is `<origin>/mcp`; webhook/slash/OAuth URLs keep the `/lobu` base. Do not change this to `/lobu/mcp`.
-- OAuth/redirect/`WWW-Authenticate` URLs come from `PUBLIC_GATEWAY_URL` cached at boot. For Slack cloud flows this must be a public HTTPS origin; update env and restart when switching origins.
+- `PUBLIC_GATEWAY_URL` is the canonical web/OAuth origin advertised in protected-resource metadata. MCP `WWW-Authenticate` resource metadata uses the request host when it is the configured origin or belongs to `AUTH_COOKIE_DOMAIN`; otherwise it falls back to `PUBLIC_GATEWAY_URL`. For Slack cloud flows these must resolve to public HTTPS origins; update env and restart when switching origins.
 - Local public dev endpoint is Tailscale Funnel to gateway `:8787`; verify `/mcp` returns auth challenge, not 404.

--- a/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
@@ -650,7 +650,12 @@ describe("connections.connect — setup_required continuation", () => {
 
 		const failed = await client.runSdk<{
 			success: boolean;
-			error?: { name: string; message: string; details?: unknown };
+			error?: {
+				name: string;
+				message: string;
+				code?: string;
+				retryable?: boolean;
+			};
 		}>(
 			`export default async (_ctx, client) => client.connections.connect({ connector_key: "missing-continuation-connector" });`,
 		);
@@ -658,10 +663,9 @@ describe("connections.connect — setup_required continuation", () => {
 		expect(failed.error).toMatchObject({
 			name: "ClientSdkActionError",
 			message: expect.stringMatching(/connector.*not found/i),
-			details: {
-				error: expect.stringMatching(/connector.*not found/i),
-			},
 		});
+		expect(failed.error).not.toHaveProperty("details");
+		expect(failed.error).not.toHaveProperty("stack");
 		expect(failed.error?.message).not.toContain('{"');
 	});
 });

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -79,7 +79,7 @@ describe('MCP Authentication', () => {
       expect(response.status).toBe(400);
       expect(await response.json()).toEqual({
         error: 'invalid_request',
-        error_description: 'A valid same-origin MCP resource is required',
+        error_description: 'A valid trusted MCP resource is required',
       });
     });
 

--- a/packages/server/src/__tests__/integration/oauth/discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/discovery.test.ts
@@ -60,8 +60,10 @@ describe('OAuth Discovery Endpoints', () => {
 
     it('keeps the configured MCP resource origin when OAuth is served on a workspace host', async () => {
       const originalPublicGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+      const originalAuthCookieDomain = process.env.AUTH_COOKIE_DOMAIN;
       try {
         process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+        process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
         __resetPublicOriginCachesForTests();
 
         const response = await get('/.well-known/oauth-protected-resource/mcp/acme', {
@@ -80,6 +82,11 @@ describe('OAuth Discovery Endpoints', () => {
           delete process.env.PUBLIC_GATEWAY_URL;
         } else {
           process.env.PUBLIC_GATEWAY_URL = originalPublicGatewayUrl;
+        }
+        if (originalAuthCookieDomain === undefined) {
+          delete process.env.AUTH_COOKIE_DOMAIN;
+        } else {
+          process.env.AUTH_COOKIE_DOMAIN = originalAuthCookieDomain;
         }
         __resetPublicOriginCachesForTests();
       }

--- a/packages/server/src/__tests__/integration/oauth/discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/discovery.test.ts
@@ -44,14 +44,18 @@ describe('OAuth Discovery Endpoints', () => {
       expect(body.resource_name).toBeDefined();
     });
 
-    it('should have consistent base URL in resource and authorization_servers', async () => {
+    it('should advertise a valid authorization server independently of the resource origin', async () => {
       const response = await get('/.well-known/oauth-protected-resource');
       const body = await response.json();
 
-      const resourceOrigin = new URL(body.resource).origin;
-      const authServerOrigin = new URL(body.authorization_servers[0]).origin;
+      const resource = new URL(body.resource);
+      const authServer = new URL(body.authorization_servers[0]);
 
-      expect(resourceOrigin).toBe(authServerOrigin);
+      expect(resource.pathname).toBe('/mcp');
+      expect(authServer.pathname).toBe('/');
+      // RFC 9728 explicitly permits the protected resource and authorization
+      // server to use different origins (prod does: lobu.ai vs app.lobu.ai).
+      expect(['http:', 'https:']).toContain(authServer.protocol);
     });
 
     it('keeps the configured MCP resource origin when OAuth is served on a workspace host', async () => {
@@ -69,8 +73,8 @@ describe('OAuth Discovery Endpoints', () => {
         const body = await response.json();
 
         expect(response.status).toBe(200);
-        expect(body.resource).toBe('https://app.lobu.ai/mcp/acme');
-        expect(body.authorization_servers).toEqual(['https://acme.lobu.ai']);
+        expect(body.resource).toBe('https://acme.lobu.ai/mcp/acme');
+        expect(body.authorization_servers).toEqual(['https://app.lobu.ai']);
       } finally {
         if (originalPublicGatewayUrl === undefined) {
           delete process.env.PUBLIC_GATEWAY_URL;

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -188,10 +188,9 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 		}
 	});
 
-	it("a representative runSandbox result validates against SdkScriptResultSchema", () => {
-		// Mirrors the object assembled in sdk_run.ts runSandbox(). If this
-		// drifts (renamed field, changed type), structuredContent silently
-		// degrades to text-only — catch it here instead.
+	it("representative public SDK results validate against SdkScriptResultSchema", () => {
+		// Public MCP schema: return value + concise error + dry-run proposal only.
+		// Internal diagnostics (logs, stacks, call traces, timings) are audit-only.
 		const preview = '{"anything":[1,"two",nul… [truncated]';
 		const sample = {
 			success: true,
@@ -200,30 +199,20 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 				total_bytes: 2_000_000,
 				kept_bytes: Buffer.byteLength(preview, "utf8"),
 			},
-			logs: [{ level: "warn", message: "m", ts: 123 }],
-			duration_ms: 42,
-			sdk_calls: 2,
 			skipped_calls: 2,
-			sdk_call_trace: [
-				{ path: "entities.list", orgPath: [], access: "read", args: [{}], skipped: false },
-			],
-			sdk_call_trace_truncated: { dropped_entries: 3 },
 			side_effect_preview: [
-				{ path: "entities.create", orgPath: ["acme"], access: "write", args: [{}], skipped: true },
-				{ path: "connections.connect", orgPath: ["acme"], access: "admin", args: [{}], skipped: true },
+				{ path: "entities.create", access: "write", args: [{}] },
+				{ path: "connections.connect", access: "admin", args: [{}] },
 			],
+			side_effect_preview_truncated: { dropped_entries: 3 },
 			dry_run: true,
 		};
 		expect(validateToolResult(SdkScriptResultSchema, sample)).not.toBeNull();
 		// Failure path: optional return fields absent (undefined is dropped on the wire).
 		const minimal = {
 			success: false,
-			logs: [],
-			error: { name: "TypeError", message: "boom", stack: "s", line: 3, column: 7 },
-			duration_ms: 1,
-			sdk_calls: 0,
+			error: { name: "TypeError", message: "boom", code: "VALIDATION", retryable: false },
 			skipped_calls: 0,
-			sdk_call_trace: [],
 			side_effect_preview: [],
 			dry_run: false,
 		};

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -90,6 +90,9 @@ describe('MCP OAuth resource indicators', () => {
     expect(
       canonicalizeMcpResource('https://evil.example/mcp', 'https://app.lobu.ai/oauth/authorize')
     ).toBeNull();
+    expect(
+      canonicalizeMcpResource('https://evil.example/mcp', 'https://evil.example/oauth/authorize')
+    ).toBeNull();
   });
 
   test('rejects port, credential, and scheme changes even inside the configured zone', () => {
@@ -104,6 +107,7 @@ describe('MCP OAuth resource indicators', () => {
 
   test('uses the canonical origin embedded in an already-public request URL', () => {
     process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
     __resetPublicOriginCachesForTests();
 
     expect(
@@ -114,8 +118,18 @@ describe('MCP OAuth resource indicators', () => {
     );
   });
 
+  test('accepts same-origin IPv6 resources without treating the port separator as a host delimiter', () => {
+    delete process.env.PUBLIC_GATEWAY_URL;
+    __resetPublicOriginCachesForTests();
+
+    expect(
+      canonicalizeMcpResource('http://[::1]:8787/mcp', 'http://[::1]:8787/oauth/authorize')
+    ).toBe('http://[::1]:8787/mcp');
+  });
+
   test('publicMcpRequestUrl prefers the MCP request host over PUBLIC_GATEWAY_URL', () => {
     process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
     __resetPublicOriginCachesForTests();
 
     const request = new Request('https://lobu.ai/mcp', {
@@ -129,5 +143,35 @@ describe('MCP OAuth resource indicators', () => {
     expect(buildMcpBearerChallenge(publicMcpRequestUrl(request))).toContain(
       'resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp"'
     );
+  });
+
+  test('publicMcpRequestUrl rejects an unconfigured forwarded host', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://app.lobu.ai/oauth/authorize', {
+      headers: {
+        host: 'app.lobu.ai',
+        'x-forwarded-host': 'evil.example',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/oauth/authorize');
+  });
+
+  test('publicMcpRequestUrl uses the request origin when only the configured zone is trusted', () => {
+    delete process.env.PUBLIC_GATEWAY_URL;
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://lobu.ai/mcp', {
+      headers: {
+        host: 'lobu.ai',
+        'x-forwarded-host': 'evil.example',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
   });
 });

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -74,6 +74,9 @@ describe('MCP OAuth resource indicators', () => {
     expect(
       canonicalizeMcpResource('https://acme.lobu.ai/mcp/acme', 'https://app.lobu.ai/oauth/token')
     ).toBe('https://acme.lobu.ai/mcp/acme');
+    expect(
+      canonicalizeMcpResource('https://lobu.ai/mcp', 'https://evil.example/oauth/authorize')
+    ).toBeNull();
   });
 
   test('rejects cross-origin MCP resources when no explicit zone authorizes them', () => {

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -3,13 +3,16 @@ import {
   buildMcpBearerChallenge,
   canonicalizeMcpResource,
   getProtectedResourceMetadataUrl,
+  publicMcpRequestUrl,
 } from '../../auth/oauth/resource-indicator.js';
 import { __resetPublicOriginCachesForTests } from '../../utils/public-origin.js';
 
 const originalPublicGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+const originalAuthCookieDomain = process.env.AUTH_COOKIE_DOMAIN;
 
 beforeEach(() => {
   process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+  delete process.env.AUTH_COOKIE_DOMAIN;
   __resetPublicOriginCachesForTests();
 });
 
@@ -19,6 +22,8 @@ afterEach(() => {
   } else {
     process.env.PUBLIC_GATEWAY_URL = originalPublicGatewayUrl;
   }
+  if (originalAuthCookieDomain === undefined) delete process.env.AUTH_COOKIE_DOMAIN;
+  else process.env.AUTH_COOKIE_DOMAIN = originalAuthCookieDomain;
   __resetPublicOriginCachesForTests();
 });
 
@@ -57,15 +62,69 @@ describe('MCP OAuth resource indicators', () => {
     );
   });
 
-  test('uses the configured public origin rather than an internal request host', () => {
-    process.env.PUBLIC_GATEWAY_URL = 'https://lobu.example/lobu';
+
+  test('accepts the hosted MCP resource across the explicitly configured Lobu zone', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
     __resetPublicOriginCachesForTests();
 
     expect(
-      canonicalizeMcpResource('https://lobu.example/mcp/acme', 'http://internal:8787/mcp/acme')
-    ).toBe('https://lobu.example/mcp/acme');
-    expect(getProtectedResourceMetadataUrl('http://internal:8787/mcp/acme')).toBe(
-      'https://lobu.example/.well-known/oauth-protected-resource/mcp/acme'
+      canonicalizeMcpResource('https://lobu.ai/mcp', 'https://app.lobu.ai/oauth/authorize')
+    ).toBe('https://lobu.ai/mcp');
+    expect(
+      canonicalizeMcpResource('https://acme.lobu.ai/mcp/acme', 'https://app.lobu.ai/oauth/token')
+    ).toBe('https://acme.lobu.ai/mcp/acme');
+  });
+
+  test('rejects cross-origin MCP resources when no explicit zone authorizes them', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    delete process.env.AUTH_COOKIE_DOMAIN;
+    __resetPublicOriginCachesForTests();
+
+    expect(
+      canonicalizeMcpResource('https://lobu.ai/mcp', 'https://app.lobu.ai/oauth/authorize')
+    ).toBeNull();
+    expect(
+      canonicalizeMcpResource('https://evil.example/mcp', 'https://app.lobu.ai/oauth/authorize')
+    ).toBeNull();
+  });
+
+  test('rejects port, credential, and scheme changes even inside the configured zone', () => {
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+    const requestUrl = 'https://app.lobu.ai/oauth/authorize';
+
+    expect(canonicalizeMcpResource('https://lobu.ai:444/mcp', requestUrl)).toBeNull();
+    expect(canonicalizeMcpResource('http://lobu.ai/mcp', requestUrl)).toBeNull();
+    expect(canonicalizeMcpResource('https://user@lobu.ai/mcp', requestUrl)).toBeNull();
+  });
+
+  test('uses the canonical origin embedded in an already-public request URL', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    __resetPublicOriginCachesForTests();
+
+    expect(
+      canonicalizeMcpResource('https://lobu.ai/mcp/acme', 'https://lobu.ai/mcp/acme')
+    ).toBe('https://lobu.ai/mcp/acme');
+    expect(getProtectedResourceMetadataUrl('https://lobu.ai/mcp/acme')).toBe(
+      'https://lobu.ai/.well-known/oauth-protected-resource/mcp/acme'
+    );
+  });
+
+  test('publicMcpRequestUrl prefers the MCP request host over PUBLIC_GATEWAY_URL', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://lobu.ai/mcp', {
+      headers: {
+        host: 'lobu.ai',
+        'x-forwarded-host': 'lobu.ai',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
+    expect(buildMcpBearerChallenge(publicMcpRequestUrl(request))).toContain(
+      'resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp"'
     );
   });
 });

--- a/packages/server/src/__tests__/unit/query-sql-unknown-table-error.test.ts
+++ b/packages/server/src/__tests__/unit/query-sql-unknown-table-error.test.ts
@@ -107,22 +107,22 @@ describe('query_sql unknown-table errors are never rendered as an empty result',
 
   // A run_sdk/query_sdk SCRIPT throw is NOT a tool failure: the tool ran the
   // caller's code and faithfully reported the outcome as data (success=false
-  // plus name/message/line/column, per SdkScriptResultSchema). Flagging it
+  // plus a concise public error, per SdkScriptResultSchema). Flagging it
   // isError makes `mcpToolsCall` throw before a caller can read that payload,
   // and makes interaction-bridge relabel it "Tool error:" to the agent.
   it('does NOT flag an SDK script failure as a tool-level error', () => {
     expect(
       isSoftErrorResult({
         success: false,
-        logs: [],
         error: {
           name: 'TypeError',
           message: 'client.connections.installConnector is not a function',
-          line: 1,
-          column: 42,
+          code: 'VALIDATION',
+          retryable: false,
         },
-        duration_ms: 3,
-        sdk_calls: 0,
+        skipped_calls: 0,
+        side_effect_preview: [],
+        dry_run: false,
       })
     ).toBe(false);
   });

--- a/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
+++ b/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
@@ -84,4 +84,26 @@ describe("SDK MCP public result", () => {
 			expect(schema).not.toContain(forbidden);
 		}
 	});
+
+	test("normalizes the bounded dry-run preview contract", () => {
+		const publicResult = toMcpPublicSdkScriptResult({
+			success: true,
+			skipped_calls: 3,
+			side_effect_preview: [
+				{ path: "entities.create", access: "mystery", args: [] },
+				{ path: 42, args: [] },
+			],
+			return_value_preview: "head",
+			return_truncated: { total_bytes: 10, kept_bytes: 4 },
+			dry_run: true,
+		}) as Record<string, unknown>;
+
+		expect(validateToolResult(SdkScriptResultSchema, publicResult)).not.toBeNull();
+		expect(publicResult.side_effect_preview).toEqual([
+			{ path: "entities.create", access: "unknown", args: [] },
+		]);
+		expect(publicResult.side_effect_preview_truncated).toEqual({ dropped_entries: 2 });
+		expect(publicResult.return_value_preview).toBe("head");
+		expect(publicResult.return_truncated).toEqual({ total_bytes: 10, kept_bytes: 4 });
+	});
 });

--- a/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
+++ b/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
@@ -5,6 +5,7 @@ import { validateToolResult } from "../../tools/validate-args";
 describe("SDK MCP public result", () => {
 	test("strips internal diagnostics while preserving the requested result and dry-run proposal", () => {
 		const richInternal = {
+			title: "  Company pipeline  ",
 			success: false,
 			return_value: { answer: 42 },
 			logs: [{ level: "warn", message: "private diagnostic", ts: 123 }],
@@ -45,6 +46,10 @@ describe("SDK MCP public result", () => {
 		const publicResult = toMcpPublicSdkScriptResult(richInternal) as Record<string, unknown>;
 
 		expect(validateToolResult(SdkScriptResultSchema, publicResult)).not.toBeNull();
+		expect(publicResult.title).toBe("Company pipeline");
+		expect(publicResult.success).toBe(false);
+		expect(publicResult.dry_run).toBe(true);
+		expect(publicResult.skipped_calls).toBe(1);
 		expect(publicResult.return_value).toEqual({ answer: 42 });
 		expect(publicResult.side_effect_preview).toEqual([
 			{ path: "entities.create", access: "write", args: [{ name: "A" }] },
@@ -105,5 +110,30 @@ describe("SDK MCP public result", () => {
 		expect(publicResult.side_effect_preview_truncated).toEqual({ dropped_entries: 2 });
 		expect(publicResult.return_value_preview).toBe("head");
 		expect(publicResult.return_truncated).toEqual({ total_bytes: 10, kept_bytes: 4 });
+	});
+
+	test("preserves a caller-supplied title and drops blank titles", () => {
+		expect(
+			(
+				toMcpPublicSdkScriptResult({
+					title: "Pipeline",
+					success: true,
+					skipped_calls: 0,
+					side_effect_preview: [],
+					dry_run: false,
+				}) as Record<string, unknown>
+			).title,
+		).toBe("Pipeline");
+		expect(
+			(
+				toMcpPublicSdkScriptResult({
+					title: "   ",
+					success: true,
+					skipped_calls: 0,
+					side_effect_preview: [],
+					dry_run: false,
+				}) as Record<string, unknown>
+			).title,
+		).toBeUndefined();
 	});
 });

--- a/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
+++ b/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { SdkScriptResultSchema, toMcpPublicSdkScriptResult } from "../../tools/sdk_run";
+import { validateToolResult } from "../../tools/validate-args";
+
+describe("SDK MCP public result", () => {
+	test("strips internal diagnostics while preserving the requested result and dry-run proposal", () => {
+		const richInternal = {
+			success: false,
+			return_value: { answer: 42 },
+			logs: [{ level: "warn", message: "private diagnostic", ts: 123 }],
+			error: {
+				name: "TypeError",
+				message: "boom",
+				details: { request_id: "internal-123" },
+				stack: "secret stack",
+				line: 3,
+				column: 7,
+				code: "VALIDATION",
+				retryable: false,
+			},
+			duration_ms: 42,
+			sdk_calls: 3,
+			skipped_calls: 1,
+			sdk_call_trace: [
+				{
+					path: "entities.list",
+					orgPath: ["private-org"],
+					access: "read",
+					args: [{}],
+					skipped: false,
+				},
+			],
+			side_effect_preview: [
+				{
+					path: "entities.create",
+					orgPath: ["private-org"],
+					access: "write",
+					args: [{ name: "A" }],
+					skipped: true,
+				},
+			],
+			dry_run: true,
+		};
+
+		const publicResult = toMcpPublicSdkScriptResult(richInternal) as Record<string, unknown>;
+
+		expect(validateToolResult(SdkScriptResultSchema, publicResult)).not.toBeNull();
+		expect(publicResult.return_value).toEqual({ answer: 42 });
+		expect(publicResult.side_effect_preview).toEqual([
+			{ path: "entities.create", access: "write", args: [{ name: "A" }] },
+		]);
+		expect(publicResult.error).toEqual({
+			name: "TypeError",
+			message: "boom",
+			code: "VALIDATION",
+			retryable: false,
+		});
+
+		const serialized = JSON.stringify(publicResult);
+		for (const forbidden of [
+			"private diagnostic",
+			"internal-123",
+			"secret stack",
+			"private-org",
+			"duration_ms",
+			"sdk_call_trace",
+		]) {
+			expect(serialized).not.toContain(forbidden);
+		}
+	});
+
+	test("does not advertise diagnostic-only fields in the public schema", () => {
+		const schema = JSON.stringify(SdkScriptResultSchema);
+		for (const forbidden of [
+			'"logs"',
+			'"ts"',
+			'"stack"',
+			'"details"',
+			'"duration_ms"',
+			'"sdk_calls"',
+			'"sdk_call_trace"',
+			'"orgPath"',
+		]) {
+			expect(schema).not.toContain(forbidden);
+		}
+	});
+});

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -6,20 +6,23 @@
  * and advertises the matching RFC 9728 metadata URL in `WWW-Authenticate`.
  */
 
-import { getConfiguredSubdomainZone, normalizeHost } from '../../utils/public-origin';
+import {
+  getConfiguredPublicOrigin,
+  getConfiguredSubdomainZone,
+} from '../../utils/public-origin';
 import { resolveBaseUrl } from '../base-url';
 import { DEFAULT_SCOPES_STRING } from './scopes';
 
 /**
- * The request URL as the client sees it: the configured public origin, else the
- * reverse proxy's forwarded origin, plus the request path with any trailing
- * slash removed.
+ * The request URL as the client sees it: the serving/forwarded origin when it
+ * belongs to the configured public host set, else the configured public origin,
+ * plus the request path with any trailing slash removed.
  *
- * Every site in this module — the `WWW-Authenticate` challenge, the
- * authorize/consent/device/token canonicalization, and the per-request audience
- * check — starts here, so all four agree on one string. Resolving the origin
- * differently at any one of them would reject a correctly-bound token behind a
- * TLS-terminating proxy.
+ * Every site in this module — the `WWW-Authenticate` challenge, OAuth resource
+ * canonicalization, and the per-request audience check — starts here. The OAuth
+ * routes may then accept a resource on another host in the configured zone.
+ * Resolving the request origin differently at any site would reject a correctly
+ * bound token behind a TLS-terminating proxy.
  */
 export function publicMcpRequestUrl(request: Request): string {
   // The MCP protected-resource identifier belongs to the resource server, not
@@ -27,9 +30,34 @@ export function publicMcpRequestUrl(request: Request): string {
   // intentionally different (`lobu.ai/mcp` vs `app.lobu.ai`). Prefer the
   // actual serving/forwarded host for the MCP request so RFC 9728 metadata and
   // WWW-Authenticate stay bound to the URL the client called.
-  const origin = resolveBaseUrl({ request, skipEnvOverride: true });
+  const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
+  const configuredOrigin = getConfiguredPublicOrigin();
+  const origin = isTrustedPublicOrigin(servingOrigin, configuredOrigin)
+    ? servingOrigin
+    : (configuredOrigin ?? new URL(request.url).origin);
   const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
   return `${origin}${pathname}`;
+}
+
+function isTrustedPublicOrigin(
+  candidateOrigin: string,
+  configuredOrigin = getConfiguredPublicOrigin()
+): boolean {
+  const candidate = new URL(candidateOrigin);
+  const zone = getConfiguredSubdomainZone();
+  if (!configuredOrigin) {
+    return !zone || candidate.hostname === zone || candidate.hostname.endsWith(`.${zone}`);
+  }
+  if (candidateOrigin === configuredOrigin) return true;
+
+  const configured = new URL(configuredOrigin);
+  if (!zone || candidate.protocol !== configured.protocol || candidate.port !== configured.port) {
+    return false;
+  }
+  return (
+    (candidate.hostname === zone || candidate.hostname.endsWith(`.${zone}`)) &&
+    (configured.hostname === zone || configured.hostname.endsWith(`.${zone}`))
+  );
 }
 
 /** Canonical MCP protected-resource URI accepted for OAuth audience binding. */
@@ -50,8 +78,8 @@ export function canonicalizeMcpResource(
   // workspace zone. Never infer a parent domain from hostname text: without an
   // explicit AUTH_COOKIE_DOMAIN, cross-origin resources stay fail-closed.
   const request = new URL(requestUrl);
-  const resourceHost = normalizeHost(parsed.hostname);
-  const requestHost = normalizeHost(request.hostname);
+  const resourceHost = parsed.hostname;
+  const requestHost = request.hostname;
   const zone = getConfiguredSubdomainZone();
   const sameOrigin = parsed.origin === request.origin;
   const sameTransport = parsed.protocol === request.protocol && parsed.port === request.port;
@@ -66,6 +94,7 @@ export function canonicalizeMcpResource(
       (resourceHost === zone || resourceHost.endsWith(`.${zone}`))
   );
   if (
+    !isTrustedPublicOrigin(request.origin) ||
     (!sameOrigin && !inConfiguredZone) ||
     !resourceHost ||
     !requestHost ||

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -6,7 +6,7 @@
  * and advertises the matching RFC 9728 metadata URL in `WWW-Authenticate`.
  */
 
-import { resolvePublicOrigin } from '../../utils/public-origin';
+import { getConfiguredSubdomainZone, normalizeHost } from '../../utils/public-origin';
 import { resolveBaseUrl } from '../base-url';
 import { DEFAULT_SCOPES_STRING } from './scopes';
 
@@ -22,7 +22,12 @@ import { DEFAULT_SCOPES_STRING } from './scopes';
  * TLS-terminating proxy.
  */
 export function publicMcpRequestUrl(request: Request): string {
-  const origin = resolveBaseUrl({ request });
+  // The MCP protected-resource identifier belongs to the resource server, not
+  // the authorization server / general web gateway. In production those are
+  // intentionally different (`lobu.ai/mcp` vs `app.lobu.ai`). Prefer the
+  // actual serving/forwarded host for the MCP request so RFC 9728 metadata and
+  // WWW-Authenticate stay bound to the URL the client called.
+  const origin = resolveBaseUrl({ request, skipEnvOverride: true });
   const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
   return `${origin}${pathname}`;
 }
@@ -39,25 +44,51 @@ export function canonicalizeMcpResource(
   } catch {
     return null;
   }
-  const publicOrigin = resolvePublicOrigin(requestUrl);
-  if (parsed.origin !== publicOrigin || parsed.search || parsed.hash) return null;
+  // The resource server may intentionally use a sibling/parent host from the
+  // authorization server (prod: lobu.ai/mcp vs app.lobu.ai/oauth/*). Accept the
+  // exact request origin, plus hosts inside the explicitly configured cookie /
+  // workspace zone. Never infer a parent domain from hostname text: without an
+  // explicit AUTH_COOKIE_DOMAIN, cross-origin resources stay fail-closed.
+  const request = new URL(requestUrl);
+  const resourceHost = normalizeHost(parsed.hostname);
+  const requestHost = normalizeHost(request.hostname);
+  const zone = getConfiguredSubdomainZone();
+  const sameOrigin = parsed.origin === request.origin;
+  const sameTransport = parsed.protocol === request.protocol && parsed.port === request.port;
+  const inConfiguredZone = Boolean(
+    sameTransport &&
+      zone &&
+      resourceHost &&
+      (resourceHost === zone || resourceHost.endsWith(`.${zone}`))
+  );
+  if (
+    (!sameOrigin && !inConfiguredZone) ||
+    !resourceHost ||
+    !requestHost ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    return null;
+  }
   const path = parsed.pathname.replace(/\/+$/, '') || '/';
   if (path !== '/mcp' && !/^\/mcp\/[^/]+$/.test(path)) return null;
-  return `${publicOrigin}${path}`;
+  return `${parsed.origin}${path}`;
 }
 
 /** The resource URI the incoming request is addressing, if it is an MCP route. */
 export function getMcpResourceForRequest(requestUrl: string): string | null {
   const request = new URL(requestUrl);
   return canonicalizeMcpResource(
-    `${resolvePublicOrigin(requestUrl)}${request.pathname}`,
+    `${request.origin}${request.pathname}`,
     requestUrl
   );
 }
 
 /** RFC 9728 metadata URL for the resource the request addresses. */
 export function getProtectedResourceMetadataUrl(requestUrl: string): string {
-  const publicOrigin = resolvePublicOrigin(requestUrl);
+  const publicOrigin = new URL(requestUrl).origin;
   const resource = getMcpResourceForRequest(requestUrl);
   if (!resource) return `${publicOrigin}/.well-known/oauth-protected-resource`;
   return `${publicOrigin}/.well-known/oauth-protected-resource${new URL(resource).pathname}`;

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -55,8 +55,12 @@ export function canonicalizeMcpResource(
   const zone = getConfiguredSubdomainZone();
   const sameOrigin = parsed.origin === request.origin;
   const sameTransport = parsed.protocol === request.protocol && parsed.port === request.port;
+  const requestInConfiguredZone = Boolean(
+    zone && requestHost && (requestHost === zone || requestHost.endsWith(`.${zone}`))
+  );
   const inConfiguredZone = Boolean(
     sameTransport &&
+      requestInConfiguredZone &&
       zone &&
       resourceHost &&
       (resourceHost === zone || resourceHost.endsWith(`.${zone}`))

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -303,6 +303,12 @@ oauthRoutes.get('/.well-known/oauth-protected-resource/:path{.+}', (c) => {
   setOAuthDiscoveryNoCache(c);
   if (!resource) return c.json({ error: 'Not Found' }, 404);
   metadata.resource = resource;
+  // The protected resource and OAuth authorization server are intentionally
+  // separate in Lobu Cloud: MCP is canonical on lobu.ai, while OAuth is issued
+  // by app.lobu.ai. RFC 9728 permits this and clients discover the issuer from
+  // authorization_servers. PUBLIC_GATEWAY_URL is the stable OAuth/web origin.
+  const authorizationServer = getConfiguredPublicOrigin();
+  if (authorizationServer) metadata.authorization_servers = [authorizationServer];
   return c.json(metadata);
 });
 
@@ -313,6 +319,8 @@ oauthRoutes.get('/.well-known/oauth-protected-resource', (c) => {
   setOAuthDiscoveryNoCache(c);
   if (!resource) return c.json({ error: 'Not Found' }, 404);
   metadata.resource = resource;
+  const authorizationServer = getConfiguredPublicOrigin();
+  if (authorizationServer) metadata.authorization_servers = [authorizationServer];
   return c.json(metadata);
 });
 
@@ -495,7 +503,7 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     const resource = canonicalizeMcpResource(params.resource, publicMcpRequestUrl(c.req.raw));
     if (!resource) {
       return c.json(
-        createOAuthError('invalid_request', 'A valid same-origin MCP resource is required'),
+        createOAuthError('invalid_request', 'A valid trusted MCP resource is required'),
         400
       );
     }
@@ -639,7 +647,7 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
     const resource = canonicalizeMcpResource(body.resource, publicMcpRequestUrl(c.req.raw));
     if (!resource) {
       return c.json(
-        createOAuthError('invalid_request', 'A valid same-origin MCP resource is required'),
+        createOAuthError('invalid_request', 'A valid trusted MCP resource is required'),
         400
       );
     }
@@ -782,7 +790,7 @@ oauthRoutes.post('/oauth/device_authorization', async (c) => {
     const resource = canonicalizeMcpResource(body.resource, publicMcpRequestUrl(c.req.raw));
     if (!resource) {
       return c.json(
-        createOAuthError('invalid_request', 'The MCP resource must be a valid same-origin URI'),
+        createOAuthError('invalid_request', 'The MCP resource must be a valid trusted URI'),
         400
       );
     }
@@ -1142,7 +1150,7 @@ oauthRoutes.post('/oauth/token', async (c) => {
     const resource = canonicalizeMcpResource(params.resource, publicMcpRequestUrl(c.req.raw));
     if (!resource) {
       return c.json(
-        createOAuthError('invalid_request', 'The MCP resource must be a valid same-origin URI'),
+        createOAuthError('invalid_request', 'The MCP resource must be a valid trusted URI'),
         400
       );
     }

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -504,8 +504,9 @@ function createServerForContext(
         await touchAgentLastUsed(authCtx.organizationId, authCtx.agentId);
       }
 
-      // Keep rich SDK diagnostics in Lobu's internal audit result, but never
-      // expose logs/timestamps/stacks/org traversal/call traces to MCP clients.
+      // executeTool has already passed the rich SDK result through the internal
+      // audit seam. Do not expose logs, stacks, org traversal, or call traces to
+      // MCP clients.
       const publicResult =
         name === 'run_sdk' || name === 'query_sdk'
           ? toMcpPublicSdkScriptResult(result)

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -55,6 +55,7 @@ import {
 } from './tools/execute';
 import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
+import { toMcpPublicSdkScriptResult } from './tools/sdk_run';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { readMcpAppBundle, renderMcpAppTemplate } from './utils/mcp-app-bundle';
@@ -503,9 +504,15 @@ function createServerForContext(
         await touchAgentLastUsed(authCtx.organizationId, authCtx.agentId);
       }
 
+      // Keep rich SDK diagnostics in Lobu's internal audit result, but never
+      // expose logs/timestamps/stacks/org traversal/call traces to MCP clients.
+      const publicResult =
+        name === 'run_sdk' || name === 'query_sdk'
+          ? toMcpPublicSdkScriptResult(result)
+          : result;
       const text = mcpRequestFormat.getStore()?.rawJson
-        ? JSON.stringify(result)
-        : formatToolResult(name, result, { includeRawJson: false });
+        ? JSON.stringify(publicResult)
+        : formatToolResult(name, publicResult, { includeRawJson: false });
       // When the tool declares an `outputSchema`, also return the result as
       // `structuredContent` (MCP spec: declaring outputSchema implies the result
       // is structured — and a spec-compliant client validates it against the
@@ -524,14 +531,13 @@ function createServerForContext(
       // `isError`; otherwise the client treats it as a normal result. query_sql
       // also renders the error explicitly because its formatter would otherwise
       // turn `{ rows: [], error }` into a clean empty CSV result.
-      const softError = isSoftErrorResult(result);
-      const tool = getTool(name);
+      const softError = isSoftErrorResult(publicResult);
       const attachedMeta = getMcpResultMeta(result);
       const resultMeta = uiMemberRoleMeta
         ? { ...attachedMeta, ...uiMemberRoleMeta }
         : attachedMeta;
       if (tool?.outputSchema && result && typeof result === 'object') {
-        const structured = validateToolResult(tool.outputSchema, result);
+        const structured = validateToolResult(tool.outputSchema, publicResult);
         if (structured !== null) {
           let snapshotCapability: string | null = null;
           if (tool.audit !== false) {

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -98,8 +98,8 @@ export interface AuthContext {
  *
  * Deliberately NOT a script failure. `run_sdk` / `query_sdk` execute arbitrary
  * caller code and report the outcome as DATA: `SdkScriptResultSchema` makes
- * `success` a required field and documents `error` as "the thrown error, with
- * script position" (name/message/line/column). When a script throws, the tool
+ * `success` a required field and documents `error` as concise script-failure
+ * information (name/message/code/retryable). When a script throws, the tool
  * itself ran perfectly — it executed the code and returned a faithful report.
  * Marking that `isError` conflates "the sandbox failed to run your code" with
  * "your code ran and threw", which callers must distinguish: `mcpToolsCall`

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -251,7 +251,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'search_memory',
     description:
-      'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
+      'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” A query such as `memory 4939822` performs an exact permission-checked content read. Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: SearchSchema,
     // Advertise the narrower public schema: query_embedding (server pre-compute
     // optimization) and agent_id (auth-bound) are server-internal, not client
@@ -267,7 +267,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
+      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
@@ -291,7 +291,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'query_sdk',
     description:
-      'Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change workspace content or external systems. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.) Lobu appends a private audit/activity record for the invocation.',
+      'Run capability-scoped, read-only TypeScript through the Lobu SDK. Query entities, relationships, feeds, operations, metrics, and authorized connected-source data; write, administrative, and external-action methods are rejected by the sandbox. Use `run_sdk` for mutations, `search_sdk` to discover methods, and `await ctx.sleep(ms)` for bounded polling. Lobu appends a private audit/activity record for the invocation.',
     inputSchema: QuerySchema,
     outputSchema: SdkScriptResultSchema,
     // Private connector reads do not mutate an external/public system.
@@ -316,7 +316,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'run_sdk',
     description:
-      'Perform any workspace action: create/update/delete entities, set up connections (e.g. client.connections.connect({ connector_key: "github" })), manage Behaviors and feeds, run operations, or modify templates. Use this for anything that changes data. (For read-only access: use query_sdk. To discover available methods: use search_sdk. Preview changes without executing: set dry_run=true.)',
+      'Execute a capability-scoped Lobu SDK script against the current workspace. The script can create, update, or delete Lobu data and invoke connector, agent, or device operations only through documented `client` methods; workspace permissions, operation policies, human approvals, and audit remain enforced. Use `query_sdk` for reads, `search_sdk` to discover methods, and `dry_run=true` to preview write, administrative, or external calls without executing them.',
     inputSchema: RunSchema,
     outputSchema: SdkScriptResultSchema,
     annotations: {

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -44,33 +44,30 @@ export const QuerySchema = Type.Object(SCRIPT_FIELDS);
 type RunArgs = Static<typeof RunSchema>;
 type QueryArgs = Static<typeof QuerySchema>;
 
-const SdkCallTraceEntrySchema = Type.Object({
-  path: Type.String({ description: "Dotted SDK method path (e.g. entities.list)." }),
-  orgPath: Type.Array(Type.String(), {
-    description: "Org slugs traversed via client.org(...) before the call, if any.",
-  }),
+const PublicSideEffectPreviewEntrySchema = Type.Object({
+  path: Type.String({ description: "Dotted SDK method path for the proposed action." }),
   access: Type.Union(
     [
-      Type.Literal("read"),
       Type.Literal("write"),
       Type.Literal("external"),
       Type.Literal("admin"),
       Type.Literal("unknown"),
     ],
-    { description: "Access class of the method." },
+    { description: "Access class of the proposed action." },
   ),
-  args: Type.Array(Type.Unknown(), { description: "Call arguments (redacted + truncated)." }),
-  skipped: Type.Boolean({
-    description: "true when dry_run skipped this write/external call.",
+  args: Type.Array(Type.Unknown(), {
+    description: "Redacted, bounded arguments for the proposed action.",
   }),
 });
 
 /**
- * Result of `run_sdk` / `query_sdk` — mirrors the object assembled in
- * `runSandbox` from `RunScriptResult` (run-script.ts). Advertised as the
- * tools' `outputSchema` so clients know where the script's return value and
- * the dry-run preview land; a runtime mismatch degrades to text-only
- * (`validateToolResult`), never a failed call.
+ * Public MCP result for `run_sdk` / `query_sdk`.
+ *
+ * The sandbox internally captures logs, timings, stack traces, org traversal,
+ * and a complete bounded SDK-call trace for Lobu's audit trail. Those are
+ * deliberately NOT part of this model-visible contract. ChatGPT receives only
+ * the caller-requested return value, a concise script error, and (for dry-run)
+ * the actions the user is being asked to review.
  */
 export const SdkScriptResultSchema = Type.Object({
   title: Type.Optional(
@@ -83,95 +80,126 @@ export const SdkScriptResultSchema = Type.Object({
   return_value: Type.Optional(
     Type.Unknown({
       description:
-        "The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview).",
+        "The script's default-export return value. Omitted when it exceeded the output cap.",
     }),
   ),
   return_value_preview: Type.Optional(
     Type.String({
       description:
-        "UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.",
+        "UTF-8-safe head of an oversized serialized return value. Rerun with filtering or pagination for the rest.",
     }),
   ),
   return_truncated: Type.Optional(
     Type.Object(
       {
-        total_bytes: Type.Integer({
-          description: "Serialized size of the original return value.",
-        }),
-        kept_bytes: Type.Integer({
-          description: "UTF-8 size of the preview string.",
-        }),
+        total_bytes: Type.Integer(),
+        kept_bytes: Type.Integer(),
       },
-      {
-        description: "Present with return_value_preview: the original and preview byte sizes.",
-      },
+      { description: "Present when return_value_preview is only a partial result." },
     ),
-  ),
-  logs: Type.Array(
-    Type.Object({
-      level: Type.Union([Type.Literal("log"), Type.Literal("warn"), Type.Literal("error")]),
-      message: Type.String(),
-      ts: Type.Number(),
-    }),
-    { description: "console.log/warn/error output captured from the script." },
   ),
   error: Type.Optional(
     Type.Object(
       {
         name: Type.String(),
         message: Type.String(),
-        details: Type.Optional(
-          Type.Unknown({
-            description:
-              "Redacted structured business-error details returned by the SDK action.",
-          }),
-        ),
-        stack: Type.Optional(Type.String()),
-        line: Type.Optional(Type.Number()),
-        column: Type.Optional(Type.Number()),
-        code: Type.Optional(
-          Type.String({
-            description:
-              "Structured error code (lobu#2051 Item 2), e.g. UPSTREAM_TIMEOUT / RATE_LIMITED / VALIDATION.",
-          }),
-        ),
-        retryable: Type.Optional(
-          Type.Boolean({
-            description:
-              "Whether re-running the identical script may succeed. Advisory — run_sdk is never auto-retried (may have side effects).",
-          }),
-        ),
+        code: Type.Optional(Type.String()),
+        retryable: Type.Optional(Type.Boolean()),
       },
-      { description: "Present when success=false: the thrown error, with script position." },
+      { description: "Concise script failure information, without stack traces or internal diagnostics." },
     ),
   ),
-  duration_ms: Type.Number(),
-  sdk_calls: Type.Integer({ description: "Number of SDK calls the script made (dispatched + skipped)." }),
   skipped_calls: Type.Integer({
-    description: "Total calls skipped because dry_run=true — the full dry-run surface, even when side_effect_preview is truncated.",
+    description: "Number of write/admin/external calls skipped by dry-run.",
   }),
-  sdk_call_trace: Type.Array(SdkCallTraceEntrySchema, {
-    description:
-      "Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap the oldest entries are dropped and reported in sdk_call_trace_truncated; a single entry larger than the cap is dropped and counted too.",
+  side_effect_preview: Type.Array(PublicSideEffectPreviewEntrySchema, {
+    description: "Proposed write/admin/external calls skipped because dry_run=true.",
   }),
-  side_effect_preview: Type.Array(SdkCallTraceEntrySchema, {
-    description:
-      "Write/admin/external calls that were skipped because dry_run=true (skipped: true). Bounded like sdk_call_trace; see skipped_calls for the total. Method-level side-effect preview, not proof the skipped handler would accept the payload.",
-  }),
-  sdk_call_trace_truncated: Type.Optional(
-    Type.Object(
-      {
-        dropped_entries: Type.Integer({
-          description: "Trace/preview entries dropped because the trace cap was exceeded.",
-        }),
-      },
-      {
-        description: "Present when sdk_call_trace or side_effect_preview was truncated (oldest entries dropped).",
-      },
-    ),
+  side_effect_preview_truncated: Type.Optional(
+    Type.Object({
+      dropped_entries: Type.Integer({ minimum: 1 }),
+    }),
   ),
   dry_run: Type.Boolean(),
 });
+
+type PublicSideEffectPreviewEntry = Static<typeof PublicSideEffectPreviewEntrySchema>;
+
+function asPublicPreviewEntry(value: unknown): PublicSideEffectPreviewEntry | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (typeof row.path !== "string" || !Array.isArray(row.args)) return null;
+  const access =
+    row.access === "write" ||
+    row.access === "external" ||
+    row.access === "admin" ||
+    row.access === "unknown"
+      ? row.access
+      : "unknown";
+  return { path: row.path, access, args: row.args };
+}
+
+/**
+ * Minimize a rich internal SDK result for the MCP/model boundary. The raw
+ * object remains available to executeTool's audit seam before this function is
+ * called, so removing diagnostics here does not weaken Lobu's audit trail.
+ */
+export function toMcpPublicSdkScriptResult(result: unknown): unknown {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return result;
+  const row = result as Record<string, unknown>;
+  const preview = Array.isArray(row.side_effect_preview)
+    ? row.side_effect_preview
+        .map(asPublicPreviewEntry)
+        .filter((entry): entry is PublicSideEffectPreviewEntry => entry !== null)
+    : [];
+  const skippedCalls =
+    typeof row.skipped_calls === "number" && Number.isSafeInteger(row.skipped_calls)
+      ? Math.max(0, row.skipped_calls)
+      : preview.length;
+
+  const out: Record<string, unknown> = {
+    success: row.success === true,
+    skipped_calls: skippedCalls,
+    side_effect_preview: preview,
+    dry_run: row.dry_run === true,
+  };
+
+  if (Object.hasOwn(row, "return_value") && row.return_value !== undefined) {
+    out.return_value = row.return_value;
+  }
+  if (typeof row.return_value_preview === "string") {
+    out.return_value_preview = row.return_value_preview;
+  }
+  if (row.return_truncated && typeof row.return_truncated === "object") {
+    const truncated = row.return_truncated as Record<string, unknown>;
+    if (
+      typeof truncated.total_bytes === "number" &&
+      typeof truncated.kept_bytes === "number"
+    ) {
+      out.return_truncated = {
+        total_bytes: truncated.total_bytes,
+        kept_bytes: truncated.kept_bytes,
+      };
+    }
+  }
+
+  if (row.error && typeof row.error === "object" && !Array.isArray(row.error)) {
+    const error = row.error as Record<string, unknown>;
+    if (typeof error.message === "string") {
+      out.error = {
+        name: typeof error.name === "string" ? error.name : "Error",
+        message: error.message,
+        ...(typeof error.code === "string" ? { code: error.code } : {}),
+        ...(typeof error.retryable === "boolean" ? { retryable: error.retryable } : {}),
+      };
+    }
+  }
+
+  if (skippedCalls > preview.length) {
+    out.side_effect_preview_truncated = { dropped_entries: skippedCalls - preview.length };
+  }
+  return out;
+}
 
 /**
  * Whether the sandbox runs in its skip-and-record path for this call.

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -164,6 +164,13 @@ export function toMcpPublicSdkScriptResult(result: unknown): unknown {
     dry_run: row.dry_run === true,
   };
 
+  // Echo the caller-supplied heading so MCP App / ChatGPT result cards can
+  // render it above status. Documented on the input schema and on
+  // SdkScriptResultSchema — dropping it here breaks that contract.
+  if (typeof row.title === "string" && row.title.trim()) {
+    out.title = row.title.trim();
+  }
+
   if (Object.hasOwn(row, "return_value") && row.return_value !== undefined) {
     out.return_value = row.return_value;
   }
@@ -247,17 +254,19 @@ async function runSandbox(
   ctx: ToolContext,
 ): Promise<unknown> {
   const allowCrossOrg = ctx.allowCrossOrg;
+  const agentDryRun = "dry_run" in args ? args.dry_run === true : false;
+  const dryRun = resolveSandboxDryRun({
+    executionMode: ctx.executionMode,
+    sdkMode: mode,
+    agentDryRun,
+  });
   const result = await runScript({
     source: args.script,
     sdk: (abortSignal) => buildClientSDK(ctx, env, { mode, allowCrossOrg, abortSignal }),
     sdkMode: mode,
     allowCrossOrg,
     maxAccessLevel: resolveMaxAccessLevel(ctx.memberRole, ctx.scopes),
-    dryRun: resolveSandboxDryRun({
-      executionMode: ctx.executionMode,
-      sdkMode: mode,
-      agentDryRun: "dry_run" in args ? args.dry_run === true : false,
-    }),
+    dryRun,
     dryRunDispatchPaths:
       ctx.executionMode === "capture" ? CAPTURE_DISPATCH_PATHS : undefined,
     context: {
@@ -293,7 +302,10 @@ async function runSandbox(
     side_effect_preview: result.sideEffectPreview,
     sdk_call_trace_truncated:
       result.traceDropped > 0 ? { dropped_entries: result.traceDropped } : undefined,
-    dry_run: mode === "full" && "dry_run" in args && args.dry_run === true,
+    // Effective sandbox dry-run, including capture-mode enforcement. Must match
+    // the dryRun flag passed to runScript so skipped_calls / side_effect_preview
+    // never appear under dry_run:false.
+    dry_run: dryRun,
   };
 }
 

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -64,10 +64,10 @@ const PublicSideEffectPreviewEntrySchema = Type.Object({
  * Public MCP result for `run_sdk` / `query_sdk`.
  *
  * The sandbox internally captures logs, timings, stack traces, org traversal,
- * and a complete bounded SDK-call trace for Lobu's audit trail. Those are
- * deliberately NOT part of this model-visible contract. ChatGPT receives only
- * the caller-requested return value, a concise script error, and (for dry-run)
- * the actions the user is being asked to review.
+ * and a bounded SDK-call trace. The execution and audit pipeline consumes that
+ * richer result before the MCP boundary. ChatGPT receives only the requested
+ * return value, a concise script error, and (for dry-run) the actions the user
+ * is being asked to review.
  */
 export const SdkScriptResultSchema = Type.Object({
   title: Type.Optional(


### PR DESCRIPTION
## Why
Follow-up hardening for the ChatGPT Apps review surface. This PR intentionally changes scanned MCP metadata/contracts and should be deployed together with a fresh **Scan Tools** + review resubmission.

## Changes
- keep `https://lobu.ai/mcp` as the canonical protected resource while OAuth remains on `https://app.lobu.ai`
- bind cross-origin hosted OAuth resource indicators only inside the explicitly configured `.lobu.ai` trust zone; reject scheme/port/credential/query/path abuse
- minimize model-visible `query_sdk` / `run_sdk` output: remove console logs, timestamps, stacks, internal org traversal, timings, and SDK call traces while retaining requested return values and dry-run proposals
- keep rich execution diagnostics inside Lobu for audit/observability
- tighten public tool descriptions around capability-scoped execution, approvals, audit, idempotency, and exact memory IDs

## Verification
- OAuth resource-indicator unit tests: 8/8
- MCP public SDK result tests: 2/2
- OAuth discovery: 7/7
- MCP auth: 45 passing, 2 intentionally skipped
- MCP App resources: 18/18
- exact-memory recall: 7/7
- server typecheck passing
- pre-commit checks passing

## Release note
Do **not** merge/deploy this PR as a silent compatibility patch to the currently frozen OpenAI scan. The output schemas/descriptions/OAuth metadata change, so use a new Scan Tools snapshot and resubmit after deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SDK and MCP results now provide concise, model-facing data while excluding internal diagnostics and traces.
  - Added sanitized side-effect previews and dry-run outcomes with truncation indicators.
  - OAuth resource validation now supports trusted configured domains, forwarded origins, and separate authorization-server origins.

- **Bug Fixes**
  - Improved OAuth metadata and error messaging for trusted MCP resources.
  - Added stricter validation for resource URLs, protocols, ports, credentials, and unsupported origins.

- **Documentation**
  - Clarified tool behavior for idempotency, polling, approvals, sandboxing, auditing, and dry-run operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->