### PR TITLE
feat(server): surface ACL sync failures instead of failing silently

### DIFF
--- a/db/migrations/20260816000000_acl_state_orphan_cleanup.sql
+++ b/db/migrations/20260816000000_acl_state_orphan_cleanup.sql
@@ -2,39 +2,35 @@
 
 -- Remove ACL-enforcement rows whose connection no longer exists as a LIVE
 -- `connections` row. `authz_source_acl_state` is a pure materialization of a
--- source's access graph — rebuilt from scratch by the next ACL sync, referenced
--- by nothing — and no code path ever deleted from it, so every connection
--- deleted before this change left its row orphaned forever as e.g. 'full' or
--- 'failed', inflating any "failed connections" count. Deleting orphans is safe
--- for the same reason: the row is derivable and nothing depends on it.
+-- source's access graph — rebuilt from scratch by the next ACL sync, with no
+-- foreign-key dependents — and no production deletion path removed from it.
+-- Deleting an ACL-enabled connection before this change therefore left its row
+-- orphaned as e.g. 'full' or 'failed', inflating any "failed connections"
+-- count. Deleting orphans is safe because no live connection can use those rows.
 --
 -- `authz_source_acl_state.connection_id` is the connection's RUNTIME id, which
 -- differs per connector type:
 --   * a managed Slack install is keyed by its `slackinst-…` slug verbatim;
 --   * a BYO Slack connection by its `agentconn-`-stripped runtime id;
 --   * a data connector (GitHub) by its numeric `connections.id::text`.
--- The predicate below matches every shape and must stay in lockstep with
--- `ACL_ROW_CONNECTION_ALIVE_SQL` in
--- packages/server/src/authz/acl-observability.ts (the connector-health scan
--- matches the same shapes; delete-time cleanup calls `deleteConnectionAclRows`).
+-- The predicate below mirrors `aclConnectionIdSql` in
+-- packages/server/src/authz/acl-observability.ts, which is shared by runtime
+-- health and delete paths.
 DELETE FROM public.authz_source_acl_state a
 WHERE NOT EXISTS (
   SELECT 1
   FROM public.connections c
   WHERE c.organization_id = a.organization_id
     AND c.deleted_at IS NULL
-    AND (
-      a.connection_id = c.slug
-      OR a.connection_id = c.id::text
-      OR a.connection_id = CASE
-            WHEN c.slug LIKE 'agentconn-%' THEN substr(c.slug, length('agentconn-') + 1)
-            ELSE c.slug
-          END
-    )
+    AND a.connection_id = CASE
+          WHEN c.credential_mode IS NULL THEN c.id::text
+          WHEN left(c.slug, length('agentconn-')) = 'agentconn-'
+            THEN substr(c.slug, length('agentconn-') + 1)
+          ELSE c.slug
+        END
 );
 
 -- migrate:down
 
--- No-op: the swept rows were orphans whose connection no longer exists, and
--- the ACL state is a materialization the next sync rebuilds anyway — there is
--- nothing to restore.
+-- No-op: the swept state belonged to no live connection and cannot be restored
+-- usefully.

--- a/db/migrations/20260816000000_acl_state_orphan_cleanup.sql
+++ b/db/migrations/20260816000000_acl_state_orphan_cleanup.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+
+-- Remove ACL-enforcement rows whose connection no longer exists as a LIVE
+-- `connections` row. `authz_source_acl_state` is a pure materialization of a
+-- source's access graph — rebuilt from scratch by the next ACL sync, referenced
+-- by nothing — and no code path ever deleted from it, so every connection
+-- deleted before this change left its row orphaned forever as e.g. 'full' or
+-- 'failed', inflating any "failed connections" count. Deleting orphans is safe
+-- for the same reason: the row is derivable and nothing depends on it.
+--
+-- `authz_source_acl_state.connection_id` is the connection's RUNTIME id, which
+-- differs per connector type:
+--   * a managed Slack install is keyed by its `slackinst-…` slug verbatim;
+--   * a BYO Slack connection by its `agentconn-`-stripped runtime id;
+--   * a data connector (GitHub) by its numeric `connections.id::text`.
+-- The predicate below matches every shape and must stay in lockstep with
+-- `ACL_ROW_CONNECTION_ALIVE_SQL` in
+-- packages/server/src/authz/acl-observability.ts (the connector-health scan
+-- matches the same shapes; delete-time cleanup calls `deleteConnectionAclRows`).
+DELETE FROM public.authz_source_acl_state a
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.connections c
+  WHERE c.organization_id = a.organization_id
+    AND c.deleted_at IS NULL
+    AND (
+      a.connection_id = c.slug
+      OR a.connection_id = c.id::text
+      OR a.connection_id = CASE
+            WHEN c.slug LIKE 'agentconn-%' THEN substr(c.slug, length('agentconn-') + 1)
+            ELSE c.slug
+          END
+    )
+);
+
+-- migrate:down
+
+-- No-op: the swept rows were orphans whose connection no longer exists, and
+-- the ACL state is a materialization the next sync rebuilds anyway — there is
+-- nothing to restore.

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -278,6 +278,71 @@ describe("acl observability", () => {
 			expect(changedConn?.error_message).toContain("403 Forbidden");
 			expect(changedConn?.updated_at).not.toEqual(new Date(SENTINEL));
 		});
+
+		it("does not erase a failure that commits while a clear is already waiting", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Clear Race Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
+			await sql`
+        UPDATE connections SET error_message = ${formatAclErrorMessage("older failure")}
+        WHERE id = ${conn.id}
+      `;
+
+			let signalLocked!: () => void;
+			let releaseFailure!: () => void;
+			const locked = new Promise<void>((resolve) => {
+				signalLocked = resolve;
+			});
+			const release = new Promise<void>((resolve) => {
+				releaseFailure = resolve;
+			});
+
+			// An in-flight failure that already holds the connection lock but has
+			// not yet written. This is the window the clear must not slip through.
+			const failing = sql.begin(async (tx) => {
+				await tx`SELECT 1 FROM connections WHERE id = ${conn.id} FOR UPDATE`;
+				signalLocked();
+				await release;
+				await tx`
+          UPDATE connections SET error_message = ${formatAclErrorMessage("newer failure")}
+          WHERE id = ${conn.id}
+        `;
+				await tx`
+          UPDATE authz_source_acl_state SET freshness_state = 'failed', updated_at = clock_timestamp()
+          WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+        `;
+			});
+
+			await locked;
+			// Start the clear while the failure holds the lock, so it blocks with a
+			// pre-failure view of freshness, then let the failure commit under it.
+			const clearing = clearConnectionAclError(org.id, String(conn.id));
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			releaseFailure();
+			await failing;
+			await clearing;
+
+			const [state] = await sql`
+        SELECT freshness_state FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			// A failed state with no recorded reason is precisely the blindness this
+			// module exists to remove, so the reason must survive the losing clear.
+			expect(state?.freshness_state).toBe("failed");
+			expect(row?.error_message).toBe(formatAclErrorMessage("newer failure"));
+		});
 	});
 
 	describe("connector-health alerting", () => {

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -2,9 +2,9 @@
  * ACL observability — integration tests against real Postgres.
  *
  * Pins the three surfaces of ACL-failure observability:
- *  1. a failing ACL sync PERSISTS WHY on `connections.error_message` under the
- *     `acl: ` prefix, never clobbers another subsystem's text (the collision
- *     rule), and clears only ACL-owned text once the sync recovers;
+ *  1. a failing ACL sync persists its reason on `connections.error_message`
+ *     under the `acl: ` prefix, never clobbers another subsystem's text, and
+ *     clears only ACL-owned text once the sync recovers;
  *  2. a connection whose ACL graph is fail-closed
  *     (`authz_source_acl_state.freshness_state='failed'`) is flagged
  *     `acl_failed` by the connector-health alerter, alerting exactly once per
@@ -12,7 +12,7 @@
  *  3. deleting a connection removes its `authz_source_acl_state` row.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   clearConnectionAclError,
   formatAclErrorMessage,
@@ -31,21 +31,16 @@ import { TestApiClient } from '../../setup/test-mcp-client';
 
 // The connector-health scan skips connections younger than
 // minConnectionAgeHours (24h default); backdate fixtures so the ACL rule runs.
-const OLD = () => sqlDate(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000));
-
-function sqlDate(d: Date): string {
-  return d.toISOString();
-}
+const OLD = () => new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
 
 async function seedAclFailedConnection(opts: {
   orgId: string;
-  connectorKey?: string;
-  errorMessage?: string | null;
-}): Promise<{ id: number; slug: string }> {
+  errorMessage: string;
+}): Promise<{ id: number }> {
   const sql = getTestDb();
   const conn = await createTestConnection({
     organization_id: opts.orgId,
-    connector_key: opts.connectorKey ?? 'github',
+    connector_key: 'github',
     visibility: 'org',
     createDefaultFeed: false,
   });
@@ -67,21 +62,13 @@ async function seedAclFailedConnection(opts: {
     INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
     VALUES (${opts.orgId}, ${String(conn.id)}, 'full', 'failed', now() - interval '1 hour')
   `;
-  if (opts.errorMessage != null) {
-    await sql`
-      UPDATE connections SET error_message = ${opts.errorMessage} WHERE id = ${conn.id}
-    `;
-  }
-  const [{ slug }] = await sql<{ slug: string }>`
-    SELECT slug FROM connections WHERE id = ${conn.id}
+  await sql`
+    UPDATE connections SET error_message = ${opts.errorMessage} WHERE id = ${conn.id}
   `;
-  return { id: conn.id, slug };
+  return { id: conn.id };
 }
 
 describe('acl observability', () => {
-  beforeAll(async () => {
-    await cleanupTestDatabase();
-  });
   afterAll(async () => {
     await cleanupTestDatabase();
   });
@@ -93,8 +80,6 @@ describe('acl observability', () => {
     it('persists an acl:-prefixed failure reason when a sync fails', async () => {
       const sql = getTestDb();
       const org = await createTestOrganization({ name: 'Acl Reason Org' });
-      const user = await createTestUser({ name: 'Owner', email: 'acl-reason@example.com' });
-      await addUserToOrganization(user.id, org.id, 'owner');
       const conn = await createTestConnection({
         organization_id: org.id,
         connector_key: 'github',
@@ -106,8 +91,7 @@ describe('acl observability', () => {
         VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
       `;
 
-      // Drive the REAL production sync with a GitHub call that fails — the
-      // exact shape that ran silently for months in prod (AUTH_MISSING token).
+      // Drive the production sync path with a failing GitHub call.
       const result = await syncGithubConnectionAcl(
         {
           listRepos: async () => [{ owner: 'acme', repo: 'repo-a' }],
@@ -133,11 +117,13 @@ describe('acl observability', () => {
       expect(row?.error_message).toContain('401 Unauthorized');
     });
 
+    it('caps the complete persisted failure message at 500 characters', () => {
+      expect(formatAclErrorMessage('x'.repeat(1_000))).toHaveLength(500);
+    });
+
     it('never clobbers a non-ACL error_message when an ACL sync fails', async () => {
       const sql = getTestDb();
       const org = await createTestOrganization({ name: 'Acl Collision Org' });
-      const user = await createTestUser({ name: 'Owner', email: 'acl-collision@example.com' });
-      await addUserToOrganization(user.id, org.id, 'owner');
       const conn = await createTestConnection({
         organization_id: org.id,
         connector_key: 'github',
@@ -217,11 +203,55 @@ describe('acl observability', () => {
       expect(detail?.reason).toBe('acl_failed');
       expect(detail?.lastError).toContain('GitHub ACL sync failed');
       expect(result.newlyAlerted).toBeGreaterThan(0);
+      expect(result.authNotified).toBe(0);
 
       const [row] = await sql`
         SELECT unhealthy_alerted_at FROM connections WHERE id = ${conn.id}
       `;
       expect(row?.unhealthy_alerted_at).not.toBeNull();
+    });
+
+    it('does not attribute a chat runtime ACL failure to a colliding data slug', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Collision Health Org' });
+      const data = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        slug: 'shared-runtime-id',
+        createDefaultFeed: false,
+      });
+      const chat = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'slack',
+        slug: 'agentconn-shared-runtime-id',
+        createDefaultFeed: false,
+      });
+      await sql`
+        UPDATE connections
+        SET created_at = ${OLD()}, updated_at = ${OLD()},
+            credential_mode = CASE WHEN id = ${chat.id} THEN 'byo' ELSE credential_mode END
+        WHERE id IN (${data.id}, ${chat.id})
+      `;
+      await sql`
+        INSERT INTO feeds (
+          organization_id, connection_id, feed_key, status, kind, virtual,
+          last_sync_status, last_sync_at, consecutive_failures, created_at, updated_at
+        ) VALUES (
+          ${org.id}, ${data.id}, 'ok', 'active', 'collected', false,
+          'success', now(), 0, now(), now()
+        )
+      `;
+      await sql`
+        INSERT INTO authz_source_acl_state (
+          organization_id, connection_id, acl_support, freshness_state
+        ) VALUES (${org.id}, 'shared-runtime-id', 'full', 'failed')
+      `;
+
+      const result = await runConnectorHealthCheck();
+      expect(result.details.find((detail) => detail.connectionId === data.id)).toBeUndefined();
+      expect(result.details.find((detail) => detail.connectionId === chat.id)?.reason).toBe(
+        'acl_failed',
+      );
     });
 
     it('does not double-alert while still acl_failed, and re-alerts after recovery', async () => {
@@ -266,7 +296,7 @@ describe('acl observability', () => {
   });
 
   describe('orphan cleanup', () => {
-    it('deleting a connection removes its ACL rows', async () => {
+    it('deleting a connection removes only its ACL row', async () => {
       const sql = getTestDb();
       const org = await createTestOrganization({ name: 'Acl Delete Org' });
       const user = await createTestUser({ name: 'Owner', email: 'acl-delete@example.com' });
@@ -274,14 +304,15 @@ describe('acl observability', () => {
       const conn = await createTestConnection({
         organization_id: org.id,
         connector_key: 'github',
+        slug: 'unrelated-chat-runtime',
         visibility: 'org',
         createDefaultFeed: false,
       });
       const [{ slug }] = await sql<{ slug: string }>`
         SELECT slug FROM connections WHERE id = ${conn.id}
       `;
-      // Both runtime-id shapes the ACL sync may have stamped: the numeric
-      // `id::text` (GitHub) and the slug (managed Slack / BYO-slug).
+      // The numeric key belongs to this data connection. The slug-shaped key
+      // simulates a different chat runtime id and must survive this deletion.
       await sql`
         INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state)
         VALUES
@@ -307,7 +338,8 @@ describe('acl observability', () => {
         WHERE organization_id = ${org.id}
           AND connection_id IN (${String(conn.id)}, ${slug})
       `;
-      expect(remaining.length).toBe(0);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.connection_id).toBe(slug);
     });
   });
 });

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -1,0 +1,313 @@
+/**
+ * ACL observability — integration tests against real Postgres.
+ *
+ * Pins the three surfaces of ACL-failure observability:
+ *  1. a failing ACL sync PERSISTS WHY on `connections.error_message` under the
+ *     `acl: ` prefix, never clobbers another subsystem's text (the collision
+ *     rule), and clears only ACL-owned text once the sync recovers;
+ *  2. a connection whose ACL graph is fail-closed
+ *     (`authz_source_acl_state.freshness_state='failed'`) is flagged
+ *     `acl_failed` by the connector-health alerter, alerting exactly once per
+ *     episode through the existing `unhealthy_alerted_at` claim;
+ *  3. deleting a connection removes its `authz_source_acl_state` row.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearConnectionAclError,
+  formatAclErrorMessage,
+  isAclErrorMessage,
+} from '../../../authz/acl-observability';
+import { syncGithubConnectionAcl } from '../../../authz/github-acl-sync';
+import { runConnectorHealthCheck } from '../../../connectors/connector-health';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+
+// The connector-health scan skips connections younger than
+// minConnectionAgeHours (24h default); backdate fixtures so the ACL rule runs.
+const OLD = () => sqlDate(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000));
+
+function sqlDate(d: Date): string {
+  return d.toISOString();
+}
+
+async function seedAclFailedConnection(opts: {
+  orgId: string;
+  connectorKey?: string;
+  errorMessage?: string | null;
+}): Promise<{ id: number; slug: string }> {
+  const sql = getTestDb();
+  const conn = await createTestConnection({
+    organization_id: opts.orgId,
+    connector_key: opts.connectorKey ?? 'github',
+    visibility: 'org',
+    createDefaultFeed: false,
+  });
+  await sql`
+    UPDATE connections SET created_at = ${OLD()}, updated_at = ${OLD()} WHERE id = ${conn.id}
+  `;
+  // A healthy feed, so no FEED rule can be what flags the connection — only the
+  // fail-closed ACL state may.
+  await sql`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, status, kind, virtual,
+      last_sync_status, last_sync_at, consecutive_failures, created_at, updated_at
+    ) VALUES (
+      ${opts.orgId}, ${conn.id}, 'ok', 'active', 'collected', false,
+      'success', now(), 0, now(), now()
+    )
+  `;
+  await sql`
+    INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+    VALUES (${opts.orgId}, ${String(conn.id)}, 'full', 'failed', now() - interval '1 hour')
+  `;
+  if (opts.errorMessage != null) {
+    await sql`
+      UPDATE connections SET error_message = ${opts.errorMessage} WHERE id = ${conn.id}
+    `;
+  }
+  const [{ slug }] = await sql<{ slug: string }>`
+    SELECT slug FROM connections WHERE id = ${conn.id}
+  `;
+  return { id: conn.id, slug };
+}
+
+describe('acl observability', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  describe('failure reason persistence', () => {
+    it('persists an acl:-prefixed failure reason when a sync fails', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Reason Org' });
+      const user = await createTestUser({ name: 'Owner', email: 'acl-reason@example.com' });
+      await addUserToOrganization(user.id, org.id, 'owner');
+      const conn = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        visibility: 'org',
+        createDefaultFeed: false,
+      });
+      await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
+
+      // Drive the REAL production sync with a GitHub call that fails — the
+      // exact shape that ran silently for months in prod (AUTH_MISSING token).
+      const result = await syncGithubConnectionAcl(
+        {
+          listRepos: async () => [{ owner: 'acme', repo: 'repo-a' }],
+          fetchCollaborators: async () => {
+            throw new Error('401 Unauthorized — GitHub token is not valid');
+          },
+        },
+        { connectionId: String(conn.id), organizationId: org.id },
+      );
+      expect(result.ok).toBe(false);
+
+      const [state] = await sql`
+        SELECT freshness_state FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+      expect(state?.freshness_state).toBe('failed');
+
+      const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+      expect(isAclErrorMessage(row?.error_message)).toBe(true);
+      expect(row?.error_message).toContain('GitHub ACL sync failed');
+      expect(row?.error_message).toContain('401 Unauthorized');
+    });
+
+    it('never clobbers a non-ACL error_message when an ACL sync fails', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Collision Org' });
+      const user = await createTestUser({ name: 'Owner', email: 'acl-collision@example.com' });
+      await addUserToOrganization(user.id, org.id, 'owner');
+      const conn = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        visibility: 'org',
+        createDefaultFeed: false,
+      });
+      await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
+      // A feed-sync owned message occupies the shared column.
+      await sql`
+        UPDATE connections SET error_message = 'Feed sync failed: HTTP 429 rate limited' WHERE id = ${conn.id}
+      `;
+
+      await syncGithubConnectionAcl(
+        {
+          listRepos: async () => [{ owner: 'acme', repo: 'repo-a' }],
+          fetchCollaborators: async () => {
+            throw new Error('401 Unauthorized');
+          },
+        },
+        { connectionId: String(conn.id), organizationId: org.id },
+      );
+
+      const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+      expect(row?.error_message).toBe('Feed sync failed: HTTP 429 rate limited');
+    });
+
+    it('clears only acl:-owned text once the sync recovers', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Clear Org' });
+      const aclOwned = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        display_name: 'Acl-owned Conn',
+        createDefaultFeed: false,
+      });
+      const feedOwned = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        display_name: 'Feed-owned Conn',
+        createDefaultFeed: false,
+      });
+      await sql`
+        UPDATE connections SET error_message = ${formatAclErrorMessage('GitHub ACL sync failed: 401')} WHERE id = ${aclOwned.id}
+      `;
+      await sql`
+        UPDATE connections SET error_message = 'Feed sync failed: HTTP 429' WHERE id = ${feedOwned.id}
+      `;
+
+      await clearConnectionAclError(org.id, String(aclOwned.id));
+      await clearConnectionAclError(org.id, String(feedOwned.id));
+
+      const [afterAcl, afterFeed] = await Promise.all([
+        sql`SELECT error_message FROM connections WHERE id = ${aclOwned.id}`,
+        sql`SELECT error_message FROM connections WHERE id = ${feedOwned.id}`,
+      ]);
+      expect(afterAcl[0]?.error_message).toBeNull();
+      expect(afterFeed[0]?.error_message).toBe('Feed sync failed: HTTP 429');
+    });
+  });
+
+  describe('connector-health alerting', () => {
+    it('alerts once on the transition into acl_failed', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Alert Org' });
+      const conn = await seedAclFailedConnection({
+        orgId: org.id,
+        errorMessage: formatAclErrorMessage('GitHub ACL sync failed: 401 Unauthorized'),
+      });
+
+      const result = await runConnectorHealthCheck();
+      const detail = result.details.find((d) => d.connectionId === conn.id);
+      expect(detail?.reason).toBe('acl_failed');
+      expect(detail?.lastError).toContain('GitHub ACL sync failed');
+      expect(result.newlyAlerted).toBeGreaterThan(0);
+
+      const [row] = await sql`
+        SELECT unhealthy_alerted_at FROM connections WHERE id = ${conn.id}
+      `;
+      expect(row?.unhealthy_alerted_at).not.toBeNull();
+    });
+
+    it('does not double-alert while still acl_failed, and re-alerts after recovery', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Dedupe Org' });
+      const conn = await seedAclFailedConnection({
+        orgId: org.id,
+        errorMessage: formatAclErrorMessage('GitHub ACL sync failed: 401 Unauthorized'),
+      });
+
+      const first = await runConnectorHealthCheck();
+      expect(first.details.some((d) => d.connectionId === conn.id)).toBe(true);
+      expect(first.newlyAlerted).toBeGreaterThan(0);
+
+      // Still unhealthy → no second alert (the unhealthy_alerted_at claim).
+      const second = await runConnectorHealthCheck();
+      expect(second.details.some((d) => d.connectionId === conn.id)).toBe(true);
+      expect(second.newlyAlerted).toBe(0);
+
+      // Recovery re-arms the marker...
+      await sql`
+        UPDATE authz_source_acl_state
+        SET freshness_state = 'fresh', last_synced_at = now(), updated_at = now()
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+      const afterRecovery = await runConnectorHealthCheck();
+      expect(afterRecovery.recovered).toBeGreaterThan(0);
+      const [cleared] = await sql`
+        SELECT unhealthy_alerted_at FROM connections WHERE id = ${conn.id}
+      `;
+      expect(cleared?.unhealthy_alerted_at).toBeNull();
+
+      // ...and a fresh failure alerts again (NULL→set transition once more).
+      await sql`
+        UPDATE authz_source_acl_state
+        SET freshness_state = 'failed', updated_at = now()
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+      const broken = await runConnectorHealthCheck();
+      expect(broken.newlyAlerted).toBeGreaterThan(0);
+    });
+  });
+
+  describe('orphan cleanup', () => {
+    it('deleting a connection removes its ACL rows', async () => {
+      const sql = getTestDb();
+      const org = await createTestOrganization({ name: 'Acl Delete Org' });
+      const user = await createTestUser({ name: 'Owner', email: 'acl-delete@example.com' });
+      await addUserToOrganization(user.id, org.id, 'owner');
+      const conn = await createTestConnection({
+        organization_id: org.id,
+        connector_key: 'github',
+        visibility: 'org',
+        createDefaultFeed: false,
+      });
+      const [{ slug }] = await sql<{ slug: string }>`
+        SELECT slug FROM connections WHERE id = ${conn.id}
+      `;
+      // Both runtime-id shapes the ACL sync may have stamped: the numeric
+      // `id::text` (GitHub) and the slug (managed Slack / BYO-slug).
+      await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state)
+        VALUES
+          (${org.id}, ${String(conn.id)}, 'full', 'fresh'),
+          (${org.id}, ${slug}, 'full', 'failed')
+      `;
+
+      const client = await TestApiClient.for({
+        organizationId: org.id,
+        userId: user.id,
+        memberRole: 'owner',
+      });
+      const result = (await client.connections.delete(conn.id)) as { deleted?: boolean };
+      expect(result.deleted).toBe(true);
+
+      const [tombstoned] = await sql`
+        SELECT deleted_at FROM connections WHERE id = ${conn.id}
+      `;
+      expect(tombstoned?.deleted_at).not.toBeNull();
+
+      const remaining = await sql`
+        SELECT connection_id FROM authz_source_acl_state
+        WHERE organization_id = ${org.id}
+          AND connection_id IN (${String(conn.id)}, ${slug})
+      `;
+      expect(remaining.length).toBe(0);
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -12,44 +12,44 @@
  *  3. deleting a connection removes its `authz_source_acl_state` row.
  */
 
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
-  clearConnectionAclError,
-  formatAclErrorMessage,
-  isAclErrorMessage,
-} from '../../../authz/acl-observability';
-import { syncGithubConnectionAcl } from '../../../authz/github-acl-sync';
-import { runConnectorHealthCheck } from '../../../connectors/connector-health';
-import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+	clearConnectionAclError,
+	formatAclErrorMessage,
+	isAclErrorMessage,
+} from "../../../authz/acl-observability";
+import { syncGithubConnectionAcl } from "../../../authz/github-acl-sync";
+import { runConnectorHealthCheck } from "../../../connectors/connector-health";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
-  addUserToOrganization,
-  createTestConnection,
-  createTestOrganization,
-  createTestUser,
-} from '../../setup/test-fixtures';
-import { TestApiClient } from '../../setup/test-mcp-client';
+	addUserToOrganization,
+	createTestConnection,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import { TestApiClient } from "../../setup/test-mcp-client";
 
 // The connector-health scan skips connections younger than
 // minConnectionAgeHours (24h default); backdate fixtures so the ACL rule runs.
 const OLD = () => new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
 
 async function seedAclFailedConnection(opts: {
-  orgId: string;
-  errorMessage: string;
+	orgId: string;
+	errorMessage: string;
 }): Promise<{ id: number }> {
-  const sql = getTestDb();
-  const conn = await createTestConnection({
-    organization_id: opts.orgId,
-    connector_key: 'github',
-    visibility: 'org',
-    createDefaultFeed: false,
-  });
-  await sql`
+	const sql = getTestDb();
+	const conn = await createTestConnection({
+		organization_id: opts.orgId,
+		connector_key: "github",
+		visibility: "org",
+		createDefaultFeed: false,
+	});
+	await sql`
     UPDATE connections SET created_at = ${OLD()}, updated_at = ${OLD()} WHERE id = ${conn.id}
   `;
-  // A healthy feed, so no FEED rule can be what flags the connection — only the
-  // fail-closed ACL state may.
-  await sql`
+	// A healthy feed, so no FEED rule can be what flags the connection — only the
+	// fail-closed ACL state may.
+	await sql`
     INSERT INTO feeds (
       organization_id, connection_id, feed_key, status, kind, virtual,
       last_sync_status, last_sync_at, consecutive_failures, created_at, updated_at
@@ -58,181 +58,276 @@ async function seedAclFailedConnection(opts: {
       'success', now(), 0, now(), now()
     )
   `;
-  await sql`
+	await sql`
     INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
     VALUES (${opts.orgId}, ${String(conn.id)}, 'full', 'failed', now() - interval '1 hour')
   `;
-  await sql`
+	await sql`
     UPDATE connections SET error_message = ${opts.errorMessage} WHERE id = ${conn.id}
   `;
-  return { id: conn.id };
+	return { id: conn.id };
 }
 
-describe('acl observability', () => {
-  afterAll(async () => {
-    await cleanupTestDatabase();
-  });
-  beforeEach(async () => {
-    await cleanupTestDatabase();
-  });
+describe("acl observability", () => {
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
 
-  describe('failure reason persistence', () => {
-    it('persists an acl:-prefixed failure reason when a sync fails', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Reason Org' });
-      const conn = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        visibility: 'org',
-        createDefaultFeed: false,
-      });
-      await sql`
+	describe("failure reason persistence", () => {
+		it("persists an acl:-prefixed failure reason when a sync fails", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Reason Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
         INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
         VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
       `;
 
-      // Drive the production sync path with a failing GitHub call.
-      const result = await syncGithubConnectionAcl(
-        {
-          listRepos: async () => [{ owner: 'acme', repo: 'repo-a' }],
-          fetchCollaborators: async () => {
-            throw new Error('401 Unauthorized — GitHub token is not valid');
-          },
-        },
-        { connectionId: String(conn.id), organizationId: org.id },
-      );
-      expect(result.ok).toBe(false);
+			// Drive the production sync path with a failing GitHub call.
+			const result = await syncGithubConnectionAcl(
+				{
+					listRepos: async () => [{ owner: "acme", repo: "repo-a" }],
+					fetchCollaborators: async () => {
+						throw new Error("401 Unauthorized — GitHub token is not valid");
+					},
+				},
+				{ connectionId: String(conn.id), organizationId: org.id },
+			);
+			expect(result.ok).toBe(false);
 
-      const [state] = await sql`
+			const [state] = await sql`
         SELECT freshness_state FROM authz_source_acl_state
         WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
       `;
-      expect(state?.freshness_state).toBe('failed');
+			expect(state?.freshness_state).toBe("failed");
 
-      const [row] = await sql`
+			const [row] = await sql`
         SELECT error_message FROM connections WHERE id = ${conn.id}
       `;
-      expect(isAclErrorMessage(row?.error_message)).toBe(true);
-      expect(row?.error_message).toContain('GitHub ACL sync failed');
-      expect(row?.error_message).toContain('401 Unauthorized');
-    });
+			expect(isAclErrorMessage(row?.error_message)).toBe(true);
+			expect(row?.error_message).toContain("GitHub ACL sync failed");
+			expect(row?.error_message).toContain("401 Unauthorized");
+		});
 
-    it('caps the complete persisted failure message at 500 characters', () => {
-      expect(formatAclErrorMessage('x'.repeat(1_000))).toHaveLength(500);
-    });
+		it("caps the complete persisted failure message at 500 characters", () => {
+			expect(formatAclErrorMessage("x".repeat(1_000))).toHaveLength(500);
+		});
 
-    it('never clobbers a non-ACL error_message when an ACL sync fails', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Collision Org' });
-      const conn = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        visibility: 'org',
-        createDefaultFeed: false,
-      });
-      await sql`
+		it("never clobbers a non-ACL error_message when an ACL sync fails", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Collision Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
         INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
         VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
       `;
-      // A feed-sync owned message occupies the shared column.
-      await sql`
+			// A feed-sync owned message occupies the shared column.
+			await sql`
         UPDATE connections SET error_message = 'Feed sync failed: HTTP 429 rate limited' WHERE id = ${conn.id}
       `;
 
-      await syncGithubConnectionAcl(
-        {
-          listRepos: async () => [{ owner: 'acme', repo: 'repo-a' }],
-          fetchCollaborators: async () => {
-            throw new Error('401 Unauthorized');
-          },
-        },
-        { connectionId: String(conn.id), organizationId: org.id },
-      );
+			await syncGithubConnectionAcl(
+				{
+					listRepos: async () => [{ owner: "acme", repo: "repo-a" }],
+					fetchCollaborators: async () => {
+						throw new Error("401 Unauthorized");
+					},
+				},
+				{ connectionId: String(conn.id), organizationId: org.id },
+			);
 
-      const [row] = await sql`
+			const [row] = await sql`
         SELECT error_message FROM connections WHERE id = ${conn.id}
       `;
-      expect(row?.error_message).toBe('Feed sync failed: HTTP 429 rate limited');
-    });
+			expect(row?.error_message).toBe(
+				"Feed sync failed: HTTP 429 rate limited",
+			);
+		});
 
