### PR TITLE
fix(server): stop passing retired Behavior REST args

### DIFF
--- a/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
+++ b/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
@@ -166,6 +166,11 @@ describe("fixed-action REST arg composition", () => {
 /** Guard route registrations against bypassing the tested composition. */
 describe("fixed-action REST route registrations", () => {
 	const indexSrc = readFileSync(join(__dirname, "../../../index.ts"), "utf8");
+	const restApiSrc = readFileSync(join(__dirname, "../../../rest-api.ts"), "utf8");
+
+	it("does not pass retired arguments through the strict Behavior tool boundary", () => {
+		expect(restApiSrc).not.toContain("include_template_details");
+	});
 
 	it("has no restToolProxy call that spreads caller params after an action", () => {
 		const trailingSpread =

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -44,6 +44,8 @@ import logger from "./utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "./utils/run-statuses";
 import { getRuntimeInfo } from "./utils/runtime-info";
 
+type GetBehaviorArgs = Parameters<typeof getBehavior>[0];
+
 function clamp(
 	value: number,
 	options?: { min?: number; max?: number }
@@ -187,7 +189,7 @@ export async function restGetBehaviors(c: Context<{ Bindings: Env }>) {
 			entity_id: entityId,
 			content_since: c.req.query("content_since"),
 			content_until: c.req.query("content_until"),
-			granularity: c.req.query("granularity") as any,
+			granularity: c.req.query("granularity") as GetBehaviorArgs["granularity"],
 			template_version: safeParseInt(c.req.query("template_version"), {
 				min: 1,
 			}),
@@ -197,12 +199,10 @@ export async function restGetBehaviors(c: Context<{ Bindings: Env }>) {
 				c.req.query("include_classification") || undefined,
 			include_versions: c.req.query("include_versions") === "true",
 			include_pending_ranges: c.req.query("include_pending_ranges") === "true",
-			// Always include Behavior version details (prompt / outputs / sources).
-			include_template_details: true,
-		};
+		} satisfies GetBehaviorArgs;
 
 		const ctx = toToolContext(extractAuthContext(c));
-		const result = await getBehavior(params as any, c.env, ctx);
+		const result = await getBehavior(params, c.env, ctx);
 		return c.json(toJsonSafe(result));
 	} catch (error) {
 		return restErrorResponse(c, error);
@@ -241,28 +241,29 @@ export async function publicRestGetBehaviors(c: Context<{ Bindings: Env }>) {
 			);
 		}
 
-		return getBehavior(
-			{
-				behavior_id: behaviorId,
-				entity_id: entityId,
-				content_since: c.req.query("content_since"),
-				content_until: c.req.query("content_until"),
-				granularity: c.req.query("granularity") as any,
-				template_version: safeParseInt(c.req.query("template_version"), {
-					min: 1,
-				}),
-				page: safeParseInt(c.req.query("page"), { min: 1 }),
-				page_size: safeParseInt(c.req.query("page_size"), { min: 1, max: 500 }),
-				include_classification:
-					c.req.query("include_classification") || undefined,
-				include_versions: c.req.query("include_versions") === "true",
-				include_pending_ranges:
-					c.req.query("include_pending_ranges") === "true",
-				include_template_details: behaviorId ? true : undefined,
-			} as any,
-			c.env,
-			ctx
-		);
+		const params = {
+			behavior_id: behaviorId,
+			entity_id: entityId,
+			content_since: c.req.query("content_since"),
+			content_until: c.req.query("content_until"),
+			granularity: c.req.query("granularity") as GetBehaviorArgs["granularity"],
+			template_version: safeParseInt(c.req.query("template_version"), {
+				min: 1,
+			}),
+			page: safeParseInt(c.req.query("page"), { min: 1 }),
+			page_size: safeParseInt(c.req.query("page_size"), { min: 1, max: 500 }),
+			include_classification:
+				c.req.query("include_classification") || undefined,
+			include_versions: c.req.query("include_versions") === "true",
+			include_pending_ranges:
+				c.req.query("include_pending_ranges") === "true",
+		} satisfies Partial<GetBehaviorArgs>;
+
+		// Partial + cast (not `satisfies GetBehaviorArgs`): detailRequested can
+		// be triggered by a detail query param without behavior_id, so
+		// behavior_id may be undefined here — the tool's own arg validation
+		// turns that into the 400 naming the missing field.
+		return getBehavior(params as GetBehaviorArgs, c.env, ctx);
 	});
 }
 


### PR DESCRIPTION
## Summary

- Remove the retired `include_template_details` argument from authenticated and public Behavior detail REST routes. Strict tool validation rejected every request before the handler ran, breaking `lobu init --from-org`.
- Derive the REST argument type from `getBehavior` and use `satisfies` so future schema drift is caught by TypeScript instead of hidden behind `as any`.
- Guard against reintroducing the retired field at the REST boundary.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; run `tkn5ssqftk`, 18 executions passed)
- [x] Tests run: `bun test packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts` (18 pass); `cd packages/server && bun run typecheck`; booted worktree HTTP exercise
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

Production bootstrap failed on the Behavior detail REST call before any connector/provider operation:

```text
GET /api/buremba/behaviors?behavior_id=97 failed: Invalid arguments for get_behavior: unknown argument(s): include_template_details — valid arguments are: behavior_id, entity_id, content_since, content_until, granularity, template_version, template_version_id, page, page_size, include_classification, include_versions, include_pending_ranges
```

The regression guard failed before the fix:

```text
(fail) fixed-action REST route registrations > does not pass retired arguments through the strict Behavior tool boundary
Expected to not contain: "include_template_details"
```

### Green

```text
18 pass
0 fail
27 expect() calls
Ran 18 tests across 1 file.

$ tsc --noEmit
```

Booted the exact worktree, created a disposable Behavior, and exercised both changed branches:

```json
{
  "created_behavior_id": "1",
  "authenticated_detail_id": "1",
  "public_detail_id": "1",
  "version_prompt": "Return a short test summary.",
  "archived_count": 1
}
```

The Behavior was archived, org visibility restored to private, the server stopped, and the task database dropped (`pg_database` count = 0).

## Notes

This was found while verifying the released managed-MCP bootstrap path. The failure occurs before Jira or Confluence is read or mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated behavior REST requests to use the current supported parameters.
  * Removed forwarding of the retired template-details option, improving compatibility with behavior services.
* **Tests**
  * Added regression coverage to ensure unsupported parameters are not passed through behavior requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->