### PR TITLE
feat(ci): make Owletto pointer updates non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -947,6 +947,11 @@ jobs:
           cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml
           bash scripts/lib/__tests__/remote-ci.test.sh
 
+      - name: Submodule drift policy tests
+        run: |
+          bash scripts/lib/__tests__/submodule-drift.test.sh
+          bash scripts/lib/__tests__/submodule-bump.test.sh
+
   typecheck:
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -1,9 +1,9 @@
 name: Submodule Drift
 
-# Surfaces when packages/owletto (private) has merged commits past the
-# parent's pinned SHA — i.e. the two-PR rule's parent bump is missing.
-# Bot tag-update commits (FluxCD image automation) are exempted only when both
-# the author and exact subject match — a sloppy human commit cannot slip past.
+# Surfaces when packages/owletto (private) has merged commits past the parent's
+# pinned SHA without making unrelated PRs chase a moving Owletto main. PRs
+# still fail on off-main or backward pointers; push/scheduled runs retain the
+# strict missing-bump signal.
 
 on:
   push:
@@ -33,6 +33,39 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Pointer scope is a three-dot PR diff. Full history keeps an older
+          # branch from looking like it changed a pointer advanced on base.
+          fetch-depth: 0
+
+      - name: Detect whether this PR changes the Owletto pointer
+        id: pr_scope
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Compare the PR head to its merge base, not today's base tree. If a
+          # separate pointer PR merged after this branch was cut, an endpoint
+          # comparison would falsely classify every older branch as a rollback.
+          git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null || git fetch --no-tags origin "$BASE_SHA"
+          git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null || git fetch --no-tags origin "$HEAD_SHA"
+          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          base_pointer=$(git ls-tree "$merge_base" packages/owletto | awk '{print $3}')
+          head_pointer=$(git ls-tree "$HEAD_SHA" packages/owletto | awk '{print $3}')
+          [ -n "$base_pointer" ] && [ -n "$head_pointer" ] || {
+            echo "::error::Could not resolve the packages/owletto pointer at both PR endpoints."
+            exit 1
+          }
+          echo "base_pointer=$base_pointer" >> "$GITHUB_OUTPUT"
+          echo "head_pointer=$head_pointer" >> "$GITHUB_OUTPUT"
+          if [ "$base_pointer" = "$head_pointer" ]; then
+            echo "pointer_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "pointer_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - id: submodule
         uses: ./.github/actions/setup-submodule
@@ -45,20 +78,16 @@ jobs:
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name != github.repository
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_POINTER: ${{ steps.pr_scope.outputs.base_pointer }}
+          HEAD_POINTER: ${{ steps.pr_scope.outputs.head_pointer }}
+          POINTER_CHANGED: ${{ steps.pr_scope.outputs.pointer_changed }}
         shell: bash
         run: |
           set -euo pipefail
-          # actions/checkout@v7 with default fetch-depth=1 only has the merge
-          # commit; pull the two endpoints by SHA so ls-tree can resolve them.
-          git fetch --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
-          base_pointer=$(git ls-tree "$BASE_SHA" packages/owletto | awk '{print $3}')
-          head_pointer=$(git ls-tree "$HEAD_SHA" packages/owletto | awk '{print $3}')
-          if [ "$base_pointer" != "$head_pointer" ]; then
+          if [ "$POINTER_CHANGED" = "true" ]; then
             echo "::error::Fork PRs cannot change the packages/owletto pointer."
-            echo "  base: $base_pointer"
-            echo "  head: $head_pointer"
+            echo "  base: $BASE_POINTER"
+            echo "  head: $HEAD_POINTER"
             echo "Submodule bumps must come from a same-repo PR (deploy-key-authorized)."
             exit 1
           fi
@@ -75,71 +104,9 @@ jobs:
 
       - name: Check for unmerged non-bot commits on owletto/main
         if: steps.submodule.outputs.stubbed != 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_POINTER: ${{ steps.pr_scope.outputs.base_pointer }}
+          PR_HEAD_POINTER: ${{ steps.pr_scope.outputs.head_pointer }}
         shell: bash
