### PR TITLE
fix(server): redact connector signature headers

### DIFF
--- a/packages/server/src/utils/__tests__/logger.test.ts
+++ b/packages/server/src/utils/__tests__/logger.test.ts
@@ -21,16 +21,28 @@ describe('HTTP secret redaction', () => {
     let output = '';
 
     try {
-      logger.info(
-        {
-          req: {
-            headers: {
-              authorization: 'Bearer request-secret',
-              cookie: 'session=request-cookie',
-              'proxy-authorization': 'Basic proxy-secret',
-              'x-api-key': 'api-key-secret',
-            },
+      const requestLogger = logger.child({
+        req: {
+          headers: {
+            authorization: 'Bearer request-secret',
+            cookie: 'session=request-cookie',
+            'proxy-authorization': 'Basic proxy-secret',
+            'x-api-key': 'api-key-secret',
+            'x-lobu-worker-token': 'lobu-worker-secret',
+            'x-custom-signature': 'custom-signature-secret',
+            'x-slack-signature': 'v0=slack-signature-secret',
+            'x-hub-signature-256': 'sha256=hub-signature-secret',
+            'content-type': 'application/json',
+            'idempotency-key': 'request-123',
+            'authorization-mode': 'oauth',
+            'cookie-policy': 'strict',
+            'x-keyboard-layout': 'qwerty',
+            'x-tokenizer-version': 'v1',
           },
+        },
+      });
+      requestLogger.info(
+        {
           res: {
             headers: {
               'set-cookie': 'session=response-cookie',
@@ -44,13 +56,25 @@ describe('HTTP secret redaction', () => {
       write.mockRestore();
     }
 
-    expect(output).toContain('request completed');
-    expect(output).not.toContain('request-secret');
-    expect(output).not.toContain('request-cookie');
-    expect(output).not.toContain('proxy-secret');
-    expect(output).not.toContain('api-key-secret');
-    expect(output).not.toContain('response-cookie');
-    expect(output).toContain('[redacted]');
+    const entry = JSON.parse(output);
+    expect(entry.msg).toBe('request completed');
+    expect(entry.req.headers).toEqual({
+      authorization: '[redacted]',
+      cookie: '[redacted]',
+      'proxy-authorization': '[redacted]',
+      'x-api-key': '[redacted]',
+      'x-lobu-worker-token': '[redacted]',
+      'x-custom-signature': '[redacted]',
+      'x-slack-signature': '[redacted]',
+      'x-hub-signature-256': '[redacted]',
+      'content-type': 'application/json',
+      'idempotency-key': 'request-123',
+      'authorization-mode': 'oauth',
+      'cookie-policy': 'strict',
+      'x-keyboard-layout': 'qwerty',
+      'x-tokenizer-version': 'v1',
+    });
+    expect(entry.res.headers['set-cookie']).toBe('[redacted]');
   });
 });
 

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import { isSecretKey } from '@lobu/core';
 import pino from 'pino';
 
 /**
@@ -34,13 +35,21 @@ const getLogLevel = (): pino.Level => {
 // and hid `column "events.search_tsv" does not exist`.
 const errSerializer = pino.stdSerializers.err;
 
-const HTTP_SECRET_HEADER_PATHS = [
-  'req.headers.authorization',
-  'req.headers.cookie',
-  'req.headers["proxy-authorization"]',
-  'req.headers["x-api-key"]',
+// Connector definitions may declare provider-specific signature headers, so
+// filter header names at runtime instead of maintaining a finite path list.
+const SIGNATURE_HTTP_HEADER_NAME_PATTERN = /(^|[-_])signature($|[-_])/i;
+
+const HTTP_HEADER_PATHS = [
+  'req.headers.*',
   'res.headers["set-cookie"]',
 ] as const;
+
+function censorHttpHeader(value: unknown, path: string[]): unknown {
+  const headerName = path[path.length - 1];
+  return isSecretKey(headerName) || SIGNATURE_HTTP_HEADER_NAME_PATTERN.test(headerName)
+    ? '[redacted]'
+    : value;
+}
 
 /**
  * Sentry forwarding for logger.error() and logger.fatal().
@@ -183,8 +192,8 @@ const logger = pino(
       },
     },
     redact: {
-      paths: [...HTTP_SECRET_HEADER_PATHS],
-      censor: '[redacted]',
+      paths: [...HTTP_HEADER_PATHS],
+      censor: censorHttpHeader,
     },
     serializers: {
       err: errSerializer,


### PR DESCRIPTION
## Summary
- Redact credential-bearing request headers by canonical secret-name classification instead of a finite allowlist.
- Cover connector-defined signature headers such as `x-slack-signature`, `x-hub-signature-256`, and custom signatures while preserving safe lookalikes.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; run `0g3cq9z5zq`, 18 jobs passed)
- [x] Tests run: `bun test packages/server/src/utils/__tests__/logger.test.ts` (4/4) and server `tsc --noEmit`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Red before the fix:
- the focused logger test emitted `x-slack-signature: v0=slack-signature-secret` verbatim
- read-only Loki inspection found 49 Slack-signature header occurrences over seven days, all in application request logs and none redacted

Green after the fix:
- child request logger redacts authorization, cookies, API keys, worker tokens, Slack/custom/GitHub signatures
- safe headers and false-positive lookalikes remain visible (`content-type`, `idempotency-key`, `authorization-mode`, `cookie-policy`, `x-keyboard-layout`, `x-tokenizer-version`)

## Notes
Production inspection was read-only. No production data or configuration was mutated.