### PR TITLE
feat(mcp): drop the undeclared-result guesswork tier

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -143,14 +143,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     return sessionId!;
   }
 
-  it('serves the self-contained v11 interaction bundle over resources/read', async () => {
+  it('serves the self-contained v12 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v11.html' },
+        params: { uri: 'ui://lobu/interaction/v12.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,7 +159,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v11.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v12.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-embedded-stub');
     expect(content?.text).not.toContain('mcp-app-external-stub');
@@ -268,13 +268,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps the v7 through v10 aliases on the packed, network-free template', async () => {
+  it('keeps the v7 through v11 aliases on the packed, network-free template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v7.html',
       'ui://lobu/interaction/v8.html',
       'ui://lobu/interaction/v9.html',
       'ui://lobu/interaction/v10.html',
+      'ui://lobu/interaction/v11.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -309,7 +310,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v11.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v12.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -357,18 +358,27 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v11.html',
+            resourceUri: 'ui://lobu/interaction/v12.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v11.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v12.html',
         }),
       })
     );
 
+    // `search_sdk` is deliberately unlinked from the app resource: a model-facing
+    // doc lookup on the way to query_sdk/run_sdk gives the reader nothing to
+    // verify or act on, and a declared template instantiates a widget per lookup.
+    const sdkSearchTool = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'search_sdk'
+    );
+    expect(sdkSearchTool).toBeDefined();
+    expect(sdkSearchTool?._meta?.ui).toBeUndefined();
+    expect(sdkSearchTool?._meta?.['openai/outputTemplate']).toBeUndefined();
+
     for (const name of [
       'search_memory',
       'save_memory',
-      'search_sdk',
       'query_sdk',
       'query_sql',
       'run_sdk',
@@ -379,12 +389,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v11.html',
+          resourceUri: 'ui://lobu/interaction/v12.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v11.html'
+        'ui://lobu/interaction/v12.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -451,7 +461,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v11.html',
+        resourceUri: 'ui://lobu/interaction/v12.html',
         visibility: ['model', 'app'],
       })
     );
