### PR TITLE
refactor(server): delete the orphaned config-source about writer

### DIFF
--- a/packages/server/src/__tests__/integration/authz/channel-about.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-about.test.ts
@@ -9,12 +9,11 @@ import {
 	slackChannelsToResources,
 } from "@lobu/connectors/slack-identity";
 import {
-	ensureAboutRelationshipType,
 	listChannelEntitiesAboutBusinessEntity,
-	syncConnectionChannelAboutEdges,
+	setManualChannelAboutEdges,
 } from "../../../authz/channel-about";
 import { buildAccessGraph } from "../../../authz/access-graph";
-import { EDGE_SOURCE_CONFIG } from "../../../utils/relationship-validation";
+import { EDGE_SOURCE_MANUAL } from "../../../utils/relationship-validation";
 import { clearEntityLinkRulesCache } from "../../../utils/entity-link-upsert";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -62,7 +61,7 @@ describe("channel about edges", () => {
 		clearEntityLinkRulesCache();
 	});
 
-	it("config about edge survives slack channel graph membership re-sync", async () => {
+	it("manual about edge survives slack channel graph membership re-sync", async () => {
 		const org = await createTestOrganization({ name: "About Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
@@ -77,24 +76,20 @@ describe("channel about edges", () => {
 		});
 
 		const connectionId = "conn-about-1";
-		await syncConnectionChannelAboutEdges({
+		await setManualChannelAboutEdges({
 			organizationId: org.id,
 			connectionId,
 			connectorKey: "slack",
-			channels: [
-				{
-					channelId: CHANNEL,
-					teamId: TEAM,
-					aboutEntityIds: [company.id],
-				},
-			],
+			channelId: CHANNEL,
+			teamId: TEAM,
+			aboutEntityIds: [company.id],
 			userId: user.id,
 		});
 
 		const before = await aboutEdges(org.id);
 		expect(before).toHaveLength(1);
 		expect(Number(before[0].to_entity_id)).toBe(company.id);
-		expect(before[0].source).toBe(EDGE_SOURCE_CONFIG);
+		expect(before[0].source).toBe(EDGE_SOURCE_MANUAL);
 
 		await buildAccessGraph({
 			organizationId: org.id,
@@ -129,11 +124,13 @@ describe("channel about edges", () => {
 			created_by: user.id,
 		});
 
-		await syncConnectionChannelAboutEdges({
+		await setManualChannelAboutEdges({
 			organizationId: org.id,
 			connectionId: "99",
 			connectorKey: "slack",
-			channels: [{ channelId: CHANNEL, teamId: TEAM, aboutEntityIds: [company.id] }],
+			channelId: CHANNEL,
+			teamId: TEAM,
+			aboutEntityIds: [company.id],
 		});
 
 		const channels = await listChannelEntitiesAboutBusinessEntity({
@@ -143,6 +140,5 @@ describe("channel about edges", () => {
 		expect(channels).toHaveLength(1);
 		expect(channels[0].connectionId).toBe("99");
 		expect(channels[0].channelKey).toBe(slackChannelKey(TEAM, CHANNEL));
-		await ensureAboutRelationshipType(org.id);
 	});
 });

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -7,40 +7,19 @@
  * reconcile never touches `about` edges.
  */
 
-import { createLogger } from "@lobu/core";
 import { ACL_RESOURCE_TYPE_SLUG } from "@lobu/connector-sdk";
 import {
 	type DbClient,
 	getDb,
 	pgBigintArray,
-	pgTextArray,
 } from "../db/client.js";
 import { upsertEdges } from "../utils/edge-writes.js";
 import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
 import { ensureResourceEntityType } from "./access-graph.js";
-import {
-	EDGE_SOURCE_CONFIG,
-	EDGE_SOURCE_MANUAL,
-} from "../utils/relationship-validation";
+import { EDGE_SOURCE_MANUAL } from "../utils/relationship-validation";
 import { aclSourceFor, channelReadIdentityFor } from "./sources.js";
 
-const logger = createLogger("channel-about");
-
 export const ABOUT_RELATIONSHIP_SLUG = "about";
-
-export interface ChannelAboutTarget {
-	/** Bare or platform-prefixed channel id as stored on the binding. */
-	channelId: string;
-	/** The concrete workspace/tenant this channel lives in — the SAME real team
-	 *  the subscription is keyed on (for Slack Grid: the workspace `T…`, NEVER the
-	 *  enterprise `E…`). Resolved connector-side (`resolveSubscriptionTeam`) and threaded
-	 *  in so the about edge attaches to the SAME channel resource entity the ACL
-	 *  graph + subscription own. `null`/undefined = unknown yet (skip, heal from inbound)
-	 *  for a team-scoped connector, mirroring the subscription's null-team semantics. */
-	teamId: string | null | undefined;
-	/** Resolved business-entity ids to link (channel --about--> each). */
-	aboutEntityIds: number[];
-}
 
 export interface ChannelAboutMetadata {
 	connection_id: string;
@@ -218,47 +197,6 @@ async function findChannelResourceEntityId(opts: {
 	return rows[0] ? Number(rows[0].id) : null;
 }
 
-/** Resolve entity slugs to ids; throws when any slug is missing in the org. */
-export async function resolveEntitySlugsToIds(
-	organizationId: string,
-	slugs: string[],
-	sql: DbClient = getDb(),
-): Promise<number[]> {
-	const requested = [...new Set(slugs.map((s) => s.trim()).filter(Boolean))];
-	if (requested.length === 0) return [];
-	const rows = await sql<{ id: number; slug: string }>`
-    SELECT id, slug
-    FROM entities
-    WHERE organization_id = ${organizationId}
-      AND slug = ANY(${pgTextArray(requested)}::text[])
-      AND deleted_at IS NULL
-  `;
-	const bySlug = new Map(rows.map((r) => [r.slug, Number(r.id)]));
-	const missing = requested.filter((slug) => !bySlug.has(slug));
-	if (missing.length > 0) {
-		throw new Error(
-			`entity slug(s) do not exist in this organization: ${missing.join(", ")}`,
-		);
-	}
-	return requested.map((slug) => bySlug.get(slug)!);
-}
-
-/** Normalize about targets: numbers pass through, strings resolve as slugs. */
-export async function resolveAboutEntityRefs(
-	organizationId: string,
-	refs: Array<number | string>,
-	sql: DbClient = getDb(),
-): Promise<number[]> {
-	const ids: number[] = [];
-	const slugs: string[] = [];
-	for (const ref of refs) {
-		if (typeof ref === "number" && Number.isFinite(ref)) ids.push(ref);
-		else if (typeof ref === "string" && ref.trim()) slugs.push(ref.trim());
-	}
-	const fromSlugs = await resolveEntitySlugsToIds(organizationId, slugs, sql);
-	return [...new Set([...ids, ...fromSlugs])];
-}
-
 /**
  * Take ownership of one channel's `about` edges: create what is missing and
  * re-stamp metadata/source on what already exists.
@@ -292,101 +230,6 @@ async function upsertAboutEdges(opts: {
 		metadata: opts.metadata,
 		onConflict: 'update',
 	});
-}
-
-/**
- * Upsert config-sourced `about` edges for one connection and reconcile away
- * stale config edges. A desired pair takes ownership of any existing live edge
- * for the same relationship triple.
- */
-export async function syncConnectionChannelAboutEdges(opts: {
-	organizationId: string;
-	connectionId: string | number;
-	connectorKey: string;
-	channels: ChannelAboutTarget[];
-	userId?: string | null;
-	sql?: DbClient;
-}): Promise<{ linked: number; removed: number }> {
-	const sql = opts.sql ?? getDb();
-	const typeId = await ensureAboutRelationshipType(opts.organizationId, sql);
-	const connectionId = String(opts.connectionId);
-
-	const desiredPairs = new Set<string>();
-	let linked = 0;
-
-	for (const channel of opts.channels) {
-		const { key } = channelResourceIdentity(
-			opts.connectorKey,
-			channel.teamId,
-			channel.channelId,
-		);
-		const channelEntityId = await ensureChannelResourceEntity({
-			organizationId: opts.organizationId,
-			connectorKey: opts.connectorKey,
-			teamId: channel.teamId,
-			channelId: channel.channelId,
-			sql,
-		});
-		if (channelEntityId === null) {
-			logger.warn(
-				{
-					organization_id: opts.organizationId,
-					connection_id: connectionId,
-					channel_id: channel.channelId,
-				},
-				"Skipped channel about sync — channel entity could not be resolved",
-			);
-			continue;
-		}
-
-		const metadata: ChannelAboutMetadata = {
-			connection_id: connectionId,
-			channel_key: key,
-		};
-
-		for (const businessEntityId of channel.aboutEntityIds) {
-			desiredPairs.add(`${channelEntityId}:${businessEntityId}`);
-		}
-		await upsertAboutEdges({
-			organizationId: opts.organizationId,
-			fromChannelEntityId: channelEntityId,
-			toBusinessEntityIds: channel.aboutEntityIds,
-			source: EDGE_SOURCE_CONFIG,
-			metadata,
-			userId: opts.userId,
-			typeId,
-			sql,
-		});
-		linked += channel.aboutEntityIds.length;
-	}
-
-	const existing = await sql<{
-		id: number;
-		from_entity_id: number;
-		to_entity_id: number;
-	}>`
-    SELECT r.id, r.from_entity_id, r.to_entity_id
-    FROM entity_relationships r
-    WHERE r.organization_id = ${opts.organizationId}
-      AND r.relationship_type_id = ${typeId}
-      AND r.source = ${EDGE_SOURCE_CONFIG}
-      AND r.deleted_at IS NULL
-      AND r.metadata->>'connection_id' = ${connectionId}
-  `;
-
-	let removed = 0;
-	for (const row of existing) {
-		const pairKey = `${Number(row.from_entity_id)}:${Number(row.to_entity_id)}`;
-		if (desiredPairs.has(pairKey)) continue;
-		await sql`
-      UPDATE entity_relationships
-      SET deleted_at = current_timestamp, updated_at = current_timestamp
-      WHERE id = ${row.id}
-    `;
-		removed += 1;
-	}
-
-	return { linked, removed };
 }
 
 /** Replace manual `about` edges for one channel, taking ownership of desired pairs. */


### PR DESCRIPTION
## Summary
- `syncConnectionChannelAboutEdges` and its helpers have had **no production caller** since #2023 removed `manage_connections/handlers/channel-bindings.ts`. Only the integration tests still reached them.
- The dead path carried a latent data-loss bug, so deleting it makes the defect unreachable rather than merely handled.
- Started as a fix for that bug; `make review-fix` correctly pointed out the path was dead, and the caller history confirmed it.

### Structural evidence for the deletion
```
$ git log --oneline -S"syncConnectionChannelAboutEdges" --all -- packages/server/src
c3161a785 feat: consolidate reactive automation on Behaviors (#2023)
55c0f035f feat(chat): per-channel about links for business entity context (#1767)

$ git grep -n "syncConnectionChannelAboutEdges" c3161a785^ -- packages/server/src   # before
handlers/channel-bindings.ts:41
handlers/channel-bindings.ts:567
$ git grep -n "syncConnectionChannelAboutEdges" origin/main -- packages/           # today
(only its own definition)
```
`resolveAboutEntityRefs` and `resolveEntitySlugsToIds` were orphaned by the same commit (`channel-bindings.ts` was their only caller) and are removed too, along with the `pgTextArray` import they alone used.

**No product surface is lost.** The surviving public API (`manage-connections.ts:565`) is documented as "Set **manual** business-entity links for a chat channel (UI / operator edits)" and routes to `setManualChannelAboutEdges`. No config-side `about` declaration exists in `cli`, `core`, or `connector-sdk`.

### The bug that is now unreachable
Config and manual writers shared one `(channel, business entity)` triple, and the live-triple unique index excludes `source`. The shared upsert wrote `source = EXCLUDED.source`, handing the row to whichever writer touched it last, while each sweep only ever selects its own source. Wiring a caller back up would have let a config sync capture a user's manual link and then reconcile it away, and a manual write strand a config edge beyond config's reach.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean — Depot run `8q3m2lwbnf`, **18/18 jobs passed** (includes `dead-code-report` and `knip`, the gates that judge export deletions)
- [x] Tests run: `bunx vitest run src/__tests__/integration/authz/` → **13 files, 92 passed**; `bunx tsc --noEmit` clean
- [x] Bug fix: red→fix→green pasted below

<details><summary>red → green</summary>

Red, against the pre-existing code, using two tests that exercised the config/manual overlap:
```
FAIL > config sync does not capture a manual about edge and sweep it away
  AssertionError: expected [] to have a length of 1 but got +0
FAIL > manual edge does not capture a config about edge and strand it
  AssertionError: expected [] to have a length of 1 but got +0
Tests  2 failed | 2 passed (4)
```
Green after deleting the path. Those two tests are deliberately **not** in the final diff: with only one writer left, config and manual can no longer collide, so there is nothing left for them to assert. Remaining coverage was retargeted onto the live manual writer.
```
Test Files  13 passed (13)
Tests  92 passed (92)
```
</details>

## Notes
Follow-up, not in scope here: `about` edges are one instance of a general shape — one `entity_relationships` row cannot record two independent assertions, because live uniqueness is `(from, to, type)` and excludes `source`. That is tracked in the authz grants design work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Channel “About” relationships are now managed through manual entries for more consistent results.
  * Manually added relationships retain their source and metadata reliably.
  * Reverse lookups for channel relationships now reflect manually created entries accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->