### PR TITLE
docs(connector): add executable defineConnector example to connector-authoring

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -52,6 +52,50 @@ export default class MyConnector extends ConnectorRuntime {
 }
 ```
 
+The functional `defineConnector` form derives feed/action keys from the record
+keys and dispatches each call to the handler declared on that entry:
+
+```ts
+import { defineConnector } from "@lobu/connector-sdk";
+
+export default defineConnector({
+  key: "my_connector",
+  name: "My Connector",
+  version: "1.0.0",
+  authSchema: { methods: [{ type: "none" }] },
+  feeds: {
+    items: {
+      name: "Items",
+      eventKinds: { item: { description: "An item from the service" } },
+      sync: async () => ({
+        events: [],
+        checkpoint: { last_sync_at: new Date().toISOString() },
+      }),
+    },
+  },
+  actions: {
+    create_item: {
+      name: "Create item",
+      requiresApproval: true,
+      annotations: { openWorldHint: true },
+      inputSchema: {
+        type: "object",
+        required: ["name"],
+        properties: { name: { type: "string" } },
+      },
+      execute: async (ctx) => ({
+        success: true,
+        output: { name: ctx.input.name },
+      }),
+    },
+  },
+});
+```
+
+Optional top-level handlers (`authenticate`, `query`, `search`,
+`reflectMetrics`, `registerWebhook`, `unregisterWebhook`) dispatch through the
+corresponding `ConnectorRuntime` methods.
+
 ### What a feed sync must get right
 
 - **`origin_id` stability.** Keep `origin_id` identical for the same source item


### PR DESCRIPTION
## Summary
- Add the functional `defineConnector` authoring form to `docs/connector-authoring.md`, alongside the `ConnectorRuntime` class: record keys become feed/action keys, each entry carries its own handler, and optional top-level handlers (`authenticate`/`query`/`search`/`reflectMetrics`/`registerWebhook`/`unregisterWebhook`) lower to the corresponding `ConnectorRuntime` methods.
- Closes the last documented knowledge gap: `defineConnector` previously had zero docs/examples.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; run jz0618chd4 passed)
- [x] The example typechecks against `@lobu/connector-sdk` (`tsc --noEmit`, clean) and executes; `define-connector` unit suite 9/9
- [ ] Bug fix: red→fix→green (n/a — docs only)

## Notes
- A webhook "create one" note was attempted and reverted by the review-fix pass: the normal `defineConnection`/`connections.connect` path does not generate or return the ingest token, so no supported create-flow exists to document — a pre-existing API gap, tracked out of this docs branch.