### PR TITLE
feat(server): deliver Jira webhooks through Atlassian MCP

### DIFF
--- a/packages/server/src/connect/atlassian-mcp-webhook.ts
+++ b/packages/server/src/connect/atlassian-mcp-webhook.ts
@@ -516,13 +516,6 @@ async function ensureUnderLock(params: {
 				callbackToken,
 			),
 		));
-	const registeringConfig = {
-		...connection.config,
-		webhook_callback_token: callbackTokenRef,
-		webhook_status: "registering",
-		webhook_error: null,
-	};
-	await persistConfig(sql, connection, registeringConfig);
 
 	const apiBase = jiraApiBase(cloudId);
 	const targetUrl = callbackUrl(params.baseUrl, connection.id, callbackToken);
@@ -636,6 +629,7 @@ async function ensureUnderLock(params: {
 	}
 	await persistConfig(sql, connection, {
 		...connection.config,
+		webhook_callback_token: callbackTokenRef,
 		webhook_external_id: externalId,
 		webhook_expires_at: expiresAt,
 		webhook_status: "active",

--- a/packages/server/src/connect/atlassian-mcp-webhook.ts
+++ b/packages/server/src/connect/atlassian-mcp-webhook.ts
@@ -1,0 +1,788 @@
+import { randomBytes } from "node:crypto";
+import { getErrorMessage } from "@lobu/core";
+import { resolveBaseUrl } from "../auth/base-url";
+import { CredentialService } from "../auth/credentials";
+import { normalizeScopeList } from "../auth/oauth/scopes";
+import { type DbClient, getDb } from "../db/client";
+import {
+	persistSecretValue,
+	resolveSecretValue,
+} from "../gateway/secrets/index";
+import { orgContext } from "../lobu/stores/org-context";
+import { PostgresSecretStore } from "../lobu/stores/postgres-secret-store";
+import { isAtlassianMcpConfig } from "../operations/atlassian-mcp-feed";
+import { resolveAuthCredentials } from "../utils/auth-credential-secrets";
+import logger from "../utils/logger";
+
+const JIRA_TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+const JIRA_API_ROOT = "https://api.atlassian.com/ex/jira";
+const WEBHOOK_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
+const WEBHOOK_REFRESH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface AtlassianMcpWebhookConnection {
+	id: number;
+	organizationId: string;
+	status: string;
+	config: Record<string, unknown>;
+	mcpConfig: Record<string, unknown> | null;
+}
+
+interface JiraWebhookCredentials {
+	accessToken: string;
+}
+
+interface JiraDynamicWebhook {
+	id?: number | string;
+	url?: string;
+	expirationDate?: string;
+}
+
+interface JiraWebhookListResponse {
+	values?: JiraDynamicWebhook[];
+	isLast?: boolean;
+	startAt?: number;
+	maxResults?: number;
+}
+
+interface JiraWebhookRegistrationResponse {
+	webhookRegistrationResult?: Array<{
+		createdWebhookId?: number | string;
+		errors?: string[];
+	}>;
+}
+
+interface JiraWebhookRefreshResponse {
+	expirationDate?: string;
+}
+
+export interface AtlassianMcpWebhookResult {
+	handled: boolean;
+	changed: boolean;
+	status?: "active" | "disabled";
+}
+
+function stringConfig(
+	config: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = config[key];
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function enabled(config: Record<string, unknown>): boolean {
+	return config.webhook_enabled === true || config.webhook_enabled === "true";
+}
+
+function callbackBaseUrl(baseUrl: string, connectionId: number): URL {
+	return new URL(
+		`${baseUrl.replace(/\/+$/, "")}/api/v1/webhooks/${connectionId}`,
+	);
+}
+
+function callbackUrl(
+	baseUrl: string,
+	connectionId: number,
+	callbackToken: string,
+): string {
+	const url = callbackBaseUrl(baseUrl, connectionId);
+	url.searchParams.set("token", callbackToken);
+	return url.href;
+}
+
+function hasCallbackPath(value: string | undefined, expected: URL): boolean {
+	if (!value) return false;
+	try {
+		const candidate = new URL(value);
+		candidate.search = "";
+		return candidate.href === expected.href;
+	} catch {
+		return false;
+	}
+}
+
+function jiraApiBase(cloudId: string): string {
+	return `${JIRA_API_ROOT}/${encodeURIComponent(cloudId)}/rest/api/3`;
+}
+
+function expiresSoon(value: unknown, nowMs: number): boolean {
+	if (typeof value !== "string") return true;
+	const expiresAt = new Date(value).getTime();
+	return (
+		!Number.isFinite(expiresAt) ||
+		expiresAt <= nowMs + WEBHOOK_REFRESH_WINDOW_MS
+	);
+}
+
+function errorText(response: Response, body: string): string {
+	const detail = body.trim().replace(/\s+/g, " ").slice(0, 500);
+	return detail
+		? `Jira webhook API returned ${response.status}: ${detail}`
+		: `Jira webhook API returned ${response.status}`;
+}
+
+async function jiraJson<T>(
+	fetchImpl: typeof fetch,
+	url: string,
+	accessToken: string,
+	init: RequestInit,
+): Promise<T> {
+	const response = await fetchImpl(url, {
+		...init,
+		headers: {
+			Accept: "application/json",
+			Authorization: `Bearer ${accessToken}`,
+			...(init.body ? { "Content-Type": "application/json" } : {}),
+			...(init.headers ?? {}),
+		},
+	});
+	const body = await response.text();
+	if (!response.ok) throw new Error(errorText(response, body));
+	if (!body.trim()) return {} as T;
+	return JSON.parse(body) as T;
+}
+
+async function listJiraWebhooks(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	accessToken: string,
+): Promise<JiraDynamicWebhook[]> {
+	const all: JiraDynamicWebhook[] = [];
+	let startAt = 0;
+	for (let page = 0; page < 100; page += 1) {
+		const url = new URL(`${apiBase}/webhook`);
+		url.searchParams.set("startAt", String(startAt));
+		url.searchParams.set("maxResults", "100");
+		const result = await jiraJson<JiraWebhookListResponse>(
+			fetchImpl,
+			url.href,
+			accessToken,
+			{ method: "GET" },
+		);
+		const values = result.values ?? [];
+		all.push(...values);
+		if (result.isLast === true || values.length === 0) return all;
+		const nextStart =
+			(typeof result.startAt === "number" ? result.startAt : startAt) +
+			(typeof result.maxResults === "number"
+				? result.maxResults
+				: values.length);
+		if (nextStart <= startAt || (result.isLast !== false && values.length < 100)) {
+			return all;
+		}
+		startAt = nextStart;
+	}
+	throw new Error("Jira webhook listing exceeded 100 pages");
+}
+
+async function loadConnection(
+	sql: DbClient,
+	organizationId: string,
+	connectionId: number,
+): Promise<AtlassianMcpWebhookConnection | null> {
+	const rows = await sql`
+		SELECT c.id, c.organization_id, c.status, c.config, cd.mcp_config
+		FROM connections c
+		LEFT JOIN LATERAL (
+			SELECT mcp_config
+			FROM connector_definitions
+			WHERE organization_id = c.organization_id
+			  AND key = c.connector_key
+			  AND status = 'active'
+			ORDER BY updated_at DESC
+			LIMIT 1
+		) cd ON TRUE
+		WHERE c.id = ${connectionId}
+		  AND c.organization_id = ${organizationId}
+		  AND c.deleted_at IS NULL
+		LIMIT 1
+	`;
+	const row = rows[0] as
+		| {
+				id: number;
+				organization_id: string;
+				status: string;
+				config: Record<string, unknown> | null;
+				mcp_config: Record<string, unknown> | null;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		id: Number(row.id),
+		organizationId: row.organization_id,
+		status: row.status,
+		config: row.config ?? {},
+		mcpConfig: row.mcp_config,
+	};
+}
+
+async function resolveJiraCredentials(
+	sql: DbClient,
+	connection: AtlassianMcpWebhookConnection,
+): Promise<JiraWebhookCredentials> {
+	const accountSlug = stringConfig(
+		connection.config,
+		"jira_webhook_auth_profile_slug",
+	);
+	const appSlug = stringConfig(
+		connection.config,
+		"jira_webhook_app_profile_slug",
+	);
+	if (!accountSlug || !appSlug) {
+		throw new Error(
+			"Jira webhook authorization requires both jira_webhook_auth_profile_slug and jira_webhook_app_profile_slug",
+		);
+	}
+	const rows = await sql`
+		SELECT id, slug, connector_key, profile_kind, status, auth_data,
+		       account_id, provider
+		FROM auth_profiles
+		WHERE organization_id = ${connection.organizationId}
+		  AND slug IN (${accountSlug}, ${appSlug})
+	`;
+	const accountProfile = rows.find((row) => row.slug === accountSlug) as
+		| {
+				id: number;
+				connector_key: string | null;
+				profile_kind: string;
+				status: string;
+				auth_data: Record<string, unknown> | null;
+				account_id: string | null;
+				provider: string | null;
+		  }
+		| undefined;
+	const appProfile = rows.find((row) => row.slug === appSlug) as
+		| {
+				id: number;
+				connector_key: string | null;
+				profile_kind: string;
+				status: string;
+				auth_data: Record<string, unknown> | null;
+				provider: string | null;
+		  }
+		| undefined;
+	if (
+		!accountProfile ||
+		accountProfile.profile_kind !== "oauth_account" ||
+		accountProfile.status !== "active" ||
+		accountProfile.connector_key !== "jira" ||
+		accountProfile.provider?.toLowerCase() !== "jira" ||
+		!accountProfile.account_id
+	) {
+		throw new Error(
+			`Jira webhook account profile '${accountSlug}' is missing, inactive, or not a Jira OAuth account`,
+		);
+	}
+	if (
+		!appProfile ||
+		appProfile.profile_kind !== "oauth_app" ||
+		appProfile.status !== "active" ||
+		appProfile.connector_key !== "jira" ||
+		appProfile.provider?.toLowerCase() !== "jira"
+	) {
+		throw new Error(
+			`Jira webhook app profile '${appSlug}' is missing, inactive, or not a Jira OAuth app`,
+		);
+	}
+	const appCredentials = await resolveAuthCredentials({
+		organizationId: connection.organizationId,
+		authProfileId: Number(appProfile.id),
+		authData: appProfile.auth_data,
+	});
+	const clientId = appCredentials.JIRA_CLIENT_ID;
+	const clientSecret = appCredentials.JIRA_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		throw new Error(
+			`Jira webhook app profile '${appSlug}' does not contain JIRA_CLIENT_ID and JIRA_CLIENT_SECRET`,
+		);
+	}
+	// Token refresh owns its own per-account advisory transaction. Use the root
+	// pool rather than nesting that transaction inside the per-webhook lock.
+	const tokens = await new CredentialService(getDb()).getConnectionTokens(
+		connection.id,
+		accountProfile.account_id,
+		{
+			tokenUrl: JIRA_TOKEN_URL,
+			clientId,
+			clientSecret,
+			authMethod: "client_secret_post",
+		},
+	);
+	if (!tokens?.accessToken) {
+		throw new Error(
+			`Jira webhook account profile '${accountSlug}' has no access token`,
+		);
+	}
+	if (!normalizeScopeList(tokens.scope).includes("manage:jira-webhook")) {
+		throw new Error(
+			`Jira webhook account profile '${accountSlug}' is missing manage:jira-webhook consent`,
+		);
+	}
+	return { accessToken: tokens.accessToken };
+}
+
+const WEBHOOK_STATE_KEYS = [
+	"webhook_external_id",
+	"webhook_callback_token",
+	"webhook_signature_secret",
+	"webhook_signature_header",
+	"webhook_algorithm",
+	"webhook_signature_prefix",
+	"webhook_dedupe_header",
+	"webhook_expires_at",
+	"webhook_status",
+	"webhook_error",
+] as const;
+
+function stripWebhookState(
+	config: Record<string, unknown>,
+): Record<string, unknown> {
+	const next = { ...config };
+	for (const key of WEBHOOK_STATE_KEYS) delete next[key];
+	return next;
+}
+
+async function persistConfig(
+	sql: DbClient,
+	connection: AtlassianMcpWebhookConnection,
+	config: Record<string, unknown>,
+): Promise<void> {
+	await sql`
+		UPDATE connections
+		SET config = ${sql.json(config)}, updated_at = NOW()
+		WHERE id = ${connection.id}
+		  AND organization_id = ${connection.organizationId}
+		  AND deleted_at IS NULL
+	`;
+	connection.config = config;
+}
+
+async function unregisterUnderLock(params: {
+	sql: DbClient;
+	connection: AtlassianMcpWebhookConnection;
+	fetchImpl: typeof fetch;
+	baseUrl: string;
+}): Promise<AtlassianMcpWebhookResult> {
+	const { connection } = params;
+	const externalId = stringConfig(connection.config, "webhook_external_id");
+	const callbackTokenRef = stringConfig(
+		connection.config,
+		"webhook_callback_token",
+	);
+	// Config evidence proves a registration committed. The registration tx
+	// persists the callback-token secret outside itself, so a crash between the
+	// provider POST and the config commit leaves that secret row as the only
+	// durable trace. Neither present means the provider was never contacted —
+	// skip inspection rather than fail teardown on prerequisites (cloud_id,
+	// Jira consent) that may never have existed, which would block disabling
+	// or deleting a connection that never registered.
+	let shouldInspectProvider = Boolean(externalId) || Boolean(callbackTokenRef);
+	if (!shouldInspectProvider && enabled(connection.config)) {
+		const orphans = await orgContext.run(
+			{ organizationId: connection.organizationId },
+			() =>
+				new PostgresSecretStore().list(
+					`webhook/${connection.id}/callback-token`,
+				),
+		);
+		shouldInspectProvider = orphans.length > 0;
+	}
+	const webhookIds = new Set<number>();
+	if (externalId && Number.isSafeInteger(Number(externalId))) {
+		webhookIds.add(Number(externalId));
+	}
+	if (shouldInspectProvider) {
+		const cloudId =
+			stringConfig(connection.config, "cloud_id") ??
+			stringConfig(connection.config, "site_cloud_id");
+		if (!cloudId) {
+			throw new Error("Atlassian MCP connection has no resolved Jira cloud_id");
+		}
+		const credentials = await resolveJiraCredentials(params.sql, connection);
+		const apiBase = jiraApiBase(cloudId);
+		const accessToken = credentials.accessToken;
+		const webhooks = await listJiraWebhooks(
+			params.fetchImpl,
+			apiBase,
+			accessToken,
+		);
+		const expectedPath = callbackBaseUrl(params.baseUrl, connection.id);
+		for (const item of webhooks) {
+			const id = Number(item.id);
+			if (Number.isSafeInteger(id) && hasCallbackPath(item.url, expectedPath)) {
+				webhookIds.add(id);
+			}
+		}
+		if (webhookIds.size > 0) {
+			await jiraJson(params.fetchImpl, `${apiBase}/webhook`, accessToken, {
+				method: "DELETE",
+				body: JSON.stringify({ webhookIds: [...webhookIds] }),
+			});
+		}
+	}
+	await orgContext.run({ organizationId: connection.organizationId }, () =>
+		new PostgresSecretStore().delete(
+			callbackTokenRef ?? `webhook/${connection.id}/callback-token`,
+		),
+	);
+	// A connection that never registered has nothing to strip — skip the write
+	// so every disabled-path reconcile doesn't bump updated_at.
+	if (WEBHOOK_STATE_KEYS.some((key) => key in connection.config)) {
+		await persistConfig(
+			params.sql,
+			connection,
+			stripWebhookState(connection.config),
+		);
+	}
+	return {
+		handled: true,
+		changed: webhookIds.size > 0,
+		status: "disabled",
+	};
+}
+
+async function markError(params: {
+	sql: DbClient;
+	organizationId: string;
+	connectionId: number;
+	error: unknown;
+}): Promise<void> {
+	const message = getErrorMessage(params.error).slice(0, 500);
+	await params.sql`
+		UPDATE connections
+		SET config = COALESCE(config, '{}'::jsonb) || ${params.sql.json({
+			webhook_status: "error",
+			webhook_error: message,
+		})}::jsonb,
+		updated_at = NOW()
+		WHERE id = ${params.connectionId}
+		  AND organization_id = ${params.organizationId}
+		  AND deleted_at IS NULL
+	`;
+}
+
+async function ensureUnderLock(params: {
+	sql: DbClient;
+	connection: AtlassianMcpWebhookConnection;
+	baseUrl: string;
+	fetchImpl: typeof fetch;
+	nowMs: number;
+}): Promise<AtlassianMcpWebhookResult> {
+	const { connection, sql } = params;
+	if (!isAtlassianMcpConfig(connection.mcpConfig)) {
+		return { handled: false, changed: false };
+	}
+	if (
+		!enabled(connection.config) ||
+		connection.status === "paused" ||
+		connection.status === "revoked"
+	) {
+		return unregisterUnderLock({
+			sql,
+			connection,
+			fetchImpl: params.fetchImpl,
+			baseUrl: params.baseUrl,
+		});
+	}
+	const cloudId =
+		stringConfig(connection.config, "cloud_id") ??
+		stringConfig(connection.config, "site_cloud_id");
+	if (!cloudId) {
+		throw new Error("Atlassian MCP connection has no resolved Jira cloud_id");
+	}
+	const credentials = await resolveJiraCredentials(sql, connection);
+	const secretStore = new PostgresSecretStore();
+	const existingCallbackTokenRef = stringConfig(
+		connection.config,
+		"webhook_callback_token",
+	);
+	const storedCallbackToken = existingCallbackTokenRef
+		? await orgContext.run({ organizationId: connection.organizationId }, () =>
+				resolveSecretValue(secretStore, existingCallbackTokenRef),
+			)
+		: undefined;
+	if (existingCallbackTokenRef && !storedCallbackToken) {
+		throw new Error("Stored Jira webhook callback token cannot be resolved");
+	}
+	const hadCallbackToken = Boolean(storedCallbackToken);
+	const callbackToken = storedCallbackToken ?? randomBytes(32).toString("hex");
+	const callbackTokenRef =
+		existingCallbackTokenRef ??
+		(await orgContext.run({ organizationId: connection.organizationId }, () =>
+			persistSecretValue(
+				secretStore,
+				`webhook/${connection.id}/callback-token`,
+				callbackToken,
+			),
+		));
+	const registeringConfig = {
+		...connection.config,
+		webhook_callback_token: callbackTokenRef,
+		webhook_status: "registering",
+		webhook_error: null,
+	};
+	await persistConfig(sql, connection, registeringConfig);
+
+	const apiBase = jiraApiBase(cloudId);
+	const targetUrl = callbackUrl(params.baseUrl, connection.id, callbackToken);
+	const callbackPath = callbackBaseUrl(params.baseUrl, connection.id);
+	const webhooks = await listJiraWebhooks(
+		params.fetchImpl,
+		apiBase,
+		credentials.accessToken,
+	);
+	const ownedCallbacks = webhooks.filter(
+		(item) => item.id !== undefined && hasCallbackPath(item.url, callbackPath),
+	);
+	let matches = ownedCallbacks.filter((item) => item.url === targetUrl);
+	const staleCallbacks = ownedCallbacks.filter(
+		(item) => item.url !== targetUrl,
+	);
+	if (!hadCallbackToken || staleCallbacks.length > 0) {
+		const staleIds = (!hadCallbackToken ? ownedCallbacks : staleCallbacks).map(
+			(item) => Number(item.id),
+		);
+		if (staleIds.length > 0) {
+			await jiraJson(
+				params.fetchImpl,
+				`${apiBase}/webhook`,
+				credentials.accessToken,
+				{
+					method: "DELETE",
+					body: JSON.stringify({ webhookIds: staleIds }),
+				},
+			);
+		}
+		if (!hadCallbackToken) matches = [];
+	}
+	if (matches.length > 1) {
+		const extras = matches.slice(1).map((item) => Number(item.id));
+		await jiraJson(
+			params.fetchImpl,
+			`${apiBase}/webhook`,
+			credentials.accessToken,
+			{ method: "DELETE", body: JSON.stringify({ webhookIds: extras }) },
+		);
+	}
+
+	let externalId =
+		matches[0]?.id !== undefined ? String(matches[0].id) : undefined;
+	let changed = false;
+	const providerExpiry = matches[0]?.expirationDate;
+	let refreshedExpiry: string | undefined;
+	let lifetimeExtended = false;
+	if (
+		externalId &&
+		expiresSoon(
+			providerExpiry ?? connection.config.webhook_expires_at,
+			params.nowMs,
+		)
+	) {
+		const refresh = await jiraJson<JiraWebhookRefreshResponse>(
+			params.fetchImpl,
+			`${apiBase}/webhook/refresh`,
+			credentials.accessToken,
+			{
+				method: "PUT",
+				body: JSON.stringify({ webhookIds: [Number(externalId)] }),
+			},
+		);
+		refreshedExpiry = refresh.expirationDate;
+		lifetimeExtended = true;
+		changed = true;
+	}
+	if (!externalId) {
+		const registration = await jiraJson<JiraWebhookRegistrationResponse>(
+			params.fetchImpl,
+			`${apiBase}/webhook`,
+			credentials.accessToken,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					url: targetUrl,
+					webhooks: [
+						{
+							jqlFilter: "",
+							events: [
+								"jira:issue_created",
+								"jira:issue_updated",
+								"comment_created",
+							],
+						},
+					],
+				}),
+			},
+		);
+		const result = registration.webhookRegistrationResult?.[0];
+		if (result?.createdWebhookId === undefined) {
+			throw new Error(
+				`Jira webhook registration failed: ${result?.errors?.join("; ") || "no webhook id returned"}`,
+			);
+		}
+		externalId = String(result.createdWebhookId);
+		lifetimeExtended = true;
+		changed = true;
+	}
+	const expiresAt = externalId
+		? (refreshedExpiry ??
+			(lifetimeExtended
+				? new Date(params.nowMs + WEBHOOK_LIFETIME_MS).toISOString()
+				: (providerExpiry ??
+					stringConfig(connection.config, "webhook_expires_at"))))
+		: undefined;
+	if (!expiresAt) {
+		throw new Error("Jira webhook reconciliation returned no expiration date");
+	}
+	await persistConfig(sql, connection, {
+		...connection.config,
+		webhook_external_id: externalId,
+		webhook_expires_at: expiresAt,
+		webhook_status: "active",
+		webhook_error: null,
+	});
+	logger.info(
+		{ connection_id: connection.id, external_id: externalId, changed },
+		"Reconciled Atlassian MCP Jira webhook",
+	);
+	return { handled: true, changed, status: "active" };
+}
+
+export async function ensureAtlassianMcpJiraWebhook(params: {
+	organizationId: string;
+	connectionId: number;
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+	sql?: DbClient;
+	now?: Date;
+}): Promise<AtlassianMcpWebhookResult> {
+	const sql = params.sql ?? getDb();
+	try {
+		return await sql.begin(async (tx) => {
+			await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+				`atlassian_mcp_webhook:${params.organizationId}:${params.connectionId}`,
+			]);
+			const connection = await loadConnection(
+				tx,
+				params.organizationId,
+				params.connectionId,
+			);
+			if (!connection) return { handled: false, changed: false };
+			return ensureUnderLock({
+				sql: tx,
+				connection,
+				baseUrl:
+					params.baseUrl ??
+					resolveBaseUrl({ request: null }).replace(/\/+$/, ""),
+				fetchImpl: params.fetchImpl ?? fetch,
+				nowMs: (params.now ?? new Date()).getTime(),
+			});
+		});
+	} catch (error) {
+		try {
+			await markError({
+				sql,
+				organizationId: params.organizationId,
+				connectionId: params.connectionId,
+				error,
+			});
+		} catch (markFailure) {
+			// The reconcile error is the actionable one — never mask it with a
+			// failure of the best-effort status write.
+			logger.warn(
+				{
+					connection_id: params.connectionId,
+					error: getErrorMessage(markFailure),
+				},
+				"Failed to record Atlassian MCP webhook error status",
+			);
+		}
+		throw error;
+	}
+}
+
+export async function unregisterAtlassianMcpJiraWebhook(params: {
+	organizationId: string;
+	connectionId: number;
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+	sql?: DbClient;
+}): Promise<AtlassianMcpWebhookResult> {
+	const sql = params.sql ?? getDb();
+	return sql.begin(async (tx) => {
+		await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+			`atlassian_mcp_webhook:${params.organizationId}:${params.connectionId}`,
+		]);
+		const connection = await loadConnection(
+			tx,
+			params.organizationId,
+			params.connectionId,
+		);
+		if (!connection || !isAtlassianMcpConfig(connection.mcpConfig)) {
+			return { handled: false, changed: false };
+		}
+		return unregisterUnderLock({
+			sql: tx,
+			connection,
+			fetchImpl: params.fetchImpl ?? fetch,
+			baseUrl:
+				params.baseUrl ?? resolveBaseUrl({ request: null }).replace(/\/+$/, ""),
+		});
+	});
+}
+
+export async function refreshDueAtlassianMcpJiraWebhooks(
+	params: { baseUrl?: string; fetchImpl?: typeof fetch; limit?: number } = {},
+): Promise<{ scanned: number; refreshed: number; errors: number }> {
+	const sql = getDb();
+	const refreshBefore = new Date(
+		Date.now() + WEBHOOK_REFRESH_WINDOW_MS,
+	).toISOString();
+	const rows = (await sql`
+		SELECT c.id, c.organization_id
+		FROM connections c
+		JOIN LATERAL (
+			SELECT mcp_config
+			FROM connector_definitions
+			WHERE organization_id = c.organization_id
+			  AND key = c.connector_key
+			  AND status = 'active'
+			ORDER BY updated_at DESC
+			LIMIT 1
+		) cd ON TRUE
+		WHERE c.deleted_at IS NULL
+		  AND c.status = 'active'
+		  AND c.config->>'webhook_enabled' = 'true'
+		  AND (
+			c.config->>'webhook_external_id' IS NULL
+			OR c.config->>'webhook_status' <> 'active'
+			OR c.config->>'webhook_expires_at' IS NULL
+			OR c.config->>'webhook_expires_at' !~
+			   '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:?\\d{2})$'
+			OR c.config->>'webhook_expires_at' <= ${refreshBefore}
+		  )
+		  AND cd.mcp_config IS NOT NULL
+		ORDER BY c.id
+		LIMIT ${params.limit ?? 100}
+	`) as Array<{ id: number; organization_id: string }>;
+	let refreshed = 0;
+	let errors = 0;
+	for (const row of rows) {
+		try {
+			const result = await ensureAtlassianMcpJiraWebhook({
+				organizationId: row.organization_id,
+				connectionId: Number(row.id),
+				baseUrl: params.baseUrl,
+				fetchImpl: params.fetchImpl,
+			});
+			if (result.changed) refreshed += 1;
+		} catch (error) {
+			errors += 1;
+			logger.warn(
+				{ connection_id: row.id, error: getErrorMessage(error) },
+				"Atlassian MCP Jira webhook refresh failed",
+			);
+		}
+	}
+	return { scanned: rows.length, refreshed, errors };
+}

