### PR TITLE
ci: add directory-structure gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -913,6 +913,20 @@ jobs:
         # another user's private-connection data through a new read path.
         run: bun scripts/check-connection-visibility-compiler.mjs
 
+      - name: Directory-structure gate
+        # Two shapes that made modules unfindable and drifted back in unnoticed,
+        # because nothing mechanical rejected them. (1) A directory repeating its
+        # parent's name: gateway/gateway/ held class WorkerGateway in an index.ts,
+        # so the most important object in the dispatch path could not be located
+        # by filename. (2) A <name>.ts larger than the <name>/ beside it: that
+        # pairing is this repo's extraction facade (manage_connections.ts at 140
+        # lines over 4,229), and manage_operations.ts sat at 3,488 over 627 —
+        # an abandoned extraction, shape-identical to the finished ones.
+        run: bun scripts/check-directory-structure.mjs
+
+      - name: Directory-structure gate tests
+        run: bun test scripts/__tests__/check-directory-structure.test.ts --timeout 30000
+
       - name: Review tooling shell tests
         # These previously ran inside scripts/review.sh's local unit stage; the
         # review runner is now LLM-only (CI owns the deterministic suites), so

--- a/scripts/__tests__/check-directory-structure.test.ts
+++ b/scripts/__tests__/check-directory-structure.test.ts
@@ -104,6 +104,31 @@ describe("check-directory-structure", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("governs handwritten client source but not its generated surface", () => {
+    // packages/client mixes a tool-authored src/generated/** tree with ~670
+    // lines of handwritten source. Excluding the whole package to skip the
+    // generated half would leave the handwritten half ungoverned, so the
+    // generated tree is skipped by SKIPPED_DIRS and the package is not.
+    const clientSrc = join(dir, "packages", "client", "src");
+    mkdirSync(join(clientSrc, "generated", "generated"), { recursive: true });
+    writeFileSync(
+      join(clientSrc, "generated", "generated", "types.ts"),
+      "export {};"
+    );
+    mkdirSync(join(clientSrc, "session", "session"), { recursive: true });
+    writeFileSync(
+      join(clientSrc, "session", "session", "index.ts"),
+      "export {};"
+    );
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(1);
+    const err = result.stderr.toString();
+    expect(err).toContain("1 violation(s)");
+    expect(err).toContain(join("client", "src", "session", "session"));
+    expect(err).not.toContain("generated");
+  });
+
   it("reports every violation, not just the first", () => {
     writeSrc(dir, "gateway/gateway/index.ts", 1200);
     writeSrc(dir, "tools/manage_ops.ts", 3500);

--- a/scripts/__tests__/check-directory-structure.test.ts
+++ b/scripts/__tests__/check-directory-structure.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GATE = join(REPO_ROOT, "scripts/check-directory-structure.mjs");
+
+/** Build `packages/<pkg>/src/...` inside a throwaway root and run the gate there. */
+function runGate(dir: string) {
+  return Bun.spawnSync(["node", GATE], {
+    cwd: dir,
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function writeSrc(dir: string, relPath: string, lines: number) {
+  const full = join(dir, "packages", "svc", "src", relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(
+    full,
+    Array.from({ length: lines }, () => "export {};").join("\n")
+  );
+}
+
+describe("check-directory-structure", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dir-structure-gate-"));
+    mkdirSync(join(dir, "packages", "svc", "src"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("passes a tree with no repeated segment and no stalled extraction", () => {
+    writeSrc(dir, "gateway/worker-dispatch/worker-gateway.ts", 400);
+    writeSrc(dir, "tools/manage_ops.ts", 40);
+    writeSrc(dir, "tools/manage_ops/handlers.ts", 900);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("clean");
+  });
+
+  it("rule 1: rejects a directory that repeats its parent's name", () => {
+    writeSrc(dir, "gateway/gateway/index.ts", 1200);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(1);
+    const err = result.stderr.toString();
+    expect(err).toContain("[rule 1]");
+    expect(err).toContain("gateway/gateway");
+  });
+
+  it("rule 2: rejects a facade larger than the directory it extracted into", () => {
+    writeSrc(dir, "tools/manage_ops.ts", 3500);
+    writeSrc(dir, "tools/manage_ops/activity.ts", 600);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(1);
+    const err = result.stderr.toString();
+    expect(err).toContain("[rule 2]");
+    expect(err).toContain("manage_ops.ts");
+  });
+
+  it("rule 2: ignores a small sibling directory, which is not a stalled extraction", () => {
+    // `core/src/types.ts` beside a 32-line `core/src/types/` is a real, benign
+    // shape in this repo. Below the weight threshold the rule must stay quiet.
+    writeSrc(dir, "types.ts", 435);
+    writeSrc(dir, "types/branded.ts", 30);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("rule 2: accepts the finished facade shape", () => {
+    writeSrc(dir, "tools/get_content.ts", 20);
+    writeSrc(dir, "tools/get_content/search.ts", 3200);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not walk __tests__, dist, or generated trees", () => {
+    writeSrc(dir, "gateway/__tests__/__tests__/nested.ts", 10);
+    writeSrc(dir, "gateway/dist/dist/bundle.ts", 10);
+    writeSrc(dir, "gateway/generated/generated/types.ts", 10);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("skips the owletto submodule, which has its own conventions", () => {
+    const owletto = join(dir, "packages", "owletto", "src", "app", "app");
+    mkdirSync(owletto, { recursive: true });
+    writeFileSync(join(owletto, "index.ts"), "export {};");
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports every violation, not just the first", () => {
+    writeSrc(dir, "gateway/gateway/index.ts", 1200);
+    writeSrc(dir, "tools/manage_ops.ts", 3500);
+    writeSrc(dir, "tools/manage_ops/activity.ts", 600);
+
+    const result = runGate(dir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("2 violation(s)");
+  });
+});

--- a/scripts/check-directory-structure.mjs
+++ b/scripts/check-directory-structure.mjs
@@ -41,7 +41,6 @@ const PACKAGES_DIR = "packages";
 /** Packages whose src tree this gate does not govern. */
 const EXCLUDED_PACKAGES = new Set([
   "owletto", // git submodule: separate repo, separate conventions
-  "client", // generated SDK surface (src/generated/**) is tool-authored
   "node_modules",
 ]);
 

--- a/scripts/check-directory-structure.mjs
+++ b/scripts/check-directory-structure.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Directory-structure gate.
+ *
+ * Two structural regressions cost real navigation time in this repo and are
+ * both cheap to detect mechanically. Neither is a style preference; each one
+ * is a shape that made a module unfindable until somebody went looking.
+ *
+ * RULE 1 — a directory may not share its parent's name.
+ *   `packages/server/src/gateway/gateway/` held `class WorkerGateway` (1,256
+ *   lines) in an `index.ts`. The path segment repeats, so the name carries no
+ *   information, and the file that mattered most in the dispatch path could not
+ *   be found by filename. Renaming it cost minutes; finding it cost sessions.
+ *
+ * RULE 2 — a `<name>.ts` sitting beside a `<name>/` must be the SMALLER half.
+ *   That pairing is this repo's extraction idiom: the file becomes a thin
+ *   re-exporting facade and the directory holds the implementation
+ *   (`manage_connections.ts` at 140 lines over `manage_connections/` at 4,229;
+ *   `get_content.ts` at 20 over 3,289). It only reads as intentional when the
+ *   directory won. `manage_operations.ts` sat at 3,488 lines beside a 627-line
+ *   directory for months — an extraction that was started, abandoned, and
+ *   indistinguishable from the finished ones by shape alone.
+ *
+ *   The rule applies only once the directory carries real weight (>= 300 lines).
+ *   Below that the pair is usually a small types or helper folder next to an
+ *   unrelated module (`core/src/types.ts` beside `core/src/types/`), not a
+ *   stalled extraction, and forcing a comparison there produces noise.
+ *
+ * Scope: `packages/<pkg>/src` for workspace packages, excluding tests,
+ * generated output, and the owletto submodule (separate repo, separate rules).
+ *
+ * Usage: bun scripts/check-directory-structure.mjs
+ * Exit 0 = clean, 1 = violations found.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const PACKAGES_DIR = "packages";
+
+/** Packages whose src tree this gate does not govern. */
+const EXCLUDED_PACKAGES = new Set([
+  "owletto", // git submodule: separate repo, separate conventions
+  "client", // generated SDK surface (src/generated/**) is tool-authored
+  "node_modules",
+]);
+
+/** Directory names skipped anywhere in the walk. */
+const SKIPPED_DIRS = new Set([
+  "__tests__",
+  "node_modules",
+  "dist",
+  "generated",
+  "templates",
+]);
+
+/** A sibling directory below this many lines is too small to be a stalled extraction. */
+const EXTRACTION_WEIGHT_THRESHOLD = 300;
+
+function isSourceFile(name) {
+  return (
+    (name.endsWith(".ts") || name.endsWith(".tsx")) &&
+    !name.endsWith(".test.ts") &&
+    !name.endsWith(".test.tsx") &&
+    !name.endsWith(".spec.ts") &&
+    !name.endsWith(".d.ts")
+  );
+}
+
+function countLines(filePath) {
+  return readFileSync(filePath, "utf8").split("\n").length;
+}
+
+/** Total source lines directly in `dir` and below, skipping SKIPPED_DIRS. */
+function countTreeLines(dir) {
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRS.has(entry.name)) continue;
+      total += countTreeLines(join(dir, entry.name));
+    } else if (isSourceFile(entry.name)) {
+      total += countLines(join(dir, entry.name));
+    }
+  }
+  return total;
+}
+
+function walk(dir, violations) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return; // package without a src tree
+  }
+
+  const dirNames = new Set(
+    entries.filter((e) => e.isDirectory()).map((e) => e.name)
+  );
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (SKIPPED_DIRS.has(entry.name)) continue;
+
+    const childPath = join(dir, entry.name);
+
+    // RULE 1: a directory may not repeat its parent's name.
+    if (entry.name === basename(dir)) {
+      violations.push({
+        rule: 1,
+        path: childPath,
+        detail:
+          `directory "${entry.name}/" repeats its parent's name, so the path ` +
+          `segment carries no information. Name it for what it holds.`,
+      });
+    }
+
+    walk(childPath, violations);
+  }
+
+  // RULE 2: `<name>.ts` beside `<name>/` must be the smaller half.
+  for (const entry of entries) {
+    if (entry.isDirectory()) continue;
+    if (!isSourceFile(entry.name)) continue;
+
+    const stem = entry.name.replace(/\.tsx?$/, "");
+    if (!dirNames.has(stem)) continue;
+    if (SKIPPED_DIRS.has(stem)) continue;
+
+    const filePath = join(dir, entry.name);
+    const dirPath = join(dir, stem);
+    const dirLines = countTreeLines(dirPath);
+    if (dirLines < EXTRACTION_WEIGHT_THRESHOLD) continue;
+
+    const fileLines = countLines(filePath);
+    if (fileLines > dirLines) {
+      violations.push({
+        rule: 2,
+        path: filePath,
+        detail:
+          `${fileLines} lines sits beside ${stem}/ at ${dirLines} lines. ` +
+          `A <name>.ts next to a <name>/ is this repo's extraction facade — ` +
+          `the directory should hold the implementation. Finish the ` +
+          `extraction or fold the directory back in.`,
+      });
+    }
+  }
+}
+
+function main() {
+  const violations = [];
+
+  let packages;
+  try {
+    packages = readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  } catch {
+    console.error(
+      `check-directory-structure: no ${PACKAGES_DIR}/ directory; run from the repo root.`
+    );
+    process.exit(1);
+  }
+
+  for (const pkg of packages) {
+    if (!pkg.isDirectory()) continue;
+    if (EXCLUDED_PACKAGES.has(pkg.name)) continue;
+
+    const srcDir = join(PACKAGES_DIR, pkg.name, "src");
+    try {
+      if (!statSync(srcDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    walk(srcDir, violations);
+  }
+
+  if (violations.length === 0) {
+    console.log("check-directory-structure: clean");
+    process.exit(0);
+  }
+
+  console.error(
+    `check-directory-structure: ${violations.length} violation(s)\n`
+  );
+  for (const v of violations) {
+    console.error(`  [rule ${v.rule}] ${v.path}`);
+    console.error(`              ${v.detail}\n`);
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds a CI gate for the two structural shapes that made modules unfindable in this repo and drifted back in unnoticed, because nothing mechanical rejected them.
- **Rule 1** — a directory may not repeat its parent's name. `gateway/gateway/` held `class WorkerGateway` in an `index.ts`, so the object that matters most in the dispatch path could not be found by filename.
- **Rule 2** — a `<name>.ts` beside a `<name>/` must be the smaller half. That pairing is this repo's extraction facade (`manage_connections.ts` at 140 lines over `manage_connections/` at 4,229; `get_content.ts` at 20 over 3,289). `manage_operations.ts` sat at 3,488 lines over a 627-line directory for months — an extraction started, abandoned, and indistinguishable by shape from the finished ones.

## Test plan

- [x] Intended files staged explicitly, then `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` clean (workflow change, so the override is required)
- [x] Tests run: `bun test scripts/__tests__/check-directory-structure.test.ts` — **8 pass, 0 fail**
- [ ] Bug fix: red→fix→green outputs pasted below _(not a bug fix)_
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval _(no bot behavior change)_

The gate was verified against real trees in both directions, which is also what proves the merge order:

```text
$ node scripts/check-directory-structure.mjs         # on main, before the refactor PR
check-directory-structure: 2 violation(s)
  [rule 1] packages/server/src/gateway/gateway
  [rule 2] packages/server/src/tools/admin/manage_operations.ts
             3781 lines sits beside manage_operations/ at 631 lines.

$ node scripts/check-directory-structure.mjs         # on the refactor branch
check-directory-structure: clean
```

The 8 unit tests build throwaway `packages/<pkg>/src` trees in a tmpdir and run the gate as a subprocess, covering: a clean tree, each rule firing, the finished-facade shape passing, the sub-threshold sibling staying quiet, skipped trees (`__tests__`/`dist`/`generated`), the `owletto` submodule exclusion, and multi-violation reporting.

## Notes

**Must merge after the structural-refactor PR.** This gate fails on `main` as it stands — both violations it reports are exactly what that PR removes. Landing this first would red the required check on `main`.

**Rule 2 has a weight threshold (300 lines)** so it only fires on stalled extractions. Below that, a `<name>.ts` beside a small `<name>/` is usually a types or helper folder next to an unrelated module (`core/src/types.ts` beside a 32-line `core/src/types/`), and comparing them produces noise. That case is covered by a test.

**Scope is `packages/<pkg>/src`**, excluding `owletto` (submodule, separate repo and conventions), `client` (tool-authored generated SDK surface), and `__tests__`/`node_modules`/`dist`/`generated`/`templates` anywhere in the walk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for package source directory structures.
  * Reports repeated directory names and oversized same-named source files.
  * Supports exclusions for tests, generated files, and designated directories.

* **Tests**
  * Added coverage for valid structures, violations, exclusions, missing paths, thresholds, and multiple reported issues.
  * Integrated the validation checks into the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->