### PR TITLE
refactor(connector-sdk): drop the dead uniquePerOrg identity flag

### DIFF
--- a/packages/connector-sdk/src/__tests__/identity-namespaces.test.ts
+++ b/packages/connector-sdk/src/__tests__/identity-namespaces.test.ts
@@ -46,12 +46,17 @@ describe('identity namespace registry (generic only)', () => {
     expect(new Set(namespaces).size).toBe(namespaces.length);
   });
 
-  it('registers email_domain as a derived, non-recall, non-unique person namespace', () => {
+  it('does not expose unenforced per-organization uniqueness hints', () => {
+    for (const definition of IDENTITY_NAMESPACE_REGISTRY) {
+      expect(definition).not.toHaveProperty('uniquePerOrg');
+    }
+  });
+
+  it('registers email_domain as a derived, non-recall person namespace', () => {
     expect(getIdentityNamespaceDefinition(IDENTITY.EMAIL_DOMAIN)).toMatchObject({
       subjectKind: 'person',
       normalizer: 'email_domain',
       eventRecallIndexed: false,
-      uniquePerOrg: false,
     });
     expect(isEventRecallIdentityNamespace(IDENTITY.EMAIL_DOMAIN)).toBe(false);
   });

--- a/packages/connector-sdk/src/identity-namespaces.ts
+++ b/packages/connector-sdk/src/identity-namespaces.ts
@@ -29,8 +29,6 @@ export interface IdentityNamespaceDefinition {
   normalizer: IdentityNormalizerKind;
   /** Whether read-time event recall may JOIN on events.metadata[namespace]. */
   eventRecallIndexed: boolean;
-  /** Human-review hint: true means a value should identify at most one entity per org. */
-  uniquePerOrg: boolean;
   /** Human-readable notes for connector authors and migration reviewers. */
   notes?: string;
 }
@@ -50,30 +48,26 @@ export const IDENTITY_NAMESPACE_REGISTRY = [
     subjectKind: 'person',
     normalizer: 'email',
     eventRecallIndexed: true,
-    uniquePerOrg: true,
   },
   {
     namespace: IDENTITY.EMAIL_DOMAIN,
     subjectKind: 'person',
     normalizer: 'email_domain',
     eventRecallIndexed: false,
-    uniquePerOrg: false,
     notes:
-      "A person's email domain (the part after @). Many people share a domain, so it is not unique-per-org and is not a recall key — it only ever narrows a candidate set (e.g. everyone at company.domain). Nothing derives it automatically: a connector that wants it must declare it on an entity-link rule like any other identity.",
+      "A person's email domain (the part after @). Many people share a domain, so it is not a recall key — it only ever narrows a candidate set (e.g. everyone at company.domain). Nothing derives it automatically: a connector that wants it must declare it on an entity-link rule like any other identity.",
   },
   {
     namespace: IDENTITY.PHONE,
     subjectKind: 'person',
     normalizer: 'phone',
     eventRecallIndexed: true,
-    uniquePerOrg: true,
   },
   {
     namespace: IDENTITY.AUTH_USER_ID,
     subjectKind: 'account',
     normalizer: 'auth_user_id',
     eventRecallIndexed: true,
-    uniquePerOrg: true,
   },
 ] as const satisfies readonly IdentityNamespaceDefinition[];
 

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -129,8 +129,9 @@ interface InsertEventParams {
    * heads: this function inserts the successor before stamping the
    * predecessor's `superseded_by`, so both are briefly live and a live-head
    * index would reject every ordinary supersede. Uniqueness is declared per
-   * namespace on purpose: `entity_identities` enforces one blanket index across
-   * every namespace and has carried a dead `uniquePerOrg` knob ever since.
+   * namespace on purpose: `entity_identities` instead enforces one blanket
+   * index across every namespace, so a namespace that should not be unique has
+   * no way to say so.
    *
    * Rows with no stable identity (messages, notes, tombstones, change audits)
    * leave this unset — there is no "current version of" a one-shot event.


### PR DESCRIPTION
## Summary
- `IdentityNamespaceDefinition.uniquePerOrg` is a declared hint with **zero consumers**. Two separate in-repo comments already recorded it as dead — `insert-event.ts` ("has carried a dead `uniquePerOrg` knob ever since") and `20260806120010_events_identity_key_index.sql` ("exists, is declared false for `email_domain`, and has never had a consumer").
- It also contradicts the storage it purports to describe. `idx_entity_identities_live_unique` is a blanket unique index over `(organization_id, namespace, identifier)` applying to **every** namespace, so `email_domain` is declared non-unique and enforced unique regardless.
- The contradiction is dormant, not live: nothing writes `email_domain` identities today (its own notes say "Nothing derives it automatically"). But the flag reads like a per-namespace uniqueness control that does not exist, which is actively misleading — see Notes.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `mxm34ff04q` passed)
- [x] Tests run: `bun test src/__tests__/identity-namespaces.test.ts` — 8/8
- [x] Bug fix: n/a — dead-code removal, red→green below is the guard test
- [ ] If bot runtime changed: n/a

### Guard test

`make review-fix` added a registry-wide assertion that the property cannot come back. Mutation-tested by re-adding `uniquePerOrg: true` to one entry:

```
(fail) identity namespace registry (generic only) > does not expose unenforced per-organization uniqueness hints
 7 pass
 1 fail
```

Restored, 8/8 pass.

## Notes

**Why this is worth deleting rather than leaving.** The flag looks like the answer to #2798 (identities colliding across connections) and is not. `uniquePerOrg` is about **cardinality** — does this value identify one entity or many; `email_domain` is false because many people share a domain. #2798 is about **scope** — does this identifier mean the same thing across connections; `erp_customer` `CARI-001` is a different customer in two different tenants. Those come apart cleanly: `email_domain` is many-per-org but globally meaningful, and a connector-specific key is one-per-connection but not globally meaningful. Wiring #2798 to this flag would scope `email_domain` per connection, which is backwards for it.

**Published surface.** `IdentityNamespaceDefinition` is exported from `@lobu/connector-sdk` (14.22.0, `publishConfig.access: public`), so removing a required property is a type-level break for any external consumer reading `def.uniquePerOrg`. Kept as `refactor:` so release-please cuts a patch rather than forcing a major across the whole train for a flag that never had a consumer, and whose registry is closed and core-owned (connector authors declare namespaces via `ConnectorIdentityModule`, which has no such field). Flagging explicitly so the semver call is deliberate.

**Migrations left untouched.** Two applied migrations mention the flag in comments. They are dated records of why that index was built, and CI forbids modifying applied migrations, so the references stay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Clarified identity namespace metadata so email domains are treated as derived, non-recall information.
  * Removed organization-level uniqueness indicators from identity namespace definitions.
  * Updated event documentation to clarify that identity uniqueness is namespace-specific.
* **Tests**
  * Added coverage confirming identity namespace definitions do not expose organization-level uniqueness settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->