### PR TITLE
feat(personal-agent): add live Midas net worth snapshots

### DIFF
--- a/examples/personal-agent/__tests__/market-quotes.connector.test.ts
+++ b/examples/personal-agent/__tests__/market-quotes.connector.test.ts
@@ -1,0 +1,135 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+let MarketQuotesConnector: typeof import("../market-quotes.connector").default;
+let normalizeSymbolInput: typeof import("../market-quotes.connector").normalizeSymbolInput;
+let parseYahooChartBody: typeof import("../market-quotes.connector").parseYahooChartBody;
+let quoteMany: typeof import("../market-quotes.connector").quoteMany;
+let toProviderSymbol: typeof import("../market-quotes.connector").toProviderSymbol;
+
+beforeAll(async () => {
+  const mod = await import("../market-quotes.connector");
+  MarketQuotesConnector = mod.default;
+  normalizeSymbolInput = mod.normalizeSymbolInput;
+  parseYahooChartBody = mod.parseYahooChartBody;
+  quoteMany = mod.quoteMany;
+  toProviderSymbol = mod.toProviderSymbol;
+});
+
+describe("market quote symbol mapping", () => {
+  test("maps Midas US and Turkish tickers to Yahoo symbols", () => {
+    expect(toProviderSymbol("US", "AAPL")).toBe("AAPL");
+    expect(toProviderSymbol("TR", "THYAO")).toBe("THYAO.IS");
+    expect(normalizeSymbolInput("TR:THYAO")).toEqual({
+      id: "TR:THYAO",
+      market: "TR",
+      symbol: "THYAO",
+      provider_symbol: "THYAO.IS",
+    });
+  });
+});
+
+describe("Yahoo chart parsing", () => {
+  test("requires a positive price, currency, and market timestamp", () => {
+    expect(
+      parseYahooChartBody(
+        {
+          chart: {
+            result: [
+              {
+                meta: {
+                  regularMarketPrice: 201.5,
+                  currency: "usd",
+                  regularMarketTime: 1_700_000_000,
+                },
+              },
+            ],
+          },
+        },
+        "AAPL"
+      )
+    ).toEqual({
+      price: 201.5,
+      currency: "USD",
+      asOf: "2023-11-14T22:13:20.000Z",
+    });
+
+    expect(
+      parseYahooChartBody(
+        { chart: { result: [{ meta: { regularMarketPrice: 0 } }] } },
+        "NOPE"
+      )
+    ).toEqual({ error: "no usable price for NOPE" });
+  });
+});
+
+describe("market quote action", () => {
+  test("executes one row per input and never invents zero for an unavailable symbol", async () => {
+    const fetchImpl = async (input: string | URL | Request) => {
+      if (String(input).includes("AAPL")) {
+        return new Response(
+          JSON.stringify({
+            chart: {
+              result: [
+                {
+                  meta: {
+                    regularMarketPrice: 250,
+                    currency: "USD",
+                    regularMarketTime: 1_700_000_000,
+                  },
+                },
+              ],
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response(JSON.stringify({ chart: { result: [] } }), {
+        status: 200,
+      });
+    };
+
+    const connector = new MarketQuotesConnector();
+    connector.fetchImpl = fetchImpl;
+    const result = await connector.execute({
+      actionKey: "quote",
+      input: {
+        symbols: [
+          { market: "US", symbol: "AAPL" },
+          { market: "US", symbol: "NOPE" },
+        ],
+      },
+      credentials: null,
+      config: {},
+    });
+    const rows = result.output?.quotes as Array<Record<string, unknown>>;
+
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      status: "quoted",
+      id: "US:AAPL",
+      price: 250,
+      stale: true,
+    });
+    expect(rows[1]).toMatchObject({
+      status: "quote_unavailable",
+      id: "US:NOPE",
+    });
+    expect(rows[1]).not.toHaveProperty("price");
+  });
+
+  test("exposes a read-only, approval-free action and refuses sync", async () => {
+    const connector = new MarketQuotesConnector();
+    const action = connector.definition.actions?.quote;
+    expect(action?.requiresApproval).toBe(false);
+    expect(action?.annotations).toMatchObject({
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+    await expect(connector.sync()).rejects.toThrow(/no feeds/i);
+  });
+});

--- a/examples/personal-agent/__tests__/net-worth.config.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import config from "../lobu.config";
+import taxConfig from "../../personal-finance/lobu.config";
+
+describe("Midas net-worth configuration", () => {
+  test("runs weekly in London even when Midas events are unchanged", () => {
+    const behavior = config.behaviors?.find(
+      (candidate) => candidate.slug === "midas-net-worth"
+    );
+    expect(behavior).toBeDefined();
+    expect(behavior?.triggers).toEqual([
+      {
+        kind: "schedule",
+        cron: "0 9 * * 1",
+        timezone: "Europe/London",
+        skip_if_unchanged: false,
+      },
+    ]);
+    expect(behavior?.reaction).toMatchObject({
+      path: "./net-worth.reaction.ts",
+    });
+  });
+
+  test("declares a same-org, feedless quote connection", () => {
+    expect(
+      config.connections?.find(
+        (connection) => connection.slug === "market-quotes"
+      )
+    ).toMatchObject({
+      connector: "market.quotes",
+      feeds: [],
+    });
+    expect(
+      config.connectors?.find(
+        (connector) => connector.path === "./market-quotes.connector.ts"
+      )
+    ).toBeDefined();
+  });
+
+  test("the tax workspace no longer declares a net-worth Behavior", () => {
+    expect(
+      taxConfig.behaviors?.find((behavior) => behavior.slug === "net-worth")
+    ).toBeUndefined();
+  });
+});

--- a/examples/personal-agent/__tests__/net-worth.reaction.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.reaction.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
+import runNetWorthSnapshot, {
+  buildMidasSnapshot,
+  type MidasBalanceRow,
+  type MidasHoldingMetadata,
+  type MidasHoldingRow,
+  type QuoteRow,
+} from "../net-worth.reaction";
+
+const balance: MidasBalanceRow = {
+  run_id: 22,
+  occurred_at: "2026-08-10T08:00:00.000Z",
+};
+
+function holding(
+  symbol: string,
+  value: number,
+  overrides: Partial<MidasHoldingMetadata> = {}
+): MidasHoldingRow {
+  return {
+    origin_id: `midas-holding-US-${symbol}`,
+    occurred_at: "2026-08-10T08:00:00.000Z",
+    metadata: {
+      symbol,
+      type: "US",
+      shares: 2,
+      price: value / 2,
+      avg_cost: value / 4,
+      value,
+      currency: "USD",
+      ...overrides,
+    },
+  };
+}
+
+const ctx: ReactionContext = {
+  extracted_data: { summary: "Run the deterministic valuation." },
+  entities: [],
+  window: {
+    id: 91,
+    run_id: 300,
+    behavior_id: 45,
+    window_start: "2026-08-12T08:59:00.000Z",
+    window_end: "2026-08-12T09:00:00.000Z",
+    granularity: "week",
+    content_analyzed: 0,
+  },
+  behavior: {
+    id: 45,
+    slug: "midas-net-worth",
+    name: "Midas net worth",
+    version: 1,
+  },
+  organization_id: "org-buremba",
+  organization_slug: "buremba",
+};
+
+describe("buildMidasSnapshot", () => {
+  test("uses live quotes while retaining unavailable holdings at their broker mark", () => {
+    const holdings = [holding("AAPL", 200), holding("NOPE", 80)];
+    const quotes: QuoteRow[] = [
+      {
+        status: "quoted",
+        id: "US:AAPL",
+        market: "US",
+        symbol: "AAPL",
+        provider_symbol: "AAPL",
+        provider: "yahoo",
+        price: 250,
+        currency: "USD",
+        as_of: "2026-08-12T08:58:00.000Z",
+        stale: false,
+        tier: "delayed",
+      },
+      {
+        status: "quote_unavailable",
+        id: "US:NOPE",
+        market: "US",
+        symbol: "NOPE",
+        provider_symbol: "NOPE",
+        provider: "yahoo",
+        reason: "not found",
+      },
+    ];
+
+    const snapshot = buildMidasSnapshot(
+      balance,
+      holdings,
+      quotes,
+      "2026-08-12T09:00:00.000Z"
+    );
+
+    expect(snapshot.midas_run_id).toBe(22);
+    expect(snapshot.positions).toHaveLength(2);
+    expect(snapshot.positions[0]).toMatchObject({
+      symbol: "AAPL",
+      current_value: 500,
+      mark_source: "market_quote",
+      acquisition_cost: 100,
+    });
+    expect(snapshot.positions[1]).toMatchObject({
+      symbol: "NOPE",
+      current_value: 80,
+      mark_source: "broker_snapshot",
+      quote_status: "quote_unavailable",
+    });
+    expect(snapshot.by_currency).toEqual([
+      {
+        currency: "USD",
+        current_value: 580,
+        broker_value: 280,
+        acquisition_cost: 140,
+        unrealized_gain: 440,
+        position_count: 2,
+        quoted_count: 1,
+        stale_quote_count: 0,
+        unavailable_count: 1,
+      },
+    ]);
+  });
+
+  test("rejects a quote in a different currency instead of mixing currencies", () => {
+    const snapshot = buildMidasSnapshot(
+      balance,
+      [holding("AAPL", 200)],
+      [
+        {
+          status: "quoted",
+          id: "US:AAPL",
+          market: "US",
+          symbol: "AAPL",
+          provider_symbol: "AAPL",
+          provider: "yahoo",
+          price: 250,
+          currency: "EUR",
+          as_of: "2026-08-12T08:58:00.000Z",
+          stale: false,
+          tier: "delayed",
+        },
+      ],
+      "2026-08-12T09:00:00.000Z"
+    );
+
+    expect(snapshot.positions[0]).toMatchObject({
+      current_value: 200,
+      mark_source: "broker_snapshot",
+      quote_status: "quote_unavailable",
+      quote_reason: "quote currency EUR does not match holding currency USD",
+    });
+  });
+});
+
+describe("weekly net-worth reaction", () => {
+  test("queries one Midas cohort, executes the local quote action, and saves one derived event", async () => {
+    const queries: string[] = [];
+    const operationInputs: unknown[] = [];
+    const saved: unknown[] = [];
+    const notified: unknown[] = [];
+    const client = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        return queries.length === 1
+          ? [balance]
+          : [holding("AAPL", 200), holding("NOPE", 80)];
+      },
+      connections: {
+        list: async () => ({
+          connections: [
+            {
+              id: 77,
+              slug: "market-quotes",
+              connector_key: "market.quotes",
+              status: "active",
+            },
+          ],
+        }),
+      },
+      operations: {
+        execute: async (input: unknown) => {
+          operationInputs.push(input);
+          return {
+            status: "completed",
+            output: {
+              quotes: [
+                {
+                  status: "quoted",
+                  id: "US:AAPL",
+                  market: "US",
+                  symbol: "AAPL",
+                  provider_symbol: "AAPL",
+                  provider: "yahoo",
+                  price: 250,
+                  currency: "USD",
+                  as_of: "2026-08-12T08:58:00.000Z",
+                  stale: false,
+                  tier: "delayed",
+                },
+                {
+                  status: "quote_unavailable",
+                  id: "US:NOPE",
+                  market: "US",
+                  symbol: "NOPE",
+                  provider_symbol: "NOPE",
+                  provider: "yahoo",
+                  reason: "not found",
+                },
+              ],
+            },
+          };
+        },
+      },
+      knowledge: {
+        save: async (input: unknown) => {
+          saved.push(input);
+          return { id: 501, created: true, metadata: {} };
+        },
+      },
+      notifications: {
+        send: async (input: unknown) => {
+          notified.push(input);
+          return { notified_count: 1, event_id: 502, url: null };
+        },
+      },
+      log: () => undefined,
+    } as unknown as ReactionClient;
+
+    await runNetWorthSnapshot(ctx, client);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[1]).toContain("run_id = 22");
+    expect(operationInputs).toEqual([
+      {
+        connection_id: 77,
+        operation_key: "quote",
+        input: {
+          symbols: [
+            { market: "US", symbol: "AAPL" },
+            { market: "US", symbol: "NOPE" },
+          ],
+        },
+        idempotency_key: "midas-net-worth:quotes:window:91:midas-run:22",
+        behavior_source: { behavior_id: 45, window_id: 91 },
+      },
+    ]);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      semantic_type: "net_worth_snapshot",
+      title: "Midas net worth snapshot",
+      idempotency_key: "midas-net-worth:snapshot:window:91",
+      behavior_source: { behavior_id: 45, window_id: 91 },
+      metadata: {
+        scope: "midas",
+        midas_run_id: 22,
+        by_currency: [{ currency: "USD", current_value: 580 }],
+      },
+    });
+    expect(notified).toHaveLength(1);
+  });
+
+  test("notifies from the persisted snapshot after an idempotent save replay", async () => {
+    const persistedSnapshot = buildMidasSnapshot(
+      balance,
+      [holding("AAPL", 200)],
+      [],
+      ctx.window.window_end
+    );
+    const notified: Array<{ body?: string }> = [];
+    const client = {
+      query: async (sql: string) =>
+        sql.includes("midas-balance") ? [balance] : [holding("AAPL", 200)],
+      connections: {
+        list: async () => ({
+          connections: [
+            {
+              id: 77,
+              slug: "market-quotes",
+              connector_key: "market.quotes",
+              status: "active",
+            },
+          ],
+        }),
+      },
+      operations: {
+        execute: async () => ({
+          status: "completed",
+          output: {
+            quotes: [
+              {
+                status: "quoted",
+                id: "US:AAPL",
+                market: "US",
+                symbol: "AAPL",
+                provider_symbol: "AAPL",
+                provider: "yahoo",
+                price: 250,
+                currency: "USD",
+                as_of: "2026-08-12T08:58:00.000Z",
+                stale: false,
+                tier: "delayed",
+              },
+            ],
+          },
+        }),
+      },
+      knowledge: {
+        save: async () => ({
+          id: 501,
+          created: false,
+          metadata: persistedSnapshot as unknown as Record<string, unknown>,
+        }),
+      },
+      notifications: {
+        send: async (input: { body?: string }) => {
+          notified.push(input);
+          return { notified_count: 1, event_id: 502, url: null };
+        },
+      },
+      log: () => undefined,
+    } as unknown as ReactionClient;
+
+    await runNetWorthSnapshot(ctx, client);
+
+    expect(notified[0]?.body).toContain("USD 200.00 current");
+    expect(notified[0]?.body).not.toContain("USD 500.00 current");
+  });
+
+  test("includes every holding when a Midas cohort contains more than 200 positions", async () => {
+    const cohort = Array.from({ length: 1_001 }, (_, index) =>
+      holding(`STOCK${index}`, 4)
+    );
+    const saved: Array<{ metadata?: { positions?: unknown[] } }> = [];
+    const client = {
+      query: async (sql: string) => {
+        if (sql.includes("midas-balance")) return [balance];
+        const limit = Number(sql.match(/LIMIT (\d+)/)?.[1] ?? cohort.length);
+        const offset = Number(sql.match(/OFFSET (\d+)/)?.[1] ?? 0);
+        return cohort.slice(offset, offset + limit);
+      },
+      connections: {
+        list: async () => ({
+          connections: [
+            {
+              id: 77,
+              slug: "market-quotes",
+              connector_key: "market.quotes",
+              status: "active",
+            },
+          ],
+        }),
+      },
+      operations: {
+        execute: async (input: {
+          input: { symbols: Array<{ market: string; symbol: string }> };
+        }) => ({
+          status: "completed",
+          output: {
+            quotes: input.input.symbols.map(({ market, symbol }) => ({
+              status: "quoted",
+              id: `${market}:${symbol}`,
+              market,
+              symbol,
+              provider_symbol: symbol,
+              provider: "yahoo",
+              price: 2,
+              currency: "USD",
+              as_of: "2026-08-12T08:58:00.000Z",
+              stale: false,
+              tier: "delayed",
+            })),
+          },
+        }),
+      },
+      knowledge: {
+        save: async (input: { metadata?: { positions?: unknown[] } }) => {
+          saved.push(input);
+          return { id: 501, created: true, metadata: {} };
+        },
+      },
+      notifications: {
+        send: async () => ({ notified_count: 1, event_id: 502, url: null }),
+      },
+      log: () => undefined,
+    } as unknown as ReactionClient;
+
+    await runNetWorthSnapshot(ctx, client);
+
+    expect(saved).toHaveLength(1);
+    expect(saved[0]?.metadata?.positions).toHaveLength(cohort.length);
+  });
+
+  test("fails closed when the configured quote connection is absent", async () => {
+    const client = {
+      query: async (sql: string) =>
+        sql.includes("midas-balance") ? [balance] : [holding("AAPL", 200)],
+      connections: { list: async () => ({ connections: [] }) },
+      log: () => undefined,
+    } as unknown as ReactionClient;
+
+    await expect(runNetWorthSnapshot(ctx, client)).rejects.toThrow(
+      /active market-quotes connection/i
+    );
+  });
+});

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -13,11 +13,13 @@ import {
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
 import type LinkedInConnector from "./linkedin.connector.ts";
+import type MarketQuotesConnector from "./market-quotes.connector.ts";
 import type RevolutTransactionsConnector from "./revolut-transactions.connector.ts";
 import type SpotifyConnector from "./spotify.connector.ts";
 import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
 import type WhatsAppCloudConnector from "./whatsapp.cloud.connector.ts";
 import type MidasConnector from "./midas.connector.ts";
+import type NetWorthReaction from "./net-worth.reaction.ts";
 import type SocialInterestRadarReaction from "./social-interest-radar.reaction.ts";
 import { takeoutConfig } from "./takeout-dirs.ts";
 
@@ -957,6 +959,16 @@ const midasConnection = defineConnection({
   feeds: [{ feed: "assets", config: {} }],
 });
 
+// A same-workspace execution target for market marks. It has no credentials or
+// feeds: the weekly reaction receives quotes directly from its read-only action
+// without persisting raw quote events.
+const marketQuotesConnection = defineConnection({
+  slug: "market-quotes",
+  connector: "market.quotes",
+  name: "Market Quotes",
+  feeds: [],
+});
+
 // Gmail person-building, not mailbox mirroring. One narrow collected feed syncs
 // only person-relevant threads (human_senders_only) so the DB holds a small
 // high-signal set that drives person minting/merging — full email content stays
@@ -1205,6 +1217,33 @@ const socialInterestRadar = defineBehavior({
   ),
 });
 
