### PR TITLE
docs(agents): halve the always-loaded root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,74 +1,54 @@
-<!-- Project rules for agents (Claude, pi, codex). CLAUDE.md inlines this into every session — keep this file lean. Put package-specific detail in the nearest package AGENTS.md. -->
+<!-- Rules for agents (Claude, pi, codex); CLAUDE.md inlines this into every session. Keep it to facts an agent cannot derive and boundaries it must not cross. Reasoning and recipes go in docs/AGENT_PLAYBOOK.md, package specifics in the nearest package AGENTS.md. -->
 
 ## Repo map
-- Bun workspace under `packages/*`; TS source is in `src`, tests in `__tests__`.
-- Main packages: `core` shared types/utils, `plugin-api` native plugin contracts, `plugin-host` deterministic plugin composition, `server` gateway + embedded runtime, `agent-worker` Lobu agent execution, `connectors` built-in connectors, `owletto` frontend submodule.
-- Before editing a package, read its nearest `AGENTS.md` if present.
-- `docs/GOTCHAS.md` collects the mechanical traps (build, SQL, testing, submodule, browser) that have each cost a debugging session. Skim the section for the surface you are touching before you start, and grep it when something looks inexplicable.
+- Bun workspace under `packages/*`; TS source in `src`, tests in `__tests__`.
+- `core` types/utils · `plugin-api` plugin contracts · `plugin-host` plugin composition · `server` gateway + embedded runtime · `agent-worker` agent execution · `connectors` built-in connectors · `owletto` frontend submodule.
+- Read the nearest package `AGENTS.md` before editing that package; grep `docs/GOTCHAS.md` when something looks inexplicable.
 
