### PR TITLE
refactor(server): funnel eval entity projections

### DIFF
--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -90,6 +90,93 @@ beforeAll(async () => {
 });
 
 describe("promoteEvalCase", () => {
+	// Promote writes an entity TYPE, an entity and an identity claim; a failure
+	// at the claim must leave none of them. A trigger that raises on the claim
+	// insert is the only way to fail exactly that step from outside.
+	//
+	// Runs FIRST on purpose: the entity-type assertion is only load-bearing
+	// while no earlier test has already created the `$eval_case` type, because
+	// promote's `ON CONFLICT DO UPDATE` would then insert nothing to roll back.
+	test("rolls the entity back when the identity claim fails", async () => {
+		const caseKey = "rollback-probe";
+		const identifier = `${sourceRunId}:${caseKey}`;
+		// One name for both objects — a trigger and a function do not share a
+		// namespace in Postgres. Pid-scoped so a concurrent suite on a shared
+		// DATABASE_URL cannot drop this one out from under it.
+		const probeName = `eval_case_rollback_${process.pid}`;
+		const beforeTypes = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM entity_types
+			WHERE organization_id = ${organizationId}
+				AND slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+				AND deleted_at IS NULL
+		`;
+
+		await sql.unsafe(
+			`DROP TRIGGER IF EXISTS ${probeName} ON entity_identities`,
+		);
+		await sql.unsafe(`DROP FUNCTION IF EXISTS public.${probeName}()`);
+		try {
+			await sql.unsafe(`
+				CREATE FUNCTION public.${probeName}()
+				RETURNS trigger
+				LANGUAGE plpgsql
+				AS $$
+				BEGIN
+					RAISE EXCEPTION 'eval identity rollback probe';
+				END;
+				$$
+			`);
+			await sql.unsafe(`
+				CREATE TRIGGER ${probeName}
+				BEFORE INSERT ON entity_identities
+				FOR EACH ROW
+				WHEN (
+					NEW.namespace = '${EVAL_CASE_NAMESPACE}'
+					AND NEW.identifier = '${identifier}'
+				)
+				EXECUTE FUNCTION public.${probeName}()
+			`);
+
+			await expect(
+				promoteEvalCase({ sourceRunId, caseKey }),
+			).rejects.toThrow("eval identity rollback probe");
+		} finally {
+			await sql.unsafe(
+				`DROP TRIGGER IF EXISTS ${probeName} ON entity_identities`,
+			);
+			await sql.unsafe(`DROP FUNCTION IF EXISTS public.${probeName}()`);
+		}
+
+		const entities = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM entities e
+			JOIN entity_types et ON et.id = e.entity_type_id
+			WHERE e.organization_id = ${organizationId}
+				AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+				AND e.metadata->>'case_key' = ${caseKey}
+		`;
+		expect(entities[0].count).toBe(0);
+
+		const claims = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM entity_identities
+			WHERE organization_id = ${organizationId}
+				AND namespace = ${EVAL_CASE_NAMESPACE}
+				AND identifier = ${identifier}
+		`;
+		expect(claims[0].count).toBe(0);
+
+		const afterTypes = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM entity_types
+			WHERE organization_id = ${organizationId}
+				AND slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+				AND deleted_at IS NULL
+		`;
+		expect(afterTypes[0].count).toBe(beforeTypes[0].count);
+	});
+
 	test("creates a $eval_case entity pointing at the source run", async () => {
 		const result = await promoteEvalCase({
 			sourceRunId,
@@ -174,6 +261,33 @@ describe("promoteEvalCase", () => {
         AND e.deleted_at IS NULL
     `) as unknown as Array<{ n: number }>;
 		expect(entities[0].n).toBe(1);
+	});
+
+	// Guards the transaction wrapper, not the identity index: two promotes now
+	// hold the `$eval_case` entity-type row and the slug index for a whole
+	// transaction each, so the pair could deadlock or commit two entities where
+	// the un-wrapped path committed one.
+	test("concurrent promotes resolve to one entity", async () => {
+		const [first, second] = await Promise.all([
+			promoteEvalCase({ sourceRunId, caseKey: "concurrent" }),
+			promoteEvalCase({ sourceRunId, caseKey: "concurrent" }),
+		]);
+
+		expect(first.ok && second.ok).toBe(true);
+		if (!first.ok || !second.ok) return;
+		expect(second.evalCase.entityId).toBe(first.evalCase.entityId);
+		expect([first.created, second.created].sort()).toEqual([false, true]);
+
+		const entities = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM entities e
+			JOIN entity_types et ON et.id = e.entity_type_id
+			WHERE e.organization_id = ${organizationId}
+				AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+				AND e.metadata->>'case_key' = 'concurrent'
+				AND e.deleted_at IS NULL
+		`;
+		expect(entities[0].count).toBe(1);
 	});
 
 	test("adopts its own entity when the identity claim is missing", async () => {

--- a/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
@@ -117,6 +117,18 @@ describe("runEvalSuite", () => {
 		});
 		expect(promoted.ok).toBe(true);
 		if (!promoted.ok) return;
+		const [before] = await sql<{ metadata: Record<string, unknown> }[]>`
+			SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+		`;
+		await sql`
+			UPDATE entities
+			SET metadata = ${sql.json({
+				...before.metadata,
+				judge_model: "test/judge",
+				recent_scores: [{ run_id: 1, score: 1 }],
+			})}
+			WHERE id = ${promoted.evalCase.entityId}
+		`;
 
 		const suite = await runEvalSuite({
 			organizationId,
@@ -130,6 +142,13 @@ describe("runEvalSuite", () => {
 		expect(suite.cases[0].runIds).toHaveLength(3);
 		expect(new Set(suite.cases[0].runIds).size).toBe(3);
 		expect(suite.skipped).toEqual([]);
+
+		const [after] = await sql<{ metadata: Record<string, unknown> }[]>`
+			SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+		`;
+		expect(after.metadata.suite_trials).toBe(3);
+		expect(after.metadata.judge_model).toBe("test/judge");
+		expect(after.metadata.recent_scores).toEqual([{ run_id: 1, score: 1 }]);
 	});
 
 	test("every trial resolves back to its case despite the suffixed key", async () => {

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -27,6 +27,12 @@
 
 import { type DbClient, getDb } from "../db/client.js";
 import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../tools/constants.js";
+import {
+	hardDeleteEntityRows,
+	patchEntityRows,
+	tryInsertEntityRow,
+	withEntityWriteTransaction,
+} from "../utils/entity-management.js";
 import logger from "../utils/logger.js";
 import { resolveEntityCreator } from "../utils/resolve-entity-creator.js";
 import {
@@ -166,6 +172,22 @@ export type PromoteEvalCaseResult =
 				| "slug_unavailable";
 	  };
 
+interface PromoteEvalCaseParams {
+	sourceRunId: number;
+	caseKey: string;
+	expectation?: string | null;
+	/** Who is promoting. Falls back to an org owner/admin when absent. */
+	createdBy?: string | null;
+	/**
+	 * Org the caller is authenticated for. Required by every request-path
+	 * caller: the org is resolved from the RUN, so without this a caller who
+	 * knows (or guesses) a run id creates an `$eval_case` entity — and an
+	 * `$eval_case` entity TYPE — inside another tenant's workspace. Checking
+	 * after the fact does not help; by then the row exists.
+	 */
+	organizationId?: string;
+}
+
 /**
  * Promote a real Automation run into a reusable eval case.
  *
@@ -178,24 +200,19 @@ export type PromoteEvalCaseResult =
  * existing case rather than minting a second entity for the same question.
  */
 export async function promoteEvalCase(
-	params: {
-		sourceRunId: number;
-		caseKey: string;
-		expectation?: string | null;
-		/** Who is promoting. Falls back to an org owner/admin when absent. */
-		createdBy?: string | null;
-		/**
-		 * Org the caller is authenticated for. Required by every request-path
-		 * caller: the org is resolved from the RUN, so without this a caller who
-		 * knows (or guesses) a run id creates an `$eval_case` entity — and an
-		 * `$eval_case` entity TYPE — inside another tenant's workspace. Checking
-		 * after the fact does not help; by then the row exists.
-		 */
-		organizationId?: string;
-	},
+	params: PromoteEvalCaseParams,
 	db?: DbClient,
 ): Promise<PromoteEvalCaseResult> {
 	const sql = db ?? getDb();
+	return withEntityWriteTransaction(sql, (tx) =>
+		promoteEvalCaseInTransaction(params, tx),
+	);
+}
+
+async function promoteEvalCaseInTransaction(
+	params: PromoteEvalCaseParams,
+	sql: DbClient,
+): Promise<PromoteEvalCaseResult> {
 	const caseKey = params.caseKey.trim() || "default";
 
 	const loaded = await loadReplayableSource(params.sourceRunId, sql);
@@ -290,6 +307,12 @@ export async function promoteEvalCase(
 			{ lostEntityId: entityId, wonEntityId: winner.entityId, identifier },
 			"[evals] lost the eval-case identity race — reusing the winner",
 		);
+		// Discard only a row THIS transaction inserted. `created: false` means
+		// `insertCaseEntity` adopted a pre-existing row for the same (run, key);
+		// deleting that would destroy a case this call never wrote.
+		if (placed.created) {
+			await hardDeleteEntityRows({ tx: sql, ids: [entityId] });
+		}
 		return { ok: true, evalCase: winner, created: false };
 	}
 
@@ -335,21 +358,26 @@ export async function setEvalCaseJudgeModel(
 	db?: DbClient,
 ): Promise<void> {
 	const sql = db ?? getDb();
-	await sql`
-    UPDATE entities e
-    SET metadata = jsonb_set(
-          coalesce(e.metadata, '{}'::jsonb),
-          '{judge_model}',
-          ${sql.json(judgeModel as never)}::jsonb
-        ),
-        updated_at = current_timestamp
-    FROM entity_types et
-    WHERE e.id = ${entityId}
-      AND e.organization_id = ${organizationId}
-      AND et.id = e.entity_type_id
-      AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
-      AND e.deleted_at IS NULL
-  `;
+	await withEntityWriteTransaction(sql, async (tx) => {
+		const rows = await tx<{ metadata: Record<string, unknown> | null }>`
+      SELECT e.metadata
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.id = ${entityId}
+        AND e.organization_id = ${organizationId}
+        AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+        AND e.deleted_at IS NULL
+      FOR UPDATE OF e
+    `;
+		if (rows.length === 0) return;
+		await patchEntityRows({
+			tx,
+			ids: [entityId],
+			patch: {
+				metadata: { ...(rows[0].metadata ?? {}), judge_model: judgeModel },
+			},
+		});
+	});
 }
 
 /**
@@ -434,20 +462,19 @@ async function insertCaseEntity(params: {
 	for (let attempt = 1; attempt <= SLUG_DISAMBIGUATION_ATTEMPTS; attempt++) {
 		const slug =
 			attempt === 1 ? params.baseSlug : `${params.baseSlug}-${attempt}`;
-		const inserted = (await sql`
-      INSERT INTO entities (
-        organization_id, entity_type_id, name, slug, metadata,
-        created_by, created_at, updated_at
-      ) VALUES (
-        ${params.organizationId}, ${params.entityTypeId}, ${params.name}, ${slug},
-        ${sql.json(params.metadata as never)}, ${params.createdBy},
-        current_timestamp, current_timestamp
-      )
-      ON CONFLICT DO NOTHING
-      RETURNING id
-    `) as unknown as Array<{ id: number | string }>;
-		if (inserted.length > 0) {
-			return { entityId: Number(inserted[0].id), created: true };
+		const inserted = await tryInsertEntityRow({
+			tx: sql,
+			row: {
+				organizationId: params.organizationId,
+				entityTypeId: params.entityTypeId,
+				name: params.name,
+				slug,
+				metadata: params.metadata,
+				createdBy: params.createdBy,
+			},
+		});
+		if (inserted) {
+			return { entityId: Number(inserted.id), created: true };
 		}
 
 		// Soft-deleted rows still hold the slug (the index is not partial), so look

--- a/packages/server/src/runs/eval-scores.ts
+++ b/packages/server/src/runs/eval-scores.ts
@@ -38,6 +38,7 @@ import {
 	gatewayCompletion,
 	resolveCompletionTarget,
 } from "../gateway/inference/gateway-completion.js";
+import { patchEntityRows } from "../utils/entity-management.js";
 import { insertEvent } from "../utils/insert-event.js";
 import logger from "../utils/logger.js";
 import { resolveEntityCreator } from "../utils/resolve-entity-creator.js";
@@ -584,8 +585,13 @@ async function pushCaseScore(
 	caseEntityId: number,
 	entry: CaseScoreEntry,
 ): Promise<void> {
+	// Live-only, matching `patchEntityRows`: a deleted case would otherwise be
+	// read, merged and then silently not written by the kernel's own filter.
 	const rows = (await tx`
-    SELECT metadata FROM entities WHERE id = ${caseEntityId} FOR UPDATE
+    SELECT metadata
+    FROM entities
+    WHERE id = ${caseEntityId} AND deleted_at IS NULL
+    FOR UPDATE
   `) as unknown as Array<{ metadata: Record<string, unknown> | null }>;
 	if (rows.length === 0) return;
 
@@ -604,12 +610,11 @@ async function pushCaseScore(
 		.sort((a, b) => Number(b.run_id) - Number(a.run_id))
 		.slice(0, CASE_SCORE_WINDOW);
 
-	await tx`
-    UPDATE entities
-    SET metadata = ${tx.json({ ...metadata, recent_scores: next } as never)},
-        updated_at = current_timestamp
-    WHERE id = ${caseEntityId}
-  `;
+	await patchEntityRows({
+		tx,
+		ids: [caseEntityId],
+		patch: { metadata: { ...metadata, recent_scores: next } },
+	});
 }
 
 /**

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -21,6 +21,10 @@
 
 import { type DbClient, getDb } from "../db/client.js";
 import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../tools/constants.js";
+import {
+	patchEntityRows,
+	withEntityWriteTransaction,
+} from "../utils/entity-management.js";
 import logger from "../utils/logger.js";
 import { trialCaseKey } from "./eval-cases.js";
 import { createEvalRun } from "./eval-runs.js";
@@ -120,6 +124,33 @@ async function listActiveCases(
 	return cases;
 }
 
+/** Stamp the queued trial group without clobbering a concurrent score update. */
+async function stampSuiteTrials(
+	db: DbClient,
+	organizationId: string,
+	caseEntityId: number,
+	trials: number,
+): Promise<void> {
+	await withEntityWriteTransaction(db, async (tx) => {
+		const rows = await tx<{ metadata: Record<string, unknown> | null }>`
+      SELECT metadata
+      FROM entities
+      WHERE id = ${caseEntityId}
+        AND organization_id = ${organizationId}
+        AND deleted_at IS NULL
+      FOR UPDATE
+    `;
+		if (rows.length === 0) return;
+		await patchEntityRows({
+			tx,
+			ids: [caseEntityId],
+			patch: {
+				metadata: { ...(rows[0].metadata ?? {}), suite_trials: trials },
+			},
+		});
+	});
+}
+
 /**
  * Replay every active case `trials` times.
  *
@@ -192,16 +223,12 @@ export async function runEvalSuite(
 			// `trials` param. Positional grouping is only exact when the batch
 			// size is known: reading a trials=5 batch with the default 3 mixes one
 			// suite across both groups and reads a false regression out of it.
-			await sql`
-        UPDATE entities
-        SET metadata = jsonb_set(
-              coalesce(metadata, '{}'::jsonb),
-              '{suite_trials}',
-              ${sql.json(trials as never)}::jsonb
-            ),
-            updated_at = current_timestamp
-        WHERE id = ${evalCase.caseId}
-      `;
+			await stampSuiteTrials(
+				sql,
+				params.organizationId,
+				evalCase.caseId,
+				trials,
+			);
 		}
 	}
 

--- a/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
+++ b/packages/server/src/utils/__tests__/entity-write-kernel.test.ts
@@ -13,6 +13,7 @@ import {
 	patchEntityRows,
 	transitionEntityMergeRows,
 	tryInsertEntityRow,
+	withEntityWriteTransaction,
 } from "../entity-management";
 
 async function seedEntityType(organizationId: string): Promise<number> {
@@ -80,6 +81,52 @@ describe("entity row write kernel", () => {
 			ORDER BY id
 		`;
 		expect(rows).toEqual([{ name: "Existing" }]);
+	});
+
+	it("opens a transaction for a pool and joins an existing transaction", async () => {
+		const sql = getTestDb();
+		const organization = await createTestOrganization({
+			name: "Entity kernel transaction boundary",
+		});
+		const user = await createTestUser();
+		const entityTypeId = await seedEntityType(organization.id);
+
+		// Captured rather than asserted inside the callback: an assertion that
+		// throws in there is swallowed by the rejects matcher below and reports
+		// as the wrong failure.
+		let pooledSavepoint: unknown;
+		await expect(
+			withEntityWriteTransaction(sql, async (tx) => {
+				pooledSavepoint = tx.savepoint;
+				await insertEntityRow({
+					tx,
+					row: {
+						organizationId: organization.id,
+						entityTypeId,
+						name: "Rolled back by wrapper",
+						slug: "rolled-back-by-wrapper",
+						createdBy: user.id,
+					},
+				});
+				throw new Error("wrapper rollback sentinel");
+			}),
+		).rejects.toThrow("wrapper rollback sentinel");
+		expect(typeof pooledSavepoint).toBe("function");
+
+		const afterRollback = await sql<{ count: number }>`
+			SELECT count(*)::int AS count
+			FROM entities
+			WHERE organization_id = ${organization.id}
+		`;
+		expect(afterRollback[0].count).toBe(0);
+
+		await sql.begin(async (outerTx) => {
+			const value = await withEntityWriteTransaction(outerTx, async (innerTx) => {
+				expect(innerTx).toBe(outerTx);
+				return 42;
+			});
+			expect(value).toBe(42);
+		});
 	});
 
 	it("distinguishes omitted fields from explicit nulls", async () => {

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -32,6 +32,7 @@ import {
   hardDeleteEntityRows,
   patchEntityRows,
   tryInsertEntityRow,
+  withEntityWriteTransaction,
 } from './entity-management';
 import logger from './logger';
 import { getValueAtPath } from './object-path';
@@ -87,24 +88,6 @@ const RULES_CACHE_TTL_MS = 60_000;
 // Per-pod caches — no cross-replica sharing.
 const rulesCache = new TtlCache<RuleMap>(RULES_CACHE_TTL_MS);
 const creatorCache = new TtlCache<string | null>(RULES_CACHE_TTL_MS);
-
-/**
- * Connector attribution is one logical entity write: match/create, identity
- * claim, aliases, traits, and provisional cleanup must commit together. A real
- * transaction handle exposes savepoint(); a pool handle must open begin().
- *
- * Consequence for callers: a write that used to be logged and skipped per item
- * (a rejected entity insert, an identity claim that trips its connection FK)
- * now rolls the batch's entity writes back and propagates. On the sync path
- * that aborts the ingest batch rather than persisting events whose attribution
- * silently half-landed.
- */
-async function withEntityWriteTransaction<T>(
-  sql: DbClient,
-  write: (tx: DbClient) => Promise<T>
-): Promise<T> {
-  return typeof sql.savepoint === 'function' ? write(sql) : sql.begin(write);
-}
 
 async function resolveOrgCreator(orgId: string): Promise<string | null> {
   return creatorCache.getOrSet(orgId, async () => {
@@ -655,6 +638,11 @@ async function applyTraits(
  * item using the normalized entity_identities index, then merges declared
  * traits onto the resolved entity. Rules are loaded from the connector
  * definition (poll/sync path).
+ *
+ * Connector attribution is one logical entity write: match/create, identity
+ * claim, aliases, traits, and provisional cleanup commit together. A rejected
+ * entity or identity write therefore rolls the batch back and propagates; the
+ * sync aborts instead of persisting events whose attribution half-landed.
  */
 export async function applyEventAttributions(
   params: {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -340,6 +340,19 @@ export interface FieldMergeInfo {
 // ============================================
 
 /**
+ * Join a caller-owned transaction or open one when the caller only has the
+ * pool. The physical row helpers below deliberately never decide transaction
+ * ownership themselves; entry points use this boundary before check-then-write
+ * projections so every helper receives a real transaction handle.
+ */
+export function withEntityWriteTransaction<T>(
+	db: DbClient,
+	write: (tx: DbClient) => Promise<T>,
+): Promise<T> {
+	return typeof db.savepoint === "function" ? write(db) : db.begin(write);
+}
+
+/**
  * Physical entity-row values accepted by the internal write kernel.
  *
  * This is deliberately below the semantic CRUD layer: it performs no access,

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -53,36 +53,6 @@ const ALLOWED_BYPASSES = [
     reason: "resource rename projection",
   },
 
-  // Evaluation projections.
-  {
-    file: "packages/server/src/runs/eval-cases.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "65e074f820a415f7",
-    reason: "judge-model projection",
-  },
-  {
-    file: "packages/server/src/runs/eval-cases.ts",
-    operation: "insert",
-    dynamic: false,
-    fingerprint: "5851d53b1d3777ee",
-    reason: "eval-case entity projection",
-  },
-  {
-    file: "packages/server/src/runs/eval-scores.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "b53e657432cbb0da",
-    reason: "locked rolling score projection",
-  },
-  {
-    file: "packages/server/src/runs/eval-suite.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "cdb38e54da5ece98",
-    reason: "suite-trials projection",
-  },
-
   // Member lifecycle projections.
   {
     file: "packages/server/src/utils/member-entity.ts",


### PR DESCRIPTION
## Summary

- Route eval-case creation, judge-model updates, rolling scores, and suite-trial stamps through the shared entity row kernel.
- Make case promotion atomic with its identity claim, including safe cleanup when another replica wins.
- Retire four guarded SQL bypasses, reducing the pinned production bypass inventory from 11 to 7.

## Test plan

- [ ] Full Linux Depot graph: 15 jobs passed; integration-bun hit an unrelated shared-lane database/reset timeout in untouched message-routing and deployment-grant tests. The isolated integration-bun rerun passed completely. PR CI must be green before merge.
- [x] Focused server verification: 90 tests passed across eval runs and entity kernel/link suites; server TypeScript check passed.
- [x] Funnel guard: direct inventory reports 7 pinned bypasses and zero new; 18 guard self-tests passed.
- [x] Red to green: with the new promotion transaction wrapper temporarily removed, the rollback test failed because 1 orphan entity remained; after restoring it, the same test passed with 0 rows.

## Notes

No database, API, or SDK contract changes. These are system-owned eval projections; this removes their physical SQL escape hatches without introducing hooks or ERP-specific vocabulary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of eval case promotions by preventing partial writes when failures occur.
  * Prevented duplicate entities during concurrent promotions.
  * Preserved judge model and score history metadata during suite runs and score updates.
  * Ensured suite trial counts are recorded without overwriting concurrent metadata changes.
  * Sync ingestion now aborts cleanly if entity attribution fails.

* **Tests**
  * Added coverage for transaction rollback, concurrent promotions, metadata preservation, and shared transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->