### PR TITLE
fix(personal-agent): persist net worth as summary

### DIFF
--- a/examples/personal-agent/__tests__/net-worth.reaction.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.reaction.test.ts
@@ -245,7 +245,7 @@ describe("weekly net-worth reaction", () => {
     ]);
     expect(saved).toHaveLength(1);
     expect(saved[0]).toMatchObject({
-      semantic_type: "net_worth_snapshot",
+      semantic_type: "summary",
       title: "Midas net worth snapshot",
       idempotency_key: "midas-net-worth:snapshot:window:91",
       behavior_source: { behavior_id: 45, window_id: 91 },

--- a/examples/personal-agent/net-worth.reaction.ts
+++ b/examples/personal-agent/net-worth.reaction.ts
@@ -565,7 +565,7 @@ export default async function runNetWorthSnapshot(
   const digest = snapshotDigest(snapshot);
   const saved = await client.knowledge.save({
     content: digest,
-    semantic_type: "net_worth_snapshot",
+    semantic_type: "summary",
     title: "Midas net worth snapshot",
     payload_type: "markdown",
     metadata: snapshot as unknown as Record<string, unknown>,


### PR DESCRIPTION
## What changed

Persist Midas valuation snapshots using the registered built-in summary event kind while retaining scope=midas and the full structured valuation in metadata.

## Production reproducer (red)

Manual Behavior run 933109 completed quote action 933114, but produced no snapshot. Production logs recorded three identical reaction failures:

ValidationError: Invalid kind net_worth_snapshot. Valid kinds include summary.

The focused test was changed to expect semantic_type summary before implementation; it failed 1 test / passed 5 because the reaction still emitted net_worth_snapshot.

## Fix verification (green)

- Focused suite: 13 pass, 0 fail, 36 expectations.
- Full pre-pr-remote Depot gate: passed all 18 jobs, run fv6cthskws.
- Independent review: bug-free 95, simplicity 100, 0 bugs, 0 blockers.
- UI review: not applicable.

## Scope

Two one-line changes only: reaction persistence kind and its regression expectation. No schema, API, SDK, UI, or connector changes.