### PR TITLE
feat(server): install OAuth-protected MCP connectors

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
+import type { Env } from '../../../index';
+import { connectRoutes } from '../../../connect/routes';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { manageOperations } from '../../../tools/admin/manage_operations';
+import { __resetPublicOriginCachesForTests } from '../../../utils/public-origin';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { seedOwnerContext } from '../../setup/test-fixtures';
+
+const TEST_ENV = {} as Env;
+const upstreamUrl = 'https://mcp.example.com/rpc';
+const resourceMetadataUrl =
+  'https://mcp.example.com/.well-known/oauth-protected-resource/rpc';
+const authorizationServer = 'https://auth.example.com/tenant';
+const authorizationMetadataUrl =
+  'https://auth.example.com/.well-known/oauth-authorization-server/tenant';
+const registrationUrl = 'https://auth.example.com/register';
+const originalFetch = globalThis.fetch;
+const originalPublicGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('OAuth-protected MCP connector installation', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalPublicGatewayUrl === undefined) {
+      delete process.env.PUBLIC_GATEWAY_URL;
+    } else {
+      process.env.PUBLIC_GATEWAY_URL = originalPublicGatewayUrl;
+    }
+    __resetPublicOriginCachesForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('discovers OAuth, registers one app client, and returns a user consent URL', async () => {
+    let registrationCount = 0;
+    let registrationBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href === upstreamUrl) {
+        const headers = new Headers(init?.headers);
+        if (headers.get('authorization') === 'Bearer mcp-access-token') {
+          const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          if (body.method === 'initialize') {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: 0,
+                result: {
+                  protocolVersion: MCP_PROTOCOL_VERSION,
+                  capabilities: { tools: {} },
+                  serverInfo: { name: 'Example MCP', version: '1.0.0' },
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Mcp-Session-Id': 'authenticated-session',
+                },
+              }
+            );
+          }
+          if (body.method === 'tools/list') {
+            return jsonResponse({
+              jsonrpc: '2.0',
+              id: 1,
+              result: {
+                tools: [
+                  {
+                    name: 'get_issue',
+                    description: 'Get an issue',
+                    inputSchema: { type: 'object', properties: {} },
+                    annotations: { readOnlyHint: true },
+                  },
+                  {
+                    name: 'create_issue',
+                    description: 'Create an issue',
+                    inputSchema: { type: 'object', properties: {} },
+                    annotations: { readOnlyHint: false, destructiveHint: true },
+                  },
+                ],
+              },
+            });
+          }
+          return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
+        }
+        return new Response(JSON.stringify({ error: 'invalid_token' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+      if (href === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: upstreamUrl,
+          authorization_servers: [authorizationServer],
+          scopes_supported: ['read:issues', 'write:issues', 'offline_access'],
+        });
+      }
+      if (href === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer: authorizationServer,
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+          registration_endpoint: registrationUrl,
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      if (href === registrationUrl) {
+        registrationCount += 1;
+        registrationBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return jsonResponse({
+          client_id: 'registered-mcp-client',
+          token_endpoint_auth_method: 'none',
+        });
+      }
+      if (href === 'https://auth.example.com/token') {
+        return jsonResponse({
+          access_token: 'mcp-access-token',
+          refresh_token: 'mcp-refresh-token',
+          expires_in: 3600,
+          scope: 'read:issues write:issues offline_access',
+          token_type: 'Bearer',
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    }) as typeof fetch;
+
+    const { org, ctx } = await seedOwnerContext({
+      orgName: 'MCP OAuth Org',
+      userName: 'MCP OAuth Owner',
+    });
+    process.env.PUBLIC_GATEWAY_URL = 'https://gateway.test';
+    __resetPublicOriginCachesForTests();
+    ctx.baseUrl = 'https://gateway.test';
+
+    const installed = await manageConnections(
+      { action: 'install_connector', mcp_url: upstreamUrl },
+      TEST_ENV,
+      ctx
+    );
+    expect(installed).toMatchObject({
+      action: 'install_connector',
+      installed: true,
+      connector_key: 'mcp.mcp-example-com',
+    });
+    expect(registrationCount).toBe(1);
+    expect(registrationBody).toMatchObject({
+      redirect_uris: ['https://gateway.test/connect/oauth/callback'],
+      token_endpoint_auth_method: 'none',
+      scope: 'read:issues write:issues offline_access',
+    });
+
+    // Reinstalling refreshes metadata but reuses the durable org-level client.
+    const reinstalled = await manageConnections(
+      { action: 'install_connector', mcp_url: upstreamUrl },
+      TEST_ENV,
+      ctx
+    );
+    expect(reinstalled).toMatchObject({
+      action: 'install_connector',
+      installed: true,
+      connector_key: 'mcp.mcp-example-com',
+      updated: true,
+    });
+    expect(registrationCount).toBe(1);
+
+    const sql = getTestDb();
+    const [definition] = (await sql`
+      SELECT auth_schema, mcp_config
+      FROM connector_definitions
+      WHERE organization_id = ${org.id}
+        AND key = 'mcp.mcp-example-com'
+        AND status = 'active'
+    `) as Array<{
+      auth_schema: { methods: Array<Record<string, unknown>> };
+      mcp_config: Record<string, unknown>;
+    }>;
+    expect(definition.mcp_config).toEqual({
+      upstream_url: upstreamUrl,
+      tool_prefix: 'mcp_example_com',
+    });
+    expect(definition.auth_schema.methods[0]).toMatchObject({
+      type: 'oauth',
+      provider: 'mcp.mcp-example-com',
+      requiredScopes: ['read:issues', 'write:issues', 'offline_access'],
+      tokenEndpointAuthMethod: 'none',
+      usePkce: true,
+      resource: upstreamUrl,
+    });
+
+    const appProfiles = (await sql`
+      SELECT id, provider, status, auth_data
+      FROM auth_profiles
+      WHERE organization_id = ${org.id}
+        AND connector_key = 'mcp.mcp-example-com'
+        AND profile_kind = 'oauth_app'
+    `) as Array<{
+      id: number;
+      provider: string;
+      status: string;
+      auth_data: Record<string, unknown>;
+    }>;
+    expect(appProfiles).toHaveLength(1);
+    expect(appProfiles[0]).toMatchObject({
+      provider: 'mcp.mcp-example-com',
+      status: 'active',
+      auth_data: { MCP_CLIENT_ID: 'registered-mcp-client' },
+    });
+
+    const connected = await manageConnections(
+      { action: 'connect', connector_key: 'mcp.mcp-example-com' },
+      TEST_ENV,
+      ctx
+    );
+    expect(connected).toMatchObject({
+      action: 'connect',
+      status: 'pending_auth',
+      auth_type: 'oauth',
+      connect_url: expect.stringMatching(
+        /^https:\/\/gateway\.test\/connect\/[A-Za-z0-9_-]+\/oauth\/start$/
+      ),
+    });
+
+    const connectionId = 'connection_id' in connected ? Number(connected.connection_id) : 0;
+    expect(connectionId).toBeGreaterThan(0);
+    const [connection] = (await sql`
+      SELECT app_auth_profile_id
+      FROM connections
+      WHERE id = ${connectionId}
+        AND organization_id = ${org.id}
+    `) as Array<{ app_auth_profile_id: number }>;
+    expect(Number(connection.app_auth_profile_id)).toBe(Number(appProfiles[0].id));
+
+    const [connectToken] = (await sql`
+      SELECT auth_config
+      FROM connect_tokens
+      WHERE connection_id = ${connectionId}
+        AND organization_id = ${org.id}
+        AND status = 'pending'
+    `) as Array<{ auth_config: Record<string, unknown> }>;
+    expect(connectToken.auth_config).toMatchObject({
+      provider: 'mcp.mcp-example-com',
+      scopes: ['read:issues', 'write:issues', 'offline_access'],
+      tokenEndpointAuthMethod: 'none',
+      usePkce: true,
+      resource: upstreamUrl,
+    });
+
+    const startResponse = await connectRoutes.request(
+      `/${String(connected.connect_token)}/oauth/start`
+    );
+    expect(startResponse.status).toBe(302);
+    const authorizeUrl = new URL(startResponse.headers.get('location')!);
+    expect(authorizeUrl.origin + authorizeUrl.pathname).toBe(
+      'https://auth.example.com/authorize'
+    );
+    expect(authorizeUrl.searchParams.get('client_id')).toBe('registered-mcp-client');
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
+      'https://gateway.test/connect/oauth/callback'
+    );
+    expect(authorizeUrl.searchParams.get('scope')).toBe(
+      'read:issues write:issues offline_access'
+    );
+    expect(authorizeUrl.searchParams.get('resource')).toBe(upstreamUrl);
+    expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256');
+
+    const callbackResponse = await connectRoutes.request(
+      `/oauth/callback?state=${encodeURIComponent(String(connected.connect_token))}&code=approved-code`
+    );
+    expect(callbackResponse.status).toBe(302);
+
+    const [activeConnection] = (await sql`
+      SELECT status, auth_profile_id
+      FROM connections
+      WHERE id = ${connectionId}
+        AND organization_id = ${org.id}
+    `) as Array<{ status: string; auth_profile_id: number | null }>;
+    expect(activeConnection.status).toBe('active');
+    expect(activeConnection.auth_profile_id).not.toBeNull();
+
+    const available = (await manageOperations(
+      { action: 'list_available', connection_id: connectionId },
+      TEST_ENV,
+      ctx
+    )) as {
+      operations: Array<Record<string, unknown>>;
+    };
+    expect(available.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation_key: 'get_issue',
+          kind: 'read',
+          backend: 'mcp_tool',
+          requires_approval: false,
+          readiness: 'ready',
+        }),
+        expect.objectContaining({
+          operation_key: 'create_issue',
+          kind: 'write',
+          backend: 'mcp_tool',
+          requires_approval: true,
+          readiness: 'ready',
+        }),
+      ])
+    );
+  });
+});

