### PR TITLE
fix(server,cli): canonicalize entity-type slugs in the schema verbs and CLI apply

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -191,6 +191,49 @@ describe("mapProjectToDesiredState", () => {
     ]);
   });
 
+  test("maps normalized and system entity-type references to stored slugs", () => {
+    const agent = defineAgent({ id: "inventory" });
+    const movement = defineEntityType({ key: "stock_movement" });
+    const tracks = defineRelationshipType({
+      key: "tracks",
+      rules: [{ source: movement, target: "$member" }],
+    });
+    const automation = defineAutomation({
+      agent,
+      slug: "record-movement",
+      skills: ["inventory"],
+      outputs: { movements: { entity: movement, key: ["sku"] } },
+      triggers: [
+        {
+          kind: "event",
+          source: "workspace",
+          entity_type: "stock_movement",
+          event_types: ["movement-recorded"],
+        },
+      ],
+    });
+
+    const state = mapProjectToDesiredState(
+      defineConfig({
+        agents: [agent],
+        entities: [movement],
+        relationships: [tracks],
+        automations: [automation],
+      })
+    );
+
+    expect(state.memorySchema.entityTypes[0]?.slug).toBe("stock-movement");
+    expect(state.memorySchema.relationshipTypes[0]?.rules).toEqual([
+      { source: "stock-movement", target: "$member" },
+    ]);
+    expect(state.automations[0]?.outputs).toEqual({
+      movements: { entity: "stock-movement", key: ["sku"] },
+    });
+    expect(state.automations[0]?.triggers[0]).toMatchObject({
+      entity_type: "stock-movement",
+    });
+  });
+
   test("preserves explicit null outputs so apply can clear an Automation", () => {
     const agent = defineAgent({ id: "radar" });
     const automation = defineAutomation({

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -9,7 +9,11 @@
  */
 
 import { validateEntityMetrics } from "@lobu/connector-sdk/metrics";
-import { type AgentSettings, isHostedChatPlatform } from "@lobu/core";
+import {
+  type AgentSettings,
+  isHostedChatPlatform,
+  normalizeEntityTypeSlug,
+} from "@lobu/core";
 import type { AgentSettingsStored } from "@lobu/core/contracts/agent-settings";
 import {
   normalizeWorkspaceEventTrigger,
@@ -212,7 +216,7 @@ function connectorKey(ref: ConnectorRef): string {
 }
 
 function entitySlug(ref: EntityType | string): string {
-  return typeof ref === "string" ? ref : ref.key;
+  return normalizeEntityTypeSlug(typeof ref === "string" ? ref : ref.key);
 }
 
 function agentId(ref: Agent | string): string {
@@ -482,7 +486,7 @@ function mapEntityType(entity: EntityType): DesiredEntityType {
     }
   }
   return {
-    slug: entity.key,
+    slug: normalizeEntityTypeSlug(entity.key),
     ...(entity.name ? { name: entity.name } : {}),
     ...(entity.description ? { description: entity.description } : {}),
     ...(entity.required ? { required: entity.required } : {}),
@@ -670,7 +674,13 @@ function mapAutomation(automation: Automation): DesiredAutomation {
       };
     }
     if (trigger.kind === "event" && trigger.source === "workspace") {
-      return normalizeWorkspaceEventTrigger(trigger);
+      const normalizedTrigger = normalizeWorkspaceEventTrigger(trigger);
+      return normalizedTrigger.entity_type
+        ? {
+            ...normalizedTrigger,
+            entity_type: normalizeEntityTypeSlug(normalizedTrigger.entity_type),
+          }
+        : normalizedTrigger;
     }
     const { connection, ...eventTrigger } = trigger;
     const normalizedEventTrigger = {

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   isReservedEntityTypeSlug,
   isSystemEntityType,
+  normalizeEntityTypeSlug,
   RESERVED_ENTITY_TYPE_SLUGS,
   RESERVED_PATHS,
 } from "../reserved";
@@ -35,6 +36,16 @@ describe("isReservedEntityTypeSlug", () => {
     expect(isReservedEntityTypeSlug("inference-providers")).toBe(true);
     expect(isReservedEntityTypeSlug("environments")).toBe(true);
     expect(isReservedEntityTypeSlug("infrastructure")).toBe(true);
+  });
+});
+
+describe("normalizeEntityTypeSlug", () => {
+  it("matches stored domain slugs without rewriting system slugs", () => {
+    expect(normalizeEntityTypeSlug("Stock_Movement")).toBe("stock-movement");
+    expect(normalizeEntityTypeSlug("stock--movement!")).toBe(
+      "stock--movement-"
+    );
+    expect(normalizeEntityTypeSlug("$MEMBER")).toBe("$member");
   });
 });
 

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -133,6 +133,29 @@ export function isReservedEntityTypeSlug(slug: string): boolean {
   return (RESERVED_ENTITY_TYPE_SLUGS as readonly string[]).includes(s);
 }
 
+/**
+ * Canonical stored form of an entity-type slug.
+ *
+ * Entity-type create has always rewritten anything outside `[a-z0-9-]` to `-`,
+ * so a `snake_case` key from `lobu.config.ts` is STORED hyphenated. Every other
+ * verb must resolve through this same function or it looks up a spelling that
+ * was never written: `lobu apply` upserts by probing create and retrying as
+ * update on the 409, so a one-sided normalization turned that retry into a 404
+ * and halted apply for every snake_case entity key.
+ *
+ * `$` system slugs (`$member`, `$resource`) are passed through untouched —
+ * they are stored WITH the sigil, so canonicalizing them would rewrite
+ * `$member` to `-member` and strand every system-type lookup.
+ *
+ * Deliberately NOT `slugify()` from ./utils/slug — that one also strips
+ * diacritics and trims edge hyphens, which would retarget slugs that existing
+ * rows are already stored under.
+ */
+export function normalizeEntityTypeSlug(slug: string): string {
+  const lower = slug.toLowerCase();
+  return lower.startsWith("$") ? lower : lower.replace(/[^a-z0-9-]/g, "-");
+}
+
 // ── Inference-provider connector keys ───────────────────────────────────────
 
 /**

--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -61,6 +61,53 @@ describe('entity schema CRUD', () => {
       expect(tombstone.entity_type).toBeNull();
     });
 
+    it('round-trips a slug that needs normalizing through every entity-type verb', async () => {
+      await owner.entity_schema.createType({
+        slug: 'stock_movement',
+        name: 'Stock Movement',
+      });
+
+      const got = (await owner.entity_schema.getType('stock_movement')) as {
+        entity_type?: { slug: string; name: string };
+      };
+      expect(got.entity_type?.name).toBe('Stock Movement');
+      expect(got.entity_type?.slug).toBe('stock-movement');
+
+      const alias = (await owner.entity_schema.getType('stock-movement')) as {
+        entity_type?: { slug: string };
+      };
+      expect(alias.entity_type?.slug).toBe('stock-movement');
+
+      await owner.entity_schema.updateType({
+        slug: 'stock_movement',
+        name: 'Stok Fisi',
+      });
+      const after = (await owner.entity_schema.getType('stock-movement')) as {
+        entity_type?: { name: string };
+      };
+      expect(after.entity_type?.name).toBe('Stok Fisi');
+
+      const audit = (await owner.entity_schema.auditType('stock_movement')) as {
+        audit_entries?: Array<{ action: string }>;
+      };
+      expect(audit.audit_entries?.map((entry) => entry.action)).toEqual(
+        expect.arrayContaining(['create', 'update'])
+      );
+
+      await owner.entity_schema.deleteType({ slug: 'stock_movement' });
+      const tombstone = (await owner.entity_schema.getType('stock-movement')) as {
+        entity_type: null | unknown;
+      };
+      expect(tombstone.entity_type).toBeNull();
+    });
+
+    it('preserves system entity-type slugs while normalizing lookups', async () => {
+      const got = (await owner.entity_schema.getType('$MEMBER')) as {
+        entity_type?: { slug: string };
+      };
+      expect(got.entity_type?.slug).toBe('$member');
+    });
+
     it('accepts event_kinds with a jsonTemplate, and event_kinds:null to clear (lobu apply)', async () => {
       // `lobu apply` sends event_kinds on every upsert: an object to declare,
       // `null` to clear. The schema must accept BOTH — a regression here halted

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -45,6 +45,7 @@ import {
 } from '../../utils/entity-management';
 import {
   isReservedEntityTypeSlug,
+  normalizeEntityTypeSlug,
   RESERVED_ENTITY_TYPE_SLUGS,
 } from '../../utils/reserved';
 import { resolveUsernames } from '../../utils/resolve-usernames';
@@ -410,6 +411,7 @@ async function etHandleGet(
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
   if (!slug) throw new ToolUserError('slug is required for get action', 400);
+  const normalizedSlug = normalizeEntityTypeSlug(slug);
 
   const sql = getDb();
   const fetchRow = () =>
@@ -422,14 +424,14 @@ async function etHandleGet(
          AND (et.organization_id = $2 OR o.visibility = 'public')
        ORDER BY (et.organization_id = $2) DESC, et.id ASC
        LIMIT 1`,
-      [slug, ctx.organizationId]
+      [normalizedSlug, ctx.organizationId]
     );
 
   let rows = await fetchRow();
 
   // $member is per-tenant: if the resolved row is cross-org (or missing), provision in the caller's org.
   const needsMemberProvision =
-    slug === '$member' &&
+    normalizedSlug === '$member' &&
     (rows.length === 0 || rows[0].organization_id !== ctx.organizationId);
   if (needsMemberProvision) {
     await ensureMemberEntityType(ctx.organizationId);
@@ -490,7 +492,7 @@ async function etHandleCreate(
     );
   }
 
-  const slug = args.slug.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  const slug = normalizeEntityTypeSlug(args.slug);
 
   const sql = getDb();
 
@@ -598,11 +600,12 @@ async function etHandleUpdate(
   if (!args.slug) throw new ToolUserError('slug is required for update action', 400);
   if (!ctx.userId) throw new ToolUserError('Authentication required to update entity types', 401);
 
+  const slug = normalizeEntityTypeSlug(args.slug);
   const sql = getDb();
 
   const existing = await sql`
     SELECT * FROM entity_types
-    WHERE slug = ${args.slug}
+    WHERE slug = ${slug}
       AND deleted_at IS NULL
       AND organization_id = ${ctx.organizationId}
     LIMIT 1
@@ -735,7 +738,7 @@ async function etHandleUpdate(
   ];
   recordToolConfigChange(ctx, {
     resourceKind: 'entity-type',
-    resourceId: args.slug,
+    resourceId: slug,
     op: 'updated',
     summary: `Entity type '${result.name ?? args.slug}' updated`,
     state: updated[0] as Record<string, unknown>,
@@ -746,10 +749,11 @@ async function etHandleUpdate(
 }
 
 async function etHandleDelete(
-  slug: string | undefined,
+  rawSlug: string | undefined,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!slug) throw new ToolUserError('slug is required for delete action', 400);
+  if (!rawSlug) throw new ToolUserError('slug is required for delete action', 400);
+  const slug = normalizeEntityTypeSlug(rawSlug);
   if (!ctx.userId) throw new ToolUserError('Authentication required to delete entity types', 401);
 
   const sql = getDb();
@@ -807,10 +811,11 @@ async function etHandleDelete(
 }
 
 async function etHandleAudit(
-  slug: string | undefined,
+  rawSlug: string | undefined,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!slug) throw new ToolUserError('slug is required for audit action', 400);
+  if (!rawSlug) throw new ToolUserError('slug is required for audit action', 400);
+  const slug = normalizeEntityTypeSlug(rawSlug);
 
   const sql = getDb();
 

--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -5,6 +5,7 @@
 export {
   isReservedConnectorKey,
   isReservedEntityTypeSlug,
+  normalizeEntityTypeSlug,
   RESERVED_ENTITY_TYPE_SLUGS,
   RESERVED_PATHS_SET,
 } from "@lobu/core";


### PR DESCRIPTION
## Summary
- Entity-type create rewrites anything outside `[a-z0-9-]` to `-`, so a snake_case key from `lobu.config.ts` is **stored hyphenated** — but get/update/delete/audit queried the raw slug. `lobu apply` upserts by probing create and retrying as update on the 409, so the retry 404'd and apply **halted** with `Entity type 'stock_movement' not found`.
- The CLI had a **second, independent** bug: desired state sent `slug: entity.key` verbatim and diffed it against the stored slug, so apply re-planned a create every run and reported the stored row as undeclared drift.
- `normalizeEntityTypeSlug()` in `@lobu/core` is now the single definition, applied at both layers. `$` system slugs pass through untouched — canonicalizing them would rewrite `$member` to `-member` and strand every system-type lookup through the newly normalized read paths.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `4x624zj8wx`, 18/18 jobs passed)
- [x] Tests run: server `entity-schema/` integration **43/43**, CLI `apply/` **330/330**, core `reserved.test.ts` **5/5**; `tsc --noEmit` clean on server + CLI
- [x] Bug fix: red→fix→green outputs pasted below

### red → green

Same snake_case config, applied twice, against three stacks:

| stack | apply #2 |
|---|---|
| neither fix | `error: POST .../manage_entity_schema failed: Entity type 'stock_movement' not found` — **halts** |
| server fix only | `2 create, 0 update, 2 noop, 3 drift` — never converges |
| both fixes | `0 create, 0 update, 5 noop, 1 drift` (the 1 is the system `$member` type) |

Relationship rules with snake_case endpoints verified resolving in the DB:
`"source_entity_type_slug": "stock-movement"`, `"target_entity_type_slug": "work-order"`.

The regression test in `entity-types.test.ts` was written red first — it failed on the initial read-back before the server fix landed.

## Notes
Every pre-existing test in `entity-types.test.ts` used hyphenated slugs, which is why this shipped unnoticed.

Relationship-**type** keys are deliberately left verbatim: the server never normalizes those, so normalizing them client-side would reintroduce the same class of mismatch in the other direction.

`make review-fix` caught two things beyond the original fix, both kept: the `$` passthrough above, and a third chokepoint at `map-config.ts:663` where a Behavior's workspace event trigger references an entity type by key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity type names are now normalized consistently with lowercase formatting and standardized separators.
  * System-defined entity references remain preserved during configuration and schema operations.
  * Entity type lookup, creation, updates, auditing, and deletion support normalized names.

* **Bug Fixes**
  * Improved handling of relationship rules, automation outputs, workspace triggers, metrics, public pages, and schema operations when entity names use different formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->