### PR TITLE
fix(examples): adopt Lobu Team lunch schema

### DIFF
--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -97,8 +97,11 @@ const lunchRun = defineEntityType({
     },
     thread_ref: {
       type: "string",
+      // Adopted verbatim from the live lobu-team schema so `lobu apply`
+      // converges instead of blocking on undeclared drift — "lunch-finalize"
+      // is the remote wording, not a typo for the Behavior slug.
       description:
-        "Reference to the thread/message where the run is happening — lobu-team-lunch-finalize uses this to find the conversation",
+        "Reference to the thread/message where the run is happening — lunch-finalize uses this to find the conversation",
     },
     items: {
       type: "array",


### PR DESCRIPTION
## Summary
- Adopt the live `lunch-run.thread_ref` description verbatim so the consolidated Lobu Team declaration converges under the production drift guard.
- Document why the historical `lunch-finalize` wording is intentionally preserved in this schema string.

## Test plan
- [x] Intended file staged explicitly, then `make pre-pr-remote` clean: Depot run `w9qh1t01tj` (18 jobs).
- [x] `bun test examples/lobu-team --timeout 30000`: 18 pass, 0 fail, 56 expectations.
- [x] `bunx tsc -p examples/lobu-team/tsconfig.json --noEmit`.
- [x] Production apply dry-run: 4 creates, 4 updates, 9 no-ops, 17 unrelated resources ignored, 0 blocked drift, 0 deletes.

### Red
Production apply blocked without mutations on `entity-type lunch-run · definition`. Live inspection isolated the mismatch to the `thread_ref` description.

### Green
The desired description is now byte-identical to production; the full production dry-run passes with no blocked drift and no deletes.

## Notes
- This preserves production schema/data; it does not alter a database, API, SDK, or core runtime contract.
- No Owletto/UI change.