-## Hard invariants
-- **Never write to `~/Code/lobu` directly — work in a worktree.** Run `make task-setup NAME=<slug>` first, and never `git switch` in the main checkout.
-- One branch = one concern (not one file). Tangential task → commit/push/open current work, then branch fresh from `main`. Split only for genuinely independent concerns or an unreviewable diff.
-- **Multi-replica correctness is mandatory.** Never put shared required state in an in-memory Map/singleton another replica must read or mutate. If a feature relies on cross-pod visibility, use Postgres-mediated state/signal.
-- **`events` is append-only.** Never `DELETE FROM events`; tombstone/supersede instead.
-- **`events.id` is a stored-version id, not stable source identity.** Connector resyncs can supersede a row and allocate a new id for the same source item. Cross-sync identity and dedupe must use the connector's stable `origin_id` (scoped to its connection/source) or an explicit domain key, never `events.id`.
-- **Request paths never aggregate history.** No `GROUP BY`, `DISTINCT ON`, per-row `regexp_*`, or leading-wildcard `LIKE` over an append-only / run-history table (`events`, `agent_transcript_snapshot`, `session_calls`, …) on a user-facing read path. History only grows, so read-time aggregation cost grows with it while the answer stays bounded. Materialize the row or counter at WRITE time and read it back by index; run the one-time aggregation in a migration, never per request. Aggregating bounded config tables (`connections`, `watchers`, `agent_users`) is fine.
-- **Never bulk-delete prod `organization` rows**, including zero-activity ones — empty-looking orgs are frequently real human signups. Surface them one at a time for confirmation.
-- **Workers never receive real credentials.** They may receive only placeholders/proxied access. The only exceptions are device-pinned connectors and short-lived provider-derived credential leases (see `packages/server/AGENTS.md`); a durable stored credential is never one of them.
-- Default to static `import`. New dynamic imports require measured cost justification here or in the package AGENTS plus a rationale comment at the call site. Tests may dynamically import after mocks.
-  - Node-version gate exceptions: `packages/cli/bin/lobu.js` defers the existing CLI graph without duplicating it, and `packages/server/src/server-entry.ts` adds an 842-byte gate in front of the 4.34 MB server graph (measured 2026-07-24). Both call sites must stay dependency-free until their checks pass.
-- Bug fixes require red→fix→green evidence, with both outputs pasted into the PR body. If you cannot reproduce, stop and report the dead end — do not ship a speculative fix.
-- Mutation checks require proof that the mutation landed: assert the old pattern exists, verify a countable source change, and confirm the focused test fails before restoring the fix and rerunning green. A green test after a no-op mutation proves nothing.
-- Never report done off a green typecheck. Boot it, exercise every branch you touched, clean up test data. If "compiles" is all you ran, say so explicitly.
-- Gates are non-negotiable (sequence in "Ship a change" below). `make pre-pr-remote` runs the full Linux CI graph on Depot against the staged tree and builds before checks that consume dist — that build step protects against a stale-dist false green. `make pre-pr` is the CPU-heavy local fallback. `make review` is an LLM verdict only: it does NOT run typecheck/knip/tests and is not proof CI will pass.
-- The agent-facing product name is **Behavior**; `watcher` is internal engine/DB vocabulary. It must not appear in MCP tool schemas/names/descriptions, ClientSDK discovery metadata, or the connector-sdk public reaction contract — `make pre-pr-remote` fails on it. Internal identifiers (`actingWatcherId`, table/column names, comments) are fine.
-- `make review-fix` is the unposted fixer pass and runs BEFORE the first `make review`; verify its diff and commit it. Never iterate `make review` as a find-fix loop — each posted round costs a review + CI cycle.
-- **A UI change owes visual proof.** For an Owletto pointer PR, `make ui-review` publishes the before/after comparison on the exact merged Owletto PR and links it from the parent. Publishing the proof is what the gate asserts — review it like any other change on the PR. A changed pointer republishes it.
-- Fix the class, not the instance: on the first hit, grep every other instance and fix in one pass — a diff-scoped reviewer only ever finds the next one. Same root cause twice = stop reviewing, grep-enumerate. A class-wide fix is in scope for the branch that found it and does not count as scope creep.
-- **Fail closed on durable dispatch/delivery state.** When a durable coordination or delivery operation fails, its caller must not reinterpret the error as proceed/deliver/skip. Propagate a retry, defer, or terminal-failure outcome with a visible log; if the operation may already have succeeded, reconcile idempotently before retrying. Treat lock timeouts, pool errors, and ambiguous or expired rows as failures, not as "nothing changed."
-- **Coordination design brake.** A change that needs a second lock, a second retry/deferral budget, or a prose termination argument to explain why it halts is patching a misplaced check — stop and re-derive where the decision belongs before adding mechanism. Find the chokepoint that already serializes the action (e.g. worker dispatch is serialized by `job-router` on the worker-SSE-owner pod) and put the check there; prefer deleting the state transition over coordinating it, and reuse queue-native retry over hand-rolled hold/requeue.
-- **Interactive browser drafts are page-activated, never tab-pushed.** Persist the draft operation and its normal Lobu notification; let the generic Chrome extension badge exact pending URLs and activate the run only when the user visits one in a user-owned tab. Extension/server core must contain no connector, Behavior, selector, or site-specific rules. Connector/reaction code owns URL shapes and page interaction. Never auto-submit. Only scrape-owned scratch tabs may be opened and closed automatically.
-- **Stage by explicit path; never commit the whole tree of a worktree that hosted other work.** A commit is a snapshot — stale file copies silently revert already-merged PRs. After commit/rebase, `git diff --name-only origin/main...HEAD` must equal the task's intended file list; extra files = stop. Verify a "reverts merged work" review finding by diff direction against `origin/main`, never dismiss it as merge-base noise.
+## Unrecoverable — never do these
+- **Never write to `~/Code/lobu` directly.** Run `make task-setup NAME=<slug>` first, and never `git switch` in the main checkout — other sessions share it.
+- **Stage by explicit path** (`git add -- <paths>`, never `-A`). A commit is a snapshot, so a stale file copy left by earlier work in the same worktree silently reverts merged PRs. After commit/rebase, `git diff --name-only origin/main...HEAD` must equal your intended file list; extras = stop.
+- **`events` is append-only.** Never `DELETE FROM events`; tombstone or supersede instead.
+- **Never bulk-delete prod `organization` rows**, including zero-activity ones — empty-looking orgs are usually real signups. Surface them one at a time for confirmation.
+- **Never resolve merge conflicts in the GitHub web UI** — it has silently dropped 1000+ lines of feature work. Rebase locally against `origin/main`; submodule-pointer branches `git merge` instead (`docs/GOTCHAS.md`).
+- **Two writing agents must never share a worktree** — they overwrite each other's uncommitted work. Every subagent with Edit/Write/Bash gets its own through `make task-setup` (only task-setup does submodule pinning, `bun install`, `.env` copy, and port allocation); only read-only agents share the parent.
+- **Never add a table or change DB design, API surface, or SDK surface** without surfacing the proposal and receiving confirmation first.
+- **Never auto-submit an interactive browser draft, in any package.** Drafts are page-activated: persist the operation, notify normally, and let the extension activate the run only when the user visits a pending URL in a user-owned tab. Only scrape-owned scratch tabs may be opened and closed automatically. Server, connector, and Owletto code all obey this (`packages/server/AGENTS.md`).
+
+## Facts you cannot derive
+- **`events.id` is a stored-version id, not stable source identity.** A resync supersedes the row and mints a new id for the same source item, so cross-sync identity and dedupe must key on the connector's `origin_id` (scoped to its connection/source) or an explicit domain key.
+- **Request paths never aggregate history.** No `GROUP BY`, `DISTINCT ON`, per-row `regexp_*`, or leading-wildcard `LIKE` over `events`, `agent_transcript_snapshot`, `session_calls`, … on a user-facing read path: history grows, the answer doesn't. Materialize at write time, read back by index, backfill in a migration. Bounded config tables (`connections`, `watchers`, `agent_users`) are fine.
+- **Shared state must be Postgres-mediated.** An in-memory Map or singleton is invisible to other replicas — correct in dev, broken in prod.
+- **Workers never receive real credentials** — placeholders or proxied access only. The exceptions are device-pinned connectors and short-lived provider-derived leases (`packages/server/AGENTS.md`); a durable stored credential is never one.
+- **The product word is Behavior; `watcher` is DB/engine vocabulary.** `watcher` must not appear in MCP tool schemas, names, or descriptions, ClientSDK discovery metadata, or the connector-sdk public reaction contract — `make pre-pr-remote` fails on it. Internal identifiers and columns are fine.
+- **`make review` is the semantic review gate, not CI.** It runs no typecheck, knip, or tests; a verdict or safe-class skip is not evidence CI will pass.
+- **Depot serializes org-wide.** A newer dispatch silently cancels a peer session's running gate, and `gh run rerun` counts as a dispatch. Check `pgrep -f "make pre-pr-remote"` before dispatching.
+- Default to static `import`; a new production dynamic import needs measured justification plus a call-site rationale comment. Tests may import dynamically after mocks; two Node-version gates are grandfathered (playbook).
 
 ## Ship a change
 1. `make task-setup NAME=<slug>` → work in `.claude/worktrees/<slug>/`.