+const midasNetWorth = defineBehavior({
+  agent: personalAgent,
+  slug: "midas-net-worth",
+  name: "Midas net worth",
+  description:
+    "Values the latest Midas holdings cohort with available market marks and saves one derived snapshot.",
+  triggers: [
+    {
+      kind: "schedule",
+      cron: "0 9 * * 1",
+      timezone: "Europe/London",
+      // Prices change even when the latest broker sync cohort does not.
+      skip_if_unchanged: false,
+    },
+  ],
+  notification: { channel: "canvas", priority: "low" },
+  minCooldownSeconds: 300,
+  tags: ["finance", "midas", "net-worth"],
+  prompt:
+    'The deterministic reaction performs this scheduled Midas valuation. Return only {"summary":"Run the deterministic Midas valuation."}; do not calculate values, create entities, or call connector operations yourself.',
+  reactionsGuidance:
+    "The reaction owns quote execution, cohort selection, derived snapshot persistence, and the notification. It fails if the local quote execution path is missing and labels per-symbol broker fallbacks explicitly.",
+  reaction: reactionFromFile<typeof NetWorthReaction>(
+    "./net-worth.reaction.ts"
+  ),
+});
+
 const hourlyTaskCollaborator = defineBehavior({
   agent: personalAgent,
   slug: "hourly-task-collaborator",
@@ -1283,6 +1322,9 @@ export default defineConfig({
   prune: true,
   connectors: [
     connectorFromFile<typeof MidasConnector>("./midas.connector.ts"),
+    connectorFromFile<typeof MarketQuotesConnector>(
+      "./market-quotes.connector.ts"
+    ),
     connectorFromFile<typeof RevolutTransactionsConnector>(
       "./revolut-transactions.connector.ts"
     ),
@@ -1332,10 +1374,12 @@ export default defineConfig({
     duplicateEntityResolution,
     voiceProfileSynthesis,
     socialInterestRadar,
+    midasNetWorth,
   ],
   authProfiles: [gmailAccountAuth, gmailAppAuth],
   connections: [
     midasConnection,
+    marketQuotesConnection,
     revolutConnection,
     takeoutConnection,
     twitterTakeoutConnection,

--- a/examples/personal-agent/market-quotes.connector.ts
+++ b/examples/personal-agent/market-quotes.connector.ts
@@ -1,0 +1,372 @@
+/**
+ * Credential-free market marks for the personal net-worth Behavior.
+ *
+ * This connector exposes one read-only action and no feeds. Quotes are returned
+ * to the caller and are never persisted as raw market-price events.
+ */
+import {
+  type ActionContext,
+  type ActionResult,
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type SyncResult,
+} from "@lobu/connector-sdk";
+
+type QuoteOk = {
+  status: "quoted";
+  id: string;
+  market: string;
+  symbol: string;
+  provider_symbol: string;
+  price: number;
+  currency: string;
+  as_of: string;
+  stale: boolean;
+  tier: "delayed";
+  provider: string;
+};
+
+type QuoteUnavailable = {
+  status: "quote_unavailable";
+  id: string;
+  market: string;
+  symbol: string;
+  provider_symbol: string | null;
+  provider: string;
+  reason: string;
+};
+
+type QuoteRow = QuoteOk | QuoteUnavailable;
+
+type QuoteSymbolInput = {
+  market?: string;
+  symbol?: string;
+  id?: string;
+  provider_symbol?: string;
+};
+
+type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit
+) => Promise<Response>;
+
+const YAHOO_CHART_URL = "https://query2.finance.yahoo.com/v8/finance/chart";
+const QUOTE_TIMEOUT_MS = 8_000;
+const STALE_AFTER_MS = 24 * 60 * 60 * 1_000;
+const MAX_CONCURRENT_QUOTES = 5;
+
+export function toProviderSymbol(market: string, symbol: string): string {
+  const normalizedMarket = market.trim().toUpperCase();
+  const normalizedSymbol = symbol.trim().toUpperCase();
+  if (!normalizedSymbol) return "";
+  if (normalizedMarket === "TR" || normalizedMarket === "BIST") {
+    return normalizedSymbol.endsWith(".IS")
+      ? normalizedSymbol
+      : `${normalizedSymbol}.IS`;
+  }
+  return normalizedSymbol;
+}
+
+export function normalizeSymbolInput(raw: QuoteSymbolInput | string): {
+  id: string;
+  market: string;
+  symbol: string;
+  provider_symbol: string;
+} {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    const separator = trimmed.indexOf(":");
+    const market = (
+      separator >= 0 ? trimmed.slice(0, separator) : "US"
+    ).toUpperCase();
+    const symbol = (
+      separator >= 0 ? trimmed.slice(separator + 1) : trimmed
+    ).toUpperCase();
+    return {
+      id: `${market}:${symbol}`,
+      market,
+      symbol,
+      provider_symbol: toProviderSymbol(market, symbol),
+    };
+  }
+
+  const idParts = raw.id?.split(":") ?? [];
+  const market = (raw.market ?? idParts[0] ?? "US").trim().toUpperCase();
+  const symbol = (raw.symbol ?? idParts.slice(1).join(":") ?? "")
+    .trim()
+    .toUpperCase();
+  const id = (raw.id ?? `${market}:${symbol}`).trim().toUpperCase();
+  return {
+    id,
+    market,
+    symbol,
+    provider_symbol:
+      raw.provider_symbol?.trim() ?? toProviderSymbol(market, symbol),
+  };
+}
+
+export function parseYahooChartBody(
+  body: unknown,
+  providerSymbol: string
+): { price: number; currency: string; asOf: string } | { error: string } {
+  const chart = body as {
+    chart?: {
+      result?: Array<{
+        meta?: {
+          regularMarketPrice?: number;
+          currency?: string;
+          regularMarketTime?: number;
+        };
+      }>;
+      error?: { description?: string; code?: string };
+    };
+  };
+  if (chart.chart?.error) {
+    return {
+      error:
+        chart.chart.error.description ??
+        chart.chart.error.code ??
+        `quote provider error for ${providerSymbol}`,
+    };
+  }
+
+  const meta = chart.chart?.result?.[0]?.meta;
+  if (
+    typeof meta?.regularMarketPrice !== "number" ||
+    !Number.isFinite(meta.regularMarketPrice) ||
+    meta.regularMarketPrice <= 0
+  ) {
+    return { error: `no usable price for ${providerSymbol}` };
+  }
+  const currency = meta.currency?.trim().toUpperCase();
+  if (!currency) {
+    return { error: `no quote currency for ${providerSymbol}` };
+  }
+  if (
+    typeof meta.regularMarketTime !== "number" ||
+    !Number.isFinite(meta.regularMarketTime)
+  ) {
+    return { error: `no market timestamp for ${providerSymbol}` };
+  }
+  const asOf = new Date(meta.regularMarketTime * 1_000);
+  if (!Number.isFinite(asOf.getTime())) {
+    return { error: `invalid market timestamp for ${providerSymbol}` };
+  }
+  return {
+    price: meta.regularMarketPrice,
+    currency,
+    asOf: asOf.toISOString(),
+  };
+}
+
+async function fetchYahooQuote(
+  providerSymbol: string,
+  fetchImpl: FetchLike = fetch
+): Promise<
+  | { ok: true; price: number; currency: string; asOf: string }
+  | { ok: false; reason: string }
+> {
+  if (!providerSymbol) {
+    return { ok: false, reason: "missing symbol" };
+  }
+  const url = `${YAHOO_CHART_URL}/${encodeURIComponent(
+    providerSymbol
+  )}?interval=1d&range=1d`;
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "LobuMarketQuotes/1.0 (+https://lobu.ai)",
+      },
+      signal: AbortSignal.timeout(QUOTE_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return { ok: false, reason: `quote provider HTTP ${response.status}` };
+    }
+    const parsed = parseYahooChartBody(await response.json(), providerSymbol);
+    if ("error" in parsed) {
+      return { ok: false, reason: parsed.error };
+    }
+    return {
+      ok: true,
+      price: parsed.price,
+      currency: parsed.currency,
+      asOf: parsed.asOf,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function quoteMany(
+  inputs: Array<QuoteSymbolInput | string>,
+  options?: { fetchImpl?: FetchLike; now?: Date }
+): Promise<QuoteRow[]> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const now = options?.now ?? new Date();
+  const normalized = inputs.map(normalizeSymbolInput);
+  const results = new Array<QuoteRow>(normalized.length);
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < normalized.length) {
+      const index = nextIndex++;
+      const item = normalized[index];
+      if (!item?.symbol || !item.provider_symbol) {
+        results[index] = {
+          status: "quote_unavailable",
+          id: item?.id ?? "UNKNOWN",
+          market: item?.market ?? "",
+          symbol: item?.symbol ?? "",
+          provider_symbol: item?.provider_symbol || null,
+          provider: "yahoo",
+          reason: "missing symbol",
+        };
+        continue;
+      }
+
+      const quote = await fetchYahooQuote(item.provider_symbol, fetchImpl);
+      if (!quote.ok) {
+        results[index] = {
+          status: "quote_unavailable",
+          id: item.id,
+          market: item.market,
+          symbol: item.symbol,
+          provider_symbol: item.provider_symbol,
+          provider: "yahoo",
+          reason: quote.reason,
+        };
+        continue;
+      }
+      results[index] = {
+        status: "quoted",
+        id: item.id,
+        market: item.market,
+        symbol: item.symbol,
+        provider_symbol: item.provider_symbol,
+        price: quote.price,
+        currency: quote.currency,
+        as_of: quote.asOf,
+        stale: now.getTime() - new Date(quote.asOf).getTime() > STALE_AFTER_MS,
+        tier: "delayed",
+        provider: "yahoo",
+      };
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(MAX_CONCURRENT_QUOTES, normalized.length) },
+      () => worker()
+    )
+  );
+  return results;
+}
+
+const quoteInputSchema = {
+  type: "object",
+  required: ["symbols"],
+  properties: {
+    symbols: {
+      type: "array",
+      minItems: 1,
+      maxItems: 50,
+      items: {
+        oneOf: [
+          { type: "string" },
+          {
+            type: "object",
+            properties: {
+              market: { type: "string" },
+              symbol: { type: "string" },
+              id: { type: "string" },
+              provider_symbol: { type: "string" },
+            },
+          },
+        ],
+      },
+    },
+  },
+} as const;
+
+export default class MarketQuotesConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: "market.quotes",
+    name: "Market Quotes",
+    description:
+      "Credential-free current market marks returned on demand without a price feed.",
+    version: "1.0.0",
+    faviconDomain: "finance.yahoo.com",
+    authSchema: { methods: [{ type: "none" }] },
+    actions: {
+      quote: {
+        key: "quote",
+        kind: "read",
+        name: "Quote symbols",
+        description:
+          "Return a quoted or quote_unavailable result for every requested symbol.",
+        requiresApproval: false,
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+        inputSchema: quoteInputSchema as unknown as Record<string, unknown>,
+        outputSchema: {
+          type: "object",
+          required: ["quotes", "quoted", "unavailable", "provider"],
+          properties: {
+            quotes: { type: "array", items: { type: "object" } },
+            quoted: { type: "integer" },
+            unavailable: { type: "integer" },
+            provider: { type: "string" },
+          },
+        },
+      },
+    },
+    optionsSchema: { type: "object", properties: {} },
+  };
+
+  fetchImpl: FetchLike = fetch;
+
+  async sync(): Promise<SyncResult> {
+    throw new Error(
+      "market.quotes has no feeds; use its quote action for current marks."
+    );
+  }
+
+  async execute(ctx: ActionContext): Promise<ActionResult> {
+    if (ctx.actionKey !== "quote") {
+      return { success: false, error: `Unknown action: ${ctx.actionKey}` };
+    }
+    const symbols = (ctx.input as { symbols?: unknown }).symbols;
+    if (!Array.isArray(symbols) || symbols.length === 0) {
+      return {
+        success: false,
+        error: "quote requires a non-empty symbols array",
+      };
+    }
+    if (symbols.length > 50) {
+      return { success: false, error: "quote accepts at most 50 symbols" };
+    }
+
+    const quotes = await quoteMany(
+      symbols as Array<QuoteSymbolInput | string>,
+      { fetchImpl: this.fetchImpl }
+    );
+    return {
+      success: true,
+      output: {
+        quotes,
+        quoted: quotes.filter((quote) => quote.status === "quoted").length,
+        unavailable: quotes.filter(
+          (quote) => quote.status === "quote_unavailable"
+        ).length,
+        provider: "yahoo",
+      },
+    };
+  }
+}

