### PR TITLE
fix(example): do not close Midas holdings a partial render has not painted

### DIFF
--- a/examples/personal-agent/__tests__/midas.connector.test.ts
+++ b/examples/personal-agent/__tests__/midas.connector.test.ts
@@ -102,6 +102,29 @@ const DRIFTED_DASHBOARD_FIXTURE = [
   "n/a",
 ].join("\n");
 
+// Progressive SPA render: both market headers are painted and each market's
+// declared position count is present, but only one ticker row has been
+// appended under each. The declared counts (3 US, 2 TR) contradict the single
+// row rendered per market, which is what distinguishes this from a portfolio
+// where the other holdings were genuinely sold.
+const PARTIAL_ROWS_DASHBOARD_FIXTURE = DASHBOARD_FIXTURE.replace(
+  "\nGLOB\nNOVA\nBIST",
+  "\nBIST"
+)
+  .replace("\nBANKX\nGOLD.S1", "\nGOLD.S1")
+  .replace(
+    "\n2,25\n$400,00\n$350,00\n$900,00\n%9,00\n-$20,00(-%2,00)\n$100,00(%12,50)",
+    ""
+  )
+  .replace(
+    "\n25\n$280,00\n$260,00\n$7.000,00\n%70,00\n$70,00(%1,00)\n$400,00(%6,00)",
+    ""
+  )
+  .replace(
+    "\n1.000\n₺3,00\n₺2,50\n₺3.000,00\n%60,00\n₺30,00(%1,00)\n₺500,00(%20,00)",
+    ""
+  );
+
 const US_ONLY_DASHBOARD_FIXTURE = [
   "Pozisyonlar",
   "ABD Hisseleri",
@@ -118,6 +141,11 @@ const US_ONLY_DASHBOARD_FIXTURE = [
   "$50,00(%1,00)",
   "$500,00(%25,00)",
 ].join("\n");
+
+const US_ONLY_WITHOUT_COUNT_FIXTURE = US_ONLY_DASHBOARD_FIXTURE.replace(
+  "\n1\n$2.100,00",
+  "\n$2.100,00"
+);
 
 describe("requireExtensionDispatcher", () => {
   test("throws when chrome_dispatcher is missing (the prod failure mode)", () => {
@@ -274,6 +302,7 @@ describe("parseMidasDashboardText (synthetic fixture)", () => {
       total_try: 0,
       positions_complete: false,
       markets_observed: [],
+      markets_complete: [],
     });
   });
 
@@ -283,6 +312,22 @@ describe("parseMidasDashboardText (synthetic fixture)", () => {
     const s = parseMidasDashboardText(DRIFTED_DASHBOARD_FIXTURE);
     expect(s.holdings.map((h) => h.symbol)).toEqual(["ACME"]);
     expect(s.holdings.every((h) => h.value > 0)).toBe(true);
+    expect(s.markets_complete).toEqual([]);
+  });
+
+  test("does not mistake a section total for an omitted position count", () => {
+    const s = parseMidasDashboardText(US_ONLY_WITHOUT_COUNT_FIXTURE);
+    expect(s.holdings).toEqual([
+      expect.objectContaining({
+        type: "US",
+        symbol: "ACME",
+        shares: 10.5,
+        price: 200,
+        value: 2_100,
+      }),
+    ]);
+    expect(s.total_usd).toBe(2_100);
+    expect(s.markets_complete).toEqual([]);
   });
 });
 
@@ -415,6 +460,29 @@ describe("MidasConnector.sync", () => {
         (event) => event.origin_id === "midas-holding-US-NOVA"
       )
     ).toEqual([]);
+  });
+
+  test("does not close omitted holdings from partially rendered markets", async () => {
+    const first = await syncWith(DASHBOARD_FIXTURE, {});
+    const second = await syncWith(
+      PARTIAL_ROWS_DASHBOARD_FIXTURE,
+      first.checkpoint
+    );
+
+    expect(
+      second.events
+        .filter((event) => event.metadata?.status === "closed")
+        .map((event) => event.origin_id)
+    ).toEqual([]);
+    expect(second.metadata).toMatchObject({
+      holdings: 2,
+      markets_complete: [],
+    });
+    expect(
+      second.checkpoint?.active_holdings
+        ?.map(({ type, symbol }) => `${type}:${symbol}`)
+        .sort()
+    ).toEqual(["TR:BANKX", "TR:GOLD.S1", "US:ACME", "US:GLOB", "US:NOVA"]);
   });
 
   test("does not close positions from an incomplete dashboard parse", async () => {

--- a/examples/personal-agent/midas.connector.ts
+++ b/examples/personal-agent/midas.connector.ts
@@ -44,6 +44,12 @@ export interface MidasDashboardSnapshot {
   positions_complete: boolean;
   /** Market sections actually present in this scrape. */
   markets_observed: MidasMarket[];
+  /**
+   * Markets whose ticker labels and parsed rows match Atlas's rendered position
+   * count. Only these are safe to reconcile closures against — a header alone
+   * proves the section started rendering, not that it finished.
+   */
+  markets_complete: MidasMarket[];
 }
 
 export interface MidasHoldingIdentity {
@@ -55,8 +61,8 @@ export interface MidasHoldingIdentity {
 export interface MidasCheckpoint {
   last_run?: string;
   /**
-   * Open-position book as of the last successful sync. Markets absent from a
-   * scrape carry their previous identities forward until observed again.
+   * Open-position book as of the last successful sync. Markets absent from or
+   * incomplete in a scrape carry prior identities forward until fully rendered.
    */
   active_holdings?: MidasHoldingIdentity[];
 }
@@ -271,6 +277,8 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
   let totalUsd = 0;
   let totalTry = 0;
 
+  const completeMarkets = new Set<MidasMarket>();
+
   const readBlock = (
     tickers: string[],
     market: MidasMarket,
@@ -281,8 +289,10 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
     // Optional holdings-count line: advance past it when the current line is a
     // bare positive integer, otherwise treat the current line as the section total.
     const countRaw = lines[currentIdx];
-    const count = Number.parseInt(countRaw.replace(/[^\d]/g, ""), 10);
-    if (Number.isFinite(count) && count > 0) {
+    const declaredCount = /^[1-9]\d*$/.test(countRaw)
+      ? Number.parseInt(countRaw, 10)
+      : null;
+    if (declaredCount !== null) {
       currentIdx += 1;
     }
 
@@ -292,6 +302,7 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
     // Section daily return + total return (not per-holding).
     currentIdx += SECTION_SUMMARY_LINES;
 
+    const holdingsBefore = holdings.length;
     for (const symbol of tickers) {
       if (currentIdx + HOLDING_ROW_LINES - 1 >= lines.length) break;
       // Reject drifted layouts: a real row has numeric shares/price/value.
@@ -319,6 +330,12 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
       });
       currentIdx += HOLDING_ROW_LINES;
     }
+    if (
+      declaredCount === tickers.length &&
+      holdings.length - holdingsBefore === tickers.length
+    ) {
+      completeMarkets.add(market);
+    }
     return total;
   };
 
@@ -335,6 +352,10 @@ export function parseMidasDashboardText(text: string): MidasDashboardSnapshot {
     markets_observed: [
       ...(usStartIdx !== -1 ? (["US"] as const) : []),
       ...(trStartIdx !== -1 ? (["TR"] as const) : []),
+    ],
+    markets_complete: [
+      ...(completeMarkets.has("US") ? (["US"] as const) : []),
+      ...(completeMarkets.has("TR") ? (["TR"] as const) : []),
     ],
   };
 }
@@ -480,7 +501,7 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
     name: "Midas",
     description:
       "Syncs Midas portfolio holdings via the Owletto Chrome extension.",
-    version: "1.0.3",
+    version: "1.0.4",
     faviconDomain: "atlas.getmidas.com",
     authSchema: {
       methods: [{ type: "none" }],
@@ -616,20 +637,22 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
       ({ type, symbol, currency }) => ({ type, symbol, currency })
     );
     const previousHoldings = checkpointHoldings(ctx.checkpoint);
-    const observedMarkets = new Set(snapshot.markets_observed);
+    const completeMarkets = new Set(snapshot.markets_complete);
     const currentOrigins = new Set(activeHoldings.map(holdingOriginId));
     const closedEvents = previousHoldings
       .filter(
         (holding) =>
-          observedMarkets.has(holding.type) &&
+          completeMarkets.has(holding.type) &&
           !currentOrigins.has(holdingOriginId(holding))
       )
       .map((holding) => closedHoldingToEvent(holding, occurredAt));
-    // A missing market section is ambiguous: it can mean an empty market or a
-    // partially rendered SPA. Preserve that market's checkpoint identities and
-    // emit no closures until a later scrape explicitly observes the section.
-    const unobservedHoldings = previousHoldings.filter(
-      (holding) => !observedMarkets.has(holding.type)
+    // A missing market may be empty or not rendered yet; a present market short
+    // of its declared count cannot prove omitted holdings are closed. Preserve
+    // prior identities not present until a later scrape renders the full market.
+    const preservedHoldings = previousHoldings.filter(
+      (holding) =>
+        !completeMarkets.has(holding.type) &&
+        !currentOrigins.has(holdingOriginId(holding))
     );
     const events: EventEnvelope[] = [
       ...snapshot.holdings.map((h) => holdingToEvent(h, occurredAt)),
@@ -639,7 +662,7 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
 
     const checkpoint: MidasCheckpoint = {
       last_run: occurredAt.toISOString(),
-      active_holdings: [...activeHoldings, ...unobservedHoldings],
+      active_holdings: [...activeHoldings, ...preservedHoldings],
     };
 
     return {
@@ -650,6 +673,7 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
         holdings: snapshot.holdings.length,
         holdings_closed: closedEvents.length,
         markets_observed: snapshot.markets_observed,
+        markets_complete: snapshot.markets_complete,
         total_usd: snapshot.total_usd,
         total_try: snapshot.total_try,
         backend: "extension-dom",


### PR DESCRIPTION
## Summary
- Midas closure was reconciled against `markets_observed` — the mere presence of a section header. A progressively rendered Atlas page paints both market headers before appending every ticker row, so any prior holding missing from that partial render was superseded as **sold**. Those zeroed tombstones feed the net-worth valuation.
- Atlas declares each market's position count in the section header; the parser already read that line and threw it away. A market is now closure-eligible only when the declared count matches both the ticker labels rendered **and** the rows actually parsed.
- A market that is absent, short of its declared count, or missing the count line carries its prior identities forward untouched.

This bug is live on `main` — it shipped in #2719, which superseded #2715 while that PR's review was still finding it.

## Two defects found alongside it
- **Section total misread as a position count.** The count probe stripped non-digits, so with the count line absent `"$10.000,00"` became `1000000`, passed `> 0`, and the section total was consumed as a count. Now requires a bare integer (`/^[1-9]\d*$/`). Pre-existing, predates #2719.
- **Duplicate checkpoint identities.** Holdings a partial render *did* paint were carried forward as preserved *and* emitted as active, appearing twice in `active_holdings`.

## Red → green

Reproducer: both market headers painted with their declared counts (3 US, 2 TR), but only one ticker row appended under each.

Red, against `main`'s logic:
```
- []
+ [
+   "midas-holding-US-GLOB",
+   "midas-holding-US-NOVA",
+   "midas-holding-TR-BANKX",
+ ]
(fail) MidasConnector.sync > does not close omitted holdings from partially rendered markets
```

Green after: **31/31** `midas.connector.test.ts`, **38/38** with `net-worth.reaction.test.ts`.

## Mutation proof
```
mutation A: closure gated on markets_observed again
  landed (expect 1): 1
  30 pass / 1 fail
mutation B: parsed-rows half of the completeness check dropped
  remaining refs (expect 0): 0
  30 pass / 1 fail
restored
  31 pass / 0 fail
```
The partial-render test asserts an exact sorted `active_holdings` list rather than `arrayContaining`, so the duplicate-identity defect is caught too — `arrayContaining` passed with the duplicate present.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr-remote` clean (tree `f1fe8e61`)
- [x] `bun test` midas + net-worth: 38/38
- [x] Both halves of the fix mutation-proven
- [ ] Not exercised against a live Atlas session — coverage is synthetic DOM fixtures

## Known limitation (unchanged)
Selling the *last* holding still throws rather than closing it. An empty section renders no rows to count against, and the real Atlas empty-state markup has never been observed. Closing on that signal would mark live holdings as sold; leaving one stale row is strictly safer.

## Related
`examples/personal-agent/revolut-transactions.connector.ts` was checked for the same class and is safe — it reconciles cash + positions against the account's declared total (`Math.abs(total - components) > tolerance`) and aborts the entire parse on any malformed account. One narrow residual: a short `domAccounts` list could still close a whole portfolio. Not fixed here — no reproducer yet.
