### PR TITLE
fix(server): verify Atlassian webhook bearer JWTs

### DIFF
--- a/packages/server/src/connect/__tests__/atlassian-webhook-auth.test.ts
+++ b/packages/server/src/connect/__tests__/atlassian-webhook-auth.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the Atlassian OAuth-app webhook JWT verifier (HS256/384/512
+ * bearer sent on dynamic-webhook deliveries). Pure-function coverage of the
+ * rejection paths the gateway e2e test does not reach: alg confusion, expiry,
+ * nbf, and malformed tokens.
+ */
+
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifyAtlassianWebhookJwt } from "../atlassian-webhook-auth";
+
+const SECRET = "jira-client-secret";
+
+function b64url(value: unknown): string {
+	return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function mintJwt(params: {
+	secret?: string;
+	alg?: string;
+	algForSigning?: string;
+	payload?: Record<string, unknown>;
+}): string {
+	const alg = params.alg ?? "HS256";
+	const header = b64url({ alg, typ: "JWT" });
+	const payload = b64url(
+		params.payload ?? { exp: Math.floor(Date.now() / 1000) + 60 },
+	);
+	const digest = (params.algForSigning ?? alg)
+		.replace("HS", "sha")
+		.toLowerCase();
+	const signature = createHmac(digest, params.secret ?? SECRET)
+		.update(`${header}.${payload}`)
+		.digest("base64url");
+	return `${header}.${payload}.${signature}`;
+}
+
+describe("verifyAtlassianWebhookJwt", () => {
+	it("accepts a valid HS256 token signed with the client secret", () => {
+		expect(verifyAtlassianWebhookJwt(mintJwt({}), SECRET)).toBe(true);
+	});
+
+	it.each(["HS384", "HS512"] as const)("accepts %s", (alg) => {
+		expect(verifyAtlassianWebhookJwt(mintJwt({ alg }), SECRET)).toBe(true);
+	});
+
+	it("rejects a token signed with a different secret", () => {
+		expect(
+			verifyAtlassianWebhookJwt(mintJwt({ secret: "forged" }), SECRET),
+		).toBe(false);
+	});
+
+	it("rejects alg none and unknown algorithms", () => {
+		const header = b64url({ alg: "none", typ: "JWT" });
+		const payload = b64url({ exp: Math.floor(Date.now() / 1000) + 60 });
+		expect(verifyAtlassianWebhookJwt(`${header}.${payload}.sig`, SECRET)).toBe(
+			false,
+		);
+		expect(
+			verifyAtlassianWebhookJwt(
+				mintJwt({ alg: "RS256", algForSigning: "HS256" }),
+				SECRET,
+			),
+		).toBe(false);
+	});
+
+	it("rejects a header/signature algorithm mismatch", () => {
+		expect(
+			verifyAtlassianWebhookJwt(
+				mintJwt({ alg: "HS512", algForSigning: "HS256" }),
+				SECRET,
+			),
+		).toBe(false);
+	});
+
+	it("rejects a tampered payload", () => {
+		const token = mintJwt({});
+		const [header, , signature] = token.split(".");
+		const tampered = `${header}.${b64url({ exp: Math.floor(Date.now() / 1000) + 9999 })}.${signature}`;
+		expect(verifyAtlassianWebhookJwt(tampered, SECRET)).toBe(false);
+	});
+
+	it("rejects an expired token and a non-numeric exp", () => {
+		expect(
+			verifyAtlassianWebhookJwt(
+				mintJwt({ payload: { exp: Math.floor(Date.now() / 1000) - 10 } }),
+				SECRET,
+			),
+		).toBe(false);
+		expect(
+			verifyAtlassianWebhookJwt(mintJwt({ payload: { exp: "soon" } }), SECRET),
+		).toBe(false);
+	});
+
+	it("rejects a token that is not yet valid (nbf in the future)", () => {
+		expect(
+			verifyAtlassianWebhookJwt(
+				mintJwt({
+					payload: {
+						exp: Math.floor(Date.now() / 1000) + 120,
+						nbf: Math.floor(Date.now() / 1000) + 60,
+					},
+				}),
+				SECRET,
+			),
+		).toBe(false);
+	});
+
+	it("accepts a signed token without exp/nbf claims", () => {
+		expect(verifyAtlassianWebhookJwt(mintJwt({ payload: {} }), SECRET)).toBe(
+			true,
+		);
+	});
+
+	it("rejects malformed tokens", () => {
+		expect(verifyAtlassianWebhookJwt("", SECRET)).toBe(false);
+		expect(verifyAtlassianWebhookJwt("a.b", SECRET)).toBe(false);
+		expect(verifyAtlassianWebhookJwt("..", SECRET)).toBe(false);
+		expect(verifyAtlassianWebhookJwt("not-json.also-not.sig", SECRET)).toBe(
+			false,
+		);
+		expect(verifyAtlassianWebhookJwt("x".repeat(20_000), SECRET)).toBe(false);
+	});
+});

--- a/packages/server/src/connect/atlassian-mcp-webhook.ts
+++ b/packages/server/src/connect/atlassian-mcp-webhook.ts
@@ -95,11 +95,8 @@ function callbackBaseUrl(baseUrl: string, connectionId: number): URL {
 function callbackUrl(
 	baseUrl: string,
 	connectionId: number,
-	callbackToken: string,
 ): string {
-	const url = callbackBaseUrl(baseUrl, connectionId);
-	url.searchParams.set("token", callbackToken);
-	return url.href;
+	return callbackBaseUrl(baseUrl, connectionId).href;
 }
 
 function hasCallbackPath(value: string | undefined, expected: URL): boolean {
@@ -598,7 +595,10 @@ async function ensureUnderLock(params: {
 		));
 
 	const apiBase = jiraApiBase(cloudId);
-	const targetUrl = callbackUrl(params.baseUrl, connection.id, callbackToken);
+	// OAuth-app dynamic webhooks authenticate with Atlassian's bearer JWT.
+	// Keep the legacy callback-token secret only as durable crash-window evidence
+	// for teardown; Jira drops callback query parameters from deliveries.
+	const targetUrl = callbackUrl(params.baseUrl, connection.id);
 	const callbackPath = callbackBaseUrl(params.baseUrl, connection.id);
 	const webhooks = await listJiraWebhooks(
 		params.fetchImpl,

--- a/packages/server/src/connect/atlassian-webhook-auth.ts
+++ b/packages/server/src/connect/atlassian-webhook-auth.ts
@@ -1,0 +1,127 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { type DbClient, getDb } from "../db/client";
+import { resolveAuthCredentials } from "../utils/auth-credential-secrets";
+
+const JWT_ALGORITHMS = {
+	HS256: "sha256",
+	HS384: "sha384",
+	HS512: "sha512",
+} as const;
+
+function stringConfig(
+	config: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = config[key];
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function decodeJson(value: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+/** Verify Atlassian's OAuth-app webhook JWT without ever logging the bearer. */
+export function verifyAtlassianWebhookJwt(
+	token: string,
+	clientSecret: string,
+	nowMs = Date.now(),
+): boolean {
+	if (!token || token.length > 16_384) return false;
+	const parts = token.split(".");
+	if (parts.length !== 3 || parts.some((part) => part.length === 0)) return false;
+	const [encodedHeader, encodedPayload, encodedSignature] = parts;
+	const header = decodeJson(encodedHeader);
+	const payload = decodeJson(encodedPayload);
+	if (!header || !payload) return false;
+	const algorithm = header.alg;
+	if (typeof algorithm !== "string" || !Object.hasOwn(JWT_ALGORITHMS, algorithm)) {
+		return false;
+	}
+	const expected = createHmac(
+		JWT_ALGORITHMS[algorithm as keyof typeof JWT_ALGORITHMS],
+		clientSecret,
+	)
+		.update(`${encodedHeader}.${encodedPayload}`)
+		.digest();
+	// base64url decoding is lenient; malformed input decodes to the wrong length.
+	const presented = Buffer.from(encodedSignature, "base64url");
+	if (presented.length !== expected.length) return false;
+	if (!timingSafeEqual(presented, expected)) return false;
+
+	const nowSeconds = nowMs / 1000;
+	if (
+		payload.exp !== undefined &&
+		(typeof payload.exp !== "number" ||
+			!Number.isFinite(payload.exp) ||
+			payload.exp <= nowSeconds)
+	) {
+		return false;
+	}
+	if (
+		payload.nbf !== undefined &&
+		(typeof payload.nbf !== "number" ||
+			!Number.isFinite(payload.nbf) ||
+			payload.nbf > nowSeconds)
+	) {
+		return false;
+	}
+	return true;
+}
+
+export async function verifyAtlassianWebhookAuthorization(params: {
+	organizationId: string;
+	connectionConfig: Record<string, unknown>;
+	token: string;
+	sql?: DbClient;
+}): Promise<boolean> {
+	const appSlug = stringConfig(
+		params.connectionConfig,
+		"jira_webhook_app_profile_slug",
+	);
+	if (!appSlug) return false;
+	const sql = params.sql ?? getDb();
+	const rows = await sql`
+		SELECT id, connector_key, profile_kind, status, auth_data, provider
+		FROM auth_profiles
+		WHERE organization_id = ${params.organizationId}
+		  AND slug = ${appSlug}
+		LIMIT 1
+	`;
+	const profile = rows[0] as
+		| {
+				id: number;
+				connector_key: string | null;
+				profile_kind: string;
+				status: string;
+				auth_data: Record<string, unknown> | null;
+				provider: string | null;
+		  }
+		| undefined;
+	if (
+		!profile ||
+		profile.connector_key !== "jira" ||
+		profile.profile_kind !== "oauth_app" ||
+		profile.status !== "active" ||
+		profile.provider?.toLowerCase() !== "jira"
+	) {
+		return false;
+	}
+	const credentials = await resolveAuthCredentials({
+		organizationId: params.organizationId,
+		authProfileId: Number(profile.id),
+		authData: profile.auth_data,
+	});
+	const clientSecret = credentials.JIRA_CLIENT_SECRET;
+	return typeof clientSecret === "string" && clientSecret.length > 0
+		? verifyAtlassianWebhookJwt(params.token, clientSecret)
+		: false;
+}

--- a/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
+++ b/packages/server/src/gateway/__tests__/atlassian-mcp-webhook-lifecycle.test.ts
@@ -238,9 +238,7 @@ describe("Atlassian MCP Jira dynamic webhooks", () => {
 		expect(`${callback.origin}${callback.pathname}`).toBe(
 			`https://lobu.example.com/api/v1/webhooks/${connectionId}`,
 		);
-		expect(callback.searchParams.get("token")?.length).toBeGreaterThanOrEqual(
-			32,
-		);
+		expect(callback.search).toBe("");
 		expect(body.webhooks[0].events).toEqual([
 			"jira:issue_created",
 			"jira:issue_updated",

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -32,12 +32,11 @@ import {
 	resetTestDatabase,
 	seedAgentRow,
 } from "./helpers/db-setup.js";
-import type { WritableSecretStore } from "../secrets/index.js";
-
 const ORG = "org-webhook";
 const AGENT = "agent-webhook";
 const TOKEN = "whk-test-token-0123456789abcdef";
 const SIG_SECRET = "whk-sig-secret-0123456789abcdef";
+const JIRA_CLIENT_SECRET = "jira-client-secret";
 
 /** Compute a provider HMAC signature header value over the exact raw bytes. */
 function sign(
@@ -58,6 +57,20 @@ const githubSigConfig = {
 	signaturePrefix: "sha256=",
 	signatureSecret: SIG_SECRET,
 };
+
+function signAtlassianWebhookJwt(secret = JIRA_CLIENT_SECRET): string {
+	const encodedHeader = Buffer.from(
+		JSON.stringify({ alg: "HS256", typ: "JWT" }),
+	).toString("base64url");
+	const encodedPayload = Buffer.from(
+		JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 60 }),
+	).toString("base64url");
+	const signingInput = `${encodedHeader}.${encodedPayload}`;
+	const signature = createHmac("sha256", secret)
+		.update(signingInput)
+		.digest("base64url");
+	return `${signingInput}.${signature}`;
+}
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -1054,12 +1067,12 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		return id;
 	}
 
-	async function seedRegisteredAtlassianConnection(
-		secretStore: WritableSecretStore,
-	): Promise<{ id: string; callbackToken: string }> {
+	async function seedRegisteredAtlassianConnection(): Promise<{ id: string }> {
 		const { getDb } = await import("../../db/client.js");
-		const { orgContext } = await import("../../lobu/stores/org-context.js");
-		const { persistSecretValue } = await import("../secrets/index.js");
+		const { createAuthProfile } = await import("../../utils/auth-profiles.js");
+		const { persistAuthCredentials } = await import(
+			"../../utils/auth-credential-secrets.js"
+		);
 		const sql = getDb();
 		const connectorKey = "mcp.mcp-atlassian-com";
 		await sql`
@@ -1071,6 +1084,24 @@ describe("connector-connection webhook bridge (connections table)", () => {
 				${sql.json({ issues: { key: "issues", virtual: true } })}
 			)
 		`;
+		const appProfile = await createAuthProfile({
+			organizationId: ORG,
+			connectorKey: "jira",
+			displayName: "Jira Webhook App",
+			slug: "jira-webhook-app",
+			profileKind: "oauth_app",
+			status: "active",
+			provider: "jira",
+			createdBy: AGENT,
+		});
+		await persistAuthCredentials({
+			organizationId: ORG,
+			authProfileId: appProfile.id,
+			credentials: {
+				JIRA_CLIENT_ID: "jira-client-id",
+				JIRA_CLIENT_SECRET,
+			},
+		});
 		const [connection] = await sql`
 			INSERT INTO connections (
 				organization_id, connector_key, slug, display_name, status, config, visibility
@@ -1080,6 +1111,7 @@ describe("connector-connection webhook bridge (connections table)", () => {
 					cloud_id: "cloud-1",
 					site_cloud_id: "cloud-1",
 					site_url: "https://acme.atlassian.net",
+					jira_webhook_app_profile_slug: appProfile.slug,
 				})},
 				'org'
 			)
@@ -1093,23 +1125,14 @@ describe("connector-connection webhook bridge (connections table)", () => {
 				${ORG}, ${id}, 'issues', 'Issues', 'active', 'virtual', true, '{}'::jsonb
 			)
 		`;
-		const callbackToken = SIG_SECRET;
-		const callbackTokenRef = await orgContext.run({ organizationId: ORG }, () =>
-			persistSecretValue(
-				secretStore,
-				`webhook/${id}/callback-token`,
-				callbackToken,
-			),
-		);
 		await sql`
 			UPDATE connections
 			SET config = config || ${sql.json({
 				webhook_external_id: "jira-hook-123",
-				webhook_callback_token: callbackTokenRef,
 			})}::jsonb
 			WHERE id = ${id}
 		`;
-		return { id, callbackToken };
+		return { id };
 	}
 
 	test("a signed GitHub delivery to a connector connection marks the feed due (poll-canonical)", async () => {
@@ -1190,13 +1213,12 @@ describe("connector-connection webhook bridge (connections table)", () => {
 
 	test("an authenticated Jira delivery lands as a structured event on the Atlassian Rovo feed", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
-		const { manager, secretStore } = await buildManager();
+		const { manager } = await buildManager();
 		const { createConnectionWebhookRoutes } = await import(
 			"../routes/public/connections.js"
 		);
 		const { getDb } = await import("../../db/client.js");
-		const { id, callbackToken } =
-			await seedRegisteredAtlassianConnection(secretStore);
+		const { id } = await seedRegisteredAtlassianConnection();
 		const app = createConnectionWebhookRoutes(manager);
 		const raw = JSON.stringify({
 			webhookEvent: "jira:issue_updated",
@@ -1213,16 +1235,14 @@ describe("connector-connection webhook bridge (connections table)", () => {
 			},
 		});
 		const res = await app.fetch(
-			new Request(
-				`http://gateway.test/api/v1/webhooks/${id}?token=${callbackToken}`,
-				{
-					method: "POST",
-					body: raw,
-					headers: {
-						"content-type": "application/json",
-					},
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
+				method: "POST",
+				body: raw,
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${signAtlassianWebhookJwt()}`,
 				},
-			),
+			}),
 		);
 		expect(res.status).toBe(202);
 		const rows = await getDb()`
@@ -1260,16 +1280,14 @@ describe("connector-connection webhook bridge (connections table)", () => {
 			},
 		});
 		const commentRes = await app.fetch(
-			new Request(
-				`http://gateway.test/api/v1/webhooks/${id}?token=${callbackToken}`,
-				{
-					method: "POST",
-					body: commentRaw,
-					headers: {
-						"content-type": "application/json",
-					},
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
+				method: "POST",
+				body: commentRaw,
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${signAtlassianWebhookJwt()}`,
 				},
-			),
+			}),
 		);
 		expect(commentRes.status).toBe(202);
 		const [comment] = await getDb()`
@@ -1285,11 +1303,12 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		});
 
 		const forged = await app.fetch(
-			new Request(`http://gateway.test/api/v1/webhooks/${id}?token=forged`, {
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
 				method: "POST",
 				body: commentRaw,
 				headers: {
 					"content-type": "application/json",
+					authorization: `Bearer ${signAtlassianWebhookJwt("forged-secret")}`,
 				},
 			}),
 		);

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import type { AgentConnectionStore, StoredConnection } from "@lobu/core";
 import { createLogger, getErrorMessage, isSecretRef } from "@lobu/core";
 import { type AdapterPostableMessage, Chat } from "chat";
+import { verifyAtlassianWebhookAuthorization } from "../../connect/atlassian-webhook-auth.js";
 import { resolveConnectionWebhookConfig } from "../../connect/webhook-registration.js";
 import { getDb } from "../../db/client.js";
 import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
@@ -1320,6 +1321,12 @@ export class ChatInstanceManager {
                 }
               : bridged.structuredWebhook === "jira_mcp"
                 ? {
+                    verifyBearerToken: (token: string) =>
+                      verifyAtlassianWebhookAuthorization({
+                        organizationId: bridged.stored.organizationId!,
+                        connectionConfig: bridged.connectionConfig,
+                        token,
+                      }),
                     handleInsteadOfPersist: async ({
                       rawBody,
                       organizationId,
@@ -1393,6 +1400,7 @@ export class ChatInstanceManager {
     stored: StoredConnection;
     connectorKey: string;
     structuredWebhook: "jira_mcp" | null;
+    connectionConfig: Record<string, unknown>;
   } | null> {
     // Connector connection ids are bigints; a non-numeric id can't match.
     if (!/^\d+$/.test(connectionId)) return null;
@@ -1448,6 +1456,7 @@ export class ChatInstanceManager {
       structuredWebhook: isAtlassianMcpConfig(row.mcp_config)
         ? "jira_mcp"
         : null,
+      connectionConfig: row.config ?? {},
     };
   }
 

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -336,6 +336,8 @@ export interface WebhookActorAttribution {
 export interface WebhookIngestOverrides {
 	title?: string | null;
 	sourceUrl?: string | null;
+	/** Provider-specific bearer verification (Atlassian OAuth webhook JWTs). */
+	verifyBearerToken?: (token: string) => Promise<boolean>;
 	/**
 	 * Resolve the authoring actor → a person. Invoked only on the WINNING insert,
 	 * inside the persist transaction (the `sql` handle IS that tx), so the actor
@@ -410,11 +412,10 @@ export async function handleWebhookIngest(
 		});
 	}
 
-	// 3. Auth. A delivery authenticates by EITHER a matching bearer token OR a
-	//    verified provider HMAC signature (connector webhooks: GitHub/Linear/Jira
-	//    sign, they don't send a bearer). Fail closed when neither method is
-	//    configured — an ingest endpoint must never be open just because its
-	//    secret went missing.
+	// 3. Auth. A delivery authenticates by a matching bearer token, a verified
+	//    provider HMAC signature (connector webhooks: GitHub/Linear sign), or a
+	//    provider-verified bearer JWT (Atlassian OAuth-app webhooks). Fail closed
+	//    when no method is configured.
 	// Resolve both candidate secrets concurrently — either (or both) may gate
 	// this delivery, so we need them before deciding auth.
 	const [configuredToken, signatureSecret] = await Promise.all([
@@ -427,7 +428,7 @@ export async function handleWebhookIngest(
 			typeof config.signatureSecret === "string" ? config.signatureSecret : undefined,
 		),
 	]);
-	if (!configuredToken && !signatureSecret) {
+	if (!configuredToken && !signatureSecret && !overrides?.verifyBearerToken) {
 		logger.warn(
 			{ connectionId: stored.id },
 			"[webhook-ingest] no resolvable token or signature secret — rejecting delivery",
@@ -443,6 +444,13 @@ export async function handleWebhookIngest(
 		!!configuredToken &&
 		!!presentedToken &&
 		tokensMatch(presentedToken, configuredToken);
+	if (
+		!authenticated &&
+		presentedToken &&
+		overrides?.verifyBearerToken
+	) {
+		authenticated = await overrides.verifyBearerToken(presentedToken);
+	}
 	if (!authenticated && !signatureSecret) {
 		return json(401, { error: "Unauthorized" });
 	}


### PR DESCRIPTION
## Summary
- Atlassian OAuth 2.0 dynamic webhooks send a signed bearer JWT and omit callback query parameters; verify that JWT with the org-scoped Jira OAuth app secret.
- Register a tokenless callback URL while retaining the durable callback token only as teardown/crash-window evidence.
- Route Jira MCP webhook delivery through the provider-specific verifier and keep structured event ingestion unchanged.

## Test plan
- [x] Intended files staged explicitly, then make pre-pr-remote clean (full Linux CI graph on Depot)
- [x] Focused server suites: 57/57 green
- [x] JWT verifier suite: 11/11 green
- [x] Server TypeScript typecheck green
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red
Before the source fix, the Jira delivery integration used an Atlassian-style signed bearer JWT:
(fail) Jira MCP webhook event delivery > delivers verified provider event
Expected: 202
Received: 401

### Green
After the fix:
- Jira delivery integration: 1 pass, 0 fail
- Webhook ingest + Atlassian lifecycle: 57 pass, 0 fail
- Atlassian JWT verifier: 11 pass, 0 fail
- Full remote staged-tree preflight: passed; attestation 978c398d1111bef8a11c0e33892d1a0229fc8bd7

## Notes
- No API, SDK, or database schema changes.
- Live provider E2E will be repeated after rollout before the legacy Jira connector definition is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure JWT authentication for incoming Jira webhooks.
  * Webhook requests now validate signatures, supported algorithms, expiration, and activation timing.
  * Added authorization against configured Jira OAuth application credentials.
  * Callback URLs no longer expose authentication tokens in query parameters.

* **Bug Fixes**
  * Improved rejection of forged, tampered, malformed, expired, and improperly configured webhook tokens.
  * Preserved existing token and HMAC authentication methods for other webhook integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->