--- a/packages/server/src/auth/credentials.ts
+++ b/packages/server/src/auth/credentials.ts
@@ -52,6 +52,7 @@ export class CredentialService {
       clientId: string;
       clientSecret?: string;
       authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+      resource?: string;
     }
   ): Promise<CredentialTokens | null> {
     const result = await this.sql`
@@ -100,6 +101,7 @@ export class CredentialService {
     clientSecret?: string;
     refreshToken: string;
     authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+    resource?: string;
     accountId: string;
   }): Promise<{ accessToken: string; expiresAt: Date; refreshToken?: string } | null> {
     return this.refreshAccountUnderLock(config.accountId, {
@@ -107,6 +109,7 @@ export class CredentialService {
       clientId: config.clientId,
       clientSecret: config.clientSecret,
       authMethod: config.authMethod,
+      resource: config.resource,
     });
   }
 
@@ -125,6 +128,7 @@ export class CredentialService {
       clientId: string;
       clientSecret?: string;
       authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+      resource?: string;
     }
   ): Promise<{ accessToken: string; expiresAt: Date; refreshToken?: string } | null> {
     return this.sql.begin(async (tx) => {
@@ -192,6 +196,7 @@ export class CredentialService {
     clientSecret?: string;
     refreshToken: string;
     authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+    resource?: string;
   }): Promise<{ accessToken: string; expiresAt: Date; refreshToken?: string } | null> {
     const { headers, body } = buildRefreshRequest({
       profile: 'account-credential',
@@ -199,6 +204,7 @@ export class CredentialService {
       clientSecret: params.clientSecret,
       refreshToken: params.refreshToken,
       authMethod: params.authMethod,
+      resource: params.resource,
     });
 
     try {

--- a/packages/server/src/auth/oauth/token-refresh.ts
+++ b/packages/server/src/auth/oauth/token-refresh.ts
@@ -101,6 +101,9 @@ export function buildRefreshRequest(options: RefreshRequestOptions): RefreshHttp
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
   });
+  if (resource) {
+    body.set('resource', resource);
+  }
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
   };

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -4,7 +4,10 @@ import { getErrorMessage } from "@lobu/core";
 import { getLoginProviderScopes } from "../auth/config";
 import { type DbClient, type DbQuery, getDb } from "../db/client";
 import { getLocalActionKind } from "../operations/connector-operations";
-import { probeMcpServer } from "../mcp-proxy/client";
+import {
+	probeMcpServer,
+	selectMcpOAuthClientAuthMethod,
+} from "../mcp-proxy/client";
 import { computeCodeHash } from "../utils/compiler-core";
 import {
 	getCatalogConnectorInstallability,
@@ -251,13 +254,39 @@ export async function installConnectorFromMcpUrl(params: {
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "_")
 		.replace(/^_+|_+$/g, "");
+	const authSchema = probed.oauth
+		? {
+				methods: [
+					{
+						type: "oauth",
+						provider: connectorKey,
+						required: true,
+						requiredScopes: probed.oauth.scopesSupported,
+						authorizationUrl: probed.oauth.authorizationUrl,
+						tokenUrl: probed.oauth.tokenUrl,
+						tokenEndpointAuthMethod:
+							selectMcpOAuthClientAuthMethod(probed.oauth),
+						usePkce:
+							probed.oauth.codeChallengeMethodsSupported.includes("S256"),
+						clientIdKey: "MCP_CLIENT_ID",
+						clientSecretKey: "MCP_CLIENT_SECRET",
+						resource: probed.oauth.resource,
+						description:
+							"Authorize Lobu to use this remote MCP server on your behalf.",
+						setupInstructions: probed.oauth.registrationUrl
+							? "Lobu registers the OAuth client automatically; connect an account to continue."
+							: "Configure an OAuth client for this MCP server, then connect an account.",
+					},
+				],
+			}
+		: null;
 
 	const metadata = {
 		key: connectorKey,
 		name: serverName,
 		description: probed.instructions,
 		version: probed.serverInfo.version || "0.0.0",
-		authSchema: null,
+		authSchema,
 		webhook: null,
 		feeds: null,
 		actions: null,
@@ -318,8 +347,9 @@ export async function installConnectorFromMcpUrl(params: {
 			.digest("hex")
 			.slice(0, 16),
 		updated,
-		authSchema: null,
+		authSchema,
 		mcpConfig: metadata.mcpConfig,
+		...(probed.oauth ? { mcpOAuth: probed.oauth } : {}),
 	};
 }
 

--- a/packages/server/src/connect/__tests__/oauth-resource-indicator.test.ts
+++ b/packages/server/src/connect/__tests__/oauth-resource-indicator.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildRefreshRequest } from '../../auth/oauth/token-refresh';
+import { buildAuthorizationUrl, exchangeCodeForTokens } from '../oauth-providers';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('OAuth resource indicators', () => {
+  it('includes the MCP resource in authorization and code exchange requests', async () => {
+    const resource = 'https://mcp.example.com/rpc';
+    const authorizationUrl = buildAuthorizationUrl({
+      provider: 'mcp.example',
+      clientId: 'client-id',
+      redirectUri: 'https://lobu.example.com/connect/oauth/callback',
+      scopes: ['read:issues', 'write:issues'],
+      state: 'state-token',
+      authorizationUrl: 'https://auth.example.com/authorize',
+      codeChallenge: 'pkce-challenge',
+      resource,
+    });
+    expect(authorizationUrl).not.toBeNull();
+    const authorize = new URL(authorizationUrl!);
+    expect(authorize.searchParams.get('resource')).toBe(resource);
+    expect(authorize.searchParams.get('code_challenge')).toBe('pkce-challenge');
+
+    let tokenBody = '';
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      tokenBody = String(init?.body);
+      return new Response(
+        JSON.stringify({
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }) as typeof fetch;
+
+    await expect(
+      exchangeCodeForTokens({
+        provider: 'mcp.example',
+        code: 'authorization-code',
+        clientId: 'client-id',
+        redirectUri: 'https://lobu.example.com/connect/oauth/callback',
+        tokenUrl: 'https://auth.example.com/token',
+        tokenEndpointAuthMethod: 'none',
+        codeVerifier: 'pkce-verifier',
+        resource,
+      })
+    ).resolves.toMatchObject({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    expect(new URLSearchParams(tokenBody).get('resource')).toBe(resource);
+    expect(new URLSearchParams(tokenBody).get('code_verifier')).toBe('pkce-verifier');
+  });
+
+  it('keeps the MCP resource on account-token refresh', () => {
+    const resource = 'https://mcp.example.com/rpc';
+    const request = buildRefreshRequest({
+      profile: 'account-credential',
+      clientId: 'client-id',
+      refreshToken: 'refresh-token',
+      authMethod: 'none',
+      resource,
+    });
+    expect(new URLSearchParams(request.body).get('resource')).toBe(resource);
+  });
+});

--- a/packages/server/src/connect/oauth-providers.ts
+++ b/packages/server/src/connect/oauth-providers.ts
@@ -114,6 +114,7 @@ export function buildAuthorizationUrl(params: {
   authorizationUrl?: string;
   authParams?: Record<string, string>;
   codeChallenge?: string;
+  resource?: string;
 }): string | null {
   const config = resolveProviderConfig({
     provider: params.provider,
@@ -129,6 +130,9 @@ export function buildAuthorizationUrl(params: {
   url.searchParams.set('state', params.state);
 
   url.searchParams.set('scope', params.scopes.join(' '));
+  if (params.resource) {
+    url.searchParams.set('resource', params.resource);
+  }
 
   // Add provider-specific or connector-specific extra params
   if (config.authParams) {
@@ -165,6 +169,7 @@ export async function exchangeCodeForTokens(params: {
   tokenUrl?: string;
   tokenEndpointAuthMethod?: OAuthTokenEndpointAuthMethod;
   codeVerifier?: string;
+  resource?: string;
 }): Promise<OAuthTokens | null> {
   const config = resolveProviderConfig({
     provider: params.provider,
@@ -183,6 +188,9 @@ export async function exchangeCodeForTokens(params: {
 
   if (params.codeVerifier) {
     bodyParams.code_verifier = params.codeVerifier;
+  }
+  if (params.resource) {
+    bodyParams.resource = params.resource;
   }
 
   if (authMethod === 'client_secret_post') {

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -71,6 +71,7 @@ interface OAuthAuthConfig {
   pkceCodeVerifier?: string;
   redirectUri?: string;
   requestedScopes?: string[];
+  resource?: string;
 }
 
 type ConnectTokenEnv = { Bindings: Env; Variables: { tokenRow: ConnectTokenRow } };
@@ -626,6 +627,7 @@ connectRoutes.get('/:token/oauth/start', requireConnectToken, async (c) => {
     authorizationUrl: authConfig.authorizationUrl,
     authParams: authConfig.authParams,
     codeChallenge: pkceCodeVerifier ? buildPkceChallenge(pkceCodeVerifier) : undefined,
+    resource: authConfig.resource,
   });
 
   if (!authUrl) {
@@ -720,6 +722,7 @@ async function handleOAuthCallback(
     tokenUrl: authConfig.tokenUrl,
     tokenEndpointAuthMethod: authConfig.tokenEndpointAuthMethod,
     codeVerifier: authConfig.pkceCodeVerifier,
+    resource: authConfig.resource,
   });
 
   if (!tokens) {

--- a/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
@@ -6,7 +6,12 @@ vi.mock('../credential-resolver', () => ({
   resolveCredentialsByConnectionId: vi.fn(async () => null),
 }));
 
-import { callTool, discoverTools, probeMcpServer } from '../client';
+import {
+  callTool,
+  discoverTools,
+  probeMcpServer,
+  registerMcpOAuthClient,
+} from '../client';
 
 const jsonResponse = (body: unknown, sessionId?: string) =>
   new Response(JSON.stringify(body), {
@@ -24,6 +29,66 @@ afterEach(() => {
 });
 
 describe('probeMcpServer capability discovery', () => {
+  it('discovers OAuth metadata when initialize returns a protected-resource challenge', async () => {
+    const upstreamUrl = 'https://mcp.example.com/rpc';
+    const resourceMetadataUrl =
+      'https://mcp.example.com/.well-known/oauth-protected-resource/rpc';
+    const authorizationServer = 'https://auth.example.com/tenant';
+    const authorizationMetadataUrl =
+      'https://auth.example.com/.well-known/oauth-authorization-server/tenant';
+
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href === upstreamUrl) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_token' }),
+          {
+            status: 401,
+            headers: {
+              'Content-Type': 'application/json',
+              'WWW-Authenticate': `Bearer resource_metadata="${resourceMetadataUrl}", error="invalid_token"`,
+            },
+          }
+        );
+      }
+      if (href === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: upstreamUrl,
+          authorization_servers: [authorizationServer],
+          scopes_supported: ['read:issues', 'write:issues', 'offline_access'],
+        });
+      }
+      if (href === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer: authorizationServer,
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+          registration_endpoint: 'https://auth.example.com/register',
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    }) as typeof fetch;
+
+    const result = await probeMcpServer(upstreamUrl);
+    expect(result).toMatchObject({
+      serverInfo: { name: 'mcp.example.com', version: '0.0.0' },
+      tools: [],
+      oauth: {
+        resource: upstreamUrl,
+        resourceMetadataUrl,
+        authorizationServer,
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        registrationUrl: 'https://auth.example.com/register',
+        scopesSupported: ['read:issues', 'write:issues', 'offline_access'],
+        tokenEndpointAuthMethodsSupported: ['none'],
+        codeChallengeMethodsSupported: ['S256'],
+      },
+    });
+  });
+
   it('accepts a truly toolless server without calling tools/list', async () => {
     const requests: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
     globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -106,6 +171,63 @@ describe('probeMcpServer capability discovery', () => {
     await expect(probeMcpServer('https://mcp.example.com/rpc')).rejects.toThrow(
       /MCP tools\/list response omitted tools/
     );
+  });
+});
+
+describe('MCP OAuth dynamic client registration', () => {
+  const metadata = {
+    resource: 'https://mcp.example.com/rpc',
+    resourceMetadataUrl: 'https://mcp.example.com/.well-known/oauth-protected-resource/rpc',
+    authorizationServer: 'https://auth.example.com/tenant',
+    authorizationUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    registrationUrl: 'https://auth.example.com/register',
+    scopesSupported: ['read:issues', 'write:issues', 'offline_access'],
+    tokenEndpointAuthMethodsSupported: ['none'],
+    codeChallengeMethodsSupported: ['S256'],
+  };
+
+  it('registers a public PKCE client with the Lobu callback', async () => {
+    let registrationBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      registrationBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return jsonResponse({
+        client_id: 'registered-client',
+        token_endpoint_auth_method: 'none',
+      });
+    }) as typeof fetch;
+
+    await expect(
+      registerMcpOAuthClient({
+        metadata,
+        redirectUris: ['http://127.0.0.1:8787/connect/oauth/callback'],
+        clientName: 'Lobu',
+      })
+    ).resolves.toEqual({
+      clientId: 'registered-client',
+      tokenEndpointAuthMethod: 'none',
+    });
+    expect(registrationBody).toEqual({
+      client_name: 'Lobu',
+      redirect_uris: ['http://127.0.0.1:8787/connect/oauth/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: 'read:issues write:issues offline_access',
+    });
+  });
+
+  it('rejects a non-HTTPS callback that is not loopback before registration', async () => {
+    globalThis.fetch = vi.fn();
+
+    await expect(
+      registerMcpOAuthClient({
+        metadata,
+        redirectUris: ['http://lobu.example.com/connect/oauth/callback'],
+        clientName: 'Lobu',
+      })
+    ).rejects.toThrow(/HTTPS or HTTP on a loopback host/);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -16,7 +16,13 @@ import {
   resolveCredentials,
   resolveCredentialsByConnectionId,
 } from './credential-resolver';
-import type { DiscoveredTool, JsonRpcResponse, McpProxyConfig } from './types';
+import type {
+  DiscoveredTool,
+  JsonRpcResponse,
+  McpOAuthClientRegistration,
+  McpOAuthMetadata,
+  McpProxyConfig,
+} from './types';
 
 const FETCH_TIMEOUT_INIT_MS = 10_000;
 const FETCH_TIMEOUT_TOOL_MS = 30_000;
@@ -44,6 +50,13 @@ const sessions = new TtlCache<McpSessionState>(SESSION_TTL_MS);
  * double-execute an action — unlike a timeout or a 5xx, which stay fatal.
  */
 class McpSessionExpiredError extends Error {}
+
+class McpOAuthRequiredError extends Error {
+  constructor(readonly metadata: McpOAuthMetadata) {
+    super('MCP server requires OAuth authorization');
+    this.name = 'McpOAuthRequiredError';
+  }
+}
 
 function sessionKey(orgId: string, connectorKey: string, connectionId?: number): string {
   return connectionId === undefined
@@ -433,6 +446,239 @@ export function assertSafeUrl(url: string): void {
   }
 }
 
+function normalizeUrlForComparison(value: string): string {
+  const url = new URL(value);
+  url.hash = '';
+  return url.toString();
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function readResourceMetadataUrl(header: string | null): string | null {
+  if (!header) return null;
+  const match = /(?:^|[,\s])resource_metadata\s*=\s*"([^"]+)"/i.exec(header);
+  return match?.[1] ?? null;
+}
+
+function authorizationMetadataUrls(authorizationServer: string): string[] {
+  const issuer = new URL(authorizationServer);
+  const issuerPath = issuer.pathname.replace(/\/+$/, '');
+  const candidates = [
+    `${issuer.origin}/.well-known/oauth-authorization-server${issuerPath}`,
+    `${issuer.origin}/.well-known/openid-configuration${issuerPath}`,
+    `${authorizationServer.replace(/\/+$/, '')}/.well-known/oauth-authorization-server`,
+    `${authorizationServer.replace(/\/+$/, '')}/.well-known/openid-configuration`,
+  ];
+  return candidates.filter((value, index) => candidates.indexOf(value) === index);
+}
+
+function assertSafeOAuthEndpoint(url: string): void {
+  assertSafeUrl(url);
+  if (new URL(url).protocol !== 'https:') {
+    throw new Error('MCP OAuth metadata and authorization endpoints must use HTTPS');
+  }
+}
+
+async function fetchJsonObject(url: string): Promise<Record<string, unknown> | null> {
+  assertSafeOAuthEndpoint(url);
+  const response = await fetchWithTimeout(
+    url,
+    { headers: { Accept: 'application/json' } },
+    FETCH_TIMEOUT_INIT_MS
+  );
+  if (!response.ok) return null;
+  const value = (await response.json()) as unknown;
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+async function discoverMcpOAuthMetadata(
+  upstreamUrl: string,
+  authenticateHeader: string | null
+): Promise<McpOAuthMetadata | null> {
+  const resourceMetadataUrl = readResourceMetadataUrl(authenticateHeader);
+  if (!resourceMetadataUrl) return null;
+
+  const resourceMetadata = await fetchJsonObject(resourceMetadataUrl);
+  if (!resourceMetadata) {
+    throw new Error(`MCP OAuth resource metadata was unavailable: ${resourceMetadataUrl}`);
+  }
+
+  const resource =
+    typeof resourceMetadata.resource === 'string' ? resourceMetadata.resource : null;
+  if (!resource) throw new Error('MCP OAuth resource metadata omitted resource');
+  if (normalizeUrlForComparison(resource) !== normalizeUrlForComparison(upstreamUrl)) {
+    throw new Error('MCP OAuth resource metadata does not match the requested server URL');
+  }
+
+  const authorizationServers = readStringArray(resourceMetadata.authorization_servers);
+  if (authorizationServers.length === 0) {
+    throw new Error('MCP OAuth resource metadata omitted authorization_servers');
+  }
+
+  const authorizationServer = authorizationServers[0];
+  assertSafeOAuthEndpoint(authorizationServer);
+  let authorizationMetadata: Record<string, unknown> | null = null;
+  for (const metadataUrl of authorizationMetadataUrls(authorizationServer)) {
+    const candidate = await fetchJsonObject(metadataUrl);
+    if (!candidate) continue;
+    const issuer = typeof candidate.issuer === 'string' ? candidate.issuer : null;
+    if (
+      issuer &&
+      normalizeUrlForComparison(issuer) !== normalizeUrlForComparison(authorizationServer)
+    ) {
+      continue;
+    }
+    authorizationMetadata = candidate;
+    break;
+  }
+  if (!authorizationMetadata) {
+    throw new Error(`MCP OAuth authorization metadata was unavailable: ${authorizationServer}`);
+  }
+
+  const authorizationUrl =
+    typeof authorizationMetadata.authorization_endpoint === 'string'
+      ? authorizationMetadata.authorization_endpoint
+      : null;
+  const tokenUrl =
+    typeof authorizationMetadata.token_endpoint === 'string'
+      ? authorizationMetadata.token_endpoint
+      : null;
+  if (!authorizationUrl || !tokenUrl) {
+    throw new Error('MCP OAuth authorization metadata omitted required endpoints');
+  }
+  assertSafeOAuthEndpoint(authorizationUrl);
+  assertSafeOAuthEndpoint(tokenUrl);
+
+  const registrationUrl =
+    typeof authorizationMetadata.registration_endpoint === 'string'
+      ? authorizationMetadata.registration_endpoint
+      : undefined;
+  if (registrationUrl) assertSafeOAuthEndpoint(registrationUrl);
+
+  return {
+    resource,
+    resourceMetadataUrl,
+    ...(typeof resourceMetadata.resource_documentation === 'string'
+      ? { resourceDocumentation: resourceMetadata.resource_documentation }
+      : {}),
+    authorizationServer,
+    authorizationUrl,
+    tokenUrl,
+    ...(registrationUrl ? { registrationUrl } : {}),
+    scopesSupported: readStringArray(resourceMetadata.scopes_supported),
+    tokenEndpointAuthMethodsSupported: readStringArray(
+      authorizationMetadata.token_endpoint_auth_methods_supported
+    ),
+    codeChallengeMethodsSupported: readStringArray(
+      authorizationMetadata.code_challenge_methods_supported
+    ),
+  };
+}
+
+export function selectMcpOAuthClientAuthMethod(
+  metadata: McpOAuthMetadata
+): McpOAuthClientRegistration['tokenEndpointAuthMethod'] {
+  const methods = metadata.tokenEndpointAuthMethodsSupported;
+  if (methods.includes('none') && metadata.codeChallengeMethodsSupported.includes('S256')) {
+    return 'none';
+  }
+  if (methods.includes('client_secret_basic')) return 'client_secret_basic';
+  if (methods.includes('client_secret_post')) return 'client_secret_post';
+  // RFC 8414 defaults an omitted token_endpoint_auth_methods_supported to
+  // client_secret_basic.
+  if (methods.length === 0) return 'client_secret_basic';
+  throw new Error('MCP OAuth server has no supported dynamic-client authentication method');
+}
+
+function assertSafeOAuthRedirectUri(value: string): void {
+  let redirectUri: URL;
+  try {
+    redirectUri = new URL(value);
+  } catch {
+    throw new Error(`Invalid OAuth callback URL: ${value}`);
+  }
+
+  if (redirectUri.protocol === 'https:') return;
+
+  const hostname = stripIpv6Brackets(redirectUri.hostname.toLowerCase());
+  const isLoopback =
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname === '::1' ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname);
+  if (redirectUri.protocol !== 'http:' || !isLoopback) {
+    throw new Error('OAuth callback URL must use HTTPS or HTTP on a loopback host');
+  }
+}
+
+export async function registerMcpOAuthClient(params: {
+  metadata: McpOAuthMetadata;
+  redirectUris: string[];
+  clientName: string;
+}): Promise<McpOAuthClientRegistration | null> {
+  const registrationUrl = params.metadata.registrationUrl;
+  if (!registrationUrl) return null;
+  const redirectUris = params.redirectUris.filter(
+    (value, index, values) => value.length > 0 && values.indexOf(value) === index
+  );
+  if (redirectUris.length === 0) {
+    throw new Error('MCP OAuth dynamic registration requires a callback URL');
+  }
+  for (const redirectUri of redirectUris) assertSafeOAuthRedirectUri(redirectUri);
+
+  const requestedMethod = selectMcpOAuthClientAuthMethod(params.metadata);
+  const response = await fetchWithTimeout(
+    registrationUrl,
+    {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_name: params.clientName,
+        redirect_uris: redirectUris,
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: requestedMethod,
+        ...(params.metadata.scopesSupported.length > 0
+          ? { scope: params.metadata.scopesSupported.join(' ') }
+          : {}),
+      }),
+    },
+    FETCH_TIMEOUT_INIT_MS
+  );
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`MCP OAuth dynamic registration returned ${response.status}: ${text}`);
+  }
+
+  const body = (await response.json()) as Record<string, unknown>;
+  const clientId = typeof body.client_id === 'string' ? body.client_id : null;
+  if (!clientId) throw new Error('MCP OAuth dynamic registration omitted client_id');
+  const returnedMethod =
+    body.token_endpoint_auth_method === 'none' ||
+    body.token_endpoint_auth_method === 'client_secret_post' ||
+    body.token_endpoint_auth_method === 'client_secret_basic'
+      ? body.token_endpoint_auth_method
+      : requestedMethod;
+  const clientSecret = typeof body.client_secret === 'string' ? body.client_secret : undefined;
+  if (returnedMethod !== requestedMethod) {
+    throw new Error('MCP OAuth dynamic registration changed the requested client auth method');
+  }
+  if (returnedMethod !== 'none' && !clientSecret) {
+    throw new Error('MCP OAuth confidential client registration omitted client_secret');
+  }
+
+  return {
+    clientId,
+    ...(clientSecret ? { clientSecret } : {}),
+    tokenEndpointAuthMethod: returnedMethod,
+  };
+}
+
 /**
  * Probe a remote MCP server to extract server info and available tools.
  * Uses a temporary session (no stored session or credentials).
@@ -441,6 +687,7 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
   serverInfo: { name: string; version: string };
   instructions?: string;
   tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>;
+  oauth?: McpOAuthMetadata;
 }> {
   assertSafeUrl(upstreamUrl);
   let mcpSessionId: string | null = null;
@@ -466,6 +713,13 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
     if (newSessionId) mcpSessionId = newSessionId;
 
     if (!response.ok) {
+      if (response.status === 401) {
+        const metadata = await discoverMcpOAuthMetadata(
+          upstreamUrl,
+          response.headers.get('WWW-Authenticate')
+        );
+        if (metadata) throw new McpOAuthRequiredError(metadata);
+      }
       const text = await response.text();
       throw new Error(`MCP server returned ${response.status}: ${text}`);
     }
@@ -474,16 +728,29 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
   };
 
   // Initialize
-  const initResponse = await send({
-    jsonrpc: '2.0',
-    method: 'initialize',
-    params: {
-      protocolVersion: MCP_PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: { name: 'lobu-mcp-proxy', version: '1.0.0' },
-    },
-    id: 0,
-  });
+  let initResponse: JsonRpcResponse;
+  try {
+    initResponse = await send({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'lobu-mcp-proxy', version: '1.0.0' },
+      },
+      id: 0,
+    });
+  } catch (error) {
+    if (!(error instanceof McpOAuthRequiredError)) throw error;
+    return {
+      serverInfo: { name: new URL(upstreamUrl).hostname, version: '0.0.0' },
+      ...(error.metadata.resourceDocumentation
+        ? { instructions: `OAuth-protected remote MCP server. ${error.metadata.resourceDocumentation}` }
+        : { instructions: 'OAuth-protected remote MCP server.' }),
+      tools: [],
+      oauth: error.metadata,
+    };
+  }
 
   if (initResponse.error) {
     throw new Error(`MCP initialize failed: ${initResponse.error.message}`);

--- a/packages/server/src/mcp-proxy/credential-resolver.ts
+++ b/packages/server/src/mcp-proxy/credential-resolver.ts
@@ -118,6 +118,7 @@ async function resolveCredentialsForConnection(
         clientId: string;
         clientSecret?: string;
         authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+        resource?: string;
       }
     | undefined;
 
@@ -147,6 +148,7 @@ async function resolveCredentialsForConnection(
           clientId,
           clientSecret,
           authMethod: oauthMethod.tokenEndpointAuthMethod,
+          resource: oauthMethod.resource,
         };
       }
     }
@@ -180,7 +182,7 @@ async function getOAuthMethodForConnector(
 ): Promise<ConnectorAuthOAuthMethod | null> {
   const sql = getDb();
   const rows = await sql`
-    SELECT auth_schema
+    SELECT auth_schema, mcp_config
     FROM connector_definitions
     WHERE key = ${connectorKey}
       AND status = 'active'
@@ -190,7 +192,19 @@ async function getOAuthMethodForConnector(
 
   if (rows.length === 0 || !rows[0].auth_schema) return null;
 
-  const authSchema = normalizeConnectorAuthSchema(rows[0].auth_schema);
+  const row = rows[0] as { auth_schema: unknown; mcp_config: unknown };
+  const authSchema = normalizeConnectorAuthSchema(row.auth_schema);
   const oauthMethods = getOAuthAuthMethods(authSchema);
-  return oauthMethods.length > 0 ? oauthMethods[0] : null;
+  const oauthMethod = oauthMethods[0];
+  if (!oauthMethod) return null;
+  const mcpConfig =
+    row.mcp_config && typeof row.mcp_config === 'object'
+      ? (row.mcp_config as Record<string, unknown>)
+      : null;
+  return {
+    ...oauthMethod,
+    ...(typeof mcpConfig?.upstream_url === 'string'
+      ? { resource: mcpConfig.upstream_url }
+      : {}),
+  };
 }

--- a/packages/server/src/mcp-proxy/types.ts
+++ b/packages/server/src/mcp-proxy/types.ts
@@ -13,6 +13,27 @@ export interface McpProxyConfig {
   tool_prefix: string;
 }
 
+/** OAuth metadata discovered from an RFC 9728 protected-resource challenge. */
+export interface McpOAuthMetadata {
+  resource: string;
+  resourceMetadataUrl: string;
+  resourceDocumentation?: string;
+  authorizationServer: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  registrationUrl?: string;
+  scopesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+  codeChallengeMethodsSupported: string[];
+}
+
+/** Dynamic client credentials returned by RFC 7591 registration. */
+export interface McpOAuthClientRegistration {
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod: 'none' | 'client_secret_post' | 'client_secret_basic';
+}
+
 /**
  * An MCP tool discovered from an upstream server, with its prefix applied.
  */

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -30,6 +30,8 @@ import { buildConnectionsUrl } from '../../../utils/url-builder';
 import type { ToolContext } from '../../registry';
 import { getOrgUrlContext } from '../../view-urls';
 import { isAdminOrOwnerRole } from '../../access-control';
+import { registerMcpOAuthClient } from '../../../mcp-proxy/client';
+import type { McpOAuthMetadata } from '../../../mcp-proxy/types';
 
 // ============================================
 // Auth Schema Types
@@ -40,6 +42,7 @@ type OAuthAuthMethod = {
   provider: string;
   requiredScopes?: string[];
   optionalScopes?: string[];
+  resource?: string;
   loginScopes?: string[];
   authorizationUrl?: string;
   tokenUrl?: string;
@@ -297,6 +300,7 @@ export function buildOAuthConnectConfig(
       ? { tokenEndpointAuthMethod: method.tokenEndpointAuthMethod }
       : {}),
     ...(typeof method.usePkce === 'boolean' ? { usePkce: method.usePkce } : {}),
+    ...(typeof method.resource === 'string' ? { resource: method.resource } : {}),
   };
 }
 
