### PR TITLE
chore(ci): guard entity write funnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,6 +905,14 @@ jobs:
         # gate: a value whose static type is a JS array, bound as a SQL param, fails.
         run: bun scripts/check-raw-array-params.mjs
 
+      - name: Entity-write funnel gate
+        # Production entity-row writes must converge on entity-management.ts.
+        # Historical bypasses are fingerprinted as a shrinking allowlist; both a
+        # new literal write and a dynamic table target fail this required lane.
+        run: |
+          bun scripts/check-entity-write-funnel.mjs
+          bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000
+
       - name: Connection-visibility compiler gate
         # The per-user connection-visibility READ-SEAM gate (connection_id IN
         # (SELECT ... FROM connections ... visibility ...)) must come from the one

--- a/Makefile
+++ b/Makefile
@@ -317,25 +317,28 @@ ui-review:
 # NOT a substitute for the DB-backed suites (make test-integration) when you
 # touch server/runtime code — but it catches the cheap, common misses.
 pre-pr:
-	@echo "🔎 [1/6] Build workspace packages (fresh dist)..."
+	@echo "🔎 [1/7] Build workspace packages (fresh dist)..."
 	@# Typecheck resolves @lobu/* against built dist, not src. Without this a
 	@# stale core dist yields PHANTOM errors on any contract change (e.g. a new
 	@# field the dist predates) — the exact trap CI avoids by building first.
 	@make build-packages
-	@echo "🔎 [2/6] Strict typecheck (root + excluded packages)..."
+	@echo "🔎 [2/7] Strict typecheck (root + excluded packages)..."
 	@bun run typecheck
 	@for pkg in server connector-worker connector-sdk plugin-api plugin-host plugin-toolkit plugin-memory plugin-conversations plugin-media plugin-mcp embeddings cli; do \
 		echo "   typecheck packages/$$pkg..."; \
 		( cd "packages/$$pkg" && bunx tsc --noEmit ) || exit $$?; \
 	done
-	@echo "🔎 [3/6] Dead-code gate (knip --include files)..."
+	@echo "🔎 [3/7] Dead-code gate (knip --include files)..."
 	@bun run knip --include files
-	@echo "🔎 [4/6] Lint/format (biome)..."
+	@echo "🔎 [4/7] Lint/format (biome)..."
 	@bun run check
-	@echo "🔎 [5/6] Exposed surface naming (no agent-facing 'watcher')..."
+	@echo "🔎 [5/7] Exposed surface naming (no agent-facing 'watcher')..."
 	@bun scripts/check-exposed-surface-naming.ts
-	@echo "🔎 [6/6] Gateway LLM calls (no unapproved one-off clients)..."
+	@echo "🔎 [6/7] Gateway LLM calls (no unapproved one-off clients)..."
 	@node scripts/check-gateway-llm-calls.mjs
+	@echo "🔎 [7/7] Entity writes (no unapproved funnel bypasses)..."
+	@bun scripts/check-entity-write-funnel.mjs
+	@bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000
 	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
 	@echo "   not just the working tree — a fix that isn't committed won't reach CI."
 

