### PR TITLE
fix(server): harden ACL sync failure observability

### DIFF
--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -117,6 +117,47 @@ describe("acl observability", () => {
 			expect(row?.error_message).toContain("401 Unauthorized");
 		});
 
+		it("marks an existing ACL graph failed when its repository feeds drop to zero", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Empty Repos Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				visibility: "org",
+				createDefaultFeed: false,
+			});
+			await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
+
+			const result = await syncGithubConnectionAcl(
+				{
+					listRepos: async () => [],
+					fetchCollaborators: async () => {
+						throw new Error("must not fetch collaborators without repository feeds");
+					},
+				},
+				{ connectionId: String(conn.id), organizationId: org.id },
+			);
+
+			expect(result).toEqual({ ok: false, reposSynced: 0 });
+			const [state] = await sql`
+        SELECT freshness_state FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+			expect(state?.freshness_state).toBe("failed");
+
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(row?.error_message).toBe(
+				formatAclErrorMessage(
+					"GitHub ACL sync unavailable: no repository feeds configured",
+				),
+			);
+		});
+
 		it("caps the complete persisted failure message at 500 characters", () => {
 			expect(formatAclErrorMessage("x".repeat(1_000))).toHaveLength(500);
 		});

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { normalizeSlackUserId } from "@lobu/connectors/slack-identity";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	invalidateSlackConnectionAcl,
 	resolveSlackBotIdentity,
@@ -901,24 +901,34 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
 
 	it("still FAILS CLOSED on a systemic Slack error (not a stale-channel error)", async () => {
     const { org } = await setupWorkspace();
+    const errorLines: string[] = [];
+    const errorLog = vi.spyOn(console, "error").mockImplementation((line) => {
+      errorLines.push(String(line));
+    });
     // A rate-limit / auth error is systemic — it must propagate and fail the
     // connection closed, not be swallowed like a stale-channel error.
-    const result = await syncSlackConnectionAcl(
-      {
-        slackWeb: {
-          conversationMembers: async () => {
-						throw new Error("Slack conversations.members failed: ratelimited");
+    try {
+      const result = await syncSlackConnectionAcl(
+        {
+          slackWeb: {
+            conversationMembers: async () => {
+              throw new Error("Slack conversations.members failed: ratelimited");
+            },
           },
+          resolveBotIdentity: async () => ({
+            token: "xoxb-test-token",
+            botUserId: null,
+          }),
         },
-				resolveBotIdentity: async () => ({
-					token: "xoxb-test-token",
-					botUserId: null,
-				}),
-      },
-      { connectionId: CONN, organizationId: org.id },
-    );
-    expect(result.ok).toBe(false);
-    expect(result.channelsSynced).toBe(0);
+        { connectionId: CONN, organizationId: org.id },
+      );
+      expect(result.ok).toBe(false);
+      expect(result.channelsSynced).toBe(0);
+      expect(errorLines.join("\n")).toContain(`"organization_id":"${org.id}"`);
+      expect(errorLines.join("\n")).toContain(`"connection_id":"${CONN}"`);
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
 	it("production sync FAILS CLOSED for an already-graphed connection when Slack fetch throws", async () => {

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -68,7 +68,13 @@ export async function syncGithubConnectionAcl(
 
   const repos = await deps.listRepos({ organizationId, connectionId });
   if (repos.length === 0) {
-    return { ok: true, reposSynced: 0 };
+    const reason = 'GitHub ACL sync unavailable: no repository feeds configured';
+    logger.error(
+      `${reason} — downgrading any existing ACL graph`,
+      { organization_id: organizationId, connection_id: connectionId },
+    );
+    await markConnectionAclFailed(organizationId, connectionId, reason);
+    return { ok: false, reposSynced: 0 };
   }
 
   try {
@@ -89,8 +95,8 @@ export async function syncGithubConnectionAcl(
     return { ok: true, reposSynced: repoInputs.length };
   } catch (error) {
     logger.error(
-      { organization_id: organizationId, connection_id: connectionId, error: String(error) },
       'GitHub ACL sync failed — marking connection fail-closed',
+      { organization_id: organizationId, connection_id: connectionId, error: String(error) },
     );
     await markConnectionAclFailed(
       organizationId,
@@ -196,7 +202,7 @@ export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<
     if (result.ok) ok += 1;
     else failed += 1;
   }
-  logger.info({ connections: connections.length, ok, failed }, 'GitHub ACL sync tick complete');
+  logger.info('GitHub ACL sync tick complete', { connections: connections.length, ok, failed });
 }
 
 /** Resolve an org's GitHub App installation token (collaborator-capable), minted

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -255,8 +255,13 @@ export async function syncSlackConnectionAcl(
             // errors (ratelimit/auth) fall through to `throw` → whole connection
             // fails closed, so we never wipe edges on a flaky fetch.
             logger.warn(
-              { organization_id: organizationId, channel_id: channelId, error: msg },
               'Slack conversations.members: channel unreadable (stale binding) — reconciling to no members',
+              {
+                organization_id: organizationId,
+                connection_id: connectionId,
+                channel_id: channelId,
+                error: msg,
+              },
             );
             channels.push({ channelId, memberSlackUserIds: [] });
             continue;
@@ -282,8 +287,13 @@ export async function syncSlackConnectionAcl(
           isPrivate = info.isPrivate;
         } catch (error) {
           logger.warn(
-            { organization_id: organizationId, channel_id: channelId, error: String(error) },
             'Slack conversations.info failed — syncing channel without a name',
+            {
+              organization_id: organizationId,
+              connection_id: connectionId,
+              channel_id: channelId,
+              error: String(error),
+            },
           );
         }
         channels.push({ channelId, name, isPrivate, memberSlackUserIds });
@@ -317,12 +327,12 @@ export async function syncSlackConnectionAcl(
     return { ok: true, teamsSynced, channelsSynced };
   } catch (error) {
     logger.error(
+      'Slack ACL sync failed — marking connection fail-closed',
       {
         organization_id: organizationId,
         connection_id: connectionId,
         error: String(error),
       },
-      'Slack ACL sync failed — marking connection fail-closed',
     );
     await markConnectionAclFailed(
       organizationId,
@@ -449,8 +459,13 @@ export async function resolveSlackBotIdentity(
       // (leave the connection ungraphed rather than risk wiping a foreign
       // team's edges). Transient failures retry on the next tick.
       logger.warn(
-        { connectionId, teamId, error: String(error) },
         'Slack auth.test failed resolving BYO connection team; skipping',
+        {
+          organization_id: organizationId,
+          connection_id: connectionId,
+          team_id: teamId,
+          error: String(error),
+        },
       );
       return null;
     }
@@ -463,8 +478,12 @@ export async function resolveSlackBotIdentity(
 			  AND external_tenant_id IS NULL
 		`;
     logger.info(
-      { connectionId, teamId: realTeamId },
       'Backfilled teamId onto BYO Slack connection from auth.test',
+      {
+        organization_id: organizationId,
+        connection_id: connectionId,
+        team_id: realTeamId,
+      },
     );
     // Only hand back the token when the confirmed team is the one being graphed;
     // a token for a different workspace must not touch this team's edges.
