### PR TITLE
fix(personal-agent): version net-worth idempotency keys

### DIFF
--- a/examples/personal-agent/__tests__/net-worth.reaction.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.reaction.test.ts
@@ -232,7 +232,7 @@ describe("weekly net-worth reaction", () => {
             { market: "US", symbol: "NOPE" },
           ],
         },
-        idempotency_key: "midas-net-worth:quotes:window:91",
+        idempotency_key: "midas-net-worth:v2:quotes:window:91",
         behavior_source: { behavior_id: 45, window_id: 91 },
       },
     ]);
@@ -240,7 +240,7 @@ describe("weekly net-worth reaction", () => {
     expect(saved[0]).toMatchObject({
       semantic_type: "summary",
       title: "Midas net worth snapshot",
-      idempotency_key: "midas-net-worth:snapshot:window:91",
+      idempotency_key: "midas-net-worth:v2:snapshot:window:91",
       behavior_source: { behavior_id: 45, window_id: 91 },
       metadata: {
         scope: "midas",
@@ -248,7 +248,11 @@ describe("weekly net-worth reaction", () => {
         by_currency: [{ currency: "USD", current_value: 580 }],
       },
     });
-    expect(notified).toHaveLength(1);
+    expect(notified).toEqual([
+      expect.objectContaining({
+        idempotency_key: "midas-net-worth:v2:notification:window:91",
+      }),
+    ]);
   });
 
   test("notifies from the persisted snapshot after an idempotent save replay", async () => {

--- a/examples/personal-agent/net-worth.reaction.ts
+++ b/examples/personal-agent/net-worth.reaction.ts
@@ -17,6 +17,10 @@ export const input = {
 } as const;
 
 const MIDAS_HOLDING_PAGE_SIZE = 1_000;
+// The suffix must track MidasNetWorthSnapshot's `version`: replaying under a
+// prior version's key returns that version's persisted metadata as the
+// snapshot, so the notification would be built from a stale-schema payload.
+const MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX = "midas-net-worth:v2";
 
 export interface MidasHoldingMetadata {
   symbol?: string;
@@ -427,7 +431,7 @@ async function notifySyncNeeded(
   await client.notifications.send({
     title: "Midas net worth needs attention",
     body: `${reason} Open Atlas in the paired browser and sync Midas before the next valuation.`,
-    idempotency_key: `midas-net-worth:needs-sync:window:${ctx.window.id}`,
+    idempotency_key: `${MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX}:needs-sync:window:${ctx.window.id}`,
     behavior_source: {
       behavior_id: ctx.behavior.id,
       window_id: ctx.window.id,
@@ -510,8 +514,8 @@ export default async function runNetWorthSnapshot(
       input: { symbols: batch },
       idempotency_key:
         batches.length === 1
-          ? `midas-net-worth:quotes:window:${ctx.window.id}`
-          : `midas-net-worth:quotes:window:${ctx.window.id}:batch:${index + 1}`,
+          ? `${MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX}:quotes:window:${ctx.window.id}`
+          : `${MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX}:quotes:window:${ctx.window.id}:batch:${index + 1}`,
       behavior_source: behaviorSource,
     });
     if (operation.status !== "completed") {
@@ -541,7 +545,7 @@ export default async function runNetWorthSnapshot(
     payload_type: "markdown",
     metadata: snapshot as unknown as Record<string, unknown>,
     occurred_at: snapshot.calculated_at,
-    idempotency_key: `midas-net-worth:snapshot:window:${ctx.window.id}`,
+    idempotency_key: `${MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX}:snapshot:window:${ctx.window.id}`,
     behavior_source: behaviorSource,
   });
   const persistedSnapshot = saved.created
@@ -550,7 +554,7 @@ export default async function runNetWorthSnapshot(
   await client.notifications.send({
     title: "Midas net worth updated",
     body: snapshotDigest(persistedSnapshot).slice(0, 1_000),
-    idempotency_key: `midas-net-worth:notification:window:${ctx.window.id}`,
+    idempotency_key: `${MIDAS_NET_WORTH_IDEMPOTENCY_PREFIX}:notification:window:${ctx.window.id}`,
     behavior_source: behaviorSource,
   });
 }


### PR DESCRIPTION
## Summary
- Namespace quote, snapshot, notification, and attention idempotency keys by snapshot schema version.
- Prevent a v2 reaction replay from reusing persisted v1 metadata for the same weekly Behavior window.

## Test plan
- [x] Intended files staged explicitly, then make pre-pr-remote clean (full Linux CI graph on Depot)
- [x] Tests run: bun test examples/personal-agent/__tests__/net-worth.reaction.test.ts (7 pass)
- [x] Bug fix: red→fix→green outputs pasted below

### Red
Expected midas-net-worth:v2:quotes:window:91; received midas-net-worth:quotes:window:91.
6 pass, 1 fail.

### Green
7 pass, 0 fail, 21 assertions.
Full Depot run 7934bhm5gm passed all 16 Linux CI jobs (18 matrix jobs).

## Notes
Production E2E exposed the collision safely: the v2 reaction executed, but knowledge.save replayed the existing v1 snapshot for the same weekly window. No schema or API changes.
