### PR TITLE
feat(ui-review): pass deploy-only Owletto pointer moves as not applicable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 6. Commit, then confirm `git diff --name-only origin/main...HEAD` is exactly your intended file list.
 7. `git push -u origin <branch>` → `gh pr create` (fill `.github/pull_request_template.md`; conventional-commit title).
 8. `make review` **once** on the settled HEAD; it posts the required `pi-review` status.
-9. `make ui-review`. Non-Owletto changes pass as not applicable; an Owletto pointer change needs exact hosted proof (`ARTIFACT=<url>`; see the playbook).
+9. `make ui-review`. Non-Owletto changes and complete, forward-only Owletto pointer diffs confined to `deploy/` pass as not applicable; other pointer changes need exact hosted proof (`ARTIFACT=<url>`; see the playbook).
 10. `gh pr merge <n> --squash --admin` once green — never `--admin` past a check that has not reported. Lobu's required `integration` fan-in is absent from `gh pr checks` until it starts, not pending, so diff against the branch-protection list (playbook).
 11. Prod-visible surface? Verify live after rollout: gate on the **squash commit**, not your branch head, keeping the argument order `git merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA"`. Record the result.
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"
 	@echo "  make review [BASE=<branch>]                - Run the cross-harness LLM reviewer against the local diff (deterministic suites run in CI); posts pi-review status and PR comment"
 	@echo "  make review-fix [BASE=<branch>]            - Pre-review fixer: reviewer CLI with write access fixes review-grade findings in the tree; posts nothing"
-	@echo "  make ui-review [ARTIFACT=<https-url>]       - Publish exact-SHA visual proof for an Owletto pointer on its merged PR; OPEN=1 opens that PR"
+	@echo "  make ui-review [ARTIFACT=<https-url>]       - Record Owletto UI proof; complete forward deploy-only pointer diffs pass as not applicable; OPEN=1 opens the merged PR"
 	@echo "  make pre-pr-remote-fast                    - Run required Linux merge jobs on Depot (broad iteration; no attestation)"
 	@echo "  make pre-pr-remote [REMOTE_JOBS='unit …']  - Run staged full Linux CI on Depot (default final gate; no local CPU)"
 	@echo "  make pre-pr                                - Run the CPU-heavy deterministic gate locally (explicit fallback)"
@@ -299,12 +299,12 @@ review:
 review-fix:
 	@./scripts/review-fix.sh $(if $(BASE),--base $(BASE),)
 
