### PR TITLE
fix(example): wait for Midas position rows

### DIFF
--- a/examples/personal-agent/__tests__/midas.connector.test.ts
+++ b/examples/personal-agent/__tests__/midas.connector.test.ts
@@ -28,6 +28,7 @@ let holdingToEvent: typeof import("../midas.connector").holdingToEvent;
 let balanceToEvent: typeof import("../midas.connector").balanceToEvent;
 let MIDAS_DASHBOARD_URL: typeof import("../midas.connector").MIDAS_DASHBOARD_URL;
 let MIDAS_ALLOWED_ORIGINS: typeof import("../midas.connector").MIDAS_ALLOWED_ORIGINS;
+let MIDAS_DASHBOARD_TEXT_EXPRESSION: typeof import("../midas.connector").MIDAS_DASHBOARD_TEXT_EXPRESSION;
 
 beforeAll(async () => {
   const mod = await import("../midas.connector");
@@ -41,6 +42,7 @@ beforeAll(async () => {
   balanceToEvent = mod.balanceToEvent;
   MIDAS_DASHBOARD_URL = mod.MIDAS_DASHBOARD_URL;
   MIDAS_ALLOWED_ORIGINS = mod.MIDAS_ALLOWED_ORIGINS;
+  MIDAS_DASHBOARD_TEXT_EXPRESSION = mod.MIDAS_DASHBOARD_TEXT_EXPRESSION;
 });
 
 function dispatcherFor(bodyText: string) {
@@ -146,6 +148,45 @@ const US_ONLY_WITHOUT_COUNT_FIXTURE = US_ONLY_DASHBOARD_FIXTURE.replace(
   "\n1\n$2.100,00",
   "\n$2.100,00"
 );
+
+describe("Midas dashboard settle", () => {
+  test("waits for numeric position data after headings render", async () => {
+    const headingsOnly = [
+      "Pozisyonlar",
+      "ABD Hisseleri",
+      "BIST Hisseleri",
+    ].join("\n");
+    let reads = 0;
+    const document = {
+      body: {
+        get innerText() {
+          reads += 1;
+          return reads <= 2 ? headingsOnly : DASHBOARD_FIXTURE;
+        },
+      },
+    };
+    const evaluate = Function(
+      "document",
+      "setTimeout",
+      `return ${MIDAS_DASHBOARD_TEXT_EXPRESSION}`
+    ) as (
+      document: object,
+      setTimeout: (callback: () => void) => number
+    ) => Promise<string>;
+
+    const result = await evaluate(document, (callback) => {
+      callback();
+      return 0;
+    });
+
+    expect(result).toBe(DASHBOARD_FIXTURE);
+    expect(reads).toBeGreaterThan(2);
+    // A handful of reads means the loop exited via readiness. Thousands would
+    // mean ready() never matched the fixture and the 12s deadline bailed us
+    // out — which must fail, not pass slowly.
+    expect(reads).toBeLessThan(10);
+  });
+});
 
 describe("requireExtensionDispatcher", () => {
   test("throws when chrome_dispatcher is missing (the prod failure mode)", () => {

--- a/examples/personal-agent/midas.connector.ts
+++ b/examples/personal-agent/midas.connector.ts
@@ -19,6 +19,34 @@ export const MIDAS_ALLOWED_ORIGINS = [
   "*.getmidas.com",
 ] as const;
 
+/**
+ * Runs inside the Atlas page via the extension's `evaluate` action. Atlas
+ * paints the "Pozisyonlar" headings before appending the numeric rows, so
+ * readiness requires a market heading AND a currency amount on its own line
+ * within the section — a heading alone is a partial render. Returns the body
+ * text either way once the 12s deadline passes.
+ */
+export const MIDAS_DASHBOARD_TEXT_EXPRESSION = `(async () => {
+  const deadline = Date.now() + 12000;
+  const bodyText = () => (document.body ? document.body.innerText : "");
+  const ready = () => {
+    const t = bodyText();
+    const positionsStart = t.indexOf("Pozisyonlar");
+    if (positionsStart === -1) return false;
+    const positions = t.slice(positionsStart);
+    const hasMarket =
+      positions.includes("ABD Hisseleri") ||
+      positions.includes("BIST Hisseleri");
+    const hasSectionTotal =
+      /(?:^|\\n)(?:\\$|₺)\\d[\\d.]*,\\d{2}(?:\\n|$)/.test(positions);
+    return hasMarket && hasSectionTotal;
+  };
+  while (Date.now() < deadline && !ready()) {
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return bodyText();
+})()`;
+
 export type MidasMarket = "US" | "TR";
 
 export interface MidasHolding {
@@ -501,7 +529,7 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
     name: "Midas",
     description:
       "Syncs Midas portfolio holdings via the Owletto Chrome extension.",
-    version: "1.0.4",
+    version: "1.0.5",
     faviconDomain: "atlas.getmidas.com",
     authSchema: {
       methods: [{ type: "none" }],
@@ -585,23 +613,11 @@ export default class MidasConnector extends ConnectorRuntime<MidasCheckpoint> {
       );
     }
 
-    // SPA settle: poll for the Pozisyonlar section markers until they render
-    // (bounded), rather than a blind fixed sleep that races slow sessions.
+    // SPA settle: headings paint before Atlas appends the numeric rows. Wait
+    // for a section total inside Pozisyonlar, not just for an early marker.
     const textObs = await dispatcher.dispatch<{ value?: string }>("evaluate", {
       tab_id: nav.tab_id,
-      expression: `(async () => {
-        const markers = ["Pozisyonlar", "ABD Hisseleri", "BIST Hisseleri"];
-        const deadline = Date.now() + 12000;
-        const bodyText = () => (document.body ? document.body.innerText : "");
-        const ready = () => {
-          const t = bodyText();
-          return markers.some((m) => t.includes(m));
-        };
-        while (Date.now() < deadline && !ready()) {
-          await new Promise((r) => setTimeout(r, 250));
-        }
-        return bodyText();
-      })()`,
+      expression: MIDAS_DASHBOARD_TEXT_EXPRESSION,
       allowed_origins: [...MIDAS_ALLOWED_ORIGINS],
     });
 


### PR DESCRIPTION
## Summary
- Wait for a numeric Midas position-section total before reading the Atlas dashboard; headings render earlier than holding rows.
- Keep the change scoped to the Midas connector and its regression test; no Owletto/Chrome-extension files change.

## Test plan
- [x] Intended files staged explicitly, then make pre-pr-remote clean (full Linux CI graph on Depot)
- [x] Tests run: bun test examples/personal-agent/__tests__/midas.connector.test.ts (32 pass)
- [x] Bug fix: red→fix→green outputs pasted below

### Red
Midas dashboard settle > waits for numeric position data after headings render
Expected full positions fixture; received only BIST Hisseleri after the old marker-only readiness probe exited.
31 pass, 1 fail

### Green
Midas dashboard settle > waits for numeric position data after headings render
32 pass, 0 fail, 97 assertions
Full Depot run hzf75h8s5m passed all 16 Linux CI jobs (18 matrix jobs).

## Notes
Production dry-run reproduced the race safely: authenticated Atlas rendered both market headings but the connector returned no holdings. No financial events were written by the failed dry-run.
