### PR TITLE
chore(personal-agent): rename social radar to 'Social interest radar'

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1222,7 +1222,7 @@ const voiceProfileSynthesis = defineBehavior({
 const socialInterestRadar = defineBehavior({
   agent: personalAgent,
   slug: "social-interest-radar-v2",
-  name: "Social interest radar (X + LinkedIn + Hacker News)",
+  name: "Social interest radar",
   tags: ["social", "x", "linkedin", "notifications"],
   triggers: [
     { kind: "schedule", cron: "25 * * * *", skip_if_unchanged: false },


### PR DESCRIPTION
## Summary

The deployed behavior (prod v16) was renamed to `Social interest radar` — the config still declared `Social interest radar (X + LinkedIn + Hacker News)`, which was one of the version-bound drifts blocking `lobu apply` convergence. Aligning the config with the deployed name removes that drift so future applies converge (the user wants the config to be the source of truth).

## Test plan

- [x] `lobu validate` — config valid
- [ ] Will run `make pre-pr-remote` + `make review`