-# Visual counterpart to `make review`: non-Owletto PRs pass as not applicable.
-# Pointer PRs post/update proof on the exact merged Owletto PR, link it from
-# this Lobu PR, and attach a passing `ui-review` status. Publishing the proof is
-# what the gate asserts, so no ARTIFACT means no proof and no pass. ARTIFACT and
-# OPEN are read directly by scripts/ui-review.ts, avoiding shell interpolation
-# of URLs.
+# Visual counterpart to `make review`: non-Owletto PRs and complete,
+# forward-only pointer diffs confined to deploy/ pass as not applicable. Other
+# pointer PRs post/update proof on the exact merged Owletto PR, link it from this
+# Lobu PR, and attach a passing `ui-review` status. Without reusable exact proof,
+# they need ARTIFACT. ARTIFACT and OPEN are read directly by scripts/ui-review.ts
+# to avoid shell interpolation of URLs.
 ui-review:
 	@bun scripts/ui-review.ts
 

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -55,7 +55,7 @@ Mechanical traps (build, SQL, testing, submodule, browser) live in `docs/GOTCHAS
 | `make pre-pr` | CPU-heavy local fallback for when Depot is unavailable. |
 | `make review` | Handles the review verdict/status or safe-class skip. Runs no typecheck, knip, or tests — **not** proof CI will pass. |
 | `make review-fix` | Unposted fixer pass. Edits the working tree; re-read files before trusting them. |
-| `make ui-review` | Records exact UI proof for Owletto pointer changes; passes other changes as not applicable. |
+| `make ui-review` | Records exact UI proof for Owletto pointer changes; passes non-Owletto changes and complete, forward-only pointer diffs confined to `deploy/` as not applicable. |
 
 The macOS app lane stays on GitHub/Mac hardware. Subset runs (`make pre-pr-remote REMOTE_JOBS=unit`) rerun one lane but never attest. A fresh full `make review` requires the matching Depot tree attestation and refuses a surprise local build; safe-class skips and cached verdicts do not rebuild. Only a documented Depot outage permits `REVIEW_ALLOW_LOCAL_BUILD=1 make review`.
 
@@ -82,7 +82,7 @@ The chain must exit zero **and** print nothing before merge. Nonzero does not me
 
 **`make review` skip rule.** Small safe-class diffs (docs, renames, generated, additive tests; under 100 lines) skip the cross-harness reviewer by default. `REVIEWER_MODE=full make review` forces the independent review; `REVIEWER_SHADOW=1` measures the skip rule instead of trusting it.
 
-**UI proof.** `gh` cannot upload images inline. Capture before shots from the unmodified branch and after shots from the same booted app (auth recipe in `docs/BROWSER_TESTING.md`), base64-embed the PNGs into one self-contained HTML comparison page, host it at an HTTPS URL, and pass that URL as `ARTIFACT` to `make ui-review`. The gate records it on the exact merged Owletto PR, links it from the parent, and binds the evidence to that parent-base and Owletto-pointer pair for normal PR review. A rerun may reuse an exact proof already recorded for that pointer pair; otherwise no `ARTIFACT` means no proof and no pass.
+**UI proof.** `gh` cannot upload images inline. Capture before shots from the unmodified branch and after shots from the same booted app (auth recipe in `docs/BROWSER_TESTING.md`), base64-embed the PNGs into one self-contained HTML comparison page, host it at an HTTPS URL, and pass that URL as `ARTIFACT` to `make ui-review`. The gate records it on the exact merged Owletto PR, links it from the parent, and binds the evidence to that parent-base and Owletto-pointer pair for normal PR review. A rerun may reuse an exact proof already recorded for that pointer pair. Complete, forward-only endpoint diffs confined to `deploy/` pass as not applicable; every other pointer change needs reusable exact proof or an `ARTIFACT`.
 
 ## Post-merge rollout verification
 

--- a/scripts/__tests__/ui-review-command.test.ts
+++ b/scripts/__tests__/ui-review-command.test.ts
@@ -23,6 +23,7 @@ interface MockState {
     method: string;
     payload: Record<string, unknown>;
   }>;
+  opened?: string;
 }
 
 const temporaryDirectories: string[] = [];
@@ -132,6 +133,13 @@ if (endpoint.includes("/contents/packages/owletto?ref=")) {
     files: [{ filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" }],
     parents: [{ sha: process.env.MOCK_PRODUCT_POINTER }],
   });
+} else if (endpoint.startsWith("repos/lobu-ai/owletto/compare/")) {
+  output({
+    status: process.env.MOCK_COMPARE_STATUS || "ahead",
+    files: JSON.parse(
+      process.env.MOCK_OWLETTO_FILES || '[{"filename":"src/app.tsx"}]'
+    ),
+  });
 } else if (endpoint.includes("/collaborators/") && endpoint.endsWith("/permission")) {
   output({ permission: "admin" });
 } else if (endpoint.includes("/statuses/") && method === "POST") {
@@ -173,6 +181,16 @@ await writeState();
 `;
   writeFileSync(join(bin, "gh"), mockGh);
   chmodSync(join(bin, "gh"), 0o755);
+  const mockOpen = `#!/usr/bin/env bun
+const stateFile = process.env.MOCK_STATE_FILE;
+const state = JSON.parse(await Bun.file(stateFile).text());
+state.opened = process.argv[2];
+await Bun.write(stateFile, JSON.stringify(state));
+`;
+  for (const command of ["open", "xdg-open"]) {
+    writeFileSync(join(bin, command), mockOpen);
+    chmodSync(join(bin, command), 0o755);
+  }
   return { repo, bin, stateFile, head };
 }
 
