### PR TITLE
refactor(server): close entity write funnel

### DIFF
--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -241,6 +241,30 @@ describe('slack channel graph', () => {
     expect(await memberOfEdges(org.id)).toHaveLength(2);
   });
 
+  it('refreshes a renamed channel on the existing resource entity', async () => {
+    const { org } = await seedOrg('Channel rename org');
+    const base = {
+      organizationId: org.id,
+      connectionId: 'conn-acme',
+      teamId: TEAM,
+    };
+    const first = await buildSlackChannelGraph({
+      ...base,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: [] }],
+    });
+    const resourceId = first.resourceEntityIds[slackChannelKey(TEAM, 'C01ENG')];
+
+    const second = await buildSlackChannelGraph({
+      ...base,
+      channels: [{ channelId: 'C01ENG', name: 'engineering', memberSlackUserIds: [] }],
+    });
+
+    expect(second.resourceEntityIds[slackChannelKey(TEAM, 'C01ENG')]).toBe(resourceId);
+    expect(await entitiesOfType(org.id, '$resource')).toEqual([
+      { id: resourceId, name: 'engineering' },
+    ]);
+  });
+
   it('revokes a departed member — re-sync without Alice soft-deletes her edge', async () => {
     const { org } = await seedOrg('Revoke Org');
     const base = { organizationId: org.id, connectionId: 'conn-acme', teamId: TEAM };

--- a/packages/server/src/__tests__/integration/entities/member-entity-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-entity-lifecycle.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  deleteMemberEntity,
+  ensureMemberEntity,
+  updateMemberEntityAccess,
+  updateMemberEntityStatus,
+} from '../../../utils/member-entity';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function memberRow(organizationId: string, email: string) {
+  const sql = getTestDb();
+  const rows = await sql<{
+    id: number;
+    metadata: Record<string, unknown>;
+    deleted_at: Date | null;
+  }[]>`
+    SELECT e.id, e.metadata, e.deleted_at
+    FROM entities e
+    JOIN entity_types et
+      ON et.id = e.entity_type_id
+     AND et.organization_id = e.organization_id
+    WHERE et.slug = '$member'
+      AND e.organization_id = ${organizationId}
+      AND e.metadata->>'email' = ${email}
+    ORDER BY e.id
+  `;
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+describe('$member entity lifecycle projections', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('preserves unrelated metadata across status and access writes', async () => {
+    const organization = await createTestOrganization({ name: 'Member projection org' });
+    const user = await createTestUser({ email: 'member-projection@test.example.com' });
+    await ensureMemberEntity({
+      organizationId: organization.id,
+      userId: user.id,
+      name: 'Projection Member',
+      email: user.email,
+      role: 'member',
+      status: 'invited',
+    });
+
+    const sql = getTestDb();
+    const original = await memberRow(organization.id, user.email);
+    await sql`
+      UPDATE entities
+      SET metadata = metadata || ${sql.json({ connector_profile: 'keep-me' })}
+      WHERE id = ${original.id}
+    `;
+
+    await updateMemberEntityStatus(organization.id, user.email, 'active');
+    await updateMemberEntityAccess(organization.id, user.email, { role: 'admin' });
+
+    const updated = await memberRow(organization.id, user.email);
+    expect(updated.metadata).toMatchObject({
+      email: user.email,
+      status: 'active',
+      role: 'admin',
+      connector_profile: 'keep-me',
+    });
+    expect(updated.deleted_at).toBeNull();
+  });
+
+  it('soft-deletes only the matching organization member', async () => {
+    const first = await createTestOrganization({ name: 'Member delete first org' });
+    const second = await createTestOrganization({ name: 'Member delete second org' });
+    const user = await createTestUser({ email: 'shared-member@test.example.com' });
+
+    for (const organization of [first, second]) {
+      await ensureMemberEntity({
+        organizationId: organization.id,
+        userId: user.id,
+        name: 'Shared Member',
+        email: user.email,
+        role: 'member',
+        status: 'active',
+      });
+    }
+
+    await deleteMemberEntity(first.id, user.email);
+
+    expect((await memberRow(first.id, user.email)).deleted_at).not.toBeNull();
+    expect((await memberRow(second.id, user.email)).deleted_at).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/tools/entity-view-templates.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-view-templates.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { manageViewTemplates } from '../../../tools/admin/manage_view_templates';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function seedEntityViewTarget() {
+  const organization = await createTestOrganization({ name: 'Entity view template org' });
+  const user = await createTestUser({ email: 'entity-view-template@example.com' });
+  await addUserToOrganization(user.id, organization.id, 'owner');
+  const entity = await createTestEntity({
+    organization_id: organization.id,
+    entity_type: 'deal',
+    name: 'Template target',
+    created_by: user.id,
+  });
+  const ctx = {
+    organizationId: organization.id,
+    userId: user.id,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: true,
+    scopes: ['mcp:admin'],
+  } as ToolContext;
+  return { organization, entity, ctx };
+}
+
+async function currentVersionId(entityId: number): Promise<number | null> {
+  const sql = getTestDb();
+  const [row] = await sql`
+    SELECT current_view_template_version_id
+    FROM entities
+    WHERE id = ${entityId}
+  `;
+  const value = row?.current_view_template_version_id;
+  return value == null ? null : Number(value);
+}
+
+describe('entity-scoped view templates', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('sets, rolls back, and clears the entity pointer through the write kernel', async () => {
+    const { entity, ctx } = await seedEntityViewTarget();
+    const first = (await manageViewTemplates(
+      {
+        action: 'set',
+        resource_type: 'entity',
+        resource_id: entity.id,
+        json_template: { type: 'card', children: [] },
+      } as never,
+      {} as never,
+      ctx
+    )) as { version: { id: number; version: number } };
+    expect(await currentVersionId(entity.id)).toBe(first.version.id);
+
+    const second = (await manageViewTemplates(
+      {
+        action: 'set',
+        resource_type: 'entity',
+        resource_id: entity.id,
+        json_template: { type: 'div', children: [] },
+      } as never,
+      {} as never,
+      ctx
+    )) as { version: { id: number; version: number } };
+    expect(second.version.id).not.toBe(first.version.id);
+    expect(await currentVersionId(entity.id)).toBe(second.version.id);
+
+    await manageViewTemplates(
+      {
+        action: 'rollback',
+        resource_type: 'entity',
+        resource_id: entity.id,
+        version: first.version.version,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(await currentVersionId(entity.id)).toBe(first.version.id);
+
+    await manageViewTemplates(
+      { action: 'clear', resource_type: 'entity', resource_id: entity.id } as never,
+      {} as never,
+      ctx
+    );
+    expect(await currentVersionId(entity.id)).toBeNull();
+
+    const sql = getTestDb();
+    const [history] = await sql<{ count: number }>`
+      SELECT count(*)::int AS count
+      FROM view_template_versions
+      WHERE resource_type = 'entity'
+        AND resource_id = ${String(entity.id)}
+        AND organization_id = ${ctx.organizationId}
+    `;
+    expect(history.count).toBe(2);
+  });
+
+  it('does not read or version a soft-deleted entity', async () => {
+    const { entity, ctx } = await seedEntityViewTarget();
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities
+      SET deleted_at = current_timestamp
+      WHERE id = ${entity.id}
+    `;
+
+    // A tombstoned entity is gone for reads too, not just for writes.
+    await expect(
+      manageViewTemplates(
+        { action: 'get', resource_type: 'entity', resource_id: entity.id } as never,
+        {} as never,
+        ctx
+      )
+    ).rejects.toThrow(`Entity ${entity.id} not found`);
+
+    await expect(
+      manageViewTemplates(
+        {
+          action: 'set',
+          resource_type: 'entity',
+          resource_id: entity.id,
+          json_template: { type: 'card', children: [] },
+        } as never,
+        {} as never,
+        ctx
+      )
+    ).rejects.toThrow(`Entity ${entity.id} not found`);
+
+    const [history] = await sql<{ count: number }>`
+      SELECT count(*)::int AS count
+      FROM view_template_versions
+      WHERE resource_type = 'entity'
+        AND resource_id = ${String(entity.id)}
+        AND organization_id = ${ctx.organizationId}
+    `;
+    expect(history.count).toBe(0);
+  });
+});

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -41,6 +41,10 @@ import {
 import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
 import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection.js';
 import { resolveEventAttributionsForItems } from '../utils/entity-link-upsert.js';
+import {
+  patchEntityRows,
+  withEntityWriteTransaction,
+} from '../utils/entity-management.js';
 import { aclConnectionIdSql } from './acl-observability.js';
 import { ensureResourceEntityType } from './acl-resource-type.js';
 
@@ -450,20 +454,36 @@ export async function buildAccessGraph(params: {
   // name on auto-CREATE, so a name that wasn't available at first graph (or a
   // later channel/repo RENAME) would otherwise stick to the stale value / the
   // raw id. Refresh from the source-provided name here. Scoped to the resources
-  // in this build; idempotent (the `name <>` guard no-ops when unchanged).
+  // in this build; idempotent (the locked selector skips unchanged names).
+  const resourceNames = new Map<number, string>();
   for (let i = 0; i < resources.length; i++) {
     const id = resourceEntityIdByIndex.get(i);
     const name = resources[i].name;
     if (id && name) {
-      await sql`
-        UPDATE entities
-        SET name = ${name}, updated_at = current_timestamp
-        WHERE id = ${id}
-          AND organization_id = ${organizationId}
-          AND name <> ${name}
-          AND deleted_at IS NULL
-      `;
+      resourceNames.set(id, name);
     }
+  }
+  if (resourceNames.size > 0) {
+    await withEntityWriteTransaction(sql, async (tx) => {
+      // `ORDER BY id` before FOR UPDATE takes the row locks in id order, so
+      // overlapping graph builds over the same resources cannot deadlock.
+      const lockedRows = await tx<{ id: number; name: string }>`
+        SELECT id, name
+        FROM entities
+        WHERE id = ANY(${pgBigintArray([...resourceNames.keys()])}::bigint[])
+          AND organization_id = ${organizationId}
+          AND deleted_at IS NULL
+        ORDER BY id
+        FOR UPDATE
+      `;
+      for (const row of lockedRows) {
+        const id = Number(row.id);
+        const name = resourceNames.get(id);
+        if (name !== undefined && row.name !== name) {
+          await patchEntityRows({ tx, ids: [id], patch: { name } });
+        }
+      }
+    });
   }
 
   const memberEntityIds = new Set<number>();

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -13,10 +13,11 @@ import {
   type ManageViewTemplatesResult,
   type ViewTemplateVersionRow,
 } from '@lobu/core/contracts/tools/manage-view-templates';
-import { getDb } from '../../db/client';
+import { type DbClient, getDb } from '../../db/client';
 import { emit } from '../../events/emitter';
 import { recordToolConfigChange } from './helpers/config-audit';
 import { ToolUserError } from '../../utils/errors';
+import { patchEntityRows } from '../../utils/entity-management';
 import { validateDataSourceQuery } from '../../utils/execute-data-sources';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { validateJsonTemplate } from '../../utils/validate-json-template';
@@ -77,6 +78,53 @@ function parentTable(resourceType: string): string {
 /** Resolve resource_id to a consistent string for view_template_versions.resource_id */
 function rid(args: ManageViewTemplatesArgs): string {
   return String(args.resource_id);
+}
+
+/**
+ * Point a verified resource at a default template version while rechecking the
+ * mutable parent under the caller's transaction — `verifyAccess` ran outside
+ * it. An entity row is rechecked (and pinned) by a `FOR UPDATE` select before
+ * the physical write kernel patches it; an entity type, a configuration row on
+ * a separate statically selected table, is rechecked by its own UPDATE.
+ */
+async function setCurrentDefaultVersion(
+  tx: DbClient,
+  args: ManageViewTemplatesArgs,
+  ctx: ToolContext,
+  rowId: number,
+  versionId: number | null
+): Promise<void> {
+  if (args.resource_type === 'entity') {
+    const locked = await tx<{ id: number }>`
+      SELECT id
+      FROM entities
+      WHERE id = ${rowId}
+        AND organization_id = ${ctx.organizationId}
+        AND deleted_at IS NULL
+      FOR UPDATE
+    `;
+    if (locked.length === 0) {
+      throw new ToolUserError(`Entity ${rid(args)} not found`, 404);
+    }
+    await patchEntityRows({
+      tx,
+      ids: [rowId],
+      patch: { currentViewTemplateVersionId: versionId },
+    });
+    return;
+  }
+
+  const changed = await tx<{ id: number }>`
+    UPDATE entity_types
+    SET current_view_template_version_id = ${versionId}, updated_at = NOW()
+    WHERE id = ${rowId}
+      AND organization_id = ${ctx.organizationId}
+      AND deleted_at IS NULL
+    RETURNING id
+  `;
+  if (changed.length !== 1) {
+    throw new ToolUserError(`Entity type '${rid(args)}' not found`, 404);
+  }
 }
 
 /**
@@ -146,7 +194,9 @@ async function verifyAccess(
   }
   const rows = await sql`
     SELECT id FROM entities
-    WHERE id = ${numericId} AND organization_id = ${ctx.organizationId}
+    WHERE id = ${numericId}
+      AND organization_id = ${ctx.organizationId}
+      AND deleted_at IS NULL
     LIMIT 1
   `;
   if (rows.length === 0) throw new Error(`Entity ${id} not found`);
@@ -217,12 +267,7 @@ async function handleSet(
     const vid = Number(row.id);
 
     if (tabName === null) {
-      await tx.unsafe(
-        `UPDATE ${parentTable(args.resource_type)}
-         SET current_view_template_version_id = $1, updated_at = NOW()
-         WHERE id = $2`,
-        [vid, rowId]
-      );
+      await setCurrentDefaultVersion(tx, args, ctx, rowId, vid);
     } else {
       await tx`
         INSERT INTO view_template_active_tabs (
@@ -356,12 +401,7 @@ async function handleClear(
   const sql = getDb();
   const rowId = await verifyAccess(sql, args, ctx, true);
 
-  await sql.unsafe(
-    `UPDATE ${parentTable(args.resource_type)}
-     SET current_view_template_version_id = NULL, updated_at = NOW()
-     WHERE id = $1`,
-    [rowId]
-  );
+  await sql.begin((tx) => setCurrentDefaultVersion(tx, args, ctx, rowId, null));
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],
@@ -411,12 +451,7 @@ async function handleRollback(
     const versionId = Number(row.id);
 
     if (tabName === null) {
-      await tx.unsafe(
-        `UPDATE ${parentTable(args.resource_type)}
-         SET current_view_template_version_id = $1, updated_at = NOW()
-         WHERE id = $2`,
-        [versionId, rowId]
-      );
+      await setCurrentDefaultVersion(tx, args, ctx, rowId, versionId);
     } else {
       const updated = await tx`
         UPDATE view_template_active_tabs

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -380,6 +380,7 @@ export interface EntityRowPatch {
 	name?: string;
 	slug?: string;
 	parentId?: number | null;
+	currentViewTemplateVersionId?: number | null;
 	metadata?: Record<string, unknown> | null;
 	fieldControls?: Record<string, unknown>;
 	enabledClassifiers?: string[] | null;
@@ -480,6 +481,7 @@ export async function patchEntityRows(params: {
 	const hasName = patch.name !== undefined;
 	const hasSlug = patch.slug !== undefined;
 	const hasParent = patch.parentId !== undefined;
+	const hasCurrentViewTemplateVersion = patch.currentViewTemplateVersionId !== undefined;
 	const hasMetadata = patch.metadata !== undefined;
 	const hasFieldControls = patch.fieldControls !== undefined;
 	const hasEnabledClassifiers = patch.enabledClassifiers !== undefined;
@@ -493,6 +495,7 @@ export async function patchEntityRows(params: {
       name = CASE WHEN ${hasName} THEN ${patch.name ?? null} ELSE name END,
       slug = CASE WHEN ${hasSlug} THEN ${patch.slug ?? null} ELSE slug END,
       parent_id = CASE WHEN ${hasParent} THEN ${patch.parentId ?? null}::bigint ELSE parent_id END,
+      current_view_template_version_id = CASE WHEN ${hasCurrentViewTemplateVersion} THEN ${patch.currentViewTemplateVersionId ?? null}::bigint ELSE current_view_template_version_id END,
       metadata = CASE WHEN ${hasMetadata} THEN ${patch.metadata == null ? null : tx.json(patch.metadata)} ELSE metadata END,
       field_controls = CASE WHEN ${hasFieldControls} THEN ${tx.json(patch.fieldControls ?? {})} ELSE field_controls END,
       enabled_classifiers = CASE WHEN ${hasEnabledClassifiers} THEN ${patch.enabledClassifiers != null ? pgTextArray(patch.enabledClassifiers) : null}::text[] ELSE enabled_classifiers END,

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -7,7 +7,12 @@
  */
 
 import { getDb } from '../db/client';
-import { createEntity, type EntityData } from './entity-management';
+import {
+  createEntity,
+  type EntityData,
+  patchEntityRows,
+  withEntityWriteTransaction,
+} from './entity-management';
 import { ensureMemberEntityType, resolveMemberSchemaFieldsFromSchema } from './member-entity-type';
 
 /**
@@ -155,18 +160,36 @@ export async function updateMemberEntityStatus(
   await ensureMemberEntityType(organizationId);
   const { emailField } = await resolveMemberSchemaFields(organizationId);
   const sql = getDb();
-  await sql`
-    UPDATE entities
-    SET metadata = jsonb_set(metadata, '{status}', to_jsonb(${status}::text)),
-        updated_at = current_timestamp
-    WHERE entity_type_id = (
-        SELECT id FROM entity_types
-        WHERE slug = '$member' AND organization_id = ${organizationId} AND deleted_at IS NULL
-      )
-      AND organization_id = ${organizationId}
-      AND metadata->>${emailField} = ${email}
-      AND deleted_at IS NULL
-  `;
+  await withEntityWriteTransaction(sql, async (tx) => {
+    // `OF e` keeps the lock on the member rows: a bare FOR UPDATE would also
+    // lock the org's shared `$member` entity_types row, serializing unrelated
+    // member writes against each other and against ensureMemberEntityType.
+    const rows = await tx.unsafe<{ id: number; metadata: Record<string, unknown> | null }>(
+      `SELECT e.id, e.metadata
+       FROM entities e
+       JOIN entity_types et ON et.id = e.entity_type_id
+       WHERE et.slug = '$member'
+         AND et.organization_id = $1
+         AND et.deleted_at IS NULL
+         AND e.organization_id = $1
+         AND e.metadata->>$2 = $3
+         AND e.deleted_at IS NULL
+       ORDER BY e.id
+       FOR UPDATE OF e`,
+      [organizationId, emailField, email]
+    );
+
+    // Duplicate live members are legacy-invalid but the old status projection
+    // updated all of them. Preserve that repair-friendly result while each
+    // row's unrelated metadata survives the full-row kernel patch.
+    for (const row of rows) {
+      await patchEntityRows({
+        tx,
+        ids: [Number(row.id)],
+        patch: { metadata: { ...(row.metadata ?? {}), status } },
+      });
+    }
+  });
 }
 
 export async function updateMemberEntityAccess(
@@ -177,29 +200,34 @@ export async function updateMemberEntityAccess(
   await ensureMemberEntityType(organizationId);
   const { emailField } = await resolveMemberSchemaFields(organizationId);
   const sql = getDb();
-  const rows = await sql.unsafe<{ id: number; metadata: Record<string, unknown> }>(
-    `SELECT e.id, e.metadata
-     FROM entities e
-     JOIN entity_types et ON et.id = e.entity_type_id
-     WHERE et.slug = '$member'
-       AND e.organization_id = $1
-       AND e.metadata->>$2 = $3
-       AND e.deleted_at IS NULL
-     LIMIT 1`,
-    [organizationId, emailField, email]
-  );
-  if (rows.length === 0) return;
+  await withEntityWriteTransaction(sql, async (tx) => {
+    const rows = await tx.unsafe<{ id: number; metadata: Record<string, unknown> | null }>(
+      `SELECT e.id, e.metadata
+       FROM entities e
+       JOIN entity_types et ON et.id = e.entity_type_id
+       WHERE et.slug = '$member'
+         AND et.organization_id = $1
+         AND et.deleted_at IS NULL
+         AND e.organization_id = $1
+         AND e.metadata->>$2 = $3
+         AND e.deleted_at IS NULL
+       ORDER BY e.id
+       LIMIT 1
+       FOR UPDATE OF e`,
+      [organizationId, emailField, email]
+    );
+    if (rows.length === 0) return;
 
-  const metadata = { ...(rows[0].metadata ?? {}) } as Record<string, unknown>;
-  if (updates.role !== undefined) metadata.role = updates.role;
-  if (updates.status !== undefined) metadata.status = updates.status;
+    const metadata = { ...(rows[0].metadata ?? {}) } as Record<string, unknown>;
+    if (updates.role !== undefined) metadata.role = updates.role;
+    if (updates.status !== undefined) metadata.status = updates.status;
 
-  await sql`
-    UPDATE entities
-    SET metadata = ${sql.json(metadata)},
-        updated_at = current_timestamp
-    WHERE id = ${rows[0].id}
-  `;
+    await patchEntityRows({
+      tx,
+      ids: [Number(rows[0].id)],
+      patch: { metadata },
+    });
+  });
 }
 
 /**
@@ -209,16 +237,25 @@ export async function deleteMemberEntity(organizationId: string, email: string):
   await ensureMemberEntityType(organizationId);
   const { emailField } = await resolveMemberSchemaFields(organizationId);
   const sql = getDb();
-  await sql.unsafe(
-    `UPDATE entities
-    SET deleted_at = current_timestamp, updated_at = current_timestamp
-    WHERE entity_type_id = (
-        SELECT id FROM entity_types
-        WHERE slug = '$member' AND organization_id = $1 AND deleted_at IS NULL
-      )
-      AND organization_id = $1
-      AND metadata->>$2 = $3
-      AND deleted_at IS NULL`,
-    [organizationId, emailField, email]
-  );
+  await withEntityWriteTransaction(sql, async (tx) => {
+    const rows = await tx.unsafe<{ id: number }>(
+      `SELECT e.id
+       FROM entities e
+       JOIN entity_types et ON et.id = e.entity_type_id
+       WHERE et.slug = '$member'
+         AND et.organization_id = $1
+         AND et.deleted_at IS NULL
+         AND e.organization_id = $1
+         AND e.metadata->>$2 = $3
+         AND e.deleted_at IS NULL
+       ORDER BY e.id
+       FOR UPDATE OF e`,
+      [organizationId, emailField, email]
+    );
+    await patchEntityRows({
+      tx,
+      ids: rows.map((row) => Number(row.id)),
+      patch: { softDelete: true },
+    });
+  });
 }

--- a/scripts/__tests__/check-entity-write-funnel.test.ts
+++ b/scripts/__tests__/check-entity-write-funnel.test.ts
@@ -1,7 +1,9 @@
 /**
  * The entity-write funnel guard is only useful if it rejects both obvious SQL
  * and dynamically selected table names. These probes run in the real scanned
- * tree so the test exercises the same baseline allowlist as CI.
+ * tree so the test exercises the same files as CI. The committed allowance
+ * list is empty, so allowance handling is probed against a patched copy of the
+ * guard rather than against a production entry.
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
@@ -14,9 +16,9 @@ const PROBE = join(
   REPO_ROOT,
   "packages/server/src/utils/entity-write-funnel-probe.ts"
 );
-const STALE_GUARD_PROBE = join(
+const GUARD_COPY = join(
   REPO_ROOT,
-  "scripts/check-entity-write-funnel-stale-probe.mjs"
+  "scripts/check-entity-write-funnel-allowance-probe.mjs"
 );
 const OUTSIDE_SERVER_PROBE = join(
   REPO_ROOT,
@@ -31,16 +33,48 @@ function runGuard() {
   });
 }
 
+/** Run a copy of the guard whose allowance list holds exactly `allowance`. */
+function runGuardWithAllowance(allowance: Record<string, unknown>) {
+  writeFileSync(
+    GUARD_COPY,
+    readFileSync(GUARD, "utf8").replace(
+      "const ALLOWED_BYPASSES = [",
+      `const ALLOWED_BYPASSES = [\n  ${JSON.stringify(allowance)},`
+    )
+  );
+  return Bun.spawnSync(["bun", GUARD_COPY], {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+/** The bypasses the guard currently sees, via its own audit output. */
+function guardInventory(): Record<string, unknown>[] {
+  const result = Bun.spawnSync(["bun", GUARD, "--print-inventory"], {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  return result.stdout
+    .toString()
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line));
+}
+
 afterEach(() => {
   rmSync(PROBE, { force: true });
-  rmSync(STALE_GUARD_PROBE, { force: true });
+  rmSync(GUARD_COPY, { force: true });
   rmSync(OUTSIDE_SERVER_PROBE, { force: true });
 });
 
 describe("check-entity-write-funnel", () => {
-  it("passes on the pinned production baseline", () => {
+  it("passes on the production tree with an empty allowance list", () => {
     const result = runGuard();
     expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("0 pinned bypasses");
   });
 
   it("rejects a new direct entity write", () => {
@@ -293,38 +327,55 @@ describe("check-entity-write-funnel", () => {
     );
   });
 
-  it("rejects a stale bypass allowance", () => {
-    const guardSource = readFileSync(GUARD, "utf8");
+  it("suppresses exactly the bypass its allowance pins", () => {
     writeFileSync(
-      STALE_GUARD_PROBE,
-      guardSource.replace("1280c3ed0fdded46", "0000000000000000")
+      PROBE,
+      `export async function probe(sql: any) {
+  await sql\`UPDATE entities SET name = \${"new"} WHERE id = \${1}\`;
+}
+`
     );
+    expect(runGuard().exitCode).toBe(1);
 
-    const result = Bun.spawnSync(["bun", STALE_GUARD_PROBE], {
-      cwd: REPO_ROOT,
-      stdout: "pipe",
-      stderr: "pipe",
+    const pinned = guardInventory().find((item) =>
+      String(item.file).endsWith("entity-write-funnel-probe.ts")
+    );
+    expect(pinned).toBeDefined();
+
+    const result = runGuardWithAllowance({
+      file: pinned?.file,
+      operation: pinned?.operation,
+      dynamic: pinned?.dynamic,
+      fingerprint: pinned?.fingerprint,
+      reason: "matching allowance probe",
+    });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("rejects a stale bypass allowance", () => {
+    const result = runGuardWithAllowance({
+      file: "packages/server/src/utils/no-such-entity-writer.ts",
+      operation: "update",
+      dynamic: false,
+      fingerprint: "0000000000000000",
+      reason: "stale allowance probe",
     });
     expect(result.exitCode).toBe(1);
     expect(result.stderr.toString()).toContain("stale allowance(s)");
   });
 
   it("reports the count for a duplicated stale allowance", () => {
-    const guardSource = readFileSync(GUARD, "utf8");
-    writeFileSync(
-      STALE_GUARD_PROBE,
-      guardSource.replace("6c2d50be50c02a93", "0000000000000000")
-    );
-
-    const result = Bun.spawnSync(["bun", STALE_GUARD_PROBE], {
-      cwd: REPO_ROOT,
-      stdout: "pipe",
-      stderr: "pipe",
+    const result = runGuardWithAllowance({
+      file: "packages/server/src/utils/no-such-entity-writer.ts",
+      operation: "update",
+      dynamic: false,
+      fingerprint: "0000000000000000",
+      count: 2,
+      reason: "stale allowance probe",
     });
     expect(result.exitCode).toBe(1);
-    expect(result.stderr.toString()).toContain(
-      "x2 [set or rollback default entity view template]"
-    );
+    expect(result.stderr.toString()).toContain("x2 [stale allowance probe]");
   });
 
   it("does not govern test fixtures", () => {

--- a/scripts/check-entity-write-funnel.mjs
+++ b/scripts/check-entity-write-funnel.mjs
@@ -2,11 +2,10 @@
 /**
  * Entity-write funnel gate.
  *
- * Production entity-row mutations belong in entity-management.ts. The
- * remaining historical bypasses are pinned below by a whitespace-normalized
- * source fingerprint. The list is intentionally shrinking: removing or
- * changing a bypass makes this gate fail until the allowance is deleted, and
- * adding a bypass fails because it has no allowance.
+ * Production entity-row mutations belong in entity-management.ts, and as of
+ * the member/resource/view-template migrations every one of them is there:
+ * the allowance list below is empty, so any entity write outside the funnel
+ * fails this gate.
  *
  * A dynamically selected mutation target is treated conservatively because a
  * helper such as `parentTable("entity")` can hide an entity write from a
@@ -39,60 +38,12 @@ const SKIPPED_DIRS = new Set([
 ]);
 
 /**
- * Temporary production bypasses, frozen from origin/main on 2026-08-15.
- * Every entry must continue to match exactly one mutation. Delete entries as
- * callers move into the funnel; never add one merely to make CI green.
+ * Temporary production bypasses, pinned by whitespace-normalized source
+ * fingerprint. Empty — the historical bypasses have all moved into the funnel,
+ * and a stale entry fails this gate just as a new bypass does. An entry must
+ * match exactly one mutation; never add one merely to make CI green.
  */
-const ALLOWED_BYPASSES = [
-  // Access/resource projection.
-  {
-    file: "packages/server/src/authz/access-graph.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "1280c3ed0fdded46",
-    reason: "resource rename projection",
-  },
-
-  // Member lifecycle projections.
-  {
-    file: "packages/server/src/utils/member-entity.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "eda8f87e28c0f602",
-    reason: "member status projection",
-  },
-  {
-    file: "packages/server/src/utils/member-entity.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "1d4a7505da557ec9",
-    reason: "member access projection",
-  },
-  {
-    file: "packages/server/src/utils/member-entity.ts",
-    operation: "update",
-    dynamic: false,
-    fingerprint: "ea1d914a77903682",
-    reason: "member soft delete",
-  },
-
-  // Per-entity view-template pointer, hidden behind parentTable(resourceType).
-  {
-    file: "packages/server/src/tools/admin/manage_view_templates.ts",
-    operation: "update",
-    dynamic: true,
-    fingerprint: "6c2d50be50c02a93",
-    count: 2,
-    reason: "set or rollback default entity view template",
-  },
-  {
-    file: "packages/server/src/tools/admin/manage_view_templates.ts",
-    operation: "update",
-    dynamic: true,
-    fingerprint: "e18b52b5f5dfdd8a",
-    reason: "clear default entity view template",
-  },
-];
+const ALLOWED_BYPASSES = [];
 
 const STATIC_IDENTIFIER = '(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)';
 const ENTITY_TARGET = String.raw`(?:(?:${STATIC_IDENTIFIER}\s*\.\s*)?"?entities"?)`;
@@ -436,5 +387,5 @@ if (violations.length > 0 || staleAllowances.length > 0) {
 
 console.log(
   `✓ entity-write funnel gate: ${files.length} runtime package source files scanned; ` +
-    `${bypasses.length} pinned bypasses, zero new bypasses`
+    `${bypasses.length} pinned bypasses, zero entity writes outside ${CANONICAL_FUNNEL}`
 );


### PR DESCRIPTION
## Summary
- Route the final seven runtime entity-row bypasses through the transaction-bound physical kernel: access-resource renames, member lifecycle projections, and entity view-template pointers.
- Preserve system-owned projection semantics while adding live-row, tenant, and row-lock rechecks. Keep entity-type view configuration on its separate static table.
- Empty the production bypass allowlist and strengthen the guard tests so any future entity write outside entity-management fails CI.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean. Final Depot run `gd8m5qrmxk`: 18 finished job instances, pass; recorded tree `c987fd77b2ae022f878000e214edc64b3fbb1077`.
- [x] Targeted PostgreSQL tests: 32 tests across member, ACL, invitation, and entity/entity-type view-template suites passed in the semantic fixer; focused final set/rollback/clear/member/access run passed 19/19.
- [x] Guard coverage: `bun test scripts/__tests__/check-entity-write-funnel.test.ts` passed 19/19; scanner reports 990 runtime files, 0 pinned bypasses, zero entity writes outside the canonical funnel.
- [x] `bunx tsc --noEmit`, exposed-surface naming, knip file analysis, diff check, and package build passed.
- [ ] Bug fix red-to-green output: not applicable; this is the planned architecture consolidation. The measurable inventory moved from 7 pinned bypasses on the base to 0.
- [ ] Bot runtime changed: not applicable.

## Notes
- No database schema, public API, or SDK contract changes.
- The first Depot dispatch correctly caught two retired-vocabulary words in new comments. After correction, the final full remote preflight passed.
- Platform-owned `$member`, ACL-resource, and view-pointer projections remain explicit privileged writers; agent/business mutations continue through the Automation and approval policy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of renamed Slack channels without creating duplicate resources.
  * Member status, access, and deletion updates now preserve unrelated data and remain correctly scoped.
  * Soft-deleted entities are excluded from view-template operations.
  * View-template updates now reliably support setting, replacing, rolling back, and clearing versions.
  * Entity name and default-template updates now complete more reliably during concurrent changes.

* **Tests**
  * Expanded integration coverage for entity lifecycles, Slack channel synchronization, and view-template behavior.
  * Strengthened validation of entity write safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->