### PR TITLE
fix(server): deliver production digest to private Slack

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
@@ -17,6 +17,28 @@ afterEach(() => {
 });
 
 describe("createSlackWebApi wire format", () => {
+  test("forwards chat.postMessage client_msg_id for retry deduplication", async () => {
+    let request: RequestInit | undefined;
+    globalThis.fetch = mock(async (_url: string, init: RequestInit) => {
+      request = init;
+      return { json: async () => ({ ok: true }) } as Response;
+    }) as unknown as typeof fetch;
+
+    await createSlackWebApi().postMessage(
+      "xoxb-token",
+      "C123",
+      "digest",
+      "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+    );
+
+    const body = new URLSearchParams(request?.body as string);
+    expect(body.get("channel")).toBe("C123");
+    expect(body.get("text")).toBe("digest");
+    expect(body.get("client_msg_id")).toBe(
+      "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+    );
+  });
+
   test("posts conversations.members as form-urlencoded (NOT json) and paginates", async () => {
     const calls: Array<[string, RequestInit]> = [];
     const pages = [

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@lobu/core";
 
 const logger = createLogger("slack-web");
+const SLACK_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Minimal Slack Web API surface used by the connected-apps onboarding flow:
@@ -15,8 +16,17 @@ const logger = createLogger("slack-web");
 export interface SlackWebApi {
   /** `conversations.open` with a single user → the IM channel id (`D…`). */
   openDm(botToken: string, slackUserId: string): Promise<string>;
-  /** `chat.postMessage` of a plain-text body. Throws on a Slack-level error. */
-  postMessage(botToken: string, channel: string, text: string): Promise<void>;
+  /**
+   * `chat.postMessage` of a plain-text body. Throws on a Slack-level error.
+   * `clientMessageId` is forwarded as `client_msg_id`; Slack returns the same
+   * message timestamp when the same UUID is retried in the same channel.
+   */
+  postMessage(
+    botToken: string,
+    channel: string,
+    text: string,
+    clientMessageId?: string,
+  ): Promise<void>;
   /**
    * `conversations.members` for one channel — the bare `U…` ids of every member,
    * following `response_metadata.next_cursor` to completion. Throws on a
@@ -122,6 +132,7 @@ async function slackPost(
       "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
     },
     body: form.toString(),
+    signal: AbortSignal.timeout(SLACK_REQUEST_TIMEOUT_MS),
   });
   const json = (await res.json()) as Record<string, unknown>;
   if (json.ok !== true) {
@@ -143,11 +154,16 @@ export function createSlackWebApi(): SlackWebApi {
       }
       return channelId;
     },
-    async postMessage(botToken, channel, text) {
+    async postMessage(botToken, channel, text, clientMessageId) {
       try {
-        await slackPost(botToken, "chat.postMessage", { channel, text });
+        await slackPost(botToken, "chat.postMessage", {
+          channel,
+          text,
+          client_msg_id: clientMessageId,
+        });
       } catch (error) {
-        // The welcome message is best-effort; the binding is the contract.
+        // Callers own the failure policy (the welcome DM is best-effort, the
+        // ops digest fails closed); log the Slack-level detail either way.
         logger.warn(
           { channel, error: String(error) },
           "Slack chat.postMessage failed"

--- a/packages/server/src/scheduled/__tests__/product-ops-digest.test.ts
+++ b/packages/server/src/scheduled/__tests__/product-ops-digest.test.ts
@@ -45,9 +45,12 @@ function lokiResponse(levels: Record<string, number>): Response {
 
 const CONFIG = {
   lokiUrl: "http://loki.monitoring:3100",
-  alertmanagerUrl: "http://alertmanager.monitoring:9093",
   namespace: "summaries-prod",
   grafanaUrl: "https://grafana.example.test/explore",
+  slackOrganizationId: "org_lobucrm",
+  slackConnectionSlug: "agentconn-lobu",
+  slackTeamId: "T09513HDQ77",
+  slackChannelId: "C0BPWNXR0MP",
 };
 
 describe("product operations digest", () => {
@@ -98,6 +101,9 @@ describe("product operations digest", () => {
         requests.push(String(input));
         return lokiResponse({ info: 999 });
       },
+      deliverDigest: async () => {
+        throw new Error("empty windows must not be delivered");
+      },
     });
 
     expect(result).toEqual({
@@ -132,63 +138,54 @@ describe("product operations digest", () => {
         },
       ],
     };
-    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const requests: string[] = [];
+    const deliveries: Array<{ message: string; clientMessageId: string }> = [];
 
     const result = await runProductOpsDigest({
       taskRunId: 43,
       config: CONFIG,
       store: store(activity),
-      now: () => new Date("2026-08-12T12:00:05.000Z"),
-      fetchImpl: async (input, init) => {
+      fetchImpl: async (input) => {
         const url = String(input);
-        requests.push({ url, init });
-        if (url.startsWith(CONFIG.lokiUrl)) {
-          return lokiResponse({ error: 2, warning: 3, info: 999 });
-        }
-        return new Response(null, { status: 200 });
+        requests.push(url);
+        return lokiResponse({ error: 2, warning: 3, info: 999 });
+      },
+      deliverDigest: async ({ message, clientMessageId }) => {
+        deliveries.push({ message, clientMessageId });
       },
     });
 
     expect(result.posted).toBe(true);
     expect(result.logs).toEqual({ errors: 2, warnings: 3 });
-    expect(requests).toHaveLength(2);
-    expect(requests[1]?.url).toBe(`${CONFIG.alertmanagerUrl}/api/v2/alerts`);
-    expect(requests[1]?.init?.method).toBe("POST");
-
-    const alerts = JSON.parse(String(requests[1]?.init?.body)) as Array<{
-      labels: Record<string, string>;
-      annotations: Record<string, string>;
-      endsAt: string;
-    }>;
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0]?.labels).toMatchObject({
-      alertname: "LobuProductOpsDigest",
-      severity: "info",
-      namespace: CONFIG.namespace,
-      digest_window_end: "2026-08-12T12_00_00_000Z",
-    });
-    expect(alerts[0]?.annotations.description).toContain(
+    expect(requests).toHaveLength(1);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.clientMessageId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(deliveries[0]?.message).toStartWith(
+      "*Lobu production activity digest*\n",
+    );
+    expect(deliveries[0]?.message).toContain(
       "Signups: 1 — Ada (ada@example.test)",
     );
-    expect(alerts[0]?.annotations.description).toContain(
+    expect(deliveries[0]?.message).toContain(
       "Logins: 2 sessions / 1 user",
     );
-    expect(alerts[0]?.annotations.description).toContain(
+    expect(deliveries[0]?.message).toContain(
       "New connections: 1 — slack: Acme Slack (Acme)",
     );
-    expect(alerts[0]?.annotations.description).toContain(
+    expect(deliveries[0]?.message).toContain(
       "MCP activity: 1 new conversation / 1 authenticated user / 1 client — codex (Acme)",
     );
-    expect(alerts[0]?.annotations.description).toContain(
+    expect(deliveries[0]?.message).toContain(
       "Kubernetes logs: 2 errors / 3 warnings",
     );
-    expect(alerts[0]?.annotations.description).toContain(CONFIG.grafanaUrl);
-    expect(alerts[0]?.endsAt).toBe("2026-08-12T12:15:05.000Z");
+    expect(deliveries[0]?.message).toContain(CONFIG.grafanaUrl);
   });
 
-  test("splits catch-up work into independently deduplicated 20-minute alerts", async () => {
+  test("splits catch-up work into independently deduplicated 20-minute digests", async () => {
     const collected: ProductOpsDigestWindow[] = [];
-    const alerts: Array<{ labels: Record<string, string> }> = [];
+    const clientMessageIds: string[] = [];
     await runProductOpsDigest({
       taskRunId: 46,
       config: CONFIG,
@@ -211,10 +208,9 @@ describe("product operations digest", () => {
           };
         },
       },
-      fetchImpl: async (input, init) => {
-        if (String(input).startsWith(CONFIG.lokiUrl)) return lokiResponse({});
-        alerts.push(...JSON.parse(String(init?.body)));
-        return new Response(null, { status: 200 });
+      fetchImpl: async () => lokiResponse({}),
+      deliverDigest: async ({ clientMessageId }) => {
+        clientMessageIds.push(clientMessageId);
       },
     });
 
@@ -225,10 +221,8 @@ describe("product operations digest", () => {
       },
       WINDOW,
     ]);
-    expect(alerts.map((alert) => alert.labels.digest_window_end)).toEqual([
-      "2026-08-12T11_40_00_000Z",
-      "2026-08-12T12_00_00_000Z",
-    ]);
+    expect(clientMessageIds).toHaveLength(2);
+    expect(new Set(clientMessageIds).size).toBe(2);
   });
 
   test("fails closed when Loki cannot be checked", async () => {
@@ -238,11 +232,12 @@ describe("product operations digest", () => {
         config: CONFIG,
         store: store(),
         fetchImpl: async () => new Response("unavailable", { status: 503 }),
+        deliverDigest: async () => {},
       }),
     ).rejects.toThrow("Loki query failed with 503");
   });
 
-  test("fails closed when Alertmanager does not accept an active digest", async () => {
+  test("fails closed when Slack delivery rejects the digest", async () => {
     await expect(
       runProductOpsDigest({
         taskRunId: 45,
@@ -253,11 +248,11 @@ describe("product operations digest", () => {
             { userId: "user-2", name: null, email: "new@example.test" },
           ],
         }),
-        fetchImpl: async (input) =>
-          String(input).startsWith(CONFIG.lokiUrl)
-            ? lokiResponse({})
-            : new Response("rejected", { status: 500 }),
+        fetchImpl: async () => lokiResponse({}),
+        deliverDigest: async () => {
+          throw new Error("Slack chat.postMessage failed: not_in_channel");
+        },
       }),
-    ).rejects.toThrow("Alertmanager delivery failed with 500");
+    ).rejects.toThrow("Slack chat.postMessage failed: not_in_channel");
   });
 });

--- a/packages/server/src/scheduled/__tests__/product-ops-slack-delivery.test.ts
+++ b/packages/server/src/scheduled/__tests__/product-ops-slack-delivery.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import type { DbClient } from "../../db/client";
+import type { SlackWebApi } from "../../gateway/connections/slack-web";
+import type { SecretStore } from "../../gateway/secrets/index";
+import { getOrgId } from "../../lobu/stores/org-context";
+import type { ProductOpsDigestConfig } from "../product-ops-digest";
+import {
+  createProductOpsSlackDelivery,
+  createProductOpsSlackDeliveryStore,
+} from "../product-ops-slack-delivery";
+
+const CONFIG: ProductOpsDigestConfig = {
+  lokiUrl: "http://loki.monitoring:3100",
+  namespace: "summaries-prod",
+  slackOrganizationId: "org_lobucrm",
+  slackConnectionSlug: "agentconn-lobu",
+  slackTeamId: "T09513HDQ77",
+  slackChannelId: "C0BPWNXR0MP",
+};
+
+function slackWeb(overrides: Partial<SlackWebApi> = {}): SlackWebApi {
+  return {
+    openDm: async () => "D1",
+    postMessage: async () => {},
+    conversationMembers: async () => [],
+    conversationInfo: async () => ({
+      name: "whats-happening",
+      isPrivate: true,
+      contextTeamId: CONFIG.slackTeamId,
+    }),
+    usersInfo: async () => ({ isAdmin: false, isOwner: false }),
+    revokeToken: async () => true,
+    authTest: async () => ({ teamId: CONFIG.slackTeamId }),
+    exchangeOAuthCode: async () => {
+      throw new Error("not used");
+    },
+    ...overrides,
+  };
+}
+
+describe("product operations Slack delivery", () => {
+  test("resolves only the configured active workspace connection in its org context", async () => {
+    let queryValues: unknown[] = [];
+    const sql = ((_strings: TemplateStringsArray, ...values: unknown[]) => {
+      queryValues = values;
+      return Promise.resolve([{ bot_token_ref: "secret://slack-bot" }]);
+    }) as unknown as DbClient;
+    const secretStore = {
+      get: async (ref: string) => {
+        expect(getOrgId()).toBe(CONFIG.slackOrganizationId);
+        expect(ref).toBe("secret://slack-bot");
+        return "xoxb-test";
+      },
+    } as SecretStore;
+
+    const token = await createProductOpsSlackDeliveryStore(
+      secretStore,
+      sql,
+    ).resolveBotToken(CONFIG);
+
+    expect(token).toBe("xoxb-test");
+    expect(queryValues).toEqual([
+      CONFIG.slackOrganizationId,
+      CONFIG.slackConnectionSlug,
+      CONFIG.slackTeamId,
+    ]);
+  });
+
+  test("posts to the exact private channel with a deterministic client id", async () => {
+    const posts: unknown[][] = [];
+    const deliver = createProductOpsSlackDelivery({
+      store: { resolveBotToken: async () => "xoxb-test" },
+      slackWeb: slackWeb({
+        postMessage: async (...args) => {
+          posts.push(args);
+        },
+      }),
+    });
+
+    await deliver({
+      config: CONFIG,
+      window: {
+        start: new Date("2026-08-12T20:00:00.000Z"),
+        end: new Date("2026-08-12T20:20:00.000Z"),
+      },
+      message: "digest",
+      clientMessageId: "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+    });
+
+    expect(posts).toEqual([
+      [
+        "xoxb-test",
+        "C0BPWNXR0MP",
+        "digest",
+        "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+      ],
+    ]);
+  });
+
+  test("fails closed when the bot token belongs to another workspace", async () => {
+    await expect(
+      createProductOpsSlackDelivery({
+        store: { resolveBotToken: async () => "xoxb-test" },
+        slackWeb: slackWeb({
+          authTest: async () => ({ teamId: "T_OTHER" }),
+        }),
+      })({
+        config: CONFIG,
+        window: {
+          start: new Date("2026-08-12T20:00:00.000Z"),
+          end: new Date("2026-08-12T20:20:00.000Z"),
+        },
+        message: "digest",
+        clientMessageId: "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+      }),
+    ).rejects.toThrow("does not belong to configured workspace");
+  });
+
+  test("fails closed when the private channel belongs to another workspace", async () => {
+    await expect(
+      createProductOpsSlackDelivery({
+        store: { resolveBotToken: async () => "xoxb-test" },
+        slackWeb: slackWeb({
+          conversationInfo: async () => ({
+            name: "whats-happening",
+            isPrivate: true,
+            contextTeamId: "T_OTHER",
+          }),
+        }),
+      })({
+        config: CONFIG,
+        window: {
+          start: new Date("2026-08-12T20:00:00.000Z"),
+          end: new Date("2026-08-12T20:20:00.000Z"),
+        },
+        message: "digest",
+        clientMessageId: "2963902b-df7b-5f85-b3a6-e09f40685ac9",
+      }),
+    ).rejects.toThrow("channel does not belong to configured workspace");
+  });
+});

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -50,6 +50,10 @@ import {
   productOpsDigestConfigFromEnv,
   runProductOpsDigest,
 } from './product-ops-digest';
+import {
+  createProductOpsSlackDelivery,
+  createProductOpsSlackDeliveryStore,
+} from './product-ops-slack-delivery';
 
 function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   if (!value || typeof value !== 'object') return null;
@@ -115,12 +119,16 @@ function registerMaintenanceTasks(
 ): void {
   const productOpsDigestConfig = productOpsDigestConfigFromEnv(env);
   if (productOpsDigestConfig) {
+    const deliverProductOpsDigest = createProductOpsSlackDelivery({
+      store: createProductOpsSlackDeliveryStore(coreServices.getSecretStore()),
+    });
     scheduler.register(
       PRODUCT_OPS_DIGEST_TASK,
       async ({ taskRunId }) => {
         const result = await runProductOpsDigest({
           taskRunId,
           config: productOpsDigestConfig,
+          deliverDigest: deliverProductOpsDigest,
         });
         logger.info(
           {

--- a/packages/server/src/scheduled/product-ops-digest.ts
+++ b/packages/server/src/scheduled/product-ops-digest.ts
@@ -1,18 +1,21 @@
 import type { Env } from "@lobu/connector-sdk";
+import { createHash } from "node:crypto";
 import { type DbClient, getDb } from "../db/client";
 
 export const PRODUCT_OPS_DIGEST_TASK = "product-ops-digest";
 const DEFAULT_WINDOW_MS = 20 * 60 * 1000;
 const LOG_INGESTION_LAG_MS = 2 * 60 * 1000;
-const ACTIVE_ALERT_MS = 15 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 15_000;
 const DETAIL_LIMIT = 10;
 
 export interface ProductOpsDigestConfig {
   lokiUrl: string;
-  alertmanagerUrl: string;
   namespace: string;
   grafanaUrl?: string;
+  slackOrganizationId: string;
+  slackConnectionSlug: string;
+  slackTeamId: string;
+  slackChannelId: string;
 }
 
 export interface ProductOpsDigestWindow {
@@ -60,8 +63,15 @@ interface RunProductOpsDigestParams {
   config: ProductOpsDigestConfig;
   store?: ProductOpsDigestStore;
   fetchImpl?: typeof fetch;
-  now?: () => Date;
+  deliverDigest: ProductOpsDigestDelivery;
 }
+
+export type ProductOpsDigestDelivery = (params: {
+  config: ProductOpsDigestConfig;
+  window: ProductOpsDigestWindow;
+  message: string;
+  clientMessageId: string;
+}) => Promise<void>;
 
 export interface ProductOpsDigestResult {
   posted: boolean;
@@ -76,20 +86,37 @@ export function productOpsDigestConfigFromEnv(
   if (env.LOBU_PRODUCT_OPS_DIGEST_ENABLED !== "1") return null;
 
   const lokiUrl = env.LOBU_PRODUCT_OPS_LOKI_URL?.trim();
-  const alertmanagerUrl = env.LOBU_PRODUCT_OPS_ALERTMANAGER_URL?.trim();
   const namespace = env.LOBU_PRODUCT_OPS_NAMESPACE?.trim();
-  if (!lokiUrl || !alertmanagerUrl || !namespace) {
+  const slackOrganizationId =
+    env.LOBU_PRODUCT_OPS_SLACK_ORGANIZATION_ID?.trim();
+  const slackConnectionSlug =
+    env.LOBU_PRODUCT_OPS_SLACK_CONNECTION_SLUG?.trim();
+  const slackTeamId = env.LOBU_PRODUCT_OPS_SLACK_TEAM_ID?.trim();
+  const slackChannelId = env.LOBU_PRODUCT_OPS_SLACK_CHANNEL_ID?.trim();
+  if (
+    !lokiUrl ||
+    !namespace ||
+    !slackOrganizationId ||
+    !slackConnectionSlug ||
+    !slackTeamId ||
+    !slackChannelId
+  ) {
     throw new Error(
       "LOBU_PRODUCT_OPS_DIGEST_ENABLED requires LOBU_PRODUCT_OPS_LOKI_URL, " +
-        "LOBU_PRODUCT_OPS_ALERTMANAGER_URL, and LOBU_PRODUCT_OPS_NAMESPACE",
+        "LOBU_PRODUCT_OPS_NAMESPACE, LOBU_PRODUCT_OPS_SLACK_ORGANIZATION_ID, " +
+        "LOBU_PRODUCT_OPS_SLACK_CONNECTION_SLUG, LOBU_PRODUCT_OPS_SLACK_TEAM_ID, " +
+        "and LOBU_PRODUCT_OPS_SLACK_CHANNEL_ID",
     );
   }
 
   const grafanaUrl = env.LOBU_PRODUCT_OPS_GRAFANA_URL?.trim();
   return {
     lokiUrl: trimTrailingSlash(lokiUrl),
-    alertmanagerUrl: trimTrailingSlash(alertmanagerUrl),
     namespace,
+    slackOrganizationId,
+    slackConnectionSlug,
+    slackTeamId,
+    slackChannelId,
     ...(grafanaUrl ? { grafanaUrl } : {}),
   };
 }
@@ -193,7 +220,7 @@ export async function runProductOpsDigest({
   config,
   store = createProductOpsDigestStore(),
   fetchImpl = fetch,
-  now = () => new Date(),
+  deliverDigest,
 }: RunProductOpsDigestParams): Promise<ProductOpsDigestResult> {
   const window = await store.resolveWindow(taskRunId);
   const activity: ProductOpsActivity = {
@@ -206,9 +233,9 @@ export async function runProductOpsDigest({
   let posted = false;
 
   // A later tick may be claimed by another replica while an older tick is
-  // retrying. Catch up one exact interval at a time: the interval end is the
-  // Alertmanager fingerprint, so concurrent/retried sends dedupe without a
-  // second lock while every missed interval remains recoverable.
+  // retrying. Catch up one exact interval at a time: the interval end derives
+  // Slack's deterministic client_msg_id, so concurrent/retried sends resolve
+  // to the same message while every missed interval remains recoverable.
   for (const interval of splitDigestWindows(window)) {
     const [intervalActivity, intervalLogs] = await Promise.all([
       store.collectActivity(interval),
@@ -222,53 +249,23 @@ export async function runProductOpsDigest({
     logs.warnings += intervalLogs.warnings;
 
     if (!hasDigestActivity(intervalActivity, intervalLogs)) continue;
-    await deliverDigestAlert(
+    await deliverDigest({
       config,
-      interval,
-      intervalActivity,
-      intervalLogs,
-      fetchImpl,
-      now(),
-    );
+      window: interval,
+      message:
+        `*Lobu production activity digest*\n` +
+        formatDigestDescription(
+          config,
+          interval,
+          intervalActivity,
+          intervalLogs,
+        ),
+      clientMessageId: digestClientMessageId(interval.end),
+    });
     posted = true;
   }
 
   return { posted, window, activity, logs };
-}
-
-async function deliverDigestAlert(
-  config: ProductOpsDigestConfig,
-  window: ProductOpsDigestWindow,
-  activity: ProductOpsActivity,
-  logs: ProductOpsLogCounts,
-  fetchImpl: typeof fetch,
-  deliveryTime: Date,
-): Promise<void> {
-  const description = formatDigestDescription(config, window, activity, logs);
-  const alert = {
-    labels: {
-      alertname: "LobuProductOpsDigest",
-      severity: "info",
-      namespace: config.namespace,
-      digest_window_end: window.end.toISOString().replace(/[.:]/g, "_"),
-    },
-    annotations: {
-      summary: "Lobu production activity digest",
-      description,
-    },
-    startsAt: deliveryTime.toISOString(),
-    endsAt: new Date(deliveryTime.getTime() + ACTIVE_ALERT_MS).toISOString(),
-    ...(config.grafanaUrl ? { generatorURL: config.grafanaUrl } : {}),
-  };
-  const response = await fetchImpl(`${config.alertmanagerUrl}/api/v2/alerts`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify([alert]),
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
-  if (!response.ok) {
-    throw new Error(`Alertmanager delivery failed with ${response.status}`);
-  }
 }
 
 function splitDigestWindows(
@@ -480,4 +477,16 @@ function escapeLogQlString(value: string): string {
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function digestClientMessageId(windowEnd: Date): string {
+  const bytes = createHash("sha256")
+    .update(`lobu-product-ops-digest:${windowEnd.toISOString()}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-` +
+    `${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/packages/server/src/scheduled/product-ops-slack-delivery.ts
+++ b/packages/server/src/scheduled/product-ops-slack-delivery.ts
@@ -1,0 +1,98 @@
+import { type DbClient, getDb } from "../db/client";
+import {
+  createSlackWebApi,
+  type SlackWebApi,
+} from "../gateway/connections/slack-web";
+import { orgContext } from "../lobu/stores/org-context";
+import {
+  resolveSecretValue,
+  type SecretStore,
+} from "../gateway/secrets/index";
+import type {
+  ProductOpsDigestConfig,
+  ProductOpsDigestDelivery,
+} from "./product-ops-digest";
+
+export interface ProductOpsSlackDeliveryStore {
+  resolveBotToken(config: ProductOpsDigestConfig): Promise<string>;
+}
+
+interface ProductOpsSlackDeliveryDeps {
+  store: ProductOpsSlackDeliveryStore;
+  slackWeb?: SlackWebApi;
+}
+
+export function createProductOpsSlackDeliveryStore(
+  secretStore: SecretStore,
+  sql: DbClient = getDb(),
+): ProductOpsSlackDeliveryStore {
+  return {
+    async resolveBotToken(config) {
+      const rows = await sql<{ bot_token_ref: string | null }>`
+        SELECT COALESCE(
+          config->>'botToken',
+          config->'chatMetadata'->>'botToken'
+        ) AS bot_token_ref
+        FROM public.connections
+        WHERE organization_id = ${config.slackOrganizationId}
+          AND slug = ${config.slackConnectionSlug}
+          AND connector_key = 'slack'
+          AND status = 'active'
+          AND deleted_at IS NULL
+          AND external_tenant_id = ${config.slackTeamId}
+        LIMIT 1
+      `;
+      const tokenRef = rows[0]?.bot_token_ref;
+      if (!tokenRef) {
+        throw new Error(
+          "Product operations Slack connection is missing, inactive, or belongs to another workspace",
+        );
+      }
+      const botToken = await orgContext.run(
+        { organizationId: config.slackOrganizationId },
+        () => resolveSecretValue(secretStore, tokenRef),
+      );
+      if (!botToken) {
+        throw new Error(
+          "Product operations Slack connection has no resolvable bot token",
+        );
+      }
+      return botToken;
+    },
+  };
+}
+
+export function createProductOpsSlackDelivery({
+  store,
+  slackWeb = createSlackWebApi(),
+}: ProductOpsSlackDeliveryDeps): ProductOpsDigestDelivery {
+  return async ({ config, message, clientMessageId }) => {
+    const botToken = await store.resolveBotToken(config);
+    const identity = await slackWeb.authTest(botToken);
+    if (identity.teamId !== config.slackTeamId) {
+      throw new Error(
+        "Product operations Slack bot does not belong to configured workspace",
+      );
+    }
+    const channel = await slackWeb.conversationInfo(
+      botToken,
+      config.slackChannelId,
+    );
+    if (!channel.isPrivate) {
+      throw new Error(
+        "Product operations Slack channel is not the configured private channel",
+      );
+    }
+    if (channel.contextTeamId !== config.slackTeamId) {
+      throw new Error(
+        "Product operations Slack channel does not belong to configured workspace",
+      );
+    }
+    await slackWeb.postMessage(
+      botToken,
+      config.slackChannelId,
+      message,
+      clientMessageId,
+    );
+  };
+}


### PR DESCRIPTION
## Summary
- deliver the 20-minute production activity digest directly through the existing workspace-scoped Lobu Slack bot to private channel `C0BPWNXR0MP` (`#whats-happening`)
- summarize Lobu Postgres activity plus Kubernetes warning/error logs from Loki; remain silent when the interval has no activity
- validate the exact organization, Slack connection, workspace, and private channel before posting; use a deterministic `client_msg_id` for retry-safe delivery
- retain Alertmanager for ordinary `#devops` infrastructure alerts and for old-server rollout compatibility only

The previous incoming webhook was pinned to `#devops` and ignored the attempted per-message channel override, even though Alertmanager reported success.

## Test plan
- [x] Intended files staged explicitly; branch diff contains exactly eight intended paths
- [x] Full `make pre-pr-remote`: 18/18 Linux lanes passed; attestation `067d3674f2f1dc9c27fb7aceb429e3c15a0cb0c6`
- [x] Targeted tests: `18 pass, 0 fail, 52 expect()`
- [x] Server TypeScript: `bunx tsc -p packages/server/tsconfig.json --noEmit`
- [x] Bug fix: red-to-fix-to-green outputs pasted below
- [x] Relevant bot eval: live `chat.postMessage` probe to the exact private channel
- [x] `make review`: bug-free 88, 0 bugs, 0 blockers
- [x] `make ui-review`: proof recorded on Owletto #820

### Red
```
5 pass
3 fail
- expected the old Alertmanager call
- rejected missing Slack routing identifiers
- Slack delivery rejection did not fail the digest job
```

The new focused delivery suite also failed before implementation with:
```
error: Cannot find module '../product-ops-slack-delivery.js'
```

### Green
```
18 pass
0 fail
52 expect() calls
```

A live production-scoped probe sent the same deterministic `client_msg_id` twice; Slack returned the same timestamp both times, leaving one message in the target channel:
https://lobu-ai.slack.com/archives/C0BPWNXR0MP/p1786567662137779

## Notes
- Owletto compatibility-first config: https://github.com/lobu-ai/owletto/pull/820
- UI proof: https://claude.ai/code/artifact/820d1500-0a9c-4f3f-b568-b44cfc98561b
- Supersedes the incomplete runtime portion of https://github.com/lobu-ai/lobu/pull/2703, which merged only the older Owletto pointer.
- The merged Owletto config keeps the old Alertmanager URL during a rolling deploy so the previous server revision remains healthy; the new server ignores it.
- No database design, API surface, or SDK surface change.
