### PR TITLE
feat(server): give Atlassian Rovo MCP the Jira virtual issues feed

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/mcp-oauth-install.test.ts
@@ -395,6 +395,84 @@ describe('OAuth-protected MCP connector installation', () => {
     ).toBe(true);
   });
 
+  it('stamps the Jira virtual issues feed onto an Atlassian Rovo MCP install', async () => {
+    const atlassianUrl = 'https://mcp.atlassian.com/v1/mcp';
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href === atlassianUrl) {
+        return new Response(JSON.stringify({ error: 'invalid_token' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+      if (href === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: atlassianUrl,
+          authorization_servers: [authorizationServer],
+          scopes_supported: ['read:jira-work', 'write:jira-work', 'offline_access'],
+        });
+      }
+      if (href === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer: authorizationServer,
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+          registration_endpoint: registrationUrl,
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      if (href === registrationUrl) {
+        return jsonResponse({
+          client_id: 'atlassian-mcp-client',
+          token_endpoint_auth_method: 'none',
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href} ${init?.method ?? ''}`);
+    }) as typeof fetch;
+
+    const { org, ctx } = await seedOwnerContext({
+      orgName: 'Atlassian MCP Feed Org',
+      userName: 'Atlassian MCP Feed Owner',
+    });
+    process.env.PUBLIC_GATEWAY_URL = 'https://gateway.test';
+    __resetPublicOriginCachesForTests();
+    ctx.baseUrl = 'https://gateway.test';
+
+    const installed = await manageConnections(
+      { action: 'install_connector', mcp_url: atlassianUrl },
+      TEST_ENV,
+      ctx
+    );
+    expect(installed).toMatchObject({
+      action: 'install_connector',
+      installed: true,
+      connector_key: 'mcp.mcp-atlassian-com',
+    });
+
+    const sql = getTestDb();
+    const [definition] = (await sql`
+      SELECT feeds_schema, mcp_config
+      FROM connector_definitions
+      WHERE organization_id = ${org.id}
+        AND key = 'mcp.mcp-atlassian-com'
+        AND status = 'active'
+    `) as Array<{
+      feeds_schema: Record<string, unknown> | null;
+      mcp_config: Record<string, unknown>;
+    }>;
+    expect(definition.mcp_config).toEqual({
+      upstream_url: atlassianUrl,
+      tool_prefix: 'mcp_atlassian_com',
+    });
+    expect(definition.feeds_schema).toMatchObject({
+      issues: { key: 'issues', virtual: true },
+    });
+  });
+
   it('installs a managed MCP manifest from trusted source without registering a local OAuth client', async () => {
     const { org, ctx } = await seedOwnerContext({
       orgName: 'Managed MCP Clone Org',

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
@@ -1,0 +1,101 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+
+const calls: Array<{
+	tool: string;
+	args: Record<string, unknown>;
+}> = [];
+
+mock.module("../../mcp-proxy/client", () => ({
+	callTool: async (
+		_connectorKey: string,
+		_config: unknown,
+		_orgId: string,
+		toolName: string,
+		toolArgs: Record<string, unknown>,
+	) => {
+		calls.push({ tool: toolName, args: toolArgs });
+		if (toolName === "getAccessibleAtlassianResources") {
+			return {
+				isError: false,
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify([{ id: "cloud-1", url: "https://acme.atlassian.net" }]),
+					},
+				],
+			};
+		}
+		const token = typeof toolArgs.nextPageToken === "string" ? toolArgs.nextPageToken : undefined;
+		if (!token) {
+			return {
+				isError: false,
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({
+							issues: [
+								{ id: "1", key: "KAN-1", summary: "one" },
+								{ id: "2", key: "KAN-2", summary: "two" },
+							],
+							nextPageToken: "page-2",
+						}),
+					},
+				],
+			};
+		}
+		return {
+			isError: false,
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						issues: [
+							{ id: "3", key: "KAN-3", summary: "three" },
+							{ id: "4", key: "KAN-4", summary: "four" },
+						],
+					}),
+				},
+			],
+		};
+	},
+}));
+
+let readAtlassianMcpVirtualFeed: typeof import("../../operations/atlassian-mcp-feed").readAtlassianMcpVirtualFeed;
+
+beforeAll(async () => {
+	({ readAtlassianMcpVirtualFeed } = await import("../../operations/atlassian-mcp-feed"));
+});
+
+describe("readAtlassianMcpVirtualFeed", () => {
+	it("pages with nextPageToken and windows offset/limit across pages", async () => {
+		calls.length = 0;
+		const result = await readAtlassianMcpVirtualFeed({
+			organizationId: "org-1",
+			connectionId: 505,
+			connectorKey: "mcp.mcp-atlassian-com",
+			mcpConfig: {
+				upstream_url: "https://mcp.atlassian.com/v1/mcp",
+				tool_prefix: "mcp_atlassian_com",
+			},
+			feedConfig: {},
+			connectionConfig: {},
+			query: "project = KAN",
+			offset: 2,
+			limit: 2,
+		});
+
+		expect(calls.map((call) => call.tool)).toEqual([
+			"getAccessibleAtlassianResources",
+			"searchJiraIssuesUsingJql",
+			"searchJiraIssuesUsingJql",
+		]);
+		expect(calls[1].args).toMatchObject({
+			cloudId: "cloud-1",
+			jql: "project = KAN ORDER BY updated DESC",
+			maxResults: 2,
+		});
+		expect(calls[1].args.nextPageToken).toBeUndefined();
+		expect(calls[2].args.nextPageToken).toBe("page-2");
+		expect(result.rows.map((row) => row.key)).toEqual(["KAN-3", "KAN-4"]);
+	});
+});

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import {
+	ATLASSIAN_MCP_FEEDS,
+	buildAtlassianMcpJql,
+	isAtlassianMcpUrl,
+	parseAtlassianCloudId,
+	parseAtlassianMcpIssues,
+} from "../../operations/atlassian-mcp-feed";
+
+describe("Atlassian MCP virtual feed helpers", () => {
+	it("recognizes the Rovo MCP host and ignores other MCP URLs", () => {
+		expect(isAtlassianMcpUrl("https://mcp.atlassian.com/v1/mcp")).toBe(true);
+		expect(isAtlassianMcpUrl("https://mcp.example.com/rpc")).toBe(false);
+	});
+
+	it("declares the same virtual issues feed the bundled Jira connector uses", () => {
+		expect(ATLASSIAN_MCP_FEEDS.issues.key).toBe("issues");
+		expect(ATLASSIAN_MCP_FEEDS.issues.virtual).toBe(true);
+	});
+
+	it("builds bounded JQL and AND-composes recall terms", () => {
+		expect(buildAtlassianMcpJql({ baseQuery: "" })).toBe(
+			"updated >= -90d ORDER BY updated DESC",
+		);
+		expect(
+			buildAtlassianMcpJql({
+				baseQuery: "project = KAN",
+				terms: ["timeout"],
+			}),
+		).toBe('(project = KAN) AND (text ~ "timeout") ORDER BY updated DESC');
+	});
+
+	it("maps REST-shaped and flattened MCP issue payloads onto the Jira row", () => {
+		const rows = parseAtlassianMcpIssues({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						issues: [
+							{
+								id: "10001",
+								key: "KAN-1",
+								fields: {
+									summary: "Verify feed",
+									status: { name: "To Do" },
+									assignee: { displayName: "Ada" },
+									labels: ["e2e"],
+								},
+							},
+							{
+								id: "10002",
+								key: "KAN-2",
+								summary: "Flat issue",
+								status: "Done",
+							},
+						],
+					}),
+				},
+			],
+		});
+		expect(rows).toEqual([
+			expect.objectContaining({
+				id: "10001",
+				key: "KAN-1",
+				summary: "Verify feed",
+				status: "To Do",
+				assignee: "Ada",
+				labels: "e2e",
+			}),
+			expect.objectContaining({
+				id: "10002",
+				key: "KAN-2",
+				summary: "Flat issue",
+				status: "Done",
+			}),
+		]);
+	});
+
+	it("reads a cloud id out of accessible-resources MCP text", () => {
+		expect(
+			parseAtlassianCloudId({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify([
+							{ id: "49140293-40ce-45b6-8cdc-ec4e1356a7c8", url: "https://acme.atlassian.net" },
+						]),
+					},
+				],
+			}),
+		).toBe("49140293-40ce-45b6-8cdc-ec4e1356a7c8");
+	});
+});

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
@@ -5,6 +5,7 @@ import {
 	isAtlassianMcpUrl,
 	parseAtlassianCloudId,
 	parseAtlassianMcpIssues,
+	parseAtlassianMcpNextPageToken,
 } from "../../operations/atlassian-mcp-feed";
 
 describe("Atlassian MCP virtual feed helpers", () => {
@@ -74,6 +75,22 @@ describe("Atlassian MCP virtual feed helpers", () => {
 				status: "Done",
 			}),
 		]);
+	});
+
+	it("reads nextPageToken out of an MCP tools/call payload", () => {
+		expect(
+			parseAtlassianMcpNextPageToken({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({
+							issues: [{ id: "1", key: "KAN-1" }],
+							nextPageToken: "cursor-2",
+						}),
+					},
+				],
+			}),
+		).toBe("cursor-2");
 	});
 
 	it("reads a cloud id out of accessible-resources MCP text", () => {

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -30,6 +30,10 @@ import {
 } from "../utils/ensure-connector-installed";
 import logger from "../utils/logger";
 import { listCatalogEntries } from "./load";
+import {
+	ATLASSIAN_MCP_FEEDS,
+	isAtlassianMcpUrl,
+} from "../operations/atlassian-mcp-feed";
 
 type AuthSchema =
 	| { methods?: Array<Record<string, unknown>> }
@@ -289,7 +293,7 @@ export async function installConnectorFromMcpUrl(params: {
 		version: probed.serverInfo.version || "0.0.0",
 		authSchema,
 		webhook: null,
-		feeds: null,
+		feeds: isAtlassianMcpUrl(params.mcpUrl) ? ATLASSIAN_MCP_FEEDS : null,
 		actions: null,
 		behaviorEvents: null,
 		optionsSchema: null,

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -45,6 +45,7 @@ import { mergeOAuthScopeAuthData, normalizeScopeList } from '../auth/oauth/scope
 import { createSyncRun, describeSyncRunSkip } from '../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { buildConnectionsUrl, getOrganizationSlug, getPublicWebUrl } from '../utils/url-builder';
+import { isAtlassianMcpConfig } from '../operations/atlassian-mcp-feed';
 import {
   jiraSiteConfigPatch,
   resolveJiraCloudSite,
@@ -735,7 +736,18 @@ async function handleOAuthCallback(
   // discovery failure or a multi-site grant does not fail OAuth; an ambiguous
   // connection must set config.cloud_id before its first Jira read.
   let jiraSite: JiraCloudSite | null = null;
-  if (tokenRow.connector_key === 'jira') {
+  const [mcpDefinition] = (await sql`
+    SELECT mcp_config
+    FROM connector_definitions
+    WHERE key = ${tokenRow.connector_key}
+      AND organization_id = ${tokenRow.organization_id}
+      AND status = 'active'
+    LIMIT 1
+  `) as Array<{ mcp_config: Record<string, unknown> | null }>;
+  if (
+    tokenRow.connector_key === 'jira' ||
+    isAtlassianMcpConfig(mcpDefinition?.mcp_config)
+  ) {
     jiraSite = await resolveJiraCloudSite(tokens.accessToken);
     if (jiraSite) {
       logger.info(

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -15,6 +15,11 @@ import { dbEgressConfig } from '../utils/cloud-mode';
 import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCodeForKey } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
+import {
+  isAtlassianMcpConfig,
+  normalizeMcpProxyConfig,
+  readAtlassianMcpVirtualFeed,
+} from '../operations/atlassian-mcp-feed';
 
 interface ConnectorQueryParams {
   /** The ACL gate — tenant + principal. Its `organizationId`/`principal` drive
@@ -178,9 +183,19 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
     `SELECT f.id, f.feed_key, f.config, f.virtual,
             c.id AS connection_id, c.connector_key,
             c.auth_profile_id, c.app_auth_profile_id,
-            COALESCE(c.config, '{}'::jsonb) AS connection_config
+            COALESCE(c.config, '{}'::jsonb) AS connection_config,
+            cd.mcp_config
      FROM feeds f
      JOIN connections c ON c.id = f.connection_id
+     LEFT JOIN LATERAL (
+       SELECT mcp_config
+       FROM connector_definitions
+       WHERE key = c.connector_key
+         AND status = 'active'
+         AND organization_id = $2
+       ORDER BY updated_at DESC
+       LIMIT 1
+     ) cd ON TRUE
      WHERE f.id = $1
        AND f.organization_id = $2
        AND f.deleted_at IS NULL
@@ -200,6 +215,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
     auth_profile_id: number | null;
     app_auth_profile_id: number | null;
     connection_config: Record<string, unknown>;
+    mcp_config: Record<string, unknown> | null;
   }>;
 
   if (feedRows.length === 0) {
@@ -215,6 +231,25 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
 
   // Execution-time cloud gate, identical to the slug pushdown above.
   assertConnectorAllowedInCloud(feed.connector_key);
+
+  const mcpConfig = isAtlassianMcpConfig(feed.mcp_config)
+    ? normalizeMcpProxyConfig(feed.mcp_config)
+    : null;
+  if (mcpConfig) {
+    return readAtlassianMcpVirtualFeed({
+      organizationId: p.scope.organizationId,
+      connectionId: Number(feed.connection_id),
+      connectorKey: feed.connector_key,
+      mcpConfig,
+      feedConfig,
+      connectionConfig: feed.connection_config,
+      query: storedQuery || (typeof feedConfig.jql === 'string' ? feedConfig.jql : ''),
+      terms: p.terms,
+      limit: p.limit,
+      offset: p.offset,
+      sort: p.sort,
+    });
+  }
 
   const compiledCode = await resolveConnectorCodeForKey(
     feed.connector_key,

--- a/packages/server/src/operations/atlassian-mcp-feed.ts
+++ b/packages/server/src/operations/atlassian-mcp-feed.ts
@@ -1,0 +1,490 @@
+/**
+ * Atlassian Rovo MCP virtual-feed adapter.
+ *
+ * MCP install is tools-only (`feeds: null`). Rovo already exposes
+ * `searchJiraIssuesUsingJql`, the same primitive the bundled Jira virtual
+ * feed uses. This module stamps that feed onto an Atlassian MCP definition
+ * and reads it through the existing MCP proxy — no second connector, no
+ * approval-gated manage_operations execute.
+ */
+
+import { callTool } from "../mcp-proxy/client";
+import type { McpProxyConfig } from "../mcp-proxy/types";
+
+export const ATLASSIAN_JIRA_ISSUES_FEED_KEY = "issues";
+
+export const ATLASSIAN_JIRA_ISSUE_COLUMNS = [
+	{ name: "id", type: "string" },
+	{ name: "key", type: "string" },
+	{ name: "summary", type: "string" },
+	{ name: "status", type: "string" },
+	{ name: "assignee", type: "string" },
+	{ name: "reporter", type: "string" },
+	{ name: "priority", type: "string" },
+	{ name: "project_key", type: "string" },
+	{ name: "project_name", type: "string" },
+	{ name: "labels", type: "string" },
+	{ name: "created_at", type: "string" },
+	{ name: "updated_at", type: "string" },
+	{ name: "description", type: "string" },
+	{ name: "url", type: "string" },
+] as const;
+
+/** Same issues feed the bundled Jira connector declares. */
+export const ATLASSIAN_MCP_FEEDS = {
+	issues: {
+		key: ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+		name: "Issues",
+		description:
+			"Live Jira issues via JQL (virtual by default); collected sync remains available when explicitly requested.",
+		virtual: true,
+		configSchema: {
+			type: "object",
+			properties: {
+				cloud_id: {
+					type: "string",
+					description:
+						"Atlassian Cloud id (usually auto-set on the connection after OAuth). Optional feed-level override for multi-site tokens.",
+				},
+				query: {
+					type: "string",
+					description:
+						"Base JQL for virtual reads (platform config.query). Empty defaults to updated >= -90d.",
+				},
+				jql: {
+					type: "string",
+					description:
+						"Legacy JQL filter (collected sync + fallback when query is unset). Defaults to recently-updated issues on sync.",
+				},
+				lookback_days: {
+					type: "integer",
+					minimum: 1,
+					maximum: 730,
+					default: 365,
+					description: "Collected-sync lookback window when jql/query is unset.",
+				},
+				max_results: {
+					type: "integer",
+					minimum: 1,
+					maximum: 100,
+					description:
+						"Optional cap on issues returned per virtual-feed read. The uncapped default request size is 50.",
+				},
+			},
+		},
+		eventKinds: {
+			issue: {
+				description: "A Jira issue",
+				metadataSchema: {
+					type: "object",
+					properties: {
+						key: { type: "string" },
+						status: { type: "string" },
+						assignee: { type: "string" },
+						reporter: { type: "string" },
+						updated_at: { type: "string" },
+					},
+				},
+			},
+			comment: {
+				description: "A comment on a Jira issue",
+				metadataSchema: {
+					type: "object",
+					properties: {
+						updated_at: { type: "string" },
+					},
+				},
+			},
+		},
+	},
+};
+
+const SORT_COLUMNS: Record<string, string> = {
+	updated: "updated",
+	updated_at: "updated",
+	created: "created",
+	created_at: "created",
+	key: "key",
+	priority: "priority",
+	status: "status",
+};
+
+export function isAtlassianMcpUrl(url: string | null | undefined): boolean {
+	if (!url) return false;
+	try {
+		const host = new URL(url).hostname.toLowerCase();
+		return host === "mcp.atlassian.com" || host.endsWith(".mcp.atlassian.com");
+	} catch {
+		return false;
+	}
+}
+
+export function isAtlassianMcpConfig(
+	raw: Record<string, unknown> | null | undefined,
+): raw is Record<string, unknown> & { upstream_url: string } {
+	if (!raw) return false;
+	const upstream =
+		typeof raw.upstream_url === "string"
+			? raw.upstream_url
+			: typeof raw.upstreamUrl === "string"
+				? raw.upstreamUrl
+				: null;
+	return isAtlassianMcpUrl(upstream);
+}
+
+export function normalizeMcpProxyConfig(
+	raw: Record<string, unknown>,
+): McpProxyConfig | null {
+	const upstream =
+		typeof raw.upstream_url === "string"
+			? raw.upstream_url
+			: typeof raw.upstreamUrl === "string"
+				? raw.upstreamUrl
+				: null;
+	if (!upstream) return null;
+	return {
+		upstream_url: upstream,
+		tool_prefix:
+			typeof raw.tool_prefix === "string"
+				? raw.tool_prefix
+				: typeof raw.toolPrefix === "string"
+					? raw.toolPrefix
+					: "",
+	};
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function actorName(user: unknown): string | undefined {
+	if (!user || typeof user !== "object") {
+		return typeof user === "string" && user.trim() ? user.trim() : undefined;
+	}
+	const record = user as Record<string, unknown>;
+	return (
+		asString(record.displayName) ??
+		asString(record.emailAddress) ??
+		asString(record.name)
+	);
+}
+
+function namedField(value: unknown): string | undefined {
+	if (typeof value === "string") return asString(value);
+	if (!value || typeof value !== "object") return undefined;
+	return asString((value as Record<string, unknown>).name);
+}
+
+function adfToText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!value || typeof value !== "object") return "";
+	const node = value as { type?: string; text?: string; content?: unknown[] };
+	if (node.type === "hardBreak") return "\n";
+	if (typeof node.text === "string") return node.text;
+	if (Array.isArray(node.content)) {
+		return node.content.map((child) => adfToText(child)).join("").trim();
+	}
+	return "";
+}
+
+function escapeJqlString(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function splitTrailingOrderBy(jql: string): { body: string; orderBy: string | null } {
+	let quote: '"' | "'" | null = null;
+	let escaped = false;
+	let depth = 0;
+	for (let i = 0; i < jql.length; i += 1) {
+		const char = jql[i];
+		if (quote) {
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === quote) quote = null;
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			quote = char;
+			continue;
+		}
+		if (char === "(") {
+			depth += 1;
+			continue;
+		}
+		if (char === ")") {
+			depth = Math.max(0, depth - 1);
+			continue;
+		}
+		if (
+			depth === 0 &&
+			(i === 0 || /\s/.test(jql[i - 1])) &&
+			/^order\s+by\b/i.test(jql.slice(i))
+		) {
+			return { body: jql.slice(0, i).trim(), orderBy: jql.slice(i).trim() };
+		}
+	}
+	return { body: jql.trim(), orderBy: null };
+}
+
+export function buildAtlassianMcpJql(args: {
+	baseQuery: string;
+	terms?: string[];
+	sort?: { column: string; order: "asc" | "desc" };
+}): string {
+	const trimmed = args.baseQuery.trim();
+	const jql = trimmed.length > 0 ? trimmed : "updated >= -90d";
+	let { body, orderBy } = splitTrailingOrderBy(jql);
+	if (!body && orderBy) body = "updated >= -90d";
+
+	const terms = (args.terms ?? []).map((term) => term.trim()).filter(Boolean);
+	if (terms.length > 0) {
+		const textClauses = terms
+			.map((term) => `text ~ "${escapeJqlString(term)}"`)
+			.join(" AND ");
+		body = body.length > 0 ? `(${body}) AND (${textClauses})` : textClauses;
+	}
+
+	if (orderBy) {
+		if (args.sort) {
+			throw new Error(
+				"Jira virtual feed: cannot apply sort when the base JQL already contains ORDER BY",
+			);
+		}
+		return body.length > 0 ? `${body} ${orderBy}` : orderBy;
+	}
+
+	if (args.sort) {
+		const field = SORT_COLUMNS[args.sort.column];
+		if (!field) {
+			throw new Error(
+				`Jira virtual feed sort column '${args.sort.column}' is unsupported`,
+			);
+		}
+		const dir = args.sort.order === "asc" ? "ASC" : "DESC";
+		return body.length > 0
+			? `${body} ORDER BY ${field} ${dir}`
+			: `ORDER BY ${field} ${dir}`;
+	}
+
+	return body.length > 0
+		? `${body} ORDER BY updated DESC`
+		: "updated >= -90d ORDER BY updated DESC";
+}
+
+function issueUrl(
+	issue: Record<string, unknown>,
+	fields: Record<string, unknown>,
+	config: Record<string, unknown>,
+): string | undefined {
+	const key = asString(issue.key);
+	const siteUrl = asString(config.site_url);
+	const cloudId = asString(config.cloud_id);
+	const siteCloudId = asString(config.site_cloud_id);
+	if (siteUrl && key && cloudId && siteCloudId && cloudId === siteCloudId) {
+		return `${siteUrl.replace(/\/+$/, "")}/browse/${encodeURIComponent(key)}`;
+	}
+	return asString(issue.self) ?? asString(fields.url) ?? asString(issue.url);
+}
+
+export function mapAtlassianIssueToRow(
+	raw: unknown,
+	config: Record<string, unknown> = {},
+): Record<string, unknown> | null {
+	if (!raw || typeof raw !== "object") return null;
+	const issue = raw as Record<string, unknown>;
+	const fields =
+		issue.fields && typeof issue.fields === "object"
+			? (issue.fields as Record<string, unknown>)
+			: issue;
+	const id = asString(issue.id) ?? asString(issue.key) ?? asString(fields.id);
+	if (!id) return null;
+	const labelsRaw = fields.labels ?? issue.labels;
+	const labels = Array.isArray(labelsRaw)
+		? labelsRaw.filter((label): label is string => typeof label === "string").join(", ")
+		: asString(labelsRaw) ?? null;
+	return {
+		id,
+		key: asString(issue.key) ?? asString(fields.key) ?? null,
+		summary: asString(fields.summary) ?? asString(issue.summary) ?? null,
+		status: namedField(fields.status) ?? namedField(issue.status) ?? null,
+		assignee: actorName(fields.assignee ?? issue.assignee) ?? null,
+		reporter: actorName(fields.reporter ?? issue.reporter) ?? null,
+		priority: namedField(fields.priority) ?? namedField(issue.priority) ?? null,
+		project_key:
+			asString((fields.project as { key?: unknown } | undefined)?.key) ??
+			asString(fields.projectKey) ??
+			asString(issue.project_key) ??
+			null,
+		project_name:
+			asString((fields.project as { name?: unknown } | undefined)?.name) ??
+			asString(fields.projectName) ??
+			null,
+		labels,
+		created_at: asString(fields.created) ?? asString(issue.created) ?? null,
+		updated_at: asString(fields.updated) ?? asString(issue.updated) ?? null,
+		description:
+			adfToText(fields.description ?? issue.description) || null,
+		url: issueUrl(issue, fields, config) ?? null,
+	};
+}
+
+function tryParseJson(text: string): unknown {
+	const trimmed = text.trim();
+	if (!trimmed) return null;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		const start = trimmed.search(/[\[{]/);
+		if (start < 0) return null;
+		try {
+			return JSON.parse(trimmed.slice(start));
+		} catch {
+			return null;
+		}
+	}
+}
+
+function collectIssues(value: unknown, into: unknown[]): void {
+	if (!value) return;
+	if (Array.isArray(value)) {
+		for (const item of value) collectIssues(item, into);
+		return;
+	}
+	if (typeof value === "string") {
+		collectIssues(tryParseJson(value), into);
+		return;
+	}
+	if (typeof value !== "object") return;
+	const record = value as Record<string, unknown>;
+	if (record.type === "text" && typeof record.text === "string") {
+		collectIssues(tryParseJson(record.text), into);
+		return;
+	}
+	if (Array.isArray(record.issues)) {
+		into.push(...record.issues);
+		return;
+	}
+	if (Array.isArray(record.values)) {
+		into.push(...record.values);
+		return;
+	}
+	if (Array.isArray(record.content)) {
+		collectIssues(record.content, into);
+		return;
+	}
+	if (asString(record.id) || asString(record.key)) {
+		into.push(record);
+	}
+}
+
+export function parseAtlassianMcpIssues(
+	payload: unknown,
+	config: Record<string, unknown> = {},
+): Record<string, unknown>[] {
+	const collected: unknown[] = [];
+	collectIssues(payload, collected);
+	const rows: Record<string, unknown>[] = [];
+	for (const item of collected) {
+		const row = mapAtlassianIssueToRow(item, config);
+		if (row) rows.push(row);
+	}
+	return rows;
+}
+
+export function parseAtlassianCloudId(payload: unknown): string | undefined {
+	const collected: unknown[] = [];
+	collectIssues(payload, collected);
+	if (typeof payload === "object" && payload) collected.unshift(payload);
+	for (const item of collected) {
+		if (!item || typeof item !== "object") continue;
+		const record = item as Record<string, unknown>;
+		const id =
+			asString(record.id) ??
+			asString(record.cloudId) ??
+			asString(record.cloud_id);
+		if (id) return id;
+	}
+	if (typeof payload === "string") {
+		const parsed = tryParseJson(payload);
+		if (parsed !== payload) return parseAtlassianCloudId(parsed);
+	}
+	return undefined;
+}
+
+export async function readAtlassianMcpVirtualFeed(params: {
+	organizationId: string;
+	connectionId: number;
+	connectorKey: string;
+	mcpConfig: McpProxyConfig;
+	feedConfig: Record<string, unknown>;
+	connectionConfig: Record<string, unknown>;
+	query: string;
+	terms?: string[];
+	limit?: number;
+	offset?: number;
+	sort?: { column: string; order: "asc" | "desc" };
+}): Promise<{
+	rows: Record<string, unknown>[];
+	columns: { name: string; type: string }[];
+	total?: number;
+}> {
+	const config = { ...params.connectionConfig, ...params.feedConfig };
+	let cloudId = asString(config.cloud_id) ?? asString(config.cloudId);
+	if (!cloudId) {
+		const resources = await callTool(
+			params.connectorKey,
+			params.mcpConfig,
+			params.organizationId,
+			"getAccessibleAtlassianResources",
+			{},
+			params.connectionId,
+		);
+		if (resources.isError) {
+			throw new Error("Atlassian MCP did not return an accessible site for this connection");
+		}
+		cloudId = parseAtlassianCloudId(resources.content);
+	}
+	if (!cloudId) {
+		throw new Error(
+			"Jira virtual feed requires a cloud_id. Reconnect the Atlassian connection or set config.cloud_id.",
+		);
+	}
+
+	const jql = buildAtlassianMcpJql({
+		baseQuery: params.query,
+		terms: params.terms,
+		sort: params.sort,
+	});
+	const maxResults = Math.min(
+		100,
+		Math.max(1, Number(config.max_results) || params.limit || 50),
+	);
+
+	const result = await callTool(
+		params.connectorKey,
+		params.mcpConfig,
+		params.organizationId,
+		"searchJiraIssuesUsingJql",
+		{ cloudId, jql, maxResults },
+		params.connectionId,
+	);
+	if (result.isError) {
+		const text =
+			Array.isArray(result.content) &&
+			typeof (result.content[0] as { text?: string } | undefined)?.text ===
+				"string"
+				? (result.content[0] as { text: string }).text
+				: "searchJiraIssuesUsingJql failed";
+		throw new Error(text);
+	}
+
+	const rows = parseAtlassianMcpIssues(result.content, config);
+	const offset = Math.max(0, params.offset ?? 0);
+	const limit = params.limit ?? rows.length;
+	return {
+		rows: rows.slice(offset, offset + limit),
+		columns: [...ATLASSIAN_JIRA_ISSUE_COLUMNS],
+	};
+}

--- a/packages/server/src/operations/atlassian-mcp-feed.ts
+++ b/packages/server/src/operations/atlassian-mcp-feed.ts
@@ -36,7 +36,7 @@ export const ATLASSIAN_MCP_FEEDS = {
 		key: ATLASSIAN_JIRA_ISSUES_FEED_KEY,
 		name: "Issues",
 		description:
-			"Live Jira issues via JQL (virtual by default); collected sync remains available when explicitly requested.",
+			"Live Jira issues via JQL. Reads call Rovo searchJiraIssuesUsingJql; nothing is copied into events.",
 		virtual: true,
 		configSchema: {
 			type: "object",
@@ -54,14 +54,7 @@ export const ATLASSIAN_MCP_FEEDS = {
 				jql: {
 					type: "string",
 					description:
-						"Legacy JQL filter (collected sync + fallback when query is unset). Defaults to recently-updated issues on sync.",
-				},
-				lookback_days: {
-					type: "integer",
-					minimum: 1,
-					maximum: 730,
-					default: 365,
-					description: "Collected-sync lookback window when jql/query is unset.",
+						"Fallback JQL when query is unset (same as the bundled Jira feed).",
 				},
 				max_results: {
 					type: "integer",
@@ -393,6 +386,38 @@ export function parseAtlassianMcpIssues(
 	return rows;
 }
 
+export function parseAtlassianMcpNextPageToken(payload: unknown): string | undefined {
+	if (!payload) return undefined;
+	if (typeof payload === "string") {
+		return parseAtlassianMcpNextPageToken(tryParseJson(payload));
+	}
+	if (Array.isArray(payload)) {
+		for (const item of payload) {
+			const token = parseAtlassianMcpNextPageToken(item);
+			if (token) return token;
+		}
+		return undefined;
+	}
+	if (typeof payload !== "object") return undefined;
+	const record = payload as Record<string, unknown>;
+	if (record.type === "text" && typeof record.text === "string") {
+		return parseAtlassianMcpNextPageToken(tryParseJson(record.text));
+	}
+	return (
+		asString(record.nextPageToken) ??
+		asString(record.next_page_token) ??
+		parseAtlassianMcpNextPageToken(record.content)
+	);
+}
+
+function mcpTextError(content: unknown, fallback: string): string {
+	if (Array.isArray(content)) {
+		const text = (content[0] as { text?: string } | undefined)?.text;
+		if (typeof text === "string" && text.trim()) return text;
+	}
+	return fallback;
+}
+
 export function parseAtlassianCloudId(payload: unknown): string | undefined {
 	const collected: unknown[] = [];
 	collectIssues(payload, collected);
@@ -457,32 +482,42 @@ export async function readAtlassianMcpVirtualFeed(params: {
 		terms: params.terms,
 		sort: params.sort,
 	});
-	const maxResults = Math.min(
+	const offset = Math.max(0, params.offset ?? 0);
+	const limit = Math.max(1, params.limit ?? 50);
+	const pageSize = Math.min(
 		100,
-		Math.max(1, Number(config.max_results) || params.limit || 50),
+		Math.max(1, Number(config.max_results) || Math.min(limit, 50)),
 	);
+	const needed = offset + limit;
+	const rows: Record<string, unknown>[] = [];
+	let nextPageToken: string | undefined;
 
-	const result = await callTool(
-		params.connectorKey,
-		params.mcpConfig,
-		params.organizationId,
-		"searchJiraIssuesUsingJql",
-		{ cloudId, jql, maxResults },
-		params.connectionId,
-	);
-	if (result.isError) {
-		const text =
-			Array.isArray(result.content) &&
-			typeof (result.content[0] as { text?: string } | undefined)?.text ===
-				"string"
-				? (result.content[0] as { text: string }).text
-				: "searchJiraIssuesUsingJql failed";
-		throw new Error(text);
+	// Walk Rovo pages until the requested window is filled. Jira's token has
+	// no random access, so we fetch and discard the prefix — same as bundled
+	// jira liveSearch.
+	for (let page = 0; page < 20 && rows.length < needed; page += 1) {
+		const result = await callTool(
+			params.connectorKey,
+			params.mcpConfig,
+			params.organizationId,
+			"searchJiraIssuesUsingJql",
+			{
+				cloudId,
+				jql,
+				maxResults: pageSize,
+				...(nextPageToken ? { nextPageToken } : {}),
+			},
+			params.connectionId,
+		);
+		if (result.isError) {
+			throw new Error(mcpTextError(result.content, "searchJiraIssuesUsingJql failed"));
+		}
+		const pageRows = parseAtlassianMcpIssues(result.content, config);
+		rows.push(...pageRows);
+		nextPageToken = parseAtlassianMcpNextPageToken(result.content);
+		if (pageRows.length === 0 || !nextPageToken) break;
 	}
 
-	const rows = parseAtlassianMcpIssues(result.content, config);
-	const offset = Math.max(0, params.offset ?? 0);
-	const limit = params.limit ?? rows.length;
 	return {
 		rows: rows.slice(offset, offset + limit),
 		columns: [...ATLASSIAN_JIRA_ISSUE_COLUMNS],

--- a/packages/server/src/operations/atlassian-mcp-feed.ts
+++ b/packages/server/src/operations/atlassian-mcp-feed.ts
@@ -61,7 +61,7 @@ export const ATLASSIAN_MCP_FEEDS = {
 					minimum: 1,
 					maximum: 100,
 					description:
-						"Optional cap on issues returned per virtual-feed read. The uncapped default request size is 50.",
+						"Page size per Rovo search request (default min(limit, 50), max 100).",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Rovo MCP already has `searchJiraIssuesUsingJql`. Install was leaving `feeds: null`, so we kept a second built-in `jira` connector just for the virtual issues feed.
- Stamp that same `issues` feed onto an Atlassian MCP install and read it through the existing MCP proxy (not approval-gated `manage_operations.execute`).
- Does not delete bundled `jira` yet. Webhooks still land on `/api/v1/app-webhooks/jira`. After this is live on `atlassian-rovo-mcp` (`505`) we move the existing virtual feed and then remove `jira`.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `wc36cvjn0r`)
- [x] Tests run: `bun test packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts` and `bunx vitest run src/__tests__/integration/connectors/mcp-oauth-install.test.ts`
- [x] Bug fix / feature: red→green for install stamp (`feeds_schema.issues.virtual === true` on `https://mcp.atlassian.com/v1/mcp`)
- [ ] Live: after deploy, reinstall the Rovo MCP definition, create `issues` on connection 505, read `KAN-1`, then delete `jira-buremba`

## Notes
`make review-fix` skipped: Codex usage limit. Reviewer should use `REVIEWER_CLI=claude`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to Atlassian Rovo MCP.
  * Added a virtual Jira Issues feed with filtering, sorting, pagination, and normalized issue details.
  * Automatically discovers Atlassian site information when needed during connection setup.

* **Bug Fixes**
  * Improved handling of Atlassian MCP configurations and issue responses.
  * Added validation for MCP errors and malformed data.

* **Tests**
  * Added integration and unit test coverage for Atlassian MCP installation, discovery, querying, and data parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->