### PR TITLE
refactor(server): delete the unused incidentEligible feed derivation

### DIFF
--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -156,24 +156,24 @@ describe("list_feeds health filter and true total", () => {
 		).rejects.toThrow();
 	});
 
-	it("surfaces derived execution_mode / attention / incident_eligible per feed", async () => {
+	it("surfaces derived execution_mode / attention without incident_eligible", async () => {
 		const res = await list({ limit: 10 });
 		const byKey = new Map(
 			res.feeds.map((f) => [f.feed_key, f as Record<string, unknown>]),
 		);
-		// h3 (never synced) has no schedule → manual, never_run, not incident-eligible.
+		// h3 (never synced) carries no cron → no_schedule, never_run.
 		const h3 = byKey.get("h3");
-		expect(h3?.execution_mode).toBe("manual");
+		expect(h3?.execution_mode).toBe("no_schedule");
 		expect(h3?.attention).toBe("never_run");
-		expect(h3?.incident_eligible).toBe(false);
-		// bad1 is active-but-failing with no schedule → manual, last_attempt_failed,
-		// and still not incident-eligible (a manual feed is never an unattended incident).
+		// bad1 is active-but-failing with no cron → no_schedule, last_attempt_failed.
 		const bad1 = byKey.get("bad1");
-		expect(bad1?.execution_mode).toBe("manual");
+		expect(bad1?.execution_mode).toBe("no_schedule");
 		expect(bad1?.attention).toBe("last_attempt_failed");
-		expect(bad1?.incident_eligible).toBe(false);
 		// h1/h2 succeeded → healthy.
 		expect(byKey.get("h1")?.attention).toBe("healthy");
 		expect(byKey.get("h2")?.attention).toBe("healthy");
+		for (const f of res.feeds) {
+			expect(f).not.toHaveProperty("incident_eligible");
+		}
 	});
 });

