### PR TITLE
fix(connectors): declare os.files + macos runtime on the takeout connectors

### DIFF
--- a/examples/personal-agent/__tests__/takeout-connector-runtime.test.ts
+++ b/examples/personal-agent/__tests__/takeout-connector-runtime.test.ts
@@ -1,0 +1,53 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { authorizeCapabilities } from "@lobu/core";
+import type { ConnectorDefinition } from "@lobu/connector-sdk";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+const CONNECTOR_MODULES = [
+  "../google-takeout.connector",
+  "../instagram-takeout.connector",
+  "../twitter-takeout.connector",
+] as const;
+
+type ConnectorModule = {
+  default: new () => { definition: ConnectorDefinition };
+};
+
+let definitions: ConnectorDefinition[] = [];
+
+beforeAll(async () => {
+  definitions = await Promise.all(
+    CONNECTOR_MODULES.map(async (mod) => {
+      const { default: Connector } = (await import(mod)) as ConnectorModule;
+      return new Connector().definition;
+    })
+  );
+  definitions.sort((a, b) => a.key.localeCompare(b.key));
+});
+
+describe("local takeout connectors declare a device runtime", () => {
+  test("each requires os.files on macos", () => {
+    expect(definitions.map((definition) => definition.key)).toEqual([
+      "google.takeout",
+      "instagram.takeout",
+      "twitter.takeout",
+    ]);
+    for (const definition of definitions) {
+      expect(definition.requiredCapability).toBe("os.files");
+      expect(definition.runtime?.platforms).toEqual(["macos"]);
+    }
+  });
+
+  test("os.files is authorized for macos but not chrome-extension", () => {
+    expect(authorizeCapabilities("macos", ["os.files"])).toEqual({
+      authorized: ["os.files"],
+      dropped: [],
+    });
+    expect(authorizeCapabilities("chrome-extension", ["os.files"])).toEqual({
+      authorized: [],
+      dropped: ["os.files"],
+    });
+  });
+});

--- a/examples/personal-agent/google-takeout.connector.ts
+++ b/examples/personal-agent/google-takeout.connector.ts
@@ -46,6 +46,11 @@ export default class GoogleTakeoutConnector extends ConnectorRuntime<
     description:
       "Ingests local Google Takeout exports for YouTube history and Keep notes.",
     authSchema: { methods: [{ type: "none" }] },
