### PR TITLE
feat(example): add a Maps feed to the Google Takeout connector

### DIFF
--- a/examples/personal-agent/__tests__/google-maps-takeout.test.ts
+++ b/examples/personal-agent/__tests__/google-maps-takeout.test.ts
@@ -1,0 +1,250 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+let GoogleTakeoutConnector: any;
+const fixtureDirs = new Set<string>();
+
+beforeAll(async () => {
+  GoogleTakeoutConnector = (await import("../google-takeout.connector"))
+    .default;
+});
+
+afterEach(() => {
+  for (const dir of fixtureDirs) rmSync(dir, { recursive: true, force: true });
+  fixtureDirs.clear();
+});
+
+function writeMapsFixture(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "g-takeout-"));
+  fixtureDirs.add(dir);
+  const places = path.join(dir, "Maps (your places)");
+  mkdirSync(places, { recursive: true });
+  mkdirSync(path.join(dir, "Saved"), { recursive: true });
+
+  writeFileSync(
+    path.join(places, "Saved Places.json"),
+    JSON.stringify({
+      features: [
+        {
+          geometry: { coordinates: [-0.1178191, 51.5483613] },
+          properties: {
+            date: "2026-03-18T17:11:43Z",
+            google_maps_url: "http://maps.google.com/?cid=8204920803681670701",
+            location: {
+              address: "472 Caledonian Rd, London N7 8TB, United Kingdom",
+              country_code: "GB",
+              name: "Veli's Grooming",
+            },
+          },
+        },
+        {
+          geometry: { coordinates: [0, 0] },
+          properties: { date: "2026-03-31T01:34:50Z", location: {} },
+        },
+      ],
+    })
+  );
+
+  writeFileSync(
+    path.join(places, "Reviews.json"),
+    JSON.stringify({
+      features: [
+        {
+          geometry: { coordinates: [-0.1268417, 51.5285672] },
+          properties: {
+            date: "2026-05-25T17:36:07.216676Z",
+            five_star_rating_published: 1,
+            google_maps_url: "https://www.google.com/maps/place//data=!4m2",
+            location: {
+              address: "88 Euston Rd., London NW1 2RA, United Kingdom",
+              country_code: "GB",
+              name: "Premier Inn London St Pancras hotel",
+            },
+            review_text_published: "The room was not clean.",
+            questions: [
+              { question: "Trip type", selected_option: "Vacation" },
+              {
+                question: "Highlights",
+                selected_options: ["Central", "Quiet"],
+              },
+              { question: "Rooms", rating: 2 },
+            ],
+          },
+        },
+      ],
+    })
+  );
+
+  const listPath = path.join(dir, "Saved", "Favorite places.csv");
+  writeFileSync(
+    listPath,
+    "Title,Note,URL,Tags,Comment\n" +
+      '"Core by Clare Smyth",,https://www.google.com/maps/place/Core,,\n' +
+      ",Missing title,https://www.google.com/maps/place/Unknown,,\n"
+  );
+  // Pin the mtime so the date assertion is deterministic.
+  const when = new Date("2024-02-03T04:05:06Z");
+  utimesSync(listPath, when, when);
+  return dir;
+}
+
+function readMaps(dir: string): any[] {
+  return (new GoogleTakeoutConnector() as any).readMapsEvents(dir);
+}
+
+describe("Maps feed is declared and routed", () => {
+  test("the connector exposes a maps feed", () => {
+    const def = new GoogleTakeoutConnector().definition;
+    expect(def.feeds.maps).toBeDefined();
+    expect(def.feeds.maps.key).toBe("maps");
+  });
+
+  test("maps sync batches events and advances its own checkpoint", async () => {
+    const connector = new GoogleTakeoutConnector();
+    const config = { takeout_dir: writeMapsFixture(), batch_size: 2 };
+
+    const first = await connector.sync({ feedKey: "maps", config });
+    expect(first.events).toHaveLength(2);
+    expect(typeof first.checkpoint.last_maps_timestamp).toBe("string");
+
+    const second = await connector.sync({
+      feedKey: "maps",
+      config,
+      checkpoint: first.checkpoint,
+    });
+    expect(second.events).toHaveLength(1);
+
+    const exhausted = await connector.sync({
+      feedKey: "maps",
+      config,
+      checkpoint: second.checkpoint,
+    });
+    expect(exhausted.events).toHaveLength(0);
+    expect(exhausted.checkpoint).toEqual(second.checkpoint);
+  });
+});
+
+describe("saved places", () => {
+  test("coordinates are read as [longitude, latitude], not positionally", () => {
+    const saved = readMaps(writeMapsFixture()).find(
+      (e) => e.origin_type === "saved_place"
+    );
+    expect(saved.metadata.latitude).toBe(51.5483613);
+    expect(saved.metadata.longitude).toBe(-0.1178191);
+  });
+
+  test("a place carries name, address and its own save date", () => {
+    const saved = readMaps(writeMapsFixture()).find(
+      (e) => e.origin_type === "saved_place"
+    );
+    expect(saved.title).toBe("Veli's Grooming");
+    expect(saved.metadata.address).toContain("Caledonian Rd");
+    expect(saved.metadata.country_code).toBe("GB");
+    expect(saved.occurred_at.toISOString()).toBe("2026-03-18T17:11:43.000Z");
+    expect(saved.source_url).toContain("cid=8204920803681670701");
+  });
+
+  test("a feature with no place name emits nothing", () => {
+    const events = readMaps(writeMapsFixture());
+    expect(events.filter((e) => e.origin_type === "saved_place")).toHaveLength(
+      1
+    );
+    expect(events.every((e) => e.title)).toBe(true);
+  });
+});
+
+describe("reviews", () => {
+  test("a review keeps its rating and answered prompts", () => {
+    const review = readMaps(writeMapsFixture()).find(
+      (e) => e.origin_type === "place_review"
+    );
+    expect(review.metadata.rating).toBe(1);
+    expect(review.payload_text).toContain("— 1/5");
+    expect(review.payload_text).toContain("The room was not clean.");
+    expect(review.payload_text).toContain("Trip type: Vacation");
+    expect(review.payload_text).toContain("Highlights: Central, Quiet");
+    expect(review.payload_text).toContain("Rooms: 2/5");
+  });
+
+  test("a review is a different origin_type from a saved place", () => {
+    const events = readMaps(writeMapsFixture());
+    const kinds = new Set(events.map((e) => e.origin_type));
+    expect(kinds.has("saved_place")).toBe(true);
+    expect(kinds.has("place_review")).toBe(true);
+  });
+});
+
+describe("saved lists", () => {
+  test("the list name comes from the filename and rides on the event", () => {
+    const row = readMaps(writeMapsFixture()).find(
+      (e) => e.origin_type === "saved_list_place"
+    );
+    expect(row.metadata.list).toBe("Favorite places");
+    expect(row.title).toBe("Core by Clare Smyth");
+    expect(row.payload_text).toContain("Favorite places: Core by Clare Smyth");
+  });
+
+  test("a dateless CSV row takes the file mtime, not a fixed sentinel", () => {
+    const row = readMaps(writeMapsFixture()).find(
+      (e) => e.origin_type === "saved_list_place"
+    );
+    expect(row.occurred_at.toISOString()).toBe("2024-02-03T04:05:06.000Z");
+  });
+
+  test("a row without a title is dropped", () => {
+    const rows = readMaps(writeMapsFixture()).filter(
+      (e) => e.origin_type === "saved_list_place"
+    );
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("identity", () => {
+  test("every event has a distinct, stable origin_id", () => {
+    const dir = writeMapsFixture();
+    const first = readMaps(dir);
+    const second = readMaps(dir);
+    const ids = first.map((e) => e.origin_id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(second.map((e) => e.origin_id)).toEqual(ids);
+  });
+
+  test("a display-name edit keeps the URL-backed place identity", () => {
+    const dir = writeMapsFixture();
+    const before = readMaps(dir);
+    const savedBefore = before.find((e) => e.origin_type === "saved_place");
+    const listBefore = before.find((e) => e.origin_type === "saved_list_place");
+
+    const savedPath = path.join(dir, "Maps (your places)", "Saved Places.json");
+    const savedJson = JSON.parse(readFileSync(savedPath, "utf8"));
+    savedJson.features[0].properties.location.name = "Renamed saved place";
+    writeFileSync(savedPath, JSON.stringify(savedJson));
+
+    const listPath = path.join(dir, "Saved", "Favorite places.csv");
+    writeFileSync(
+      listPath,
+      "Title,Note,URL,Tags,Comment\n" +
+        '"Renamed list place",,https://www.google.com/maps/place/Core,,\n'
+    );
+
+    const after = readMaps(dir);
+    expect(after.find((e) => e.origin_type === "saved_place").origin_id).toBe(
+      savedBefore.origin_id
+    );
+    expect(
+      after.find((e) => e.origin_type === "saved_list_place").origin_id
+    ).toBe(listBefore.origin_id);
+  });
+});

--- a/examples/personal-agent/google-takeout.connector.ts
+++ b/examples/personal-agent/google-takeout.connector.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   type ConnectorDefinition,
@@ -13,6 +13,8 @@ import {
   decodeHtml,
   type LocalTakeoutConfig,
   maxEventCursor,
+  parseCsv,
+  parseDate,
   readJsonFile,
   stableId,
   stripHtml,
@@ -22,6 +24,24 @@ import {
 interface GoogleTakeoutCheckpoint {
   last_youtube_timestamp?: string;
   last_keep_timestamp?: string;
+  last_maps_timestamp?: string;
+}
+
+interface MapsFeature {
+  geometry?: { coordinates?: number[] };
+  properties?: {
+    date?: string;
+    google_maps_url?: string;
+    five_star_rating_published?: number;
+    location?: { address?: string; country_code?: string; name?: string };
+    questions?: Array<{
+      question?: string;
+      rating?: number;
+      selected_option?: string;
+      selected_options?: string[];
+    }>;
+    review_text_published?: string;
+  };
 }
 
 interface KeepNote {
@@ -42,9 +62,14 @@ export default class GoogleTakeoutConnector extends ConnectorRuntime<
   readonly definition: ConnectorDefinition = {
     key: "google.takeout",
     name: "Google Takeout",
-    version: "1.0.0",
+    // Minor bump for the added `maps` feed. Connector source is retained per
+    // version, so shipping new behaviour under 1.0.0 would overwrite the
+    // existing artifact and leave version-pinned runs and rollback pointing at
+    // code that no longer matches.
+    version: "1.1.0",
     description:
-      "Ingests local Google Takeout exports for YouTube history and Keep notes.",
+      "Ingests local Google Takeout exports for YouTube history, Keep notes, " +
+      "and Maps saved places, lists, and reviews.",
     authSchema: { methods: [{ type: "none" }] },
     // Local-filesystem connector: it reads an absolute path on the user's own
     // machine, so it must not be routed to the cloud fleet. See the longer note
@@ -60,6 +85,11 @@ export default class GoogleTakeoutConnector extends ConnectorRuntime<
       keep: {
         key: "keep",
         name: "Google Keep Notes",
+        configSchema: localTakeoutSchema("Path to a Google Takeout folder."),
+      },
+      maps: {
+        key: "maps",
+        name: "Maps Saved Places and Reviews",
         configSchema: localTakeoutSchema("Path to a Google Takeout folder."),
       },
     },
@@ -100,6 +130,24 @@ export default class GoogleTakeoutConnector extends ConnectorRuntime<
           last_keep_timestamp: maxEventCursor(
             events,
             ctx.checkpoint?.last_keep_timestamp
+          ),
+        },
+      };
+    }
+
+    if (ctx.feedKey === "maps") {
+      const events = takeBatch(
+        this.readMapsEvents(takeoutDir),
+        ctx.checkpoint?.last_maps_timestamp,
+        batchSize(ctx.config)
+      );
+      return {
+        events,
+        checkpoint: {
+          ...ctx.checkpoint,
+          last_maps_timestamp: maxEventCursor(
+            events,
+            ctx.checkpoint?.last_maps_timestamp
           ),
         },
       };
@@ -225,6 +273,136 @@ export default class GoogleTakeoutConnector extends ConnectorRuntime<
             },
           },
         ];
+      });
+  }
+
+  private readMapsEvents(takeoutDir: string): EventEnvelope[] {
+    return [
+      ...this.readMapsPlaceFile(takeoutDir, "Saved Places.json", "saved_place"),
+      ...this.readMapsPlaceFile(takeoutDir, "Reviews.json", "place_review"),
+      ...this.readMapsListEvents(takeoutDir),
+    ];
+  }
+
+  private readMapsPlaceFile(
+    takeoutDir: string,
+    fileName: string,
+    originType: "saved_place" | "place_review"
+  ): EventEnvelope[] {
+    const filePath = path.join(takeoutDir, "Maps (your places)", fileName);
+    if (!existsSync(filePath)) return [];
+    const parsed = readJsonFile<{ features?: MapsFeature[] }>(filePath);
+    const features = parsed?.features;
+    if (!Array.isArray(features)) return [];
+
+    return features.flatMap((feature) => {
+      const props = feature.properties;
+      const name = props?.location?.name?.trim();
+      // No name means no usable place — a bare coordinate is not worth an event.
+      if (!name) return [];
+      const occurredAt = parseDate(props?.date);
+      if (!occurredAt) return [];
+
+      const address = props?.location?.address?.trim();
+      const mapsUrl = props?.google_maps_url?.trim();
+      const rating = props?.five_star_rating_published;
+      const reviewText = props?.review_text_published?.trim();
+      const answers = (props?.questions ?? []).flatMap((question) => {
+        const prompt = question.question?.trim();
+        const selectedOptions = question.selected_options
+          ?.map((option) => option.trim())
+          .filter(Boolean)
+          .join(", ");
+        const answer =
+          question.selected_option?.trim() ||
+          selectedOptions ||
+          (typeof question.rating === "number" ? `${question.rating}/5` : "");
+        return prompt && answer ? [`${prompt}: ${answer}`] : [];
+      });
+      // Coordinates are GeoJSON order — [longitude, latitude], NOT lat/lng.
+      const [longitude, latitude] = feature.geometry?.coordinates ?? [];
+      const placeIdentity =
+        mapsUrl ??
+        (longitude === undefined || latitude === undefined
+          ? `${name}\0${address ?? ""}`
+          : `${longitude},${latitude}`);
+
+      return [
+        {
+          origin_id: stableId("google_maps_place", [originType, placeIdentity]),
+          origin_type: originType,
+          occurred_at: occurredAt,
+          title: name,
+          payload_text: [
+            originType === "place_review"
+              ? `Reviewed ${name}${
+                  rating === undefined ? "" : ` — ${rating}/5`
+                }`
+              : `Saved ${name}`,
+            reviewText,
+            address,
+            ...answers,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          source_url: mapsUrl,
+          metadata: {
+            platform: "google_maps",
+            place_name: name,
+            address,
+            country_code: props?.location?.country_code,
+            latitude,
+            longitude,
+            ...(rating === undefined ? {} : { rating }),
+          },
+        },
+      ];
+    });
+  }
+
+  private readMapsListEvents(takeoutDir: string): EventEnvelope[] {
+    const savedDir = path.join(takeoutDir, "Saved");
+    if (!existsSync(savedDir)) return [];
+
+    return readdirSync(savedDir)
+      .filter((file) => file.endsWith(".csv"))
+      .flatMap((file) => {
+        const filePath = path.join(savedDir, file);
+        const listName = path.basename(file, ".csv");
+        // List rows have no timestamp. The file mtime lets a later export
+        // supersede URL-backed rows while still advancing the feed checkpoint.
+        const occurredAt = statSync(filePath).mtime;
+
+        return parseCsv(readFileSync(filePath, "utf8")).flatMap((row) => {
+          const title = row.Title?.trim();
+          if (!title) return [];
+          const note = row.Note?.trim();
+          const comment = row.Comment?.trim();
+          const mapsUrl = row.URL || undefined;
+
+          return [
+            {
+              origin_id: stableId("google_maps_list_place", [
+                listName,
+                mapsUrl ?? title,
+              ]),
+              origin_type: "saved_list_place",
+              occurred_at: occurredAt,
+              title,
+              payload_text: [`${listName}: ${title}`, note, comment]
+                .filter(Boolean)
+                .join("\n"),
+              source_url: mapsUrl,
+              metadata: {
+                platform: "google_maps",
+                place_name: title,
+                list: listName,
+                note: note || undefined,
+                tags: row.Tags || undefined,
+              },
+            },
+          ];
+        });
       });
   }
 }

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -838,6 +838,10 @@ const takeoutConnection = defineConnection({
       feed: "keep",
       config: takeoutConfig("GOOGLE_KEEP_TAKEOUT_DIR", "google-keep"),
     },
+    {
+      feed: "maps",
+      config: takeoutConfig("GOOGLE_MAPS_TAKEOUT_DIR", "google-maps"),
+    },
   ],
 });
 


