### PR TITLE
refactor(server): funnel canvas entity writes

### DIFF
--- a/packages/server/src/utils/__tests__/canvas-events.test.ts
+++ b/packages/server/src/utils/__tests__/canvas-events.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { DbClient } from "../../db/client";
+import {
+	cleanupTestDatabase,
+	getTestDb,
+} from "../../__tests__/setup/test-db";
+import { createTestEntity } from "../../__tests__/setup/test-fixtures";
+import { TestWorkspace } from "../../__tests__/setup/test-mcp-client";
+import { ensureCanvasEntity, WATCHER_CANVAS_NAMESPACE } from "../canvas-events";
+
+/**
+ * Wait until the losing transaction has passed its empty identity fast-path
+ * and is blocked behind the winner's canvas-type upsert. Releasing the winner
+ * earlier can let the loser observe the committed identity and skip the
+ * provisional entity path this test exists to prove.
+ */
+async function waitForBlockedCanvasTypeUpsert(
+	sql: ReturnType<typeof getTestDb>,
+	timeoutMs = 10_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const rows = await sql<{ count: number }>`
+			SELECT count(*)::int AS count
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+				AND wait_event_type = 'Lock'
+				AND query ILIKE '%INSERT INTO entity_types%'
+		`;
+		if (Number(rows[0].count) > 0) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error("the losing canvas transaction never reached the type-upsert lock");
+}
+
+describe("canvas entity materialization", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("deletes a provisional canvas when a stale parent loses the identity race", async () => {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({ name: "Canvas race" });
+		const parentA = await createTestEntity({
+			name: "Current parent",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const parentB = await createTestEntity({
+			name: "Stale parent",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const watcherId = 7001;
+		const ensure = (tx: DbClient, parentEntityId: number) =>
+			ensureCanvasEntity({
+				tx,
+				watcherId,
+				organizationId: workspace.org.id,
+				parentEntityId,
+				createdBy: workspace.users.owner.id,
+			});
+
+		let signalWinnerReady!: () => void;
+		const winnerReady = new Promise<void>((resolve) => {
+			signalWinnerReady = resolve;
+		});
+		let releaseWinner!: () => void;
+		const winnerMayCommit = new Promise<void>((resolve) => {
+			releaseWinner = resolve;
+		});
+
+		const winnerRun = sql.begin(async (tx) => {
+			const entityId = await ensure(tx, parentA.id);
+			signalWinnerReady();
+			await winnerMayCommit;
+			return entityId;
+		});
+		await winnerReady;
+
+		const loserRun = sql.begin((tx) => ensure(tx, parentB.id));
+		try {
+			await waitForBlockedCanvasTypeUpsert(sql);
+		} finally {
+			releaseWinner();
+		}
+		const [winnerId, loserResult] = await Promise.all([winnerRun, loserRun]);
+
+		expect(winnerId).not.toBeNull();
+		expect(loserResult).toBe(winnerId);
+		const entities = await sql<{ id: number; parent_id: number | null }>`
+			SELECT id, parent_id
+			FROM entities
+			WHERE organization_id = ${workspace.org.id}
+				AND metadata->>'source' = 'watcher_canvas'
+				AND (metadata->>'watcher_id')::bigint = ${watcherId}
+		`;
+		expect(entities).toEqual([{ id: winnerId, parent_id: parentA.id }]);
+		const claims = await sql<{ entity_id: number }>`
+			SELECT entity_id
+			FROM entity_identities
+			WHERE organization_id = ${workspace.org.id}
+				AND namespace = ${WATCHER_CANVAS_NAMESPACE}
+				AND identifier = ${String(watcherId)}
+				AND deleted_at IS NULL
+		`;
+		expect(claims).toEqual([{ entity_id: winnerId }]);
+	});
+});

--- a/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
+++ b/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
@@ -11,6 +11,7 @@ import {
 	hardDeleteEntityRows,
 	insertEntityRow,
 	patchEntityRows,
+	tryInsertEntityRow,
 } from "../entity-management";
 
 async function seedEntityType(organizationId: string): Promise<number> {
@@ -128,6 +129,44 @@ describe("entity row write kernel", () => {
 			metadata: { current: true },
 			enabled_classifiers: "{}",
 		});
+	});
+
+	it("returns null without changing the existing row on an insert conflict", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel conflict",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+		const existing = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Existing",
+				slug: "same-slug",
+				createdBy: user.id,
+			},
+		});
+
+		const conflicted = await tryInsertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Conflicting",
+				slug: "same-slug",
+				createdBy: user.id,
+			},
+		});
+
+		expect(conflicted).toBeNull();
+		const rows = await sql<{ id: number; name: string }>`
+			SELECT id, name
+			FROM entities
+			WHERE organization_id = ${organization.id}
+		`;
+		expect(rows).toEqual([{ id: existing.id, name: "Existing" }]);
 	});
 
 	it("stamps a tombstone once and then skips the row", async () => {

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -26,6 +26,7 @@
 
 import type { DbClient } from '../db/client';
 import { CANVAS_ENTITY_TYPE_SLUG } from '../tools/constants';
+import { hardDeleteEntityRows, tryInsertEntityRow } from './entity-management';
 import { resolveEntityCreator } from './resolve-entity-creator';
 
 /** Namespace for the per-watcher canvas identity claim in `entity_identities`. */
@@ -105,20 +106,20 @@ export async function ensureCanvasEntity(params: {
   //    unique per (org, parent); a collision here is astronomically unlikely
   //    (one canvas per watcher) but tolerate it by suffixing the watcher id.
   const baseSlug = `watcher-canvas-${watcherId}`;
-  const inserted = await tx<{ id: number | string }>`
-    INSERT INTO entities (
-      organization_id, entity_type_id, name, slug, parent_id, metadata,
-      created_by, created_at, updated_at
-    ) VALUES (
-      ${organizationId}, ${entityTypeId}, ${`Canvas · watcher ${watcherId}`}, ${baseSlug},
-      ${parentEntityId}, ${tx.json({ watcher_id: watcherId, source: 'watcher_canvas' })},
-      ${createdBy}, current_timestamp, current_timestamp
-    )
-    ON CONFLICT DO NOTHING
-    RETURNING id
-  `;
+  const inserted = await tryInsertEntityRow({
+    tx,
+    row: {
+      organizationId,
+      entityTypeId,
+      name: `Canvas · watcher ${watcherId}`,
+      slug: baseSlug,
+      parentId: parentEntityId,
+      metadata: { watcher_id: watcherId, source: 'watcher_canvas' },
+      createdBy,
+    },
+  });
 
-  let entityId: number | null = inserted.length > 0 ? Number(inserted[0].id) : null;
+  let entityId: number | null = inserted?.id ?? null;
   if (entityId == null) {
     // Slug collision (pre-existing canvas entity for this watcher). Resolve it.
     const bySlug = await tx<{ id: number | string }>`
@@ -156,11 +157,11 @@ export async function ensureCanvasEntity(params: {
       AND deleted_at IS NULL
     LIMIT 1
   `;
-  if (winner.length > 0 && inserted.length > 0) {
+  if (winner.length > 0 && inserted) {
     // Safe: our entity is brand-new in THIS transaction (no identity, children,
     // events, or relationships) — its only blocking FK is parent_id RESTRICT,
     // which can't fire on a freshly-created leaf.
-    await tx`DELETE FROM entities WHERE id = ${entityId}`;
+    await hardDeleteEntityRows({ tx, ids: [entityId] });
   }
   return winner.length > 0 ? Number(winner[0].entity_id) : entityId;
 }

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -385,13 +385,16 @@ export interface InsertedEntityRow {
 	created_at: Date;
 }
 
-/** Insert one physical entity row using exactly the caller's DB handle. */
-export async function insertEntityRow(params: {
-	tx: DbClient;
-	row: EntityRowInsert;
-}): Promise<InsertedEntityRow> {
+async function insertEntityRowWithConflictMode(
+	params: {
+		tx: DbClient;
+		row: EntityRowInsert;
+	},
+	onConflictDoNothing: boolean,
+): Promise<InsertedEntityRow | null> {
 	const { tx, row } = params;
 	const embeddingLiteral = toVectorLiteral(row.embedding);
+	const conflictClause = onConflictDoNothing ? tx`ON CONFLICT DO NOTHING` : tx``;
 	const rows = await tx<InsertedEntityRow>`
     INSERT INTO entities (
       organization_id, entity_type_id, name, slug, parent_id, metadata,
@@ -404,10 +407,32 @@ export async function insertEntityRow(params: {
       ${row.createdBy}, ${row.content ?? null}, ${embeddingLiteral}::vector,
       ${row.contentHash ?? null}, current_timestamp, current_timestamp
     )
+    ${conflictClause}
     RETURNING id, name, slug, parent_id, metadata, created_at
   `;
-	if (rows.length === 0) throw new Error("Failed to create entity");
-	return rows[0];
+	return rows[0] ?? null;
+}
+
+/** Insert one physical entity row using exactly the caller's DB handle. */
+export async function insertEntityRow(params: {
+	tx: DbClient;
+	row: EntityRowInsert;
+}): Promise<InsertedEntityRow> {
+	const inserted = await insertEntityRowWithConflictMode(params, false);
+	if (!inserted) throw new Error("Failed to create entity");
+	return inserted;
+}
+
+/**
+ * Try one physical entity insert and return null on any uniqueness conflict.
+ * This deliberately mirrors PostgreSQL's untargeted `ON CONFLICT DO NOTHING`;
+ * callers own the domain-specific lookup that resolves the winning row.
+ */
+export function tryInsertEntityRow(params: {
+	tx: DbClient;
+	row: EntityRowInsert;
+}): Promise<InsertedEntityRow | null> {
+	return insertEntityRowWithConflictMode(params, true);
 }
 
 /**

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -83,22 +83,6 @@ const ALLOWED_BYPASSES = [
     reason: "suite-trials projection",
   },
 
-  // Canvas materialization and provisional cleanup.
-  {
-    file: "packages/server/src/utils/canvas-events.ts",
-    operation: "insert",
-    dynamic: false,
-    fingerprint: "de2364b8740703fe",
-    reason: "canvas entity materialization",
-  },
-  {
-    file: "packages/server/src/utils/canvas-events.ts",
-    operation: "delete",
-    dynamic: false,
-    fingerprint: "e2d8719a612a3712",
-    reason: "provisional canvas cleanup",
-  },
-
   // Connector identity attribution and provisional cleanup.
   {
     file: "packages/server/src/utils/entity-link-upsert.ts",


### PR DESCRIPTION
## Summary
- Route lazy canvas entity creation and provisional-race cleanup through the transaction-bound entity row kernel.
- Add an explicit conflict-tolerant kernel insert that preserves the existing untargeted `ON CONFLICT DO NOTHING` behavior.
- Remove two pinned write-funnel bypasses, reducing the production inventory from 25 to 23 with no DB, API, SDK, UI, approval, or policy change.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
- [x] Tests run: targeted and adjacent Vitest suites, funnel guard tests, server `tsc --noEmit`, and package build
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Red before the kernel capability existed:

```text
FAIL entity row write kernel > returns null without changing the existing row on an insert conflict
TypeError: tryInsertEntityRow is not a function
Test Files 1 failed | 1 passed
Tests 1 failed | 4 passed
```

Green evidence on the settled tree:

```text
✓ entity-write funnel gate: 991 runtime package source files scanned; 23 pinned bypasses, zero new bypasses
Test Files 5 passed (5)
Tests 80 passed (80)
```

The focused kernel and canvas suite passed 5/5. The real two-transaction canvas race was then run ten independent times and passed 10/10 without a timeout or flake. The funnel guard suite passed 18/18. Server TypeScript and `make build-packages` are clean.

The independent fixer additionally mutation-tested both new branches: disabling provisional cleanup leaves two canvas rows and fails the race test; disabling conflict tolerance raises `entities_slug_parent_unique` and fails the kernel test.

Full remote preflight passed all 18 reported jobs on base `00e6ee556`: Depot run `gwnxkrp5m9`, verified tree `8e796cc5b823123aeb7971bed0e5da46797dea9d`.

## Notes
This preserves Behavior-as-writer. Canvas identity resolution stays in `ensureCanvasEntity`; the low-level kernel only performs the already-decided physical row insert/delete on the caller-supplied transaction. Scheduled skip, normal Behavior completion, and feedback correction callers all provide a real transaction, so routing through the funnel is sufficient mechanically and remains atomic with the canvas event.

Both former raw SQL sites could mechanically skip a rule enforced only in the physical writer. Semantically, they create an internal canvas anchor as part of a Behavior/window write rather than exposing an alternate business-entity command, so this PR does not add `runMutationGate` or move business policy into the kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent canvas entity creation to prevent duplicate provisional entities and identity claims.
  * Ensured losing concurrent operations resolve to the already-created entity.
  * Prevented insert conflicts from modifying existing entity records.
  * Improved cleanup when concurrent entity creation loses a conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->