### PR TITLE
refactor(server): funnel approved entity writes

### DIFF
--- a/packages/server/src/__tests__/integration/tools/entity-field-approval-apply.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-field-approval-apply.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Applying an approved proposal writes metadata, field ownership, and the
+ * reserved $-attributes through the entity write funnel instead of raw SQL.
+ *
+ * The attribute write patches only name/parent_id/content, so `slug` is
+ * asserted unchanged: the funnel kernel can also write slug, and an approved
+ * rename must not start re-slugging the row as a side effect.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyEntityFieldChangeProposal } from "../../../tools/admin/entity-field-approval";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+describe("approved entity field application", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("applies approved metadata and attributes through one transaction", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Approved entity write",
+		});
+		const approver = await createTestUser();
+		const parent = await createTestEntity({
+			name: "Approved parent",
+			organization_id: organization.id,
+			created_by: approver.id,
+		});
+		const entity = await createTestEntity({
+			name: "Original name",
+			organization_id: organization.id,
+			created_by: approver.id,
+		});
+		await sql`
+			UPDATE entities
+			SET metadata = ${sql.json({ status: "pending" })}, content = 'draft'
+			WHERE id = ${entity.id}
+		`;
+
+		const result = await applyEntityFieldChangeProposal(
+			{
+				entity_id: entity.id,
+				fields: {
+					status: "approved",
+					$name: "Approved name",
+					$parent_id: parent.id,
+					$content: null,
+				},
+				current: {
+					status: "pending",
+					$name: "Original name",
+					$parent_id: null,
+					$content: "draft",
+				},
+				reason: "Human approved the proposed entity changes",
+			},
+			approver.id,
+		);
+
+		expect(Object.keys(result.applied).sort()).toEqual([
+			"$content",
+			"$name",
+			"$parent_id",
+			"status",
+		]);
+		const [row] = await sql<{
+			name: string;
+			slug: string;
+			parent_id: number;
+			content: string | null;
+			metadata: Record<string, unknown>;
+			field_controls: Record<string, { set_by?: string | null }>;
+		}>`
+			SELECT name, slug, parent_id, content, metadata, field_controls
+			FROM entities
+			WHERE id = ${entity.id}
+		`;
+		expect(row).toMatchObject({
+			name: "Approved name",
+			slug: "original-name",
+			parent_id: parent.id,
+			content: null,
+			metadata: { status: "approved" },
+		});
+		expect(row.field_controls.status?.set_by).toBe(approver.id);
+	});
+});

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -39,14 +39,13 @@ import {
 	formatLabel,
 	notifyActionApprovalNeeded,
 } from "../../notifications/triggers";
-import {
-	type FieldMergeResult,
-	mergeEntityFields,
-} from "../../utils/entity-field-merge";
+import type { FieldMergeResult } from "../../utils/entity-field-merge";
 import {
 	createEntity,
 	deleteEntity,
 	type EntityData,
+	mergeEntityFields,
+	patchEntityRows,
 } from "../../utils/entity-management";
 import { applyMergeGroupInTransaction } from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
@@ -1159,18 +1158,19 @@ export async function applyEntityFieldChangeProposal(
 			if (Object.keys(apply).length > 0) {
 				const nextName =
 					"$name" in apply ? String(apply.$name ?? "") || null : null;
-				await tx`
-          UPDATE entities SET
-            name = COALESCE(${nextName}, name),
-            parent_id = CASE WHEN ${"$parent_id" in apply} THEN ${
-							("$parent_id" in apply ? apply.$parent_id : null) as number | null
-						}::bigint ELSE parent_id END,
-            content = CASE WHEN ${"$content" in apply} THEN ${
-							"$content" in apply ? (apply.$content as string | null) : null
-						} ELSE content END,
-            updated_at = current_timestamp
-          WHERE id = ${proposal.entity_id} AND deleted_at IS NULL
-        `;
+				await patchEntityRows({
+					tx,
+					ids: [proposal.entity_id],
+					patch: {
+						...(nextName !== null ? { name: nextName } : {}),
+						...("$parent_id" in apply
+							? { parentId: apply.$parent_id as number | null }
+							: {}),
+						...("$content" in apply
+							? { content: apply.$content as string | null }
+							: {}),
+					},
+				});
 			}
 		}
 		return merge;

--- a/packages/server/src/utils/entity-field-merge.ts
+++ b/packages/server/src/utils/entity-field-merge.ts
@@ -8,13 +8,11 @@
  *   - source='watcher': writes only fields that are NOT human-owned; owned fields are
  *     returned in `blocked` (the caller emits an approval) and never overwritten.
  *