@@ -846,7 +850,12 @@ export function serializeAuthProfile(authProfile: AuthProfileRow): Record<string
 // ============================================
 
 export async function maybeUpsertAuthAfterInstall(
-  installed: { connectorKey: string; name: string; authSchema: AuthSchema },
+  installed: {
+    connectorKey: string;
+    name: string;
+    authSchema: AuthSchema;
+    mcpOAuth?: McpOAuthMetadata;
+  },
   authValues: Record<string, string> | undefined,
   ctx: ToolContext
 ): Promise<void> {
@@ -861,4 +870,76 @@ export async function maybeUpsertAuthAfterInstall(
       createdBy: ctx.userId ?? 'api',
     });
   }
+
+  const oauthMetadata = installed.mcpOAuth;
+  if (!oauthMetadata?.registrationUrl) return;
+
+  const oauthMethod = getOAuthMethods(installed.authSchema)[0];
+  if (!oauthMethod) {
+    throw new Error('OAuth-protected MCP connector is missing its OAuth auth method');
+  }
+
+  const callbackBase = getConnectBaseUrl(ctx);
+  if (!callbackBase) {
+    throw new Error('A public Lobu callback URL is required to register the MCP OAuth client');
+  }
+  const redirectUri = `${callbackBase}/connect/oauth/callback`;
+  const { clientIdKey, clientSecretKey } = getOAuthCredentialKeys(oauthMethod);
+  const provider = oauthMethod.provider.toLowerCase();
+  const sql = getDb();
+
+  // The connector-definition row is the existing durable install chokepoint.
+  // Lock it while checking/creating the one org-scoped dynamic client so two
+  // replicas cannot both register separate provider clients for one connector.
+  await sql.begin(async (tx) => {
+    const connectorRows = await tx`
+      SELECT id
+      FROM connector_definitions
+      WHERE organization_id = ${ctx.organizationId}
+        AND key = ${installed.connectorKey}
+        AND status = 'active'
+      FOR UPDATE
+    `;
+    if (connectorRows.length === 0) {
+      throw new Error(`Installed connector '${installed.connectorKey}' was not found`);
+    }
+
+    const existingRows = await tx`
+      SELECT id
+      FROM auth_profiles
+      WHERE organization_id = ${ctx.organizationId}
+        AND connector_key = ${installed.connectorKey}
+        AND profile_kind = 'oauth_app'
+        AND status = 'active'
+        AND lower(provider) = ${provider}
+      LIMIT 1
+    `;
+    if (existingRows.length > 0) return;
+
+    const registration = await registerMcpOAuthClient({
+      metadata: oauthMetadata,
+      redirectUris: [redirectUri],
+      clientName: `Lobu - ${installed.name}`,
+    });
+    if (!registration) return;
+
+    await createAuthProfile(
+      {
+        organizationId: ctx.organizationId,
+        connectorKey: installed.connectorKey,
+        displayName: `${installed.name} OAuth App`,
+        slug: normalizeAuthProfileSlug(`${installed.connectorKey}-${provider}-app`),
+        profileKind: 'oauth_app',
+        authData: {
+          [clientIdKey]: registration.clientId,
+          ...(registration.clientSecret
+            ? { [clientSecretKey]: registration.clientSecret }
+            : {}),
+        },
+        provider,
+        createdBy: ctx.userId ?? 'api',
+      },
+      tx
+    );
+  });
 }

