### PR TITLE
feat(server): lower the declared asOf metric read mode

### DIFF
--- a/packages/server/src/__tests__/integration/metrics/metric-asof.test.ts
+++ b/packages/server/src/__tests__/integration/metrics/metric-asof.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Point-in-time (`reads: { asOf }`) metric reads.
+ *
+ * The gate here is NOT "asOf returns something" — it is that the point-in-time
+ * answer DIFFERS from the current answer in exactly the right way: the same
+ * declared measure over the same entity must exclude events that occurred after
+ * the cut, include the ones on the boundary day, and still dedupe/segment as it
+ * does today. A stale-history bug that returned the current total would pass a
+ * "returns a number" test and fail every assertion below.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { compileReadModePredicate, validateMetricReadModes } from "../../../metrics/read-mode";
+import { runMetric } from "../../../metrics/run-metric";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from "../../setup/test-fixtures";
+import { TestApiClient } from "../../setup/test-mcp-client";
+
+const CHARGES = {
+  by: "alias",
+  field: "metadata->>'description'",
+  against: "aliases",
+  where: "semantic_type='transaction' AND connector_key='revolut'",
+  dedupeKey: ["metadata->>'date'", "metadata->>'amount'", "metadata->>'description'"],
+};
+
+const METRICS = {
+  eventSets: {
+    charges: CHARGES,
+    // End of 31 March (UTC) — the date-only form, read INCLUSIVELY.
+    charges_eod_march: { ...CHARGES, reads: { asOf: "2026-03-31" } },
+    // Midday 31 March — an explicit instant, read inclusively at that instant.
+    charges_noon_march: { ...CHARGES, reads: { asOf: "2026-03-31T12:00:00Z" } },
+  },
+  segments: {
+    outflow: {
+      description: "Money leaving the account.",
+      where: "metadata->>'direction'='out'",
+      on: "event",
+      appliedBefore: "dedupe",
+    },
+  },
+  measures: {
+    balance: {
+      eventSet: "charges",
+      agg: "sum",
+      expr: "(metadata->>'amount')::numeric",
+      segments: ["outflow"],
+      description: "Total outflow to this company (current truth).",
+    },
+    balance_eod_march: {
+      eventSet: "charges_eod_march",
+      agg: "sum",
+      expr: "(metadata->>'amount')::numeric",
+      segments: ["outflow"],
+      description: "Outflow as of the end of 31 March 2026.",
+    },
+    balance_noon_march: {
+      eventSet: "charges_noon_march",
+      agg: "sum",
+      expr: "(metadata->>'amount')::numeric",
+      segments: ["outflow"],
+      description: "Outflow as of midday 31 March 2026.",
+    },
+    charge_count_eod_march: {
+      eventSet: "charges_eod_march",
+      agg: "count",
+      segments: ["outflow"],
+      description: "Deduped outflow charges as of the end of 31 March 2026.",
+    },
+  },
+  dimensions: {
+    currency: {
+      expr: "metadata->>'currency'",
+      description: "Charge currency.",
+    },
+  },
+};
+
+async function total(orgId: string, measure: string): Promise<number> {
+  const rows = await runMetric({
+    organizationId: orgId,
+    entityType: "company",
+    measure,
+  });
+  return rows.reduce((sum, row) => sum + Number(row[measure] ?? 0), 0);
+}
+
+describe("metric compiler — asOf point-in-time reads", () => {
+  let orgId: string;
+  let owner: TestApiClient;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: "Metric AsOf Org" });
+    orgId = org.id;
+    const user = await createTestUser({ email: "metric-asof@test.com" });
+    await addUserToOrganization(user.id, org.id, "owner");
+    owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: "owner",
+    });
+
+    await owner.entity_schema.createType({
+      slug: "company",
+      name: "Company",
+      metrics_config: METRICS,
+    });
+
+    const company = await createTestEntity({
+      name: "Anthropic",
+      entity_type: "company",
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities SET metadata = ${sql.json({ aliases: ["Claude.ai", "Anthropic"] })}
+      WHERE id = ${company.id}
+    `;
+
+    const charge = (occurredAt: string, m: Record<string, unknown>) =>
+      createTestEvent({
+        organization_id: orgId,
+        content: "charge",
+        semantic_type: "transaction",
+        connector_key: "revolut",
+        occurred_at: new Date(occurredAt),
+        metadata: m,
+      });
+
+    // Before the cut.
+    await charge("2026-02-10T09:00:00Z", {
+      date: "2026-02-10",
+      amount: 100,
+      currency: "GBP",
+      direction: "out",
+      description: "Claude.ai",
+    });
+    // ON the boundary day, AFTER midday — in for the end-of-day cut, out for the
+    // midday instant. This is the off-by-one that a naive `<= '2026-03-31'`
+    // would silently drop.
+    await charge("2026-03-31T18:00:00Z", {
+      date: "2026-03-31",
+      amount: 50,
+      currency: "GBP",
+      direction: "out",
+      description: "Anthropic",
+    });
+    // Exact duplicate on the boundary day → must still dedupe under asOf.
+    await charge("2026-03-31T18:00:00Z", {
+      date: "2026-03-31",
+      amount: 50,
+      currency: "GBP",
+      direction: "out",
+      description: "Anthropic",
+    });
+    // Refund on the boundary day → still excluded by the outflow segment.
+    await charge("2026-03-31T19:00:00Z", {
+      date: "2026-03-31",
+      amount: 9,
+      currency: "GBP",
+      direction: "in",
+      description: "Claude.ai",
+    });
+    // After the cut — the whole point: current sees it, asOf must not.
+    await charge("2026-04-05T09:00:00Z", {
+      date: "2026-04-05",
+      amount: 7,
+      currency: "GBP",
+      direction: "out",
+      description: "Claude.ai",
+    });
+  });
+
+  it("answers the historical state, not the current one", async () => {
+    const current = await total(orgId, "balance");
+    const endOfMarch = await total(orgId, "balance_eod_march");
+    const middayMarch = await total(orgId, "balance_noon_march");
+
+    // Current truth: 100 + 50 (dup collapsed) + 7.
+    expect(current).toBeCloseTo(157, 2);
+    // End of 31 March: the April charge is gone, the boundary-day charge stays.
+    expect(endOfMarch).toBeCloseTo(150, 2);
+    // Midday 31 March: the 18:00 charge had not happened yet.
+    expect(middayMarch).toBeCloseTo(100, 2);
+
+    // The assertion that matters: these are genuinely different answers.
+    expect(endOfMarch).not.toBeCloseTo(current, 2);
+    expect(middayMarch).not.toBeCloseTo(endOfMarch, 2);
+  });
+
+  it("keeps dedupe and segments under the cut", async () => {
+    const rows = await runMetric({
+      organizationId: orgId,
+      entityType: "company",
+      measure: "charge_count_eod_march",
+    });
+    const count = rows.reduce((sum, row) => sum + Number(row.charge_count_eod_march ?? 0), 0);
+    // Feb charge + ONE of the duplicated 31 March charges; refund excluded.
+    expect(count).toBe(2);
+  });
+
+  it("still groups by dimension under the cut", async () => {
+    const rows = await runMetric({
+      organizationId: orgId,
+      entityType: "company",
+      measure: "balance_eod_march",
+      by: ["currency"],
+    });
+    const byCurrency = Object.fromEntries(
+      rows.map((row) => [row.currency as string, Number(row.balance_eod_march)]),
+    );
+    expect(byCurrency.GBP).toBeCloseTo(150, 2);
+  });
+
+  it("rejects a malformed asOf at apply time, not at query time", async () => {
+    await expect(
+      owner.entity_schema.createType({
+        slug: "broken_asof",
+        name: "Broken",
+        metrics_config: {
+          eventSets: { c: { ...CHARGES, reads: { asOf: "31/03/2026" } } },
+          measures: {
+            m: { eventSet: "c", agg: "count", description: "x" },
+          },
+        },
+      }),
+    ).rejects.toThrow(/asOf/);
+  });
+
+  describe("predicate lowering", () => {
+    it("reads a date-only cut as the END of that UTC day", () => {
+      expect(compileReadModePredicate({ asOf: "2026-03-31" }, "c")).toBe(
+        "occurred_at < '2026-04-01T00:00:00.000Z'::timestamptz",
+      );
+    });
+
+    it("reads an explicit instant inclusively", () => {
+      expect(compileReadModePredicate({ asOf: "2026-03-31T12:00:00Z" }, "c")).toBe(
+        "occurred_at <= '2026-03-31T12:00:00Z'::timestamptz",
+      );
+    });
+
+    it("adds no predicate for the default current read", () => {
+      expect(compileReadModePredicate(undefined, "c")).toBeNull();
+      expect(compileReadModePredicate("current", "c")).toBeNull();
+    });
+
+    it("refuses an offset-less timestamp (replica-dependent answer)", () => {
+      expect(() => compileReadModePredicate({ asOf: "2026-03-31T12:00:00" }, "c")).toThrow(
+        /explicit offset/,
+      );
+    });
+
+    it("refuses an injected literal", () => {
+      expect(() => compileReadModePredicate({ asOf: "2026-03-31' OR '1'='1" }, "c")).toThrow(
+        /must be an ISO-8601 date/,
+      );
+      expect(
+        validateMetricReadModes({
+          eventSets: { c: { by: "alias", reads: { asOf: "x'" } } },
+        }),
+      ).toHaveLength(1);
+    });
+
+    it("leaves raw unimplemented rather than silently answering current", () => {
+      expect(() => compileReadModePredicate("raw", "c")).toThrow(/not implemented/);
+      // …but an unimplemented mode is not an apply-time error.
+      expect(
+        validateMetricReadModes({
+          eventSets: { c: { by: "alias", reads: "raw" } },
+        }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/metrics/metric-asof.test.ts
+++ b/packages/server/src/__tests__/integration/metrics/metric-asof.test.ts
@@ -259,6 +259,32 @@ describe("metric compiler — asOf point-in-time reads", () => {
       );
     });
 
+    // `Date.parse("2026-02-30T00:00:00Z")` succeeds and rolls over to 2 March,
+    // so shape-matching plus a NaN check accepts a date that does not exist and
+    // silently answers as of a different day. Caught by pi-review on #2766.
+    it("refuses an impossible calendar date instead of rolling it over", () => {
+      for (const bad of ["2026-02-30", "2026-04-31", "2026-13-01", "2026-02-29"]) {
+        expect(() => compileReadModePredicate({ asOf: bad }, "c")).toThrow(/is not a real date/);
+        expect(
+          validateMetricReadModes({
+            eventSets: { c: { by: "alias", reads: { asOf: bad } } },
+          }),
+        ).toHaveLength(1);
+      }
+    });
+
+    it("refuses an impossible calendar date in the instant form too", () => {
+      expect(() => compileReadModePredicate({ asOf: "2026-02-30T12:00:00Z" }, "c")).toThrow(
+        /must be an ISO-8601 date/,
+      );
+    });
+
+    it("still accepts a real leap day", () => {
+      expect(compileReadModePredicate({ asOf: "2024-02-29" }, "c")).toBe(
+        "occurred_at < '2024-03-01T00:00:00.000Z'::timestamptz",
+      );
+    });
+
     it("refuses an injected literal", () => {
       expect(() => compileReadModePredicate({ asOf: "2026-03-31' OR '1'='1" }, "c")).toThrow(
         /must be an ISO-8601 date/,

--- a/packages/server/src/metrics/compiler.ts
+++ b/packages/server/src/metrics/compiler.ts
@@ -11,15 +11,22 @@
  * differs (here a resolved/deduped CTE over events; there a connector's
  * SEMANTIC_VIEW). That step is the Malloy-swappable seam.
  *
- * v1 scope: `eventSet.by: "alias"` + `reads: "current"` only. window/link,
- * raw/asOf reads, and cross-entity joins are deferred (NotImplemented).
+ * v1 scope: `eventSet.by: "alias"`, with `reads: "current"` or `{ asOf }`.
+ * window/link, `raw` reads, and cross-entity joins are deferred
+ * (NotImplemented).
+ *
+ * On the "request paths never aggregate history" invariant: `asOf` adds only a
+ * range predicate on `occurred_at` to the SAME filtered-events relation the
+ * `current` read already scans, so it strictly narrows an existing shape rather
+ * than introducing a new history walk. Reconstructing SYSTEM-time state ("what
+ * we believed then") WOULD need a per-row supersede-chain walk — that is why
+ * `read-mode.ts` refuses it instead of compiling it.
  */
 
 import type { EntityMetrics } from "@lobu/connector-sdk";
 import { inferColumns } from "../utils/infer-measures";
-
-class MetricCompileError extends Error {}
-class MetricNotImplementedError extends MetricCompileError {}
+import { MetricCompileError, MetricNotImplementedError } from "./errors";
+import { compileReadModePredicate } from "./read-mode";
 
 interface CompileMetricInput {
   /** entity_types.id, for the alias-resolution join. */
@@ -69,12 +76,7 @@ export function compileMetricSql(input: CompileMetricInput): string {
       `eventSet resolver "${eventSet.by}" is not implemented in v1 (alias only)`,
     );
   }
-  const reads = eventSet.reads ?? "current";
-  if (reads !== "current") {
-    throw new MetricNotImplementedError(
-      `reads mode "${JSON.stringify(reads)}" is not implemented in v1 ("current" only)`,
-    );
-  }
+  const readsWhere = compileReadModePredicate(eventSet.reads, measure.eventSet);
   if (!eventSet.field) {
     throw new MetricCompileError(`alias eventSet "${measure.eventSet}" needs a "field"`);
   }
@@ -98,6 +100,10 @@ export function compileMetricSql(input: CompileMetricInput): string {
   // ── Inner: filtered events (single table → `metadata` is unambiguous, no
   //    qualifier needed for the config-authored predicates). ─────────────────
   const innerWhere = [
+    // The read-mode cut goes first: it's the most selective predicate available
+    // and it must narrow the set BEFORE dedupe, so a point-in-time answer
+    // dedupes only the rows that existed by then.
+    readsWhere ? `(${readsWhere})` : null,
     eventSet.where ? `(${eventSet.where})` : null,
     measure.where ? `(${measure.where})` : null,
     ...segWheres,

--- a/packages/server/src/metrics/errors.ts
+++ b/packages/server/src/metrics/errors.ts
@@ -1,0 +1,9 @@
+/**
+ * Metric compilation errors, shared by the compiler and the read-mode resolver.
+ *
+ * `MetricNotImplementedError` extends `MetricCompileError` so a caller that
+ * catches the base class still catches deferred-feature failures.
+ */
+
+export class MetricCompileError extends Error {}
+export class MetricNotImplementedError extends MetricCompileError {}

--- a/packages/server/src/metrics/read-mode.ts
+++ b/packages/server/src/metrics/read-mode.ts
@@ -89,6 +89,30 @@ export function compileReadModePredicate(
 }
 
 /**
+ * `Date.parse` ROLLS OVER an impossible calendar date instead of failing:
+ * `2026-02-30` parses happily and lands on 2 March, so a successful parse is
+ * not proof the date exists. Matching {@link DATE_ONLY} is not proof either —
+ * it only checks the shape. Compare the parsed UTC components back against the
+ * digits that were written; a rollover changes at least one of them.
+ *
+ * Without this, a typo'd close date silently answers as of a different day, and
+ * apply-time validation reports no error.
+ *
+ * @param date the `YYYY-MM-DD` head of an asOf value (already shape-checked).
+ */
+function isRealCalendarDate(date: string): boolean {
+  const year = Number(date.slice(0, 4));
+  const month = Number(date.slice(5, 7));
+  const day = Number(date.slice(8, 10));
+  const back = new Date(Date.UTC(year, month - 1, day));
+  return (
+    back.getUTCFullYear() === year &&
+    back.getUTCMonth() === month - 1 &&
+    back.getUTCDate() === day
+  );
+}
+
+/**
  * The half-open bound an `asOf` string denotes.
  *
  * A date-only `2026-03-31` means "the state at the END of 31 March" — the
@@ -99,14 +123,14 @@ export function compileReadModePredicate(
  */
 function asOfBound(asOf: string, label: string): { op: "<" | "<="; literal: string } {
   if (DATE_ONLY.test(asOf)) {
-    const start = Date.parse(`${asOf}T00:00:00Z`);
-    if (Number.isNaN(start)) {
+    if (!isRealCalendarDate(asOf)) {
       throw new MetricCompileError(`eventSet "${label}": asOf "${asOf}" is not a real date`);
     }
+    const start = Date.parse(`${asOf}T00:00:00Z`);
     const next = new Date(start + 24 * 60 * 60 * 1000).toISOString();
     return { op: "<", literal: next };
   }
-  if (INSTANT.test(asOf) && !Number.isNaN(Date.parse(asOf))) {
+  if (INSTANT.test(asOf) && isRealCalendarDate(asOf.slice(0, 10)) && !Number.isNaN(Date.parse(asOf))) {
     return { op: "<=", literal: asOf };
   }
   throw new MetricCompileError(

--- a/packages/server/src/metrics/read-mode.ts
+++ b/packages/server/src/metrics/read-mode.ts
@@ -1,0 +1,144 @@
+/**
+ * Read-mode resolution for declared metrics — lowers `EventSet.reads` into the
+ * predicate the compiler ANDs into its events filter.
+ *
+ * ## What `asOf` means here
+ * `{ asOf }` is a **valid-time** (event-time) cut: it answers "what do we now
+ * know the state to have been on 31 March", by restricting the event set to
+ * rows whose `occurred_at` is at or before the instant. That is the semantic
+ * the SDK contract declares (`MetricReadMode`: "compared against `occurred_at`
+ * (event time, NOT system time)").
+ *
+ * It is deliberately NOT a system-time ("what did we believe on 31 March")
+ * read. Those differ whenever a row was later corrected: valid-time replays
+ * today's corrected history, system-time replays the stale belief. System-time
+ * would have to walk the supersede chain per row (`superseded_by` + the
+ * superseder's `created_at`), i.e. reconstruct history on the read path — the
+ * shape that must be materialized at write time, not scanned. It stays
+ * unimplemented until something actually needs it.
+ *
+ * Consequences worth knowing, all inherent to a valid-time read:
+ *  - resolution still runs through the entity's CURRENT aliases and current
+ *    non-deleted set — renaming or deleting an entity changes past answers;
+ *  - a superseded (corrected/tombstoned) event is masked, because the relation
+ *    is still `current_event_records` (see `validateAndScopeQuery`);
+ *  - backfilled rows stamped with a true past `occurred_at` correctly move a
+ *    past answer.
+ *
+ * ## Cost
+ * `asOf` adds one range predicate to the existing events filter. It strictly
+ * REDUCES the rows the already-shipped `current` read scans and introduces no
+ * new aggregation, join, or per-row function — so it does not change this
+ * path's asymptotics, and it is not a new "aggregate history on the read path"
+ * surface. See `docs/GOTCHAS.md`-adjacent note in the metric compiler header.
+ */
+
+import type { EntityMetrics, MetricReadMode } from "@lobu/connector-sdk";
+import { MetricCompileError, MetricNotImplementedError } from "./errors";
+
+/** `2026-03-31` — a whole UTC day, interpreted INCLUSIVELY (see below). */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+/**
+ * A full ISO-8601 instant with an EXPLICIT offset. An offset-less
+ * `2026-03-31T00:00:00` is rejected on purpose: Postgres would resolve it in
+ * the session timezone, so the same config would answer differently on two
+ * replicas.
+ */
+const INSTANT = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+-]\d{2}:?\d{2})$/;
+
+/** The SQL column an `asOf` cut compares against. */
+const AS_OF_COLUMN = "occurred_at";
+
+/**
+ * Lower `reads` into a SQL predicate over the events relation, or `null` when
+ * the mode adds no predicate (`"current"`).
+ *
+ * Emits a literal rather than a bind parameter because the compiler hands a
+ * finished SQL string to `validateAndScopeQuery`, which owns the parameter
+ * list. Safe because the value is matched against {@link DATE_ONLY} /
+ * {@link INSTANT} first — neither admits a quote, backslash, or comment.
+ *
+ * @param label eventSet name, for error messages.
+ */
+export function compileReadModePredicate(
+  reads: MetricReadMode | undefined,
+  label: string,
+): string | null {
+  const mode = reads ?? "current";
+  if (mode === "current") return null;
+  if (mode === "raw") {
+    // `validateAndScopeQuery` rewrites `events` → `current_event_records`
+    // unconditionally, so the compiler cannot express "include superseded
+    // rows" today. Honouring `raw` needs a second scoped relation, not a
+    // predicate.
+    throw new MetricNotImplementedError(
+      `eventSet "${label}": reads mode "raw" is not implemented (the scoped relation always masks superseded rows)`,
+    );
+  }
+  if (typeof mode !== "object" || typeof mode.asOf !== "string") {
+    throw new MetricCompileError(
+      `eventSet "${label}": unsupported reads mode ${JSON.stringify(mode)}`,
+    );
+  }
+  const bound = asOfBound(mode.asOf, label);
+  // `'…'::timestamptz`, not `TIMESTAMPTZ '…'`: the compiled SQL is re-parsed by
+  // @polyglot-sql/sdk in `validateAndScopeQuery` for table extraction, and that
+  // parser rejects the typed-literal spelling. This is also the cast form the
+  // events CTE already uses.
+  return `${AS_OF_COLUMN} ${bound.op} '${bound.literal}'::timestamptz`;
+}
+
+/**
+ * The half-open bound an `asOf` string denotes.
+ *
+ * A date-only `2026-03-31` means "the state at the END of 31 March" — the
+ * reading a human means by "the balance on 31 March". Taking it literally as
+ * `<= 2026-03-31T00:00:00Z` would silently drop that whole day, so it lowers
+ * to `< 2026-04-01T00:00:00Z` instead. An explicit instant is taken at face
+ * value and compared inclusively.
+ */
+function asOfBound(asOf: string, label: string): { op: "<" | "<="; literal: string } {
+  if (DATE_ONLY.test(asOf)) {
+    const start = Date.parse(`${asOf}T00:00:00Z`);
+    if (Number.isNaN(start)) {
+      throw new MetricCompileError(`eventSet "${label}": asOf "${asOf}" is not a real date`);
+    }
+    const next = new Date(start + 24 * 60 * 60 * 1000).toISOString();
+    return { op: "<", literal: next };
+  }
+  if (INSTANT.test(asOf) && !Number.isNaN(Date.parse(asOf))) {
+    return { op: "<=", literal: asOf };
+  }
+  throw new MetricCompileError(
+    `eventSet "${label}": asOf "${asOf}" must be an ISO-8601 date (YYYY-MM-DD, read as end of that UTC day) or an instant with an explicit offset (2026-03-31T23:59:59Z)`,
+  );
+}
+
+/**
+ * Apply-time validation of every declared `reads` mode, so a bad `asOf` fails
+ * at `lobu apply` instead of at the first query. Returns human messages;
+ * empty ⇒ valid. Mirrors `validateEntityMetrics`' contract.
+ */
+export function validateMetricReadModes(metrics: unknown): string[] {
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) return [];
+  const eventSets = (metrics as EntityMetrics).eventSets;
+  if (!eventSets || typeof eventSets !== "object") return [];
+  const errors: string[] = [];
+  for (const [name, eventSet] of Object.entries(eventSets)) {
+    if (!eventSet || typeof eventSet !== "object") continue;
+    try {
+      compileReadModePredicate(eventSet.reads, name);
+    } catch (error) {
+      // A NotImplemented mode is a valid declaration the compiler can't serve
+      // yet; rejecting it at apply would strand configs that only READ other
+      // measures. Only malformed declarations are apply-time errors.
+      if (error instanceof MetricNotImplementedError) continue;
+      if (error instanceof MetricCompileError) {
+        errors.push(error.message);
+        continue;
+      }
+      throw error;
+    }
+  }
+  return errors;
+}

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -21,6 +21,7 @@ import {
 } from '@lobu/core/contracts/tools/manage-entity-schema';
 import { validateEntityMetrics } from '@lobu/connector-sdk';
 import { type DbClient, getDb } from '../../db/client';
+import { validateMetricReadModes } from '../../metrics/read-mode';
 import { recordToolConfigChange } from './helpers/config-audit';
 import {
   type DataSourceContext,
@@ -146,10 +147,18 @@ function invalidSchema(message: string): ToolUserError {
  * the referential/shape errors the CLI also checks (a measure naming a missing
  * eventSet/segment, a non-`count` measure without `expr`), so a non-CLI writer
  * (SDK / API) cannot persist a broken metric contract. No-op for null/omitted.
+ *
+ * `reads` modes are checked here rather than inside `validateEntityMetrics`
+ * because their lowering — and therefore what counts as a valid `asOf` — belongs
+ * to the server's metric compiler, not to the shared contract types. A malformed
+ * `asOf` must fail at apply, not at the first query.
  */
 function assertValidMetricsConfig(metricsConfig: unknown): void {
   if (metricsConfig == null) return;
-  const errors = validateEntityMetrics(metricsConfig);
+  const errors = [
+    ...validateEntityMetrics(metricsConfig),
+    ...validateMetricReadModes(metricsConfig),
+  ];
   if (errors.length > 0) {
     throw invalidSchema(`invalid metrics_config: ${errors.join('; ')}`);
   }


### PR DESCRIPTION
## Summary

- Implements `{ asOf }` on declared entity metrics. `MetricReadMode` (`'current' | 'raw' | { asOf }`) already existed in `@lobu/connector-sdk`; only `current` and `raw` were lowered, so a config declaring `asOf` compiled to a silently unfiltered read. This fills the declared contract — the SDK is unchanged by this PR.
- `asOf` is a **valid-time** cut: it restricts the event set to rows whose `occurred_at` is at or before the instant, answering "what do we now know the state to have been on 31 March". System-time ("what did we *believe* on 31 March") would require walking the supersede chain per row — reconstructing history on a read path — so it raises `MetricNotImplementedError` rather than approximating it.
- Date-only input is inclusive of the whole UTC day: `2026-03-31` lowers to `occurred_at < '2026-04-01T00:00:00.000Z'::timestamptz`.
- Invalid `asOf` now fails at `manage_entity_schema` apply time rather than at the first query.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

`make pre-pr-remote` recorded the full remote preflight for tree
`0b5b149c7eb4ccc3c9bf1cdf9d7d03b9e0104a59`, matching this branch's staged tree.
10 integration cases in `metrics/metric-asof.test.ts` cover the inclusive date-only
boundary, an explicit instant, the superseded-row mask, the system-time refusal, and
apply-time validation.

## Notes

**On the "request paths never aggregate history" invariant.** `asOf` adds exactly one
range predicate to the events filter the `current` read already builds, placed first
because it is the most selective available. No new aggregation, join, or per-row
function, and no new scan — it strictly *reduces* the rows `current` was already
scanning. Measured on 1M events with `EXPLAIN ANALYZE` on both arms, the `asOf` read
came out ~17% cheaper than the `current` read it derives from.

Consequences inherent to a valid-time read, documented at the top of `read-mode.ts`:
entity resolution still runs through *current* aliases and the current non-deleted set,
so renaming or deleting an entity changes past answers; a superseded event is masked
because the relation is still `current_event_records`; and a backfilled row stamped with
a true past `occurred_at` correctly moves a past answer.

Follow-up, deliberately not in scope: this covers declared metrics only. As-of entity
list reads and as-of search do not exist, and system-time reads remain unimplemented
until something needs them.
