### PR TITLE
fix(connectors): expose Jira webhook delivery scopes

### DIFF
--- a/packages/connectors/src/__tests__/jira-virtual-pushdown.test.ts
+++ b/packages/connectors/src/__tests__/jira-virtual-pushdown.test.ts
@@ -441,7 +441,24 @@ describe('Jira virtual-feed pushdown', () => {
   test('feed definition defaults issues to virtual', () => {
     const c = new JiraConnector();
     expect(c.definition.feeds?.issues?.virtual).toBe(true);
-    expect(c.definition.version).toBe('1.1.2');
+    expect(c.definition.version).toBe('1.1.3');
+  });
+
+  test('offers every scope Jira requires to deliver issue and comment webhooks', () => {
+    const c = new JiraConnector();
+    expect(c.definition.authSchema?.methods?.[0]?.optionalScopes).toEqual([
+      'read:issue-details:jira',
+      'read:comment.property:jira',
+      'read:comment:jira',
+      'read:epic:jira-software',
+      'read:group:jira',
+      'read:issue.property:jira',
+      'read:issue-type:jira',
+      'read:project:jira',
+      'read:project-role:jira',
+      'read:status:jira',
+      'read:user:jira',
+    ]);
   });
 
   test('lazy-resolves cloud_id via accessible-resources when config omits it', async () => {

--- a/packages/connectors/src/jira.ts
+++ b/packages/connectors/src/jira.ts
@@ -289,7 +289,7 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
     name: 'Jira',
     description:
       'Live-reads Jira Cloud issues via JQL (virtual feeds) and receives real-time issue/comment webhooks.',
-    version: '1.1.2',
+    version: '1.1.3',
     faviconDomain: 'atlassian.com',
     webhook: {
       // Jira Connect app webhooks HMAC-sign the raw body with the installation
@@ -324,6 +324,27 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
             'read:jira-user',
             'manage:jira-webhook',
             'offline_access',
+          ],
+          // Granular scopes Jira checks before DELIVERING registered webhook
+          // events (registration alone only needs manage:jira-webhook):
+          // jira:issue_created/updated require read:issue-details:jira, and
+          // comment_created requires the other ten — see the scope table under
+          // "Registering a webhook via the REST API" in the Jira webhooks docs.
+          // Optional rather than required because Atlassian fails the entire
+          // authorize redirect when the app config doesn't have a requested
+          // scope enabled, which would break JQL reads for existing apps.
+          optionalScopes: [
+            'read:issue-details:jira',
+            'read:comment.property:jira',
+            'read:comment:jira',
+            'read:epic:jira-software',
+            'read:group:jira',
+            'read:issue.property:jira',
+            'read:issue-type:jira',
+            'read:project:jira',
+            'read:project-role:jira',
+            'read:status:jira',
+            'read:user:jira',
           ],
           authorizationUrl: 'https://auth.atlassian.com/authorize',
           tokenUrl: 'https://auth.atlassian.com/oauth/token',


### PR DESCRIPTION
## Summary
- expose the documented Jira granular scopes required for issue/comment webhook delivery as optional OAuth scopes
- bump the built-in Jira connector definition to 1.1.3
- cover the complete delivery-scope set in the connector definition test

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: `bun test packages/connectors/src/__tests__/jira-virtual-pushdown.test.ts` and `bun test packages/connectors/src/__tests__/jira.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval (not applicable)

### Red
`bun test packages/connectors/src/__tests__/jira-virtual-pushdown.test.ts`

- 21 passed, 2 failed
- expected connector version `1.1.3`, received `1.1.2`
- expected the 11 documented Jira webhook delivery scopes, received `undefined`

### Green
`bun test packages/connectors/src/__tests__/jira-virtual-pushdown.test.ts`

- 23 passed, 0 failed

`bun test packages/connectors/src/__tests__/jira.test.ts`

- 2 passed, 0 failed

`make pre-pr-remote`

- full 16-lane Linux CI graph passed
- attested tree: `edef594191c5452f25709e02069f6a94d7203d5a`

## Notes
Atlassian accepts dynamic webhook registration with the classic webhook-management scope, but withholds deliveries unless the app grant includes every event-specific scope. The scopes remain optional so existing Jira apps that have not enabled the granular scope set can continue using JQL reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Jira integration support for issue and comment webhook events by adding the required optional authorization scopes.
  * Maintained compatibility for connections where these optional scopes are unavailable.
  * Updated the Jira connector version to 1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->