### PR TITLE
fix(server,example,chrome): review-fix findings from production-hardening merge

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2529,7 +2529,7 @@ describe("prepare_comment helpers", () => {
     expect(dispatches).toBe(0);
   });
 
-  test("buildHomeFeedEvents persists durable post identity in metadata when available", () => {
+  test("buildHomeFeedEvents persists the canonical post URL as source_url", () => {
     const [ev] = buildHomeFeedEvents(
       [
         {
@@ -2546,15 +2546,9 @@ describe("prepare_comment helpers", () => {
     expect(ev.source_url).toBe(
       "https://www.linkedin.com/feed/update/urn:li:activity:7345678901234567890"
     );
-    expect(ev.metadata?.post_url).toBe(
-      "https://www.linkedin.com/feed/update/urn:li:activity:7345678901234567890"
-    );
-    expect(ev.metadata?.post_identity).toBe(
-      "urn:li:activity:7345678901234567890"
-    );
   });
 
-  test("buildHomeFeedEvents derives post identity from the canonical URL", () => {
+  test("buildHomeFeedEvents derives the canonical URL for share/ugcPost ids", () => {
     const [ev] = buildHomeFeedEvents(
       [
         {
@@ -2567,7 +2561,9 @@ describe("prepare_comment helpers", () => {
       ],
       new Date("2026-08-01T12:00:00.000Z")
     );
-    expect(ev.metadata?.post_identity).toBe("urn:li:share:7345678901234567890");
+    expect(ev.source_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:share:7345678901234567890"
+    );
   });
 
   test("buildHomeFeedEvents does NOT emit the generic feed URL as a fake post identity", () => {
@@ -2583,8 +2579,6 @@ describe("prepare_comment helpers", () => {
     );
     // No post_url / post_identity → no source_url at all (not the /feed/ root).
     expect(ev.source_url).toBeUndefined();
-    expect(ev.metadata?.post_url).toBeUndefined();
-    expect(ev.metadata?.post_identity).toBeUndefined();
   });
 
   test("isGenericLinkedInFeedUrl identifies home-feed URLs with no post id", () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -664,8 +664,8 @@ export function isHomeFeedNoise(body: string): boolean {
  * recovered from LinkedIn's Copy-link action or a stable activity id embedded
  * in the card DOM; when no durable identity is recoverable, source_url is
  * OMITTED (never a generic /feed/ URL — that would look like a specific post
- * id). The durable identity is also persisted on metadata.post_url /
- * metadata.post_identity so downstream actions can address the post.
+ * id). source_url is the single durable post identifier; action callers
+ * (prepare_comment) resolve it directly.
  * Home-feed posts expose no reliable timestamp, so the caller stamps
  * occurred_at with the sync time.
  */
@@ -753,21 +753,6 @@ export function buildHomeFeedEvents(
       row.post_url ??
         (embeddedId ? `urn:li:${embeddedNamespace}:${embeddedId}` : "")
     );
-    const canonicalUrn = postUrl?.match(
-      /urn:li:(activity|share|ugcPost):(\d{6,})/i
-    );
-    const postIdentity = canonicalUrn
-      ? `urn:li:${linkedInUrnNamespace(canonicalUrn[1] ?? "")}:${canonicalUrn[2]}`
-      : null;
-
-    // Persist the durable post identity (canonical URL + URN) so downstream
-    // action callers (prepare_comment) can address the post with a supported
-    // durable identifier. When no durable identity is recoverable the event
-    // carries NONE — never substitute the generic linkedin.com/feed/ root,
-    // which looks like a specific post identity but resolves to the whole
-    // feed.
-    if (postUrl) metadata.post_url = postUrl;
-    if (postIdentity) metadata.post_identity = postIdentity;
 
     events.push({
       origin_id: `li_home_${row.id}`,
@@ -778,7 +763,8 @@ export function buildHomeFeedEvents(
       origin_type: "post",
       // Omitted when no durable identity was recoverable — a missing
       // source_url is the explicit "this event has no canonical post URL"
-      // signal, not a bug.
+      // signal, not a bug. source_url is the durable identifier; action
+      // callers (prepare_comment) resolve it directly.
       ...(postUrl ? { source_url: postUrl } : {}),
       metadata,
     });
@@ -2310,16 +2296,6 @@ export default class LinkedInConnector extends ConnectorRuntime<
                 },
                 social_actor_slug: { type: "string" },
                 social_actor_profile_url: { type: "string" },
-                post_url: {
-                  type: "string",
-                  description:
-                    "Canonical durable post URL (feed/update/urn:li:…), recovered from LinkedIn's Copy link or an embedded share/ugcPost/activity id. Absent when the post exposes no durable identity.",
-                },
-                post_identity: {
-                  type: "string",
-                  description:
-                    "Durable post URN (urn:li:activity|share|ugcPost:<id>) recovered from the card. Absent when no durable identity is exposed.",
-                },
               },
             },
           },
@@ -2620,7 +2596,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
             reason: {
               type: "string",
               description:
-                "Present with status=not_actionable: why the input was not actionable (e.g. missing_durable_post_id).",
+                "Present whenever verification did not succeed: why (e.g. missing_durable_post_id, no_matching_comment, no_comments_visible, scrape_exception).",
             },
             post_url: { type: "string" },
             body: { type: "string" },

--- a/packages/server/src/__tests__/unit/gateway-completion.test.ts
+++ b/packages/server/src/__tests__/unit/gateway-completion.test.ts
@@ -173,18 +173,6 @@ describe("gatewayCompletion", () => {
     expect(calls.length).toBe(1);
   });
 
-  test("throws when the response carries no text", async () => {
-    stubFetch({ choices: [{ message: { content: null } }] });
-    await expect(
-      gatewayCompletion({
-        target: TARGET,
-        systemPrompt: "s",
-        userPrompt: "u",
-        timeoutMs: 5_000,
-      })
-    ).rejects.toThrow(/no text/);
-  });
-
   test("an elapsed timeout aborts the request", async () => {
     const original = globalThis.fetch;
     let calls = 0;

--- a/packages/server/src/gateway/inference/gateway-completion.ts
+++ b/packages/server/src/gateway/inference/gateway-completion.ts
@@ -253,7 +253,6 @@ export async function gatewayCompletion(
         // upcoming delay fits inside the caller's shared deadline.
         maxRetries: 2,
         baseDelay,
-        maxDelay: 2000,
         jitter: "full",
         shouldRetry: (error, attempt) => {
           if (


### PR DESCRIPTION
## Summary

Independent review (codex) of the production-hardening merge (#2676) surfaced one blocker, one bug, and cleanup. This PR fixes all of them.

### Blocker — run-scoped tab isolation (owletto pointer)
`packages/owletto` → `f2cf3017`: the stale-target retry used a global `isOwnedTab()` check, so a later run's retry could close and replace a tab its own flow created. Now gated on `isOwnedTabForRun(tabId, holderRunId)`; regression test proves a different holder's tab is neither removed nor forgotten.

### Bug — verify_staged_comment `reason` schema description
The description claimed `reason` is present only with `status=not_actionable`, but it's returned on all three `verified:false` paths (scrape exception, error, no-match). Reworded to cover them.

### Cleanup
- Remove unreachable `maxDelay: 2000` from `gatewayCompletion` retry (with baseDelay=200 and maxRetries=2, max delay is 400ms)
- Drop duplicate 'no text' test in `gateway-completion.test.ts` (the no-retry case already covers it)
- Drop `metadata.post_url`/`post_identity` writes that duplicated `source_url` with no reader; removed from the home_feed metadata schema too

## Tests
- 122 local tests pass (LinkedIn + gateway)
- 208 owletto chrome tests pass
- Full Depot CI + pi-review gate to follow

## Risk
- Non-visual; the owletto change is background logic. ui-review N/A (no visual diff).