### PR TITLE
fix(server): copy event lineage on supersede

### DIFF
--- a/packages/server/src/__tests__/integration/events/insert-event-lineage.test.ts
+++ b/packages/server/src/__tests__/integration/events/insert-event-lineage.test.ts
@@ -1,0 +1,467 @@
+/**
+ * A supersede is the next version of the same thing. Lineage is copied from
+ * the predecessor inside insertEvent — omit or null cannot drop it. A later
+ * number restamps this version's producer/run.
+ *
+ * Human canvas corrections keep the producer stamp and stay visible because
+ * self-exclusion excepts canvas_state + metadata.correction. Tombstones keep
+ * the stamp and stay hidden.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { supersedeActionEvent } from '../../../tools/admin/approval-events';
+import { TOMBSTONE_SEMANTIC_TYPE } from '../../../tools/constants';
+import { executeDataSources } from '../../../utils/execute-data-sources';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function insertBehavior(
+  organizationId: string,
+  userId: string,
+  slug: string
+): Promise<{ id: number; versionId: number }> {
+  const sql = getDb();
+  const [behavior] = await sql`
+    INSERT INTO watchers (
+      organization_id, created_by, watcher_group_id, name, slug, agent_id
+    ) VALUES (
+      ${organizationId}, ${userId}, 0, ${slug}, ${slug}, 'lineage-agent'
+    )
+    RETURNING id
+  `;
+  const id = Number(behavior.id);
+  await sql`UPDATE watchers SET watcher_group_id = ${id} WHERE id = ${id}`;
+  const [version] = await sql`
+    INSERT INTO watcher_versions (
+      watcher_id, version, name, created_by, prompt
+    ) VALUES (
+      ${id}, 1, ${slug}, ${userId}, 'prompt'
+    )
+    RETURNING id
+  `;
+  return { id, versionId: Number(version.id) };
+}
+
+async function insertRun(organizationId: string): Promise<number> {
+  const [row] = await getDb()`
+    INSERT INTO runs
+      (organization_id, run_type, status, approval_status, action_key, created_at)
+    VALUES
+      (${organizationId}, 'action', 'pending', 'pending', 'screenshot', NOW())
+    RETURNING id
+  `;
+  return Number((row as { id: number }).id);
+}
+
+async function insertFeed(
+  organizationId: string,
+  connectionId: number,
+  feedKey: string
+): Promise<number> {
+  const [row] = await getDb()`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, status, created_at, updated_at
+    ) VALUES (
+      ${organizationId}, ${connectionId}, ${feedKey}, 'active', NOW(), NOW()
+    )
+    RETURNING id
+  `;
+  return Number((row as { id: number }).id);
+}
+
+async function lineageOf(eventId: number): Promise<{
+  behavior_id: number | null;
+  behavior_version_id: number | null;
+  run_id: number | null;
+  connection_id: number | null;
+  connector_key: string | null;
+  feed_id: number | null;
+  feed_key: string | null;
+  identity_ns: string | null;
+  identity_key: string | null;
+  origin_parent_id: string | null;
+}> {
+  const [row] = await getDb()`
+    SELECT behavior_id, behavior_version_id, run_id, connection_id, connector_key,
+           feed_id, feed_key, identity_ns, identity_key, origin_parent_id
+    FROM events WHERE id = ${eventId}
+  `;
+  const r = row as Record<string, unknown>;
+  return {
+    behavior_id: r.behavior_id == null ? null : Number(r.behavior_id),
+    behavior_version_id:
+      r.behavior_version_id == null ? null : Number(r.behavior_version_id),
+    run_id: r.run_id == null ? null : Number(r.run_id),
+    connection_id: r.connection_id == null ? null : Number(r.connection_id),
+    connector_key: (r.connector_key as string | null) ?? null,
+    feed_id: r.feed_id == null ? null : Number(r.feed_id),
+    feed_key: (r.feed_key as string | null) ?? null,
+    identity_ns: (r.identity_ns as string | null) ?? null,
+    identity_key: (r.identity_key as string | null) ?? null,
+    origin_parent_id: (r.origin_parent_id as string | null) ?? null,
+  };
+}
+
+describe('insertEvent lineage on supersede', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('copies producer and source lineage even when the successor omits them', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const behavior = await insertBehavior(org.id, user.id, 'lineage-copy');
+    const runId = await insertRun(org.id);
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+    const feedId = await insertFeed(org.id, Number(connection.id), 'front');
+
+    const prior = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-root',
+      title: 'root',
+      content: 'root',
+      semanticType: 'observation',
+      connectorKey: 'reddit',
+      connectionId: Number(connection.id),
+      feedKey: 'front',
+      feedId,
+      runId,
+      behaviorId: behavior.id,
+      behaviorVersionId: behavior.versionId,
+      parentOriginId: 'parent-origin',
+      identity: { ns: 'test.lineage', key: 'thing-1' },
+    });
+
+    const next = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-next',
+      title: 'next',
+      content: 'next',
+      semanticType: 'observation',
+      supersedesEventId: Number(prior.id),
+    });
+
+    expect(await lineageOf(Number(next.id))).toEqual({
+      behavior_id: behavior.id,
+      behavior_version_id: behavior.versionId,
+      run_id: runId,
+      connection_id: Number(connection.id),
+      connector_key: 'reddit',
+      feed_id: feedId,
+      feed_key: 'front',
+      identity_ns: 'test.lineage',
+      identity_key: 'thing-1',
+      origin_parent_id: 'parent-origin',
+    });
+  });
+
+  it('keeps lineage when the successor explicitly passes nulls', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const behavior = await insertBehavior(org.id, user.id, 'lineage-nulls');
+    const runId = await insertRun(org.id);
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+    const feedId = await insertFeed(org.id, Number(connection.id), 'front');
+
+    const prior = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-nulls-root',
+      title: 'root',
+      content: 'root',
+      semanticType: 'observation',
+      connectorKey: 'reddit',
+      connectionId: Number(connection.id),
+      feedKey: 'front',
+      feedId,
+      runId,
+      behaviorId: behavior.id,
+      behaviorVersionId: behavior.versionId,
+      parentOriginId: 'parent-origin',
+      identity: { ns: 'test.lineage', key: 'thing-nulls' },
+    });
+
+    const next = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-nulls-next',
+      title: 'next',
+      content: 'next',
+      semanticType: 'observation',
+      behaviorId: null,
+      behaviorVersionId: null,
+      runId: null,
+      connectionId: null,
+      connectorKey: null,
+      feedId: null,
+      feedKey: null,
+      parentOriginId: null,
+      identity: null,
+      supersedesEventId: Number(prior.id),
+    });
+
+    expect(await lineageOf(Number(next.id))).toEqual({
+      behavior_id: behavior.id,
+      behavior_version_id: behavior.versionId,
+      run_id: runId,
+      connection_id: Number(connection.id),
+      connector_key: 'reddit',
+      feed_id: feedId,
+      feed_key: 'front',
+      identity_ns: 'test.lineage',
+      identity_key: 'thing-nulls',
+      origin_parent_id: 'parent-origin',
+    });
+  });
+
+  it('uses explicitly supplied attribution for the new stored version', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const firstBehavior = await insertBehavior(
+      org.id,
+      user.id,
+      'lineage-first-producer'
+    );
+    const nextBehavior = await insertBehavior(
+      org.id,
+      user.id,
+      'lineage-next-producer'
+    );
+    const firstRunId = await insertRun(org.id);
+    const nextRunId = await insertRun(org.id);
+
+    const prior = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-attribution-root',
+      title: 'root',
+      content: 'root',
+      semanticType: 'observation',
+      runId: firstRunId,
+      behaviorId: firstBehavior.id,
+      behaviorVersionId: firstBehavior.versionId,
+      parentOriginId: 'first-parent',
+    });
+
+    const next = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-attribution-next',
+      title: 'next',
+      content: 'next',
+      semanticType: 'observation',
+      runId: nextRunId,
+      behaviorId: nextBehavior.id,
+      behaviorVersionId: nextBehavior.versionId,
+      parentOriginId: 'next-parent',
+      supersedesEventId: Number(prior.id),
+    });
+
+    expect(await lineageOf(Number(next.id))).toMatchObject({
+      run_id: nextRunId,
+      behavior_id: nextBehavior.id,
+      behavior_version_id: nextBehavior.versionId,
+      origin_parent_id: 'next-parent',
+    });
+  });
+
+  it('does not re-supersede a copied-parent head on a parentless re-sync', async () => {
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+
+    const root = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId: 'lineage-resync',
+        title: 'item',
+        content: 'v1',
+        semanticType: 'observation',
+        connectorKey: 'reddit',
+        connectionId: Number(connection.id),
+        parentOriginId: 'resync-parent',
+      },
+      { onConflictUpdate: true }
+    );
+    expect(root.change).toBe('inserted');
+
+    // Content changed, parent omitted: supersedes and copies the parent.
+    const resyncParams = {
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'lineage-resync',
+      title: 'item',
+      content: 'v2',
+      semanticType: 'observation',
+      connectorKey: 'reddit',
+      connectionId: Number(connection.id),
+    };
+    const superseded = await insertEvent(resyncParams, { onConflictUpdate: true });
+    expect(superseded.change).toBe('superseded');
+    expect(await lineageOf(Number(superseded.id))).toMatchObject({
+      origin_parent_id: 'resync-parent',
+    });
+
+    // Identical parentless re-sync: the copied parent must not read as a
+    // difference, or every sync would mint a new stored version forever.
+    const resync = await insertEvent(resyncParams, { onConflictUpdate: true });
+    expect(resync.change).toBe('unchanged');
+    expect(Number(resync.id)).toBe(Number(superseded.id));
+  });
+
+  it('fails closed when the predecessor is missing', async () => {
+    const org = await createTestOrganization();
+    await expect(
+      insertEvent({
+        entityIds: [],
+        organizationId: org.id,
+        originId: 'lineage-missing-prior',
+        title: 'next',
+        content: 'next',
+        semanticType: 'observation',
+        supersedesEventId: 9_000_000_001,
+      })
+    ).rejects.toThrow(/cannot supersede event 9000000001/i);
+  });
+
+  it('preserves Behavior attribution through an approval successor that does not pass it', async () => {
+    const org = await createTestOrganization();
+    const reviewer = await createTestUser({ name: 'Ada Approver' });
+    const behavior = await insertBehavior(org.id, reviewer.id, 'lineage-approval');
+    const runId = await insertRun(org.id);
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'apple.computer_use',
+    });
+
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `run_${runId}_pending`,
+      title: 'screenshot — pending approval',
+      content: 'Agent requested a screenshot.',
+      semanticType: 'operation',
+      connectorKey: 'apple.computer_use',
+      connectionId: Number(connection.id),
+      runId,
+      behaviorId: behavior.id,
+      behaviorVersionId: behavior.versionId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      metadata: { status: 'pending_approval' },
+    });
+
+    const approvedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'confirmed',
+      'screenshot — executing',
+      'Operation confirmed',
+      {},
+      { userId: reviewer.id, name: reviewer.name }
+    );
+
+    expect(await lineageOf(approvedId!)).toMatchObject({
+      behavior_id: behavior.id,
+      behavior_version_id: behavior.versionId,
+      run_id: runId,
+      connector_key: 'apple.computer_use',
+      connection_id: Number(connection.id),
+    });
+  });
+
+  it('shows a human canvas correction, but not other self-produced rows or its tombstone', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const behavior = await insertBehavior(org.id, user.id, 'lineage-visibility');
+
+    const output = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'produced-output',
+      title: 'produced',
+      content: 'produced',
+      semanticType: 'observation',
+      behaviorId: behavior.id,
+      occurredAt: new Date('2026-08-01T12:00:00Z'),
+    });
+
+    const spoofedCorrection = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'produced-correction-flag',
+      title: 'still produced',
+      content: 'still produced',
+      semanticType: 'observation',
+      behaviorId: behavior.id,
+      metadata: { correction: true },
+      occurredAt: new Date('2026-08-01T12:30:00Z'),
+    });
+
+    const correction = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'produced-correction',
+      title: 'corrected',
+      content: 'corrected',
+      semanticType: 'canvas_state',
+      metadata: { correction: true },
+      occurredAt: new Date('2026-08-01T13:00:00Z'),
+      supersedesEventId: Number(output.id),
+    });
+
+    const sql = getTestDb();
+    const afterCorrection = await executeDataSources(
+      { stories: { query: 'SELECT id, semantic_type FROM events ORDER BY id' } },
+      { organizationId: org.id, excludeProducedByBehaviorId: behavior.id },
+      sql
+    );
+    const correctionIds = (afterCorrection.stories ?? []).map((row) =>
+      Number((row as { id: number }).id)
+    );
+    expect(correctionIds).toContain(Number(correction.id));
+    expect(correctionIds).not.toContain(Number(output.id));
+    expect(correctionIds).not.toContain(Number(spoofedCorrection.id));
+
+    const tombstone = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `tomb_${Number(correction.id)}`,
+      semanticType: TOMBSTONE_SEMANTIC_TYPE,
+      payloadType: 'empty',
+      content: null,
+      metadata: { tombstone: true, deleted_event_id: Number(correction.id) },
+      supersedesEventId: Number(correction.id),
+    });
+
+    const afterTombstone = await executeDataSources(
+      { stories: { query: 'SELECT id, semantic_type FROM events ORDER BY id' } },
+      { organizationId: org.id, excludeProducedByBehaviorId: behavior.id },
+      sql
+    );
+    const tombstoneIds = (afterTombstone.stories ?? []).map((row) =>
+      Number((row as { id: number }).id)
+    );
+    expect(tombstoneIds).not.toContain(Number(tombstone.id));
+    expect(await lineageOf(Number(tombstone.id))).toMatchObject({
+      behavior_id: behavior.id,
+    });
+  });
+});

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -100,8 +100,7 @@ export async function supersedeActionEvent(
 ): Promise<number | undefined> {
 	const sql = db;
 	const originalEvent = await sql`
-    SELECT id, entity_ids, connection_id, connector_key, metadata, author_name,
-      behavior_id, behavior_version_id, interaction_input_schema, interaction_input
+    SELECT id, entity_ids, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
     WHERE run_id = ${runId}
       AND organization_id = ${organizationId}
@@ -134,15 +133,7 @@ export async function supersedeActionEvent(
 			title,
 			content,
 			semanticType: "operation",
-			connectorKey: orig.connector_key,
-			connectionId: orig.connection_id,
 			runId,
-			behaviorId:
-				orig.behavior_id == null ? null : Number(orig.behavior_id),
-			behaviorVersionId:
-				orig.behavior_version_id == null
-					? null
-					: Number(orig.behavior_version_id),
 			interactionType: "approval",
 			interactionStatus:
 				status === "confirmed"

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -59,9 +59,11 @@ export interface DataSourceContext {
   windowStart?: string;
   windowEnd?: string;
   /**
-   * When set, the events CTE drops rows this Behavior produced. Set it for a
-   * Behavior's own source execution and nowhere else — a generic reader
-   * (`query_sql`, entity templates) must still see Behavior-produced events.
+   * When set, the events CTE drops rows this Behavior produced, except human
+   * canvas corrections (`semantic_type='canvas_state'` with
+   * `metadata.correction`). Set it for a Behavior's own source execution and
+   * nowhere else — a generic reader (`query_sql`, entity templates) must still
+   * see Behavior-produced events.
    */
   excludeProducedByBehaviorId?: number | null;
 }