--- a/packages/server/src/connect/webhook-registration.ts
+++ b/packages/server/src/connect/webhook-registration.ts
@@ -26,6 +26,10 @@ import { resolveConnectorCodeForKey } from '../utils/ensure-connector-installed'
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
 import logger from '../utils/logger';
 import { getErrorMessage } from "@lobu/core";
+import {
+  ensureAtlassianMcpJiraWebhook,
+  unregisterAtlassianMcpJiraWebhook,
+} from './atlassian-mcp-webhook';
 
 interface ConnectorConnectionRow {
   id: number;
@@ -43,6 +47,8 @@ interface ConnectorConnectionRow {
 export interface ConnectionWebhookState {
   /** Provider subscription id, for teardown. */
   webhook_external_id?: string;
+  /** `secret://` ref to the unguessable token embedded in a callback URL. */
+  webhook_callback_token?: string;
   /** `secret://` ref to the signing secret the provider HMACs deliveries with. */
   webhook_signature_secret?: string;
   /** The connector's declarative verification scheme, stamped at register time. */
@@ -50,6 +56,9 @@ export interface ConnectionWebhookState {
   webhook_algorithm?: 'sha256' | 'sha1';
   webhook_signature_prefix?: string;
   webhook_dedupe_header?: string;
+  webhook_expires_at?: string;
+  webhook_status?: 'registering' | 'active' | 'error';
+  webhook_error?: string | null;
 }
 
 function toNumberOrNull(value: number | string | null): number | null {
@@ -128,9 +137,21 @@ export async function registerConnectorWebhook(params: {
   connectionId: number;
   /** When this connector doesn't declare a webhook block, callers can skip. */
   request?: Request | null;
+  /** Explicit public gateway origin for request-less admin/scheduled callers. */
+  baseUrl?: string;
+  /** Config mutations that disable durable delivery must fail closed. */
+  throwOnError?: boolean;
 }): Promise<void> {
   const { organizationId, connectionId } = params;
   try {
+    const atlassian = await ensureAtlassianMcpJiraWebhook({
+      organizationId,
+      connectionId,
+      baseUrl:
+        params.baseUrl ??
+        resolveBaseUrl({ request: params.request ?? null }).replace(/\/+$/, ''),
+    });
+    if (atlassian.handled) return;
     await orgContext.run({ organizationId }, async () => {
       const connection = await loadConnection(organizationId, connectionId);
       if (!connection) return;
@@ -224,6 +245,7 @@ export async function registerConnectorWebhook(params: {
       },
       'Connector webhook registration failed (connection stays active)'
     );
+    if (params.throwOnError) throw error;
   }
 }
 
@@ -236,9 +258,19 @@ export async function registerConnectorWebhook(params: {
 export async function unregisterConnectorWebhook(params: {
   organizationId: string;
   connectionId: number;
+  /** Deletion must fail closed when external teardown fails. */
+  throwOnError?: boolean;
+  /** Explicit public gateway origin used to reconcile ambiguous provider state. */
+  baseUrl?: string;
 }): Promise<void> {
   const { organizationId, connectionId } = params;
   try {
+    const atlassian = await unregisterAtlassianMcpJiraWebhook({
+      organizationId,
+      connectionId,
+      baseUrl: params.baseUrl,
+    });
+    if (atlassian.handled) return;
     await orgContext.run({ organizationId }, async () => {
       const connection = await loadConnection(organizationId, connectionId);
       if (!connection) return;
@@ -312,6 +344,7 @@ export async function unregisterConnectorWebhook(params: {
       },
       'Connector webhook teardown failed'
     );
+    if (params.throwOnError) throw error;
   }
 }
 
@@ -325,9 +358,14 @@ export async function resolveConnectionWebhookConfig(
   config: Record<string, unknown> | null | undefined
 ): Promise<Record<string, unknown> | null> {
   const c = (config ?? {}) as Record<string, unknown> & ConnectionWebhookState;
-  if (!c.webhook_signature_secret && !c.webhook_external_id) return null;
+  if (!c.webhook_signature_secret && !c.webhook_callback_token && !c.webhook_external_id) {
+    return null;
+  }
   return {
     platform: 'webhook',
+    ...(c.webhook_callback_token
+      ? { token: c.webhook_callback_token, allowQueryAuth: true }
+      : {}),
     ...(c.webhook_signature_secret ? { signatureSecret: c.webhook_signature_secret } : {}),
     ...(c.webhook_signature_header ? { signatureHeader: c.webhook_signature_header } : {}),
     ...(c.webhook_algorithm ? { algorithm: c.webhook_algorithm } : {}),

--- a/packages/server/src/connect/webhook-registration.ts
+++ b/packages/server/src/connect/webhook-registration.ts
@@ -57,7 +57,7 @@ export interface ConnectionWebhookState {
   webhook_signature_prefix?: string;
   webhook_dedupe_header?: string;
   webhook_expires_at?: string;
-  webhook_status?: 'registering' | 'active' | 'error';
+  webhook_status?: 'active' | 'error';
   webhook_error?: string | null;
 }
 

--- a/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
+++ b/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { Env } from "../../index.js";
+import type { ToolContext } from "../../tools/registry.js";
 import {
 	ensureDbForGatewayTests,
 	ensureEncryptionKey,
@@ -9,6 +11,8 @@ import {
 const ORG = "org-atlassian-webhook";
 const AGENT = "agent-atlassian-webhook";
 const USER = "user-atlassian-webhook";
+const ADMIN_ONLY_ERROR =
+	"Only admins can configure the secondary Jira authorization used by Atlassian webhook delivery.";
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -20,7 +24,24 @@ beforeEach(async () => {
 	await seedAgentRow(AGENT, { organizationId: ORG });
 });
 
-async function seedConfiguredConnection(): Promise<number> {
+function memberContext(): ToolContext {
+	return {
+		organizationId: ORG,
+		userId: USER,
+		memberRole: "member",
+		agentId: AGENT,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as ToolContext;
+}
+
+async function seedConfiguredConnection(options?: {
+	memberRole?: "member";
+}): Promise<number> {
 	const { getDb } = await import("../../db/client.js");
 	const { createAuthProfile } = await import("../../utils/auth-profiles.js");
 	const { persistAuthCredentials } = await import(
@@ -31,6 +52,12 @@ async function seedConfiguredConnection(): Promise<number> {
 		INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
 		VALUES (${USER}, 'Owner', 'owner-atlassian-webhook@example.com', true, NOW(), NOW())
 	`;
+	if (options?.memberRole) {
+		await sql`
+			INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+			VALUES ('member-atlassian-webhook', ${ORG}, ${USER}, ${options.memberRole}, NOW())
+		`;
+	}
 	await sql`
 		INSERT INTO connector_definitions (
 			organization_id, key, name, version, status, mcp_config, feeds_schema
@@ -100,6 +127,62 @@ async function seedConfiguredConnection(): Promise<number> {
 }
 
 describe("Atlassian MCP Jira dynamic webhooks", () => {
+	test("rejects secondary Jira webhook credentials from a member on create", async () => {
+		await seedConfiguredConnection({ memberRole: "member" });
+		const { manageConnections } = await import(
+			"../../tools/admin/manage_connections.js"
+		);
+		const result = await manageConnections(
+			{
+				action: "create",
+				connector_key: "mcp.mcp-atlassian-com",
+				slug: "member-atlassian-create",
+				display_name: "Member Atlassian",
+				config: {
+					webhook_enabled: true,
+					jira_webhook_auth_profile_slug: "jira-webhook-account",
+					jira_webhook_app_profile_slug: "jira-webhook-app",
+				},
+			},
+			{} as Env,
+			memberContext(),
+		);
+		expect(result).toEqual({ error: ADMIN_ONLY_ERROR });
+		const { getDb } = await import("../../db/client.js");
+		const [row] = await getDb()`
+			SELECT count(*)::int AS count FROM connections
+			WHERE organization_id = ${ORG} AND slug = 'member-atlassian-create'
+		`;
+		expect(row.count).toBe(0);
+	});
+
+	test("rejects secondary Jira webhook credentials from a member on update", async () => {
+		const connectionId = await seedConfiguredConnection({
+			memberRole: "member",
+		});
+		const { getDb } = await import("../../db/client.js");
+		const [before] = await getDb()`
+			SELECT config FROM connections WHERE id = ${connectionId}
+		`;
+		const { manageConnections } = await import(
+			"../../tools/admin/manage_connections.js"
+		);
+		const result = await manageConnections(
+			{
+				action: "update",
+				connection_id: connectionId,
+				config: { webhook_enabled: false },
+			},
+			{} as Env,
+			memberContext(),
+		);
+		expect(result).toEqual({ error: ADMIN_ONLY_ERROR });
+		const [after] = await getDb()`
+			SELECT config FROM connections WHERE id = ${connectionId}
+		`;
+		expect(after.config).toEqual(before.config);
+	});
+
 	test("registers an authenticated per-connection webhook and persists verification state", async () => {
 		const connectionId = await seedConfiguredConnection();
 		const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
+++ b/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
@@ -1,0 +1,388 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+	ensureDbForGatewayTests,
+	ensureEncryptionKey,
+	resetTestDatabase,
+	seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const ORG = "org-atlassian-webhook";
+const AGENT = "agent-atlassian-webhook";
+const USER = "user-atlassian-webhook";
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	ensureEncryptionKey();
+	await seedAgentRow(AGENT, { organizationId: ORG });
+});
+
+async function seedConfiguredConnection(): Promise<number> {
+	const { getDb } = await import("../../db/client.js");
+	const { createAuthProfile } = await import("../../utils/auth-profiles.js");
+	const { persistAuthCredentials } = await import(
+		"../../utils/auth-credential-secrets.js"
+	);
+	const sql = getDb();
+	await sql`
+		INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+		VALUES (${USER}, 'Owner', 'owner-atlassian-webhook@example.com', true, NOW(), NOW())
+	`;
+	await sql`
+		INSERT INTO connector_definitions (
+			organization_id, key, name, version, status, mcp_config, feeds_schema
+		) VALUES (
+			${ORG}, 'mcp.mcp-atlassian-com', 'Atlassian', '1.0.0', 'active',
+			${sql.json({ upstream_url: "https://mcp.atlassian.com/v1/mcp" })},
+			${sql.json({ issues: { key: "issues", virtual: true } })}
+		)
+	`;
+	const accountId = "jira-webhook-account";
+	await sql`
+		INSERT INTO account (
+			id, "accountId", "providerId", "userId", "accessToken", "refreshToken",
+			"accessTokenExpiresAt", scope, "createdAt", "updatedAt"
+		) VALUES (
+			${accountId}, ${accountId}, 'jira', ${USER}, 'jira-access-token',
+			'jira-refresh-token', ${new Date(Date.now() + 3_600_000).toISOString()},
+			'read:jira-work manage:jira-webhook offline_access', NOW(), NOW()
+		)
+	`;
+	const accountProfile = await createAuthProfile({
+		organizationId: ORG,
+		connectorKey: "jira",
+		displayName: "Jira Webhook Account",
+		slug: "jira-webhook-account",
+		profileKind: "oauth_account",
+		status: "active",
+		provider: "jira",
+		accountId,
+		createdBy: USER,
+	});
+	const appProfile = await createAuthProfile({
+		organizationId: ORG,
+		connectorKey: "jira",
+		displayName: "Jira Webhook App",
+		slug: "jira-webhook-app",
+		profileKind: "oauth_app",
+		status: "active",
+		provider: "jira",
+		createdBy: USER,
+	});
+	await persistAuthCredentials({
+		organizationId: ORG,
+		authProfileId: appProfile.id,
+		credentials: {
+			JIRA_CLIENT_ID: "jira-client-id",
+			JIRA_CLIENT_SECRET: "jira-client-secret",
+		},
+	});
+	const [connection] = await sql`
+		INSERT INTO connections (
+			organization_id, connector_key, slug, display_name, status, visibility,
+			created_by, config
+		) VALUES (
+			${ORG}, 'mcp.mcp-atlassian-com', 'atlassian-rovo', 'Atlassian', 'active',
+			'private', ${USER}, ${sql.json({
+				cloud_id: "cloud-1",
+				site_url: "https://acme.atlassian.net",
+				webhook_enabled: true,
+				jira_webhook_auth_profile_slug: accountProfile.slug,
+				jira_webhook_app_profile_slug: appProfile.slug,
+			})}
+		)
+		RETURNING id
+	`;
+	return Number(connection.id);
+}
+
+describe("Atlassian MCP Jira dynamic webhooks", () => {
+	test("registers an authenticated per-connection webhook and persists verification state", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchImpl = async (
+			input: string | URL | Request,
+			init?: RequestInit,
+		): Promise<Response> => {
+			const url =
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.href
+						: input.url;
+			requests.push({ url, init });
+			if (init?.method === "GET") {
+				return Response.json({ values: [] });
+			}
+			return Response.json({
+				webhookRegistrationResult: [{ createdWebhookId: 123 }],
+			});
+		};
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl,
+		});
+
+		expect(requests).toHaveLength(2);
+		expect(requests[0].init?.headers).toMatchObject({
+			Authorization: "Bearer jira-access-token",
+		});
+		const body = JSON.parse(String(requests[1].init?.body));
+		const callback = new URL(body.url);
+		expect(`${callback.origin}${callback.pathname}`).toBe(
+			`https://lobu.example.com/api/v1/webhooks/${connectionId}`,
+		);
+		expect(callback.searchParams.get("token")?.length).toBeGreaterThanOrEqual(
+			32,
+		);
+		expect(body.webhooks[0].events).toEqual([
+			"jira:issue_created",
+			"jira:issue_updated",
+			"comment_created",
+		]);
+		expect(body.secret).toBeUndefined();
+
+		const { getDb } = await import("../../db/client.js");
+		const [row] = await getDb()`
+			SELECT config FROM connections
+			WHERE id = ${connectionId} AND organization_id = ${ORG}
+		`;
+		expect(row.config).toMatchObject({
+			webhook_external_id: "123",
+			webhook_status: "active",
+		});
+		expect(String(row.config.webhook_callback_token)).toStartWith("secret://");
+		expect(
+			new Date(String(row.config.webhook_expires_at)).getTime(),
+		).toBeGreaterThan(Date.now() + 20 * 24 * 60 * 60 * 1000);
+	});
+
+	test("refreshes a due subscription without registering a duplicate", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		const firstNow = new Date("2026-08-13T12:00:00.000Z");
+		let registeredUrl = "";
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			now: firstNow,
+			fetchImpl: async (_input, init) => {
+				if (init?.method === "GET") return Response.json({ values: [] });
+				registeredUrl = JSON.parse(String(init?.body)).url;
+				return Response.json({
+					webhookRegistrationResult: [{ createdWebhookId: 123 }],
+				});
+			},
+		});
+		const methods: string[] = [];
+		const secondNow = new Date("2026-09-08T12:00:00.000Z");
+		const refreshedExpiry = "2026-10-08T12:00:00.000Z";
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			now: secondNow,
+			fetchImpl: async (_input, init) => {
+				methods.push(String(init?.method));
+				return init?.method === "GET"
+					? Response.json({
+							values: [
+								{
+									id: 123,
+									url: registeredUrl,
+									expirationDate: "2026-09-09T12:00:00.000Z",
+								},
+							],
+						})
+					: Response.json({ expirationDate: refreshedExpiry });
+			},
+		});
+		expect(methods).toEqual(["GET", "PUT"]);
+		const { getDb } = await import("../../db/client.js");
+		const [row] =
+			await getDb()`SELECT config FROM connections WHERE id = ${connectionId}`;
+		expect(row.config.webhook_external_id).toBe("123");
+		expect(row.config.webhook_expires_at).toBe(refreshedExpiry);
+	});
+
+	test("reconciles ambiguous provider state before clearing the local callback token", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { ensureAtlassianMcpJiraWebhook, unregisterAtlassianMcpJiraWebhook } =
+			await import("../../connect/atlassian-mcp-webhook.js");
+		let registeredUrl = "";
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (_input, init) => {
+				if (init?.method === "GET") return Response.json({ values: [] });
+				registeredUrl = JSON.parse(String(init?.body)).url;
+				return Response.json({
+					webhookRegistrationResult: [{ createdWebhookId: 123 }],
+				});
+			},
+		});
+		const { getDb } = await import("../../db/client.js");
+		await getDb()`
+			UPDATE connections
+			SET config = config - 'webhook_external_id'
+			WHERE id = ${connectionId}
+		`;
+		let deleteBody: unknown;
+		await unregisterAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (_input, init) => {
+				if (init?.method === "GET") {
+					return Response.json({
+						values: [{ id: 123, url: registeredUrl }],
+						isLast: true,
+					});
+				}
+				deleteBody = JSON.parse(String(init?.body));
+				return Response.json({});
+			},
+		});
+		expect(deleteBody).toEqual({ webhookIds: [123] });
+		const [row] =
+			await getDb()`SELECT config FROM connections WHERE id = ${connectionId}`;
+		expect(row.config.webhook_external_id).toBeUndefined();
+		expect(row.config.webhook_callback_token).toBeUndefined();
+		const [secrets] = await getDb()`
+			SELECT count(*)::int AS count
+			FROM agent_secrets
+			WHERE organization_id = ${ORG}
+			  AND name = ${`webhook/${connectionId}/callback-token`}
+		`;
+		expect(secrets.count).toBe(0);
+	});
+
+	test("teardown of a never-registered connection skips provider inspection", async () => {
+		// webhook_enabled=true but registration never ran (no external id, no
+		// callback token, no orphan secret) — teardown must not demand provider
+		// prerequisites like a resolved cloud_id, or the connection could never
+		// be disabled or deleted.
+		const connectionId = await seedConfiguredConnection();
+		const { getDb } = await import("../../db/client.js");
+		await getDb()`
+			UPDATE connections
+			SET config = config - 'cloud_id'
+			WHERE id = ${connectionId}
+		`;
+		let fetchCalls = 0;
+		const { unregisterAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		const result = await unregisterAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async () => {
+				fetchCalls += 1;
+				return Response.json({});
+			},
+		});
+		expect(fetchCalls).toBe(0);
+		expect(result).toEqual({ handled: true, changed: false, status: "disabled" });
+	});
+
+	test("an orphaned callback-token secret forces provider reconciliation on teardown", async () => {
+		// Crash window: the registration tx persists the callback-token secret
+		// outside itself, then rolls back the config write. The secret row is the
+		// only durable trace that the provider may hold a webhook — teardown must
+		// inspect and delete it.
+		const connectionId = await seedConfiguredConnection();
+		const { orgContext } = await import("../../lobu/stores/org-context.js");
+		const { PostgresSecretStore } = await import(
+			"../../lobu/stores/postgres-secret-store.js"
+		);
+		await orgContext.run({ organizationId: ORG }, () =>
+			new PostgresSecretStore().put(
+				`webhook/${connectionId}/callback-token`,
+				"orphaned-token",
+			),
+		);
+		const requests: string[] = [];
+		let deleteBody: unknown;
+		const { unregisterAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		await unregisterAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (_input, init) => {
+				requests.push(String(init?.method));
+				if (init?.method === "GET") {
+					return Response.json({
+						values: [
+							{
+								id: 77,
+								url: `https://lobu.example.com/api/v1/webhooks/${connectionId}?token=orphaned-token`,
+							},
+						],
+						isLast: true,
+					});
+				}
+				deleteBody = JSON.parse(String(init?.body));
+				return Response.json({});
+			},
+		});
+		expect(requests).toEqual(["GET", "DELETE"]);
+		expect(deleteBody).toEqual({ webhookIds: [77] });
+		const { getDb } = await import("../../db/client.js");
+		const [secrets] = await getDb()`
+			SELECT count(*)::int AS count
+			FROM agent_secrets
+			WHERE organization_id = ${ORG}
+			  AND name = ${`webhook/${connectionId}/callback-token`}
+		`;
+		expect(secrets.count).toBe(0);
+	});
+
+	test("fails closed and records a visible error when webhook consent is missing", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { getDb } = await import("../../db/client.js");
+		await getDb()`
+			UPDATE account
+			SET scope = 'read:jira-work offline_access'
+			WHERE id = 'jira-webhook-account'
+		`;
+		let fetchCalls = 0;
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		await expect(
+			ensureAtlassianMcpJiraWebhook({
+				organizationId: ORG,
+				connectionId,
+				baseUrl: "https://lobu.example.com",
+				fetchImpl: async () => {
+					fetchCalls += 1;
+					return Response.json({});
+				},
+			}),
+		).rejects.toThrow("missing manage:jira-webhook consent");
+		expect(fetchCalls).toBe(0);
+		const [row] =
+			await getDb()`SELECT config FROM connections WHERE id = ${connectionId}`;
+		expect(row.config).toMatchObject({
+			webhook_status: "error",
+		});
+		expect(String(row.config.webhook_error)).toContain(
+			"missing manage:jira-webhook consent",
+		);
+	});
+});

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -32,6 +32,7 @@ import {
 	resetTestDatabase,
 	seedAgentRow,
 } from "./helpers/db-setup.js";
+import type { WritableSecretStore } from "../secrets/index.js";
 
 const ORG = "org-webhook";
 const AGENT = "agent-webhook";
@@ -1053,6 +1054,64 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		return id;
 	}
 
+	async function seedRegisteredAtlassianConnection(
+		secretStore: WritableSecretStore,
+	): Promise<{ id: string; callbackToken: string }> {
+		const { getDb } = await import("../../db/client.js");
+		const { orgContext } = await import("../../lobu/stores/org-context.js");
+		const { persistSecretValue } = await import("../secrets/index.js");
+		const sql = getDb();
+		const connectorKey = "mcp.mcp-atlassian-com";
+		await sql`
+			INSERT INTO connector_definitions (
+				organization_id, key, name, version, status, mcp_config, feeds_schema
+			) VALUES (
+				${ORG}, ${connectorKey}, 'Atlassian', '1.0.0', 'active',
+				${sql.json({ upstream_url: "https://mcp.atlassian.com/v1/mcp" })},
+				${sql.json({ issues: { key: "issues", virtual: true } })}
+			)
+		`;
+		const [connection] = await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, visibility
+			) VALUES (
+				${ORG}, ${connectorKey}, 'atlassian-rovo', 'Atlassian', 'active',
+				${sql.json({
+					cloud_id: "cloud-1",
+					site_cloud_id: "cloud-1",
+					site_url: "https://acme.atlassian.net",
+				})},
+				'org'
+			)
+			RETURNING id
+		`;
+		const id = String(connection.id);
+		await sql`
+			INSERT INTO feeds (
+				organization_id, connection_id, feed_key, display_name, status, kind, virtual, config
+			) VALUES (
+				${ORG}, ${id}, 'issues', 'Issues', 'active', 'virtual', true, '{}'::jsonb
+			)
+		`;
+		const callbackToken = SIG_SECRET;
+		const callbackTokenRef = await orgContext.run({ organizationId: ORG }, () =>
+			persistSecretValue(
+				secretStore,
+				`webhook/${id}/callback-token`,
+				callbackToken,
+			),
+		);
+		await sql`
+			UPDATE connections
+			SET config = config || ${sql.json({
+				webhook_external_id: "jira-hook-123",
+				webhook_callback_token: callbackTokenRef,
+			})}::jsonb
+			WHERE id = ${id}
+		`;
+		return { id, callbackToken };
+	}
+
 	test("a signed GitHub delivery to a connector connection marks the feed due (poll-canonical)", async () => {
 		// Clean-cut: OAuth/PAT GitHub webhooks do NOT raw-store under webhook:<id>.
 		// They mark the matching feed due so CheckDueFeeds + poll attach
@@ -1127,6 +1186,114 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		expect(new Date(String(feed.next_run_at)).getTime()).toBeLessThanOrEqual(
 			Date.now() + 1000,
 		);
+	});
+
+	test("an authenticated Jira delivery lands as a structured event on the Atlassian Rovo feed", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const { manager, secretStore } = await buildManager();
+		const { createConnectionWebhookRoutes } = await import(
+			"../routes/public/connections.js"
+		);
+		const { getDb } = await import("../../db/client.js");
+		const { id, callbackToken } =
+			await seedRegisteredAtlassianConnection(secretStore);
+		const app = createConnectionWebhookRoutes(manager);
+		const raw = JSON.stringify({
+			webhookEvent: "jira:issue_updated",
+			issue: {
+				id: "10000",
+				key: "KAN-1",
+				self: "https://api.atlassian.com/ex/jira/cloud-1/rest/api/3/issue/10000",
+				fields: {
+					summary: "Webhook bridge works",
+					status: { name: "To Do" },
+					created: "2026-08-13T10:00:00.000Z",
+					updated: "2026-08-13T10:01:00.000Z",
+				},
+			},
+		});
+		const res = await app.fetch(
+			new Request(
+				`http://gateway.test/api/v1/webhooks/${id}?token=${callbackToken}`,
+				{
+					method: "POST",
+					body: raw,
+					headers: {
+						"content-type": "application/json",
+					},
+				},
+			),
+		);
+		expect(res.status).toBe(202);
+		const rows = await getDb()`
+			SELECT connector_key, connection_id, feed_key, origin_id, semantic_type
+			FROM events
+			WHERE connection_id = ${id}
+			ORDER BY id
+		`;
+		expect(rows).toEqual([
+			{
+				connector_key: "mcp.mcp-atlassian-com",
+				connection_id: Number(id),
+				feed_key: "issues",
+				origin_id: "jira_issue_10000",
+				semantic_type: "issue",
+			},
+		]);
+
+		const commentRaw = JSON.stringify({
+			webhookEvent: "comment_created",
+			issue: { id: "10000", key: "KAN-1", fields: {} },
+			comment: {
+				id: "20000",
+				body: {
+					type: "doc",
+					content: [
+						{
+							type: "paragraph",
+							content: [{ type: "text", text: "Webhook comment" }],
+						},
+					],
+				},
+				author: { displayName: "Jira User" },
+				created: "2026-08-13T10:02:00.000Z",
+			},
+		});
+		const commentRes = await app.fetch(
+			new Request(
+				`http://gateway.test/api/v1/webhooks/${id}?token=${callbackToken}`,
+				{
+					method: "POST",
+					body: commentRaw,
+					headers: {
+						"content-type": "application/json",
+					},
+				},
+			),
+		);
+		expect(commentRes.status).toBe(202);
+		const [comment] = await getDb()`
+			SELECT origin_id, origin_parent_id, semantic_type, payload_text
+			FROM events
+			WHERE connection_id = ${id} AND origin_id = 'jira_comment_20000'
+		`;
+		expect(comment).toMatchObject({
+			origin_id: "jira_comment_20000",
+			origin_parent_id: "jira_issue_10000",
+			semantic_type: "comment",
+			payload_text: "Webhook comment",
+		});
+
+		const forged = await app.fetch(
+			new Request(`http://gateway.test/api/v1/webhooks/${id}?token=forged`, {
+				method: "POST",
+				body: commentRaw,
+				headers: {
+					"content-type": "application/json",
+				},
+			}),
+		);
+		expect(forged.status).toBe(401);
 	});
 
 	test("a forged signature to a connector connection is rejected with 401", async () => {

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -58,6 +58,8 @@ import {
   type PlatformConnection,
 } from "./types.js";
 import { deliverGithubConnectorConnectionWebhook } from "../routes/public/app-webhooks.js";
+import { deliverJiraMcpConnectionWebhook } from "../routes/public/jira-mcp-webhook-delivery.js";
+import { isAtlassianMcpConfig } from "../../operations/atlassian-mcp-feed.js";
 import {
 	handleWebhookIngest,
 	prepareWebhookIngestConfig,
@@ -1316,7 +1318,32 @@ export class ChatInstanceManager {
                     );
                   },
                 }
-              : undefined,
+              : bridged.structuredWebhook === "jira_mcp"
+                ? {
+                    handleInsteadOfPersist: async ({
+                      rawBody,
+                      organizationId,
+                      connectionId: connId,
+                    }) => {
+                      const result = await deliverJiraMcpConnectionWebhook({
+                        sql: getDb(),
+                        connectionId: Number(connId),
+                        organizationId,
+                        rawBody,
+                      });
+                      return new Response(
+                        JSON.stringify({
+                          ok: result.handled,
+                          triggered: result.triggered,
+                        }),
+                        {
+                          status: result.handled ? 202 : 400,
+                          headers: { "content-type": "application/json" },
+                        },
+                      );
+                    },
+                  }
+                : undefined,
 					),
         );
       }
