### PR TITLE
fix(server): emit the caller's role on MCP app result _meta

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -504,6 +504,49 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
   });
 
+  it('emits the caller authoritatively, not a stale role from another card', async () => {
+    // The key is always present with the CURRENT caller's role. A plain member
+    // must receive 'member' — never an owner/admin value a different card's
+    // metadata might have carried — so the interaction app's Debug gate can
+    // trust the value it renders.
+    const member = await createTestUser({
+      email: `mcp-app-member-${Date.now()}@test.example.com`,
+    });
+    await addUserToOrganization(member.id, org.id, 'member');
+    const { token: memberToken } = await createTestAccessToken(
+      member.id,
+      org.id,
+      client.client_id,
+      { scope: 'mcp:admin mcp:write mcp:read profile:read' }
+    );
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      sessionToken: memberToken,
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 13,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            title: 'Member probe',
+            tone: 'default',
+            blocks: [{ type: 'text', label: 'Status', value: 'ok' }],
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token: memberToken,
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?._meta).toHaveProperty('lobu/member-role');
+    expect(body.result?._meta?.['lobu/member-role']).toBe('member');
+  });
+
   it('binds reused backend request ids to distinct host cards and restores exact state', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const conversationId = 'chatgpt-conversation-restore-test';

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -547,6 +547,30 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?._meta?.['lobu/member-role']).toBe('member');
   });
 
+  it('keeps lobu/member-role on a thrown tool-call error', async () => {
+    // An erroring tool must still emit the key so the app can clear stale
+    // owner/admin Debug state even when the call fails.
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 14,
+        method: 'tools/call',
+        params: {
+          name: 'query_sql',
+          arguments: { sql: 'SELECT definitely_not_a_column FROM' },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?._meta).toHaveProperty('lobu/member-role');
+    expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
+  });
+
   it('binds reused backend request ids to distinct host cards and restores exact state', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const conversationId = 'chatgpt-conversation-restore-test';

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -499,6 +499,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).toContain('Release readiness');
     expect(body.result?.content?.[0]?.text).toContain('Ready for review\\.');
     expect(JSON.stringify(body.result)).not.toContain('must-not-render');
+    // The caller's role rides the result _meta so the interaction app can gate
+    // Debug for owner/admin without trusting stale unrelated-card metadata.
+    expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
   });
 
   it('binds reused backend request ids to distinct host cards and restores exact state', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -558,7 +558,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         method: 'tools/call',
         params: {
           name: 'query_sql',
-          arguments: { sql: 'SELECT definitely_not_a_column FROM' },
+          // Missing required `sql` throws a ToolUserError -> the catch branch,
+          // which is the path that must carry the role meta.
+          arguments: {},
         },
       },
       headers: { 'mcp-session-id': sessionId },

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -503,22 +503,19 @@ function createServerForContext(
       const softError = isSoftErrorResult(result);
       const tool = getTool(name);
       const resultMeta = getMcpResultMeta(result);
-      // The caller's role rides the result _meta so MCP apps (e.g. the
+      // The caller's role rides EVERY result _meta so MCP apps (e.g. the
       // interaction app's Debug gate) can render caller-appropriate controls.
-      // Emitted fresh per request from the current auth context, so a stale
-      // owner/admin role from an uncorrelated card can never escalate a
-      // non-admin result — it is exactly the correlation the owletto gate
-      // relies on. Capped to the reader's contract (owletto
-      // memberRoleFromMeta rejects values over 40 chars).
+      // The key is always present, with explicit null on no-membership/absent
+      // roles: the app only clears prior owner/admin state when the key exists,
+      // so omitting it on a downgrade would retain stale Debug access. Capped
+      // to the reader's contract (owletto memberRoleFromMeta rejects >40 chars).
       const callerMemberRole =
         typeof callAuthCtx.memberRole === 'string' &&
-        callAuthCtx.memberRole.length > 0
+        callAuthCtx.memberRole.length > 0 &&
+        callAuthCtx.memberRole.length <= 40
           ? callAuthCtx.memberRole
           : null;
-      const memberRoleMeta =
-        callerMemberRole && callerMemberRole.length <= 40
-          ? { 'lobu/member-role': callerMemberRole }
-          : undefined;
+      const memberRoleMeta = { 'lobu/member-role': callerMemberRole };
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
@@ -541,34 +538,26 @@ function createServerForContext(
               );
             }
           }
-          const appMeta = {
-            ...(resultMeta ?? {}),
-            ...(memberRoleMeta ?? {}),
-          };
           return {
             content: [{ type: 'text' as const, text }],
             structuredContent: structured as Record<string, unknown>,
-            ...(appMeta || snapshotCapability
-              ? {
-                  _meta: {
-                    ...appMeta,
-                    ...(snapshotCapability
-                      ? { 'lobu/mcp-app-snapshot-capability': snapshotCapability }
-                      : {}),
-                  },
-                }
-              : {}),
+            _meta: {
+              ...(resultMeta ?? {}),
+              ...memberRoleMeta,
+              ...(snapshotCapability
+                ? { 'lobu/mcp-app-snapshot-capability': snapshotCapability }
+                : {}),
+            },
             ...(softError ? { isError: true } : {}),
           };
         }
       }
