### PR TITLE
feat(server): record edge change history for link, unlink and update_link

### DIFF
--- a/packages/server/src/__tests__/integration/relationships/edge-change-history.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/edge-change-history.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Edge change history.
+ *
+ * Link, unlink, and update_link used to mutate `entity_relationships` without
+ * appending the equivalent relationship audit rows. These tests pin that
+ * history while keeping it in the existing `semantic_type='change'` contract.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+type EdgeChangeRow = {
+  metadata: {
+    category: string;
+    op: string;
+    relationshipId: string;
+    fromEntityId: string;
+    toEntityId: string;
+    relationshipTypeSlug: string | null;
+    changes: Array<{ field: string; old: unknown; new: unknown }>;
+  };
+  created_by: string | null;
+  entity_ids: number[] | null;
+};
+
+async function readEdgeChanges(relationshipId: number): Promise<EdgeChangeRow[]> {
+  const sql = getTestDb();
+  return (await sql`
+    -- fetch_types:false hands arrays back as their Postgres literal, so
+    -- convert server-side rather than parsing the literal in the test.
+    SELECT metadata, created_by, to_jsonb(entity_ids) AS entity_ids
+    FROM events
+    WHERE semantic_type = 'change'
+      AND metadata ? '_lobu_relationship_change'
+      AND metadata->>'category' = 'relationship'
+      AND metadata->>'relationshipId' = ${String(relationshipId)}
+    ORDER BY id ASC
+  `) as unknown as EdgeChangeRow[];
+}
+
+/** The writer is fire-and-forget, so poll until the expected count lands. */
+async function waitForEdgeChanges(
+  relationshipId: number,
+  count: number
+): Promise<EdgeChangeRow[]> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const rows = await readEdgeChanges(relationshipId);
+    if (rows.length >= count) return rows;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Timed out waiting for ${count} relationship change rows for relationship ${relationshipId}`
+  );
+}
+
+function changeFor(row: EdgeChangeRow, field: string) {
+  return row.metadata.changes.find((c) => c.field === field);
+}
+
+describe('edge change history', () => {
+  let workspace: TestWorkspace;
+  let relationshipSlug: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    workspace = await TestWorkspace.create({ name: 'Edge History Org' });
+    await workspace.owner.entity_schema.createType({ slug: 'invoice', name: 'Invoice' });
+    await workspace.owner.entity_schema.createType({ slug: 'customer', name: 'Customer' });
+    relationshipSlug = 'invoice-customer';
+    await workspace.owner.entity_schema.createRelType({
+      slug: relationshipSlug,
+      name: 'Invoice Customer',
+    });
+  });
+
+  async function seedEdge(prefix: string) {
+    const invoice = (await workspace.owner.entities.create({
+      type: 'invoice',
+      name: `${prefix} Invoice`,
+    })) as { entity: { id: number } };
+    const customer = (await workspace.owner.entities.create({
+      type: 'customer',
+      name: `${prefix} Customer`,
+    })) as { entity: { id: number } };
+
+    const linked = (await workspace.owner.entities.link({
+      from_entity_id: invoice.entity.id,
+      to_entity_id: customer.entity.id,
+      relationship_type_slug: relationshipSlug,
+      source: 'feed',
+      confidence: 0.5,
+      metadata: { origin: 'erp' },
+    })) as { relationship: { id: number } };
+
+    return {
+      invoiceId: invoice.entity.id,
+      customerId: customer.entity.id,
+      relationshipId: linked.relationship.id,
+    };
+  }
+
+  it('records the link, on both endpoints, with the creating user', async () => {
+    const { invoiceId, customerId, relationshipId } = await seedEdge('Link');
+
+    const [row] = await waitForEdgeChanges(relationshipId, 1);
+    expect(row.metadata.op).toBe('link');
+    expect(row.metadata.relationshipTypeSlug).toBe(relationshipSlug);
+    expect(row.metadata.fromEntityId).toBe(String(invoiceId));
+    expect(row.metadata.toEntityId).toBe(String(customerId));
+    // Both endpoints, so the change shows up on either entity's timeline.
+    expect(row.entity_ids?.map(Number).sort((a, b) => a - b)).toEqual(
+      [invoiceId, customerId].sort((a, b) => a - b)
+    );
+    expect(row.created_by).toBe(workspace.users.owner.id);
+
+    expect(changeFor(row, 'exists')).toMatchObject({ old: false, new: true });
+    expect(changeFor(row, 'source')).toMatchObject({ old: null, new: 'feed' });
+    expect(changeFor(row, 'confidence')).toMatchObject({ old: null, new: 0.5 });
+    expect(changeFor(row, 'metadata')?.new).toEqual({ origin: 'erp' });
+  });
+
+  it('records only the fields an update actually moved', async () => {
+    const { relationshipId } = await seedEdge('Update');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: relationshipId,
+      confidence: 0.9,
+    });
+
+    const rows = await waitForEdgeChanges(relationshipId, 2);
+    const update = rows[1];
+    expect(update.metadata.op).toBe('update_link');
+    expect(changeFor(update, 'confidence')).toMatchObject({ old: 0.5, new: 0.9 });
+    // `update_link` COALESCEs the args it was not given, so source and metadata
+    // did not move and must not appear as changes.
+    expect(update.metadata.changes.map((c) => c.field)).toEqual(['confidence']);
+  });
+
+  it('records every successive update, not just the first', async () => {
+    const { relationshipId } = await seedEdge('Successive');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: relationshipId,
+      confidence: 0.6,
+    });
+    await waitForEdgeChanges(relationshipId, 2);
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: relationshipId,
+      confidence: 0.7,
+    });
+
+    // Audit rows are idempotency-keyed on originId. Without a per-occurrence
+    // discriminator every update on this edge would collapse onto the first
+    // one's key and silently vanish.
+    const rows = await waitForEdgeChanges(relationshipId, 3);
+    expect(rows.map((r) => r.metadata.op)).toEqual(['link', 'update_link', 'update_link']);
+    expect(changeFor(rows[1], 'confidence')).toMatchObject({ old: 0.5, new: 0.6 });
+    expect(changeFor(rows[2], 'confidence')).toMatchObject({ old: 0.6, new: 0.7 });
+  });
+
+  it('serializes concurrent updates so their pre-images form one chain', async () => {
+    const { relationshipId } = await seedEdge('Concurrent');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await Promise.all([
+      workspace.owner.entities.manage({
+        action: 'update_link',
+        relationship_id: relationshipId,
+        confidence: 0.6,
+      }),
+      workspace.owner.entities.manage({
+        action: 'update_link',
+        relationship_id: relationshipId,
+        confidence: 0.7,
+      }),
+    ]);
+
+    const rows = await waitForEdgeChanges(relationshipId, 3);
+    const transitions = rows
+      .filter((row) => row.metadata.op === 'update_link')
+      .map((row) => changeFor(row, 'confidence'));
+    const first = transitions.find((change) => change?.old === 0.5);
+    const second = transitions.find((change) => change?.old === first?.new);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(transitions.map((change) => change?.new).sort()).toEqual([0.6, 0.7]);
+  });
+
+  it('does not record an update that changed nothing', async () => {
+    const { relationshipId } = await seedEdge('Noop');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: relationshipId,
+      confidence: 0.5, // the value it already has
+    });
+
+    // Give the fire-and-forget writer a real chance to append before asserting
+    // it did not — otherwise this passes for the wrong reason.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const rows = await readEdgeChanges(relationshipId);
+    expect(rows.map((r) => r.metadata.op)).toEqual(['link']);
+  });
+
+  it('records the unlink carrying the pre-image of the removed edge', async () => {
+    const { relationshipId } = await seedEdge('Unlink');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: relationshipId,
+    });
+
+    const rows = await waitForEdgeChanges(relationshipId, 2);
+    const removal = rows[1];
+    expect(removal.metadata.op).toBe('unlink');
+    expect(changeFor(removal, 'exists')).toMatchObject({ old: true, new: false });
+    expect(changeFor(removal, 'source')?.old).toBe('feed');
+    expect(changeFor(removal, 'confidence')?.old).toBe(0.5);
+    expect(changeFor(removal, 'metadata')?.old).toEqual({ origin: 'erp' });
+  });
+
+  it('keeps the full history of one edge across its lifetime', async () => {
+    const { relationshipId } = await seedEdge('Lifetime');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: relationshipId,
+      source: 'llm',
+    });
+    await waitForEdgeChanges(relationshipId, 2);
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: relationshipId,
+    });
+
+    const rows = await waitForEdgeChanges(relationshipId, 3);
+    expect(rows.map((r) => r.metadata.op)).toEqual(['link', 'update_link', 'unlink']);
+    // The source transition is readable end to end: feed → llm → gone.
+    expect(changeFor(rows[1], 'source')).toMatchObject({ old: 'feed', new: 'llm' });
+    expect(changeFor(rows[2], 'source')?.old).toBe('llm');
+  });
+
+  it('distinguishes relationship changes from entity-field changes', async () => {
+    const { invoiceId, relationshipId } = await seedEdge('Separate');
+    await waitForEdgeChanges(relationshipId, 1);
+
+    await workspace.owner.entities.update({
+      entity_id: invoiceId,
+      metadata: { status: 'paid' },
+    });
+
+    const sql = getTestDb();
+    let rows: Array<{ category: string | null }> = [];
+    for (let attempt = 0; attempt < 20; attempt++) {
+      rows = (await sql`
+        SELECT metadata->>'category' AS category FROM events
+        WHERE semantic_type = 'change'
+          AND ${invoiceId} = ANY(entity_ids)
+        ORDER BY id ASC
+      `) as Array<{ category: string | null }>;
+      if (rows.length >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(rows.map((row) => row.category)).toEqual(
+      expect.arrayContaining(['relationship', null])
+    );
+  });
+});

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -44,7 +44,12 @@ import {
 	RESOLUTION_FINGERPRINT_VERSION,
 } from "../../entity-resolution/policy";
 import { wasResolutionRejected } from "../../entity-resolution/rejection";
-import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
+import {
+	type DbClient,
+	getDb,
+	pgBigintArray,
+	pgTextArray,
+} from "../../db/client";
 import type { Env } from "../../index";
 import {
 	batchLoadRelationships,
@@ -58,7 +63,11 @@ import {
 } from "../../utils/entity-management";
 import { applyMergeGroup, applyUnmerge } from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
-import { recordChangeEvent } from "../../utils/insert-event";
+import {
+	recordChangeEvent,
+	recordEdgeChangeEvent,
+	stableJson,
+} from "../../utils/insert-event";
 import { resolveMemberSchemaFieldsFromSchema } from "../../utils/member-entity-type";
 import {
 	canonicalizeSymmetricEdge,
@@ -1487,6 +1496,50 @@ const RELATIONSHIP_JOINS = `
 // Relationship (Link) Action Handlers
 // ============================================
 
