### PR TITLE
test(server): stop entity-history contract racing the edge audit write

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
@@ -28,6 +28,36 @@ async function waitForChangeEvent(entityId: number) {
   throw new Error(`Timed out waiting for change event for entity ${entityId}`);
 }
 
+/**
+ * Wait for a relationship audit event to land.
+ *
+ * `recordEdgeChangeEvent` is deliberately fire-and-forget — an audit write must
+ * not fail the mutation that caused it — so the row appears some time AFTER
+ * link/unlink has already returned. A test that deletes the entity in between
+ * races the delete's entity_ids detach sweep against the arriving event.
+ *
+ * Keyed on the relationship rather than the entity, because `waitForChangeEvent`
+ * would return the metadata update's own change event immediately and prove
+ * nothing about this one.
+ */
+async function waitForEdgeChangeEvent(relationshipId: number, op: 'link' | 'unlink') {
+  const sql = getTestDb();
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const rows = await sql`
+      SELECT id
+      FROM events
+      WHERE semantic_type = 'change'
+        AND metadata->>'category' = 'relationship'
+        AND metadata->>'relationshipId' = ${String(relationshipId)}
+        AND metadata->>'op' = ${op}
+      LIMIT 1
+    `;
+    if (rows.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${op} audit event on relationship ${relationshipId}`);
+}
+
 describe('entity history contracts', () => {
   let workspace: TestWorkspace;
 
@@ -168,10 +198,22 @@ describe('entity history contracts', () => {
       to_entity_id: b.entity.id,
       relationship_type_slug: 'related-brand',
     })) as { relationship: { id: number } };
+    await waitForEdgeChangeEvent(linked.relationship.id, 'link');
     await workspace.owner.entities.manage({
       action: 'unlink',
       relationship_id: linked.relationship.id,
     });
+    await waitForEdgeChangeEvent(linked.relationship.id, 'unlink');
+
+    // Prove the events are ATTACHED before deleting. Without this, the final
+    // assertion below passes vacuously whenever the audit rows simply had not
+    // arrived yet — it would prove nothing about detachment.
+    const beforeDelete = await getTestDb()`
+      SELECT COUNT(*)::int AS count FROM events
+      WHERE semantic_type = 'change'
+        AND ${a.entity.id} = ANY(entity_ids)
+    `;
+    expect(beforeDelete[0].count).toBeGreaterThanOrEqual(3);
 
     for (const id of [a.entity.id, b.entity.id]) {
       const result = (await workspace.owner.entities.delete({


### PR DESCRIPTION
## Summary
- `entity-history-contract.test.ts` > "force-deletes fresh entities whose own lifecycle produced platform change events (#2049)" is flaky on `main` and has been failing unrelated PRs.
- Root cause: `recordEdgeChangeEvent` (added in #2807) is fire-and-forget by design — an audit write must not fail the mutation that caused it — so the row lands some time *after* `link`/`unlink` returns. The test deleted both entities immediately afterwards, racing the delete's `entity_ids` detach sweep against the arriving audit rows.
- The assertion was also weak in the other direction: `expect(changeEvents).toHaveLength(0)` passes **vacuously** whenever the audit rows have not arrived at all, so it proved nothing about detachment.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `lfb5tbbzb5` passed; all three vitest shards green on attempt #1, `Vitest matrix: success`)
- [x] Tests run: `bunx vitest run src/__tests__/integration/entities/entity-history-contract.test.ts` — 4/4, three consecutive runs
- [x] Bug fix: red→green below
- [ ] If bot runtime changed: n/a — test-only diff

### Red

Observed on Depot (run `m4jnc1hsjs`, attempt #1 of `server-integration-vitest:matrix-1`), and again on a clean CI rerun of an unrelated PR:

```
FAIL src/__tests__/integration/entities/entity-history-contract.test.ts
AssertionError: expected [ { entity_ids: '{278}' } ] to have a length of +0 but got 1
```

Reproduced deterministically by removing the two new waits — the added attachment assertion catches it as the *inverse* symptom, proving the audit rows had not landed yet:

```
AssertionError: expected 2 to be greater than or equal to 3
  212|     expect(beforeDelete[0].count).toBeGreaterThanOrEqual(3);
```

### Green

```
run 1 exit=0 ::   Tests  4 passed (4)
run 2 exit=0 ::   Tests  4 passed (4)
run 3 exit=0 ::   Tests  4 passed (4)
```

## Notes

Test-only change; production behaviour is untouched.

- `waitForEdgeChangeEvent` is keyed on the **relationship**, not the entity. `waitForChangeEvent` would return the metadata update's own change event immediately and prove nothing about the link/unlink rows.
- The new `beforeDelete` assertion is the substantive part: it makes the final `toHaveLength(0)` a real test of detachment rather than of absence.

The production half of this race is filed separately as #2812 — the same window can orphan an `entity_ids` reference on a genuine force-delete and make `force_delete_tree`'s `events_detached` count undercount. This PR does **not** address that; it only makes the suite deterministic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of relationship history tracking during entity deletion.
  * Ensured relationship link and unlink events are recorded before deletion checks run.
  * Strengthened verification that entity change history includes the expected relationship events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->