### PR TITLE
fix(example): resolve takeout dirs strictly and declare gmail auth profiles

### DIFF
--- a/examples/personal-agent/__tests__/takeout-dirs.test.ts
+++ b/examples/personal-agent/__tests__/takeout-dirs.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression coverage for the takeout-dir footgun.
+ *
+ * An apply run without these env vars once wrote `./takeout/...` over every
+ * prod `takeout_dir`, and each takeout feed then read an empty directory. Two
+ * properties have to hold at the same time, and they pull in opposite
+ * directions:
+ *
+ *   1. a full apply must FAIL rather than silently substitute a path, and
+ *   2. `lobu apply --only agents` must still LOAD — it never touches a feed,
+ *      so it must not require connector env vars.
+ *
+ * Which is why resolution is lazy: constructing the config is safe, reading
+ * `takeout_dir` is what enforces (1).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { localTakeoutDir, takeoutConfig } from "../takeout-dirs.ts";
+
+const VARS = ["GOOGLE_YOUTUBE_TAKEOUT_DIR", "LOCAL_TAKEOUT_ROOT"];
+const saved = new Map<string, string | undefined>();
+for (const v of VARS) saved.set(v, process.env[v]);
+
+afterEach(() => {
+  for (const v of VARS) {
+    const was = saved.get(v);
+    if (was === undefined) delete process.env[v];
+    else process.env[v] = was;
+  }
+});
+
+function clear() {
+  for (const v of VARS) delete process.env[v];
+}
+
+describe("localTakeoutDir", () => {
+  test("throws naming the missing variable rather than returning a relative path", () => {
+    clear();
+    expect(() => localTakeoutDir("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt")).toThrow(
+      /GOOGLE_YOUTUBE_TAKEOUT_DIR is not set/
+    );
+    // The specific regression: `./takeout/yt` is a plausible-looking string
+    // that apply would happily persist over a correct absolute path.
+    try {
+      localTakeoutDir("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt");
+    } catch (err) {
+      expect(String(err)).not.toContain("./takeout/yt");
+    }
+  });
+
+  test("an explicit variable wins", () => {
+    clear();
+    process.env.GOOGLE_YOUTUBE_TAKEOUT_DIR = "/Users/x/Downloads/Takeout 3";
+    expect(localTakeoutDir("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt")).toBe(
+      "/Users/x/Downloads/Takeout 3"
+    );
+  });
+
+  test("LOCAL_TAKEOUT_ROOT supplies a shared parent when set explicitly", () => {
+    clear();
+    process.env.LOCAL_TAKEOUT_ROOT = "/archives";
+    expect(localTakeoutDir("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt")).toBe(
+      "/archives/yt"
+    );
+  });
+
+  test("an explicit variable still beats the shared root", () => {
+    clear();
+    process.env.LOCAL_TAKEOUT_ROOT = "/archives";
+    process.env.GOOGLE_YOUTUBE_TAKEOUT_DIR = "/explicit";
+    expect(localTakeoutDir("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt")).toBe(
+      "/explicit"
+    );
+  });
+});
+
+describe("takeoutConfig laziness", () => {
+  test("building the config does not throw when the variable is unset", () => {
+    clear();
+    // This is what `--only agents` depends on: the module loads, the feed
+    // config object exists, and nothing resolves until someone reads it.
+    expect(() =>
+      takeoutConfig("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt")
+    ).not.toThrow();
+  });
+
+  test("reading takeout_dir is what fails closed", () => {
+    clear();
+    const cfg = takeoutConfig("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt");
+    expect(() => cfg.takeout_dir).toThrow(/is not set/);
+  });
+
+  test("reading resolves the current value, not one captured at build time", () => {
+    clear();
+    const cfg = takeoutConfig("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt");
+    process.env.GOOGLE_YOUTUBE_TAKEOUT_DIR = "/set/afterwards";
+    expect(cfg.takeout_dir).toBe("/set/afterwards");
+  });
+
+  test("serializing the config surfaces the failure — apply maps via JSON", () => {
+    clear();
+    const cfg = takeoutConfig("GOOGLE_YOUTUBE_TAKEOUT_DIR", "yt");
+    // A getter that stayed invisible to serialization would let a full apply
+    // write `{}` for the feed config instead of failing.
+    expect(() => JSON.stringify(cfg)).toThrow(/is not set/);
+
+    process.env.GOOGLE_YOUTUBE_TAKEOUT_DIR = "/Users/x/Takeout 3";
+    expect(JSON.parse(JSON.stringify(cfg))).toEqual({
+      takeout_dir: "/Users/x/Takeout 3",
+    });
+  });
+});

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -838,19 +838,18 @@ const localTakeoutDir = (envName: string, fallback: string): string => {
   );
 };
 