-        run: |
-          set -euo pipefail
-          PINNED=$(git -C packages/owletto rev-parse HEAD)
-          git -C packages/owletto fetch --quiet origin main
-          REMOTE=$(git -C packages/owletto rev-parse origin/main)
-
-          echo "Pinned (parent):   $PINNED"
-          echo "owletto/main:  $REMOTE"
-
-          # Hard rule: parent must never pin a SHA that isn't on owletto/main.
-          # FluxCD reads charts from owletto/main; an off-main pin breaks deploy.
-          if ! git -C packages/owletto merge-base --is-ancestor "$PINNED" origin/main; then
-            echo "::error::Pinned SHA $PINNED is not reachable from owletto/main."
-            echo "This violates the rule against pinning unmerged submodule SHAs (see AGENTS.md)."
-            exit 1
-          fi
-
-          if [ "$PINNED" = "$REMOTE" ]; then
-            echo "Submodule pin matches owletto/main — no drift."
-            exit 0
-          fi
-
-          # Capture the log first so set -e propagates a git failure (process
-          # substitution would swallow it). tformat: guarantees a trailing
-          # newline so `read` doesn't drop the last commit.
-          LOG=$(git -C packages/owletto log \
-            --pretty='tformat:%h|%ae|%s' "$PINNED..origin/main")
-
-          # Walk each commit; exempt only those whose author email AND exact
-          # subject match the FluxCD image-tag bot AND that touch only deploy
-          # paths — a forged "chore: update images" with random contents
-          # outside deploy/ is treated as drift.
-          DRIFT=""
-          while IFS='|' read -r sha email subject; do
-            [ -z "$sha" ] && continue
-            if [ "$email" = "$BOT_AUTHOR_EMAIL" ] && [ "$subject" = "$BOT_SUBJECT" ]; then
-              outside=$(git -C packages/owletto show --name-only \
-                --pretty='format:' "$sha" \
-                | sed '/^$/d' \
-                | grep -v '^deploy/' || true)
-              if [ -z "$outside" ]; then
-                continue
-              fi
-              echo "::warning::Commit $sha matches bot author/subject but touches non-deploy paths; treating as drift."
-            fi
-            DRIFT+="$sha $subject"$'\n'
-          done <<< "$LOG"
-
-          if [ -z "$DRIFT" ]; then
-            echo "owletto/main is ahead, but only by FluxCD image-tag commits — no parent bump needed."
-            exit 0
-          fi
-
-          echo "::error::owletto/main has merged commits past the pinned SHA. The parent bump PR is missing."
-          echo ""
-          echo "Pinned:           $PINNED"
-          echo "owletto/main: $REMOTE"
-          echo ""
-          echo "Commits needing a parent bump:"
-          printf '%s' "$DRIFT"
-          echo ""
-          echo "Fix (open as a separate PR):"
-          echo "  git -C packages/owletto fetch origin"
-          echo "  git -C packages/owletto checkout origin/main"
-          echo "  git add packages/owletto"
-          echo "  git commit -m 'chore(submodule): bump owletto to current main'"
-          exit 1
+        run: scripts/check-submodule-drift.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Read the nearest package `AGENTS.md` before editing that package; grep `docs/GOTCHAS.md` when something looks inexplicable.
 
 ## Unrecoverable — never do these
-- **Never write to `~/Code/lobu` directly.** Run `make task-setup NAME=<slug>` first, and never `git switch` in the main checkout — other sessions share it.
+- **Never write to `~/Code/lobu` directly.** Run `make task-setup NAME=<slug>` first, and never `git switch` in the main checkout — other sessions share it. For a pure submodule-pointer bump, `make bump SUBMODULE=packages/owletto` is the lightweight isolated-worktree exception; it also posts the required statuses.
 - **Stage by explicit path** (`git add -- <paths>`, never `-A`). A commit is a snapshot, so a stale file copy left by earlier work in the same worktree silently reverts merged PRs. After commit/rebase, `git diff --name-only origin/main...HEAD` must equal your intended file list; extras = stop.
 - **`events` is append-only.** Never `DELETE FROM events`; tombstone or supersede instead.
 - **Never bulk-delete prod `organization` rows**, including zero-activity ones — empty-looking orgs are usually real signups. Surface them one at a time for confirmation.

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  make task-setup NAME=<name> [CONTEXT=1]    - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule, .env/ports; CONTEXT=1 registers Lobu CLI context)"
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make e2e-browser [RESTART=1]               - Launch/reuse the stable 'owletto' Chrome harness (extension from this worktree) for Chrome e2e"
-	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"
+	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>] [ARTIFACT=<url>] - Lightweight pointer PR + required statuses (skips bun install, .env, ports)"
 	@echo "  make review [BASE=<branch>]                - Run the cross-harness LLM reviewer against the local diff (deterministic suites run in CI); posts pi-review status and PR comment"
 	@echo "  make review-fix [BASE=<branch>]            - Pre-review fixer: reviewer CLI with write access fixes review-grade findings in the tree; posts nothing"
 	@echo "  make ui-review [ARTIFACT=<https-url>]       - Record Owletto UI proof; complete forward deploy-only pointer diffs pass as not applicable; OPEN=1 opens the merged PR"
@@ -157,10 +157,11 @@ e2e-browser:
 
 # Lightweight shortcut for "trivial submodule pointer bump" work. Creates a
 # minimal worktree (no bun install, no .env copy, no port allocation), advances
-# the submodule, opens an auto-merge PR. For agent work that also touches
-# submodule *code*, use `make task-setup` instead — it sets up the full env.
+# the submodule, posts both required local statuses, and opens an auto-merge PR.
+# For agent work that also touches submodule *code*, use `make task-setup`
+# instead — it sets up the full env.
 bump:
-	@: $${SUBMODULE?Usage: make bump SUBMODULE=<path> [TARGET=<sha-or-ref>] [NAME=<slug>]}
+	@: $${SUBMODULE?Usage: make bump SUBMODULE=<path> [TARGET=<sha-or-ref>] [NAME=<slug>] [ARTIFACT=<url>]}
 	@NAME="$(NAME)" ./scripts/bump-submodule.sh "$(SUBMODULE)" "$(TARGET)"
 
 # --- Test pipelines ---------------------------------------------------------

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -82,6 +82,8 @@ The chain must exit zero **and** print nothing before merge. Nonzero does not me
 
 **`make review` skip rule.** Small safe-class diffs (docs, renames, generated, additive tests, or a pure `packages/owletto` pointer bump; under 100 lines) skip the cross-harness reviewer by default. An Owletto bump mixed with any parent change still runs the reviewer. `REVIEWER_MODE=full make review` forces the independent review; `REVIEWER_SHADOW=1` measures the skip rule instead of trusting it.
 
