### PR TITLE
fix(server): scope Jira dynamic webhooks to visible projects

### DIFF
--- a/packages/server/src/connect/atlassian-mcp-webhook.ts
+++ b/packages/server/src/connect/atlassian-mcp-webhook.ts
@@ -55,6 +55,17 @@ interface JiraWebhookRefreshResponse {
 	expirationDate?: string;
 }
 
+interface JiraProject {
+	key?: string;
+}
+
+interface JiraProjectSearchResponse {
+	values?: JiraProject[];
+	isLast?: boolean;
+	startAt?: number;
+	maxResults?: number;
+}
+
 export interface AtlassianMcpWebhookResult {
 	handled: boolean;
 	changed: boolean;
@@ -168,12 +179,80 @@ async function listJiraWebhooks(
 			(typeof result.maxResults === "number"
 				? result.maxResults
 				: values.length);
-		if (nextStart <= startAt || (result.isLast !== false && values.length < 100)) {
+		if (
+			nextStart <= startAt ||
+			(result.isLast !== false && values.length < 100)
+		) {
 			return all;
 		}
 		startAt = nextStart;
 	}
 	throw new Error("Jira webhook listing exceeded 100 pages");
+}
+
+function quoteJqlString(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+async function listJiraProjectKeys(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	accessToken: string,
+): Promise<Set<string>> {
+	const projectKeys = new Set<string>();
+	let startAt = 0;
+	for (let page = 0; page < 100; page += 1) {
+		const url = new URL(`${apiBase}/project/search`);
+		url.searchParams.set("startAt", String(startAt));
+		url.searchParams.set("maxResults", "100");
+		const result = await jiraJson<JiraProjectSearchResponse>(
+			fetchImpl,
+			url.href,
+			accessToken,
+			{ method: "GET" },
+		);
+		const values = result.values ?? [];
+		for (const project of values) {
+			const key = project.key?.trim();
+			if (key) projectKeys.add(key);
+		}
+		if (result.isLast === true || values.length === 0) return projectKeys;
+		const nextStart =
+			(typeof result.startAt === "number" ? result.startAt : startAt) +
+			(typeof result.maxResults === "number"
+				? result.maxResults
+				: values.length);
+		if (
+			nextStart <= startAt ||
+			(result.isLast !== false && values.length < 100)
+		) {
+			return projectKeys;
+		}
+		startAt = nextStart;
+	}
+	throw new Error("Jira project listing exceeded 100 pages");
+}
+
+async function jiraProjectJql(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	accessToken: string,
+): Promise<string> {
+	const projectKeys = await listJiraProjectKeys(
+		fetchImpl,
+		apiBase,
+		accessToken,
+	);
+	if (projectKeys.size === 0) {
+		throw new Error(
+			"Jira webhook registration requires at least one accessible project",
+		);
+	}
+	// Code-unit sort, not localeCompare: reconciliation equality-compares this
+	// string against the webhook_project_jql persisted at registration, so
+	// ordering must not vary with the process locale.
+	const sortedKeys = [...projectKeys].sort();
+	return `project IN (${sortedKeys.map(quoteJqlString).join(", ")})`;
 }
 
 async function loadConnection(
@@ -330,6 +409,7 @@ const WEBHOOK_STATE_KEYS = [
 	"webhook_algorithm",
 	"webhook_signature_prefix",
 	"webhook_dedupe_header",
+	"webhook_project_jql",
 	"webhook_expires_at",
 	"webhook_status",
 	"webhook_error",
@@ -525,13 +605,25 @@ async function ensureUnderLock(params: {
 		apiBase,
 		credentials.accessToken,
 	);
+	const projectJql = await jiraProjectJql(
+		params.fetchImpl,
+		apiBase,
+		credentials.accessToken,
+	);
+	// Compare against our persisted copy, not the jqlFilter Jira echoes back:
+	// Jira normalizes the stored JQL, so a provider-side compare would delete
+	// and re-register the webhook on every reconcile.
+	const projectScopeMatches =
+		stringConfig(connection.config, "webhook_project_jql") === projectJql;
 	const ownedCallbacks = webhooks.filter(
 		(item) => item.id !== undefined && hasCallbackPath(item.url, callbackPath),
 	);
-	let matches = ownedCallbacks.filter((item) => item.url === targetUrl);
-	const staleCallbacks = ownedCallbacks.filter(
-		(item) => item.url !== targetUrl,
-	);
+	let matches = projectScopeMatches
+		? ownedCallbacks.filter((item) => item.url === targetUrl)
+		: [];
+	const staleCallbacks = projectScopeMatches
+		? ownedCallbacks.filter((item) => item.url !== targetUrl)
+		: ownedCallbacks;
 	if (!hadCallbackToken || staleCallbacks.length > 0) {
 		const staleIds = (!hadCallbackToken ? ownedCallbacks : staleCallbacks).map(
 			(item) => Number(item.id),
@@ -596,7 +688,7 @@ async function ensureUnderLock(params: {
 					url: targetUrl,
 					webhooks: [
 						{
-							jqlFilter: "",
+							jqlFilter: projectJql,
 							events: [
 								"jira:issue_created",
 								"jira:issue_updated",
@@ -631,6 +723,7 @@ async function ensureUnderLock(params: {
 		...connection.config,
 		webhook_callback_token: callbackTokenRef,
 		webhook_external_id: externalId,
+		webhook_project_jql: projectJql,
 		webhook_expires_at: expiresAt,
 		webhook_status: "active",
 		webhook_error: null,

--- a/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
+++ b/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
@@ -13,6 +13,24 @@ const AGENT = "agent-atlassian-webhook";
 const USER = "user-atlassian-webhook";
 const ADMIN_ONLY_ERROR =
 	"Only admins can configure the secondary Jira authorization used by Atlassian webhook delivery.";
+const PROJECT_JQL = 'project IN ("KAN")';
+
+function requestUrl(input: string | URL | Request): string {
+	return typeof input === "string"
+		? input
+		: input instanceof URL
+			? input.href
+			: input.url;
+}
+
+function projectSearchResponse(): Response {
+	return Response.json({
+		values: [{ id: "10000", key: "KAN" }],
+		isLast: true,
+		startAt: 0,
+		maxResults: 100,
+	});
+}
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -190,15 +208,12 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			input: string | URL | Request,
 			init?: RequestInit,
 		): Promise<Response> => {
-			const url =
-				typeof input === "string"
-					? input
-					: input instanceof URL
-						? input.href
-						: input.url;
+			const url = requestUrl(input);
 			requests.push({ url, init });
 			if (init?.method === "GET") {
-				return Response.json({ values: [] });
+				return url.includes("/project/search")
+					? projectSearchResponse()
+					: Response.json({ values: [], isLast: true });
 			}
 			return Response.json({
 				webhookRegistrationResult: [{ createdWebhookId: 123 }],
@@ -214,11 +229,11 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			fetchImpl,
 		});
 
-		expect(requests).toHaveLength(2);
+		expect(requests).toHaveLength(3);
 		expect(requests[0].init?.headers).toMatchObject({
 			Authorization: "Bearer jira-access-token",
 		});
-		const body = JSON.parse(String(requests[1].init?.body));
+		const body = JSON.parse(String(requests[2].init?.body));
 		const callback = new URL(body.url);
 		expect(`${callback.origin}${callback.pathname}`).toBe(
 			`https://lobu.example.com/api/v1/webhooks/${connectionId}`,
@@ -231,6 +246,7 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			"jira:issue_updated",
 			"comment_created",
 		]);
+		expect(body.webhooks[0].jqlFilter).toBe(PROJECT_JQL);
 		expect(body.secret).toBeUndefined();
 
 		const { getDb } = await import("../../db/client.js");
@@ -240,12 +256,153 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 		`;
 		expect(row.config).toMatchObject({
 			webhook_external_id: "123",
+			webhook_project_jql: PROJECT_JQL,
 			webhook_status: "active",
 		});
 		expect(String(row.config.webhook_callback_token)).toStartWith("secret://");
 		expect(
 			new Date(String(row.config.webhook_expires_at)).getTime(),
 		).toBeGreaterThan(Date.now() + 20 * 24 * 60 * 60 * 1000);
+	});
+
+	test("fails closed when the Jira grant has no accessible projects", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		await expect(
+			ensureAtlassianMcpJiraWebhook({
+				organizationId: ORG,
+				connectionId,
+				baseUrl: "https://lobu.example.com",
+				fetchImpl: async () => Response.json({ values: [], isLast: true }),
+			}),
+		).rejects.toThrow(
+			"Jira webhook registration requires at least one accessible project",
+		);
+		const { getDb } = await import("../../db/client.js");
+		const [row] =
+			await getDb()`SELECT config FROM connections WHERE id = ${connectionId}`;
+		expect(row.config.webhook_status).toBe("error");
+		expect(String(row.config.webhook_error)).toContain(
+			"requires at least one accessible project",
+		);
+	});
+
+	test("re-registers when the accessible Jira project set changes", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		let registeredUrl = "";
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (input, init) => {
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? projectSearchResponse()
+						: Response.json({ values: [], isLast: true });
+				}
+				registeredUrl = JSON.parse(String(init?.body)).url;
+				return Response.json({
+					webhookRegistrationResult: [{ createdWebhookId: 123 }],
+				});
+			},
+		});
+
+		const methods: string[] = [];
+		let deleteBody: unknown;
+		let registrationBody: Record<string, unknown> | undefined;
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (input, init) => {
+				methods.push(String(init?.method));
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? Response.json({
+								values: [
+									{ id: "10000", key: "KAN" },
+									{ id: "10001", key: "NEW" },
+								],
+								isLast: true,
+							})
+						: Response.json({
+								values: [
+									{
+										id: 123,
+										url: registeredUrl,
+										jqlFilter: PROJECT_JQL,
+									},
+								],
+								isLast: true,
+							});
+				}
+				if (init?.method === "DELETE") {
+					deleteBody = JSON.parse(String(init.body));
+					return Response.json({});
+				}
+				registrationBody = JSON.parse(String(init?.body));
+				return Response.json({
+					webhookRegistrationResult: [{ createdWebhookId: 456 }],
+				});
+			},
+		});
+		expect(methods).toEqual(["GET", "GET", "DELETE", "POST"]);
+		expect(deleteBody).toEqual({ webhookIds: [123] });
+		expect(
+			(registrationBody?.webhooks as Array<{ jqlFilter: string }>)[0].jqlFilter,
+		).toBe('project IN ("KAN", "NEW")');
+	});
+
+	test("does not re-register when Jira normalizes the stored project filter", async () => {
+		const connectionId = await seedConfiguredConnection();
+		const { ensureAtlassianMcpJiraWebhook } = await import(
+			"../../connect/atlassian-mcp-webhook.js"
+		);
+		let registeredUrl = "";
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (input, init) => {
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? projectSearchResponse()
+						: Response.json({ values: [], isLast: true });
+				}
+				registeredUrl = JSON.parse(String(init?.body)).url;
+				return Response.json({
+					webhookRegistrationResult: [{ createdWebhookId: 123 }],
+				});
+			},
+		});
+
+		const methods: string[] = [];
+		await ensureAtlassianMcpJiraWebhook({
+			organizationId: ORG,
+			connectionId,
+			baseUrl: "https://lobu.example.com",
+			fetchImpl: async (input, init) => {
+				methods.push(String(init?.method));
+				return requestUrl(input).includes("/project/search")
+					? projectSearchResponse()
+					: Response.json({
+							values: [
+								{
+									id: 123,
+									url: registeredUrl,
+									jqlFilter: "project = KAN",
+								},
+							],
+							isLast: true,
+						});
+			},
+		});
+		expect(methods).toEqual(["GET", "GET"]);
 	});
 
 	test("refreshes a due subscription without registering a duplicate", async () => {
@@ -260,8 +417,12 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			connectionId,
 			baseUrl: "https://lobu.example.com",
 			now: firstNow,
-			fetchImpl: async (_input, init) => {
-				if (init?.method === "GET") return Response.json({ values: [] });
+			fetchImpl: async (input, init) => {
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? projectSearchResponse()
+						: Response.json({ values: [], isLast: true });
+				}
 				registeredUrl = JSON.parse(String(init?.body)).url;
 				return Response.json({
 					webhookRegistrationResult: [{ createdWebhookId: 123 }],
@@ -276,22 +437,27 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			connectionId,
 			baseUrl: "https://lobu.example.com",
 			now: secondNow,
-			fetchImpl: async (_input, init) => {
+			fetchImpl: async (input, init) => {
 				methods.push(String(init?.method));
-				return init?.method === "GET"
-					? Response.json({
-							values: [
-								{
-									id: 123,
-									url: registeredUrl,
-									expirationDate: "2026-09-09T12:00:00.000Z",
-								},
-							],
-						})
-					: Response.json({ expirationDate: refreshedExpiry });
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? projectSearchResponse()
+						: Response.json({
+								values: [
+									{
+										id: 123,
+										url: registeredUrl,
+										jqlFilter: PROJECT_JQL,
+										expirationDate: "2026-09-09T12:00:00.000Z",
+									},
+								],
+								isLast: true,
+							});
+				}
+				return Response.json({ expirationDate: refreshedExpiry });
 			},
 		});
-		expect(methods).toEqual(["GET", "PUT"]);
+		expect(methods).toEqual(["GET", "GET", "PUT"]);
 		const { getDb } = await import("../../db/client.js");
 		const [row] =
 			await getDb()`SELECT config FROM connections WHERE id = ${connectionId}`;
@@ -308,8 +474,12 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			organizationId: ORG,
 			connectionId,
 			baseUrl: "https://lobu.example.com",
-			fetchImpl: async (_input, init) => {
-				if (init?.method === "GET") return Response.json({ values: [] });
+			fetchImpl: async (input, init) => {
+				if (init?.method === "GET") {
+					return requestUrl(input).includes("/project/search")
+						? projectSearchResponse()
+						: Response.json({ values: [], isLast: true });
+				}
 				registeredUrl = JSON.parse(String(init?.body)).url;
 				return Response.json({
 					webhookRegistrationResult: [{ createdWebhookId: 123 }],
@@ -378,7 +548,11 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 			},
 		});
 		expect(fetchCalls).toBe(0);
-		expect(result).toEqual({ handled: true, changed: false, status: "disabled" });
+		expect(result).toEqual({
+			handled: true,
+			changed: false,
+			status: "disabled",
+		});
 	});
 
 	test("an orphaned callback-token secret forces provider reconciliation on teardown", async () => {


### PR DESCRIPTION
## Summary
- Fix live Atlassian dynamic-webhook registration failing closed with `Empty JQL search not supported`.
- Enumerate every Jira project visible to the secondary OAuth grant and register a deterministic `project IN (...)` filter.
- Persist Lobu's canonical project scope so Jira JQL normalization cannot cause delete/re-register churn; still re-register when the accessible project set changes.
- Fail closed with a visible connection error when no project is accessible.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (final Depot run `0lkh7wnpwh`, 18/18 jobs passed)
- [x] Tests run: `bun test packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts packages/server/src/gateway/__tests__/webhook-ingest.test.ts` (57 pass, 0 fail, 277 assertions)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red: empty JQL
```
Expected: project IN ("KAN")
Received: ""
1 fail
```

Live Jira registration before the fix:
```
Jira webhook registration failed: Empty JQL search not supported
```

### Red: provider-normalized JQL churn
```
Jira webhook registration failed: no webhook id returned
10 pass
1 fail
36 expect() calls
```

### Green
```
11 pass
0 fail
37 expect() calls
```

Broader lifecycle + ingestion coverage:
```
57 pass
0 fail
277 expect() calls
```

Server typecheck:
```
$ tsc --noEmit
```

## Notes
The live Jira registration and Jira mutation → Lobu event proof will be rerun after this fix is deployed.