### PR TITLE
fix(server): bound the cleanup TRUNCATE lock wait instead of hanging

### DIFF
--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -407,15 +407,54 @@ export async function cleanupTestDatabase(): Promise<void> {
 const TRUNCATE_DEADLOCK_RETRIES = 8;
 
 /**
+ * Ceiling on each cleanup TRUNCATE lock wait (#2818). Deadlock detection does
+ * not help when another session holds a conflicting lock without forming a
+ * cycle. The 8s timeout is far above the measured whole-database truncate cost
+ * (~150ms for 76 tables in `run-gateway-test-lanes.mjs`) and within the 30s
+ * per-test timeout.
+ */
+const TRUNCATE_LOCK_TIMEOUT_MS = 8_000;
+
+/**
+ * Best-effort non-idle session snapshot for an exhausted lock timeout. The
+ * original wait has ended by the time this runs, so the rows are diagnostic
+ * context rather than a guaranteed list of blockers.
+ */
+async function describeNonIdleDbSessions(db: postgres.Sql): Promise<string> {
+  try {
+    const rows = await db.unsafe(`
+      SELECT pid, state, wait_event_type, wait_event,
+             left(regexp_replace(query, '\\s+', ' ', 'g'), 200) AS query
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND pid <> pg_backend_pid()
+        AND state IS DISTINCT FROM 'idle'
+      ORDER BY xact_start NULLS LAST
+      LIMIT 10
+    `);
+    if (rows.length === 0) return 'no non-idle sessions visible in pg_stat_activity';
+    return rows
+      .map(
+        (r) =>
+          `pid=${r.pid} state=${r.state} wait=${r.wait_event_type ?? '-'}/${r.wait_event ?? '-'} query=${r.query}`
+      )
+      .join('\n  ');
+  } catch (err) {
+    return `could not read pg_stat_activity: ${(err as Error)?.message ?? err}`;
+  }
+}
+
+/**
  * Run the (whole-database) cleanup `TRUNCATE … CASCADE`, retrying on deadlock.
  *
  * These bun:test suites co-run many files in ONE process against a SHARED
  * database, and several of them start background DB pollers that are never
- * stopped — e.g. `ChatInstanceManager.initialize()`'s 15s exclusive-lease tick,
- * the task-scheduler, and the stale-run reaper. Those timers keep firing
- * `INSERT`/`UPDATE` statements on the app connection pool AFTER the test that
- * created them has finished, overlapping the NEXT test's `beforeEach`
- * `cleanupTestDatabase()`.
+ * stopped — e.g. `ChatInstanceManager`'s 15s exclusive-lease tick
+ * (`EXCLUSIVE_TICK_MS`, `chat-instance-manager.ts:264`, driven by the
+ * `exclusiveTimer` interval at `:327`), the task-scheduler, and the stale-run
+ * reaper. Those timers keep firing `INSERT`/`UPDATE` statements on the app
+ * connection pool AFTER the test that created them has finished, overlapping
+ * the NEXT test's `beforeEach` `cleanupTestDatabase()`.
  *
  * That overlap is a textbook deadlock cycle:
  *   - `TRUNCATE … CASCADE` grabs `AccessExclusiveLock` on every table, one at a
@@ -433,10 +472,9 @@ const TRUNCATE_DEADLOCK_RETRIES = 8;
  * The conflicting background statement completes in milliseconds, so retrying
  * the begin/TRUNCATE after a short backoff is deterministic recovery (the lock
  * the INSERT held is gone by the next attempt) — NOT a probabilistic
- * odds-lowering hack, and NOT a re-broadening of the 42P01-only catch. We retry
- * ONLY on 40P01, tolerate ONLY 42P01 (a listed table vanished mid-truncate),
- * and re-throw every other error and the final deadlock so a genuinely stuck
- * cleanup still surfaces.
+ * odds-lowering hack. We also bound non-cyclic lock waits below, tolerate
+ * 42P01 when a listed table vanished mid-truncate, and re-throw every other
+ * error and the final deadlock so a genuinely stuck cleanup still surfaces.
  */
 export async function truncateAllTables(
   db: postgres.Sql,
@@ -445,24 +483,27 @@ export async function truncateAllTables(
 ): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
-      if (canDisableTriggers) {
-        // Disable triggers for faster truncation, but ONLY via `SET LOCAL`
-        // inside a single transaction. `SET LOCAL` is scoped to the
-        // transaction and reverts on COMMIT, and the whole `db.begin` callback
-        // runs on ONE reserved connection — so the `replica` role can never
-        // leak back onto a pooled connection (the bug fixed in #1607).
-        //
-        // `session_replication_role` is superuser-only; on a non-superuser test
-        // role (the PG15+ fresh-`createdb` shape from #950) we skip the disable
-        // entirely. `TRUNCATE … CASCADE` respects FK ordering on its own, so
-        // this only forgoes the speedup, never correctness.
-        await db.begin(async (tx) => {
+      // Both branches run inside `db.begin` so `SET LOCAL lock_timeout` applies
+      // to the TRUNCATE and reverts on COMMIT without touching the pooled
+      // connection's session state. TRUNCATE is transactional in Postgres, so
+      // wrapping the non-trigger branch changes nothing about its effect.
+      await db.begin(async (tx) => {
+        await tx.unsafe(`SET LOCAL lock_timeout = ${TRUNCATE_LOCK_TIMEOUT_MS}`);
+        if (canDisableTriggers) {
+          // Disable triggers for faster truncation, but ONLY via `SET LOCAL`.
+          // `SET LOCAL` is scoped to the transaction and reverts on COMMIT, and
+          // the whole `db.begin` callback runs on ONE reserved connection — so
+          // the `replica` role can never leak back onto a pooled connection
+          // (the bug fixed in #1607).
+          //
+          // `session_replication_role` is superuser-only; on a non-superuser
+          // test role (the PG15+ fresh-`createdb` shape from #950) we skip the
+          // disable entirely. `TRUNCATE … CASCADE` respects FK ordering on its
+          // own, so this only forgoes the speedup, never correctness.
           await tx.unsafe(`SET LOCAL session_replication_role = 'replica'`);
-          await tx.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
-        });
-      } else {
-        await db.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
-      }
+        }
+        await tx.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
+      });
       return;
     } catch (err) {
       const code = (err as { code?: string } | null)?.code;
@@ -475,10 +516,23 @@ export async function truncateAllTables(
         await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
         continue;
       }
+      // 55P03 (lock_not_available): our `lock_timeout` fired because another
+      // session holds a conflicting lock without forming a deadlock cycle.
+      // Fail with enough session context to diagnose the holder (#2818).
+      if (code === '55P03') {
+        const activity = await describeNonIdleDbSessions(db);
+        throw Object.assign(
+          new Error(
+            `cleanup TRUNCATE waited ${TRUNCATE_LOCK_TIMEOUT_MS}ms for a conflicting lock. ` +
+              `Non-idle database sessions:\n  ${activity}`
+          ),
+          { code, cause: err }
+        );
+      }
       // Anything else — a permission error, a failed `SET LOCAL`, a transaction
-      // abort, a lock timeout — or a deadlock that survived every retry is a
-      // real cleanup failure that would leave the DB dirty for the next test,
-      // so re-throw rather than silently swallow.
+      // abort — or a deadlock that survived every retry is a real cleanup
+      // failure that would leave the DB dirty for the next test, so re-throw
+      // rather than silently swallow.
       throw err;
     }
   }

