### PR TITLE
fix(examples): avoid archived Lobu Team Behavior slugs

### DIFF
--- a/examples/lobu-team/SOUL.md
+++ b/examples/lobu-team/SOUL.md
@@ -1,8 +1,8 @@
 # Instructions
 
-The lunch run is a two-step flow driven by two Behaviors (`lunch-open` at ~11:00, `lunch-finalize` at ~11:35). You can also be triggered ad-hoc by someone messaging you ("do lunch", "start the lunch order") — in that case do step 1 immediately and tell people you'll post the options shortly.
+The lunch run is a two-step flow driven by two Behaviors (`lobu-team-lunch-open` at ~11:00, `lobu-team-lunch-finalize` at ~11:35). You can also be triggered ad-hoc by someone messaging you ("do lunch", "start the lunch order") — in that case do step 1 immediately and tell people you'll post the options shortly.
 
-## Step 1 — open the run (`lunch-open` Behavior, or an ad-hoc ask)
+## Step 1 — open the run (`lobu-team-lunch-open` Behavior, or an ad-hoc ask)
 
 1. **Guess who's in.** Look at recent chat activity, anyone who's mentioned lunch/the office today, and what you remember from past `lunch-run` entities about who's usually in. Presence is a hint, not a fact — don't treat it as a confirmed list.
 2. **Check you're not double-running.** Search memory for a `lunch-run` entity dated today. If one exists and isn't `cancelled`, don't open another — reply in its thread instead.