--- a/scripts/__tests__/check-entity-write-funnel.test.ts
+++ b/scripts/__tests__/check-entity-write-funnel.test.ts
@@ -1,0 +1,349 @@
+/**
+ * The entity-write funnel guard is only useful if it rejects both obvious SQL
+ * and dynamically selected table names. These probes run in the real scanned
+ * tree so the test exercises the same baseline allowlist as CI.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/check-entity-write-funnel.mjs");
+const PROBE = join(
+  REPO_ROOT,
+  "packages/server/src/utils/entity-write-funnel-probe.ts"
+);
+const STALE_GUARD_PROBE = join(
+  REPO_ROOT,
+  "scripts/check-entity-write-funnel-stale-probe.mjs"
+);
+const OUTSIDE_SERVER_PROBE = join(
+  REPO_ROOT,
+  "packages/core/src/entity-write-funnel-probe.ts"
+);
+
+function runGuard() {
+  return Bun.spawnSync(["bun", GUARD], {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+afterEach(() => {
+  rmSync(PROBE, { force: true });
+  rmSync(STALE_GUARD_PROBE, { force: true });
+  rmSync(OUTSIDE_SERVER_PROBE, { force: true });
+});
+
+describe("check-entity-write-funnel", () => {
+  it("passes on the pinned production baseline", () => {
+    const result = runGuard();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("rejects a new direct entity write", () => {
+    // The statement deliberately starts on a later line than the literal's
+    // opening backtick, so the reported line has to come from the match offset
+    // rather than from the enclosing node's position.
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any) {
+  await sql\`
+    SELECT 1;
+    UPDATE entities SET name = \${"new"} WHERE id = \${1}\`;
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "entity-write-funnel-probe.ts:4"
+    );
+  });
+
+  it("rejects formatter-split inserts and hard deletes", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any) {
+  await sql\`
+    INSERT INTO entities (name)
+    VALUES (\${"new"})
+  \`;
+  await sql\`
+    DELETE FROM entities
+    WHERE id = \${1}
+  \`;
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("direct entity insert");
+    expect(result.stderr.toString()).toContain("direct entity delete");
+  });
+
+  it("rejects direct and dynamic insert aliases", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, table: string) {
+  await sql\`INSERT INTO entities AS "entity row" (name) VALUES (\${"new"})\`;
+  await sql\`UPDATE entities AS "entity row" SET name = \${"new"}\`;
+  await sql.unsafe(\`INSERT INTO public.\${table} AS entity_row (name) VALUES ($1)\`, ["new"]);
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toContain("direct entity insert");
+    expect(stderr).toContain("direct entity update");
+    expect(stderr).toContain("dynamic mutation target");
+  });
+
+  it("rejects postgres.js row-helper inserts", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, table: string, row: object) {
+  await sql\`INSERT INTO entities \${sql(row)}\`;
+  await sql\`INSERT INTO \${table} \${sql(row)}\`;
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toContain("direct entity insert");
+    expect(stderr).toContain("dynamic mutation target");
+  });
+
+  it("rejects bare deletes and every table-level mutation form", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any) {
+  await sql.unsafe("DELETE FROM ONLY entities");
+  await sql.unsafe("UPDATE ONLY entities SET name = 'new'");
+  await sql.unsafe("TRUNCATE TABLE entities");
+  await sql.unsafe("MERGE INTO ONLY entities AS target USING incoming AS source ON false");
+  await sql.unsafe("COPY entities FROM STDIN");
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toContain("direct entity delete");
+    expect(stderr).toContain("direct entity update");
+    expect(stderr).toContain("direct entity truncate");
+    expect(stderr).toContain("direct entity merge");
+    expect(stderr).toContain("direct entity copy");
+  });
+
+  it("rejects non-public schema qualification", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any) {
+  await sql.unsafe("UPDATE app.entities SET name = 'new'");
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("direct entity update");
+  });
+
+  it("rejects entities later in direct and dynamic TRUNCATE lists", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, schema: string) {
+  await sql.unsafe("TRUNCATE other_table, ONLY app.entities");
+  await sql.unsafe(\`TRUNCATE other_table, \${schema}.entities\`);
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toContain("direct entity truncate");
+    expect(stderr).toContain("dynamic mutation target");
+  });
+
+  it("rejects an entity writer in another runtime package", () => {
+    writeFileSync(
+      OUTSIDE_SERVER_PROBE,
+      `export async function probe(sql: any) {
+  await sql\`DELETE FROM entities\`;
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "packages/core/src/entity-write-funnel-probe.ts:2"
+    );
+  });
+
+  it("allows COPY TO entity exports", () => {
+    writeFileSync(
+      PROBE,
+      `export async function exportEntities(sql: any) {
+  await sql.unsafe("COPY entities (id, name) TO STDOUT");
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("rejects a dynamically selected mutation target", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, schema: string, table: string) {
+  await sql.unsafe(\`UPDATE \${schema}.entities SET name = $1\`, ["new"]);
+  await sql.unsafe(\`DELETE FROM public.\${table}\`);
+  await sql.unsafe(\`TRUNCATE \${schema}.\${table}\`);
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("dynamic mutation target");
+  });
+
+  it("rejects quoted dynamic identifiers", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, table: string) {
+  await sql.unsafe(\`UPDATE "\${table}" SET name = $1\`, ["new"]);
+  await sql.unsafe(\`DELETE FROM "\${table}"\`);
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr.match(/dynamic mutation target/g)).toHaveLength(2);
+  });
+
+  it("gives actionable advice for a dynamic non-entity target", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, schema: string) {
+  await sql.unsafe(\`INSERT INTO \${schema}.audit_log (message) VALUES ($1)\`, ["new"]);
+}
+`
+    );
+
+    const result = runGuard();
+    const stderr = result.stderr.toString();
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toContain(
+      "A dynamically named table cannot be proven non-entity"
+    );
+    expect(stderr).not.toContain(
+      "Route production entity-row mutations through"
+    );
+  });
+
+  it("rejects a dynamic target whose expression contains nested braces", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, key: string) {
+  const tables = { entity: "entities" };
+  await sql.unsafe(\`UPDATE \${/* } */ tables[\`\${key}\`] /* } */} SET name = $1\`, ["new"]);
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("dynamic mutation target");
+  });
+
+  it("reports the exact line after a multiline interpolation", () => {
+    writeFileSync(
+      PROBE,
+      `export async function probe(sql: any, table: string) {
+  await sql.unsafe(\`
+    SELECT \${(() => {
+      return 1;
+    })()};
+    UPDATE \${table} SET name = $1
+  \`, ["new"]);
+}
+`
+    );
+
+    const result = runGuard();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "entity-write-funnel-probe.ts:6"
+    );
+  });
+
+  it("rejects a stale bypass allowance", () => {
+    const guardSource = readFileSync(GUARD, "utf8");
+    writeFileSync(
+      STALE_GUARD_PROBE,
+      guardSource.replace("1280c3ed0fdded46", "0000000000000000")
+    );
+
+    const result = Bun.spawnSync(["bun", STALE_GUARD_PROBE], {
+      cwd: REPO_ROOT,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("stale allowance(s)");
+  });
+
+  it("reports the count for a duplicated stale allowance", () => {
+    const guardSource = readFileSync(GUARD, "utf8");
+    writeFileSync(
+      STALE_GUARD_PROBE,
+      guardSource.replace("28b38f1cbc483794", "0000000000000000")
+    );
+
+    const result = Bun.spawnSync(["bun", STALE_GUARD_PROBE], {
+      cwd: REPO_ROOT,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "x2 [lost identity or mint race cleanup]"
+    );
+  });
+
+  it("does not govern test fixtures", () => {
+    const testProbe = join(
+      REPO_ROOT,
+      "packages/server/src/utils/__tests__/entity-write-funnel-probe.test.ts"
+    );
+    writeFileSync(
+      testProbe,
+      `export async function seed(sql: any) {
+  await sql\`INSERT INTO entities (name) VALUES (\${"fixture"})\`;
+}
+`
+    );
+    try {
+      const result = runGuard();
+      expect(result.exitCode).toBe(0);
+    } finally {
+      rmSync(testProbe, { force: true });
+    }
+  });
+});

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -1,0 +1,602 @@
+#!/usr/bin/env node
+/**
+ * Entity-write funnel gate.
+ *
+ * Production entity-row mutations belong in entity-management.ts. The
+ * remaining historical bypasses are pinned below by a whitespace-normalized
+ * source fingerprint. The list is intentionally shrinking: removing or
+ * changing a bypass makes this gate fail until the allowance is deleted, and
+ * adding a bypass fails because it has no allowance.
+ *
+ * A dynamically selected mutation target is treated conservatively because a
+ * helper such as `parentTable("entity")` can hide an entity write from a
+ * literal `UPDATE entities` grep.
+ *
+ * HONEST GAP: this recognizes SQL held in string/template literals. SQL
+ * assembled from multiple runtime fragments or expressed through a query
+ * builder needs review; the verified origin/main inventory contains neither.
+ *
+ * Tests, generated trees, and the Owletto submodule are excluded. No database
+ * or build is required.
+ * Run: `bun scripts/check-entity-write-funnel.mjs`
+ * Audit: `bun scripts/check-entity-write-funnel.mjs --print-inventory`
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+const REPO_ROOT = process.cwd();
+const PACKAGES_ROOT = join(REPO_ROOT, "packages");
+const CANONICAL_FUNNEL = "packages/server/src/utils/entity-management.ts";
+const SKIPPED_DIRS = new Set([
+  "__tests__",
+  "dist",
+  "generated",
+  "node_modules",
+  "owletto",
+]);
+
+/**
+ * Temporary production bypasses, frozen from origin/main on 2026-08-15.
+ * Every entry must continue to match exactly one mutation. Delete entries as
+ * callers move into the funnel; never add one merely to make CI green.
+ */
+const ALLOWED_BYPASSES = [
+  // Access/resource projection.
+  {
+    file: "packages/server/src/authz/access-graph.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "1280c3ed0fdded46",
+    reason: "resource rename projection",
+  },
+
+  // Evaluation projections.
+  {
+    file: "packages/server/src/runs/eval-cases.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "65e074f820a415f7",
+    reason: "judge-model projection",
+  },
+  {
+    file: "packages/server/src/runs/eval-cases.ts",
+    operation: "insert",
+    dynamic: false,
+    fingerprint: "5851d53b1d3777ee",
+    reason: "eval-case entity projection",
+  },
+  {
+    file: "packages/server/src/runs/eval-scores.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "b53e657432cbb0da",
+    reason: "locked rolling score projection",
+  },
+  {
+    file: "packages/server/src/runs/eval-suite.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "cdb38e54da5ece98",
+    reason: "suite-trials projection",
+  },
+
+  // Pre-authorized field application.
+  {
+    file: "packages/server/src/tools/admin/entity-field-approval.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "fafff2cf303a2897",
+    reason: "approved field application",
+  },
+  {
+    file: "packages/server/src/utils/entity-field-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "faba984f6f828f86",
+    reason: "owned field merge in caller transaction",
+  },
+
+  // Canvas materialization and provisional cleanup.
+  {
+    file: "packages/server/src/utils/canvas-events.ts",
+    operation: "insert",
+    dynamic: false,
+    fingerprint: "de2364b8740703fe",
+    reason: "canvas entity materialization",
+  },
+  {
+    file: "packages/server/src/utils/canvas-events.ts",
+    operation: "delete",
+    dynamic: false,
+    fingerprint: "e2d8719a612a3712",
+    reason: "provisional canvas cleanup",
+  },
+
+  // Connector identity attribution and provisional cleanup.
+  {
+    file: "packages/server/src/utils/entity-link-upsert.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "2861920694ec0b57",
+    reason: "atomic connector alias union",
+  },
+  {
+    file: "packages/server/src/utils/entity-link-upsert.ts",
+    operation: "insert",
+    dynamic: false,
+    fingerprint: "53a1d02d941dbf12",
+    reason: "connector-attributed entity create",
+  },
+  {
+    file: "packages/server/src/utils/entity-link-upsert.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "c3df275b1acf2aa4",
+    reason: "connector trait projection",
+  },
+  {
+    file: "packages/server/src/utils/entity-link-upsert.ts",
+    operation: "delete",
+    dynamic: false,
+    fingerprint: "28b38f1cbc483794",
+    count: 2,
+    reason: "lost identity or mint race cleanup",
+  },
+
+  // Merge and unmerge compound transaction. Never add runMutationGate here.
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "e77cba72098c5fbf",
+    reason: "merge winner state",
+  },
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "d6bda7fd7951c50a",
+    reason: "merge flattened redirects",
+  },
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "57edeaf7d0e925bb",
+    reason: "merge loser tombstone",
+  },
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "7629cfa8fba9cac8",
+    reason: "unmerge redirect restore",
+  },
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "454f4072c996a016",
+    reason: "unmerge winner restore",
+  },
+  {
+    file: "packages/server/src/utils/entity-merge.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "45cc1d85cddd8374",
+    reason: "unmerge loser revive",
+  },
+
+  // Member lifecycle projections.
+  {
+    file: "packages/server/src/utils/member-entity.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "eda8f87e28c0f602",
+    reason: "member status projection",
+  },
+  {
+    file: "packages/server/src/utils/member-entity.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "1d4a7505da557ec9",
+    reason: "member access projection",
+  },
+  {
+    file: "packages/server/src/utils/member-entity.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "ea1d914a77903682",
+    reason: "member soft delete",
+  },
+
+  // Behavior keyed-entity promotion and provisional cleanup.
+  {
+    file: "packages/server/src/utils/promote-keyed-entities.ts",
+    operation: "insert",
+    dynamic: false,
+    fingerprint: "079c819d8e1848c1",
+    reason: "keyed entity promotion",
+  },
+  {
+    file: "packages/server/src/utils/promote-keyed-entities.ts",
+    operation: "delete",
+    dynamic: false,
+    fingerprint: "8e1babc83c35ebd9",
+    reason: "lost promotion-race cleanup",
+  },
+
+  // Behavior classifier configuration projection.
+  {
+    file: "packages/server/src/watchers/classifier-extraction.ts",
+    operation: "update",
+    dynamic: false,
+    fingerprint: "985025144395f419",
+    reason: "enabled-classifier projection",
+  },
+
+  // Per-entity view-template pointer, hidden behind parentTable(resourceType).
+  {
+    file: "packages/server/src/tools/admin/manage_view_templates.ts",
+    operation: "update",
+    dynamic: true,
+    fingerprint: "6c2d50be50c02a93",
+    count: 2,
+    reason: "set or rollback default entity view template",
+  },
+  {
+    file: "packages/server/src/tools/admin/manage_view_templates.ts",
+    operation: "update",
+    dynamic: true,
+    fingerprint: "e18b52b5f5dfdd8a",
+    reason: "clear default entity view template",
+  },
+];
+
+const STATIC_IDENTIFIER = '(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)';
+const ENTITY_TARGET = String.raw`(?:(?:${STATIC_IDENTIFIER}\s*\.\s*)?"?entities"?)`;
+const DYNAMIC_TABLE = String.raw`(?:"\$\{[^}]+\}"|\$\{[^}]+\})`;
+const DYNAMIC_TARGET = String.raw`(?:(?:${STATIC_IDENTIFIER}|${DYNAMIC_TABLE})\s*\.\s*)*${DYNAMIC_TABLE}(?:\s*\.\s*(?:${STATIC_IDENTIFIER}|${DYNAMIC_TABLE}))*`;
+const MUTATION_PATTERNS = [
+  {
+    operation: "insert",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bINSERT\s+INTO\s+${ENTITY_TARGET}(?:\s+AS\s+${STATIC_IDENTIFIER})?\s*(?:\(|\$\{|DEFAULT\b|OVERRIDING\b|VALUES\b|SELECT\b)`,
+      "gi"
+    ),
+  },
+  {
+    operation: "update",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bUPDATE(?:\s+ONLY)?\s+${ENTITY_TARGET}(?:\s*\*)?(?:\s+(?:AS\s+)?${STATIC_IDENTIFIER})?\s+SET\b`,
+      "gi"
+    ),
+  },
+  {
+    operation: "delete",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bDELETE\s+FROM(?:\s+ONLY)?\s+${ENTITY_TARGET}(?![A-Za-z0-9_])`,
+      "gi"
+    ),
+  },
+  {
+    operation: "insert",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bINSERT\s+INTO\s+${DYNAMIC_TARGET}(?:\s+AS\s+${STATIC_IDENTIFIER})?\s*(?:\(|\$\{|DEFAULT\b|OVERRIDING\b|VALUES\b|SELECT\b)`,
+      "gi"
+    ),
+  },
+  {
+    operation: "update",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bUPDATE(?:\s+ONLY)?\s+${DYNAMIC_TARGET}(?:\s*\*)?(?:\s+(?:AS\s+)?${STATIC_IDENTIFIER})?\s+SET\b`,
+      "gi"
+    ),
+  },
+  {
+    operation: "delete",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bDELETE\s+FROM(?:\s+ONLY)?\s+${DYNAMIC_TARGET}`,
+      "gi"
+    ),
+  },
+  {
+    operation: "truncate",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bTRUNCATE(?:\s+TABLE)?\s+(?:[^;]*?,\s*)?(?:ONLY\s+)?${ENTITY_TARGET}(?![A-Za-z0-9_])`,
+      "gi"
+    ),
+  },
+  {
+    operation: "truncate",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bTRUNCATE(?:\s+TABLE)?\s+(?:[^;]*?,\s*)?(?:ONLY\s+)?${DYNAMIC_TARGET}`,
+      "gi"
+    ),
+  },
+  {
+    operation: "merge",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bMERGE\s+INTO(?:\s+ONLY)?\s+${ENTITY_TARGET}(?![A-Za-z0-9_])`,
+      "gi"
+    ),
+  },
+  {
+    operation: "merge",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bMERGE\s+INTO(?:\s+ONLY)?\s+${DYNAMIC_TARGET}`,
+      "gi"
+    ),
+  },
+  {
+    operation: "copy",
+    dynamic: false,
+    regex: new RegExp(
+      String.raw`\bCOPY\s+${ENTITY_TARGET}(?![A-Za-z0-9_])(?:\s*\([^)]*\))?\s+FROM\b`,
+      "gi"
+    ),
+  },
+  {
+    operation: "copy",
+    dynamic: true,
+    regex: new RegExp(
+      String.raw`\bCOPY\s+${DYNAMIC_TARGET}(?:\s*\([^)]*\))?\s+FROM\b`,
+      "gi"
+    ),
+  },
+];
+
+function collectSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) {
+        files.push(...collectSourceFiles(join(dir, entry.name)));
+      }
+      continue;
+    }
+    if (
+      (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+      !entry.name.endsWith(".test.ts") &&
+      !entry.name.endsWith(".test.tsx") &&
+      !entry.name.endsWith(".spec.ts") &&
+      !entry.name.endsWith(".spec.tsx") &&
+      !entry.name.endsWith(".d.ts")
+    ) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function literalSources(node, sourceFile) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    const source = node.getText(sourceFile);
+    const unquoted = source.length >= 2 ? source.slice(1, -1) : "";
+    return { fingerprintSource: unquoted, scanSource: unquoted };
+  }
+  if (ts.isTemplateExpression(node)) {
+    const source = node.getText(sourceFile);
+    const fingerprintSource = source.length >= 2 ? source.slice(1, -1) : "";
+    let scanSource = fingerprintSource;
+    const innerStart = node.getStart(sourceFile) + 1;
+    for (const span of [...node.templateSpans].reverse()) {
+      // The AST already knows where each interpolation ends, even when its
+      // expression contains nested object blocks or nested template literals.
+      // Mask its braces while preserving every character and newline, so the
+      // SQL regex sees one placeholder and reported source lines remain exact.
+      const start = span.expression.getFullStart() - innerStart;
+      const end = span.literal.getStart(sourceFile) - innerStart;
+      const masked = scanSource.slice(start, end).replace(/[^\r\n]/g, "e");
+      scanSource = scanSource.slice(0, start) + masked + scanSource.slice(end);
+    }
+    return { fingerprintSource, scanSource };
+  }
+  return null;
+}
+
+function normalizedFingerprint(source) {
+  const normalized = source.replace(/\s+/g, " ").trim();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+function scanLiteral(
+  scanSource,
+  fingerprintSource,
+  node,
+  sourceFile,
+  file,
+  mutations
+) {
+  for (const { regex, dynamic, operation } of MUTATION_PATTERNS) {
+    regex.lastIndex = 0;
+    for (const match of scanSource.matchAll(regex)) {
+      const offset = node.getStart(sourceFile) + 1 + (match.index ?? 0);
+      const { line } = sourceFile.getLineAndCharacterOfPosition(offset);
+      mutations.push({
+        file,
+        line: line + 1,
+        operation,
+        dynamic,
+        fingerprint: normalizedFingerprint(fingerprintSource),
+      });
+    }
+  }
+}
+
+function scanFile(filePath) {
+  const source = readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const file = relative(REPO_ROOT, filePath);
+  const mutations = [];
+
+  function visit(node) {
+    const literal = literalSources(node, sourceFile);
+    if (literal !== null) {
+      scanLiteral(
+        literal.scanSource,
+        literal.fingerprintSource,
+        node,
+        sourceFile,
+        file,
+        mutations
+      );
+      if (ts.isTemplateExpression(node)) {
+        for (const span of node.templateSpans) visit(span.expression);
+      }
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return mutations;
+}
+
+function allowanceKey(item) {
+  return `${item.file}|${item.operation}|${item.dynamic ? "dynamic" : "direct"}|${item.fingerprint}`;
+}
+
+if (!existsSync(PACKAGES_ROOT)) {
+  console.error(`✗ expected ${PACKAGES_ROOT} to exist`);
+  process.exit(1);
+}
+if (!existsSync(join(REPO_ROOT, CANONICAL_FUNNEL))) {
+  console.error(
+    `✗ entity-write funnel gate: canonical funnel ${CANONICAL_FUNNEL} is missing`
+  );
+  process.exit(1);
+}
+
+const files = collectSourceFiles(PACKAGES_ROOT);
+if (files.length === 0) {
+  console.error(
+    "✗ entity-write funnel gate scanned ZERO runtime package source files; failing closed"
+  );
+  process.exit(1);
+}
+
+const mutations = files.flatMap(scanFile);
+const canonicalMutations = mutations.filter(
+  (item) => item.file === CANONICAL_FUNNEL
+);
+if (canonicalMutations.length === 0) {
+  console.error(
+    `✗ entity-write funnel gate found zero writes in ${CANONICAL_FUNNEL}; failing closed`
+  );
+  process.exit(1);
+}
+const bypasses = mutations.filter((item) => item.file !== CANONICAL_FUNNEL);
+
+if (process.argv.includes("--print-inventory")) {
+  for (const item of bypasses) {
+    console.log(
+      JSON.stringify({
+        file: item.file,
+        line: item.line,
+        operation: item.operation,
+        dynamic: item.dynamic,
+        fingerprint: item.fingerprint,
+      })
+    );
+  }
+  process.exit(0);
+}
+
+const remainingAllowances = new Map();
+for (const allowance of ALLOWED_BYPASSES) {
+  const key = allowanceKey(allowance);
+  const count = allowance.count ?? 1;
+  remainingAllowances.set(key, (remainingAllowances.get(key) ?? 0) + count);
+}
+
+const violations = [];
+for (const bypass of bypasses) {
+  const key = allowanceKey(bypass);
+  const remaining = remainingAllowances.get(key) ?? 0;
+  if (remaining > 0) {
+    remainingAllowances.set(key, remaining - 1);
+  } else {
+    violations.push(bypass);
+  }
+}
+
+const staleAllowances = [];
+for (const allowance of ALLOWED_BYPASSES) {
+  const key = allowanceKey(allowance);
+  const remaining = remainingAllowances.get(key) ?? 0;
+  if (remaining > 0) {
+    staleAllowances.push({ ...allowance, remaining });
+    remainingAllowances.set(key, 0);
+  }
+}
+
+const staleAllowanceCount = staleAllowances.reduce(
+  (count, allowance) => count + allowance.remaining,
+  0
+);
+
+if (violations.length > 0 || staleAllowances.length > 0) {
+  if (violations.length > 0) {
+    console.error(
+      `\n✗ entity-write funnel gate found ${violations.length} unapproved bypass(es):\n`
+    );
+    for (const violation of violations) {
+      const target = violation.dynamic
+        ? "dynamic mutation target"
+        : `direct entity ${violation.operation}`;
+      console.error(`  - ${violation.file}:${violation.line} [${target}]`);
+    }
+  }
+  if (staleAllowances.length > 0) {
+    console.error(
+      `\n✗ entity-write funnel gate found ${staleAllowanceCount} stale allowance(s):\n`
+    );
+    for (const allowance of staleAllowances) {
+      const count = allowance.remaining > 1 ? ` x${allowance.remaining}` : "";
+      console.error(`  - ${allowance.file}${count} [${allowance.reason}]`);
+    }
+  }
+  const remediation = [];
+  if (violations.some((violation) => !violation.dynamic)) {
+    remediation.push(
+      "Route production entity-row mutations through " +
+        `${CANONICAL_FUNNEL}; do not add an allowance for new code.`
+    );
+  }
+  if (violations.some((violation) => violation.dynamic)) {
+    remediation.push(
+      "A dynamically named table cannot be proven non-entity; use a literal " +
+        "table name or pin the statement in ALLOWED_BYPASSES with a reason."
+    );
+  }
+  if (staleAllowances.length > 0) {
+    remediation.push("Remove an allowance when its bypass is migrated.");
+  }
+  console.error(`\n${remediation.join("\n")}\n`);
+  process.exit(1);
+}
+
+console.log(
+  `✓ entity-write funnel gate: ${files.length} runtime package source files scanned; ` +
+    `${bypasses.length} pinned bypasses, zero new bypasses`
+);


### PR DESCRIPTION
## Summary
- Freeze the verified `origin/main` production inventory at 25 noncanonical entity inserts/updates plus 4 hard deletes.
- Reject new literal entity mutations and dynamically selected SQL mutation targets outside `entity-management.ts`.
- Make the bypass allowlist shrink-only: changed, duplicated, or removed historical statements fail until their allowance is updated or removed.

## Test plan
- [x] Intended files staged explicitly, then `DEPOT_ALLOW_WORKFLOW_CHANGES=1 make pre-pr-remote` clean on the final tree (18/18 job instances; Depot run `004sjnbklb`; tree `835a531e34d7386f4692478708df76db2602caf5`)
- [x] Tests run: `bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

Red before the guard existed:
```text
0 pass, 4 fail
Module not found scripts/check-entity-write-funnel.mjs
```

Review regression red:
```text
rejects quoted dynamic identifiers
Expected exit 1; received exit 0
```

Green on the final head:
```text
18 pass, 0 fail, 43 expect() calls
entity-write funnel gate: 991 runtime package source files scanned; 29 pinned bypasses, zero new bypasses
```

Also passed: project format, project lint, `actionlint .github/workflows/ci.yml`, `git diff --check`, commit-hook TypeScript check, and the full remote graph.

## Notes
- No runtime entity behavior, database design, API, or SDK surface changes.
- Semantic and CodeRabbit reviews reproduced nested-interpolation, bare-delete, line-offset, insert-alias, postgres.js row-helper insert, duplicate-allowance, arbitrary-schema, multi-target-TRUNCATE, misleading dynamic-target remediation, and quoted-dynamic-identifier gaps. The final implementation uses parsed TypeScript template spans, scans all runtime packages, preserves exact source offsets, gives target-specific remediation, and covers direct/dynamic `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `MERGE`, and `COPY`, including schema-qualified targets, quoted aliases and dynamic identifiers, PostgreSQL `ONLY`, and postgres.js row helpers. `COPY TO` exports remain allowed.
- Arbitrary runtime string assembly and query-builder expressions remain an explicit review backstop; neither exists in the verified baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated checks to ensure entity changes follow the approved write pathway.
  * Added regression coverage for direct and dynamic database mutations, reporting accurate source locations.
  * Validation now detects stale exceptions and excludes tests, generated files, dependencies, and approved exports.
* **Developer Experience**
  * The pre-PR validation process now includes the new entity-write checks.
  * Continuous integration now requires these checks to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->