### PR TITLE
refactor(server): add entity row write kernel

### DIFF
--- a/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
+++ b/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createTestOrganization,
+	createTestUser,
+} from "../../__tests__/setup/test-fixtures";
+import {
+	cleanupTestDatabase,
+	getTestDb,
+} from "../../__tests__/setup/test-db";
+import {
+	hardDeleteEntityRows,
+	insertEntityRow,
+	patchEntityRows,
+} from "../entity-management";
+
+async function seedEntityType(organizationId: string): Promise<number> {
+	const sql = getTestDb();
+	const rows = await sql<{ id: number }>`
+		INSERT INTO entity_types (
+			organization_id, slug, name, created_at, updated_at
+		) VALUES (
+			${organizationId}, 'kernel-test', 'Kernel test',
+			current_timestamp, current_timestamp
+		)
+		RETURNING id
+	`;
+	return Number(rows[0].id);
+}
+
+describe("entity row write kernel", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("participates in the caller transaction for insert, patch, and delete", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel rollback",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+		const existing = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Existing",
+				slug: "existing",
+				createdBy: user.id,
+			},
+		});
+
+		await expect(
+			sql.begin(async (tx) => {
+				await insertEntityRow({
+					tx,
+					row: {
+						organizationId: organization.id,
+						entityTypeId,
+						name: "Rolled back",
+						slug: "rolled-back",
+						createdBy: user.id,
+					},
+				});
+				await patchEntityRows({
+					tx,
+					ids: [existing.id],
+					patch: { name: "Also rolled back" },
+				});
+				await hardDeleteEntityRows({ tx, ids: [existing.id] });
+				throw new Error("rollback sentinel");
+			}),
+		).rejects.toThrow("rollback sentinel");
+
+		const rows = await sql<{ name: string }>`
+			SELECT name FROM entities
+			WHERE organization_id = ${organization.id}
+			ORDER BY id
+		`;
+		expect(rows).toEqual([{ name: "Existing" }]);
+	});
+
+	it("distinguishes omitted fields from explicit nulls", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel patch",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+		const entity = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Keep me",
+				slug: "keep-me",
+				content: "clear me",
+				metadata: { old: true },
+				enabledClassifiers: ["sentiment"],
+				createdBy: user.id,
+			},
+		});
+
+		const changed = await patchEntityRows({
+			tx: sql,
+			ids: [entity.id],
+			patch: {
+				content: null,
+				metadata: { current: true },
+				enabledClassifiers: [],
+			},
+		});
+
+		expect(changed).toEqual([entity.id]);
+		const rows = await sql<{
+			name: string;
+			content: string | null;
+			metadata: Record<string, unknown>;
+			enabled_classifiers: string;
+		}>`
+			SELECT name, content, metadata, enabled_classifiers::text
+			FROM entities
+			WHERE id = ${entity.id}
+		`;
+		expect(rows[0]).toEqual({
+			name: "Keep me",
+			content: null,
+			metadata: { current: true },
+			enabled_classifiers: "{}",
+		});
+	});
+
+	it("stamps a tombstone once and then skips the row", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel tombstone",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+		const entity = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Delete me",
+				slug: "delete-me",
+				createdBy: user.id,
+			},
+		});
+
+		expect(
+			await patchEntityRows({
+				tx: sql,
+				ids: [entity.id],
+				patch: { softDelete: true },
+			}),
+		).toEqual([entity.id]);
+		const deletedAt = (
+			await sql<{ deleted_at: Date | null }>`
+				SELECT deleted_at FROM entities WHERE id = ${entity.id}
+			`
+		)[0].deleted_at;
+		expect(deletedAt).not.toBeNull();
+
+		// A tombstoned row is invisible to the kernel: no further patch lands on
+		// it, so a later write can neither edit nor resurrect a deleted entity.
+		expect(
+			await patchEntityRows({
+				tx: sql,
+				ids: [entity.id],
+				patch: { name: "Edited after delete" },
+			}),
+		).toEqual([]);
+
+		const rows = await sql<{ name: string; deleted_at: Date | null }>`
+			SELECT name, deleted_at FROM entities WHERE id = ${entity.id}
+		`;
+		expect(rows[0].name).toBe("Delete me");
+		expect(rows[0].deleted_at).toEqual(deletedAt);
+	});
+});

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -331,6 +331,142 @@ export interface FieldMergeInfo {
 }
 
 // ============================================