@@ -1365,14 +1392,25 @@ export class ChatInstanceManager {
   ): Promise<{
     stored: StoredConnection;
     connectorKey: string;
+    structuredWebhook: "jira_mcp" | null;
   } | null> {
     // Connector connection ids are bigints; a non-numeric id can't match.
     if (!/^\d+$/.test(connectionId)) return null;
     const rows = await getDb()`
-      SELECT id, organization_id, connector_key, config, status
-      FROM connections
-      WHERE id = ${connectionId}
-        AND deleted_at IS NULL
+      SELECT c.id, c.organization_id, c.connector_key, c.config, c.status,
+             cd.mcp_config
+      FROM connections c
+      LEFT JOIN LATERAL (
+        SELECT mcp_config
+        FROM connector_definitions
+        WHERE organization_id = c.organization_id
+          AND key = c.connector_key
+          AND status = 'active'
+        ORDER BY updated_at DESC
+        LIMIT 1
+      ) cd ON TRUE
+      WHERE c.id = ${connectionId}
+        AND c.deleted_at IS NULL
       LIMIT 1
     `;
     const row = rows[0] as
@@ -1382,6 +1420,7 @@ export class ChatInstanceManager {
           connector_key: string;
           config: Record<string, unknown> | null;
           status: string;
+          mcp_config: Record<string, unknown> | null;
         }
       | undefined;
     if (!row || !row.organization_id) return null;
@@ -1406,6 +1445,9 @@ export class ChatInstanceManager {
         updatedAt: Date.now(),
       },
       connectorKey: String(row.connector_key),
+      structuredWebhook: isAtlassianMcpConfig(row.mcp_config)
+        ? "jira_mcp"
+        : null,
     };
   }
 