-    it('clears only acl:-owned text once the sync recovers', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Clear Org' });
-      const aclOwned = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        display_name: 'Acl-owned Conn',
-        createDefaultFeed: false,
-      });
-      const feedOwned = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        display_name: 'Feed-owned Conn',
-        createDefaultFeed: false,
-      });
-      await sql`
-        UPDATE connections SET error_message = ${formatAclErrorMessage('GitHub ACL sync failed: 401')} WHERE id = ${aclOwned.id}
+		it("clears only acl:-owned text once the sync recovers", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Clear Org" });
+			const aclOwned = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				display_name: "Acl-owned Conn",
+				createDefaultFeed: false,
+			});
+			const feedOwned = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				display_name: "Feed-owned Conn",
+				createDefaultFeed: false,
+			});
+			const newerFailure = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				display_name: "Newer ACL Failure Conn",
+				createDefaultFeed: false,
+			});
+			await sql`
+        UPDATE connections SET error_message = ${formatAclErrorMessage("GitHub ACL sync failed: 401")} WHERE id = ${aclOwned.id}
       `;
-      await sql`
+			await sql`
         UPDATE connections SET error_message = 'Feed sync failed: HTTP 429' WHERE id = ${feedOwned.id}
       `;
+			await sql`
+        UPDATE connections SET error_message = ${formatAclErrorMessage("GitHub ACL sync failed: 403")} WHERE id = ${newerFailure.id}
+      `;
+			await sql`
+        INSERT INTO authz_source_acl_state (
+          organization_id, connection_id, acl_support, freshness_state
+        ) VALUES
+          (${org.id}, ${String(aclOwned.id)}, 'full', 'fresh'),
+          (${org.id}, ${String(feedOwned.id)}, 'full', 'fresh'),
+          (${org.id}, ${String(newerFailure.id)}, 'full', 'failed')
+      `;
 
-      await clearConnectionAclError(org.id, String(aclOwned.id));
-      await clearConnectionAclError(org.id, String(feedOwned.id));
+			await clearConnectionAclError(org.id, String(aclOwned.id));
+			await clearConnectionAclError(org.id, String(feedOwned.id));
+			await clearConnectionAclError(org.id, String(newerFailure.id));
 
-      const [afterAcl, afterFeed] = await Promise.all([
-        sql`SELECT error_message FROM connections WHERE id = ${aclOwned.id}`,
-        sql`SELECT error_message FROM connections WHERE id = ${feedOwned.id}`,
-      ]);
-      expect(afterAcl[0]?.error_message).toBeNull();
-      expect(afterFeed[0]?.error_message).toBe('Feed sync failed: HTTP 429');
-    });
-  });
+			const [afterAcl, afterFeed, afterNewerFailure] = await Promise.all([
+				sql`SELECT error_message FROM connections WHERE id = ${aclOwned.id}`,
+				sql`SELECT error_message FROM connections WHERE id = ${feedOwned.id}`,
+				sql`SELECT error_message FROM connections WHERE id = ${newerFailure.id}`,
+			]);
+			expect(afterAcl[0]?.error_message).toBeNull();
+			expect(afterFeed[0]?.error_message).toBe("Feed sync failed: HTTP 429");
+			expect(afterNewerFailure[0]?.error_message).toContain("403");
+		});
 
-  describe('connector-health alerting', () => {
-    it('alerts once on the transition into acl_failed', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Alert Org' });
-      const conn = await seedAclFailedConnection({
-        orgId: org.id,
-        errorMessage: formatAclErrorMessage('GitHub ACL sync failed: 401 Unauthorized'),
-      });
+		it("leaves connections.updated_at untouched when the same failure repeats", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Repeat Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
 
-      const result = await runConnectorHealthCheck();
-      const detail = result.details.find((d) => d.connectionId === conn.id);
-      expect(detail?.reason).toBe('acl_failed');
-      expect(detail?.lastError).toContain('GitHub ACL sync failed');
-      expect(result.newlyAlerted).toBeGreaterThan(0);
-      expect(result.authNotified).toBe(0);
+			const failWith = (message: string) =>
+				syncGithubConnectionAcl(
+					{
+						listRepos: async () => [{ owner: "acme", repo: "repo-a" }],
+						fetchCollaborators: async () => {
+							throw new Error(message);
+						},
+					},
+					{ connectionId: String(conn.id), organizationId: org.id },
+				);
 
-      const [row] = await sql`
+			await failWith("401 Unauthorized");
+			const [firstConn] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(isAclErrorMessage(firstConn?.error_message)).toBe(true);
+
+			// Backdate both rows to a fixed sentinel so "was it rewritten?" is an
+			// exact-value question rather than a sub-millisecond clock comparison,
+			// which two consecutive transactions can lose.
+			const SENTINEL = "2001-01-01T00:00:00.000Z";
+			await sql`UPDATE connections SET updated_at = ${SENTINEL} WHERE id = ${conn.id}`;
+			await sql`
+        UPDATE authz_source_acl_state SET updated_at = ${SENTINEL}
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+
+			// The ACL sync retries on a fixed tick. `connections.updated_at` is the
+			// memo key chat adapters hydrate against, so an unchanged failure must
+			// not rewrite the row — otherwise every tick rehydrates live Slack
+			// instances for the length of the outage.
+			await failWith("401 Unauthorized");
+			const [repeatConn] = await sql`
+        SELECT updated_at FROM connections WHERE id = ${conn.id}
+      `;
+			const [repeatState] = await sql`
+        SELECT updated_at FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+			expect(repeatConn?.updated_at).toEqual(new Date(SENTINEL));
+			// Unlike the shared connection row, ACL state must record every failure.
+			// `markAclFresh` compares this timestamp with its snapshot start, so an
+			// older in-flight sync cannot overwrite a newer repeated failure.
+			expect(repeatState?.updated_at).not.toEqual(new Date(SENTINEL));
+
+			// A genuinely different reason still lands — the guard suppresses
+			// duplicates, not updates.
+			await failWith("403 Forbidden — SAML enforcement");
+			const [changedConn] = await sql`
+        SELECT error_message, updated_at FROM connections WHERE id = ${conn.id}
+      `;
+			expect(changedConn?.error_message).toContain("403 Forbidden");
+			expect(changedConn?.updated_at).not.toEqual(new Date(SENTINEL));
+		});
+	});
+
+	describe("connector-health alerting", () => {
+		it("alerts once on the transition into acl_failed", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Alert Org" });
+			const conn = await seedAclFailedConnection({
+				orgId: org.id,
+				errorMessage: formatAclErrorMessage(
+					"GitHub ACL sync failed: 401 Unauthorized",
+				),
+			});
+
+			const result = await runConnectorHealthCheck();
+			const detail = result.details.find((d) => d.connectionId === conn.id);
+			expect(detail?.reason).toBe("acl_failed");
+			expect(detail?.lastError).toContain("GitHub ACL sync failed");
+			expect(result.newlyAlerted).toBeGreaterThan(0);
+			expect(result.authNotified).toBe(0);
+
+			const [row] = await sql`
         SELECT unhealthy_alerted_at FROM connections WHERE id = ${conn.id}
       `;
-      expect(row?.unhealthy_alerted_at).not.toBeNull();
-    });
+			expect(row?.unhealthy_alerted_at).not.toBeNull();
+		});
 
-    it('does not attribute a chat runtime ACL failure to a colliding data slug', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Collision Health Org' });
-      const data = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        slug: 'shared-runtime-id',
-        createDefaultFeed: false,
-      });
-      const chat = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'slack',
-        slug: 'agentconn-shared-runtime-id',
-        createDefaultFeed: false,
-      });
-      await sql`
+		it("does not attribute a chat runtime ACL failure to a colliding data slug", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({
+				name: "Acl Collision Health Org",
+			});
+			const data = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				slug: "shared-runtime-id",
+				createDefaultFeed: false,
+			});
+			const chat = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "slack",
+				slug: "agentconn-shared-runtime-id",
+				createDefaultFeed: false,
+			});
+			await sql`
         UPDATE connections
         SET created_at = ${OLD()}, updated_at = ${OLD()},
             credential_mode = CASE WHEN id = ${chat.id} THEN 'byo' ELSE credential_mode END
         WHERE id IN (${data.id}, ${chat.id})
       `;
-      await sql`
+			await sql`
         INSERT INTO feeds (
           organization_id, connection_id, feed_key, status, kind, virtual,
           last_sync_status, last_sync_at, consecutive_failures, created_at, updated_at
@@ -241,105 +336,180 @@ describe('acl observability', () => {
           'success', now(), 0, now(), now()
         )
       `;
-      await sql`
+			await sql`
         INSERT INTO authz_source_acl_state (
           organization_id, connection_id, acl_support, freshness_state
         ) VALUES (${org.id}, 'shared-runtime-id', 'full', 'failed')
       `;
 
-      const result = await runConnectorHealthCheck();
-      expect(result.details.find((detail) => detail.connectionId === data.id)).toBeUndefined();
-      expect(result.details.find((detail) => detail.connectionId === chat.id)?.reason).toBe(
-        'acl_failed',
-      );
-    });
+			const result = await runConnectorHealthCheck();
+			expect(
+				result.details.find((detail) => detail.connectionId === data.id),
+			).toBeUndefined();
+			expect(
+				result.details.find((detail) => detail.connectionId === chat.id)
+					?.reason,
+			).toBe("acl_failed");
+		});
 
