### PR TITLE
fix(example): stop takeout connectors naming people by URL or reserved route

### DIFF
--- a/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
@@ -169,6 +169,37 @@ describe("InstagramTakeoutConnector emits metadata the attributions resolve", ()
     expect(new Set(usernames)).toEqual(new Set(["aykut.gk"]));
   });
 
+  test("a following row whose visible text is a URL is named by handle", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ig-takeout-url-text-"));
+    const root = path.join(dir, "connections", "followers_and_following");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      path.join(root, "following.html"),
+      `<html><body><main>
+        <a href="https://www.instagram.com/_u/rampue">https://www.instagram.com/_u/rampue</a>
+      </main></body></html>`
+    );
+    const connector = new InstagramTakeoutConnector();
+    const events = (connector as any).readConnectionEvents(dir);
+    const row = events.find((e: any) => e.origin_type === "following");
+    expect(row).toBeDefined();
+    expect(row.author_name).toBe("rampue");
+    expect(row.author_name).not.toMatch(/^https?:\/\//);
+    expect(row.payload_text).toBe("following: rampue");
+    expect(resolvePath(row, "metadata.username")).toBe("rampue");
+    expect(resolvePath(row, "metadata.profile_url")).toBe(
+      "https://www.instagram.com/_u/rampue"
+    );
+  });
+
+  test("a real display name in the anchor text is preserved verbatim", () => {
+    const dir = writeConnectionsFixture();
+    const connector = new InstagramTakeoutConnector();
+    const events = (connector as any).readConnectionEvents(dir);
+    const follower = events.find((e: any) => e.origin_type === "follower");
+    expect(follower.author_name).toBe("Aykut Gedik");
+  });
+
   test("a non-profile link (shared post) emits no username -> mint-gated off", () => {
     const dir = writeConnectionsFixture();
     const connector = new InstagramTakeoutConnector();

--- a/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
@@ -43,6 +43,33 @@ describe("x-identity normalization", () => {
     expect(normalizeXHandle("")).toBe(null);
   });
 
+  test("handleFromUserLink rejects nested non-profile routes", () => {
+    expect(
+      handleFromUserLink(
+        "https://twitter.com/intent/user?user_id=1703117072769683456"
+      )
+    ).toBe(null);
+    expect(handleFromUserLink("https://x.com/i/lists/123")).toBe(null);
+    expect(handleFromUserLink("https://example.com/twitter.com/jack")).toBe(
+      null
+    );
+    // URL routing must not make the normalizer discard a real handle supplied
+    // by tweet metadata.
+    expect(normalizeXHandle("@Intent")).toBe("intent");
+  });
+
+  test("handleFromUserLink rejects BARE reserved routes too", () => {
+    // These are single-segment and therefore indistinguishable from a profile
+    // link by shape alone — the anchored pattern matches them happily, so the
+    // reserved list is what stops `twitter.com/home` minting a person "home".
+    expect(handleFromUserLink("https://twitter.com/home")).toBe(null);
+    expect(handleFromUserLink("https://twitter.com/search?q=x")).toBe(null);
+    expect(handleFromUserLink("https://x.com/notifications")).toBe(null);
+    // The guard lives in the URL reader, not the normalizer: a real @home
+    // handle arriving from tweet metadata still survives.
+    expect(normalizeXHandle("@home")).toBe("home");
+  });
+
   test("handleFromUserLink recovers the normalized handle from a profile link", () => {
     expect(handleFromUserLink("https://twitter.com/Jack")).toBe("jack");
     expect(handleFromUserLink("https://x.com/elonmusk?ref=1")).toBe("elonmusk");
@@ -161,6 +188,34 @@ describe("TwitterTakeoutConnector identity attributions", () => {
 });
 
 describe("TwitterTakeoutConnector emits metadata the attributions resolve", () => {
+  test("an intent userLink does not emit a bogus handle", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "x-takeout-"));
+    const dataDir = path.join(dir, "data");
+    mkdirSync(dataDir);
+    writeFileSync(
+      path.join(dataDir, "follower.js"),
+      `window.YTD.follower.part0 = ${JSON.stringify([
+        {
+          follower: {
+            accountId: "1703117072769683456",
+            userLink:
+              "https://twitter.com/intent/user?user_id=1703117072769683456",
+          },
+        },
+      ])}`
+    );
+
+    const connector = new TwitterTakeoutConnector();
+    const events = (connector as any).readFollowEvents(dataDir, "follower");
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(resolvePath(event, "metadata.account_id")).toBe(
+      "1703117072769683456"
+    );
+    expect(resolvePath(event, "metadata.handle")).toBeNull();
+    expect(event.payload_text).toBe("Follower: 1703117072769683456");
+  });
+
   test("a reply row emits normalized handle + numeric id the identity keys on", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "x-takeout-"));
     const dataDir = path.join(dir, "data");

--- a/examples/personal-agent/instagram-takeout.connector.ts
+++ b/examples/personal-agent/instagram-takeout.connector.ts
@@ -407,13 +407,21 @@ export default class InstagramTakeoutConnector extends ConnectorRuntime<
         // when the link is not a resolvable profile, so `createWhen exists`
         // gates minting a person on a real handle being present.
         const username = usernameFromProfileUrl(url) ?? undefined;
+        // `following.html` can repeat the profile URL as its anchor text. Use
+        // the resolved handle for display in that case, while preserving real
+        // display names from the other connection files.
+        const displayName = /^https?:\/\//i.test(name)
+          ? (username ?? name)
+          : name;
         return [
           {
+            // Keep source identity based on the original export fields; display
+            // normalization must not cause existing rows to be minted again.
             origin_id: stableId("ig_connection", [kind, url, name]),
             origin_type: kind.startsWith("follower") ? "follower" : kind,
             occurred_at: snapshotDate(),
-            payload_text: `${kind}: ${name}`,
-            author_name: name,
+            payload_text: `${kind}: ${displayName}`,
+            author_name: displayName,
             source_url: url,
             metadata: {
               platform: "instagram",

--- a/examples/personal-agent/x-identity.ts
+++ b/examples/personal-agent/x-identity.ts
@@ -49,13 +49,50 @@ export function normalizeXHandle(
   return trimmed;
 }
 
-/** Pull a normalized @handle out of a `twitter.com/<handle>` profile link. */
+// Single-segment routes that are shaped exactly like a profile link but are
+// not one. The anchored pattern below cannot separate `twitter.com/home` from
+// `twitter.com/jack` structurally — only a list can.
+//
+// Deliberately checked HERE and not in `normalizeXHandle`: a real @home or
+// @intent account exists, and a handle that arrives from tweet metadata rather
+// than from URL parsing must survive. Only the URL reading is ambiguous.
+const RESERVED_X_ROUTES = new Set([
+  "home",
+  "explore",
+  "notifications",
+  "messages",
+  "settings",
+  "compose",
+  "search",
+  "login",
+  "logout",
+  "signup",
+  "privacy",
+  "tos",
+]);
+
+/**
+ * Pull a normalized @handle out of a direct `twitter.com/<handle>` profile
+ * link.
+ *
+ * Returns null for the `/intent/user?user_id=<id>` form the takeout actually
+ * emits — the archive carries no handle for a follow, and the caller already
+ * holds the immutable `accountId`, which is the better identity anyway. Reading
+ * the first path segment instead named 824 prod entities `intent`.
+ *
+ * The pattern is anchored to the whole URL so a nested route cannot match and
+ * an unrelated host cannot smuggle one in (`example.com/twitter.com/jack`).
+ */
 export function handleFromUserLink(
   userLink: string | null | undefined
 ): string | null {
   if (typeof userLink !== "string") return null;
-  const match = userLink.match(/(?:twitter|x)\.com\/([^/?#]+)/i);
-  return match ? normalizeXHandle(match[1]) : null;
+  const match = userLink.match(
+    /^https?:\/\/(?:www\.)?(?:twitter|x)\.com\/([^/?#]+)\/?(?:[?#].*)?$/i
+  );
+  if (!match) return null;
+  const handle = normalizeXHandle(match[1]);
+  return handle && RESERVED_X_ROUTES.has(handle) ? null : handle;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two takeout connectors were minting person entities whose **name is a URL** instead of a handle, because the entity name comes from `author_name` and both connectors were passing raw export text through.

- **Instagram** — `following.html` repeats the profile URL as its own anchor text, so `author_name` became `https://www.instagram.com/_u/rampue`. Entity names use `INSERT … ON CONFLICT DO NOTHING`, so a name set at creation **never self-heals**; every one of these was permanent. Now a URL-shaped anchor falls back to the resolved handle, while real display names from the other connection files pass through verbatim.
- **X/Twitter** — `handleFromUserLink` accepted any single-segment path, so `twitter.com/home`, `/search`, `/notifications` minted people named `home`, `search`, `notifications`. Those routes are structurally indistinguishable from a profile link, so a reserved-route list is the only thing that can separate them.

Two deliberate scope limits, both load-bearing:

- The reserved check lives in `handleFromUserLink`, **not** in `normalizeXHandle`. A real `@home` / `@intent` account exists; a handle arriving from tweet metadata must survive. Only the *URL reading* is ambiguous.
- `origin_id` still hashes the **original** export fields. Display normalization must not re-mint rows that already exist.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Tests run: `bun test examples/personal-agent/__tests__/` → **207 pass, 0 fail** (9 files)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: n/a

### red (both fixes mutated out, asserted present first)

```
$ grep -n 'const displayName' instagram-takeout.connector.ts
413:        const displayName = /^https?:\/\//i.test(name)
$ grep -n 'RESERVED_X_ROUTES.has' x-identity.ts
95:  return handle && RESERVED_X_ROUTES.has(handle) ? null : handle;

# mutate: displayName -> raw anchor text; handleFromUserLink -> no reserved check

expect(row.author_name).toBe("rampue");
Expected: "rampue"
Received: "https://www.instagram.com/_u/rampue"
(fail) a following row whose visible text is a URL is named by handle

expect(handleFromUserLink("https://twitter.com/home")).toBe(null);
Expected: null
Received: "home"
(fail) handleFromUserLink rejects BARE reserved routes too

 25 pass
 2 fail
Ran 27 tests across 2 files.
```

### green (fixes restored, tree byte-identical to staged)

```
 207 pass
 0 fail
 664 expect() calls
Ran 207 tests across 9 files. [242.00ms]
```

### e2e on real archives (not fixtures)

Both fixed connectors were run through a local device worker against the real Instagram and X takeout exports, then the resulting entities were queried directly:

```
   connector_key   | events
-------------------+--------
 twitter.takeout   |   2100
 instagram.takeout |    789

SELECT count(*) FROM entities;                        -->  1199
SELECT count(*) FROM entities WHERE name LIKE 'http%'; -->     0
SELECT name FROM entities WHERE name IN
  ('home','search','intent','notifications','explore',
   'messages','settings','compose','login','signup');  --> (0 rows)
```

1,199 entities minted from 2,889 real events, **zero** named by URL and **zero** named after a reserved route. The `0`s are not vacuous — the event counts above show the ingest actually ran.

## Notes

The ~1,100 already-corrupted prod rows were repaired separately by direct SQL (backed up first); this PR stops new ones being minted. `handleFromUserLink`'s regex is also anchored here — the previous pattern was unanchored and matched `example.com/twitter.com/jack`.