--- a/packages/server/src/utils/connector-auth.ts
+++ b/packages/server/src/utils/connector-auth.ts
@@ -14,6 +14,7 @@ export type ConnectorAuthOAuthMethod = ConnectorAuthOAuth & {
   usePkce?: boolean;
   loginScopes?: string[];
   optionalScopes?: string[];
+  resource?: string;
   loginProvisioning?: {
     autoCreateConnection?: boolean;
   };
@@ -248,4 +249,3 @@ export function isPrimaryAuthMethodAppInstallation(
   const primary = authSchema.methods.find((method) => method.type !== 'none');
   return primary?.type === 'app_installation';
 }
-

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -18,6 +18,7 @@ import {
   validateConnectorMetadata,
 } from './connector-compiler';
 import { isInternalUrl } from '../gateway/proxy/ssrf-guard';
+import type { McpOAuthMetadata } from '../mcp-proxy/types';
 
 type SqlClient = ReturnType<typeof getDb>;
 
@@ -29,6 +30,7 @@ export type ConnectorInstallResult = {
   updated: boolean;
   authSchema: Record<string, unknown> | null;
   mcpConfig?: Record<string, unknown> | null;
+  mcpOAuth?: McpOAuthMetadata;
   openapiConfig?: Record<string, unknown> | null;
 };
 

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -616,12 +616,13 @@ async function resolveExecutionOAuthConfig(
       clientId: string;
       clientSecret?: string;
       authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+      resource?: string;
     }
   | undefined
 > {
   const sql = getDb();
   const rows = await sql`
-    SELECT c.connector_key, cd.auth_schema
+    SELECT c.connector_key, cd.auth_schema, cd.mcp_config
     FROM connections c
     JOIN connector_definitions cd
       ON cd.key = c.connector_key
@@ -634,7 +635,11 @@ async function resolveExecutionOAuthConfig(
 
   if (rows.length === 0) return undefined;
 
-  const row = rows[0] as { connector_key: string; auth_schema: unknown };
+  const row = rows[0] as {
+    connector_key: string;
+    auth_schema: unknown;
+    mcp_config: unknown;
+  };
   const authSchema = normalizeConnectorAuthSchema(row.auth_schema);
   const oauthMethod = getOAuthAuthMethods(authSchema)[0];
   if (!oauthMethod) return undefined;
@@ -651,11 +656,18 @@ async function resolveExecutionOAuthConfig(
 
   const clientSecret = appAuthValues[clientSecretKey];
   const authMethod = oauthMethod.tokenEndpointAuthMethod ?? builtin?.tokenEndpointAuthMethod;
+  const mcpConfig =
+    row.mcp_config && typeof row.mcp_config === 'object'
+      ? (row.mcp_config as Record<string, unknown>)
+      : null;
   return {
     tokenUrl,
     clientId,
     ...(clientSecret ? { clientSecret } : {}),
     ...(authMethod ? { authMethod } : {}),
+    ...(typeof mcpConfig?.upstream_url === 'string'
+      ? { resource: mcpConfig.upstream_url }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Discover RFC 9728 protected-resource challenges when an MCP URL requires OAuth instead of failing the anonymous probe.
- Register one org-level OAuth client through RFC 7591 when the provider supports dynamic registration, then reuse the existing install -> connect -> human consent -> operations flow.
- Carry PKCE and RFC 8707 resource binding through authorization, code exchange, and refresh. Authenticated MCP write tools remain approval-gated by the existing operation policy.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean: all 18 expanded Depot jobs passed; tree `b3e459911a139bf96b9a9481ba9273eb081679a2`.
- [x] Focused tests: `probe-discovery.test.ts` (9), `oauth-resource-indicator.test.ts` (2), `credentials-refresh-lock.test.ts` (3), and `mcp-oauth-install.test.ts` (1 end-to-end integration).
- [x] Bug fix: red -> fix -> green outputs pasted below.
- [ ] If bot behavior: not applicable.

### Red

Command: `SKIP_TEST_DB_SETUP=1 bunx vitest run src/mcp-proxy/__tests__/probe-discovery.test.ts`

Before the fix, the OAuth-protected install case failed while the other six tests passed:

```text
FAIL probeMcpServer capability discovery > discovers OAuth metadata when initialize returns a protected-resource challenge
Error: MCP server returned 401: {"error":"invalid_token"}
Test Files 1 failed (1)
Tests 1 failed | 6 passed (7)
```

### Green

```text
Test Files 3 passed (3)
Tests 14 passed (14)
```

The database-backed integration also passed the complete flow:

```text
Connector installed from MCP URL
Connect token created
Auth profile activated via OAuth connect flow
[McpProxy] Discovered tools from upstream MCP
Test Files 1 passed (1)
Tests 1 passed (1)
```

### Mutation proof

Changed the guarded source branch from `if (response.status === 401)` to `if (false && response.status === 401)` and verified the source mutation at `client.ts:716`. The focused test failed with the original 401 error. Restoring the branch returned 9/9 green.

## Notes
- No new table, database design, SDK method, or public API contract.
- OAuth metadata and authorization endpoints discovered from remote MCP servers must use HTTPS. Dynamic client registration accepts HTTPS callbacks or HTTP loopback callbacks for local development.
- `make review-fix` completed through Claude fable at medium effort and made no edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and connecting to OAuth-protected MCP connectors.
  * Automatically discovers OAuth server capabilities, supported scopes, PKCE, endpoints, and client authentication requirements.
  * Supports dynamic OAuth client registration during connector setup.
  * Preserves OAuth configuration and credentials for future connections.
  * Includes resource indicators throughout authorization, token exchange, and token refresh flows.
* **Security**
  * Validates OAuth endpoints and callback URLs before connecting.
  * Supports read/write approval behavior for authenticated MCP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->