--- a/examples/personal-agent/net-worth.reaction.ts
+++ b/examples/personal-agent/net-worth.reaction.ts
@@ -1,0 +1,585 @@
+/**
+ * Deterministic weekly Midas valuation.
+ *
+ * Stored reactions are single-file artifacts, so the valuation logic lives
+ * here instead of importing a project helper. It reads the latest Midas sync
+ * cohort, marks each holding through the same-org market.quotes
+ * action, persists one derived snapshot event, and sends a concise digest.
+ */
+import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
+
+export const input = {
+  type: "object",
+  properties: {
+    summary: { type: "string" },
+  },
+  required: ["summary"],
+} as const;
+
+const MIDAS_HOLDING_PAGE_SIZE = 1_000;
+
+export interface MidasBalanceRow {
+  run_id: number | string;
+  occurred_at: Date | string;
+}
+
+export interface MidasHoldingMetadata {
+  symbol?: string;
+  type?: string;
+  shares?: number;
+  price?: number;
+  avg_cost?: number;
+  value?: number;
+  currency?: string;
+}
+
+export interface MidasHoldingRow {
+  origin_id: string;
+  occurred_at: Date | string;
+  metadata: MidasHoldingMetadata | string | null;
+}
+
+export type QuoteRow =
+  | {
+      status: "quoted";
+      id: string;
+      market: string;
+      symbol: string;
+      provider_symbol: string;
+      provider: string;
+      price: number;
+      currency: string;
+      as_of: string;
+      stale: boolean;
+      tier: string;
+    }
+  | {
+      status: "quote_unavailable";
+      id: string;
+      market: string;
+      symbol: string;
+      provider_symbol: string | null;
+      provider: string;
+      reason: string;
+    };
+
+interface MidasSnapshotPosition {
+  origin_id: string;
+  market: string;
+  symbol: string;
+  quantity: number;
+  currency: string;
+  average_cost: number;
+  acquisition_cost: number;
+  broker_price: number;
+  broker_value: number;
+  current_price: number;
+  current_value: number;
+  mark_source: "market_quote" | "broker_snapshot";
+  quote_status: QuoteRow["status"];
+  quote_provider: string | null;
+  quote_tier: string | null;
+  quote_stale: boolean | null;
+  quote_as_of: string | null;
+  quote_reason: string | null;
+}
+
+interface MidasSnapshotTotal {
+  currency: string;
+  current_value: number;
+  broker_value: number;
+  acquisition_cost: number;
+  unrealized_gain: number;
+  position_count: number;
+  quoted_count: number;
+  stale_quote_count: number;
+  unavailable_count: number;
+}
+
+interface MidasNetWorthSnapshot {
+  version: 1;
+  scope: "midas";
+  calculated_at: string;
+  broker_as_of: string;
+  quote_as_of: string | null;
+  midas_run_id: number;
+  by_currency: MidasSnapshotTotal[];
+  positions: MidasSnapshotPosition[];
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function finiteNumber(value: unknown): number | null {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function isoTimestamp(value: Date | string, field: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error(`Midas ${field} is not a valid timestamp.`);
+  }
+  return date.toISOString();
+}
+
+function quoteId(market: string, symbol: string): string {
+  return `${market.trim().toUpperCase()}:${symbol.trim().toUpperCase()}`;
+}
+
+function normalizeHolding(row: MidasHoldingRow): {
+  originId: string;
+  market: string;
+  symbol: string;
+  quantity: number;
+  currency: string;
+  averageCost: number;
+  brokerPrice: number;
+  brokerValue: number;
+  occurredAt: string;
+} {
+  const metadata = objectValue(row.metadata);
+  const market = String(metadata.type ?? "")
+    .trim()
+    .toUpperCase();
+  const symbol = String(metadata.symbol ?? "")
+    .trim()
+    .toUpperCase();
+  const currency = String(metadata.currency ?? "")
+    .trim()
+    .toUpperCase();
+  const quantity = finiteNumber(metadata.shares);
+  const averageCost = finiteNumber(metadata.avg_cost);
+  const brokerPrice = finiteNumber(metadata.price);
+  const statedValue = finiteNumber(metadata.value);
+
+  if (!market || !symbol || !currency) {
+    throw new Error(`Midas holding ${row.origin_id} has incomplete identity.`);
+  }
+  if (quantity == null || quantity <= 0) {
+    throw new Error(`Midas holding ${row.origin_id} has invalid shares.`);
+  }
+  if (averageCost == null || averageCost < 0) {
+    throw new Error(`Midas holding ${row.origin_id} has invalid average cost.`);
+  }
+  if (brokerPrice == null || brokerPrice <= 0) {
+    throw new Error(`Midas holding ${row.origin_id} has invalid broker price.`);
+  }
+  const brokerValue =
+    statedValue != null && statedValue > 0
+      ? statedValue
+      : quantity * brokerPrice;
+
+  return {
+    originId: row.origin_id,
+    market,
+    symbol,
+    quantity,
+    currency,
+    averageCost,
+    brokerPrice,
+    brokerValue,
+    occurredAt: isoTimestamp(row.occurred_at, "holding occurred_at"),
+  };
+}
+
+function unavailableQuote(
+  id: string,
+  market: string,
+  symbol: string,
+  reason: string,
+  provider: string | null = null
+): Extract<QuoteRow, { status: "quote_unavailable" }> {
+  return {
+    status: "quote_unavailable",
+    id,
+    market,
+    symbol,
+    provider_symbol: null,
+    provider: provider ?? "unknown",
+    reason,
+  };
+}
+
+function fallbackQuote(
+  quote: QuoteRow,
+  id: string,
+  market: string,
+  symbol: string
+): Extract<QuoteRow, { status: "quote_unavailable" }> {
+  return quote.status === "quote_unavailable"
+    ? quote
+    : unavailableQuote(id, market, symbol, "quote could not be used");
+}
+
+export function buildMidasSnapshot(
+  balance: MidasBalanceRow,
+  holdingRows: MidasHoldingRow[],
+  quoteRows: QuoteRow[],
+  calculatedAt: string
+): MidasNetWorthSnapshot {
+  const midasRunId = finiteNumber(balance.run_id);
+  if (midasRunId == null || !Number.isSafeInteger(midasRunId)) {
+    throw new Error("The latest Midas balance has no valid sync run id.");
+  }
+  if (holdingRows.length === 0) {
+    throw new Error(`Midas sync run ${midasRunId} contains no holdings.`);
+  }
+
+  const holdings = holdingRows.map(normalizeHolding);
+  const quotes = new Map(
+    quoteRows.map((quote) => [quote.id.trim().toUpperCase(), quote])
+  );
+  const positions: MidasSnapshotPosition[] = holdings.map((holding) => {
+    const id = quoteId(holding.market, holding.symbol);
+    let quote =
+      quotes.get(id) ??
+      unavailableQuote(
+        id,
+        holding.market,
+        holding.symbol,
+        "quote action returned no row for this holding"
+      );
+
+    if (quote.status === "quoted") {
+      const quotePrice = finiteNumber(quote.price);
+      const quoteCurrency = quote.currency.trim().toUpperCase();
+      if (quotePrice == null || quotePrice <= 0) {
+        quote = unavailableQuote(
+          id,
+          holding.market,
+          holding.symbol,
+          "quote price is not a positive finite number",
+          quote.provider
+        );
+      } else if (quoteCurrency !== holding.currency) {
+        quote = unavailableQuote(
+          id,
+          holding.market,
+          holding.symbol,
+          `quote currency ${quoteCurrency} does not match holding currency ${holding.currency}`,
+          quote.provider
+        );
+      } else {
+        return {
+          origin_id: holding.originId,
+          market: holding.market,
+          symbol: holding.symbol,
+          quantity: holding.quantity,
+          currency: holding.currency,
+          average_cost: holding.averageCost,
+          acquisition_cost: holding.quantity * holding.averageCost,
+          broker_price: holding.brokerPrice,
+          broker_value: holding.brokerValue,
+          current_price: quotePrice,
+          current_value: holding.quantity * quotePrice,
+          mark_source: "market_quote" as const,
+          quote_status: quote.status,
+          quote_provider: quote.provider,
+          quote_tier: quote.tier,
+          quote_stale: quote.stale,
+          quote_as_of: quote.as_of,
+          quote_reason: null,
+        };
+      }
+    }
+
+    const unavailable = fallbackQuote(
+      quote,
+      id,
+      holding.market,
+      holding.symbol
+    );
+    return {
+      origin_id: holding.originId,
+      market: holding.market,
+      symbol: holding.symbol,
+      quantity: holding.quantity,
+      currency: holding.currency,
+      average_cost: holding.averageCost,
+      acquisition_cost: holding.quantity * holding.averageCost,
+      broker_price: holding.brokerPrice,
+      broker_value: holding.brokerValue,
+      current_price: holding.brokerPrice,
+      current_value: holding.brokerValue,
+      mark_source: "broker_snapshot",
+      quote_status: unavailable.status,
+      quote_provider:
+        unavailable.provider === "unknown" ? null : unavailable.provider,
+      quote_tier: null,
+      quote_stale: null,
+      quote_as_of: null,
+      quote_reason: unavailable.reason,
+    };
+  });
+
+  const totals = new Map<string, MidasSnapshotTotal>();
+  for (const position of positions) {
+    const total = totals.get(position.currency) ?? {
+      currency: position.currency,
+      current_value: 0,
+      broker_value: 0,
+      acquisition_cost: 0,
+      unrealized_gain: 0,
+      position_count: 0,
+      quoted_count: 0,
+      stale_quote_count: 0,
+      unavailable_count: 0,
+    };
+    total.current_value += position.current_value;
+    total.broker_value += position.broker_value;
+    total.acquisition_cost += position.acquisition_cost;
+    total.position_count += 1;
+    if (position.mark_source === "market_quote") {
+      total.quoted_count += 1;
+      if (position.quote_stale) total.stale_quote_count += 1;
+    } else {
+      total.unavailable_count += 1;
+    }
+    total.unrealized_gain = total.current_value - total.acquisition_cost;
+    totals.set(position.currency, total);
+  }
+
+  const brokerAsOf = holdings.reduce(
+    (latest, holding) =>
+      new Date(holding.occurredAt).getTime() > new Date(latest).getTime()
+        ? holding.occurredAt
+        : latest,
+    isoTimestamp(balance.occurred_at, "balance occurred_at")
+  );
+  const quoteAsOf = positions.reduce<string | null>((latest, position) => {
+    if (!position.quote_as_of) return latest;
+    if (!latest) return position.quote_as_of;
+    return new Date(position.quote_as_of).getTime() > new Date(latest).getTime()
+      ? position.quote_as_of
+      : latest;
+  }, null);
+
+  return {
+    version: 1,
+    scope: "midas",
+    calculated_at: isoTimestamp(calculatedAt, "calculated_at"),
+    broker_as_of: brokerAsOf,
+    quote_as_of: quoteAsOf,
+    midas_run_id: midasRunId,
+    by_currency: [...totals.values()].sort((left, right) =>
+      left.currency.localeCompare(right.currency)
+    ),
+    positions,
+  };
+}
+
+function connectionRows(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value as Array<Record<string, unknown>>;
+  const object = objectValue(value);
+  return Array.isArray(object.connections)
+    ? (object.connections as Array<Record<string, unknown>>)
+    : [];
+}
+
+function quoteRows(value: unknown): QuoteRow[] {
+  const object = objectValue(value);
+  return Array.isArray(object.quotes) ? (object.quotes as QuoteRow[]) : [];
+}
+
+function formatAmount(currency: string, amount: number): string {
+  return `${currency} ${amount.toLocaleString("en-GB", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function snapshotDigest(snapshot: MidasNetWorthSnapshot): string {
+  const totals = snapshot.by_currency.map(
+    (total) =>
+      `${formatAmount(total.currency, total.current_value)} current; ` +
+      `${formatAmount(total.currency, total.acquisition_cost)} acquisition cost; ` +
+      `${formatAmount(total.currency, total.unrealized_gain)} unrealized gain. ` +
+      `${total.quoted_count}/${total.position_count} positions quoted` +
+      (total.stale_quote_count > 0
+        ? ` (${total.stale_quote_count} stale)`
+        : "") +
+      (total.unavailable_count > 0
+        ? `; ${total.unavailable_count} using broker snapshots`
+        : "")
+  );
+  return [
+    `Midas valuation calculated ${snapshot.calculated_at}.`,
+    ...totals,
+    `Broker snapshot: ${snapshot.broker_as_of}. Latest market mark: ${
+      snapshot.quote_as_of ?? "none"
+    }.`,
+  ].join("\n");
+}
+
+async function notifySyncNeeded(
+  ctx: ReactionContext,
+  client: ReactionClient,
+  reason: string
+): Promise<void> {
+  await client.notifications.send({
+    title: "Midas net worth needs attention",
+    body: `${reason} Open Atlas in the paired browser and sync Midas before the next valuation.`,
+    idempotency_key: `midas-net-worth:needs-sync:window:${ctx.window.id}`,
+    behavior_source: {
+      behavior_id: ctx.behavior.id,
+      window_id: ctx.window.id,
+    },
+  });
+}
+
+export default async function runNetWorthSnapshot(
+  ctx: ReactionContext,
+  client: ReactionClient
+): Promise<void> {
+  const behaviorSource = {
+    behavior_id: ctx.behavior.id,
+    window_id: ctx.window.id,
+  };
+  const balances = (await client.query(
+    `SELECT run_id, occurred_at
+     FROM events
+     WHERE connector_key = 'midas'
+       AND origin_id = 'midas-balance'
+       AND run_id IS NOT NULL
+     ORDER BY occurred_at DESC, id DESC
+     LIMIT 1`
+  )) as MidasBalanceRow[];
+  const balance = balances[0];
+  if (!balance) {
+    await notifySyncNeeded(ctx, client, "No Midas balance cohort exists.");
+    return;
+  }
+  const midasRunId = finiteNumber(balance.run_id);
+  if (midasRunId == null || !Number.isSafeInteger(midasRunId)) {
+    throw new Error("The latest Midas balance has no valid sync run id.");
+  }
+
+  const holdings: MidasHoldingRow[] = [];
+  while (true) {
+    const page = (await client.query(
+      `SELECT origin_id, occurred_at, metadata
+       FROM events
+       WHERE connector_key = 'midas'
+         AND semantic_type = 'financial_asset'
+         AND origin_id LIKE 'midas-holding-%'
+         AND run_id = ${midasRunId}
+       ORDER BY origin_id, id
+       LIMIT ${MIDAS_HOLDING_PAGE_SIZE}
+       OFFSET ${holdings.length}`
+    )) as MidasHoldingRow[];
+    holdings.push(...page);
+    if (page.length < MIDAS_HOLDING_PAGE_SIZE) break;
+  }
+  if (holdings.length === 0) {
+    await notifySyncNeeded(
+      ctx,
+      client,
+      `Midas sync run ${midasRunId} contains no holdings.`
+    );
+    return;
+  }
+
+  const listedConnections = await client.connections.list({
+    connector_key: "market.quotes",
+    status: "active",
+    limit: 10,
+  });
+  const quoteConnection = connectionRows(listedConnections).find(
+    (connection) => connection.slug === "market-quotes"
+  );
+  const quoteConnectionId = finiteNumber(quoteConnection?.id);
+  if (
+    quoteConnectionId == null ||
+    !Number.isSafeInteger(quoteConnectionId) ||
+    quoteConnectionId <= 0
+  ) {
+    throw new Error(
+      "The active market-quotes connection is missing from this workspace."
+    );
+  }
+
+  const symbols = holdings.map((row) => {
+    const metadata = objectValue(row.metadata);
+    return {
+      market: String(metadata.type ?? "")
+        .trim()
+        .toUpperCase(),
+      symbol: String(metadata.symbol ?? "")
+        .trim()
+        .toUpperCase(),
+    };
+  });
+  const allQuotes: QuoteRow[] = [];
+  const batches = Array.from(
+    { length: Math.ceil(symbols.length / 50) },
+    (_, index) => symbols.slice(index * 50, (index + 1) * 50)
+  );
+  for (const [index, batch] of batches.entries()) {
+    const operation = await client.operations.execute({
+      connection_id: quoteConnectionId,
+      operation_key: "quote",
+      input: { symbols: batch },
+      idempotency_key:
+        batches.length === 1
+          ? `midas-net-worth:quotes:window:${ctx.window.id}:midas-run:${midasRunId}`
+          : `midas-net-worth:quotes:window:${ctx.window.id}:midas-run:${midasRunId}:batch:${
+              index + 1
+            }`,
+      behavior_source: behaviorSource,
+    });
+    if (operation.status !== "completed") {
+      throw new Error(
+        `Market quote operation did not complete (${operation.status ?? "unknown"}): ${
+          operation.error_message ?? "no error detail"
+        }`
+      );
+    }
+    const batchQuotes = quoteRows(operation.output);
+    if (batchQuotes.length === 0) {
+      throw new Error("Market quote operation completed without quote rows.");
+    }
+    allQuotes.push(...batchQuotes);
+  }
+
+  const snapshot = buildMidasSnapshot(
+    balance,
+    holdings,
+    allQuotes,
+    ctx.window.window_end
+  );
+  const digest = snapshotDigest(snapshot);
+  const saved = await client.knowledge.save({
+    content: digest,
+    semantic_type: "net_worth_snapshot",
+    title: "Midas net worth snapshot",
+    payload_type: "markdown",
+    metadata: snapshot as unknown as Record<string, unknown>,
+    occurred_at: snapshot.calculated_at,
+    idempotency_key: `midas-net-worth:snapshot:window:${ctx.window.id}`,
+    behavior_source: behaviorSource,
+  });
+  const persistedSnapshot = saved.created
+    ? snapshot
+    : (saved.metadata as unknown as MidasNetWorthSnapshot);
+  await client.notifications.send({
+    title: "Midas net worth updated",
+    body: snapshotDigest(persistedSnapshot).slice(0, 1_000),
+    idempotency_key: `midas-net-worth:notification:window:${ctx.window.id}`,
+    behavior_source: behaviorSource,
+  });
+}

--- a/examples/personal-finance/lobu.config.ts
+++ b/examples/personal-finance/lobu.config.ts
@@ -14,15 +14,9 @@ const gmailTxSkill = defineSkill({
     'You are a private financial accountant scanning the user\'s forwarded Gmail messages for events that matter to a UK Self Assessment return.\n\nThe emails to scan arrive in the payload\'s `gmail_messages` source (an empty source means no new messages this window). The active tax year, when one is bound, appears in the payload\'s `entities` array.\n\nIdentify and extract financial events. Each email may yield zero, one, or many events. Be conservative: skip noise (marketing, password resets, etc.).\n\nCategories to extract:\n- **transactions** — deposits, debits, transfers, salary credits, dividend payments hitting an account\n- **cgt_events** — broker contract notes for sells/disposals, gifts, transfers out of a GIA\n- **dividends** — UK or foreign dividend notifications (gross + currency)\n- **documents** — P60/P45/P11D/SA302/contract notes/mortgage statements arriving as attachments or linked PDFs\n\nFor each item, set `gmail_message_id` to the `id` value of the `gmail_messages` row it came from — that column is the provider message ID. Never invent or omit it; if you cannot attribute an item to a specific row, drop the item. Prefer GBP unless the message clearly states a different currency.\n\nSkip transactions inside ISAs and SIPPs unless they are dividends or contributions (which are still reportable). Mark `tax_relevance="none"` for ISA-internal transactions; mark `tax_relevance="cgt"` for non-wrapper disposals.\n',
 });
 
-const netWorthSkill = defineSkill({
-  name: "net-worth",
-  content:
-    "You are a wealth manager tracking the user's global net worth.\n\nAccount activity arrives in the payload's `revolut_events` and `midas_events` sources; either may be empty when a provider has no new data.\n\nExtract the latest known balance for each unique account or asset. For Revolut, create/update `account` entities (setting `provider` to \"Revolut\" and updating `current_amount`). For Midas, create/update `holding` entities (setting `ticker`, `quantity`, and `avg_cost` based on the price).",
-});
-
 const personal_finance = defineAgent({
   id: "personal-finance",
-  skills: [gmailTxSkill, netWorthSkill],
+  skills: [gmailTxSkill],
   dir: ".",
   name: "personal-finance",
   description:
@@ -1144,25 +1138,6 @@ const gmailTxBehavior = defineBehavior({
   skills: ["gmail-tx"],
 });
 
-const netWorthBehavior = defineBehavior({
-  agent: personal_finance,
-  slug: "net-worth",
-  name: "Net Worth Aggregator",
-  triggers: [{ kind: "schedule", cron: "*/15 * * * *" }],
-  notification: { priority: "low" },
-  minCooldownSeconds: 60,
-  tags: ["net-worth", "assets", "revolut", "midas"],
-  reactionsGuidance:
-    "1. Parse the most recent balance for each distinct currency pocket from `revolut_events`.\n2. Parse the investment asset holdings from `midas_events`.\n3. Create or update `account` entities for Revolut balances and `holding` entities for Midas assets so the user's dashboard has a live, unified view of their net worth.\n",
-  sources: {
-    revolut_events:
-      "SELECT feed_id, payload_text, metadata::json->>'amount' as amount, metadata::json->>'balance' as balance, metadata::json->>'currency' as currency, metadata::json->>'description' as description, occurred_at FROM events WHERE connector_key = 'revolut' AND (metadata::json->>'balance' IS NOT NULL OR semantic_type = 'balance_raw') ORDER BY occurred_at DESC LIMIT 100\n",
-    midas_events:
-      "SELECT metadata, occurred_at FROM events WHERE connector_key = 'midas' ORDER BY occurred_at DESC LIMIT 50\n",
-  },
-  skills: ["net-worth"],
-});
-
 export default defineConfig({
   org: "personal-finance",
   orgName: "Personal Finance",
@@ -1212,5 +1187,5 @@ export default defineConfig({
     spouse_of,
     transfer_pair,
   ],
-  behaviors: [gmailTxBehavior, netWorthBehavior],
+  behaviors: [gmailTxBehavior],
 });


### PR DESCRIPTION
## Summary

- Add a credential-free same-organization market quote connector for US and BIST symbols.
- Add a weekly Midas net-worth Behavior that pages the latest Midas sync cohort, uses available live quotes with an explicit per-symbol broker fallback, writes an append-only derived snapshot, and sends a digest.
- Remove the old personal-finance net-worth Behavior, which ran in the wrong organization and referenced unavailable entity fields.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; amended run `3xc4cpvlml`, all jobs passed)
- [x] Tests run: `bun test examples/personal-agent/__tests__` (232 pass, 0 fail, 733 assertions)
- [x] Feature and review finding red to green evidence pasted below
- [x] Bot behavior: compiled the production reaction and connector, validated both affected configs, and exercised the quote/calculation boundary against the latest production Midas cohort

Feature red before implementation:

```text
Cannot find module '../net-worth.reaction'
Cannot find module '../market-quotes.connector'
```

Completeness regression red:

```text
Expected length: 1001
Received length: 200
4 pass
1 fail
```

Green after paging the cohort:

```text
232 pass
0 fail
733 expect() calls
```

Real-data verification used Midas run `667845` with 22 holdings. Live quotes succeeded for 21 holdings; unsupported `ALTIN.S1` used its broker snapshot rather than zero. Calculated totals were TRY 2,701,342.35 and USD 1,029,229.455213126 as of 2026-08-12T19:54:39Z.

## Notes

No database migration, public API, SDK, or UI change.

A production `lobu apply` and scheduled delivery were not run from this worktree because the personal-agent dry run requires `GOOGLE_YOUTUBE_TAKEOUT_DIR` or `LOCAL_TAKEOUT_ROOT`. Exact local reaction schema extraction is also unavailable on this machine because `isolated-vm` is not installed; production compilation succeeded.
