### PR TITLE
fix(server): declare the stored relationship source vocabulary and protect reconciled edges

### DIFF
--- a/packages/server/src/__tests__/integration/authz/channel-about.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-about.test.ts
@@ -9,12 +9,12 @@ import {
 	slackChannelsToResources,
 } from "@lobu/connectors/slack-identity";
 import {
-	ABOUT_EDGE_SOURCE_CONFIG,
 	ensureAboutRelationshipType,
 	listChannelEntitiesAboutBusinessEntity,
 	syncConnectionChannelAboutEdges,
 } from "../../../authz/channel-about";
 import { buildAccessGraph } from "../../../authz/access-graph";
+import { EDGE_SOURCE_CONFIG } from "../../../utils/relationship-validation";
 import { clearEntityLinkRulesCache } from "../../../utils/entity-link-upsert";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -94,7 +94,7 @@ describe("channel about edges", () => {
 		const before = await aboutEdges(org.id);
 		expect(before).toHaveLength(1);
 		expect(Number(before[0].to_entity_id)).toBe(company.id);
-		expect(before[0].source).toBe(ABOUT_EDGE_SOURCE_CONFIG);
+		expect(before[0].source).toBe(EDGE_SOURCE_CONFIG);
 
 		await buildAccessGraph({
 			organizationId: org.id,

--- a/packages/server/src/__tests__/integration/relationships/edge-source-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/edge-source-vocabulary.test.ts
@@ -1,0 +1,157 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+import {
+  EDGE_SOURCE_CONFIG,
+  EDGE_SOURCE_MANUAL,
+} from '../../../utils/relationship-validation';
+
+describe('relationship source vocabulary', () => {
+  let workspace: TestWorkspace;
+  let relationshipSlug: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    workspace = await TestWorkspace.create({ name: 'Source Vocab Org' });
+    await workspace.owner.entity_schema.createType({ slug: 'doc', name: 'Doc' });
+    relationshipSlug = 'doc-doc';
+    await workspace.owner.entity_schema.createRelType({
+      slug: relationshipSlug,
+      name: 'Doc Doc',
+    });
+  });
+
+  async function seedEdge(
+    prefix: string,
+    source?: typeof EDGE_SOURCE_CONFIG | typeof EDGE_SOURCE_MANUAL
+  ) {
+    const a = (await workspace.owner.entities.create({
+      type: 'doc',
+      name: `${prefix} A`,
+    })) as { entity: { id: number } };
+    const b = (await workspace.owner.entities.create({
+      type: 'doc',
+      name: `${prefix} B`,
+    })) as { entity: { id: number } };
+    const linked = (await workspace.owner.entities.link({
+      from_entity_id: a.entity.id,
+      to_entity_id: b.entity.id,
+      relationship_type_slug: relationshipSlug,
+      source: 'api',
+    })) as { relationship: { id: number } };
+
+    // Reconciled sources are internal and cannot be set through manage_entity.
+    if (source !== undefined) {
+      const sql = getTestDb();
+      await sql`
+        UPDATE entity_relationships
+        SET source = ${source},
+            metadata = ${sql.json({
+              connection_id: 'test-connection',
+              channel_key: prefix,
+            })}
+        WHERE id = ${linked.relationship.id}
+      `;
+    }
+    return linked.relationship.id;
+  }
+
+  async function sourceOf(relationshipId: number): Promise<string | null> {
+    const sql = getTestDb();
+    const [row] = await sql<{ source: string | null }>`
+      SELECT source FROM entity_relationships WHERE id = ${relationshipId}
+    `;
+    return row.source;
+  }
+
+  it.each([
+    [EDGE_SOURCE_CONFIG, 'api'],
+    [EDGE_SOURCE_MANUAL, 'ui'],
+  ] as const)(
+    'refuses to move a %s-owned edge out of its reconcile scope',
+    async (current, next) => {
+      const id = await seedEdge(current, current);
+      // A caller mistake, not an operational failure: it must carry a 4xx so
+      // the tool layer reports it instead of logging it as a fault.
+      await expect(
+        workspace.owner.entities.manage({
+          action: 'update_link',
+          relationship_id: id,
+          source: next,
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringMatching(/cannot change source/i),
+        httpStatus: 400,
+      });
+      expect(await sourceOf(id)).toBe(current);
+    }
+  );
+
+  it.each([EDGE_SOURCE_CONFIG, EDGE_SOURCE_MANUAL] as const)(
+    'refuses to mint a new edge directly into the %s reconcile scope',
+    async (source) => {
+      const a = (await workspace.owner.entities.create({
+        type: 'doc',
+        name: `Mint ${source} A`,
+      })) as { entity: { id: number } };
+      const b = (await workspace.owner.entities.create({
+        type: 'doc',
+        name: `Mint ${source} B`,
+      })) as { entity: { id: number } };
+
+      // Stamping a reconciled source at create time would enrol the edge in a
+      // sweep that deletes everything it did not put there. Two layers refuse
+      // it — the request schema's enum and `validateSource` behind it — and the
+      // schema is the one that fires first, so match either.
+      await expect(
+        workspace.owner.entities.link({
+          from_entity_id: a.entity.id,
+          to_entity_id: b.entity.id,
+          relationship_type_slug: relationshipSlug,
+          source,
+        })
+      ).rejects.toThrow(/invalid source|expected one of/i);
+    }
+  );
+
+  it('still allows an ordinary source change between authored values', async () => {
+    const id = await seedEdge('Plain');
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: id,
+      source: 'llm',
+    });
+    expect(await sourceOf(id)).toBe('llm');
+  });
+
+  it('refuses to replace metadata that scopes a reconciled edge', async () => {
+    const id = await seedEdge('Metadata', EDGE_SOURCE_CONFIG);
+    await expect(
+      workspace.owner.entities.manage({
+        action: 'update_link',
+        relationship_id: id,
+        metadata: { connection_id: 'other-connection' },
+      })
+    ).rejects.toThrow(/cannot change source or metadata/i);
+
+    const sql = getTestDb();
+    const [row] = await sql<{ metadata: { connection_id: string } }>`
+      SELECT metadata FROM entity_relationships WHERE id = ${id}
+    `;
+    expect(row.metadata.connection_id).toBe('test-connection');
+  });
+
+  it('allows confidence updates with unchanged reconciler metadata', async () => {
+    const id = await seedEdge('Confidence', EDGE_SOURCE_CONFIG);
+    const result = (await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: id,
+      confidence: 0.75,
+      metadata: { channel_key: 'Confidence', connection_id: 'test-connection' },
+    })) as { relationship: { confidence: number; source: string } };
+    expect(result.relationship).toMatchObject({
+      confidence: 0.75,
+      source: EDGE_SOURCE_CONFIG,
+    });
+  });
+});

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -17,13 +17,15 @@ import {
 } from "../db/client.js";
 import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
 import { ensureResourceEntityType } from "./access-graph.js";
