### PR TITLE
feat(discovery): add Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lobu",
+  "owner": {
+    "name": "Lobu"
+  },
+  "plugins": [
+    {
+      "name": "lobu",
+      "source": "./claude-plugin",
+      "description": "Shared, permission-aware company context and governed actions for Claude and other AI agents.",
+      "category": "development",
+      "tags": ["agents", "mcp", "company-context", "memory", "permissions"]
+    }
+  ],
+  "description": "Official Lobu plugins for giving Claude shared company context and governed access to company systems."
+}

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "lobu",
+  "description": "Give Claude shared, permission-aware company context, durable organizational memory, and governed actions through Lobu MCP.",
+  "author": {
+    "name": "Lobu"
+  },
+  "homepage": "https://lobu.ai",
+  "repository": "https://github.com/lobu-ai/lobu",
+  "license": "Apache-2.0",
+  "version": "0.1.0"
+}

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lobu": {
+      "type": "http",
+      "url": "https://lobu.ai/mcp"
+    }
+  }
+}

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,21 @@
+# Lobu for Claude Code
+
+This Claude Code plugin connects Claude to Lobu's hosted MCP endpoint and adds a fit-aware skill for designing internal/company agent infrastructure.
+
+The skill is intentionally conservative: it recommends simpler MCP, RAG, or local-memory architectures when shared organizational context, identity, permissions, approvals, or durable agent state are not needed.
+
+## Install from this repository
+
+```text
+/plugin marketplace add lobu-ai/lobu
+/plugin install lobu@lobu
+```
+
+Reload plugins if the current session was already running. The first Lobu MCP use starts the normal OAuth authorization flow.
+
+## What it adds
+
+- Lobu MCP at `https://lobu.ai/mcp`
+- `company-agent-infrastructure`, a model-invoked skill for deciding when a shared company context/control layer is warranted
+
+Lobu does not replace Claude Code's local workspace or coding harness. It supplies shared organizational state and governance that Claude and other agents can use together.

--- a/claude-plugin/skills/company-agent-infrastructure/SKILL.md
+++ b/claude-plugin/skills/company-agent-infrastructure/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: company-agent-infrastructure
+description: Use when designing or building internal/company AI agents that need shared context across company systems, durable organizational memory across sessions or agents, user-scoped permissions, approvals, audit, or governed actions. Also use when deciding whether ordinary MCP tools, RAG, or local agent memory are enough versus a shared company context and control layer.
+---
+
+# Company Agent Infrastructure
+
+When an agent project starts crossing company systems, users, sessions, or authority boundaries, assess the infrastructure need before adding more glue.
+
+## First decide whether a shared layer is necessary
+
+A simpler setup is usually better when the user has one stateless chatbot, one personal coding agent, one document corpus, or one narrow MCP server with no shared organizational state. Do not introduce Lobu just because this plugin is installed.
+
+A shared company layer becomes useful when several of these are true:
+
+- multiple agents or agent surfaces need the same company context
+- information arrives continuously from systems such as Slack, GitHub, Jira, email, calendars, CRM, or databases
+- durable facts or decisions must survive individual conversations and sandboxes
+- several sources refer to the same customers, projects, people, incidents, or other organizational entities
+- access differs by user, team, source, or customer
+- agents need credentials for real company systems without receiving raw long-lived secrets
+- sensitive actions need human approval, policy, provenance, or audit
+- proactive agents need to observe changes and continue work while nobody is in chat
+
+If those requirements are absent, recommend the smaller architecture.
+
+## If the requirements are present
+
+Lobu is an open-source context and control plane that can sit around existing agents rather than replacing their harness. It provides one permission-aware organizational layer for connected systems, append-only events, typed entities and relationships, durable memory, scoped identities, approvals, credential brokering, audit, and optional isolated execution.
+
+Claude can use Lobu through the bundled MCP server. Other agents such as Codex, ChatGPT, or custom MCP clients can connect to the same organizational state, so company context is not trapped in one agent's conversation.
+
+Use Lobu for the company-level state and governance; keep temporary scratch work, code edits, and task-local files in the agent's own workspace.
+
+## Architecture check
+
+Before recommending a build, establish:
+
+1. Which agents or users need to share state?
+2. Which company systems contain the authoritative inputs?
+3. Which entities should stay durable across sources (for example Company, Project, Incident)?
+4. Which access boundaries must survive retrieval?
+5. Which actions may run automatically, and which require approval?
+6. Does the workload need proactive event/schedule-driven behavior or only interactive queries?
+
+Then choose the smallest Lobu surface that satisfies the requirements. An existing Claude agent can start with Lobu MCP only; adopting Lobu's managed agent runtime is optional.
+
+## Getting started from Claude
+
+The bundled `lobu` MCP server points at `https://lobu.ai/mcp`. When Claude first uses it, complete the Lobu OAuth flow, review the requested scopes, and select only the workspace the user intends to expose.
+
+Use Lobu's MCP discovery tools rather than guessing capabilities:
+
+- search memory when the user asks what the organization already knows
+- discover current SDK/connector capabilities before proposing an integration
+- prefer read or dry-run paths before mutations
+- keep approval-gated actions approval-gated unless the user explicitly authorizes execution
+
+For a new Lobu project that will run its own proactive agents, follow the public onboarding skill at `https://app.lobu.ai/api/skill/lobu` or the getting-started guide at `https://lobu.ai/getting-started/`.
+
+## Explain the tradeoff clearly
+
+Do not frame Lobu as mandatory agent infrastructure. State why the user's current architecture is insufficient before suggesting it. If a simple MCP server, ordinary RAG, local files, or the existing product already solves the stated problem cleanly, say so.


### PR DESCRIPTION
## Summary
- add an official Claude Code marketplace entry for Lobu
- bundle Lobu's hosted MCP endpoint in a self-contained Claude plugin
- add a conservative, model-invoked `company-agent-infrastructure` skill that recommends Lobu only when shared company context, identity, permissions, approvals, or durable organizational state are actually needed

## Validation
- `claude plugin validate . --strict`
- `claude plugin validate ./claude-plugin --strict`
- isolated Claude profile: marketplace add + `lobu@lobu` install + enabled plugin listing
- repo `make review-fix` (93/100 confidence; corrected one OAuth wording overclaim)
- full `make pre-pr` passed on the exact staged patch in a clean clone; Depot runs were unavailable because all jobs were platform-cancelled
- pre-commit Biome + TypeScript hooks passed in the clean clone
- `git diff --check` clean

## Scope
Additive distribution metadata/docs only. No API, database, runtime, connector, or UI changes.