- * The risky decision logic is the pure `computeFieldMerge` — unit-tested without a DB.
- * `mergeEntityFields` is the thin DB wrapper: it locks the entity row FOR UPDATE inside
- * the caller's transaction, applies the merge, and persists metadata + field_controls
- * atomically. Callers own the audit `'change'` event (handleUpdate / promotion emit it).
+ * This module is the pure decision engine — unit-testable without a DB. The
+ * transaction-bound persistence wrapper is `mergeEntityFields`, which lives in
+ * entity-management.ts so the write goes through the physical row kernel.
+ * Callers own the audit `'change'` event (handleUpdate / promotion emit it).
  */
-
-import type { DbClient } from "../db/client";
 
 export type FieldWriteSource = "human" | "watcher";
 
@@ -175,80 +173,4 @@ export function computeFieldMerge(args: {
 		nextControls,
 		changed: Object.keys(applied).length > 0 || affirmed.length > 0,
 	};
-}
-
-/**
- * DB wrapper: lock the entity row in the caller's transaction, apply the merge, and
- * persist metadata + field_controls atomically. Returns applied/blocked so the caller
- * can emit the audit event (human path) or the approval interactions (watcher path).
- */
-export async function mergeEntityFields(params: {
-	tx: DbClient;
-	entityId: number;
-	fields: Record<string, unknown>;
-	source: FieldWriteSource;
-	/** User id for a human edit; null/system otherwise. */
-	actorId: string | null;
-	note?: string | null;
-	/** Snapshot the proposal was built on (deferred-apply staleness guard). */
-	expectedCurrent?: Record<string, unknown> | null;
-	/** Fields (human source) whose current value is approved as-is, claiming
-	 *  ownership without a value change. */
-	affirm?: string[];
-	/** Additional fields a non-human policy decision requires approval for. */
-	requireApproval?: string[] | Set<string>;
-}): Promise<FieldMergeResult> {
-	const { tx, entityId, fields, source, actorId } = params;
-
-	const rows = await tx<{ metadata: unknown; field_controls: unknown }>`
-    SELECT metadata, field_controls FROM entities
-    WHERE id = ${entityId} AND deleted_at IS NULL
-    FOR UPDATE
-  `;
-	if (rows.length === 0) {
-		throw new Error(`Entity ${entityId} not found`);
-	}
-
-	const metadata = parseJsonObject(rows[0].metadata);
-	const controls = parseJsonObject(rows[0].field_controls) as Record<
-		string,
-		FieldControl
-	>;
-
-	const merge = computeFieldMerge({
-		metadata,
-		controls,
-		fields,
-		source,
-		actorId,
-		note: params.note ?? null,
-		nowIso: new Date().toISOString(),
-		expectedCurrent: params.expectedCurrent ?? null,
-		affirm: params.affirm,
-		requireApproval: params.requireApproval,
-	});
-
-	if (merge.changed) {
-		await tx`
-      UPDATE entities
-      SET metadata = ${tx.json(merge.nextMetadata)},
-          field_controls = ${tx.json(merge.nextControls)},
-          updated_at = current_timestamp
-      WHERE id = ${entityId}
-    `;
-	}
-
-	return merge;
-}
-
-function parseJsonObject(value: unknown): Record<string, unknown> {
-	if (value == null) return {};
-	if (typeof value === "string") {
-		try {
-			return JSON.parse(value) as Record<string, unknown>;
-		} catch {
-			return {};
-		}
-	}
-	return value as Record<string, unknown>;
 }

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -30,7 +30,12 @@ import type { Env } from "../index";
 import { querySqlImpl } from "../tools/admin/query_sql";
 import type { ToolContext } from "../tools/registry";
 import { entityLinkMatchSql } from "./content-search";
-import { computeFieldMerge, type FieldControl } from "./entity-field-merge";
+import {
+	computeFieldMerge,
+	type FieldControl,
+	type FieldMergeResult,
+	type FieldWriteSource,
+} from "./entity-field-merge";
 import { type EntityHookContext, getEntityHooks } from "./entity-hooks";
 import { ToolUserError } from "./errors";
 import logger from "./logger";
