### PR TITLE
feat(behaviors): route notifications to one channel

### DIFF
--- a/db/migrations/20260815203000_behavior_delivery_target.sql
+++ b/db/migrations/20260815203000_behavior_delivery_target.sql
@@ -1,0 +1,62 @@
+-- migrate:up
+
+ALTER TABLE public.watchers
+  ADD COLUMN IF NOT EXISTS delivery_target jsonb;
+
+COMMENT ON COLUMN public.watchers.delivery_target IS
+  'Strict bound chat destination for Behavior notifications: {connection_id, channel_id}. NULL keeps legacy org-wide delivery.';
+
+-- ADD CONSTRAINT has no IF NOT EXISTS. Guard it so a manually recovered
+-- partial application can be replayed and still converge.
+DO $add_delivery_target_shape$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.watchers'::regclass
+      AND conname = 'watchers_delivery_target_shape'
+  ) THEN
+    EXECUTE $ddl$
+      ALTER TABLE public.watchers
+        ADD CONSTRAINT watchers_delivery_target_shape
+        CHECK (
+          delivery_target IS NULL
+          OR (
+            jsonb_typeof(delivery_target) = 'object'
+            AND jsonb_typeof(delivery_target->'connection_id') = 'number'
+            AND delivery_target->>'connection_id' ~ '^[1-9][0-9]*$'
+            AND jsonb_typeof(delivery_target->'channel_id') = 'string'
+            AND length(delivery_target->>'channel_id') > 0
+            AND delivery_target - 'connection_id' - 'channel_id' = '{}'::jsonb
+          )
+        ) NOT VALID
+    $ddl$;
+  END IF;
+END
+$add_delivery_target_shape$;
+
+-- The column add is metadata-only. Validation scans the bounded watchers config
+-- table without rewriting it; the surrounding dbmate transaction retains the
+-- brief ADD lock until this scan completes.
+DO $validate_delivery_target_shape$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.watchers'::regclass
+      AND conname = 'watchers_delivery_target_shape'
+      AND NOT convalidated
+  ) THEN
+    ALTER TABLE public.watchers
+      VALIDATE CONSTRAINT watchers_delivery_target_shape;
+  END IF;
+END
+$validate_delivery_target_shape$;
+
+-- migrate:down
+
+ALTER TABLE public.watchers
+  DROP CONSTRAINT IF EXISTS watchers_delivery_target_shape;
+
+ALTER TABLE public.watchers
+  DROP COLUMN IF EXISTS delivery_target;

--- a/docs/BEHAVIORS.md
+++ b/docs/BEHAVIORS.md
@@ -141,6 +141,22 @@ events are included even when those sources return nothing. They are read
 through the same governed `events` scope as any source, so a Behavior bound to
 specific entities still only sees trigger inputs linked to those entities.
 
+## Notification routing
+
+A Behavior may set `delivery_target` to one active chat channel already bound
+to its agent: `{ connection_id, channel_id }`. Notifications emitted by that
+Behavior then go only to that channel. The server resolves the stored binding
+from the Behavior ID on the run; worker-supplied notification arguments cannot
+override it.
+
+The target is strict. If the channel is unlinked, archived, moved to another
+agent, or its connection becomes inactive, the send fails closed and does not
+fall back to other linked channels. When the durable notification already
+exists, the delivery error is recorded on it. A null target preserves the legacy
+behavior of delivering to all linked channels. This setting routes notifications;
+it does not change trigger sources, durable outputs, or replies to an inbound
+chat message.
+
 ## Delivery and safety semantics
 
 - Exact metadata matching supports scalar string, number, boolean, and null
@@ -215,6 +231,7 @@ map when changing the system:
 | Queue, dedupe, coalescing, cooldown | `packages/server/src/runs/queue-service.ts` |
 | Atomic output-to-task handoff | `packages/server/src/tools/admin/manage_behaviors/complete-window.ts` |
 | Exact governed input reads | `packages/server/src/tools/get_content/` |
