### PR TITLE
feat(connector-worker): run os.files device connectors on a local worker

### DIFF
--- a/packages/connector-worker/src/__tests__/connector-env-excludes-worker-token.test.ts
+++ b/packages/connector-worker/src/__tests__/connector-env-excludes-worker-token.test.ts
@@ -20,12 +20,23 @@
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
+import { WorkerClient } from '../daemon/client.js';
 import { buildConnectorWorkerEnv } from '../env.js';
 
-const original = process.env.WORKER_API_TOKEN;
+// Snapshot every process-env key these tests write. Restoring only
+// WORKER_API_TOKEN would leak GITHUB_TOKEN into whatever runs next in this
+// process, which is the same shared-mutable-state hazard the exclusion below
+// exists to prevent.
+const SNAPSHOT_KEYS = ['WORKER_API_TOKEN', 'GITHUB_TOKEN'] as const;
+const original = new Map(SNAPSHOT_KEYS.map((k) => [k, process.env[k]]));
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
-  if (original === undefined) delete process.env.WORKER_API_TOKEN;
-  else process.env.WORKER_API_TOKEN = original;
+  for (const [key, value] of original) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  globalThis.fetch = originalFetch;
 });
 
 describe('connector-facing env', () => {
@@ -48,5 +59,48 @@ describe('connector-facing env', () => {
 
     expect(env.GITHUB_TOKEN).toBe('gh-sentinel');
     expect(env.LOBU_DB_EGRESS_POLICY).toBeDefined();
+  });
+
+  test('the daemon authenticates with the token that Env omits', async () => {
+    // Excluding the token from Env is only correct because the daemon still
+    // sends it on the wire. Asserting the exclusion alone would stay green if
+    // the token stopped reaching `/api/workers/*` entirely, which would break
+    // every device worker while looking like a passing security test.
+    process.env.WORKER_API_TOKEN = 'owl_pat_sentinel';
+    let seen: { url: string; auth: string | null; body: string } | undefined;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seen = {
+        url: String(input),
+        auth: headers.get('Authorization'),
+        body: String(init?.body ?? ''),
+      };
+      return new Response(JSON.stringify({ runs: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const client = new WorkerClient({
+      apiUrl: 'https://api.example.com',
+      workerId: 'macos:test-device',
+      authToken: process.env.WORKER_API_TOKEN,
+      capabilities: { 'os.files': true },
+      platform: 'macos',
+    });
+    await client.poll();
+
+    expect(seen?.url).toBe('https://api.example.com/api/workers/poll');
+    expect(seen?.auth).toBe('Bearer owl_pat_sentinel');
+    // The device registration fields ride the same authenticated request.
+    expect(JSON.parse(seen?.body ?? '{}')).toMatchObject({
+      worker_id: 'macos:test-device',
+      platform: 'macos',
+    });
+
+    // Same process, same token in env — still absent from the connector Env.
+    const env = buildConnectorWorkerEnv() as Record<string, unknown>;
+    expect(env.WORKER_API_TOKEN).toBeUndefined();
+    expect(Object.values(env)).not.toContain('owl_pat_sentinel');
   });
 });

--- a/packages/connector-worker/src/__tests__/connector-env-excludes-worker-token.test.ts
+++ b/packages/connector-worker/src/__tests__/connector-env-excludes-worker-token.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `WORKER_API_TOKEN` must never reach connector code.
+ *
+ * The token authenticates the worker to `/api/workers/*`. `poll.ts` treats a
+ * request bearing it as a TRUSTED FLEET worker (claim branch 1A), so a leaked
+ * token lets its holder claim and complete runs for other tenants — a much
+ * wider grant than the connector's own scope.
+ *
+ * `buildConnectorWorkerEnv()` is the single chokepoint: both the standalone CLI
+ * (`bin.ts`) and the in-process embedded worker
+ * (`server/src/scheduled/embedded-connector-worker.ts`) build the connector-
+ * facing `Env` through it, precisely so gateway secrets stay out of connector
+ * runs. Everything it returns reaches connector code two ways —
+ * `subprocess.ts` spreads `job.env` into the child process environment, and
+ * `buildConnectorConfig()` merges `job.env` into the connector's own config
+ * object — so exclusion here is what keeps it unreachable.
+ *
+ * The daemon still authenticates: both callers pass the token explicitly as
+ * `DaemonConfig.workerApiToken`, which never enters `Env`.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { buildConnectorWorkerEnv } from '../env.js';
+
+const original = process.env.WORKER_API_TOKEN;
+afterEach(() => {
+  if (original === undefined) delete process.env.WORKER_API_TOKEN;
+  else process.env.WORKER_API_TOKEN = original;
+});
+
+describe('connector-facing env', () => {
+  test('omits WORKER_API_TOKEN even when the worker process holds one', () => {
+    process.env.WORKER_API_TOKEN = 'sentinel-worker-token';
+
+    const env = buildConnectorWorkerEnv() as Record<string, unknown>;
+
+    expect(env.WORKER_API_TOKEN).toBeUndefined();
+    // Guard the value too: a rename would keep the key assertion green while
+    // still handing the secret to connector code under a different name.
+    expect(Object.values(env)).not.toContain('sentinel-worker-token');
+  });
+
+  test('still carries the env connectors legitimately need', () => {
+    // Pins the exclusion as targeted rather than a blanket empty env, which
+    // would pass the assertion above while breaking every connector.
+    process.env.GITHUB_TOKEN = 'gh-sentinel';
+    const env = buildConnectorWorkerEnv() as Record<string, unknown>;
+
+    expect(env.GITHUB_TOKEN).toBe('gh-sentinel');
+    expect(env.LOBU_DB_EGRESS_POLICY).toBeDefined();
+  });
+});

--- a/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
+++ b/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
@@ -1,0 +1,111 @@
+/**
+ * A device daemon runs for weeks and snapshots its bearer once at startup —
+ * `WorkerClient` never refreshes it.
+ *
+ * `lobu whoami --json` returns `workerToken ?? accessToken` (packages/cli
+ * whoami.ts), so a user without a durable agent token silently receives their
+ * OAuth SESSION token. That expires within 24h, after which the daemon polls
+ * 401 forever and every scheduled os.files run stops — with no failure surfaced
+ * anywhere the user would look.
+ *
+ * The daemon therefore refuses a non-durable credential at boot rather than
+ * accepting one guaranteed to die. These tests pin that it fails CLOSED in
+ * device mode and stays out of the fleet path, which authenticates with a
+ * long-lived WORKER_API_TOKEN.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const BIN = path.join(import.meta.dir, "..", "bin.ts");
+// Port 1 is never listening, so the daemon cannot get past its first poll —
+// these tests assert on the STARTUP decision, not on any network behaviour.
+const DEAD_API = "http://127.0.0.1:1";
+
+/** Run the daemon briefly and return whatever it wrote to stderr. */
+async function runDaemon(
+  env: Record<string, string | undefined>,
+  args: string[]
+): Promise<string> {
+  const proc = Bun.spawn(["bun", BIN, "daemon", "--api-url", DEAD_API, ...args], {
+    env: { ...process.env, WORKER_API_TOKEN: undefined, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  // The guard exits immediately; the pass-through cases would run forever, so
+  // cap them and read whatever startup output exists by then.
+  const timer = setTimeout(() => proc.kill(), 8000);
+  try {
+    return await new Response(proc.stderr).text();
+  } finally {
+    clearTimeout(timer);
+    proc.kill();
+  }
+}
+
+const DEVICE_ARGS = [
+  "--platform",
+  "macos",
+  "--worker-id",
+  "test-device",
+  "--capabilities",
+  "os.files",
+];
+
+describe("device mode requires a durable token", () => {
+  test("refuses to start with no token at all", async () => {
+    const stderr = await runDaemon({}, DEVICE_ARGS);
+    expect(stderr).toContain("device mode requires a durable personal access token");
+    // The message must name the actual trap, not just the missing variable.
+    expect(stderr).toContain("expires within 24h");
+    expect(stderr).not.toContain("Starting worker daemon");
+  }, 20000);
+
+  test("refuses an OAuth session access token", async () => {
+    // The exact shape `whoami` falls back to. It is a perfectly valid bearer
+    // TODAY, which is what makes accepting it so damaging.
+    const stderr = await runDaemon(
+      { WORKER_API_TOKEN: "ya29.a0AfB_byC-oauth-access-token" },
+      DEVICE_ARGS
+    );
+    expect(stderr).toContain("device mode requires a durable personal access token");
+    expect(stderr).not.toContain("Starting worker daemon");
+  }, 20000);
+
+  test("accepts a durable PAT and proceeds to start", async () => {
+    // Pins the guard as targeted — rejecting everything would satisfy both
+    // assertions above while making device mode unusable.
+    const stderr = await runDaemon(
+      { WORKER_API_TOKEN: "owl_pat_durabletoken0123456789" },
+      DEVICE_ARGS
+    );
+    expect(stderr).not.toContain("device mode requires a durable");
+    expect(stderr).toContain("Starting worker daemon");
+    expect(stderr).toContain("device mode: platform=macos");
+  }, 20000);
+
+  test("a fleet worker with no PAT is unaffected", async () => {
+    // Fleet workers pass no --platform and authenticate with a long-lived
+    // WORKER_API_TOKEN; the guard must not reach them.
+    const stderr = await runDaemon({}, ["--worker-id", "test-fleet"]);
+    expect(stderr).not.toContain("device mode requires a durable");
+    expect(stderr).toContain("Starting worker daemon");
+  }, 20000);
+
+  test("--help does not send users to a credential the guard rejects", async () => {
+    // The guard and the setup instructions are edited in different places, so
+    // they can drift apart silently: --help used to name the `lobu whoami
+    // --json` workerToken, which is exactly the OAuth token refused above, so
+    // following the documented setup could not produce a daemon that starts.
+    const proc = Bun.spawn(["bun", BIN, "--help"], { stdout: "pipe" });
+    const help = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    expect(help).toContain("lobu token create");
+    expect(help).toContain("owl_pat_");
+    // `whoami` may only appear as the warning, never as the source to use.
+    for (const line of help.split("\n").filter((l) => l.includes("whoami"))) {
+      expect(line).not.toMatch(/requires|use|from/i);
+    }
+  }, 20000);
+});

--- a/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
+++ b/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pins the device REGISTRATION wire shape: the fields `worker-api/poll.ts`
+ * reads are present, correctly typed, and unnormalized.
+ *
+ * Omitting `platform` is fail-closed, not a bypass — the server authorizes
+ * every user-scoped worker and `authorizeCapabilities(undefined, declared)`
+ * drops everything, so the worker simply never claims. Sending the platform is
+ * what makes it functional. The allowlist itself is covered by @lobu/core.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { WorkerClient } from "../daemon/client";
+
+type Captured = { url: string; body: Record<string, unknown> };
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Stub fetch, capture the one poll request, return an empty poll response. */
+function capturePoll(): { calls: Captured[] } {
+  const calls: Captured[] = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+    });
+    return new Response(JSON.stringify({ next_poll_seconds: 5 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { calls };
+}
+
+describe("device worker poll body", () => {
+  test("a configured platform is sent, alongside app_version", async () => {
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-1",
+      capabilities: { "os.files": true },
+      platform: "macos",
+      version: "2.3.4",
+    }).poll();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://app.example.com/api/workers/poll");
+    expect(calls[0].body).toMatchObject({
+      worker_id: "w-1",
+      capabilities: { "os.files": true },
+      platform: "macos",
+      app_version: "2.3.4",
+    });
+  });
+
+  test("a fleet worker (no platform) sends no platform key at all", async () => {
+    // Sending platform:null/"" would bind the device_workers row to a bogus
+    // platform; the field must be absent, not empty.
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-2",
+      capabilities: { db_egress_hardening: true },
+    }).poll();
+
+    expect(calls[0].body).not.toHaveProperty("platform");
+    expect(calls[0].body).not.toHaveProperty("app_version");
+    expect(calls[0].body).toMatchObject({
+      worker_id: "w-2",
+      capabilities: { db_egress_hardening: true },
+    });
+  });
+
+  test("a blank platform is treated as absent, never sent as an empty string", async () => {
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-3",
+      capabilities: {},
+      platform: "   ",
+      label: "   ",
+    }).poll();
+
+    expect(calls[0].body).not.toHaveProperty("platform");
+    expect(calls[0].body).not.toHaveProperty("label");
+  });
+
+  test("a label is forwarded for the Devices page", async () => {
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-4",
+      capabilities: { "os.files": true },
+      platform: "macos",
+      label: "Buraks-MacBook-Pro",
+    }).poll();
+
+    expect(calls[0].body).toMatchObject({ label: "Buraks-MacBook-Pro" });
+  });
+
+  test("capability names survive verbatim — the server matches them as strings", async () => {
+    // `required_capability` is compared with `= ANY(...)` against these exact
+    // strings, so any normalization here (case-folding, dot handling) would
+    // silently stop claim branch (1B) from ever matching.
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-5",
+      capabilities: { "os.files": true, "os.shell": false },
+      platform: "macos",
+    }).poll();
+
+    expect(calls[0].body.capabilities).toEqual({
+      "os.files": true,
+      "os.shell": false,
+    });
+  });
+});

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -10,6 +10,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
+import { isKnownPlatform } from '@lobu/core';
 import { startDaemon } from './daemon/index.js';
 import { buildConnectorWorkerEnv } from './env.js';
 import { assertExternalDepsResolvable } from './compile/index.js';
