### PR TITLE
refactor(server): funnel Behavior keyed entity writes

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -24,6 +24,7 @@ import type { AuthContext } from '../../../tools/execute';
 import { executeTool } from '../../../tools/execute';
 import { createWatcherRun } from '../../../runs/queue-service';
 import { computePendingWindow } from '../../../utils/window-utils';
+import { promoteBehaviorEntityOutput } from '../../../utils/promote-keyed-entities';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
@@ -70,6 +71,40 @@ const TEST_ENV: Env = {
   JWT_SECRET: 'test-jwt-secret-for-testing-only',
   BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
 };
+
+/**
+ * Block until some backend is waiting on a transaction lock — the state the
+ * losing promotion's INSERT enters while the sibling slug it collides with is
+ * still uncommitted. Polls on a THIRD connection so it observes A and B rather
+ * than participating.
+ *
+ * Releasing A directly instead would be a coin flip, not a race: A usually
+ * commits before B has even acquired its connection, so B's identity probe
+ * finds the committed claim and returns down the ordinary idempotent path,
+ * never reaching the lost-race cleanup this test exists to prove. Throws rather
+ * than hanging, so a future version where the race stops being reachable fails
+ * loudly instead of silently testing nothing.
+ */
+async function waitForBlockedEntityInsert(
+  sql: ReturnType<typeof getTestDb>,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await sql<{ count: number }>`
+      SELECT count(*)::int AS count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%INSERT INTO entities%'
+    `;
+    if (Number(rows[0].count) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(
+    'no entity INSERT blocked on the uncommitted sibling slug; the promotion race was not reached'
+  );
+}
 
 /** Owner web-session auth context for invoking manage_operations.approve. */
 function ownerAuthCtx(orgId: string, userId: string): AuthContext {
@@ -579,6 +614,78 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     );
   });
 
