### PR TITLE
test: stop bun's 5000ms default from failing unrelated tests

### DIFF
--- a/packages/core/src/__tests__/credentials.test.ts
+++ b/packages/core/src/__tests__/credentials.test.ts
@@ -4,7 +4,7 @@
  * resolver, so the v2 file format + refresh semantics must stay exact.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,20 +20,34 @@ import {
 } from "../credentials";
 
 const DEFAULT = "lobu";
-let dir: string;
-let file: string;
 
-beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), "lobu-cred-"));
-  file = join(dir, "credentials.json");
-});
+// Bun lets a timed-out async test body keep running. Per-test paths keep that
+// straggler from reading or deleting another test's fixture, and cleanup is
+// deferred to `afterAll` so it cannot race one either.
+//
+// Do not collapse this back into one shared dir rebuilt by a `beforeEach`: with
+// that shape, clamping this file to `--timeout 1` failed FIVE tests and emitted
+// an unhandled `ENOENT: rename '.tmp-…' -> 'credentials.json'` between them.
+// Four victims were unrelated, including the pure synchronous predicate tests
+// that touch no filesystem — a file-scoped fixture hook runs for every test in
+// the file, so one slow test is contagious.
+const createdDirs: string[] = [];
 
-afterEach(async () => {
-  await rm(dir, { recursive: true, force: true });
+async function newStore(): Promise<{ dir: string; file: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "lobu-cred-"));
+  createdDirs.push(dir);
+  return { dir, file: join(dir, "credentials.json") };
+}
+
+afterAll(async () => {
+  await Promise.all(
+    createdDirs.map((d) => rm(d, { recursive: true, force: true }))
+  );
 });
 
 describe("credential store I/O", () => {
   test("write → read round-trips and preserves extra (non-base) fields", async () => {
+    const { file } = await newStore();
     interface Rich extends BaseCredential {
       email?: string;
       localWorkerToken?: string;
@@ -56,6 +70,7 @@ describe("credential store I/O", () => {
   });
 
   test("writes are 0600 and a second context does not clobber the first", async () => {
+    const { file } = await newStore();
     await writeContextCredential(file, "lobu", DEFAULT, { accessToken: "a" });
     await writeContextCredential(file, "work", DEFAULT, { accessToken: "b" });
     const store = await readCredentialStore(file, DEFAULT);
@@ -68,6 +83,7 @@ describe("credential store I/O", () => {
   });
 
   test("a legacy single-context file migrates under the default context", async () => {
+    const { file } = await newStore();
     const { writeFile } = await import("node:fs/promises");
     await writeFile(
       file,
@@ -80,6 +96,7 @@ describe("credential store I/O", () => {
   });
 
   test("a missing or corrupt file reads as an empty store", async () => {
+    const { file } = await newStore();
     expect((await readCredentialStore(file, DEFAULT)).contexts).toEqual({});
     const { writeFile } = await import("node:fs/promises");
     await writeFile(file, "{not json");
@@ -87,6 +104,7 @@ describe("credential store I/O", () => {
   });
 
   test("entries without an accessToken (or an EMPTY-string one) are dropped on read", async () => {
+    const { file } = await newStore();
     const { writeFile } = await import("node:fs/promises");
     await writeFile(
       file,
@@ -115,6 +133,7 @@ describe("credential store I/O", () => {
     // we don't merge concurrent read-modify-writes — so not every context is
     // guaranteed to survive; the invariant being proven here is no CORRUPTION,
     // not no-lost-update.)
+    const { dir, file } = await newStore();
     const { readdir } = await import("node:fs/promises");
     await Promise.all(
       Array.from({ length: 25 }, (_, i) =>
@@ -141,9 +160,12 @@ describe("credential store I/O", () => {
     const entries = await readdir(dir);
     expect(entries.filter((n) => n.includes(".tmp-"))).toEqual([]);
     expect(entries).toContain("credentials.json");
-  });
+    // Bun 1.3.5 ignores bunfig's test timeout, so keep the larger budget local
+    // to this I/O stress test.
+  }, 30_000);
 
   test("delete removes one context; deletes the file when none remain", async () => {
+    const { file } = await newStore();
     await writeContextCredential(file, "lobu", DEFAULT, { accessToken: "a" });
     await writeContextCredential(file, "work", DEFAULT, { accessToken: "b" });
     await deleteContextCredential(file, "lobu", DEFAULT);

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -344,6 +344,15 @@ describe("expirePendingApprovals", () => {
  * drained and no other org's approvals were ever reached.
  */
 describe("expirePendingApprovals — draining and cross-org fairness", () => {
+	// Each of these seeds hundreds of rows and then drives real batched DB
+	// work, so they are the only tests in this file that genuinely approach a
+	// multi-second runtime. Two of them (the 620-row drain and the single-tenant
+	// backlog) timed out at 5088ms and 6275ms on a loaded CI runner against bun's
+	// 5000ms default, taking the lane red. The budget has to be set per test: bun
+	// ignores `timeout` in bunfig and honours only the --timeout CLI flag, which
+	// no lane passes.
+	const DRAIN_TIMEOUT_MS = 30_000;
+
 	/** Seed `count` stale pending approvals for an org in one statement. */
 	async function seedManyStale(
 		organizationId: string,
@@ -413,7 +422,7 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		expect(result.expired).toBe(620);
 		expect(await pendingCount(ORG_ID)).toBe(0);
 		expect(await expiredCount(ORG_ID)).toBe(620);
-	});
+	}, DRAIN_TIMEOUT_MS);
 
 	test("a huge single-tenant backlog does NOT starve other orgs", async () => {
 		// The starvation reproducer. ORG_ID's rows are all OLDER than the other
@@ -438,7 +447,7 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		}
 		expect(await expiredCount(hogOrg)).toBe(hogRows);
 		expect(result.expired).toBe(hogRows + smallOrgs.length * 5);
-	});
+	}, DRAIN_TIMEOUT_MS);
 
 	test("the per-org cap bounds how much one tenant takes from a single batch", async () => {
 		// Fairness is a per-BATCH property, not only an end-state one. Seed a hog
@@ -466,7 +475,7 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		// The hog cannot take the whole batch: the per-org cap bounds its share,
 		// leaving room for other orgs even though its rows are the oldest.
 		expect(await expiredCount(hogOrg)).toBeLessThan(batchCeiling);
-	});
+	}, DRAIN_TIMEOUT_MS);
 
 	test("more backlogged orgs than the batch can cover: a newer org still gets rows in the FIRST batch", async () => {
 		// The per-org cap alone does NOT give fairness. With batch=500 and
@@ -499,7 +508,7 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		// The newcomer must be represented in that first batch. Under global age
 		// ordering it gets 0: all 14 older orgs rank ahead of it.
 		expect(await expiredCount("starve-newcomer")).toBeGreaterThan(0);
-	});
+	}, DRAIN_TIMEOUT_MS);
 
 	test("respects the per-invocation ceiling on a pathological backlog", async () => {
 		// A backlog larger than the ceiling must stop AT the ceiling rather than
@@ -518,5 +527,5 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		const second = await expirePendingApprovals(TTL_DAYS, ceiling);
 		expect(second.expired).toBe(30);
 		expect(await pendingCount(ORG_ID)).toBe(0);
-	});
+	}, DRAIN_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
Two test files that ride bun's 5000ms default timeout and fail in CI while passing locally. Same root cause, different symptoms.

## `credentials.test.ts` — one slow test was failing four unrelated ones
File-scoped `beforeEach`/`afterEach` shared a single temp dir across all 12 tests and `rm`'d it after each. bun does **not** abort a timed-out test's async body, so a straggler's writes race that `rm` and its later statements read bindings the next `beforeEach` has already reassigned. Because the hooks were registered at *file* scope they ran for every test, including ones needing no temp dir.

**Red** (`--timeout 1`, before):
```
(fail) concurrent writes never corrupt the store and leave no temp files
# Unhandled error between tests
ENOENT: no such file or directory, rename '/…/lobu-cred-LR5ySs/.tmp-49725…' -> '/…/lobu-cred-LR5ySs/credentials.json'
(fail) delete removes one context; deletes the file when none remain
(fail) credentialNeedsRefresh respects the expiry buffer      <- pure sync, no filesystem
(fail) credentialCanRefresh requires a refresh token…         <- pure sync, no filesystem
(fail) refreshOAuthToken > returns rotated tokens on success
 7 pass, 5 fail, 1 error
```

**Green** (same clamp, after): `10 pass, 2 fail` — only the two genuinely-async fs tests, no unhandled error, pure predicates unaffected.

Fix: per-test temp dirs, cleanup moved to `afterAll` where it cannot race a straggler, explicit 30s on the 25-way concurrent-write test.

## `expire-pending-approvals.test.ts` — drain tests exceed the default
Two timed out in CI at **5088ms** and **6275ms** (`this test timed out after 5000ms` — the body, not a hook) while the other ~260 tests in the lane passed. They are not slow by accident: each seeds hundreds of rows via a single CTE with `generate_series` and then drives real batched DB work, so >5s on a contended runner is legitimate rather than a hang.

All five tests in the drain/fairness block get the budget via a shared `DRAIN_TIMEOUT_MS`, not just the two that happened to fail — same shape.

## Test plan
- [x] Tests run: `bun test packages/core/src` → **403 pass**; `bun test src/scheduled/__tests__/expire-pending-approvals.test.ts` → **15 pass** (6.18s)
- [x] Bug fix: red→fix→green pasted above
- [x] Mutation-checked, both files:
  - `credentials.test.ts`: `30_000 → 1` fails that test and **only** that test (11 pass) — proving the timeout is live *and* that a trip is now contained
  - `expire-pending-approvals.test.ts`: `DRAIN_TIMEOUT_MS 30_000 → 1` turns exactly those five red, rest of file green; restored 15/15
- [x] `make pre-pr-remote`: **17 of 18 lanes green** on run `p9xm77jfk8` — `unit`, `integration`, `server-integration-bun`, all three vitest matrices, `typecheck`, `frontend`, `format-lint`, both smokes, all four sdk lanes. No attestation: `dead-code-report` was cancelled with `error_message: Cancelled due to the workflow concurrency policy` and **zero** `failed` attempts (superseded, not a failure). Re-gate pending a free slot.

## Notes
`migrations` shows `failed,finished` on that run — attempt 1 hit `curl: (22) … 503` fetching dbmate from GitHub releases, attempt 2 passed on the identical tree. That transient is the case #2704 fixes; it is not related to this diff.

Companion to #2711, which raises the ceiling repo-wide. Neither depends on the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved credential-store test isolation by using temporary stores for each test.
  * Added cleanup handling for temporary test directories.
  * Extended timeouts for credential concurrency and pending-approval batching tests to support longer-running scenarios.
  * Existing test coverage, assertions, and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->