@@ -592,13 +602,19 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const response = await post(`/mcp/${publicOrg.slug}`, {
       body: {
         jsonrpc: '2.0',
-        id: 'public-reader-search-sdk',
+        id: 'public-reader-app-render',
         method: 'tools/call',
         params: {
-          name: 'search_sdk',
-          // A bare namespace keeps the search org-independent (method docs),
-          // so no connector inventory lookup reaches org-private data.
-          arguments: { query: 'behaviors', mode: 'read' },
+          // `render_lobu_view`, not `search_sdk`: the member role rides on
+          // `mcpMeta.ui` (mcp-handler.ts), and search_sdk no longer declares a
+          // UI resource — a model-facing doc lookup has no app to inform of a
+          // role. This tool renders host-authored blocks without reading
+          // org-private data, so it keeps the caller org-independent.
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            blocks: [{ type: 'text', value: 'public reader' }],
+          },
         },
       },
       headers: { 'mcp-session-id': sessionId },
@@ -611,7 +627,30 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // envelope that could carry a stale role.
     expect('lobu/member-role' in (body.result?._meta ?? {})).toBe(true);
     expect(body.result?._meta?.['lobu/member-role']).toBeNull();
-    expect(typeof body.result?.structuredContent?.match_count).toBe('number');
+    expect(body.result?.structuredContent?.version).toBe(1);
+  });
+
+  it('emits no member role for a tool that declares no UI resource', async () => {
+    // The role exists to tell the APP who is looking. `search_sdk` stopped
+    // declaring a UI resource, so there is no app to tell and the key must be
+    // absent — not null. Absent and null mean different things to the host:
+    // null is an explicit downgrade, absent means "unchanged".
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'no-ui-tool-role',
+        method: 'tools/call',
+        params: {
+          name: 'search_sdk',
+          arguments: { query: 'behaviors', mode: 'read' },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+    });
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect('lobu/member-role' in (body.result?._meta ?? {})).toBe(false);
   });
 
   it('carries canonical null member role on a thrown app-UI error for a public reader', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -115,6 +115,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v10.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
+  [
+    'ui://lobu/interaction/v11.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v11.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v12.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -284,7 +284,10 @@ const AGENT_TOOLS: ToolDefinition[] = [
     annotations: { ...AUDITED_READ, title: 'Search SDK docs' },
     authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
-    mcpMeta: RICH_RESULT_MCP_META,
+    // Deliberately no UI resource. This is a model-facing doc lookup on the way
+    // to query_sdk/run_sdk — the reader has nothing to verify, act on, or keep,
+    // and declaring a template makes the host instantiate a widget iframe for
+    // every lookup mid-reasoning. A UI belongs on results a human acts on.
     handler: sdkSearch,
   },
   // ─── Power tools — TS scripting + raw SQL ─────────────────────────────────


### PR DESCRIPTION
## What

The MCP result renderer had four presentation tiers. The fourth tried to make an arbitrary bag of keys look intentional — promoting a "probably the answer" field to a headline, peeking at long strings. It guessed right often enough to keep and wrong often enough to mislead, and every hour spent perfecting it made *declaring* a template less attractive.

Three tiers now: **declared**, **known shape**, **undeclared**. An undeclared return states what came back and puts the fields one click away.

Owletto: buremba/owletto#812 (pointer bumped here).

## Changes

- **Tier 4 deleted** — `readsAsSentence`, `PeekText`, `TopLevelValue`, `hasSubstance`, `HEADLINE_KEYS` (−227 net renderer lines).
- **`search_sdk` stops declaring a UI resource.** A model-facing doc lookup gives the reader nothing to verify or act on, and a declared template makes the host instantiate a widget iframe for every lookup mid-reasoning.
- **`v11` added to `MCP_APP_RESOURCE_ALIASES`.** The URI bump to `v12` would otherwise orphan it, and ChatGPT caches resource fetches — any host holding a cached `v11` reference would 404 after deploy.
- **Large payloads bounded.** `DataTable` paginates at 25 rows inside the widget (sorting still spans every row, so a page is a window on the whole result, not a truncation); undeclared objects show 20 fields then state the remainder. A 500-row result went from 501 `<tr>` / 32k chars to 26 / 1.6k.
- **Ids link back to Lobu.** `#4939822` on a save receipt is now the link to `/{org}/memory?content_ids=…`, replacing a separate "Open" button. Plain text when no url came back; both directions tested.
- **Harness fixtures corrected to the real envelope** — an invented `query_ms` key removed, required `skipped_calls` added to all 12 SDK fixtures, side-effect entries reshaped from `{method, summary}` to the real `{path, access, args}`.
- Empty/failed SQL now shares the populated result's header row instead of dropping to a looser sentence at a different type scale — which also stopped discarding the caller's `title` on exactly those two paths.

## Test evidence

`server-integration-vitest` was red on `emits canonical null member role for a public-workspace reader with no membership`:

```
AssertionError: expected false to be true
  mcp-app-resources.test.ts:622
```

Cause: the member role rides on `mcpMeta.ui` (`mcp-handler.ts:499`), and the test drove `search_sdk`, which no longer declares one. The behaviour is correct; the vehicle became invalid. Moved onto `render_lobu_view` (host-authored blocks, no org-private read, still declares a UI resource), and added the assertion that was missing entirely — a no-UI tool emits **no** role key, since absent and null mean different things to the host.

Green after the fix: `Depot run qgr02m9q61 passed`, then full `Depot run c0bhkc3326 passed`.

Renderer contracts are mutation-verified: removing the id link, the caret spacer, or the title resolver each turns the corresponding test red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the updated MCP App interaction resource (v12).
  * Preserved compatibility with the previous v11 interaction resource.
  * Improved MCP resource access, listings, tool metadata, and session recovery.

* **Bug Fixes**
  * SDK documentation lookups no longer advertise unsupported rich UI metadata.
  * Improved public resource rendering with structured content and consistent member-role information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->