### PR TITLE
chore(example): establish Atlas source of truth

### DIFF
--- a/examples/atlas/lobu.config.ts
+++ b/examples/atlas/lobu.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@lobu/cli/config";
+
+export default defineConfig({
+  // Atlas also contains device- and platform-managed definitions that this
+  // project must preserve. Legacy resources are decommissioned explicitly.
+  prune: false,
+  org: "atlas",
+  agents: [],
+});


### PR DESCRIPTION
## Summary
- add a repository-owned Atlas configuration that deliberately declares no health-triage resources
- keep pruning disabled because Atlas also contains device- and platform-managed definitions

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] `bunx tsc --noEmit --moduleResolution bundler --module preserve --target es2022 --skipLibCheck lobu.config.ts`
- [x] `lobu apply --dry-run --org atlas --force`: 0 create, 0 update, 0 delete, 19 ignored drift
- [ ] Bug fix: not applicable
- [ ] Bot behavior: not applicable

## Notes
- `make review-fix` was attempted before CI but the local reviewer was not authenticated; it made no changes.
- Live health-triage resources are removed explicitly after merge; this config cannot delete unrelated Atlas definitions.