+| Behavior notification routing | `packages/server/src/behaviors/delivery-target.ts`, `packages/server/src/notifications/service.ts` |
 | Server/device dispatch | `packages/server/src/watchers/automation.ts`, `packages/server/src/worker-api/poll.ts`, Owletto Mac `BehaviorDispatcher.swift` |
 | Web authoring and projection | Owletto `behavior-trigger-editor.tsx`, `lib/behaviors/model.ts` |
 | Generated public client | `packages/client/src/generated/` |

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4533,6 +4533,19 @@ export type ManageBehaviorsData = {
      */
     notification_priority?: "low" | "normal" | "high";
     /**
+     * [create/update] Strict bound chat channel for this Behavior's notifications. Null clears it; omitted keeps the current destination on update.
+     */
+    delivery_target?: null | {
+      /**
+       * Numeric ID of the active chat connection that owns the bound channel.
+       */
+      connection_id: number;
+      /**
+       * Bound channel key, preferably platform-prefixed (for example "slack:C0123ABCD").
+       */
+      channel_id: string;
+    };
+    /**
      * [create/update] Minimum seconds between two firings of this Behavior (0 = no cooldown).
      */
     min_cooldown_seconds?: number;
@@ -5049,6 +5062,16 @@ export type GetBehaviorResponses = {
       >;
       next_run_at?: string | null;
       agent_id?: string | null;
+      delivery_target?: {
+        /**
+         * Numeric ID of the active chat connection that owns the bound channel.
+         */
+        connection_id: number;
+        /**
+         * Bound channel key, preferably platform-prefixed (for example "slack:C0123ABCD").
+         */
+        channel_id: string;
+      } | null;
       device_worker_id?: string | null;
       agent_kind?: string | null;
       version: number;

--- a/packages/core/src/__tests__/normalize-watcher-update-patch.test.ts
+++ b/packages/core/src/__tests__/normalize-watcher-update-patch.test.ts
@@ -57,6 +57,23 @@ describe("normalizeBehaviorUpdatePatch", () => {
     expect(p.execution_config).toBeNull();
   });
 
+  it("delivery_target is patchable and null clears it", () => {
+    const target = {
+      connection_id: 541,
+      channel_id: "slack:C0BQEB5JPU6",
+    };
+    const setPatch = normalizeBehaviorUpdatePatch(
+      update({ delivery_target: target } as never)
+    );
+    expect(setPatch).toMatchObject({ delivery_target: target });
+
+    const clearPatch = normalizeBehaviorUpdatePatch(
+      update({ delivery_target: null } as never)
+    );
+    expect("delivery_target" in clearPatch).toBe(true);
+    expect((clearPatch as Record<string, unknown>).delivery_target).toBeNull();
+  });
+
   it("notification defaults: channel→'canvas', priority→'normal', cooldown→0", () => {
     const p = normalizeBehaviorUpdatePatch(
       update({

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -360,6 +360,29 @@ export type BehaviorExecutionConfig = Static<
   typeof BehaviorExecutionConfigSchema
 >;
 
+export const BehaviorDeliveryTargetSchema = Type.Object(
+  {
+    connection_id: Type.Integer({
+      minimum: 1,
+      description:
+        "Numeric ID of the active chat connection that owns the bound channel.",
+    }),
+    channel_id: Type.String({
+      minLength: 1,
+      description:
+        'Bound channel key, preferably platform-prefixed (for example "slack:C0123ABCD").',
+    }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Strict destination for notifications emitted by this Behavior. The channel must already be bound to the Behavior's agent. Null clears the destination.",
+  }
+);
+export type BehaviorDeliveryTarget = Static<
+  typeof BehaviorDeliveryTargetSchema
+>;
+
 /**
  * Local CLI runtimes a device-pinned Behavior can name in `agent_kind`.
  *
@@ -696,6 +719,12 @@ export const ManageBehaviorsSchema = Type.Object(
         }
       )
     ),
+    delivery_target: Type.Optional(
+      Type.Union([Type.Null(), BehaviorDeliveryTargetSchema], {
+        description:
+          "[create/update] Strict bound chat channel for this Behavior's notifications. Null clears it; omitted keeps the current destination on update.",
+      })
+    ),
     min_cooldown_seconds: Type.Optional(
       Type.Number({
         description:
@@ -892,6 +921,7 @@ export type BehaviorUpdatePatch = Pick<
   | "agent_kind"
   | "notification_channel"
   | "notification_priority"
+  | "delivery_target"
   | "min_cooldown_seconds"
 >;
 
@@ -929,9 +959,9 @@ export function normalizeBehaviorTags(values: unknown): string[] {
  *   - tags → normalizeBehaviorTags (trim/drop-empty/dedupe)
  *   - notification_channel ?? 'canvas', notification_priority ?? 'normal',
  *     min_cooldown_seconds ?? 0
- *   - null-clearable scalars (agent_id/
- *     device_worker_id/agent_kind) and execution_config keep null (a real clear
- *     the write applies) — NOT coerced to undefined, which would hide the clear.
+ *   - null-clearable fields (agent_id/device_worker_id/agent_kind,
+ *     delivery_target, and execution_config) keep null (a real clear the write
+ *     applies) — NOT coerced to undefined, which would hide the clear.
  */
 export function normalizeBehaviorUpdatePatch(
   args: ManageBehaviorsArgs
@@ -953,6 +983,8 @@ export function normalizeBehaviorUpdatePatch(
     patch.notification_channel = args.notification_channel ?? "canvas";
   if (args.notification_priority !== undefined)
     patch.notification_priority = args.notification_priority ?? "normal";
+  if (args.delivery_target !== undefined)
+    patch.delivery_target = args.delivery_target ?? null;
   if (args.min_cooldown_seconds !== undefined)
     patch.min_cooldown_seconds = args.min_cooldown_seconds ?? 0;
   return patch;

--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
 	createNotificationForUsers,
 	resolveBotDeliveryTargets,
+	resolveNotificationDeliveryPlan,
 } from "../../../notifications/service";
 import { notify } from "../../../tools/admin/notify";
 import type { ToolContext } from "../../../tools/registry";
@@ -56,7 +57,9 @@ async function seedBinding(opts: {
   await createTestBehaviorSubscription({
     organizationId: opts.organizationId,
     agentId: opts.agentId,
-    connectionSlug: `agentconn-${opts.connectionId}`,
+    connectionSlug: opts.connectionId.startsWith("slackinst-")
+      ? opts.connectionId
+      : `agentconn-${opts.connectionId}`,
     platform: "slack",
     channelId: opts.channelId,
     teamId: opts.teamId ?? "T_TEST",
@@ -352,6 +355,134 @@ describe("resolveBotDeliveryTargets", () => {
 		const targets = await resolveBotDeliveryTargets(org.id, "conn-2");
 		expect(targets.map((t) => t.connectionId)).toEqual(["conn-2"]);
   });
+
+	it("routes a Behavior only to its configured channel and fails closed when that binding disappears", async () => {
+		const org = await createTestOrganization();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "personal-agent",
+		});
+		await seedSlackConnection({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "slackinst-routing",
+			metadata: { teamId: "T_ROUTING" },
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "slackinst-routing",
+			channelId: "slack:C_TASKS",
+			teamId: "T_ROUTING",
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "slackinst-routing",
+			channelId: "slack:C_FINANCE",
+			teamId: "T_ROUTING",
+		});
+
+		const sql = getTestDb();
+		const [connection] = await sql<{ id: number }>`
+			SELECT id FROM connections
+			WHERE organization_id = ${org.id}
+			  AND slug = 'slackinst-routing'
+		`;
+		const subscriptions = await sql<{
+			behavior_id: number;
+			channel_id: string;
+		}>`
+			SELECT behavior_id, channel_id
+			FROM behavior_message_subscriptions
+			WHERE organization_id = ${org.id}
+			ORDER BY behavior_id
+		`;
+		const tasks = subscriptions.find((row) => row.channel_id === "slack:C_TASKS")!;
+		const finance = subscriptions.find((row) => row.channel_id === "slack:C_FINANCE")!;
+		await sql`
+			UPDATE watchers
+			SET delivery_target = ${sql.json({
+				connection_id: Number(connection.id),
+				channel_id: "slack:C_TASKS",
+			})}
+			WHERE id = ${finance.behavior_id}
+		`;
+
+		const targeted = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			behaviorId: finance.behavior_id,
+			// A worker-supplied target cannot override the server-owned Behavior route.
+			connectionId: "slackinst-routing",
+			channelId: "slack:C_FINANCE",
+		});
+		expect(targeted).toEqual({
+			strictBehaviorTarget: true,
+			targets: [
+				{
+					connectionId: "slackinst-routing",
+					platform: "slack",
+					channelKey: "slack:C_TASKS",
+					teamId: "T_ROUTING",
+				},
+			],
+		});
+
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const behaviorCtx = {
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: false,
+			allowCrossOrg: true,
+			scopes: ["mcp:admin"],
+			sourceContext: null,
+			actingWatcherId: finance.behavior_id,
+		} as ToolContext;
+		const repeatArgs = {
+			action: "send" as const,
+			title: "Strict Behavior delivery",
+			idempotency_key: "strict-behavior-delivery",
+		};
+		const first = (await notify(
+			repeatArgs,
+			{} as never,
+			behaviorCtx,
+		)) as { event_id: number | null };
+
+		await sql`UPDATE watchers SET status = 'archived' WHERE id = ${tasks.behavior_id}`;
+		const unavailable = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			behaviorId: finance.behavior_id,
+		});
+		// #finance is still bound, but a stale strict #tasks target must never fan
+		// out there as a fallback.
+		expect(unavailable).toEqual({
+			strictBehaviorTarget: true,
+			targets: [],
+		});
+
+		const retry = (await notify(
+			repeatArgs,
+			{} as never,
+			behaviorCtx,
+		)) as { event_id: number | null; notified_count: number };
+		expect(retry).toMatchObject({
+			event_id: first.event_id,
+			notified_count: 0,
+		});
+
+		await expect(
+			notify(
+				{ action: "send", title: "New strict Behavior delivery" },
+				{} as never,
+				behaviorCtx,
+			),
+		).rejects.toThrow(/delivery channel is no longer available/);
+	});
 
   // --- Hosted-preview cross-org delivery (the proactive-notification bug) ---
   // The shared preview bot is ONE connection, in its OWN org, under a placeholder

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -44,6 +44,7 @@ type PendingApproval = {
 	event_id?: number;
 	action: string;
 	proposal?: { args?: { action?: string; slug?: string } };
+	current?: Record<string, unknown> | null;
 };
 
 async function watcherExists(orgId: string, slug: string): Promise<boolean> {
@@ -251,6 +252,48 @@ describe("manage_behaviors — builder gate e2e", () => {
 		expect(res.status).toBe("pending_approval");
 		expect(res.proposal?.args?.slug).toBe("agent-proposed-skills-only");
 		expect(await watcherExists(orgId, "agent-proposed-skills-only")).toBe(false);
+	});
+
+	it("includes the existing delivery target in an update approval snapshot", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "delivery-target-approval",
+				name: "Delivery Target Approval",
+				prompt: "Track routed notifications.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		const behaviorId = created.behavior_id!;
+		const sql = getTestDb();
+		await sql`
+			UPDATE watchers
+			SET delivery_target = ${sql.json({
+				connection_id: 541,
+				channel_id: "slack:C_TASKS",
+			})}
+			WHERE organization_id = ${orgId} AND id = ${Number(behaviorId)}
+		`;
+
+		const pending = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "update",
+				behavior_id: behaviorId,
+				tags: ["routed"],
+			},
+			TEST_ENV,
+			agentCtx
+		)) as PendingApproval;
+
+		expect(pending.status).toBe("pending_approval");
+		expect(pending.current?.delivery_target).toEqual({
+			connection_id: 541,
+			channel_id: "slack:C_TASKS",
+		});
 	});
 
 	it("approve applies the held create: watcher exists, run completed, event superseded", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-delivery-target.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-delivery-target.test.ts
@@ -83,7 +83,9 @@ describe("manage_behaviors delivery_target", () => {
 			agentId,
 			connectionId,
 			platform: "slack",
-			channelId: "slack:C_TASKS",
+			// Legacy bindings may store the native channel id without a platform
+			// prefix. The public target still uses the recommended canonical key.
+			channelId: "C_TASKS",
 			teamId: "T_DELIVERY",
 			configuredBy: owner.id,
 		});
@@ -100,7 +102,7 @@ describe("manage_behaviors delivery_target", () => {
 				agent_id: agentId,
 				delivery_target: {
 					connection_id: connectionId,
-					channel_id: "C_TASKS",
+					channel_id: "slack:C_TASKS",
 				},
 			},
 			TEST_ENV,

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-delivery-target.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-delivery-target.test.ts
@@ -1,0 +1,186 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { initWorkspaceProvider } from "../../../workspace";
+import { createTestBehaviorSubscription } from "../../setup/behavior-subscriptions";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+	insertChatConnectionRow,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+describe("manage_behaviors delivery_target", () => {
+	let ownerCtx: AuthContext;
+	let organizationId: string;
+	let agentId: string;
+	let otherAgentId: string;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "Behavior delivery target" });
+		organizationId = org.id;
+		const owner = await createTestUser({ email: "delivery-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = {
+			organizationId: org.id,
+			tokenOrganizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			agentId: null,
+			requestedAgentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			requestUrl: `http://localhost/api/${org.id}`,
+			baseUrl: "",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		};
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "delivery-agent",
+			ownerUserId: owner.id,
+		});
+		agentId = agent.agentId;
+		const otherAgent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "other-delivery-agent",
+			ownerUserId: owner.id,
+		});
+		otherAgentId = otherAgent.agentId;
+		await insertChatConnectionRow({
+			id: "slackinst-delivery",
+			organizationId: org.id,
+			agentId: null,
+			platform: "slack",
+			metadata: { teamId: "T_DELIVERY" },
+		});
+		const sql = getTestDb();
+		const [connection] = await sql<{ id: number }>`
+			SELECT id FROM connections
+			WHERE organization_id = ${org.id}
+			  AND slug = 'slackinst-delivery'
+		`;
+		connectionId = Number(connection.id);
+		await createTestBehaviorSubscription({
+			organizationId: org.id,
+			agentId,
+			connectionId,
+			platform: "slack",
+			channelId: "slack:C_TASKS",
+			teamId: "T_DELIVERY",
+			configuredBy: owner.id,
+		});
+	});
+
+	it("persists, projects, validates, and clears a strict bound channel", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "delivery-targeted",
+				name: "Delivery targeted",
+				prompt: "Send a concise update.",
+				agent_id: agentId,
+				delivery_target: {
+					connection_id: connectionId,
+					channel_id: "C_TASKS",
+				},
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { behavior_id: string };
+
+		const sql = getTestDb();
+		const [stored] = await sql<{ delivery_target: Record<string, unknown> }>`
+			SELECT delivery_target FROM watchers WHERE id = ${created.behavior_id}
+		`;
+		expect(stored.delivery_target).toEqual({
+			connection_id: connectionId,
+			channel_id: "slack:C_TASKS",
+		});
+
+		const listed = (await executeTool(
+			"manage_behaviors",
+			{ action: "list", status: "active" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { behaviors: Array<Record<string, unknown>> };
+		expect(
+			listed.behaviors.find((row) => row.behavior_id === created.behavior_id),
+		).toMatchObject({ delivery_target: stored.delivery_target });
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "update",
+					behavior_id: created.behavior_id,
+					delivery_target: {
+						connection_id: connectionId,
+						channel_id: "slack:C_FINANCE",
+					},
+				},
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/must be an active chat channel already bound to the same agent/);
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "update",
+					behavior_id: created.behavior_id,
+					agent_id: otherAgentId,
+				},
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/must be an active chat channel already bound to the same agent/);
+		const [afterRejectedMove] = await sql<{
+			agent_id: string;
+			delivery_target: Record<string, unknown>;
+		}>`
+			SELECT agent_id, delivery_target
+			FROM watchers
+			WHERE id = ${created.behavior_id}
+		`;
+		expect(afterRejectedMove).toMatchObject({
+			agent_id: agentId,
+			delivery_target: stored.delivery_target,
+		});
+
+		const cleared = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "update",
+				behavior_id: created.behavior_id,
+				delivery_target: null,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { updated_fields: string[] };
+		expect(cleared.updated_fields).toContain("delivery_target");
+		const [afterClear] = await sql<{ delivery_target: unknown }>`
+			SELECT delivery_target FROM watchers WHERE id = ${created.behavior_id}
+		`;
+		expect(afterClear.delivery_target).toBeNull();
+	});
+});