-      const textMeta = {
-        ...(resultMeta ?? {}),
-        ...(memberRoleMeta ?? {}),
-      };
       return {
         content: [{ type: 'text' as const, text }],
-        ...(textMeta ? { _meta: textMeta } : {}),
+        _meta: {
+          ...(resultMeta ?? {}),
+          ...memberRoleMeta,
+        },
         ...(softError ? { isError: true } : {}),
       };
     } catch (error: any) {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -503,6 +503,22 @@ function createServerForContext(
       const softError = isSoftErrorResult(result);
       const tool = getTool(name);
       const resultMeta = getMcpResultMeta(result);
+      // The caller's role rides the result _meta so MCP apps (e.g. the
+      // interaction app's Debug gate) can render caller-appropriate controls.
+      // Emitted fresh per request from the current auth context, so a stale
+      // owner/admin role from an uncorrelated card can never escalate a
+      // non-admin result — it is exactly the correlation the owletto gate
+      // relies on. Capped to the reader's contract (owletto
+      // memberRoleFromMeta rejects values over 40 chars).
+      const callerMemberRole =
+        typeof callAuthCtx.memberRole === 'string' &&
+        callAuthCtx.memberRole.length > 0
+          ? callAuthCtx.memberRole
+          : null;
+      const memberRoleMeta =
+        callerMemberRole && callerMemberRole.length <= 40
+          ? { 'lobu/member-role': callerMemberRole }
+          : undefined;
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
@@ -525,13 +541,17 @@ function createServerForContext(
               );
             }
           }
+          const appMeta = {
+            ...(resultMeta ?? {}),
+            ...(memberRoleMeta ?? {}),
+          };
           return {
             content: [{ type: 'text' as const, text }],
             structuredContent: structured as Record<string, unknown>,
-            ...(resultMeta || snapshotCapability
+            ...(appMeta || snapshotCapability
               ? {
                   _meta: {
-                    ...(resultMeta ?? {}),
+                    ...appMeta,
                     ...(snapshotCapability
                       ? { 'lobu/mcp-app-snapshot-capability': snapshotCapability }
                       : {}),
@@ -542,9 +562,13 @@ function createServerForContext(
           };
         }
       }
+      const textMeta = {
+        ...(resultMeta ?? {}),
+        ...(memberRoleMeta ?? {}),
+      };
       return {
         content: [{ type: 'text' as const, text }],
-        ...(resultMeta ? { _meta: resultMeta } : {}),
+        ...(textMeta ? { _meta: textMeta } : {}),
         ...(softError ? { isError: true } : {}),
       };
     } catch (error: any) {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -470,6 +470,19 @@ function createServerForContext(
       mcpAppApprovalCapability: approvalCapabilityFromMeta(request.params._meta),
       mcpAppSnapshotCapability: snapshotCapabilityFromMeta(request.params._meta),
     };
+    // The caller's role rides EVERY result _meta — success, soft error, or
+    // thrown error — so MCP apps (e.g. the interaction app's Debug gate) can
+    // render caller-appropriate controls and, crucially, CLEAR prior owner/admin
+    // state on a downgrade: the app only does so when the key is present. The
+    // key is always emitted, with explicit null on no-membership/absent roles.
+    // Capped to the reader's contract (owletto memberRoleFromMeta rejects >40).
+    const callerMemberRole =
+      typeof callAuthCtx.memberRole === 'string' &&
+      callAuthCtx.memberRole.length > 0 &&
+      callAuthCtx.memberRole.length <= 40
+        ? callAuthCtx.memberRole
+        : null;
+    const memberRoleMeta = { 'lobu/member-role': callerMemberRole };
 
     // Regular tool execution
     try {
@@ -503,19 +516,6 @@ function createServerForContext(
       const softError = isSoftErrorResult(result);
       const tool = getTool(name);
       const resultMeta = getMcpResultMeta(result);
-      // The caller's role rides EVERY result _meta so MCP apps (e.g. the
-      // interaction app's Debug gate) can render caller-appropriate controls.
-      // The key is always present, with explicit null on no-membership/absent
-      // roles: the app only clears prior owner/admin state when the key exists,
-      // so omitting it on a downgrade would retain stale Debug access. Capped
-      // to the reader's contract (owletto memberRoleFromMeta rejects >40 chars).
-      const callerMemberRole =
-        typeof callAuthCtx.memberRole === 'string' &&
-        callAuthCtx.memberRole.length > 0 &&
-        callAuthCtx.memberRole.length <= 40
-          ? callAuthCtx.memberRole
-          : null;
-      const memberRoleMeta = { 'lobu/member-role': callerMemberRole };
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
@@ -605,7 +605,10 @@ function createServerForContext(
         ],
         isError: true,
         ...(structuredError ? { structuredContent: { error: structuredError } } : {}),
-        ...(scopeChallenge ? { _meta: { 'mcp/www_authenticate': [scopeChallenge] } } : {}),
+        _meta: {
+          ...memberRoleMeta,
+          ...(scopeChallenge ? { 'mcp/www_authenticate': [scopeChallenge] } : {}),
+        },
       };
     }
   });


### PR DESCRIPTION
## Summary
The interaction MCP app gates its Debug view on `lobu/member-role` (`canViewDebug={memberRole === "owner" || memberRole === "admin"}`), but the server never emitted it — so the Debug button was hidden for every caller, including real owner/admins.

Emit the caller's `memberRole` fresh per request in the MCP tool-result `_meta` (capped to the reader's 40-char contract in `memberRoleFromMeta`). Being fresh per request is what makes the owletto security gate (correlate memberRole with the current result, #804) work as intended: a stale owner/admin role from an unrelated card can never escalate a non-admin result.

## Test plan
- [x] `bunx vitest run src/__tests__/integration/mcp/mcp-app-resources.test.ts` (18 pass)
- [x] `bunx tsc --noEmit` clean
- New assertion: a `render_lobu_view` call as the org owner returns `_meta['lobu/member-role'] === 'owner'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * MCP tool-call responses now consistently include the caller’s member role when available.
  * Responses explicitly indicate when no valid member role is present.
  * Member-role metadata is preserved for successful results, structured responses, and errors.
  * Existing metadata, capabilities, and authorization challenges continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->