### PR TITLE
refactor(personal-agent): derive Midas net worth from current state

### DIFF
--- a/examples/personal-agent/__tests__/midas.connector.test.ts
+++ b/examples/personal-agent/__tests__/midas.connector.test.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import type { ChromeActionDispatcher } from "@lobu/connector-sdk";
+import type { MidasCheckpoint } from "../midas.connector";
 import { connectorSdkMock } from "./connector-sdk.mock";
 
 // Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
@@ -42,12 +43,81 @@ beforeAll(async () => {
   MIDAS_ALLOWED_ORIGINS = mod.MIDAS_ALLOWED_ORIGINS;
 });
 
+function dispatcherFor(bodyText: string) {
+  return {
+    dispatch: async (action: string) =>
+      action === "navigate"
+        ? { tab_id: 42, current_url: MIDAS_DASHBOARD_URL }
+        : { value: bodyText },
+  };
+}
+
+function syncWith(bodyText: string, checkpoint: MidasCheckpoint | null = {}) {
+  return new MidasConnector().sync({
+    feedKey: "assets",
+    config: {},
+    checkpoint,
+    sessionState: { chrome_dispatcher: dispatcherFor(bodyText) },
+  } as never);
+}
+
 // Synthetic Atlas TR "Pozisyonlar" capture — layout mirrors production, values
 // are fabricated (no real holdings/quantities/prices) to avoid committing PII.
 const DASHBOARD_FIXTURE = readFileSync(
   path.join(import.meta.dir, "fixtures/midas-dashboard-positions.txt"),
   "utf8"
 );
+
+const DASHBOARD_WITHOUT_NOVA = DASHBOARD_FIXTURE.replace(
+  "\nNOVA\nBIST Hisseleri",
+  "\nBIST Hisseleri"
+)
+  .replace("\n3\n$10.000,00", "\n2\n$3.000,00")
+  .replace(
+    "\n25\n$280,00\n$260,00\n$7.000,00\n%70,00\n$70,00(%1,00)\n$400,00(%6,00)",
+    ""
+  );
+
+const DRIFTED_DASHBOARD_FIXTURE = [
+  "ABD Hisseleri",
+  "ACME",
+  "GLOB",
+  "2",
+  "$1.000,00",
+  "$10,00(%1,00)",
+  "$100,00(%10,00)",
+  "10",
+  "$50,00",
+  "$40,00",
+  "$500,00",
+  "%50,00",
+  "$5,00(%1,00)",
+  "$50,00(%12,50)",
+  "n/a",
+  "n/a",
+  "n/a",
+  "n/a",
+  "n/a",
+  "n/a",
+  "n/a",
+].join("\n");
+
+const US_ONLY_DASHBOARD_FIXTURE = [
+  "Pozisyonlar",
+  "ABD Hisseleri",
+  "ACME",
+  "1",
+  "$2.100,00",
+  "$50,00(%1,00)",
+  "$500,00(%25,00)",
+  "10,5",
+  "$200,00",
+  "$150,00",
+  "$2.100,00",
+  "%100,00",
+  "$50,00(%1,00)",
+  "$500,00(%25,00)",
+].join("\n");
 
 describe("requireExtensionDispatcher", () => {
   test("throws when chrome_dispatcher is missing (the prod failure mode)", () => {
@@ -202,36 +272,15 @@ describe("parseMidasDashboardText (synthetic fixture)", () => {
       holdings: [],
       total_usd: 0,
       total_try: 0,
+      positions_complete: false,
+      markets_observed: [],
     });
   });
 
   test("malformed rows are skipped, not emitted as zero-valued holdings", () => {
     // Second holding row is non-numeric (layout drift). The parser must stop
     // rather than push a corrupt { shares: 0, price: 0, value: 0 } holding.
-    const drifted = [
-      "ABD Hisseleri",
-      "ACME",
-      "GLOB",
-      "2",
-      "$1.000,00",
-      "$10,00(%1,00)",
-      "$100,00(%10,00)",
-      "10",
-      "$50,00",
-      "$40,00",
-      "$500,00",
-      "%50,00",
-      "$5,00(%1,00)",
-      "$50,00(%12,50)",
-      "n/a",
-      "n/a",
-      "n/a",
-      "n/a",
-      "n/a",
-      "n/a",
-      "n/a",
-    ].join("\n");
-    const s = parseMidasDashboardText(drifted);
+    const s = parseMidasDashboardText(DRIFTED_DASHBOARD_FIXTURE);
     expect(s.holdings.map((h) => h.symbol)).toEqual(["ACME"]);
     expect(s.holdings.every((h) => h.value > 0)).toBe(true);
   });
@@ -334,6 +383,65 @@ describe("MidasConnector.sync", () => {
       holdings: 5,
       backend: "extension-dom",
     });
+  });
+
+  test("emits a closed superseding observation when a holding disappears", async () => {
+    const first = await syncWith(DASHBOARD_FIXTURE, {});
+    const second = await syncWith(DASHBOARD_WITHOUT_NOVA, first.checkpoint);
+
+    expect(
+      second.events.filter(
+        (event) => event.origin_id === "midas-holding-US-NOVA"
+      )
+    ).toEqual([
+      expect.objectContaining({
+        semantic_type: "financial_asset",
+        metadata: expect.objectContaining({
+          type: "US",
+          symbol: "NOVA",
+          shares: 0,
+          price: 0,
+          avg_cost: 0,
+          value: 0,
+          currency: "USD",
+          status: "closed",
+        }),
+      }),
+    ]);
+
+    const third = await syncWith(DASHBOARD_WITHOUT_NOVA, second.checkpoint);
+    expect(
+      third.events.filter(
+        (event) => event.origin_id === "midas-holding-US-NOVA"
+      )
+    ).toEqual([]);
+  });
+
+  test("does not close positions from an incomplete dashboard parse", async () => {
+    const first = await syncWith(DASHBOARD_FIXTURE);
+
+    await expect(
+      syncWith(DRIFTED_DASHBOARD_FIXTURE, first.checkpoint)
+    ).rejects.toThrow(/incomplete/i);
+  });
+
+  test("preserves checkpoint positions when their market section is absent", async () => {
+    const first = await syncWith(DASHBOARD_FIXTURE);
+    const second = await syncWith(US_ONLY_DASHBOARD_FIXTURE, first.checkpoint);
+
+    const closedOrigins = second.events
+      .filter((event) => event.metadata?.status === "closed")
+      .map((event) => event.origin_id);
+    expect(closedOrigins).toEqual([
+      "midas-holding-US-GLOB",
+      "midas-holding-US-NOVA",
+    ]);
+    expect(second.checkpoint?.active_holdings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "TR", symbol: "BANKX" }),
+        expect.objectContaining({ type: "TR", symbol: "GOLD.S1" }),
+      ])
+    );
   });
 
   test("throws a clear error when chrome_dispatcher is missing", async () => {

--- a/examples/personal-agent/__tests__/net-worth.config.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.config.test.ts
@@ -21,7 +21,7 @@ describe("Midas net-worth configuration", () => {
     });
   });
 