--- a/packages/server/src/lobu/__tests__/cleanup-truncate-deadlock-retry.test.ts
+++ b/packages/server/src/lobu/__tests__/cleanup-truncate-deadlock-retry.test.ts
@@ -3,41 +3,36 @@
  * survive a deadlock (Postgres `40P01`) with a background DML transaction.
  *
  * The `lobu/scheduled/workspace` bun:test step co-runs many files in ONE
- * process against a SHARED database. Several of those files start background DB
- * pollers that are never stopped — `ChatInstanceManager.initialize()`'s 15s
- * exclusive-lease tick, the task-scheduler, the stale-run reaper — so their
- * `INSERT`/`UPDATE` statements keep firing on the app pool after the creating
- * test finished, overlapping the NEXT test's `beforeEach` cleanup TRUNCATE.
+ * process against a SHARED database. Background DB work from one test can
+ * outlive it and overlap the NEXT test's `beforeEach` cleanup TRUNCATE.
  *
  * That overlap is a deadlock cycle: TRUNCATE takes `AccessExclusiveLock` on the
  * tables in list order, while a concurrent FK-bearing INSERT takes
  * `RowExclusiveLock` on the child then needs `RowShareLock` on the referenced
- * parent (for example a connection child row → organization). Opposite
- * lock-acquire orders → when
+ * parent (for example `connections → organization`). Opposite lock-acquire
+ * orders → when
  * Postgres aborts OUR `db.begin(…)` TRUNCATE as the victim, the `40P01`
  * propagated out of `cleanupTestDatabase()` and failed whichever test's
  * `beforeEach` ran it (surfaced after #1607 narrowed the catch to rethrow
  * non-`42P01`).
  *
