### PR TITLE
feat(cli): show before → after values in the apply plan

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/diff-baseline.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff-baseline.test.ts
@@ -110,9 +110,23 @@ describe("three-way attribution (baseline present)", () => {
     });
     const row = plan.rows.find((r) => r.kind === "entity-type");
     expect(row?.verb).toBe("update");
-    expect("changedFields" in row! ? row.changedFields : []).toEqual(
+    expect(row?.changedFields).toEqual(
       expect.arrayContaining(["name", "properties.status"])
     );
+    expect(row?.changedValues).toEqual([
+      { field: "name", from: "Task", to: "Task v2" },
+      {
+        field: "properties.status",
+        from: {
+          type: "string",
+          enum: ["backlog", "active", "done"],
+        },
+        to: {
+          type: "string",
+          enum: ["backlog", "active", "done", "archived"],
+        },
+      },
+    ]);
     expect(plan.counts.drift).toBe(0);
   });
 
@@ -561,6 +575,48 @@ describe("three-way edge cases", () => {
       rules?: unknown;
     };
     expect(attr.rules).toEqual([]);
+
+    const nextDesired = buildState([]);
+    nextDesired.memorySchema.relationshipTypes = [
+      {
+        slug: "owns",
+        name: "Owns",
+        rules: [{ source: "a", target: "c" }],
+      },
+    ];
+    const afterRemote = emptyRemote();
+    afterRemote.relationshipTypes = [
+      {
+        id: 3,
+        slug: "owns",
+        name: "Owns",
+        rules: [],
+        organization_id: "org-1",
+      },
+    ];
+    const baseline: Baseline = {
+      recorded: true,
+      attribution: {
+        entityTypes: [],
+        relationshipTypes: recorded.attribution
+          .relationshipTypes as Baseline["attribution"]["relationshipTypes"],
+        watchers: [],
+      },
+      owned: new Set(recorded.owned),
+    };
+    const plan = computeDiff(nextDesired, afterRemote, {
+      orgId: "org-1",
+      baseline,
+    });
+    const row = plan.rows.find((r) => r.kind === "relationship-type");
+    expect(row?.verb).toBe("update");
+    expect(row?.changedValues).toEqual([
+      {
+        field: "rules",
+        from: [],
+        to: [{ source: "a", target: "c" }],
+      },
+    ]);
   });
 
   test("outside prune, omitted description is preserved so a later owned delete stays eligible", () => {
@@ -737,10 +793,18 @@ describe("Behavior three-way attribution", () => {
       baseline,
     });
     const drift = plan.rows.filter((r) => r.verb === "drift");
-    const row = drift.find((r) => (r as any).blocking && r.id === "digest");
-    expect(row).toBeTruthy();
-    // Per-field: only the remote-moved agent blocks (not the whole definition).
-    expect((row as any).field).toBe("agent");
+    const row = drift.find(
+      (r) =>
+        r.kind === "watcher" &&
+        "blocking" in r &&
+        r.blocking &&
+        r.id === "digest"
+    );
+    expect(row).toMatchObject({
+      field: "agent",
+      remoteChange: "agent-b",
+      desiredChange: "agent-a",
+    });
   });
 
   test("unnamed Behavior inherits remote name (server slug default) — second apply is noop", () => {
@@ -773,9 +837,11 @@ describe("Behavior three-way attribution", () => {
     ).toBe("noop");
   });
 
-  test("declared Behavior rename is an update (not a silent noop)", () => {
+  test("declared Behavior changes carry field names but deliberately no values", () => {
     const desired = buildState([]);
-    desired.watchers = [desiredWatcher({ name: "Daily Digest" }) as any];
+    desired.watchers = [
+      desiredWatcher({ agent: "agent-b", name: "Daily Digest" }) as any,
+    ];
     const remote = emptyRemote();
     remote.watchers = [remoteWatcher({ name: "Digest" }) as any];
     const baseline = {
@@ -792,9 +858,14 @@ describe("Behavior three-way attribution", () => {
       (r) => r.kind === "watcher" && r.id === "digest"
     );
     expect(row?.verb).toBe("update");
-    expect(row && "changedFields" in row ? row.changedFields : []).toContain(
-      "name"
+    expect(row?.changedFields).toEqual(
+      expect.arrayContaining(["agent_id", "name"])
     );
+    // Behaviors reach the plan through the two-way `diffWatcher` row, whose
+    // field identifiers differ from the projection's (`agent` vs `agent_id`).
+    // Rendering values there needed a name-mapping table that was not worth
+    // its weight, so Behaviors keep the bare field-name list on purpose.
+    expect(row).not.toHaveProperty("changedValues");
   });
 
   test("adopted remote agent + config prompt change converges (no whole-object false block)", () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/render-values.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/render-values.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import chalk from "chalk";
+import type {
+  DiffPlan,
+  DiffRow,
+  EntityTypeDiffRow,
+  WatcherDiffRow,
+} from "../diff.js";
+import { renderBlockedReport, renderPlan } from "../render.js";
+
+chalk.level = 0;
+
+function planOf(rows: DiffRow[]): DiffPlan {
+  return {
+    rows,
+    counts: { create: 0, update: rows.length, noop: 0, drift: 0, delete: 0 },
+    notes: [],
+  };
+}
+
+function updateRow(
+  changedValues?: Array<{ field: string; from: unknown; to: unknown }>
+): EntityTypeDiffRow {
+  return {
+    kind: "entity-type",
+    verb: "update",
+    id: "task",
+    changedFields: ["name", "description"],
+    ...(changedValues ? { changedValues } : {}),
+  };
+}
+
+describe("plan renders the values an update would overwrite", () => {
+  test("prints `field: remote → config` instead of a bare field-name list", () => {
+    const out = renderPlan(
+      planOf([
+        updateRow([
+          { field: "name", from: "Task", to: "Task Renamed" },
+          { field: "description", from: undefined, to: "A unit of work." },
+        ]),
+      ])
+    );
+    expect(out).toContain('name: "Task" → "Task Renamed"');
+    expect(out).toContain('description: (unset) → "A unit of work."');
+    // The trailing "(name, description)" would now repeat the same information.
+    expect(out).not.toContain("(name, description)");
+  });
+
+  test("falls back to the field-name list when no values were computed", () => {
+    // Two-way rows (agents, connections, provider keys) carry no value pair —
+    // deliberately, since that path covers the secret-bearing always-update
+    // rows. They must keep rendering, just without values.
+    const out = renderPlan(planOf([updateRow()]));
+    expect(out).toContain("(name, description)");
+    expect(out).not.toContain("→");
+  });
+
+  test("keeps names for changes whose values are intentionally hidden", () => {
+    const row: EntityTypeDiffRow = {
+      kind: "entity-type",
+      verb: "update",
+      id: "task",
+      changedFields: ["name", "backing"],
+      changedValues: [{ field: "name", from: "Old", to: "New" }],
+    };
+    const out = renderPlan(planOf([row]));
+    expect(out).toContain("(backing)");
+    expect(out).toContain('name: "Old" → "New"');
+  });
+
+  test("a Behavior row renders field names only — no values, by design", () => {
+    // Behaviors carry no `changedValues`; WatcherDiffRow has no such field, so
+    // this is enforced by the type system, not just by this assertion.
+    const row: WatcherDiffRow = {
+      kind: "watcher",
+      verb: "update",
+      id: "digest",
+      changedFields: ["prompt", "reaction_script"],
+    };
+    const out = renderPlan(planOf([row]));
+    expect(out).toContain("(prompt, reaction_script)");
+    expect(out).not.toContain("→");
+  });
+
+  test("truncates a long value instead of flooding the plan", () => {
+    const long = "x".repeat(400);
+    const out = renderPlan(
+      planOf([updateRow([{ field: "description", from: "short", to: long }])])
+    );
+    expect(out).toContain("…");
+    expect(out).not.toContain(long);
+    for (const line of out.split("\n")) expect(line.length).toBeLessThan(200);
+  });
+});
+
+describe("blocked report shows both sides of the disagreement", () => {
+  test("prints the config value next to the remote one", () => {
+    const out = renderBlockedReport([
+      {
+        kind: "entity-type",
+        verb: "drift",
+        blocking: true,
+        id: "task",
+        field: "name",
+        remoteChange: "Task EDITED IN UI",
+        desiredChange: "Task",
+      },
+    ]);
+    expect(out).toContain('remote: "Task EDITED IN UI"');
+    expect(out).toContain('config: "Task"');
+  });
+
+  test("a desired field absent remotely still shows both sides", () => {
+    // Gating the pair on `remoteChange` alone would hide this disagreement.
+    const out = renderBlockedReport([
+      {
+        kind: "entity-type",
+        verb: "drift",
+        blocking: true,
+        id: "task",
+        field: "properties.status",
+        remoteChange: undefined,
+        desiredChange: { type: "string" },
+      },
+    ]);
+    expect(out).toContain("remote: (absent)");
+    expect(out).toContain('"type": "string"');
+  });
+
+  test("a field the config does not declare still renders", () => {
+    const out = renderBlockedReport([
+      {
+        kind: "entity-type",
+        verb: "drift",
+        blocking: true,
+        id: "task",
+        field: "eventKinds",
+        remoteChange: ["ui.created"],
+        desiredChange: undefined,
+      },
+    ]);
+    expect(out).toContain('"ui.created"');
+    expect(out).toContain("config: (not declared)");
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -46,12 +46,28 @@ interface BaseRow {
 
 /**
  * The desired/remote/changed-fields triple shared by every per-resource row
- * kind. `changedFields` carries field-level changes when verb === "update".
+ * kind. `changedFields` carries field-level changes when verb === "update" and
+ * remains the sole input to apply-cmd routing and the audit `changed_fields`.
  */
 interface ResourceRow<D, R> extends BaseRow {
   desired?: D;
   remote?: R;
   changedFields?: string[];
+}
+
+/**
+ * Before/after pairs are restricted to the baseline-aware memory-schema rows.
+ * The other resource rows include provider keys, BYO connection config, and
+ * auth profiles whose values must never be printed in a plan, so they have no
+ * field to populate and the unsafe version does not typecheck.
+ *
+ * Behaviors are deliberately excluded too, though they are not secret-bearing:
+ * their values reach the plan only through the two-way `diffWatcher` row, whose
+ * field identifiers differ from the projection's (`agent` vs `agent_id`), and
+ * the name-mapping table that reconciled them was not worth its weight.
+ */
+interface ValuePreviewRow {
+  changedValues?: Array<{ field: string; from: unknown; to: unknown }>;
 }
 
 export interface AgentDiffRow
@@ -66,12 +82,14 @@ export interface SettingsDiffRow extends BaseRow {
 }
 
 export interface EntityTypeDiffRow
-  extends ResourceRow<DesiredEntityType, RemoteEntityType> {
+  extends ResourceRow<DesiredEntityType, RemoteEntityType>,
+    ValuePreviewRow {
   kind: "entity-type";
 }
 
 export interface RelationshipTypeDiffRow
-  extends ResourceRow<DesiredRelationshipType, RemoteRelationshipType> {
+  extends ResourceRow<DesiredRelationshipType, RemoteRelationshipType>,
+    ValuePreviewRow {
   kind: "relationship-type";
 }
 
@@ -153,6 +171,8 @@ export interface BlockingDriftRow extends BaseRow {
   field?: string;
   /** The remote-side value that moved — shown in the blocked report. */
   remoteChange?: unknown;
+  /** What the config declares for that field — what apply would have written. */
+  desiredChange?: unknown;
 }
 
 /**
@@ -563,30 +583,51 @@ function classifyField(
   return "remoteMoved";
 }
 
-interface ThreeWayResult {
-  changedFields: string[];
-  blockingFields: Array<{ field: string; remoteChange: unknown }>;
+interface ThreeWayResult<Field extends string = string> {
+  changedFields: Field[];
+  /**
+   * The same changes as `changedFields`, carrying the values the plan is
+   * about to move `from` → `to`. Derived from the very triples the classifier
+   * compared, so the rendered pair is exactly what the decision was made on —
+   * a renderer that re-read the values off `desired`/`remote` would have to
+   * re-encode per-kind quirks (`resolutionPolicy` lives under
+   * `schemaExtras["x-lobu-resolution"]`, `required` normalizes to `[]` under
+   * prune) and would drift from the classifier the first time one changed.
+   */
+  changedValues: Array<{ field: Field; from: unknown; to: unknown }>;
+  blockingFields: Array<{
+    field: Field;
+    remoteChange: unknown;
+    desiredChange: unknown;
+  }>;
 }
 
 /** Three-way per-field classification over a list of (name, desired, remote, attribution) triples. */
-function classifyThreeWay(
+function classifyThreeWay<Field extends string>(
   triples: Array<{
-    field: string;
+    field: Field;
     desired: unknown;
     remote: unknown;
     attribution: unknown | undefined;
   }>
-): ThreeWayResult {
-  const changedFields: string[] = [];
-  const blockingFields: Array<{ field: string; remoteChange: unknown }> = [];
+): ThreeWayResult<Field> {
+  const changedFields: Field[] = [];
+  const changedValues: ThreeWayResult<Field>["changedValues"] = [];
+  const blockingFields: ThreeWayResult<Field>["blockingFields"] = [];
   for (const t of triples) {
     const outcome = classifyField(t.desired, t.remote, t.attribution);
-    if (outcome === "configMoved") changedFields.push(t.field);
-    else if (outcome === "remoteMoved") {
-      blockingFields.push({ field: t.field, remoteChange: t.remote });
+    if (outcome === "configMoved") {
+      changedFields.push(t.field);
+      changedValues.push({ field: t.field, from: t.remote, to: t.desired });
+    } else if (outcome === "remoteMoved") {
+      blockingFields.push({
+        field: t.field,
+        remoteChange: t.remote,
+        desiredChange: t.desired,
+      });
     }
   }
-  return { changedFields, blockingFields };
+  return { changedFields, changedValues, blockingFields };
 }
 
 /** Entity-type fields compared per-property-key, three-way, with the baseline. */
@@ -810,7 +851,10 @@ function diffEntityTypeWithBaseline(
       desired,
       remote,
       ...(threeWay.changedFields.length > 0
-        ? { changedFields: threeWay.changedFields }
+        ? {
+            changedFields: threeWay.changedFields,
+            changedValues: threeWay.changedValues,
+          }
         : {}),
     },
     blocking: threeWay.blockingFields.map((b) => ({
@@ -820,6 +864,7 @@ function diffEntityTypeWithBaseline(
       id: desired.slug,
       field: b.field,
       remoteChange: b.remoteChange,
+      desiredChange: b.desiredChange,
     })),
   };
 }
@@ -886,7 +931,10 @@ function diffRelationshipTypeWithBaseline(
       desired,
       remote,
       ...(threeWay.changedFields.length > 0
-        ? { changedFields: threeWay.changedFields }
+        ? {
+            changedFields: threeWay.changedFields,
+            changedValues: threeWay.changedValues,
+          }
         : {}),
     },
     blocking: threeWay.blockingFields.map((b) => ({
@@ -896,6 +944,7 @@ function diffRelationshipTypeWithBaseline(
       id: desired.slug,
       field: b.field,
       remoteChange: b.remoteChange,
+      desiredChange: b.desiredChange,
     })),
   };
 }
@@ -1248,6 +1297,7 @@ function diffWatcherWithBaseline(
         id: desired.slug,
         field: b.field,
         remoteChange: b.remoteChange,
+        desiredChange: b.desiredChange,
       })),
     };
   }

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { DiffPlan, DiffRow } from "./diff.js";
+import type { BlockingDriftRow, DiffPlan, DiffRow } from "./diff.js";
 
 const VERB_PREFIX = {
   create: chalk.green("+"),
@@ -38,6 +38,36 @@ const KIND_HEADING: Record<DiffRow["kind"], string> = {
 function fieldsList(fields: string[] | undefined): string {
   if (!fields?.length) return "";
   return chalk.dim(` (${fields.join(", ")})`);
+}
+
+/**
+ * One-line preview of a value for the plan. Objects and arrays are the common
+ * case (a property schema, an eventKinds list), so they are compacted rather
+ * than pretty-printed — the plan is a scannable summary, and an operator who
+ * needs the full body has the config and the dashboard.
+ */
+const VALUE_PREVIEW_MAX = 72;
+function valuePreview(value: unknown): string {
+  if (value === undefined) return chalk.dim("(unset)");
+  const text = JSON.stringify(value) ?? String(value);
+  return text.length > VALUE_PREVIEW_MAX
+    ? `${text.slice(0, VALUE_PREVIEW_MAX - 1)}…`
+    : text;
+}
+
+/**
+ * `field: <remote> → <config>` lines under an update row, so the operator can
+ * see what the apply overwrites instead of only which field names move. Absent
+ * on rows from the two-way paths, which never computed the pair.
+ */
+function changedValueLines(
+  changed: Array<{ field: string; from: unknown; to: unknown }> | undefined
+): string[] {
+  if (!changed?.length) return [];
+  return changed.map(
+    (c) =>
+      `      ${chalk.cyan(c.field)}: ${chalk.dim(valuePreview(c.from))} → ${valuePreview(c.to)}`
+  );
 }
 
 function rowId(row: DiffRow): string {
@@ -80,16 +110,25 @@ function renderRow(row: DiffRow): string[] {
         );
       }
       break;
-    case "update":
-      lines.push(
-        `  ${prefix} ${label} ${id}${fieldsList("changedFields" in row ? row.changedFields : undefined)}`
+    case "update": {
+      const changedValues =
+        "changedValues" in row ? row.changedValues : undefined;
+      const previewedFields = new Set(
+        changedValues?.map((change) => change.field) ?? []
       );
+      const unpreviewedFields =
+        "changedFields" in row
+          ? row.changedFields?.filter((field) => !previewedFields.has(field))
+          : undefined;
+      lines.push(`  ${prefix} ${label} ${id}${fieldsList(unpreviewedFields)}`);
+      lines.push(...changedValueLines(changedValues));
       if (row.kind === "auth-profile" && row.needsAuth) {
         lines.push(
           `      ${chalk.yellow("⚠")} interactive auth — complete it via the connect URL printed after apply`
         );
       }
       break;
+    }
     case "noop":
       lines.push(`  ${prefix} ${label} ${id}`);
       if (row.kind === "auth-profile" && row.needsAuth) {
@@ -205,19 +244,21 @@ export function renderProgress(
 }
 
 /**
+ * Blocked-report value. Unlike the plan's one-liner this stays pretty-printed —
+ * the report is the artifact an operator reads carefully to resolve the drift,
+ * so a truncated schema body would be the wrong trade there.
+ */
+function blockedValue(value: unknown, absentLabel: string): string {
+  if (value === undefined) return chalk.dim(absentLabel);
+  const text = JSON.stringify(value, null, 2) ?? String(value);
+  return text.split("\n").join("\n    ");
+}
+
+/**
  * The blocking-drift report shown when apply halts (exit 1, nothing mutated).
  * Names each remote-moved field / remote-only definition and the resolution.
  */
-export function renderBlockedReport(
-  blocking: Array<
-    Extract<DiffRow, { blocking: true }> & {
-      id: string;
-      kind: string;
-      field?: string;
-      remoteChange?: unknown;
-    }
-  >
-): string {
+export function renderBlockedReport(blocking: BlockingDriftRow[]): string {
   const lines = [
     "",
     chalk.red(
@@ -228,13 +269,16 @@ export function renderBlockedReport(
     ),
   ];
   for (const item of blocking) {
-    const label = chalk.bold(KIND_LABEL[item.kind as keyof typeof KIND_LABEL]);
+    const label = chalk.bold(KIND_LABEL[item.kind]);
     const field = item.field ? chalk.cyan(` · ${item.field}`) : "";
     lines.push("");
     lines.push(`  ${label} ${item.id}${field}`);
-    if (item.remoteChange !== undefined) {
+    // Checking only `remoteChange` would hide both sides when the remote value
+    // is absent but the config still declares one.
+    if (item.remoteChange !== undefined || item.desiredChange !== undefined) {
+      lines.push(`    remote: ${blockedValue(item.remoteChange, "(absent)")}`);
       lines.push(
-        `    remote: ${JSON.stringify(item.remoteChange, null, 2).split("\n").join("\n    ")}`
+        `    config: ${blockedValue(item.desiredChange, "(not declared)")}`
       );
     }
   }


### PR DESCRIPTION
## Summary

- A plan row named the fields an update would change but never the values: `~ entity-type task (name, description)`. The operator could not tell that the thing about to be overwritten was their own dashboard edit.
- The blocked report was worse — it printed the remote value alone, so "what would apply have written instead?" was unanswerable, and a field the config *adds* printed nothing at all.
- Values now come from the three-way triples the classifier already compared, not from re-reading `desired`/`remote` in the renderer.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Tests run: `bun test packages/cli/src/commands/_lib/apply/__tests__/` → **313 pass / 0 fail** (8 new in `render-values.test.ts`, which did not exist); `tsc --noEmit` exit 0
- [x] E2E against a live `make dev` stack (real `lobu apply` → gateway → Postgres), rebuilding `dist` between the before and after arms

### plan row

```
BEFORE   ~ entity-type task (name, description)

AFTER    ~ entity-type task
             name: "Task" → "Task Renamed"
             description: "A unit of work." → "A tracked unit of work."
             properties.status: (unset) → {"type":"string","description":"backlog | doing | done."}
```

### blocked report

```
BEFORE                              AFTER
  entity-type task · name             entity-type task · name
    remote: "Task"                      remote: "Task"
                                        config: "Task Renamed"

  entity-type task · properties.status
    (no values at all)                  remote: (absent)
                                        config: { "type": "string", … }
```

## Notes

**Why only the three-way paths carry values — this is a security boundary, not an omission.** The two-way `buildDiffRow` path covers the always-update rows, which are exactly the secret-bearing ones: provider keys, BYO connection `config`, auth profiles. Printing values there would put credentials in the plan.

That boundary is enforced by the **type system**, not by convention: `changedValues` lives on a `ValuePreviewRow` interface mixed into only `EntityTypeDiffRow` and `RelationshipTypeDiffRow`. A secret-bearing row has no such field to populate, so the unsafe version does not typecheck. Rows without a value pair keep rendering the old field-name list (tested).

**Behaviors are excluded, deliberately.** They are not secret-bearing, but their values reach the plan only through the two-way `diffWatcher` row, whose field identifiers differ from the projection's (`agent` vs `agent_id`). Bridging that needed an 18-entry name-mapping table, 9 of whose rows mapped a name to itself — not worth its weight for this PR. Behaviors keep the bare field-name list, and both the diff and render sides pin that with a test so it isn't silently re-added:

```
(pass) declared Behavior changes carry field names but deliberately no values
(pass) a Behavior row renders field names only — no values, by design
```

`changedFields` is unchanged and remains the sole input to apply-cmd's routing and the audit `changed_fields` — that type is a wide cross-cutting contract with 60+ writers across the server, so `changedValues` is additive and derived from the same loop rather than a retype.

**One bug the e2e caught that the unit tests missed.** The value pair was gated on `remoteChange !== undefined`, so a property the config adds and the remote lacks rendered a bare `· properties.status` with nothing under it. My fixture had always set the remote side. Now gated on either side being present, with `(absent)` / `(not declared)` for the missing one, plus a regression test.

Plan values are truncated to one line (72 chars); the blocked report stays pretty-printed, since that is the artifact an operator reads carefully to choose adopt vs revert.

`valuePreview` deliberately has **no** try/catch around `JSON.stringify`. An earlier revision did, with a test for it; both were dropped after checking the call graph. Every value that reaches `changedValues` has already been through `canonical()` (`diff.ts:261`), a recursive `JSON.stringify` serializer, inside `classifyField` — a cyclic or BigInt value throws there, before any row is constructed. The guard was unreachable and its test asserted a state the code cannot be in.

### mutation check

Both new behaviours are pinned, verified by mutating the source and confirming the focused tests go red:

| mutation | result |
| --- | --- |
| `changedValueLines` → always `return []` | **3 fail** / 4 pass |
| blocked-report gate `remoteChange \|\| desiredChange` → `remoteChange` alone (reintroduces the e2e bug) | **1 fail** / 6 pass |

The second reproduced the original defect exactly — `entity-type task · properties.status` with no values beneath it. Restored from backup, re-verified 313 pass / 0 fail.

Both mutation runs predate the Behaviors cut; the counts above are from that tree. The post-cut suite is 313 pass / 0 fail and the two pinning tests listed earlier were added by the cut.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added detailed before-and-after value previews to update and drift reports.
  * Improved blocked-drift reporting to show both remote and configured values, including missing fields.
  * Expanded change details for entity, relationship, and watcher updates.
  * Improved output formatting for hidden, truncated, and undeclared fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->