### PR TITLE
fix(server): raise the gateway test ceiling via CLI, not bunfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,7 +682,9 @@ jobs:
           rc=0
           for d in $dirs; do
             echo "::group::bun test $d"
-            bun test "$d" --coverage || rc=1
+            # Database setup hooks can exceed Bun's 5s default under CI load;
+            # Bun 1.3.5 ignores `[test].timeout`, so use the CLI flag.
+            bun test "$d" --coverage --timeout 30000 || rc=1
             if [ -f coverage/lcov.info ]; then
               safe=$(printf '%s' "$d" | tr '/' '-')
               mv coverage/lcov.info "coverage/gateway-${safe}.lcov.info"

--- a/packages/server/bunfig.gateway-lane-1.toml
+++ b/packages/server/bunfig.gateway-lane-1.toml
@@ -1,5 +1,5 @@
 [test]
 preload = ["./src/__tests__/setup/bun-test-teardown.ts"]
-timeout = 10000
+# Bun 1.3.5 ignores `[test].timeout`; the lane runner passes `--timeout`.
 coverageDir = "coverage/gateway-lane-1"
 coverageReporter = ["lcov"]

--- a/packages/server/bunfig.gateway-lane-2.toml
+++ b/packages/server/bunfig.gateway-lane-2.toml
@@ -1,5 +1,5 @@
 [test]
 preload = ["./src/__tests__/setup/bun-test-teardown.ts"]
-timeout = 10000
+# Bun 1.3.5 ignores `[test].timeout`; the lane runner passes `--timeout`.
 coverageDir = "coverage/gateway-lane-2"
 coverageReporter = ["lcov"]

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
 		"start": "tsx src/server.ts",
 		"build:server": "node ./scripts/build-server-bundle.mjs && bun ./scripts/build-catalog-manifests.ts",
 		"test": "vitest",
-		"test:gateway": "dirs=$(find src/gateway -type d -name __tests__ | sort); [ -n \"$dirs\" ] || { echo 'no gateway __tests__ dirs found' >&2; exit 1; }; rc=0; for d in $dirs; do bun test \"$d\" || rc=1; done; exit $rc",
+		"test:gateway": "dirs=$(find src/gateway -type d -name __tests__ | sort); [ -n \"$dirs\" ] || { echo 'no gateway __tests__ dirs found' >&2; exit 1; }; rc=0; for d in $dirs; do bun test \"$d\" --timeout 30000 || rc=1; done; exit $rc",
 		"test:sandbox-runtime": "SKIP_TEST_DB_SETUP=1 vitest run src/__tests__/integration/sandbox/run-script-runtime.test.ts",
 		"typecheck": "tsc --noEmit",
 		"lint": "biome lint src",

--- a/scripts/run-gateway-test-lanes.mjs
+++ b/scripts/run-gateway-test-lanes.mjs
@@ -6,6 +6,27 @@ import { dirname, join, relative } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
+/**
+ * Per-test/per-hook ceiling for the gateway lanes. Must be a CLI flag: bun
+ * 1.3.5 silently ignores `[test].timeout` in bunfig — these lanes carried
+ * `timeout = 10000` for a long time and still died at exactly 5000ms, which is
+ * why the flake survived every previous encounter looking already-handled.
+ *
+ * The number is derived, not guessed. Profiled 2026-08-12 on
+ * `oauth-state-store.test.ts`: the once-per-lane `beforeAll`
+ * (`ensureDbForGatewayTests`) costs ~1.43s — 659ms to spawn embedded Postgres
+ * plus 768ms to run every migration — and bun charges it to the FIRST test in
+ * the lane, which is why failures always surfaced as `OAuthStateStore >
+ * (unnamed)`. The `beforeEach` `resetTestDatabase()` TRUNCATE of all 76 tables
+ * is only ~150ms, so it was never the driver.
+ *
+ * Nothing here is pathologically slow; 1.43s of legitimate setup simply needs
+ * more than 5s of headroom once several CI graphs share the machine. 30s keeps
+ * ~20x margin over the measured cost while still failing a genuine hang far
+ * inside the job's 15-minute limit.
+ */
+const GATEWAY_TEST_TIMEOUT_MS = 30_000;
+
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const serverRoot = join(repoRoot, "packages/server");
 const gatewayRoot = join(serverRoot, "src/gateway/__tests__");
