### PR TITLE
fix(handoff): retry stale composer refs on X + Open post opens a fresh tab

### DIFF
--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -885,10 +885,15 @@ function stagingDispatcher(
 		stagedText?: string;
 		currentUrl?: string;
 		submitEnabled?: boolean;
+		a11ySnapshots?: readonly [
+			{ refId: number; documentEpoch: number },
+			...Array<{ refId: number; documentEpoch: number }>,
+		];
 	} = {},
 ) {
 	const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
 	let typedText = "";
+	let treeReadCount = 0;
 	const dispatcher = {
 		dispatch: async (action: string, input: Record<string, unknown>) => {
 			calls.push({ action, input });
@@ -900,18 +905,25 @@ function stagingDispatcher(
 					};
 				case "wait_for_selector":
 					return { found: true };
-				case "get_accessibility_tree":
+				case "get_accessibility_tree": {
+					const snapshots =
+						overrides.a11ySnapshots ??
+						([{ refId: 36, documentEpoch: 3 }] as const);
+					const snapshot =
+						snapshots[Math.min(treeReadCount, snapshots.length - 1)];
+					treeReadCount += 1;
 					return {
-						document_epoch: 3,
+						document_epoch: snapshot.documentEpoch,
 						tree: [
 							{ ref_id: 29, role: "button", name: "5 Replies. Reply" },
 							{
-								ref_id: 36,
+								ref_id: snapshot.refId,
 								role: "textbox",
 								name: overrides.composerName ?? "Post text",
 							},
 						],
 					};
+				}
 				case "type_ref":
 					typedText = input.text as string;
 					return { ok: true };
@@ -999,7 +1011,7 @@ describe("isReplySubmitLabel", () => {
 
 describe("prepare_reply action contract", () => {
 	test("pins the connector version for catalog upgrades", () => {
-		expect(new XConnector().definition.version).toBe("3.12.0");
+		expect(new XConnector().definition.version).toBe("3.12.1");
 	});
 
 	// This is a deliberate design decision, not an oversight. Publishing is
@@ -1105,7 +1117,12 @@ describe("prepareXReply", () => {
 	// go stale between get_accessibility_tree and click_ref. The action must
 	// re-extract and retry the click once instead of failing on a transient race.
 	test("retries once when the composer click hits a stale a11y ref", async () => {
-		const { dispatcher, calls } = stagingDispatcher();
+		const { dispatcher, calls } = stagingDispatcher({
+			a11ySnapshots: [
+				{ refId: 36, documentEpoch: 3 },
+				{ refId: 47, documentEpoch: 4 },
+			],
+		});
 		let clickAttempts = 0;
 		const result = await prepareXReply(
 			{
@@ -1124,15 +1141,45 @@ describe("prepareXReply", () => {
 
 		expect(result.prepared).toBe(true);
 		expect(clickAttempts).toBe(2);
-		// The tree was re-extracted (fresh epoch) so the retry click had a valid
-		// ref; the second click_ref recorded against the healthy dispatcher.
 		const trees = calls.filter((c) => c.action === "get_accessibility_tree");
-		expect(trees.length).toBeGreaterThanOrEqual(2);
+		expect(trees).toHaveLength(2);
 		const clicks = calls.filter((c) => c.action === "click_ref");
 		expect(clicks).toHaveLength(1);
-		// The type uses the retry's ref — the one that actually succeeded.
 		const typed = calls.find((c) => c.action === "type_ref");
-		expect(typed?.input.ref).toEqual({ ref_id: 36, document_epoch: 3 });
+		expect(typed?.input.ref).toEqual({ ref_id: 47, document_epoch: 4 });
+	});
+
+	test("retries the focus and type once when typing hits a stale a11y ref", async () => {
+		const { dispatcher, calls } = stagingDispatcher({
+			a11ySnapshots: [
+				{ refId: 36, documentEpoch: 3 },
+				{ refId: 47, documentEpoch: 4 },
+			],
+		});
+		let typeAttempts = 0;
+		const result = await prepareXReply(
+			{
+				dispatch: async (action, input) => {
+					if (action === "type_ref") {
+						typeAttempts += 1;
+						if (typeAttempts === 1) {
+							throw new Error("type_ref: stale ref (epoch 3)");
+						}
+					}
+					return dispatcher.dispatch(action, input);
+				},
+			},
+			{ tweetUrl: "2083959735481716957", body: "hi" },
+		);
+
+		expect(result.prepared).toBe(true);
+		expect(typeAttempts).toBe(2);
+		expect(
+			calls.filter((c) => c.action === "get_accessibility_tree"),
+		).toHaveLength(2);
+		expect(calls.filter((c) => c.action === "click_ref")).toHaveLength(2);
+		const typed = calls.find((c) => c.action === "type_ref");
+		expect(typed?.input.ref).toEqual({ ref_id: 47, document_epoch: 4 });
 	});
 
 	test("fails when the composer click stays stale across the retry", async () => {

--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -1101,6 +1101,57 @@ describe("prepareXReply", () => {
 		).rejects.toThrow(/could not locate the reply composer/);
 	});
 
+	// X re-renders the timeline in place, so a ref captured before a render can
+	// go stale between get_accessibility_tree and click_ref. The action must
+	// re-extract and retry the click once instead of failing on a transient race.
+	test("retries once when the composer click hits a stale a11y ref", async () => {
+		const { dispatcher, calls } = stagingDispatcher();
+		let clickAttempts = 0;
+		const result = await prepareXReply(
+			{
+				dispatch: async (action, input) => {
+					if (action === "click_ref") {
+						clickAttempts += 1;
+						if (clickAttempts === 1) {
+							throw new Error("click_ref: stale ref (epoch 3)");
+						}
+					}
+					return dispatcher.dispatch(action, input);
+				},
+			},
+			{ tweetUrl: "2083959735481716957", body: "hi" },
+		);
+
+		expect(result.prepared).toBe(true);
+		expect(clickAttempts).toBe(2);
+		// The tree was re-extracted (fresh epoch) so the retry click had a valid
+		// ref; the second click_ref recorded against the healthy dispatcher.
+		const trees = calls.filter((c) => c.action === "get_accessibility_tree");
+		expect(trees.length).toBeGreaterThanOrEqual(2);
+		const clicks = calls.filter((c) => c.action === "click_ref");
+		expect(clicks).toHaveLength(1);
+		// The type uses the retry's ref — the one that actually succeeded.
+		const typed = calls.find((c) => c.action === "type_ref");
+		expect(typed?.input.ref).toEqual({ ref_id: 36, document_epoch: 3 });
+	});
+
+	test("fails when the composer click stays stale across the retry", async () => {
+		const { dispatcher } = stagingDispatcher();
+		await expect(
+			prepareXReply(
+				{
+					dispatch: async (action, input) => {
+						if (action === "click_ref") {
+							throw new Error("click_ref: stale ref (epoch 3)");
+						}
+						return dispatcher.dispatch(action, input);
+					},
+				},
+				{ tweetUrl: "2083959735481716957", body: "hi" },
+			),
+		).rejects.toThrow(/stale ref/);
+	});
+
 	test("refuses when the located node is a submit control", async () => {
 		const { dispatcher } = stagingDispatcher({ composerName: "Reply" });
 		await expect(

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -2098,6 +2098,12 @@ interface XA11yNode {
 	name?: string;
 }
 
+/** A captured accessibility-tree ref: valid only for the tab + document epoch. */
+interface XA11yRef {
+	ref_id: number;
+	document_epoch: number;
+}
+
 /**
  * Read back what actually landed in the composer, so the caller can fail loudly
  * instead of reporting a staged draft that is not there.
@@ -2223,42 +2229,67 @@ export async function prepareXReply(
 		allowed_origins: X_ALLOWED_ORIGINS,
 	});
 
-	const tree = await safeDispatch.dispatch<{
-		tree?: XA11yNode[];
-		document_epoch?: number;
-	}>("get_accessibility_tree", {
-		tab_id: tabId,
-		filter: "interactive",
-		allowed_origins: X_ALLOWED_ORIGINS,
-	});
-	const nodes = Array.isArray(tree.tree) ? tree.tree : [];
-	// X labels the reply box "Post text" today. Prefer that, but fall back to the
-	// first textbox so a relabel degrades instead of breaking — the submit-label
-	// check below is what keeps the fallback safe.
-	const textboxes = nodes.filter((n) => n.role === "textbox");
-	const composer =
-		textboxes.find((n) => /post text/i.test(n.name ?? "")) ?? textboxes[0];
-	if (!composer || typeof tree.document_epoch !== "number") {
-		throw new Error(
-			"prepare_reply: could not locate the reply composer in the accessibility tree",
-		);
-	}
-	// Belt and braces: the a11y name is X's, not ours. If a relabelled node ever
-	// matches the textbox lookup, refuse rather than click a submit control.
-	if (isReplySubmitLabel(composer.name)) {
-		throw new Error(
-			`prepare_reply: refusing to click "${composer.name}" — that is a submit control, not the composer`,
-		);
-	}
-	// The ref is only valid for this tab + document snapshot.
-	const ref = { ref_id: composer.ref_id, document_epoch: tree.document_epoch };
+	// Focus the reply composer, retrying the a11y ref once on a stale snapshot.
+	// X re-renders the timeline in place, so a ref captured before a render can
+	// go stale between get_accessibility_tree and click_ref ("stale ref (epoch
+	// N)"). Re-extracting and retrying once clears a transient render race;
+	// two stale refs in a row mean the page is genuinely unstable, so we fail
+	// loudly rather than type into the wrong element.
+	const focusComposer = async (): Promise<XA11yRef> => {
+		for (let attempt = 0; attempt < 2; attempt++) {
+			const tree = await safeDispatch.dispatch<{
+				tree?: XA11yNode[];
+				document_epoch?: number;
+			}>("get_accessibility_tree", {
+				tab_id: tabId,
+				filter: "interactive",
+				allowed_origins: X_ALLOWED_ORIGINS,
+			});
+			const nodes = Array.isArray(tree.tree) ? tree.tree : [];
+			// X labels the reply box "Post text" today. Prefer that, but fall back to
+			// the first textbox so a relabel degrades instead of breaking — the
+			// submit-label check below is what keeps the fallback safe.
+			const textboxes = nodes.filter((n) => n.role === "textbox");
+			const composer =
+				textboxes.find((n) => /post text/i.test(n.name ?? "")) ??
+				textboxes[0];
+			if (!composer || typeof tree.document_epoch !== "number") {
+				throw new Error(
+					"prepare_reply: could not locate the reply composer in the accessibility tree",
+				);
+			}
+			// Belt and braces: the a11y name is X's, not ours. If a relabelled node
+			// ever matches the textbox lookup, refuse rather than click a submit
+			// control.
+			if (isReplySubmitLabel(composer.name)) {
+				throw new Error(
+					`prepare_reply: refusing to click "${composer.name}" — that is a submit control, not the composer`,
+				);
+			}
+			// The ref is only valid for this tab + document snapshot.
+			const freshRef: XA11yRef = {
+				ref_id: composer.ref_id,
+				document_epoch: tree.document_epoch,
+			};
+			try {
+				await safeDispatch.dispatch("click_ref", {
+					tab_id: tabId,
+					ref: freshRef,
+					allowed_click: "reply_open",
+					allowed_origins: X_ALLOWED_ORIGINS,
+				});
+				return freshRef;
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				if (/stale ref/.test(message) && attempt === 0) continue;
+				throw error;
+			}
+		}
+		throw new Error("prepare_reply: could not focus the reply composer");
+	};
+	const ref = await focusComposer();
 
-	await safeDispatch.dispatch("click_ref", {
-		tab_id: tabId,
-		ref,
-		allowed_click: "reply_open",
-		allowed_origins: X_ALLOWED_ORIGINS,
-	});
 	await safeDispatch.dispatch("type_ref", {
 		tab_id: tabId,
 		ref,

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -2098,12 +2098,6 @@ interface XA11yNode {
 	name?: string;
 }
 
-/** A captured accessibility-tree ref: valid only for the tab + document epoch. */
-interface XA11yRef {
-	ref_id: number;
-	document_epoch: number;
-}
-
 /**
  * Read back what actually landed in the composer, so the caller can fail loudly
  * instead of reporting a staged draft that is not there.
@@ -2229,74 +2223,65 @@ export async function prepareXReply(
 		allowed_origins: X_ALLOWED_ORIGINS,
 	});
 
-	// Focus the reply composer, retrying the a11y ref once on a stale snapshot.
-	// X re-renders the timeline in place, so a ref captured before a render can
-	// go stale between get_accessibility_tree and click_ref ("stale ref (epoch
-	// N)"). Re-extracting and retrying once clears a transient render race;
-	// two stale refs in a row mean the page is genuinely unstable, so we fail
-	// loudly rather than type into the wrong element.
-	const focusComposer = async (): Promise<XA11yRef> => {
-		for (let attempt = 0; attempt < 2; attempt++) {
-			const tree = await safeDispatch.dispatch<{
-				tree?: XA11yNode[];
-				document_epoch?: number;
-			}>("get_accessibility_tree", {
-				tab_id: tabId,
-				filter: "interactive",
-				allowed_origins: X_ALLOWED_ORIGINS,
-			});
-			const nodes = Array.isArray(tree.tree) ? tree.tree : [];
-			// X labels the reply box "Post text" today. Prefer that, but fall back to
-			// the first textbox so a relabel degrades instead of breaking — the
-			// submit-label check below is what keeps the fallback safe.
-			const textboxes = nodes.filter((n) => n.role === "textbox");
-			const composer =
-				textboxes.find((n) => /post text/i.test(n.name ?? "")) ??
-				textboxes[0];
-			if (!composer || typeof tree.document_epoch !== "number") {
-				throw new Error(
-					"prepare_reply: could not locate the reply composer in the accessibility tree",
-				);
-			}
-			// Belt and braces: the a11y name is X's, not ours. If a relabelled node
-			// ever matches the textbox lookup, refuse rather than click a submit
-			// control.
-			if (isReplySubmitLabel(composer.name)) {
-				throw new Error(
-					`prepare_reply: refusing to click "${composer.name}" — that is a submit control, not the composer`,
-				);
-			}
-			// The ref is only valid for this tab + document snapshot.
-			const freshRef: XA11yRef = {
-				ref_id: composer.ref_id,
-				document_epoch: tree.document_epoch,
-			};
-			try {
-				await safeDispatch.dispatch("click_ref", {
-					tab_id: tabId,
-					ref: freshRef,
-					allowed_click: "reply_open",
-					allowed_origins: X_ALLOWED_ORIGINS,
-				});
-				return freshRef;
-			} catch (error) {
-				const message =
-					error instanceof Error ? error.message : String(error);
-				if (/stale ref/.test(message) && attempt === 0) continue;
-				throw error;
-			}
+	// Both click_ref and type_ref reject an accessibility ref after X re-renders
+	// the document. Re-extract and retry the whole focus-and-type sequence once;
+	// a second stale ref still fails loudly.
+	const stageDraftOnce = async () => {
+		const tree = await safeDispatch.dispatch<{
+			tree?: XA11yNode[];
+			document_epoch?: number;
+		}>("get_accessibility_tree", {
+			tab_id: tabId,
+			filter: "interactive",
+			allowed_origins: X_ALLOWED_ORIGINS,
+		});
+		const nodes = Array.isArray(tree.tree) ? tree.tree : [];
+		// X labels the reply box "Post text" today. Prefer that, but fall back to
+		// the first textbox so a relabel degrades instead of breaking — the
+		// submit-label check below is what keeps the fallback safe.
+		const textboxes = nodes.filter((n) => n.role === "textbox");
+		const composer =
+			textboxes.find((n) => /post text/i.test(n.name ?? "")) ?? textboxes[0];
+		if (!composer || typeof tree.document_epoch !== "number") {
+			throw new Error(
+				"prepare_reply: could not locate the reply composer in the accessibility tree",
+			);
 		}
-		throw new Error("prepare_reply: could not focus the reply composer");
+		// Belt and braces: the a11y name is X's, not ours. If a relabelled node
+		// ever matches the textbox lookup, refuse rather than click a submit
+		// control.
+		if (isReplySubmitLabel(composer.name)) {
+			throw new Error(
+				`prepare_reply: refusing to click "${composer.name}" — that is a submit control, not the composer`,
+			);
+		}
+		const ref = {
+			ref_id: composer.ref_id,
+			document_epoch: tree.document_epoch,
+		};
+		await safeDispatch.dispatch("click_ref", {
+			tab_id: tabId,
+			ref,
+			allowed_click: "reply_open",
+			allowed_origins: X_ALLOWED_ORIGINS,
+		});
+		await safeDispatch.dispatch("type_ref", {
+			tab_id: tabId,
+			ref,
+			text: body,
+			clear_first: true,
+			allowed_origins: X_ALLOWED_ORIGINS,
+		});
 	};
-	const ref = await focusComposer();
-
-	await safeDispatch.dispatch("type_ref", {
-		tab_id: tabId,
-		ref,
-		text: body,
-		clear_first: true,
-		allowed_origins: X_ALLOWED_ORIGINS,
-	});
+	try {
+		await stageDraftOnce();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!/^(?:click_ref|type_ref): stale ref \(epoch \d+\)$/.test(message)) {
+			throw error;
+		}
+		await stageDraftOnce();
+	}
 
 	const read = await safeDispatch.dispatch<{
 		value?: {
@@ -2373,7 +2358,7 @@ export default class XConnector extends ConnectorRuntime {
 		name: "X (Twitter)",
 		description:
 			"Fetches tweets, likes, bookmarks, and DMs via the X API v2 or the paired Owletto Chrome extension. Links authors and DM counterparts into the person identity graph.",
-		version: "3.12.0",
+		version: "3.12.1",
 		faviconDomain: "x.com",
 		authSchema: {
 			methods: [


### PR DESCRIPTION
## Summary

Two fixes for the browser-handoff draft flow, found by testing live on the Mac mini:

1. **X `prepare_reply` stale-ref retry** (connectors): X re-renders the timeline in place, so a composer ref captured in `get_accessibility_tree` can go stale before `click_ref` (seen as `click_ref: stale ref (epoch N)` in prod runs 951919/951511). Re-extract and retry the click once; two stale refs fail loudly rather than type into the wrong element.
2. **Owletto pointer bump → `13dfa2105`** (#843): Open post now opens a fresh tab instead of hijacking the active one — kills the `enforceAllowedOrigin` (active tab on chatgpt.com) and `active_tab_is_extension_owned` failures, and never yanks the user away from what they had open.

## Test plan
- [x] Intended files staged explicitly (will run `make pre-pr-remote` after PR creation)
- [x] Tests run: `bun test packages/connectors/src/__tests__/x.test.ts` (60 pass, incl. new stale-ref retry + fail-loudly cases); owletto `extension-bridge.test.tsx` (3), `bridge.test.js` (2), attention-inbox + peek suites (31) all green
- [x] Bug fix: reproduced live (run 954414 completed, draft staged in X composer on Mac mini; runs 951919/951511 failed with stale ref); fixed + unit-tested

## Notes
Owletto #843 merged as `13dfa2105`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reply composition reliability when accessibility references become outdated.
  * The composer now refreshes accessibility information and retries once automatically, reducing interaction failures.
  * Invalid or missing composer controls continue to be handled safely, while repeated failures are reported clearly.
  * Updated the connector for improved stability.

* **Tests**
  * Added coverage for successful recovery and expected failure scenarios involving stale accessibility references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->