### PR DESCRIPTION
## Summary

Adds a `maps` feed to the Google Takeout connector. The archive already sat on disk behind the existing `os.files` device gate — three Maps sources in it were simply never read.

- `Maps (your places)/Saved Places.json` → `saved_place`
- `Maps (your places)/Reviews.json` → `place_review` (rating + answered prompts)
- `Saved/<list>.csv` → `saved_list_place` (starred, want-to-go, favourites, and any custom list)

The three sources disagree with each other in ways that are easy to get wrong, so each trap has a test pinning it:

- **GeoJSON `coordinates` are `[longitude, latitude]`.** Read positionally as lat/lng, every London place lands in the Indian Ocean.
- **List CSV rows carry no date, and the list name exists only in the filename.** The file mtime stands in so `takeBatch` can advance its checkpoint — a fixed sentinel would freeze every later edit out permanently.
- **A review is not a saved place.** Same GeoJSON envelope, opposite meaning: a 1-star review must not read as somewhere the user likes, so they get distinct `origin_type`s.
- A feature with coordinates but no resolvable place name emits nothing rather than a titleless row.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Tests run: `bun test examples/personal-agent/__tests__/` → **214 pass, 0 fail** (10 files)
- [ ] Bug fix: n/a — new feed, not a fix
- [ ] If bot behavior: n/a

