### PR TITLE
fix(examples): pre-approve digest completion

### DIFF
--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -54,7 +54,11 @@ describe("Lobu Team configuration", () => {
     });
     expect(digest?.agent).toMatchObject({
       id: "product-ops",
-      tools: { allowed: [], strict: true },
+      tools: {
+        allowed: [],
+        strict: true,
+        preApproved: ["/mcp/lobu-memory/tools/run_sdk"],
+      },
     });
     expect(digest?.reaction).toMatchObject({
       kind: "reactionSource",

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -183,7 +183,15 @@ const productOps = defineAgent({
   description:
     "Summarizes Lobu production activity from organization-owned read-only feeds",
   providers: [{ id: "qwen", model: "qwen3.8-max" }],
-  tools: { allowed: [], strict: true },
+  tools: {
+    // Keep the headless lockdown (no native worker tools) and pre-approve the
+    // one MCP write the Behavior needs: run_sdk carries completeWindow, is not
+    // read-only, and would otherwise stall an unattended run on an approval
+    // card. query_sdk is readOnlyHint and needs no grant.
+    allowed: [],
+    strict: true,
+    preApproved: ["/mcp/lobu-memory/tools/run_sdk"],
+  },
 });
 
 // Reuse the Lobu Team read-only database credentials already stored in Lobu.


### PR DESCRIPTION
## Summary
- keep the Lobu Team product agent locked out of native worker tools
- pre-approve only `/mcp/lobu-memory/tools/run_sdk`, which carries the headless `completeWindow` call
- keep the fix entirely in `examples/lobu-team`

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (18 Depot jobs, run `5l0ch0clj3`)
- [x] Targeted tests: `bun test examples/lobu-team/__tests__/lobu-team.config.test.ts examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts` (7 pass)
- [x] Bug fix: red→fix→green outputs below

### Red

```text
Behavior run 936621 failed after the first fix was applied:
Behavior run blocked on tool approval after 2 attempt(s): lobu-memory/run_sdk queued for human approval, so complete_window never ran.
```

### Green

```text
7 pass, 0 fail, 32 expect() calls
```

## Notes
The earlier deny-all policy and this grant are orthogonal: strict mode prevents native worker tools; this exact MCP grant prevents the unattended completion protocol from stalling on an approval card. No runtime/core, database, API, or SDK changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Strengthened tool access controls for product activity digests.
  - Required operations now use explicit approval while all other tools remain restricted.
  - Improved consistency and reliability when completing activity digest windows.
- **Tests**
  - Updated coverage to verify strict tool enforcement and approved operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->