### PR TITLE
fix(server): stub tooling fold in fake-based MessageConsumer tests

### DIFF
--- a/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
+++ b/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
@@ -36,6 +36,7 @@ import type {
 } from "../orchestration/deployment-manager.js";
 import { MessageConsumer } from "../orchestration/message-consumer.js";
 import { ensureEncryptionKey } from "./helpers/db-setup.js";
+import { TestMessageConsumer } from "./helpers/test-message-consumer.js";
 
 // This suite drives `handleMessage`, which mints a run-job token via
 // buildRunJobToken() → encrypt(). That lazily reads ENCRYPTION_KEY, and a
@@ -155,7 +156,7 @@ async function runTurn(
 
 describe("multi-replica: conversation owned by another pod", () => {
   test("owned-elsewhere → drops silently, no user-facing failure", async () => {
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeDeploymentManager(
         new ConversationOwnedElsewhereError("owned by another replica"),
@@ -189,7 +190,7 @@ describe("multi-replica: conversation owned by another pod", () => {
   });
 
   test("genuine startup failure → still surfaces a user-facing error", async () => {
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeDeploymentManager(new Error("worker spawn failed: OOM")),
       makeFakeQueue(),
@@ -215,7 +216,7 @@ describe("multi-replica: conversation owned by another pod", () => {
     const dm = makeDeploymentManager(
       new ConversationOwnedElsewhereError("owned by another replica"),
     );
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       dm,
       makeFakeQueue(),

--- a/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
@@ -21,6 +21,7 @@ import type {
 import { enforceModelAllowList } from "../auth/settings/model-selection.js";
 import { generateDeploymentName } from "../orchestration/deployment-manager.js";
 import { MessageConsumer } from "../orchestration/message-consumer.js";
+import { TestMessageConsumer } from "./helpers/test-message-consumer.js";
 
 // The deployment name the consumer derives for makePayload()'s routing keys.
 // Returning a deployment with THIS name from listDeployments makes
@@ -221,7 +222,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
   test("a disallowed model on the WARM path is gated BEFORE the payload is persisted", async () => {
     const { queue, sends } = makeCapturingQueue();
     // agent.models = ["openai/gpt-5"]; the request asks for openai/gpt-4o.
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(["openai/gpt-5"]),
       queue,
@@ -238,7 +239,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("an in-list model passes through unchanged", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(["openai/gpt-5", "claude/claude-sonnet-5"]),
       queue,
@@ -252,7 +253,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("allow-all (null policy) leaves the requested model unchanged", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(null),
       queue,
@@ -266,7 +267,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("a sentinel-only policy drops the model (fails closed) before persistence", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(["chatgpt/__unresolved__"]),
       queue,
@@ -284,7 +285,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
     const { queue, sends } = makeCapturingQueue();
     // resolveDispatchModel throws "db down". The disallowed model MUST NOT
     // survive on the persisted payload — the warm path won't re-gate later.
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeThrowingDeploymentManager(),
       queue,
@@ -299,7 +300,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("#2 CROSS-TENANT GUARD: a payload with NO organizationId is rejected before enqueue", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(["openai/gpt-5"]),
       queue,
@@ -324,7 +325,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("a payload with no agentId is rejected before enqueue", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(["openai/gpt-5"]),
       queue,
@@ -345,7 +346,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
 
   test("the same channel thread routes different agents to different worker queues", async () => {
     const { queue, sends } = makeCapturingQueue();
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeWarmDeploymentManager(null),
       queue,
@@ -373,7 +374,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
     // allow=["xai/grok-4","openai/gpt-5"]; xai UNCREDENTIALED, openai routable.
     // A disallowed request must replace onto openai/gpt-5 (routable), NOT the
     // first non-sentinel xai/grok-4 (which would fail at run).
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeRoutableDeploymentManager(
         ["xai/grok-4", "openai/gpt-5"],
@@ -393,7 +394,7 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
     const { queue, sends } = makeCapturingQueue();
     // The catalog isn't injected yet (startup / a persisted job drained before
     // wiring). The unvalidated model MUST NOT survive to the warm worker.
-    const consumer = new MessageConsumer(
+    const consumer = new TestMessageConsumer(
       makeConfig(),
       makeUnwiredCatalogDeploymentManager(),
       queue,

--- a/packages/server/src/gateway/__tests__/helpers/test-message-consumer.ts
+++ b/packages/server/src/gateway/__tests__/helpers/test-message-consumer.ts
@@ -1,0 +1,36 @@
+import type { MessagePayload } from "@lobu/core";
+import type { IMessageQueue } from "../../infrastructure/queue/index.js";
+import type {
+  DeploymentManager,
+  OrchestratorConfig,
+} from "../../orchestration/deployment-manager.js";
+import { MessageConsumer } from "../../orchestration/message-consumer.js";
+
+type RecordRunInput = (payload: MessagePayload, deploymentName: string) => Promise<void>;
+
+/**
+ * A `MessageConsumer` whose tooling fold is stubbed, for tests that drive
+ * `handleMessage` with fakes and must NOT touch Postgres.
+ *
+ * `handleMessage` unconditionally calls `foldConnectorTooling`, which folds
+ * org-scoped connector tooling via a live `connections` query. Tests that only
+ * exercise routing / ownership / model-gating pass fakes for the queue and
+ * deployment manager and otherwise never open a database; without this stub
+ * they hit the real `connections` table, and fail (or flake, racing a
+ * co-running file's schema reset) the moment that table is absent.
+ */
+export class TestMessageConsumer extends MessageConsumer {
+  constructor(
+    config: OrchestratorConfig,
+    deploymentManager: DeploymentManager,
+    queue: IMessageQueue = {} as IMessageQueue,
+    recordRunInput: RecordRunInput = async () => {},
+  ) {
+    super(config, deploymentManager, queue, recordRunInput);
+  }
+
+  /** No connector tooling contribution — fake-based tests never need one. */
+  protected async foldConnectorTooling(_data: MessagePayload): Promise<string> {
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
`handleMessage` unconditionally folds org-scoped connector tooling via a live `connections` query. The fake-based `MessageConsumer` tests (owned-elsewhere, enqueue-model-gate) never set up Postgres, so the fold hit the real table and failed whenever the schema was absent — a class-wide flake surfacing in CI as `relation "connections" does not exist` racing a co-running file's schema reset.

Add a `TestMessageConsumer` helper that overrides the protected fold to return empty; use it in both suites. `connector-tooling-enqueue` keeps the real fold (it exercises it deliberately).

## Test plan
- [x] `make pre-pr` clean
- [x] Tests run (reproduced red→green, outputs below)
- [x] Bug fix: red→fix→green

### Red (before fix — reproduced locally against a schema-less test DB)
```
conversation-owned-elsewhere.test.ts: 0 pass, 3 fail
  PostgresError: relation "connections" does not exist
  at loadToolingConnections (agent-tooling/resolver.ts:505)
enqueue-model-gate.test.ts: 2 pass, 8 fail (same root cause)
```

### Green (after fix)
```
conversation-owned-elsewhere: 3 pass, 0 fail
enqueue-model-gate: 10 pass, 0 fail
connector-tooling-enqueue: 5 pass, 0 fail  (real fold untouched)
```

## Notes
Root cause: `handleMessage` → `foldConnectorTooling` → `resolveAgentToolingDeclaration` → `loadToolingConnections` queries `connections`. The two fake-based suites' comment claimed they never touch Postgres — the fold was the silent exception.