@@ -29,8 +30,18 @@ Commands:
 
 Options:
   --api-url <url>    Backend API URL (required for daemon)
-  --worker-id <id>   Worker ID (default: auto-generated UUID)
+  --worker-id <id>   Worker ID (required in device mode; fleet default: UUID)
   --version <ver>    Worker version (default: 1.0.0)
+  --platform <name>  Run as a device worker on this host platform (e.g. macos)
+                     instead of a cloud-fleet worker. Requires a durable
+                     personal access token in WORKER_API_TOKEN — mint one with
+                     \`lobu token create --raw\`. Note \`lobu whoami --json\`
+                     returns a session OAuth token that expires within 24h;
+                     device mode rejects it at startup.
+  --capabilities <a,b>  Comma-separated capabilities to advertise (device mode),
+                     e.g. os.files. The server drops anything the platform's
+                     allowlist does not grant.
+  --label <name>     Human-readable device name shown on the Devices page
   --json             (self-check) Emit machine-readable JSON to stdout
   --help             Show this help message
 
@@ -40,11 +51,21 @@ Environment Variables:
   GITHUB_TOKEN       GitHub API token (for GitHub feed)
   GOOGLE_MAPS_API_KEY Google Maps API key
   EMBEDDINGS_SERVICE_URL Embeddings service URL (if set, uses service; otherwise local)
-  WORKER_API_TOKEN  Optional bearer token for /api/workers/* authentication
+  WORKER_API_TOKEN  Bearer token for /api/workers/* authentication (device
+                    mode requires a durable owl_pat_ personal access token)
+  WORKER_PLATFORM   Host platform (same as --platform)
+  WORKER_CAPABILITIES Comma-separated capabilities (same as --capabilities)
+  WORKER_LABEL      Human-readable device name (same as --label)
 
 Examples:
   # Worker daemon
   connector-worker daemon --api-url https://api.example.com
+
+  # Local device worker serving filesystem connectors (local takeout archives)
+  WORKER_API_TOKEN=owl_pat_... connector-worker daemon \\
+    --api-url https://app.lobu.ai --platform macos \\
+    --worker-id "macos:$(hostname -s)" --capabilities os.files \\
+    --label "$(hostname -s)"
 
   # Connector-runtime parity self-check (CI smoke gate)
   connector-worker self-check --json
@@ -107,34 +128,80 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const workerId =
-    options['worker-id'] || process.env.WORKER_ID || `worker-${randomUUID().slice(0, 8)}`;
+  const configuredWorkerId = (options['worker-id'] || process.env.WORKER_ID)?.trim() || undefined;
   const version = options.version || '1.0.0';
 
   switch (command) {
     case 'daemon': {
-      // Crash loud at boot if the runtime image is missing any connector
-      // external dep, instead of letting every feed silently fail with
-      // "Missing npm dependency: X" hours later.
+      const platform = (options.platform || process.env.WORKER_PLATFORM)?.trim() || undefined;
+      const label = (options.label || process.env.WORKER_LABEL)?.trim() || undefined;
+      const declared = (options.capabilities || process.env.WORKER_CAPABILITIES || '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (platform && !isKnownPlatform(platform)) {
+        console.error(`Error: unknown device platform '${platform}'`);
+        process.exit(1);
+      }
+      if (declared.length > 0 && !platform) {
+        console.error(
+          'Error: --capabilities requires --platform so the server can authorize the device capability set'
+        );
+        process.exit(1);
+      }
+      if (platform && !configuredWorkerId) {
+        console.error('Error: --worker-id or WORKER_ID is required in device mode');
+        process.exit(1);
+      }
+      // A device daemon runs for weeks; its bearer is snapshotted once at
+      // startup and never refreshed. `lobu whoami --json` returns
+      // `workerToken ?? accessToken`, so a user without a durable agent token
+      // silently gets the OAuth SESSION token — which expires in 24h. The
+      // daemon would then poll 401 forever and every scheduled os.files run
+      // would stop with no failure anywhere the user looks.
+      //
+      // Fail closed at boot instead: refuse anything that is not a durable PAT
+      // rather than accept a credential guaranteed to die. Fleet workers are
+      // unaffected — they authenticate with a long-lived WORKER_API_TOKEN and
+      // never take this branch.
+      if (platform && !process.env.WORKER_API_TOKEN?.startsWith('owl_pat_')) {
+        console.error(
+          'Error: device mode requires a durable personal access token in WORKER_API_TOKEN.\n' +
+            "       `lobu whoami --json` falls back to your session's OAuth access token, which\n" +
+            '       expires within 24h and would leave this daemon polling 401 indefinitely.\n' +
+            '       Mint a device token and pass it as WORKER_API_TOKEN (expects an owl_pat_ prefix).'
+        );
+        process.exit(1);
+      }
+
+      // Fleet workers advertise the DB-egress contract by default. Device
+      // workers advertise only their declared, server-authorized capabilities.
+      const capabilities: Record<string, boolean> = platform
+        ? Object.fromEntries(declared.map((name) => [name, true]))
+        : { db_egress_hardening: true };
+      const workerId = configuredWorkerId ?? `worker-${randomUUID().slice(0, 8)}`;
+
+      // Crash loud at boot if the runtime image is missing a connector dep.
       assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
       console.error(`[cli] Starting worker daemon (ID: ${workerId}, API: ${apiUrl})`);
       const env = buildEnv();
       const maxConcurrentJobs = process.env.WORKER_MAX_CONCURRENT_JOBS
         ? Math.max(1, Number.parseInt(process.env.WORKER_MAX_CONCURRENT_JOBS, 10))
         : undefined;
+      if (platform) {
+        console.error(
+          `[cli] device mode: platform=${platform} capabilities=${declared.join(',') || '(none)'}`
+        );
+      }
       await startDaemon(
         {
           apiUrl,
           workerId,
           version,
           workerApiToken: process.env.WORKER_API_TOKEN,
-          // Advertise DB-egress hardening: this worker folds the gateway's
-          // authoritative `db_egress_policy` into the connector subprocess env
-          // (resolve-then-pin IP, DNS-rebind guard, forced TLS). The gateway
-          // refuses to dispatch db-egress-hardened connector runs (e.g.
-          // postgres) to workers that do NOT advertise this, so an old worker
-          // can never claim one during a rolling deploy.
-          capabilities: { db_egress_hardening: true },
+          capabilities,
+          ...(platform ? { platform } : {}),
+          ...(label ? { label } : {}),
           ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
         },
         env

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -101,6 +101,8 @@ export class WorkerClient implements ExecutorClient {
   private capabilities: WorkerCapabilities;
   private authToken?: string;
   private version: string;
+  private platform?: string;
+  private label?: string;
 
   constructor(config: {
     apiUrl: string;
@@ -108,12 +110,18 @@ export class WorkerClient implements ExecutorClient {
     authToken?: string;
     capabilities: WorkerCapabilities;
     version?: string;
+    /** Host platform for server-side device registration and capability authorization. */
+    platform?: string;
+    /** Human-readable device name for the Devices page. */
+    label?: string;
   }) {
     this.apiUrl = trimTrailingSlashes(config.apiUrl);
     this.workerId = config.workerId;
     this.capabilities = config.capabilities;
     this.authToken = config.authToken?.trim() || undefined;
     this.version = config.version ?? '1.0.0';
+    this.platform = config.platform?.trim() || undefined;
+    this.label = config.label?.trim() || undefined;
   }
 
   private authHeaders(): Record<string, string> {
@@ -153,6 +161,10 @@ export class WorkerClient implements ExecutorClient {
       worker_id: this.workerId,
       capabilities: this.capabilities,
       version: this.version,
+      // app_version belongs to the device registration fields, so omit both for
+      // fleet workers rather than sending empty values.
+      ...(this.platform ? { platform: this.platform, app_version: this.version } : {}),
+      ...(this.label ? { label: this.label } : {}),
     });
   }
 

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -17,6 +17,10 @@ export interface DaemonConfig {
   maxConcurrentJobs?: number;
   executor?: Partial<ExecutorConfig>;
   version?: string;
+  /** Set only for a device worker; cloud-fleet daemons leave this undefined. */
+  platform?: string;
+  /** Human-readable device name for the Devices page. */
+  label?: string;
 }
 
 const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
@@ -42,9 +46,11 @@ export class WorkerDaemon {
     this.client = new WorkerClient({
       apiUrl: daemonConfig.apiUrl,
       workerId: daemonConfig.workerId,
-      authToken: daemonConfig.workerApiToken ?? env.WORKER_API_TOKEN,
+      authToken: daemonConfig.workerApiToken,
       capabilities: daemonConfig.capabilities ?? DEFAULT_CAPABILITIES,
       version: daemonConfig.version,
+      platform: daemonConfig.platform,
+      label: daemonConfig.label,
     });
 
     this.env = env;

--- a/packages/connector-worker/src/env.ts
+++ b/packages/connector-worker/src/env.ts
@@ -32,7 +32,13 @@ export function buildConnectorWorkerEnv(): Env {
     REDDIT_CLIENT_ID: process.env.REDDIT_CLIENT_ID,
     REDDIT_CLIENT_SECRET: process.env.REDDIT_CLIENT_SECRET,
     REDDIT_USER_AGENT: process.env.REDDIT_USER_AGENT,
-    WORKER_API_TOKEN: process.env.WORKER_API_TOKEN,
+    // WORKER_API_TOKEN is deliberately absent. Everything returned here reaches
+    // connector code — `subprocess.ts` spreads `job.env` into the child process
+    // environment and `buildConnectorConfig()` merges it into the connector's
+    // config — and a request bearing this token authenticates as a TRUSTED
+    // FLEET worker, which can claim and complete runs across tenants. The
+    // daemon authenticates via `DaemonConfig.workerApiToken` instead, which
+    // never enters this Env.
     // WORKER-DERIVED DEFAULT egress policy. The gateway ships its OWN
     // cloud-mode decision on the poll response (`db_egress_policy`); the daemon's
     // resolveEffectiveEnv() folds it in and takes the STRICTER of the two, so a

--- a/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
+++ b/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Platform names arrive from a worker's poll body, so `PLATFORM_ALLOWLIST`
+ * lookups must never resolve up the prototype chain.
+ *
+ * `"toString" in PLATFORM_ALLOWLIST` is `true`, so a bare `in` check made
+ * `isKnownPlatform("toString")` pass. The connector-worker CLI validates
+ * `--platform` with exactly that call, so the daemon would start and register,
+ * and the server would then throw inside `authorizeCapabilities` — where the
+ * inherited value is a function and `new Set(fn)` is not iterable.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { authorizeCapabilities, isKnownPlatform } from "../capabilities.js";
+
+// Inherited keys present on every object literal.
+const INHERITED_KEYS = [
+  "toString",
+  "constructor",
+  "valueOf",
+  "hasOwnProperty",
+  "__proto__",
+];
+
+describe("platform allowlist lookups ignore inherited keys", () => {
+  test.each(INHERITED_KEYS)("isKnownPlatform(%p) is false", (key) => {
+    expect(isKnownPlatform(key)).toBe(false);
+  });
+
+  test.each(
+    INHERITED_KEYS
+  )("authorizeCapabilities(%p) drops everything", (key) => {
+    // Must return the empty/dropped shape rather than throwing: the server
+    // calls this on every user-scoped poll, so a throw is a 500 on a request
+    // whose input is entirely attacker-chosen.
+    expect(() => authorizeCapabilities(key, ["os.files"])).not.toThrow();
+    expect(authorizeCapabilities(key, ["os.files"])).toEqual({
+      authorized: [],
+      dropped: ["os.files"],
+    });
+  });
+
+  test("a real platform still authorizes its own capabilities", () => {
+    // Pins the fix as targeted — a blanket `return false` would satisfy every
+    // assertion above while disabling device workers entirely.
+    expect(isKnownPlatform("macos")).toBe(true);
+    expect(authorizeCapabilities("macos", ["os.files"]).authorized).toContain(
+      "os.files"
+    );
+  });
+});

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -68,6 +68,20 @@ export interface CapabilityAuthorizationResult {
   dropped: string[];
 }
 
+// The set of real platform keys, captured once.
+//
+// Membership must be tested against this rather than `key in PLATFORM_ALLOWLIST`
+// or a bare index: `in` and property access both walk the prototype chain, so
+// `"toString"` reads as a known platform and then yields a FUNCTION as its
+// allowlist — which throws in `new Set(allowed)` below. Platform strings come
+// straight off a worker's poll body, so that is attacker-chosen input reaching
+// a 500.
+//
+// `Object.keys` rather than `Object.hasOwn`: this package targets ES2020 and
+// `Object.hasOwn` is ES2022, and biome's `useObjectHasOwn` rewrites a
+// `hasOwnProperty.call` guard back into the ES2022 form on every `check:fix`.
+const KNOWN_PLATFORMS = new Set(Object.keys(PLATFORM_ALLOWLIST));
+
 // Returns the subset of `declared` that the platform is allowed to advertise,
 // plus the dropped tail for logging. `platform` of null/undefined/unknown is
 // treated as "untrusted, unknown" and returns an empty authorized set —
@@ -77,7 +91,13 @@ export function authorizeCapabilities(
   platform: string | null | undefined,
   declared: readonly string[]
 ): CapabilityAuthorizationResult {
-  const allowed = platform ? PLATFORM_ALLOWLIST[platform] : undefined;
+  // Gate the index on KNOWN_PLATFORMS (see above): a bare
+  // `PLATFORM_ALLOWLIST[platform]` returns an inherited function for keys like
+  // `toString`, which is truthy and then throws in `new Set(allowed)` below.
+  const allowed =
+    platform && KNOWN_PLATFORMS.has(platform)
+      ? PLATFORM_ALLOWLIST[platform]
+      : undefined;
   if (!allowed) {
     return { authorized: [], dropped: [...declared] };
   }
@@ -95,5 +115,9 @@ export function authorizeCapabilities(
 }
 
 export function isKnownPlatform(platform: string | null | undefined): boolean {
-  return !!platform && platform in PLATFORM_ALLOWLIST;
+  // Same reason as above: `in` walks the prototype chain, so `toString` and
+  // `constructor` would pass this check. The connector-worker CLI validates
+  // `--platform` with it, so a bare `in` lets an operator start a daemon that
+  // the server then rejects while authorizing capabilities.
+  return !!platform && KNOWN_PLATFORMS.has(platform);
 }

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -6,6 +6,7 @@ import { generateSecureToken } from '../../auth/oauth/utils';
 import type { Env } from '../../index';
 import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestConnection, createTestConnectorDefinition } from '../setup/test-fixtures';
 import { post } from '../setup/test-helpers';
 
 const CONNECTOR_KEY = 'apple.test_device_manifest';
@@ -214,6 +215,47 @@ describe('device connector manifests', () => {
     `) as unknown as Array<{ compiled_code: string | null; source_path: string | null }>;
     expect(versionRows[0]?.compiled_code).toBeNull();
     expect(versionRows[0]?.source_path).toBe(`device-manifest://macos/${CONNECTOR_KEY}@0.1.0`);
