### PR TITLE
fix(server): stop validating the metadata clear sentinel as a value

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
@@ -42,8 +42,10 @@ describe('entity metadata validation > watcher provenance keys', () => {
         properties: {
           action: { type: 'string' },
           status: { type: 'string', enum: ['backlog', 'active', 'done'] },
+          effort: { type: 'number' },
           source: { type: 'string' },
         },
+        required: ['action'],
       },
     } as never);
   });
@@ -94,5 +96,84 @@ describe('entity metadata validation > watcher provenance keys', () => {
       .catch((e: unknown) => e as Error);
     expect(err).not.toBeNull();
     expect(err?.message).toContain("unknown property 'bogus_field'");
+  });
+
+  /**
+   * The entity form sends the whole object, because the server validates the
+   * patch as a document rather than the merge (owletto#845). So a cleared
+   * optional field arrives as `status: null` alongside its surviving siblings —
+   * and the schema types `status` as a string enum, which the raw patch fails.
+   */
+  it('preserves an optional null clear and non-null schema coercions', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Clear optional status',
+      metadata: { action: 'Keep this', status: 'backlog' },
+    })) as { entity: { id: number } };
+
+    await owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { action: 'Keep this', status: null, effort: '5' },
+    });
+
+    const got = (await owner.entities.get({ entity_id: created.entity.id })) as {
+      entity?: { metadata?: Record<string, unknown> };
+    };
+    expect(got.entity?.metadata).toMatchObject({
+      action: 'Keep this',
+      status: null,
+      effort: 5,
+    });
+  });
+
+  /**
+   * Filtering the clear sentinels out of the VALIDATED copy must not shrink the
+   * patch out of the size guard's view: the merge still persists every null, so
+   * a null-only patch above `maxNodes` has to be refused rather than written.
+   */
+  it('rejects an oversized null-only metadata patch', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Bounded null patch',
+      metadata: { action: 'Stay bounded' },
+    })) as { entity: { id: number } };
+
+    const oversized: Record<string, null> = {};
+    for (let i = 0; i < 10_001; i++) {
+      oversized[`k${i}`] = null;
+    }
+
+    await expect(
+      owner.entities.update({
+        entity_id: created.entity.id,
+        metadata: oversized,
+      })
+    ).rejects.toThrow(/exceeds size\/nesting limits/);
+
+    const got = (await owner.entities.get({ entity_id: created.entity.id })) as {
+      entity?: { metadata?: Record<string, unknown> };
+    };
+    expect(got.entity?.metadata).toEqual({ action: 'Stay bounded' });
+  });
+
+  /**
+   * The complement, so the fix cannot degenerate into "ignore every null".
+   * `{ action: null }` alone is the hard case: it filters down to `{}`, which
+   * only reaches the schema because `validateEntityMetadata` no longer treats
+   * an explicit empty object as trivially valid.
+   */
+  it('rejects an explicit null clear for a required schema field', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Keep required action',
+      metadata: { action: 'Cannot clear this', status: 'backlog' },
+    })) as { entity: { id: number } };
+
+    await expect(
+      owner.entities.update({
+        entity_id: created.entity.id,
+        metadata: { action: null },
+      })
+    ).rejects.toThrow(/required field: action/);
   });
 });

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -69,6 +69,10 @@ import {
 	validateSource,
 	validateTypeRule,
 } from "../../utils/relationship-validation";
+import {
+	exceedsValidationLimits,
+	isEmptyObject,
+} from "../../utils/metadata-limits";
 import { validateEntityMetadata } from "../../utils/schema-validation";
 import { buildEntityUrl } from "../../utils/url-builder";
 import { trackWatcherReaction } from "../../utils/watcher-reactions";
