### PR TITLE
fix(server): let behaviors use creator private connections

### DIFF
--- a/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../../index';
 import {
   dispatchChromeAction,
@@ -8,6 +8,8 @@ import {
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import {
   addUserToOrganization,
+  createTestAgent,
+  createTestConnectorDefinition,
   createTestOrganization,
   createTestUser,
 } from '../setup/test-fixtures';
@@ -74,15 +76,17 @@ describe('dispatchChromeAction target browser routing', () => {
 
   async function seedParentRun(
     orgId: string,
-    createdByUserId?: string
+    createdByUserId?: string,
+    watcherId?: number,
+    windowId?: number
   ): Promise<number> {
     const [run] = (await sql`
       INSERT INTO runs (
         organization_id, run_type, action_key, status, claimed_by, claimed_at,
-        created_by_user_id
+        created_by_user_id, watcher_id, window_id
       ) VALUES (
         ${orgId}, 'action', 'prepare_reply', 'running', 'connector-worker-1', NOW(),
-        ${createdByUserId ?? null}
+        ${createdByUserId ?? null}, ${watcherId ?? null}, ${windowId ?? null}
       )
       RETURNING id
     `) as unknown as Array<{ id: number }>;
@@ -227,6 +231,107 @@ describe('dispatchChromeAction target browser routing', () => {
     expect(body.error_message).toContain(
       'The browser this action is set to open in is offline'
     );
+  });
+
+  it("accepts a Behavior creator's private chrome connection", async () => {
+    const org = await createTestOrganization({ name: 'Behavior private browser' });
+    await createTestConnectorDefinition({
+      key: 'chrome',
+      name: 'Chrome',
+      organization_id: org.id,
+    });
+    const creator = await createTestUser({ email: 'behavior-browser@test.com' });
+    await addUserToOrganization(creator.id, org.id);
+    const agent = await createTestAgent({
+      organizationId: org.id,
+      ownerUserId: creator.id,
+    });
+    const [behavior] = await sql`
+      WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+      INSERT INTO watchers (
+        id, watcher_group_id, organization_id, agent_id, created_by, name, slug
+      )
+      SELECT id, id, ${org.id}, ${agent.agentId}, ${creator.id},
+        'Private browser behavior', 'private-browser-behavior'
+      FROM next_id
+      RETURNING id
+    `;
+    const [window] = await sql`
+      INSERT INTO events (
+        organization_id, semantic_type, payload_type, payload_data,
+        metadata, occurred_at, created_at, created_by
+      ) VALUES (
+        ${org.id}, 'canvas_state', 'json_template', '{}'::jsonb,
+        ${sql.json({ watcher_id: Number(behavior.id) })}, NOW(), NOW(), ${creator.id}
+      )
+      RETURNING id
+    `;
+    const [worker] = await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+      ) VALUES (
+        ${creator.id}, 'ext-behavior-browser', 'chrome-extension',
+        ${sql.json(['browser.tabs', 'browser.debugger'])}, 'Behavior Browser',
+        ${org.id}, NOW()
+      )
+      RETURNING id
+    `;
+    const [conn] = await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        created_by, visibility, device_worker_id, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'chrome', 'chrome-behavior-private', 'Chrome', 'active',
+        ${creator.id}, 'private', ${worker.id}::uuid, NOW(), NOW()
+      )
+      RETURNING id
+    `;
+    const runId = await seedParentRun(
+      org.id,
+      undefined,
+      Number(behavior.id),
+      Number(window.id)
+    );
+
+    const responsePromise = app.request('/dispatch', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        parent_run_id: runId,
+        worker_id: 'connector-worker-1',
+        action_key: 'navigate',
+        action_input: {
+          url: 'https://x.com/i/web/status/2083959735481716957',
+          [TARGET_BROWSER_CONNECTION_INPUT_KEY]: Number(conn.id),
+        },
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      const childRows = await sql`
+        SELECT id, created_by_user_id, watcher_id, window_id
+        FROM runs
+        WHERE organization_id = ${org.id}
+          AND connector_key = 'chrome'
+          AND id <> ${runId}
+        ORDER BY id DESC
+        LIMIT 1
+      `;
+      expect(childRows).toHaveLength(1);
+      const child = childRows[0];
+      expect(child.created_by_user_id).toBeNull();
+      expect(Number(child.watcher_id)).toBe(Number(behavior.id));
+      expect(Number(child.window_id)).toBe(Number(window.id));
+      await sql`
+        UPDATE runs
+        SET status = 'completed', action_output = '{}'::jsonb, completed_at = NOW()
+        WHERE id = ${child.id}
+      `;
+    });
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: 'completed' });
   });
 
   it("refuses the requester's connection when pinned to another member's browser", async () => {

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -7,9 +7,11 @@ import { createAuthProfile } from "../../utils/auth-profiles";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
+	addUserToOrganization,
 	createTestAgent,
 	createTestConnection,
 	createTestConnectorDefinition,
+	createTestUser,
 	seedOwnerContext,
 } from "../setup/test-fixtures";
 
@@ -108,6 +110,15 @@ describe("operations.execute backend lifecycle", () => {
 					kind: "write",
 					requiresApproval: true,
 				},
+				stage_browser: {
+					name: "Stage browser",
+					kind: "write",
+					input_schema: {
+						type: "object",
+						properties: { browser_connection_id: { type: "integer" } },
+						required: ["browser_connection_id"],
+					},
+				},
 			})}
 			WHERE organization_id = ${orgId} AND key = ${LOCAL}
 		`;
@@ -117,6 +128,12 @@ describe("operations.execute backend lifecycle", () => {
 				class ConnectorRuntime {
 					async sync() { return { items: [] }; }
 					async execute(ctx) {
+						if (ctx.actionKey === 'stage_browser') {
+							await ctx.sessionState.chrome_dispatcher.dispatch('navigate', {
+								url: 'https://example.test/',
+								target_browser_connection_id: ctx.input.browser_connection_id,
+							});
+						}
 						return { success: true, output: { backend: 'local_action', value: ctx.input.value ?? null } };
 					}
 				}
@@ -400,6 +417,212 @@ describe("operations.execute backend lifecycle", () => {
 		`;
 		expect(reactions).toHaveLength(1);
 		expect(Number(reactions[0]?.run_id)).toBe(result.run_id);
