### PR TITLE
fix(ci): give local Depot dispatches their own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,20 @@ permissions:
 # CI_LINUX_RUNNER is an optional repository variable used for runner A/B tests.
 # Leaving it unset preserves GitHub-hosted execution; setting it changes only
 # the machine behind these jobs, not their names, events, secrets, or checks.
+#
+# The `github.run_id` fallback exists for `depot ci run`, which `make
+# pre-pr-remote` uses to execute this same file against a local staged tree.
+# That path supplies no ref, so `github.ref` expanded empty and every local
+# dispatch in the org collapsed into one group literally named `ci-`. Combined
+# with cancel-in-progress, the newest gate anywhere killed whatever was running
+# — a different branch, a different worktree, a different person — and the
+# victim saw only "Cancelled due to the workflow concurrency policy", which
+# names this block rather than any Depot-side limit. Two dispatchers that each
+# retry on cancellation then deadlock, neither ever attesting. Falling back to
+# the run id gives each local dispatch its own group. GitHub keeps the per-ref
+# behaviour unchanged: `github.ref` is always set for push and pull_request.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- `make pre-pr-remote` executes `.github/workflows/ci.yml` through `depot ci run`, which supplies no ref. `github.ref` expanded empty, so **every local dispatch in the org collapsed into one concurrency group literally named `ci-`** — and with `cancel-in-progress: true`, the newest gate cancelled whatever was running on any branch, in any worktree, for anyone.
- The victim only ever saw `Cancelled due to the workflow concurrency policy`, which reads like a Depot-side limit but is naming *this block*. That misattribution cost real time: cancelled runs were repeatedly re-run as if the diff were at fault.
- Worse than lost throughput, two dispatchers that each retry on cancellation **deadlock** — neither ever reaches a tree attestation. That happened tonight between this session and a codex harness running from the main checkout: three consecutive full gates died `cancelled=17`, zero `failed`, inside one poll of dispatch.
- Fix: fall back to `github.run_id` when there is no ref, giving each local dispatch its own group.

## Test plan

- [x] Intended files staged explicitly (`git add -- .github/workflows/ci.yml`), then `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` clean — 18/18, tree `103ff4ab77c2f27aef5f49ebccd3f02d524f66dc`
- [ ] Tests run: n/a — no source changed
- [ ] Bug fix: red→green below
- [ ] If bot behavior: n/a

**Red** — three full gates on the pointer-bump branch, each killed within one poll while a codex `make pre-pr-remote` held the slot:

```
>> Depot run n7cs28dgwz: finished=1 queued=7 running=10
>> Depot run n7cs28dgwz: cancelled=17 finished=1
>> Depot run 13n2h26j8d: cancelled=17 finished=1
>> Depot run fdglqv99kj: cancelled=17 finished=1

$ depot ci status fdglqv99kj --org b9ffw2rv84 --output json | jq -r '.workflows[0].error_message'
Cancelled due to the workflow concurrency policy
```

Zero attempts with status `failed` in every case — the discriminator for "superseded", not "your diff is bad".

**Green** — this branch, dispatched *while a codex gate was live*, and it survived:

```
>> Depot run tpg49h68g3: finished=18
>> Depot run tpg49h68g3 passed
>> recorded full remote preflight for tree 103ff4ab77c2f27aef5f49ebccd3f02d524f66dc
```

Concurrency confirmed by process tree during the run — mine at 0:11 alongside the codex one at 2:52, and a further codex dispatch (pid 71935) started mid-run and did not cancel it:

```
64129 64127  00:11  make pre-pr-remote      <- this branch
54132 45007  02:52  make pre-pr-remote      <- codex, cwd /Users/burakemre/Code/lobu
```

## Notes

**What the green does and does not prove.** It proves the local path: two concurrent dispatches coexisted where three earlier ones could not, so `github.run_id` is populated for `depot ci run` and the group no longer collapses. It does **not** prove the GitHub-side behaviour is unchanged — that rests on inspection, not this run: `github.ref` is always set for `push` and `pull_request`, so the `||` never reaches the fallback there and per-ref auto-cancel is preserved exactly.

If you want independent confirmation after merge, dispatch two local gates from different worktrees at the same time and check both reach a terminal status.

**Scope.** Only `ci.yml` is reachable this way — `scripts/run-remote-ci.sh:18` hardcodes it as the only workflow given to `depot ci run`. The other seven workflows with a `github.ref` group (`merge-integrity`, `submodule-drift`, `supply-chain`, …) are GitHub-triggered only, where the ref is always set, so they do not have this bug and are left alone.

**Why the override was used.** `DEPOT_ALLOW_WORKFLOW_CHANGES=1` is required because the diff touches a workflow file that can read Depot secrets. The change is one expression in a `concurrency` key; it adds no step, no secret access, and no job.
