### PR TITLE
fix(personal-agent): route task behavior through Hetzner

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1297,6 +1297,7 @@ const hourlyTaskCollaborator = defineBehavior({
   agent: personalAgent,
   slug: "hourly-task-collaborator",
   name: "Hourly Task Collaborator",
+  model: "hetzner/DeepSeek-V4-Flash-0731",
   triggers: [{ kind: "schedule", cron: "0 * * * *" }],
   notification: { channel: "both", priority: "normal" },
   minCooldownSeconds: 300,


### PR DESCRIPTION
## Summary

- Pin the Buremba Hourly Task Collaborator to `hetzner/DeepSeek-V4-Flash-0731`.
- Keep the checked-in Behavior routing aligned with the live production recovery.

## Test plan

- [x] Intended file scope verified, then full `make pre-pr-remote` passed on the rebased tree (18 executions; attested tree `6de8843ee34c20d5662a911f784078810b5dc0c6`).
- [x] `bun test packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts` — 66 pass, 0 fail.
- [x] `bun run build:packages` — passed.
- [x] Repo-built CLI 14.22.0 `validate` — passed.
- [x] Repo-built CLI 14.22.0 full production dry-run — `hourly-task-collaborator` is an exact match; four unrelated remote-drift blockers remain and nothing was changed.
- [x] `make review-fix` — no findings and no edits.
- [x] `make pre-pr-remote-fast` — passed all executions.

### Red to green

Red: scheduled Behavior runs `954100` and `977300` failed while the Behavior was pinned to quota-exhausted Qwen.

Green: live production run `981591` dispatched with `hetzner/DeepSeek-V4-Flash-0731`, completed as window `5117154`, analyzed 25 items, persisted exactly one deduplicated task, and restored Behavior health to `healthy`. The stale quota park was cleared without changing the cron; `next_run_at` is restored to the next hourly tick.

## Notes

- This PR changes provider routing only. Overdue reminder semantics are a separate concern and are not added here.
- No Owletto files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the hourly task collaborator to use the DeepSeek-V4-Flash-0731 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->