### PR TITLE
fix(server): accept extra public origins for MCP OAuth resources

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -64,6 +64,12 @@ app:
     # Bounded wait for in-flight HTTP responses (incl. SSE/MCP streams) to drain
     # before process exit. Keep below the remaining grace-period budget.
     HTTP_CLOSE_TIMEOUT_MS: "10000"
+    # Extra public origins whose /mcp resources the OAuth authorize flow
+    # accepts (RFC 8707 resource indicators). The canonical public endpoint
+    # lobu.ai/mcp is edge-proxied to this gateway origin, so strict OAuth MCP
+    # clients discover resource=https://lobu.ai/mcp from the 401 challenge.
+    # Clear when the gateway is only served on its own origin.
+    MCP_PUBLIC_RESOURCE_ORIGINS: "https://lobu.ai"
 
   # Graceful-shutdown budget. Must comfortably exceed the sum of the readiness
   # drain + in-flight HTTP close + gateway/worker teardown, or the kubelet

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -64,12 +64,6 @@ app:
     # Bounded wait for in-flight HTTP responses (incl. SSE/MCP streams) to drain
     # before process exit. Keep below the remaining grace-period budget.
     HTTP_CLOSE_TIMEOUT_MS: "10000"
-    # Extra public origins whose /mcp resources the OAuth authorize flow
-    # accepts (RFC 8707 resource indicators). The canonical public endpoint
-    # lobu.ai/mcp is edge-proxied to this gateway origin, so strict OAuth MCP
-    # clients discover resource=https://lobu.ai/mcp from the 401 challenge.
-    # Clear when the gateway is only served on its own origin.
-    MCP_PUBLIC_RESOURCE_ORIGINS: "https://lobu.ai"
 
   # Graceful-shutdown budget. Must comfortably exceed the sum of the readiness
   # drain + in-flight HTTP close + gateway/worker teardown, or the kubelet

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -68,4 +68,27 @@ describe('MCP OAuth resource indicators', () => {
       'https://lobu.example/.well-known/oauth-protected-resource/mcp/acme'
     );
   });
+
+  test('accepts extra configured public origins and canonicalizes to the gateway origin', () => {
+    process.env.MCP_PUBLIC_RESOURCE_ORIGINS = 'https://lobu.ai, https://mcp.example/';
+    __resetPublicOriginCachesForTests();
+
+    expect(
+      canonicalizeMcpResource('https://lobu.ai/mcp', 'https://app.lobu.ai/mcp')
+    ).toBe('https://app.lobu.ai/mcp');
+    expect(
+      canonicalizeMcpResource('https://lobu.ai/mcp/acme', 'https://app.lobu.ai/mcp')
+    ).toBe('https://app.lobu.ai/mcp/acme');
+    expect(
+      canonicalizeMcpResource('https://mcp.example/mcp', 'https://app.lobu.ai/mcp')
+    ).toBe('https://app.lobu.ai/mcp');
+  });
+
+  test('still rejects origins outside the public origin allowlist', () => {
+    process.env.MCP_PUBLIC_RESOURCE_ORIGINS = 'https://lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    expect(canonicalizeMcpResource('https://evil.example/mcp', 'https://app.lobu.ai/mcp')).toBeNull();
+    expect(canonicalizeMcpResource('https://lobu.ai/mcp/../../admin', 'https://app.lobu.ai/mcp')).toBeNull();
+  });
 });

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -27,6 +27,21 @@ export function publicMcpRequestUrl(request: Request): string {
   return `${origin}${pathname}`;
 }
 
+/**
+ * Extra public origins that may address the MCP endpoints (RFC 8707
+ * resource indicators). The gateway canonicalizes any allowed origin to its
+ * own public origin, so audience checks stay a single string compare. Set
+ * `MCP_PUBLIC_RESOURCE_ORIGINS` to a comma-separated list of origins, e.g.
+ * `https://lobu.ai` when the edge proxies the same gateway under another
+ * domain.
+ */
+function extraMcpResourceOrigins(): string[] {
+  return (process.env.MCP_PUBLIC_RESOURCE_ORIGINS ?? '')
+    .split(',')
+    .map((origin) => origin.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+}
+
 /** Canonical MCP protected-resource URI accepted for OAuth audience binding. */
 export function canonicalizeMcpResource(
   rawResource: string | null | undefined,
@@ -40,7 +55,8 @@ export function canonicalizeMcpResource(
     return null;
   }
   const publicOrigin = resolvePublicOrigin(requestUrl);
-  if (parsed.origin !== publicOrigin || parsed.search || parsed.hash) return null;
+  const allowedOrigins = new Set([publicOrigin, ...extraMcpResourceOrigins()]);
+  if (!allowedOrigins.has(parsed.origin) || parsed.search || parsed.hash) return null;
   const path = parsed.pathname.replace(/\/+$/, '') || '/';
   if (path !== '/mcp' && !/^\/mcp\/[^/]+$/.test(path)) return null;
   return `${publicOrigin}${path}`;


### PR DESCRIPTION
## Summary

The MCP OAuth authorize endpoint only accepts resource indicators whose origin matches the gateway's public origin ("A valid same-origin MCP resource is required"). Edge-proxied and self-hosted deployments address the same gateway under an extra domain — `lobu.ai/mcp` is proxied to `app.lobu.ai/mcp` — and strict OAuth MCP clients (e.g. Smithery, RFC 9728 validators) discover the resource from the 401 challenge, then fail to authorize with `invalid_request`.

Adds `MCP_PUBLIC_RESOURCE_ORIGINS` (comma-separated origins) to the `canonicalizeMcpResource` allowlist. Canonical output still normalizes to the gateway's own public origin, so token audience binding remains a single string compare and no token format changes.

## Test plan

- [x] Targeted `bun test src/__tests__/unit/oauth-resource-indicator.test.ts` (6 pass)
- [x] Server `tsc --noEmit` clean (after building workspace deps)
- [x] Pre-commit gate (biome + tsc) passed on push
- [ ] `make pre-pr-remote` full CI graph (Depot) — runs on this PR
- [x] Bug fix red→fix→green outputs pasted below

Red (before fix):

```
error: expect(received).toBe(expected)
Expected: "https://app.lobu.ai/mcp"
Received: null
(fail) MCP OAuth resource indicators > accepts extra configured public origins and canonicalizes to the gateway origin
```

Green (after fix):

```
 6 pass
 0 fail
 14 expect() calls
Ran 6 tests across 1 file.
```

## Notes

Follow-up for the hosted deployment: set `MCP_PUBLIC_RESOURCE_ORIGINS=https://lobu.ai` so the public `lobu.ai/mcp` endpoint (edge-proxied to the orgless endpoint) completes OAuth for strict clients. Companion edge fix in lobu-ai/landing rewrites the 401 `resource_metadata` challenge to the same-host path-derived URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional public MCP resource origins.
  * Accepted configured origins are canonicalized to the gateway’s public origin for root and organization-scoped MCP paths.

* **Bug Fixes**
  * Unlisted origins and traversal-like resource paths continue to be rejected for improved request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->