### PR TITLE
fix(mcp): render saved memory inline

### DIFF
--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -196,9 +196,9 @@ export const searchMemory = <ThrowOnError extends boolean = false>(
   });
 
 /**
- * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory
+ * Save facts, preferences, decisions, observations, and notes to workspace memory
  *
- * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; the result echoes the stored payload, so showing what was saved needs no follow-up read.
+ * Save facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`.
  */
 export const saveMemory = <ThrowOnError extends boolean = false>(
   options: Options<SaveMemoryData, ThrowOnError>,

--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -196,9 +196,9 @@ export const searchMemory = <ThrowOnError extends boolean = false>(
   });
 
 /**
- * Save facts, preferences, decisions, observations, and notes to workspace memory
+ * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory
  *
- * Save facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`.
+ * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`.
  */
 export const saveMemory = <ThrowOnError extends boolean = false>(
   options: Options<SaveMemoryData, ThrowOnError>,

--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -198,7 +198,7 @@ export const searchMemory = <ThrowOnError extends boolean = false>(
 /**
  * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory
  *
- * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`.
+ * Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; the result echoes the stored payload, so showing what was saved needs no follow-up read.
  */
 export const saveMemory = <ThrowOnError extends boolean = false>(
   options: Options<SaveMemoryData, ThrowOnError>,

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -343,6 +343,16 @@ export type SaveMemoryResponses = {
     entity_ids: Array<number>;
     title: string | null;
     semantic_type: string;
+    payload_type: "text" | "markdown" | "json_template" | "media" | "empty";
+    payload_text: string | null;
+    payload_data: {
+      [key: string]: unknown;
+    };
+    payload_template: {
+      [key: string]: unknown;
+    } | null;
+    attachments: Array<unknown>;
+    source_url: string | null;
     created_at: string;
     supersedes_event_id?: number;
     view_url?: string;

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -343,16 +343,16 @@ export type SaveMemoryResponses = {
     entity_ids: Array<number>;
     title: string | null;
     semantic_type: string;
-    payload_type: "text" | "markdown" | "json_template" | "media" | "empty";
-    payload_text: string | null;
-    payload_data: {
+    payload_type?: "text" | "markdown" | "json_template" | "media" | "empty";
+    payload_text?: string | null;
+    payload_data?: {
       [key: string]: unknown;
     };
-    payload_template: {
+    payload_template?: {
       [key: string]: unknown;
     } | null;
-    attachments: Array<unknown>;
-    source_url: string | null;
+    attachments?: Array<unknown>;
+    source_url?: string | null;
     created_at: string;
     supersedes_event_id?: number;
     view_url?: string;

--- a/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
@@ -75,6 +75,17 @@ describe('saveContent > honest indexing status', () => {
     expect(result.durable_at).toBe(result.created_at);
     expect(result.exact_read.content_ids).toEqual([result.id]);
 
+    // The result echoes the persisted row, so the ordinary text save — not just
+    // the json_template one — carries its own body back with no second read.
+    expect(result.payload_type).toBe('text');
+    expect(result.payload_text).toBe(
+      'A memory whose embedding the async backfill has not produced yet.'
+    );
+    expect(result.payload_data).toEqual({});
+    expect(result.payload_template).toBeNull();
+    expect(result.attachments).toEqual([]);
+    expect(result.source_url).toBeNull();
+
     // No current-model embedding was written inline and no embed service ran,
     // so this content is genuinely not yet searchable.
     expect(result.indexing_status).toBe('pending');

--- a/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
@@ -44,7 +44,7 @@ describe('saveContent > honest indexing status', () => {
     await addUserToOrganization(user.id, org.id, 'owner');
   });
 
-  function ctx(): ToolContext {
+  function ctx(mcpAppsSupported = false): ToolContext {
     return {
       organizationId: org.id,
       userId: user.id,
@@ -55,6 +55,7 @@ describe('saveContent > honest indexing status', () => {
       allowCrossOrg: true,
       scopes: ['mcp:write'],
       sourceContext: null,
+      mcpAppsSupported,
     } as ToolContext;
   }
 
@@ -67,7 +68,7 @@ describe('saveContent > honest indexing status', () => {
         metadata: {},
       } as never,
       {} as never,
-      ctx()
+      ctx(true)
     );
 
     // Durable storage is synchronous — always reported, always exact-readable.
@@ -75,8 +76,9 @@ describe('saveContent > honest indexing status', () => {
     expect(result.durable_at).toBe(result.created_at);
     expect(result.exact_read.content_ids).toEqual([result.id]);
 
-    // The result echoes the persisted row, so the ordinary text save — not just
-    // the json_template one — carries its own body back with no second read.
+    // For an MCP App caller the result echoes the persisted row, so the ordinary
+    // text save — not just the json_template one — carries its own body back with
+    // no second read. The non-App shape is pinned by the next test.
     expect(result.payload_type).toBe('text');
     expect(result.payload_text).toBe(
       'A memory whose embedding the async backfill has not produced yet.'
@@ -104,6 +106,9 @@ describe('saveContent > honest indexing status', () => {
       ctx()
     );
     expect(result.indexing_status).toBe('pending');
+    // No MCP App to render an inline card, so the payload echo is withheld and
+    // the caller keeps the compact receipt plus the exact-read id.
+    expect(result.payload_type).toBeUndefined();
 
     // Simulate the backfill/worker writing the chunk-0 embedding under the
     // configured model. The probe keys on exactly (event_id, model, chunk 0).

--- a/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
@@ -52,6 +52,9 @@ describe('saveContent > json_template save-side schema', () => {
       scopedToOrg: false,
       allowCrossOrg: true,
       scopes: ['mcp:write'],
+      // The render-payload echo below is gated on an MCP App caller; without
+      // this the save still succeeds but returns the compact receipt only.
+      mcpAppsSupported: true,
     };
   });
 

--- a/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
@@ -87,6 +87,16 @@ describe('saveContent > json_template save-side schema', () => {
 
     expect(result.id).toBeGreaterThan(0);
     expect(result.semantic_type).toBe('content');
+    expect(result).toEqual(
+      expect.objectContaining({
+        payload_type: 'json_template',
+        payload_text: null,
+        payload_data: { score: 42 },
+        payload_template: { version: 1 },
+        attachments: [],
+        source_url: null,
+      })
+    );
 
     // The rootless template is persisted exactly as given.
     const sql = getTestDb();
@@ -97,6 +107,43 @@ describe('saveContent > json_template save-side schema', () => {
     expect(rows[0].payload_type).toBe('json_template');
     expect(rows[0].payload_template).toMatchObject({ version: 1 });
     expect((rows[0].payload_template as Record<string, unknown>).root).toBeUndefined();
+  });
+
+  it('returns the original persisted render payload on an idempotent replay', async () => {
+    const first = await saveContent(
+      {
+        payload_type: 'json_template',
+        payload_template: { root: { type: 'text', content: 'Original' } },
+        payload_data: { score: 7 },
+        semantic_type: 'content',
+        title: 'Original chart',
+        metadata: {},
+        idempotency_key: 'json-template-render-replay',
+      } as never,
+      {} as never,
+      ctx
+    );
+    const replay = await saveContent(
+      {
+        payload_type: 'json_template',
+        payload_template: { root: { type: 'text', content: 'Different retry' } },
+        payload_data: { score: 99 },
+        semantic_type: 'content',
+        title: 'Different retry',
+        metadata: {},
+        idempotency_key: 'json-template-render-replay',
+      } as never,
+      {} as never,
+      ctx
+    );
+
+    expect(replay.id).toBe(first.id);
+    expect(replay.created).toBe(false);
+    expect(replay.title).toBe('Original chart');
+    expect(replay.payload_data).toEqual({ score: 7 });
+    expect(replay.payload_template).toEqual({
+      root: { type: 'text', content: 'Original' },
+    });
   });
 
   it('rejects a handler prop without an action binding', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -333,7 +333,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(resource._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('links only view-producing tools to the App resource and keeps helpers app-only', async () => {
+  it('links direct saves and explicit view-producing tools to the App resource and keeps helpers app-only', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
@@ -366,13 +366,28 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       })
     );
 
-    // Data and action tools stay headless so multi-step SDK/memory work does
-    // not mount an iframe for every intermediate call. The model explicitly
-    // calls render_lobu_view once it has selected the final content a person
-    // should inspect, edit, or approve.
+    const saveMemory = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'save_memory'
+    );
+    expect(saveMemory).toEqual(
+      expect.objectContaining({
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+        _meta: expect.objectContaining({
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+          ui: expect.objectContaining({
+            resourceUri: 'ui://lobu/interaction/v12.html',
+            visibility: ['model', 'app'],
+          }),
+          'openai/outputTemplate': 'ui://lobu/interaction/v12.html',
+        }),
+      })
+    );
+
+    // Reads and general SDK actions stay headless so multi-step work does not
+    // mount an iframe for every intermediate call. save_memory is the narrow
+    // exception: its one durable write is itself the final inspectable result.
     for (const name of [
       'search_memory',
-      'save_memory',
       'search_sdk',
       'query_sdk',
       'query_sql',
@@ -457,6 +472,64 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         visibility: ['model', 'app'],
       })
     );
+  });
+
+  it('returns the exact saved event payload for the save_memory App card', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const payloadTemplate = {
+      root: {
+        type: 'bar-chart',
+        data: '{{points}}',
+        labelField: 'label',
+        valueField: 'value',
+      },
+    };
+    const payloadData = {
+      points: [
+        { label: 'Saved', value: 12 },
+        { label: 'Rendered', value: 7 },
+      ],
+    };
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'save-memory-app-result',
+        method: 'tools/call',
+        params: {
+          name: 'save_memory',
+          arguments: {
+            title: 'Saved chart',
+            semantic_type: 'content',
+            payload_type: 'json_template',
+            payload_template: payloadTemplate,
+            payload_data: payloadData,
+            metadata: {},
+            idempotency_key: 'mcp-app-save-memory-render-result',
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual(
+      expect.objectContaining({
+        title: 'Saved chart',
+        payload_type: 'json_template',
+        payload_data: payloadData,
+        payload_template: payloadTemplate,
+        payload_text: null,
+        attachments: [],
+        source_url: null,
+        view_url: expect.stringContaining('content_ids='),
+      })
+    );
+    expect(body.result?.content?.[0]?.text).toContain('"title": "Saved chart"');
+    expect(body.result?.content?.[0]?.text).not.toContain('payload_data');
+    expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
   });
 
   it('returns a validated LobuViewV1 with a safe text fallback', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -143,14 +143,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     return sessionId!;
   }
 
-  it('serves the self-contained v12 interaction bundle over resources/read', async () => {
+  it('serves the self-contained v13 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v12.html' },
+        params: { uri: 'ui://lobu/interaction/v13.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,7 +159,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v12.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v13.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-embedded-stub');
     expect(content?.text).not.toContain('mcp-app-external-stub');
@@ -268,7 +268,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps the v7 through v11 aliases on the packed, network-free template', async () => {
+  it('keeps the v7 through v12 aliases on the packed, network-free template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v7.html',
@@ -276,6 +276,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       'ui://lobu/interaction/v9.html',
       'ui://lobu/interaction/v10.html',
       'ui://lobu/interaction/v11.html',
+      'ui://lobu/interaction/v12.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -310,7 +311,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v12.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v13.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -358,10 +359,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v12.html',
+            resourceUri: 'ui://lobu/interaction/v13.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v12.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v13.html',
         }),
       })
     );
@@ -375,10 +376,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v12.html',
+            resourceUri: 'ui://lobu/interaction/v13.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v12.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v13.html',
         }),
       })
     );
@@ -417,10 +418,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
         _meta: expect.objectContaining({
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v12.html',
+            resourceUri: 'ui://lobu/interaction/v13.html',
             visibility: ['app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v12.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v13.html',
         }),
       })
     );
@@ -468,7 +469,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v12.html',
+        resourceUri: 'ui://lobu/interaction/v13.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -4,8 +4,12 @@ import { join } from 'node:path';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
+import type { Env } from '../../../index';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
+import { buildClientSDK } from '../../../sandbox/client-sdk';
+import type { ToolContext } from '../../../tools/registry';
 import { insertEvent } from '../../../utils/insert-event';
+import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
@@ -630,6 +634,52 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain(
       'body-visible-only-to-app-hosts'
     );
+  });
+
+  it('keeps ClientSDK saves headless when their source session supports Apps', async () => {
+    // run_sdk builds this same in-process SDK from the outer MCP session. The
+    // direct SDK call keeps the boundary test independent of isolated-vm.
+    await initWorkspaceProvider();
+    const ctx: ToolContext = {
+      organizationId: org.id,
+      userId: owner.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      scopedToOrg: true,
+      allowCrossOrg: false,
+      mcpAppsSupported: true,
+    };
+    const sdk = buildClientSDK(ctx, {
+      ENVIRONMENT: 'test',
+      DATABASE_URL: process.env.DATABASE_URL,
+    } as Env);
+    const receipt = await sdk.knowledge.save({
+      title: 'Nested SDK save',
+      semantic_type: 'content',
+      content: 'nested-sdk-save-body-must-stay-headless',
+      metadata: {},
+      idempotency_key: 'mcp-app-nested-sdk-save-headless',
+    });
+
+    expect(receipt).toEqual(
+      expect.objectContaining({
+        title: 'Nested SDK save',
+        exact_read: expect.objectContaining({ method: 'client.knowledge.read' }),
+      })
+    );
+    for (const key of [
+      'payload_type',
+      'payload_text',
+      'payload_data',
+      'payload_template',
+      'attachments',
+      'source_url',
+    ]) {
+      expect(receipt).not.toHaveProperty(key);
+    }
+    expect(JSON.stringify(receipt)).not.toContain('nested-sdk-save-body-must-stay-headless');
   });
 
   it('returns a validated LobuViewV1 with a safe text fallback', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -532,6 +532,105 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
   });
 
+  it('keeps oversized saved payloads out of the App response', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'save-memory-oversized-result',
+        method: 'tools/call',
+        params: {
+          name: 'save_memory',
+          arguments: {
+            title: 'Large durable note',
+            semantic_type: 'content',
+            payload_type: 'json_template',
+            payload_template: { root: { type: 'data', path: 'body' } },
+            payload_data: { body: 'x'.repeat(600 * 1024) },
+            metadata: {},
+            idempotency_key: 'mcp-app-save-memory-oversized-result',
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual(
+      expect.objectContaining({
+        title: 'Large durable note',
+        view_url: expect.stringContaining('content_ids='),
+        exact_read: expect.objectContaining({
+          method: 'client.knowledge.read',
+        }),
+      })
+    );
+    for (const key of [
+      'payload_type',
+      'payload_text',
+      'payload_data',
+      'payload_template',
+      'attachments',
+      'source_url',
+    ]) {
+      expect(body.result?.structuredContent).not.toHaveProperty(key);
+    }
+    expect(body.result?.content?.[0]?.text.length).toBeLessThan(10_000);
+  });
+
+  it('omits the saved payload when the client does not advertise MCP Apps', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      advertiseMcpApps: false,
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'save-memory-no-app-result',
+        method: 'tools/call',
+        params: {
+          name: 'save_memory',
+          arguments: {
+            title: 'Plain note',
+            semantic_type: 'content',
+            content: 'body-visible-only-to-app-hosts',
+            metadata: {},
+            idempotency_key: 'mcp-app-save-memory-no-app-result',
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    // The write still succeeds and stays exactly readable by id — only the
+    // inline render payload, which this client cannot render, is withheld.
+    expect(body.result?.structuredContent).toEqual(
+      expect.objectContaining({
+        title: 'Plain note',
+        exact_read: expect.objectContaining({ method: 'client.knowledge.read' }),
+      })
+    );
+    for (const key of [
+      'payload_type',
+      'payload_text',
+      'payload_data',
+      'payload_template',
+      'attachments',
+      'source_url',
+    ]) {
+      expect(body.result?.structuredContent).not.toHaveProperty(key);
+    }
+    expect(body.result?.content?.[0]?.text).not.toContain(
+      'body-visible-only-to-app-hosts'
+    );
+  });
+
   it('returns a validated LobuViewV1 with a safe text fallback', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {

--- a/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
+++ b/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
@@ -157,6 +157,33 @@ describe('formatToolResult', () => {
     });
   });
 
+  describe('save_memory tool', () => {
+    it('keeps render payload out of the compact text fallback', () => {
+      const md = formatToolResult('save_memory', {
+        id: 42,
+        title: 'Saved chart',
+        semantic_type: 'observation',
+        payload_type: 'json_template',
+        payload_text: 'large-payload-marker'.repeat(10_000),
+        payload_data: { privateMarker: 'structured-content-only' },
+        payload_template: { root: { type: 'text', content: '{{privateMarker}}' } },
+        attachments: [{ name: 'large.json' }],
+        source_url: 'https://example.com/source',
+        created: true,
+        view_url: 'https://example.com/memory?content_ids=42',
+      });
+
+      expect(md).toContain('"id": 42');
+      expect(md).toContain('"title": "Saved chart"');
+      expect(md).toContain('"created": true');
+      expect(md).toContain('"view_url"');
+      expect(md).not.toContain('large-payload-marker');
+      expect(md).not.toContain('structured-content-only');
+      expect(md).not.toContain('payload_template');
+      expect(md.length).toBeLessThan(1_000);
+    });
+  });
+
   describe('get_behavior tool', () => {
     it('should format Behavior windows', () => {
       const result = {

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -289,6 +289,7 @@ export function formatToolResult(
 ): string {
   const formatters: Record<string, (result: any, options: FormatterOptions) => string> = {
     search_memory: formatSearchResult,
+    save_memory: formatSaveMemoryResult,
     get_behavior: formatGetBehaviorResult,
     read_knowledge: formatGetContentResult,
     manage_behaviors: formatManageBehaviorsResult,
@@ -310,6 +311,25 @@ export function formatToolResult(
 
   // Fallback: pretty-print JSON
   return `\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``;
+}
+
+function formatSaveMemoryResult(result: Record<string, unknown>): string {
+  // The App card reads these fields off structuredContent, which carries them
+  // already. Keep the text fallback as the compact receipt save_memory returned
+  // before it gained an inline App, otherwise a large note or template is
+  // echoed twice to the model (once here and once in structuredContent).
+  const receipt = { ...result };
+  for (const key of [
+    'payload_type',
+    'payload_text',
+    'payload_data',
+    'payload_template',
+    'attachments',
+    'source_url',
+  ]) {
+    delete receipt[key];
+  }
+  return `\`\`\`json\n${JSON.stringify(receipt, null, 2)}\n\`\`\``;
 }
 
 function escapeLobuViewMarkdown(value: unknown, singleLine = false): string {

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -6,6 +6,7 @@
  * Includes content formatting with proper thread hierarchy (Reddit/HN/X style).
  */
 
+import { SAVE_MEMORY_RENDER_PAYLOAD_KEYS } from '../tools/save_content.js';
 import type { Entity } from '../tools/search.js';
 
 // ============================================
@@ -319,14 +320,7 @@ function formatSaveMemoryResult(result: Record<string, unknown>): string {
   // before it gained an inline App, otherwise a large note or template is
   // echoed twice to the model (once here and once in structuredContent).
   const receipt = { ...result };
-  for (const key of [
-    'payload_type',
-    'payload_text',
-    'payload_data',
-    'payload_template',
-    'attachments',
-    'source_url',
-  ]) {
+  for (const key of SAVE_MEMORY_RENDER_PAYLOAD_KEYS) {
     delete receipt[key];
   }
   return `\`\`\`json\n${JSON.stringify(receipt, null, 2)}\n\`\`\``;

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -119,6 +119,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v11.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
+  [
+    'ui://lobu/interaction/v12.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -181,10 +181,11 @@ export function buildClientSDK(
 	const mode: SDKMode = opts?.mode ?? "full";
 	const allowCrossOrg = opts?.allowCrossOrg ?? ctx.allowCrossOrg ?? false;
 	// ClientSDK calls are headless even when the outer MCP session supports
-	// Apps. Only the directly advertised save_memory tool owns an inline result
-	// card; a nested client.knowledge.save inside run_sdk must keep the
-	// compact SDK receipt instead of echoing the saved payload into a headless
-	// result.
+	// Apps. An inline result card belongs to the directly advertised tool call
+	// that produced it (save_memory, render_lobu_view, …); a nested
+	// client.knowledge.save inside run_sdk has no card of its own, so it must
+	// keep the compact SDK receipt instead of echoing the saved payload into a
+	// headless result.
 	const headlessCtx: ToolContext = { ...ctx, mcpAppsSupported: false };
 	ctx = opts?.abortSignal
 		? { ...headlessCtx, abortSignal: opts.abortSignal }

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -180,10 +180,15 @@ export function buildClientSDK(
 ): ClientSDK {
 	const mode: SDKMode = opts?.mode ?? "full";
 	const allowCrossOrg = opts?.allowCrossOrg ?? ctx.allowCrossOrg ?? false;
-	const ctxWithSignal: ToolContext = opts?.abortSignal
-		? { ...ctx, abortSignal: opts.abortSignal }
-		: ctx;
-	ctx = ctxWithSignal;
+	// ClientSDK calls are headless even when the outer MCP session supports
+	// Apps. Only the directly advertised save_memory tool owns an inline result
+	// card; a nested client.knowledge.save inside run_sdk must keep the
+	// compact SDK receipt instead of echoing the saved payload into a headless
+	// result.
+	const headlessCtx: ToolContext = { ...ctx, mcpAppsSupported: false };
+	ctx = opts?.abortSignal
+		? { ...headlessCtx, abortSignal: opts.abortSignal }
+		: headlessCtx;
 
 	const namespaces = {
 		agents: buildAgentsNamespace(ctx, env),

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v12.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v13.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -273,7 +273,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; the result echoes the stored payload, so showing what was saved needs no follow-up read. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
+      'Save facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -247,9 +247,11 @@ const LOBU_VIEW_MCP_META = {
 
 /**
  * Data and action tools advertised on MCP `tools/list` and external OpenAPI.
- * These deliberately have no Apps UI resource: agents can chain them without
- * mounting an iframe for every intermediate result, then call
- * `render_lobu_view` once for the final user-facing view or approval.
+ * These deliberately have no Apps UI resource except save_memory: agents can
+ * chain reads and general SDK actions without mounting an iframe for every
+ * intermediate result, while a direct save mounts one card for the durable
+ * event it just created. Other final user-facing views still use
+ * render_lobu_view.
  */
 const AGENT_TOOLS: ToolDefinition[] = [
   // ─── Memory hot path — read ───────────────────────────────────────────────
@@ -271,11 +273,12 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
+      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; the result echoes the stored payload, so showing what was saved needs no follow-up read. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     securityScopes: ['mcp:write'],
+    mcpMeta: LOBU_VIEW_MCP_META,
     handler: saveContent,
   },
   {

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -273,7 +273,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      'Save facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
+      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -246,12 +246,17 @@ const LOBU_VIEW_MCP_META = {
 } as const;
 
 /**
- * Data and action tools advertised on MCP `tools/list` and external OpenAPI.
- * These deliberately have no Apps UI resource except save_memory: agents can
- * chain reads and general SDK actions without mounting an iframe for every
- * intermediate result, while a direct save mounts one card for the durable
- * event it just created. Other final user-facing views still use
- * render_lobu_view.
+ * Tools advertised on MCP `tools/list` and external OpenAPI.
+ *
+ * The data and action tools here (search_memory, search_sdk, query_sdk,
+ * query_sql, run_sdk) deliberately have no Apps UI resource: agents can chain
+ * reads and general SDK actions without mounting an iframe for every
+ * intermediate result. save_memory is the one exception among them — its single
+ * durable write is itself the final result a person inspects, so it mounts one
+ * card for the event it just created. The App tools further down
+ * (render_lobu_view, resolve_lobu_approval, restore_lobu_app_result,
+ * save_lobu_app_state) carry the UI resource by definition; any other
+ * final user-facing view still goes through render_lobu_view.
  */
 const AGENT_TOOLS: ToolDefinition[] = [
   // ─── Memory hot path — read ───────────────────────────────────────────────

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -196,6 +196,21 @@ export const SaveContentResultSchema = Type.Object({
   entity_ids: Type.Array(Type.Integer()),
   title: Type.Union([Type.String(), Type.Null()]),
   semantic_type: Type.String(),
+  payload_type: Type.Union([
+    Type.Literal('text'),
+    Type.Literal('markdown'),
+    Type.Literal('json_template'),
+    Type.Literal('media'),
+    Type.Literal('empty'),
+  ]),
+  payload_text: Type.Union([Type.String(), Type.Null()]),
+  payload_data: Type.Record(Type.String(), Type.Unknown()),
+  payload_template: Type.Union([
+    Type.Record(Type.String(), Type.Unknown()),
+    Type.Null(),
+  ]),
+  attachments: Type.Array(Type.Unknown()),
+  source_url: Type.Union([Type.String(), Type.Null()]),
   created_at: Type.String(),
   supersedes_event_id: Type.Optional(Type.Integer()),
   view_url: Type.Optional(Type.String()),
@@ -215,6 +230,12 @@ interface SaveContentResult {
   entity_ids: number[];
   title: string | null;
   semantic_type: string;
+  payload_type: 'text' | 'markdown' | 'json_template' | 'media' | 'empty';
+  payload_text: string | null;
+  payload_data: Record<string, unknown>;
+  payload_template: Record<string, unknown> | null;
+  attachments: unknown[];
+  source_url: string | null;
   created_at: string;
   supersedes_event_id?: number;
   view_url?: string;
@@ -652,24 +673,48 @@ async function saveContentImpl(
     });
   }
 
-  // Probe real semantic-index readiness for this specific event rather than
-  // asserting a fixed 'pending'. `needsEmbeddingSql` is the same predicate the
-  // embed backfill and worker use, so callers can never disagree with the
+  // Read the durable row back: the persisted payload echoed in the result
+  // below, plus real semantic-index readiness for this specific event rather
+  // than asserting a fixed 'pending'. `needsEmbeddingSql` is the same predicate
+  // the embed backfill and worker use, so callers can never disagree with the
   // pipeline on what "indexed" means. Embeddings are usually produced by the
   // async backfill (so this is 'pending'), but when one is supplied inline the
   // row is already searchable — reporting a hardcoded 'pending' would be wrong.
   const savedId = Number(row.id);
-  const [readiness] = await sql`
-    SELECT ${sql.unsafe(needsEmbeddingSql('e', getConfiguredEmbeddingModel()))} AS needs_embedding
+  const [savedEvent] = await sql`
+    SELECT
+      e.payload_type,
+      e.payload_text,
+      e.payload_data,
+      e.payload_template,
+      e.attachments,
+      e.source_url,
+      ${sql.unsafe(needsEmbeddingSql('e', getConfiguredEmbeddingModel()))} AS needs_embedding
     FROM events e WHERE e.id = ${savedId}
   `;
-  const searchable = readiness ? !readiness.needs_embedding : false;
+  if (!savedEvent) {
+    throw new Error(`Saved event ${savedId} was not readable after commit`);
+  }
+  const searchable = !savedEvent.needs_embedding;
 
   const result: SaveContentResult = {
     id: savedId,
     entity_ids: Array.isArray(row.entity_ids) ? row.entity_ids.map(Number) : finalEntityIds,
     title: row.title as string | null,
     semantic_type: semanticType,
+    // Return the exact durable payload, not the caller's arguments. This keeps
+    // idempotent retries honest and gives MCP App hosts the same event that the
+    // Lobu Activity UI reads from Postgres.
+    payload_type: String(savedEvent.payload_type) as SaveContentResult['payload_type'],
+    payload_text:
+      savedEvent.payload_text == null ? null : String(savedEvent.payload_text),
+    payload_data: (savedEvent.payload_data ?? {}) as Record<string, unknown>,
+    payload_template:
+      savedEvent.payload_template == null
+        ? null
+        : (savedEvent.payload_template as Record<string, unknown>),
+    attachments: Array.isArray(savedEvent.attachments) ? savedEvent.attachments : [],
+    source_url: savedEvent.source_url == null ? null : String(savedEvent.source_url),
     created_at: String(row.created_at),
     // Row is committed by now; exact reads by id are available from this instant.
     durable_at: String(row.created_at),

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -9,6 +9,7 @@
 
 import { normalizeAuthUserId, normalizeEmail } from '@lobu/connector-sdk/identity-normalize';
 import { type Static, Type } from '@sinclair/typebox';
+import { Buffer } from 'node:buffer';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
 import { type DbClient, getDb, parsePgNumberArray } from '../db/client';
@@ -34,6 +35,11 @@ import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 import { buildEventViewUrl } from './view-urls';
+
+// Leave headroom below the 512 KiB MCP App snapshot ceiling for the receipt,
+// tool name, and snapshot envelope. Larger events remain exactly readable by
+// the returned id instead of being copied into every caller's response.
+const SAVE_MEMORY_INLINE_PAYLOAD_MAX_BYTES = 480 * 1024;
 
 /**
  * True when a Postgres error is the unique-violation (23505) on the partial
@@ -196,21 +202,22 @@ export const SaveContentResultSchema = Type.Object({
   entity_ids: Type.Array(Type.Integer()),
   title: Type.Union([Type.String(), Type.Null()]),
   semantic_type: Type.String(),
-  payload_type: Type.Union([
-    Type.Literal('text'),
-    Type.Literal('markdown'),
-    Type.Literal('json_template'),
-    Type.Literal('media'),
-    Type.Literal('empty'),
-  ]),
-  payload_text: Type.Union([Type.String(), Type.Null()]),
-  payload_data: Type.Record(Type.String(), Type.Unknown()),
-  payload_template: Type.Union([
-    Type.Record(Type.String(), Type.Unknown()),
-    Type.Null(),
-  ]),
-  attachments: Type.Array(Type.Unknown()),
-  source_url: Type.Union([Type.String(), Type.Null()]),
+  payload_type: Type.Optional(
+    Type.Union([
+      Type.Literal('text'),
+      Type.Literal('markdown'),
+      Type.Literal('json_template'),
+      Type.Literal('media'),
+      Type.Literal('empty'),
+    ])
+  ),
+  payload_text: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  payload_data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  payload_template: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  attachments: Type.Optional(Type.Array(Type.Unknown())),
+  source_url: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   created_at: Type.String(),
   supersedes_event_id: Type.Optional(Type.Integer()),
   view_url: Type.Optional(Type.String()),
@@ -230,12 +237,12 @@ interface SaveContentResult {
   entity_ids: number[];
   title: string | null;
   semantic_type: string;
-  payload_type: 'text' | 'markdown' | 'json_template' | 'media' | 'empty';
-  payload_text: string | null;
-  payload_data: Record<string, unknown>;
-  payload_template: Record<string, unknown> | null;
-  attachments: unknown[];
-  source_url: string | null;
+  payload_type?: 'text' | 'markdown' | 'json_template' | 'media' | 'empty';
+  payload_text?: string | null;
+  payload_data?: Record<string, unknown>;
+  payload_template?: Record<string, unknown> | null;
+  attachments?: unknown[];
+  source_url?: string | null;
   created_at: string;
   supersedes_event_id?: number;
   view_url?: string;
@@ -673,48 +680,67 @@ async function saveContentImpl(
     });
   }
 
-  // Read the durable row back: the persisted payload echoed in the result
-  // below, plus real semantic-index readiness for this specific event rather
-  // than asserting a fixed 'pending'. `needsEmbeddingSql` is the same predicate
-  // the embed backfill and worker use, so callers can never disagree with the
-  // pipeline on what "indexed" means. Embeddings are usually produced by the
-  // async backfill (so this is 'pending'), but when one is supplied inline the
-  // row is already searchable — reporting a hardcoded 'pending' would be wrong.
+  // Read real semantic-index readiness for this specific event rather than
+  // asserting a fixed 'pending'. For MCP App callers, also read the persisted
+  // payload for the inline card; other surfaces keep their compact receipt.
+  // `needsEmbeddingSql` is the same predicate the embed backfill and worker use,
+  // so callers can never disagree with the pipeline on what "indexed" means.
+  // Embeddings are usually produced by the async backfill (so this is 'pending'),
+  // but when one is supplied inline the row is already searchable.
   const savedId = Number(row.id);
+  const shouldReadInlinePayload = ctx.mcpAppsSupported === true;
   const [savedEvent] = await sql`
     SELECT
-      e.payload_type,
-      e.payload_text,
-      e.payload_data,
-      e.payload_template,
-      e.attachments,
-      e.source_url,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.payload_type END AS payload_type,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.payload_text END AS payload_text,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.payload_data END AS payload_data,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.payload_template END AS payload_template,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.attachments END AS attachments,
+      CASE WHEN ${shouldReadInlinePayload} THEN e.source_url END AS source_url,
       ${sql.unsafe(needsEmbeddingSql('e', getConfiguredEmbeddingModel()))} AS needs_embedding
     FROM events e WHERE e.id = ${savedId}
   `;
-  if (!savedEvent) {
-    throw new Error(`Saved event ${savedId} was not readable after commit`);
-  }
-  const searchable = !savedEvent.needs_embedding;
+  // The row is already committed, so a read-back miss must never fail the call:
+  // reporting an error for a durable write invites a retry that appends a
+  // duplicate. Degrade to "not searchable yet" and no inline payload instead.
+  const searchable = savedEvent ? !savedEvent.needs_embedding : false;
+
+  const inlinePayload =
+    shouldReadInlinePayload && savedEvent
+      ? {
+          payload_type: String(savedEvent.payload_type) as NonNullable<
+            SaveContentResult['payload_type']
+          >,
+          payload_text:
+            savedEvent.payload_text == null ? null : String(savedEvent.payload_text),
+          payload_data: (savedEvent.payload_data ?? {}) as Record<string, unknown>,
+          payload_template:
+            savedEvent.payload_template == null
+              ? null
+              : (savedEvent.payload_template as Record<string, unknown>),
+          attachments: Array.isArray(savedEvent.attachments) ? savedEvent.attachments : [],
+          source_url:
+            savedEvent.source_url == null ? null : String(savedEvent.source_url),
+        }
+      : null;
+  const boundedInlinePayload =
+    inlinePayload &&
+    Buffer.byteLength(JSON.stringify(inlinePayload), 'utf8') <=
+      SAVE_MEMORY_INLINE_PAYLOAD_MAX_BYTES
+      ? inlinePayload
+      : null;
 
   const result: SaveContentResult = {
     id: savedId,
     entity_ids: Array.isArray(row.entity_ids) ? row.entity_ids.map(Number) : finalEntityIds,
     title: row.title as string | null,
     semantic_type: semanticType,
-    // Return the exact durable payload, not the caller's arguments. This keeps
-    // idempotent retries honest and gives MCP App hosts the same event that the
-    // Lobu Activity UI reads from Postgres.
-    payload_type: String(savedEvent.payload_type) as SaveContentResult['payload_type'],
-    payload_text:
-      savedEvent.payload_text == null ? null : String(savedEvent.payload_text),
-    payload_data: (savedEvent.payload_data ?? {}) as Record<string, unknown>,
-    payload_template:
-      savedEvent.payload_template == null
-        ? null
-        : (savedEvent.payload_template as Record<string, unknown>),
-    attachments: Array.isArray(savedEvent.attachments) ? savedEvent.attachments : [],
-    source_url: savedEvent.source_url == null ? null : String(savedEvent.source_url),
+    // When present, this is the exact durable payload, not the caller's
+    // arguments: it keeps idempotent retries honest and gives MCP App hosts the
+    // same event the Lobu Activity UI reads from Postgres. Absent for non-App
+    // callers and for oversized events, which keep the compact receipt and the
+    // exact-read id rather than exceeding the App snapshot limit.
+    ...(boundedInlinePayload ?? {}),
     created_at: String(row.created_at),
     // Row is committed by now; exact reads by id are available from this instant.
     durable_at: String(row.created_at),

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -7,9 +7,9 @@
  * Embeddings are left null for background worker backfill.
  */
 
+import { Buffer } from 'node:buffer';
 import { normalizeAuthUserId, normalizeEmail } from '@lobu/connector-sdk/identity-normalize';
 import { type Static, Type } from '@sinclair/typebox';
-import { Buffer } from 'node:buffer';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
 import { type DbClient, getDb, parsePgNumberArray } from '../db/client';

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -42,6 +42,20 @@ import { buildEventViewUrl } from './view-urls';
 const SAVE_MEMORY_INLINE_PAYLOAD_MAX_BYTES = 480 * 1024;
 
 /**
+ * Result fields that carry the saved event's render payload, as opposed to the
+ * compact receipt. The text fallback strips exactly these (see
+ * `formatToolResult`), so both sides must move together when one is added.
+ */
+export const SAVE_MEMORY_RENDER_PAYLOAD_KEYS = [
+  'payload_type',
+  'payload_text',
+  'payload_data',
+  'payload_template',
+  'attachments',
+  'source_url',
+] as const;
+
+/**
  * True when a Postgres error is the unique-violation (23505) on the partial
  * index that guards "at most one event supersedes a given target". The loser
  * of a concurrent-supersede race hits this; postgres.js exposes the SQLSTATE
@@ -682,7 +696,9 @@ async function saveContentImpl(
 
   // Read real semantic-index readiness for this specific event rather than
   // asserting a fixed 'pending'. For MCP App callers, also read the persisted
-  // payload for the inline card; other surfaces keep their compact receipt.
+  // payload for the inline card; other surfaces keep their compact receipt. The
+  // per-column CASE keeps that a single round trip — a caller that cannot render
+  // the payload never pays to ship it.
   // `needsEmbeddingSql` is the same predicate the embed backfill and worker use,
   // so callers can never disagree with the pipeline on what "indexed" means.
   // Embeddings are usually produced by the async backfill (so this is 'pending'),


### PR DESCRIPTION
## Summary
- render direct `save_memory` calls as an MCP App receipt plus the persisted text, markdown, media, or JSON-template payload
- keep search, SQL, SDK, and ordinary non-App callers headless; nested `client.knowledge.save()` calls explicitly remain compact even when the outer `run_sdk` session advertises Apps
- use a fresh immutable v13 App resource (with v12 compatibility alias) and cap inline payloads at 480 KiB

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Tests run: targeted server/Owletto suites, typechecks, bundle check, formatter checks, and reviewer-selected integration breadth
- [x] Bug fix: red→fix→green outputs recorded below
- [x] `make review` passed on final pushed HEAD (0 bugs, 0 blockers)
- [x] `make ui-review` recorded hosted proof on the pinned Owletto PR

### Red → green
- Server red: 3 failed / 25 passed (missing persisted payload and App metadata)
- Owletto red: 2 failed / 60 passed (saved text and saved chart receipt absent)
- Size-guard red: 1 failed / 25 passed (oversized payload exposed)
- Cache review red: v12 could reuse the pre-fix widget and drop the write receipt
- Nested-SDK red: Apps-capable `run_sdk` context exposed `payload_type: "text"` from `client.knowledge.save()`; green after ClientSDK forces a headless context
- Green: 34 focused integration + 19 formatter + 62 Owletto result-view tests; MCP App bundle check passed against v13; server typecheck clean
- Final remote gate: all 18 executions passed — https://depot.dev/orgs/b9ffw2rv84/workflows/5r6hn3dhn3

## Proof and implementation notes
- Fresh MCP Inspector handshake on the settled renderer: Apps listed `save_memory` and `render_lobu_view`; `tools/call save_memory` rendered the receipt, metric, bar chart, and table; the next successful protocol call read `ui://lobu/interaction/v13.html`. Activity read back the same durable event as #7.
- Hosted before/after: https://htmlpreview.github.io/?https://gist.githubusercontent.com/buremba/b35f89258f35eff5ab480c3bbafe2b8f/raw/139b062d37b69dd67613be85f3ec84d923be94d9/index.html
- Compatible pinned Owletto range: https://github.com/lobu-ai/owletto/pull/871 plus https://github.com/lobu-ai/owletto/pull/872, ending at `b577d9264bb15510e0b7b9e47e200e3d8fee2d34`.
- Ancestry-only https://github.com/lobu-ai/owletto/pull/874 makes that compatible commit reachable from `owletto/main` without changing the main tree. This avoids pulling newer frontend/API vocabulary ahead of the parent Lobu base.
- Final UI-review proof: https://github.com/lobu-ai/owletto/pull/872#issuecomment-5304668567
- Post-commit readback misses soft-degrade instead of failing an already-durable save and inviting a duplicate retry.