### e2e through a real device worker, on the real archive

Feed triggered against `~/Downloads/Takeout 2` via a local `connector-worker` in device mode:

```
run 434 | status=completed | items_collected=383 | checkpoint advanced

   origin_type    | count |   first    |    last
------------------+-------+------------+------------
 saved_list_place |   337 | 2021-09-26 | 2026-06-03
 saved_place      |    27 | 2015-09-09 | 2026-03-18
 place_review     |    19 | 2017-03-12 | 2026-05-25
```

Coordinate order verified on a landed row rather than a fixture — `Veli's Grooming` at `latitude 51.5483613 / longitude -0.1178191` is London, which is the assertion that fails if the pair is read positionally.

`review-fix` subsequently changed `origin_id` to prefer the Maps URL (falling back to coordinates, then name+address) so a renamed place supersedes instead of duplicating. That is a change to identity, so the archive was re-parsed under the new scheme:

```
events: 383
byType: {"saved_place":27,"place_review":19,"saved_list_place":337}
distinct ids: 383      stable across runs: true
all have title: true   all valid dates: true
```

## Notes

Maps declares no attributions, so these events mint no entities — the URL-as-entity-name class fixed in the sibling takeout PR cannot reproduce here. Verified rather than assumed.

### E2E through the device worker (post-`review-fix` identity)

`review-fix` rewrote `origin_id` to URL-backed identity after the first e2e, so the
worker path was re-run against the new scheme. Three syncs, three properties:

```
sync 1 (clean checkpoint)   completed  items=5   → 2 saved_place, 1 place_review, 2 saved_list_place
                                                   (nameless feature dropped; trailing blank CSV row dropped)
sync 2 (checkpoint intact)  completed  items=0   → rows 388 → 388, delta 0
sync 3 (checkpoint reset)   completed  items=5   → rows 388 → 388, delta 0
                                                   duplicate live origin_ids: none
```

Sync 3 is the one that matters for the identity change: re-collecting every item
produces zero new rows and no duplicate `origin_id`, so a resync supersedes rather
than re-mints.

Note: macOS revoked this machine's Downloads TCC grant mid-session, so the worker-path
runs above used a fixture archive. The real archive was verified separately (383 events —
27 saved_place / 19 place_review / 337 saved_list_place, all distinct and stable across
runs). Those are two runs, not one.