--- a/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
+++ b/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
@@ -1,9 +1,9 @@
 /**
  * Derived feed-health semantics — pure classification tests.
  *
- * Guards the executionMode / attention / incidentEligible derivation. No DB —
- * the module is a pure function over the joined row fields, so every state is
- * testable with plain objects.
+ * Guards the executionMode / attention derivation. No DB — the module is a pure
+ * function over the joined row fields, so every state is testable with plain
+ * objects.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -31,17 +31,21 @@ describe("executionMode", () => {
     ).toBe("scheduled");
   });
 
-  test("non-virtual feed without a schedule is manual", () => {
+  test("non-virtual feed without a schedule is no_schedule", () => {
     expect(
       deriveFeedHealthSemantics({
         kind: "collected",
         schedule: null,
         status: "active",
       }).executionMode
-    ).toBe("manual");
+    ).toBe("no_schedule");
   });
 
-  test("streaming feed is streaming, not a never-run manual collector", () => {
+  test("streaming feed is streaming, not a never-run collector", () => {
+    // Exact-shape assertion: the derivation returns EXACTLY these two outputs.
+    // An `incidentEligible` (or any other) third field reappearing here fails
+    // this test — see the header of feed-health-semantics.ts for why one must
+    // not come back.
     expect(
       deriveFeedHealthSemantics({
         kind: "streaming",
@@ -51,18 +55,17 @@ describe("executionMode", () => {
     ).toEqual({
       executionMode: "streaming",
       attention: "healthy",
-      incidentEligible: false,
     });
   });
 
-  test("empty-string schedule is manual (treated as absent)", () => {
+  test("empty-string schedule is no_schedule (treated as absent)", () => {
     expect(
       deriveFeedHealthSemantics({
         kind: "collected",
         schedule: "",
         status: "active",
       }).executionMode
-    ).toBe("manual");
+    ).toBe("no_schedule");
   });
 });
 
@@ -280,15 +283,11 @@ describe("attention state", () => {
   });
 });
 
-describe("incidentEligible", () => {
-  test("false for virtual feeds", () => {
-    expect(
-      deriveFeedHealthSemantics({ kind: "virtual", status: "active" })
-        .incidentEligible
-    ).toBe(false);
-  });
-
-  test("false for manual feeds even when the last attempt failed (Midas)", () => {
+describe("output shape", () => {
+  test("a collected feed derives exactly executionMode + attention", () => {
+    // The collector path's counterpart to the streaming exact-shape assertion
+    // above. "Is this failure worth paging someone about" is decided in
+    // connectors/connector-health.ts, not derived here.
     expect(
       deriveFeedHealthSemantics({
         kind: "collected",
@@ -297,97 +296,10 @@ describe("incidentEligible", () => {
         connection_status: "active",
         last_sync_status: "failed",
         consecutive_failures: 5,
-      }).incidentEligible
-    ).toBe(false);
-  });
-
-  test("false for paused feeds", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "paused",
-        connection_status: "active",
-        last_sync_status: "failed",
-        consecutive_failures: 21,
-      }).incidentEligible
-    ).toBe(false);
-  });
-
-  test("false for scheduled feed awaiting auth", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "pending_auth",
-        last_sync_status: "failed",
-        consecutive_failures: 2,
-      }).incidentEligible
-    ).toBe(false);
-  });
-
-  test("true for a failing active scheduled feed on an active connection", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "active",
-        last_sync_status: "failed",
-        consecutive_failures: 2,
-      }).incidentEligible
-    ).toBe(true);
-  });
-
-  test("true when a scheduled feed's pinned device is offline", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "active",
-        device_worker_id: "dw-1",
-        device_online: false,
-      }).incidentEligible
-    ).toBe(true);
-  });
-
-  test("false for a healthy scheduled feed", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "active",
-        last_sync_status: "success",
-        consecutive_failures: 0,
-      }).incidentEligible
-    ).toBe(false);
-  });
-
-  test("false for a never-run scheduled feed", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "active",
-        last_sync_at: null,
-      }).incidentEligible
-    ).toBe(false);
-  });
-
-  test("false when the connection is not active", () => {
-    expect(
-      deriveFeedHealthSemantics({
-        kind: "collected",
-        schedule: "0 */6 * * *",
-        status: "active",
-        connection_status: "error",
-        last_sync_status: "failed",
-        consecutive_failures: 2,
-      }).incidentEligible
-    ).toBe(false);
+      })
+    ).toEqual({
+      executionMode: "no_schedule",
+      attention: "last_attempt_failed",
+    });
   });
 });

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -24,7 +24,7 @@
  *
  * ## Relationship to `feed-health-semantics`
  *
- * Per-feed `execution_mode` / `attention` / `incident_eligible` are DERIVED by
+ * Per-feed `execution_mode` / `attention` are DERIVED by
  * `deriveFeedHealthSemantics` at read time and surfaced by `list_feeds`. This
  * alerter consumes that module for the two classifications that are ground
  * truth on the row — which feeds can run a collector sync at all, and whether
@@ -54,9 +54,10 @@
  * ## Why `execution_mode === 'scheduled'` is NOT the expected predicate
  *
  * `deriveFeedHealthSemantics` calls a non-virtual feed without a cron in