-const googleYoutubeTakeoutDir = localTakeoutDir(
-  "GOOGLE_YOUTUBE_TAKEOUT_DIR",
-  "google-youtube"
-);
-const googleKeepTakeoutDir = localTakeoutDir(
-  "GOOGLE_KEEP_TAKEOUT_DIR",
-  "google-keep"
-);
-const twitterTakeoutDir = localTakeoutDir("TWITTER_TAKEOUT_DIR", "twitter");
-const instagramTakeoutDir = localTakeoutDir(
-  "INSTAGRAM_TAKEOUT_DIR",
-  "instagram"
-);
+// Resolve lazily, on read. Throwing at module scope would break scoped applies
+// that never touch connections — `lobu apply --only agents` exits at import
+// even though it would skip every feed here. The getter defers the check to
+// connection mapping, so a full apply still fails closed.
+const takeoutConfig = (
+  envName: string,
+  fallback: string
+): { takeout_dir: string } => ({
+  get takeout_dir(): string {
+    return localTakeoutDir(envName, fallback);
+  },
+});
 // LinkedIn is also a browser connector. Unlike takeout-only connections, never
 // synthesize a local path for it: a browser-only deployment must not provision
 // CSV feeds that can only fail forever. Opt in with either an explicit LinkedIn
@@ -866,8 +865,14 @@ const takeoutConnection = defineConnection({
   connector: "google.takeout",
   name: "Google Takeout Local",
   feeds: [
-    { feed: "youtube", config: { takeout_dir: googleYoutubeTakeoutDir } },
-    { feed: "keep", config: { takeout_dir: googleKeepTakeoutDir } },
+    {
+      feed: "youtube",
+      config: takeoutConfig("GOOGLE_YOUTUBE_TAKEOUT_DIR", "google-youtube"),
+    },
+    {
+      feed: "keep",
+      config: takeoutConfig("GOOGLE_KEEP_TAKEOUT_DIR", "google-keep"),
+    },
   ],
 });
 
@@ -876,11 +881,20 @@ const twitterTakeoutConnection = defineConnection({
   connector: "twitter.takeout",
   name: "X/Twitter Takeout Local",
   feeds: [
-    { feed: "tweets", config: { takeout_dir: twitterTakeoutDir } },
-    { feed: "messages", config: { takeout_dir: twitterTakeoutDir } },
-    { feed: "likes", config: { takeout_dir: twitterTakeoutDir } },
-    { feed: "followers", config: { takeout_dir: twitterTakeoutDir } },
-    { feed: "following", config: { takeout_dir: twitterTakeoutDir } },
+    { feed: "tweets", config: takeoutConfig("TWITTER_TAKEOUT_DIR", "twitter") },
+    {
+      feed: "messages",
+      config: takeoutConfig("TWITTER_TAKEOUT_DIR", "twitter"),
+    },
+    { feed: "likes", config: takeoutConfig("TWITTER_TAKEOUT_DIR", "twitter") },
+    {
+      feed: "followers",
+      config: takeoutConfig("TWITTER_TAKEOUT_DIR", "twitter"),
+    },
+    {
+      feed: "following",
+      config: takeoutConfig("TWITTER_TAKEOUT_DIR", "twitter"),
+    },
   ],
 });
 