+// Transaction-bound row writes
+// ============================================
+
+/**
+ * Physical entity-row values accepted by the internal write kernel.
+ *
+ * This is deliberately below the semantic CRUD layer: it performs no access,
+ * policy, hook, schema, or hierarchy checks and never opens a transaction. A
+ * caller must pass the pool/transaction handle that already owns those
+ * decisions. Keeping the handle explicit lets projection writers join their
+ * surrounding transaction without issuing entity SQL outside this module.
+ */
+export interface EntityRowInsert {
+	organizationId: string;
+	entityTypeId: number;
+	name: string;
+	slug: string;
+	parentId?: number | null;
+	metadata?: Record<string, unknown>;
+	enabledClassifiers?: string[] | null;
+	createdBy: string;
+	content?: string | null;
+	embedding?: number[] | null;
+	contentHash?: string | null;
+}
+
+/** Columns the physical kernel may change without making selectors dynamic. */
+export interface EntityRowPatch {
+	name?: string;
+	slug?: string;
+	parentId?: number | null;
+	metadata?: Record<string, unknown> | null;
+	fieldControls?: Record<string, unknown>;
+	enabledClassifiers?: string[] | null;
+	content?: string | null;
+	embedding?: number[] | null;
+	/** true stamps deleted_at. The kernel never clears an existing tombstone. */
+	softDelete?: boolean;
+}
+
+export interface InsertedEntityRow {
+	id: number;
+	name: string;
+	slug: string;
+	parent_id: number | null;
+	metadata: Record<string, unknown> | null;
+	created_at: Date;
+}
+
+/** Insert one physical entity row using exactly the caller's DB handle. */
+export async function insertEntityRow(params: {
+	tx: DbClient;
+	row: EntityRowInsert;
+}): Promise<InsertedEntityRow> {
+	const { tx, row } = params;
+	const embeddingLiteral = toVectorLiteral(row.embedding);
+	const rows = await tx<InsertedEntityRow>`
+    INSERT INTO entities (
+      organization_id, entity_type_id, name, slug, parent_id, metadata,
+      enabled_classifiers, created_by, content, embedding, content_hash,
+      created_at, updated_at
+    ) VALUES (
+      ${row.organizationId}, ${row.entityTypeId}, ${row.name}, ${row.slug},
+      ${row.parentId ?? null}, ${tx.json(row.metadata ?? {})},
+      ${row.enabledClassifiers != null ? pgTextArray(row.enabledClassifiers) : null}::text[],
+      ${row.createdBy}, ${row.content ?? null}, ${embeddingLiteral}::vector,
+      ${row.contentHash ?? null}, current_timestamp, current_timestamp
+    )
+    RETURNING id, name, slug, parent_id, metadata, created_at
+  `;
+	if (rows.length === 0) throw new Error("Failed to create entity");
+	return rows[0];
+}
+
+/**
+ * Patch an explicit, bounded set of entity ids using the caller's DB handle.
+ * Omitted fields remain unchanged; nullable fields distinguish null from
+ * omission. Only live rows are patched — a tombstoned row is skipped, so the
+ * kernel can never resurrect one. Every call touches updated_at, including a
+ * fully blocked update whose patch ends up empty.
+ *
+ * Returns the ids actually written, ascending.
+ */
+export async function patchEntityRows(params: {
+	tx: DbClient;
+	ids: number[];
+	patch: EntityRowPatch;
+}): Promise<number[]> {
+	if (params.ids.length === 0) return [];
+	const { tx, patch } = params;
+	const hasName = patch.name !== undefined;
+	const hasSlug = patch.slug !== undefined;
+	const hasParent = patch.parentId !== undefined;
+	const hasMetadata = patch.metadata !== undefined;
+	const hasFieldControls = patch.fieldControls !== undefined;
+	const hasEnabledClassifiers = patch.enabledClassifiers !== undefined;
+	const hasContent = patch.content !== undefined;
+	const hasEmbedding = patch.embedding !== undefined;
+
+	const idsLiteral = pgBigintArray(params.ids);
+	const embeddingLiteral = toVectorLiteral(patch.embedding);
+	const rows = await tx<{ id: number }>`
+    UPDATE entities SET
+      name = CASE WHEN ${hasName} THEN ${patch.name ?? null} ELSE name END,
+      slug = CASE WHEN ${hasSlug} THEN ${patch.slug ?? null} ELSE slug END,
+      parent_id = CASE WHEN ${hasParent} THEN ${patch.parentId ?? null}::bigint ELSE parent_id END,
+      metadata = CASE WHEN ${hasMetadata} THEN ${patch.metadata == null ? null : tx.json(patch.metadata)} ELSE metadata END,
+      field_controls = CASE WHEN ${hasFieldControls} THEN ${tx.json(patch.fieldControls ?? {})} ELSE field_controls END,
+      enabled_classifiers = CASE WHEN ${hasEnabledClassifiers} THEN ${patch.enabledClassifiers != null ? pgTextArray(patch.enabledClassifiers) : null}::text[] ELSE enabled_classifiers END,
+      content = CASE WHEN ${hasContent} THEN ${patch.content ?? null} ELSE content END,
+      embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,
+      deleted_at = CASE WHEN ${patch.softDelete === true} THEN current_timestamp ELSE deleted_at END,
+      updated_at = current_timestamp
+    WHERE id = ANY(${idsLiteral}::bigint[])
+      AND deleted_at IS NULL
+    RETURNING id
+  `;
+	return rows.map((row) => Number(row.id)).sort((a, b) => a - b);
+}
+
+/** Hard-delete an explicit, bounded set of entity ids on the caller's handle. */
+export async function hardDeleteEntityRows(params: {
+	tx: DbClient;
+	ids: number[];
+}): Promise<number[]> {
+	if (params.ids.length === 0) return [];
+	const idsLiteral = pgBigintArray(params.ids);
+	const rows = await params.tx<{ id: number }>`
+    DELETE FROM entities
+    WHERE id = ANY(${idsLiteral}::bigint[])
+    RETURNING id
+  `;
+	return rows.map((row) => Number(row.id)).sort((a, b) => a - b);
+}
+
+// ============================================
 // Validation Helpers
 // ============================================
 
