### PR TITLE
feat(cli): sync managed MCP connectors automatically

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { ApiError } from "../../../memory/_lib/errors.js";
 import {
   executePlan,
@@ -260,6 +260,130 @@ describe("executePlan — BYO chat connection dependencies", () => {
         output: "reply_to_source",
       },
     ]);
+  });
+});
+
+describe("executePlan — managed MCP connector install", () => {
+  test("installs the hydrated Cloud manifest before creating the managed connection", async () => {
+    const connection: DesiredConnection = {
+      slug: "atlassian-burak",
+      connector: "mcp.atlassian",
+      config: {
+        managedBy: {
+          org: "lobu-managed",
+          connectionSlug: "atlassian-burak",
+        },
+      },
+      feeds: [],
+      sourceFile: "lobu.config.ts",
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [connection],
+    });
+    const installable: RemoteConnectorDefinition = {
+      key: "mcp.atlassian",
+      installed: false,
+      installable: true,
+      mcp_config: {
+        upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+        tool_prefix: "atlassian",
+      },
+      managed_mcp_source: "export default class ManagedAtlassian {}",
+    };
+    const installed: RemoteConnectorDefinition = {
+      ...installable,
+      id: 92,
+      installed: true,
+      installable: false,
+      version: "1.0.0",
+      managed_mcp_source: undefined,
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      watchers: [],
+      connectorDefinitions: [installable],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "connector-definition",
+          verb: "create",
+          id: "mcp.atlassian",
+        },
+        {
+          kind: "connection",
+          verb: "create",
+          id: connection.slug,
+          desired: connection,
+        },
+      ],
+      counts: { create: 2, update: 0, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const calls: string[] = [];
+    const stdout: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk) => {
+        stdout.push(String(chunk));
+        return true;
+      }
+    );
+    const installConnector = mock(async (payload: { sourceCode?: string }) => {
+      calls.push(`install:${payload.sourceCode}`);
+      return {
+        connectorKey: "mcp.atlassian",
+        updated: false,
+        version: "1.0.0",
+      };
+    });
+    const listConnectors = mock(async () => [installed]);
+    const createConnection = mock(async () => {
+      calls.push("connection");
+      return { id: 93 };
+    });
+    const client = {
+      installConnector,
+      listConnectors,
+      createConnection,
+    } as unknown as ApplyClient;
+
+    try {
+      await executePlan({ client, state, plan, remote }, []);
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+
+    expect(installConnector).toHaveBeenCalledWith({
+      sourceCode: "export default class ManagedAtlassian {}",
+    });
+    expect(calls).toEqual([
+      "install:export default class ManagedAtlassian {}",
+      "connection",
+    ]);
+    expect(stdout.join("")).toContain("mcp.atlassian");
+    expect(stdout.join("")).toContain("installed managed");
+    expect(createConnection).toHaveBeenCalledWith({
+      slug: "atlassian-burak",
+      connector: "mcp.atlassian",
+      name: undefined,
+      authProfileSlug: undefined,
+      appAuthProfileSlug: undefined,
+      config: {
+        managedBy: {
+          org: "lobu-managed",
+          connectionSlug: "atlassian-burak",
+        },
+      },
+    });
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -3,6 +3,51 @@ import { ApiError } from "../../../memory/_lib/errors.js";
 import { ApplyClient, isDuplicateError } from "../client.js";
 
 describe("ApplyClient", () => {
+  test("maps non-secret managed MCP catalog metadata", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        if (body.action === "list_installed") {
+          return new Response(
+            JSON.stringify({
+              installed: {
+                connectors: {
+                  items: [
+                    {
+                      id: "mcp.atlassian",
+                      name: "Atlassian",
+                      detail: {
+                        installed: true,
+                        mcp_config: {
+                          upstream_url:
+                            "https://mcp.atlassian.com/v1/mcp/authv2",
+                          tool_prefix: "atlassian",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            { status: 200 }
+          );
+        }
+        throw new Error(`Unexpected action: ${String(body.action)}`);
+      }) as typeof fetch
+    );
+
+    const [definition] = await client.listConnectors(true);
+    expect(definition?.mcp_config).toEqual({
+      upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+      tool_prefix: "atlassian",
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+
   test("applyChatConnection returns the persisted connection id", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1440,6 +1440,78 @@ describe("apply diff — connectors", () => {
     ).toBe(true);
   });
 
+  test("referenced managed MCP connector becomes an install row without project source", () => {
+    const state = buildState([]);
+    state.connectors.connections.push({
+      slug: "atlassian",
+      connector: "mcp.atlassian",
+      config: {
+        managedBy: {
+          org: "lobu-managed",
+          connectionSlug: "atlassian-burak",
+        },
+      },
+      feeds: [],
+      sourceFile: "lobu.config.ts",
+    });
+    const plan = computeDiff(state, {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        {
+          key: "mcp.atlassian",
+          installed: false,
+          installable: true,
+          mcp_config: {
+            upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+            tool_prefix: "atlassian",
+          },
+          managed_mcp_source: "export default class ManagedAtlassian {}",
+        },
+      ],
+    });
+
+    expect(
+      plan.rows.find(
+        (row) =>
+          row.kind === "connector-definition" && row.id === "mcp.atlassian"
+      )?.verb
+    ).toBe("create");
+  });
+
+  test("installed managed MCP connector becomes a refresh row", () => {
+    const state = buildState([]);
+    state.connectors.connections.push({
+      slug: "atlassian",
+      connector: "mcp.atlassian",
+      config: {
+        managedBy: {
+          org: "lobu-managed",
+          connectionSlug: "atlassian-burak",
+        },
+      },
+      feeds: [],
+      sourceFile: "lobu.config.ts",
+    });
+    const plan = computeDiff(state, {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        {
+          key: "mcp.atlassian",
+          installed: true,
+          installable: true,
+          managed_mcp_source: "export default class ManagedAtlassian {}",
+        },
+      ],
+    });
+
+    expect(
+      plan.rows.find(
+        (row) =>
+          row.kind === "connector-definition" && row.id === "mcp.atlassian"
+      )?.verb
+    ).toBe("update");
+  });
+
   test("a locally-supplied connector key is NOT also a bundled-install row (no double mutation)", () => {
     // Pretend "acme" is *also* in the bundled catalog with a source_uri; the
     // local .connector.ts should win — no bundled row for "acme".

--- a/packages/cli/src/commands/_lib/apply/__tests__/managed-connector-catalog.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/managed-connector-catalog.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  buildManagedMcpConnectorSource,
+  hydrateManagedConnectorCatalog,
+  isManagedCloudTarget,
+} from "../managed-connector-catalog.js";
+import type { DesiredState } from "../desired-state.js";
+
+function managedState(
+  connections: Array<{
+    slug: string;
+    connector: string;
+    organization?: string;
+  }>
+): DesiredState {
+  return {
+    agents: [],
+    prune: false,
+    memorySchema: { entityTypes: [], relationshipTypes: [] },
+    watchers: [],
+    connectors: {
+      definitions: [],
+      authProfiles: [],
+      connections: connections.map(({ slug, connector, organization }) => ({
+        slug,
+        connector,
+        config: organization
+          ? { managedBy: { org: organization, connectionSlug: slug } }
+          : undefined,
+        feeds: [],
+        sourceFile: "lobu.config.ts",
+      })),
+    },
+    providers: [],
+    requiredSecrets: [],
+  };
+}
+
+describe("hydrateManagedConnectorCatalog", () => {
+  test("hydrates one missing connector from its authenticated Cloud org", async () => {
+    const requestedOrgs: string[] = [];
+    const result = await hydrateManagedConnectorCatalog(
+      managedState([
+        {
+          slug: "atlassian-burak",
+          connector: "mcp.atlassian",
+          organization: "lobu-managed",
+        },
+      ]),
+      [],
+      async (organization) => {
+        requestedOrgs.push(organization);
+        return [
+          {
+            id: 91,
+            key: "mcp.atlassian",
+            name: "Atlassian",
+            version: "1.2.3",
+            installed: true,
+            auth_schema: {
+              methods: [{ type: "oauth", provider: "mcp.atlassian" }],
+            },
+            mcp_config: {
+              upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+              tool_prefix: "atlassian",
+            },
+          },
+        ];
+      }
+    );
+
+    expect(requestedOrgs).toEqual(["lobu-managed"]);
+    expect(result).toEqual([
+      {
+        key: "mcp.atlassian",
+        name: "Atlassian",
+        version: "1.2.3",
+        installed: false,
+        installable: true,
+        catalog_origin: "managed",
+        source_uri: null,
+        mcp_config: {
+          upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+          tool_prefix: "atlassian",
+        },
+        auth_schema: {
+          methods: [{ type: "oauth", provider: "mcp.atlassian" }],
+        },
+        managed_mcp_source: expect.stringContaining(
+          '"upstream_url":"https://mcp.atlassian.com/v1/mcp/authv2"'
+        ),
+      },
+    ]);
+  });
+
+  test("does not contact Cloud for an installed or bundled local connector", async () => {
+    const state = managedState([
+      {
+        slug: "gmail",
+        connector: "gmail",
+        organization: "lobu-managed",
+      },
+      {
+        slug: "atlassian",
+        connector: "mcp.atlassian",
+        organization: "lobu-managed",
+      },
+    ]);
+    const local = [
+      { key: "gmail", installed: true },
+      {
+        key: "mcp.atlassian",
+        installed: false,
+        installable: true,
+        source_uri: "file:///catalog/atlassian.ts",
+      },
+    ];
+    const result = await hydrateManagedConnectorCatalog(
+      state,
+      local,
+      async () => {
+        throw new Error("Cloud should not be contacted");
+      }
+    );
+    expect(result).toBe(local);
+  });
+
+  test("fails closed when Cloud has no portable HTTPS MCP definition", async () => {
+    await expect(
+      hydrateManagedConnectorCatalog(
+        managedState([
+          {
+            slug: "atlassian",
+            connector: "mcp.atlassian",
+            organization: "lobu-managed",
+          },
+        ]),
+        [],
+        async () => [
+          {
+            key: "mcp.atlassian",
+            installed: true,
+            mcp_config: { upstream_url: "http://internal.test/mcp" },
+          },
+        ]
+      )
+    ).rejects.toThrow(/does not expose an installed HTTPS MCP definition/);
+  });
+
+  test("fails closed when the same connector key resolves to different servers", async () => {
+    await expect(
+      hydrateManagedConnectorCatalog(
+        managedState([
+          { slug: "one", connector: "mcp.shared", organization: "org-one" },
+          { slug: "two", connector: "mcp.shared", organization: "org-two" },
+        ]),
+        [],
+        async (organization) => [
+          {
+            key: "mcp.shared",
+            installed: true,
+            mcp_config: {
+              upstream_url: `https://${organization}.example.test/mcp`,
+            },
+          },
+        ]
+      )
+    ).rejects.toThrow(/resolves to different definitions/);
+  });
+
+  test("fails closed when Cloud orgs disagree on one connector manifest", async () => {
+    await expect(
+      hydrateManagedConnectorCatalog(
+        managedState([
+          { slug: "one", connector: "mcp.shared", organization: "org-one" },
+          { slug: "two", connector: "mcp.shared", organization: "org-two" },
+        ]),
+        [],
+        async (organization) => [
+          {
+            key: "mcp.shared",
+            installed: true,
+            mcp_config: {
+              upstream_url: "https://shared.example.test/mcp",
+              tool_prefix: organization,
+            },
+          },
+        ]
+      )
+    ).rejects.toThrow(/resolves to different definitions/);
+  });
+
+  test("refreshes an installed dynamic MCP definition while preserving its local identity", async () => {
+    const result = await hydrateManagedConnectorCatalog(
+      managedState([
+        {
+          slug: "atlassian",
+          connector: "mcp.atlassian",
+          organization: "lobu-managed",
+        },
+      ]),
+      [
+        {
+          id: 44,
+          key: "mcp.atlassian",
+          installed: true,
+          installable: false,
+          version: "1.0.0",
+          source_uri: null,
+          mcp_config: {
+            upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+            tool_prefix: "old-prefix",
+          },
+        },
+      ],
+      async () => [
+        {
+          id: 91,
+          key: "mcp.atlassian",
+          name: "Atlassian",
+          installed: true,
+          version: "2.0.0",
+          mcp_config: {
+            upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+            tool_prefix: "atlassian",
+          },
+        },
+      ]
+    );
+
+    expect(result[0]).toMatchObject({
+      id: 44,
+      key: "mcp.atlassian",
+      installed: true,
+      version: "2.0.0",
+      mcp_config: {
+        upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+        tool_prefix: "atlassian",
+      },
+    });
+    expect(result[0]?.managed_mcp_source).toContain('"version":"2.0.0"');
+  });
+
+  test("does not refresh an installed dynamic MCP definition that matches Cloud", async () => {
+    const matchingDefinition = {
+      key: "mcp.atlassian",
+      name: "Atlassian",
+      installed: true,
+      version: "2.0.0",
+      source_uri: null,
+      auth_schema: {
+        methods: [{ type: "oauth", provider: "mcp.atlassian" }],
+      },
+      mcp_config: {
+        upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+        tool_prefix: "atlassian",
+      },
+    };
+    const result = await hydrateManagedConnectorCatalog(
+      managedState([
+        {
+          slug: "atlassian",
+          connector: "mcp.atlassian",
+          organization: "lobu-managed",
+        },
+      ]),
+      [{ id: 44, installable: false, ...matchingDefinition }],
+      async () => [{ id: 91, ...matchingDefinition }]
+    );
+
+    expect(result[0]).toMatchObject({ id: 44, installed: true });
+    expect(result[0]?.managed_mcp_source).toBeUndefined();
+  });
+});
+
+describe("buildManagedMcpConnectorSource", () => {
+  test("builds fixed declarative source with no OAuth credential values", () => {
+    const source = buildManagedMcpConnectorSource({
+      key: "mcp.atlassian",
+      name: "Atlassian",
+      version: "1.2.3",
+      auth_schema: {
+        methods: [
+          {
+            type: "oauth",
+            provider: "mcp.atlassian",
+            clientIdKey: "MCP_CLIENT_ID",
+            clientSecretKey: "MCP_CLIENT_SECRET",
+          },
+        ],
+      },
+      mcp_config: {
+        upstream_url: "https://mcp.atlassian.com/v1/mcp/authv2",
+        tool_prefix: "atlassian",
+      },
+    });
+
+    expect(source).toContain("defineConnector");
+    expect(source).toContain('"tool_prefix":"atlassian"');
+    expect(source).not.toContain("access_token");
+    expect(source).not.toContain("refresh_token");
+  });
+
+  test("rejects an MCP route that embeds credentials", () => {
+    expect(() =>
+      buildManagedMcpConnectorSource({
+        key: "mcp.unsafe",
+        installed: true,
+        mcp_config: {
+          upstream_url: "https://mcp.example.test/rpc?access_token=secret",
+        },
+      })
+    ).toThrow(/no valid HTTPS MCP upstream URL/);
+  });
+});
+
+describe("isManagedCloudTarget", () => {
+  const originalCloudUrl = process.env.LOBU_CLOUD_URL;
+  const originalCloudContext = process.env.LOBU_CLOUD_CONTEXT;
+
+  afterEach(() => {
+    if (originalCloudUrl === undefined) delete process.env.LOBU_CLOUD_URL;
+    else process.env.LOBU_CLOUD_URL = originalCloudUrl;
+    if (originalCloudContext === undefined) {
+      delete process.env.LOBU_CLOUD_CONTEXT;
+    } else {
+      process.env.LOBU_CLOUD_CONTEXT = originalCloudContext;
+    }
+  });
+
+  test("distinguishes the credential-holding Cloud from another remote runtime", async () => {
+    process.env.LOBU_CLOUD_URL = "https://managed-cloud.example.test/api/v1";
+    process.env.LOBU_CLOUD_CONTEXT = "managed-mcp-test-absent-context";
+
+    expect(
+      await isManagedCloudTarget("https://managed-cloud.example.test")
+    ).toBe(true);
+    expect(await isManagedCloudTarget("https://daytona.example.test")).toBe(
+      false
+    );
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -47,6 +47,11 @@ import {
   confirmPlan,
 } from "./prompt.js";
 import {
+  hydrateManagedConnectorCatalog,
+  isManagedCloudTarget,
+  loadManagedCloudConnectorCatalog,
+} from "./managed-connector-catalog.js";
+import {
   renderBlockedReport,
   renderMissingSecrets,
   renderPlan,
@@ -458,10 +463,10 @@ export async function fetchRemoteSnapshot(
 // ── Connector definition install (runs INSIDE executePlan, after confirm) ──
 
 /**
- * Install/update the project's custom connector definitions, then any *bundled*
- * connectors referenced by an auth-profile / connection (the server only
- * resolves *installed* defs in `create_auth_profile` / `create_feed`, not the
- * catalog). Returns the fresh connector-definition catalog.
+ * Install/update the project's custom connector definitions, then any bundled
+ * or managed connectors referenced by an auth-profile / connection (the server
+ * resolves only installed defs in create_auth_profile/create_feed, not raw
+ * catalog entries). Returns the fresh connector-definition catalog.
  */
 async function installConnectorDefinitions(
   client: ApplyClient,
@@ -547,23 +552,32 @@ async function installConnectorDefinitions(
   // or just installed from local source above). A locally-supplied key is never
   // overwritten by the bundled `source_uri`.
   const catalogByKey = new Map(
-    catalog.filter((d) => d.installable && d.source_uri).map((d) => [d.key, d])
+    catalog
+      .filter((d) => d.installable && (d.source_uri || d.managed_mcp_source))
+      .map((d) => [d.key, d])
   );
   const referenced = referencedConnectorKeys(state.connectors);
   for (const key of [...referenced].sort()) {
-    if (installedKeys.has(key) || locallySuppliedKeys.has(key)) continue;
+    if (locallySuppliedKeys.has(key)) continue;
     const entry = catalogByKey.get(key);
-    if (!entry?.source_uri) continue; // custom local-only — handled above
-    const result = await client.installConnector({
-      sourceUri: entry.source_uri,
-    });
+    if (installedKeys.has(key) && !entry?.managed_mcp_source) continue;
+    if (!entry?.source_uri && !entry?.managed_mcp_source) continue;
+    const wasInstalled = installedKeys.has(key);
+    const installPayload = entry.managed_mcp_source
+      ? { sourceCode: entry.managed_mcp_source }
+      : entry.source_uri
+        ? { sourceUri: entry.source_uri }
+        : null;
+    if (!installPayload) continue;
+    const result = await client.installConnector(installPayload);
     mutated = true;
+    const origin = entry.managed_mcp_source ? "managed" : "bundled";
     printText(
       renderProgress(
-        "create",
+        wasInstalled ? "update" : "create",
         "connector-definition",
         result.connectorKey || key,
-        result.updated ? "(installed bundled)" : "(bundled — unchanged)"
+        `(${wasInstalled ? "synced" : "installed"} ${origin})`
       )
     );
   }
@@ -1522,6 +1536,13 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     prune,
     resolvedOrg?.id
   );
+  if (!opts.only && !(await isManagedCloudTarget(apiBaseUrl))) {
+    remote.connectorDefinitions = await hydrateManagedConnectorCatalog(
+      state,
+      remote.connectorDefinitions,
+      (managedOrg) => loadManagedCloudConnectorCatalog(managedOrg, fetchImpl)
+    );
+  }
   resolveBehaviorConnectionRefs(
     state.watchers,
     new Map(

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -189,6 +189,10 @@ export interface RemoteConnectorDefinition {
   catalog_origin?: string;
   /** `file://` URI of the bundled source on the server host (catalog entries). */
   source_uri?: string | null;
+  /** Non-secret remote MCP transport metadata exposed by the connector catalog. */
+  mcp_config?: Record<string, unknown> | null;
+  /** Trusted in-memory connector artifact synthesized from a managed Cloud catalog. */
+  managed_mcp_source?: string;
 }
 
 export interface RemoteAuthProfile {
@@ -1691,6 +1695,12 @@ function mapConnectorDefinitionItem(item: {
           : "catalog",
     source_uri:
       typeof detail.source_uri === "string" ? detail.source_uri : null,
+    mcp_config:
+      detail.mcp_config &&
+      typeof detail.mcp_config === "object" &&
+      !Array.isArray(detail.mcp_config)
+        ? (detail.mcp_config as Record<string, unknown>)
+        : null,
   };
 }
 

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -2069,14 +2069,23 @@ export function computeDiff(
     // a locally-supplied connector declares the same key — that one wins.)
     const installableByKey = new Map(
       remoteConnectorDefinitions
-        .filter((d) => d.installable && d.source_uri)
+        .filter((d) => d.installable && (d.source_uri || d.managed_mcp_source))
         .map((d) => [d.key, d])
     );
     for (const key of [...referencedKeys].sort()) {
-      if (installedKeys.has(key)) continue;
       if (declaredKeys.has(key)) continue; // a local def supplies this key
       const entry = installableByKey.get(key);
-      if (!entry?.source_uri) continue;
+      if (installedKeys.has(key)) {
+        if (entry?.managed_mcp_source) {
+          rows.push({
+            kind: "connector-definition",
+            verb: "update",
+            id: key,
+          });
+        }
+        continue;
+      }
+      if (!entry?.source_uri && !entry?.managed_mcp_source) continue;
       rows.push({
         kind: "connector-definition",
         verb: "create",

--- a/packages/cli/src/commands/_lib/apply/managed-connector-catalog.ts
+++ b/packages/cli/src/commands/_lib/apply/managed-connector-catalog.ts
@@ -1,0 +1,255 @@
+import { apiBaseFromContextUrl } from "../../../internal/api-client.js";
+import {
+  DEFAULT_CONTEXT_NAME,
+  loadContextConfig,
+} from "../../../internal/context.js";
+import { getContextToken } from "../../../internal/credentials.js";
+import { ValidationError } from "../../memory/_lib/errors.js";
+import { ApplyClient, type RemoteConnectorDefinition } from "./client.js";
+import type { DesiredState } from "./desired-state.js";
+
+type CatalogLoader = (
+  organizationSlug: string
+) => Promise<RemoteConnectorDefinition[]>;
+
+function managedOrganization(
+  connection: DesiredState["connectors"]["connections"][number]
+): string | null {
+  const raw = connection.config?.managedBy;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const organization = (raw as Record<string, unknown>).org;
+  return typeof organization === "string" && organization.trim()
+    ? organization.trim()
+    : null;
+}
+
+function mcpUpstreamUrl(definition: RemoteConnectorDefinition): string | null {
+  const raw = definition.mcp_config?.upstream_url;
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  try {
+    const url = new URL(raw);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function buildManagedMcpConnectorSource(
+  definition: RemoteConnectorDefinition
+): string {
+  const upstreamUrl = mcpUpstreamUrl(definition);
+  if (!upstreamUrl) {
+    throw new ValidationError(
+      `Managed connector "${definition.key}" has no valid HTTPS MCP upstream URL.`
+    );
+  }
+  const spec = {
+    key: definition.key,
+    name: definition.name ?? definition.key,
+    version: definition.version ?? "0.0.0",
+    authSchema: definition.auth_schema ?? null,
+    // Preserve the catalog's canonical snake-case proxy config, including its
+    // operation prefix. The connector compiler persists metadata verbatim.
+    mcpConfig: {
+      ...definition.mcp_config,
+      upstream_url: upstreamUrl,
+    },
+  };
+  return [
+    'import { defineConnector } from "@lobu/connector-sdk";',
+    `export default defineConnector(${JSON.stringify(spec)} as never);`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Add installable definitions for managed MCP connections that a local Lobu
+ * catalog does not know. The authenticated Cloud org remains the source of
+ * truth; only its non-secret connector manifest crosses into the install plan.
+ */
+export async function hydrateManagedConnectorCatalog(
+  state: DesiredState,
+  localCatalog: RemoteConnectorDefinition[],
+  loadCatalog: CatalogLoader
+): Promise<RemoteConnectorDefinition[]> {
+  const localByKey = new Map(
+    localCatalog.map((definition) => [definition.key, definition])
+  );
+  const locallyDeclared = new Set<string>();
+  for (const definition of state.connectors.definitions) {
+    if (definition.key) locallyDeclared.add(definition.key);
+    if (definition.declaredKeyHint) {
+      locallyDeclared.add(definition.declaredKeyHint);
+    }
+  }
+
+  const requested = new Map<string, Map<string, string[]>>();
+  for (const connection of state.connectors.connections) {
+    const organization = managedOrganization(connection);
+    if (!organization || locallyDeclared.has(connection.connector)) continue;
+    const localDefinition = localByKey.get(connection.connector);
+    const needsManagedDefinition =
+      !localDefinition ||
+      (!localDefinition.source_uri && Boolean(localDefinition.mcp_config));
+    if (!needsManagedDefinition) continue;
+    const byConnector =
+      requested.get(organization) ?? new Map<string, string[]>();
+    const connectionSlugs = byConnector.get(connection.connector) ?? [];
+    connectionSlugs.push(connection.slug);
+    byConnector.set(connection.connector, connectionSlugs);
+    requested.set(organization, byConnector);
+  }
+  if (requested.size === 0) return localCatalog;
+
+  const additions = new Map<string, RemoteConnectorDefinition>();
+  const desiredSources = new Map<string, string>();
+  for (const [organization, byConnector] of requested) {
+    let cloudCatalog: RemoteConnectorDefinition[];
+    try {
+      cloudCatalog = await loadCatalog(organization);
+    } catch (error) {
+      const connectors = [...byConnector.keys()].sort().join(", ");
+      throw new ValidationError(
+        `Could not read managed connector${byConnector.size === 1 ? "" : "s"} ${connectors} from Cloud org "${organization}": ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const cloudByKey = new Map(cloudCatalog.map((item) => [item.key, item]));
+    for (const [connectorKey, connectionSlugs] of byConnector) {
+      const cloudDefinition = cloudByKey.get(connectorKey);
+      const upstreamUrl = cloudDefinition
+        ? mcpUpstreamUrl(cloudDefinition)
+        : null;
+      if (!cloudDefinition || !upstreamUrl) {
+        throw new ValidationError(
+          `Managed connection${connectionSlugs.length === 1 ? "" : "s"} ${connectionSlugs.map((slug) => `"${slug}"`).join(", ")} reference${connectionSlugs.length === 1 ? "s" : ""} connector "${connectorKey}", but Cloud org "${organization}" does not expose an installed HTTPS MCP definition for it.`
+        );
+      }
+
+      const managedMcpSource = buildManagedMcpConnectorSource(cloudDefinition);
+      const priorSource = desiredSources.get(connectorKey);
+      if (priorSource && priorSource !== managedMcpSource) {
+        throw new ValidationError(
+          `Managed connector "${connectorKey}" resolves to different definitions across Cloud orgs; one local connector key cannot safely represent both.`
+        );
+      }
+      desiredSources.set(connectorKey, managedMcpSource);
+      const { id: _cloudId, ...portableDefinition } = cloudDefinition;
+      const localDefinition = localByKey.get(connectorKey);
+      const localSource = localDefinition
+        ? buildManagedMcpConnectorSource(localDefinition)
+        : null;
+      const needsSync =
+        !localDefinition?.installed || localSource !== managedMcpSource;
+      additions.set(connectorKey, {
+        ...(localDefinition ?? {}),
+        ...portableDefinition,
+        // The local row contributes only target-local identity/state. Cloud is
+        // authoritative for every portable manifest field, including version.
+        ...(localDefinition?.id !== undefined
+          ? { id: localDefinition.id }
+          : {}),
+        installed: localDefinition?.installed ?? false,
+        installable: true,
+        catalog_origin: "managed",
+        source_uri: localDefinition?.source_uri ?? null,
+        ...(needsSync ? { managed_mcp_source: managedMcpSource } : {}),
+      });
+    }
+  }
+
+  const remaining = new Map(additions);
+  const merged = localCatalog.map((definition) => {
+    const replacement = remaining.get(definition.key);
+    if (!replacement) return definition;
+    remaining.delete(definition.key);
+    return replacement;
+  });
+  return [...merged, ...remaining.values()];
+}
+
+/** Read a managed org's catalog with its Cloud context credential, never local auth. */
+export async function loadManagedCloudConnectorCatalog(
+  organizationSlug: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<RemoteConnectorDefinition[]> {
+  const contextName =
+    process.env.LOBU_CLOUD_CONTEXT?.trim() || DEFAULT_CONTEXT_NAME;
+  let contextError: unknown;
+  let contextAuth: { apiBaseUrl: string; token: string } | null = null;
+  try {
+    const config = await loadContextConfig();
+    const context = config.contexts[contextName];
+    if (!context) throw new Error(`Unknown context "${contextName}"`);
+    const token = await getContextToken(contextName);
+    if (token) {
+      contextAuth = {
+        apiBaseUrl: apiBaseFromContextUrl(context.url),
+        token,
+      };
+    }
+  } catch (error) {
+    contextError = error;
+  }
+  if (contextAuth) {
+    return new ApplyClient(
+      { ...contextAuth, orgSlug: organizationSlug },
+      fetchImpl
+    ).listConnectors(true);
+  }
+
+  const envToken = process.env.LOBU_CLOUD_PAT?.trim();
+  const envUrl = process.env.LOBU_CLOUD_URL?.trim();
+  if (envToken && envUrl) {
+    return new ApplyClient(
+      {
+        apiBaseUrl: apiBaseFromContextUrl(envUrl),
+        orgSlug: organizationSlug,
+        token: envToken,
+      },
+      fetchImpl
+    ).listConnectors(true);
+  }
+
+  const detail =
+    contextError instanceof Error ? ` (${contextError.message})` : "";
+  throw new ValidationError(
+    `No Lobu Cloud login is available for context "${contextName}"${detail}. Run \`lobu login --context ${contextName}\`, or configure both LOBU_CLOUD_PAT and LOBU_CLOUD_URL.`
+  );
+}
+
+export async function isManagedCloudTarget(
+  apiBaseUrl: string
+): Promise<boolean> {
+  const contextName =
+    process.env.LOBU_CLOUD_CONTEXT?.trim() || DEFAULT_CONTEXT_NAME;
+  const candidates: string[] = [];
+  const config = await loadContextConfig().catch(() => null);
+  const contextUrl = config?.contexts[contextName]?.url;
+  if (contextUrl) candidates.push(contextUrl);
+  const envUrl = process.env.LOBU_CLOUD_URL?.trim();
+  if (envUrl) candidates.push(envUrl);
+
+  let target: string;
+  try {
+    target = apiBaseFromContextUrl(apiBaseUrl);
+  } catch {
+    return false;
+  }
+  return candidates.some((candidate) => {
+    try {
+      return apiBaseFromContextUrl(candidate) === target;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/packages/cli/src/internal/__tests__/credentials.test.ts
+++ b/packages/cli/src/internal/__tests__/credentials.test.ts
@@ -13,6 +13,7 @@ import {
   type Credentials,
   clearCredentials,
   getAgentApiToken,
+  getContextToken,
   getToken,
   loadCredentials,
   refreshCredentials,
@@ -190,6 +191,74 @@ describe("credentials", () => {
 
     expect(token).toBe("env-token");
     expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  test("getContextToken uses the named stored credential, never LOBU_API_TOKEN", async () => {
+    process.env.LOBU_API_TOKEN = "local-target-token";
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        version: 2,
+        contexts: {
+          [currentContextName]: buildCreds({ accessToken: "cloud-token" }),
+        },
+      })
+    );
+
+    expect(await getContextToken(currentContextName)).toBe("cloud-token");
+  });
+
+  test("getContextToken never mints a loopback credential when the named credential is absent", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: currentContextName,
+      url: "http://localhost:8787/api/v1",
+      source: "config",
+    });
+    readFileSpy.mockRejectedValue(new Error("ENOENT"));
+    const fetchSpy = spyOn(globalThis, "fetch");
+
+    expect(await getContextToken(currentContextName)).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("getContextToken refreshes an expired named credential", async () => {
+    const creds = buildCreds({
+      accessToken: "expired",
+      expiresAt: Date.now() - 60_000,
+    });
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        version: 2,
+        contexts: { [currentContextName]: creds },
+      })
+    );
+    spyOn(oauth, "refreshTokens").mockResolvedValue({
+      accessToken: "refreshed-cloud-token",
+      refreshToken: "rotated-refresh-token",
+      expiresIn: 3600,
+    });
+
+    expect(await getContextToken(currentContextName)).toBe(
+      "refreshed-cloud-token"
+    );
+    expect(writeFileSpy).toHaveBeenCalled();
+  });
+
+  test("getContextToken leaves an expired non-refreshable credential stored", async () => {
+    const creds = buildCreds({
+      accessToken: "expired",
+      refreshToken: undefined,
+      expiresAt: Date.now() - 60_000,
+    });
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        version: 2,
+        contexts: { [currentContextName]: creds },
+      })
+    );
+
+    expect(await getContextToken(currentContextName)).toBeNull();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(rmSpy).not.toHaveBeenCalled();
   });
 
   test("getToken returns null when no creds exist", async () => {

--- a/packages/cli/src/internal/credentials.ts
+++ b/packages/cli/src/internal/credentials.ts
@@ -100,6 +100,22 @@ export async function getToken(contextName?: string): Promise<string | null> {
 }
 
 /**
+ * Resolve one named context's own credential without the process-wide
+ * `LOBU_API_TOKEN` override. Cross-context callers use this so a token meant
+ * for the active local runtime is never forwarded to a Cloud context.
+ */
+export async function getContextToken(
+  contextName?: string
+): Promise<string | null> {
+  const creds = await loadCredentials(contextName);
+  if (!creds) return null;
+  if (!credentialNeedsRefresh(creds)) return creds.accessToken;
+  if (!credentialCanRefresh(creds)) return null;
+  const refreshed = await refreshCredentials(creds, contextName);
+  return refreshed?.accessToken ?? null;
+}
+
+/**
  * Token for the gateway agent API (`/lobu/api/v1/agents/*`). Local embedded
  * installs need the worker PAT from /api/local-init for that surface, while
  * admin REST + MCP need the Better Auth session token returned by getToken().

--- a/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
@@ -3,6 +3,7 @@ import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import type { Env } from '../../../index';
 import { connectRoutes } from '../../../connect/routes';
 import { manageConnections } from '../../../tools/admin/manage_connections';
+import { manageCatalog } from '../../../tools/admin/manage_catalog';
 import { manageOperations } from '../../../tools/admin/manage_operations';
 import { __resetPublicOriginCachesForTests } from '../../../utils/public-origin';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -208,6 +209,26 @@ describe('OAuth-protected MCP connector installation', () => {
       resource: upstreamUrl,
     });
 
+    const catalog = await manageCatalog(
+      { action: 'list_installed', kinds: ['connectors'] },
+      TEST_ENV,
+      ctx
+    );
+    const catalogItems = (
+      catalog as {
+        installed?: { connectors?: { items?: Array<Record<string, unknown>> } };
+      }
+    ).installed?.connectors?.items;
+    const catalogDefinition = catalogItems?.find(
+      (item) => item.id === 'mcp.mcp-example-com'
+    );
+    expect(catalogDefinition?.detail).toMatchObject({
+      mcp_config: {
+        upstream_url: upstreamUrl,
+        tool_prefix: 'mcp_example_com',
+      },
+    });
+
     const appProfiles = (await sql`
       SELECT id, provider, status, auth_data
       FROM auth_profiles
@@ -323,5 +344,110 @@ describe('OAuth-protected MCP connector installation', () => {
         }),
       ])
     );
+  });
+
+  it('installs a managed MCP manifest from trusted source without registering a local OAuth client', async () => {
+    const { org, ctx } = await seedOwnerContext({
+      orgName: 'Managed MCP Clone Org',
+      userName: 'Managed MCP Clone Owner',
+    });
+    const sourceCode = `
+      import { defineConnector } from "@lobu/connector-sdk";
+      export default defineConnector({
+        key: "mcp.managed-clone",
+        name: "Managed Clone",
+        version: "1.0.0",
+        authSchema: {
+          methods: [{
+            type: "oauth",
+            provider: "mcp.managed-clone",
+            clientIdKey: "MCP_CLIENT_ID",
+            clientSecretKey: "MCP_CLIENT_SECRET",
+          }],
+        },
+        mcpConfig: {
+          upstream_url: "https://mcp.example.com/rpc",
+          tool_prefix: "managed_clone",
+        },
+      } as never);
+    `;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const installed = await manageConnections(
+      { action: 'install_connector', source_code: sourceCode },
+      TEST_ENV,
+      ctx
+    );
+    expect(installed).toMatchObject({
+      action: 'install_connector',
+      installed: true,
+      connector_key: 'mcp.managed-clone',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const sql = getTestDb();
+    const [definition] = (await sql`
+      SELECT mcp_config
+      FROM connector_definitions
+      WHERE organization_id = ${org.id}
+        AND key = 'mcp.managed-clone'
+        AND status = 'active'
+    `) as Array<{ mcp_config: Record<string, unknown> }>;
+    expect(definition.mcp_config).toEqual({
+      upstream_url: 'https://mcp.example.com/rpc',
+      tool_prefix: 'managed_clone',
+    });
+    const catalog = await manageCatalog(
+      { action: 'list_installed', kinds: ['connectors'] },
+      TEST_ENV,
+      ctx
+    );
+    const catalogItems = (
+      catalog as {
+        installed?: { connectors?: { items?: Array<Record<string, unknown>> } };
+      }
+    ).installed?.connectors?.items;
+    const catalogDefinition = catalogItems?.find(
+      (item) => item.id === 'mcp.managed-clone'
+    );
+    expect(catalogDefinition?.detail).toMatchObject({
+      source_uri: null,
+      mcp_config: {
+        upstream_url: 'https://mcp.example.com/rpc',
+        tool_prefix: 'managed_clone',
+      },
+    });
+
+    await sql`
+      UPDATE connector_definitions
+      SET mcp_config = ${sql.json({
+        upstream_url: 'https://mcp.example.com/rpc?access_token=secret',
+        tool_prefix: 'managed_clone',
+      })}
+      WHERE organization_id = ${org.id}
+        AND key = 'mcp.managed-clone'
+        AND status = 'active'
+    `;
+    const secretBearingCatalog = await manageCatalog(
+      { action: 'list_installed', kinds: ['connectors'] },
+      TEST_ENV,
+      ctx
+    );
+    const secretBearingItems = (
+      secretBearingCatalog as {
+        installed?: { connectors?: { items?: Array<Record<string, unknown>> } };
+      }
+    ).installed?.connectors?.items;
+    expect(
+      secretBearingItems?.find((item) => item.id === 'mcp.managed-clone')?.detail
+    ).toMatchObject({ mcp_config: null });
+
+    const [profileCount] = (await sql`
+      SELECT COUNT(*)::int AS count
+      FROM auth_profiles
+      WHERE organization_id = ${org.id}
+        AND connector_key = 'mcp.managed-clone'
+    `) as Array<{ count: number }>;
+    expect(profileCount.count).toBe(0);
   });
 });

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -47,6 +47,47 @@ function behaviorEventsForUi(
 
 const configStore = createPostgresAgentConfigStore();
 
+/** Only MCP routing fields are public catalog metadata; credentials never are. */
+function publicMcpConfig(
+	raw: Record<string, unknown> | null | undefined,
+): Record<string, string> | null {
+	if (!raw) return null;
+	const upstreamUrl =
+		typeof raw.upstream_url === "string"
+			? raw.upstream_url
+			: typeof raw.upstreamUrl === "string"
+				? raw.upstreamUrl
+				: null;
+	if (!upstreamUrl) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(upstreamUrl);
+	} catch {
+		return null;
+	}
+	// A portable route is HTTPS metadata, never a credential container. Query,
+	// fragment, and userinfo values remain private to the credential-holding org.
+	if (
+		parsed.protocol !== "https:" ||
+		parsed.username ||
+		parsed.password ||
+		parsed.search ||
+		parsed.hash
+	) {
+		return null;
+	}
+	const toolPrefix =
+		typeof raw.tool_prefix === "string"
+			? raw.tool_prefix
+			: typeof raw.toolPrefix === "string"
+				? raw.toolPrefix
+				: null;
+	return {
+		upstream_url: parsed.toString(),
+		...(toolPrefix ? { tool_prefix: toolPrefix } : {}),
+	};
+}
+
 export type ListInstalledOptions = {
 	includeCatalog?: boolean;
 };
@@ -101,6 +142,9 @@ export async function listOrgInstalled(
 						row.source_org_id == null,
 					),
 					options_schema: row.options_schema,
+					// Non-secret transport metadata lets a managed local install
+					// reproduce an MCP definition without exporting OAuth credentials.
+					mcp_config: publicMcpConfig(row.mcp_config),
 					favicon_domain: row.favicon_domain,
 					required_capability: row.required_capability,
 					runtime: row.runtime,


### PR DESCRIPTION
## Summary
- let `lobu apply` hydrate managed MCP connector manifests automatically from the authenticated Lobu Cloud org, so bootstrap projects need no generated connector file or local OAuth app
- install the trusted manifest in memory before creating the managed connection, refresh it only when Cloud changes it, and keep the Cloud connection as the only credential holder
- expose only clean HTTPS MCP routing metadata; reject credential-bearing URLs and conflicting cross-org manifests

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: targeted CLI apply/credentials suites, server MCP OAuth install integration, CLI build, server typecheck
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval (not applicable)

### Red evidence

CLI catalog mapping/install planning before implementation:

```text
Expected mcp_config, received undefined
Expected connector-definition create row, received undefined
92 pass
2 fail
```

Server catalog before the portable manifest output:

```text
expected detail to match mcp_config
received detail without mcp_config
1 failed | 1 passed
```

Real trusted-source installation exposed an invalid generated SDK subpath import:

```text
Could not resolve @lobu/connector-sdk/define-connector
1 failed | 1 passed
```

Credential-bearing MCP routes were initially exportable:

```text
Expected { mcp_config: null }
Received { mcp_config: { upstream_url: "https://mcp.example.com/rpc?access_token=secret" } }
1 failed | 1 passed
```

Repeat-apply convergence before the review fix:

```text
Expected managed_mcp_source to be undefined for a matching installed manifest
Received generated managed source
1 failed | 67 passed
```

### Green evidence

```text
163 pass, 0 fail — focused CLI apply + credentials suites
2 passed, 0 failed — mcp-oauth-install server integration
packages/cli build — clean
packages/server typecheck — clean
Depot run h57jll9csr — 18 jobs passed
Attested tree: d032707bdeb3bbf2165996a66af96df95214668e
pi-review — 0 bugs, 0 blockers, tests adequate
```

## Notes
- No database migration and no new public input surface.
- The generated connector artifact exists only in memory during apply; it is never written into the user's project.
- Source installation deliberately does not perform MCP dynamic OAuth client registration, and the integration test proves no local auth profile is created.