+  it('hard-deletes the provisional entity after losing a concurrent identity race', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId, parentEntityId } = ctx;
+    const promote = (tx: DbClient, windowId: number) =>
+      promoteBehaviorEntityOutput({
+        tx,
+        extractedData: {
+          problems: [{ category: 'Stability', name: 'App Crashes' }],
+        },
+        outputName: 'problems',
+        output: OUTPUTS.problems,
+        watcherId,
+        organizationId: workspace.org.id,
+        windowId,
+        parentEntityId,
+        createdBy: workspace.users.owner.id,
+        validContentIds: new Set<number>(),
+      });
+
+    let signalAReady!: () => void;
+    const aReady = new Promise<void>((resolve) => {
+      signalAReady = resolve;
+    });
+    let releaseA!: () => void;
+    const aMayCommit = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    // A promotes (entity insert + identity claim) and parks with its
+    // transaction still OPEN, so neither row is visible to B yet.
+    const runA = sql.begin(async (tx) => {
+      const result = await promote(tx as unknown as DbClient, 1001);
+      signalAReady();
+      await aMayCommit;
+      return result;
+    });
+    await aReady;
+
+    // B must NOT be awaited before A is released: B's entity insert blocks on
+    // A's uncommitted sibling slug, so awaiting here deadlocks the test against
+    // itself instead of exercising the race.
+    const runB = sql.begin((tx) => promote(tx as unknown as DbClient, 1002));
+    try {
+      await waitForBlockedEntityInsert(sql);
+    } finally {
+      releaseA();
+    }
+    const [a, b] = await Promise.all([runA, runB]);
+
+    expect(a.created).toBe(1);
+    expect(b.created).toBe(0);
+    const identity = topicIdentity(watcherId, APP_CRASHES_KEY);
+    const rows = await sql`
+      SELECT e.id, e.slug
+      FROM entities e
+      WHERE e.organization_id = ${workspace.org.id}
+        AND e.parent_id = ${parentEntityId}
+        AND e.metadata->>'stable_key' = ${APP_CRASHES_KEY}
+    `;
+    expect(rows).toHaveLength(1);
+    const claims = await sql`
+      SELECT entity_id
+      FROM entity_identities
+      WHERE organization_id = ${workspace.org.id}
+        AND namespace = 'watcher_key'
+        AND identifier = ${identity}
+        AND deleted_at IS NULL
+    `;
+    expect(claims).toHaveLength(1);
+    expect(Number(claims[0].entity_id)).toBe(Number(rows[0].id));
+  });
+
   it('syncs extracted fields into entities and respects a human-owned field on re-run, queuing an approval', async () => {
     const ctx = await setupKeyedWatcher();
     const { sql, workspace } = ctx;
@@ -985,15 +1092,78 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     `;
     expect(identities).toHaveLength(2);
 
-    // The "App Crashes" promotion got a DISAMBIGUATED slug (not the squatter's).
+    // The "App Crashes" promotion took the FIRST readable suffix, not the
+    // squatter's slug and not the identifier fallback.
     const appCrashes = identities.find(
       (r) => String(r.identifier) === topicIdentity(watcherId, APP_CRASHES_KEY)
     );
     expect(appCrashes).toBeDefined();
-    expect(String(appCrashes?.slug)).not.toBe(collidingSlug);
-    expect(String(appCrashes?.slug).startsWith(`${collidingSlug}-`)).toBe(true);
+    expect(String(appCrashes?.slug)).toBe(`${collidingSlug}-2`);
 
-    // The squatter is untouched; the promoted entity carries its origin window.
+    // The promoted entity carries its origin window.
+    const promoted = await sql`SELECT metadata FROM entities WHERE id = ${appCrashes?.entity_id}`;
+    expect(Number((promoted[0].metadata as Record<string, unknown>).window_id)).toBe(windowId);
+  });
+
+  it('uses the identifier fallback after every readable slug suffix collides', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, parentEntityId, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    // Occupy the base slug and all four readable suffixes. Promotion must reach
+    // the final identifier-derived fallback without poison-pilling the window.
+    const collidingSlug = slugify('Stability · App Crashes');
+    const [topicType] = (await sql`
+      SELECT id FROM entity_types
+      WHERE organization_id = ${workspace.org.id} AND slug = 'topic'
+      LIMIT 1
+    `) as Array<{ id: number }>;
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const occupiedSlug = attempt === 1 ? collidingSlug : `${collidingSlug}-${attempt}`;
+      await sql`
+        INSERT INTO entities (
+          organization_id, entity_type_id, name, slug, parent_id, created_by,
+          created_at, updated_at
+        ) VALUES (
+          ${workspace.org.id}, ${topicType.id}, ${`Squatter ${attempt}`}, ${occupiedSlug},
+          ${parentEntityId}, ${workspace.users.owner.id}, current_timestamp, current_timestamp
+        )
+      `;
+    }
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+    // MUST NOT throw — the window completes despite the slug collision.
+    const windowId = await completeWithToken(ctx, token, runId);
+
+    // Both keyed rows promoted: two watcher_key identities exist.
+    const identities = await sql`
+      SELECT ei.identifier, ei.entity_id, e.slug
+      FROM entity_identities ei
+      JOIN entities e ON e.id = ei.entity_id
+      WHERE ei.organization_id = ${workspace.org.id}
+        AND ei.namespace = 'watcher_key'
+      ORDER BY ei.identifier
+    `;
+    expect(identities).toHaveLength(2);
+
+    // The "App Crashes" promotion exhausted the readable suffixes and used its
+    // identity-derived fallback.
+    const appCrashes = identities.find(
+      (r) => String(r.identifier) === topicIdentity(watcherId, APP_CRASHES_KEY)
+    );
+    expect(appCrashes).toBeDefined();
+    expect(String(appCrashes?.slug)).toBe(
+      `${collidingSlug}-${slugify(topicIdentity(watcherId, APP_CRASHES_KEY))}`
+    );
+
+    // The promoted entity carries its origin window.
     const promoted = await sql`SELECT metadata FROM entities WHERE id = ${appCrashes?.entity_id}`;
     expect(Number((promoted[0].metadata as Record<string, unknown>).window_id)).toBe(windowId);
   });

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -47,7 +47,11 @@ import {
 import type { DbClient } from '../db/client';
 import type { EntityOutput } from '../types/watchers';
 import type { AppliedChange, BlockedChange } from './entity-field-merge';
-import { mergeEntityFields } from './entity-management';
+import {
+  hardDeleteEntityRows,
+  insertEntityRow,
+  mergeEntityFields,
+} from './entity-management';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
 import { resolveEntityCreator } from './resolve-entity-creator';
@@ -208,25 +212,26 @@ async function insertEntityWithUniqueSlug(params: {
 }): Promise<number> {
   const { tx } = params;
   const insertWithSlug = (slug: string) =>
-    tx.savepoint(
-      (sp) => sp<{ id: number | string }>`
-        INSERT INTO entities (
-          organization_id, entity_type_id, name, slug, parent_id, metadata,
-          created_by, created_at, updated_at
-        ) VALUES (
-          ${params.organizationId}, ${params.entityTypeId}, ${params.name}, ${slug},
-          ${params.parentEntityId}, ${tx.json(params.metadata)}, ${params.createdBy},
-          current_timestamp, current_timestamp
-        )
-        RETURNING id
-      `
+    tx.savepoint((sp) =>
+      insertEntityRow({
+        tx: sp,
+        row: {
+          organizationId: params.organizationId,
+          entityTypeId: params.entityTypeId,
+          name: params.name,
+          slug,
+          parentId: params.parentEntityId,
+          metadata: params.metadata,
+          createdBy: params.createdBy,
+        },
+      })
     );
 
   for (let attempt = 1; attempt <= SLUG_DISAMBIGUATION_ATTEMPTS; attempt++) {
     const slug = attempt === 1 ? params.baseSlug : `${params.baseSlug}-${attempt}`;
     try {
       const inserted = await insertWithSlug(slug);
-      return Number(inserted[0].id);
+      return Number(inserted.id);
     } catch (err) {
       if (isUniqueViolation(err, 'entities_slug_parent_unique')) continue;
       throw err;
@@ -236,7 +241,7 @@ async function insertEntityWithUniqueSlug(params: {
   // this slug is collision-free among promotions (and effectively so against any
   // sibling). A final failure here propagates to the per-row guard in the loop.
   const inserted = await insertWithSlug(`${params.baseSlug}-${slugify(params.identifier)}`);
-  return Number(inserted[0].id);
+  return Number(inserted.id);
 }
 
 /**
@@ -409,11 +414,10 @@ async function upsertKeyedEntity(params: {
     // Safe hard delete: this entity is brand-new in THIS transaction — nothing
     // references it yet (no identity, children, events, or relationships), and
     // entities' only blocking FK is `parent_id ON DELETE RESTRICT`, which can't
-    // fire on a freshly-created leaf.
-    await tx`
-      DELETE FROM entities
-      WHERE id = ${entityId} AND organization_id = ${organizationId}
-    `;
+    // fire on a freshly-created leaf. The kernel keys on id alone; this id was
+    // minted by our own insert above under `organizationId`, so it cannot
+    // address another tenant's row.
+    await hardDeleteEntityRows({ tx, ids: [entityId] });
     return {
       entityId: Number(winner[0].entity_id),
       created: false,

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -197,22 +197,6 @@ const ALLOWED_BYPASSES = [
     reason: "member soft delete",
   },
 
-  // Behavior keyed-entity promotion and provisional cleanup.
-  {
-    file: "packages/server/src/utils/promote-keyed-entities.ts",
-    operation: "insert",
-    dynamic: false,
-    fingerprint: "079c819d8e1848c1",
-    reason: "keyed entity promotion",
-  },
-  {
-    file: "packages/server/src/utils/promote-keyed-entities.ts",
-    operation: "delete",
-    dynamic: false,
-    fingerprint: "8e1babc83c35ebd9",
-    reason: "lost promotion-race cleanup",
-  },
-
   // Behavior classifier configuration projection.
   {
     file: "packages/server/src/watchers/classifier-extraction.ts",


### PR DESCRIPTION
## Summary
- Route Behavior keyed-entity creation and lost-race cleanup through the transaction-bound entity row kernel.
- Preserve the existing savepoint retries, identity claim, and atomic Behavior completion transaction.
- Remove two pinned write-funnel bypasses, reducing the production inventory from 27 to 25 with no DB, API, SDK, UI, or policy change.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: targeted Vitest integration/kernel suites, funnel guard tests, and server `tsc --noEmit`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Red inventory proof before deleting the retired allowances:

```text
✗ entity-write funnel gate found 2 stale allowance(s):
- promote-keyed-entities [keyed entity promotion]
- promote-keyed-entities [lost promotion-race cleanup]
```

Green evidence on the settled tree:

```text
✓ entity-write funnel gate: 991 runtime package source files scanned; 25 pinned bypasses, zero new bypasses
Test Files  3 passed (3)
Tests  20 passed (20)
```

The focused suite covers the ordinary `-2` slug retry, the final identity-derived slug fallback, a deterministic two-transaction identity race that proves the losing provisional entity is hard-deleted, fail-closed promotion gating, and caller-transaction rollback for the physical kernel. Funnel guard suite: 18 passed. Server TypeScript: clean.

Full remote preflight passed all 18 reported jobs on current `origin/main` base `b3313527a`: Depot run `9vtb2lcj4p`, verified tree `25d95cf894edfd0ca4220b99f1261faafbfe4315`.

## Notes
This is a Behavior-as-writer consolidation slice, not a hook framework. Business decisions remain in `promoteBehaviorEntityOutput`; the low-level kernel only executes the already-decided row write on the caller-supplied transaction. All callers in this path have a real transaction, and each slug attempt remains inside its transaction savepoint.

Mechanically, either former raw SQL site could bypass a rule placed only in the physical writer. Semantically, this caller already is the enforcing Behavior path, so this PR does not introduce or relocate business policy; it removes alternate physical SQL while preserving that Behavior-owned decision point.