### PR TITLE
feat(server): complete Atlassian Rovo Jira feeds

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/atlassian-mcp-feed-create.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/atlassian-mcp-feed-create.test.ts
@@ -1,0 +1,188 @@
+import { MCP_PROTOCOL_VERSION } from "@lobu/core";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import type { Env } from "../../../index";
+import { manageFeeds } from "../../../tools/admin/manage_feeds";
+import { createAuthProfile } from "../../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { seedOwnerContext } from "../../setup/test-fixtures";
+
+const TEST_ENV = {} as Env;
+const ATLASSIAN_URL = "https://mcp.atlassian.com/v1/mcp";
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(
+	body: unknown,
+	headers: Record<string, string> = {},
+): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json", ...headers },
+	});
+}
+
+describe("Atlassian MCP feed creation", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("resolves a unique site through authenticated MCP and persists routing identity", async () => {
+		globalThis.fetch = vi.fn(
+			async (url: string | URL | Request, init?: RequestInit) => {
+				expect(String(url)).toBe(ATLASSIAN_URL);
+				expect(new Headers(init?.headers).get("authorization")).toBe(
+					"Bearer rovo-token",
+				);
+				const body = JSON.parse(String(init?.body)) as {
+					id?: unknown;
+					method?: string;
+					params?: { name?: string };
+				};
+				if (body.method === "initialize") {
+					return jsonResponse(
+						{
+							jsonrpc: "2.0",
+							id: body.id,
+							result: {
+								protocolVersion: MCP_PROTOCOL_VERSION,
+								capabilities: { tools: {} },
+								serverInfo: { name: "Atlassian", version: "1.0.0" },
+							},
+						},
+						{ "Mcp-Session-Id": "atlassian-feed-create" },
+					);
+				}
+				if (body.method === "tools/call") {
+					expect(body.params?.name).toBe("getAccessibleAtlassianResources");
+					return jsonResponse({
+						jsonrpc: "2.0",
+						id: body.id,
+						result: {
+							content: [
+								{
+									type: "text",
+									text: JSON.stringify([
+										{
+											id: "cloud-acme",
+											url: "https://acme.atlassian.net",
+											name: "Acme",
+											scopes: ["read:jira-work"],
+										},
+									]),
+								},
+							],
+							isError: false,
+						},
+					});
+				}
+				return jsonResponse({ jsonrpc: "2.0", id: body.id, result: {} });
+			},
+		) as typeof fetch;
+
+		const { org, user, ctx } = await seedOwnerContext({
+			orgName: "Atlassian Feed Create Org",
+			userName: "Atlassian Feed Create Owner",
+		});
+		const sql = getTestDb();
+		const connectorKey = "mcp.mcp-atlassian-com";
+		await sql`
+      INSERT INTO connector_definitions (
+        organization_id, key, name, version, status, auth_schema,
+        mcp_config, feeds_schema
+      ) VALUES (
+        ${org.id}, ${connectorKey}, 'Atlassian', '1.0.0', 'active',
+        ${sql.json({
+					methods: [{ type: "oauth", provider: connectorKey, required: true }],
+				})},
+        ${sql.json({ upstream_url: ATLASSIAN_URL, tool_prefix: "mcp_atlassian_com" })},
+        ${sql.json({
+					issues: {
+						key: "issues",
+						virtual: true,
+						configSchema: {
+							type: "object",
+							properties: { query: { type: "string" } },
+						},
+					},
+				})}
+      )
+    `;
+
+		const accountId = `atlassian-account-${org.id}`;
+		await sql`
+      INSERT INTO account (
+        id, "accountId", "providerId", "userId", "accessToken",
+        "accessTokenExpiresAt", "createdAt", "updatedAt"
+      ) VALUES (
+        ${accountId}, ${accountId}, ${connectorKey}, ${user.id}, 'rovo-token',
+        ${new Date(Date.now() + 3600_000).toISOString()}, NOW(), NOW()
+      )
+    `;
+		const profile = await createAuthProfile({
+			organizationId: org.id,
+			connectorKey,
+			displayName: "Atlassian Account",
+			profileKind: "oauth_account",
+			provider: connectorKey,
+			accountId,
+			createdBy: user.id,
+		});
+		const [connection] = await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        account_id, auth_profile_id, created_by, visibility
+      ) VALUES (
+        ${org.id}, ${connectorKey}, 'atlassian-rovo', 'Atlassian', 'active',
+        ${accountId}, ${profile.id}, ${user.id}, 'private'
+      )
+      RETURNING id
+    `;
+
+		const result = (await manageFeeds(
+			{
+				action: "create_feed",
+				connection_id: Number(connection.id),
+				feed_key: "issues",
+				config: { query: "project = ACME" },
+			},
+			TEST_ENV,
+			ctx,
+		)) as { error?: string; feed?: { config: Record<string, unknown> } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.config).toMatchObject({
+			query: "project = ACME",
+			cloud_id: "cloud-acme",
+			site_cloud_id: "cloud-acme",
+			site_url: "https://acme.atlassian.net",
+			site_name: "Acme",
+		});
+		const [configured] = await sql`
+      SELECT external_tenant_id, config
+      FROM connections
+      WHERE id = ${connection.id} AND organization_id = ${org.id}
+    `;
+		expect(configured.external_tenant_id).toBe("cloud-acme");
+		expect(configured.config).toMatchObject({
+			cloud_id: "cloud-acme",
+			site_url: "https://acme.atlassian.net",
+		});
+	});
+});

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
@@ -5,7 +5,19 @@ const calls: Array<{
 	args: Record<string, unknown>;
 }> = [];
 
+let responseMode: "normal" | "ambiguous-sites" | "endless-pages" = "normal";
+
 mock.module("../../mcp-proxy/client", () => ({
+	discoverTools: async () => [],
+	assertSafeUrl: () => undefined,
+	getMcpOAuthRequestedScopes: () => [],
+	selectMcpOAuthClientAuthMethod: () => "none",
+	registerMcpOAuthClient: async () => {
+		throw new Error("unused in Atlassian feed read test");
+	},
+	probeMcpServer: async () => {
+		throw new Error("unused in Atlassian feed read test");
+	},
 	callTool: async (
 		_connectorKey: string,
 		_config: unknown,
@@ -20,7 +32,28 @@ mock.module("../../mcp-proxy/client", () => ({
 				content: [
 					{
 						type: "text",
-						text: JSON.stringify([{ id: "cloud-1", url: "https://acme.atlassian.net" }]),
+						text: JSON.stringify(
+							responseMode === "ambiguous-sites"
+								? [
+										{ id: "cloud-1", url: "https://one.atlassian.net" },
+										{ id: "cloud-2", url: "https://two.atlassian.net" },
+									]
+								: [{ id: "cloud-1", url: "https://acme.atlassian.net" }],
+						),
+					},
+				],
+			};
+		}
+		if (responseMode === "endless-pages") {
+			return {
+				isError: false,
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({
+							issues: [{ id: String(calls.length), key: `KAN-${calls.length}` }],
+							nextPageToken: `page-${calls.length}`,
+						}),
 					},
 				],
 			};
@@ -69,6 +102,7 @@ beforeAll(async () => {
 describe("readAtlassianMcpVirtualFeed", () => {
 	it("pages with nextPageToken and windows offset/limit across pages", async () => {
 		calls.length = 0;
+		responseMode = "normal";
 		const result = await readAtlassianMcpVirtualFeed({
 			organizationId: "org-1",
 			connectionId: 505,
@@ -97,5 +131,45 @@ describe("readAtlassianMcpVirtualFeed", () => {
 		expect(calls[1].args.nextPageToken).toBeUndefined();
 		expect(calls[2].args.nextPageToken).toBe("page-2");
 		expect(result.rows.map((row) => row.key)).toEqual(["KAN-3", "KAN-4"]);
+	});
+
+	it("rejects an ambiguous multi-site grant", async () => {
+		calls.length = 0;
+		responseMode = "ambiguous-sites";
+		await expect(
+			readAtlassianMcpVirtualFeed({
+				organizationId: "org-1",
+				connectionId: 505,
+				connectorKey: "mcp.mcp-atlassian-com",
+				mcpConfig: {
+					upstream_url: "https://mcp.atlassian.com/v1/mcp",
+					tool_prefix: "mcp_atlassian_com",
+				},
+				feedConfig: {},
+				connectionConfig: {},
+				query: "project = KAN",
+			}),
+		).rejects.toThrow("multiple accessible Jira sites");
+	});
+
+	it("fails visibly when the bounded page budget cannot fill the requested window", async () => {
+		calls.length = 0;
+		responseMode = "endless-pages";
+		await expect(
+			readAtlassianMcpVirtualFeed({
+				organizationId: "org-1",
+				connectionId: 505,
+				connectorKey: "mcp.mcp-atlassian-com",
+				mcpConfig: {
+					upstream_url: "https://mcp.atlassian.com/v1/mcp",
+					tool_prefix: "mcp_atlassian_com",
+				},
+				feedConfig: { cloud_id: "cloud-1", max_results: 1 },
+				connectionConfig: {},
+				query: "project = KAN",
+				offset: 20,
+				limit: 1,
+			}),
+		).rejects.toThrow("pagination limit");
 	});
 });

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed.test.ts
@@ -3,8 +3,8 @@ import {
 	ATLASSIAN_MCP_FEEDS,
 	buildAtlassianMcpJql,
 	isAtlassianMcpUrl,
-	parseAtlassianCloudId,
 	parseAtlassianMcpIssues,
+	parseAtlassianMcpJiraSite,
 	parseAtlassianMcpNextPageToken,
 } from "../../operations/atlassian-mcp-feed";
 
@@ -95,7 +95,7 @@ describe("Atlassian MCP virtual feed helpers", () => {
 
 	it("reads a cloud id out of accessible-resources MCP text", () => {
 		expect(
-			parseAtlassianCloudId({
+			parseAtlassianMcpJiraSite({
 				content: [
 					{
 						type: "text",
@@ -104,7 +104,23 @@ describe("Atlassian MCP virtual feed helpers", () => {
 						]),
 					},
 				],
-			}),
+			})?.cloudId,
 		).toBe("49140293-40ce-45b6-8cdc-ec4e1356a7c8");
+	});
+
+	it("fails closed instead of choosing the first accessible Jira site", () => {
+		expect(
+			parseAtlassianMcpJiraSite({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify([
+							{ id: "cloud-1", url: "https://one.atlassian.net" },
+							{ id: "cloud-2", url: "https://two.atlassian.net" },
+						]),
+					},
+				],
+			}),
+		).toBeNull();
 	});
 });

--- a/packages/server/src/connect/atlassian-mcp-site.ts
+++ b/packages/server/src/connect/atlassian-mcp-site.ts
@@ -1,0 +1,51 @@
+import { type DbClient, getDb } from '../db/client';
+import type { McpProxyConfig } from '../mcp-proxy/types';
+import { resolveAtlassianMcpJiraSite } from '../operations/atlassian-mcp-feed';
+import { jiraSiteConfigPatch, type JiraCloudSite } from './atlassian-resources';
+
+/**
+ * Resolve Jira site identity through the authenticated Rovo MCP connection and
+ * persist it at the narrowest durable scope. A unique site is connection-wide;
+ * an explicit selection from a multi-site grant stays feed-scoped.
+ */
+export async function reconcileAtlassianMcpJiraSite(params: {
+  organizationId: string;
+  connectionId: number;
+  connectorKey: string;
+  mcpConfig: McpProxyConfig;
+  preferredCloudId?: string;
+  feedId?: number;
+  sql?: DbClient;
+}): Promise<{ site: JiraCloudSite; configPatch: Record<string, unknown> }> {
+  const sql = params.sql ?? getDb();
+  const site = await resolveAtlassianMcpJiraSite(params);
+  const configPatch = jiraSiteConfigPatch(site);
+
+  if (params.feedId) {
+    await sql`
+      UPDATE feeds
+      SET config = COALESCE(config, '{}'::jsonb) || ${sql.json(configPatch)}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${params.feedId}
+        AND organization_id = ${params.organizationId}
+        AND connection_id = ${params.connectionId}
+    `;
+  }
+
+  if (site.resourceCount === 1) {
+    await sql`
+      UPDATE connections
+      SET config = (
+            (COALESCE(config, '{}'::jsonb)
+              - 'cloud_id' - 'site_cloud_id' - 'site_url' - 'site_name')
+            || ${sql.json(configPatch)}::jsonb
+          ),
+          external_tenant_id = ${site.cloudId},
+          updated_at = NOW()
+      WHERE id = ${params.connectionId}
+        AND organization_id = ${params.organizationId}
+    `;
+  }
+
+  return { site, configPatch };
+}

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -45,7 +45,12 @@ import { mergeOAuthScopeAuthData, normalizeScopeList } from '../auth/oauth/scope
 import { createSyncRun, describeSyncRunSkip } from '../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { buildConnectionsUrl, getOrganizationSlug, getPublicWebUrl } from '../utils/url-builder';
-import { isAtlassianMcpConfig } from '../operations/atlassian-mcp-feed';
+import {
+  ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+  isAtlassianMcpConfig,
+  normalizeMcpProxyConfig,
+} from '../operations/atlassian-mcp-feed';
+import { reconcileAtlassianMcpJiraSite } from './atlassian-mcp-site';
 import {
   jiraSiteConfigPatch,
   resolveJiraCloudSite,
@@ -742,12 +747,13 @@ async function handleOAuthCallback(
     WHERE key = ${tokenRow.connector_key}
       AND organization_id = ${tokenRow.organization_id}
       AND status = 'active'
+    ORDER BY updated_at DESC
     LIMIT 1
   `) as Array<{ mcp_config: Record<string, unknown> | null }>;
-  if (
-    tokenRow.connector_key === 'jira' ||
-    isAtlassianMcpConfig(mcpDefinition?.mcp_config)
-  ) {
+  const atlassianMcpConfig = isAtlassianMcpConfig(mcpDefinition?.mcp_config)
+    ? normalizeMcpProxyConfig(mcpDefinition.mcp_config)
+    : null;
+  if (tokenRow.connector_key === 'jira') {
     jiraSite = await resolveJiraCloudSite(tokens.accessToken);
     if (jiraSite) {
       logger.info(
@@ -996,6 +1002,53 @@ async function handleOAuthCallback(
 
   if (resolvedAuthProfileId) {
     await syncOAuthConnectionsForAuthProfile(tokenRow.organization_id, resolvedAuthProfileId);
+  }
+
+  // Rovo tokens target the MCP resource, not api.atlassian.com. Once the token
+  // is durably attached, ask Rovo for its site and persist the identity. This is
+  // best-effort like Jira REST discovery: ambiguous grants stay connected but
+  // must select cloud_id before creating or reading a feed.
+  if (tokenRow.connection_id && atlassianMcpConfig) {
+    try {
+      const feedRows = (await sql`
+        SELECT id, config
+        FROM feeds
+        WHERE organization_id = ${tokenRow.organization_id}
+          AND connection_id = ${tokenRow.connection_id}
+          AND feed_key = ${ATLASSIAN_JIRA_ISSUES_FEED_KEY}
+          AND deleted_at IS NULL
+        ORDER BY id
+      `) as Array<{ id: number; config: Record<string, unknown> | null }>;
+      const feed = feedRows[0];
+      const preferredCloudId =
+        typeof feed?.config?.cloud_id === 'string'
+          ? feed.config.cloud_id.trim() || undefined
+          : undefined;
+      const { site } = await reconcileAtlassianMcpJiraSite({
+        organizationId: tokenRow.organization_id,
+        connectionId: tokenRow.connection_id,
+        connectorKey: tokenRow.connector_key,
+        mcpConfig: atlassianMcpConfig,
+        preferredCloudId,
+        feedId: feed?.id,
+        sql,
+      });
+      logger.info(
+        {
+          connector_key: tokenRow.connector_key,
+          connection_id: tokenRow.connection_id,
+          cloud_id: site.cloudId,
+          site_url: site.siteUrl,
+          site_count: site.resourceCount,
+        },
+        'Resolved Jira Cloud site through Atlassian MCP after OAuth'
+      );
+    } catch (error) {
+      logger.warn(
+        { connector_key: tokenRow.connector_key, connection_id: tokenRow.connection_id, error },
+        'Atlassian MCP OAuth succeeded but Jira site reconciliation did not complete'
+      );
+    }
   }
 
   logger.info(

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -33,6 +33,7 @@ import {
 	extractTenantFromSchema,
 	verifyDeclaredWebhook,
 } from "../routes/public/app-webhooks.js";
+import { createJiraWebhookDelivery } from "../routes/public/jira-mcp-webhook-delivery.js";
 
 // The connectors' DECLARED webhook schemas (mirrors of their `webhook` blocks).
 // Drives the generic engine in tests exactly as the bundled declaration does in
@@ -741,7 +742,14 @@ function buildJiraApp() {
 	return createAppWebhookRoutes({
 		installationStore: createPostgresAppInstallationStore(),
 		secretStore: fakeSecretStore,
-		providers: [createDeclaredAppWebhookProvider({ provider: "jira", appId: JIRA_APP_ID, webhookSchema: JIRA_WEBHOOK_SCHEMA })],
+		providers: [
+			createDeclaredAppWebhookProvider({
+				provider: "jira",
+				appId: JIRA_APP_ID,
+				webhookSchema: JIRA_WEBHOOK_SCHEMA,
+				onDelivery: createJiraWebhookDelivery(),
+			}),
+		],
 		resolveAppWebhookSecret: async () => JIRA_SECRET,
 	});
 }
@@ -759,6 +767,52 @@ async function seedJiraInstall(): Promise<number> {
 	return row.id;
 }
 
+async function seedAtlassianMcpIssuesFeed(): Promise<{
+	connectionId: number;
+	feedId: number;
+	connectorKey: string;
+}> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const connectorKey = "mcp.mcp-atlassian-com";
+	await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, status, mcp_config, feeds_schema
+    ) VALUES (
+      ${ORG}, ${connectorKey}, 'Atlassian', '1.0.0', 'active',
+      ${sql.json({ upstream_url: "https://mcp.atlassian.com/v1/mcp" })},
+      ${sql.json({ issues: { key: "issues", virtual: true } })}
+    )
+  `;
+	const [connection] = await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status, config, visibility
+    ) VALUES (
+      ${ORG}, ${connectorKey}, 'atlassian-rovo', 'Atlassian', 'active',
+      ${sql.json({
+			cloud_id: "cloud-1",
+			site_cloud_id: "cloud-1",
+			site_url: `https://${JIRA_SITE}`,
+		})},
+      'org'
+    )
+    RETURNING id
+  `;
+	const [feed] = await sql`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, display_name, status, kind, virtual, config
+    ) VALUES (
+      ${ORG}, ${connection.id}, 'issues', 'Issues', 'active', 'virtual', true, '{}'::jsonb
+    )
+    RETURNING id
+  `;
+	return {
+		connectionId: Number(connection.id),
+		feedId: Number(feed.id),
+		connectorKey,
+	};
+}
+
 function jiraDelivery(
 	rawBody: string,
 	{ signature = jiraSign(rawBody) }: { signature?: string } = {},
@@ -774,6 +828,82 @@ function jiraDelivery(
 }
 
 describe("app-webhook router (Jira)", () => {
+	test("a signed issue delivery lands as a structured event on the matching Atlassian MCP feed", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedJiraInstall();
+		const target = await seedAtlassianMcpIssuesFeed();
+		const app = buildJiraApp();
+
+		const raw = JSON.stringify({
+			webhookEvent: "jira:issue_updated",
+			issue: {
+				id: "10000",
+				key: "ACME-1",
+				self: `https://${JIRA_SITE}/rest/api/2/issue/10000`,
+				fields: {
+					summary: "Rovo webhook",
+					description: "Arrived through the Jira app",
+					status: { name: "In Progress" },
+					reporter: { displayName: "Ada" },
+					created: "2026-08-13T10:00:00.000Z",
+					updated: "2026-08-13T11:00:00.000Z",
+				},
+			},
+		});
+		const res = await app.fetch(jiraDelivery(raw));
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ ok: true, triggered: true });
+
+		const rows = await eventRows(target.connectorKey);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			connection_id: target.connectionId,
+			feed_id: target.feedId,
+			feed_key: "issues",
+			origin_id: "jira_issue_10000",
+			origin_type: "issue",
+			title: "Rovo webhook",
+			author_name: "Ada",
+		});
+		expect(await appInstallEventCount()).toBe(0);
+	});
+
+	test("a signed comment delivery lands under the issue as a structured comment event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedJiraInstall();
+		const target = await seedAtlassianMcpIssuesFeed();
+		const app = buildJiraApp();
+
+		const raw = JSON.stringify({
+			webhookEvent: "comment_created",
+			issue: {
+				id: "10000",
+				key: "ACME-1",
+				self: `https://${JIRA_SITE}/rest/api/2/issue/10000`,
+				fields: { summary: "Rovo webhook" },
+			},
+			comment: {
+				id: "20000",
+				self: `https://${JIRA_SITE}/rest/api/2/issue/10000/comment/20000`,
+				body: "Looks good",
+				author: { displayName: "Grace" },
+				created: "2026-08-13T11:05:00.000Z",
+			},
+		});
+		const res = await app.fetch(jiraDelivery(raw));
+		expect(res.status).toBe(200);
+
+		const rows = await eventRows(target.connectorKey);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			origin_id: "jira_comment_20000",
+			origin_parent_id: "jira_issue_10000",
+			origin_type: "comment",
+			author_name: "Grace",
+			payload_text: "Looks good",
+		});
+	});
+
 	test("a signed issue delivery routes to the owning org via its site host", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedJiraInstall();

--- a/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
+++ b/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
@@ -65,6 +65,22 @@ async function loadGithubDef(orgId: string): Promise<{
 	return rows[0];
 }
 
+async function seedStaleAtlassianMcpDef(orgId: string): Promise<void> {
+	const sql = getDb();
+	await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, status, mcp_config, feeds_schema
+    ) VALUES (
+      ${orgId}, 'mcp.mcp-atlassian-com', 'Atlassian', '1.0.0', 'active',
+      ${sql.json({
+			upstream_url: "https://mcp.atlassian.com/v1/mcp",
+			tool_prefix: "mcp_atlassian_com",
+		})},
+      NULL
+    )
+  `;
+}
+
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
 }, 60_000);
@@ -138,5 +154,28 @@ describe("refreshConnectorDefinitions", () => {
 
 		const other = await loadGithubDef(OTHER_ORG);
 		expect(other).toBeUndefined();
+	});
+
+	test("backfills the Jira feed onto an existing Atlassian MCP definition", async () => {
+		await seedAgentRow("agent-refresh", { organizationId: ORG });
+		await seedStaleAtlassianMcpDef(ORG);
+
+		const [before] = await getDb()`
+      SELECT feeds_schema FROM connector_definitions
+      WHERE organization_id = ${ORG} AND key = 'mcp.mcp-atlassian-com'
+    `;
+		expect(before?.feeds_schema).toBeNull();
+
+		const result = await refreshConnectorDefinitions();
+		expect(result.refreshed).toBeGreaterThanOrEqual(1);
+
+		const [after] = await getDb()`
+      SELECT feeds_schema FROM connector_definitions
+      WHERE organization_id = ${ORG} AND key = 'mcp.mcp-atlassian-com'
+    `;
+		expect(after?.feeds_schema?.issues).toMatchObject({
+			key: "issues",
+			virtual: true,
+		});
 	});
 });

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -643,9 +643,10 @@ export function createGatewayApp(
       // Per-KIND delivery, dispatched off the DECLARED `deliveryKind` — never a
       // provider name. A `chat` connector forwards verified deliveries to the
       // chat adapter for its provider (Slack today); a `data` connector lands
-      // them through the data path: its poll-canonical trigger/store hook when it
-      // ships one (GitHub), else the raw event-ingest fallback (Jira/Linear → no
-      // hook). Both the chat-forward routing and the data hooks live outside this
+      // them through the data path: its per-connector delivery hook when it
+      // ships one (GitHub sync-now triggers, Jira → Rovo issue events), else the
+      // raw event-ingest fallback (Linear, and Jira until a Rovo feed exists).
+      // Both the chat-forward routing and the data hooks live outside this
       // wiring, keyed off the connector, so gateway core carries no provider
       // literal.
       const deliveryKind = integration.webhookSchema.deliveryKind ?? "data";

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -54,6 +54,7 @@ import {
 	githubUserIdentityKey,
 } from "@lobu/connectors/github-identity";
 import { extractGithubActor, resolveGithubWebhookActor } from "./github-webhook-actor.js";
+import { createJiraWebhookDelivery } from "./jira-mcp-webhook-delivery.js";
 
 const logger = createLogger("app-webhook-routes");
 
@@ -148,9 +149,13 @@ export interface AppWebhookProvider {
 	onDelivery?(params: {
 		rawBody: Uint8Array;
 		headers: Headers;
-		install: { id: number | string; organizationId: string };
+		install: {
+			id: number | string;
+			organizationId: string;
+			externalTenantId: string;
+		};
 		sql: DbClient;
-	}): Promise<{ triggered: boolean }>;
+	}): Promise<{ triggered: boolean; handled?: boolean }>;
 	/**
 	 * Optional: take over the ENTIRE delivery after `verify`, bypassing the
 	 * router's `extractTenant` → `resolveActiveByTenant` (`app_installations`) →
@@ -513,12 +518,13 @@ export function createGithubWebhookDelivery(options: {
  * data delivery — NOT by a provider-name branch in the gateway wiring. A data
  * integration whose deliveries are POLL-CANONICAL (GitHub: trigger the affected
  * feed / store event-complete signals) ships a hook here; data integrations that
- * RAW-STORE their deliveries (Jira/Linear) ship none, so the router falls through
- * to the raw event-ingest path. This lookup lives in the data-delivery module
- * (alongside the hook impls), so the gateway selects `data` vs `chat` by
- * deliveryKind and delegates the per-connector data hook to this — gateway core
- * stays free of provider literals. A new poll-canonical data integration adds its
- * hook here; everything else needs no change.
+ * RAW-STORE their deliveries (Linear) ship none, so the router falls through to
+ * the raw event-ingest path. Jira routes matching sites to Atlassian Rovo
+ * issue feeds and explicitly falls through while no Rovo feed exists. This
+ * lookup lives in the data-delivery module, so the gateway selects `data` vs
+ * `chat` by deliveryKind and delegates the per-connector data hook to this —
+ * gateway core stays free of provider literals. A new hook-shipping data
+ * integration adds its hook here; everything else needs no change.
  */
 export function createDataWebhookDelivery(
 	connectorKey: string,
@@ -529,6 +535,7 @@ export function createDataWebhookDelivery(
 			storeWebhookEvents: process.env.GITHUB_WEBHOOK_STORE_EVENTS !== "false",
 		});
 	}
+	if (connectorKey === "jira") return createJiraWebhookDelivery();
 	return undefined;
 }
 
@@ -1122,20 +1129,26 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			return json(200, { ok: true, landed: false });
 		}
 
-		// 4. Trigger-handling providers (github) treat the delivery as a "sync now"
-		//    signal rather than a record: resolve identity + mark the affected
-		//    repo's feeds due, no raw event. The canonical record is the poll, so
-		//    push and backfill stay one consolidated dataset. Providers without
-		//    onDelivery fall through to the raw store below (jira/linear).
+		// 4. Structured-delivery providers handle the delivery as a sync signal
+		//    (GitHub: resolve identity + mark the affected repo's feeds due, no raw
+		//    event — the poll stays the canonical record, so push and backfill are
+		//    one consolidated dataset) or as a structured connector event (Jira →
+		//    Rovo issues feed). A handler may return handled:false when its target
+		//    is not configured yet; that falls through to the raw store below,
+		//    preserving the staged migration (Atlassian Rovo before the legacy Jira
+		//    connector is removed). Providers without onDelivery (linear) fall
+		//    through the same way.
 		if (provider.onDelivery) {
 			try {
-				const { triggered } = await provider.onDelivery({
+				const { triggered, handled } = await provider.onDelivery({
 					rawBody,
 					headers: c.req.raw.headers,
 					install,
 					sql: getDb(),
 				});
-				return json(200, { ok: true, triggered });
+				if (handled !== false) {
+					return json(200, { ok: true, triggered });
+				}
 			} catch (error) {
 				routeLogger.error(
 					{ provider: providerName, installationId: install.id, error: String(error) },

--- a/packages/server/src/gateway/routes/public/jira-mcp-webhook-delivery.ts
+++ b/packages/server/src/gateway/routes/public/jira-mcp-webhook-delivery.ts
@@ -1,0 +1,320 @@
+import type { DbClient } from "../../../db/client.js";
+import {
+	activateBehaviorSignal,
+	dispatchBehaviorRunsBestEffort,
+	type BehaviorActivationResult,
+} from "../../../behaviors/activation.js";
+import {
+	deriveConnectorActivationSignals,
+	loadConnectorDeriveFeedContext,
+} from "../../../behaviors/connector-derived.js";
+import {
+	atlassianDocumentToText,
+	ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+	isAtlassianMcpConfig,
+	mapAtlassianIssueToRow,
+} from "../../../operations/atlassian-mcp-feed.js";
+import { insertEvent } from "../../../utils/insert-event.js";
+import type { AppWebhookProvider } from "./app-webhooks.js";
+
+interface JiraMcpFeedTarget {
+	connectionId: number;
+	feedId: number;
+	connectorKey: string;
+	config: Record<string, unknown>;
+	siteUrl: string;
+}
+
+function strField(node: unknown, key: string): string | undefined {
+	if (node === null || typeof node !== "object") return undefined;
+	const value = (node as Record<string, unknown>)[key];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseJson(rawBody: Uint8Array): unknown {
+	try {
+		return JSON.parse(new TextDecoder().decode(rawBody));
+	} catch {
+		return undefined;
+	}
+}
+
+function siteHost(value: unknown): string | null {
+	if (typeof value !== "string" || value.trim().length === 0) return null;
+	try {
+		return new URL(value).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+async function resolveJiraMcpFeedTarget(params: {
+	sql: DbClient;
+	organizationId: string;
+	siteHost: string;
+}): Promise<JiraMcpFeedTarget | null> {
+	const rows = (await params.sql`
+		SELECT f.id AS feed_id, f.connection_id, f.config AS feed_config,
+		       c.connector_key, c.config AS connection_config, cd.mcp_config
+		FROM feeds f
+		JOIN connections c ON c.id = f.connection_id
+		JOIN LATERAL (
+			SELECT mcp_config
+			FROM connector_definitions
+			WHERE organization_id = c.organization_id
+			  AND key = c.connector_key
+			  AND status = 'active'
+			ORDER BY updated_at DESC
+			LIMIT 1
+		) cd ON TRUE
+		WHERE f.organization_id = ${params.organizationId}
+		  AND f.feed_key = ${ATLASSIAN_JIRA_ISSUES_FEED_KEY}
+		  AND f.status = 'active'
+		  AND f.deleted_at IS NULL
+		  AND c.status = 'active'
+		  AND c.deleted_at IS NULL
+	`) as Array<{
+		feed_id: number;
+		connection_id: number;
+		feed_config: Record<string, unknown> | null;
+		connector_key: string;
+		connection_config: Record<string, unknown> | null;
+		mcp_config: Record<string, unknown> | null;
+	}>;
+
+	const matches: JiraMcpFeedTarget[] = [];
+	for (const row of rows) {
+		if (!isAtlassianMcpConfig(row.mcp_config)) continue;
+		const config = {
+			...(row.connection_config ?? {}),
+			...(row.feed_config ?? {}),
+		};
+		const configuredUrl =
+			typeof config.site_url === "string" ? config.site_url : undefined;
+		if (siteHost(configuredUrl) !== params.siteHost.toLowerCase()) continue;
+		matches.push({
+			connectionId: Number(row.connection_id),
+			feedId: Number(row.feed_id),
+			connectorKey: row.connector_key,
+			config,
+			siteUrl: configuredUrl as string,
+		});
+	}
+	if (matches.length > 1) {
+		throw new Error(
+			`Multiple active Atlassian MCP issue feeds match Jira site ${params.siteHost}`,
+		);
+	}
+	return matches[0] ?? null;
+}
+
+function issueUrl(target: JiraMcpFeedTarget, issueKey?: string): string {
+	if (!issueKey) return target.siteUrl;
+	return `${target.siteUrl.replace(/\/+$/, "")}/browse/${encodeURIComponent(issueKey)}`;
+}
+
+async function landJiraMcpWebhookEvent(params: {
+	sql: DbClient;
+	organizationId: string;
+	target: JiraMcpFeedTarget;
+	payload: Record<string, unknown>;
+}): Promise<boolean> {
+	const eventType = strField(params.payload, "webhookEvent");
+	const issue =
+		params.payload.issue && typeof params.payload.issue === "object"
+			? (params.payload.issue as Record<string, unknown>)
+			: null;
+	const issueRow = mapAtlassianIssueToRow(issue, params.target.config);
+	const issueId =
+		issueRow && typeof issueRow.id === "string" ? issueRow.id : undefined;
+	const issueKey =
+		issueRow && typeof issueRow.key === "string" ? issueRow.key : undefined;
+
+	let event: {
+		originId: string;
+		kind: "issue" | "comment";
+		title: string | null;
+		content: string | null;
+		authorName: string | null;
+		sourceUrl: string;
+		occurredAt: string | null;
+		parentOriginId?: string;
+		metadata: Record<string, unknown>;
+	};
+
+	if (
+		eventType === "jira:issue_created" ||
+		eventType === "jira:issue_updated"
+	) {
+		if (!issueId || !issueRow) {
+			throw new Error(`Jira ${eventType} delivery is missing issue.id`);
+		}
+		event = {
+			originId: `jira_issue_${issueId}`,
+			kind: "issue",
+			title:
+				typeof issueRow.summary === "string"
+					? issueRow.summary
+					: (issueKey ?? null),
+			content:
+				typeof issueRow.description === "string" ? issueRow.description : null,
+			authorName:
+				typeof issueRow.reporter === "string"
+					? issueRow.reporter
+					: typeof issueRow.assignee === "string"
+						? issueRow.assignee
+						: null,
+			sourceUrl:
+				typeof issueRow.url === "string"
+					? issueRow.url
+					: issueUrl(params.target, issueKey),
+			occurredAt:
+				typeof issueRow.created_at === "string"
+					? issueRow.created_at
+					: typeof issueRow.updated_at === "string"
+						? issueRow.updated_at
+						: null,
+			metadata: {
+				key: issueKey ?? null,
+				status: issueRow.status ?? null,
+				assignee: issueRow.assignee ?? null,
+				reporter: issueRow.reporter ?? null,
+				updated_at: issueRow.updated_at ?? null,
+			},
+		};
+	} else if (eventType === "comment_created") {
+		const comment =
+			params.payload.comment && typeof params.payload.comment === "object"
+				? (params.payload.comment as Record<string, unknown>)
+				: null;
+		const commentId = comment ? strField(comment, "id") : undefined;
+		if (!comment || !commentId) {
+			throw new Error("Jira comment_created delivery is missing comment.id");
+		}
+		const author =
+			comment.author && typeof comment.author === "object"
+				? (comment.author as Record<string, unknown>)
+				: null;
+		event = {
+			originId: `jira_comment_${commentId}`,
+			kind: "comment",
+			title: issueKey ? `Comment on ${issueKey}` : "Jira comment",
+			content: atlassianDocumentToText(comment.body) || null,
+			authorName:
+				(author &&
+					(strField(author, "displayName") ??
+						strField(author, "emailAddress") ??
+						strField(author, "name"))) ??
+				null,
+			sourceUrl: issueUrl(params.target, issueKey),
+			occurredAt:
+				strField(comment, "created") ?? strField(comment, "updated") ?? null,
+			...(issueId ? { parentOriginId: `jira_issue_${issueId}` } : {}),
+			metadata: {
+				issue_key: issueKey ?? null,
+				updated_at:
+					strField(comment, "updated") ?? strField(comment, "created") ?? null,
+			},
+		};
+	} else {
+		return false;
+	}
+
+	const deriveContext = await loadConnectorDeriveFeedContext(
+		{
+			organizationId: params.organizationId,
+			connectorKey: params.target.connectorKey,
+			feedKey: ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+			feedId: params.target.feedId,
+		},
+		params.sql,
+	);
+	// Verified webhooks are live pushes, not a cold-start backfill. Virtual feeds
+	// never have sync runs, so bypass only that gate and retain the persisted
+	// eventKinds catalog check.
+	deriveContext.feedPreviouslySynced = true;
+	const activations: BehaviorActivationResult[] = [];
+	await insertEvent(
+		{
+			organizationId: params.organizationId,
+			connectorKey: params.target.connectorKey,
+			connectionId: params.target.connectionId,
+			feedKey: ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+			feedId: params.target.feedId,
+			originId: event.originId,
+			originType: event.kind,
+			semanticType: event.kind,
+			title: event.title,
+			content: event.content,
+			payloadData: params.payload,
+			authorName: event.authorName,
+			sourceUrl: event.sourceUrl,
+			occurredAt: event.occurredAt,
+			parentOriginId: event.parentOriginId,
+			entityIds: [],
+			metadata: event.metadata,
+		},
+		{
+			onConflictUpdate: true,
+			afterPersist: async (persisted, tx) => {
+				const signals = deriveConnectorActivationSignals(
+					deriveContext,
+					{
+						connectionId: params.target.connectionId,
+						originId: event.originId,
+						kind: event.kind,
+						title: event.title,
+						payloadText: event.content,
+						sourceUrl: event.sourceUrl,
+						occurredAt: event.occurredAt ?? new Date(),
+						metadata: event.metadata,
+					},
+					persisted.change,
+					persisted.id,
+				);
+				for (const signal of signals) {
+					activations.push(
+						...(await activateBehaviorSignal({
+							organizationId: params.organizationId,
+							signal,
+							db: tx,
+						})),
+					);
+				}
+			},
+		},
+	);
+	await dispatchBehaviorRunsBestEffort(activations);
+	return true;
+}
+
+/**
+ * Route signed Jira App deliveries by exact org + site host to an active Rovo
+ * issues feed. Until the legacy Jira connector is deleted, an org without such
+ * a feed falls through to its existing raw app-install event path.
+ */
+export function createJiraWebhookDelivery(): NonNullable<
+	AppWebhookProvider["onDelivery"]
+> {
+	return async ({ rawBody, install, sql }) => {
+		const payload = parseJson(rawBody);
+		if (!payload || typeof payload !== "object") {
+			return { triggered: false, handled: false };
+		}
+		const target = await resolveJiraMcpFeedTarget({
+			sql,
+			organizationId: install.organizationId,
+			siteHost: install.externalTenantId,
+		});
+		if (!target) return { triggered: false, handled: false };
+		const triggered = await landJiraMcpWebhookEvent({
+			sql,
+			organizationId: install.organizationId,
+			target,
+			payload: payload as Record<string, unknown>,
+		});
+		return triggered
+			? { triggered: true }
+			: { triggered: false, handled: false };
+	};
+}

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -16,6 +16,7 @@ import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCodeForKey } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
 import {
+  ATLASSIAN_JIRA_ISSUES_FEED_KEY,
   isAtlassianMcpConfig,
   normalizeMcpProxyConfig,
   readAtlassianMcpVirtualFeed,
@@ -236,6 +237,11 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
     ? normalizeMcpProxyConfig(feed.mcp_config)
     : null;
   if (mcpConfig) {
+    if (feed.feed_key !== ATLASSIAN_JIRA_ISSUES_FEED_KEY) {
+      throw new Error(
+        `Atlassian MCP virtual feed '${feed.feed_key}' has no registered live-read adapter`
+      );
+    }
     return readAtlassianMcpVirtualFeed({
       organizationId: p.scope.organizationId,
       connectionId: Number(feed.connection_id),

--- a/packages/server/src/operations/atlassian-mcp-feed.ts
+++ b/packages/server/src/operations/atlassian-mcp-feed.ts
@@ -10,6 +10,11 @@
 
 import { callTool } from "../mcp-proxy/client";
 import type { McpProxyConfig } from "../mcp-proxy/types";
+import {
+	pickUniqueJiraSite,
+	type AtlassianAccessibleResource,
+	type JiraCloudSite,
+} from "../connect/atlassian-resources";
 
 export const ATLASSIAN_JIRA_ISSUES_FEED_KEY = "issues";
 
@@ -36,7 +41,7 @@ export const ATLASSIAN_MCP_FEEDS = {
 		key: ATLASSIAN_JIRA_ISSUES_FEED_KEY,
 		name: "Issues",
 		description:
-			"Live Jira issues via JQL. Reads call Rovo searchJiraIssuesUsingJql; nothing is copied into events.",
+			"Live Jira issues via JQL. Reads call Rovo searchJiraIssuesUsingJql; signed Jira issue/comment webhooks are copied into events.",
 		virtual: true,
 		configSchema: {
 			type: "object",
@@ -170,14 +175,17 @@ function namedField(value: unknown): string | undefined {
 	return asString((value as Record<string, unknown>).name);
 }
 
-function adfToText(value: unknown): string {
+export function atlassianDocumentToText(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (!value || typeof value !== "object") return "";
 	const node = value as { type?: string; text?: string; content?: unknown[] };
 	if (node.type === "hardBreak") return "\n";
 	if (typeof node.text === "string") return node.text;
 	if (Array.isArray(node.content)) {
-		return node.content.map((child) => adfToText(child)).join("").trim();
+		return node.content
+			.map((child) => atlassianDocumentToText(child))
+			.join("")
+			.trim();
 	}
 	return "";
 }
@@ -318,7 +326,7 @@ export function mapAtlassianIssueToRow(
 		created_at: asString(fields.created) ?? asString(issue.created) ?? null,
 		updated_at: asString(fields.updated) ?? asString(issue.updated) ?? null,
 		description:
-			adfToText(fields.description ?? issue.description) || null,
+			atlassianDocumentToText(fields.description ?? issue.description) || null,
 		url: issueUrl(issue, fields, config) ?? null,
 	};
 }
@@ -418,24 +426,118 @@ function mcpTextError(content: unknown, fallback: string): string {
 	return fallback;
 }
 
-export function parseAtlassianCloudId(payload: unknown): string | undefined {
-	const collected: unknown[] = [];
-	collectIssues(payload, collected);
-	if (typeof payload === "object" && payload) collected.unshift(payload);
-	for (const item of collected) {
-		if (!item || typeof item !== "object") continue;
-		const record = item as Record<string, unknown>;
-		const id =
-			asString(record.id) ??
-			asString(record.cloudId) ??
-			asString(record.cloud_id);
-		if (id) return id;
+function collectAtlassianResources(
+	value: unknown,
+	into: AtlassianAccessibleResource[],
+): void {
+	if (!value) return;
+	if (typeof value === "string") {
+		collectAtlassianResources(tryParseJson(value), into);
+		return;
 	}
-	if (typeof payload === "string") {
-		const parsed = tryParseJson(payload);
-		if (parsed !== payload) return parseAtlassianCloudId(parsed);
+	if (Array.isArray(value)) {
+		for (const item of value) collectAtlassianResources(item, into);
+		return;
 	}
-	return undefined;
+	if (typeof value !== "object") return;
+	const record = value as Record<string, unknown>;
+	if (record.type === "text" && typeof record.text === "string") {
+		collectAtlassianResources(record.text, into);
+		return;
+	}
+	const id =
+		asString(record.id) ?? asString(record.cloudId) ?? asString(record.cloud_id);
+	if (id) {
+		into.push({
+			id,
+			url: asString(record.url) ?? null,
+			name: asString(record.name) ?? null,
+			scopes: Array.isArray(record.scopes)
+				? record.scopes.filter(
+						(scope): scope is string => typeof scope === "string",
+					)
+				: [],
+		});
+		return;
+	}
+	for (const nested of [record.content, record.values, record.resources]) {
+		collectAtlassianResources(nested, into);
+	}
+}
+
+export function parseAtlassianMcpResources(
+	payload: unknown,
+): AtlassianAccessibleResource[] {
+	const resources: AtlassianAccessibleResource[] = [];
+	collectAtlassianResources(payload, resources);
+	return [
+		...new Map(resources.map((resource) => [resource.id, resource])).values(),
+	];
+}
+
+export function parseAtlassianMcpJiraSite(
+	payload: unknown,
+	preferredCloudId?: string,
+): JiraCloudSite | null {
+	const resources = parseAtlassianMcpResources(payload);
+	if (preferredCloudId) {
+		const preferred = resources.find(
+			(resource) => resource.id === preferredCloudId,
+		);
+		return preferred
+			? {
+					cloudId: preferred.id,
+					siteUrl: preferred.url,
+					siteName: preferred.name,
+					resourceCount: resources.length,
+				}
+			: null;
+	}
+	return pickUniqueJiraSite(resources);
+}
+
+export async function resolveAtlassianMcpJiraSite(params: {
+	organizationId: string;
+	connectionId: number;
+	connectorKey: string;
+	mcpConfig: McpProxyConfig;
+	preferredCloudId?: string;
+}): Promise<JiraCloudSite> {
+	const result = await callTool(
+		params.connectorKey,
+		params.mcpConfig,
+		params.organizationId,
+		"getAccessibleAtlassianResources",
+		{},
+		params.connectionId,
+	);
+	if (result.isError) {
+		throw new Error(
+			mcpTextError(
+				result.content,
+				"Atlassian MCP did not return an accessible Jira site",
+			),
+		);
+	}
+	const resources = parseAtlassianMcpResources(result.content);
+	if (resources.length === 0) {
+		throw new Error(
+			"Atlassian MCP did not return an accessible Jira site for this connection",
+		);
+	}
+	const site = parseAtlassianMcpJiraSite(
+		result.content,
+		params.preferredCloudId,
+	);
+	if (site) return site;
+	if (params.preferredCloudId) {
+		throw new Error(
+			`Atlassian cloud_id '${params.preferredCloudId}' is not accessible to this connection`,
+		);
+	}
+	throw new Error(
+		"Atlassian MCP returned multiple accessible Jira sites; set feed config.cloud_id explicitly",
+	);
 }
 
 export async function readAtlassianMcpVirtualFeed(params: {
@@ -458,18 +560,14 @@ export async function readAtlassianMcpVirtualFeed(params: {
 	const config = { ...params.connectionConfig, ...params.feedConfig };
 	let cloudId = asString(config.cloud_id) ?? asString(config.cloudId);
 	if (!cloudId) {
-		const resources = await callTool(
-			params.connectorKey,
-			params.mcpConfig,
-			params.organizationId,
-			"getAccessibleAtlassianResources",
-			{},
-			params.connectionId,
-		);
-		if (resources.isError) {
-			throw new Error("Atlassian MCP did not return an accessible site for this connection");
-		}
-		cloudId = parseAtlassianCloudId(resources.content);
+		cloudId = (
+			await resolveAtlassianMcpJiraSite({
+				organizationId: params.organizationId,
+				connectionId: params.connectionId,
+				connectorKey: params.connectorKey,
+				mcpConfig: params.mcpConfig,
+			})
+		).cloudId;
 	}
 	if (!cloudId) {
 		throw new Error(
@@ -495,7 +593,8 @@ export async function readAtlassianMcpVirtualFeed(params: {
 	// Walk Rovo pages until the requested window is filled. Jira's token has
 	// no random access, so we fetch and discard the prefix — same as bundled
 	// jira liveSearch.
-	for (let page = 0; page < 20 && rows.length < needed; page += 1) {
+	const maxPages = 20;
+	for (let page = 0; page < maxPages && rows.length < needed; page += 1) {
 		const result = await callTool(
 			params.connectorKey,
 			params.mcpConfig,
@@ -516,6 +615,11 @@ export async function readAtlassianMcpVirtualFeed(params: {
 		rows.push(...pageRows);
 		nextPageToken = parseAtlassianMcpNextPageToken(result.content);
 		if (pageRows.length === 0 || !nextPageToken) break;
+	}
+	if (rows.length < needed && nextPageToken) {
+		throw new Error(
+			`Jira virtual feed pagination limit (${maxPages} pages) reached before offset+limit (${needed}); narrow the JQL or lower offset`,
+		);
 	}
 
 	return {

--- a/packages/server/src/scheduled/refresh-connector-definitions.ts
+++ b/packages/server/src/scheduled/refresh-connector-definitions.ts
@@ -7,6 +7,10 @@
  */
 
 import { getDb } from '../db/client';
+import {
+  ATLASSIAN_MCP_FEEDS,
+  isAtlassianMcpConfig,
+} from '../operations/atlassian-mcp-feed';
 import { upsertBundledConnectorForOrg } from '../utils/ensure-connector-installed';
 import logger from '../utils/logger';
 
@@ -24,6 +28,7 @@ interface RefreshResult {
 interface DefRow {
   organization_id: string;
   key: string;
+  mcp_config: Record<string, unknown> | null;
 }
 
 export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
@@ -32,11 +37,12 @@ export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
   // Every (org, key) that currently has an ACTIVE built-in definition. We only
   // refresh what an org already installed — never auto-install a new connector.
   const rows = (await sql`
-    SELECT DISTINCT organization_id, key
+    SELECT DISTINCT ON (organization_id, key)
+      organization_id, key, mcp_config
     FROM connector_definitions
     WHERE status = 'active'
       AND organization_id IS NOT NULL
-    ORDER BY key
+    ORDER BY organization_id, key, updated_at DESC
   `) as unknown as DefRow[];
 
   const result: RefreshResult = {
@@ -51,6 +57,30 @@ export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
   const noSourceKeys = new Set<string>();
 
   for (const row of rows) {
+    // MCP definitions have no bundled source file. Atlassian Rovo gained its
+    // Jira feed after existing installs were already stored, so converge those
+    // snapshots here instead of requiring every user to reinstall.
+    if (isAtlassianMcpConfig(row.mcp_config)) {
+      try {
+        await sql`
+          UPDATE connector_definitions
+          SET feeds_schema = COALESCE(feeds_schema, '{}'::jsonb)
+                || ${sql.json(ATLASSIAN_MCP_FEEDS)}::jsonb,
+              updated_at = NOW()
+          WHERE organization_id = ${row.organization_id}
+            AND key = ${row.key}
+            AND status = 'active'
+        `;
+        result.refreshed += 1;
+      } catch (err) {
+        result.errored += 1;
+        logger.error(
+          { connector_key: row.key, organization_id: row.organization_id, err },
+          '[refresh-connector-definitions] Failed to refresh Atlassian MCP definition for org'
+        );
+      }
+      continue;
+    }
     if (noSourceKeys.has(row.key)) {
       result.skippedNoSource += 1;
       continue;

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -40,6 +40,12 @@ import {
 } from '../../authz/channel-about';
 import { filterChannelsForRequester } from '../../authz/channel-visibility';
 import { readVirtualFeed } from '../../lib/connector-pushdown';
+import {
+  ATLASSIAN_JIRA_ISSUES_FEED_KEY,
+  isAtlassianMcpConfig,
+  normalizeMcpProxyConfig,
+} from '../../operations/atlassian-mcp-feed';
+import { reconcileAtlassianMcpJiraSite } from '../../connect/atlassian-mcp-site';
 import { readChannelTranscript } from '../../gateway/connections/channel-transcript';
 import type { Env } from '../../index';
 import { getAuthProfileById } from '../../utils/auth-profiles';
@@ -526,10 +532,11 @@ async function handleCreateFeed(
   const { organizationId } = ctx;
 
   const connRows = await sql`
-    SELECT c.id, c.connector_key, c.status, c.auth_profile_id, c.config, cd.feeds_schema
+    SELECT c.id, c.connector_key, c.status, c.auth_profile_id, c.config,
+           cd.feeds_schema, cd.mcp_config
     FROM connections c
     LEFT JOIN LATERAL (
-      SELECT feeds_schema
+      SELECT feeds_schema, mcp_config
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -581,13 +588,43 @@ async function handleCreateFeed(
   const isVirtual =
     args.virtual === true || (args.virtual !== false && schemaDefaultVirtual);
 
+  // Resolve the concrete Atlassian site through the authenticated MCP
+  // connection at this write-time chokepoint. Persisting site identity makes
+  // future live reads and Jira app webhook routing exact and replica-safe.
+  let effectiveFeedConfig: Record<string, unknown> = { ...(args.config ?? {}) };
+  const mcpConfig = isAtlassianMcpConfig(conn.mcp_config)
+    ? normalizeMcpProxyConfig(conn.mcp_config)
+    : null;
+  if (
+    conn.status === 'active' &&
+    mcpConfig &&
+    args.feed_key === ATLASSIAN_JIRA_ISSUES_FEED_KEY
+  ) {
+    try {
+      const preferredCloudId =
+        typeof effectiveFeedConfig.cloud_id === 'string'
+          ? effectiveFeedConfig.cloud_id.trim() || undefined
+          : undefined;
+      const { configPatch } = await reconcileAtlassianMcpJiraSite({
+        organizationId,
+        connectionId: Number(conn.id),
+        connectorKey: String(conn.connector_key),
+        mcpConfig,
+        preferredCloudId,
+      });
+      effectiveFeedConfig = { ...effectiveFeedConfig, ...configPatch };
+    } catch (err) {
+      return { error: getErrorMessage(err) };
+    }
+  }
+
   // Validate config against the connector's declared feed configSchema up
   // front so a mis-shaped config fails here instead of at sync or live-read
   // time. The schema describes both collected and virtual feed configuration,
   // but its `required` fields are the sync contract only, and a virtual feed is
   // never synced, so a missing one must not gate creation (rss `articles`
   // requires feed_urls; a virtual read of it needs only the query fence).
-  const configError = validateFeedConfig(feedsSchema, args.feed_key, args.config ?? {}, {
+  const configError = validateFeedConfig(feedsSchema, args.feed_key, effectiveFeedConfig, {
     ignoreRequired: isVirtual,
   });
   if (configError) return { error: configError };
@@ -633,7 +670,7 @@ async function handleCreateFeed(
   const displayName = await resolveFeedDisplayName({
     explicitName: args.display_name,
     feedKey: args.feed_key,
-    config: args.config ?? null,
+    config: effectiveFeedConfig,
     entityIds: args.entity_ids ?? null,
     feedsSchema,
   });
@@ -645,7 +682,7 @@ async function handleCreateFeed(
     ) VALUES (
       ${organizationId}, ${args.connection_id}, ${args.feed_key}, ${displayName}, ${feedInitialStatus},
       ${entityIdsValue}::bigint[],
-      ${args.config ? sql.json(args.config) : null},
+      ${args.config || Object.keys(effectiveFeedConfig).length > 0 ? sql.json(effectiveFeedConfig) : null},
       ${schedule}, ${timezone}, ${nextRunAtVal},
       ${isVirtual ? 'virtual' : 'collected'}, ${isVirtual}
     )


### PR DESCRIPTION
## Summary

- Complete Atlassian Rovo Jira feed support with deterministic site selection, persisted site identity, definition backfill, and fail-closed pagination.
- Route signed Jira app webhooks into matching Rovo issue feeds while preserving stable issue/comment identity and existing raw Jira fallback.
- Keep the legacy Jira connector installed for a separate, explicitly approved cleanup after production Rovo E2E proof.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Tests run: targeted Bun/Vitest suites and server typecheck
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Production E2E after squash merge and rollout
- [ ] If bot behavior: not applicable

### Red

Before the implementation, the focused suites reported:

```text
10 pass
5 fail
1 error
```

Failures proved the missing behaviors: multi-site grants selected the first site instead of rejecting ambiguity, pagination silently returned a partial window after 20 pages, definition refresh did not backfill existing Rovo connectors, and the Jira-to-Rovo webhook delivery module did not exist.

### Green

```text
Bun unit/router suites: 48 pass, 0 fail, 132 expect() calls
Vitest integration/resource suites: 16 pass, 0 fail
make pre-pr-remote: 18 jobs finished, passed
Depot run: hdcb350rgg
Tree attestation: b24c47a6c41f13e87218674ef1ab1ca55368f542
```

Mutation proof: removed the feed-config reconciliation assignment after asserting the exact source line existed; the focused integration test failed because the persisted feed retained only `{ query }` and lost `cloud_id`/site metadata. Restored the single assignment and reran the test green.

## Notes

- No new table or database design change.
- No public API or SDK surface change.
- Unknown Jira events and sites without a unique active Rovo issues feed continue through the existing raw Jira installation path.
- The old Jira connection is intentionally not deleted by this PR.