+	});
+
+	it("lets a headless Behavior execute through its author's private connection", async () => {
+		const result = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "behavior-private-connection" },
+				idempotency_key: "operation-backend-test:behavior-private-connection",
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: behaviorId,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		)) as { run_id: number; status: string };
+
+		expect(result.status).toBe("completed");
+		const [run] = await getTestDb()`
+			SELECT created_by_user_id, watcher_id, window_id
+			FROM runs
+			WHERE id = ${result.run_id}
+		`;
+		expect(run.created_by_user_id).toBeNull();
+		expect(Number(run.watcher_id)).toBe(behaviorId);
+		expect(Number(run.window_id)).toBe(windowId);
+	});
+
+	it("lets a headless Behavior discover its author's private operation target", async () => {
+		const otherUser = await createTestUser();
+		await addUserToOrganization(otherUser.id, orgId);
+		const otherPrivate = await createTestConnection({
+			organization_id: orgId,
+			connector_key: LOCAL,
+			created_by: otherUser.id,
+			visibility: "private",
+		});
+		const result = (await manageOperations(
+			{
+				action: "list_available",
+				connector_key: LOCAL,
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: behaviorId,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		)) as {
+			operations: Array<{
+				operation_key: string;
+				execution_targets: Array<{ connection_id: number }>;
+			}>;
+		};
+
+		const echo = result.operations.find(
+			(operation) => operation.operation_key === "echo",
+		);
+		expect(echo?.execution_targets.map((target) => target.connection_id)).toContain(
+			localConnectionId,
+		);
+		expect(echo?.execution_targets.map((target) => target.connection_id)).not.toContain(
+			otherPrivate.id,
+		);
+	});
+
+	it("carries the Behavior author through private browser target authorization", async () => {
+		const sql = getTestDb();
+		const [worker] = await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, label,
+				organization_id, last_seen_at
+			) VALUES (
+				${userId}, 'behavior-private-browser', 'chrome-extension',
+				${sql.json(["browser.tabs", "browser.debugger"])}, 'Behavior Browser',
+				${orgId}, NOW() - INTERVAL '1 day'
+			)
+			RETURNING id
+		`;
+		const [browserConnection] = await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status,
+				created_by, visibility, device_worker_id, created_at, updated_at
+			) VALUES (
+				${orgId}, 'chrome', 'behavior-private-browser', 'Behavior Browser', 'active',
+				${userId}, 'private', ${worker.id}::uuid, NOW(), NOW()
+			)
+			RETURNING id
+		`;
+
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "stage_browser",
+				input: { browser_connection_id: Number(browserConnection.id) },
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: behaviorId,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		);
+
+		expect(result).toMatchObject({
+			status: "failed",
+			error_message: expect.stringContaining(
+				"The browser this action is set to open in is offline",
+			),
+		});
+	});
+
+	it("does not let a Behavior use another member's private connection", async () => {
+		const otherUser = await createTestUser();
+		await addUserToOrganization(otherUser.id, orgId);
+		const otherPrivate = await createTestConnection({
+			organization_id: orgId,
+			connector_key: LOCAL,
+			created_by: otherUser.id,
+			visibility: "private",
+		});
+
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: otherPrivate.id,
+				operation_key: "echo",
+				input: { value: "must-not-run" },
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: behaviorId,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		);
+
+		expect(result).toEqual({ error: "Connection not found or not visible." });
+	});
+
+	it("keeps organization-visible operations available to a headless Behavior", async () => {
+		const orgConnection = await createTestConnection({
+			organization_id: orgId,
+			connector_key: LOCAL,
+			visibility: "org",
+		});
+
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: orgConnection.id,
+				operation_key: "echo",
+				input: { value: "behavior-org-connection" },
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: behaviorId,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		);
+
+		expect(result).toMatchObject({
+			status: "completed",
+			output: { backend: "local_action", value: "behavior-org-connection" },
+		});
+	});
+
+	it("fails closed when the stamped Behavior no longer exists", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "must-not-run" },
+			},
+			{} as Env,
+			{
+				...ctx,
+				userId: null,
+				memberRole: null,
+				actingWatcherId: 2_147_483_647,
+				actingWindowId: windowId,
+				sourceContext: { source: "watcher-run" },
+			},
+		);
+
+		expect(result).toEqual({ error: "Connection not found or not visible." });
 	});
 
 	it("repairs a failed feedback link without stranding or repeating an inline action", async () => {

--- a/packages/server/src/authz/behavior-connection-visibility.ts
+++ b/packages/server/src/authz/behavior-connection-visibility.ts
@@ -1,0 +1,34 @@
+import type { DbClient } from '../db/client';
+
+interface BehaviorConnectionVisibilityContext {
+  organizationId: string;
+  userId: string | null;
+  actingWatcherId?: number | null;
+}
+
+/**
+ * Resolve the user identity used only for connection row visibility.
+ *
+ * Behavior reactions are headless, so their execution context intentionally has
+ * no user principal. They may still use private connections owned by their
+ * durable creator. Policy, provenance, and approval checks continue to use the
+ * autonomous Behavior principal; this resolver only supplies the principal for
+ * connection visibility predicates.
+ */
+export async function resolveBehaviorConnectionVisibilityUserId(
+  ctx: BehaviorConnectionVisibilityContext,
+  sql: DbClient
+): Promise<string | null> {
+  if (ctx.userId !== null || ctx.actingWatcherId == null) {
+    return ctx.userId;
+  }
+
+  const rows = await sql<{ created_by: string }>`
+    SELECT created_by
+    FROM watchers
+    WHERE id = ${ctx.actingWatcherId}
+      AND organization_id = ${ctx.organizationId}
+    LIMIT 1
+  `;
+  return rows[0]?.created_by ?? null;
+}

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -30,6 +30,7 @@ import {
 	readRequestedScopesFromAuthData,
 } from "../../auth/oauth/scopes";
 import { resolveMaxAccessLevel, type ToolAccessLevel } from "../../auth/tool-access";
+import { resolveBehaviorConnectionVisibilityUserId } from "../../authz/behavior-connection-visibility";
 import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import {
 	agentExistsInOrg,
@@ -364,7 +365,7 @@ async function executeLocalActionInline(
 						// Browser affinity: data connection pin to a chrome-extension
 						// selects which Owletto browser receives scrapes.
 						parentConnectionId: connection.id,
-						requesterUserId,
+						visibilityUserId: requesterUserId,
 						abortSignal,
 					});
 
@@ -959,14 +960,20 @@ async function loadVisibleOperationTargets(
 	args: Static<typeof ListAvailableAction>,
 	ctx: ToolContext,
 ): Promise<OperationTargetRow[]> {
+	const sql = getDb();
+	const visibilityUserId = await resolveBehaviorConnectionVisibilityUserId(
+		ctx,
+		sql,
+	);
 	const visibility = compileConnectionRowVisibility(
 		{
 			...authzScopeFromToolContext(ctx),
-			principalIsAdmin: await callerIsAdmin(getDb(), ctx),
+			principal: visibilityUserId,
+			principalIsAdmin: await callerIsAdmin(sql, ctx),
 		},
 		"c",
 	);
-	return (await getDb().unsafe(
+	return (await sql.unsafe(
 		`SELECT c.id,
 		        c.connector_key,
 		        c.slug,
@@ -1261,9 +1268,14 @@ async function handleExecute(
 			422,
 		);
 	}
+	const visibilityUserId = await resolveBehaviorConnectionVisibilityUserId(
+		ctx,
+		sql,
+	);
 	const visibility = compileConnectionRowVisibility(
 		{
 			...authzScopeFromToolContext(ctx),
+			principal: visibilityUserId,
 			principalIsAdmin: await callerIsAdmin(sql, ctx),
 		},
 		"c",
@@ -1631,7 +1643,7 @@ async function handleExecute(
 		connection,
 		operation,
 		input,
-		ctx.userId,
+		visibilityUserId,
 		env,
 		ctx.abortSignal,
 	);

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -21,6 +21,7 @@
 
 import type { DispatchChromeActionRequest } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
+import { resolveBehaviorConnectionVisibilityUserId } from '../authz/behavior-connection-visibility';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
@@ -528,7 +529,7 @@ export const TARGET_BROWSER_CONNECTION_INPUT_KEY = 'target_browser_connection_id
  */
 async function resolveTargetBrowserWorker(
   organizationId: string,
-  requesterUserId: string | null,
+  visibilityUserId: string | null,
   rawTarget: unknown,
   sql: ReturnType<typeof getDb>
 ): Promise<{ deviceWorkerId: string } | { error: string }> {
@@ -544,7 +545,7 @@ async function resolveTargetBrowserWorker(
   // only; a user may additionally target their own private browser.
   const visibility = sql`${sql.unsafe(
     compileConnectionRowVisibility(
-      { organizationId, principal: requesterUserId },
+      { organizationId, principal: visibilityUserId },
       'con'
     )
   )}`;
@@ -612,8 +613,8 @@ export async function dispatchChromeActionToExtension(params: {
    * a chrome-extension, scrapes target that browser.
    */
   parentConnectionId?: number | null;
-  /** Trusted requesting user. Null means headless and permits org-visible targets only. */
-  requesterUserId?: string | null;
+  /** User principal used only to resolve private browser visibility. */
+  visibilityUserId?: string | null;
   /** Abort the wait early (e.g. the calling reaction hit its budget). */
   abortSignal?: AbortSignal;
 }): Promise<ChromeActionDispatchResult> {
@@ -623,10 +624,38 @@ export async function dispatchChromeActionToExtension(params: {
     actionInput,
     parentRunId,
     parentConnectionId,
-    requesterUserId = null,
+    visibilityUserId = null,
     abortSignal,
   } = params;
   const sql = getDb();
+
+  let createdByUserId = visibilityUserId;
+  let watcherId: number | null = null;
+  let windowId: number | null = null;
+  if (parentRunId != null) {
+    const parentRows = (await sql`
+      SELECT created_by_user_id, watcher_id, window_id
+      FROM runs
+      WHERE id = ${parentRunId}
+        AND organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{
+      created_by_user_id: string | null;
+      watcher_id: number | null;
+      window_id: number | null;
+    }>;
+    if (parentRows.length === 0) {
+      return {
+        status: 'failed',
+        error_message: `Parent run ${parentRunId} was not found in this organization.`,
+      };
+    }
+    createdByUserId = parentRows[0].created_by_user_id;
+    watcherId =
+      parentRows[0].watcher_id == null ? null : Number(parentRows[0].watcher_id);
+    windowId =
+      parentRows[0].window_id == null ? null : Number(parentRows[0].window_id);
+  }
 
   // An interactive action may name the browser it wants to be seen in. That
   // beats the parent connection's scrape pin, which points at whichever machine
@@ -637,7 +666,7 @@ export async function dispatchChromeActionToExtension(params: {
   if (rawTarget != null) {
     const resolved = await resolveTargetBrowserWorker(
       organizationId,
-      requesterUserId,
+      visibilityUserId,
       rawTarget,
       sql
     );
@@ -692,7 +721,9 @@ export async function dispatchChromeActionToExtension(params: {
       operationInput,
       approvalMode: 'device',
       requireCompiledCode: false,
-      createdByUserId: requesterUserId,
+      createdByUserId,
+      watcherId,
+      windowId,
     });
     runId = claim.runId;
   } catch (err) {
@@ -753,7 +784,7 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
   // overrides it.
   const parentRows = (await sql`
     SELECT r.organization_id, r.status, r.claimed_by, r.run_type, r.connection_id,
-           r.created_by_user_id
+           r.created_by_user_id, r.watcher_id
     FROM runs r
     WHERE r.id = ${body.parent_run_id}
     LIMIT 1
@@ -764,6 +795,7 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
     run_type: string;
     connection_id: number | null;
     created_by_user_id: string | null;
+    watcher_id: number | null;
   }>;
   if (parentRows.length === 0) {
     return c.json({ error: 'parent_run not found' }, 404);
@@ -785,13 +817,21 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
     );
   }
 
+  const visibilityUserId = await resolveBehaviorConnectionVisibilityUserId(
+    {
+      organizationId: parentRun.organization_id,
+      userId: parentRun.created_by_user_id,
+      actingWatcherId: parentRun.watcher_id,
+    },
+    sql
+  );
   const result = await dispatchChromeActionToExtension({
     organizationId: parentRun.organization_id,
     actionKey: body.action_key,
     actionInput: body.action_input ?? {},
     parentRunId: body.parent_run_id,
     parentConnectionId: parentRun.connection_id,
-    requesterUserId: parentRun.created_by_user_id,
+    visibilityUserId,
   });
   return c.json(result);
 }


### PR DESCRIPTION
## Summary

- Let a headless Behavior use private connections owned by its durable creator for operation discovery and execution.
- Use that creator only as the private-connection visibility principal; keep child Chrome runs attributed to the parent human or Behavior provenance.
- Carry the same visibility rule through nested Chrome dispatch and connector-worker Chrome dispatch.
- Continue to hide and reject another member's private connections, and fail closed when the stamped Behavior is missing.

Root cause: reaction execution correctly stamps `actingWatcherId` but has no user identity. Connection visibility therefore treated it as a generic headless caller. The shared resolver now supplies the Behavior creator at each connection-visibility seam without turning that creator into the autonomous run's audit identity.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean: all 16 Linux lanes passed on staged tree `7d782f6b22ee53cf0d9c3a2bffab91f15ed86b56`.
- [x] Four focused integration suites: 58 passed.
- [x] `bun run typecheck` in `packages/server`.
- [x] Bug fix red→fix→green outputs included below.
- [ ] Live Behavior → X/LinkedIn browser staging → Community Slack DM after deployment.

### Red: private connection visibility

```text
FAIL operations.execute backend lifecycle > lets a headless Behavior execute through its author's private connection
Expected: "completed"
Received: undefined
Tests 1 failed | 15 passed
```

Follow-up cases proved discovery and downstream browser dispatch lost the same visibility identity:

```text
FAIL dispatchChromeAction target browser routing > accepts a Behavior creator's private chrome connection
FAIL operations.execute backend lifecycle > lets a headless Behavior discover its author's private operation target
FAIL operations.execute backend lifecycle > carries the Behavior author through private browser target authorization
Tests 3 failed | 26 passed
```

### Red: provenance after visibility fix

The online browser dispatch reached child-run creation and exposed the visibility/provenance collision:

```text
FAIL dispatchChromeAction target browser routing > accepts a Behavior creator's private chrome connection
AssertionError: expected 'user_SFqHELS8j6U' to be null
```

### Green

```text
Test Files 4 passed (4)
Tests 58 passed (58)
$ tsc --noEmit
make pre-pr-remote: 16 Linux lanes passed
```

## Notes

No database, public API, SDK, connector, or organization configuration changes.

`make review-fix` could not run because its Claude CLI session is logged out; it made no changes. Posted review findings for discovery, downstream dispatch, and child-run provenance are addressed in this revision.