+import {
+	EDGE_SOURCE_CONFIG,
+	EDGE_SOURCE_MANUAL,
+} from "../utils/relationship-validation";
 import { aclSourceFor, channelReadIdentityFor } from "./sources.js";
 
 const logger = createLogger("channel-about");
 
 export const ABOUT_RELATIONSHIP_SLUG = "about";
-export const ABOUT_EDGE_SOURCE_CONFIG = "config";
-export const ABOUT_EDGE_SOURCE_MANUAL = "manual";
 
 export interface ChannelAboutTarget {
 	/** Bare or platform-prefixed channel id as stored on the binding. */
@@ -287,7 +289,8 @@ async function upsertAboutEdge(opts: {
 
 /**
  * Upsert config-sourced `about` edges for one connection and reconcile away
- * stale config edges (manual edges are never touched).
+ * stale config edges. A desired pair takes ownership of any existing live edge
+ * for the same relationship triple.
  */
 export async function syncConnectionChannelAboutEdges(opts: {
 	organizationId: string;
@@ -341,7 +344,7 @@ export async function syncConnectionChannelAboutEdges(opts: {
 				organizationId: opts.organizationId,
 				fromChannelEntityId: channelEntityId,
 				toBusinessEntityId: businessEntityId,
-				source: ABOUT_EDGE_SOURCE_CONFIG,
+				source: EDGE_SOURCE_CONFIG,
 				metadata,
 				userId: opts.userId,
 				typeId,
@@ -360,7 +363,7 @@ export async function syncConnectionChannelAboutEdges(opts: {
     FROM entity_relationships r
     WHERE r.organization_id = ${opts.organizationId}
       AND r.relationship_type_id = ${typeId}
-      AND r.source = ${ABOUT_EDGE_SOURCE_CONFIG}
+      AND r.source = ${EDGE_SOURCE_CONFIG}
       AND r.deleted_at IS NULL
       AND r.metadata->>'connection_id' = ${connectionId}
   `;
@@ -380,7 +383,7 @@ export async function syncConnectionChannelAboutEdges(opts: {
 	return { linked, removed };
 }
 
-/** Replace manual `about` edges for one channel (UI picker). */
+/** Replace manual `about` edges for one channel, taking ownership of desired pairs. */
 export async function setManualChannelAboutEdges(opts: {
 	organizationId: string;
 	connectionId: string | number;
@@ -424,7 +427,7 @@ export async function setManualChannelAboutEdges(opts: {
     WHERE r.organization_id = ${opts.organizationId}
       AND r.from_entity_id = ${channelEntityId}
       AND r.relationship_type_id = ${typeId}
-      AND r.source = ${ABOUT_EDGE_SOURCE_MANUAL}
+      AND r.source = ${EDGE_SOURCE_MANUAL}
       AND r.deleted_at IS NULL
       AND r.metadata->>'connection_id' = ${connectionId}
   `;
@@ -447,7 +450,7 @@ export async function setManualChannelAboutEdges(opts: {
 			organizationId: opts.organizationId,
 			fromChannelEntityId: channelEntityId,
 			toBusinessEntityId: businessEntityId,
-			source: ABOUT_EDGE_SOURCE_MANUAL,
+			source: EDGE_SOURCE_MANUAL,
 			metadata,
 			userId: opts.userId,
 			typeId,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -74,6 +74,7 @@ import {
 	checkDuplicateEdge,
 	validateConfidence,
 	validateNoSelfReference,
+	validateReconciledEdgeUpdate,
 	validateScopeRule,
 	validateSource,
 	validateTypeRule,
@@ -1735,6 +1736,11 @@ async function handleUpdateLink(
 		validateConfidence(args.confidence);
 		validateSource(args.source);
 		const hasMetadata = args.metadata !== undefined;
+		const metadataChanged =
+			hasMetadata && stableJson(edge.metadata ?? null) !== stableJson(args.metadata ?? null);
+		// Check the locked pre-image so concurrent updates cannot move a reconciled
+		// edge out of the scope that retires it.
+		validateReconciledEdgeUpdate(edge.source, args.source, metadataChanged);
 		const metadataJson = hasMetadata ? tx.json(args.metadata) : null;
 		const updatedRows = await tx<{
 			metadata: unknown;

--- a/packages/server/src/utils/relationship-validation.ts
+++ b/packages/server/src/utils/relationship-validation.ts
@@ -7,19 +7,27 @@
  */
 
 import { type DbClient, getDb } from '../db/client';
+import { ToolUserError } from './errors';
 import type { Env } from '../index';
 import type { ToolContext } from '../tools/registry';
 
-// Valid relationship sources
-const RELATIONSHIP_SOURCES = ['ui', 'llm', 'feed', 'api'] as const;
-type RelationshipSource = (typeof RELATIONSHIP_SOURCES)[number];
+/** Sources accepted from the manage_entity link/update_link surface. */
+const CALLER_SETTABLE_SOURCES = ['ui', 'llm', 'feed', 'api'] as const;
+
+export const EDGE_SOURCE_CONFIG = 'config';
+export const EDGE_SOURCE_MANUAL = 'manual';
+
+/** Source values used to select edges during reconciliation. */
+const RECONCILED_SOURCES = [EDGE_SOURCE_CONFIG, EDGE_SOURCE_MANUAL] as const;
+
+type CallerSettableSource = (typeof CALLER_SETTABLE_SOURCES)[number];
 
 /**
  * Validate that a relationship does not reference itself.
  */
 export function validateNoSelfReference(fromId: number, toId: number): void {
   if (fromId === toId) {
-    throw new Error('Self-referencing relationships are not allowed');
+    throw new ToolUserError('Self-referencing relationships are not allowed', 400);
   }
 }
 
@@ -29,20 +37,42 @@ export function validateNoSelfReference(fromId: number, toId: number): void {
 export function validateConfidence(confidence: number | undefined | null): void {
   if (confidence === undefined || confidence === null) return;
   if (typeof confidence !== 'number' || confidence < 0 || confidence > 1) {
-    throw new Error('Confidence must be a number between 0 and 1');
+    throw new ToolUserError('Confidence must be a number between 0 and 1', 400);
   }
 }
 
 /**
- * Validate source is a known enum value.
+ * Validate a caller-supplied source.
+ *
+ * Reconciled sources are internal: callers may neither create edges in a
+ * reconciler's scope nor move existing edges into it.
  */
 export function validateSource(source: string | undefined | null): void {
   if (source === undefined || source === null) return;
-  if (!RELATIONSHIP_SOURCES.includes(source as RelationshipSource)) {
-    throw new Error(
-      `Invalid source "${source}". Must be one of: ${RELATIONSHIP_SOURCES.join(', ')}`
+  if (!CALLER_SETTABLE_SOURCES.includes(source as CallerSettableSource)) {
+    throw new ToolUserError(
+      `Invalid source "${source}". Must be one of: ${CALLER_SETTABLE_SOURCES.join(', ')}`,
+      400
     );
   }
+}
+
+/**
+ * Refuse to change the source or metadata that identify a reconciled edge.
+ */
+export function validateReconciledEdgeUpdate(
+  current: string | null | undefined,
+  next: string | undefined | null,
+  metadataChanged: boolean
+): void {
+  if (!RECONCILED_SOURCES.includes(current as (typeof RECONCILED_SOURCES)[number])) {
+    return;
+  }
+  if ((next === undefined || next === null) && !metadataChanged) return;
+  throw new ToolUserError(
+    `Cannot change source or metadata of a "${current}"-owned relationship. It is reconciled by the subsystem that created it; edit that configuration instead.`,
+    400
+  );
 }
 
 /**
@@ -87,7 +117,7 @@ export async function validateScopeRule(
   if (rows.length < 2) {
     const foundIds = rows.map((r) => r.id);
     const missingId = [fromEntityId, toEntityId].find((id) => !foundIds.includes(id));
-    throw new Error(`Entity ${missingId} not found`);
+    throw new ToolUserError(`Entity ${missingId} not found`, 404);
   }
 
   const fromEntity = rows.find((r) => Number(r.id) === fromEntityId)!;
@@ -96,7 +126,7 @@ export async function validateScopeRule(
   // Source must always be in the caller's org — you can't author relationships
   // *from* someone else's entity.
   if (String(fromEntity.organization_id) !== ctx.organizationId) {
-    throw new Error(`Entity ${fromEntityId} does not belong to your organization`);
+    throw new ToolUserError(`Entity ${fromEntityId} does not belong to your organization`, 403);
   }
 
   // Target may be same-org OR a public-catalog entity. Anything else (a
@@ -104,8 +134,9 @@ export async function validateScopeRule(
   const toOrgId = String(toEntity.organization_id);
   const toVisibility = String(toEntity.visibility ?? 'private');
   if (toOrgId !== ctx.organizationId && toVisibility !== 'public') {
-    throw new Error(
-      `Entity ${toEntityId} is in a private organization that does not belong to you. Cross-org references are only allowed to entities in public catalogs.`
+    throw new ToolUserError(
+      `Entity ${toEntityId} is in a private organization that does not belong to you. Cross-org references are only allowed to entities in public catalogs.`,
+      403
     );
   }
 }
@@ -128,7 +159,7 @@ export async function validateTypeRule(
       AND deleted_at IS NULL
   `;
   if (typeRows.length === 0) {
-    throw new Error(`Relationship type ${relationshipTypeId} not found`);
+    throw new ToolUserError(`Relationship type ${relationshipTypeId} not found`, 404);
   }
   const isSymmetric = Boolean(typeRows[0].is_symmetric);
 
@@ -164,8 +195,9 @@ export async function validateTypeRule(
   });
 
   if (!matches) {
-    throw new Error(
-      `Relationship type ${relationshipTypeId} does not allow ${fromEntityType} → ${toEntityType}`
+    throw new ToolUserError(
+      `Relationship type ${relationshipTypeId} does not allow ${fromEntityType} → ${toEntityType}`,
+      400
     );
   }
 }
@@ -188,8 +220,9 @@ export async function checkDuplicateEdge(
     LIMIT 1
   `;
   if (existing.length > 0) {
-    throw new Error(
-      `An active relationship of this type already exists between entities ${fromId} and ${toId}`
+    throw new ToolUserError(
+      `An active relationship of this type already exists between entities ${fromId} and ${toId}`,
+      409
     );
   }
 }


### PR DESCRIPTION
## Summary
- `entity_relationships.source` declared four caller-settable values while `channel-about` wrote two more (`config`, `manual`) straight to the column. Those two are not labels: the reconcile sweep selects on `source = 'config'` **together with** `metadata->>'connection_id'` (`channel-about.ts:363`), so the pair is the ownership scope a sweep runs against.
- `update_link` COALESCEd a caller's `source` over the old one and replaced `metadata` wholesale. Either move orphans a reconciled edge — it stops matching the sweep that would retire it, and no other sweep claims it, so it outlives the configuration that created it with nothing left to clean it up.
- Names both vocabularies in one place and refuses either mutation on a reconciled edge, checked against the **locked pre-image** so a concurrent write cannot slip an edge out of scope between read and update.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `49vs2nw9x0` passed, 18/18 jobs)
- [x] Tests run: targeted `bunx vitest run src/__tests__/integration/relationships/ src/__tests__/integration/authz/channel-about.test.ts` → **20/20 passed**
- [x] Bug fix: red→green below
- [ ] If bot runtime changed: n/a

### Red → green

Red, before the guard (new test `refuses to move a config-owned edge out of its reconcile scope`):

```
AssertionError: expected [Function] to reject
  → update_link succeeded; source moved 'config' → 'api'
```

Green, after:

```
 Test Files  4 passed (4)
      Tests  20 passed (20)
```

### Mutation coverage

Both guards were mutation-tested against the green baseline of 20:

| Mutation | Result |
|---|---|
| `validateReconciledEdgeUpdate` returns immediately (guard never fires) | **killed** — 3 failures |
| `metadataChanged` forced to `false` (metadata term dropped) | **killed** — 1 failure |

## Notes

Refs #2799. Deliberately narrower than that issue in two places, both verified rather than assumed:

- The issue asks to route `auto-linker`, `github-team-graph`, and `access-graph` through `validateSource`. All three write the literal `'feed'` (`auto-linker.ts:131`, `github-team-graph.ts:317`, `access-graph.ts:488`), which is already a valid caller-settable value — routing a hardcoded constant through a validator changes nothing, so this PR leaves them alone. The real defect was only that the six stored values were never declared together.
- The issue also asks for a `CHECK` constraint. That is a DB design change and is left out pending sign-off; it is the right follow-up once the vocabulary is settled here.

Two comments in `channel-about.ts` were corrected as part of this: they claimed manual edges are never touched by the config sweep, but the triple upsert does `ON CONFLICT ... DO UPDATE SET source = EXCLUDED.source`, so a config sync takes ownership of an existing manual edge on the same triple. That last-writer-wins behaviour on a shared triple is left as-is — changing it needs a product/DB decision, not a comment fix.

Caller-settable sources are additionally guarded by the request schema's own enum, which rejects `config`/`manual` before `validateSource` runs; the new test asserts either layer may fire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for reconciled relationships, preventing unauthorized changes to their source or metadata.
  * Added structured validation errors for invalid relationship operations, including scope, type, duplicates, and self-references.
  * Configuration- and manually managed relationships now consistently retain ownership when synchronized.

* **Bug Fixes**
  * Improved relationship source validation and update behavior.
  * Updated channel relationship handling to use standardized source classifications.

* **Tests**
  * Added integration coverage for relationship source rules, reconciliation protections, and permitted updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->