+    // Local-filesystem connector: it reads an absolute path on the user's own
+    // machine, so it must not be routed to the cloud fleet. See the longer note
+    // on the same two fields in twitter-takeout.connector.ts.
+    requiredCapability: "os.files",
+    runtime: { platforms: ["macos"] },
     feeds: {
       youtube: {
         key: "youtube",

--- a/examples/personal-agent/instagram-takeout.connector.ts
+++ b/examples/personal-agent/instagram-takeout.connector.ts
@@ -89,6 +89,11 @@ export default class InstagramTakeoutConnector extends ConnectorRuntime<
     description:
       "Ingests local Instagram export HTML for messages and activity.",
     authSchema: { methods: [{ type: "none" }] },
+    // Local-filesystem connector: it reads an absolute path on the user's own
+    // machine, so it must not be routed to the cloud fleet. See the longer note
+    // on the same two fields in twitter-takeout.connector.ts.
+    requiredCapability: "os.files",
+    runtime: { platforms: ["macos"] },
     feeds: {
       messages: {
         key: "messages",

--- a/examples/personal-agent/twitter-takeout.connector.ts
+++ b/examples/personal-agent/twitter-takeout.connector.ts
@@ -213,6 +213,20 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
     version: "1.0.0",
     description: "Ingests local X/Twitter archive exports.",
     authSchema: { methods: [{ type: "none" }] },
+    // sync() reads an absolute path on the user's own machine. Per the SDK
+    // contract, omitting `runtime` means "runs on the cloud worker fleet" and
+    // omitting `requiredCapability` means "any worker" — so declaring neither
+    // is what let `worker-api/poll.ts` hand these runs to a Kubernetes pod with
+    // no ~/Downloads (unpinned connections), or to the Swift Mac bridge, which
+    // cannot execute a TypeScript connector at all (pinned connections). Two
+    // error strings, one missing declaration.
+    //
+    // `os.files` is already in OS_CAPABILITIES and allowlisted for macos, so no
+    // core change is needed. NOTE: no worker advertises `os.files` today, so
+    // this does not make takeout ingest work — it makes the failure honest
+    // ("no worker serves this") instead of a silent misroute.
+    requiredCapability: "os.files",
+    runtime: { platforms: ["macos"] },
     feeds: {
       tweets: {
         key: "tweets",


### PR DESCRIPTION
## What

`google.takeout`, `instagram.takeout` and `twitter.takeout` now declare `requiredCapability: "os.files"` and `runtime: { platforms: ["macos"] }`. Plus one class guard test.

## Why

All three read an absolute path on the user's own machine (`assertDirectory` on `takeout_dir`), and all three declared neither field. Per `packages/connector-sdk/src/connector-types.ts`, that means:

- `requiredCapability` unset → *"any worker (default API/browser fleet)"*
- `runtime` unset → *"Omitting this field means the connector runs on the server-side worker fleet (cloud)"*

Which is the opposite of what a local-filesystem connector needs. `worker-api/poll.ts` then had no good option:

```sql
-- fleet lane:  AND con.device_worker_id IS NULL              -- pinned ⇒ fleet can never claim
-- device lane: AND con.device_worker_id = <me>
--              AND ( cd.required_capability IS NULL OR ... ) -- NULL ⇒ ANY pinned device claims
```

| connection state | claimer | failure |
|---|---|---|
| unpinned | cloud worker fleet | `takeout directory does not exist: /Users/...` |
| pinned to a Mac | that Mac only | `Mac bridge cannot run connector <key>` (the bridge is Swift — it cannot execute a TypeScript connector at all) |

Two different error strings, one missing declaration. Prod connection 412's ten LinkedIn takeout feeds were failing the first way — `device_worker_id` is NULL on that row, so a Kubernetes pod with no `~/Downloads` was claiming the runs:

```
419|messages    |failed|15|LinkedIn takeout directory does not exist: /
420|connections |failed|16|LinkedIn takeout directory does not exist: /
...  (10 of 11 feeds; 429 home_feed is healthy on the same connection)
```

`os.files` is already in `OS_CAPABILITIES` and allowlisted for `macos` in `packages/core/src/capabilities.ts`, so no core change is needed.

## What this does NOT do

**No worker advertises `os.files` today.** These feeds still will not sync. What changes is that they fail honestly — "no worker serves this" instead of a silent misroute to a machine that was never going to have the file — and the future local takeout worker has a capability to claim on. Ten prod feeds on connection 412 were paused separately so this does not just relabel a live alert.

## Test

A class guard, not a per-connector one: all three definitions are asserted together, so a fourth local-filesystem connector added without the declaration fails here rather than in prod weeks later.

It checks the capability through `authorizeCapabilities` rather than comparing to a literal. A typo'd or non-allowlisted capability string is silently **dropped** at poll time, which is indistinguishable from declaring nothing — the exact failure mode this file exists to prevent. It also asserts `os.files` is dropped for `chrome-extension`, since an extension cannot read `~/Downloads` either.

## Mutation evidence

**A** — delete both fields from `google-takeout.connector.ts`:

```
error: expect(received).toBe(expected)
Expected: "os.files"
Received: undefined
(fail) local takeout connectors declare a device runtime > each requires os.files on macos
 1 pass  1 fail
```

**B** — flip instagram's `platforms` to `["linux"]`: same test red.

**Restored, green:** `bun test examples/personal-agent` → `194 pass, 0 fail`.

## Gate

`make pre-pr-remote` → Depot run `qst860zdrx`, passed, tree `797b1362968b773737e08904ac317204d02feb80`.

## Follow-up (not in this PR)

`connector_definitions` rows on prod still carry `required_capability = NULL`; a `lobu apply` is what moves them. And the thing that actually makes takeout ingest work is the local `os.files` worker — ~150 lines, every dependency already verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Google, Instagram, and Twitter takeout connectors now require file access and run on macOS.

- **Tests**
  - Added runtime coverage to verify connector capabilities, platform requirements, and authorization behavior across macOS and Chrome extension environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->