### PR TITLE
fix(connectors): align health and deletion lifecycle

### DIFF
--- a/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
+++ b/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
@@ -1,11 +1,12 @@
 /**
- * Connection delete — pending-approval reconcile.
+ * Connection delete — dependent-work reconcile.
  *
  * Deleting a connection makes its pending approvals unreviewable: the approval
  * card disappears from every content read (connection-visibility predicate), so
  * approve/reject would be blind. The delete must transition those runs terminal
  * (expired/cancelled) instead of leaving them dangling behind a "needs
- * approval" notification with nothing to review.
+ * approval" notification with nothing to review. It must also pause retained
+ * feed rows and clear their queued occurrences.
  */
 
 import { randomUUID } from "node:crypto";
@@ -66,7 +67,7 @@ describe("connection delete expires pending approvals", () => {
 		await cleanupTestDatabase();
 	});
 
-	it("transitions a pending approval run on the deleted connection to expired/cancelled", async () => {
+	it("expires pending approval and pauses queued feed work on delete", async () => {
 		const sql = getTestDb();
 		const org = await createTestOrganization({ name: "Acme" });
 		const user = await createTestUser();
@@ -75,6 +76,17 @@ describe("connection delete expires pending approvals", () => {
 			connector_key: "apple.computer_use",
 			created_by: user.id,
 		});
+		const [feed] = await sql`
+			INSERT INTO feeds (
+				organization_id, connection_id, feed_key, display_name,
+				status, kind, schedule, next_run_at, created_at, updated_at
+			) VALUES (
+				${org.id}, ${conn.id}, 'pending-work', 'Pending work',
+				'active', 'collected', '0 * * * *', NOW() + INTERVAL '30 minutes',
+				NOW(), NOW()
+			)
+			RETURNING id
+		`;
 		const runId = await seedPendingApprovalRun({
 			organizationId: org.id,
 			connectionId: conn.id,
@@ -100,6 +112,14 @@ describe("connection delete expires pending approvals", () => {
 		expect(row?.approval_status).toBe("expired");
 		expect(row?.status).toBe("cancelled");
 		expect(row?.completed_at).not.toBeNull();
+		const [feedAfterDelete] = await sql`
+			SELECT status, schedule, next_run_at
+			FROM feeds
+			WHERE id = ${feed.id}
+		`;
+		expect(feedAfterDelete?.status).toBe("paused");
+		expect(feedAfterDelete?.schedule).toBe("0 * * * *");
+		expect(feedAfterDelete?.next_run_at).toBeNull();
 		const [card] = await sql`
 			SELECT interaction_status, metadata
 			FROM current_event_records

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -25,11 +25,18 @@ import {
   type UnhealthyReason,
 } from '../../connectors/connector-health';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
-import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+import {
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
 
 const cfg = DEFAULT_CONNECTOR_HEALTH_CONFIG;
-// Created comfortably outside the min-age grace window so age never masks a flag.
-const OLD = new Date(Date.now() - (cfg.minConnectionAgeHours + 24) * 60 * 60 * 1000);
+// Created comfortably outside every connection-age grace window.
+const OLD = new Date(
+  Date.now() -
+    (Math.max(cfg.minConnectionAgeHours, cfg.zeroFeedsGraceHours) + 24) * 60 * 60 * 1000,
+);
 
 interface SeededConn {
   id: number;
@@ -144,6 +151,31 @@ describe('connector-health alerter', () => {
     orgId = org.id;
     const user = await createTestUser({ email: 'health-owner@test.com' });
     userId = user.id;
+
+    await createTestConnectorDefinition({
+      key: 'linkedin',
+      name: 'LinkedIn',
+      organization_id: orgId,
+      feeds_schema: { posts: {} },
+    });
+    await createTestConnectorDefinition({
+      key: 'market.quotes',
+      name: 'Market Quotes',
+      organization_id: orgId,
+      feeds_schema: {},
+    });
+    await createTestConnectorDefinition({
+      key: 'health.virtual-only',
+      name: 'Virtual-only Health Fixture',
+      organization_id: orgId,
+      feeds_schema: { live_query: { virtual: true } },
+    });
+    await createTestConnectorDefinition({
+      key: 'health.user-managed-only',
+      name: 'User-managed Health Fixture',
+      organization_id: orgId,
+      feeds_schema: { folder: { userManaged: true } },
+    });
 
     // 1. all-feeds-failing: two feeds, both last_sync_status='failed'.
     const allFailing = await seedConnection({
@@ -773,6 +805,87 @@ describe('connector-health alerter', () => {
       SELECT unhealthy_alerted_at FROM connections WHERE id = ${chat.id}
     `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
     expect(row.unhealthy_alerted_at).toBeNull();
+  });
+
+  it('does not apply the zero-feed rule when the definition has no automatic feeds', async () => {
+    const sql = getTestDb();
+    const operationOnly = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'market.quotes',
+      slug: 'operation-only',
+      createdAt: OLD,
+    });
+    const virtualOnly = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'health.virtual-only',
+      slug: 'definition-virtual-only',
+      createdAt: OLD,
+    });
+    const userManagedOnly = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'health.user-managed-only',
+      slug: 'definition-user-managed-only',
+      createdAt: OLD,
+    });
+    await sql`
+      UPDATE connections
+      SET unhealthy_alerted_at = NOW()
+      WHERE id IN (${operationOnly.id}, ${virtualOnly.id}, ${userManagedOnly.id})
+    `;
+
+    const res = await runConnectorHealthCheck();
+    expect(
+      res.details.some(
+        (detail) =>
+          detail.connectionId === operationOnly.id ||
+          detail.connectionId === virtualOnly.id ||
+          detail.connectionId === userManagedOnly.id,
+      ),
+    ).toBe(false);
+
+    const rows = (await sql`
+      SELECT id, unhealthy_alerted_at
+      FROM connections
+      WHERE id IN (${operationOnly.id}, ${virtualOnly.id}, ${userManagedOnly.id})
+      ORDER BY id
+    `) as unknown as Array<{ id: string; unhealthy_alerted_at: Date | null }>;
+    expect(rows).toHaveLength(3);
+    expect(rows.every((row) => row.unhealthy_alerted_at === null)).toBe(true);
+  });
+
+  it('keeps the zero-feed alert fail-closed when the definition is missing', async () => {
+    const missingDefinition = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'health.missing-definition',
+      slug: 'missing-definition',
+      createdAt: OLD,
+    });
+
+    const res = await runConnectorHealthCheck();
+    expect(reasonFor(res.details, missingDefinition.id)).toBe('zero_feeds');
+  });
+
+  it('waits for the zero-feed grace window even after the general minimum age', async () => {
+    expect(cfg.zeroFeedsGraceHours).toBeGreaterThan(cfg.minConnectionAgeHours);
+    const withinZeroFeedGrace = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'linkedin',
+      slug: 'within-zero-feed-grace',
+      createdAt: new Date(
+        Date.now() -
+          ((cfg.minConnectionAgeHours + cfg.zeroFeedsGraceHours) / 2) * 60 * 60 * 1000,
+      ),
+    });
+
+    const res = await runConnectorHealthCheck();
+    expect(res.details.some((detail) => detail.connectionId === withinZeroFeedGrace.id)).toBe(
+      false,
+    );
   });
 
   // A connection waiting on human sign-in is not an operational incident: the

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -249,8 +249,13 @@ interface FeedHealthRow {
   organization_id: string;
   connector_key: string;
   display_name: string | null;
+  connection_created_at: Date | string;
   connection_status: string | null;
   credential_mode: string | null;
+  /** Whether the installed definition declares a non-virtual feed that Lobu
+   *  can create without user-supplied instance config. NULL means no active
+   *  definition was found, preserving the fail-closed zero-feed alert. */
+  connector_has_auto_syncable_feeds: boolean | null;
   auth_profile_status: string | null;
   /** Device pinned but silent for longer than `cfg.deviceOfflineHours`, or its
    *  worker row is gone entirely. */
@@ -286,8 +291,10 @@ async function loadConnectionHealthRows(
       c.organization_id,
       c.connector_key,
       c.display_name,
+      c.created_at AS connection_created_at,
       c.status AS connection_status,
       c.credential_mode,
+      cd.has_auto_syncable_feeds AS connector_has_auto_syncable_feeds,
       ap.status AS auth_profile_status,
       -- Fails CLOSED on a missing/blank worker row: a connection pinned to a
       -- worker that is no longer there is collecting nothing either. (The FK is
@@ -314,6 +321,20 @@ async function loadConnectionHealthRows(
     LEFT JOIN feeds f
       ON f.connection_id = c.id
      AND f.deleted_at IS NULL
+    LEFT JOIN LATERAL (
+      SELECT EXISTS (
+        SELECT 1
+        FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)
+        WHERE COALESCE((declared.config ->> 'virtual')::boolean, false) = false
+          AND COALESCE((declared.config ->> 'userManaged')::boolean, false) = false
+      ) AS has_auto_syncable_feeds
+      FROM connector_definitions definition
+      WHERE definition.key = c.connector_key
+        AND definition.status = 'active'
+        AND definition.organization_id = c.organization_id
+      ORDER BY definition.updated_at DESC
+      LIMIT 1
+    ) cd ON TRUE
     LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     WHERE c.status = 'active'
@@ -409,13 +430,24 @@ function classify(
   const feeds = rows.filter((r) => r.feed_id != null);
   const feedCount = feeds.length;
 
-  // Rule B: active connection, zero non-deleted feeds. (Grace handled by the
-  // query's min-age window — a connection that has existed > min age and still
-  // has no feeds is collecting nothing.)
+  // Rule B: active connection that should have an automatically-created
+  // collector feed but has zero non-deleted feeds after the longer zero-feed
+  // grace window.
   if (feedCount === 0) {
     // Chat rows are transports, not collectors. A channel-less chat connection
     // must not trip the collector-only zero-feed rule.
     if (rows[0]?.credential_mode != null) return null;
+    // Operation-only, virtual-only, and user-managed-only connectors
+    // legitimately have no automatic collector rows. If the definition is
+    // missing, keep the alert fail-closed instead of hiding an install problem.
+    if (rows[0]?.connector_has_auto_syncable_feeds === false) return null;
+    const createdAtMs = tsTimeOrNull(rows[0]?.connection_created_at);
+    if (
+      createdAtMs !== undefined &&
+      nowMs - createdAtMs < cfg.zeroFeedsGraceHours * 60 * 60 * 1000
+    ) {
+      return null;
+    }
     return {
       reason: 'zero_feeds',
       feedCount: 0,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2257,8 +2257,19 @@ export async function handleDelete(
 
     await expirePendingApprovalsBeforeDelete(tx);
 
-    // Preserve the existing lifecycle: feed work is cancelled as part of the
-    // same atomic commit, so a deleted connection never leaves active runs.
+    // Pause the connection's existing feeds in the same atomic lifecycle
+    // transition. Keep each schedule as historical configuration, but clear its
+    // queued occurrence so the retained rows no longer look runnable.
+    await tx`
+      UPDATE feeds
+      SET status = 'paused', next_run_at = NULL, updated_at = NOW()
+      WHERE connection_id = ${args.connection_id}
+        AND organization_id = ${organizationId}
+        AND deleted_at IS NULL
+        AND (status <> 'paused' OR next_run_at IS NOT NULL)
+    `;
+
+    // Cancel runs that are active at this point in the same atomic commit.
     await tx`
       UPDATE runs SET status = 'cancelled', completed_at = NOW()
       WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})


### PR DESCRIPTION
## Summary

- Classify zero-feed connector health from installed capabilities: operation-only, virtual-only, and user-managed-only definitions are healthy without auto-created feeds; missing definitions remain fail-closed.
- Enforce the existing 48-hour zero-feed grace independently from the general connection-age scan window.
- When a connection is deleted, atomically pause retained feeds and clear queued occurrences before cancelling active runs; schedules remain for audit/recovery.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: targeted real-Postgres Vitest suites plus server typecheck
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red → green

Before the fix, the focused integration run had 2 failures out of 27: an operation-only/virtual-only connector was classified `zero_feeds`, and deleting a connection left its feed status `active` with pending schedule work.

After the reviewed class fix:

- 29/29 focused real-Postgres integration tests pass, covering operation-only, virtual-only, user-managed-only, missing-definition fail-closed, zero-feed grace, and deletion lifecycle behavior.
- `bun run typecheck` passes in `packages/server`.
- `git diff --check` passes.
- `make pre-pr-remote` passed all 16 Linux CI jobs: Depot run `s8dgzd03nk`.

## Notes

Production cleanup was performed separately through the public SDK: obsolete manual Takeout feeds were paused, and residual active feeds under deleted connections were reduced to zero. No events were deleted.