@@ -523,5 +542,5 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
     if (result.ok) ok += 1;
     else failed += 1;
   }
-  logger.info({ connections: connections.length, ok, failed }, 'Slack ACL sync tick complete');
+  logger.info('Slack ACL sync tick complete', { connections: connections.length, ok, failed });
 }


### PR DESCRIPTION
## Summary
- Treat a GitHub ACL sync with zero configured repository feeds as unhealthy, preserving fail-closed state and a precise persisted reason.
- Preserve organization and connection context for GitHub and Slack ACL logs by using the supported message-first logger form at ACL call sites.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; run `hvbb3f5m6p`, 18 jobs passed)
- [x] Tests run: `acl-observability.test.ts` (12/12) and `slack-channel-visibility.test.ts` (18/18) against ephemeral Postgres
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Red before the fix:
- zero-repository GitHub ACL sync returned `{ ok: true, reposSynced: 0 }` instead of the expected fail-closed result
- Slack ACL failure output was only `Slack ACL sync failed — marking connection fail-closed`, without organization or connection context

Green after the fix:
- ACL observability: 12 passed, including `fresh` → `failed` plus persisted `acl: GitHub ACL sync unavailable: no repository feeds configured`
- Slack channel visibility E2E: 18 passed, and failure output includes both `organization_id` and `connection_id`

## Notes
Production inspection was read-only. No feed, connection, organization, or event was deleted or mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub access-control synchronization now fails safely when repository data is unavailable, preventing incomplete permissions from being reported as successful.
  - Failed synchronization states now clearly indicate that access information is unavailable.

- **Logging and Reliability**
  - Improved diagnostic logging for GitHub and Slack synchronization failures, including relevant connection context.
  - Slack synchronization continues to fail closed when systemic errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->