+/**
+ * Pre-image of an edge, read before unlink/update_link so the change log can
+ * carry what the row held before the mutation. `RELATIONSHIP_SELECT` is the
+ * caller-facing projection; this is the audit one.
+ */
+interface EdgeAuditRow {
+	id: number | string;
+	organization_id: string;
+	from_entity_id: number | string;
+	to_entity_id: number | string;
+	relationship_type_id: number | string;
+	metadata: unknown;
+	confidence: number | null;
+	source: string | null;
+	relationship_type_slug: string | null;
+}
+
+async function lockEdgeForMutation(
+	tx: DbClient,
+	relationshipId: number,
+	organizationId: string,
+): Promise<EdgeAuditRow> {
+	const rows = await tx<EdgeAuditRow>`
+    SELECT r.id, r.organization_id, r.from_entity_id, r.to_entity_id,
+           r.relationship_type_id, r.metadata, r.confidence, r.source,
+           rt.slug AS relationship_type_slug
+    FROM entity_relationships r
+    LEFT JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.id = ${relationshipId} AND r.deleted_at IS NULL
+    LIMIT 1
+    FOR UPDATE OF r
+  `;
+	if (rows.length === 0) {
+		throw new ToolUserError(`Relationship ${relationshipId} not found`, 404);
+	}
+	if (String(rows[0].organization_id) !== organizationId) {
+		throw new ToolUserError(
+			"Access denied: relationship belongs to another organization",
+			403,
+		);
+	}
+	return rows[0];
+}
+
 async function handleLink(
 	args: ManageEntityArgs,
 	env: Env,
@@ -1595,6 +1648,24 @@ async function handleLink(
 		[relationshipId],
   );
 
+	recordEdgeChangeEvent({
+		organizationId: ctx.organizationId,
+		relationshipId,
+		fromEntityId: fromId,
+		toEntityId: toId,
+		relationshipTypeId: typeId,
+		relationshipTypeSlug: args.relationship_type_slug,
+		op: "link",
+		changes: [
+			{ field: "exists", old: false, new: true },
+			{ field: "metadata", old: null, new: args.metadata ?? null },
+			{ field: "confidence", old: null, new: confidence },
+			{ field: "source", old: null, new: source },
+		],
+		createdBy: ctx.userId,
+		clientId: ctx.clientId,
+	});
+
 	return { action: "link", relationship: created[0] };
 }
 
