### PR TITLE
fix(ci): pin bun in images and retry GitHub release downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,7 +1148,9 @@ jobs:
 
       - name: Install dbmate
         run: |
-          curl -fsSL -o /usr/local/bin/dbmate \
+          # Retry transient GitHub release failures such as HTTP 503.
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o /usr/local/bin/dbmate \
             https://github.com/amacneil/dbmate/releases/download/v2.21.0/dbmate-linux-amd64
           chmod +x /usr/local/bin/dbmate
 

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -460,7 +460,9 @@ jobs:
           # the easier source from CI.
           set -x
           SPARKLE_VERSION="2.9.1"
-          curl -fsSL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+          # Retry transient GitHub release failures such as HTTP 503.
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o "$RUNNER_TEMP/sparkle.tar.xz" \
             "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
           mkdir -p "$RUNNER_TEMP/sparkle" && tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP/sparkle"
           SIGN_UPDATE="$RUNNER_TEMP/sparkle/bin/sign_update"

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -29,9 +29,12 @@ jobs:
         run: |
           set -euo pipefail
           version=1.8.0
-          curl -fsSL -o mcp-publisher_linux_amd64.tar.gz \
+          # Retry transient GitHub release failures such as HTTP 503.
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o mcp-publisher_linux_amd64.tar.gz \
             "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_linux_amd64.tar.gz"
-          curl -fsSL -o checksums.txt \
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o checksums.txt \
             "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/registry_${version}_checksums.txt"
           grep " mcp-publisher_linux_amd64.tar.gz$" checksums.txt | sha256sum -c -
           tar xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -3,7 +3,12 @@
 # ===========================================
 # Hono server that runs the gateway in-process and serves the web frontend.
 
+# Keep container builds on the same Bun version as the workflow lanes instead
+# of resolving a different `latest` release when a layer must be rebuilt.
+ARG BUN_VERSION=1.3.5
+
 FROM node:22-slim AS builder
+ARG BUN_VERSION
 
 WORKDIR /app
 
@@ -13,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git ca-certificates curl unzip \
       python3 build-essential \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"
@@ -161,6 +166,7 @@ RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto/package.json ]; 
 # Runtime
 # ===========================================
 FROM node:22-slim AS runtime
+ARG BUN_VERSION
 
 WORKDIR /app
 
@@ -178,7 +184,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
       libgbm1 libpango-1.0-0 libcairo2 libasound2 libwayland-client0 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"

--- a/docker/embeddings-service/Dockerfile
+++ b/docker/embeddings-service/Dockerfile
@@ -2,14 +2,19 @@
 # Embeddings Service (embeddings)
 # ===========================================
 
+# Keep container builds on the same Bun version as the workflow lanes instead
+# of resolving a different `latest` release when a layer must be rebuilt.
+ARG BUN_VERSION=1.3.5
+
 FROM node:22-slim AS builder
+ARG BUN_VERSION
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"
@@ -40,13 +45,14 @@ RUN cd packages/embeddings && bunx tsc --noEmit
 # Runtime
 # ===========================================
 FROM node:22-slim AS runtime
+ARG BUN_VERSION
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -3,14 +3,19 @@
 # ===========================================
 # Self-hosted worker for Lobu connectors and embedding generation.
 
+# Keep container builds on the same Bun version as the workflow lanes instead
+# of resolving a different `latest` release when a layer must be rebuilt.
+ARG BUN_VERSION=1.3.5
+
 FROM node:22-bookworm AS builder
+ARG BUN_VERSION
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"
@@ -59,6 +64,7 @@ RUN cd packages/core && bunx tsc \
 # Runtime
 # ===========================================
 FROM node:22-bookworm-slim AS runtime
+ARG BUN_VERSION
 
 WORKDIR /app
 
@@ -69,7 +75,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
       libcairo2 libasound2 libxshmfence1 libxfixes3 libglib2.0-0 fonts-liberation \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
     && chmod +x /usr/local/bin/bun
 
 ENV PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
## What & why

Two independent defects in how the build fetches its toolchain, found while diagnosing repeated `connector-parity-smoke` and `migrations` failures.

**1. Container images ran an unpinned bun.** The workflows pin `bun-version: 1.3.5` in 15 places across 4 files. All six Dockerfile install sites instead ran `curl -fsSL https://bun.sh/install | bash` with no argument, which resolves to `releases/latest/download/bun-linux-x64.zip`. So container lanes and prod images ran a silently drifting bun while the workflow lanes stayed pinned — a bun release could change test behaviour with no diff to blame.

**2. Release downloads had no retry.** GitHub releases returned intermittent 503s and took down whichever unretried download drew the short straw. Three real failures observed on two different URLs.

These fix different properties and neither substitutes for the other — dbmate was *already pinned* and still 503'd.

## Evidence

`migrations` on #2641, the release PR, blocked on:

```
curl -fsSL -o /usr/local/bin/dbmate \
  https://github.com/amacneil/dbmate/releases/download/v2.21.0/dbmate-linux-amd64
curl: (22) The requested URL returned error: 503
```

A second branch hit the identical failure on the same URL ~90 minutes later, so it is not a one-off.

## Why this pin works

Read from the installer source rather than assumed (no Docker locally):

```sh
if [[ $# = 0 ]]; then
    bun_uri=$github_repo/releases/latest/download/bun-$target.zip   # before
else
    bun_uri=$github_repo/releases/download/$1/bun-$target.zip       # after
fi
```

Line 60 documents the tag form (`bun-v0.1.4`). `scripts/dev-remote.ts:698` already uses this exact invocation, so it is the established pattern in this repo.

## Why plain `--retry`

`--retry` already covers the failure we saw: curl's transient set is 408, 429, 500, 502, 503, 504. `--retry-all-errors` was considered and dropped — it is documented as the "sledgehammer" and the only failure it would add coverage for (`curl: (56) Connection died`) occurred inside the bun installer's own curl, not at any of the three call sites edited here.

## Scope

Six Dockerfile install sites pinned; three direct release downloads retried.

Deliberately **not** touched: `scripts/dev-native.sh:27`, `scripts/setup-dev.sh:5` and `scripts/build-owletto-mac.sh:45` match a grep for the installer URL but are error-message text, not calls. `scripts/dev-remote.ts:698` is a real call and is already pinned with a version guard.

## Testing

- Full Depot gate green 18/18, tree `392b2d32`. `migrations` passed on attempt 1 with the retry in place, during a live intermittent outage that failed the same lane on a branch without it.
- Both artifact URLs probed directly: `200`, including the pinned `bun-v1.3.5` URL.
- All three workflow files re-validated with `yaml.safe_load` after the fixer pass.
- Not verified locally: the image build itself (no Docker on this machine). CI builds these images, so the gate covers it.

## Known limitation

Pinning does not fix bun *availability* — our curl fetches the installer from bun.sh, and the GitHub fetch happens inside that script where our flags cannot reach. The lever there is layer caching from a now-stable URL.