@@ -486,25 +622,26 @@ export async function createEntity(
 	}
 
 	const contentValue = data.content?.trim() || null;
-	const embeddingLiteral = toVectorLiteral(data.embedding);
 	const contentHash = data.content_hash || null;
 
 	try {
 		const inserted = await sql.begin(async (tx) => {
-			const rows = await tx<Omit<CreatedEntity, "entity_type">>`
-        INSERT INTO entities (
-          organization_id, entity_type_id, name, slug, parent_id, metadata, enabled_classifiers, created_by, content, embedding, content_hash, created_at, updated_at
-        ) VALUES (
-          ${data.organization_id}, ${entityTypeId}, ${data.name.trim()}, ${slug}, ${data.parent_id || null},
-          ${sql.json(metadata)}, ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[], ${createdBy},
-          ${contentValue}, ${embeddingLiteral}::vector, ${contentHash}, current_timestamp, current_timestamp
-        )
-        RETURNING id, name, slug, parent_id, metadata, created_at
-      `;
-			if (rows.length === 0) {
-				throw new Error("Failed to create entity");
-			}
-			return rows[0];
+			return insertEntityRow({
+				tx,
+				row: {
+					organizationId: data.organization_id as string,
+					entityTypeId,
+					name: data.name.trim(),
+					slug,
+					parentId: data.parent_id || null,
+					metadata,
+					enabledClassifiers: data.enabled_classifiers,
+					createdBy,
+					content: contentValue,
+					embedding: data.embedding,
+					contentHash,
+				},
+			});
 		});
 
 		// The validator above already resolved data.entity_type → entityTypeId.
@@ -600,7 +737,6 @@ export async function updateEntity(
 	const hasContent = data.content !== undefined;
 	const contentValue = data.content?.trim() || null;
 	const hasEmbedding = data.embedding !== undefined;
-	const embeddingLiteral = toVectorLiteral(data.embedding);
 
 	// An affirm-only edit (approve a value as-is) has no metadata delta but still
 	// must run the merge so it can claim field ownership.
@@ -763,19 +899,21 @@ export async function updateEntity(
 			};
 		}
 
-		await tx`
-      UPDATE entities SET
-        name = COALESCE(${applyName ? (data.name ?? null) : null}, name),
-        slug = COALESCE(${data.slug ?? (applyName ? newSlug : null)}, slug),
-        parent_id = CASE WHEN ${applyParent} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
-        metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
-        field_controls = CASE WHEN ${mergedControls !== null} THEN ${mergedControls ? sql.json(mergedControls) : sql.json({})} ELSE field_controls END,
-        enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[] ELSE enabled_classifiers END,
-        content = CASE WHEN ${applyContent} THEN ${contentValue} ELSE content END,
-        embedding = CASE WHEN ${hasEmbedding && (applyContent || !hasContent)} THEN ${embeddingLiteral}::vector ELSE embedding END,
-        updated_at = current_timestamp
-      WHERE id = ${entityId} AND deleted_at IS NULL
-    `;
+		const rowPatch: EntityRowPatch = {};
+		if (applyName && data.name !== undefined) rowPatch.name = data.name;
+		const slugPatch = data.slug ?? (applyName ? newSlug : null);
+		if (slugPatch !== null) rowPatch.slug = slugPatch;
+		if (applyParent) rowPatch.parentId = data.parent_id ?? null;
+		if (hasMetadataUpdates) rowPatch.metadata = mergedMetadata;
+		if (mergedControls !== null) rowPatch.fieldControls = mergedControls;
+		if (data.enabled_classifiers !== undefined) {
+			rowPatch.enabledClassifiers = data.enabled_classifiers;
+		}
+		if (applyContent) rowPatch.content = contentValue;
+		if (hasEmbedding && (applyContent || !hasContent)) {
+			rowPatch.embedding = data.embedding ?? null;
+		}
+		await patchEntityRows({ tx, ids: [entityId], patch: rowPatch });
 
     const sel = await tx<CreatedEntity>`
       SELECT e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at
@@ -1159,10 +1297,7 @@ export async function deleteEntity(
         if (detached.length < EVENT_DETACH_BATCH) break;
       }
 
-      await tx`
-        DELETE FROM entities
-        WHERE id = ANY(${entityTreeIdsLiteral}::bigint[])
-      `;
+      await hardDeleteEntityRows({ tx, ids: entityTreeIds });
     });
 
     return {
@@ -1182,13 +1317,9 @@ export async function deleteEntity(
       dry_run: true,
     };
   }
-
-  // Soft delete: set deleted_at timestamp
-  await sql`
-    UPDATE entities
-    SET deleted_at = current_timestamp, updated_at = current_timestamp
-    WHERE id = ${entityId} AND deleted_at IS NULL
-  `;
+  // Soft delete: stamp deleted_at. Stays a single pool-level statement, so the
+  // semantic layer's existing transaction boundary is unchanged.
+  await patchEntityRows({ tx: sql, ids: [entityId], patch: { softDelete: true } });
 
   return {
     message: 'Entity soft-deleted successfully',


### PR DESCRIPTION
## Summary
- Add a typed physical entity-row write kernel inside the existing canonical `entity-management.ts` funnel.
- Require every kernel operation to use the caller-provided database handle, so projection writers can join an existing transaction without issuing entity SQL elsewhere.
- Route canonical create, update, soft delete, and hard delete through the kernel while leaving access checks, mutation policy, hooks, locks, and existing transaction boundaries in the semantic CRUD layer.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (18/18 job instances; Depot run `t2jqwqk0m3`; tree `331a6bfefb29e13b6e4a22c42410ff44421bf8da`)
- [x] Tests run: 29 focused integration tests across kernel transaction semantics, CRUD, schema search, entity history, and approval routing/dedupe
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

Red before the kernel existed:
```text
entity-write-kernel.test.ts: 0 passed, 3 failed
TypeError: insertEntityRow is not a function
```

Green on the settled implementation:
```text
entity-write-kernel.test.ts: 3 passed, 0 failed
focused existing contracts: 20 passed, 0 failed
approval/invariant contracts: 9 passed, 0 failed
server tsc --noEmit: passed
entity-write funnel gate: 991 runtime package source files scanned; 29 pinned bypasses, zero new bypasses
```

## Notes
- No database design, migration, product API, SDK, or UI surface changes.
- The kernel is intentionally physical and internal. It does not bypass or duplicate access, policy, hook, schema, or hierarchy logic; current canonical CRUD still owns those semantics.
- Patch operations only touch live rows, tombstones are one-way at this layer, and every patch preserves the canonical update timestamp behavior.
- This foundation does not migrate any of the 29 pinned bypasses yet; later category PRs can remove allowances one group at a time.
