### PR TITLE
fix(chart): make registry credentials opt-in

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -12,8 +12,8 @@ image:
   # Tag defaults to chart appVersion
   tag: "latest"
 
-imagePullSecrets:
-  - name: ghcr-credentials
+# Set pull secrets when using a private registry or mirror.
+imagePullSecrets: []
 
 # App deployment settings (API backend)
 app:


### PR DESCRIPTION
## Summary
- stop requiring a hard-coded `ghcr-credentials` secret for the public Lobu application images
- keep private registries and mirrors supported through an explicit `imagePullSecrets` override

## Test plan
- [x] Intended file staged explicitly, then `make pre-pr-remote` passed all remote jobs (Depot run `m916n4d6qr`)
- [x] Tests run: `helm lint charts/lobu`; default and override Helm render checks
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red
```text
$ helm template ... | rg "imagePullSecrets:|ghcr-credentials"
113:      imagePullSecrets:
114:        - name: ghcr-credentials
225:      imagePullSecrets:
226:        - name: ghcr-credentials
310:      imagePullSecrets:
311:        - name: ghcr-credentials
458:      imagePullSecrets:
459:        - name: ghcr-credentials
```

### Green
```text
default_pull_secret_refs=0
override_pull_secret_refs=4
==> Linting charts/lobu
1 chart(s) linted, 0 chart(s) failed
Depot run m916n4d6qr passed
```

## Notes
The three Lobu application packages are public. Dedicated production now also explicitly renders `imagePullSecrets: []`; this chart default fixes the same class for future installations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default deployment configuration to no longer require a preconfigured container image pull secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->