--- a/packages/server/src/behaviors/delivery-target.ts
+++ b/packages/server/src/behaviors/delivery-target.ts
@@ -37,17 +37,24 @@ async function resolveBehaviorDeliveryTarget(
     agentId,
     connectionDbId: target.connection_id,
   });
-  const row = rows.find(
-    (candidate) =>
-      candidate.channel_id === target.channel_id ||
-      (!target.channel_id.includes(':') &&
-        stripPlatformPrefix(candidate.platform, candidate.channel_id) ===
-          target.channel_id)
-  );
+  const row = rows.find((candidate) => {
+    const candidateNativeId = stripPlatformPrefix(
+      candidate.platform,
+      candidate.channel_id
+    );
+    const targetNativeId = stripPlatformPrefix(
+      candidate.platform,
+      target.channel_id
+    );
+    return candidateNativeId === targetNativeId;
+  });
   if (!row) return null;
   return {
     connectionId: row.id,
-    channelId: row.channel_id,
+    channelId: `${row.platform}:${stripPlatformPrefix(
+      row.platform,
+      row.channel_id
+    )}`,
     teamId: row.team_id,
   };
 }

--- a/packages/server/src/behaviors/delivery-target.ts
+++ b/packages/server/src/behaviors/delivery-target.ts
@@ -1,0 +1,110 @@
+import type { BehaviorDeliveryTarget } from '@lobu/core/contracts/tools/manage-behaviors';
+import type { DbClient } from '../db/client';
+import {
+  resolveBoundChannelRows,
+  stripPlatformPrefix,
+} from '../gateway/channels/bound-channels';
+import { ToolUserError } from '../utils/errors';
+
+interface ResolvedBehaviorDeliveryTarget {
+  connectionId: string;
+  channelId: string;
+  teamId: string | null;
+}
+
+interface ConfiguredBehaviorDeliveryTarget {
+  configured: boolean;
+  target: ResolvedBehaviorDeliveryTarget | null;
+}
+
+/**
+ * Resolve a public Behavior delivery target through the canonical bound-channel
+ * resolver. A numeric connection id alone is never authority: the target must
+ * be an active channel binding owned by the same organization and agent as the
+ * Behavior. Hosted-preview bindings retain the same workspace guard as normal
+ * inbound/proactive routing.
+ */
+async function resolveBehaviorDeliveryTarget(
+  sql: DbClient,
+  organizationId: string,
+  agentId: string | null,
+  target: BehaviorDeliveryTarget
+): Promise<ResolvedBehaviorDeliveryTarget | null> {
+  if (!agentId) return null;
+
+  const rows = await resolveBoundChannelRows(sql, {
+    organizationId,
+    agentId,
+    connectionDbId: target.connection_id,
+  });
+  const row = rows.find(
+    (candidate) =>
+      candidate.channel_id === target.channel_id ||
+      (!target.channel_id.includes(':') &&
+        stripPlatformPrefix(candidate.platform, candidate.channel_id) ===
+          target.channel_id)
+  );
+  if (!row) return null;
+  return {
+    connectionId: row.id,
+    channelId: row.channel_id,
+    teamId: row.team_id,
+  };
+}
+
+export async function assertBehaviorDeliveryTarget(
+  sql: DbClient,
+  organizationId: string,
+  agentId: string | null,
+  target: BehaviorDeliveryTarget
+): Promise<BehaviorDeliveryTarget> {
+  const resolved = await resolveBehaviorDeliveryTarget(
+    sql,
+    organizationId,
+    agentId,
+    target
+  );
+  if (!resolved) {
+    throw new ToolUserError(
+      'Behavior delivery target must be an active chat channel already bound to the same agent. Link the private channel first, then select it as the delivery channel.',
+      422
+    );
+  }
+  return {
+    connection_id: target.connection_id,
+    channel_id: resolved.channelId,
+  };
+}
+
+/**
+ * Read the server-owned route for a notification emitted by a Behavior.
+ * `configured: true, target: null` means the stored target became unavailable;
+ * callers must fail closed rather than fall back to another bound channel.
+ */
+export async function loadConfiguredBehaviorDeliveryTarget(
+  sql: DbClient,
+  organizationId: string,
+  behaviorId: number
+): Promise<ConfiguredBehaviorDeliveryTarget> {
+  const rows = await sql<{
+    agent_id: string | null;
+    delivery_target: BehaviorDeliveryTarget | null;
+  }>`
+    SELECT agent_id, delivery_target
+    FROM watchers
+    WHERE id = ${behaviorId}
+      AND organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row?.delivery_target) return { configured: false, target: null };
+  return {
+    configured: true,
+    target: await resolveBehaviorDeliveryTarget(
+      sql,
+      organizationId,
+      row.agent_id,
+      row.delivery_target
+    ),
+  };
+}

--- a/packages/server/src/gateway/channels/bound-channels.ts
+++ b/packages/server/src/gateway/channels/bound-channels.ts
@@ -22,8 +22,9 @@
  *
  * `agentId` (optional) scopes BOTH branches to one agent — set for the
  * conversation tools (an agent may only address ITS OWN bindings), omitted for
- * org-wide notification delivery. `connectionId` (optional) narrows to a single
- * connection (used by targeted notify).
+ * org-wide notification delivery. `connectionId` (optional) narrows by runtime
+ * id (used by targeted notify); `connectionDbId` narrows by the exact stored row
+ * id for contracts that persist that identity.
  *
  * The preview connection's first-class tenant id is useful routing scope, not a
  * reason to disable hosted delivery. A legacy tenantless preview connection may
@@ -49,9 +50,10 @@ export async function resolveBoundChannelRows(
     organizationId: string;
     agentId?: string | null;
     connectionId?: string | null;
+    connectionDbId?: number | null;
   }
 ): Promise<BoundChannelRow[]> {
-  const { organizationId, agentId, connectionId } = opts;
+  const { organizationId, agentId, connectionId, connectionDbId } = opts;
   const slugFilter = connectionId ? runtimeConnectionIdToSlug(connectionId) : null;
   // Agent scope is BINDING ownership (`b.agent_id`), NOT the connection's
   // agent_id — a managed Slack install has agent_id NULL but its bindings still
@@ -65,6 +67,12 @@ export async function resolveBoundChannelRows(
     : sql``;
   const connFilterB = slugFilter
     ? sql`AND b.connection_slug = ${slugFilter}`
+    : sql``;
+  const connDbFilterA = connectionDbId != null
+    ? sql`AND b.connection_id = ${connectionDbId}`
+    : sql``;
+  const connDbFilterB = connectionDbId != null
+    ? sql`AND b.connection_id = ${connectionDbId}`
     : sql``;
 
   // `connections` keys chat rows by `slug` (`agentconn-<id>` for BYO,
@@ -89,6 +97,7 @@ export async function resolveBoundChannelRows(
           AND b.credential_mode IS NOT NULL
           ${agentFilterA}
           ${connFilterA}
+          ${connDbFilterA}
 
         UNION ALL
 
@@ -110,6 +119,7 @@ export async function resolveBoundChannelRows(
           )
           ${agentFilterB}
           ${connFilterB}
+          ${connDbFilterB}
           -- Skip channels the org/agent already owns via branch A.
           AND NOT EXISTS (
             SELECT 1

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { CardElement } from "chat";
+import { loadConfiguredBehaviorDeliveryTarget } from "../behaviors/delivery-target";
 import { getDb, pgTextArray } from "../db/client";
 import { resolveBoundChannelRows } from "../gateway/channels/bound-channels";
 import { getChatInstanceManager, isLobuGatewayRunning } from "../lobu/gateway";
@@ -191,6 +192,58 @@ export async function resolveBotDeliveryTargets(
 		}));
 }
 
+export async function resolveNotificationDeliveryPlan(params: {
+	organizationId: string;
+	behaviorId?: number | null;
+	connectionId?: string | null;
+	channelId?: string | null;
+	teamId?: string | null;
+}): Promise<{ strictBehaviorTarget: boolean; targets: BotDeliveryTarget[] }> {
+	const configuredBehaviorTarget =
+		params.behaviorId == null
+			? { configured: false, target: null }
+			: await loadConfiguredBehaviorDeliveryTarget(
+					getDb(),
+					params.organizationId,
+					params.behaviorId,
+				);
+	if (configuredBehaviorTarget.configured) {
+		if (!configuredBehaviorTarget.target) {
+			return { strictBehaviorTarget: true, targets: [] };
+		}
+		return {
+			strictBehaviorTarget: true,
+			targets: await resolveBotDeliveryTargets(params.organizationId, {
+				connectionId: configuredBehaviorTarget.target.connectionId,
+				channelId: configuredBehaviorTarget.target.channelId,
+				teamId: configuredBehaviorTarget.target.teamId,
+			}),
+		};
+	}
+
+	let targets = await resolveBotDeliveryTargets(params.organizationId, {
+		connectionId: params.connectionId,
+		channelId: params.channelId,
+		teamId: params.teamId,
+	});
+	if (
+		targets.length === 0 &&
+		(params.connectionId || params.channelId || params.teamId)
+	) {
+		logger.warn(
+			{
+				organizationId: params.organizationId,
+				connectionId: params.connectionId,
+				channelId: params.channelId,
+				teamId: params.teamId,
+			},
+			"[Notifications] Configured delivery target resolved to no bound channels — falling back to org-wide delivery",
+		);
+		targets = await resolveBotDeliveryTargets(params.organizationId, null);
+	}
+	return { strictBehaviorTarget: false, targets };
+}
+
 /**
  * Owner-routed delivery target: the Slack identity of `ownerUserId` in a
  * workspace one of the org's bot connections lives in. Reverse-looks-up
@@ -327,6 +380,29 @@ async function recordDelivery(
 	}
 }
 
+async function recordDeliveryError(
+	eventId: number,
+	code: "behavior_target_unavailable" | "behavior_target_post_failed",
+): Promise<void> {
+	try {
+		const sql = getDb();
+		await sql`
+      UPDATE events
+      SET metadata = coalesce(metadata, '{}'::jsonb)
+        || jsonb_build_object(
+          'delivery_error',
+          jsonb_build_object('code', ${code}, 'recorded_at', NOW())
+        )
+      WHERE id = ${eventId}
+    `;
+	} catch (err) {
+		logger.warn(
+			{ err, eventId, code },
+			"[Notifications] Failed to record delivery error",
+		);
+	}
+}
+
 async function deliverToBotConnections(
 	params: Omit<CreateNotificationParams, "userId">,
 	eventId: number,
@@ -338,13 +414,31 @@ async function deliverToBotConnections(
 	const text = params.body ? `${params.title}\n\n${params.body}` : params.title;
 	// A rich card takes precedence over the markdown body for the channel post.
 	const content = params.card ? { card: params.card } : { markdown: text };
+	const deliveryPlan = await resolveNotificationDeliveryPlan({
+		organizationId: params.organizationId,
+		behaviorId: params.behaviorId,
+		connectionId: params.connectionId,
+		channelId: params.channelId,
+		teamId: params.teamId,
+	});
+	if (deliveryPlan.strictBehaviorTarget && deliveryPlan.targets.length === 0) {
+		logger.error(
+			{
+				organizationId: params.organizationId,
+				behaviorId: params.behaviorId,
+			},
+			"[Notifications] Behavior delivery target is unavailable — refusing org-wide fallback",
+		);
+		await recordDeliveryError(eventId, "behavior_target_unavailable");
+		return;
+	}
 
 	// Owner-routed tier: an approval whose gated fields have ONE human owner
 	// goes to that owner's Slack DM first (same card, same approve/reject
 	// buttons — the interaction bridge is connection-scoped, so clicks route
 	// identically). Any miss — no identity row, DM open/post failure — logs and
 	// falls through to the configured-target/org-wide chain unchanged.
-	if (params.ownerUserId) {
+	if (params.ownerUserId && !deliveryPlan.strictBehaviorTarget) {
 		try {
 			const dm = await resolveOwnerDmTarget(
 				params.organizationId,
@@ -384,30 +478,7 @@ async function deliverToBotConnections(
 	}
 
 	try {
-		let targets = await resolveBotDeliveryTargets(params.organizationId, {
-			connectionId: params.connectionId,
-			channelId: params.channelId,
-			teamId: params.teamId,
-		});
-		// A configured target that no longer resolves (channel unbound, connection
-		// removed, team drifted) must not silently swallow the notification — the
-		// admin explicitly asked for Slack review. Fall back to org-wide delivery
-		// and say so, instead of nothing arriving anywhere.
-		if (
-			targets.length === 0 &&
-			(params.connectionId || params.channelId || params.teamId)
-		) {
-			logger.warn(
-				{
-					organizationId: params.organizationId,
-					connectionId: params.connectionId,
-					channelId: params.channelId,
-					teamId: params.teamId,
-				},
-				"[Notifications] Configured delivery target resolved to no bound channels — falling back to org-wide delivery",
-			);
-			targets = await resolveBotDeliveryTargets(params.organizationId, null);
-		}
+		const targets = deliveryPlan.targets;
 		if (targets.length === 0) return;
 
 		const posted = await Promise.allSettled(
@@ -446,6 +517,9 @@ async function deliverToBotConnections(
 			);
 		});
 		await recordDelivery(eventId, delivered);
+		if (deliveryPlan.strictBehaviorTarget && delivered.length === 0) {
+			await recordDeliveryError(eventId, "behavior_target_post_failed");
+		}
 	} catch (err) {
 		logger.warn(
 			{ err },

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -565,7 +565,7 @@ export default async (_ctx, client) => {
 	},
 	"behaviors.update": {
 		summary:
-			"Update runtime config only: triggers, agent_id, model_config, execution_config, device_worker_id, agent_kind, notification_channel, notification_priority, min_cooldown_seconds, tags. Version-owned fields (name, description, prompt, sources) are immutable here — use createVersion. Status is not patchable here (a Behavior is retired via delete → archived).",
+			"Update runtime config only: triggers, agent_id, model_config, execution_config, device_worker_id, agent_kind, notification_channel, notification_priority, delivery_target, min_cooldown_seconds, tags. delivery_target is a strict bound chat destination `{ connection_id, channel_id }`; null clears it. Version-owned fields (name, description, prompt, sources) are immutable here — use createVersion. Status is not patchable here (a Behavior is retired via delete → archived).",
 		access: "admin",
 	},
 	"behaviors.createVersion": {

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -544,6 +544,7 @@ const WATCHER_PATCHABLE_FIELDS = [
   'agent_kind',
   'notification_channel',
   'notification_priority',
+  'delivery_target',
   'min_cooldown_seconds',
 ] as const;
 
@@ -646,6 +647,7 @@ const WATCHER_APPROVAL_FIELD_TITLES: Record<string, string> = {
   reactions_guidance: 'Reactions guidance',
   notification_channel: 'Notification channel',
   notification_priority: 'Notification priority',
+  delivery_target: 'Delivery channel',
   min_cooldown_seconds: 'Min cooldown (seconds)',
   name_pattern: 'Name pattern',
 };

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -440,7 +440,8 @@ async function fetchCurrentWatcher(
   if (args.behavior_id == null) return null;
   const sql = getDb();
   const rows = await sql`
-    SELECT id, slug, name, description, agent_id, schedule, timezone, triggers, status
+    SELECT id, slug, name, description, agent_id, schedule, timezone, triggers,
+           delivery_target, status
     FROM watchers
     WHERE organization_id = ${organizationId} AND id = ${Number(args.behavior_id)}
     LIMIT 1

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -65,6 +65,7 @@ import {
   syncBehaviorChannelFeeds,
   syncBehaviorChannelFeedsBestEffort,
 } from '../../../behaviors/channel-subscriptions';
+import { assertBehaviorDeliveryTarget } from '../../../behaviors/delivery-target';
 
 /**
  * Drop chat-link style triggers when cloning a Behavior onto an entity.
@@ -242,6 +243,14 @@ export async function handleCreate(
     executorDefaults,
     ctx
   );
+  const deliveryTarget = args.delivery_target
+    ? await assertBehaviorDeliveryTarget(
+        sql,
+        organizationId,
+        args.agent_id ?? null,
+        args.delivery_target
+      )
+    : null;
   const skills = args.skills ?? [];
   assertBehaviorInstructions(triggerWrite.triggers, args.prompt, skills);
   assertPromptSkillTokensPinned(args.prompt, skills);
@@ -308,7 +317,7 @@ export async function handleCreate(
         watcher_group_id,
         device_worker_id, agent_kind,
         notification_channel, notification_priority, min_cooldown_seconds,
-        execution_config,
+        delivery_target, execution_config,
         reaction_script, reaction_script_compiled, reaction_input_schema
       ) VALUES (
         ${watcherId}, ${args.name ?? args.slug}, ${args.slug}, ${organizationId},
@@ -323,6 +332,7 @@ export async function handleCreate(
         ${args.notification_channel ?? 'canvas'},
         ${args.notification_priority ?? 'normal'},
         ${args.min_cooldown_seconds ?? 0},
+        ${toJsonParam(tx, deliveryTarget)},
         ${toJsonParam(tx, args.execution_config)},
         ${reactionScript}, ${reactionScriptCompiled},
         ${reactionInputSchema ? tx.json(reactionInputSchema) : null}
@@ -441,6 +451,7 @@ export async function handleCreate(
         tags: args.tags ?? [],
         notification_channel: args.notification_channel ?? 'canvas',
         notification_priority: args.notification_priority ?? 'normal',
+        delivery_target: deliveryTarget,
         min_cooldown_seconds: args.min_cooldown_seconds ?? 0,
         prompt: args.prompt ?? '',
         description: args.description ?? null,
@@ -487,6 +498,7 @@ export async function handleUpdate(
   const currentRows = await sql`
     SELECT w.organization_id, w.agent_id, w.schedule, w.timezone, w.triggers,
            w.device_worker_id::text AS device_worker_id, w.agent_kind,
+           w.delivery_target,
            cv.prompt AS current_prompt, cv.skills AS current_skills,
            cv.outputs AS current_outputs
     FROM watchers w
@@ -502,6 +514,7 @@ export async function handleUpdate(
     schedule: string | null;
     timezone: string | null;
     triggers: ManageBehaviorsArgs['triggers'];
+    delivery_target: ManageBehaviorsArgs['delivery_target'];
     current_prompt: string | null;
     current_skills: Array<{ name: string; content: string }> | null;
     current_outputs: Record<string, unknown> | null;
@@ -557,6 +570,27 @@ export async function handleUpdate(
     ctx
   );
 
+  let normalizedDeliveryTarget = args.delivery_target ?? null;
+  if (args.delivery_target) {
+    normalizedDeliveryTarget = await assertBehaviorDeliveryTarget(
+      sql,
+      currentRow.organization_id,
+      effectiveDefaults.agentId ?? null,
+      args.delivery_target
+    );
+  } else if (
+    args.agent_id !== undefined &&
+    args.delivery_target === undefined &&
+    currentRow.delivery_target
+  ) {
+    await assertBehaviorDeliveryTarget(
+      sql,
+      currentRow.organization_id,
+      effectiveDefaults.agentId ?? null,
+      currentRow.delivery_target
+    );
+  }
+
   const updatedFields: string[] = [];
   if (args.model_config !== undefined) updatedFields.push('model_config');
   if (args.execution_config !== undefined) updatedFields.push('execution_config');
@@ -567,6 +601,7 @@ export async function handleUpdate(
   if (args.agent_kind !== undefined) updatedFields.push('agent_kind');
   if (args.notification_channel !== undefined) updatedFields.push('notification_channel');
   if (args.notification_priority !== undefined) updatedFields.push('notification_priority');
+  if (args.delivery_target !== undefined) updatedFields.push('delivery_target');
   if (args.min_cooldown_seconds !== undefined) updatedFields.push('min_cooldown_seconds');
 
   if (updatedFields.length === 0) {
@@ -585,6 +620,9 @@ export async function handleUpdate(
   const patch = normalizeBehaviorUpdatePatch(args);
   if (args.triggers !== undefined) {
     patch.triggers = triggerWrite.triggers;
+  }
+  if (args.delivery_target !== undefined) {
+    patch.delivery_target = normalizedDeliveryTarget;
   }
   const has = (k: keyof BehaviorUpdatePatch) => k in patch;
   // Recompute next_run_at when the cadence OR its zone changes; the effective
@@ -613,6 +651,7 @@ export async function handleUpdate(
       agent_kind = CASE WHEN ${has('agent_kind')} THEN ${patch.agent_kind ?? null} ELSE agent_kind END,
       notification_channel = CASE WHEN ${has('notification_channel')} THEN ${patch.notification_channel ?? 'canvas'} ELSE notification_channel END,
       notification_priority = CASE WHEN ${has('notification_priority')} THEN ${patch.notification_priority ?? 'normal'} ELSE notification_priority END,
+      delivery_target = CASE WHEN ${has('delivery_target')} THEN ${toJsonParam(sql, patch.delivery_target)} ELSE delivery_target END,
       min_cooldown_seconds = CASE WHEN ${has('min_cooldown_seconds')} THEN ${patch.min_cooldown_seconds ?? 0} ELSE min_cooldown_seconds END
     WHERE id = ${args.behavior_id} AND organization_id = ${ctx.organizationId}
     RETURNING *

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -76,6 +76,7 @@ export async function handleList(
       to_jsonb(i.tags) AS tags,
       i.notification_channel,
       i.notification_priority,
+      i.delivery_target,
       i.min_cooldown_seconds,
       i.agent_kind,
       i.watcher_group_id::text AS behavior_group_id,

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -25,6 +25,7 @@ import { validateSaveContentSemanticType } from '../../utils/event-kind-validati
 import logger from '../../utils/logger';
 import { buildResourcePermalink } from '../../utils/url-builder';
 import { trackWatcherReaction } from '../../utils/watcher-reactions';
+import { loadConfiguredBehaviorDeliveryTarget } from '../../behaviors/delivery-target';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
 
@@ -252,6 +253,28 @@ async function handleSend(
   // already makes.
   const actingBehaviorId = ctx.actingWatcherId ?? null;
   const actingRunId = ctx.actingRunId ?? null;
+  // A repeat performs no new delivery, so resolve it before rejecting a route
+  // that may have become stale after the original notification was created.
+  const priorNotificationId =
+    args.idempotency_key && (args.input_schema || actingBehaviorId !== null)
+      ? await findNotificationByIdempotencyKey(
+          ctx.organizationId,
+          args.idempotency_key
+        )
+      : null;
+  if (actingBehaviorId !== null && priorNotificationId === null) {
+    const configuredDelivery = await loadConfiguredBehaviorDeliveryTarget(
+      getDb(),
+      ctx.organizationId,
+      actingBehaviorId
+    );
+    if (configuredDelivery.configured && !configuredDelivery.target) {
+      throw new ToolUserError(
+        'This Behavior\'s delivery channel is no longer available. Re-link the private channel or choose another delivery channel before retrying.',
+        422
+      );
+    }
+  }
   const actingVersionRows =
     actingBehaviorId && actingRunId
       ? await getDb()<{ version_id: string | null }>`
@@ -294,27 +317,27 @@ async function handleSend(
   // the notification insert dedupe would strand an orphan pending run — and
   // hand the agent a run_id no inbox points at, which it would poll forever
   // while the human answers the original.
-  if (args.input_schema && args.idempotency_key) {
-    const prior = await findNotificationByIdempotencyKey(
+  if (args.input_schema && priorNotificationId !== null) {
+    const priorRunId = await findAskRunForNotification(
       ctx.organizationId,
-      args.idempotency_key
+      priorNotificationId
     );
-    if (prior !== null) {
-      const priorRunId = await findAskRunForNotification(ctx.organizationId, prior);
-      if (priorRunId !== null) {
-        // The notification can commit before this feedback edge. A failed first
-        // attempt therefore reconciles here on retry instead of returning early
-        // forever with an ask the Behavior cannot learn from.
-        await trackNotificationReaction(priorRunId);
-      }
-      return {
-        notified_count: 0,
-        event_id: prior,
-        url:
-          buildResourcePermalink(orgSlug, { kind: 'event', eventId: prior }) ?? null,
-        ...(priorRunId !== null ? { run_id: priorRunId } : {}),
-      };
+    if (priorRunId !== null) {
+      // The notification can commit before this feedback edge. A failed first
+      // attempt therefore reconciles here on retry instead of returning early
+      // forever with an ask the Behavior cannot learn from.
+      await trackNotificationReaction(priorRunId);
     }
+    return {
+      notified_count: 0,
+      event_id: priorNotificationId,
+      url:
+        buildResourcePermalink(orgSlug, {
+          kind: 'event',
+          eventId: priorNotificationId,
+        }) ?? null,
+      ...(priorRunId !== null ? { run_id: priorRunId } : {}),
+    };
   }
 
   // An `input_schema` turns this from an FYI into a QUESTION: queue the pending

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -220,6 +220,10 @@ interface WatcherQueryRow {
   triggers: BehaviorTrigger[] | null;
   next_run_at: string | null;
   agent_id: string | null;
+  delivery_target: {
+    connection_id: number;
+    channel_id: string;
+  } | null;
   device_worker_id: string | null;
   agent_kind: string | null;
   version: number;
@@ -549,6 +553,7 @@ async function getBehaviorImpl(
         i.triggers,
         i.next_run_at,
         i.agent_id,
+        i.delivery_target,
         i.device_worker_id,
         i.agent_kind,
         i.version,
@@ -795,6 +800,7 @@ async function getBehaviorImpl(
       triggers: watcherRow.triggers ?? [],
       next_run_at: watcherRow.next_run_at,
       agent_id: watcherRow.agent_id,
+      delivery_target: watcherRow.delivery_target ?? null,
       device_worker_id: watcherRow.device_worker_id ?? null,
       agent_kind: watcherRow.agent_kind ?? null,
       version: pinnedVersion,

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -11,6 +11,7 @@ import { type Static, Type } from '@sinclair/typebox';
 import {
   BehaviorTriggerSchema,
   type BehaviorTrigger,
+  BehaviorDeliveryTargetSchema,
   BehaviorSourceSchema,
   type BehaviorSource,
   BehaviorOutputsSchema,
@@ -135,6 +136,9 @@ export const WatcherMetadataSchema = Type.Object({
   triggers: Type.Optional(Type.Array(BehaviorTriggerSchema)),
   next_run_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   agent_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  delivery_target: Type.Optional(
+    Type.Union([BehaviorDeliveryTargetSchema, Type.Null()])
+  ),
   /**
    * Optional FK into `device_workers.id` pinning this watcher (and its run)
    * to a specific device worker. NULL/undefined means any worker can claim.

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -494,13 +494,13 @@ export const QUERYABLE_SCHEMA = {
           type: 'text',
           expr: `${ROW_REF}"watcher_group_id"`,
         },
-        // Scalar columns added in earlier features (device pinning, notification
-        // routing, run rate-limiting) that were missing from this list — drift
-        // test caught it.
+        // Runtime columns for device pinning, notification routing, and run
+        // rate-limiting; query_sql exposes them so those settings are auditable.
         'device_worker_id',
         'agent_kind',
         'notification_channel',
         'notification_priority',
+        'delivery_target',
         'min_cooldown_seconds',
         'last_fired_at',
         // Dispatch-time cursor for the min_cooldown_seconds debounce. Distinct


### PR DESCRIPTION
## Summary

- add an optional strict `delivery_target: { connection_id, channel_id }` to a Behavior
- validate that the target is an active channel bound to the same agent, and enforce the server-owned route at the shared notification delivery chokepoint
- fail closed with durable delivery error metadata when a configured target disappears; legacy Behaviors without a target retain all-linked-channel delivery
- expose the field through Behavior list/detail, query schema, OpenAPI client types, and source docs

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; final rebased run `fl6nfdln9b`, 18/18 jobs passed)
- [x] Tests run: 17 focused notification/manage-Behavior integration tests, 8 managed-install routing tests, 9 core patch-normalization tests, fresh embedded-Postgres boot/migrations, package build, strict server/Owletto typecheck, migration lint
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot behavior: ran relevant notification and managed-install routing integration suites

### Red → green

Before the contract was implemented:

```
normalizeBehaviorUpdatePatch > delivery_target is patchable and null clears it
Expected {} to match { delivery_target: { connection_id: 541, channel_id: "slack:C0BQEB5JPU6" } }
8 pass, 1 fail
```

After the implementation:

```
packages/core ... 9 pass, 0 fail
server focused integration ... 17 pass, 0 fail
managed-install routing integration ... 8 pass, 0 fail
Depot final rebased preflight ... 18/18 jobs passed
```

## Notes

- No Owletto pointer bump. The currently pinned UI revision remains unchanged; this rollout is configured through the canonical SDK/API surface.
- A stale strict target never falls back to another linked channel. Idempotent retries still return the previously-created notification without creating a new delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Behaviors can now route notifications to a specific connected chat channel.
  - Delivery targets can be set, updated, viewed, or cleared.
  - Routes are validated against active channel bindings and remain consistent through approvals and updates.
  - Notifications fail safely when a configured channel is unavailable, with errors recorded for troubleshooting.
  - Repeated notification requests remain safely deduplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->