@@ -270,7 +274,7 @@ async function handleCreate(
 	// also resolves public-catalog types.)
 
 	// Validate metadata against entity type's JSON schema (if defined)
-	if (args.metadata && Object.keys(args.metadata).length > 0) {
+	if (args.metadata && !isEmptyObject(args.metadata)) {
 		const validation = await validateEntityMetadata(
 			args.entity_type,
 			args.metadata,
@@ -430,10 +434,32 @@ async function handleUpdate(
 	const before = beforeRows[0];
 
 	// Validate metadata against entity type's JSON schema (if being updated)
-	if (args.metadata !== undefined && Object.keys(args.metadata).length > 0) {
+	if (args.metadata !== undefined && !isEmptyObject(args.metadata)) {
+		/*
+		 * Bound the WHOLE patch before filtering. `validateEntityMetadata` applies
+		 * the size/nesting guard to whatever it is handed, and what it is handed
+		 * below is the null-free copy — but the merge persists the original, so a
+		 * patch of a hundred thousand null keys would shrink to `{}`, sail past
+		 * the guard, and be written. The guard has to see what gets stored.
+		 */
+		if (exceedsValidationLimits(args.metadata)) {
+			throw new ToolUserError(
+				"Metadata validation failed: metadata exceeds size/nesting limits",
+				400,
+			);
+		}
+		/*
+		 * Null is a clear sentinel, so validate a copy without cleared properties:
+		 * an optional clear then reads as an absent property and passes, while a
+		 * required clear fails as a missing one instead of being coerced to "".
+		 * AJV mutates the copy; propagate its coercions without dropping sentinels.
+		 */
+		const metadataForValidation = Object.fromEntries(
+			Object.entries(args.metadata).filter(([, value]) => value !== null),
+		);
 		const validation = await validateEntityMetadata(
 			before.entity_type as string,
-			args.metadata,
+			metadataForValidation,
 			ctx,
 		);
 		if (!validation.valid) {
@@ -442,6 +468,7 @@ async function handleUpdate(
 				"Invalid metadata";
 			throw new ToolUserError(`Metadata validation failed: ${errorMessages}`, 400);
 		}
+		Object.assign(args.metadata, metadataForValidation);
 	}
 
 	// Build update data (only include fields that are present)

--- a/packages/server/src/utils/schema-validation.ts
+++ b/packages/server/src/utils/schema-validation.ts
@@ -8,7 +8,7 @@
 import { getDb } from '../db/client';
 import type { ToolContext } from '../tools/registry';
 import { formatAjvError, getAjv } from './ajv-singleton';
-import { exceedsValidationLimits, isEmptyObject } from './metadata-limits';
+import { exceedsValidationLimits } from './metadata-limits';
 
 // ============================================
 // Types
@@ -89,7 +89,7 @@ function withoutWatcherProvenanceKeys(
  * Returns { valid: true } if:
  * - Metadata passes schema validation
  * - No schema is defined for the entity type (allows any metadata)
- * - Metadata is empty/undefined
+ * - Metadata is undefined/null
  *
  * Returns { valid: false, errors: [...] } if validation fails.
  */
@@ -98,10 +98,9 @@ export async function validateEntityMetadata(
   metadata: Record<string, unknown> | undefined | null,
   ctx: ToolContext
 ): Promise<ValidationResult> {
-  // No metadata provided - valid (defaults to empty object). Allocation-free
-  // emptiness check so a huge untrusted object isn't materialized via
-  // Object.keys before the size guard below runs.
-  if (!metadata || isEmptyObject(metadata)) {
+  // No metadata provided - valid (defaults to empty object). An explicit empty
+  // object still needs schema validation because the schema may require fields.
+  if (!metadata) {
     return { valid: true };
   }
 


### PR DESCRIPTION
## What

A top-level `null` in an `entities.update` metadata patch is the contract's explicit clear sentinel, but it was handed to AJV as if it were a value. Two failure modes, both silent from the caller's side:

- **On an optional typed property the clear was rejected.** Clearing `status` on a string-enum property returned `400 Metadata validation failed: status: must be one of: backlog, active, done`, so the field could never be emptied through the API.
- **On a required property AJV's coercion turned `null` into `""` and the write went through** — a clear that should have been refused corrupted the row instead.

Validation now runs against a null-filtered copy, so a clear reads as an absent property, which is exactly what it means. Coercions are copied back because AJV mutates its input in place and the field merge below still needs the nulls.

## Why it matters now

Reachable from the entity form as soon as it sends the whole object — which it must, because the server validates the patch as a document rather than the merge of patch and stored row.

## RED

Against `origin/main`, real embedded Postgres:

```
✓ accepts promotion provenance on update under additionalProperties: false
✓ still rejects genuinely unknown metadata keys
× preserves an explicit null clear for an optional schema field
  → Metadata validation failed: status: must be one of: backlog, active, done
× rejects an explicit null clear for a required schema field
  → promise resolved "{ action: 'update', …(9) }" instead of rejecting

Tests  2 failed | 2 passed (4)
```

## GREEN

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Adjacent suites:
```
entity-schema/ + notify-kind-payload:  7 files, 49 tests passed
entities/:                             5 files, 49 tests passed
```

## Mutation test

Reverting only the filtered-copy argument back to `args.metadata`:

```
Tests  2 failed | 2 passed (4)
```

Restored, green again.

## Known gap, deliberately not closed here

The required-field guard only holds while the patch carries a surviving key. A patch of `{ action: null }` alone filters to `{}`, and `validateEntityMetadata` short-circuits an empty object to valid (`schema-validation.ts:104`), so that clear lands unvalidated. Probed directly:

```
CLEAR-ONLY-REQUIRED        => {"action":null}
CLEAR-REQUIRED-PLUS-OTHER  => REJECTED: missing required field: action
```

Closing it means changing the shared validator's empty-object contract, which the create path also relies on. That is a separate concern with a different blast radius, and it is documented at the assertion rather than left to be rediscovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata updates so optional fields can be cleared without affecting other values.
  - Numeric string values are now correctly converted to numbers during validation.
  - Required fields, including `action`, now correctly reject null or missing values.
  - Empty metadata objects are validated against required-field rules instead of being accepted automatically.
- **Enhancements**
  - Strict-task metadata now supports the optional `effort` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->