### PR TITLE
feat(x-connector): support scraping the user's open x.com tab for home_feed

### DIFF
--- a/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
+++ b/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
@@ -155,4 +155,108 @@ describe('extensionDomScrape', () => {
       })
     ).rejects.toThrow(/landedUrl reported evil\.example\.net/);
   });
+
+  test('passes existing_tab_match and reports usedExistingTab when set', async () => {
+    const { dispatcher, log } = makeDispatcher({
+      tab_id: 9,
+      cs_scrape: true,
+      existing_tab: true,
+      result: {
+        loggedIn: true,
+        host: 'www.example.com',
+        rows: [{ id: 'open-tab-row' }],
+      },
+    });
+
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+      existingTabMatch: 'example.com/feed',
+    });
+
+    expect(log).toHaveLength(1);
+    expect(log[0].input.existing_tab_match).toBe('example.com/feed');
+    expect(log[0].input.persistent).toBe(false);
+    expect(res.usedExistingTab).toBe(true);
+    expect(res.items).toEqual([{ id: 'open-tab-row' }]);
+  });
+
+  test('omits existing_tab_match and reports usedExistingTab false by default', async () => {
+    const { dispatcher, log } = makeDispatcher({
+      tab_id: 10,
+      cs_scrape: true,
+      result: { loggedIn: true, rows: [{ id: 'scratch-row' }] },
+    });
+
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+    });
+
+    expect(log).toHaveLength(1);
+    expect(log[0].input.existing_tab_match).toBeUndefined();
+    expect(res.usedExistingTab).toBe(false);
+  });
+
+  test('falls back to a scratch tab on no_matching_tab when fallbackToScratch is default', async () => {
+    const observations = [
+      {
+        cs_scrape: true,
+        result: { error: 'no_matching_tab', match: 'example.com/feed' },
+      },
+      {
+        tab_id: 11,
+        cs_scrape: true,
+        result: { loggedIn: true, rows: [{ id: 'fallback-row' }] },
+      },
+    ];
+    const log: DispatchLog[] = [];
+    const dispatcher: ChromeActionDispatcher = {
+      dispatch: async (action: string, input: Record<string, unknown>) => {
+        log.push({ action, input });
+        return observations.shift() as never;
+      },
+    };
+
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+      existingTabMatch: 'example.com/feed',
+    });
+
+    expect(log).toHaveLength(2);
+    expect(log[0].input.existing_tab_match).toBe('example.com/feed');
+    expect(log[1].input.existing_tab_match).toBeUndefined();
+    expect(res.usedExistingTab).toBe(false);
+    expect(res.items).toEqual([{ id: 'fallback-row' }]);
+  });
+
+  test('fails loudly on no_matching_tab when fallbackToScratch is false', async () => {
+    const { dispatcher, log } = makeDispatcher({
+      cs_scrape: true,
+      result: { error: 'no_matching_tab', match: 'example.com/feed' },
+    });
+
+    await expect(
+      extensionDomScrape({
+        dispatcher,
+        url: 'https://www.example.com/feed/',
+        config: {},
+        parseRows: (rows) => rows,
+        allowedOrigins: ['example.com'],
+        existingTabMatch: 'example.com/feed',
+        fallbackToScratch: false,
+      })
+    ).rejects.toThrow(/no open tab matches existing_tab_match/);
+    expect(log).toHaveLength(1);
+  });
 });

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -99,6 +99,9 @@ export interface ExtensionDomScrapeResult<TItem> {
   landedUrl?: string;
   /** Tab the content-script scrape ran in. Useful for focusing an auth-wall tab. */
   tabId?: number;
+  /** Whether rows came from a user's already-open tab (true) or a run-scoped
+   * scratch tab the extension opened and closed (false). */
+  usedExistingTab: boolean;
 }
 
 function hostMatchesPattern(host: string, pattern: string): boolean {
@@ -145,6 +148,11 @@ function assertExpectedScrapeSite(
  * Scrapes default to a background, action-scoped tab that the extension closes
  * after harvesting. Set `persistent:true` only for a site with tab-bound state;
  * it selects that site's sticky anchor and serializes work on that anchor.
+ *
+ * Set `existingTabMatch` to prefer the user's ALREADY-OPEN tab whose URL
+ * contains the substring. That tab is read in place — never created, navigated,
+ * or closed. When no tab matches, the scrape falls back to a fresh scratch tab
+ * unless `fallbackToScratch:false` makes it fail loudly instead.
  */
 export async function extensionDomScrape<TItem>(opts: {
   dispatcher: ChromeActionDispatcher;
@@ -154,17 +162,46 @@ export async function extensionDomScrape<TItem>(opts: {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
+  /** Prefer a user's already-open tab whose URL includes this substring. */
+  existingTabMatch?: string;
+  /** When existingTabMatch finds no open tab, fall back to the default scratch
+   * tab instead of failing (default true). */
+  fallbackToScratch?: boolean;
 }): Promise<ExtensionDomScrapeResult<TItem>> {
-  const observation =
-    await opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
+  const wantsExistingTab =
+    typeof opts.existingTabMatch === 'string' && opts.existingTabMatch.length > 0;
+  const fallbackToScratch = opts.fallbackToScratch ?? true;
+  const dispatchScrape = (existing: boolean) =>
+    opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
       cs_scrape: true,
       persistent: opts.persistent ?? false,
       focus: opts.focus ?? false,
       url: opts.url,
       scrape_config: opts.config,
       allowed_origins: opts.allowedOrigins,
+      ...(existing && wantsExistingTab
+        ? { existing_tab_match: opts.existingTabMatch }
+        : {}),
     });
-  const result = observation?.result;
+
+  let usedExistingTab = false;
+  let observation = await dispatchScrape(wantsExistingTab);
+  let result = observation?.result;
+  // The extension reports a missing user tab via the error field — it is not a
+  // scrape failure. With a fallback, retry against a fresh scratch tab; without
+  // one, surface a distinct error instead of the generic "failed in the page".
+  if (wantsExistingTab && result?.error === 'no_matching_tab') {
+    if (!fallbackToScratch) {
+      throw new Error(
+        `cs_scrape: no open tab matches existing_tab_match "${opts.existingTabMatch}".`
+      );
+    }
+    observation = await dispatchScrape(false);
+    result = observation?.result;
+  } else if (wantsExistingTab) {
+    usedExistingTab = true;
+  }
+
   // Fail loudly on a broken scrape. A missing result (dispatch never produced
   // one) or an `error` field (the in-page script threw — e.g. CSP blocked
   // injection) must NOT be silently coerced into a logged-in, zero-row
@@ -189,5 +226,6 @@ export async function extensionDomScrape<TItem>(opts: {
     host: result.host,
     landedUrl: result.landedUrl,
     tabId: observation.tab_id,
+    usedExistingTab,
   };
 }

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -27,6 +27,8 @@ interface DomScrapeOpts {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
+  existingTabMatch?: string;
+  fallbackToScratch?: boolean;
 }
 
 // Faithful copies of the SDK's pure pagination generators (no browser stack).
@@ -168,15 +170,35 @@ export function connectorSdkMock() {
       properties: {},
     },
     extensionDomScrape: async (opts: DomScrapeOpts) => {
-      const observation = await opts.dispatcher.dispatch('navigate', {
-        cs_scrape: true,
-		persistent: opts.persistent ?? false,
-		focus: opts.focus ?? false,
-        url: opts.url,
-        scrape_config: opts.config,
-        allowed_origins: opts.allowedOrigins,
-      });
-      const result = observation?.result;
+      const wantsExistingTab =
+        typeof opts.existingTabMatch === 'string' && opts.existingTabMatch.length > 0;
+      const fallbackToScratch = opts.fallbackToScratch ?? true;
+      const dispatchScrape = (existing: boolean) =>
+        opts.dispatcher.dispatch('navigate', {
+          cs_scrape: true,
+          persistent: opts.persistent ?? false,
+          focus: opts.focus ?? false,
+          url: opts.url,
+          scrape_config: opts.config,
+          allowed_origins: opts.allowedOrigins,
+          ...(existing && wantsExistingTab
+            ? { existing_tab_match: opts.existingTabMatch }
+            : {}),
+        });
+      let usedExistingTab = false;
+      let observation = await dispatchScrape(wantsExistingTab);
+      let result = observation?.result;
+      if (wantsExistingTab && result?.error === 'no_matching_tab') {
+        if (!fallbackToScratch) {
+          throw new Error(
+            `cs_scrape: no open tab matches existing_tab_match "${opts.existingTabMatch}".`
+          );
+        }
+        observation = await dispatchScrape(false);
+        result = observation?.result;
+      } else if (wantsExistingTab) {
+        usedExistingTab = true;
+      }
       const items = opts.parseRows(result?.rows ?? []);
       return {
         items,
@@ -184,6 +206,7 @@ export function connectorSdkMock() {
         count: result?.count ?? items.length,
         host: result?.host,
         landedUrl: result?.landedUrl,
+        usedExistingTab,
       };
     },
   };

--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -736,6 +736,86 @@ describe("XConnector home_feed", () => {
 		expect(props.min_scrolls?.type).toBe("integer");
 	});
 
+	test("home_feed configSchema accepts use_existing_tab", () => {
+		const props = new XConnector().definition.feeds.home_feed.configSchema
+			.properties as Record<string, { type?: string }>;
+		expect(props.use_existing_tab?.type).toBe("boolean");
+	});
+
+	test("use_existing_tab passes existing_tab_match and reports the existing-tab backend", async () => {
+		const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
+		const dispatcher = {
+			dispatch: async (action: string, input: Record<string, unknown>) => {
+				calls.push({ action, input });
+				return {
+					tab_id: 1,
+					cs_scrape: true,
+					existing_tab: true,
+					result: {
+						loggedIn: true,
+						rows: [
+							{
+								id: "111",
+								body: "first tweet on my timeline",
+								status_path: "/alice/status/111",
+								published_at: "2026-06-30T12:00:00.000Z",
+							},
+						],
+					},
+				};
+			},
+		};
+
+		const connector = new XConnector();
+		const res = await connector.sync({
+			feedKey: "home_feed",
+			config: { max_scrolls: 4, use_existing_tab: true },
+			checkpoint: {},
+			sessionState: { chrome_dispatcher: dispatcher },
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].input.existing_tab_match).toBe("x.com/home");
+		expect(res.events).toHaveLength(1);
+		expect(res.metadata.backend).toBe("extension-cs-scrape-existing-tab");
+	});
+
+	test("without use_existing_tab no existing_tab_match is sent and backend stays extension-cs-scrape", async () => {
+		const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
+		const dispatcher = {
+			dispatch: async (action: string, input: Record<string, unknown>) => {
+				calls.push({ action, input });
+				return {
+					tab_id: 1,
+					cs_scrape: true,
+					result: {
+						loggedIn: true,
+						rows: [
+							{
+								id: "111",
+								body: "first tweet on my timeline",
+								status_path: "/alice/status/111",
+								published_at: "2026-06-30T12:00:00.000Z",
+							},
+						],
+					},
+				};
+			},
+		};
+
+		const connector = new XConnector();
+		const res = await connector.sync({
+			feedKey: "home_feed",
+			config: { max_scrolls: 4 },
+			checkpoint: {},
+			sessionState: { chrome_dispatcher: dispatcher },
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].input.existing_tab_match).toBeUndefined();
+		expect(res.metadata.backend).toBe("extension-cs-scrape");
+	});
+
 	test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
 		const scrollMaxes: number[] = [];
 		const dispatcher = {

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -1685,7 +1685,7 @@ async function syncHomeFeedViaDomScrape(
 	checkpoint: XCheckpoint,
 ): Promise<SyncResult> {
 	const maxScrolls = readScrollBudget(config, { defaultMax: 10, cap: 30 });
-	const { items: rows, loggedIn } = await extensionDomScrape<HomeFeedRow>({
+	const { items: rows, loggedIn, usedExistingTab } = await extensionDomScrape<HomeFeedRow>({
 		dispatcher: requireExtensionDispatcher(ctx),
 		url: "https://x.com/home",
 		config: {
@@ -1694,6 +1694,7 @@ async function syncHomeFeedViaDomScrape(
 		},
 		parseRows: (raw) => raw as HomeFeedRow[],
 		allowedOrigins: X_ALLOWED_ORIGINS,
+		existingTabMatch: config.use_existing_tab === true ? "x.com/home" : undefined,
 	});
 
 	if (!loggedIn) {
@@ -1704,7 +1705,7 @@ async function syncHomeFeedViaDomScrape(
 
 	const tweets = buildHomeFeedTweets(rows);
 	return finalizeSyncResult(tweets, checkpoint, {
-		backend: "extension-cs-scrape",
+		backend: usedExistingTab ? "extension-cs-scrape-existing-tab" : "extension-cs-scrape",
 		items_scraped: rows.length,
 		scrolls_this_run: maxScrolls,
 		timeline: "home",
@@ -1791,6 +1792,12 @@ const homeFeedConfigSchema = {
 			maximum: 30,
 			description:
 				"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls].",
+		},
+		use_existing_tab: {
+			type: "boolean",
+			default: false,
+			description:
+				"Scrape your already-open x.com tab instead of opening a throwaway window. The tab is read in place (never navigated or closed); when no matching tab is open, falls back to a throwaway tab. Note: this scrolls your real timeline.",
 		},
 	},
 };


### PR DESCRIPTION
## Summary

The X `home_feed` timeline has no public API, so it is served by content-script scrape (`cs_scrape`) through the paired Owletto Chrome extension. Today every sync opens a throwaway scratch tab, scrapes, and closes it.

This adds an opt-in `use_existing_tab` config so the sync can instead scrape the user's **already-open** x.com tab in place — no throwaway window churn. It reuses the extension's existing `existing_tab_match` op (already shipped in the extension; no owletto change).

## Changes

- **connector-sdk**: `extensionDomScrape` gains `existingTabMatch` + `fallbackToScratch` options. When a user tab matching the substring is open, it is scraped in place (never navigated or closed); when absent, `no_matching_tab` falls back to the throwaway scratch tab (or fails loudly with `fallbackToScratch: false`). Result gains `usedExistingTab`.
- **x connector**: `use_existing_tab` boolean on the home_feed config schema; passes `existing_tab_match: "x.com/home"` when set and reports backend `extension-cs-scrape-existing-tab` vs `extension-cs-scrape`.
- **tests**: SDK (10), X connector (58), full connectors suite (355) green; shared `connector-sdk.mock.ts` updated to mirror the new contract.

## Verification

- Unit + `make pre-pr-remote-fast`: 10/10 Depot jobs passed.
- Live e2e on the Mac mini paired Chrome: opened `x.com/home`, dispatched the exact `cs_scrape` + `existing_tab_match` payload this connector now emits → found the open tab (`existing_tab: true`, `loggedIn: true`), scraped 5 real tweets, then closed the tab cleanly.

## Notes

- When enabled, the scrape **scrolls the user's real open timeline** — inherent to reading a live tab; documented on the config option.
- Pre-existing baseline: connectors package typecheck fails on `hackernews.ts`/`slack.ts`/`youtube.ts` (present on `origin/main`, untouched by this diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home-feed scraping can now reuse an already-open matching tab.
  * Added an option to control existing-tab reuse and fallback to a new tab when no match is found.
  * Scraping results now indicate whether an existing tab was used.

* **Bug Fixes**
  * Improved handling when no matching tab is available, including configurable retry or error behavior.

* **Tests**
  * Added coverage for existing-tab matching, fallback behavior, configuration validation, and result reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->