### PR TITLE
fix(apply): never block or prune system-tagged Behaviors

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1917,6 +1917,40 @@ describe("apply diff — prune", () => {
     expect(verbOf("watcher", "$system-watcher")).toBe("drift");
   });
 
+  test("prune never deletes or blocks a system-tagged (non-$ slug) Behavior", () => {
+    // chat-link bindings (e.g. chat-slack-97) are system-created with a
+    // `system:chat-link` tag and a plain slug — they are NOT config-owned, so
+    // they must be ignored (drift), not pruned or made to block the apply.
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "chat-slack-97",
+          behavior_id: "97",
+          tags: ["system:chat-link"],
+        },
+      ],
+    };
+    const plan = computeDiff(desiredKeepingLead(), remote, {
+      prune: true,
+      orgId: "org_self",
+    });
+    const row = plan.rows.find(
+      (r) => r.kind === "watcher" && r.id === "chat-slack-97"
+    );
+    expect(row?.verb).toBe("drift");
+    expect(plan.counts.delete).toBe(0);
+    // No blocking drift rows → the apply is not stalled by it.
+    expect(
+      plan.rows.some(
+        (r) =>
+          r.verb === "drift" &&
+          "blocking" in r &&
+          (r as { blocking: boolean }).blocking
+      )
+    ).toBe(false);
+  });
+
   test("matching prefers the org's own type over a foreign public type with the same slug", () => {
     // Server returns the org's own row first, then a public row with the same
     // slug. Matching must compare desired against the org-owned row (noop), not

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1829,6 +1829,14 @@ export function computeDiff(
     definitionOrgId === orgId;
   // Platform-owned entity types must NEVER be pruned (`$` slug prefix).
   const isSystemSlug = (slug: string): boolean => slug.startsWith("$");
+  // Behaviors the platform/connectors create outside the config (e.g. Slack
+  // chat-link bindings) carry a `system:<kind>` tag and are NOT config-owned.
+  // They must never block an apply or be pruned — like Terraform, unmanaged
+  // resources are ignored, not fought.
+  const isSystemTagged = (tags: string[] | null | undefined): boolean =>
+    (tags ?? []).some((t) => t.startsWith("system:"));
+  const isSystemWatcher = (w: RemoteBehavior): boolean =>
+    isSystemSlug(w.slug) || isSystemTagged(w.tags);
 
   if (only !== "memory") {
     const remoteByAgent = new Map(remote.agents.map((a) => [a.agentId, a]));
@@ -2001,7 +2009,7 @@ export function computeDiff(
     }
     for (const remoteWatcher of remote.watchers) {
       if (!desiredWatcherSlugs.has(remoteWatcher.slug)) {
-        if (isSystemSlug(remoteWatcher.slug)) {
+        if (isSystemWatcher(remoteWatcher)) {
           rows.push({
             kind: "watcher",
             verb: "drift",


### PR DESCRIPTION
## Summary

A Behavior the platform/connectors create outside the config (e.g. a Slack chat-link binding like `chat-slack-97`) carries a `system:<kind>` tag but a **plain slug**. The apply only excluded `$'`-prefixed slugs, so these system-created Behaviors were reported as **blocking drift** (`remote change not in config — blocks this apply`) and stalled **every** `lobu apply` until manually deleted.

Fixes the immediate pain from #2776: system-created Behaviors now behave like Terraform's unmanaged resources — reported as drift (ignored, not deleted), never blocking an apply.

## Test plan

- [x] New unit test: `prune never deletes or blocks a system-tagged (non-$ slug) Behavior` — a `chat-slack-97`-style watcher with `tags: ["system:chat-link"]` is `drift`, not deleted, not blocking. All 335 apply tests pass.
- [x] **Live reproduction**: created a `system:test`-tagged Behavior in prod; the new CLI's apply dry-run reports `? behavior ... (drift — ignored, not deleted)` with no BLOCKED line. Deleted the test Behavior after.
- [ ] Will run `make pre-pr-remote` + `make review`.

## Notes

The `author\\'s` escaping issue in #2776 was not a code defect — it was my manual gateway push extracting the config's single-quoted JS string verbatim. The apply itself round-trips correctly. This PR covers the system-tag exclusion.