- * `feeds.schedule` `manual`, and `incident_eligible` is false for it. That
- * holds for Midas (a failed manual attempt is user-visible, never an unattended
- * incident) but it does not generalise: measured on prod 2026-08-12, 196 of 215
+ * `feeds.schedule` `no_schedule`, and that label carries no dispatch meaning.
+ * It is tempting to read "no cron" as "human-triggered, so a failure is
+ * user-visible and never an unattended incident" — which holds for Midas but
+ * does not generalise: measured on prod 2026-08-12, 196 of 215
  * active collected feeds have NO `schedule`, yet many run unattended through
  * other dispatch paths (github `issue_comments`: 4551 sync runs in 14 days with
  * `schedule` and `next_run_at` both NULL; linkedin `home_feed` ~hourly; gmail
@@ -65,8 +66,11 @@
  * connections to 14 and silences the exact shape it exists for (connection 412,
  * 10 of 11 feeds failing) — so `schedule` is deliberately not read here.
  * Nothing stored today distinguishes an unattended event-driven feed from a
- * human-triggered one; until something does, `incident_eligible` cannot be this
- * scan's predicate.
+ * human-triggered one; until something does, `schedule` cannot be this scan's
+ * predicate. (`deriveFeedHealthSemantics` used to publish an `incidentEligible`
+ * flag built on that same inference. Nothing consumed it and it disagreed with
+ * this scan, so it was deleted — the paging decision lives here, in the one
+ * place that acts on it.)
  */
 
 import { type DbClient, getDb, tsTimeOrNull } from '../db/client';

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -1,26 +1,32 @@
 /**
  * Derived feed-health semantics.
  *
- * Execution mode, attention state, and incident eligibility are DERIVED from
- * existing feed/connection/device columns at read time — never stored. The
- * stored columns keep their historical meaning; this module only classifies.
+ * Execution mode and attention state are DERIVED from existing
+ * feed/connection/device columns at read time — never stored. The stored
+ * columns keep their historical meaning; this module only classifies.
  *
  * ## Why derive instead of store
  *
  * A feed's execution nature (`virtual` vs `streaming` vs `scheduled` vs
- * `manual`) is a pure function of `kind`/`virtual`/`schedule`. Its attention
- * state is a pure function of lifecycle/sync state, auth-profile status, and
- * device liveness. Storing these would duplicate state that already lives on
- * the row and drift when the source columns move (auto-pause, backoff, resume).
- * Read-time derivation is O(1) per feed and cannot diverge.
+ * `no_schedule`) is a pure function of `kind`/`virtual`/`schedule`. Its
+ * attention state is a pure function of lifecycle/sync state, auth-profile
+ * status, and device liveness. Storing these would duplicate state that already
+ * lives on the row and drift when the source columns move (auto-pause, backoff,
+ * resume). Read-time derivation is O(1) per feed and cannot diverge.
  *
- * ## The three outputs
+ * ## The two outputs
  *
- * - `executionMode` — how this feed is *supposed* to run:
+ * - `executionMode` — what the row says about how this feed runs:
  *   - `virtual` — a virtual (live-pushdown) feed evaluated on demand.
  *   - `streaming` — a chat channel populated by incoming messages.
- *   - `scheduled` — a non-virtual feed with an active schedule.
- *   - `manual` — a non-virtual feed without a schedule.
+ *   - `scheduled` — a non-virtual feed with a cron in `feeds.schedule`.
+ *   - `no_schedule` — a non-virtual feed with no cron. This says the feed has
+ *     no cron and NOTHING MORE. It was called `manual` until 2026-08-12, which
+ *     read an intent into it that the column does not carry: measured on prod
+ *     that day, 196 of 215 active collected feeds have no cron, and many are
+ *     driven unattended through other dispatch paths (github `issue_comments` =
+ *     4551 sync runs in 14 days with `schedule` and `next_run_at` both NULL).
+ *     Do not reintroduce the intent reading under a new name.
  * - `attention` — what a human/UI should be told about the feed right now,
  *   ordered so the most actionable state wins:
  *   - `needs_auth` — the connection/auth profile is not usable (pending_auth,
@@ -33,19 +39,21 @@
  *     including backoff episodes).
  *   - `never_run` — never synced.
  *   - `healthy` — everything else.
- * - `incidentEligible` — whether this feed, if failing, should count as an
- *   UNATTENDED INCIDENT. True only for an active SCHEDULED feed that is
- *   expected to run unattended and is currently failing for a platform-relevant
- *   reason. Always false for:
- *   - manual feeds (e.g. Midas — a failed manual attempt is user-visible but
- *     not a scheduled-feed incident)
- *   - paused feeds
- *   - virtual feeds (evaluated on demand)
- *   - known `needs_auth` / manual-login conditions (the user must act; not an
- *     infra incident)
+ *
+ * ## There is deliberately no `incidentEligible` here
+ *
+ * An earlier version derived one, defined as "an active SCHEDULED feed failing
+ * for a platform-relevant reason". It rested on the cron inference above, and
+ * nothing consumed it — `list_feeds` copied it into its output and no caller
+ * ever read it, while the alerter that actually pages disagreed with it. "Is
+ * this failure worth paging someone about" is a decision, not a property of a
+ * row; it lives in `connectors/connector-health.ts`, the one place that acts on
+ * it, alongside the prod measurements justifying its predicate. Do not
+ * reintroduce a second copy here without a stored signal that distinguishes an
+ * unattended event-driven feed from a human-triggered one.
  */
 
-type FeedExecutionMode = "virtual" | "streaming" | "scheduled" | "manual";
+type FeedExecutionMode = "virtual" | "streaming" | "scheduled" | "no_schedule";
 
 type FeedAttentionState =
   | "healthy"
@@ -63,7 +71,8 @@ interface FeedHealthSemanticsInput {
   virtual?: boolean | null;
   /** `feeds.status` — 'active' | 'paused' | 'error'. */
   status?: string | null;
-  /** `feeds.schedule` — cron; NULL means manual-only. */
+  /** `feeds.schedule` — cron; NULL means no cron is configured, which does NOT
+   *  imply the feed is human-triggered (see the header). */
   schedule?: string | null;
   /** `feeds.last_sync_status` — 'success' | 'failed' | 'pending' | NULL. */
   last_sync_status?: string | null;
@@ -85,7 +94,6 @@ interface FeedHealthSemanticsInput {
 interface FeedHealthSemantics {
   executionMode: FeedExecutionMode;
   attention: FeedAttentionState;
-  incidentEligible: boolean;
 }
 
 const isVirtual = (input: FeedHealthSemanticsInput): boolean =>
@@ -98,8 +106,6 @@ const isScheduled = (input: FeedHealthSemanticsInput): boolean =>
   !isVirtual(input) &&
   typeof input.schedule === "string" &&
   input.schedule.length > 0;
-
-const isActive = (status?: string | null): boolean => status === "active";
 
 /** The connection or auth profile is not usable without human action. */
 function needsAuth(input: FeedHealthSemanticsInput): boolean {
@@ -152,10 +158,10 @@ function nonCollectorAttention(
 }
 
 /**
- * Derive execution mode + attention state + incident eligibility from the
- * stored feed/connection/device columns. Pure: the caller feeds the joined row
- * fields and gets back the classification. Order of checks fixes the
- * precedence (the most actionable state wins).
+ * Derive execution mode + attention state from the stored feed/connection/device
+ * columns. Pure: the caller feeds the joined row fields and gets back the
+ * classification. Order of checks fixes the precedence (the most actionable
+ * state wins).
  */
 export function deriveFeedHealthSemantics(
   input: FeedHealthSemanticsInput
@@ -165,7 +171,6 @@ export function deriveFeedHealthSemantics(
     return {
       executionMode: "virtual",
       attention: nonCollectorAttention(input),
-      incidentEligible: false,
     };
   }
 
@@ -175,20 +180,12 @@ export function deriveFeedHealthSemantics(
     return {
       executionMode: "streaming",
       attention: nonCollectorAttention(input),
-      incidentEligible: false,
     };
   }
 
   const executionMode: FeedExecutionMode = isScheduled(input)
     ? "scheduled"
-    : "manual";
-
-  // A feed counts as unattended only when it is an active scheduled capability
-  // on an active connection — never manual, paused, virtual, or broken.
-  const unattended =
-    executionMode === "scheduled" &&
-    isActive(input.status) &&
-    isActive(input.connection_status);
+    : "no_schedule";
 
   let attention: FeedAttentionState;
   if (needsAuth(input)) {
@@ -210,15 +207,5 @@ export function deriveFeedHealthSemantics(
     attention = "healthy";
   }
 
-  // Unattended scheduled feeds are incident-eligible when currently failing
-  // for a platform-relevant reason: a failed attempt, a failure episode, or a
-  // pinned device that has gone offline (the unattended capability is down).
-  // Auth-waiting feeds are excluded — the user must act, it is not an infra
-  // incident.
-  const incidentEligible =
-    unattended &&
-    !needsAuth(input) &&
-    (lastAttemptFailed(input) || deviceOffline(input));
-
-  return { executionMode, attention, incidentEligible };
+  return { executionMode, attention };
 }

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -290,8 +290,8 @@ async function handleListFeeds(
   // Strip the window-count helper column from each feed row — it is metadata
   // about the result set, not a feed field — then sanitize the row itself
   // (checkpoint out, config redacted). Attach the derived health semantics
-  // (execution mode / attention / incident eligibility) computed from the
-  // joined row fields at read time — never stored.
+  // (execution mode / attention) computed from the joined row fields at read
+  // time — never stored.
   const feeds = await toPublicFeeds(
     organizationId,
     rows.map(({ filtered_total: _filtered_total, ...feed }) => feed)
@@ -314,7 +314,6 @@ async function handleListFeeds(
       ...feed,
       execution_mode: semantics.executionMode,
       attention: semantics.attention,
-      incident_eligible: semantics.incidentEligible,
     };
   });
   return {


### PR DESCRIPTION
## What

`deriveFeedHealthSemantics` published three outputs. This deletes the third, `incidentEligible`, and renames the cron-less execution mode `manual` → `no_schedule`.

## Why

**It had no consumers.** `list_feeds` copied `incident_eligible` onto every feed row; nothing read it. Verified against `origin/main`, not the working tree:

```
$ git fetch -q origin && git grep -n "incident_eligible\|incidentEligible" origin/main
# only feed-health-semantics.ts, manage_feeds.ts, and their own tests
```

**And it was wrong.** It was derived from "the feed has a cron in `feeds.schedule`", which does not mean "runs unattended". Measured on prod 2026-08-12:

| fact | value |
|---|---|
| active collected feeds with NO `schedule` | 196 of 215 |
| github `issue_comments` sync runs in 14 days, `schedule` and `next_run_at` both NULL | 4551 |
| linkedin `home_feed` cadence, no cron | ~hourly |

So the flag reported "not an incident" about feeds the connector-health alerter (#2683) correctly pages on. That is the failure mode: a second, lying copy of a decision that already lives somewhere else. "Is this failure worth paging someone about" is a decision, not a property of a row — it stays in `connectors/connector-health.ts`, the one surface that acts on it, with the measurements that justify its predicate recorded there.

The `manual` → `no_schedule` rename is the same inference wearing a value name. `no_schedule` says only what the column says. No consumer outside these files reads the value (same `origin/main` grep), so it is not a contract change.

## Mutation evidence

The new assertions are the guard against this being reintroduced, so both were proven to fail on a mutation before being trusted.

**Mutation A** — re-add the field to the derivation (`return { executionMode, attention, incidentEligible: false }`):

```
(fail) output shape > a collected feed derives exactly executionMode + attention
 20 pass
 1 fail
```

**Mutation B** — re-add `incident_eligible: false` to the `list_feeds` row in `manage_feeds.ts`:

```
× surfaces derived execution_mode / attention without incident_eligible
  → expected { id: 5, …(47) } to not have property "incident_eligible"
```

**Restored, green:**

```
 21 pass  0 fail        (bun test src/__tests__/unit/feed-health-semantics.test.ts)
 Test Files  2 passed   Tests  26 passed
   (vitest: feeds-list-health-and-count.test.ts + connector-health-alert.test.ts)
```

## Gate

`make pre-pr-remote` → Depot run `jn5xbd1fnz`, 18/18 passed, tree `176da2a9c2e4470bdc9439d458564367022c8076`.

## Risk

Low. Deletes an unread output and renames a value with no external reader. The alerter's behaviour is unchanged — it never consumed `incidentEligible`; it reads `executionMode` only to exclude `virtual` and `streaming`, and both those literals are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unscheduled feeds now consistently report `no_schedule` as their execution mode.
  * Removed obsolete incident eligibility information from feed health results.
  * Feed health metadata now contains only execution mode and attention details.

* **Documentation**
  * Updated health and alerting documentation to clarify schedule handling and derived feed status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->