-2. Reproduce the bug (red) before fixing it. Fix, then prove green.
-3. Iterate with focused local tests: one file via `bun test <path>`, or `cd packages/server && bunx vitest run <path>` for vitest suites. Use `make pre-pr-remote-fast` when broad required-gate confidence is useful before the diff settles; it runs remotely and never substitutes for the final full gate.
-4. `make review-fix` on the settled diff and verify what it changed — it edits the working tree, so re-read the files before trusting them.
-5. Stage every intended file by explicit path (`git add -- <paths>`, never `-A`), then `make pre-pr-remote` to run the full staged Linux CI graph on Depot. It fails closed on untracked or unstaged changes so the successful tree attestation survives the following commit. The macOS app lane remains on GitHub/Mac hardware. Use the CPU-heavy local `make pre-pr` only when Depot is unavailable; intentional workflow/action changes require `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` after review.
-6. Commit, then confirm `git diff --name-only origin/main...HEAD` is exactly your intended file list. Extra files = stop.
-7. `git push -u origin <branch>` → `gh pr create` (fill `.github/pull_request_template.md`; conventional-commit title, e.g. `fix(server): …`).
-8. `make review` **once** on the settled HEAD. It posts the `pi-review` status, which is a REQUIRED check. Small safe-class diffs (docs/renames/generated/additive-tests, <100 lines) skip the cross-harness reviewer by default; run `REVIEWER_MODE=full make review` to force the independent review, and `REVIEWER_SHADOW=1` to measure the skip rule instead of trusting it.
-9. `make ui-review`. It passes non-Owletto changes as not applicable. For an Owletto pointer change, run `ARTIFACT=<hosted-html-url> make ui-review`; it publishes the before/after proof on the exact merged Owletto PR, links it from the parent, and passes. No `ARTIFACT` means no proof and no pass.
-10. Merge squash once CI is green: `gh pr merge <n> --squash --admin`. Never `--admin` past a check that has not reported.
-11. Prod-visible surface? Verify it live after rollout. Set a self-rescheduling `ScheduleWakeup` (~1500s) carrying the rollout gate: poll the deployed SHA, then `git merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA"` with `MERGE_SHA=$(gh pr view <n> --json mergeCommit --jq .mergeCommit.oid)`. Two ways this gate silently never opens — **gate on the squash commit, not your branch head** (a squash merge writes a new commit with no ancestry link to the branch, so the branch head exits 1 forever: PR #2280 has identical trees and still fails), and **keep that argument order** (merge commit first; reversed, it accepts a stale deploy). Run the live check when it lands, and write the result back to memory.
+2. Reproduce red → fix → prove green, and paste both outputs in the PR. Cannot reproduce = report the dead end; never ship a speculative fix.
+3. Iterate on focused tests: `bun test <path>`, or `cd packages/server && bunx vitest run <path>` for vitest suites. `make pre-pr-remote-fast` gives interim breadth and never substitutes for the final gate.
+4. `make review-fix` on the settled diff, then re-read what it touched. It runs BEFORE the first `make review` — never iterate `make review` as a find-fix loop, since each posted round costs a review + CI cycle.
+5. Stage by explicit path, then `make pre-pr-remote`; it fails closed on unstaged or untracked changes. Reviewed workflow/action changes need `DEPOT_ALLOW_WORKFLOW_CHANGES=1`.
+6. Commit, then confirm `git diff --name-only origin/main...HEAD` is exactly your intended file list.
+7. `git push -u origin <branch>` → `gh pr create` (fill `.github/pull_request_template.md`; conventional-commit title).
+8. `make review` **once** on the settled HEAD; it posts the required `pi-review` status.
+9. `make ui-review`. Non-Owletto changes pass as not applicable; an Owletto pointer change needs exact hosted proof (`ARTIFACT=<url>`; see the playbook).
+10. `gh pr merge <n> --squash --admin` once green — never `--admin` past a check that has not reported.
+11. Prod-visible surface? Verify live after rollout: gate on the **squash commit**, not your branch head, keeping the argument order `git merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA"`. Record the result.
 
-## Agent workflow
-- Do only what was asked. Delete ephemeral files you create. Do not create `*.md` unless asked.
-- Never introduce a new table or change the database design, API surface, or SDK surface without explicitly surfacing the proposal and receiving user confirmation first.
-- Prefer `bun`; do not use npm/yarn/pnpm for repo work.
-- Fix unused params by deleting them, not `_`-prefixing.
-- Never `git stash`; use WIP commits and squash later.
-- Never resolve merge conflicts in the GitHub web UI (it has silently dropped 1000+ lines of feature work). Rebase locally against `origin/main`, then diff against the last real feature commit before squashing — except on submodule-pointer branches, where you must `git merge` (see `docs/GOTCHAS.md`, "Submodule & cross-repo").
+## How to work
+- Do only what was asked. Delete ephemeral files you create; no new `*.md` unless asked.
 - Run mandated gates automatically; never ask permission to run one.
-- Show the diff, not a summary. Before claiming done — on your own work or a dispatched agent's — surface `git status` plus `git diff --stat <base>...HEAD`. An agent's self-report is a claim; the diff is the evidence.
-- UI PRs owe before/after screenshots, and `gh` cannot upload images inline. Capture before shots from the unmodified branch and after shots from the same booted app (auth recipe in `docs/BROWSER_TESTING.md`), base64-embed the PNGs into one self-contained HTML comparison page, publish it as a claude.ai artifact, and pass that URL as `ARTIFACT` to `make ui-review`. The gate records it on the Owletto PR and binds human approval to the exact parent-base and Owletto-pointer pair.
-- Any subagent with write access (Edit/Write/Bash) runs in its own worktree; only grep/read agents share the parent. Two writing agents must NEVER share a worktree — they overwrite each other's uncommitted work.
-- Dispatch code-writing agents through `make task-setup NAME=<slug>` and brief them with the absolute `.claude/worktrees/<slug>/` path. Only task-setup does the submodule branch pinning, post-init `bun install`, `.env` copy, and port allocation.
-- Do repetitive multi-file edits (renames, signature changes, import rewrites) inline or with one script. Reserve subagents for read-only breadth or genuinely isolated parallel work.
-- Before adding an env var, grep for the one the codebase already reads. Do not rename existing vars to a "cleaner" convention unasked.
-- Deleting code needs structural evidence (dangling import, completed migration, superseded impl). Low prod usage is not a delete signal; trace the workflow, not just the import graph — docs and help text are load-bearing too.
-- **Absence is never proven by a grep on a working tree.** To prove code does *not* exist, run `git fetch -q origin && git grep <pattern> origin/main` — the fetch is load-bearing, `origin/main` itself goes stale. Applies to every existence check, including the deletion-evidence rule above.
-- Slack link pasted (`slack.com/archives/…?thread_ts=`) → run `scripts/slack-thread-viewer.js "<link>"` first.
-- To drive the user's real logged-in browser, use the paired Owletto extension — recipe in `docs/BROWSER_TESTING.md`. Do **not** assume CDP/browser-auth is required.
-- Unsure in planning → ask before making conflicting or irreversible choices. Mid-execution, block on a question only for irreversible/destructive actions or decisions that are genuinely the user's; for reversible choices with a clear recommended option, take it and flag the choice in your summary.
-
-## Session efficiency
-- Default broad iteration to `make pre-pr-remote-fast` and final full validation to `make pre-pr-remote`; never start a simultaneous local full gate. Exact local tests remain the fastest red-green loop, while Depot owns CPU-heavy breadth. To rerun one failed lane, pass it explicitly, for example `make pre-pr-remote REMOTE_JOBS=unit`; subset runs never attest. `make review` requires the matching full Depot tree attestation and refuses a surprise local build; only a documented Depot outage permits `REVIEW_ALLOW_LOCAL_BUILD=1 make review`.
-- When a live app is needed without loading the developer's machine, commit first and run `make dev-remote`; it syncs tracked code to private Daytona compute, resumes or starts Lobu, and prints a signed preview URL. Run `make dev-remote-pause` when finished. Keep this direct and private: do not add hooks, a public preview, or a custom proxy.
-- Never poll in the foreground (`sleep`/`until`/`while` wait loops, repeated `tail`). Run long waits (dev-server boot, CI, deploys) in the background and act on the completion notification.
-- **Poll delegated CLIs at most once every 4.5 minutes (270 seconds).** After starting OpenCode, Claude CLI, or another long-running delegated agent, do not check its status sooner unless it completes, requests input/approval, or the user asks for an immediate update. At each check, read only output since the last cursor; never replay the full session or stream verbose diffs/test logs into the supervising context. Ask the delegated agent to persist detailed evidence to files and return compact status, counts, and exit codes.
-- Prefer DOM reads (`get_page_text`, `read_page`, `javascript_tool`) over screenshots; screenshot only when visual layout itself is under test. Screenshots are the #1 context-bloat source.
-- Read a file before editing it, and re-read it after any external change (a fixer pass, another agent, a rebase). Blind edits fail and cost a retry round-trip.
-- Read PR status compactly: `gh pr view <n> --json number,title,isDraft,mergeStateStatus,reviewDecision` plus `gh pr checks <n> --required`. Never `--json statusCheckRollup` — measured on PR 2280 it is 7520 bytes against 861, 8.7x larger and less legible.
-- Batch narrow fixes into one commit, verified once at the end of the batch — not per fix. It never justifies skipping a reproducer or a correctness-critical test. For a one-line or config-only change, take one CI snapshot and move on.
+- **Evidence, not assertion.** Never report done off a green typecheck — boot it, exercise every branch you touched, and clean up test data; if "compiles" is all you ran, say so. Show `git status` plus `git diff --stat <base>...HEAD`, including for a dispatched agent's work.
+- **Absence needs `origin/main`:** `git fetch -q origin && git grep <pattern> origin/main`. A working-tree grep proves nothing, and the fetch is load-bearing.
+- Deleting code needs structural evidence — a dangling import, a completed migration, a superseded implementation. Low prod usage is not evidence, and docs and help text are load-bearing.
+- Fix the class, not the instance: on the first hit, grep every other occurrence and fix in one pass. A diff-scoped reviewer only ever finds the next one.
+- One branch = one concern. Never `git stash`; use WIP commits.
+- Prefer `bun`, never npm/yarn/pnpm. Before adding an env var, grep for the one already read, and do not rename existing vars unasked.
+- Block only on irreversible or destructive actions and decisions genuinely the user's; otherwise take the recommended option and flag it in your summary.
+- Never poll in the foreground — run long waits in the background and act on the notification. Poll delegated CLIs at most once every 4.5 minutes unless they finish or request input.
+- Prefer DOM reads over screenshots, the top context-bloat source. The paired Owletto extension drives the user's real logged-in browser; CDP is not required (`docs/BROWSER_TESTING.md`).
+- Slack link pasted → run `scripts/slack-thread-viewer.js "<link>"` first.
+- `make dev-remote` runs the live app on remote compute (commit first; `make dev-remote-pause` when finished).

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -1,0 +1,90 @@
+# Agent playbook
+
+Supporting rationale, incident history, and exact flags for the root and package agent rules.
+
+The root `AGENTS.md` is loaded into agent sessions (`CLAUDE.md` inlines it for Claude), so it carries concise rules. Package `AGENTS.md` files add local rules; this file carries supporting context for both. Read the relevant section when a rule looks arbitrary, when you are about to argue yourself out of one, or when you need the full command.
+
+Mechanical traps (build, SQL, testing, submodule, browser) live in `docs/GOTCHAS.md` instead.
+
+## Workspace
+
+**Explicit-path staging.** A commit is a snapshot of the index, not a diff of your intentions. A worktree that hosted earlier work still holds those files; `git add -A` commits the stale copies, which silently reverts already-merged PRs. Verify a "reverts merged work" review finding by diff direction against `origin/main` — never dismiss it as merge-base noise.
+
+**One branch = one concern** means one concern, not one file. Split only for genuinely independent concerns or when the diff would be unreviewable.
+
+**Conflict resolution.** Never resolve conflicts in the GitHub UI. Rebase ordinary branches locally against `origin/main`, then diff against the last real feature commit before squashing so a resolution cannot silently drop work. Submodule-pointer branches merge instead; follow `docs/GOTCHAS.md`.
+
+## Data
+
+**Request paths never aggregate history.** History only grows, so read-time aggregation cost grows with it while the answer stays bounded — the query gets slower every day for a result that does not change shape. Materialize the row or counter at write time and read it back by index. Run the one-time backfill in a migration, never per request.
+
+**`events.id` is a stored-version id.** Connector resyncs supersede a row and allocate a new id for the same source item, so any identity or dedupe keyed on `events.id` breaks silently on the next resync.
+
+**Organization rows.** Empty-looking orgs are frequently real human signups that have not been used yet. There is no bulk-delete that is safe, including "zero activity" filters.
+
+## Runtime
+
+**Dynamic-import exceptions.** Two call sites are grandfathered because they gate on the Node version before loading a large graph, and both must stay dependency-free until their checks pass:
+- `packages/cli/bin/lobu.js` defers the existing CLI graph without duplicating it.
+- `packages/server/src/server-entry.ts` runs the gate before dynamically loading the separate server bundle.
+
+**Fail closed on durable state.** The failure mode this prevents: an operation that may already have succeeded is retried as if nothing happened, or an error is read as "safe to skip" and a delivery is dropped. Treat ambiguity as failure and reconcile idempotently.
+
+**Coordination design brake.** If a change needs a second lock, a second retry budget, or a prose argument for why it terminates, the check is in the wrong place. Re-derive where the decision belongs before adding mechanism.
+
+**Page-activated browser drafts.** Persist the draft operation and its normal Lobu notification. The generic extension badges exact pending URLs and activates the run only when the user visits one in a user-owned tab. Connector/reaction code owns the URL and page interaction, but no layer auto-submits — neither core nor connector nor extension code pushes a user-owned tab or submits the draft on the user's behalf.
+
+## Evidence
+
+**Red→fix→green.** Both outputs belong in the PR body. If you cannot reproduce the bug, that is a reportable dead end — a speculative fix costs more than the bug.
+
+**Mutation checks.** A test that passes after you break the code proves nothing. Assert the old pattern exists, make a countable source change, confirm the focused test fails, then restore and rerun green.
+
+**Absence needs `origin/main`.** A working-tree grep proves nothing about what exists — your tree is stale by definition. `git fetch -q origin && git grep <pattern> origin/main`; the fetch is load-bearing because `origin/main` itself goes stale.
+
+**Never done off a typecheck.** Boot it, exercise every branch you touched, clean up test data you created. "It compiles" is a legitimate report only if you say that is all you ran.
+
+**Deletion evidence.** Trace the full workflow, not only the import graph. Low production usage is not evidence that code is safe to delete, and docs and help text are load-bearing too.
+
+## Gates
+
+| Command | What it actually does |
+|---|---|
+| `make pre-pr-remote` | Full Linux CI graph on Depot against the **staged** tree; builds before checks that consume dist, which is what protects against a stale-dist false green. Fails closed on untracked/unstaged changes so the tree attestation survives the following commit. |
+| `make pre-pr-remote-fast` | Broad interim confidence, remote. Never substitutes for the final gate. |
+| `make pre-pr` | CPU-heavy local fallback for when Depot is unavailable. |
+| `make review` | Handles the review verdict/status or safe-class skip. Runs no typecheck, knip, or tests — **not** proof CI will pass. |
+| `make review-fix` | Unposted fixer pass. Edits the working tree; re-read files before trusting them. |
+| `make ui-review` | Records exact UI proof for Owletto pointer changes; passes other changes as not applicable. |
+
+The macOS app lane stays on GitHub/Mac hardware. Subset runs (`make pre-pr-remote REMOTE_JOBS=unit`) rerun one lane but never attest. A fresh full `make review` requires the matching Depot tree attestation and refuses a surprise local build; safe-class skips and cached verdicts do not rebuild. Only a documented Depot outage permits `REVIEW_ALLOW_LOCAL_BUILD=1 make review`.
+
+**Depot serializes org-wide.** A newer dispatch silently cancels the older run, and `gh run rerun` counts as a dispatch — re-running an *old* commit's CI cancels the run for the current HEAD. Check `pgrep -f "make pre-pr-remote"` immediately before dispatching.
+
+**`make review` skip rule.** Small safe-class diffs (docs, renames, generated, additive tests; under 100 lines) skip the cross-harness reviewer by default. `REVIEWER_MODE=full make review` forces the independent review; `REVIEWER_SHADOW=1` measures the skip rule instead of trusting it.
+
+**UI proof.** `gh` cannot upload images inline. Capture before shots from the unmodified branch and after shots from the same booted app (auth recipe in `docs/BROWSER_TESTING.md`), base64-embed the PNGs into one self-contained HTML comparison page, host it at an HTTPS URL, and pass that URL as `ARTIFACT` to `make ui-review`. The gate records it on the exact merged Owletto PR, links it from the parent, and binds the evidence to that parent-base and Owletto-pointer pair for normal PR review. A rerun may reuse an exact proof already recorded for that pointer pair; otherwise no `ARTIFACT` means no proof and no pass.
+
+## Post-merge rollout verification
+
+For a prod-visible surface, schedule a follow-up around 25 minutes later. If the deploy is still stale, reschedule instead of polling in the foreground. Once it lands, run:
+
+```sh
+MERGE_SHA=$(gh pr view <n> --json mergeCommit --jq .mergeCommit.oid)
+git merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA"
+```
+
+Two ways this gate silently never opens:
+- **Gating on the branch head instead of the squash commit.** A squash merge writes a new commit with no ancestry link to the branch, so the branch head cannot prove the rollout.
+- **Reversing the argument order.** Merge commit first; reversed, it accepts a stale deploy.
+
+Record the result when it lands.
+
+## Session efficiency
+
+- Exact local tests remain the fastest red-green loop; Depot owns CPU-heavy breadth. Never start a local full gate alongside a remote one.
+- `make dev-remote` syncs committed code to private Daytona compute by default, resumes or starts Lobu, and prints a signed preview URL. Commit first. Run `make dev-remote-pause` when finished, and keep it private — no hooks, public preview, or custom proxy.
+- `gh pr checks <n> --required` plus `gh pr view <n> --json number,title,isDraft,mergeStateStatus,reviewDecision` is the compact status read; avoid the much larger `statusCheckRollup` payload.
+- Delegated CLIs (OpenCode, Claude CLI) get polled at most once per 4.5 minutes unless they finish, request input or approval, or the user asks for an immediate update. Read only output since the last cursor. Ask them to persist detailed evidence to files and return compact status, counts, failures, and exit codes; never replay a full session or stream verbose diffs into the supervising context.
+- Screenshots are the single largest context-bloat source. Prefer `get_page_text` / `read_page` / `javascript_tool`, and screenshot only when visual layout itself is under test.
+- For a one-line or config-only change, take one CI snapshot and move on.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ docs below for shipped behavior.
 
 ## Operate the repo
 
+- **`AGENT_PLAYBOOK.md`** — supporting rationale, incident history, and exact
+  flags for the root and package agent rules.
 - **`GOTCHAS.md`** — symptom-indexed traps by surface (build, SQL, testing,
   submodule, browser).
 - **`BROWSER_TESTING.md`** — authenticated browser verification runbook.

--- a/packages/agent-worker/AGENTS.md
+++ b/packages/agent-worker/AGENTS.md
@@ -24,4 +24,4 @@ Read root `AGENTS.md` first. This package owns agent execution and Lobu integrat
 
 ## Validation
 - After editing `packages/agent-worker/*`, run `make clean-workers`.
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`) plus targeted worker tests.
+- Validation: the root gates (see root `AGENTS.md`) plus targeted worker tests.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -15,4 +15,4 @@ Read root `AGENTS.md` first. This package is the `lobu` binary users install fro
 - `packages/cli` builds last in every build list because it bundles the others; a new workspace package it depends on must be added *before* it. See `docs/GOTCHAS.md`, "Build & typecheck".
 
 ## Validation
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`) plus targeted CLI tests. Changing command output or the version gate needs a real invocation — run the built binary, not just the unit test.
+- Validation: the root gates (see root `AGENTS.md`) plus targeted CLI tests. Changing command output or the version gate needs a real invocation — run the built binary, not just the unit test.