-    it('does not double-alert while still acl_failed, and re-alerts after recovery', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Dedupe Org' });
-      const conn = await seedAclFailedConnection({
-        orgId: org.id,
-        errorMessage: formatAclErrorMessage('GitHub ACL sync failed: 401 Unauthorized'),
-      });
+		it("does not double-alert while still acl_failed, and re-alerts after recovery", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Dedupe Org" });
+			const conn = await seedAclFailedConnection({
+				orgId: org.id,
+				errorMessage: formatAclErrorMessage(
+					"GitHub ACL sync failed: 401 Unauthorized",
+				),
+			});
 
-      const first = await runConnectorHealthCheck();
-      expect(first.details.some((d) => d.connectionId === conn.id)).toBe(true);
-      expect(first.newlyAlerted).toBeGreaterThan(0);
+			const first = await runConnectorHealthCheck();
+			expect(first.details.some((d) => d.connectionId === conn.id)).toBe(true);
+			expect(first.newlyAlerted).toBeGreaterThan(0);
 
-      // Still unhealthy → no second alert (the unhealthy_alerted_at claim).
-      const second = await runConnectorHealthCheck();
-      expect(second.details.some((d) => d.connectionId === conn.id)).toBe(true);
-      expect(second.newlyAlerted).toBe(0);
+			// Still unhealthy → no second alert (the unhealthy_alerted_at claim).
+			const second = await runConnectorHealthCheck();
+			expect(second.details.some((d) => d.connectionId === conn.id)).toBe(true);
+			expect(second.newlyAlerted).toBe(0);
 
-      // Recovery re-arms the marker...
-      await sql`
+			// Recovery re-arms the marker...
+			await sql`
         UPDATE authz_source_acl_state
         SET freshness_state = 'fresh', last_synced_at = now(), updated_at = now()
         WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
       `;
-      const afterRecovery = await runConnectorHealthCheck();
-      expect(afterRecovery.recovered).toBeGreaterThan(0);
-      const [cleared] = await sql`
+			const afterRecovery = await runConnectorHealthCheck();
+			expect(afterRecovery.recovered).toBeGreaterThan(0);
+			const [cleared] = await sql`
         SELECT unhealthy_alerted_at FROM connections WHERE id = ${conn.id}
       `;
-      expect(cleared?.unhealthy_alerted_at).toBeNull();
+			expect(cleared?.unhealthy_alerted_at).toBeNull();
 
-      // ...and a fresh failure alerts again (NULL→set transition once more).
-      await sql`
+			// ...and a fresh failure alerts again (NULL→set transition once more).
+			await sql`
         UPDATE authz_source_acl_state
         SET freshness_state = 'failed', updated_at = now()
         WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
       `;
-      const broken = await runConnectorHealthCheck();
-      expect(broken.newlyAlerted).toBeGreaterThan(0);
-    });
-  });
+			const broken = await runConnectorHealthCheck();
+			expect(broken.newlyAlerted).toBeGreaterThan(0);
+		});
+	});
 
-  describe('orphan cleanup', () => {
-    it('deleting a connection removes only its ACL row', async () => {
-      const sql = getTestDb();
-      const org = await createTestOrganization({ name: 'Acl Delete Org' });
-      const user = await createTestUser({ name: 'Owner', email: 'acl-delete@example.com' });
-      await addUserToOrganization(user.id, org.id, 'owner');
-      const conn = await createTestConnection({
-        organization_id: org.id,
-        connector_key: 'github',
-        slug: 'unrelated-chat-runtime',
-        visibility: 'org',
-        createDefaultFeed: false,
-      });
-      const [{ slug }] = await sql<{ slug: string }>`
+	describe("orphan cleanup", () => {
+		it("deleting a connection removes only its ACL row", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Delete Org" });
+			const user = await createTestUser({
+				name: "Owner",
+				email: "acl-delete@example.com",
+			});
+			await addUserToOrganization(user.id, org.id, "owner");
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				slug: "unrelated-chat-runtime",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			const [{ slug }] = await sql<{ slug: string }>`
         SELECT slug FROM connections WHERE id = ${conn.id}
       `;
-      // The numeric key belongs to this data connection. The slug-shaped key
-      // simulates a different chat runtime id and must survive this deletion.
-      await sql`
+			// The numeric key belongs to this data connection. The slug-shaped key
+			// simulates a different chat runtime id and must survive this deletion.
+			await sql`
         INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state)
         VALUES
           (${org.id}, ${String(conn.id)}, 'full', 'fresh'),
           (${org.id}, ${slug}, 'full', 'failed')
       `;
 
-      const client = await TestApiClient.for({
-        organizationId: org.id,
-        userId: user.id,
-        memberRole: 'owner',
-      });
-      const result = (await client.connections.delete(conn.id)) as { deleted?: boolean };
-      expect(result.deleted).toBe(true);
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			const result = (await client.connections.delete(conn.id)) as {
+				deleted?: boolean;
+			};
+			expect(result.deleted).toBe(true);
 
-      const [tombstoned] = await sql`
+			const [tombstoned] = await sql`
         SELECT deleted_at FROM connections WHERE id = ${conn.id}
       `;
-      expect(tombstoned?.deleted_at).not.toBeNull();
+			expect(tombstoned?.deleted_at).not.toBeNull();
 
-      const remaining = await sql`
+			const remaining = await sql`
         SELECT connection_id FROM authz_source_acl_state
         WHERE organization_id = ${org.id}
           AND connection_id IN (${String(conn.id)}, ${slug})
       `;
-      expect(remaining).toHaveLength(1);
-      expect(remaining[0]?.connection_id).toBe(slug);
-    });
-  });
+			expect(remaining).toHaveLength(1);
+			expect(remaining[0]?.connection_id).toBe(slug);
+		});
+
+		it("does not recreate ACL state when an in-flight sync finishes after deletion", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Delete Race Org" });
+			const user = await createTestUser({
+				name: "Owner",
+				email: "acl-delete-race@example.com",
+			});
+			await addUserToOrganization(user.id, org.id, "owner");
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
+        INSERT INTO authz_source_acl_state (
+          organization_id, connection_id, acl_support, freshness_state
+        ) VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh')
+      `;
+
+			let signalFetchStarted!: () => void;
+			let releaseFetch!: () => void;
+			const fetchStarted = new Promise<void>((resolve) => {
+				signalFetchStarted = resolve;
+			});
+			const fetchRelease = new Promise<void>((resolve) => {
+				releaseFetch = resolve;
+			});
+			const sync = syncGithubConnectionAcl(
+				{
+					listRepos: async () => [{ owner: "acme", repo: "repo-a" }],
+					fetchCollaborators: async () => {
+						signalFetchStarted();
+						await fetchRelease;
+						return [{ login: "alice", id: 1 }];
+					},
+				},
+				{ connectionId: String(conn.id), organizationId: org.id },
+			);
+			await fetchStarted;
+
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			let deleted: { deleted?: boolean };
+			try {
+				deleted = (await client.connections.delete(conn.id)) as {
+					deleted?: boolean;
+				};
+			} finally {
+				releaseFetch();
+			}
+			expect(deleted.deleted).toBe(true);
+			expect((await sync).ok).toBe(true);
+
+			const state = await sql`
+        SELECT connection_id
+        FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+			expect(state).toHaveLength(0);
+		});
+	});
 });

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -31,46 +31,47 @@
  * data-shaped problem (the CALLER's fetch layer owns fail-closed-on-error).
  */
 
-import { createLogger } from '@lobu/core';
 import {
-  ACL_RESOURCE_TYPE_SLUG,
-  type AccessIdentitySpec,
-  type AccessMember,
-  type AccessResource,
-} from '@lobu/connector-sdk';
-import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
-import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection.js';
-import { resolveEventAttributionsForItems } from '../utils/entity-link-upsert.js';
-import { ensureResourceEntityType } from './acl-resource-type.js';
+	ACL_RESOURCE_TYPE_SLUG,
+	type AccessIdentitySpec,
+	type AccessMember,
+	type AccessResource,
+} from "@lobu/connector-sdk";
+import { createLogger } from "@lobu/core";
+import { getDb, pgBigintArray, pgTextArray } from "../db/client.js";
+import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection.js";
+import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
+import { aclConnectionIdSql } from "./acl-observability.js";
+import { ensureResourceEntityType } from "./acl-resource-type.js";
 
-const logger = createLogger('access-graph');
+const logger = createLogger("access-graph");
 
-const MEMBER_OF_TYPE_SLUG = 'member_of';
+const MEMBER_OF_TYPE_SLUG = "member_of";
 
+export { ensureResourceEntityType } from "./acl-resource-type.js";
 export type { AccessIdentitySpec, AccessMember, AccessResource };
-export { ensureResourceEntityType } from './acl-resource-type.js';
 
 export interface AccessGraphResult {
-  /** Resource key → the entity id that now represents it. */
-  resourceEntityIds: Record<string, number>;
-  /** Distinct member entity ids that gained a `member_of` edge. */
-  memberEntityIds: number[];
-  createdEdges: number;
-  removedEdges: number;
+	/** Resource key → the entity id that now represents it. */
+	resourceEntityIds: Record<string, number>;
+	/** Distinct member entity ids that gained a `member_of` edge. */
+	memberEntityIds: number[];
+	createdEdges: number;
+	removedEdges: number;
 }
 
 const EMPTY_RESULT: AccessGraphResult = {
-  resourceEntityIds: {},
-  memberEntityIds: [],
-  createdEdges: 0,
-  removedEdges: 0,
+	resourceEntityIds: {},
+	memberEntityIds: [],
+	createdEdges: 0,
+	removedEdges: 0,
 };
 
 /** Resolve an org owner/admin as `entities.created_by` / edge `created_by`
  * (NOT NULL). Same query both source builders used. */
 async function resolveOrgCreator(orgId: string): Promise<string | null> {
-  const sql = getDb();
-  const rows = await sql<{ userId: string }>`
+	const sql = getDb();
+	const rows = await sql<{ userId: string }>`
 		SELECT "userId"
 		FROM "member"
 		WHERE "organizationId" = ${orgId}
@@ -78,7 +79,7 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
 		         "createdAt" ASC
 		LIMIT 1
 	`;
-  return rows.length > 0 ? rows[0].userId : null;
+	return rows.length > 0 ? rows[0].userId : null;
 }
 
 /** Ensure the org has a `person` entity type — the type new (genuinely-unknown)
@@ -87,8 +88,8 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
  * silently fail to resolve while the connection is still stamped enforced (their
  * recall would then fail closed). */
 async function ensurePersonEntityType(orgId: string): Promise<void> {
-  const sql = getDb();
-  await sql`
+	const sql = getDb();
+	await sql`
 		INSERT INTO entity_types (slug, name, organization_id, created_at, updated_at)
 		VALUES ('person', 'Person', ${orgId}, current_timestamp, current_timestamp)
 		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
@@ -98,8 +99,8 @@ async function ensurePersonEntityType(orgId: string): Promise<void> {
 
 /** Find-or-create the org-scoped `member_of` relationship type. */
 async function ensureMemberOfType(orgId: string): Promise<number> {
-  const sql = getDb();
-  const rows = await sql`
+	const sql = getDb();
+	const rows = await sql`
 		INSERT INTO entity_relationship_types
 			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
 		VALUES
@@ -109,7 +110,7 @@ async function ensureMemberOfType(orgId: string): Promise<number> {
 		DO UPDATE SET updated_at = EXCLUDED.updated_at
 		RETURNING id
 	`;
-  return Number(rows[0].id);
+	return Number(rows[0].id);
 }
 
 /**
@@ -135,20 +136,42 @@ async function ensureMemberOfType(orgId: string): Promise<number> {
  * pre-revocation edges.
  */
 export async function markAclFresh(
-  orgId: string,
-  connectionId: string,
-  syncStartedAt: string,
+	orgId: string,
+	connectionId: string,
+	syncStartedAt: string,
 ): Promise<void> {
-  const sql = getDb();
-  await sql`
-		INSERT INTO authz_source_acl_state
-			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
-		VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
-		ON CONFLICT (organization_id, connection_id)
-		DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
-		              last_synced_at = clock_timestamp(), updated_at = clock_timestamp()
-		WHERE authz_source_acl_state.updated_at < ${syncStartedAt}::timestamptz
-	`;
+	const sql = getDb();
+	await sql.begin(async (tx) => {
+		// Serialize the state stamp with the connection tombstone. A sync can spend
+		// seconds fetching a remote membership snapshot after the scheduler selected
+		// the row; without this lock, deletion can remove the old ACL state and the
+		// in-flight sync can recreate it after the delete commits. Standalone graph
+		// tests intentionally use synthetic connection ids, so no matching row keeps
+		// the historical materializer behavior; a matching tombstoned row skips the
+		// stamp.
+		const connections = await tx<{ deleted_at: Date | string | null }>`
+      SELECT c.deleted_at
+      FROM connections c
+      WHERE c.organization_id = ${orgId}
+        AND ${tx.unsafe(aclConnectionIdSql("c"))} = ${connectionId}
+      FOR UPDATE
+    `;
+		if (
+			connections.length > 0 &&
+			connections.every((row) => row.deleted_at != null)
+		)
+			return;
+
+		await tx`
+		  INSERT INTO authz_source_acl_state
+			  (organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
+		  VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
+		  ON CONFLICT (organization_id, connection_id)
+		  DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
+		                last_synced_at = clock_timestamp(), updated_at = clock_timestamp()
+		  WHERE authz_source_acl_state.updated_at < ${syncStartedAt}::timestamptz
+	  `;
+	});
 }
 
 /**
@@ -158,38 +181,38 @@ export async function markAclFresh(
  * a freshly-created `person`. Returns a map member.key → entity id.
  */
 async function resolveMembers(
-  orgId: string,
-  connectorKey: string,
-  connectionId: number | null,
-  members: AccessMember[],
-  memberIdentities: AccessIdentitySpec[],
+	orgId: string,
+	connectorKey: string,
+	connectionId: number | null,
+	members: AccessMember[],
+	memberIdentities: AccessIdentitySpec[],
 ): Promise<Map<string, number>> {
-  const byKey = new Map<string, number>();
-  if (members.length === 0) return byKey;
+	const byKey = new Map<string, number>();
+	if (members.length === 0) return byKey;
 
-  // Gather identity values per namespace and look up existing owners (any type).
-  const valuesByNamespace = new Map<string, Set<string>>();
-  for (const m of members) {
-    for (const id of m.identities) {
-      if (!id.value) continue;
-      const set = valuesByNamespace.get(id.namespace) ?? new Set<string>();
-      set.add(id.value);
-      valuesByNamespace.set(id.namespace, set);
-    }
-  }
-  const existing = new Map<string, number>(); // `${namespace}|${value}` → entity id
-  const sql = getDb();
-  for (const [namespace, values] of valuesByNamespace) {
-    const list = [...values];
-    if (list.length === 0) continue;
-    // The JOIN is load-bearing: an ordinary entity delete soft-deletes the
-    // ENTITY but leaves its `entity_identities` rows live, still pointing at
-    // it (only a merge or sign-in adoption repoints them). Matching on the
-    // identity alone therefore resolves onto a dead entity, writes `member_of`
-    // to it, and never mints a replacement — so the member silently vanishes
-    // from the audience of every channel they are in. `lookupMatches` in
-    // entity-link-upsert already joins for this reason; this matcher did not.
-    const rows = await sql<{ identifier: string; entity_id: number }>`
+	// Gather identity values per namespace and look up existing owners (any type).
+	const valuesByNamespace = new Map<string, Set<string>>();
+	for (const m of members) {
+		for (const id of m.identities) {
+			if (!id.value) continue;
+			const set = valuesByNamespace.get(id.namespace) ?? new Set<string>();
+			set.add(id.value);
+			valuesByNamespace.set(id.namespace, set);
+		}
+	}
+	const existing = new Map<string, number>(); // `${namespace}|${value}` → entity id
+	const sql = getDb();
+	for (const [namespace, values] of valuesByNamespace) {
+		const list = [...values];
+		if (list.length === 0) continue;
+		// The JOIN is load-bearing: an ordinary entity delete soft-deletes the
+		// ENTITY but leaves its `entity_identities` rows live, still pointing at
+		// it (only a merge or sign-in adoption repoints them). Matching on the
+		// identity alone therefore resolves onto a dead entity, writes `member_of`
+		// to it, and never mints a replacement — so the member silently vanishes
+		// from the audience of every channel they are in. `lookupMatches` in
+		// entity-link-upsert already joins for this reason; this matcher did not.
+		const rows = await sql<{ identifier: string; entity_id: number }>`
 			SELECT ei.identifier, ei.entity_id
 			FROM entity_identities ei
 			JOIN entities e ON e.id = ei.entity_id
@@ -199,102 +222,102 @@ async function resolveMembers(
 			  AND ei.deleted_at IS NULL
 			  AND e.deleted_at IS NULL
 		`;
-    for (const r of rows) {
-      existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
-    }
-  }
+		for (const r of rows) {
+			existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
+		}
+	}
 
-  // Which entity a member's claims resolve to follows the tier semantics the
-  // create path below (`resolveEventAttributionsForItems`) already implements —
-  // see `primary` in connector-types.ts. Stopping at the first array hit made
-  // the answer depend on the order a connector pushed its identities, and
-  // `member_of` is a read ACL, so that was a mis-grant waiting to happen: a
-  // stale or recycled secondary claim (an old email, a reused login) would hand
-  // one person another person's channel access. A PRESENT primary identity —
-  // the source's stable per-account key — therefore governs alone and never
-  // falls through to a secondary match: a fresh primary means a distinct
-  // account even when a recycled secondary still points at the old person.
-  // This fast path only claims a member when its answer matches what the
-  // create-path engine would decide; every other case (primary present but
-  // unmatched, a same-tier conflict) falls through to `toCreate`, where that
-  // engine mints a new entity keyed on the primary or refuses the ambiguous
-  // match outright (no edge — fail closed) with its 'merge candidate' warning.
-  const primaryNamespaces = new Set(
-    memberIdentities.filter((s) => s.primary).map((s) => s.namespace)
-  );
-  const toCreate: AccessMember[] = [];
-  for (const m of members) {
-    const primaryHits = new Set<number>();
-    const secondaryHits = new Set<number>();
-    let primaryPresent = false;
-    for (const id of m.identities) {
-      if (!id.value) continue;
-      const isPrimary = primaryNamespaces.has(id.namespace);
-      if (isPrimary) primaryPresent = true;
-      const found = existing.get(`${id.namespace}|${id.value}`);
-      if (found === undefined) continue;
-      (isPrimary ? primaryHits : secondaryHits).add(found);
-    }
-    let hit: number | undefined;
-    if (primaryPresent) {
-      if (primaryHits.size === 1) {
-        hit = [...primaryHits][0];
-        const overridden = [...secondaryHits].filter((id) => id !== hit);
-        if (overridden.length > 0) {
-          logger.warn(
-            {
-              organization_id: orgId,
-              connector_key: connectorKey,
-              member_key: m.key,
-              resolved_to: hit,
-              overridden_entity_ids: overridden,
-            },
-            'access-graph: member matched multiple entities — resolved via the primary identity'
-          );
-        }
-      }
-    } else if (secondaryHits.size === 1) {
-      hit = [...secondaryHits][0];
-    }
-    if (hit !== undefined) byKey.set(m.key, hit);
-    else toCreate.push(m);
-  }
+	// Which entity a member's claims resolve to follows the tier semantics the
+	// create path below (`resolveEventAttributionsForItems`) already implements —
+	// see `primary` in connector-types.ts. Stopping at the first array hit made
+	// the answer depend on the order a connector pushed its identities, and
+	// `member_of` is a read ACL, so that was a mis-grant waiting to happen: a
+	// stale or recycled secondary claim (an old email, a reused login) would hand
+	// one person another person's channel access. A PRESENT primary identity —
+	// the source's stable per-account key — therefore governs alone and never
+	// falls through to a secondary match: a fresh primary means a distinct
+	// account even when a recycled secondary still points at the old person.
+	// This fast path only claims a member when its answer matches what the
+	// create-path engine would decide; every other case (primary present but
+	// unmatched, a same-tier conflict) falls through to `toCreate`, where that
+	// engine mints a new entity keyed on the primary or refuses the ambiguous
+	// match outright (no edge — fail closed) with its 'merge candidate' warning.
+	const primaryNamespaces = new Set(
+		memberIdentities.filter((s) => s.primary).map((s) => s.namespace),
+	);
+	const toCreate: AccessMember[] = [];
+	for (const m of members) {
+		const primaryHits = new Set<number>();
+		const secondaryHits = new Set<number>();
+		let primaryPresent = false;
+		for (const id of m.identities) {
+			if (!id.value) continue;
+			const isPrimary = primaryNamespaces.has(id.namespace);
+			if (isPrimary) primaryPresent = true;
+			const found = existing.get(`${id.namespace}|${id.value}`);
+			if (found === undefined) continue;
+			(isPrimary ? primaryHits : secondaryHits).add(found);
+		}
+		let hit: number | undefined;
+		if (primaryPresent) {
+			if (primaryHits.size === 1) {
+				hit = [...primaryHits][0];
+				const overridden = [...secondaryHits].filter((id) => id !== hit);
+				if (overridden.length > 0) {
+					logger.warn(
+						{
+							organization_id: orgId,
+							connector_key: connectorKey,
+							member_key: m.key,
+							resolved_to: hit,
+							overridden_entity_ids: overridden,
+						},
+						"access-graph: member matched multiple entities — resolved via the primary identity",
+					);
+				}
+			}
+		} else if (secondaryHits.size === 1) {
+			hit = [...secondaryHits][0];
+		}
+		if (hit !== undefined) byKey.set(m.key, hit);
+		else toCreate.push(m);
+	}
 
-  if (toCreate.length === 0) return byKey;
+	if (toCreate.length === 0) return byKey;
 
-  // Auto-create a `person` for each genuinely-new member, carrying ALL their
-  // declared identities so a later source (or login) collapses onto them.
-  const items = toCreate.map((m) => {
-    const metadata: Record<string, unknown> = { display_name: m.name ?? m.key };
-    for (const id of m.identities) metadata[id.namespace] = id.value;
-    return { origin_type: 'access_member', metadata };
-  });
-  const resolved = await resolveEventAttributionsForItems({
-    connectorKey,
-    connectionId,
-    orgId,
-    items,
-    rules: {
-      access_member: [
-        {
-          role: 'authored_by',
-          entityType: 'person',
-          autoCreate: true,
-          titlePath: 'metadata.display_name',
-          identities: memberIdentities.map((spec) => ({
-            namespace: spec.namespace,
-            eventPath: `metadata.${spec.namespace}`,
-            primary: spec.primary,
-          })),
-        },
-      ],
-    },
-  });
-  for (let i = 0; i < toCreate.length; i++) {
-    const ids = resolved.get(i);
-    if (ids && ids.length > 0) byKey.set(toCreate[i].key, ids[0]);
-  }
-  return byKey;
+	// Auto-create a `person` for each genuinely-new member, carrying ALL their
+	// declared identities so a later source (or login) collapses onto them.
+	const items = toCreate.map((m) => {
+		const metadata: Record<string, unknown> = { display_name: m.name ?? m.key };
+		for (const id of m.identities) metadata[id.namespace] = id.value;
+		return { origin_type: "access_member", metadata };
+	});
+	const resolved = await resolveEventAttributionsForItems({
+		connectorKey,
+		connectionId,
+		orgId,
+		items,
+		rules: {
+			access_member: [
+				{
+					role: "authored_by",
+					entityType: "person",
+					autoCreate: true,
+					titlePath: "metadata.display_name",
+					identities: memberIdentities.map((spec) => ({
+						namespace: spec.namespace,
+						eventPath: `metadata.${spec.namespace}`,
+						primary: spec.primary,
+					})),
+				},
+			],
+		},
+	});
+	for (let i = 0; i < toCreate.length; i++) {
+		const ids = resolved.get(i);
+		if (ids && ids.length > 0) byKey.set(toCreate[i].key, ids[0]);
+	}
+	return byKey;
 }
 
 /**
@@ -304,56 +327,61 @@ async function resolveMembers(
  * this body is source-agnostic.
  */
 export async function buildAccessGraph(params: {
-  organizationId: string;
-  connectionId: string;
-  connectorKey: string;
-  /** Identity namespace for resource keys (e.g. `slack_channel_id`). */
-  resourceNamespace: string;
-  memberIdentities: AccessIdentitySpec[];
-  resources: AccessResource[];
-  /**
-   * Database time captured before the source snapshot began. A newer ACL-state
-   * write means that snapshot lost a revocation race and must not mark the
-   * connection fresh.
-   */
-  syncStartedAt?: string;
-  /**
-   * Whether this build may stamp the connection fresh. Default true — one build
-   * IS the whole connection for a single-scope source (GitHub). A caller that
-   * loops several scopes over one connection passes false and calls
-   * `markAclFresh` itself after the last scope; see that function.
-   */
-  markFresh?: boolean;
+	organizationId: string;
+	connectionId: string;
+	connectorKey: string;
+	/** Identity namespace for resource keys (e.g. `slack_channel_id`). */
+	resourceNamespace: string;
+	memberIdentities: AccessIdentitySpec[];
+	resources: AccessResource[];
+	/**
+	 * Database time captured before the source snapshot began. A newer ACL-state
+	 * write means that snapshot lost a revocation race and must not mark the
+	 * connection fresh.
+	 */
+	syncStartedAt?: string;
+	/**
+	 * Whether this build may stamp the connection fresh. Default true — one build
+	 * IS the whole connection for a single-scope source (GitHub). A caller that
+	 * loops several scopes over one connection passes false and calls
+	 * `markAclFresh` itself after the last scope; see that function.
+	 */
+	markFresh?: boolean;
 }): Promise<AccessGraphResult> {
-  const { organizationId, connectionId, connectorKey, resourceNamespace, memberIdentities } =
-    params;
-  const resources = params.resources.filter((r) => r.key);
-  if (resources.length === 0) return EMPTY_RESULT;
+	const {
+		organizationId,
+		connectionId,
+		connectorKey,
+		resourceNamespace,
+		memberIdentities,
+	} = params;
+	const resources = params.resources.filter((r) => r.key);
+	if (resources.length === 0) return EMPTY_RESULT;
 
-  const syncStartedAt =
-    params.syncStartedAt ??
-    (
-      await getDb()<{ sync_started_at: string }>`
+	const syncStartedAt =
+		params.syncStartedAt ??
+		(
+			await getDb()<{ sync_started_at: string }>`
         SELECT clock_timestamp()::text AS sync_started_at
       `
-    )[0].sync_started_at;
+		)[0].sync_started_at;
 
-  const creatorUserId = await resolveOrgCreator(organizationId);
-  if (!creatorUserId) {
-    logger.warn(
-      { organization_id: organizationId, connector: connectorKey },
-      'Access graph skipped: org has no member to attribute as entity creator',
-    );
-    return EMPTY_RESULT;
-  }
+	const creatorUserId = await resolveOrgCreator(organizationId);
+	if (!creatorUserId) {
+		logger.warn(
+			{ organization_id: organizationId, connector: connectorKey },
+			"Access graph skipped: org has no member to attribute as entity creator",
+		);
+		return EMPTY_RESULT;
+	}
 
-  await ensureResourceEntityType(organizationId);
-  await ensurePersonEntityType(organizationId);
+	await ensureResourceEntityType(organizationId);
+	await ensurePersonEntityType(organizationId);
 
-  // ACL state uses a runtime connection id, while identity provenance references
-  // the stored numeric row. Resolve by slug (chat connections) or id text (data
-  // connectors) without assuming the runtime id itself is numeric.
-  const [storedConnection] = await getDb()<{ id: number }>`
+	// ACL state uses a runtime connection id, while identity provenance references
+	// the stored numeric row. Resolve by slug (chat connections) or id text (data
+	// connectors) without assuming the runtime id itself is numeric.
+	const [storedConnection] = await getDb()<{ id: number }>`
     SELECT id
     FROM connections
     WHERE organization_id = ${organizationId}
@@ -365,78 +393,78 @@ export async function buildAccessGraph(params: {
       )
     LIMIT 1
   `;
-  const identityConnectionId = storedConnection
-    ? Number(storedConnection.id)
-    : null;
+	const identityConnectionId = storedConnection
+		? Number(storedConnection.id)
+		: null;
 
-  // 1) Resolve every resource to its entity, keyed on the source identity namespace.
-  const resourceItems = resources.map((r) => ({
-    origin_type: 'access_resource',
-    metadata: { resource_key: r.key, resource_name: r.name ?? r.key },
-  }));
-  const resolvedResources = await resolveEventAttributionsForItems({
-    connectorKey,
-    connectionId: identityConnectionId,
-    orgId: organizationId,
-    items: resourceItems,
-    rules: {
-      access_resource: [
-        {
-          role: 'belongs_to',
-          entityType: ACL_RESOURCE_TYPE_SLUG,
-          autoCreate: true,
-          titlePath: 'metadata.resource_name',
-          identities: [
-            {
-              namespace: resourceNamespace,
-              eventPath: 'metadata.resource_key',
-              primary: true,
-            },
-          ],
-        },
-      ],
-    },
-  });
-  const resourceEntityIds: Record<string, number> = {};
-  const resourceEntityIdByIndex = new Map<number, number>();
-  for (let i = 0; i < resources.length; i++) {
-    const ids = resolvedResources.get(i);
-    if (ids && ids.length > 0) {
-      resourceEntityIds[resources[i].key] = ids[0];
-      resourceEntityIdByIndex.set(i, ids[0]);
-    }
-  }
+	// 1) Resolve every resource to its entity, keyed on the source identity namespace.
+	const resourceItems = resources.map((r) => ({
+		origin_type: "access_resource",
+		metadata: { resource_key: r.key, resource_name: r.name ?? r.key },
+	}));
+	const resolvedResources = await resolveEventAttributionsForItems({
+		connectorKey,
+		connectionId: identityConnectionId,
+		orgId: organizationId,
+		items: resourceItems,
+		rules: {
+			access_resource: [
+				{
+					role: "belongs_to",
+					entityType: ACL_RESOURCE_TYPE_SLUG,
+					autoCreate: true,
+					titlePath: "metadata.resource_name",
+					identities: [
+						{
+							namespace: resourceNamespace,
+							eventPath: "metadata.resource_key",
+							primary: true,
+						},
+					],
+				},
+			],
+		},
+	});
+	const resourceEntityIds: Record<string, number> = {};
+	const resourceEntityIdByIndex = new Map<number, number>();
+	for (let i = 0; i < resources.length; i++) {
+		const ids = resolvedResources.get(i);
+		if (ids && ids.length > 0) {
+			resourceEntityIds[resources[i].key] = ids[0];
+			resourceEntityIdByIndex.set(i, ids[0]);
+		}
+	}
 
-  // 2) Resolve every DISTINCT member (identity-first, type-agnostic).
-  const distinctMembers = new Map<string, AccessMember>();
-  for (const r of resources) {
-    for (const m of r.members) {
-      if (m.key && !distinctMembers.has(m.key)) distinctMembers.set(m.key, m);
-    }
-  }
-  const memberEntityByKey = await resolveMembers(
-    organizationId,
-    connectorKey,
-    identityConnectionId,
-    [...distinctMembers.values()],
-    memberIdentities,
-  );
+	// 2) Resolve every DISTINCT member (identity-first, type-agnostic).
+	const distinctMembers = new Map<string, AccessMember>();
+	for (const r of resources) {
+		for (const m of r.members) {
+			if (m.key && !distinctMembers.has(m.key)) distinctMembers.set(m.key, m);
+		}
+	}
+	const memberEntityByKey = await resolveMembers(
+		organizationId,
+		connectorKey,
+		identityConnectionId,
+		[...distinctMembers.values()],
+		memberIdentities,
+	);
 
-  // 3) Write member → resource `member_of` edges, idempotent on the live-triple
-  // unique index. Accumulate the CURRENT member set per resource for reconcile.
-  const typeId = await ensureMemberOfType(organizationId);
-  const sql = getDb();
+	// 3) Write member → resource `member_of` edges, idempotent on the live-triple
+	// unique index. Accumulate the CURRENT member set per resource for reconcile.
+	const typeId = await ensureMemberOfType(organizationId);
+	const sql = getDb();
 
-  // Keep each resource entity's display name fresh. `titlePath` only sets the
-  // name on auto-CREATE, so a name that wasn't available at first graph (or a
-  // later channel/repo RENAME) would otherwise stick to the stale value / the
-  // raw id. Refresh from the source-provided name here. Scoped to the resources
-  // in this build; idempotent (the `name <>` guard no-ops when unchanged).
-  for (let i = 0; i < resources.length; i++) {
-    const id = resourceEntityIdByIndex.get(i);
-    const name = resources[i].name;
-    if (id && name) {
-      await sql`
+	// Keep each resource entity's display name fresh. `titlePath` only sets the
+	// name on auto-CREATE, so a name that wasn't available at first graph (or a
+	// later channel/repo RENAME) would otherwise stick to the stale value / the
+	// raw id. Refresh from the source-provided name here. Scoped to the resources
+	// in this build; idempotent (the `name <>` guard no-ops when unchanged).
+	for (let i = 0; i < resources.length; i++) {
+		const id = resourceEntityIdByIndex.get(i);
+		const name = resources[i].name;
+		if (id && name) {
+			await sql`
         UPDATE entities
         SET name = ${name}, updated_at = current_timestamp
         WHERE id = ${id}
@@ -444,23 +472,24 @@ export async function buildAccessGraph(params: {
           AND name <> ${name}
           AND deleted_at IS NULL
       `;
-    }
-  }
+		}
+	}
 
-  const memberEntityIds = new Set<number>();
-  const currentMembersByResource = new Map<number, Set<number>>();
-  let createdEdges = 0;
-  for (let i = 0; i < resources.length; i++) {
-    const resourceEntityId = resourceEntityIdByIndex.get(i);
-    if (resourceEntityId === undefined) continue;
-    const resourceMembers = currentMembersByResource.get(resourceEntityId) ?? new Set<number>();
-    currentMembersByResource.set(resourceEntityId, resourceMembers);
-    for (const m of resources[i].members) {
-      const memberEntityId = memberEntityByKey.get(m.key);
-      if (memberEntityId === undefined) continue;
-      memberEntityIds.add(memberEntityId);
-      resourceMembers.add(memberEntityId);
-      const inserted = await sql<{ id: number }[]>`
+	const memberEntityIds = new Set<number>();
+	const currentMembersByResource = new Map<number, Set<number>>();
+	let createdEdges = 0;
+	for (let i = 0; i < resources.length; i++) {
+		const resourceEntityId = resourceEntityIdByIndex.get(i);
+		if (resourceEntityId === undefined) continue;
+		const resourceMembers =
+			currentMembersByResource.get(resourceEntityId) ?? new Set<number>();
+		currentMembersByResource.set(resourceEntityId, resourceMembers);
+		for (const m of resources[i].members) {
+			const memberEntityId = memberEntityByKey.get(m.key);
+			if (memberEntityId === undefined) continue;
+			memberEntityIds.add(memberEntityId);
+			resourceMembers.add(memberEntityId);
+			const inserted = await sql<{ id: number }[]>`
 				INSERT INTO entity_relationships (
 					organization_id, from_entity_id, to_entity_id, relationship_type_id,
 					confidence, source, created_by, updated_by, created_at, updated_at
@@ -474,21 +503,21 @@ export async function buildAccessGraph(params: {
 				DO NOTHING
 				RETURNING id
 			`;
-      if (inserted.length > 0) createdEdges += 1;
-    }
-  }
+			if (inserted.length > 0) createdEdges += 1;
+		}
+	}
 
-  // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
-  // membership, so a `member_of` edge to a synced resource whose member is NOT
-  // in the current set means that person left: soft-delete it so they lose
-  // access immediately. Scoped to `to_entity_id` = a resource we just synced, so
-  // edges to OTHER resource types (a different source's graph) are never touched.
-  // An empty member set deletes all of that resource's edges — the caller must
-  // not pass empty-on-fetch-error.
-  let removedEdges = 0;
-  for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
-    const keep = [...resourceMembers];
-    const removed = await sql<{ id: number }[]>`
+	// 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
+	// membership, so a `member_of` edge to a synced resource whose member is NOT
+	// in the current set means that person left: soft-delete it so they lose
+	// access immediately. Scoped to `to_entity_id` = a resource we just synced, so
+	// edges to OTHER resource types (a different source's graph) are never touched.
+	// An empty member set deletes all of that resource's edges — the caller must
+	// not pass empty-on-fetch-error.
+	let removedEdges = 0;
+	for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
+		const keep = [...resourceMembers];
+		const removed = await sql<{ id: number }[]>`
 			UPDATE entity_relationships
 			SET deleted_at = current_timestamp, updated_at = current_timestamp
 			WHERE organization_id = ${organizationId}
@@ -498,32 +527,32 @@ export async function buildAccessGraph(params: {
 			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
 			RETURNING id
 		`;
-    removedEdges += removed.length;
-  }
+		removedEdges += removed.length;
+	}
 
-  if (params.markFresh !== false) {
-    await markAclFresh(organizationId, connectionId, syncStartedAt);
-  }
+	if (params.markFresh !== false) {
+		await markAclFresh(organizationId, connectionId, syncStartedAt);
+	}
 
-  logger.info(
-    {
-      organization_id: organizationId,
-      connection_id: connectionId,
-      connector: connectorKey,
-      resource_type: ACL_RESOURCE_TYPE_SLUG,
-      resource_namespace: resourceNamespace,
-      resources: Object.keys(resourceEntityIds).length,
-      members: memberEntityIds.size,
-      created_edges: createdEdges,
-      removed_edges: removedEdges,
-    },
-    'Built access graph',
-  );
+	logger.info(
+		{
+			organization_id: organizationId,
+			connection_id: connectionId,
+			connector: connectorKey,
+			resource_type: ACL_RESOURCE_TYPE_SLUG,
+			resource_namespace: resourceNamespace,
+			resources: Object.keys(resourceEntityIds).length,
+			members: memberEntityIds.size,
+			created_edges: createdEdges,
+			removed_edges: removedEdges,
+		},
+		"Built access graph",
+	);
 
-  return {
-    resourceEntityIds,
-    memberEntityIds: [...memberEntityIds],
-    createdEdges,
-    removedEdges,
-  };
+	return {
+		resourceEntityIds,
+		memberEntityIds: [...memberEntityIds],
+		createdEdges,
+		removedEdges,
+	};
 }

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -31,47 +31,47 @@
  * data-shaped problem (the CALLER's fetch layer owns fail-closed-on-error).
  */
 
+import { createLogger } from '@lobu/core';
 import {
-	ACL_RESOURCE_TYPE_SLUG,
-	type AccessIdentitySpec,
-	type AccessMember,
-	type AccessResource,
-} from "@lobu/connector-sdk";
-import { createLogger } from "@lobu/core";
-import { getDb, pgBigintArray, pgTextArray } from "../db/client.js";
-import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection.js";
-import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
-import { aclConnectionIdSql } from "./acl-observability.js";
-import { ensureResourceEntityType } from "./acl-resource-type.js";
+  ACL_RESOURCE_TYPE_SLUG,
+  type AccessIdentitySpec,
+  type AccessMember,
+  type AccessResource,
+} from '@lobu/connector-sdk';
+import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
+import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection.js';
+import { resolveEventAttributionsForItems } from '../utils/entity-link-upsert.js';
+import { aclConnectionIdSql } from './acl-observability.js';
+import { ensureResourceEntityType } from './acl-resource-type.js';
 
-const logger = createLogger("access-graph");
+const logger = createLogger('access-graph');
 
-const MEMBER_OF_TYPE_SLUG = "member_of";
+const MEMBER_OF_TYPE_SLUG = 'member_of';
 
-export { ensureResourceEntityType } from "./acl-resource-type.js";
 export type { AccessIdentitySpec, AccessMember, AccessResource };
+export { ensureResourceEntityType } from './acl-resource-type.js';
 
 export interface AccessGraphResult {
-	/** Resource key → the entity id that now represents it. */
-	resourceEntityIds: Record<string, number>;
-	/** Distinct member entity ids that gained a `member_of` edge. */
-	memberEntityIds: number[];
-	createdEdges: number;
-	removedEdges: number;
+  /** Resource key → the entity id that now represents it. */
+  resourceEntityIds: Record<string, number>;
+  /** Distinct member entity ids that gained a `member_of` edge. */
+  memberEntityIds: number[];
+  createdEdges: number;
+  removedEdges: number;
 }
 
 const EMPTY_RESULT: AccessGraphResult = {
-	resourceEntityIds: {},
-	memberEntityIds: [],
-	createdEdges: 0,
-	removedEdges: 0,
+  resourceEntityIds: {},
+  memberEntityIds: [],
+  createdEdges: 0,
+  removedEdges: 0,
 };
 
 /** Resolve an org owner/admin as `entities.created_by` / edge `created_by`
  * (NOT NULL). Same query both source builders used. */
 async function resolveOrgCreator(orgId: string): Promise<string | null> {
-	const sql = getDb();
-	const rows = await sql<{ userId: string }>`
+  const sql = getDb();
+  const rows = await sql<{ userId: string }>`
 		SELECT "userId"
 		FROM "member"
 		WHERE "organizationId" = ${orgId}
@@ -79,7 +79,7 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
 		         "createdAt" ASC
 		LIMIT 1
 	`;
-	return rows.length > 0 ? rows[0].userId : null;
+  return rows.length > 0 ? rows[0].userId : null;
 }
 
 /** Ensure the org has a `person` entity type — the type new (genuinely-unknown)
@@ -88,8 +88,8 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
  * silently fail to resolve while the connection is still stamped enforced (their
  * recall would then fail closed). */
 async function ensurePersonEntityType(orgId: string): Promise<void> {
-	const sql = getDb();
-	await sql`
+  const sql = getDb();
+  await sql`
 		INSERT INTO entity_types (slug, name, organization_id, created_at, updated_at)
 		VALUES ('person', 'Person', ${orgId}, current_timestamp, current_timestamp)
 		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
@@ -99,8 +99,8 @@ async function ensurePersonEntityType(orgId: string): Promise<void> {
 
 /** Find-or-create the org-scoped `member_of` relationship type. */
 async function ensureMemberOfType(orgId: string): Promise<number> {
-	const sql = getDb();
-	const rows = await sql`
+  const sql = getDb();
+  const rows = await sql`
 		INSERT INTO entity_relationship_types
 			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
 		VALUES
@@ -110,7 +110,7 @@ async function ensureMemberOfType(orgId: string): Promise<number> {
 		DO UPDATE SET updated_at = EXCLUDED.updated_at
 		RETURNING id
 	`;
-	return Number(rows[0].id);
+  return Number(rows[0].id);
 }
 
 /**
@@ -136,42 +136,38 @@ async function ensureMemberOfType(orgId: string): Promise<number> {
  * pre-revocation edges.
  */
 export async function markAclFresh(
-	orgId: string,
-	connectionId: string,
-	syncStartedAt: string,
+  orgId: string,
+  connectionId: string,
+  syncStartedAt: string,
 ): Promise<void> {
-	const sql = getDb();
-	await sql.begin(async (tx) => {
-		// Serialize the state stamp with the connection tombstone. A sync can spend
-		// seconds fetching a remote membership snapshot after the scheduler selected
-		// the row; without this lock, deletion can remove the old ACL state and the
-		// in-flight sync can recreate it after the delete commits. Standalone graph
-		// tests intentionally use synthetic connection ids, so no matching row keeps
-		// the historical materializer behavior; a matching tombstoned row skips the
-		// stamp.
-		const connections = await tx<{ deleted_at: Date | string | null }>`
+  const sql = getDb();
+  await sql.begin(async (tx) => {
+    // Serialize the state stamp with the connection tombstone. A sync can spend
+    // seconds fetching a remote membership snapshot after the scheduler selected
+    // the row; without this lock, deletion can remove the old ACL state and the
+    // in-flight sync can recreate it after the delete commits. Standalone graph
+    // tests intentionally use synthetic connection ids, so no matching row keeps
+    // the historical materializer behavior; a matching tombstoned row skips the
+    // stamp.
+    const connections = await tx<{ deleted_at: Date | string | null }>`
       SELECT c.deleted_at
       FROM connections c
       WHERE c.organization_id = ${orgId}
-        AND ${tx.unsafe(aclConnectionIdSql("c"))} = ${connectionId}
+        AND ${tx.unsafe(aclConnectionIdSql('c'))} = ${connectionId}
       FOR UPDATE
     `;
-		if (
-			connections.length > 0 &&
-			connections.every((row) => row.deleted_at != null)
-		)
-			return;
+    if (connections.length > 0 && connections.every((row) => row.deleted_at != null)) return;
 
-		await tx`
-		  INSERT INTO authz_source_acl_state
-			  (organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
-		  VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
-		  ON CONFLICT (organization_id, connection_id)
-		  DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
-		                last_synced_at = clock_timestamp(), updated_at = clock_timestamp()
-		  WHERE authz_source_acl_state.updated_at < ${syncStartedAt}::timestamptz
-	  `;
-	});
+    await tx`
+		INSERT INTO authz_source_acl_state
+			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
+		VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, connection_id)
+		DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
+		              last_synced_at = clock_timestamp(), updated_at = clock_timestamp()
+		WHERE authz_source_acl_state.updated_at < ${syncStartedAt}::timestamptz
+	`;
+  });
 }
 
 /**
@@ -181,38 +177,38 @@ export async function markAclFresh(
  * a freshly-created `person`. Returns a map member.key → entity id.
  */
 async function resolveMembers(
-	orgId: string,
-	connectorKey: string,
-	connectionId: number | null,
-	members: AccessMember[],
-	memberIdentities: AccessIdentitySpec[],
+  orgId: string,
+  connectorKey: string,
+  connectionId: number | null,
+  members: AccessMember[],
+  memberIdentities: AccessIdentitySpec[],
 ): Promise<Map<string, number>> {
-	const byKey = new Map<string, number>();
-	if (members.length === 0) return byKey;
+  const byKey = new Map<string, number>();
+  if (members.length === 0) return byKey;
 
-	// Gather identity values per namespace and look up existing owners (any type).
-	const valuesByNamespace = new Map<string, Set<string>>();
-	for (const m of members) {
-		for (const id of m.identities) {
-			if (!id.value) continue;
-			const set = valuesByNamespace.get(id.namespace) ?? new Set<string>();
-			set.add(id.value);
-			valuesByNamespace.set(id.namespace, set);
-		}
-	}
-	const existing = new Map<string, number>(); // `${namespace}|${value}` → entity id
-	const sql = getDb();
-	for (const [namespace, values] of valuesByNamespace) {
-		const list = [...values];
-		if (list.length === 0) continue;
-		// The JOIN is load-bearing: an ordinary entity delete soft-deletes the
-		// ENTITY but leaves its `entity_identities` rows live, still pointing at
-		// it (only a merge or sign-in adoption repoints them). Matching on the
-		// identity alone therefore resolves onto a dead entity, writes `member_of`
-		// to it, and never mints a replacement — so the member silently vanishes
-		// from the audience of every channel they are in. `lookupMatches` in
-		// entity-link-upsert already joins for this reason; this matcher did not.
-		const rows = await sql<{ identifier: string; entity_id: number }>`
+  // Gather identity values per namespace and look up existing owners (any type).
+  const valuesByNamespace = new Map<string, Set<string>>();
+  for (const m of members) {
+    for (const id of m.identities) {
+      if (!id.value) continue;
+      const set = valuesByNamespace.get(id.namespace) ?? new Set<string>();
+      set.add(id.value);
+      valuesByNamespace.set(id.namespace, set);
+    }
+  }
+  const existing = new Map<string, number>(); // `${namespace}|${value}` → entity id
+  const sql = getDb();
+  for (const [namespace, values] of valuesByNamespace) {
+    const list = [...values];
+    if (list.length === 0) continue;
+    // The JOIN is load-bearing: an ordinary entity delete soft-deletes the
+    // ENTITY but leaves its `entity_identities` rows live, still pointing at
+    // it (only a merge or sign-in adoption repoints them). Matching on the
+    // identity alone therefore resolves onto a dead entity, writes `member_of`
+    // to it, and never mints a replacement — so the member silently vanishes
+    // from the audience of every channel they are in. `lookupMatches` in
+    // entity-link-upsert already joins for this reason; this matcher did not.
+    const rows = await sql<{ identifier: string; entity_id: number }>`
 			SELECT ei.identifier, ei.entity_id
 			FROM entity_identities ei
 			JOIN entities e ON e.id = ei.entity_id
@@ -222,102 +218,102 @@ async function resolveMembers(
 			  AND ei.deleted_at IS NULL
 			  AND e.deleted_at IS NULL
 		`;
-		for (const r of rows) {
-			existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
-		}
-	}
+    for (const r of rows) {
+      existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
+    }
+  }
 
-	// Which entity a member's claims resolve to follows the tier semantics the
-	// create path below (`resolveEventAttributionsForItems`) already implements —
-	// see `primary` in connector-types.ts. Stopping at the first array hit made
-	// the answer depend on the order a connector pushed its identities, and
-	// `member_of` is a read ACL, so that was a mis-grant waiting to happen: a
-	// stale or recycled secondary claim (an old email, a reused login) would hand
-	// one person another person's channel access. A PRESENT primary identity —
-	// the source's stable per-account key — therefore governs alone and never
-	// falls through to a secondary match: a fresh primary means a distinct
-	// account even when a recycled secondary still points at the old person.
-	// This fast path only claims a member when its answer matches what the
-	// create-path engine would decide; every other case (primary present but
-	// unmatched, a same-tier conflict) falls through to `toCreate`, where that
-	// engine mints a new entity keyed on the primary or refuses the ambiguous
-	// match outright (no edge — fail closed) with its 'merge candidate' warning.
-	const primaryNamespaces = new Set(
-		memberIdentities.filter((s) => s.primary).map((s) => s.namespace),
-	);
-	const toCreate: AccessMember[] = [];
-	for (const m of members) {
-		const primaryHits = new Set<number>();
-		const secondaryHits = new Set<number>();
-		let primaryPresent = false;
-		for (const id of m.identities) {
-			if (!id.value) continue;
-			const isPrimary = primaryNamespaces.has(id.namespace);
-			if (isPrimary) primaryPresent = true;
-			const found = existing.get(`${id.namespace}|${id.value}`);
-			if (found === undefined) continue;
-			(isPrimary ? primaryHits : secondaryHits).add(found);
-		}
-		let hit: number | undefined;
-		if (primaryPresent) {
-			if (primaryHits.size === 1) {
-				hit = [...primaryHits][0];
-				const overridden = [...secondaryHits].filter((id) => id !== hit);
-				if (overridden.length > 0) {
-					logger.warn(
-						{
-							organization_id: orgId,
-							connector_key: connectorKey,
-							member_key: m.key,
-							resolved_to: hit,
-							overridden_entity_ids: overridden,
-						},
-						"access-graph: member matched multiple entities — resolved via the primary identity",
-					);
-				}
-			}
-		} else if (secondaryHits.size === 1) {
-			hit = [...secondaryHits][0];
-		}
-		if (hit !== undefined) byKey.set(m.key, hit);
-		else toCreate.push(m);
-	}
+  // Which entity a member's claims resolve to follows the tier semantics the
+  // create path below (`resolveEventAttributionsForItems`) already implements —
+  // see `primary` in connector-types.ts. Stopping at the first array hit made
+  // the answer depend on the order a connector pushed its identities, and
+  // `member_of` is a read ACL, so that was a mis-grant waiting to happen: a
+  // stale or recycled secondary claim (an old email, a reused login) would hand
+  // one person another person's channel access. A PRESENT primary identity —
+  // the source's stable per-account key — therefore governs alone and never
+  // falls through to a secondary match: a fresh primary means a distinct
+  // account even when a recycled secondary still points at the old person.
+  // This fast path only claims a member when its answer matches what the
+  // create-path engine would decide; every other case (primary present but
+  // unmatched, a same-tier conflict) falls through to `toCreate`, where that
+  // engine mints a new entity keyed on the primary or refuses the ambiguous
+  // match outright (no edge — fail closed) with its 'merge candidate' warning.
+  const primaryNamespaces = new Set(
+    memberIdentities.filter((s) => s.primary).map((s) => s.namespace)
+  );
+  const toCreate: AccessMember[] = [];
+  for (const m of members) {
+    const primaryHits = new Set<number>();
+    const secondaryHits = new Set<number>();
+    let primaryPresent = false;
+    for (const id of m.identities) {
+      if (!id.value) continue;
+      const isPrimary = primaryNamespaces.has(id.namespace);
+      if (isPrimary) primaryPresent = true;
+      const found = existing.get(`${id.namespace}|${id.value}`);
+      if (found === undefined) continue;
+      (isPrimary ? primaryHits : secondaryHits).add(found);
+    }
+    let hit: number | undefined;
+    if (primaryPresent) {
+      if (primaryHits.size === 1) {
+        hit = [...primaryHits][0];
+        const overridden = [...secondaryHits].filter((id) => id !== hit);
+        if (overridden.length > 0) {
+          logger.warn(
+            {
+              organization_id: orgId,
+              connector_key: connectorKey,
+              member_key: m.key,
+              resolved_to: hit,
+              overridden_entity_ids: overridden,
+            },
+            'access-graph: member matched multiple entities — resolved via the primary identity'
+          );
+        }
+      }
+    } else if (secondaryHits.size === 1) {
+      hit = [...secondaryHits][0];
+    }
+    if (hit !== undefined) byKey.set(m.key, hit);
+    else toCreate.push(m);
+  }
 
-	if (toCreate.length === 0) return byKey;
+  if (toCreate.length === 0) return byKey;
 
-	// Auto-create a `person` for each genuinely-new member, carrying ALL their
-	// declared identities so a later source (or login) collapses onto them.
-	const items = toCreate.map((m) => {
-		const metadata: Record<string, unknown> = { display_name: m.name ?? m.key };
-		for (const id of m.identities) metadata[id.namespace] = id.value;
-		return { origin_type: "access_member", metadata };
-	});
-	const resolved = await resolveEventAttributionsForItems({
-		connectorKey,
-		connectionId,
-		orgId,
-		items,
-		rules: {
-			access_member: [
-				{
-					role: "authored_by",
-					entityType: "person",
-					autoCreate: true,
-					titlePath: "metadata.display_name",
-					identities: memberIdentities.map((spec) => ({
-						namespace: spec.namespace,
-						eventPath: `metadata.${spec.namespace}`,
-						primary: spec.primary,
-					})),
-				},
-			],
-		},
-	});
-	for (let i = 0; i < toCreate.length; i++) {
-		const ids = resolved.get(i);
-		if (ids && ids.length > 0) byKey.set(toCreate[i].key, ids[0]);
-	}
-	return byKey;
+  // Auto-create a `person` for each genuinely-new member, carrying ALL their
+  // declared identities so a later source (or login) collapses onto them.
+  const items = toCreate.map((m) => {
+    const metadata: Record<string, unknown> = { display_name: m.name ?? m.key };
+    for (const id of m.identities) metadata[id.namespace] = id.value;
+    return { origin_type: 'access_member', metadata };
+  });
+  const resolved = await resolveEventAttributionsForItems({
+    connectorKey,
+    connectionId,
+    orgId,
+    items,
+    rules: {
+      access_member: [
+        {
+          role: 'authored_by',
+          entityType: 'person',
+          autoCreate: true,
+          titlePath: 'metadata.display_name',
+          identities: memberIdentities.map((spec) => ({
+            namespace: spec.namespace,
+            eventPath: `metadata.${spec.namespace}`,
+            primary: spec.primary,
+          })),
+        },
+      ],
+    },
+  });
+  for (let i = 0; i < toCreate.length; i++) {
+    const ids = resolved.get(i);
+    if (ids && ids.length > 0) byKey.set(toCreate[i].key, ids[0]);
+  }
+  return byKey;
 }
 
 /**
@@ -327,61 +323,56 @@ async function resolveMembers(
  * this body is source-agnostic.
  */
 export async function buildAccessGraph(params: {
-	organizationId: string;
-	connectionId: string;
-	connectorKey: string;
-	/** Identity namespace for resource keys (e.g. `slack_channel_id`). */
-	resourceNamespace: string;
-	memberIdentities: AccessIdentitySpec[];
-	resources: AccessResource[];
-	/**
-	 * Database time captured before the source snapshot began. A newer ACL-state
-	 * write means that snapshot lost a revocation race and must not mark the
-	 * connection fresh.
-	 */
-	syncStartedAt?: string;
-	/**
-	 * Whether this build may stamp the connection fresh. Default true — one build
-	 * IS the whole connection for a single-scope source (GitHub). A caller that
-	 * loops several scopes over one connection passes false and calls
-	 * `markAclFresh` itself after the last scope; see that function.
-	 */
-	markFresh?: boolean;
+  organizationId: string;
+  connectionId: string;
+  connectorKey: string;
+  /** Identity namespace for resource keys (e.g. `slack_channel_id`). */
+  resourceNamespace: string;
+  memberIdentities: AccessIdentitySpec[];
+  resources: AccessResource[];
+  /**
+   * Database time captured before the source snapshot began. A newer ACL-state
+   * write means that snapshot lost a revocation race and must not mark the
+   * connection fresh.
+   */
+  syncStartedAt?: string;
+  /**
+   * Whether this build may stamp the connection fresh. Default true — one build
+   * IS the whole connection for a single-scope source (GitHub). A caller that
+   * loops several scopes over one connection passes false and calls
+   * `markAclFresh` itself after the last scope; see that function.
+   */
+  markFresh?: boolean;
 }): Promise<AccessGraphResult> {
-	const {
-		organizationId,
-		connectionId,
-		connectorKey,
-		resourceNamespace,
-		memberIdentities,
-	} = params;
-	const resources = params.resources.filter((r) => r.key);
-	if (resources.length === 0) return EMPTY_RESULT;
+  const { organizationId, connectionId, connectorKey, resourceNamespace, memberIdentities } =
+    params;
+  const resources = params.resources.filter((r) => r.key);
+  if (resources.length === 0) return EMPTY_RESULT;
 
-	const syncStartedAt =
-		params.syncStartedAt ??
-		(
-			await getDb()<{ sync_started_at: string }>`
+  const syncStartedAt =
+    params.syncStartedAt ??
+    (
+      await getDb()<{ sync_started_at: string }>`
         SELECT clock_timestamp()::text AS sync_started_at
       `
-		)[0].sync_started_at;
+    )[0].sync_started_at;
 
-	const creatorUserId = await resolveOrgCreator(organizationId);
-	if (!creatorUserId) {
-		logger.warn(
-			{ organization_id: organizationId, connector: connectorKey },
-			"Access graph skipped: org has no member to attribute as entity creator",
-		);
-		return EMPTY_RESULT;
-	}
+  const creatorUserId = await resolveOrgCreator(organizationId);
+  if (!creatorUserId) {
+    logger.warn(
+      { organization_id: organizationId, connector: connectorKey },
+      'Access graph skipped: org has no member to attribute as entity creator',
+    );
+    return EMPTY_RESULT;
+  }
 
-	await ensureResourceEntityType(organizationId);
-	await ensurePersonEntityType(organizationId);
+  await ensureResourceEntityType(organizationId);
+  await ensurePersonEntityType(organizationId);
 
-	// ACL state uses a runtime connection id, while identity provenance references
-	// the stored numeric row. Resolve by slug (chat connections) or id text (data
-	// connectors) without assuming the runtime id itself is numeric.
-	const [storedConnection] = await getDb()<{ id: number }>`
+  // ACL state uses a runtime connection id, while identity provenance references
+  // the stored numeric row. Resolve by slug (chat connections) or id text (data
+  // connectors) without assuming the runtime id itself is numeric.
+  const [storedConnection] = await getDb()<{ id: number }>`
     SELECT id
     FROM connections
     WHERE organization_id = ${organizationId}
@@ -393,78 +384,78 @@ export async function buildAccessGraph(params: {
       )
     LIMIT 1
   `;
-	const identityConnectionId = storedConnection
-		? Number(storedConnection.id)
-		: null;
+  const identityConnectionId = storedConnection
+    ? Number(storedConnection.id)
+    : null;
 
-	// 1) Resolve every resource to its entity, keyed on the source identity namespace.
-	const resourceItems = resources.map((r) => ({
-		origin_type: "access_resource",
-		metadata: { resource_key: r.key, resource_name: r.name ?? r.key },
-	}));
-	const resolvedResources = await resolveEventAttributionsForItems({
-		connectorKey,
-		connectionId: identityConnectionId,
-		orgId: organizationId,
-		items: resourceItems,
-		rules: {
-			access_resource: [
-				{
-					role: "belongs_to",
-					entityType: ACL_RESOURCE_TYPE_SLUG,
-					autoCreate: true,
-					titlePath: "metadata.resource_name",
-					identities: [
-						{
-							namespace: resourceNamespace,
-							eventPath: "metadata.resource_key",
-							primary: true,
-						},
-					],
-				},
-			],
-		},
-	});
-	const resourceEntityIds: Record<string, number> = {};
-	const resourceEntityIdByIndex = new Map<number, number>();
-	for (let i = 0; i < resources.length; i++) {
-		const ids = resolvedResources.get(i);
-		if (ids && ids.length > 0) {
-			resourceEntityIds[resources[i].key] = ids[0];
-			resourceEntityIdByIndex.set(i, ids[0]);
-		}
-	}
+  // 1) Resolve every resource to its entity, keyed on the source identity namespace.
+  const resourceItems = resources.map((r) => ({
+    origin_type: 'access_resource',
+    metadata: { resource_key: r.key, resource_name: r.name ?? r.key },
+  }));
+  const resolvedResources = await resolveEventAttributionsForItems({
+    connectorKey,
+    connectionId: identityConnectionId,
+    orgId: organizationId,
+    items: resourceItems,
+    rules: {
+      access_resource: [
+        {
+          role: 'belongs_to',
+          entityType: ACL_RESOURCE_TYPE_SLUG,
+          autoCreate: true,
+          titlePath: 'metadata.resource_name',
+          identities: [
+            {
+              namespace: resourceNamespace,
+              eventPath: 'metadata.resource_key',
+              primary: true,
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const resourceEntityIds: Record<string, number> = {};
+  const resourceEntityIdByIndex = new Map<number, number>();
+  for (let i = 0; i < resources.length; i++) {
+    const ids = resolvedResources.get(i);
+    if (ids && ids.length > 0) {
+      resourceEntityIds[resources[i].key] = ids[0];
+      resourceEntityIdByIndex.set(i, ids[0]);
+    }
+  }
 
-	// 2) Resolve every DISTINCT member (identity-first, type-agnostic).
-	const distinctMembers = new Map<string, AccessMember>();
-	for (const r of resources) {
-		for (const m of r.members) {
-			if (m.key && !distinctMembers.has(m.key)) distinctMembers.set(m.key, m);
-		}
-	}
-	const memberEntityByKey = await resolveMembers(
-		organizationId,
-		connectorKey,
-		identityConnectionId,
-		[...distinctMembers.values()],
-		memberIdentities,
-	);
+  // 2) Resolve every DISTINCT member (identity-first, type-agnostic).
+  const distinctMembers = new Map<string, AccessMember>();
+  for (const r of resources) {
+    for (const m of r.members) {
+      if (m.key && !distinctMembers.has(m.key)) distinctMembers.set(m.key, m);
+    }
+  }
+  const memberEntityByKey = await resolveMembers(
+    organizationId,
+    connectorKey,
+    identityConnectionId,
+    [...distinctMembers.values()],
+    memberIdentities,
+  );
 
-	// 3) Write member → resource `member_of` edges, idempotent on the live-triple
-	// unique index. Accumulate the CURRENT member set per resource for reconcile.
-	const typeId = await ensureMemberOfType(organizationId);
-	const sql = getDb();
+  // 3) Write member → resource `member_of` edges, idempotent on the live-triple
+  // unique index. Accumulate the CURRENT member set per resource for reconcile.
+  const typeId = await ensureMemberOfType(organizationId);
+  const sql = getDb();
 
-	// Keep each resource entity's display name fresh. `titlePath` only sets the
-	// name on auto-CREATE, so a name that wasn't available at first graph (or a
-	// later channel/repo RENAME) would otherwise stick to the stale value / the
-	// raw id. Refresh from the source-provided name here. Scoped to the resources
-	// in this build; idempotent (the `name <>` guard no-ops when unchanged).
-	for (let i = 0; i < resources.length; i++) {
-		const id = resourceEntityIdByIndex.get(i);
-		const name = resources[i].name;
-		if (id && name) {
-			await sql`
+  // Keep each resource entity's display name fresh. `titlePath` only sets the
+  // name on auto-CREATE, so a name that wasn't available at first graph (or a
+  // later channel/repo RENAME) would otherwise stick to the stale value / the
+  // raw id. Refresh from the source-provided name here. Scoped to the resources
+  // in this build; idempotent (the `name <>` guard no-ops when unchanged).
+  for (let i = 0; i < resources.length; i++) {
+    const id = resourceEntityIdByIndex.get(i);
+    const name = resources[i].name;
+    if (id && name) {
+      await sql`
         UPDATE entities
         SET name = ${name}, updated_at = current_timestamp
         WHERE id = ${id}
@@ -472,24 +463,23 @@ export async function buildAccessGraph(params: {
           AND name <> ${name}
           AND deleted_at IS NULL
       `;
-		}
-	}
+    }
+  }
 
-	const memberEntityIds = new Set<number>();
-	const currentMembersByResource = new Map<number, Set<number>>();
-	let createdEdges = 0;
-	for (let i = 0; i < resources.length; i++) {
-		const resourceEntityId = resourceEntityIdByIndex.get(i);
-		if (resourceEntityId === undefined) continue;
-		const resourceMembers =
-			currentMembersByResource.get(resourceEntityId) ?? new Set<number>();
-		currentMembersByResource.set(resourceEntityId, resourceMembers);
-		for (const m of resources[i].members) {
-			const memberEntityId = memberEntityByKey.get(m.key);
-			if (memberEntityId === undefined) continue;
-			memberEntityIds.add(memberEntityId);
-			resourceMembers.add(memberEntityId);
-			const inserted = await sql<{ id: number }[]>`
+  const memberEntityIds = new Set<number>();
+  const currentMembersByResource = new Map<number, Set<number>>();
+  let createdEdges = 0;
+  for (let i = 0; i < resources.length; i++) {
+    const resourceEntityId = resourceEntityIdByIndex.get(i);
+    if (resourceEntityId === undefined) continue;
+    const resourceMembers = currentMembersByResource.get(resourceEntityId) ?? new Set<number>();
+    currentMembersByResource.set(resourceEntityId, resourceMembers);
+    for (const m of resources[i].members) {
+      const memberEntityId = memberEntityByKey.get(m.key);
+      if (memberEntityId === undefined) continue;
+      memberEntityIds.add(memberEntityId);
+      resourceMembers.add(memberEntityId);
+      const inserted = await sql<{ id: number }[]>`
 				INSERT INTO entity_relationships (
 					organization_id, from_entity_id, to_entity_id, relationship_type_id,
 					confidence, source, created_by, updated_by, created_at, updated_at
@@ -503,21 +493,21 @@ export async function buildAccessGraph(params: {
 				DO NOTHING
 				RETURNING id
 			`;
-			if (inserted.length > 0) createdEdges += 1;
-		}
-	}
+      if (inserted.length > 0) createdEdges += 1;
+    }
+  }
 
-	// 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
-	// membership, so a `member_of` edge to a synced resource whose member is NOT
-	// in the current set means that person left: soft-delete it so they lose
-	// access immediately. Scoped to `to_entity_id` = a resource we just synced, so
-	// edges to OTHER resource types (a different source's graph) are never touched.
-	// An empty member set deletes all of that resource's edges — the caller must
-	// not pass empty-on-fetch-error.
-	let removedEdges = 0;
-	for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
-		const keep = [...resourceMembers];
-		const removed = await sql<{ id: number }[]>`
+  // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
+  // membership, so a `member_of` edge to a synced resource whose member is NOT
+  // in the current set means that person left: soft-delete it so they lose
+  // access immediately. Scoped to `to_entity_id` = a resource we just synced, so
+  // edges to OTHER resource types (a different source's graph) are never touched.
+  // An empty member set deletes all of that resource's edges — the caller must
+  // not pass empty-on-fetch-error.
+  let removedEdges = 0;
+  for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
+    const keep = [...resourceMembers];
+    const removed = await sql<{ id: number }[]>`
 			UPDATE entity_relationships
 			SET deleted_at = current_timestamp, updated_at = current_timestamp
 			WHERE organization_id = ${organizationId}
@@ -527,32 +517,32 @@ export async function buildAccessGraph(params: {
 			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
 			RETURNING id
 		`;
-		removedEdges += removed.length;
-	}
+    removedEdges += removed.length;
+  }
 
-	if (params.markFresh !== false) {
-		await markAclFresh(organizationId, connectionId, syncStartedAt);
-	}
+  if (params.markFresh !== false) {
+    await markAclFresh(organizationId, connectionId, syncStartedAt);
+  }
 
-	logger.info(
-		{
-			organization_id: organizationId,
-			connection_id: connectionId,
-			connector: connectorKey,
-			resource_type: ACL_RESOURCE_TYPE_SLUG,
-			resource_namespace: resourceNamespace,
-			resources: Object.keys(resourceEntityIds).length,
-			members: memberEntityIds.size,
-			created_edges: createdEdges,
-			removed_edges: removedEdges,
-		},
-		"Built access graph",
-	);
+  logger.info(
+    {
+      organization_id: organizationId,
+      connection_id: connectionId,
+      connector: connectorKey,
+      resource_type: ACL_RESOURCE_TYPE_SLUG,
+      resource_namespace: resourceNamespace,
+      resources: Object.keys(resourceEntityIds).length,
+      members: memberEntityIds.size,
+      created_edges: createdEdges,
+      removed_edges: removedEdges,
+    },
+    'Built access graph',
+  );
 
-	return {
-		resourceEntityIds,
-		memberEntityIds: [...memberEntityIds],
-		createdEdges,
-		removedEdges,
-	};
+  return {
+    resourceEntityIds,
+    memberEntityIds: [...memberEntityIds],
+    createdEdges,
+    removedEdges,
+  };
 }

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -63,10 +63,20 @@ export async function markConnectionAclFailed(
 	const sql = getDb();
 	const message = formatAclErrorMessage(reason);
 	await sql.begin(async (tx) => {
-		// Lock order is connections → ACL state, matching connection deletion and
-		// fresh-state stamping. Reversing it can deadlock a failing sync against a
-		// concurrent delete (each transaction would hold one row and wait on the
-		// other).
+		// Lock the live connection row FIRST and UNCONDITIONALLY. Two reasons:
+		// (1) lock order is connections → ACL state, matching connection deletion
+		// and fresh-state stamping, so a failing sync cannot deadlock against a
+		// concurrent delete; (2) the message UPDATE below is conditional, so a
+		// repeated identical failure would take no row lock at all and could
+		// interleave with `clearConnectionAclError`.
+		await tx`
+      SELECT 1
+      FROM connections
+      WHERE organization_id = ${organizationId}
+        AND deleted_at IS NULL
+        AND ${tx.unsafe(aclConnectionIdSql())} = ${connectionId}
+      FOR UPDATE
+    `;
 		await tx`
       UPDATE connections
       SET error_message = ${message}, updated_at = current_timestamp
@@ -99,21 +109,41 @@ export async function clearConnectionAclError(
 	connectionId: string,
 ): Promise<void> {
 	const sql = getDb();
-	await sql`
-    UPDATE connections
-    SET error_message = NULL, updated_at = current_timestamp
-    WHERE organization_id = ${organizationId}
-      AND deleted_at IS NULL
-      AND left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
-      AND ${sql.unsafe(aclConnectionIdSql())} = ${connectionId}
-      AND EXISTS (
-        SELECT 1
-        FROM authz_source_acl_state a
-        WHERE a.organization_id = ${organizationId}
-          AND a.connection_id = ${connectionId}
-          AND a.freshness_state = 'fresh'
-      )
-  `;
+	await sql.begin(async (tx) => {
+		// Take the connection lock BEFORE reading freshness, in the same order as
+		// `markConnectionAclFailed`. Without it these two can interleave: under
+		// READ COMMITTED a single UPDATE evaluates its freshness subquery against
+		// the snapshot taken when the statement began, and re-checking a blocked
+		// row does NOT re-run that subquery against the newer snapshot. A clear
+		// could therefore observe `fresh`, wait behind a failure that then
+		// commits, and erase the newly recorded reason — leaving
+		// `freshness_state='failed'` with no cause, which is exactly the blindness
+		// this module exists to remove. Locking first forces the freshness read
+		// into a statement that begins after the failure has committed.
+		await tx`
+      SELECT 1
+      FROM connections
+      WHERE organization_id = ${organizationId}
+        AND deleted_at IS NULL
+        AND ${tx.unsafe(aclConnectionIdSql())} = ${connectionId}
+      FOR UPDATE
+    `;
+		await tx`
+      UPDATE connections
+      SET error_message = NULL, updated_at = current_timestamp
+      WHERE organization_id = ${organizationId}
+        AND deleted_at IS NULL
+        AND left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
+        AND ${tx.unsafe(aclConnectionIdSql())} = ${connectionId}
+        AND EXISTS (
+          SELECT 1
+          FROM authz_source_acl_state a
+          WHERE a.organization_id = ${organizationId}
+            AND a.connection_id = ${connectionId}
+            AND a.freshness_state = 'fresh'
+        )
+    `;
+	});
 }
 
 /**

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -1,0 +1,195 @@
+/**
+ * ACL observability — the three surfaces a failing ACL sync is surfaced on:
+ *  1. the failure REASON persisted on the existing `connections.error_message`
+ *     column (the ACL sync previously wrote only the `'failed'` freshness state,
+ *     which is why a connection could fail every tick for months unseen);
+ *  2. the connector-health alert (the alerter reads the `'failed'` ACL state as
+ *     one more unhealthy reason);
+ *  3. orphan cleanup — `authz_source_acl_state` rows are deleted when their
+ *     connection is deleted, instead of lingering forever as `full`/`failed`.
+ *
+ * Everything here reuses EXISTING columns/rows. No new tables, no API/SDK
+ * surface.
+ *
+ * ## `connections.error_message` ownership (the collision rule)
+ *
+ * The column is shared, single-text, and NOT ACL-owned. Today it carries
+ * device-pin tombstones (`Device was removed` / `Device was moved to another
+ * workspace`), feed-sync connection errors, and the chat projection writer's
+ * copy of the same value. An ACL writer must therefore NEVER clobber a value it
+ * did not write:
+ *
+ *   - **Write**: the reason is stored as `${ACL_ERROR_MESSAGE_PREFIX}${reason}`
+ *     (`acl: …`), and the UPDATE's WHERE guard only matches rows whose current
+ *     `error_message` is NULL or already `acl: `-prefixed. A value owned by any
+ *     other subsystem (feed-sync error, device-pin tombstone) is left untouched
+ *     — the ACL failure still surfaces on `authz_source_acl_state` and in the
+ *     alert, and the operator still sees the OTHER subsystem's message.
+ *   - **Clear**: on a successful re-sync the reason is cleared, but only when it
+ *     is `acl: `-prefixed. The ACL writer never removes another subsystem's text.
+ *
+ * This is deliberately asymmetric: it guarantees the ACL writer cannot silently
+ * overwrite feed text (the failure the brief guards against). The INVERSE — a
+ * non-ACL writer (e.g. the chat projection upsert) overwriting an `acl:` value —
+ * is out of scope here; `acl:`-prefixed text is at least greppable and clearly
+ * attributed when it does happen.
+ */
+
+import {
+  type DbClient,
+  getDb,
+  pgTextArray,
+} from "../db/client.js";
+
+export const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
+
+/** Failure reasons are truncated to this length before persisting. */
+export const ACL_ERROR_MESSAGE_MAX_LENGTH = 500;
+
+export function isAclErrorMessage(message: string | null | undefined): boolean {
+  return typeof message === "string" && message.startsWith(ACL_ERROR_MESSAGE_PREFIX);
+}
+
+export function formatAclErrorMessage(reason: string): string {
+  const body =
+    reason.length > ACL_ERROR_MESSAGE_MAX_LENGTH
+      ? `${reason.slice(0, ACL_ERROR_MESSAGE_MAX_LENGTH)}…`
+      : reason;
+  return `${ACL_ERROR_MESSAGE_PREFIX}${body}`;
+}
+
+/*
+ * Slug⇄runtime-id mapping, MIRRORED here so this module stays free of a
+ * circular import with `lobu/stores/connections-projection.ts` (that file
+ * imports nothing here, but `softDeleteChatConnectionProjection` will call
+ * `deleteConnectionAclRows`). Kept byte-identical to `runtimeConnectionIdToSlug`
+ * / `slugToRuntimeConnectionId` in that file — change both if the prefixes move.
+ */
+const BYO_SLUG_PREFIX = "agentconn-";
+const SLACK_INSTALLATION_ID_PREFIX = "slackinst-";
+
+/** Runtime connection id → `connections.slug`. Mirror of connections-projection. */
+function runtimeConnectionIdToSlug(id: string): string {
+  return id.startsWith(SLACK_INSTALLATION_ID_PREFIX)
+    ? id
+    : `${BYO_SLUG_PREFIX}${id}`;
+}
+
+/** `connections.slug` → the runtime connection id. Mirror of connections-projection. */
+function slugToRuntimeConnectionId(slug: string): string {
+  return slug.startsWith(BYO_SLUG_PREFIX) ? slug.slice(BYO_SLUG_PREFIX.length) : slug;
+}
+
+/**
+ * The runtime connection ids that may key a row in `authz_source_acl_state` for
+ * the given `connections` row: a managed Slack install is keyed by its
+ * `slackinst-…` slug verbatim, a BYO Slack connection by its `agentconn-`-stripped
+ * runtime id, and a data connector (GitHub) by its numeric `id::text`.
+ */
+function aclConnectionIdCandidates(params: {
+  slug: string;
+  connectionId: string | number;
+}): string[] {
+  return [
+    params.slug,
+    slugToRuntimeConnectionId(params.slug),
+    String(params.connectionId),
+  ];
+}
+
+/**
+ * Downgrade an EXISTING ACL row to `failed` (the gate fails closed) and persist
+ * WHY on `connections.error_message` under the `acl: ` prefix. A no-op when the
+ * connection was never graphed (no `authz_source_acl_state` row) — it stays on
+ * the legacy fence rather than flipping to drop-everything on its first failure.
+ *
+ * Both writes commit in one transaction so the persisted reason cannot be lost
+ * between the state flip and the column write.
+ */
+export async function markConnectionAclFailed(
+  organizationId: string,
+  connectionId: string,
+  reason: string,
+  sql: DbClient = getDb(),
+): Promise<void> {
+  await sql.begin(async (tx) => {
+    await tx`
+      UPDATE authz_source_acl_state
+      SET freshness_state = 'failed', updated_at = current_timestamp
+      WHERE organization_id = ${organizationId}
+        AND connection_id = ${connectionId}
+    `;
+    // See the file header for the collision rule: only NULL-or-`acl:`-owned
+    // text may be overwritten, so a feed-sync message is never clobbered.
+    await tx`
+      UPDATE connections
+      SET error_message = ${formatAclErrorMessage(reason)}, updated_at = current_timestamp
+      WHERE organization_id = ${organizationId}
+        AND deleted_at IS NULL
+        AND (slug = ${runtimeConnectionIdToSlug(connectionId)} OR id::text = ${connectionId})
+        AND (error_message IS NULL OR error_message LIKE ${ACL_ERROR_MESSAGE_PREFIX + "%"})
+    `;
+  });
+}
+
+/**
+ * Clear the persisted ACL failure reason once a sync succeeds. ONLY clears
+ * `acl:`-owned text (see the collision rule in the file header) — another
+ * subsystem's message is never removed.
+ */
+export async function clearConnectionAclError(
+  organizationId: string,
+  connectionId: string,
+  sql: DbClient = getDb(),
+): Promise<void> {
+  await sql`
+    UPDATE connections
+    SET error_message = NULL, updated_at = current_timestamp
+    WHERE organization_id = ${organizationId}
+      AND deleted_at IS NULL
+      AND error_message LIKE ${ACL_ERROR_MESSAGE_PREFIX + "%"}
+      AND (slug = ${runtimeConnectionIdToSlug(connectionId)} OR id::text = ${connectionId})
+  `;
+}
+
+/**
+ * Delete a connection's ACL-enforcement row when its connection is deleted.
+ * `authz_source_acl_state` is a pure materialization (rebuildable by the next
+ * sync) and nothing references it, so removing it on deletion is safe — and
+ * without this it lingers forever as `full`/`failed`, inflating any "failed
+ * connections" count.
+ *
+ * `connectionId` is the numeric `connections.id` where known; the delete matches
+ * every runtime-id shape the sync may have stamped.
+ */
+export async function deleteConnectionAclRows(
+  sql: DbClient,
+  params: {
+    organizationId: string;
+    slug: string;
+    connectionId: string | number;
+  },
+): Promise<void> {
+  const candidates = aclConnectionIdCandidates(params);
+  await sql`
+    DELETE FROM authz_source_acl_state
+    WHERE organization_id = ${params.organizationId}
+      AND connection_id = ANY(${pgTextArray([...new Set(candidates)])}::text[])
+  `;
+}
+
+/**
+ * SQL predicate for "this ACL row's connection still exists as a LIVE
+ * `connections` row". Shared between the connector-health scan (which flags
+ * `freshness_state='failed'` rows) and the orphan-cleanup migration, so the
+ * runtime-id matching cannot drift between them. Expects the aliases `a`
+ * (authz_source_acl_state) and `c` (connections).
+ */
+export const ACL_ROW_CONNECTION_ALIVE_SQL = `(
+  a.connection_id = c.slug
+  OR a.connection_id = c.id::text
+  OR a.connection_id = CASE
+        WHEN c.slug LIKE 'agentconn-%' THEN substr(c.slug, length('agentconn-') + 1)
+        ELSE c.slug
+      END
+)`;

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -1,107 +1,45 @@
 /**
- * ACL observability — the three surfaces a failing ACL sync is surfaced on:
- *  1. the failure REASON persisted on the existing `connections.error_message`
- *     column (the ACL sync previously wrote only the `'failed'` freshness state,
- *     which is why a connection could fail every tick for months unseen);
- *  2. the connector-health alert (the alerter reads the `'failed'` ACL state as
- *     one more unhealthy reason);
- *  3. orphan cleanup — `authz_source_acl_state` rows are deleted when their
- *     connection is deleted, instead of lingering forever as `full`/`failed`.
- *
- * Everything here reuses EXISTING columns/rows. No new tables, no API/SDK
- * surface.
- *
- * ## `connections.error_message` ownership (the collision rule)
- *
- * The column is shared, single-text, and NOT ACL-owned. Today it carries
- * device-pin tombstones (`Device was removed` / `Device was moved to another
- * workspace`), feed-sync connection errors, and the chat projection writer's
- * copy of the same value. An ACL writer must therefore NEVER clobber a value it
- * did not write:
- *
- *   - **Write**: the reason is stored as `${ACL_ERROR_MESSAGE_PREFIX}${reason}`
- *     (`acl: …`), and the UPDATE's WHERE guard only matches rows whose current
- *     `error_message` is NULL or already `acl: `-prefixed. A value owned by any
- *     other subsystem (feed-sync error, device-pin tombstone) is left untouched
- *     — the ACL failure still surfaces on `authz_source_acl_state` and in the
- *     alert, and the operator still sees the OTHER subsystem's message.
- *   - **Clear**: on a successful re-sync the reason is cleared, but only when it
- *     is `acl: `-prefixed. The ACL writer never removes another subsystem's text.
- *
- * This is deliberately asymmetric: it guarantees the ACL writer cannot silently
- * overwrite feed text (the failure the brief guards against). The INVERSE — a
- * non-ACL writer (e.g. the chat projection upsert) overwriting an `acl:` value —
- * is out of scope here; `acl:`-prefixed text is at least greppable and clearly
- * attributed when it does happen.
+ * Persistence helpers for ACL-sync failures and derived ACL state. The shared
+ * `connections.error_message` column is not ACL-owned, so ACL writes and clears
+ * only touch values carrying the `acl: ` prefix. Other connection errors remain
+ * authoritative when both subsystems fail at once.
  */
 
-import {
-  type DbClient,
-  getDb,
-  pgTextArray,
-} from "../db/client.js";
+import { type DbClient, getDb } from "../db/client.js";
 
-export const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
+const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
 
-/** Failure reasons are truncated to this length before persisting. */
-export const ACL_ERROR_MESSAGE_MAX_LENGTH = 500;
+/** Maximum length of the complete persisted message, including its prefix. */
+const ACL_ERROR_MESSAGE_MAX_LENGTH = 500;
 
 export function isAclErrorMessage(message: string | null | undefined): boolean {
   return typeof message === "string" && message.startsWith(ACL_ERROR_MESSAGE_PREFIX);
 }
 
 export function formatAclErrorMessage(reason: string): string {
+  const maxReasonLength = ACL_ERROR_MESSAGE_MAX_LENGTH - ACL_ERROR_MESSAGE_PREFIX.length;
   const body =
-    reason.length > ACL_ERROR_MESSAGE_MAX_LENGTH
-      ? `${reason.slice(0, ACL_ERROR_MESSAGE_MAX_LENGTH)}…`
+    reason.length > maxReasonLength
+      ? `${reason.slice(0, maxReasonLength - 1)}…`
       : reason;
   return `${ACL_ERROR_MESSAGE_PREFIX}${body}`;
 }
 
-/*
- * Slug⇄runtime-id mapping, MIRRORED here so this module stays free of a
- * circular import with `lobu/stores/connections-projection.ts` (that file
- * imports nothing here, but `softDeleteChatConnectionProjection` will call
- * `deleteConnectionAclRows`). Kept byte-identical to `runtimeConnectionIdToSlug`
- * / `slugToRuntimeConnectionId` in that file — change both if the prefixes move.
- */
-const BYO_SLUG_PREFIX = "agentconn-";
-const SLACK_INSTALLATION_ID_PREFIX = "slackinst-";
-
-/** Runtime connection id → `connections.slug`. Mirror of connections-projection. */
-function runtimeConnectionIdToSlug(id: string): string {
-  return id.startsWith(SLACK_INSTALLATION_ID_PREFIX)
-    ? id
-    : `${BYO_SLUG_PREFIX}${id}`;
-}
-
-/** `connections.slug` → the runtime connection id. Mirror of connections-projection. */
-function slugToRuntimeConnectionId(slug: string): string {
-  return slug.startsWith(BYO_SLUG_PREFIX) ? slug.slice(BYO_SLUG_PREFIX.length) : slug;
+/** The exact `authz_source_acl_state.connection_id` for a connections row. */
+export function aclConnectionIdSql(tableAlias?: "c"): string {
+  const prefix = tableAlias ? `${tableAlias}.` : "";
+  return `CASE
+    WHEN ${prefix}credential_mode IS NULL THEN ${prefix}id::text
+    WHEN left(${prefix}slug, length('agentconn-')) = 'agentconn-'
+      THEN substr(${prefix}slug, length('agentconn-') + 1)
+    ELSE ${prefix}slug
+  END`;
 }
 
 /**
- * The runtime connection ids that may key a row in `authz_source_acl_state` for
- * the given `connections` row: a managed Slack install is keyed by its
- * `slackinst-…` slug verbatim, a BYO Slack connection by its `agentconn-`-stripped
- * runtime id, and a data connector (GitHub) by its numeric `id::text`.
- */
-function aclConnectionIdCandidates(params: {
-  slug: string;
-  connectionId: string | number;
-}): string[] {
-  return [
-    params.slug,
-    slugToRuntimeConnectionId(params.slug),
-    String(params.connectionId),
-  ];
-}
-
-/**
- * Downgrade an EXISTING ACL row to `failed` (the gate fails closed) and persist
- * WHY on `connections.error_message` under the `acl: ` prefix. A no-op when the
- * connection was never graphed (no `authz_source_acl_state` row) — it stays on
- * the legacy fence rather than flipping to drop-everything on its first failure.
+ * Downgrade an existing ACL row to `failed` and persist the reason. When the
+ * connection was never graphed, the state update is a no-op so the gate remains
+ * on the legacy fence, but the connection error is still recorded.
  *
  * Both writes commit in one transaction so the persisted reason cannot be lost
  * between the state flip and the column write.
@@ -110,8 +48,8 @@ export async function markConnectionAclFailed(
   organizationId: string,
   connectionId: string,
   reason: string,
-  sql: DbClient = getDb(),
 ): Promise<void> {
+  const sql = getDb();
   await sql.begin(async (tx) => {
     await tx`
       UPDATE authz_source_acl_state
@@ -119,77 +57,62 @@ export async function markConnectionAclFailed(
       WHERE organization_id = ${organizationId}
         AND connection_id = ${connectionId}
     `;
-    // See the file header for the collision rule: only NULL-or-`acl:`-owned
-    // text may be overwritten, so a feed-sync message is never clobbered.
     await tx`
       UPDATE connections
       SET error_message = ${formatAclErrorMessage(reason)}, updated_at = current_timestamp
       WHERE organization_id = ${organizationId}
         AND deleted_at IS NULL
-        AND (slug = ${runtimeConnectionIdToSlug(connectionId)} OR id::text = ${connectionId})
-        AND (error_message IS NULL OR error_message LIKE ${ACL_ERROR_MESSAGE_PREFIX + "%"})
+        AND ${tx.unsafe(aclConnectionIdSql())} = ${connectionId}
+        AND (
+          error_message IS NULL
+          OR left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
+        )
     `;
   });
 }
 
 /**
- * Clear the persisted ACL failure reason once a sync succeeds. ONLY clears
- * `acl:`-owned text (see the collision rule in the file header) — another
- * subsystem's message is never removed.
+ * Clear the persisted ACL failure reason once a sync succeeds without removing
+ * another subsystem's error.
  */
 export async function clearConnectionAclError(
   organizationId: string,
   connectionId: string,
-  sql: DbClient = getDb(),
 ): Promise<void> {
+  const sql = getDb();
   await sql`
     UPDATE connections
     SET error_message = NULL, updated_at = current_timestamp
     WHERE organization_id = ${organizationId}
       AND deleted_at IS NULL
-      AND error_message LIKE ${ACL_ERROR_MESSAGE_PREFIX + "%"}
-      AND (slug = ${runtimeConnectionIdToSlug(connectionId)} OR id::text = ${connectionId})
+      AND left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
+      AND ${sql.unsafe(aclConnectionIdSql())} = ${connectionId}
   `;
 }
 
 /**
  * Delete a connection's ACL-enforcement row when its connection is deleted.
  * `authz_source_acl_state` is a pure materialization (rebuildable by the next
- * sync) and nothing references it, so removing it on deletion is safe — and
- * without this it lingers forever as `full`/`failed`, inflating any "failed
- * connections" count.
+ * sync) with no foreign-key dependents, so removing it on deletion is safe.
  *
- * `connectionId` is the numeric `connections.id` where known; the delete matches
- * every runtime-id shape the sync may have stamped.
+ * Resolve the ACL key from the stored connection row at the deletion
+ * chokepoint. Data ACL rows use `connections.id::text`; chat ACL rows use the
+ * runtime id derived from their slug. Deriving the kind here prevents a caller
+ * from deleting another connection's state through a colliding slug.
  */
-export async function deleteConnectionAclRows(
+export async function deleteConnectionAclRow(
   sql: DbClient,
   params: {
     organizationId: string;
-    slug: string;
     connectionId: string | number;
   },
 ): Promise<void> {
-  const candidates = aclConnectionIdCandidates(params);
   await sql`
-    DELETE FROM authz_source_acl_state
-    WHERE organization_id = ${params.organizationId}
-      AND connection_id = ANY(${pgTextArray([...new Set(candidates)])}::text[])
+    DELETE FROM authz_source_acl_state a
+    USING connections c
+    WHERE c.id = ${params.connectionId}
+      AND c.organization_id = ${params.organizationId}
+      AND a.organization_id = c.organization_id
+      AND a.connection_id = ${sql.unsafe(aclConnectionIdSql("c"))}
   `;
 }
-
-/**
- * SQL predicate for "this ACL row's connection still exists as a LIVE
- * `connections` row". Shared between the connector-health scan (which flags
- * `freshness_state='failed'` rows) and the orphan-cleanup migration, so the
- * runtime-id matching cannot drift between them. Expects the aliases `a`
- * (authz_source_acl_state) and `c` (connections).
- */
-export const ACL_ROW_CONNECTION_ALIVE_SQL = `(
-  a.connection_id = c.slug
-  OR a.connection_id = c.id::text
-  OR a.connection_id = CASE
-        WHEN c.slug LIKE 'agentconn-%' THEN substr(c.slug, length('agentconn-') + 1)
-        ELSE c.slug
-      END
-)`;

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -13,22 +13,25 @@ const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
 const ACL_ERROR_MESSAGE_MAX_LENGTH = 500;
 
 export function isAclErrorMessage(message: string | null | undefined): boolean {
-  return typeof message === "string" && message.startsWith(ACL_ERROR_MESSAGE_PREFIX);
+	return (
+		typeof message === "string" && message.startsWith(ACL_ERROR_MESSAGE_PREFIX)
+	);
 }
 
 export function formatAclErrorMessage(reason: string): string {
-  const maxReasonLength = ACL_ERROR_MESSAGE_MAX_LENGTH - ACL_ERROR_MESSAGE_PREFIX.length;
-  const body =
-    reason.length > maxReasonLength
-      ? `${reason.slice(0, maxReasonLength - 1)}…`
-      : reason;
-  return `${ACL_ERROR_MESSAGE_PREFIX}${body}`;
+	const maxReasonLength =
+		ACL_ERROR_MESSAGE_MAX_LENGTH - ACL_ERROR_MESSAGE_PREFIX.length;
+	const body =
+		reason.length > maxReasonLength
+			? `${reason.slice(0, maxReasonLength - 1)}…`
+			: reason;
+	return `${ACL_ERROR_MESSAGE_PREFIX}${body}`;
 }
 
 /** The exact `authz_source_acl_state.connection_id` for a connections row. */
 export function aclConnectionIdSql(tableAlias?: "c"): string {
-  const prefix = tableAlias ? `${tableAlias}.` : "";
-  return `CASE
+	const prefix = tableAlias ? `${tableAlias}.` : "";
+	return `CASE
     WHEN ${prefix}credential_mode IS NULL THEN ${prefix}id::text
     WHEN left(${prefix}slug, length('agentconn-')) = 'agentconn-'
       THEN substr(${prefix}slug, length('agentconn-') + 1)
@@ -43,23 +46,30 @@ export function aclConnectionIdSql(tableAlias?: "c"): string {
  *
  * Both writes commit in one transaction so the persisted reason cannot be lost
  * between the state flip and the column write.
+ *
+ * An unchanged reason does not rewrite `connections.updated_at`. ACL sync
+ * retries on a fixed tick, and that column is the memo key
+ * `ChatInstanceManager` hydrates chat adapters against (`rowVersion`), so a
+ * repeated identical failure would otherwise tear down and rehydrate
+ * otherwise-working Slack instances for the length of the outage. The ACL
+ * state's own timestamp still advances on every failure: `markAclFresh` uses it
+ * as a fence so an older in-flight snapshot cannot overwrite a newer failure.
  */
 export async function markConnectionAclFailed(
-  organizationId: string,
-  connectionId: string,
-  reason: string,
+	organizationId: string,
+	connectionId: string,
+	reason: string,
 ): Promise<void> {
-  const sql = getDb();
-  await sql.begin(async (tx) => {
-    await tx`
-      UPDATE authz_source_acl_state
-      SET freshness_state = 'failed', updated_at = current_timestamp
-      WHERE organization_id = ${organizationId}
-        AND connection_id = ${connectionId}
-    `;
-    await tx`
+	const sql = getDb();
+	const message = formatAclErrorMessage(reason);
+	await sql.begin(async (tx) => {
+		// Lock order is connections → ACL state, matching connection deletion and
+		// fresh-state stamping. Reversing it can deadlock a failing sync against a
+		// concurrent delete (each transaction would hold one row and wait on the
+		// other).
+		await tx`
       UPDATE connections
-      SET error_message = ${formatAclErrorMessage(reason)}, updated_at = current_timestamp
+      SET error_message = ${message}, updated_at = current_timestamp
       WHERE organization_id = ${organizationId}
         AND deleted_at IS NULL
         AND ${tx.unsafe(aclConnectionIdSql())} = ${connectionId}
@@ -67,26 +77,42 @@ export async function markConnectionAclFailed(
           error_message IS NULL
           OR left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
         )
+        AND error_message IS DISTINCT FROM ${message}
     `;
-  });
+		await tx`
+      UPDATE authz_source_acl_state
+      SET freshness_state = 'failed', updated_at = clock_timestamp()
+      WHERE organization_id = ${organizationId}
+        AND connection_id = ${connectionId}
+    `;
+	});
 }
 
 /**
  * Clear the persisted ACL failure reason once a sync succeeds without removing
- * another subsystem's error.
+ * another subsystem's error. The state must still be `fresh`: an older sync
+ * whose freshness stamp lost to a newer failure must not clear that failure's
+ * reason afterward.
  */
 export async function clearConnectionAclError(
-  organizationId: string,
-  connectionId: string,
+	organizationId: string,
+	connectionId: string,
 ): Promise<void> {
-  const sql = getDb();
-  await sql`
+	const sql = getDb();
+	await sql`
     UPDATE connections
     SET error_message = NULL, updated_at = current_timestamp
     WHERE organization_id = ${organizationId}
       AND deleted_at IS NULL
       AND left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
       AND ${sql.unsafe(aclConnectionIdSql())} = ${connectionId}
+      AND EXISTS (
+        SELECT 1
+        FROM authz_source_acl_state a
+        WHERE a.organization_id = ${organizationId}
+          AND a.connection_id = ${connectionId}
+          AND a.freshness_state = 'fresh'
+      )
   `;
 }
 
@@ -101,13 +127,13 @@ export async function clearConnectionAclError(
  * from deleting another connection's state through a colliding slug.
  */
 export async function deleteConnectionAclRow(
-  sql: DbClient,
-  params: {
-    organizationId: string;
-    connectionId: string | number;
-  },
+	sql: DbClient,
+	params: {
+		organizationId: string;
+		connectionId: string | number;
+	},
 ): Promise<void> {
-  await sql`
+	await sql`
     DELETE FROM authz_source_acl_state a
     USING connections c
     WHERE c.id = ${params.connectionId}

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -85,8 +85,6 @@ export async function syncGithubConnectionAcl(
       memberIdentities: githubAclSource.memberIdentities,
       resources: githubReposToResources(repoInputs),
     });
-    // The sync recovered — drop the persisted `acl:` reason. Only clears
-    // ACL-owned text (see acl-observability.ts).
     await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, reposSynced: repoInputs.length };
   } catch (error) {

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -24,6 +24,10 @@ import {
   githubAclSource,
   githubReposToResources,
 } from '@lobu/connectors/github-identity';
+import {
+  clearConnectionAclError,
+  markConnectionAclFailed,
+} from './acl-observability.js';
 import { buildAccessGraph } from './access-graph.js';
 
 const logger = createLogger('github-acl-sync');
@@ -49,21 +53,6 @@ export interface GithubAclSyncDeps {
 export interface GithubAclSyncResult {
   ok: boolean;
   reposSynced: number;
-}
-
-/** Downgrade an EXISTING ACL row to `failed` so the gate fails closed. No-op
- * when the connection was never graphed (it stays on the legacy fence). */
-async function markConnectionAclFailed(
-  organizationId: string,
-  connectionId: string,
-): Promise<void> {
-  const sql = getDb();
-  await sql`
-		UPDATE authz_source_acl_state
-		SET freshness_state = 'failed', updated_at = current_timestamp
-		WHERE organization_id = ${organizationId}
-		  AND connection_id = ${connectionId}
-	`;
 }
 
 /**
@@ -96,13 +85,20 @@ export async function syncGithubConnectionAcl(
       memberIdentities: githubAclSource.memberIdentities,
       resources: githubReposToResources(repoInputs),
     });
+    // The sync recovered — drop the persisted `acl:` reason. Only clears
+    // ACL-owned text (see acl-observability.ts).
+    await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, reposSynced: repoInputs.length };
   } catch (error) {
     logger.error(
       { organization_id: organizationId, connection_id: connectionId, error: String(error) },
       'GitHub ACL sync failed — marking connection fail-closed',
     );
-    await markConnectionAclFailed(organizationId, connectionId);
+    await markConnectionAclFailed(
+      organizationId,
+      connectionId,
+      `GitHub ACL sync failed: ${String(error)}`,
+    );
     return { ok: false, reposSynced: 0 };
   }
 }

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -46,6 +46,10 @@ import {
   slackAclSource,
   slackChannelsToResources,
 } from '@lobu/connectors/slack-identity';
+import {
+  clearConnectionAclError,
+  markConnectionAclFailed,
+} from './acl-observability.js';
 import { buildAccessGraph, markAclFresh } from './access-graph.js';
 
 const logger = createLogger('slack-acl-sync');
@@ -135,22 +139,6 @@ export interface SlackAclSyncResult {
   ok: boolean;
   teamsSynced: number;
   channelsSynced: number;
-}
-
-/** Downgrade an EXISTING ACL row to `failed` so the gate fails closed. A no-op
- * when the connection was never graphed (no row) — it stays on the legacy
- * fence rather than flipping to drop-everything on its first failure. */
-async function markConnectionAclFailed(
-  organizationId: string,
-  connectionId: string,
-): Promise<void> {
-  const sql = getDb();
-  await sql`
-		UPDATE authz_source_acl_state
-		SET freshness_state = 'failed', updated_at = current_timestamp
-		WHERE organization_id = ${organizationId}
-		  AND connection_id = ${connectionId}
-	`;
 }
 
 /**
@@ -325,6 +313,10 @@ export async function syncSlackConnectionAcl(
      * instead, so a partial reconcile can never be blessed fresh.
      */
     await markAclFresh(organizationId, connectionId, syncStartedAt);
+    // The sync recovered — drop the persisted `acl:` reason so a healthy
+    // connection does not keep showing last failure's text. Only clears
+    // ACL-owned text (see acl-observability.ts).
+    await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, teamsSynced, channelsSynced };
   } catch (error) {
     logger.error(
@@ -335,7 +327,11 @@ export async function syncSlackConnectionAcl(
       },
       'Slack ACL sync failed — marking connection fail-closed',
     );
-    await markConnectionAclFailed(organizationId, connectionId);
+    await markConnectionAclFailed(
+      organizationId,
+      connectionId,
+      `Slack ACL sync failed: ${String(error)}`,
+    );
     return { ok: false, teamsSynced, channelsSynced };
   }
 }

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -313,9 +313,6 @@ export async function syncSlackConnectionAcl(
      * instead, so a partial reconcile can never be blessed fresh.
      */
     await markAclFresh(organizationId, connectionId, syncStartedAt);
-    // The sync recovered — drop the persisted `acl:` reason so a healthy
-    // connection does not keep showing last failure's text. Only clears
-    // ACL-owned text (see acl-observability.ts).
     await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, teamsSynced, channelsSynced };
   } catch (error) {

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -15,6 +15,13 @@
  * `logger.error` is forwarded by the pino→Sentry bridge (`utils/logger.ts`) to
  * the existing Sentry→Slack alert path — no new alerting infra.
  *
+ * ACL sync failures ride this same path: a connection whose ACL graph is
+ * fail-closed (`authz_source_acl_state.freshness_state='failed'` — the ACL sync
+ * cannot refresh membership, e.g. a dead token) is classified `acl_failed` and
+ * alerts exactly once per episode under the same `unhealthy_alerted_at` claim.
+ * The persisted reason (`connections.error_message`, `acl: …`) rides along as
+ * `last_error`.
+ *
  * Multi-replica safety: registered as a single-claimant scheduled job (one
  * claimant per tick via the runs-queue), AND the per-connection dedupe is
  * Postgres-mediated — `connections.unhealthy_alerted_at` is flipped NULL→now()
@@ -76,6 +83,7 @@
 import { type DbClient, getDb, tsTimeOrNull } from '../db/client';
 import { notifyBrowserAuthExpired } from '../notifications/triggers';
 import logger from '../utils/logger';
+import { ACL_ROW_CONNECTION_ALIVE_SQL, isAclErrorMessage } from '../authz/acl-observability';
 import { deriveFeedHealthSemantics } from './feed-health-semantics';
 
 /**
@@ -202,7 +210,8 @@ export type UnhealthyReason =
   | 'all_feeds_failing'
   | 'feeds_degraded'
   | 'zero_feeds'
-  | 'no_recent_sync';
+  | 'no_recent_sync'
+  | 'acl_failed';
 
 export interface UnhealthyConnection {
   connectionId: number;
@@ -269,6 +278,13 @@ interface FeedHealthRow {
   last_sync_at: Date | string | null;
   consecutive_failures: string;
   last_error: string | null;
+  /** The connection's ACL graph is fail-closed (`authz_source_acl_state`
+   *  `freshness_state='failed'`) — the ACL sync cannot refresh membership.
+   *  NULL when the connection has no failed ACL row. */
+  acl_state_failed: boolean | null;
+  /** `connections.error_message` — for `acl_failed` carries the persisted
+   *  `acl: …` failure reason when the ACL writer set it. */
+  connection_error_message: string | null;
 }
 
 /**
@@ -316,7 +332,21 @@ async function loadConnectionHealthRows(
       f.last_sync_status,
       f.last_sync_at,
       f.consecutive_failures,
-      f.last_error
+      f.last_error,
+      -- Fails CLOSED: the connection's ACL graph is fail-closed. The ACL sync
+      -- stamps freshness_state='failed' on authz_source_acl_state when it cannot
+      -- refresh membership (dead token, OAuth consent never completed) — a
+      -- failure mode with NO feed symptom, which is why two GitHub connections
+      -- could fail every tick for months unseen. The runtime-id match is the
+      -- same shape the ACL sync writes (see acl-observability.ts).
+      EXISTS (
+        SELECT 1
+        FROM public.authz_source_acl_state a
+        WHERE a.organization_id = c.organization_id
+          AND a.freshness_state = 'failed'
+          AND ${sql.unsafe(ACL_ROW_CONNECTION_ALIVE_SQL)}
+      ) AS acl_state_failed,
+      c.error_message AS connection_error_message
     FROM connections c
     LEFT JOIN feeds f
       ON f.connection_id = c.id
@@ -429,6 +459,24 @@ function classify(
 } | null {
   const feeds = rows.filter((r) => r.feed_id != null);
   const feedCount = feeds.length;
+
+  // Rule E: the connection's ACL graph is fail-closed
+  // (`authz_source_acl_state.freshness_state='failed'`) — the ACL sync cannot
+  // refresh membership. This has NO feed symptom (the prod GitHub AUTH_MISSING
+  // shape: two connections failed every tick for months while their feeds
+  // stayed healthy), so it is checked BEFORE the feed rules and wins over them.
+  if (rows[0]?.acl_state_failed === true) {
+    const lastError = isAclErrorMessage(rows[0].connection_error_message)
+      ? rows[0].connection_error_message
+      : null;
+    return {
+      reason: 'acl_failed',
+      feedCount,
+      failingFeedCount: 0,
+      newestSyncAt: null,
+      lastError,
+    };
+  }
 
   // Rule B: active connection that should have an automatically-created
   // collector feed but has zero non-deleted feeds after the longer zero-feed

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -83,7 +83,7 @@
 import { type DbClient, getDb, tsTimeOrNull } from '../db/client';
 import { notifyBrowserAuthExpired } from '../notifications/triggers';
 import logger from '../utils/logger';
-import { ACL_ROW_CONNECTION_ALIVE_SQL, isAclErrorMessage } from '../authz/acl-observability';
+import { aclConnectionIdSql, isAclErrorMessage } from '../authz/acl-observability';
 import { deriveFeedHealthSemantics } from './feed-health-semantics';
 
 /**
@@ -278,12 +278,7 @@ interface FeedHealthRow {
   last_sync_at: Date | string | null;
   consecutive_failures: string;
   last_error: string | null;
-  /** The connection's ACL graph is fail-closed (`authz_source_acl_state`
-   *  `freshness_state='failed'`) — the ACL sync cannot refresh membership.
-   *  NULL when the connection has no failed ACL row. */
-  acl_state_failed: boolean | null;
-  /** `connections.error_message` — for `acl_failed` carries the persisted
-   *  `acl: …` failure reason when the ACL writer set it. */
+  acl_state_failed: boolean;
   connection_error_message: string | null;
 }
 
@@ -336,15 +331,15 @@ async function loadConnectionHealthRows(
       -- Fails CLOSED: the connection's ACL graph is fail-closed. The ACL sync
       -- stamps freshness_state='failed' on authz_source_acl_state when it cannot
       -- refresh membership (dead token, OAuth consent never completed) — a
-      -- failure mode with NO feed symptom, which is why two GitHub connections
-      -- could fail every tick for months unseen. The runtime-id match is the
-      -- same shape the ACL sync writes (see acl-observability.ts).
+      -- failure mode with no feed symptom. Select the connection's actual ACL
+      -- id shape so a data slug cannot collide with a chat runtime id. The
+      -- cleanup migration mirrors this predicate.
       EXISTS (
         SELECT 1
         FROM public.authz_source_acl_state a
         WHERE a.organization_id = c.organization_id
           AND a.freshness_state = 'failed'
-          AND ${sql.unsafe(ACL_ROW_CONNECTION_ALIVE_SQL)}
+          AND a.connection_id = ${sql.unsafe(aclConnectionIdSql('c'))}
       ) AS acl_state_failed,
       c.error_message AS connection_error_message
     FROM connections c
@@ -460,11 +455,7 @@ function classify(
   const feeds = rows.filter((r) => r.feed_id != null);
   const feedCount = feeds.length;
 
-  // Rule E: the connection's ACL graph is fail-closed
-  // (`authz_source_acl_state.freshness_state='failed'`) — the ACL sync cannot
-  // refresh membership. This has NO feed symptom (the prod GitHub AUTH_MISSING
-  // shape: two connections failed every tick for months while their feeds
-  // stayed healthy), so it is checked BEFORE the feed rules and wins over them.
+  // ACL failure has no feed symptom, so it takes precedence over feed rules.
   if (rows[0]?.acl_state_failed === true) {
     const lastError = isAclErrorMessage(rows[0].connection_error_message)
       ? rows[0].connection_error_message
@@ -684,7 +675,7 @@ export async function runConnectorHealthCheck(
     // to re-login — the operator alert above can't reach the person who has to
     // sign in. Deduped by the same unhealthy_alerted_at claim, so it fires once
     // per episode. Best-effort: a notification failure must not break the scan.
-    if (isBrowserAuthExpiredError(detail.lastError)) {
+    if (reason !== 'acl_failed' && isBrowserAuthExpiredError(detail.lastError)) {
       try {
         await notifyAuthExpired({
           orgId: first.organization_id,

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -259,7 +259,7 @@ describe("slack-installations projection over app_installations", () => {
     expect(await slack.getSlackInstallByTeamId(store, "T500")).toBeNull();
   });
 
-  test("delete removes the row and purges the secret", async () => {
+  test("delete removes the row, ACL state, and secret", async () => {
     const { orgContext } = await import("../../../lobu/stores/org-context.js");
     const { resolveSecretValue } = await import("../../secrets/index.js");
     await seedAgentRow("throwaway", { organizationId: "org-inst" });
@@ -271,16 +271,26 @@ describe("slack-installations projection over app_installations", () => {
       "T400",
       { botToken: "xoxb-doomed" }
     );
+    const sql = getDb();
+    await sql`
+      INSERT INTO authz_source_acl_state (
+        organization_id, connection_id, acl_support, freshness_state
+      ) VALUES ('org-inst', ${row.id}, 'full', 'failed')
+    `;
 
     await slack.deleteSlackInstall(store, secretStore, row.id);
 
     expect(await slack.getSlackInstallById(store, row.id)).toBeNull();
-    const sql = getDb();
     const appRows = await sql`
       SELECT id FROM app_installations
       WHERE provider = 'slack' AND metadata ->> 'external_id' = ${row.id}
     `;
     expect(appRows).toHaveLength(0);
+    const aclRows = await sql`
+      SELECT connection_id FROM authz_source_acl_state
+      WHERE organization_id = 'org-inst' AND connection_id = ${row.id}
+    `;
+    expect(aclRows).toHaveLength(0);
     const resolved = await orgContext.run({ organizationId: "org-inst" }, () =>
       resolveSecretValue(secretStore, row.config.botToken)
     );

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -15,6 +15,7 @@
 import type { StoredConnection } from "@lobu/core";
 import { createLogger } from "@lobu/core";
 import { type DbClient, tsTime } from "../../db/client";
+import { deleteConnectionAclRows } from "../../authz/acl-observability";
 
 const logger = createLogger("connections-projection");
 
@@ -444,7 +445,12 @@ export async function resolveActiveChatConnectionTenant(
 }
 
 /** Soft-delete the `connections` projection for a chat connection (by slug),
- *  inside the caller's transaction. Mirrors the legacy hard delete. */
+ *  inside the caller's transaction. Mirrors the legacy hard delete. Also
+ *  removes the connection's `authz_source_acl_state` row — it is a pure
+ *  materialization that nothing else ever cleans up, so a tombstoned connection
+ *  would otherwise leave its ACL row orphaned forever (see acl-observability.ts).
+ *  The org-less branch (no org context) cannot scope the ACL delete by
+ *  organization, so it only tombstones the projection row. */
 export async function softDeleteChatConnectionProjection(
   sql: any,
   orgId: string | null | undefined,
@@ -456,6 +462,11 @@ export async function softDeleteChatConnectionProjection(
       UPDATE connections SET deleted_at = now(), updated_at = now()
       WHERE organization_id = ${orgId} AND slug = ${slug} AND deleted_at IS NULL
     `;
+    await deleteConnectionAclRows(sql, {
+      organizationId: orgId,
+      slug,
+      connectionId,
+    });
   } else {
     await sql`
       UPDATE connections SET deleted_at = now(), updated_at = now()

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -15,7 +15,7 @@
 import type { StoredConnection } from "@lobu/core";
 import { createLogger } from "@lobu/core";
 import { type DbClient, tsTime } from "../../db/client";
-import { deleteConnectionAclRows } from "../../authz/acl-observability";
+import { deleteConnectionAclRow } from "../../authz/acl-observability";
 
 const logger = createLogger("connections-projection");
 
@@ -296,7 +296,7 @@ export async function upsertChatConnectionProjection(
               AND ai.metadata->>'external_id' = connections.slug
               AND ai.status = 'active'
           )
-        RETURNING slug, agent_id
+        RETURNING id, slug, agent_id
       `;
       if (supersededEnterprise.length > 0) {
         if (opts?.preserveAgentId) {
@@ -311,6 +311,14 @@ export async function upsertChatConnectionProjection(
           supersededEnterprise.some(
             (r: { agent_id: string | null }) => r.agent_id != null,
           );
+        for (const retired of supersededEnterprise as Array<{
+          id: string;
+        }>) {
+          await deleteConnectionAclRow(sql, {
+            organizationId: orgId,
+            connectionId: retired.id,
+          });
+        }
         logger.info(
           {
             orgId,
@@ -445,12 +453,8 @@ export async function resolveActiveChatConnectionTenant(
 }
 
 /** Soft-delete the `connections` projection for a chat connection (by slug),
- *  inside the caller's transaction. Mirrors the legacy hard delete. Also
- *  removes the connection's `authz_source_acl_state` row — it is a pure
- *  materialization that nothing else ever cleans up, so a tombstoned connection
- *  would otherwise leave its ACL row orphaned forever (see acl-observability.ts).
- *  The org-less branch (no org context) cannot scope the ACL delete by
- *  organization, so it only tombstones the projection row. */
+ *  inside the caller's transaction. Mirrors the legacy hard delete and removes
+ *  the derived `authz_source_acl_state` row. */
 export async function softDeleteChatConnectionProjection(
   sql: any,
   orgId: string | null | undefined,
@@ -458,19 +462,28 @@ export async function softDeleteChatConnectionProjection(
 ): Promise<void> {
   const slug = runtimeConnectionIdToSlug(connectionId);
   if (orgId) {
-    await sql`
+    const tombstoned = (await sql`
       UPDATE connections SET deleted_at = now(), updated_at = now()
       WHERE organization_id = ${orgId} AND slug = ${slug} AND deleted_at IS NULL
-    `;
-    await deleteConnectionAclRows(sql, {
-      organizationId: orgId,
-      slug,
-      connectionId,
-    });
+      RETURNING id::text AS id
+    `) as Array<{ id: string }>;
+    for (const row of tombstoned) {
+      await deleteConnectionAclRow(sql, {
+        organizationId: orgId,
+        connectionId: row.id,
+      });
+    }
   } else {
-    await sql`
+    const tombstoned = (await sql`
       UPDATE connections SET deleted_at = now(), updated_at = now()
       WHERE slug = ${slug} AND deleted_at IS NULL
-    `;
+      RETURNING id::text AS id, organization_id
+    `) as Array<{ id: string; organization_id: string }>;
+    for (const row of tombstoned) {
+      await deleteConnectionAclRow(sql, {
+        organizationId: row.organization_id,
+        connectionId: row.id,
+      });
+    }
   }
 }

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -538,7 +538,9 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			const orgId = tryGetOrgId();
 			// `connections` is the sole source of truth — soft-delete (`deleted_at`)
 			// the chat projection (kept for audit; getConnection filters it out).
-			await softDeleteChatConnectionProjection(sql, orgId, connectionId);
+			await sql.begin((tx) =>
+				softDeleteChatConnectionProjection(tx, orgId, connectionId),
+			);
 		},
 	};
 }

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -13,8 +13,10 @@ import {
   type AppInstallationStore,
   CrossOrgTransferBlockedError,
 } from "./app-installation-store.js";
-import { upsertChatConnectionProjection } from "./connections-projection.js";
-import { deleteConnectionAclRows } from "../../authz/acl-observability.js";
+import {
+  softDeleteChatConnectionProjection,
+  upsertChatConnectionProjection,
+} from "./connections-projection.js";
 import { orgContext } from "./org-context.js";
 
 /**
@@ -726,19 +728,8 @@ export async function deleteSlackInstall(
   // connections HIT would otherwise shadow the now-deleted install — the
   // read-fallback only covers a MISS). Slug-scoped: slackinst- ids are unique.
   if (!opts?.skipConnectionTombstone) {
-    await getDb()`
-      UPDATE connections SET deleted_at = now(), updated_at = now()
-      WHERE slug = ${id} AND deleted_at IS NULL AND credential_mode = 'managed'
-    `;
-    // Remove the install's ACL-enforcement row with the tombstone — a pure
-    // materialization that nothing else cleans up (see acl-observability.ts).
-    if (orgId) {
-      await deleteConnectionAclRows(getDb(), {
-        organizationId: orgId,
-        slug: id,
-        connectionId: id,
-      });
-    }
+    const sql = getDb();
+    await sql.begin((tx) => softDeleteChatConnectionProjection(tx, orgId, id));
   }
   const purge = () =>
     deleteSecretsByPrefix(secretStore, `installations/${id}/`);

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -14,6 +14,7 @@ import {
   CrossOrgTransferBlockedError,
 } from "./app-installation-store.js";
 import { upsertChatConnectionProjection } from "./connections-projection.js";
+import { deleteConnectionAclRows } from "../../authz/acl-observability.js";
 import { orgContext } from "./org-context.js";
 
 /**
@@ -729,6 +730,15 @@ export async function deleteSlackInstall(
       UPDATE connections SET deleted_at = now(), updated_at = now()
       WHERE slug = ${id} AND deleted_at IS NULL AND credential_mode = 'managed'
     `;
+    // Remove the install's ACL-enforcement row with the tombstone — a pure
+    // materialization that nothing else cleans up (see acl-observability.ts).
+    if (orgId) {
+      await deleteConnectionAclRows(getDb(), {
+        organizationId: orgId,
+        slug: id,
+        connectionId: id,
+      });
+    }
   }
   const purge = () =>
     deleteSecretsByPrefix(secretStore, `installations/${id}/`);

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -49,7 +49,7 @@ import {
 	effectiveConnectionErrorMessage,
 	isDevicePinTombstone,
 } from "../../../../utils/device-pin-tombstones";
-import { deleteConnectionAclRows } from "../../../../authz/acl-observability";
+import { deleteConnectionAclRow } from "../../../../authz/acl-observability";
 import {
   ConnectionSlugConflictError,
   connectionSlugFormatError,
@@ -2123,7 +2123,7 @@ export async function handleDelete(
   const sql = getDb();
   const { organizationId } = ctx;
 	const targets = await sql`
-		SELECT id, slug, display_name, connector_key, credential_mode
+		SELECT credential_mode
 		FROM connections
 		WHERE id = ${args.connection_id}
 			AND organization_id = ${organizationId}
@@ -2134,10 +2134,6 @@ export async function handleDelete(
 		return { error: "Connection not found or already deleted" };
 	}
 	const target = targets[0] as {
-		id: number;
-		slug: string;
-		display_name: string | null;
-		connector_key: string;
 		credential_mode: string | null;
 	};
 
@@ -2277,14 +2273,8 @@ export async function handleDelete(
         AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
     `;
 
-    // Delete the connection's ACL-enforcement row in the same commit. Nothing
-    // else ever removes `authz_source_acl_state` rows, so without this a deleted
-    // connection's row lingers forever as `full`/`failed`, inflating any
-    // "failed connections" count. It is a pure materialization (the next ACL
-    // sync rebuilds it) and nothing references it, so deleting is safe.
-    await deleteConnectionAclRows(tx, {
+    await deleteConnectionAclRow(tx, {
       organizationId,
-      slug: target.slug,
       connectionId: args.connection_id,
     });
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -49,6 +49,7 @@ import {
 	effectiveConnectionErrorMessage,
 	isDevicePinTombstone,
 } from "../../../../utils/device-pin-tombstones";
+import { deleteConnectionAclRows } from "../../../../authz/acl-observability";
 import {
   ConnectionSlugConflictError,
   connectionSlugFormatError,
@@ -2275,6 +2276,17 @@ export async function handleDelete(
       WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})
         AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
     `;
+
+    // Delete the connection's ACL-enforcement row in the same commit. Nothing
+    // else ever removes `authz_source_acl_state` rows, so without this a deleted
+    // connection's row lingers forever as `full`/`failed`, inflating any
+    // "failed connections" count. It is a pure materialization (the next ACL
+    // sync rebuilds it) and nothing references it, so deleting is safe.
+    await deleteConnectionAclRows(tx, {
+      organizationId,
+      slug: target.slug,
+      connectionId: args.connection_id,
+    });
 
     return tombstoned;
   });


### PR DESCRIPTION
## What

Two GitHub connections sat `AUTH_MISSING` in prod from 2026-06-21 to 2026-08-15 — an OAuth consent that could never complete — failing on **every** ACL sync tick for two months with no symptom anywhere. The only trace was `authz_source_acl_state.freshness_state = 'failed'`. No reason was recorded and nothing alerted. We found it by hand.

Three surfaces, all on **existing columns**. No new table, no API change, no SDK change.

1. **The failure reason is persisted** on `connections.error_message` under an `acl: ` prefix. That column is shared with feed sync and device-pin tombstones, so the write only overwrites NULL-or-`acl:`-owned text and the clear only removes `acl:`-owned text — an ACL writer can never clobber another subsystem's message. Both writes commit in one transaction with the state flip so the reason cannot be lost.
2. **ACL failures alert**, via the *existing* connector-health alerter and its `unhealthy_alerted_at` claim, so it fires once per episode rather than every tick. Checked before the feed rules because this failure has no feed symptom — the prod shape had healthy feeds throughout.
3. **Orphan rows are cleaned up.** Nothing ever deleted from `authz_source_acl_state`, so every deleted connection left a row behind forever, inflating any "failed connections" count. Rows are now removed at the deletion chokepoint, and a migration sweeps those already orphaned.

## The bug `make review-fix` caught

The first implementation matched ACL rows against an `ANY()` candidate list of {slug, `agentconn-`-stripped slug, numeric id}. A connection whose numeric id collided with another connection's runtime id would delete **that other connection's** ACL row. `aclConnectionIdSql()` now derives the exact `connection_id` from the joined `connections` row, so a caller structurally cannot reach another connection's state. It also caught that the persisted reason exceeded its own 500-char cap (truncated *then* prefixed).

## Surfaces

- **DB:** one migration, `20260816000000_acl_state_orphan_cleanup.sql` — a `DELETE` only. No `CREATE TABLE`, no `ALTER TABLE`, no column added or dropped.
- **API:** none. No route file touched.
- **SDK / MCP tool schemas:** none.

## Testing

- `124/124` authz + connector-health integration, `33/33` slack-installations (bun).
- `tsc --noEmit` and `biome check` clean.
- **Mutation-tested:** reinstating the `ANY()` match fails the cross-ID collision test; removing either the write- or clear-side `error_message` guard fails its test. Two mutation attempts silently failed to apply and those green runs were discarded rather than counted.
- `make pre-pr-remote` passed (Depot run `4xhtrtqxt4`, tree `80d900ba`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer monitoring for access-control synchronization failures, including connection-specific error details.
  * Connector health alerts now identify access-control failures and avoid unrelated browser-auth notifications.
* **Bug Fixes**
  * Successful synchronization clears prior access-control errors, while failure details are safely truncated.
  * Prevented stale access-control status from being recreated after connection deletion or in-flight synchronization.
  * Improved handling of concurrent and repeated synchronization failures, including alert deduplication.
* **Maintenance**
  * Removed orphaned access-control status records during cleanup and connection removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->