### PR TITLE
feat(server): send production activity digests

### DIFF
--- a/charts/lobu/templates/prometheusrule.yaml
+++ b/charts/lobu/templates/prometheusrule.yaml
@@ -68,7 +68,7 @@ spec:
         # A critical scheduled job erroring repeatedly (e.g. the stale-run reaper).
         - alert: LobuScheduledJobFailing
           expr: |
-            sum(increase(lobu_scheduled_job_runs_total{task=~"watcher-automation|check-stalled-executions",outcome="error"}[15m])) by (task) > 0
+            sum(increase(lobu_scheduled_job_runs_total{task=~"watcher-automation|check-stalled-executions|product-ops-digest",outcome="error"}[15m])) by (task) > 0
           for: 15m
           labels:
             severity: warning

--- a/packages/server/src/scheduled/__tests__/product-ops-digest.test.ts
+++ b/packages/server/src/scheduled/__tests__/product-ops-digest.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+import type { DbClient } from "../../db/client";
+import {
+  createProductOpsDigestStore,
+  type ProductOpsActivity,
+  type ProductOpsDigestStore,
+  type ProductOpsDigestWindow,
+  productOpsDigestConfigFromEnv,
+  runProductOpsDigest,
+} from "../product-ops-digest";
+
+const WINDOW = {
+  start: new Date("2026-08-12T11:40:00.000Z"),
+  end: new Date("2026-08-12T12:00:00.000Z"),
+};
+
+const EMPTY_ACTIVITY: ProductOpsActivity = {
+  signups: [],
+  logins: [],
+  connections: [],
+  mcpConversations: [],
+};
+
+function store(
+  activity: ProductOpsActivity = EMPTY_ACTIVITY,
+): ProductOpsDigestStore {
+  return {
+    resolveWindow: async () => WINDOW,
+    collectActivity: async () => activity,
+  };
+}
+
+function lokiResponse(levels: Record<string, number>): Response {
+  return Response.json({
+    status: "success",
+    data: {
+      resultType: "vector",
+      result: Object.entries(levels).map(([level, count]) => ({
+        metric: { level },
+        value: [String(WINDOW.end.getTime() / 1000), String(count)],
+      })),
+    },
+  });
+}
+
+const CONFIG = {
+  lokiUrl: "http://loki.monitoring:3100",
+  alertmanagerUrl: "http://alertmanager.monitoring:9093",
+  namespace: "summaries-prod",
+  grafanaUrl: "https://grafana.example.test/explore",
+};
+
+describe("product operations digest", () => {
+  test("uses the prior successful scheduled tick as the durable cursor", async () => {
+    const responses = [
+      [{ scheduled_tick: "2026-08-12T12:02:00.000Z" }],
+      [{ scheduled_tick: "2026-08-12T11:22:00.000Z" }],
+    ];
+    const sql = (() =>
+      Promise.resolve(responses.shift() ?? [])) as unknown as DbClient;
+
+    expect(await createProductOpsDigestStore(sql).resolveWindow(101)).toEqual({
+      start: new Date("2026-08-12T11:20:00.000Z"),
+      end: new Date("2026-08-12T12:00:00.000Z"),
+    });
+  });
+
+  test("defaults the first run to exactly one 20-minute interval", async () => {
+    const responses = [[{ scheduled_tick: "2026-08-12T12:02:00.000Z" }], []];
+    const sql = (() =>
+      Promise.resolve(responses.shift() ?? [])) as unknown as DbClient;
+
+    expect(await createProductOpsDigestStore(sql).resolveWindow(102)).toEqual(
+      WINDOW,
+    );
+  });
+
+  test("requires complete production endpoints when explicitly enabled", () => {
+    expect(
+      productOpsDigestConfigFromEnv({ ENVIRONMENT: "production" }),
+    ).toBeNull();
+    expect(() =>
+      productOpsDigestConfigFromEnv({
+        ENVIRONMENT: "production",
+        LOBU_PRODUCT_OPS_DIGEST_ENABLED: "1",
+        LOBU_PRODUCT_OPS_LOKI_URL: CONFIG.lokiUrl,
+      }),
+    ).toThrow("requires LOBU_PRODUCT_OPS_LOKI_URL");
+  });
+
+  test("checks production logs but stays silent when there is no activity", async () => {
+    const requests: string[] = [];
+    const result = await runProductOpsDigest({
+      taskRunId: 42,
+      config: CONFIG,
+      store: store(),
+      fetchImpl: async (input) => {
+        requests.push(String(input));
+        return lokiResponse({ info: 999 });
+      },
+    });
+
+    expect(result).toEqual({
+      posted: false,
+      window: WINDOW,
+      activity: EMPTY_ACTIVITY,
+      logs: { errors: 0, warnings: 0 },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toStartWith(`${CONFIG.lokiUrl}/loki/api/v1/query?`);
+  });
+
+  test("posts one idempotent digest for product activity and warning/error logs", async () => {
+    const activity: ProductOpsActivity = {
+      signups: [{ userId: "user-1", name: "Ada", email: "ada@example.test" }],
+      logins: [
+        { userId: "user-1", name: "Ada", email: "ada@example.test" },
+        { userId: "user-1", name: "Ada", email: "ada@example.test" },
+      ],
+      connections: [
+        {
+          connectorKey: "slack",
+          displayName: "Acme Slack",
+          organizationName: "Acme",
+        },
+      ],
+      mcpConversations: [
+        {
+          userId: "user-1",
+          clientSoftwareId: "codex",
+          organizationName: "Acme",
+        },
+      ],
+    };
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    const result = await runProductOpsDigest({
+      taskRunId: 43,
+      config: CONFIG,
+      store: store(activity),
+      now: () => new Date("2026-08-12T12:00:05.000Z"),
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({ url, init });
+        if (url.startsWith(CONFIG.lokiUrl)) {
+          return lokiResponse({ error: 2, warning: 3, info: 999 });
+        }
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    expect(result.posted).toBe(true);
+    expect(result.logs).toEqual({ errors: 2, warnings: 3 });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.url).toBe(`${CONFIG.alertmanagerUrl}/api/v2/alerts`);
+    expect(requests[1]?.init?.method).toBe("POST");
+
+    const alerts = JSON.parse(String(requests[1]?.init?.body)) as Array<{
+      labels: Record<string, string>;
+      annotations: Record<string, string>;
+      endsAt: string;
+    }>;
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.labels).toMatchObject({
+      alertname: "LobuProductOpsDigest",
+      severity: "info",
+      namespace: CONFIG.namespace,
+      digest_window_end: "2026-08-12T12_00_00_000Z",
+    });
+    expect(alerts[0]?.annotations.description).toContain(
+      "Signups: 1 — Ada (ada@example.test)",
+    );
+    expect(alerts[0]?.annotations.description).toContain(
+      "Logins: 2 sessions / 1 user",
+    );
+    expect(alerts[0]?.annotations.description).toContain(
+      "New connections: 1 — slack: Acme Slack (Acme)",
+    );
+    expect(alerts[0]?.annotations.description).toContain(
+      "MCP activity: 1 new conversation / 1 authenticated user / 1 client — codex (Acme)",
+    );
+    expect(alerts[0]?.annotations.description).toContain(
+      "Kubernetes logs: 2 errors / 3 warnings",
+    );
+    expect(alerts[0]?.annotations.description).toContain(CONFIG.grafanaUrl);
+    expect(alerts[0]?.endsAt).toBe("2026-08-12T12:15:05.000Z");
+  });
+
+  test("splits catch-up work into independently deduplicated 20-minute alerts", async () => {
+    const collected: ProductOpsDigestWindow[] = [];
+    const alerts: Array<{ labels: Record<string, string> }> = [];
+    await runProductOpsDigest({
+      taskRunId: 46,
+      config: CONFIG,
+      store: {
+        resolveWindow: async () => ({
+          start: new Date("2026-08-12T11:20:00.000Z"),
+          end: WINDOW.end,
+        }),
+        collectActivity: async (window) => {
+          collected.push(window);
+          return {
+            ...EMPTY_ACTIVITY,
+            signups: [
+              {
+                userId: window.end.toISOString(),
+                name: "Catch-up user",
+                email: "catch-up@example.test",
+              },
+            ],
+          };
+        },
+      },
+      fetchImpl: async (input, init) => {
+        if (String(input).startsWith(CONFIG.lokiUrl)) return lokiResponse({});
+        alerts.push(...JSON.parse(String(init?.body)));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    expect(collected).toEqual([
+      {
+        start: new Date("2026-08-12T11:20:00.000Z"),
+        end: new Date("2026-08-12T11:40:00.000Z"),
+      },
+      WINDOW,
+    ]);
+    expect(alerts.map((alert) => alert.labels.digest_window_end)).toEqual([
+      "2026-08-12T11_40_00_000Z",
+      "2026-08-12T12_00_00_000Z",
+    ]);
+  });
+
+  test("fails closed when Loki cannot be checked", async () => {
+    await expect(
+      runProductOpsDigest({
+        taskRunId: 44,
+        config: CONFIG,
+        store: store(),
+        fetchImpl: async () => new Response("unavailable", { status: 503 }),
+      }),
+    ).rejects.toThrow("Loki query failed with 503");
+  });
+
+  test("fails closed when Alertmanager does not accept an active digest", async () => {
+    await expect(
+      runProductOpsDigest({
+        taskRunId: 45,
+        config: CONFIG,
+        store: store({
+          ...EMPTY_ACTIVITY,
+          signups: [
+            { userId: "user-2", name: null, email: "new@example.test" },
+          ],
+        }),
+        fetchImpl: async (input) =>
+          String(input).startsWith(CONFIG.lokiUrl)
+            ? lokiResponse({})
+            : new Response("rejected", { status: 500 }),
+      }),
+    ).rejects.toThrow("Alertmanager delivery failed with 500");
+  });
+});

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -45,6 +45,11 @@ import {
 } from '../gateway/services/agent-threads';
 import { buildMessagePayload } from '../gateway/services/platform-helpers';
 import { migrateLegacyPlaintextAuthData } from '../utils/auth-credential-secrets';
+import {
+  PRODUCT_OPS_DIGEST_TASK,
+  productOpsDigestConfigFromEnv,
+  runProductOpsDigest,
+} from './product-ops-digest';
 
 function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   if (!value || typeof value !== 'object') return null;
@@ -108,6 +113,36 @@ function registerMaintenanceTasks(
   env: Env,
   coreServices: CoreServices,
 ): void {
+  const productOpsDigestConfig = productOpsDigestConfigFromEnv(env);
+  if (productOpsDigestConfig) {
+    scheduler.register(
+      PRODUCT_OPS_DIGEST_TASK,
+      async ({ taskRunId }) => {
+        const result = await runProductOpsDigest({
+          taskRunId,
+          config: productOpsDigestConfig,
+        });
+        logger.info(
+          {
+            posted: result.posted,
+            window_start: result.window.start.toISOString(),
+            window_end: result.window.end.toISOString(),
+            signups: result.activity.signups.length,
+            logins: result.activity.logins.length,
+            connections: result.activity.connections.length,
+            mcp_conversations: result.activity.mcpConversations.length,
+            log_errors: result.logs.errors,
+            log_warnings: result.logs.warnings,
+          },
+          '[task] product-ops-digest completed',
+        );
+      },
+      // Run two minutes after each aligned 20-minute window so Promtail has
+      // time to deliver the closing Kubernetes log entries to Loki.
+      { cron: '2,22,42 * * * *' },
+    );
+  }
+
   // OAuth token refresh — periodic safety-net at 30min intervals. The hot path
   // is at-use-time lazy refresh in AuthProfilesManager.ensureFreshCredential,
   // which spawns `refresh-token-for-user-agent` per-user when a soon-expiring

--- a/packages/server/src/scheduled/product-ops-digest.ts
+++ b/packages/server/src/scheduled/product-ops-digest.ts
@@ -1,0 +1,483 @@
+import type { Env } from "@lobu/connector-sdk";
+import { type DbClient, getDb } from "../db/client";
+
+export const PRODUCT_OPS_DIGEST_TASK = "product-ops-digest";
+const DEFAULT_WINDOW_MS = 20 * 60 * 1000;
+const LOG_INGESTION_LAG_MS = 2 * 60 * 1000;
+const ACTIVE_ALERT_MS = 15 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 15_000;
+const DETAIL_LIMIT = 10;
+
+export interface ProductOpsDigestConfig {
+  lokiUrl: string;
+  alertmanagerUrl: string;
+  namespace: string;
+  grafanaUrl?: string;
+}
+
+export interface ProductOpsDigestWindow {
+  start: Date;
+  end: Date;
+}
+
+interface UserActivity {
+  userId: string;
+  name: string | null;
+  email: string;
+}
+
+interface ConnectionActivity {
+  connectorKey: string;
+  displayName: string | null;
+  organizationName: string;
+}
+
+interface McpConversationActivity {
+  userId: string | null;
+  clientSoftwareId: string | null;
+  organizationName: string;
+}
+
+export interface ProductOpsActivity {
+  signups: UserActivity[];
+  logins: UserActivity[];
+  connections: ConnectionActivity[];
+  mcpConversations: McpConversationActivity[];
+}
+
+export interface ProductOpsDigestStore {
+  resolveWindow(taskRunId: number): Promise<ProductOpsDigestWindow>;
+  collectActivity(window: ProductOpsDigestWindow): Promise<ProductOpsActivity>;
+}
+
+interface ProductOpsLogCounts {
+  errors: number;
+  warnings: number;
+}
+
+interface RunProductOpsDigestParams {
+  taskRunId: number;
+  config: ProductOpsDigestConfig;
+  store?: ProductOpsDigestStore;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}
+
+export interface ProductOpsDigestResult {
+  posted: boolean;
+  window: ProductOpsDigestWindow;
+  activity: ProductOpsActivity;
+  logs: ProductOpsLogCounts;
+}
+
+export function productOpsDigestConfigFromEnv(
+  env: Env,
+): ProductOpsDigestConfig | null {
+  if (env.LOBU_PRODUCT_OPS_DIGEST_ENABLED !== "1") return null;
+
+  const lokiUrl = env.LOBU_PRODUCT_OPS_LOKI_URL?.trim();
+  const alertmanagerUrl = env.LOBU_PRODUCT_OPS_ALERTMANAGER_URL?.trim();
+  const namespace = env.LOBU_PRODUCT_OPS_NAMESPACE?.trim();
+  if (!lokiUrl || !alertmanagerUrl || !namespace) {
+    throw new Error(
+      "LOBU_PRODUCT_OPS_DIGEST_ENABLED requires LOBU_PRODUCT_OPS_LOKI_URL, " +
+        "LOBU_PRODUCT_OPS_ALERTMANAGER_URL, and LOBU_PRODUCT_OPS_NAMESPACE",
+    );
+  }
+
+  const grafanaUrl = env.LOBU_PRODUCT_OPS_GRAFANA_URL?.trim();
+  return {
+    lokiUrl: trimTrailingSlash(lokiUrl),
+    alertmanagerUrl: trimTrailingSlash(alertmanagerUrl),
+    namespace,
+    ...(grafanaUrl ? { grafanaUrl } : {}),
+  };
+}
+
+export function createProductOpsDigestStore(
+  sql: DbClient = getDb(),
+): ProductOpsDigestStore {
+  return {
+    async resolveWindow(taskRunId) {
+      const currentRows = await sql<{ scheduled_tick: string | Date | null }>`
+        SELECT action_input->>'__scheduledTick' AS scheduled_tick
+        FROM public.runs
+        WHERE id = ${taskRunId}
+          AND run_type = 'task'
+          AND action_key = ${PRODUCT_OPS_DIGEST_TASK}
+        LIMIT 1
+      `;
+      const scheduledTick = parseTick(currentRows[0]?.scheduled_tick);
+      if (!scheduledTick) {
+        throw new Error(
+          `Product operations task ${taskRunId} has no scheduled tick`,
+        );
+      }
+      const end = collectionBoundary(scheduledTick);
+
+      const previousRows = await sql<{ scheduled_tick: string | Date | null }>`
+        SELECT action_input->>'__scheduledTick' AS scheduled_tick
+        FROM public.runs
+        WHERE id < ${taskRunId}
+          AND run_type = 'task'
+          AND action_key = ${PRODUCT_OPS_DIGEST_TASK}
+          AND status = 'completed'
+          AND action_input->>'__scheduledTick' IS NOT NULL
+        ORDER BY id DESC
+        LIMIT 1
+      `;
+      const previousTick = parseTick(previousRows[0]?.scheduled_tick);
+      const start = previousTick
+        ? collectionBoundary(previousTick)
+        : new Date(end.getTime() - DEFAULT_WINDOW_MS);
+      if (start.getTime() >= end.getTime()) {
+        throw new Error(
+          `Product operations cursor ${start.toISOString()} is not before ${end.toISOString()}`,
+        );
+      }
+      return { start, end };
+    },
+
+    async collectActivity(window) {
+      const [signups, logins, connections, mcpConversations] =
+        await Promise.all([
+          sql<UserActivity>`
+          SELECT id AS "userId", name, email
+          FROM public."user"
+          WHERE "createdAt" > ${window.start}
+            AND "createdAt" <= ${window.end}
+            AND COALESCE(principal_kind, 'human') = 'human'
+          ORDER BY "createdAt" ASC, id ASC
+        `,
+          sql<UserActivity>`
+          SELECT u.id AS "userId", u.name, u.email
+          FROM public.session s
+          JOIN public."user" u ON u.id = s."userId"
+          WHERE s."createdAt" > ${window.start}
+            AND s."createdAt" <= ${window.end}
+            AND COALESCE(u.principal_kind, 'human') = 'human'
+          ORDER BY s."createdAt" ASC, s.id ASC
+        `,
+          sql<ConnectionActivity>`
+          SELECT
+            c.connector_key AS "connectorKey",
+            c.display_name AS "displayName",
+            o.name AS "organizationName"
+          FROM public.connections c
+          JOIN public.organization o ON o.id = c.organization_id
+          WHERE c.created_at > ${window.start}
+            AND c.created_at <= ${window.end}
+          ORDER BY c.created_at ASC, c.id ASC
+        `,
+          sql<McpConversationActivity>`
+          SELECT
+            m.user_id AS "userId",
+            m.client_software_id AS "clientSoftwareId",
+            o.name AS "organizationName"
+          FROM public.mcp_client_conversations m
+          JOIN public.organization o ON o.id = m.organization_id
+          WHERE m.first_activity_at > ${window.start}
+            AND m.first_activity_at <= ${window.end}
+            AND m.call_count > 0
+          ORDER BY m.first_activity_at ASC, m.organization_id ASC,
+            m.client_identity ASC, m.conversation_id ASC
+        `,
+        ]);
+      return { signups, logins, connections, mcpConversations };
+    },
+  };
+}
+
+export async function runProductOpsDigest({
+  taskRunId,
+  config,
+  store = createProductOpsDigestStore(),
+  fetchImpl = fetch,
+  now = () => new Date(),
+}: RunProductOpsDigestParams): Promise<ProductOpsDigestResult> {
+  const window = await store.resolveWindow(taskRunId);
+  const activity: ProductOpsActivity = {
+    signups: [],
+    logins: [],
+    connections: [],
+    mcpConversations: [],
+  };
+  const logs = { errors: 0, warnings: 0 };
+  let posted = false;
+
+  // A later tick may be claimed by another replica while an older tick is
+  // retrying. Catch up one exact interval at a time: the interval end is the
+  // Alertmanager fingerprint, so concurrent/retried sends dedupe without a
+  // second lock while every missed interval remains recoverable.
+  for (const interval of splitDigestWindows(window)) {
+    const [intervalActivity, intervalLogs] = await Promise.all([
+      store.collectActivity(interval),
+      queryLokiLogCounts(config, interval, fetchImpl),
+    ]);
+    activity.signups.push(...intervalActivity.signups);
+    activity.logins.push(...intervalActivity.logins);
+    activity.connections.push(...intervalActivity.connections);
+    activity.mcpConversations.push(...intervalActivity.mcpConversations);
+    logs.errors += intervalLogs.errors;
+    logs.warnings += intervalLogs.warnings;
+
+    if (!hasDigestActivity(intervalActivity, intervalLogs)) continue;
+    await deliverDigestAlert(
+      config,
+      interval,
+      intervalActivity,
+      intervalLogs,
+      fetchImpl,
+      now(),
+    );
+    posted = true;
+  }
+
+  return { posted, window, activity, logs };
+}
+
+async function deliverDigestAlert(
+  config: ProductOpsDigestConfig,
+  window: ProductOpsDigestWindow,
+  activity: ProductOpsActivity,
+  logs: ProductOpsLogCounts,
+  fetchImpl: typeof fetch,
+  deliveryTime: Date,
+): Promise<void> {
+  const description = formatDigestDescription(config, window, activity, logs);
+  const alert = {
+    labels: {
+      alertname: "LobuProductOpsDigest",
+      severity: "info",
+      namespace: config.namespace,
+      digest_window_end: window.end.toISOString().replace(/[.:]/g, "_"),
+    },
+    annotations: {
+      summary: "Lobu production activity digest",
+      description,
+    },
+    startsAt: deliveryTime.toISOString(),
+    endsAt: new Date(deliveryTime.getTime() + ACTIVE_ALERT_MS).toISOString(),
+    ...(config.grafanaUrl ? { generatorURL: config.grafanaUrl } : {}),
+  };
+  const response = await fetchImpl(`${config.alertmanagerUrl}/api/v2/alerts`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify([alert]),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Alertmanager delivery failed with ${response.status}`);
+  }
+}
+
+function splitDigestWindows(
+  window: ProductOpsDigestWindow,
+): ProductOpsDigestWindow[] {
+  const duration = window.end.getTime() - window.start.getTime();
+  if (duration <= 0 || duration % DEFAULT_WINDOW_MS !== 0) {
+    throw new Error(
+      `Product operations range must contain whole 20-minute windows: ` +
+        `${window.start.toISOString()} to ${window.end.toISOString()}`,
+    );
+  }
+  const windows: ProductOpsDigestWindow[] = [];
+  for (
+    let start = window.start.getTime();
+    start < window.end.getTime();
+    start += DEFAULT_WINDOW_MS
+  ) {
+    windows.push({
+      start: new Date(start),
+      end: new Date(start + DEFAULT_WINDOW_MS),
+    });
+  }
+  return windows;
+}
+
+async function queryLokiLogCounts(
+  config: ProductOpsDigestConfig,
+  window: ProductOpsDigestWindow,
+  fetchImpl: typeof fetch,
+): Promise<ProductOpsLogCounts> {
+  const seconds = Math.max(
+    1,
+    Math.ceil((window.end.getTime() - window.start.getTime()) / 1000),
+  );
+  const namespace = escapeLogQlString(config.namespace);
+  const query =
+    `sum by (level) (count_over_time({namespace="${namespace}"} ` +
+    `| json | __error__="" ` +
+    `| level=~"(?i)(warn|warning|error|fatal|panic)" [${seconds}s]))`;
+  const url = new URL(`${config.lokiUrl}/loki/api/v1/query`);
+  url.searchParams.set("query", query);
+  url.searchParams.set("time", String(window.end.getTime() / 1000));
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Loki query failed with ${response.status}`);
+  }
+
+  const body = (await response.json()) as {
+    status?: unknown;
+    data?: { resultType?: unknown; result?: unknown };
+  };
+  if (
+    body.status !== "success" ||
+    body.data?.resultType !== "vector" ||
+    !Array.isArray(body.data.result)
+  ) {
+    throw new Error("Loki query returned an invalid response");
+  }
+
+  let errors = 0;
+  let warnings = 0;
+  for (const item of body.data.result) {
+    if (!item || typeof item !== "object") continue;
+    const candidate = item as {
+      metric?: { level?: unknown };
+      value?: unknown[];
+    };
+    const level = String(candidate.metric?.level ?? "").toLowerCase();
+    const count = Number(candidate.value?.[1] ?? 0);
+    if (!Number.isFinite(count) || count < 0) {
+      throw new Error("Loki query returned an invalid log count");
+    }
+    if (level === "error" || level === "fatal" || level === "panic") {
+      errors += count;
+    } else if (level === "warn" || level === "warning") {
+      warnings += count;
+    }
+  }
+  return { errors, warnings };
+}
+
+function hasDigestActivity(
+  activity: ProductOpsActivity,
+  logs: ProductOpsLogCounts,
+): boolean {
+  return (
+    activity.signups.length > 0 ||
+    activity.logins.length > 0 ||
+    activity.connections.length > 0 ||
+    activity.mcpConversations.length > 0 ||
+    logs.errors > 0 ||
+    logs.warnings > 0
+  );
+}
+
+function formatDigestDescription(
+  config: ProductOpsDigestConfig,
+  window: ProductOpsDigestWindow,
+  activity: ProductOpsActivity,
+  logs: ProductOpsLogCounts,
+): string {
+  const lines = [
+    `Window: ${window.start.toISOString()} to ${window.end.toISOString()}`,
+  ];
+  if (activity.signups.length > 0) {
+    lines.push(
+      `Signups: ${activity.signups.length} — ${formatDetails(
+        activity.signups.map(formatUser),
+      )}`,
+    );
+  }
+  if (activity.logins.length > 0) {
+    const uniqueUsers = new Map(
+      activity.logins.map((user) => [user.userId, user]),
+    );
+    lines.push(
+      `Logins: ${activity.logins.length} ${plural(activity.logins.length, "session")} / ` +
+        `${uniqueUsers.size} ${plural(uniqueUsers.size, "user")} — ` +
+        formatDetails([...uniqueUsers.values()].map(formatUser)),
+    );
+  }
+  if (activity.connections.length > 0) {
+    lines.push(
+      `New connections: ${activity.connections.length} — ${formatDetails(
+        activity.connections.map(
+          (connection) =>
+            `${slackSafe(connection.connectorKey)}: ` +
+            `${slackSafe(connection.displayName ?? "unnamed")} ` +
+            `(${slackSafe(connection.organizationName)})`,
+        ),
+      )}`,
+    );
+  }
+  if (activity.mcpConversations.length > 0) {
+    const users = new Set(
+      activity.mcpConversations
+        .map((conversation) => conversation.userId)
+        .filter((userId): userId is string => Boolean(userId)),
+    );
+    const clients = new Set(
+      activity.mcpConversations.map(
+        (conversation) => conversation.clientSoftwareId ?? "unknown client",
+      ),
+    );
+    const clientDetails = activity.mcpConversations.map(
+      (conversation) =>
+        `${slackSafe(conversation.clientSoftwareId ?? "unknown client")} ` +
+        `(${slackSafe(conversation.organizationName)})`,
+    );
+    lines.push(
+      `MCP activity: ${activity.mcpConversations.length} new ` +
+        `${plural(activity.mcpConversations.length, "conversation")} / ` +
+        `${users.size} authenticated ${plural(users.size, "user")} / ` +
+        `${clients.size} ${plural(clients.size, "client")} — ` +
+        formatDetails(clientDetails),
+    );
+  }
+  if (logs.errors > 0 || logs.warnings > 0) {
+    lines.push(
+      `Kubernetes logs: ${logs.errors} ${plural(logs.errors, "error")} / ` +
+        `${logs.warnings} ${plural(logs.warnings, "warning")}`,
+    );
+  }
+  if (config.grafanaUrl) lines.push(`Logs: ${config.grafanaUrl}`);
+  return lines.join("\n");
+}
+
+function formatUser(user: UserActivity): string {
+  const name = slackSafe(user.name?.trim() || "Unnamed user");
+  return `${name} (${slackSafe(user.email)})`;
+}
+
+function formatDetails(values: string[]): string {
+  const unique = [...new Set(values)];
+  const shown = unique.slice(0, DETAIL_LIMIT);
+  const remainder = unique.length - shown.length;
+  return remainder > 0
+    ? `${shown.join(", ")} (+${remainder} more)`
+    : shown.join(", ");
+}
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+function slackSafe(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function parseTick(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function collectionBoundary(scheduledTick: Date): Date {
+  return new Date(scheduledTick.getTime() - LOG_INGESTION_LAG_MS);
+}
+
+function escapeLogQlString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}


### PR DESCRIPTION
## Summary
- run a durable production-only digest every 20 minutes for new signups, login sessions, connector connections, and first MCP conversation activity
- query warning/error logs from the `summaries-prod` Kubernetes namespace through Loki, and stay silent when neither product nor significant log activity occurred
- deliver through the existing #devops Alertmanager Slack route without exposing the Slack webhook to Lobu; retries and catch-up intervals dedupe by exact window end
- monitor repeated digest task failures with the existing scheduled-job Prometheus alert

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; tree `d919327128c4129aedd13f4268c5e9983dfe4c4e`)
- [x] Tests run: `bun test packages/server/src/scheduled/__tests__/product-ops-digest.test.ts` (8 pass), server `tsc --noEmit`, `helm lint charts/lobu`
- [x] Bug fix: red→fix→green outputs pasted below
- [x] Production interfaces checked read-only: live CNPG queries, exact Loki LogQL, Alertmanager CRD server dry-run

### Red → green evidence

**Catch-up window dedupe**

Red (one overlapping 40-minute collection instead of exact windows):
```
Expected two 20-minute windows; received one 11:20–12:00 window
7 pass, 1 fail
```

Green:
```
8 pass, 0 fail, 25 expect() calls
```

**Fail-closed assertions**

The mandatory fixer added missing `await` to both rejection assertions. Mutation proof made each delivery path a no-op in turn:
```
Loki mutation: 1 focused failure
Alertmanager mutation: 1 focused failure
Restored implementation: 8 pass, 0 fail
```

## Notes
- Owletto PR lobu-ai/owletto#814 merged first at `6e20f4bafbb15abafc4f755d7c7ce44a894be017`; this parent pointer is reachable from `owletto/main`.
- The merged Owletto config is already live and inert on the old image: the dedicated Alertmanager route exists, env is present, and the app rollout is healthy. Activation begins only after this code deploys.
- The job runs at minutes 02/22/42 and evaluates aligned 20-minute windows ending at 00/20/40, leaving two minutes for Promtail ingestion.
- No database, API, or SDK surface was added.