### PR TITLE
fix(auth): preserve extension sidebar organization

### DIFF
--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -26,16 +26,29 @@ describe('deep-link token exchange', () => {
     await cleanupTestDatabase();
   });
 
-  async function patForNewUser(slug: string, email: string): Promise<string> {
+  async function patForNewUser(
+    slug: string,
+    email: string
+  ): Promise<{ token: string; orgId: string }> {
     const org = await createTestOrganization({ slug });
     const user = await createTestUser({ email });
     await addUserToOrganization(user.id, org.id, 'owner');
     const { token } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
-    return token;
+    return { token, orgId: org.id };
+  }
+
+  /** The minted session's active org, read back through Better Auth itself. */
+  async function activeOrgOf(sessionToken: string): Promise<string | null | undefined> {
+    const res = await get('/api/auth/get-session', { token: sessionToken });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      session?: { activeOrganizationId?: string | null };
+    };
+    return body.session?.activeOrganizationId;
   }
 
   it('POST /extension-session returns a session token for Bearer use (extension iframe)', async () => {
-    const token = await patForNewUser('xt-post-org', 'xt-post@test.example.com');
+    const { token, orgId } = await patForNewUser('xt-post-org', 'xt-post@test.example.com');
     const res = await postForm('/api/extension-session', { token });
 
     expect(res.status).toBe(200);
@@ -43,7 +56,17 @@ describe('deep-link token exchange', () => {
     expect(res.headers.get('set-cookie')).toBeNull();
     const body = (await res.json()) as { session_token?: string };
     expect(typeof body.session_token).toBe('string');
-    expect((body.session_token ?? '').length).toBeGreaterThan(0);
+    const sessionToken = body.session_token ?? '';
+    expect(sessionToken.length).toBeGreaterThan(0);
+    // The PAT's org becomes the session's active org — the sidebar reads it.
+    expect(await activeOrgOf(sessionToken)).toBe(orgId);
+
+    // Third credential shape: exchanging that Better Auth session token itself
+    // must carry the active org forward too (menu-bar/local-init hold one).
+    const rePaired = await postForm('/api/extension-session', { token: sessionToken });
+    expect(rePaired.status).toBe(200);
+    const reBody = (await rePaired.json()) as { session_token?: string };
+    expect(await activeOrgOf(reBody.session_token ?? '')).toBe(orgId);
   });
 
   it('POST /extension-session resolves an OAuth device-code access token (cloud pairing path)', async () => {
@@ -62,11 +85,13 @@ describe('deep-link token exchange', () => {
     const res = await postForm('/api/extension-session', { token });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { session_token?: string };
-    expect((body.session_token ?? '').length).toBeGreaterThan(0);
+    const sessionToken = body.session_token ?? '';
+    expect(sessionToken.length).toBeGreaterThan(0);
+    expect(await activeOrgOf(sessionToken)).toBe(org.id);
   });
 
   it('GET /exchange-token keeps a first-party Lax cookie — never Partitioned/None (CLI/menu-bar)', async () => {
-    const token = await patForNewUser('xt-get-org', 'xt-get@test.example.com');
+    const { token } = await patForNewUser('xt-get-org', 'xt-get@test.example.com');
     const res = await get(`/api/exchange-token?token=${encodeURIComponent(token)}&next=/`);
 
     expect(res.status).toBe(302);
@@ -83,7 +108,7 @@ describe('deep-link token exchange', () => {
     const previous = process.env.AUTH_COOKIE_DOMAIN;
     process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
     try {
-      const token = await patForNewUser('xt-zone-org', 'xt-zone@test.example.com');
+      const { token } = await patForNewUser('xt-zone-org', 'xt-zone@test.example.com');
       const res = await get(`/api/exchange-token?token=${encodeURIComponent(token)}&next=/`);
       expect(res.status).toBe(302);
 

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -293,11 +293,16 @@ function assertLoopbackClient(
  */
 async function createSessionToken(
   c: Context<{ Bindings: Env }>,
-  userId: string
+  userId: string,
+  activeOrganizationId?: string | null
 ): Promise<string | null> {
   const auth = await createAuth(c.env, c.req.raw);
   const ctx = await auth.$context;
-  const session = await ctx.internalAdapter.createSession(userId);
+  const session = await ctx.internalAdapter.createSession(
+    userId,
+    undefined,
+    activeOrganizationId ? { activeOrganizationId } : undefined
+  );
   return session?.token ?? null;
 }
 
@@ -359,8 +364,8 @@ async function mintSessionCookieValue(
 }
 
 /**
- * Resolve a `?token=…` deep-link credential to a user id. Accepts all three
- * credential shapes the deep-link callers hold:
+ * Resolve a `?token=…` deep-link credential to its user and organization.
+ * Accepts all three credential shapes the deep-link callers hold:
  *   - Personal Access Tokens (`owl_pat_*`, `personal_access_tokens`)
  *   - OAuth 2.1 access tokens (`oauth_tokens`) — what the Owletto extension's
  *     device-code pairing issues; without this the cloud-paired iframe 401s at
@@ -374,17 +379,26 @@ async function mintSessionCookieValue(
 async function resolveDeepLinkToken(
   c: Context<{ Bindings: Env }>,
   token: string
-): Promise<string | null> {
+): Promise<{ userId: string; organizationId: string | null } | null> {
   const sql = createDbClientFromEnv(c.env);
   const baseUrl = resolveBaseUrl({ request: c.req.raw });
   const authInfo = await new OAuthProvider(sql, baseUrl).verifyAccessToken(token);
-  if (authInfo?.userId) return authInfo.userId;
+  if (authInfo?.userId) {
+    return {
+      userId: authInfo.userId,
+      organizationId: authInfo.organizationId,
+    };
+  }
   // Otherwise treat it as a Better Auth session token. Better Auth's adapter
   // looks it up by the raw token (the unsigned half of the cookie value).
   const auth = await createAuth(c.env, c.req.raw);
   const ctx = await auth.$context;
   const session = await ctx.internalAdapter.findSession(token);
-  return session?.session?.userId ?? null;
+  if (!session?.session?.userId) return null;
+  return {
+    userId: session.session.userId,
+    organizationId: session.session.activeOrganizationId ?? null,
+  };
 }
 
 /**
@@ -416,15 +430,15 @@ async function handleExchangeToken(
     );
   }
 
-  const userId = await resolveDeepLinkToken(c, trimmed);
-  if (!userId) {
+  const identity = await resolveDeepLinkToken(c, trimmed);
+  if (!identity) {
     return c.json(
       { error: 'invalid_token', error_description: 'token is invalid, expired, or revoked' },
       401
     );
   }
 
-  const minted = await mintSessionCookieValue(c, userId);
+  const minted = await mintSessionCookieValue(c, identity.userId);
   if ('error' in minted) {
     return c.json(
       { error: 'session_create_failed', error_description: minted.error },
@@ -470,15 +484,19 @@ credentialRoutes.post('/extension-session', async (c) => {
     );
   }
 
-  const userId = await resolveDeepLinkToken(c, token);
-  if (!userId) {
+  const identity = await resolveDeepLinkToken(c, token);
+  if (!identity) {
     return c.json(
       { error: 'invalid_token', error_description: 'token is invalid, expired, or revoked' },
       401
     );
   }
 
-  const sessionToken = await createSessionToken(c, userId);
+  const sessionToken = await createSessionToken(
+    c,
+    identity.userId,
+    identity.organizationId
+  );
   if (!sessionToken) {
     return c.json(
       { error: 'session_create_failed', error_description: 'failed to mint session' },
@@ -517,8 +535,8 @@ credentialRoutes.get('/sse-ticket', async (c) => {
     );
   }
 
-  const userId = await resolveDeepLinkToken(c, bearer);
-  if (!userId) {
+  const identity = await resolveDeepLinkToken(c, bearer);
+  if (!identity) {
     return c.json(
       { error: 'invalid_token', error_description: 'token is invalid, expired, or revoked' },
       401
@@ -530,7 +548,11 @@ credentialRoutes.get('/sse-ticket', async (c) => {
   // resolves the SAME owner it would for a first-party web session. No jti →
   // no revocation lookup needed; the short TTL is the bound.
   const ticket = encrypt(
-    JSON.stringify({ userId, platform: 'external', exp: Date.now() + SSE_TICKET_TTL_MS })
+    JSON.stringify({
+      userId: identity.userId,
+      platform: 'external',
+      exp: Date.now() + SSE_TICKET_TTL_MS,
+    })
   );
   return c.json({ ticket });
 });


### PR DESCRIPTION
## Summary
- Preserve the verified organization claim when an extension pairing token is exchanged for the sidebar Better Auth session.
- Prevent the sidebar from falling back to alphabetically-first Atlas when the paired Chrome worker belongs to Buremba.
- Cover PAT, OAuth device-code, and Better Auth session-token credential shapes.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Targeted `bun test packages/server/src/auth/__tests__/exchange-token-cookie.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Live Mac mini extension verification after production rollout

Red (before fix):

    Expected: "org_esKb9h_FiSk"
    Received: null
    10 pass, 1 fail

Green (after fix, including PAT/OAuth/session-token coverage):

    11 pass, 0 fail
    57 expect() calls

Full gate:

    Depot run bxxb9264dc passed (18 jobs)

## Notes
No database migration, public endpoint shape change, Owletto pointer change, or connector-specific code.