### PR TITLE
test(server): isolate conversation ownership suite

### DIFF
--- a/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
+++ b/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
@@ -142,6 +142,15 @@ async function runTurn(
   consumer: MessageConsumer,
   done: () => boolean,
 ): Promise<void> {
+  // This suite exercises deployment ownership only. Keep the connector-tooling
+  // fold on its test seam so importing MessageConsumer never turns these
+  // database-free tests into accidental integration tests.
+  spyOn(
+    consumer as unknown as {
+      foldConnectorTooling: (data: MessagePayload) => Promise<string>;
+    },
+    "foldConnectorTooling",
+  ).mockResolvedValue("test-no-connector-tooling");
   await (
     consumer as unknown as {
       handleMessage: (job: unknown) => Promise<void>;


### PR DESCRIPTION
## Summary

- keep the database-free conversation ownership suite on its existing connector-tooling test seam
- prevent `MessageConsumer` from reaching the real tooling resolver and querying an uninitialized `connections` table

## Evidence

- current `main` CI run 31517520778 fails the same three tests with `relation "connections" does not exist`
- pointer-only PR #2671 reproduced the failure twice
- focused suite passes locally: 3 passed, 0 failed
- pre-commit Biome and TypeScript checks pass

No product behavior changes; this is test isolation only.