@@ -634,13 +636,14 @@ export function buildScopedQuery(
       // and only this predicate stops an hourly Behavior compounding on itself.
       //
       // Self-scoped: one Behavior refining another's output is ordinary
-      // composition, so this drops rows from THIS Behavior only. Corrections
-      // are never stamped with a `behavior_id`, so human feedback still reaches
-      // the Behavior it was written about.
+      // composition, so this drops rows from THIS Behavior only. A supersede
+      // copies the producer stamp, including onto human canvas corrections —
+      // those stay visible via canvas_state + metadata.correction, not by
+      // clearing lineage. Tombstones keep the stamp and stay hidden.
       if (context.excludeProducedByBehaviorId != null) {
         idx++;
         params.push(context.excludeProducedByBehaviorId);
-        eventsCte += ` AND (ev.behavior_id IS NULL OR ev.behavior_id <> $${idx})`;
+        eventsCte += ` AND (ev.behavior_id IS NULL OR ev.behavior_id <> $${idx} OR (ev.semantic_type = 'canvas_state' AND ev.metadata->>'correction' = 'true'))`;
       }
 
       eventsCte += eventConnVisibility('ev');

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -304,8 +304,7 @@ async function transcribeOne(
   const baseRows = (await sql`
     SELECT id, entity_ids, title, payload_type, payload_data, attachments,
            author_name, source_url, occurred_at, metadata, semantic_type,
-           origin_type, connector_key, connection_id, feed_key, feed_id,
-           score, origin_parent_id
+           origin_type, score
     FROM events
     WHERE organization_id = ${organizationId}
       AND origin_id = ${job.originId}
@@ -327,12 +326,7 @@ async function transcribeOne(
     metadata: Record<string, unknown> | null;
     semantic_type: string;
     origin_type: string | null;
-    connector_key: string | null;
-    connection_id: number | null;
-    feed_key: string | null;
-    feed_id: number | null;
     score: number | null;
-    origin_parent_id: string | null;
   }>;
   const base = baseRows[0];
   if (!base) return;
@@ -357,11 +351,6 @@ async function transcribeOne(
     semanticType: base.semantic_type,
     originType: base.origin_type,
     metadata: meta,
-    connectorKey: base.connector_key,
-    connectionId: base.connection_id,
-    feedKey: base.feed_key,
-    feedId: base.feed_id,
-    parentOriginId: base.origin_parent_id,
     score: base.score,
     supersedesEventId: base.id,
   });

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -87,9 +87,11 @@ interface InsertEventParams {
    * The Behavior that PRODUCED this row, and the version of it that ran.
    * Produced, never analyzed — a Behavior reading an event does not stamp it.
    *
-   * Set it on every path that writes on a Behavior's behalf. Leaving it unset
-   * makes the row invisible to `produced_by_behavior_id` and, worse, readable
-   * by the Behavior's own next window: self-exclusion keys on this column.
+   * Set it on the first write. A supersede copies producer/source lineage
+   * from the predecessor — omit or null cannot drop it. A later number
+   * restamps this version (new run / prompt version). Self-exclusion keys
+   * on this column; human canvas corrections stay visible via
+   * `metadata.correction`, not by clearing the stamp.
    */
   behaviorId?: number | null;
   behaviorVersionId?: number | null;
@@ -241,7 +243,12 @@ function isSemanticallyEqual(
     (existing.origin_type ?? null) === (params.originType ?? null) &&
     stableJson(existing.metadata ?? {}) === stableJson(params.metadata ?? {}) &&
     Number(existing.score ?? 0) === Number(params.score ?? 0) &&
-    (existing.origin_parent_id ?? null) === (params.parentOriginId ?? null) &&
+    // Compare the value a supersede would WRITE: a null parentOriginId copies
+    // the predecessor's parent (loadEventLineage), so only a caller-supplied
+    // parent can differ. Comparing the raw param would re-supersede a
+    // copied-parent head on every parentless re-sync, forever.
+    (params.parentOriginId == null ||
+      (existing.origin_parent_id ?? null) === params.parentOriginId) &&
     existing.interaction_type === (params.interactionType ?? 'none') &&
     (existing.interaction_status ?? null) === (params.interactionStatus ?? null) &&
     stableJson(existing.interaction_input_schema ?? null) ===
@@ -274,6 +281,78 @@ async function upsertEmbedding(
     INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
     VALUES (${eventId}, 0, ${vectorLiteral}::vector, ${embeddingModel})
   `;
+}
+
+type EventLineage = {
+  connectorKey: string | null;
+  connectionId: number | null;
+  feedKey: string | null;
+  feedId: number | null;
+  runId: number | null;
+  behaviorId: number | null;
+  behaviorVersionId: number | null;
+  parentOriginId: string | null;
+  identityNs: string | null;
+  identityKey: string | null;
+};
+
+function nullableNumber(value: number | string | null): number | null {
+  return value == null ? null : Number(value);
+}
+
+/**
+ * Resolve lineage for a new stored version. Connector/feed and identity belong
+ * to the chain and are always copied. Producer, run, and parent copy unless
+ * the caller supplies a replacement value — null cannot clear them. Identity
+ * cannot first appear on a successor: uniqueness is rooted at
+ * supersedes_event_id NULL.
+ */
+async function loadEventLineage(
+  sql: DbClient,
+  supersedesEventId: number,
+  params: InsertEventParams
+): Promise<EventLineage> {
+  const rows = await sql`
+    SELECT connector_key, connection_id, feed_key, feed_id, run_id,
+           behavior_id, behavior_version_id, origin_parent_id,
+           identity_ns, identity_key
+    FROM events
+    WHERE id = ${supersedesEventId}
+      AND organization_id = ${params.organizationId}
+    LIMIT 1
+  `;
+  const prior = rows[0] as
+    | {
+        connector_key: string | null;
+        connection_id: number | string | null;
+        feed_key: string | null;
+        feed_id: number | string | null;
+        run_id: number | string | null;
+        behavior_id: number | string | null;
+        behavior_version_id: number | string | null;
+        origin_parent_id: string | null;
+        identity_ns: string | null;
+        identity_key: string | null;
+      }
+    | undefined;
+  if (!prior) {
+    throw new Error(
+      `insertEvent: cannot supersede event ${supersedesEventId} — not found in organization ${params.organizationId}`
+    );
+  }
+  return {
+    connectorKey: prior.connector_key ?? null,
+    connectionId: nullableNumber(prior.connection_id),
+    feedKey: prior.feed_key ?? null,
+    feedId: nullableNumber(prior.feed_id),
+    runId: params.runId ?? nullableNumber(prior.run_id),
+    behaviorId: params.behaviorId ?? nullableNumber(prior.behavior_id),
+    behaviorVersionId:
+      params.behaviorVersionId ?? nullableNumber(prior.behavior_version_id),
+    parentOriginId: params.parentOriginId ?? prior.origin_parent_id ?? null,
+    identityNs: prior.identity_ns ?? null,
+    identityKey: prior.identity_key ?? null,
+  };
 }
 
 function isEventsClientIdForeignKeyViolation(error: unknown): boolean {
@@ -382,6 +461,22 @@ export async function insertEvent(
     sql: DbClient,
     supersedesEventId: number | null
   ): Promise<InsertedEvent> => {
+    const lineage: EventLineage =
+      supersedesEventId != null
+        ? await loadEventLineage(sql, supersedesEventId, params)
+        : {
+            connectorKey: params.connectorKey ?? null,
+            connectionId: params.connectionId ?? null,
+            feedKey: params.feedKey ?? null,
+            feedId: params.feedId ?? null,
+            runId: params.runId ?? null,
+            behaviorId: params.behaviorId ?? null,
+            behaviorVersionId: params.behaviorVersionId ?? null,
+            parentOriginId: params.parentOriginId ?? null,
+            identityNs: params.identity?.ns ?? null,
+            identityKey: params.identity?.key ?? null,
+          };
+
     const insertWithClientId = (activeSql: DbClient, clientId: string | null) => activeSql`
     INSERT INTO events (
       entity_ids, organization_id, origin_id, title,
@@ -409,15 +504,15 @@ export async function insertEvent(
       ${params.authorName ?? null},
       ${params.sourceUrl ?? null},
       ${params.occurredAt ?? new Date()},
-      ${params.parentOriginId ?? null},
+      ${lineage.parentOriginId},
       ${params.originType ?? null},
-      ${params.connectorKey ?? null},
-      ${params.connectionId ?? null},
-      ${params.feedKey ?? null},
-      ${params.feedId ?? null},
-      ${params.runId ?? null},
-      ${params.behaviorId ?? null},
-      ${params.behaviorVersionId ?? null},
+      ${lineage.connectorKey},
+      ${lineage.connectionId},
+      ${lineage.feedKey},
+      ${lineage.feedId},
+      ${lineage.runId},
+      ${lineage.behaviorId},
+      ${lineage.behaviorVersionId},
       ${params.semanticType},
       ${clientId},
       ${params.createdBy ?? null},
@@ -428,8 +523,8 @@ export async function insertEvent(
       ${params.interactionOutput ? sql.json(params.interactionOutput) : null},
       ${params.interactionError ?? null},
       ${supersedesEventId},
-      ${params.identity?.ns ?? null},
-      ${params.identity?.key ?? null},
+      ${lineage.identityNs},
+      ${lineage.identityKey},
       (
         SELECT COALESCE(array_agg(DISTINCT x.o), '{}'::text[])
         FROM (
@@ -439,7 +534,7 @@ export async function insertEvent(
           UNION ALL
           SELECT c.organization_id AS o
           FROM public.connections c
-          WHERE c.id = ${params.connectionId ?? null}
+          WHERE c.id = ${lineage.connectionId}
         ) x
         WHERE x.o IS NOT NULL
           AND (x.o <> ${params.organizationId}::text OR ${params.organizationId}::text IS NULL)


### PR DESCRIPTION
## Summary
- Copy connector, feed, identity, producer, run, and parent lineage centrally whenever an event supersedes its predecessor.
- Keep human canvas corrections visible to their Behavior without erasing provenance, while tombstones and other self-produced rows remain excluded.
- Remove approval and transcription caller-side lineage copy lists, and keep parentless connector re-syncs convergent.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Tests run: focused and related Vitest integration suites plus server typecheck
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval (not applicable; event persistence only)

### Red

Before the centralized copy, the new lineage suite failed all five original cases:

```text
expected { behavior_id: null, ... } to deeply equal { behavior_id: 1, ... }
expected [Function] to throw /cannot supersede event 9000000001/i but got a foreign-key error
expected [ 10 ] to not include 10
Test Files  1 failed (1)
Tests  5 failed (5)
```

The settled-diff fixer also mutation-proved the connector re-sync regression before its fix:

```text
expected 'superseded' to be 'unchanged'
```

### Green

```text
Test Files  4 passed (4)
Tests  19 passed (19)
```

Related supersede/visibility suites: 6 files, 37 tests passed. Concurrency suites: 2 files, 4 tests passed. `bun run typecheck` passed in `packages/server`.

Full remote preflight passed: Depot run `scrsdphx9n` (16 Linux CI jobs; recorded tree `88989f87d16bf0824c602b8bff82769035194208`).

## Notes
No schema, migration, public API, SDK, UI, lock, retry, or compatibility changes. This follows merged PR #2726 by replacing its approval-only copy list with the centralized invariant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event lineage preservation when events are superseded, including connector, feed, producer, parent, and identity details.
  * Preserved human canvas corrections during behavior self-exclusion.
  * Prevented unintended repeated supersession during parentless resynchronization.
  * Ensured approval and transcription events retain appropriate lineage and attribution.
  * Added fail-closed handling when predecessor events are unavailable.

* **Tests**
  * Added comprehensive integration coverage for lineage inheritance, overrides, corrections, tombstones, and approval events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->