@@ -279,6 +297,96 @@ describe("ui-review command", () => {
     expect(statuses.at(-1)?.payload).toMatchObject({
       context: "ui-review",
       state: "pending",
+    });
+  });
+
+  it("passes a complete deploy-only PR and clears stale parent proof copy", () => {
+    const fixture = createFixture();
+    const state = readState(fixture.stateFile);
+    const parentEndpoint = "repos/lobu-ai/lobu/issues/2500/comments";
+    state.comments[parentEndpoint] = [
+      {
+        id: 900,
+        body: "<!-- lobu-ui-review-marker -->\n**UI review recorded**",
+        created_at: "2026-08-04T11:00:00Z",
+        updated_at: "2026-08-04T11:00:00Z",
+        html_url: "https://github.com/comment/900",
+        user: { login: "agent" },
+      },
+    ];
+    writeFileSync(fixture.stateFile, JSON.stringify(state));
+
+    const result = runUiReview(fixture, {
+      OPEN: "1",
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
+        { filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" },
+      ]),
+    });
+
+    expectExit(result, 0);
+    const finalState = readState(fixture.stateFile);
+    expect(
+      finalState.calls
+        .filter((call) => call.endpoint.includes("/statuses/"))
+        .at(-1)?.payload
+    ).toMatchObject({
+      context: "ui-review",
+      state: "success",
+      description:
+        "Owletto 111111111...222222222 is deploy-only; no UI to prove",
+      target_url: "https://github.com/lobu-ai/owletto/pull/712",
+    });
+    // The exemption is judged over the whole pointer range, so the range is what
+    // the human-readable note must name.
+    expect(finalState.comments[parentEndpoint]?.[0]?.body).toContain(
+      `\`${"1".repeat(40)}...${"2".repeat(40)}\` changes only \`deploy/\` (2 files, through Owletto #712).`
+    );
+    expect(finalState.opened).toBe(
+      "https://github.com/lobu-ai/owletto/pull/712"
+    );
+  });
+
+  it("requires proof when an earlier commit left a UI change in the range", () => {
+    const fixture = createFixture();
+    // The head PR is deploy-only on its own, but the pointer moves across a
+    // commit that touched `src/`. Judging by the head PR alone would skip proof
+    // for a real UI change, so the exemption must read the whole range.
+    const result = runUiReview(fixture, {
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "src/components/shell/responsive-app-shell.tsx" },
+        { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
+      ]),
+    });
+
+    expectExit(result, 2);
+    const status = readState(fixture.stateFile)
+      .calls.filter((call) => call.endpoint.includes("/statuses/"))
+      .at(-1);
+    expect(status?.payload).toMatchObject({
+      context: "ui-review",
+      state: "error",
+      description: "UI proof missing; rerun make ui-review with ARTIFACT=...",
+    });
+  });
+
+  it("requires proof when the pointer comparison diverged", () => {
+    const fixture = createFixture();
+    const result = runUiReview(fixture, {
+      MOCK_COMPARE_STATUS: "diverged",
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" },
+      ]),
+    });
+
+    expectExit(result, 2);
+    const status = readState(fixture.stateFile)
+      .calls.filter((call) => call.endpoint.includes("/statuses/"))
+      .at(-1);
+    expect(status?.payload).toMatchObject({
+      context: "ui-review",
+      state: "error",
+      description: "UI proof missing; rerun make ui-review with ARTIFACT=...",
     });
   });
 

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildProofBody,
+  COMPARE_FILE_CAP,
   findProofComment,
+  isDeployOnlyRange,
   isHttpsArtifact,
   parseProof,
   permittedFluxTailParent,
@@ -150,6 +152,48 @@ describe("UI review proof", () => {
     ]) {
       expect(permittedFluxTailParent(candidate)).toBeNull();
     }