--- a/packages/connector-sdk/AGENTS.md
+++ b/packages/connector-sdk/AGENTS.md
@@ -17,4 +17,4 @@ Read root `AGENTS.md` first. This package is the contract every connector compil
 - A new workspace package that imports this SDK must appear after connector-sdk in all three build lists — see `docs/GOTCHAS.md`, "Build & typecheck".
 
 ## Validation
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`) plus targeted SDK tests. Browser changes need a real connector run, not just a unit test — a green mock proves nothing about Chromium launch.
+- Validation: the root gates (see root `AGENTS.md`) plus targeted SDK tests. Browser changes need a real connector run, not just a unit test — a green mock proves nothing about Chromium launch.

--- a/packages/connector-worker/AGENTS.md
+++ b/packages/connector-worker/AGENTS.md
@@ -50,5 +50,5 @@ pipeline also used by `@lobu/cli` and `@lobu/server`.
 
 ## Validation
 
-- Validation: targeted `@lobu/connector-worker` tests plus the root gates
-  (normally `make pre-pr-remote`, then `make review`; see root `AGENTS.md`).
+- Validation: targeted `@lobu/connector-worker` tests plus the root gates (see
+  root `AGENTS.md`).

--- a/packages/connectors/AGENTS.md
+++ b/packages/connectors/AGENTS.md
@@ -12,4 +12,4 @@ Read root `AGENTS.md` first. This package owns built-in Lobu connectors.
 - For the same source object across syncs, keep `origin_id` stable. Ingestion may supersede the prior event and allocate a new `events.id`; downstream cross-sync dedupe relies on `origin_id`, not the version-row id. Change `origin_id` only when the source identity genuinely changes.
 
 ## Validation
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`) plus targeted connector tests.
+- Validation: the root gates (see root `AGENTS.md`) plus targeted connector tests.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -13,4 +13,4 @@ Read root `AGENTS.md` first. This package holds the shared contracts many other 
 - Unlike `server` and `connector-sdk`, this package **is** biome-formatted — use `bun run check:fix` from the repo root.
 
 ## Validation
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`). For a contract change, also typecheck the consumers — a green build here says nothing about downstream packages.
+- Validation: the root gates (see root `AGENTS.md`). For a contract change, also typecheck the consumers — a green build here says nothing about downstream packages.

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -40,6 +40,11 @@ Read before editing. Full list in `docs/GOTCHAS.md`; these bite most often here:
 - Streaming deltas/status are best-effort across pods today. Do not build correctness on cross-pod in-memory delivery.
 - Exclusive transports such as Telegram polling run on exactly one replica via `connection_claims`; webhook transports must run on any replica.
 
+## Durable dispatch and coordination
+- **Fail closed on durable dispatch/delivery state.** When a durable coordination or delivery operation fails, its caller must not reinterpret the error as proceed, deliver, or skip. Propagate a retry, defer, or terminal-failure outcome with a visible log; if the operation may already have succeeded, reconcile idempotently before retrying. Lock timeouts, pool errors, and ambiguous or expired rows are failures, not "nothing changed".
+- **Coordination design brake.** A change that needs a second lock, a second retry/deferral budget, or a prose termination argument to explain why it halts is patching a misplaced check. Re-derive where the decision belongs, and put it at the chokepoint that already serializes the action — worker dispatch is serialized by `job-router` on the worker-SSE-owner pod. Prefer deleting the state transition over coordinating it, and reuse queue-native retry over a hand-rolled hold/requeue.
+- **Interactive browser drafts are page-activated, never tab-pushed.** Persist the draft operation and its normal Lobu notification; the generic Chrome extension badges exact pending URLs and activates the run only when the user visits one in a user-owned tab. Extension and server core carry no connector, Behavior, selector, or site-specific rules — connector/reaction code owns URL shapes and page interaction. Never auto-submit. Only scrape-owned scratch tabs may be opened and closed automatically.
+
 ## Connector operations and feed health
 - Built-in connector definitions/catalog install in server; connector implementation details belong in `packages/connectors/AGENTS.md`.
 - The active `connector_definitions` row is capability truth. Definitions may come from bundled source, organization-scoped `connector_versions`, or device manifests, so a grep under `packages/connectors` cannot prove an action is absent; inspect the active row and `operations.listAvailable`.
@@ -59,7 +64,7 @@ Read before editing. Full list in `docs/GOTCHAS.md`; these bite most often here:
 - `make dev` uses shared brew Postgres with one DB per branch. `LOBU_EMBEDDED=1 make dev` / `make dev-embedded` uses embedded per-worktree Postgres.
 - Parallel worktrees use `.env.local` for non-default `PORT`/`WORKER_PROXY_PORT`; do not `git switch` while a dev server runs. Read your worktree's `PORT` from `.env.local` — it is not 8787.
 - Smoke a booted server: `curl -s localhost:$PORT/api/health` (readiness is `/health/ready`). The SPA is pathless at `:$PORT`; the agent API is under `:$PORT/lobu`. "It booted" is not "it works" — drive the path you changed.
-- Validation: the root gates (`make pre-pr` + `make review`, see root `AGENTS.md`) plus the relevant server `bun test` / `make test-integration` suites.
+- Validation: the root gates (see root `AGENTS.md`) plus the relevant server `bun test` / `make test-integration` suites.
 
 ## Slackbot MCP integration
 - Slackbot is an MCP client. A Slack app exposes tools/resources only with `mcp:connect` bot scope plus an `mcp_servers` manifest block; after scope changes, reinstall the app.


### PR DESCRIPTION
## Summary

- Root `AGENTS.md` is inlined into every agent session via `CLAUDE.md`, so its length is a per-session context tax. It had grown to 16.3 KB / 74 lines, much of it rationale, incident history, and exact flags that an agent only needs when a rule looks arbitrary or it needs the full command. Cut to **7.6 KB / 53 lines (−53%)** by keeping only facts an agent cannot derive and boundaries it must not cross, restructured by severity: Repo map → Unrecoverable → Facts you cannot derive → Ship a change → How to work.
- The displaced material moves to a new `docs/AGENT_PLAYBOOK.md` (rationale, incident history, gate table, rollout verification, session efficiency) rather than being deleted; three architecture rules move to `packages/server/AGENTS.md`, which is where they apply. Nothing load-bearing was dropped — every cut was audited rule by rule.
- All seven package `AGENTS.md` files described the root gates as "`make pre-pr` + `make review`", which is wrong twice: `make pre-pr-remote` is the gate (`make pre-pr` is the local fallback), and `make review` runs no typecheck, knip, or tests. Fixed as a class; they now defer to the root doc.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [ ] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Documentation-only change; no runtime surface. `make pre-pr-remote` covers the referenced-path and vocabulary checks that do apply to these files.

## Notes

Rules cut as derivable-from-tooling rather than relocated: `_`-prefixing unused params, the `statusCheckRollup` payload anti-pattern, read-before-edit, batch-narrow-fixes, and doing repetitive multi-file edits inline. Five rules stated in both "Hard invariants" and "Ship a change" were deduped to one statement each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centralized operations playbook covering workspace safety, data integrity, testing, deployment verification, and remote development.
  * Reorganized repository guidance into clearer sections for rules, workflows, evidence requirements, and working practices.
  * Updated documentation indexes and package-specific validation guidance for more consistent development and release checks.
  * Added guidance for durable dispatch, coordination, browser drafts, conflict handling, credential safety, and production data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->