@@ -80,6 +101,8 @@ async function runLane(index, files, databaseUrl) {
       "test",
       ...relativeFiles,
       "--coverage",
+      "--timeout",
+      String(GATEWAY_TEST_TIMEOUT_MS),
     ],
     {
       cwd: serverRoot,


### PR DESCRIPTION
## Summary

The gateway lanes have been failing intermittently at **exactly 5000ms** on `OAuthStateStore (Postgres-backed)` and `UserAuthProfileStore > dropAgent cascades through all secrets` / `scanAllOAuth`, on diffs with no import path into `packages/server` at all. It cost one session 5 gate runs and a peer session 4 more, today alone.

**The lanes already declared `timeout = 10000`.** `bunfig.gateway-lane-{1,2}.toml` has carried it for a long time — and **bun 1.3.5 silently ignores `timeout` in bunfig**. The lanes ran at the 5s default the whole time while the config claimed 10s. That is why the flake survived every previous encounter: anyone who looked found an apparently-handled setting and searched elsewhere.

## red → green

Controlled probe, same config, one arm adds the CLI flag:

```
# 6s test, under a bunfig declaring timeout = 10000
(fail) probe: sleeps 6s ... [5000.49ms]
  ^ this test timed out after 5000ms.        <- bunfig ignored
 0 pass, 1 fail

# identical config + CLI --timeout 30000
 1 pass, 0 fail                               <- flag honoured
```

Both previously-red suites, after the change:
```
oauth-state-store.test.ts       6 pass 0 fail  [2.97s]
user-auth-profile-store.test.ts 8 pass 0 fail  [2.86s]
```

## Why 30s — derived, not guessed

I instrumented `cleanupTestDatabase()` and `ensureDbForGatewayTests()` rather than guessing:

```
[INIT-PROF]    startEmbeddedBackend=659ms  setupTestDatabase=768ms   (beforeAll, ONCE per lane)
[CLEANUP-PROF] total=125-403ms  tables=76  truncate=123-395ms
               pg_tables=0-18ms  canDisableTriggers=0ms  fixConstraints=1-8ms
Ran 6 tests across 1 file. [3.08s]
```

- The `beforeEach` TRUNCATE is **~150ms**, not seconds. It was never the driver — the obvious "truncate only non-empty tables" optimisation would have saved ~100ms against a 5s ceiling and fixed nothing.
- The dominant cost is the **`beforeAll` at ~1.43s**, and bun charges it to the **first test in the lane** — which is exactly why the failure always reported as `(unnamed)`.
- Nothing is pathologically slow. 1.43s of legitimate setup simply needs more than 5s of headroom once several CI graphs share the machine.

30s leaves ~20x margin over the measured cost and still fails a genuine hang an order of magnitude inside the job's 15-minute cap.

## Scope

Four entry points, because a bunfig cannot cover any of them:

| file | why |
| --- | --- |
| `scripts/run-gateway-test-lanes.mjs` | the `[gateway lane N]` runs — where the failures were |
| `.github/workflows/ci.yml` | the per-directory `bun test "$d" --coverage` loop |
| `packages/server/package.json` → `test:gateway` | so local matches CI |
| `bunfig.gateway-lane-{1,2}.toml` | dead keys deleted, replaced with a note |

Deleting the dead keys is deliberate: leaving `timeout = 10000` in place guarantees someone re-derives this in three months.

## Test plan
- [x] `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` clean — first try, no retry
- [x] Red→green probe above; both previously-failing suites green
- [x] `node --check` + `--plan` on the lane runner (130 files, 2 lanes, partition unchanged)

## Note
Touches `.github/workflows/ci.yml`, so it was gated with `DEPOT_ALLOW_WORKFLOW_CHANGES=1` per AGENTS.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the gateway test timeout to 30 seconds.
  * Improved reliability for tests requiring longer database setup time.
  * Applied the timeout consistently across all gateway test lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->