### PR TITLE
fix(server): count connection-scoped MCP operations on get/list

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
@@ -344,6 +344,55 @@ describe('OAuth-protected MCP connector installation', () => {
         }),
       ])
     );
+
+    const expectedSummary = {
+      total: 2,
+      reads: 1,
+      writes: 1,
+      mcp_tool: 2,
+    };
+
+    const got = (await manageConnections(
+      { action: 'get', connection_id: connectionId },
+      TEST_ENV,
+      ctx
+    )) as {
+      connection: {
+        has_operations: boolean;
+        operations_summary: Record<string, number>;
+      };
+    };
+    expect(got.connection.has_operations).toBe(true);
+    expect(got.connection.operations_summary).toMatchObject(expectedSummary);
+
+    const listed = (await manageConnections(
+      { action: 'list', connector_key: 'mcp.mcp-example-com' },
+      TEST_ENV,
+      ctx
+    )) as {
+      connections: Array<{
+        has_operations: boolean;
+        operations_summary: Record<string, number>;
+      }>;
+    };
+    expect(listed.connections).toHaveLength(1);
+    expect(listed.connections[0].has_operations).toBe(true);
+    expect(listed.connections[0].operations_summary).toMatchObject(expectedSummary);
+
+    const groups = (await manageConnections(
+      { action: 'list_connector_groups' },
+      TEST_ENV,
+      ctx
+    )) as {
+      groups: Array<{
+        connector_key: string;
+        facets: { actions: boolean };
+      }>;
+    };
+    expect(
+      groups.groups.find((group) => group.connector_key === 'mcp.mcp-example-com')
+        ?.facets.actions
+    ).toBe(true);
   });
 
   it('installs a managed MCP manifest from trusted source without registering a local OAuth client', async () => {

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -778,23 +778,35 @@ function summarizeOperations(
 export async function getOperationsSummary(
 	organizationId: string,
 	connectorKey: string,
+	connectionId?: number,
 ): Promise<OperationsSummary> {
-	const { operations } = await listOperations({
+	const connectors = await getConnectorsForListing({
 		organizationId,
 		connectorKey,
-		includeInputSchema: false,
-		includeOutputSchema: false,
+		connectionId,
 	});
+	if (connectors.length === 0) return { ...EMPTY_SUMMARY };
+	const operations = await buildConnectorOperations(
+		connectors[0],
+		organizationId,
+		{ connectionId, tolerateMcpFailure: true },
+	);
 	return summarizeOperations(operations);
 }
 
 /**
- * Batch version — fetches all connectors for the org in a single DB query,
- * then builds summaries in parallel. Use this in list endpoints to avoid N+1.
+ * Connector-keyed summaries for catalog/group views. Fetches the org's
+ * definitions once, then builds summaries in parallel.
+ *
+ * OAuth-protected MCP tools are connection-scoped. Pass `connectionIdByKey`
+ * whenever the caller already has a connection so discovery uses that
+ * account's credentials instead of an unauthenticated probe. Per-row
+ * connection lists should use `getOperationsSummariesByConnection`.
  */
 export async function getOperationsSummaryBatch(
 	organizationId: string,
 	connectorKeys: string[],
+	connectionIdByKey?: ReadonlyMap<string, number>,
 ): Promise<Map<string, OperationsSummary>> {
 	if (connectorKeys.length === 0) return new Map();
 
@@ -806,7 +818,10 @@ export async function getOperationsSummaryBatch(
 			const operations = await buildConnectorOperations(
 				connector,
 				organizationId,
-				{ tolerateMcpFailure: true },
+				{
+					connectionId: connectionIdByKey?.get(connector.key),
+					tolerateMcpFailure: true,
+				},
 			);
 			return [connector.key, summarizeOperations(operations)] as const;
 		}),
@@ -818,4 +833,36 @@ export async function getOperationsSummaryBatch(
 		if (!result.has(key)) result.set(key, { ...EMPTY_SUMMARY });
 	}
 	return result;
+}
+
+/**
+ * Per-connection summaries. Remote MCP catalogs can differ by account, so
+ * list/get must not collapse two connections of the same connector key.
+ */
+export async function getOperationsSummariesByConnection(
+	organizationId: string,
+	connections: Array<{ id: number; connectorKey: string }>,
+): Promise<Map<number, OperationsSummary>> {
+	if (connections.length === 0) return new Map();
+
+	const connectors = await getConnectorsForListing({ organizationId });
+	const byKey = new Map(connectors.map((connector) => [connector.key, connector]));
+
+	const entries = await Promise.all(
+		connections.map(async (connection) => {
+			const connector = byKey.get(connection.connectorKey);
+			if (!connector) return [connection.id, { ...EMPTY_SUMMARY }] as const;
+			const operations = await buildConnectorOperations(
+				connector,
+				organizationId,
+				{
+					connectionId: connection.id,
+					tolerateMcpFailure: true,
+				},
+			);
+			return [connection.id, summarizeOperations(operations)] as const;
+		}),
+	);
+
+	return new Map(entries);
 }

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -647,9 +647,14 @@ export async function publicRestGetConnector(c: Context<{ Bindings: Env }>) {
       ORDER BY COALESCE(f.updated_at, f.created_at) DESC
     `;
 
+		const firstConnectionId = (feeds as Array<{ connection_id?: unknown }>)
+			.map((feed) => Number(feed.connection_id))
+			.find((id) => Number.isFinite(id) && id > 0);
+
 		const operationsSummary = await getOperationsSummary(
 			organizationId,
-			connector.key
+			connector.key,
+			firstConnectionId,
 		);
 
 		return {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../../gateway/connections/chat-connection-service";
 import {
   EMPTY_SUMMARY,
+  getOperationsSummariesByConnection,
   getOperationsSummary,
   getOperationsSummaryBatch,
 } from "../../../../operations/connector-operations";
@@ -225,9 +226,17 @@ export async function handleListConnectorGroups(
 
   const rows = await query;
   const connectorKeys = [...new Set(rows.map((r) => String(r.connector_key)))];
+  const connectionIdByKey = new Map<string, number>();
+  for (const row of rows) {
+    const connectorKey = String(row.connector_key);
+    if (connectionIdByKey.has(connectorKey)) continue;
+    const firstConnection = mapConnectorGroupSummaries(row.connections)[0];
+    if (firstConnection) connectionIdByKey.set(connectorKey, firstConnection.id);
+  }
 	const opsSummaries = await getOperationsSummaryBatch(
 		organizationId,
 		connectorKeys,
+		connectionIdByKey,
 	);
 
   const groups = rows.map((row) => {
@@ -380,9 +389,12 @@ export async function handleList(
 	const connectorKeys = [
 		...new Set(resolved.map((r) => String(r.connector_key))),
 	];
-	const summaries = await getOperationsSummaryBatch(
+	const summaries = await getOperationsSummariesByConnection(
 		organizationId,
-		connectorKeys,
+		resolved.map((r) => ({
+			id: Number(r.id),
+			connectorKey: String(r.connector_key),
+		})),
 	);
 	// `SELECT c.*` carries the raw `config` jsonb, which is written verbatim
 	// (split by feed scope, never by secrecy). Resolve each connector's
@@ -393,7 +405,7 @@ export async function handleList(
 	);
 
   const connections = resolved.map((row) => {
-		const operationsSummary = summaries.get(String(row.connector_key)) ?? {
+		const operationsSummary = summaries.get(Number(row.id)) ?? {
 			...EMPTY_SUMMARY,
 		};
     const hasOperations = operationsSummary.total > 0;
@@ -548,6 +560,7 @@ export async function handleGet(
   const operationsSummary = await getOperationsSummary(
     organizationId,
 		String((resolved as any).connector_key),
+		args.connection_id,
   );
 
   const getRow = resolved as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- `manage_connections.get` / `list` summarized MCP tools by connector key with no credentials, so an authenticated Rovo connection reported `has_operations: false` while live `list_available` executed all 40 tools.
- Pass the connection id into discovery for get, list, connector groups, and the public connector page. Remote MCP catalogs stay account-scoped.
- Does not replace the built-in `jira` connector. Prod still has both `jira` (`jira-buremba`) and `mcp.mcp-atlassian-com` (`atlassian-rovo-mcp`).

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `swg2rhzm7s`)
- [x] Tests run: targeted `bunx vitest run src/__tests__/integration/connectors/mcp-oauth-install.test.ts` (red→green) plus `connections-config-redaction.test.ts` and `operations-execute-backends.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

## Red → green

**Red** (before the fix, same OAuth MCP install test):

```
expected false to be true
❯ mcp-oauth-install.test.ts:365:43
  expect(got.connection.has_operations).toBe(true);
```

Live prod still shows the same gap on `atlassian-rovo-mcp` (505):

```
has_operations: false
operations_summary: { total: 0, reads: 0, writes: 0, mcp_tool: 0 }
```

while `list_available` on that connection returns 40 ready operations.

**Green** after passing `connection_id` into discovery:

```
✓ mcp-oauth-install.test.ts (2 tests)
✓ connections-config-redaction.test.ts (20 tests)
✓ operations-execute-backends.test.ts (20 tests)
```

## Notes
`make review-fix` could not run: Codex usage limit until 2026-08-18.