--- a/packages/server/src/gateway/routes/public/jira-mcp-webhook-delivery.ts
+++ b/packages/server/src/gateway/routes/public/jira-mcp-webhook-delivery.ts
@@ -71,7 +71,7 @@ async function resolveJiraMcpFeedTarget(params: {
 		  AND f.feed_key = ${ATLASSIAN_JIRA_ISSUES_FEED_KEY}
 		  AND f.status = 'active'
 		  AND f.deleted_at IS NULL
-		  AND c.status = 'active'
+		  AND c.status NOT IN ('paused', 'revoked')
 		  AND c.deleted_at IS NULL
 	`) as Array<{
 		feed_id: number;
@@ -106,6 +106,60 @@ async function resolveJiraMcpFeedTarget(params: {
 		);
 	}
 	return matches[0] ?? null;
+}
+
+async function resolveJiraMcpFeedTargetByConnection(params: {
+	sql: DbClient;
+	organizationId: string;
+	connectionId: number;
+}): Promise<JiraMcpFeedTarget | null> {
+	const rows = (await params.sql`
+		SELECT f.id AS feed_id, f.connection_id, f.config AS feed_config,
+		       c.connector_key, c.config AS connection_config, cd.mcp_config
+		FROM feeds f
+		JOIN connections c ON c.id = f.connection_id
+		JOIN LATERAL (
+			SELECT mcp_config
+			FROM connector_definitions
+			WHERE organization_id = c.organization_id
+			  AND key = c.connector_key
+			  AND status = 'active'
+			ORDER BY updated_at DESC
+			LIMIT 1
+		) cd ON TRUE
+		WHERE f.organization_id = ${params.organizationId}
+		  AND f.connection_id = ${params.connectionId}
+		  AND f.feed_key = ${ATLASSIAN_JIRA_ISSUES_FEED_KEY}
+		  AND f.status = 'active'
+		  AND f.deleted_at IS NULL
+		  AND c.status NOT IN ('paused', 'revoked')
+		  AND c.deleted_at IS NULL
+	`) as Array<{
+		feed_id: number;
+		connection_id: number;
+		feed_config: Record<string, unknown> | null;
+		connector_key: string;
+		connection_config: Record<string, unknown> | null;
+		mcp_config: Record<string, unknown> | null;
+	}>;
+	const row = rows[0];
+	if (!row || rows.length !== 1 || !isAtlassianMcpConfig(row.mcp_config)) {
+		return null;
+	}
+	const config = {
+		...(row.connection_config ?? {}),
+		...(row.feed_config ?? {}),
+	};
+	const configuredUrl =
+		typeof config.site_url === "string" ? config.site_url : undefined;
+	if (!configuredUrl || !siteHost(configuredUrl)) return null;
+	return {
+		connectionId: Number(row.connection_id),
+		feedId: Number(row.feed_id),
+		connectorKey: row.connector_key,
+		config,
+		siteUrl: configuredUrl,
+	};
 }
 
 function issueUrl(target: JiraMcpFeedTarget, issueKey?: string): string {
@@ -169,11 +223,17 @@ async function landJiraMcpWebhookEvent(params: {
 					? issueRow.url
 					: issueUrl(params.target, issueKey),
 			occurredAt:
-				typeof issueRow.created_at === "string"
-					? issueRow.created_at
-					: typeof issueRow.updated_at === "string"
+				eventType === "jira:issue_updated"
+					? typeof issueRow.updated_at === "string"
 						? issueRow.updated_at
-						: null,
+						: typeof issueRow.created_at === "string"
+							? issueRow.created_at
+							: null
+					: typeof issueRow.created_at === "string"
+						? issueRow.created_at
+						: typeof issueRow.updated_at === "string"
+							? issueRow.updated_at
+							: null,
 			metadata: {
 				key: issueKey ?? null,
 				status: issueRow.status ?? null,
@@ -317,4 +377,31 @@ export function createJiraWebhookDelivery(): NonNullable<
 			? { triggered: true }
 			: { triggered: false, handled: false };
 	};
+}
+
+/**
+ * Land a per-connection Jira dynamic-webhook delivery on the exact Atlassian
+ * MCP connection whose callback URL received it. Authentication and raw-body
+ * verification happen in the shared connector webhook ingest pipeline before
+ * this function runs.
+ */
+export async function deliverJiraMcpConnectionWebhook(params: {
+	sql: DbClient;
+	organizationId: string;
+	connectionId: number;
+	rawBody: Uint8Array;
+}): Promise<{ handled: boolean; triggered: boolean }> {
+	const payload = parseJson(params.rawBody);
+	if (!payload || typeof payload !== "object") {
+		return { handled: false, triggered: false };
+	}
+	const target = await resolveJiraMcpFeedTargetByConnection(params);
+	if (!target) return { handled: false, triggered: false };
+	const triggered = await landJiraMcpWebhookEvent({
+		sql: params.sql,
+		organizationId: params.organizationId,
+		target,
+		payload: payload as Record<string, unknown>,
+	});
+	return { handled: true, triggered };
 }

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -45,6 +45,7 @@ import {
 } from '../gateway/services/agent-threads';
 import { buildMessagePayload } from '../gateway/services/platform-helpers';
 import { migrateLegacyPlaintextAuthData } from '../utils/auth-credential-secrets';
+import { refreshDueAtlassianMcpJiraWebhooks } from '../connect/atlassian-mcp-webhook';
 
 function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   if (!value || typeof value !== 'object') return null;
@@ -155,6 +156,19 @@ function registerMaintenanceTasks(
       }
     },
     { cron: '23 */6 * * *' },
+  );
+
+  // Jira dynamic webhooks expire after 30 days. Refresh each separately
+  // authorized Atlassian MCP subscription before its provider expiry.
+  scheduler.register(
+    'atlassian-mcp-webhook-refresh',
+    async () => {
+      const result = await refreshDueAtlassianMcpJiraWebhooks();
+      if (result.refreshed > 0 || result.errors > 0) {
+        logger.info({ ...result }, '[task] Atlassian MCP webhook refresh swept');
+      }
+    },
+    { cron: '17 */6 * * *' },
   );
 
   // Hygiene sweep — drops expired rows from oauth_states, rate_limits,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2050,12 +2050,16 @@ export async function handleUpdate(
 		(args.config !== undefined || args.status !== undefined) &&
 		isAtlassianMcpConfig(existing.mcp_config)
 	) {
-		await registerConnectorWebhook({
-			organizationId,
-			connectionId: args.connection_id,
-			baseUrl: getGatewayBaseUrl(ctx),
-			throwOnError: true,
-		});
+		try {
+			await registerConnectorWebhook({
+				organizationId,
+				connectionId: args.connection_id,
+				baseUrl: getGatewayBaseUrl(ctx),
+				throwOnError: true,
+			});
+		} catch (error) {
+			return { error: getErrorMessage(error) };
+		}
 	}
 
   const updatedRow = updated[0] as Record<string, unknown>;

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -6,7 +6,10 @@ import { randomUUID } from "node:crypto";
 import { getErrorMessage, parseJsonObject } from "@lobu/core";
 import { getScopedConnectorDefinition } from "../../../../catalog/connector-definitions";
 import { enrichConnectorGroupsWithCatalogDisplay } from "../../../../catalog/connector-group-display";
-import { unregisterConnectorWebhook } from "../../../../connect/webhook-registration";
+import {
+	registerConnectorWebhook,
+	unregisterConnectorWebhook,
+} from "../../../../connect/webhook-registration";
 import {
 	getDb,
 	parsePgNumberArray,
@@ -27,6 +30,7 @@ import {
 	updateChatConnection,
 	upsertByoChatConnection,
 } from "../../../../gateway/connections/chat-connection-service";
+import { isAtlassianMcpConfig } from "../../../../operations/atlassian-mcp-feed";
 import {
   EMPTY_SUMMARY,
   getOperationsSummariesByConnection,
@@ -120,6 +124,17 @@ import {
 } from "../../helpers/connect-setup-continuation";
 import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
 import { supersedeActionEvent } from "../../approval-events";
+
+// These Atlassian MCP config keys select a separately-consented Jira OAuth
+// grant. A member must not bind an admin's Jira authorization to a connection.
+const JIRA_WEBHOOK_CREDENTIAL_KEYS = [
+	"jira_webhook_auth_profile_slug",
+	"jira_webhook_app_profile_slug",
+	"webhook_enabled",
+] as const;
+
+const JIRA_WEBHOOK_ADMIN_ONLY_ERROR =
+	"Only admins can configure the secondary Jira authorization used by Atlassian webhook delivery.";
 
 // ============================================
 // handleListConnectorGroups
@@ -692,6 +707,15 @@ export async function handleCreate(
 			error: `Connector '${args.connector_key}' not found or not active`,
 		};
 	}
+	if (
+		!callerIsAdmin &&
+		isAtlassianMcpConfig(connector.mcp_config) &&
+		JIRA_WEBHOOK_CREDENTIAL_KEYS.some((key) =>
+			Object.hasOwn(args.config ?? {}, key),
+		)
+	) {
+		return { error: JIRA_WEBHOOK_ADMIN_ONLY_ERROR };
+	}
 
 	// Schema-declared secret config keys for this connector — used to redact the
 	// `RETURNING *` row before it is serialized back to the caller.
@@ -1241,6 +1265,21 @@ export async function handleCreate(
 		);
   }
 
+	if (connectionStatus === "active" && isAtlassianMcpConfig(connector.mcp_config)) {
+		await registerConnectorWebhook({
+			organizationId,
+			connectionId: Number(inserted[0].id),
+			baseUrl: getGatewayBaseUrl(ctx),
+		});
+		const read = await handleGet(
+			{ action: "get", connection_id: Number(inserted[0].id) },
+			ctx,
+		);
+		if (!("error" in read) && read.action === "get") {
+			inserted[0] = read.connection as Record<string, unknown>;
+		}
+	}
+
   logger.info(
     {
       connection_id: inserted[0].id,
@@ -1362,10 +1401,11 @@ export async function handleUpdate(
   // Verify ownership
   const existingRows = await sql`
     SELECT c.id, c.connector_key, c.auth_profile_id, c.app_auth_profile_id, c.created_by,
-           c.config, c.credential_mode, cd.auth_schema, cd.options_schema, cd.feeds_schema
+           c.config, c.credential_mode, cd.auth_schema, cd.options_schema, cd.feeds_schema,
+           cd.mcp_config
     FROM connections c
     LEFT JOIN LATERAL (
-      SELECT auth_schema, options_schema, feeds_schema
+      SELECT auth_schema, options_schema, feeds_schema, mcp_config
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -1387,6 +1427,7 @@ export async function handleUpdate(
     auth_schema: { methods?: Array<Record<string, unknown>> } | null;
     options_schema: Record<string, unknown> | null;
     feeds_schema: Record<string, unknown> | null;
+    mcp_config: Record<string, unknown> | null;
     auth_profile_id: number | null;
     app_auth_profile_id: number | null;
     created_by: string | null;
@@ -1725,6 +1766,15 @@ export async function handleUpdate(
     : splitConfig.connectionConfig
       ? { ...existingConfig, ...splitConfig.connectionConfig }
       : existingConfig;
+	if (
+		!callerIsAdmin &&
+		isAtlassianMcpConfig(existing.mcp_config) &&
+		JIRA_WEBHOOK_CREDENTIAL_KEYS.some(
+			(key) => resultingConfig[key] !== existingConfig[key],
+		)
+	) {
+		return { error: JIRA_WEBHOOK_ADMIN_ONLY_ERROR };
+	}
 	const willBeConsentOnly =
 		parseJsonObject(resultingConfig).consent_only === true;
   if (willBeConsentOnly && existingConfig.consent_only !== true) {
@@ -1996,6 +2046,18 @@ export async function handleUpdate(
     await syncOAuthConnectionsForAuthProfile(organizationId, effectiveAuth.id);
   }
 
+	if (
+		(args.config !== undefined || args.status !== undefined) &&
+		isAtlassianMcpConfig(existing.mcp_config)
+	) {
+		await registerConnectorWebhook({
+			organizationId,
+			connectionId: args.connection_id,
+			baseUrl: getGatewayBaseUrl(ctx),
+			throwOnError: true,
+		});
+	}
+
   const updatedRow = updated[0] as Record<string, unknown>;
   const changedFields = [
     ...(args.display_name !== undefined ? ["display_name"] : []),
@@ -2016,6 +2078,16 @@ export async function handleUpdate(
     state: updatedRow,
     ...(changedFields.length > 0 ? { changedFields } : {}),
   });
+
+	if (args.config !== undefined || args.status !== undefined) {
+		const read = await handleGet(
+			{ action: "get", connection_id: args.connection_id },
+			ctx,
+		);
+		if (!("error" in read) && read.action === "get") {
+			return { action: "update", connection: read.connection };
+		}
+	}
 
   return {
 		action: "update",
@@ -2150,10 +2222,16 @@ export async function handleDelete(
       return { error: getErrorMessage(error) };
     }
   } else {
-    await unregisterConnectorWebhook({
-      organizationId,
-      connectionId: args.connection_id,
-    });
+		try {
+			await unregisterConnectorWebhook({
+				organizationId,
+				connectionId: args.connection_id,
+				throwOnError: true,
+				baseUrl: getGatewayBaseUrl(ctx),
+			});
+		} catch (error) {
+			return { error: getErrorMessage(error) };
+		}
   }
 
   // Phase 2 (atomic): the durable connection tombstone, every pending run/card


### PR DESCRIPTION
## Summary
- register and refresh Jira dynamic webhooks for Atlassian Rovo MCP connections using a separately consented Jira OAuth profile
- authenticate deliveries with a per-connection encrypted callback token, then land issue/comment payloads as structured events on the exact Rovo feed
- reconcile ambiguous registration state, fail closed on update/delete teardown, and gate secondary Jira authorization to admins

## Red -> green
- RED: changed the single callback bridge mapping from `allowQueryAuth: true` to `false`; the real route test failed with `Expected: 202, Received: 401` (0 pass, 1 fail)
- GREEN: restored `allowQueryAuth: true`; the same endpoint test passed (1 pass, 0 fail)
- Fixer RED: reverted the never-registered teardown guard; its focused test failed (1 fail / 5 pass)
- Fixer GREEN: restored the guard; lifecycle suite passed 6/6

## Validation
- `bun test packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts` — 6 pass
- `bun test packages/server/src/gateway/__tests__/webhook-ingest.test.ts` — 46 pass
- `bun test packages/server/src/gateway/__tests__/app-webhooks.test.ts` — 34 pass
- `bun run --filter @lobu/server typecheck` — pass
- `bun scripts/check-test-runner-coverage.mjs` — pass
- `make pre-pr-remote` — pass, Depot run `97mzb0zxdj`

## Notes
Atlassian dynamic webhooks do not accept the admin-webhook HMAC secret field. The callback therefore carries an unguessable 256-bit token stored as a `secret://` ref; Lobu verifies it with the existing constant-time webhook-ingest auth path. Jira OAuth consent remains separate from the Rovo MCP credential because webhook management requires `manage:jira-webhook`.