+**Pure pointer shortcut.** Use `make bump SUBMODULE=packages/owletto [TARGET=<ref>] [ARTIFACT=<url>]` instead of a full task worktree. It creates a lightweight isolated worktree, commits and pushes the pointer, opens the PR, posts the safe-class `pi-review`, runs `ui-review` (reusing exact proof or accepting `ARTIFACT`), and enables squash auto-merge. It stops with the PR open if either required local status cannot be posted.
+
 **UI proof.** `gh` cannot upload images inline. Capture before shots from the unmodified branch and after shots from the same booted app (auth recipe in `docs/BROWSER_TESTING.md`), base64-embed the PNGs into one self-contained HTML comparison page, host it at an HTTPS URL, and pass that URL as `ARTIFACT` to `make ui-review`. The gate records it on the exact merged Owletto PR, links it from the parent, and binds the evidence to that parent-base and Owletto-pointer pair for normal PR review. A rerun may reuse an exact proof already recorded for that pointer pair. Complete, forward-only endpoint diffs confined to `deploy/` pass as not applicable; every other pointer change needs reusable exact proof or an `ARTIFACT`.
 
 ## Post-merge rollout verification

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -146,6 +146,8 @@ PLAYWRIGHT_BROWSERS_PATH=/ms-playwright node -e "const p=require('playwright').c
 git -C packages/owletto checkout <squash-sha> && git add packages/owletto && git commit --no-edit
 ```
 
+**Owletto drift does not serialize unrelated PRs.** On a pull request, `check-drift` hard-fails only for an off-main pointer, a backward/sideways pointer move, or an unauthorized fork pointer change. If non-bot Owletto commits land past an unchanged parent pin, the PR passes with a warning; deploy-only Flux commits remain exempt. A forward pointer PR also remains policy-valid when main advances after it opened; Git may carry the newer descendant into the merge result, so the check accepts that synthetic pointer only when it contains the PR head pointer. Push and scheduled runs remain strict so missing parent bumps stay visible without making every Lobu PR chase a moving submodule head.
+
 **Never fold a private repo into public `lobu`.** Check `gh repo view --json visibility` on both sides before any "consolidate into the monorepo" move — a past fold leaked a large private frontend publicly.
 
 ## Prod safety

--- a/scripts/bump-submodule.sh
+++ b/scripts/bump-submodule.sh
@@ -5,6 +5,7 @@
 #   make bump SUBMODULE=packages/owletto                       # bump to origin/main
 #   make bump SUBMODULE=packages/owletto TARGET=abc123def      # bump to specific SHA / ref
 #   make bump SUBMODULE=packages/owletto NAME=cancel-button    # custom slug
+#   make bump SUBMODULE=packages/owletto ARTIFACT=https://...  # attach UI proof when required
 #
 # This is the cheap shortcut for the trivial "bump a submodule pointer" case.
 # For agent work that also touches submodule code, use `make task-setup` instead,
@@ -16,8 +17,9 @@
 #   - port allocation        (no listener)
 #   - Lobu CLI context       (nothing to talk to)
 #
-# It just creates a worktree off origin/main, advances the submodule pointer,
-# commits, pushes, and opens an auto-merge PR.
+# It creates a worktree off origin/main, advances the submodule pointer,
+# commits, pushes, opens a PR, posts the safe-class review status, records UI
+# proof when reusable/provided, and enables auto-merge.
 #
 # Why this exists: the convention is `~/Code/lobu` is read-only for agents
 # (see AGENTS.md "Scope discipline"). Without this shortcut, agents reach
@@ -71,7 +73,7 @@ cleanup_worktree() {
     git branch -D "$BRANCH" 2>/dev/null || true
 }
 
-if ! TARGET_SHA=$(git -C "$WT/$SUBMODULE" rev-parse "$TARGET" 2>/dev/null); then
+if ! TARGET_SHA=$(git -C "$WT/$SUBMODULE" rev-parse "$TARGET^{commit}" 2>/dev/null); then
     echo "error: can't resolve $TARGET inside $SUBMODULE" >&2
     cleanup_worktree
     exit 1
@@ -82,6 +84,16 @@ if [[ "$BEFORE_SHA" == "$TARGET_SHA" ]]; then
     cleanup_worktree
     exit 0
 fi
+if ! git -C "$WT/$SUBMODULE" merge-base --is-ancestor "$TARGET_SHA" origin/main; then
+    echo "error: target $TARGET_SHA is not reachable from $SUBMODULE origin/main" >&2
+    cleanup_worktree
+    exit 1
+fi
+if ! git -C "$WT/$SUBMODULE" merge-base --is-ancestor "$BEFORE_SHA" "$TARGET_SHA"; then
+    echo "error: target would move $SUBMODULE backwards or sideways" >&2
+    cleanup_worktree
+    exit 1
+fi
 
 SHORT_BEFORE=$(git -C "$WT/$SUBMODULE" rev-parse --short "$BEFORE_SHA")
 SHORT_AFTER=$(git -C "$WT/$SUBMODULE" rev-parse --short "$TARGET_SHA")
@@ -89,6 +101,27 @@ TARGET_SUBJECT=$(git -C "$WT/$SUBMODULE" log -1 --format='%s' "$TARGET_SHA")
 
 echo "→ advancing $SUBMODULE: $SHORT_BEFORE → $SHORT_AFTER"
 git -C "$WT/$SUBMODULE" checkout --detach "$TARGET_SHA" >/dev/null 2>&1
+
+echo "→ checking the safe-class pre-review fixer"
+if ! (cd "$WT" && make review-fix); then
+    echo "error: review-fix failed; inspect the retained worktree at $WT" >&2
+    exit 1
+fi
+
+# The fixer runs before the snapshot. Never let an unexpected parent edit or
+# nested submodule edit turn this pointer-only shortcut into a mixed commit.
+CHANGED_PATHS=$(git -C "$WT" diff --name-only HEAD)
+UNTRACKED_PATHS=$(git -C "$WT" ls-files --others --exclude-standard)
+if [[ "$CHANGED_PATHS" != "$SUBMODULE" || -n "$UNTRACKED_PATHS" ]]; then
+    echo "error: review-fix left changes beyond the $SUBMODULE pointer; inspect $WT" >&2
+    git -C "$WT" status --short >&2
+    exit 1
+fi
+if [[ -n "$(git -C "$WT/$SUBMODULE" status --porcelain)" ]] \
+    || [[ "$(git -C "$WT/$SUBMODULE" rev-parse HEAD)" != "$TARGET_SHA" ]]; then
+    echo "error: review-fix changed $SUBMODULE contents or target; inspect $WT" >&2
+    exit 1
+fi
 
 echo "→ committing pointer bump"
 git -C "$WT" add "$SUBMODULE"
@@ -115,11 +148,34 @@ After:  $SHORT_AFTER
 
 Picks up: $TARGET_SUBJECT" 2>&1 | tail -1)
     echo "  $PR_URL"
+
+    echo "→ posting required review status"
+    if ! (cd "$WT" && make review); then
+        echo "error: pi-review failed; PR remains open at $PR_URL" >&2
+        exit 1
+    fi
+
+    echo "→ recording Owletto UI review"
+    if [[ -n "${ARTIFACT:-}" ]]; then
+        if ! (cd "$WT" && make ui-review ARTIFACT="$ARTIFACT"); then
+            echo "error: ui-review failed; PR remains open at $PR_URL" >&2
+            exit 1
+        fi
+    elif ! (cd "$WT" && make ui-review); then
+        echo "error: UI proof is required; rerun in $WT with: make ui-review ARTIFACT=<https-url>" >&2
+        exit 1
+    fi
+
     echo "→ enabling auto-merge (squash)"
-    gh pr merge "$PR_URL" --auto --squash >/dev/null 2>&1 || \
-        echo "  (auto-merge enable failed — admin-merge with: gh pr merge $PR_URL --squash --admin)"
+    if ! gh pr merge "$PR_URL" --auto --squash >/dev/null 2>&1; then
+        echo "error: auto-merge could not be enabled; PR remains open at $PR_URL" >&2
+        echo "run after required checks pass: gh pr merge $PR_URL --squash --admin" >&2
+        exit 1
+    fi
 else
-    echo "→ gh CLI not available; open the PR manually for branch $BRANCH"
+    echo "error: gh CLI is required to open the PR and post its required statuses" >&2
+    echo "branch $BRANCH was pushed and remains available" >&2
+    exit 1
 fi
 
 echo

--- a/scripts/check-submodule-drift.sh
+++ b/scripts/check-submodule-drift.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Validate the parent Owletto pointer without coupling unrelated PRs to the
+# latest commit racing onto owletto/main.
+
+set -euo pipefail
+
+SUBMODULE_PATH="${SUBMODULE_PATH:-packages/owletto}"
+EVENT_NAME="${EVENT_NAME:?EVENT_NAME is required}"
+BOT_AUTHOR_EMAIL="${BOT_AUTHOR_EMAIL:-fluxcd@lobu.ai}"
+BOT_SUBJECT="${BOT_SUBJECT:-chore: update images}"
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+PINNED="$(git -C "$SUBMODULE_PATH" rev-parse HEAD)"
+git -C "$SUBMODULE_PATH" fetch --quiet origin main
+REMOTE="$(git -C "$SUBMODULE_PATH" rev-parse origin/main)"
+
+echo "Pinned (parent): $PINNED"
+echo "owletto/main:    $REMOTE"
+
+# Every proposed pin must be published on Owletto main. This remains a hard
+# failure for all event types because off-main SHAs break deployment clones.
+if ! git -C "$SUBMODULE_PATH" merge-base --is-ancestor "$PINNED" origin/main; then
+  die "Pinned SHA $PINNED is not reachable from owletto/main."
+fi
+
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  PR_BASE_POINTER="${PR_BASE_POINTER:?PR_BASE_POINTER is required for pull_request}"
+  PR_HEAD_POINTER="${PR_HEAD_POINTER:?PR_HEAD_POINTER is required for pull_request}"
+
+  # Pointer PRs may advance to any already-merged Owletto commit. They do not
+  # have to chase commits that land after the PR was opened, but rollbacks stay
+  # review-blocking.
+  if [ "$PR_BASE_POINTER" != "$PR_HEAD_POINTER" ]; then
+    if ! git -C "$SUBMODULE_PATH" merge-base --is-ancestor "$PR_BASE_POINTER" "$PR_HEAD_POINTER"; then
+      die "Owletto pointer moves backwards or sideways: $PR_BASE_POINTER -> $PR_HEAD_POINTER."
+    fi
+    # Git's submodule merge can fast-forward the synthetic merge commit past
+    # the PR's requested pointer when base already carries a newer descendant.
+    # Accept that result, but never a merge result that drops the requested SHA.
+    if ! git -C "$SUBMODULE_PATH" merge-base --is-ancestor "$PR_HEAD_POINTER" "$PINNED"; then
+      die "Checked-out pointer $PINNED does not include PR head pointer $PR_HEAD_POINTER."
+    fi
+  fi
+fi
+
+if [ "$PINNED" = "$REMOTE" ]; then
+  echo "Submodule pin matches owletto/main — no drift."
+  exit 0
+fi
+
+# Capture the log first so set -e propagates a git failure. tformat guarantees
+# a trailing newline so read does not drop the last commit.
+LOG="$(git -C "$SUBMODULE_PATH" log \
+  --pretty='tformat:%h|%ae|%s' "$PINNED..origin/main")"
+
+# FluxCD image-only commits do not require a parent pointer bump. Match both
+# identity and exact subject, then verify the changed paths, so a human commit
+# cannot bypass the drift signal with a lookalike subject.
+DRIFT=""
+while IFS='|' read -r sha email subject; do
+  [ -z "$sha" ] && continue
+  if [ "$email" = "$BOT_AUTHOR_EMAIL" ] && [ "$subject" = "$BOT_SUBJECT" ]; then
+    outside="$(git -C "$SUBMODULE_PATH" show --name-only \
+      --pretty='format:' "$sha" \
+      | sed '/^$/d' \
+      | grep -v '^deploy/' || true)"
+    if [ -z "$outside" ]; then
+      continue
+    fi
+    echo "::warning::Commit $sha matches bot author/subject but touches non-deploy paths; treating as drift."
+  fi
+  DRIFT+="$sha $subject"$'\n'
+done <<< "$LOG"
+
+if [ -z "$DRIFT" ]; then
+  echo "owletto/main is ahead, but only by FluxCD image-tag commits — no parent bump needed."
+  exit 0
+fi
+
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  if [ "$PR_BASE_POINTER" = "$PR_HEAD_POINTER" ]; then
+    echo "::warning::owletto/main is ahead of the parent pin; this unrelated PR is not blocked."
+  else
+    echo "::notice::This PR advances the Owletto pointer safely; later Owletto commits remain for a follow-up bump."
+  fi
+  printf 'Commits still needing a parent bump:\n%s' "$DRIFT"
+  exit 0
+fi
+
+echo "::error::owletto/main has merged commits past the pinned SHA. The parent bump is missing."
+echo ""
+echo "Pinned:       $PINNED"
+echo "owletto/main: $REMOTE"
+echo ""
+echo "Commits needing a parent bump:"
+printf '%s' "$DRIFT"
+exit 1

--- a/scripts/lib/__tests__/submodule-bump.test.sh
+++ b/scripts/lib/__tests__/submodule-bump.test.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+bump_script="$repo_root/scripts/bump-submodule.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+expect_calls() {
+  local label="$1" expected="$2" actual
+  actual="$(sed -n '1,$p' "$call_log")"
+  [ "$actual" = "$expected" ] || fail "$label: unexpected calls:
+$actual"
+}
+
+run_bump() {
+  local name="$1" target="$2" fail_fix="$3" fail_review="$4" fail_ui="$5"
+  local fix_extra="$6" fail_merge="$7" artifact="${8-https://proof.example/$name}"
+  (
+    cd "$driver"
+    env \
+      ARTIFACT="$artifact" \
+      CALL_LOG="$call_log" \
+      FAIL_FIX="$fail_fix" \
+      FAIL_MERGE="$fail_merge" \
+      FAIL_REVIEW="$fail_review" \
+      FAIL_UI="$fail_ui" \
+      FIX_EXTRA="$fix_extra" \
+      GIT_ALLOW_PROTOCOL=file \
+      NAME="$name" \
+      PATH="$fake_bin:$PATH" \
+      "$bump_script" packages/owletto "$target"
+  )
+}
+
+tmp_root="$(mktemp -d /tmp/lobu-submodule-bump.XXXXXX)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+submodule_remote="$tmp_root/owletto.git"
+submodule_source="$tmp_root/owletto-source"
+parent_remote="$tmp_root/lobu.git"
+parent_source="$tmp_root/lobu-source"
+driver="$tmp_root/driver"
+fake_bin="$tmp_root/bin"
+call_log="$tmp_root/calls.log"
+
+git init -q --bare "$submodule_remote"
+git init -q "$submodule_source"
+git -C "$submodule_source" config user.email dev@lobu.ai
+git -C "$submodule_source" config user.name Developer
+git -C "$submodule_source" checkout -q -b main
+printf 'a\n' > "$submodule_source/app.ts"
+git -C "$submodule_source" add app.ts
+git -C "$submodule_source" commit -q -m "feat: a"
+sha_a="$(git -C "$submodule_source" rev-parse HEAD)"
+printf 'b\n' > "$submodule_source/app.ts"
+git -C "$submodule_source" commit -qam "feat: b"
+sha_b="$(git -C "$submodule_source" rev-parse HEAD)"
+printf 'c\n' > "$submodule_source/app.ts"
+git -C "$submodule_source" commit -qam "feat: c"
+git -C "$submodule_source" tag -a release -m "release"
+git -C "$submodule_source" remote add origin "$submodule_remote"
+git -C "$submodule_source" push -q -u origin main
+git -C "$submodule_source" push -q origin release
+git -C "$submodule_source" checkout -q -b feature
+printf 'private\n' > "$submodule_source/private.ts"
+git -C "$submodule_source" add private.ts
+git -C "$submodule_source" commit -q -m "feat: private"
+git -C "$submodule_source" push -q -u origin feature
+git -C "$submodule_source" checkout -q main
+git -C "$submodule_remote" symbolic-ref HEAD refs/heads/main
+
+git init -q --bare "$parent_remote"
+git init -q "$parent_source"
+git -C "$parent_source" config user.email dev@lobu.ai
+git -C "$parent_source" config user.name Developer
+git -C "$parent_source" checkout -q -b main
+git -C "$parent_source" -c protocol.file.allow=always submodule add -q \
+  "$submodule_remote" packages/owletto
+git -C "$parent_source/packages/owletto" checkout -q --detach "$sha_b"
+printf '.task\n' > "$parent_source/.gitignore"
+git -C "$parent_source" add .gitignore .gitmodules packages/owletto
+git -C "$parent_source" commit -q -m "chore: pin owletto"
+git -C "$parent_source" remote add origin "$parent_remote"
+git -C "$parent_source" push -q -u origin main
+git -C "$parent_remote" symbolic-ref HEAD refs/heads/main
+git clone -q "$parent_remote" "$driver"
+git -C "$driver" config user.email dev@lobu.ai
+git -C "$driver" config user.name Developer
+
+mkdir -p "$fake_bin"
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'case "${1:-}:${2:-}" in' \
+  '  pr:create)' \
+  '    echo "gh:pr-create" >> "$CALL_LOG"' \
+  '    echo "https://github.example/lobu/pull/1"' \
+  '    ;;' \
+  '  pr:merge)' \
+  '    echo "gh:pr-merge" >> "$CALL_LOG"' \
+  '    if [ "$FAIL_MERGE" = "1" ]; then exit 1; fi' \
+  '    ;;' \
+  '  *) exit 2 ;;' \
+  'esac' \
+  > "$fake_bin/gh"
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'echo "make:$*" >> "$CALL_LOG"' \
+  'if [ "${1:-}" = "review-fix" ] && [ "$FAIL_FIX" = "1" ]; then exit 1; fi' \
+  'if [ "${1:-}" = "review-fix" ] && [ "$FIX_EXTRA" = "1" ]; then echo extra > unexpected.txt; fi' \
+  'if [ "${1:-}" = "review" ] && [ "$FAIL_REVIEW" = "1" ]; then exit 1; fi' \
+  'if [ "${1:-}" = "ui-review" ] && [ "$FAIL_UI" = "1" ]; then exit 1; fi' \
+  > "$fake_bin/make"
+chmod +x "$fake_bin/gh" "$fake_bin/make"
+
+: > "$call_log"
+if run_bump rollback "$sha_a" 0 0 0 0 0 >"$tmp_root/rollback.out" 2>&1; then
+  fail "backward target should stop the bump"
+fi
+grep -Fq "target would move packages/owletto backwards or sideways" "$tmp_root/rollback.out" \
+  || fail "backward target should explain the direction violation"
+expect_calls "backward target" ""
+[ ! -e "$driver/.claude/worktrees/bump-rollback" ] \
+  || fail "rejected target should remove its temporary worktree"
+if git -C "$driver" show-ref --verify --quiet refs/heads/chore/bump-rollback; then
+  fail "rejected target should remove its temporary branch"
+fi
+
+: > "$call_log"
+if run_bump off-main origin/feature 0 0 0 0 0 >"$tmp_root/off-main.out" 2>&1; then
+  fail "off-main target should stop the bump"
+fi
+grep -Fq "is not reachable from packages/owletto origin/main" "$tmp_root/off-main.out" \
+  || fail "off-main target should explain the reachability violation"
+expect_calls "off-main target" ""
+
+: > "$call_log"
+run_bump success origin/main 0 0 0 0 0 >/dev/null
+expect_calls "successful bump" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review ARTIFACT=https://proof.example/success
+gh:pr-merge"
+
+: > "$call_log"
+run_bump annotated-tag release 0 0 0 0 0 >/dev/null
+expect_calls "annotated tag target" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review ARTIFACT=https://proof.example/annotated-tag
+gh:pr-merge"
+
+: > "$call_log"
+run_bump reusable-proof origin/main 0 0 0 0 0 "" >/dev/null
+expect_calls "reusable UI proof" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review
+gh:pr-merge"
+
+: > "$call_log"
+if run_bump fix-fails origin/main 1 0 0 0 0 >"$tmp_root/fix-fails.out" 2>&1; then
+  fail "pre-review fixer failure should stop the bump"
+fi
+grep -Fq "review-fix failed; inspect the retained worktree" "$tmp_root/fix-fails.out" \
+  || fail "fixer failure should identify the retained worktree"
+expect_calls "fixer failure" "make:review-fix"
+
+: > "$call_log"
+if run_bump fix-expands-scope origin/main 0 0 0 1 0 >"$tmp_root/fix-expands-scope.out" 2>&1; then
+  fail "unexpected fixer edits should stop the bump"
+fi
+grep -Fq "review-fix left changes beyond the packages/owletto pointer" \
+  "$tmp_root/fix-expands-scope.out" \
+  || fail "unexpected fixer edits should explain the scope violation"
+expect_calls "fixer scope expansion" "make:review-fix"
+
+: > "$call_log"
+if run_bump review-fails origin/main 0 1 0 0 0 >"$tmp_root/review-fails.out" 2>&1; then
+  fail "review failure should stop the bump"
+fi
+grep -Fq "pi-review failed; PR remains open" "$tmp_root/review-fails.out" \
+  || fail "review failure should explain that the PR remains open"
+expect_calls "review failure" "make:review-fix
+gh:pr-create
+make:review"
+
+: > "$call_log"
+if run_bump ui-fails origin/main 0 0 1 0 0 >"$tmp_root/ui-fails.out" 2>&1; then
+  fail "UI review failure should stop the bump"
+fi
+grep -Fq "ui-review failed; PR remains open" "$tmp_root/ui-fails.out" \
+  || fail "UI review failure should explain that the PR remains open"
+expect_calls "UI review failure" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review ARTIFACT=https://proof.example/ui-fails"
+
+: > "$call_log"
+if run_bump proof-missing origin/main 0 0 1 0 0 "" >"$tmp_root/proof-missing.out" 2>&1; then
+  fail "missing reusable UI proof should stop the bump"
+fi
+grep -Fq "UI proof is required; rerun" "$tmp_root/proof-missing.out" \
+  || fail "missing reusable UI proof should explain how to provide an artifact"
+expect_calls "missing reusable UI proof" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review"
+
+: > "$call_log"
+if run_bump merge-fails origin/main 0 0 0 0 1 >"$tmp_root/merge-fails.out" 2>&1; then
+  fail "auto-merge failure should stop the bump"
+fi
+grep -Fq "auto-merge could not be enabled; PR remains open" "$tmp_root/merge-fails.out" \
+  || fail "auto-merge failure should explain that the PR remains open"
+expect_calls "auto-merge failure" "make:review-fix
+gh:pr-create
+make:review
+make:ui-review ARTIFACT=https://proof.example/merge-fails
+gh:pr-merge"
+
+echo "submodule bump shortcut tests passed"

--- a/scripts/lib/__tests__/submodule-drift.test.sh
+++ b/scripts/lib/__tests__/submodule-drift.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+checker="$repo_root/scripts/check-submodule-drift.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+expect_pass() {
+  local label="$1" expected="$2" output rc
+  shift 2
+  set +e
+  output="$("$@" 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "$label: expected pass, got $rc: $output"
+  case "$output" in
+    *"$expected"*) ;;
+    *) fail "$label: expected output containing '$expected', got: $output" ;;
+  esac
+}
+
+expect_fail() {
+  local label="$1" expected="$2" output rc
+  shift 2
+  set +e
+  output="$("$@" 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "$label: expected failure, got pass: $output"
+  case "$output" in
+    *"$expected"*) ;;
+    *) fail "$label: expected output containing '$expected', got: $output" ;;
+  esac
+}
+
+[ -x "$checker" ] || fail "missing executable checker: $checker"
+
+tmp_root="$(mktemp -d /tmp/lobu-submodule-drift.XXXXXX)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+remote="$tmp_root/owletto.git"
+source_repo="$tmp_root/source"
+checkout="$tmp_root/checkout"
+
+git init -q --bare "$remote"
+git init -q "$source_repo"
+git -C "$source_repo" config user.email dev@lobu.ai
+git -C "$source_repo" config user.name Developer
+git -C "$source_repo" checkout -q -b main
+
+printf 'a\n' > "$source_repo/app.ts"
+git -C "$source_repo" add app.ts
+git -C "$source_repo" commit -q -m "feat: a"
+sha_a="$(git -C "$source_repo" rev-parse HEAD)"
+
+printf 'b\n' > "$source_repo/app.ts"
+git -C "$source_repo" commit -qam "feat: b"
+sha_b="$(git -C "$source_repo" rev-parse HEAD)"
+
+printf 'c\n' > "$source_repo/app.ts"
+git -C "$source_repo" commit -qam "feat: c"
+sha_c="$(git -C "$source_repo" rev-parse HEAD)"
+
+git -C "$source_repo" remote add origin "$remote"
+git -C "$source_repo" push -q -u origin main
+git clone -q "$remote" "$checkout"
+
+git -C "$checkout" checkout -q --detach "$sha_a"
+expect_pass "unrelated PR" "unrelated PR is not blocked" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_a" PR_HEAD_POINTER="$sha_a" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$checkout" checkout -q --detach "$sha_b"
+expect_pass "unrelated PR after base pointer advanced" "unrelated PR is not blocked" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_a" PR_HEAD_POINTER="$sha_a" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+expect_pass "forward pointer PR" "later Owletto commits remain" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_a" PR_HEAD_POINTER="$sha_b" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$checkout" checkout -q --detach "$sha_c"
+expect_pass "pointer PR subsumed by advanced base" "matches owletto/main" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_a" PR_HEAD_POINTER="$sha_b" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$checkout" checkout -q --detach "$sha_a"
+expect_fail "rollback pointer PR" "moves backwards" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_b" PR_HEAD_POINTER="$sha_a" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+expect_fail "mismatched checked-out PR pointer" "does not include PR head pointer" \
+  env EVENT_NAME=pull_request PR_BASE_POINTER="$sha_a" PR_HEAD_POINTER="$sha_b" \
+  SUBMODULE_PATH="$checkout" "$checker"
+
+expect_fail "main drift" "parent bump is missing" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$checkout" config user.email dev@lobu.ai
+git -C "$checkout" config user.name Developer
+printf 'private\n' > "$checkout/private.ts"
+git -C "$checkout" add private.ts
+git -C "$checkout" commit -q -m "feat: private"
+expect_fail "off-main pin" "is not reachable from owletto/main" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$checkout" checkout -q --detach "$sha_c"
+expect_pass "up-to-date main" "matches owletto/main" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$source_repo" checkout -q -b bot-only "$sha_a"
+mkdir -p "$source_repo/deploy"
+printf 'tag: next\n' > "$source_repo/deploy/image.yaml"
+git -C "$source_repo" add deploy/image.yaml
+GIT_AUTHOR_NAME=Flux GIT_AUTHOR_EMAIL=fluxcd@lobu.ai \
+  GIT_COMMITTER_NAME=Flux GIT_COMMITTER_EMAIL=fluxcd@lobu.ai \
+  git -C "$source_repo" commit -q -m "chore: update images"
+git -C "$source_repo" push -q --force origin bot-only:main
+
+git -C "$checkout" checkout -q --detach "$sha_a"
+expect_pass "bot-only main drift" "only by FluxCD image-tag commits" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$source_repo" checkout -q -B wrong-bot-author "$sha_a"
+mkdir -p "$source_repo/deploy"
+printf 'tag: wrong-author\n' > "$source_repo/deploy/image.yaml"
+git -C "$source_repo" add deploy/image.yaml
+git -C "$source_repo" commit -q -m "chore: update images"
+git -C "$source_repo" push -q --force origin wrong-bot-author:main
+
+expect_fail "deploy-only lookalike with wrong author" "parent bump is missing" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$source_repo" checkout -q -B wrong-bot-subject "$sha_a"
+mkdir -p "$source_repo/deploy"
+printf 'tag: wrong-subject\n' > "$source_repo/deploy/image.yaml"
+git -C "$source_repo" add deploy/image.yaml
+GIT_AUTHOR_NAME=Flux GIT_AUTHOR_EMAIL=fluxcd@lobu.ai \
+  GIT_COMMITTER_NAME=Flux GIT_COMMITTER_EMAIL=fluxcd@lobu.ai \
+  git -C "$source_repo" commit -q -m "chore: update image"
+git -C "$source_repo" push -q --force origin wrong-bot-subject:main
+
+expect_fail "deploy-only lookalike with wrong subject" "parent bump is missing" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+git -C "$source_repo" checkout -q -B bot-lookalike "$sha_a"
+printf 'product\n' > "$source_repo/product.ts"
+git -C "$source_repo" add product.ts
+GIT_AUTHOR_NAME=Flux GIT_AUTHOR_EMAIL=fluxcd@lobu.ai \
+  GIT_COMMITTER_NAME=Flux GIT_COMMITTER_EMAIL=fluxcd@lobu.ai \
+  git -C "$source_repo" commit -q -m "chore: update images"
+git -C "$source_repo" push -q --force origin bot-lookalike:main
+
+expect_fail "bot lookalike with product change" "parent bump is missing" \
+  env EVENT_NAME=push SUBMODULE_PATH="$checkout" "$checker"
+
+echo "submodule drift policy tests passed"


### PR DESCRIPTION
## Summary
- Scope pull-request drift checks to the PR merge base and requested pointer, while keeping push and scheduled drift enforcement strict.
- Add a guarded `make bump` shortcut that validates forward/on-main targets, runs both review gates, opens the PR, and enables squash auto-merge.
- Add fixture coverage for stale bases, newer synthetic merge pins, forks, bot exemptions, invalid targets, review failures, and UI-proof failures.

## Test plan
- [x] Intended files staged explicitly, then `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` clean: 18/18 executions, attested tree `6872fc212a5b6aa078a75792dcaa05233517ca2a`.
- [x] Tests run: `bash scripts/lib/__tests__/submodule-drift.test.sh`, `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 bash scripts/lib/__tests__/submodule-bump.test.sh`, `bash scripts/lib/__tests__/review-skip.test.sh`, actionlint, shell syntax, and `git diff --check`.
- [x] Bug fix: the first clean Linux run exposed a fixture dependency on global Git identity; after configuring identity inside the fixture, the isolated test and the full 18/18 remote graph passed.
- [ ] If bot behavior: not applicable.

## Notes
The PR path remains strict about ancestry and branch origin. Unrelated PRs stop failing only because another Owletto commit landed after their merge base; push, schedule, and workflow dispatch still surface missing parent bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided submodule bump workflow with optional UI artifact support, validation, status checks, review, and auto-merge handling.
  - Added stricter detection of submodule pointer drift across pull requests, pushes, and scheduled checks.

- **Documentation**
  - Documented the streamlined submodule update process and clarified drift-check behavior.

- **Tests**
  - Added coverage for submodule bump validation, drift detection, review failures, merge handling, and UI proof requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->