@@ -1607,26 +1678,37 @@ async function handleUnlink(
 
   const sql = getDb();
 
-  const existing = await sql`
-    SELECT id, organization_id FROM entity_relationships
-    WHERE id = ${args.relationship_id} AND deleted_at IS NULL
-    LIMIT 1
-  `;
-	if (existing.length === 0) {
-		throw new ToolUserError(`Relationship ${args.relationship_id} not found`, 404);
-	}
-	if (String(existing[0].organization_id) !== ctx.organizationId) {
-		throw new ToolUserError(
-			"Access denied: relationship belongs to another organization",
-			403,
+	const before = await sql.begin(async (tx) => {
+		const edge = await lockEdgeForMutation(
+			tx,
+			args.relationship_id!,
+			ctx.organizationId,
 		);
-	}
+		await tx`
+      UPDATE entity_relationships
+      SET deleted_at = current_timestamp, updated_at = current_timestamp, updated_by = ${ctx.userId}
+      WHERE id = ${args.relationship_id} AND deleted_at IS NULL
+    `;
+		return edge;
+	});
 
-	await sql`
-    UPDATE entity_relationships
-    SET deleted_at = current_timestamp, updated_at = current_timestamp, updated_by = ${ctx.userId}
-    WHERE id = ${args.relationship_id}
-  `;
+	recordEdgeChangeEvent({
+		organizationId: ctx.organizationId,
+		relationshipId: Number(before.id),
+		fromEntityId: Number(before.from_entity_id),
+		toEntityId: Number(before.to_entity_id),
+		relationshipTypeId: Number(before.relationship_type_id),
+		relationshipTypeSlug: before.relationship_type_slug,
+		op: "unlink",
+		changes: [
+			{ field: "exists", old: true, new: false },
+			{ field: "metadata", old: before.metadata, new: null },
+			{ field: "confidence", old: before.confidence, new: null },
+			{ field: "source", old: before.source, new: null },
+		],
+		createdBy: ctx.userId,
+		clientId: ctx.clientId,
+	});
 
 	return {
 		action: "unlink",
@@ -1644,46 +1726,66 @@ async function handleUpdateLink(
 
   const sql = getDb();
 
-  const existing = await sql`
-    SELECT id, organization_id FROM entity_relationships
-    WHERE id = ${args.relationship_id} AND deleted_at IS NULL
-    LIMIT 1
-  `;
-	if (existing.length === 0) {
-		throw new ToolUserError(`Relationship ${args.relationship_id} not found`, 404);
-	}
-	if (String(existing[0].organization_id) !== ctx.organizationId) {
-		throw new ToolUserError(
-			"Access denied: relationship belongs to another organization",
-			403,
+	const { before, after, updated } = await sql.begin(async (tx) => {
+		const edge = await lockEdgeForMutation(
+			tx,
+			args.relationship_id!,
+			ctx.organizationId,
 		);
+		validateConfidence(args.confidence);
+		validateSource(args.source);
+		const hasMetadata = args.metadata !== undefined;
+		const metadataJson = hasMetadata ? tx.json(args.metadata) : null;
+		const updatedRows = await tx<{
+			metadata: unknown;
+			confidence: number | null;
+			source: string | null;
+		}>`
+      UPDATE entity_relationships SET
+        metadata = CASE
+          WHEN ${hasMetadata} THEN ${metadataJson}
+          ELSE metadata
+        END,
+        confidence = COALESCE(${args.confidence ?? null}, confidence),
+        source = COALESCE(${args.source ?? null}, source),
+        updated_by = ${ctx.userId},
+        updated_at = current_timestamp
+      WHERE id = ${args.relationship_id} AND deleted_at IS NULL
+      RETURNING metadata, confidence, source
+    `;
+		const relationship = await tx.unsafe<RelationshipRow>(
+			`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
+			[args.relationship_id],
+		);
+		return {
+			before: edge,
+			after: updatedRows[0],
+			updated: relationship[0],
+		};
+	});
+
+	const changes = [
+		{ field: "metadata", old: before.metadata, new: after.metadata },
+		{ field: "confidence", old: before.confidence, new: after.confidence },
+		{ field: "source", old: before.source, new: after.source },
+	].filter((c) => stableJson(c.old ?? null) !== stableJson(c.new ?? null));
+
+	if (changes.length > 0) {
+		recordEdgeChangeEvent({
+			organizationId: ctx.organizationId,
+			relationshipId: Number(before.id),
+			fromEntityId: Number(before.from_entity_id),
+			toEntityId: Number(before.to_entity_id),
+			relationshipTypeId: Number(before.relationship_type_id),
+			relationshipTypeSlug: before.relationship_type_slug,
+			op: "update_link",
+			changes,
+			createdBy: ctx.userId,
+			clientId: ctx.clientId,
+		});
 	}
 
-	validateConfidence(args.confidence);
-	validateSource(args.source);
-
-	const hasMetadata = args.metadata !== undefined;
-	const metadataJson = hasMetadata ? sql.json(args.metadata) : null;
-
-	await sql`
-    UPDATE entity_relationships SET
-      metadata = CASE
-        WHEN ${hasMetadata} THEN ${metadataJson}
-        ELSE metadata
-      END,
-      confidence = COALESCE(${args.confidence ?? null}, confidence),
-      source = COALESCE(${args.source ?? null}, source),
-      updated_by = ${ctx.userId},
-      updated_at = current_timestamp
-    WHERE id = ${args.relationship_id}
-  `;
-
-  const updated = await sql.unsafe<RelationshipRow>(
-    `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
-		[args.relationship_id],
-  );
-
-	return { action: "update_link", relationship: updated[0] };
+	return { action: "update_link", relationship: updated };
 }
 
 async function handleListLinks(

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -786,6 +786,90 @@ export function recordChangeEvent(params: ChangeEventParams): void {
   });
 }
 
+interface EdgeFieldChange {
+  field: string;
+  old: unknown;
+  new: unknown;
+}
+
+interface EdgeChangeEventParams {
+  organizationId: string;
+  relationshipId: number;
+  fromEntityId: number;
+  toEntityId: number;
+  relationshipTypeId: number;
+  relationshipTypeSlug: string | null;
+  op: 'link' | 'unlink' | 'update_link';
+  changes: EdgeFieldChange[];
+  createdBy?: string | null;
+  clientId?: string | null;
+}
+
+/**
+ * Record a relationship (edge) change for audit.
+ *
+ * Fire-and-forget with the same retry-then-log-and-drop contract as
+ * `recordChangeEvent`, and for the same reason: `entity_relationships` remains
+ * the source of truth for what is currently linked, so a dropped row costs
+ * history, never state.
+ *
+ * Metadata shape (all ids stringified so `metadata->>'...'` comparisons work):
+ *   {
+ *     "op": "update_link",
+ *     "relationshipId": "42",
+ *     "fromEntityId": "10",
+ *     "toEntityId": "11",
+ *     "relationshipTypeId": "3",
+ *     "relationshipTypeSlug": "invoice_customer",
+ *     "changes": [{ "field": "confidence", "old": 0.5, "new": 0.9 }]
+ *   }
+ */
+export function recordEdgeChangeEvent(params: EdgeChangeEventParams): void {
+  // Keep this stable across the retry below, while allowing a relationship
+  // revived by unmerge to record the same operation again later.
+  const originId = `edge:${params.relationshipId}:${params.op}:${crypto.randomUUID()}`;
+  const verb =
+    params.op === 'link' ? 'linked' : params.op === 'unlink' ? 'unlinked' : 'updated';
+
+  retryWithBackoff(
+    () =>
+      insertConnectionlessAuditEvent({
+        organizationId: params.organizationId,
+        // Both endpoints, so the change surfaces on either entity's timeline.
+        entityIds: [params.fromEntityId, params.toEntityId],
+        originId,
+        semanticType: 'change',
+        title: `Relationship ${verb}: ${params.relationshipTypeSlug ?? params.relationshipTypeId}`,
+        metadata: {
+          _lobu_relationship_change: true,
+          category: 'relationship',
+          op: params.op,
+          relationshipId: String(params.relationshipId),
+          fromEntityId: String(params.fromEntityId),
+          toEntityId: String(params.toEntityId),
+          relationshipTypeId: String(params.relationshipTypeId),
+          relationshipTypeSlug: params.relationshipTypeSlug,
+          changes: params.changes,
+        },
+        createdBy: params.createdBy ?? null,
+        clientId: params.clientId ?? null,
+      }),
+    AUDIT_EVENT_RETRY
+  ).catch((err) => {
+    logger.error(
+      {
+        err,
+        originId,
+        organizationId: params.organizationId,
+        relationshipId: params.relationshipId,
+        op: params.op,
+        changes: params.changes,
+      },
+      '[insert-event] edge change audit event DROPPED after retry — edge history is missing this row'
+    );
+  });
+}
+
 // ============================================
 // Lifecycle Event (entity create / update / delete)
 // ============================================


### PR DESCRIPTION
## Summary
- Entity *field* changes have been auditable via `recordChangeEvent`, but `handleLink`, `handleUnlink` and `handleUpdateLink` mutated `entity_relationships` and recorded nothing — "when did this link appear, and who removed it" was unanswerable.
- Adds `recordEdgeChangeEvent`, filed under the existing `semantic_type='change'` contract and discriminated by `metadata.category='relationship'`, matching how deployment and lifecycle audits already narrow that bucket (`deployment-routes.ts`, `insert-event.ts`). No existing `change` reader is polluted — they all filter on `category`.
- `handleUnlink` / `handleUpdateLink` previously read their existence check and then wrote, unlocked. Both now take a row-locked pre-image (`FOR UPDATE OF r`) inside a transaction, so concurrent mutations cannot produce a false diff.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean — Depot run `z20sdh506v` passed, 18 jobs, preflight recorded for tree `eb0084f24bb30980b62277999f2ee22cf291cf6d`
- [x] Tests run: `bunx vitest run src/__tests__/integration/relationships/ src/__tests__/integration/entities/` → **60 passed**, including 8 new tests in `edge-change-history.test.ts`
- [x] Bug fix: red→green pasted below

### red → green

The new suite caught a real defect in the first implementation. `occurrence` was `String(after.updated_at)`; a JS `Date` stringifies to whole-second resolution, so two updates ~100ms apart collapsed onto one audit idempotency key and the second was silently dropped:

```
 × edge change history > records every successive update, not just the first
   → Timed out waiting for 3 edge_change rows for relationship 1
 Tests  1 failed | 6 passed (7)
```

Observed origin ids confirming the collapse (two distinct updates, second-resolution keys):

```
edge:1:update_link:Sun Aug 16 2026 03:30:23 GMT+0100
edge:1:update_link:Sun Aug 16 2026 03:30:24 GMT+0100
```

After the fix:

```
 ✓ src/__tests__/integration/relationships/edge-change-history.test.ts (8 tests) 1332ms
 Test Files  3 passed (3)
      Tests  15 passed (15)
```

### mutation testing

Six mutations against the final design, each killed by a distinct test:

| mutation | result |
|---|---|
| drop the no-op guard on the edge recorder | killed |
| unlink pre-image loses its `old` values | killed |
| log only the `from` endpoint | killed |
| `originId` loses per-occurrence uniqueness | killed |
| drop the `category` discriminator | killed |
| drop `FOR UPDATE OF r` | killed |

## Notes

**Scope — this covers 3 of 13 edge write sites.** Still unlogged: `entity-merge.ts` (3), `authz/channel-about.ts` (3), `authz/access-graph.ts` (2), `utils/auto-linker.ts` (1), `gateway/routes/public/github-team-graph.ts` (1). That is deliberate: the question there is volume, not mechanism — ACL and auto-linked edges churn far harder than human-authored ones and `events` is append-only, so blanket logging is a durable storage cost that deserves its own decision.

Worth calling out as a hazard for whoever builds a reader on this: a *partial* audit log fails differently from a missing one. Query edge history, see nothing, conclude nobody linked it — when `auto-linker` did and didn't log. Prefer logging at the chokepoint over 13 call sites.

Because edge changes ride under `semantic_type='change'`, a Behavior cannot subscribe to them distinctly today. Introducing a dedicated event type is a Behavior-triggering decision, tracked separately rather than smuggled into an audit change.

Closes #2805


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit history for relationship changes, including links, updates, and unlink operations.
  * Audit records capture affected entities, relationship details, changed values, and operation attribution.

* **Bug Fixes**
  * Improved relationship update and unlink consistency through transactional processing and validation.
  * Prevented unchanged relationship updates from generating unnecessary audit entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->