### PR TITLE
refactor(server): funnel entity merge transitions

### DIFF
--- a/packages/server/src/__tests__/integration/events/entity-merge.test.ts
+++ b/packages/server/src/__tests__/integration/events/entity-merge.test.ts
@@ -442,6 +442,34 @@ describe('entity merge', () => {
     expect(lRow.deleted_at).toBeNull();
   });
 
+  it('restores the loser without resurrecting a canonical entity deleted after merge', async () => {
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Deleted canonical undo org' });
+    const user = await createTestUser();
+    const winner = await createTestEntity({ name: 'W', entity_type: 'person', organization_id: org.id, created_by: user.id });
+    const loser = await createTestEntity({ name: 'L', entity_type: 'person', organization_id: org.id, created_by: user.id });
+
+    await applyMerge({ orgId: org.id, loserId: loser.id, winnerId: winner.id, mergedBy: user.id });
+    // Undo restores canonical attributes onto a winner that may since have been
+    // tombstoned — it must write through that tombstone without clearing it.
+    await sql`
+      UPDATE entities
+      SET deleted_at = current_timestamp, updated_at = current_timestamp
+      WHERE id = ${winner.id}
+    `;
+
+    await applyUnmerge({ orgId: org.id, loserId: loser.id, unmergedBy: user.id });
+
+    const [winnerAfter] = await sql<{ deleted_at: string | null }>`
+      SELECT deleted_at FROM entities WHERE id = ${winner.id}
+    `;
+    const [loserAfter] = await sql<{ merged_into: number | null; deleted_at: string | null }>`
+      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    `;
+    expect(winnerAfter.deleted_at).not.toBeNull();
+    expect(loserAfter).toEqual({ merged_into: null, deleted_at: null });
+  });
+
   it('merges complementary attributes and exactly restores metadata plus relationships on undo', async () => {
     const sql = getTestDb();
     const org = await createTestOrganization({ name: 'Exact Undo Org' });

--- a/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
+++ b/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
@@ -11,6 +11,7 @@ import {
 	hardDeleteEntityRows,
 	insertEntityRow,
 	patchEntityRows,
+	transitionEntityMergeRows,
 	tryInsertEntityRow,
 } from "../entity-management";
 
@@ -201,8 +202,9 @@ describe("entity row write kernel", () => {
 		)[0].deleted_at;
 		expect(deletedAt).not.toBeNull();
 
-		// A tombstoned row is invisible to the kernel: no further patch lands on
-		// it, so a later write can neither edit nor resurrect a deleted entity.
+		// A tombstoned row is invisible to `patchEntityRows`: no further patch
+		// lands on it, so an ordinary write can neither edit nor resurrect a
+		// deleted entity.
 		expect(
 			await patchEntityRows({
 				tx: sql,
@@ -216,5 +218,105 @@ describe("entity row write kernel", () => {
 		`;
 		expect(rows[0].name).toBe("Delete me");
 		expect(rows[0].deleted_at).toEqual(deletedAt);
+	});
+
+	it("fences merge transitions by organization and locked topology", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel merge transition",
+		});
+		const otherOrganization = await createTestOrganization({
+			name: "Entity kernel merge transition other org",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+		const winner = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Winner",
+				slug: "winner",
+				createdBy: user.id,
+			},
+		});
+		const loser = await insertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: organization.id,
+				entityTypeId,
+				name: "Loser",
+				slug: "loser",
+				createdBy: user.id,
+			},
+		});
+
+		await sql.begin(async (tx) => {
+			await tx`
+				SELECT id FROM entities
+				WHERE id IN (${winner.id}, ${loser.id})
+				ORDER BY id
+				FOR UPDATE
+			`;
+
+			expect(
+				await transitionEntityMergeRows({
+					tx,
+					organizationId: otherOrganization.id,
+					ids: [loser.id],
+					expectedMergedInto: null,
+					transition: { mergedInto: winner.id, liveness: "deleted" },
+				}),
+			).toEqual([]);
+
+			expect(
+				await transitionEntityMergeRows({
+					tx,
+					organizationId: organization.id,
+					ids: [loser.id],
+					expectedMergedInto: null,
+					transition: { mergedInto: winner.id, liveness: "deleted" },
+				}),
+			).toEqual([loser.id]);
+
+			expect(
+				await transitionEntityMergeRows({
+					tx,
+					organizationId: organization.id,
+					ids: [loser.id],
+					expectedMergedInto: null,
+					transition: { mergedInto: null, liveness: "live" },
+				}),
+			).toEqual([]);
+
+			expect(
+				await transitionEntityMergeRows({
+					tx,
+					organizationId: organization.id,
+					ids: [loser.id],
+					expectedMergedInto: winner.id,
+					transition: {
+						mergedInto: null,
+						metadata: { restored: true },
+						liveness: "live",
+					},
+				}),
+			).toEqual([loser.id]);
+		});
+
+		const rows = await sql<{
+			merged_into: number | null;
+			deleted_at: Date | null;
+			metadata: Record<string, unknown>;
+		}>`
+			SELECT merged_into, deleted_at, metadata
+			FROM entities
+			WHERE id = ${loser.id}
+		`;
+		expect(rows[0]).toEqual({
+			merged_into: null,
+			deleted_at: null,
+			metadata: { restored: true },
+		});
 	});
 });

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -372,8 +372,20 @@ export interface EntityRowPatch {
 	enabledClassifiers?: string[] | null;
 	content?: string | null;
 	embedding?: number[] | null;
-	/** true stamps deleted_at. The kernel never clears an existing tombstone. */
+	/** true stamps deleted_at. This path never clears an existing tombstone. */
 	softDelete?: boolean;
+}
+
+/**
+ * Fields owned by the merge ledger rather than ordinary entity editing.
+ * `liveness` is explicit because this path may revive a tombstoned loser;
+ * normal `patchEntityRows` deliberately cannot do that.
+ */
+export interface EntityMergeRowTransition {
+	mergedInto?: number | null;
+	metadata?: Record<string, unknown>;
+	fieldControls?: Record<string, unknown>;
+	liveness?: "deleted" | "live";
 }
 
 export interface InsertedEntityRow {
@@ -438,8 +450,9 @@ export function tryInsertEntityRow(params: {
 /**
  * Patch an explicit, bounded set of entity ids using the caller's DB handle.
  * Omitted fields remain unchanged; nullable fields distinguish null from
- * omission. Only live rows are patched — a tombstoned row is skipped, so the
- * kernel can never resurrect one. Every call touches updated_at, including a
+ * omission. Only live rows are patched — a tombstoned row is skipped, so this
+ * path can never resurrect one; reviving a merge loser belongs to
+ * `transitionEntityMergeRows` alone. Every call touches updated_at, including a
  * fully blocked update whose patch ends up empty.
  *
  * Returns the ids actually written, ascending.
@@ -476,6 +489,51 @@ export async function patchEntityRows(params: {
       updated_at = current_timestamp
     WHERE id = ANY(${idsLiteral}::bigint[])
       AND deleted_at IS NULL
+    RETURNING id
+  `;
+	return rows.map((row) => Number(row.id)).sort((a, b) => a - b);
+}
+
+/**
+ * Apply one merge-ledger transition to an explicit, bounded set of rows.
+ *
+ * This is the only physical kernel path that may change `merged_into`, patch a
+ * tombstoned canonical row, or clear `deleted_at`. It does not authorize or
+ * validate a merge: the caller must hold the relevant row locks in a real
+ * transaction and supply the topology value it already proved under lock.
+ * Merge and unmerge are one compound transaction — never run `runMutationGate`
+ * from here.
+ */
+export async function transitionEntityMergeRows(params: {
+	tx: DbClient;
+	organizationId: string;
+	ids: number[];
+	expectedMergedInto: number | null;
+	transition: EntityMergeRowTransition;
+}): Promise<number[]> {
+	if (params.ids.length === 0) return [];
+	const { tx, transition } = params;
+	const hasMergedInto = transition.mergedInto !== undefined;
+	const hasMetadata = transition.metadata !== undefined;
+	const hasFieldControls = transition.fieldControls !== undefined;
+	const markDeleted = transition.liveness === "deleted";
+	const markLive = transition.liveness === "live";
+	const idsLiteral = pgBigintArray(params.ids);
+
+	const rows = await tx<{ id: number }>`
+    UPDATE entities SET
+      merged_into = CASE WHEN ${hasMergedInto} THEN ${transition.mergedInto ?? null}::bigint ELSE merged_into END,
+      metadata = CASE WHEN ${hasMetadata} THEN ${tx.json(transition.metadata ?? {})} ELSE metadata END,
+      field_controls = CASE WHEN ${hasFieldControls} THEN ${tx.json(transition.fieldControls ?? {})} ELSE field_controls END,
+      deleted_at = CASE
+        WHEN ${markDeleted} THEN current_timestamp
+        WHEN ${markLive} THEN NULL
+        ELSE deleted_at
+      END,
+      updated_at = current_timestamp
+    WHERE organization_id = ${params.organizationId}
+      AND id = ANY(${idsLiteral}::bigint[])
+      AND merged_into IS NOT DISTINCT FROM ${params.expectedMergedInto}::bigint
     RETURNING id
   `;
 	return rows.map((row) => Number(row.id)).sort((a, b) => a - b);

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -32,6 +32,7 @@ import {
 	type ResolutionEvidence,
 } from "../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../entity-resolution/staleness";
+import { transitionEntityMergeRows } from "./entity-management";
 import logger from "./logger";
 
 export interface MergeResolutionProvenance {
@@ -275,13 +276,19 @@ async function applyMergeInTransaction(
 			fieldControls: loser.field_controls ?? {},
 		},
 	);
-  await tx`
-    UPDATE entities
-    SET metadata = ${tx.json(mergedState.metadata)},
-        field_controls = ${tx.json(mergedState.fieldControls)},
-        updated_at = current_timestamp
-    WHERE id = ${winnerId} AND organization_id = ${orgId}
-  `;
+	const updatedWinnerIds = await transitionEntityMergeRows({
+		tx,
+		organizationId: orgId,
+		ids: [winnerId],
+		expectedMergedInto: null,
+		transition: {
+			metadata: mergedState.metadata,
+			fieldControls: mergedState.fieldControls,
+		},
+	});
+	if (updatedWinnerIds.length !== 1) {
+		throw new Error("applyMerge: canonical entity changed after locking");
+	}
 
   // 3. Tombstone loser edges that would become self-loops or collide with an
   //    existing winner edge. This must happen before repointing: the live-edge
@@ -333,20 +340,39 @@ async function applyMergeInTransaction(
   //    one-time indexed lookup even when X is an outer column, which a recursive
   //    chain walk would NOT be on list/count/order call sites. The identities'
   //    COALESCE'd `merged_from` markers (step 1) preserve reversibility that
-  //    the flattened `merged_into` pointer alone would lose.
-	const redirected = await tx<{ id: number }>`
-    UPDATE entities
-    SET merged_into = ${winnerId}, updated_at = current_timestamp
+  //    the flattened `merged_into` pointer alone would lose. The funnel writes
+  //    an explicit id set, so the redirects are locked here first and the write
+  //    below re-asserts the topology this read proved.
+	const redirectsToFlatten = await tx<{ id: number }>`
+    SELECT id
+    FROM entities
     WHERE organization_id = ${orgId} AND merged_into = ${loserId}
-    RETURNING id
+    ORDER BY id
+    FOR UPDATE
   `;
+	const redirectIds = redirectsToFlatten.map((entity) => Number(entity.id));
+	const redirectedIds = await transitionEntityMergeRows({
+		tx,
+		organizationId: orgId,
+		ids: redirectIds,
+		expectedMergedInto: loserId,
+		transition: { mergedInto: winnerId },
+	});
+	if (redirectedIds.length !== redirectIds.length) {
+		throw new Error("applyMerge: redirect topology changed after locking");
+	}
 
   // 5. Tombstone the loser and point it at the winner.
-  await tx`
-    UPDATE entities
-    SET merged_into = ${winnerId}, deleted_at = current_timestamp, updated_at = current_timestamp
-    WHERE organization_id = ${orgId} AND id = ${loserId}
-  `;
+	const tombstonedIds = await transitionEntityMergeRows({
+		tx,
+		organizationId: orgId,
+		ids: [loserId],
+		expectedMergedInto: null,
+		transition: { mergedInto: winnerId, liveness: "deleted" },
+	});
+	if (tombstonedIds.length !== 1) {
+		throw new Error("applyMerge: duplicate entity changed after locking");
+	}
 
 	const relationshipIds = relationshipsBefore.map((row) => Number(row.id));
 	const relationshipsAfter =
@@ -383,7 +409,7 @@ async function applyMergeInTransaction(
 					? null
 					: Number(identity.merged_from_entity_id),
 		})),
-		redirectedEntityIds: redirected.map((entity) => Number(entity.id)),
+		redirectedEntityIds: redirectedIds,
 		relationships: relationshipsBefore.map((before) => {
 			const after = afterById.get(Number(before.id));
 			if (!after)
@@ -673,27 +699,34 @@ export async function applyUnmerge(
 			}
 			const redirectedEntityIds = ledger.redirectedEntityIds ?? [];
 			if (redirectedEntityIds.length > 0) {
-				const restoredRedirects = await tx<{ id: number }>`
-          UPDATE entities
-          SET merged_into = ${loserId}, updated_at = current_timestamp
-          WHERE organization_id = ${orgId}
-            AND id = ANY(${pgBigintArray(redirectedEntityIds)}::bigint[])
-            AND merged_into = ${winnerId}
-          RETURNING id
-        `;
+				const restoredRedirects = await transitionEntityMergeRows({
+					tx,
+					organizationId: orgId,
+					ids: redirectedEntityIds,
+					expectedMergedInto: winnerId,
+					transition: { mergedInto: loserId },
+				});
 				if (restoredRedirects.length !== redirectedEntityIds.length) {
 					throw new Error(
 						"applyUnmerge: a flattened redirect changed after this merge; exact undo is unsafe",
 					);
 				}
 			}
-			await tx`
-        UPDATE entities
-        SET metadata = ${tx.json(ledger.winner.metadataBefore)},
-            field_controls = ${tx.json(ledger.winner.fieldControlsBefore)},
-            updated_at = current_timestamp
-        WHERE organization_id = ${orgId} AND id = ${winnerId}
-      `;
+			const restoredWinnerIds = await transitionEntityMergeRows({
+				tx,
+				organizationId: orgId,
+				ids: [winnerId],
+				expectedMergedInto: null,
+				transition: {
+					metadata: ledger.winner.metadataBefore,
+					fieldControls: ledger.winner.fieldControlsBefore,
+				},
+			});
+			if (restoredWinnerIds.length !== 1) {
+				throw new Error(
+					"applyUnmerge: canonical topology changed after locking; exact undo is unsafe",
+				);
+			}
 		}
 
 		// 1. Restore every identity this operation moved, including identities an
@@ -730,11 +763,18 @@ export async function applyUnmerge(
 		// 2. Un-forward and un-tombstone the loser. Ledger-backed merges restored
 		//    redirects flattened through it above; legacy merges retain the old
 		//    single-row behavior because no redirect history exists for them.
-    await tx`
-      UPDATE entities
-      SET merged_into = NULL, deleted_at = NULL, updated_at = current_timestamp
-      WHERE organization_id = ${orgId} AND id = ${loserId}
-    `;
+		const revivedIds = await transitionEntityMergeRows({
+			tx,
+			organizationId: orgId,
+			ids: [loserId],
+			expectedMergedInto: winnerId,
+			transition: { mergedInto: null, liveness: "live" },
+		});
+		if (revivedIds.length !== 1) {
+			throw new Error(
+				"applyUnmerge: duplicate topology changed after locking; exact undo is unsafe",
+			);
+		}
 		if (operation) {
 			await tx`
         UPDATE entity_merge_operations

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -114,50 +114,6 @@ const ALLOWED_BYPASSES = [
     reason: "lost identity or mint race cleanup",
   },
 
-  // Merge and unmerge compound transaction. Never add runMutationGate here.
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "e77cba72098c5fbf",
-    reason: "merge winner state",
-  },
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "d6bda7fd7951c50a",
-    reason: "merge flattened redirects",
-  },
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "57edeaf7d0e925bb",
-    reason: "merge loser tombstone",
-  },
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "7629cfa8fba9cac8",
-    reason: "unmerge redirect restore",
-  },
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "454f4072c996a016",
-    reason: "unmerge winner restore",
-  },
-  {
-    file: "packages/server/src/utils/entity-merge.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "45cc1d85cddd8374",
-    reason: "unmerge loser revive",
-  },
-
   // Member lifecycle projections.
   {
     file: "packages/server/src/utils/member-entity.ts",


### PR DESCRIPTION
## Summary
- Route all six merge and unmerge entity-row writes through one narrow merge-ledger primitive in the shared entity kernel.
- Preserve compound transaction, lock ordering, reversible ledger, one-hop redirect flattening, tombstone, and exact undo semantics.
- Remove all six pinned merge/unmerge exemptions, reducing the production bypass inventory from 22 to 16.

Every removed raw UPDATE could physically skip a future Behavior-enforced writer rule. Routing is sufficient for this category because applyMerge and applyUnmerge already own real sql.begin transactions and lock the affected rows. The merge writer remains authoritative: the kernel primitive does not authorize or validate merges, and it explicitly must not invoke runMutationGate.

The structural primitive is intentionally separate from normal live-row patching. It is fenced by organization, an explicit bounded id set, and the exact merged_into value already proved under lock. It is the sole kernel path allowed to alter merge topology or revive a merge tombstone.

## Test plan
- [x] Intended files staged explicitly, then make pre-pr-remote clean: Depot run 3c71mj22jz, all 18 jobs passed
- [x] Focused merge, tool, and kernel suites: 3 files, 48 tests passed
- [x] Funnel guard suite: 18 tests passed; 16 pinned bypasses, zero new bypasses
- [x] Server TypeScript typecheck passed
- [x] Red to green funnel proof pasted below
- [ ] If bot behavior: not applicable

Red proof after removing the temporary exemptions and before routing:

    entity-write funnel gate found 6 unapproved bypasses
    entity-merge.ts:279, 338, 346, 677, 691, 734

Green proof after routing:

    entity-write funnel gate: 991 runtime package source files scanned; 16 pinned bypasses, zero new bypasses
    Test Files 3 passed
    Tests 48 passed

The semantic fixer mutation-tested the new organization/topology fences and the deleted-canonical undo regression; each mutation failed exactly its intended test.

## Notes
- No database, public API, SDK, or UI contract change.
- Normal patchEntityRows still cannot edit or resurrect tombstoned rows.
- Unmerge continues to restore a loser without resurrecting a canonical entity that was deleted after the merge.
- No runMutationGate is added inside the merge/unmerge compound transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity merge and unmerge reliability with guarded state transitions.
  * Unmerge now correctly restores the merged entity while preserving later deletions of the canonical entity.
  * Added safeguards to prevent changes when merge relationships have changed unexpectedly.
  * Improved restoration of entity metadata, field controls, redirects, and live/deleted status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->