-  test("declares a same-org, feedless quote connection", () => {
+  test("declares a same-org catalog quote handle without shipping duplicate source", () => {
     expect(
       config.connections?.find(
         (connection) => connection.slug === "market-quotes"
@@ -34,7 +34,7 @@ describe("Midas net-worth configuration", () => {
       config.connectors?.find(
         (connector) => connector.path === "./market-quotes.connector.ts"
       )
-    ).toBeDefined();
+    ).toBeUndefined();
   });
 
   test("the tax workspace no longer declares a net-worth Behavior", () => {

--- a/examples/personal-agent/__tests__/net-worth.reaction.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.reaction.test.ts
@@ -2,16 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
 import runNetWorthSnapshot, {
   buildMidasSnapshot,
-  type MidasBalanceRow,
   type MidasHoldingMetadata,
   type MidasHoldingRow,
   type QuoteRow,
 } from "../net-worth.reaction";
-
-const balance: MidasBalanceRow = {
-  run_id: 22,
-  occurred_at: "2026-08-10T08:00:00.000Z",
-};
 
 function holding(
   symbol: string,
@@ -29,6 +23,7 @@ function holding(
       avg_cost: value / 4,
       value,
       currency: "USD",
+      status: "active",
       ...overrides,
     },
   };
@@ -85,13 +80,13 @@ describe("buildMidasSnapshot", () => {
     ];
 
     const snapshot = buildMidasSnapshot(
-      balance,
       holdings,
       quotes,
       "2026-08-12T09:00:00.000Z"
     );
 
-    expect(snapshot.midas_run_id).toBe(22);
+    expect(snapshot.version).toBe(2);
+    expect(snapshot).not.toHaveProperty("midas_run_id");
     expect(snapshot.positions).toHaveLength(2);
     expect(snapshot.positions[0]).toMatchObject({
       symbol: "AAPL",
@@ -122,7 +117,6 @@ describe("buildMidasSnapshot", () => {
 
   test("rejects a quote in a different currency instead of mixing currencies", () => {
     const snapshot = buildMidasSnapshot(
-      balance,
       [holding("AAPL", 200)],
       [
         {
@@ -152,7 +146,7 @@ describe("buildMidasSnapshot", () => {
 });
 
 describe("weekly net-worth reaction", () => {
-  test("queries one Midas cohort, executes the local quote action, and saves one derived event", async () => {
+  test("queries current active Midas holdings, executes the local quote action, and saves one derived event", async () => {
     const queries: string[] = [];
     const operationInputs: unknown[] = [];
     const saved: unknown[] = [];
@@ -160,9 +154,7 @@ describe("weekly net-worth reaction", () => {
     const client = {
       query: async (sql: string) => {
         queries.push(sql);
-        return queries.length === 1
-          ? [balance]
-          : [holding("AAPL", 200), holding("NOPE", 80)];
+        return [holding("AAPL", 200), holding("NOPE", 80)];
       },
       connections: {
         list: async () => ({
@@ -227,8 +219,9 @@ describe("weekly net-worth reaction", () => {
 
     await runNetWorthSnapshot(ctx, client);
 
-    expect(queries).toHaveLength(2);
-    expect(queries[1]).toContain("run_id = 22");
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain("metadata->>'status' = 'active'");
+    expect(queries[0]).not.toContain("run_id");
     expect(operationInputs).toEqual([
       {
         connection_id: 77,
@@ -239,7 +232,7 @@ describe("weekly net-worth reaction", () => {
             { market: "US", symbol: "NOPE" },
           ],
         },
-        idempotency_key: "midas-net-worth:quotes:window:91:midas-run:22",
+        idempotency_key: "midas-net-worth:quotes:window:91",
         behavior_source: { behavior_id: 45, window_id: 91 },
       },
     ]);
@@ -251,7 +244,7 @@ describe("weekly net-worth reaction", () => {
       behavior_source: { behavior_id: 45, window_id: 91 },
       metadata: {
         scope: "midas",
-        midas_run_id: 22,
+        version: 2,
         by_currency: [{ currency: "USD", current_value: 580 }],
       },
     });
@@ -260,15 +253,13 @@ describe("weekly net-worth reaction", () => {
 
   test("notifies from the persisted snapshot after an idempotent save replay", async () => {
     const persistedSnapshot = buildMidasSnapshot(
-      balance,
       [holding("AAPL", 200)],
       [],
       ctx.window.window_end
     );
     const notified: Array<{ body?: string }> = [];
     const client = {
-      query: async (sql: string) =>
-        sql.includes("midas-balance") ? [balance] : [holding("AAPL", 200)],
+      query: async () => [holding("AAPL", 200)],
       connections: {
         list: async () => ({
           connections: [
@@ -325,17 +316,18 @@ describe("weekly net-worth reaction", () => {
     expect(notified[0]?.body).not.toContain("USD 500.00 current");
   });
 
-  test("includes every holding when a Midas cohort contains more than 200 positions", async () => {
-    const cohort = Array.from({ length: 1_001 }, (_, index) =>
+  test("includes every holding when the active book contains more than one page", async () => {
+    const activeBook = Array.from({ length: 1_001 }, (_, index) =>
       holding(`STOCK${index}`, 4)
     );
     const saved: Array<{ metadata?: { positions?: unknown[] } }> = [];
     const client = {
       query: async (sql: string) => {
-        if (sql.includes("midas-balance")) return [balance];
-        const limit = Number(sql.match(/LIMIT (\d+)/)?.[1] ?? cohort.length);
+        const limit = Number(
+          sql.match(/LIMIT (\d+)/)?.[1] ?? activeBook.length
+        );
         const offset = Number(sql.match(/OFFSET (\d+)/)?.[1] ?? 0);
-        return cohort.slice(offset, offset + limit);
+        return activeBook.slice(offset, offset + limit);
       },
       connections: {
         list: async () => ({
@@ -386,13 +378,12 @@ describe("weekly net-worth reaction", () => {
     await runNetWorthSnapshot(ctx, client);
 
     expect(saved).toHaveLength(1);
-    expect(saved[0]?.metadata?.positions).toHaveLength(cohort.length);
+    expect(saved[0]?.metadata?.positions).toHaveLength(activeBook.length);
   });
 
   test("fails closed when the configured quote connection is absent", async () => {
     const client = {
-      query: async (sql: string) =>
-        sql.includes("midas-balance") ? [balance] : [holding("AAPL", 200)],
+      query: async () => [holding("AAPL", 200)],
       connections: { list: async () => ({ connections: [] }) },
       log: () => undefined,
     } as unknown as ReactionClient;
@@ -400,5 +391,24 @@ describe("weekly net-worth reaction", () => {
     await expect(runNetWorthSnapshot(ctx, client)).rejects.toThrow(
       /active market-quotes connection/i
     );
+  });
+
+  test("does not value closed or legacy status-less holdings", async () => {
+    const queries: string[] = [];
+    const client = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        return [];
+      },
+      notifications: {
+        send: async () => ({ notified_count: 1, event_id: 502, url: null }),
+      },
+      log: () => undefined,
+    } as unknown as ReactionClient;
+
+    await runNetWorthSnapshot(ctx, client);
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain("metadata->>'status' = 'active'");
   });
 });

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -13,7 +13,6 @@ import {
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
 import type LinkedInConnector from "./linkedin.connector.ts";
-import type MarketQuotesConnector from "./market-quotes.connector.ts";
 import type RevolutTransactionsConnector from "./revolut-transactions.connector.ts";
 import type SpotifyConnector from "./spotify.connector.ts";
 import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
@@ -1222,13 +1221,13 @@ const midasNetWorth = defineBehavior({
   slug: "midas-net-worth",
   name: "Midas net worth",
   description:
-    "Values the latest Midas holdings cohort with available market marks and saves one derived snapshot.",
+    "Values current active Midas holdings with available market marks and saves one derived snapshot.",
   triggers: [
     {
       kind: "schedule",
       cron: "0 9 * * 1",
       timezone: "Europe/London",
-      // Prices change even when the latest broker sync cohort does not.
+      // Prices change even when the current broker position book does not.
       skip_if_unchanged: false,
     },
   ],
@@ -1238,7 +1237,7 @@ const midasNetWorth = defineBehavior({
   prompt:
     'The deterministic reaction performs this scheduled Midas valuation. Return only {"summary":"Run the deterministic Midas valuation."}; do not calculate values, create entities, or call connector operations yourself.',
   reactionsGuidance:
-    "The reaction owns quote execution, cohort selection, derived snapshot persistence, and the notification. It fails if the local quote execution path is missing and labels per-symbol broker fallbacks explicitly.",
+    "The reaction owns quote execution, current active-position selection, derived snapshot persistence, and the notification. It fails if the local quote execution path is missing and labels per-symbol broker fallbacks explicitly.",
   reaction: reactionFromFile<typeof NetWorthReaction>(
     "./net-worth.reaction.ts"
   ),
@@ -1322,9 +1321,6 @@ export default defineConfig({
   prune: true,
   connectors: [
     connectorFromFile<typeof MidasConnector>("./midas.connector.ts"),
-    connectorFromFile<typeof MarketQuotesConnector>(
-      "./market-quotes.connector.ts"
-    ),
     connectorFromFile<typeof RevolutTransactionsConnector>(
       "./revolut-transactions.connector.ts"
     ),

--- a/examples/personal-agent/midas.connector.ts
+++ b/examples/personal-agent/midas.connector.ts
@@ -37,10 +37,25 @@ export interface MidasDashboardSnapshot {
   holdings: MidasHolding[];
   total_usd: number;
   total_try: number;
+  /** False when ticker rows were visible but not all parsed successfully. */
+  positions_complete: boolean;
+  /** Market sections actually present in this scrape. */
+  markets_observed: MidasMarket[];
+}
+
+export interface MidasHoldingIdentity {
+  type: MidasMarket;
+  symbol: string;
+  currency: "USD" | "TRY";
 }
 
 export interface MidasCheckpoint {
   last_run?: string;
+  /**
+   * Open-position book as of the last successful sync. Markets absent from a
+   * scrape carry their previous identities forward until observed again.
+   */
+  active_holdings?: MidasHoldingIdentity[];
 }
 
 /**
@@ -307,7 +322,24 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
   totalUsd = readBlock(usTickers, "US", "USD");
   totalTry = readBlock(trTickers, "TR", "TRY");
 
-  return { holdings, total_usd: totalUsd, total_try: totalTry };
+  return {
+    holdings,
+    total_usd: totalUsd,
+    total_try: totalTry,
+    positions_complete:
+      (usStartIdx !== -1 || trStartIdx !== -1) &&
+      holdings.length === usTickers.length + trTickers.length,
+    markets_observed: [
+      ...(usStartIdx !== -1 ? (["US"] as const) : []),
+      ...(trStartIdx !== -1 ? (["TR"] as const) : []),
+    ],
+  };
+}
+
+export function holdingOriginId(
+  holding: Pick<MidasHoldingIdentity, "type" | "symbol">
+): string {
+  return `midas-holding-${holding.type}-${holding.symbol}`;
 }
 
 export function holdingToEvent(
@@ -316,7 +348,7 @@ export function holdingToEvent(
 ): EventEnvelope {
   // Namespace by market so a dual-listed ticker cannot collide on origin_id.
   return {
-    origin_id: `midas-holding-${h.type}-${h.symbol}`,
+    origin_id: holdingOriginId(h),
     title: `Midas Holding: ${h.symbol}`,
     payload_text: `${h.symbol} (${h.type}): ${h.shares} @ ${h.price} ${h.currency} = ${h.value} ${h.currency} (avg ${h.avg_cost})`,
     occurred_at: occurredAt,
@@ -330,8 +362,57 @@ export function holdingToEvent(
       avg_cost: h.avg_cost,
       value: h.value,
       currency: h.currency,
+      status: "active",
     },
   };
+}
+
+function closedHoldingToEvent(
+  holding: MidasHoldingIdentity,
+  occurredAt: Date
+): EventEnvelope {
+  return {
+    origin_id: holdingOriginId(holding),
+    title: `Midas Holding Closed: ${holding.symbol}`,
+    payload_text: `${holding.symbol} (${holding.type}) is no longer present in the Midas portfolio.`,
+    occurred_at: occurredAt,
+    semantic_type: "financial_asset",
+    source_url: MIDAS_DASHBOARD_URL,
+    metadata: {
+      type: holding.type,
+      symbol: holding.symbol,
+      shares: 0,
+      price: 0,
+      avg_cost: 0,
+      value: 0,
+      currency: holding.currency,
+      status: "closed",
+    },
+  };
+}
+
+function checkpointHoldings(
+  checkpoint: MidasCheckpoint | null
+): MidasHoldingIdentity[] {
+  if (!Array.isArray(checkpoint?.active_holdings)) return [];
+
+  const byOrigin = new Map<string, MidasHoldingIdentity>();
+  for (const candidate of checkpoint.active_holdings) {
+    if (
+      !candidate ||
+      (candidate.type !== "US" && candidate.type !== "TR") ||
+      typeof candidate.symbol !== "string" ||
+      candidate.symbol.trim() === "" ||
+      (candidate.currency !== "USD" && candidate.currency !== "TRY") ||
+      (candidate.type === "US" && candidate.currency !== "USD") ||
+      (candidate.type === "TR" && candidate.currency !== "TRY")
+    ) {
+      continue;
+    }
+    const holding = { ...candidate, symbol: candidate.symbol.trim() };
+    byOrigin.set(holdingOriginId(holding), holding);
+  }
+  return [...byOrigin.values()];
 }
 
 export function balanceToEvent(
@@ -390,13 +471,13 @@ async function notifyMidasAuthWall(
   }
 }
 
-export default class MidasConnector extends ConnectorRuntime {
+export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
   readonly definition: ConnectorDefinition = {
     key: "midas",
     name: "Midas",
     description:
       "Syncs Midas portfolio holdings via the Owletto Chrome extension.",
-    version: "1.0.2",
+    version: "1.0.3",
     faviconDomain: "atlas.getmidas.com",
     authSchema: {
       methods: [{ type: "none" }],
@@ -421,6 +502,7 @@ export default class MidasConnector extends ConnectorRuntime {
                 avg_cost: { type: "number" },
                 value: { type: "number" },
                 currency: { type: "string" },
+                status: { type: "string", enum: ["active", "closed"] },
               },
             },
           },
@@ -441,7 +523,9 @@ export default class MidasConnector extends ConnectorRuntime {
     optionsSchema: { type: "object", properties: {} },
   };
 
-  async sync(ctx: SyncContext): Promise<SyncResult> {
+  async sync(
+    ctx: SyncContext<MidasCheckpoint>
+  ): Promise<SyncResult<MidasCheckpoint>> {
     if (ctx.feedKey !== "assets") {
       throw new Error(`Unknown feed: ${ctx.feedKey}`);
     }
@@ -518,22 +602,51 @@ export default class MidasConnector extends ConnectorRuntime {
       );
     }
 
+    if (!snapshot.positions_complete) {
+      throw new Error(
+        "Incomplete Midas dashboard parse — one or more visible holding rows were malformed. No events or closed positions were emitted."
+      );
+    }
+
     const occurredAt = new Date();
+    const activeHoldings: MidasHoldingIdentity[] = snapshot.holdings.map(
+      ({ type, symbol, currency }) => ({ type, symbol, currency })
+    );
+    const previousHoldings = checkpointHoldings(ctx.checkpoint);
+    const observedMarkets = new Set(snapshot.markets_observed);
+    const currentOrigins = new Set(activeHoldings.map(holdingOriginId));
+    const closedEvents = previousHoldings
+      .filter(
+        (holding) =>
+          observedMarkets.has(holding.type) &&
+          !currentOrigins.has(holdingOriginId(holding))
+      )
+      .map((holding) => closedHoldingToEvent(holding, occurredAt));
+    // A missing market section is ambiguous: it can mean an empty market or a
+    // partially rendered SPA. Preserve that market's checkpoint identities and
+    // emit no closures until a later scrape explicitly observes the section.
+    const unobservedHoldings = previousHoldings.filter(
+      (holding) => !observedMarkets.has(holding.type)
+    );
     const events: EventEnvelope[] = [
       ...snapshot.holdings.map((h) => holdingToEvent(h, occurredAt)),
+      ...closedEvents,
       balanceToEvent(snapshot, occurredAt),
     ];
 
     const checkpoint: MidasCheckpoint = {
       last_run: occurredAt.toISOString(),
+      active_holdings: [...activeHoldings, ...unobservedHoldings],
     };
 
     return {
       events,
-      checkpoint: checkpoint as unknown as Record<string, unknown>,
+      checkpoint,
       metadata: {
         items_found: events.length,
         holdings: snapshot.holdings.length,
+        holdings_closed: closedEvents.length,
+        markets_observed: snapshot.markets_observed,
         total_usd: snapshot.total_usd,
         total_try: snapshot.total_try,
         backend: "extension-dom",

--- a/examples/personal-agent/midas.connector.ts
+++ b/examples/personal-agent/midas.connector.ts
@@ -37,7 +37,10 @@ export interface MidasDashboardSnapshot {
   holdings: MidasHolding[];
   total_usd: number;
   total_try: number;
-  /** False when ticker rows were visible but not all parsed successfully. */
+  /**
+   * True when every visible ticker row parsed successfully. False on holding
+   * row layout drift, or when no market section header was found at all.
+   */
   positions_complete: boolean;
   /** Market sections actually present in this scrape. */
   markets_observed: MidasMarket[];

--- a/examples/personal-agent/net-worth.reaction.ts
+++ b/examples/personal-agent/net-worth.reaction.ts
@@ -2,8 +2,8 @@
  * Deterministic weekly Midas valuation.
  *
  * Stored reactions are single-file artifacts, so the valuation logic lives
- * here instead of importing a project helper. It reads the latest Midas sync
- * cohort, marks each holding through the same-org market.quotes
+ * here instead of importing a project helper. It reads current active Midas
+ * holdings, marks each holding through the same-org market.quotes
  * action, persists one derived snapshot event, and sends a concise digest.
  */
 import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
@@ -18,11 +18,6 @@ export const input = {
 
 const MIDAS_HOLDING_PAGE_SIZE = 1_000;
 
-export interface MidasBalanceRow {
-  run_id: number | string;
-  occurred_at: Date | string;
-}
-
 export interface MidasHoldingMetadata {
   symbol?: string;
   type?: string;
@@ -31,6 +26,7 @@ export interface MidasHoldingMetadata {
   avg_cost?: number;
   value?: number;
   currency?: string;
+  status?: "active" | "closed";
 }
 
 export interface MidasHoldingRow {
@@ -97,12 +93,11 @@ interface MidasSnapshotTotal {
 }
 
 interface MidasNetWorthSnapshot {
-  version: 1;
+  version: 2;
   scope: "midas";
   calculated_at: string;
   broker_as_of: string;
   quote_as_of: string | null;
-  midas_run_id: number;
   by_currency: MidasSnapshotTotal[];
   positions: MidasSnapshotPosition[];
 }
@@ -166,6 +161,7 @@ function normalizeHolding(row: MidasHoldingRow): {
   const averageCost = finiteNumber(metadata.avg_cost);
   const brokerPrice = finiteNumber(metadata.price);
   const statedValue = finiteNumber(metadata.value);
+  const status = metadata.status;
 
   if (!market || !symbol || !currency) {
     throw new Error(`Midas holding ${row.origin_id} has incomplete identity.`);
@@ -178,6 +174,9 @@ function normalizeHolding(row: MidasHoldingRow): {
   }
   if (brokerPrice == null || brokerPrice <= 0) {
     throw new Error(`Midas holding ${row.origin_id} has invalid broker price.`);
+  }
+  if (status !== "active") {
+    throw new Error(`Midas holding ${row.origin_id} is not explicitly active.`);
   }
   const brokerValue =
     statedValue != null && statedValue > 0
@@ -227,17 +226,12 @@ function fallbackQuote(
 }
 
 export function buildMidasSnapshot(
-  balance: MidasBalanceRow,
   holdingRows: MidasHoldingRow[],
   quoteRows: QuoteRow[],
   calculatedAt: string
 ): MidasNetWorthSnapshot {
-  const midasRunId = finiteNumber(balance.run_id);
-  if (midasRunId == null || !Number.isSafeInteger(midasRunId)) {
-    throw new Error("The latest Midas balance has no valid sync run id.");
-  }
   if (holdingRows.length === 0) {
-    throw new Error(`Midas sync run ${midasRunId} contains no holdings.`);
+    throw new Error("Midas has no active holdings.");
   }
 
   const holdings = holdingRows.map(normalizeHolding);
@@ -359,7 +353,7 @@ export function buildMidasSnapshot(
       new Date(holding.occurredAt).getTime() > new Date(latest).getTime()
         ? holding.occurredAt
         : latest,
-    isoTimestamp(balance.occurred_at, "balance occurred_at")
+    holdings[0]?.occurredAt ?? calculatedAt
   );
   const quoteAsOf = positions.reduce<string | null>((latest, position) => {
     if (!position.quote_as_of) return latest;
@@ -370,12 +364,11 @@ export function buildMidasSnapshot(
   }, null);
 
   return {
-    version: 1,
+    version: 2,
     scope: "midas",
     calculated_at: isoTimestamp(calculatedAt, "calculated_at"),
     broker_as_of: brokerAsOf,
     quote_as_of: quoteAsOf,
-    midas_run_id: midasRunId,
     by_currency: [...totals.values()].sort((left, right) =>
       left.currency.localeCompare(right.currency)
     ),
@@ -450,25 +443,6 @@ export default async function runNetWorthSnapshot(
     behavior_id: ctx.behavior.id,
     window_id: ctx.window.id,
   };
-  const balances = (await client.query(
-    `SELECT run_id, occurred_at
-     FROM events
-     WHERE connector_key = 'midas'
-       AND origin_id = 'midas-balance'
-       AND run_id IS NOT NULL
-     ORDER BY occurred_at DESC, id DESC
-     LIMIT 1`
-  )) as MidasBalanceRow[];
-  const balance = balances[0];
-  if (!balance) {
-    await notifySyncNeeded(ctx, client, "No Midas balance cohort exists.");
-    return;
-  }
-  const midasRunId = finiteNumber(balance.run_id);
-  if (midasRunId == null || !Number.isSafeInteger(midasRunId)) {
-    throw new Error("The latest Midas balance has no valid sync run id.");
-  }
-
   const holdings: MidasHoldingRow[] = [];
   while (true) {
     const page = (await client.query(
@@ -477,7 +451,7 @@ export default async function runNetWorthSnapshot(
        WHERE connector_key = 'midas'
          AND semantic_type = 'financial_asset'
          AND origin_id LIKE 'midas-holding-%'
-         AND run_id = ${midasRunId}
+         AND metadata->>'status' = 'active'
        ORDER BY origin_id, id
        LIMIT ${MIDAS_HOLDING_PAGE_SIZE}
        OFFSET ${holdings.length}`
@@ -489,7 +463,7 @@ export default async function runNetWorthSnapshot(
     await notifySyncNeeded(
       ctx,
       client,
-      `Midas sync run ${midasRunId} contains no holdings.`
+      "No explicitly active Midas holdings exist."
     );
     return;
   }
@@ -536,10 +510,8 @@ export default async function runNetWorthSnapshot(
       input: { symbols: batch },
       idempotency_key:
         batches.length === 1
-          ? `midas-net-worth:quotes:window:${ctx.window.id}:midas-run:${midasRunId}`
-          : `midas-net-worth:quotes:window:${ctx.window.id}:midas-run:${midasRunId}:batch:${
-              index + 1
-            }`,
+          ? `midas-net-worth:quotes:window:${ctx.window.id}`
+          : `midas-net-worth:quotes:window:${ctx.window.id}:batch:${index + 1}`,
       behavior_source: behaviorSource,
     });
     if (operation.status !== "completed") {
@@ -557,7 +529,6 @@ export default async function runNetWorthSnapshot(
   }
 
   const snapshot = buildMidasSnapshot(
-    balance,
     holdings,
     allQuotes,
     ctx.window.window_end

--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -216,7 +216,7 @@ const gh = defineConnection({
 `google.gmail`, not `gmail` or `google_gmail`): `github`, `slack`, `linear`, `jira`, `google.gmail`,
 `google.calendar`, `microsoft.outlook`, `discord`, `teams`, `telegram`, `webhook`,
 `whatsapp`, `gchat`, `rss`, `postgres`,
-`hackernews`, `reddit`, `x`, `youtube`, `producthunt`.
+`hackernews`, `market.quotes`, `reddit`, `x`, `youtube`, `producthunt`.
 
 Mac/Chrome device connectors are advertised by Owletto at poll time and appear after the relevant device grants permission.
 

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -489,6 +489,7 @@ This means edits to `.ts` files in `connectors/` take effect on the next sync wi
 |-----------|------|-------|---------|
 | `github` | oauth/env_keys | issues, PRs, comments, discussions | create/close/reopen issues, PRs |
 | `hackernews` | none | stories, comments | - |
+| `market.quotes` | none | - | quote (read-only, quotes returned to the caller, never persisted) |
 | `producthunt` | env_keys | posts & comments | - |
 | `reddit` | oauth/none | posts, comments | - |
 | `rss` | none | articles | - |

--- a/packages/connectors/src/__tests__/market-quotes.test.ts
+++ b/packages/connectors/src/__tests__/market-quotes.test.ts
@@ -3,14 +3,14 @@ import { connectorSdkMock } from "./connector-sdk.mock";
 
 mock.module("@lobu/connector-sdk", connectorSdkMock);
 
-let MarketQuotesConnector: typeof import("../market-quotes.connector").default;
-let normalizeSymbolInput: typeof import("../market-quotes.connector").normalizeSymbolInput;
-let parseYahooChartBody: typeof import("../market-quotes.connector").parseYahooChartBody;
-let quoteMany: typeof import("../market-quotes.connector").quoteMany;
-let toProviderSymbol: typeof import("../market-quotes.connector").toProviderSymbol;
+let MarketQuotesConnector: typeof import("../market_quotes").default;
+let normalizeSymbolInput: typeof import("../market_quotes").normalizeSymbolInput;
+let parseYahooChartBody: typeof import("../market_quotes").parseYahooChartBody;
+let quoteMany: typeof import("../market_quotes").quoteMany;
+let toProviderSymbol: typeof import("../market_quotes").toProviderSymbol;
 
 beforeAll(async () => {
-  const mod = await import("../market-quotes.connector");
+  const mod = await import("../market_quotes");
   MarketQuotesConnector = mod.default;
   normalizeSymbolInput = mod.normalizeSymbolInput;
   parseYahooChartBody = mod.parseYahooChartBody;

--- a/packages/connectors/src/market_quotes.ts
+++ b/packages/connectors/src/market_quotes.ts
@@ -1,5 +1,5 @@
 /**
- * Credential-free market marks for the personal net-worth Behavior.
+ * Credential-free market marks for deterministic portfolio valuation.
  *
  * This connector exposes one read-only action and no feeds. Quotes are returned
  * to the caller and are never persisted as raw market-price events.

--- a/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
+++ b/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_BUNDLED_CONNECTORS = [
 	"hackernews",
 	"jira",
 	"linear",
+	"market.quotes",
 	"microsoft.outlook",
 	"postgres",
 	"producthunt",
@@ -75,6 +76,7 @@ describe("bundled connector lifecycle matrix", () => {
 			github: 6,
 			"google.calendar": 4,
 			"google.gmail": 5,
+			"market.quotes": 1,
 			x: 1,
 			youtube: 5,
 		});


### PR DESCRIPTION
## Summary
- reconcile disappeared Midas positions as append-only closed observations, preserving unobserved market sections and failing closed on incomplete parses
- value only current explicitly active holdings; remove run-cohort coupling and snapshot `midas_run_id`
- promote the credential-free `market.quotes` action from a project-local source into the built-in connector catalog

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (rebased-head Depot run `23ld3cstdd`; 18 jobs passed)
- [x] Targeted tests: 48 net-worth/Midas/config/quote/catalog/template tests passed; 6 production connector compile/catalog tests passed
- [x] `make build-packages` and `bun ../../packages/cli/bin/lobu.js validate` passed
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Live Midas sync + quote operation + weekly Behavior run after deploy/apply

### Red evidence
Before the fix, the current-state test suite reported `0 pass, 8 fail, 1 error`: the reaction still queried a Midas balance cohort, filtered holdings by `run_id`, persisted `midas_run_id`, and shipped a project-local quote source. The catalog lifecycle matrix also failed both assertions because `market.quotes` was not a resolvable bundled connector.

### Green evidence
After the fix, the focused suite reports `48 pass, 0 fail` (264 assertions), production connector compilation/catalog tests report `6 pass, 0 fail`, and the final full Depot run `23ld3cstdd` reports all 18 expanded jobs passed.

## Notes
- No database schema or public API changes. `events` remains append-only; closed holdings supersede prior active observations by stable Midas `origin_id`.
- Legacy status-less Midas rows are intentionally excluded. A successful post-deploy Midas sync seeds explicit active state before legacy rows are tombstoned.
- Full-liquidation detection remains conservative: a missing market section is treated as ambiguous SPA rendering and does not close that market until it is observed again.