+  });
+
+  it('ships compiled code for a TypeScript connector claimed by a local-files device worker', async () => {
+    const connectorKey = 'test.local_files';
+    const compiledCode = 'module.exports = { sync: async () => ({ items: [] }) }';
+    const { orgId, userId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    await createTestConnectorDefinition({
+      key: connectorKey,
+      name: 'Local Files Test',
+      organization_id: orgId,
+    });
+    await sql`
+      UPDATE connector_definitions
+      SET required_capability = 'os.files', runtime = ${sql.json({ platforms: ['macos'] })}
+      WHERE organization_id = ${orgId} AND key = ${connectorKey}
+    `;
+    const connection = await createTestConnection({
+      organization_id: orgId,
+      connector_key: connectorKey,
+      created_by: userId,
+    });
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key, connector_version,
+        approval_status, status, created_at
+      ) VALUES (
+        ${orgId}, 'sync', ${connection.id}, ${connectorKey}, '1.0.0',
+        'auto', 'pending', NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const response = await poll(workerId, [], 'macos', { 'os.files': true });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.run_id).toBe(Number(run.id));
+    expect(body.connector_key).toBe(connectorKey);
+    expect(body.compiled_code).toBe(compiledCode);
   });
 
   it('re-syncs connector_definitions when a later poll ships a changed manifest (new action)', async () => {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -894,9 +894,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   //     from ~13 MB to ~kB and stops the gateway-side cache from being
   //     the dominant heap occupant (lobu#771 postmortem trail; 29 cached
   //     bundles totalled ~384 MB).
-  //   - Device workers (Lobu Mac Bridge) and DB-only user-uploaded
-  //     connectors don't have the source on disk; they still get
-  //     `compiled_code` shipped inline. We check the gateway-local
+  //   - Device workers and DB-only user-uploaded connectors don't have the
+  //     source on disk. When their version has stored TypeScript code, the
+  //     gateway ships `compiled_code` inline. Metadata-only device manifests
+  //     are implemented natively by the device bridge and need no bundle.
+  //     We check the gateway-local
   //     `findBundledConnectorFile` (different filesystem layout from the
   //     worker image — see worker-side resolver in
   //     connector-worker/src/compile-connector.ts) to decide whether the
@@ -936,14 +938,20 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // compiled_code on the version row. Fleet workers normally compile bundled
   // sources locally, but an explicit override must still ship inline so prod
   // picks up connector code before the next image deploy.
-  const hasOrgCompiledOverride = Boolean(row.compiled_code);
+  const hasStoredCompiledCode = Boolean(row.compiled_code);
   const workerWillResolveLocally =
-    !isUserScopedWorker && gatewayHasLocalSource && !hasOrgCompiledOverride;
-  const deviceWillExecuteBridgeOnlyConnector =
+    !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
+  // Metadata-only device manifests describe connectors implemented natively by
+  // the device bridge, so there is no TypeScript bundle to deliver. A device
+  // connector that does have compiled code (for example an `os.files` takeout
+  // connector installed from source) runs in connector-worker and needs that
+  // code inline because it is not part of the worker's bundled catalog.
+  const deviceWillExecuteNativeConnector =
     isUserScopedWorker &&
+    !hasStoredCompiledCode &&
     row.connector_required_capability != null &&
     authorizedCapabilities.includes(row.connector_required_capability);
-  if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteBridgeOnlyConnector) {
+  if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteNativeConnector) {
     try {
       compiledCode = await resolveConnectorCode(row.connector_key, {
         id: row.connector_version_row_id,


### PR DESCRIPTION
## What

Lets an operator run `connector-worker` as a **device worker** that claims capability-gated connector runs — the missing half of the `os.files` takeout connectors declared in #2685.

Adds `--platform` / `--capabilities` / `--label` (and `WORKER_PLATFORM` / `WORKER_CAPABILITIES` / `WORKER_LABEL`).

## Why

`worker-api/poll.ts` claim branch (1B) routes an unpinned, capability-matched run to a user-scoped device worker. Nothing in `connector-worker` could declare a platform or capability set, so that branch never matched: `os.files` runs sat `pending` until `reapStaleRuns()` terminalized them at the 120s threshold.

Prod confirms the gap — `google.takeout` (494) and `twitter.takeout` (495) have **never** synced, and the newest takeout event of any kind is 2026-07-09.

## Capability preservation

The server filters advertised capabilities through `authorizeCapabilities(platform, …)` **only when the poll body carries a platform**:

```ts
let authorizedCapabilities = advertisedCapabilities;
if (effectivePlatform) { ...authorizeCapabilities(...)... }
```

A worker that omitted `platform` would keep its advertised set verbatim and bypass the allowlist. So the CLI refuses `--capabilities` without `--platform`, validates against `isKnownPlatform`, and blank values are sent as *absent* rather than empty strings. `device-worker-poll-body.test.ts` (5 tests) pins that wire shape.

## Second fix: compiled_code delivery

Device workers were never sent `compiled_code`. The old predicate assumed any capability-matched device connector was bridge-native:

```ts
const deviceWillExecuteBridgeOnlyConnector =
  isUserScopedWorker && row.connector_required_capability != null && ...
```

That holds for metadata-only manifests the Mac bridge implements natively, but **not** for a connector installed from TypeScript source — it runs in `connector-worker` and isn't in the worker's bundled catalog, so it needs the bundle inline. Now gated on `!hasStoredCompiledCode`. Without this the routing works and execution still fails.

## Testing

- `device-worker-poll-body.test.ts` — 5 new tests, wire shape
- `device-connector-manifests.test.ts` — new case: compiled code ships to a local-files device worker (15 pass)
- Mutation-proven: reverting the `!hasStoredCompiledCode` term fails the new assertion
- `make pre-pr-remote` green, tree `a2d2b4ee`

## Not covered

No end-to-end run yet — that needs this merged and the daemon pointed at prod. Archives are staged on disk and verified (`Takeout 3/YouTube and YouTube Music/history/watch-history.html`, 2.3 MB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device-worker configuration for platforms, capabilities, and labels through CLI options and environment variables.
  * Device workers now send platform, app version, capabilities, and labels when polling for work.
  * Device workers can receive compiled connector code when claiming pending runs.
* **Bug Fixes**
  * Improved platform validation and capability authorization.
  * Prevented worker authentication tokens from being exposed to connector processes.
  * Device mode now requires a durable access token.
* **Compatibility**
  * Fleet workers retain their existing default capabilities and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Blocker fix: device mode requires a durable PAT

`pi-review` blocked the previous round on this. `lobu whoami --json` falls back to the session's
OAuth access token, which expires within 24h — a device daemon started with it would poll 401
indefinitely with no signal to the operator. It now fails closed at startup:

```ts
if (platform && !process.env.WORKER_API_TOKEN?.startsWith('owl_pat_')) {
  console.error(
    'Error: device mode requires a durable personal access token in WORKER_API_TOKEN.\n' +
      "       `lobu whoami --json` falls back to your session's OAuth access token, which\n" +
      '       expires within 24h and would leave this daemon polling 401 indefinitely.\n' +
      '       Mint a device token and pass it as WORKER_API_TOKEN (expects an owl_pat_ prefix).'
  );
  process.exit(1);
}
```

Four tests spawn the real binary against an unreachable backend (`http://127.0.0.1:1`) so the guard
is exercised through `main()` rather than in isolation: no token → fail closed; OAuth token
(`ya29.…`) → fail closed; `owl_pat_…` → proceeds to `Starting worker daemon`; fleet mode (no
`--platform`) → unaffected.

### red → green (mutation-verified)

The guard was mutated to `if (false)` after asserting the real predicate was present at
`src/bin.ts:163`:

```
$ grep -n "owl_pat_" src/bin.ts
163:      if (platform && !process.env.WORKER_API_TOKEN?.startsWith('owl_pat_')) {

# mutate → if (false) {

expect(stderr).toContain("device mode requires a durable personal access token");
Received: "[cli] Starting worker daemon (ID: test-device, API: http://127.0.0.1:1)
           [cli] device mode: platform=macos capabilities=os.files
           Fatal error: Backend health check failed"

 2 pass
 2 fail
```

The OAuth-token case reaching `Starting worker daemon` is the exact regression the guard prevents.
Restored → **67 pass, 0 fail across 15 files**.

### Rebase note

Rebased onto current `main` and the `packages/owletto` pin fast-forwarded
`a504a14c → 6396cb92` (ancestry verified, `--ff-only`). `check-drift` reads the branch's own
submodule pin rather than the merge ref, so this is required for it to report green even though
#2690 already fixed `main`. File list unchanged at 11.

### E2E against a live gateway

The guard was exercised through a full daemon lifecycle, not just a spawned binary:

```
owl_pat_…  device mode  → [cli] Starting worker daemon (ID: macos:e2e-device)
                          [daemon] Starting worker daemon...
                          claimed and completed 3 real sync runs
ya29.…     device mode  → Error: device mode requires a durable personal access token
                          (refused at startup, never polls)
ya29.…     fleet mode   → starts normally — the guard does not touch the fleet path
```
