### PR TITLE
fix(server): serialize classifier entity enablement

### DIFF
--- a/packages/server/src/__tests__/integration/classifiers/classifier-entity-enablement.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-entity-enablement.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { parsePgTextArray } from '../../../db/client';
+import { enableClassifiersOnEntity } from '../../../watchers/classifier-extraction';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+/**
+ * Wait until both classifier writers have read or attempted to read the row and
+ * are blocked behind the test transaction's row lock. With the old unlocked
+ * SELECT, both wait in UPDATE after computing from the same stale value. With
+ * the fixed SELECT FOR UPDATE, both wait before reading and then serialize.
+ */
+async function waitForTwoBlockedClassifierWriters(
+  sql: ReturnType<typeof getTestDb>,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await sql<{ count: number }>`
+      SELECT count(*)::int AS count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%enabled_classifiers%'
+        AND query ILIKE '%entities%'
+    `;
+    if (rows[0].count >= 2) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error('two concurrent classifier writers never reached the entity row lock');
+}
+
+describe('classifier entity enablement', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('preserves both classifier additions when two Behavior creates race', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Classifier enablement race' });
+    const entity = await createTestEntity({
+      name: 'Classified entity',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+
+    let signalLocked!: () => void;
+    const rowLocked = new Promise<void>((resolve) => {
+      signalLocked = resolve;
+    });
+    let releaseLock!: () => void;
+    const lockMayRelease = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+
+    const blocker = sql.begin(async (tx) => {
+      await tx`SELECT id FROM entities WHERE id = ${entity.id} FOR UPDATE`;
+      signalLocked();
+      await lockMayRelease;
+    });
+    await rowLocked;
+
+    const first = sql.begin((tx) =>
+      enableClassifiersOnEntity(tx, entity.id, ['sentiment'])
+    );
+    const second = sql.begin((tx) =>
+      enableClassifiersOnEntity(tx, entity.id, ['priority'])
+    );
+    try {
+      await waitForTwoBlockedClassifierWriters(sql);
+    } finally {
+      releaseLock();
+      // Settle all three transactions even when the helper times out, so an
+      // abandoned mid-transaction promise cannot resurface as an unhandled
+      // rejection that masks the real failure.
+      await Promise.allSettled([blocker, first, second]);
+    }
+    await Promise.all([blocker, first, second]);
+
+    const rows = await sql<{ enabled_classifiers: unknown }>`
+      SELECT enabled_classifiers FROM entities WHERE id = ${entity.id}
+    `;
+    expect(new Set(parsePgTextArray(rows[0].enabled_classifiers))).toEqual(
+      new Set(['sentiment', 'priority'])
+    );
+  });
+});

--- a/packages/server/src/watchers/classifier-extraction.ts
+++ b/packages/server/src/watchers/classifier-extraction.ts
@@ -12,7 +12,6 @@ import {
 	type DbClient,
 	parsePgTextArray,
 	pgBigintArray,
-	pgTextArray,
 } from "../db/client";
 import type { Env } from "../index";
 import {
@@ -21,6 +20,7 @@ import {
 	isValidEmbedding,
 	validateEmbeddingsService,
 } from "../utils/embeddings";
+import { patchEntityRows } from "../utils/entity-management";
 import logger from "../utils/logger";
 
 function cosineSimilarity(a: number[], b: number[]): number {
@@ -723,15 +723,21 @@ async function updateClassifierValues(
  * Enable classifiers on entity
  */
 export async function enableClassifiersOnEntity(
-	sql: DbClient,
+	tx: DbClient,
 	entityId: number,
 	classifierSlugs: string[],
 ): Promise<void> {
 	if (classifierSlugs.length === 0) return;
 
-	// Get current enabled classifiers
-	const entity = await sql`
-    SELECT enabled_classifiers FROM entities WHERE id = ${entityId}
+	// Lock the live row for the read half, the same way the kernel's other
+	// read-modify-write callers already do: the patch below overwrites the whole
+	// array, so without this two concurrent Behavior creates both read the same
+	// stale base and one silently loses its additions.
+	const entity = await tx`
+    SELECT enabled_classifiers
+    FROM entities
+    WHERE id = ${entityId} AND deleted_at IS NULL
+    FOR UPDATE
   `;
 
 	if (entity.length === 0) {
@@ -749,13 +755,11 @@ export async function enableClassifiersOnEntity(
 
 	// Compute combined array and set directly
 	const combined = [...currentEnabled, ...toAdd];
-	const arrayLiteral = pgTextArray(combined);
-
-	await sql`
-    UPDATE entities
-    SET enabled_classifiers = ${arrayLiteral}::text[]
-    WHERE id = ${entityId}
-  `;
+	await patchEntityRows({
+		tx,
+		ids: [entityId],
+		patch: { enabledClassifiers: combined },
+	});
 
 	logger.info(
 		`[ClassifierExtraction] Enabled ${toAdd.length} classifier(s) on entity ${entityId}`,

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -181,15 +181,6 @@ const ALLOWED_BYPASSES = [
     reason: "member soft delete",
   },
 
-  // Behavior classifier configuration projection.
-  {
-    file: "packages/server/src/watchers/classifier-extraction.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "985025144395f419",
-    reason: "enabled-classifier projection",
-  },
-
   // Per-entity view-template pointer, hidden behind parentTable(resourceType).
   {
     file: "packages/server/src/tools/admin/manage_view_templates.ts",


### PR DESCRIPTION
## Summary
- Route the Behavior classifier projection through the shared entity write kernel and remove its pinned raw-write bypass.
- Lock the live entity row before the classifier read-modify-write, preventing concurrent Behavior creates from silently replacing one another.
- Reduce the production bypass inventory from 23 to 22.

This raw UPDATE could physically skip a future Behavior-enforced writer rule. The sole production caller passes the real transaction from sql.begin, so funnel routing plus the row lock is sufficient at this site. This remains the authoritative Behavior-creation writer; no mutation gate or interceptor is added.

## Test plan
- [x] Intended files staged explicitly, then make pre-pr-remote clean: Depot run 9p03k48mv3, all 18 jobs passed
- [x] Targeted server suite: 4 files, 17 tests passed
- [x] Funnel guard suite: 18 tests passed; 22 pinned bypasses, zero new bypasses
- [x] TypeScript typecheck passed
- [x] Bug fix: red to fix to green outputs pasted below
- [ ] If bot behavior: not applicable

Red proof with the old unlocked read/direct update:

    expected Set { sentiment } to deeply equal Set { sentiment, priority }
    Test Files 1 failed
    Tests 1 failed

Green proof after the fix:

    Test Files 4 passed
    Tests 17 passed

The deterministic concurrency test also passed 20 out of 20 stress repetitions after the fix. The semantic pre-review fixer mutation-tested both possible race losers and found no product bug or blocker.

## Notes
- No database, API, SDK, or UI contract change.
- The lock is required because patchEntityRows replaces the full enabled-classifiers array. Without serializing the read, funnel routing alone preserves the existing lost-update race.
- Deleted entities are no longer touched by this projection, matching the shared kernel live-row contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple classifiers are enabled for the same entity concurrently.
  * Prevented updates to deleted entities during classifier processing.
  * Ensured classifier updates are applied consistently through the standard entity update flow.

* **Tests**
  * Added integration coverage for concurrent classifier enablement and transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->