@@ -464,6 +469,80 @@ export async function hardDeleteEntityRows(params: {
     RETURNING id
   `;
 	return rows.map((row) => Number(row.id)).sort((a, b) => a - b);
+}
+
+/**
+ * Lock one live entity in the caller's transaction, apply the pure ownership
+ * merge, and persist the resulting metadata and controls through the physical
+ * row kernel. Callers remain responsible for audit events or approval delivery.
+ */
+export async function mergeEntityFields(params: {
+	tx: DbClient;
+	entityId: number;
+	fields: Record<string, unknown>;
+	source: FieldWriteSource;
+	/** User id for a human edit; null/system otherwise. */
+	actorId: string | null;
+	note?: string | null;
+	/** Snapshot the proposal was built on (deferred-apply staleness guard). */
+	expectedCurrent?: Record<string, unknown> | null;
+	/** Fields (human source) whose current value is approved as-is, claiming
+	 * ownership without a value change. */
+	affirm?: string[];
+	/** Additional fields a non-human policy decision requires approval for. */
+	requireApproval?: string[] | Set<string>;
+}): Promise<FieldMergeResult> {
+	const { tx, entityId, fields, source, actorId } = params;
+	const rows = await tx<{ metadata: unknown; field_controls: unknown }>`
+    SELECT metadata, field_controls FROM entities
+    WHERE id = ${entityId} AND deleted_at IS NULL
+    FOR UPDATE
+  `;
+	if (rows.length === 0) {
+		throw new Error(`Entity ${entityId} not found`);
+	}
+
+	const metadata = parseEntityJsonObject(rows[0].metadata);
+	const controls = parseEntityJsonObject(rows[0].field_controls) as Record<
+		string,
+		FieldControl
+	>;
+	const merge = computeFieldMerge({
+		metadata,
+		controls,
+		fields,
+		source,
+		actorId,
+		note: params.note ?? null,
+		nowIso: new Date().toISOString(),
+		expectedCurrent: params.expectedCurrent ?? null,
+		affirm: params.affirm,
+		requireApproval: params.requireApproval,
+	});
+
+	if (merge.changed) {
+		await patchEntityRows({
+			tx,
+			ids: [entityId],
+			patch: {
+				metadata: merge.nextMetadata,
+				fieldControls: merge.nextControls,
+			},
+		});
+	}
+	return merge;
+}
+
+function parseEntityJsonObject(value: unknown): Record<string, unknown> {
+	if (value == null) return {};
+	if (typeof value === "string") {
+		try {
+			return JSON.parse(value) as Record<string, unknown>;
+		} catch {
+			return {};
+		}
+	}
+	return value as Record<string, unknown>;
 }
 
 // ============================================

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -46,11 +46,8 @@ import {
 } from '../authz/entity-policy';
 import type { DbClient } from '../db/client';
 import type { EntityOutput } from '../types/watchers';
-import {
-  type AppliedChange,
-  type BlockedChange,
-  mergeEntityFields,
-} from './entity-field-merge';
+import type { AppliedChange, BlockedChange } from './entity-field-merge';
+import { mergeEntityFields } from './entity-management';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
 import { resolveEntityCreator } from './resolve-entity-creator';

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -83,22 +83,6 @@ const ALLOWED_BYPASSES = [
     reason: "suite-trials projection",
   },
 
-  // Pre-authorized field application.
-  {
-    file: "packages/server/src/tools/admin/entity-field-approval.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "fafff2cf303a2897",
-    reason: "approved field application",
-  },
-  {
-    file: "packages/server/src/utils/entity-field-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "faba984f6f828f86",
-    reason: "owned field merge in caller transaction",
-  },
-
   // Canvas materialization and provisional cleanup.
   {
     file: "packages/server/src/utils/canvas-events.ts",


### PR DESCRIPTION
## Summary
- Route approved entity attribute application and ownership-aware metadata merging through the canonical transaction-bound entity row kernel.
- Move the `mergeEntityFields` DB wrapper into `entity-management.ts` while keeping the pure merge decision module separate, avoiding an import cycle.
- Remove the two consumed funnel allowances, shrinking the verified bypass inventory from 29 to 27.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (18/18 job instances; Depot run `sbgbk6wxll`; tree `43553908b066f6e0a0587d255d90488b45d4f7d8`)
- [x] Tests run: 24 focused kernel/merge/ownership/approved-application tests; 13 keyed Behavior promotion tests; 18 funnel-guard tests
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

Red after the two raw writes were migrated but before their allowances were removed:
```text
entity-write funnel gate found 2 stale allowance(s):
- packages/server/src/tools/admin/entity-field-approval.ts [approved field application]
- packages/server/src/utils/entity-field-merge.ts [owned field merge in caller transaction]
```

Green on the settled implementation:
```text
entity-write funnel gate: 991 runtime package source files scanned; 27 pinned bypasses, zero new bypasses
focused kernel/merge/ownership/approved-application: 24 passed, 0 failed
keyed Behavior promotion: 13 passed, 0 failed
funnel guard suite: 18 passed, 0 failed (43 assertions)
server tsc --noEmit: passed
```

## Notes
- No database design, migration, product API, SDK, or UI surface changes.
- Both migrated callers already hold a real `DbClient` transaction, so their lock/check/write behavior remains atomic.
- Before this PR, either raw statement could mechanically skip a future Behavior-enforced rule placed at the canonical write boundary. This PR removes those two escape hatches; it does not yet add the Behavior business-rule contract itself.
- Approved rename behavior is preserved: it changes `name` without implicitly re-slugging the entity.