- * `truncateAllTables` now retries the begin/TRUNCATE on `40P01` (the
- * conflicting background statement clears in milliseconds), while still
- * tolerating ONLY `42P01` and re-throwing every other error and the final
- * deadlock. These tests drive the helper with a scripted fake `postgres.Sql`
- * so they're deterministic and need no real database.
+ * These tests drive the helper with a scripted fake `postgres.Sql` to verify
+ * error handling and deadlock retry accounting. The real lock-wait semantics
+ * are covered in `cleanup-truncate-lock-timeout.test.ts`.
  */
 
 import { describe, expect, test } from 'bun:test';
 import { truncateAllTables } from '../../__tests__/setup/test-db';
 
-type Outcome = '40P01' | '42P01' | '42501' | 'ok';
+type Outcome = '40P01' | '42P01' | '42501' | '55P03' | 'ok';
 
 function pgError(code: string): Error {
   return Object.assign(new Error(`pg error ${code}`), { code });
 }
 
 /**
- * Fake `postgres.Sql` whose every TRUNCATE attempt (one `begin` call or one
- * `unsafe` call) consumes the next scripted outcome; the last entry repeats.
+ * Fake `postgres.Sql` whose every TRUNCATE transaction consumes the next
+ * scripted outcome; the last entry repeats.
  */
 function fakeDb(script: Outcome[]) {
   let i = 0;
@@ -49,8 +44,7 @@ function fakeDb(script: Outcome[]) {
   const db = {
     attempts: 0,
     async unsafe(_sql: string) {
-      // SET LOCAL / non-truncate statements inside begin are no-ops; only the
-      // top-level TRUNCATE attempt (begin or the bare unsafe) counts.
+      // Diagnostic queries are irrelevant to retry accounting.
     },
     async begin(cb: (tx: { unsafe: (s: string) => Promise<void> }) => Promise<void>) {
       db.attempts++;
@@ -64,7 +58,7 @@ function fakeDb(script: Outcome[]) {
   };
 }
 
-describe('truncateAllTables — deadlock retry', () => {
+describe('truncateAllTables — cleanup error handling', () => {
   test('recovers when the TRUNCATE deadlocks then succeeds on retry', async () => {
     const db = fakeDb(['40P01', '40P01', 'ok']);
     await truncateAllTables(db as any, '"a", "b"', true);
@@ -79,7 +73,7 @@ describe('truncateAllTables — deadlock retry', () => {
     expect(db.attempts).toBe(1);
   });
 
-  test('re-throws a non-deadlock error immediately (no retry)', async () => {
+  test('re-throws an unrelated error immediately (no retry)', async () => {
     const db = fakeDb(['42501', 'ok']);
     await expect(truncateAllTables(db as any, '"a"', true)).rejects.toMatchObject({
       code: '42501',
@@ -93,5 +87,13 @@ describe('truncateAllTables — deadlock retry', () => {
       code: '40P01',
     });
     expect(db.attempts).toBeGreaterThan(1); // it really did retry before giving up
+  });
+
+  test('reports a lock timeout without retrying the whole transaction', async () => {
+    const db = fakeDb(['55P03']);
+    await expect(truncateAllTables(db as any, '"a"', true)).rejects.toMatchObject({
+      code: '55P03',
+    });
+    expect(db.attempts).toBe(1);
   });
 });

--- a/packages/server/src/lobu/__tests__/cleanup-truncate-lock-timeout.test.ts
+++ b/packages/server/src/lobu/__tests__/cleanup-truncate-lock-timeout.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression for #2818: a conflicting lock without a deadlock cycle must not
+ * leave cleanup's `TRUNCATE … CASCADE` waiting until the test or job timeout.
+ * This needs a real database because a scripted fake cannot reproduce lock
+ * waits; the probe truncates only its own scratch table.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import postgres from 'postgres';
+import { truncateAllTables } from '../../__tests__/setup/test-db';
+import { ensureDbForGatewayTests } from '../../gateway/__tests__/helpers/db-setup';
+
+const PROBE_TABLE = 'truncate_lock_probe_2818';
+/** Release before the 25s test budget to protect later suites if this test regresses. */
+const LOCK_WATCHDOG_MS = 20_000;
+
+let owner: postgres.Sql;
+let blocker: postgres.Sql;
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  const url = process.env.DATABASE_URL as string;
+  owner = postgres(url, { max: 2, onnotice: () => {} });
+  blocker = postgres(url, { max: 1, onnotice: () => {} });
+  await owner.unsafe(`CREATE TABLE IF NOT EXISTS ${PROBE_TABLE} (id int)`);
+});
+
+afterAll(async () => {
+  await blocker?.end({ timeout: 5 });
+  await owner?.unsafe(`DROP TABLE IF EXISTS ${PROBE_TABLE}`).catch(() => {});
+  await owner?.end({ timeout: 5 });
+});
+
+/**
+ * Hold `ACCESS EXCLUSIVE` on the probe table from a second session and keep the
+ * transaction open until `release()` is called. This is the non-cyclic shape:
+ * TRUNCATE simply queues behind it, so Postgres never raises a deadlock.
+ */
+async function holdConflictingLock(): Promise<{ release: () => Promise<void> }> {
+  let signalRelease!: () => void;
+  const held = new Promise<void>((resolve) => {
+    signalRelease = resolve;
+  });
+  let released = false;
+  const releaseLock = () => {
+    if (released) return;
+    released = true;
+    signalRelease();
+  };
+  // Release before the per-test timeout even if the lock timeout regresses,
+  // so this probe cannot starve later cleanup hooks in the shared process.
+  const watchdog = setTimeout(releaseLock, LOCK_WATCHDOG_MS);
+  watchdog.unref?.();
+  let lockAcquired!: () => void;
+  let lockFailed!: (err: unknown) => void;
+  const locked = new Promise<void>((resolve, reject) => {
+    lockAcquired = resolve;
+    lockFailed = reject;
+  });
+  const transaction = blocker.begin(async (tx) => {
+    await tx.unsafe(`LOCK TABLE ${PROBE_TABLE} IN ACCESS EXCLUSIVE MODE`);
+    lockAcquired();
+    await held;
+  });
+  void transaction.catch(lockFailed);
+  await locked;
+  return {
+    release: async () => {
+      clearTimeout(watchdog);
+      releaseLock();
+      await transaction;
+    },
+  };
+}
+
+describe('truncateAllTables — blocked-lock timeout (#2818)', () => {
+  for (const canDisableTriggers of [true, false]) {
+    test(
+      `fails fast instead of blocking forever (canDisableTriggers=${canDisableTriggers})`,
+      async () => {
+        const { release } = await holdConflictingLock();
+        const startedAt = performance.now();
+        let caught: (Error & { code?: string }) | null = null;
+        try {
+          await truncateAllTables(owner, `"${PROBE_TABLE}"`, canDisableTriggers);
+        } catch (err) {
+          caught = err as Error & { code?: string };
+        } finally {
+          await release();
+        }
+        const elapsed = performance.now() - startedAt;
+
+        expect(caught).not.toBeNull();
+        expect(caught?.code).toBe('55P03');
+        // The diagnostic is the entire point of the change: a failure that does
+        // not name the holder leaves the next person exactly where CI did.
+        expect(caught?.message).toContain('conflicting lock');
+        expect(caught?.message).toMatch(/pid=\d+/);
+        expect(caught?.message).toContain(PROBE_TABLE);
+
+        // The timeout must fire before the watchdog releases the blocker;
+        // without it, this call succeeds only after the watchdog fires.
+        expect(elapsed).toBeLessThan(20_000);
+      },
+      25_000
+    );
+  }
+
+  test('still succeeds when nothing holds a conflicting lock', async () => {
+    await owner.unsafe(`INSERT INTO ${PROBE_TABLE} (id) VALUES (1)`);
+    await truncateAllTables(owner, `"${PROBE_TABLE}"`, true);
+    const rows = await owner.unsafe(`SELECT count(*)::int AS n FROM ${PROBE_TABLE}`);
+    expect(rows[0]?.n).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Bound each cleanup `TRUNCATE` lock wait with `SET LOCAL lock_timeout`; on `55P03`, fail with a snapshot of non-idle sessions instead of blocking forever (#2818).
- Collapse both truncate branches into one `db.begin`, removing the duplicated `TRUNCATE` statement the two arms carried.
- Add a real-Postgres regression test for the non-cyclic lock case, plus deterministic scripted coverage of the `55P03` branch.

The existing `40P01` retry only helps when the conflicting session forms a deadlock **cycle** — Postgres detects that and aborts a victim in milliseconds. A session that holds a lock *without* a cycle produces no deadlock, so `TRUNCATE` queued behind it indefinitely. That starved every following `beforeEach` until `server-integration-bun` hit GitHub's 15-minute cap, taking the required `integration` fan-in red on unrelated PRs.

## Test plan
- [x] **Red**, real Postgres, conflicting `ACCESS EXCLUSIVE` held from a second session — both truncate branches hang until the test cap:
```
(fail) fails fast instead of blocking forever (canDisableTriggers=true)  [25003.35ms]
  ^ this test timed out after 25000ms.
(fail) fails fast instead of blocking forever (canDisableTriggers=false) [25002.17ms]
  ^ this test timed out after 25000ms.
Ran 3 tests across 1 file. [56.83s]
```
- [x] **Green** after the fix, plus the sibling deadlock suite: `8 pass, 0 fail — Ran 8 tests across 2 files. [19.52s]`
- [x] **Cascade reproduced end-to-end.** With the fix removed, the leaked lock starved the whole lane exactly as CI does — unrelated suites dying at the per-test cap, run still going at 20 minutes:
```
(fail) GET /deployments (feed) > keyset pagination pages through without overlap [30001.14ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```
- [x] **Mutation-tested.** `TRUNCATE_LOCK_TIMEOUT_MS = 0` returns the suite to `0 pass, 3 fail` with both timeouts, so the bound is load-bearing. The test's own lock watchdog was mutated to 300ms and correctly flipped the assertions, so it is wired rather than decorative.
- [x] **No regressions**, isolated comparison of the `lobu/scheduled/workspace` lane: baseline `68 pass / 91 fail / 7 errors` vs this branch `71 pass / 91 fail / 7 errors` — identical failures, delta is exactly the three new tests. The 91 are pre-existing local-environment failures in guardrail/config route suites.
- [x] `make pre-pr-remote`: `Depot run txp0wt06xl passed`, tree `4c83e16406e2bfaa4000e526ee7468c66bdb176c`.
- [ ] Bot runtime changed: not applicable.

## Notes
- No database schema, public API, or SDK contract changes — this is test-harness only.
- **This bounds and diagnoses the hang; it does not by itself guarantee the bun lane goes green.** A transient poller lock now clears on the bounded wait, but a genuinely long-held lock will still fail — in ~8s, naming the holding `pid`, `state`, `wait_event` and query, rather than silently burning the 15-minute job cap. Identifying and stopping the leaked pollers is separate follow-up work that this makes findable.
- The diagnostic is deliberately named `describeNonIdleDbSessions`, not "blockers": by the time it runs the wait has ended, so the rows are context, not a guaranteed blocker list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database cleanup now stops waiting after 8 seconds when blocked by a lock.
  * Lock-timeout errors include diagnostic details about the blocking session and affected table.
  * Lock-timeout failures are reported immediately without unnecessary retry attempts.
  * Deadlock retries continue to work, while other errors—including exhausted retries—are still surfaced.

* **Documentation**
  * Clarified the distinction between deadlocks and other lock waits, including current cleanup polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->