+  });
+
+  it("accepts only a complete deploy-only endpoint diff", () => {
+    expect(
+      isDeployOnlyRange([
+        { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
+        { filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" },
+      ])
+    ).toBe(true);
+
+    // The range spans several merged PRs. A surviving UI change from an earlier
+    // commit must still demand proof when the head PR is deploy-only on its own.
+    expect(
+      isDeployOnlyRange([
+        { filename: "src/components/shell/responsive-app-shell.tsx" },
+        { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
+      ])
+    ).toBe(false);
+
+    // `deploy/` is a path prefix, not a substring.
+    expect(isDeployOnlyRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
+      false
+    );
+    expect(
+      isDeployOnlyRange([
+        {
+          filename: "deploy/k8s/archived-app.tsx",
+          previous_filename: "src/app.tsx",
+        },
+      ])
+    ).toBe(false);
+
+    // Fail closed when the compare response tells us nothing, and when it may
+    // have been truncated at the cap.
+    expect(isDeployOnlyRange([])).toBe(false);
+    expect(
+      isDeployOnlyRange(
+        Array.from({ length: COMPARE_FILE_CAP }, (_, index) => ({
+          filename: `deploy/k8s/generated/${index}.yaml`,
+        }))
+      )
+    ).toBe(false);
   });
 
   it("requires a hosted HTTPS artifact", () => {

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -81,7 +81,7 @@ Visual evidence for the Owletto version proposed by ${proof.lobu_repo}#${proof.l
 - Visual comparison: ${proof.artifact_url}
 
 The comparison is captured from one booted instance against the same data on
-both sides. A changed Owletto pointer republishes it.`;
+both sides. A later pointer change that needs visual proof republishes it.`;
 }
 
 export function parseProof(body: string): UiReviewProof | null {
@@ -141,6 +141,26 @@ export function selectOwlettoPullRequest(
     pulls.find(
       (pull) => pull.merged_at !== null && pull.merge_commit_sha === owlettoSha
     ) ?? null
+  );
+}
+
+/**
+ * The pointer can span several merged PRs, so inspect its endpoint diff rather
+ * than only the head PR. GitHub caps comparison files at COMPARE_FILE_CAP and
+ * reports no total, so empty and cap-sized responses fail closed. Renames must
+ * stay under `deploy/` at both ends.
+ */
+export const COMPARE_FILE_CAP = 300;
+
+export function isDeployOnlyRange(
+  files: Array<{ filename: string; previous_filename?: string }>
+): boolean {
+  if (files.length === 0 || files.length >= COMPARE_FILE_CAP) return false;
+  return files.every(
+    (file) =>
+      file.filename.startsWith("deploy/") &&
+      (file.previous_filename === undefined ||
+        file.previous_filename.startsWith("deploy/"))
   );
 }
 

--- a/scripts/ui-review.ts
+++ b/scripts/ui-review.ts
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import {
   buildProofBody,
   findProofComment,
+  isDeployOnlyRange,
   isHttpsArtifact,
   permittedFluxTailParent,
   type OwlettoPullRequest,
@@ -300,6 +301,35 @@ function main(): number {
     throw new Error(
       `Owletto ${headPointer} is neither a merged ${owlettoRepo} PR squash commit nor a permitted Flux deploy-only tail`
     );
+  }
+
+  const comparison = ghApi<{
+    status?: string;
+    files?: Array<{ filename: string; previous_filename?: string }>;
+  }>(`repos/${owlettoRepo}/compare/${basePointer}...${headPointer}`);
+  const rangeFiles = comparison.files ?? [];
+  if (comparison.status === "ahead" && isDeployOnlyRange(rangeFiles)) {
+    const parentComment = findComment(lobuRepo, parentPr.number, PARENT_MARKER);
+    if (parentComment) {
+      ghApi(`repos/${lobuRepo}/issues/comments/${parentComment.id}`, "PATCH", {
+        body: `${PARENT_MARKER}
+**UI review not applicable** for Lobu head \`${localHead}\`.
+
+\`${basePointer}...${headPointer}\` changes only \`deploy/\` (${rangeFiles.length} files, through Owletto #${owlettoPr.number}).`,
+      });
+    }
+    postStatus(
+      lobuRepo,
+      localHead,
+      "success",
+      `Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} is deploy-only; no UI to prove`,
+      owlettoPr.html_url
+    );
+    console.log(
+      `ui-review: not applicable; Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} changes only deploy/ (${rangeFiles.length} files)`
+    );
+    if (options.open) openPullRequest(owlettoPr.html_url);
+    return 0;
   }
 
   const comments = ghApiPages<ApiComment>(


### PR DESCRIPTION
## Summary

- An Owletto pointer move that touches only `deploy/` now passes `ui-review` as not applicable, instead of demanding a before/after proof for a range with no pixels in it.
- 14 of the last 40 merged Owletto PRs were deploy-only, so this is the common case, not an edge one.
- The exemption is keyed on the **whole `base...head` range**, not the head PR. A pointer move routinely spans several merged Owletto PRs, and judging only the head one would exempt a range whose earlier commits changed the UI. It also refuses to exempt an empty range, and bails out at a 300-file compare cap rather than trusting a truncated GitHub response.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

`make pre-pr-remote` recorded the full remote preflight for tree
`4db1cfe01f360c00188618833d199787f1063e8a`, matching this branch's staged tree.
`isDeployOnlyRange` is mutation-tested: inverting the `every` predicate, dropping the
empty-range guard, and removing the file-cap guard each redden a distinct case.

## Notes

**This PR modifies a required check, so it deserves more scrutiny than its size suggests.**
A bug here does not break a feature — it weakens `ui-review` for every future Owletto
pointer bump. The two failure modes worth reviewing directly:

- *Exempting too much*: any non-`deploy/` file anywhere in the range must fail the
  predicate. That is why it tests `files.every(...)` over the compare range rather than
  sampling or trusting a per-PR label.
- *Trusting a truncated response*: GitHub's compare API paginates, so a range larger than
  the cap is treated as not exempt rather than as "no non-deploy files seen".

This mirrors the narrow Flux-tail exemption `submodule-drift.yml` already applies, and
`permittedFluxTailParent` in the same module keeps that logic in one place.