@@ -889,19 +903,46 @@ const instagramTakeoutConnection = defineConnection({
   connector: "instagram.takeout",
   name: "Instagram Takeout Local",
   feeds: [
-    { feed: "messages", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "connections", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "saved", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "comments", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "likes", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "media", config: { takeout_dir: instagramTakeoutDir } },
+    {
+      feed: "messages",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "connections",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "saved",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "comments",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "likes",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "media",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
     {
       feed: "story_interactions",
-      config: { takeout_dir: instagramTakeoutDir },
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
     },
-    { feed: "searches", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "link_history", config: { takeout_dir: instagramTakeoutDir } },
-    { feed: "ads", config: { takeout_dir: instagramTakeoutDir } },
+    {
+      feed: "searches",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "link_history",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
+    {
+      feed: "ads",
+      config: takeoutConfig("INSTAGRAM_TAKEOUT_DIR", "instagram"),
+    },
   ],
 });
 

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -19,6 +19,7 @@ import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
 import type WhatsAppCloudConnector from "./whatsapp.cloud.connector.ts";
 import type MidasConnector from "./midas.connector.ts";
 import type SocialInterestRadarReaction from "./social-interest-radar.reaction.ts";
+import { takeoutConfig } from "./takeout-dirs.ts";
 
 const hourlyTaskCollaboratorSkill = defineSkill({
   name: "hourly-task-collaborator",
@@ -814,42 +815,6 @@ const revolutConnection = defineConnection({
   ],
 });
 
-// Takeout dirs are absolute machine-local paths, so they can only come from the
-// environment. Resolve them strictly: a relative fallback like `./takeout/x` is
-// a valid-looking string that apply happily writes over a correct absolute path,
-// silently pointing prod at a directory that does not exist. That is not
-// hypothetical — an apply run without these vars is what set every prod
-// `takeout_dir` to `./takeout/...`, and every takeout feed read nothing until it
-// was repaired by hand. Fail closed instead: a bare `lobu apply` must abort, not
-// quietly revert. `LOCAL_TAKEOUT_ROOT` still supplies a shared parent.
-//
-// The same reasoning already guards LinkedIn below; this generalizes it. Note
-// these must resolve to a STRING, never null — prune is on, so dropping a path
-// would remove the feed from the plan and DELETE it from prod.
-const localTakeoutRoot = process.env.LOCAL_TAKEOUT_ROOT;
-const localTakeoutDir = (envName: string, fallback: string): string => {
-  const explicit = process.env[envName];
-  if (explicit) return explicit;
-  if (localTakeoutRoot) return `${localTakeoutRoot}/${fallback}`;
-  throw new Error(
-    `${envName} is not set (and no LOCAL_TAKEOUT_ROOT fallback). ` +
-      `Set it to the absolute path of the extracted archive before applying — ` +
-      `applying without it would overwrite the stored takeout_dir in prod.`
-  );
-};
-
-// Resolve lazily, on read. Throwing at module scope would break scoped applies
-// that never touch connections — `lobu apply --only agents` exits at import
-// even though it would skip every feed here. The getter defers the check to
-// connection mapping, so a full apply still fails closed.
-const takeoutConfig = (
-  envName: string,
-  fallback: string
-): { takeout_dir: string } => ({
-  get takeout_dir(): string {
-    return localTakeoutDir(envName, fallback);
-  },
-});
 // LinkedIn is also a browser connector. Unlike takeout-only connections, never
 // synthesize a local path for it: a browser-only deployment must not provision
 // CSV feeds that can only fail forever. Opt in with either an explicit LinkedIn

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1,6 +1,7 @@
 import {
   connectorFromFile,
   defineAgent,
+  defineAuthProfile,
   defineBehavior,
   defineConfig,
   defineSkill,
@@ -792,31 +793,50 @@ const learning = defineEntityType({
   },
 });
 
-// Revolut auth is implicit: the connector reads the rendered web app through
-// the paired Owletto Chrome extension's signed-in session — there's no stored
-// secret and no browser-auth profile to grant.
+// Revolut auth is implicit: through the paired Owletto Chrome extension, the
+// connector captures request headers from a signed-in tab and pages the retail
+// API in that browser context. No secret or browser-auth profile is stored.
 //
-// Not device-pinned: the connector's sync() runs on a cloud Node worker and
-// dispatches its DOM-scrape actions down to whichever online paired Owletto
-// extension claims them (same model as LinkedIn). This is what makes Revolut
-// "extension-only" from the user's side — no Owletto Mac app required, just the
-// Chrome extension signed in to app.revolut.com. max_scrolls is capped so a
-// single run fits inside the extension's 90s per-run cap (≈150s at 100 scrolls
-// always timed out); 20 scrolls (~55s) reliably completes, and scheduled
-// incremental syncs keep history current from the top each run.
+// The connection is not device-pinned; Chrome dispatch selects an online paired
+// extension. `max_scrolls` is the compatibility name for its paging-batch cap.
 const revolutConnection = defineConnection({
   slug: "revolut-buremba",
   connector: "revolut",
   name: "Revolut",
   feeds: [
-    { feed: "transactions", config: { max_scrolls: 20 } },
+    // Apply replaces feed config wholesale. Preserve checkpointed syncs and the
+    // 60s passcode grace period within the device worker's ~95s run budget.
+    {
+      feed: "transactions",
+      config: { max_scrolls: 20, backfill: false, wait_for_data_seconds: 60 },
+    },
     { feed: "balances", config: {} },
   ],
 });
 
-const localTakeoutRoot = process.env.LOCAL_TAKEOUT_ROOT ?? "./takeout";
-const localTakeoutDir = (envName: string, fallback: string): string =>
-  process.env[envName] ?? `${localTakeoutRoot}/${fallback}`;
+// Takeout dirs are absolute machine-local paths, so they can only come from the
+// environment. Resolve them strictly: a relative fallback like `./takeout/x` is
+// a valid-looking string that apply happily writes over a correct absolute path,
+// silently pointing prod at a directory that does not exist. That is not
+// hypothetical — an apply run without these vars is what set every prod
+// `takeout_dir` to `./takeout/...`, and every takeout feed read nothing until it
+// was repaired by hand. Fail closed instead: a bare `lobu apply` must abort, not
+// quietly revert. `LOCAL_TAKEOUT_ROOT` still supplies a shared parent.
+//
+// The same reasoning already guards LinkedIn below; this generalizes it. Note
+// these must resolve to a STRING, never null — prune is on, so dropping a path
+// would remove the feed from the plan and DELETE it from prod.
+const localTakeoutRoot = process.env.LOCAL_TAKEOUT_ROOT;
+const localTakeoutDir = (envName: string, fallback: string): string => {
+  const explicit = process.env[envName];
+  if (explicit) return explicit;
+  if (localTakeoutRoot) return `${localTakeoutRoot}/${fallback}`;
+  throw new Error(
+    `${envName} is not set (and no LOCAL_TAKEOUT_ROOT fallback). ` +
+      `Set it to the absolute path of the extracted archive before applying — ` +
+      `applying without it would overwrite the stored takeout_dir in prod.`
+  );
+};
 
 const googleYoutubeTakeoutDir = localTakeoutDir(
   "GOOGLE_YOUTUBE_TAKEOUT_DIR",
@@ -933,10 +953,29 @@ const midasConnection = defineConnection({
 // a live read via the connector's search/get_thread actions, never persisted.
 // Adopts the existing `gmail-buremba` slug so the OAuth grant is reused; stale
 // duplicate gmail connections/feeds in prod surface as drift until cleaned up.
+// Apply requires referenced auth profiles to be declared. Omitting credentials
+// preserves the existing OAuth grant and app secret.
+const gmailAccountAuth = defineAuthProfile({
+  slug: "personal",
+  connector: "google.gmail",
+  authKind: "oauth_account",
+  name: "personal",
+});
+
+const gmailAppAuth = defineAuthProfile({
+  slug: "google-gmail-google-app",
+  connector: "google.gmail",
+  authKind: "oauth_app",
+  name: "Google Gmail Google App",
+});
+
 const gmailConnection = defineConnection({
   slug: "gmail-buremba",
   connector: "google.gmail",
   name: "Gmail",
+  // Apply treats omitted bindings as null, so both must remain explicit.
+  authProfile: gmailAccountAuth,
+  appAuthProfile: gmailAppAuth,
   feeds: [
     {
       feed: "threads",
@@ -1284,6 +1323,7 @@ export default defineConfig({
     voiceProfileSynthesis,
     socialInterestRadar,
   ],
+  authProfiles: [gmailAccountAuth, gmailAppAuth],
   connections: [
     midasConnection,
     revolutConnection,

--- a/examples/personal-agent/takeout-dirs.ts
+++ b/examples/personal-agent/takeout-dirs.ts
@@ -1,0 +1,51 @@
+/**
+ * Resolution for local takeout archive directories.
+ *
+ * These are absolute machine-local paths, so they can only come from the
+ * environment. Resolve them strictly: a relative fallback like `./takeout/x` is
+ * a valid-looking string that `lobu apply` happily writes over a correct
+ * absolute path, silently pointing prod at a directory that does not exist.
+ * That is not hypothetical — an apply run without these vars is what set every
+ * prod `takeout_dir` to `./takeout/...`, after which every takeout feed read an
+ * empty directory until it was repaired by hand.
+ *
+ * Lives in its own module (rather than inline in `lobu.config.ts`) so the
+ * behaviour is testable without importing `@lobu/cli`.
+ */
+
+/**
+ * Resolve one takeout directory, or throw naming the variable that is missing.
+ *
+ * Never returns null: prune is on, so a missing path would drop the feed from
+ * the apply plan and DELETE it from prod rather than leave it alone.
+ */
+export function localTakeoutDir(envName: string, fallback: string): string {
+  const explicit = process.env[envName];
+  if (explicit) return explicit;
+  const root = process.env.LOCAL_TAKEOUT_ROOT;
+  if (root) return `${root}/${fallback}`;
+  throw new Error(
+    `${envName} is not set (and no LOCAL_TAKEOUT_ROOT fallback). ` +
+      `Set it to the absolute path of the extracted archive before applying — ` +
+      `applying without it would overwrite the stored takeout_dir in prod.`
+  );
+}
+
+/**
+ * A feed config whose `takeout_dir` resolves lazily, on read.
+ *
+ * Resolving at module scope would break scoped applies that never touch
+ * connections: `lobu apply --only agents` loads the config and would exit at
+ * import even though it skips every feed here. Deferring to property access
+ * moves the check to connection mapping, so a full apply still fails closed.
+ */
+export function takeoutConfig(
+  envName: string,
+  fallback: string
+): { takeout_dir: string } {
+  return {
+    get takeout_dir(): string {
+      return localTakeoutDir(envName, fallback);
+    },
+  };
+}


### PR DESCRIPTION
## What

Makes `lobu apply` fail closed when a takeout directory env var is missing, instead of silently rewriting prod's absolute paths to a relative fallback.

## Why — this already corrupted prod

Every `takeout_dir` resolved through a silent fallback:

```ts
const localTakeoutRoot = process.env.LOCAL_TAKEOUT_ROOT ?? "./takeout";
  process.env[envName] ?? `${localTakeoutRoot}/${fallback}`;
```

`./takeout/youtube` is a perfectly valid-looking string, so apply wrote it over the correct absolute path. An apply run without these vars is what set **every** prod `takeout_dir` to `./takeout/...`, after which each takeout feed read an empty directory and produced nothing. The paths were repaired by hand — and a bare `lobu apply` would have reverted them again. The dry-run before this change had 18 such reversions queued.

The same reasoning was already documented for LinkedIn ("never synthesize a local path... a browser-only deployment must not provision CSV feeds that can only fail forever"). This generalizes that rule.

**Deliberately not LinkedIn's `null` approach for the rest**: prune is on, so a null path drops the feed from the plan and *deletes* it. 17 feeds would have gone. Failing loudly is the safe generalization.

## Red → green

Bare dry-run now aborts, naming the variable:

```
Error: Failed to load lobu.config.ts — GOOGLE_YOUTUBE_TAKEOUT_DIR is not set
(and no LOCAL_TAKEOUT_ROOT fallback). Set it to the absolute path of the
extracted archive before applying — applying without it would overwrite the
stored takeout_dir in prod.
```

With the vars set, against real prod:

```
before: Summary: 8 create, 18 update, 36 noop, 56 drift
after:  Summary: 8 create,  1 update, 53 noop, 56 drift
```

All 17 takeout feeds go to `=` noop. The remaining update is the expected behavior change.

## Also

- **Gmail auth profiles declared.** Apply rejects a connection referencing an undeclared profile. `credentials` is omitted, so `diffAuthProfile` does not re-push secrets — verified: connection 347 keeps `auth=46, app_auth=21, active`.
- **Revolut feed keys restored.** Apply replaces feed config wholesale; `backfill` and `wait_for_data_seconds` would have been dropped.
- **Stale comment corrected.** The Revolut note described a DOM-scrape path the connector no longer uses — it captures request headers and pages the JSON API in-page.

## Testing

`bun test examples/personal-agent` → 194 pass · biome clean · `make pre-pr-remote` green, tree `306b96e7`