@@ -10,10 +10,10 @@ The lunch run is a two-step flow driven by two Behaviors (`lunch-open` at ~11:00
    > 🍱 Lunch run! React 🍕 if you're in (or just say "+1"). Got a restaurant recommendation? Drop it here — I'll post the options around 11:35. Targeting ~12:30 delivery.
    @-mention the people you guessed are in (so they see it) but make clear anyone can join or skip.
 4. **Open a thread** off that message. Everything else happens in the thread.
-5. **Save a `lunch-run` entity**: `{date, channel, status: "collecting", thread_ref: <the thread/message reference>, restaurant: null, items: [], basket_url: null}`. Then `save_memory({content: "Opened lunch run for <date>", semantic_type: "lunch:opened", entity_ids: [<the lunch-run entity>]})`. The thread reference matters — `lunch-finalize` needs it to find the conversation.
-6. End the run. Don't wait around — the `lunch-finalize` Behavior picks it up.
+5. **Save a `lunch-run` entity**: `{date, channel, status: "collecting", thread_ref: <the thread/message reference>, restaurant: null, items: [], basket_url: null}`. Then `save_memory({content: "Opened lunch run for <date>", semantic_type: "lunch:opened", entity_ids: [<the lunch-run entity>]})`. The thread reference matters — `lobu-team-lunch-finalize` needs it to find the conversation.
+6. End the run. Don't wait around — the `lobu-team-lunch-finalize` Behavior picks it up.
 
-## Step 2 — collect & hand off (`lunch-finalize` Behavior)
+## Step 2 — collect & hand off (`lobu-team-lunch-finalize` Behavior)
 
 1. **Find today's run.** Search memory for today's `lunch-run` entity (status `collecting`). If there isn't one, the open step didn't fire — open one now (step 1) and stop; a human can finalize later. If status is already `done` or `cancelled`, do nothing.
 2. **Read the thread.** Pull the thread's messages and reactions. Work out:

--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -6,8 +6,8 @@ describe("Lobu Team configuration", () => {
     expect(config.org).toBe("lobu-team");
     expect(config.organizationId).toBe("UdNAH1bb3csC842vhOgxAHVcfX4tYU5A");
     expect(config.behaviors?.map((behavior) => behavior.slug)).toEqual([
-      "lunch-open",
-      "lunch-finalize",
+      "lobu-team-lunch-open",
+      "lobu-team-lunch-finalize",
       "product-activity-digest",
     ]);
   });

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -19,7 +19,7 @@ import type productActivityDigestReaction from "./product-activity-digest.reacti
 const lunchOpenSkill = defineSkill({
   name: "lunch-open",
   content:
-    "Open today's office lunch run (step 1 in your instructions):\n\n1. Check memory for a `lunch-run` entity dated today — if one exists and isn't\n   cancelled, stop (don't open a second one).\n2. Guess who's in from recent chat activity and past `lunch-run` entities.\n3. Post the lunch call in the channel: react 🍕 / \"+1\" to join, drop restaurant\n   recommendations, options coming ~11:35, targeting ~12:30 delivery. @-mention\n   the people you think are in, but make clear anyone can join or skip.\n4. Open a thread off that message.\n5. Save a `lunch-run` entity {date, channel, status: \"collecting\", thread_ref,\n   restaurant: null, items: []} and a `lunch:opened` event linked to it.\n\nThen end — the lunch-finalize Behavior takes it from here. Keep it to one short\nmessage in the channel.\n",
+    "Open today's office lunch run (step 1 in your instructions):\n\n1. Check memory for a `lunch-run` entity dated today — if one exists and isn't\n   cancelled, stop (don't open a second one).\n2. Guess who's in from recent chat activity and past `lunch-run` entities.\n3. Post the lunch call in the channel: react 🍕 / \"+1\" to join, drop restaurant\n   recommendations, options coming ~11:35, targeting ~12:30 delivery. @-mention\n   the people you think are in, but make clear anyone can join or skip.\n4. Open a thread off that message.\n5. Save a `lunch-run` entity {date, channel, status: \"collecting\", thread_ref,\n   restaurant: null, items: []} and a `lunch:opened` event linked to it.\n\nThen end — the lobu-team-lunch-finalize Behavior takes it from here. Keep it to one short\nmessage in the channel.\n",
 });
 
 const lunchFinalizeSkill = defineSkill({
@@ -98,7 +98,7 @@ const lunchRun = defineEntityType({
     thread_ref: {
       type: "string",
       description:
-        "Reference to the thread/message where the run is happening — lunch-finalize uses this to find the conversation",
+        "Reference to the thread/message where the run is happening — lobu-team-lunch-finalize uses this to find the conversation",
     },
     items: {
       type: "array",
@@ -128,7 +128,7 @@ const lunchRun = defineEntityType({
 });
 
 // The office's Deliveroo connection. Feedless — it exposes only on-demand
-// actions (search_restaurants / read_menu) that the lunch-finalize reaction
+// actions (search_restaurants / read_menu) that the lobu-team-lunch-finalize reaction
 // drives through the paired Owletto Chrome extension. `restaurants_url` is the
 // office's delivery-location restaurants list (set it to your office postcode's
 // Deliveroo page — the geohash pins delivery to that address).
@@ -144,7 +144,7 @@ const deliverooConn = defineConnection({
 
 const lunchOpen = defineBehavior({
   agent: foodOrdering,
-  slug: "lunch-open",
+  slug: "lobu-team-lunch-open",
   name: "Open the lunch run",
   triggers: [{ kind: "schedule", cron: "0 11 * * 1-5" }],
   notification: { priority: "high", channel: "both" },
@@ -157,7 +157,7 @@ const lunchOpen = defineBehavior({
 
 const lunchFinalize = defineBehavior({
   agent: foodOrdering,
-  slug: "lunch-finalize",
+  slug: "lobu-team-lunch-finalize",
   name: "Collect orders and hand off",
   triggers: [{ kind: "schedule", cron: "35 11 * * 1-5" }],
   notification: { priority: "high" },
@@ -167,7 +167,7 @@ const lunchFinalize = defineBehavior({
     "./lunch-deliveroo.reaction.ts"
   ),
   reactionsGuidance:
-    "When the run ends in `placed` or `manual`, store the per-head cost back into a\n`lunch:placed` event on the lunch-run entity so the next day's lunch-open can\nread the most-recent restaurant.\n",
+    "When the run ends in `placed` or `manual`, store the per-head cost back into a\n`lunch:placed` event on the lunch-run entity so the next day's lobu-team-lunch-open can\nread the most-recent restaurant.\n",
   skills: ["lunch-finalize"],
   // No inline schema: the reaction reads the run's outcome straight off the
   // `lunch-run` entity this prompt updates (status "done" + restaurant), so the

--- a/examples/lobu-team/lunch-deliveroo.reaction.ts
+++ b/examples/lobu-team/lunch-deliveroo.reaction.ts
@@ -1,5 +1,5 @@
 /**
- * Reaction for the `lunch-finalize` Behavior.
+ * Reaction for the `lobu-team-lunch-finalize` Behavior.
  *
  * The agent's turn collects orders and picks a restaurant; this reaction then
  * does the Deliveroo work the agent itself can't (executing connector actions

--- a/examples/lobu-team/skills/deliveroo-order/SKILL.md
+++ b/examples/lobu-team/skills/deliveroo-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deliveroo-order
-description: Turn collected lunch orders into a clean per-person order list for a human to place on Deliveroo. Use in step 2 of the lunch run, after orders are collected. The live menu is fetched automatically by the lunch-finalize reaction (via the Owletto Chrome extension) — this skill never places an order or touches payment.
+description: Turn collected lunch orders into a clean per-person order list for a human to place on Deliveroo. Use in step 2 of the lunch run, after orders are collected. The live menu is fetched automatically by the lobu-team-lunch-finalize reaction (via the Owletto Chrome extension) — this skill never places an order or touches payment.
 ---
 
 # Deliveroo lunch order
@@ -16,7 +16,7 @@ two on-demand actions, not a feed:
   (`{ name, price, price_minor, description, kcal }`).
 
 These actions need the Behavior's system context, so the **agent does not call
-them in-turn** — the `lunch-finalize` **reaction** does (see
+them in-turn** — the `lobu-team-lunch-finalize` **reaction** does (see
 `lunch-deliveroo.reaction.ts`). After the agent's turn picks a restaurant, the
 reaction searches for it, reads the live menu, and posts the menu + Deliveroo
 order link back into the channel for a human to place.


### PR DESCRIPTION
## Summary
- Use fresh `lobu-team-lunch-open` and `lobu-team-lunch-finalize` slugs because the original slugs are retained by archived production Behaviors.
- Keep the Behavior names consistent across the Lobu Team prompts, reaction documentation, and tests.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean on rebased HEAD: Depot run `0zttsncs79` (18 jobs).
- [x] `bun test examples/lobu-team --timeout 30000`: 18 pass, 0 fail, 56 expectations.
- [x] `bunx tsc -p examples/lobu-team/tsconfig.json --noEmit`.
- [x] Bug fix: red→fix→green outputs pasted below.
- [x] Production apply dry-run: 4 creates, 3 updates, 10 no-ops, 17 unrelated resources ignored, 0 deletes.

### Red
The config contract expected the fresh Lobu Team slugs but received the archived reserved slugs:

```
Expected: lobu-team-lunch-open, lobu-team-lunch-finalize
Received: lunch-open, lunch-finalize
2 pass, 1 fail
```

The first production apply also failed closed with: `Behavior with slug lunch-open already exists in this organization`. A scoped read confirmed IDs 3 and 4 are archived and retain those slugs.

### Green
```
18 pass
0 fail
56 expect() calls
```

## Notes
- No core/runtime, database, API, SDK, or Owletto change.
- Archived Behaviors are preserved; this does not delete or rewrite history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the lunch workflow to use the `lobu-team-lunch-open` and `lobu-team-lunch-finalize` behaviors.
  * Improved workflow handoff by saving the lunch thread reference before finalization.
  * Updated related instructions, documentation, reactions, and configuration references to match the new behavior names.
* **Tests**
  * Updated configuration tests to validate the renamed lunch behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->