### PR TITLE
fix(server): register URI tool format

### DIFF
--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { ManageOperationsSchema } from "@lobu/core/contracts/tools/manage-operations";
 import { Type } from "@sinclair/typebox";
 import { getAllTools, getMcpTools, getTool } from "../../tools/registry";
 import {
@@ -146,6 +147,31 @@ describe("validateToolArgs coercion", () => {
     }) as Record<string, unknown>;
     expect(ok.id).toBe("f6a7b2c1-3d4e-4f50-8a9b-0c1d2e3f4a5b");
     expect(() => validateToolArgs("t", s, { id: "not-a-uuid" })).toThrow(ToolUserError);
+  });
+
+  it("accepts the URI format used by page-activated operation URLs", () => {
+    const out = validateToolArgs("manage_operations", ManageOperationsSchema, {
+      action: "execute",
+      connection_id: 399,
+      operation_key: "prepare_reply",
+      activation: {
+        kind: "page_visit",
+        urls: ["https://x.com/dhh/status/2087839779811373514"],
+      },
+    }) as Record<string, unknown>;
+
+    expect(out.activation).toEqual({
+      kind: "page_visit",
+      urls: ["https://x.com/dhh/status/2087839779811373514"],
+    });
+    expect(() =>
+      validateToolArgs("manage_operations", ManageOperationsSchema, {
+        action: "execute",
+        connection_id: 399,
+        operation_key: "prepare_reply",
+        activation: { kind: "page_visit", urls: ["https://example.com/a b"] },
+      })
+    ).toThrow(ToolUserError);
   });
 });
 

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -25,12 +25,19 @@ import { ToolUserError } from '../utils/errors';
 import { stripNul } from '../utils/strip-nul';
 
 // typebox's Value.Check FAILS (returns false) on any `format` constraint that
-// isn't registered — there is no permissive default. `manage_schedules` gates
-// ids with `format: 'uuid'`, so without this registration every pause/cancel
-// would 400 the moment validation runs.
+// isn't registered — there is no permissive default. Register every format
+// used by a tool contract here so adding a schema annotation cannot make all
+// otherwise-valid calls fail before their handler runs.
 if (!FormatRegistry.Has('uuid')) {
   FormatRegistry.Set('uuid', (value) =>
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+if (!FormatRegistry.Has('uri')) {
+  // Same absolute-URI shape used by ajv-formats' fast validator. Individual
+  // handlers still enforce narrower contracts such as HTTP(S)-only URLs.
+  FormatRegistry.Set('uri', (value) =>
+    /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i.test(value)
   );
 }
 


### PR DESCRIPTION
## Summary
<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->

## Test plan
<!-- Check only what you actually ran. See AGENTS.md → "Ship a change". -->
- [ ] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [ ] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

## Notes
<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->
