### PR TITLE
fix(security): keep worker tokens out of run history

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/list-runs-operational-filters.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/list-runs-operational-filters.test.ts
@@ -10,6 +10,7 @@
  * Proves:
  *  - default list EXCLUDES 'chat_message' transport runs;
  *  - explicit run_types:['chat_message'] still returns them (trace view);
+ *  - trace input secrets are redacted without corrupting run timestamps;
  *  - new connector_key filter narrows to one connector;
  *  - new created_after / created_before date-range filters work;
  *  - invalid date input is a clean error, not a SQL failure.
@@ -48,15 +49,17 @@ describe("manage_operations list_runs — operational filters (#2051)", () => {
 		connection_id?: number | null;
 		connector_key?: string | null;
 		action_key?: string | null;
+		action_input?: Record<string, unknown> | null;
 		status?: string;
 		created_at?: string;
 	}): Promise<number> => {
 		const db = getTestDb();
 		const [row] = (await db`
-      INSERT INTO runs (organization_id, run_type, connection_id, connector_key, action_key, status, created_at, run_at)
+      INSERT INTO runs (organization_id, run_type, connection_id, connector_key, action_key, action_input, status, created_at, run_at)
       VALUES (
         ${orgId}, ${opts.run_type}, ${opts.connection_id ?? null},
         ${opts.connector_key ?? null}, ${opts.action_key ?? null},
+        ${opts.action_input ? db.json(opts.action_input) : null},
         ${opts.status ?? "completed"},
         ${opts.created_at ?? new Date().toISOString()},
         ${opts.created_at ?? new Date().toISOString()}
@@ -117,6 +120,14 @@ describe("manage_operations list_runs — operational filters (#2051)", () => {
 			await insertRun({
 				run_type: "chat_message",
 				action_key: "thread_response",
+				action_input:
+					i === 0
+						? {
+								runJobToken: "live-worker-bearer",
+								nested: { authorization: "Bearer live-worker-bearer" },
+								safe: "trace context",
+							}
+						: null,
 				created_at: `2026-07-15T12:00:0${i}Z`,
 			});
 		}
@@ -141,6 +152,26 @@ describe("manage_operations list_runs — operational filters (#2051)", () => {
 		const { runs, total } = await listRuns({ run_types: ["chat_message"] });
 		expect(total).toBe(5);
 		expect(runs.every((r) => r.run_type === "chat_message")).toBe(true);
+	});
+
+	it("redacts bearer credentials from the explicit trace view", async () => {
+		const { runs } = await listRuns({ run_types: ["chat_message"] });
+		const credentialBearing = runs.find(
+			(run) =>
+				(run.input as { safe?: string } | null)?.safe === "trace context",
+		);
+		expect(credentialBearing?.input).toEqual({
+			runJobToken: "__LOBU_REDACTED__",
+			nested: { authorization: "__LOBU_REDACTED__" },
+			safe: "trace context",
+		});
+		expect(JSON.stringify(credentialBearing)).not.toContain(
+			"live-worker-bearer",
+		);
+		expect(credentialBearing?.created_at).toBeInstanceOf(Date);
+		expect((credentialBearing?.created_at as Date).toISOString()).toBe(
+			"2026-07-15T12:00:00.000Z",
+		);
 	});
 
 	it("filters by connector_key", async () => {

--- a/packages/server/src/gateway/__tests__/worker-job-router.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-job-router.test.ts
@@ -6,7 +6,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __resetEncryptionKeyCacheForTests,
-  encrypt,
   verifyWorkerToken,
 } from "@lobu/core";
 import { WorkerConnectionManager } from "../worker-dispatch/connection-manager.js";
@@ -90,22 +89,7 @@ describe("WorkerJobRouter", () => {
       expect(queue.getQueue("thread_message_worker-3")).toBeDefined();
     });
 
-    test("re-enqueues durable pending inputs with a freshly minted run token", async () => {
-      const agedToken = encrypt(
-        JSON.stringify({
-          userId: "user",
-          conversationId: "conversation",
-          channelId: "channel",
-          agentId: "agent",
-          organizationId: "org",
-          deploymentName: "worker-1",
-          platform: "api",
-          runId: 42,
-          messageId: "durable-message",
-          timestamp: Date.now() - 3 * 60 * 60 * 1000,
-        }),
-      );
-      expect(verifyWorkerToken(agedToken)).toBeNull();
+    test("re-enqueues durable pending inputs without persisting a bearer token", async () => {
       const payload = {
         botId: "bot",
         userId: "user",
@@ -119,7 +103,6 @@ describe("WorkerJobRouter", () => {
         platformMetadata: {},
         agentOptions: {},
         runId: 42,
-        runJobToken: agedToken,
       };
       const input = {
         payload,
@@ -147,17 +130,11 @@ describe("WorkerJobRouter", () => {
       await router.registerWorker("worker-1");
 
       expect(send).toHaveBeenCalledTimes(1);
-      const replayed = send.mock.calls[0]?.[1] as typeof payload;
-      expect(replayed.runJobToken).not.toBe(agedToken);
-      expect(verifyWorkerToken(replayed.runJobToken)).toEqual(
-        expect.objectContaining({
-          userId: payload.userId,
-          organizationId: payload.organizationId,
-          deploymentName: "worker-1",
-          runId: payload.runId,
-          messageId: payload.messageId,
-        }),
-      );
+      const replayed = send.mock.calls[0]?.[1] as typeof payload & {
+        __lobuDurableReplay?: boolean;
+      };
+      expect(replayed).toEqual({ ...payload, __lobuDurableReplay: true });
+      expect("runJobToken" in replayed).toBe(false);
       expect(send).toHaveBeenCalledWith(
         "thread_message_worker-1",
         replayed,
@@ -174,6 +151,119 @@ describe("WorkerJobRouter", () => {
   });
 
   describe("Job Routing", () => {
+    test("mints the replay token only after the tokenless queue row is claimed", async () => {
+      const payload = {
+        botId: "bot",
+        userId: "user",
+        organizationId: "org",
+        agentId: "agent",
+        conversationId: "conversation",
+        platform: "api",
+        channelId: "channel",
+        messageId: "durable-message",
+        messageText: "steer this run",
+        platformMetadata: {},
+        agentOptions: {},
+        runId: 42,
+      };
+      const input = {
+        payload,
+        tokenClaims: {
+          userId: payload.userId,
+          conversationId: payload.conversationId,
+          channelId: payload.channelId,
+          agentId: payload.agentId,
+          organizationId: payload.organizationId,
+          deploymentName: "worker-1",
+          platform: payload.platform,
+          runId: payload.runId,
+          messageId: payload.messageId,
+        },
+      };
+      const loadPendingInput = mock(async () => input);
+      router.shutdown();
+      router = new WorkerJobRouter(
+        queue as any,
+        connectionManager,
+        async () => [],
+        loadPendingInput,
+      );
+      const res = new MockResponse() as any;
+      connectionManager.addConnection(
+        "worker-1",
+        "user",
+        "conversation",
+        "agent",
+        res,
+      );
+      await router.registerWorker("worker-1");
+      res.clearWrites();
+
+      const routePromise = queue.addJob("thread_message_worker-1", {
+        id: "replay-job",
+        data: { ...payload, __lobuDurableReplay: true },
+      });
+      await TestHelpers.delay(0);
+      const jobEvent = TestHelpers.parseSSE(res.getAllWrites()).find(
+        (event) => event.event === "job",
+      );
+      const delivered = jobEvent?.data?.payload as
+        | (typeof payload & { runJobToken?: string })
+        | undefined;
+      expect(loadPendingInput).toHaveBeenCalledWith({
+        organizationId: "org",
+        deploymentName: "worker-1",
+        messageId: "durable-message",
+        runId: 42,
+      });
+      expect(typeof delivered?.runJobToken).toBe("string");
+      expect(delivered).not.toHaveProperty("__lobuDurableReplay");
+      expect(verifyWorkerToken(delivered?.runJobToken ?? "")).toEqual(
+        expect.objectContaining({
+          organizationId: "org",
+          deploymentName: "worker-1",
+          messageId: "durable-message",
+          runId: 42,
+        }),
+      );
+      router.acknowledgeJob("replay-job");
+      await routePromise;
+    });
+
+    test("fails closed when a tokenless replay has no pending durable input", async () => {
+      const loadPendingInput = mock(async () => null);
+      router.shutdown();
+      router = new WorkerJobRouter(
+        queue as any,
+        connectionManager,
+        async () => [],
+        loadPendingInput,
+      );
+      const res = new MockResponse() as any;
+      connectionManager.addConnection(
+        "worker-1",
+        "user",
+        "conversation",
+        "agent",
+        res,
+      );
+      await router.registerWorker("worker-1");
+      res.clearWrites();
+
+      await expect(
+        queue.addJob("thread_message_worker-1", {
+          id: "missing-replay-job",
+          data: {
+            organizationId: "org",
+            messageId: "durable-message",
+            runId: 42,
+            __lobuDurableReplay: true,
+          },
+        }),
+      ).rejects.toThrow("Durable agent input missing for replayed run 42");
+      expect(res.getAllWrites()).toBe("");
+    });
+
     test("routes job to connected worker via SSE", async () => {
       const res = new MockResponse() as any;
       connectionManager.addConnection(

--- a/packages/server/src/gateway/orchestration/agent-run-input.ts
+++ b/packages/server/src/gateway/orchestration/agent-run-input.ts
@@ -16,6 +16,13 @@ export interface PendingAgentRunInput {
   tokenClaims: DurableRunTokenClaims;
 }
 
+export interface PendingAgentRunInputRef {
+  organizationId: string;
+  deploymentName: string;
+  messageId: string;
+  runId: number;
+}
+
 function durableClaims(token: WorkerTokenData): DurableRunTokenClaims {
   return {
     userId: token.userId,
@@ -206,6 +213,34 @@ export async function listPendingAgentRunInputs(
     payload: row.payload,
     tokenClaims: row.token_claims,
   }));
+}
+
+/**
+ * Resolve one replay input by its durable primary-key scope. Worker queue rows
+ * deliberately omit the bearer token; the owner pod re-mints it only after
+ * claiming the row, immediately before SSE delivery.
+ */
+export async function getPendingAgentRunInput(
+  ref: PendingAgentRunInputRef,
+): Promise<PendingAgentRunInput | null> {
+  const sql = getDb();
+  const rows = await sql<{
+    payload: MessagePayload;
+    token_claims: DurableRunTokenClaims;
+  }>`
+    SELECT payload, token_claims
+    FROM public.agent_run_input
+    WHERE organization_id = ${ref.organizationId}
+      AND deployment_name = ${ref.deploymentName}
+      AND message_id = ${ref.messageId}
+      AND run_id = ${ref.runId}
+      AND status = 'pending'
+    LIMIT 1
+  `;
+  const row = rows[0];
+  return row
+    ? { payload: row.payload, tokenClaims: row.token_claims }
+    : null;
 }
 
 export async function completeAgentRunInputs(

--- a/packages/server/src/gateway/worker-dispatch/job-router.ts
+++ b/packages/server/src/gateway/worker-dispatch/job-router.ts
@@ -4,8 +4,10 @@ import { createLogger } from "@lobu/core";
 import type { IMessageQueue } from "../infrastructure/queue/index.js";
 import {
   attachFreshRunJobToken,
+  getPendingAgentRunInput,
   listPendingAgentRunInputs,
   type PendingAgentRunInput,
+  type PendingAgentRunInputRef,
 } from "../orchestration/agent-run-input.js";
 import type { WorkerConnectionManager } from "./connection-manager.js";
 import {
@@ -47,6 +49,9 @@ export class WorkerJobRouter {
     private loadPendingInputs: (
       deploymentName: string
     ) => Promise<PendingAgentRunInput[]> = listPendingAgentRunInputs,
+    private loadPendingInput: (
+      ref: PendingAgentRunInputRef
+    ) => Promise<PendingAgentRunInput | null> = getPendingAgentRunInput,
   ) {}
 
   /**
@@ -92,7 +97,8 @@ export class WorkerJobRouter {
 
     const pendingInputs = await this.loadPendingInputs(deploymentName);
     for (const input of pendingInputs) {
-      const payload = attachFreshRunJobToken(input);
+      const payload = { ...input.payload, __lobuDurableReplay: true as const };
+      delete payload.runJobToken;
       await this.queue.send(queueName, payload, {
         // Genuine-failure budget only: a replayed input claimed while the
         // reconnected worker is stale/mid-turn is deferred by the dispatch
@@ -184,11 +190,38 @@ export class WorkerJobRouter {
       (job as { id?: string }).id ||
       `job-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
+    let deliveryData = jobData;
+    if (jobData && typeof jobData === "object") {
+      const replay = jobData as Record<string, unknown>;
+      if (
+        replay.__lobuDurableReplay === true &&
+        !(typeof replay.runJobToken === "string" && replay.runJobToken.length > 0) &&
+        typeof replay.organizationId === "string" &&
+        typeof replay.messageId === "string" &&
+        typeof replay.runId === "number" &&
+        Number.isInteger(replay.runId) &&
+        replay.runId > 0
+      ) {
+        const pendingInput = await this.loadPendingInput({
+          organizationId: replay.organizationId,
+          deploymentName,
+          messageId: replay.messageId,
+          runId: replay.runId,
+        });
+        if (!pendingInput) {
+          throw new Error(
+            `Durable agent input missing for replayed run ${replay.runId}`,
+          );
+        }
+        deliveryData = attachFreshRunJobToken(pendingInput);
+      }
+    }
+
     // Send job to worker via SSE with jobId wrapped in payload
     const jobPayload =
-      typeof jobData === "object" && jobData !== null
-        ? { payload: jobData, jobId: jobId }
-        : { payload: { data: jobData }, jobId: jobId };
+      typeof deliveryData === "object" && deliveryData !== null
+        ? { payload: deliveryData, jobId: jobId }
+        : { payload: { data: deliveryData }, jobId: jobId };
 
     const sent = this.connectionManager.sendSSE(
       connection.writer,

--- a/packages/server/src/tools/admin/manage_operations/handlers/runs.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/runs.ts
@@ -1,3 +1,4 @@
+import { deepRedactSecrets } from "@lobu/core";
 import {
 	GetRunAction,
 	LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES,
@@ -63,7 +64,7 @@ function publicBehaviorFields(value: unknown): unknown {
 function publicRunRecord(
 	row: Record<string, unknown>,
 ): Record<string, unknown> {
-	return {
+	const publicRecord: Record<string, unknown> = {
 		...row,
 		input:
 			row.run_type === "internal" &&
@@ -76,6 +77,12 @@ function publicRunRecord(
 			row.initiator_kind === "behavior"
 				? publicBehaviorFields(row.initiator_ref)
 				: row.initiator_ref,
+	};
+	const { created_at, completed_at, ...redactable } = publicRecord;
+	return {
+		...(deepRedactSecrets(redactable) as Record<string, unknown>),
+		created_at,
+		completed_at,
 	};
 }
 


### PR DESCRIPTION
## Summary

- Deep-redact secret-shaped values from member-readable operation run history while preserving Date-valued timestamps.
- Keep worker job tokens out of durable replay queue payloads; marker-bearing replays reload the exact pending input and mint a fresh token only after a worker claims the job.
- Fail closed when durable replay input is missing, without changing ordinary tokenless dispatches.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: targeted Bun/Vitest suites plus server typecheck
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red → green

Before the fix, the list-runs integration regression observed the raw run job token in the public `action_input`, and the replay router regression observed that same token in the persisted queue payload. The first full remote gate also exposed nine ordinary tokenless-dispatch failures, which led to the explicit durable-replay marker and canonical tokenless worker payload.

After the fix:

- 66 Bun tests passed across worker job routing, dispatch recycle, turn liveness, and durable-replay parity.
- 7 list-runs Vitest integration tests passed.
- `bun run typecheck` passed in `packages/server`.
- `make pre-pr-remote` passed all 16 Linux CI jobs: Depot run `pt3tdq9q9h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sensitive credentials are now recursively redacted from run records while safe fields remain available.
  - Run timestamps are preserved and returned in the expected format.
  - Replayed jobs now generate fresh access tokens instead of reusing stored tokens.
  - Replays with missing durable input are rejected instead of proceeding with incomplete data.
- **Tests**
  - Added coverage for credential redaction, timestamp preservation, token generation, and invalid replay handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->