### PR TITLE
feat: allow reaction-only Automations (prompt optional) with codified-vs-agentic UI

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -868,6 +868,85 @@ describe("executePlan — atomic Automation triggers+prompt update", () => {
       triggers: desired.triggers,
     });
   });
+
+  test("reaction-only event-turn→schedule transition installs reaction before updateAutomation", async () => {
+    const reactionSource = "export const input = z.object({});";
+    const desired = {
+      slug: "reaction-digest",
+      agent: "triage",
+      prompt: "",
+      reactionScript: { sourceCode: reactionSource },
+      triggers: [{ kind: "schedule" as const, cron: "0 9 * * *" }],
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [],
+    });
+    state.automations = [desired];
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "automation",
+          verb: "update",
+          id: desired.slug,
+          desired,
+          changedFields: ["triggers", "reaction_script"],
+          versionBoundFields: [],
+        },
+      ],
+      counts: { create: 0, update: 1, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      automations: [
+        {
+          slug: desired.slug,
+          automation_id: "50",
+          agent_id: "triage",
+          prompt: "",
+          triggers: [
+            {
+              kind: "event",
+              connector_key: "slack",
+              event_types: ["message.created"],
+              execution: "turn",
+            },
+          ],
+        },
+      ],
+      connectorDefinitions: [],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const callOrder: string[] = [];
+    const setReactionScript = mock(async () => {
+      callOrder.push("setReactionScript");
+    });
+    const updateAutomation = mock(async () => {
+      callOrder.push("updateAutomation");
+    });
+    const client = {
+      setReactionScript,
+      updateAutomation,
+      createAutomationVersion: mock(async () => ({})),
+    } as unknown as ApplyClient;
+
+    await executePlan({ client, state, plan, remote }, []);
+
+    // Reaction must be installed before the scalar update so the server's
+    // instruction rule sees the reaction when validating the trigger change.
+    expect(setReactionScript).toHaveBeenCalledTimes(1);
+    expect(setReactionScript).toHaveBeenCalledWith("50", reactionSource);
+    expect(updateAutomation).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["setReactionScript", "updateAutomation"]);
+  });
 });
 
 describe("normalizeConnectionConfigScope — feed-scoped keys demote to feeds", () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -8,6 +8,7 @@ import {
   defineConnector,
   defineEntityType,
   defineRelationshipType,
+  reactionFromFile,
   secret,
 } from "@lobu/cli/config";
 import type { AgentSettings } from "@lobu/core";
@@ -970,7 +971,7 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/more than one schedule trigger/i);
   });
 
-  test("requires prompt OR >=1 skill for schedule, window-event, and manual Automations", () => {
+  test("requires prompt, >=1 skill, or a reaction script for schedule, window-event, and manual Automations", () => {
     const crm = defineAgent({ id: "crm" });
     const map = (automation: ReturnType<typeof defineAutomation>) => () =>
       mapProjectToDesiredState(
@@ -1033,6 +1034,19 @@ describe("mapProjectToDesiredState", () => {
           agent: crm,
           slug: "prompt-only",
           prompt: "Summarise yesterday's signups.",
+          triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+        })
+      )
+    ).not.toThrow();
+    // A reaction script is the third instruction source: a schedule Automation
+    // with a reaction and no prompt/skills is valid (the loader resolves the
+    // file; the server enforces the final rule on its source).
+    expect(
+      map(
+        defineAutomation({
+          agent: crm,
+          slug: "reaction-only",
+          reaction: reactionFromFile("./reactions/dedupe.reaction.ts"),
           triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
         })
       )

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -941,6 +941,9 @@ export async function executePlan(
           description: w.description,
           prompt: w.prompt,
           ...(w.skillSnapshots?.length ? { skills: w.skillSnapshots } : {}),
+          ...(w.reactionScript
+            ? { reaction_script: w.reactionScript.sourceCode }
+            : {}),
           triggers: w.triggers,
           sources: w.sources,
           reactions_guidance: w.reactionsGuidance,
@@ -1022,7 +1025,20 @@ export async function executePlan(
               : {}),
           });
         }
-        // b) Version-bound fields → manage_automations create_version (server
+        // b) Reaction script — attach BEFORE the version write below. The final
+        //    version can be valid only because of the reaction (a reaction-only
+        //    transition clears the prompt), and the server's instruction rule
+        //    validates the version against the group's CURRENT reaction. Push
+        //    first (idempotent server-side, no drift signal because it's not
+        //    returned by Automation lists) so the rule sees it. Reaction
+        //    removal is never pushed — apply only ever sets scripts.
+        if (w.reactionScript) {
+          await ctx.client.setReactionScript(
+            automationId,
+            w.reactionScript.sourceCode
+          );
+        }
+        // c) Version-bound fields → manage_automations create_version (server
         //    inherits unset fields from the previous version row, but we always
         //    send the desired-side values for the changed keys). name/description
         //    are version-owned (update rejects them).
@@ -1057,14 +1073,6 @@ export async function executePlan(
               : {}),
           });
         }
-      }
-      // c) Reaction script — push when declared (idempotent server-side, no
-      //    drift signal available because it's not returned by Automation lists).
-      if (w.reactionScript && automationId) {
-        await ctx.client.setReactionScript(
-          automationId,
-          w.reactionScript.sourceCode
-        );
       }
       printText(
         renderProgress(

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -980,7 +980,20 @@ export async function executePlan(
         const scalarForUpdate = triggersWithVersionChange
           ? scalarChanges.filter((f) => f !== "triggers")
           : scalarChanges;
-        // a) Scalar fields → manage_automations update
+        // a) Reaction script — attach BEFORE scalar updates and version writes.
+        //    The server's instruction rule validates trigger/prompt/skills
+        //    against the group's CURRENT reaction, so a reaction-only transition
+        //    (no prompt/skills) must install the reaction before the trigger
+        //    update reaches the server. Push first (idempotent, no drift signal
+        //    because it's not returned by Automation lists) so the rule sees it.
+        //    Reaction removal is never pushed — apply only ever sets scripts.
+        if (w.reactionScript) {
+          await ctx.client.setReactionScript(
+            automationId,
+            w.reactionScript.sourceCode
+          );
+        }
+        // b) Scalar fields → manage_automations update
         if (scalarForUpdate.length > 0) {
           await ctx.client.updateAutomation({
             automation_id: automationId,
@@ -1024,19 +1037,6 @@ export async function executePlan(
                 }
               : {}),
           });
-        }
-        // b) Reaction script — attach BEFORE the version write below. The final
-        //    version can be valid only because of the reaction (a reaction-only
-        //    transition clears the prompt), and the server's instruction rule
-        //    validates the version against the group's CURRENT reaction. Push
-        //    first (idempotent server-side, no drift signal because it's not
-        //    returned by Automation lists) so the rule sees it. Reaction
-        //    removal is never pushed — apply only ever sets scripts.
-        if (w.reactionScript) {
-          await ctx.client.setReactionScript(
-            automationId,
-            w.reactionScript.sourceCode
-          );
         }
         // c) Version-bound fields → manage_automations create_version (server
         //    inherits unset fields from the previous version row, but we always

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -1068,6 +1068,7 @@ export class ApplyClient {
     description?: string;
     prompt: string;
     skills?: Array<{ name: string; content: string }>;
+    reaction_script?: string;
     triggers?: import("@lobu/core/contracts/tools/manage-automations").AutomationTrigger[];
     sources?: AutomationSource[];
     reactions_guidance?: string;
@@ -1092,6 +1093,9 @@ export class ApplyClient {
         ...(payload.description ? { description: payload.description } : {}),
         prompt: payload.prompt,
         ...(payload.skills?.length ? { skills: payload.skills } : {}),
+        ...(payload.reaction_script !== undefined
+          ? { reaction_script: payload.reaction_script }
+          : {}),
         ...(payload.triggers !== undefined
           ? { triggers: payload.triggers }
           : {}),

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -566,18 +566,21 @@ function mapAutomationOutputs(
 const MAX_AUTOMATION_SKILLS = 5;
 
 /**
- * Skills-presence rule. An event trigger executing as "turn" carries its own
- * content (the incoming message/event), so it may run with zero skills on the
- * built-in default instruction. Everything else — schedule triggers, event
- * triggers with execution "window", and Automations with no triggers at all
- * (manual runs) — needs a prompt, at least one skill, or both.
+ * Instruction-presence rule. An event trigger executing as "turn" carries its own
+ * content (the incoming message/event), so it may run with zero instructions on
+ * the built-in default. Everything else — schedule triggers, event triggers with
+ * execution "window", and Automations with no triggers at all (manual runs) —
+ * needs a prompt, at least one skill, or a reaction script.
  *
  * This CLI preflight mirrors the server rule, catching the error against the
  * config file (naming the slug) rather than as a 422 mid-apply. When both
  * triggers and instructions change, apply sends them together through
  * create_version so the final pair is validated atomically.
  */
-function assertAutomationSkills(automation: DesiredAutomation): void {
+function assertAutomationSkills(
+  automation: DesiredAutomation,
+  reactionDeclared: boolean
+): void {
   const skills = automation.skills ?? [];
   const duplicates = skills.filter((name, i) => skills.indexOf(name) !== i);
   if (duplicates.length > 0) {
@@ -611,13 +614,17 @@ function assertAutomationSkills(automation: DesiredAutomation): void {
         (trigger.kind === "event" &&
           resolvedEventExecution(trigger) === "window")
     );
-  // Either instruction source satisfies the rule. An Automation whose whole job is
-  // "run this skill" has no task statement to write, and one that spells its
-  // task out inline needs no skill — demanding both would be stricter than the
-  // server and would reject configs the API accepts.
-  if (requiresSkills && skills.length === 0 && !automation.prompt.trim()) {
+  // Any one of the three instruction sources satisfies the rule. An Automation
+  // whose whole job is "run this skill" has no task statement to write, one
+  // that spells its task out inline needs no skill, and one that runs entirely
+  // as a reaction script needs neither — demanding two would be stricter than
+  // the server and would reject configs the API accepts. The mapper runs
+  // BEFORE the loader reads the reaction file, so `reactionDeclared` is the
+  // config marker (present for `reactionFromFile(path)`); the loader validates
+  // the file and the server enforces the final rule on its source.
+  if (requiresSkills && skills.length === 0 && !automation.prompt.trim() && !reactionDeclared) {
     throw new ValidationError(
-      `Automation "${automation.slug}" needs instructions: schedule triggers, event triggers with execution "window", and Automations with no triggers run on stored instructions alone, so give it a "prompt", at least one skill, or both. Only event triggers with execution "turn" may omit both.`
+      `Automation "${automation.slug}" needs instructions: schedule triggers, event triggers with execution "window", and Automations with no triggers run on stored instructions alone, so give it a "prompt", at least one skill, or a reaction script. Only event triggers with execution "turn" may omit all three.`
     );
   }
 }
@@ -981,13 +988,22 @@ export function mapProjectToDesiredState(
   assertUniqueBy(providers, (p) => p.slug, "provider slug");
 
   const agentIds = new Set(project.agents.map((agent) => agent.id));
-  for (const automation of automations) {
+  for (let i = 0; i < automations.length; i++) {
+    const automation = automations[i];
+    if (!automation) continue;
     if (!agentIds.has(automation.agent)) {
       throw new ValidationError(
         `Automation "${automation.slug}" names agent "${automation.agent}", but no agent with that id is declared in lobu.config.ts`
       );
     }
-    assertAutomationSkills(automation);
+    // The config's `reaction` marker (from `reactionFromFile(path)`) drives the
+    // instruction-presence preflight — the reaction SOURCE is only resolved
+    // later by the loader. `automations` is index-aligned with
+    // `project.automations` (the mapper maps in order).
+    assertAutomationSkills(
+      automation,
+      project.automations?.[i]?.reaction !== undefined
+    );
     for (const trigger of automation.triggers ?? []) {
       if (
         trigger.kind !== "event" ||

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -622,7 +622,12 @@ function assertAutomationSkills(
   // BEFORE the loader reads the reaction file, so `reactionDeclared` is the
   // config marker (present for `reactionFromFile(path)`); the loader validates
   // the file and the server enforces the final rule on its source.
-  if (requiresSkills && skills.length === 0 && !automation.prompt.trim() && !reactionDeclared) {
+  if (
+    requiresSkills &&
+    skills.length === 0 &&
+    !automation.prompt.trim() &&
+    !reactionDeclared
+  ) {
     throw new ValidationError(
       `Automation "${automation.slug}" needs instructions: schedule triggers, event triggers with execution "window", and Automations with no triggers run on stored instructions alone, so give it a "prompt", at least one skill, or a reaction script. Only event triggers with execution "turn" may omit all three.`
     );

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -503,8 +503,9 @@ function emitRelationshipType(
 
 /**
  * Instruction-presence rule, mirrored from `lobu apply` validation: only an
- * event-turn-only Automation may omit both prompt and skills (the built-in
- * default applies).
+ * event-turn-only Automation may omit all instruction sources (the built-in
+ * default applies). Schedule/window/manual shapes need a prompt, a skill, or a
+ * reaction script.
  */
 function automationRequiresInstructions(
   triggers: RemoteAutomation["triggers"]
@@ -971,14 +972,15 @@ function generateProject(
   const agentsById = new Map(
     state.agents.map(({ agent, settings }) => [agent.agentId, settings])
   );
-  for (const { automation } of state.automations) {
+  for (const { automation, reactionScript } of state.automations) {
     if (
       !automation.prompt?.trim() &&
       !automation.skills?.length &&
+      !reactionScript?.trim() &&
       automationRequiresInstructions(automation.triggers)
     ) {
       warnings.push(
-        `Automation "${automation.slug}" has no stored instructions but is not event-turn-only — give it a prompt or attach at least one skill before the next \`lobu apply\`.`
+        `Automation "${automation.slug}" has no stored instructions but is not event-turn-only — give it a prompt, attach at least one skill, or set a reaction script before the next \`lobu apply\`.`
       );
     }
     const library =

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -606,11 +606,11 @@ export interface Automation {
    * Automation until the next `lobu apply`; re-applying is the explicit upgrade
    * action for a declarative project.
    *
-   * Supply {@link Automation.prompt}, `skills`, or both. One of the two is
-   * required for schedule triggers, event triggers with execution `"window"`,
-   * and Automations with no triggers (manual runs); an event trigger with
-   * execution `"turn"` may omit both, since the incoming event is the content
-   * and a built-in default applies.
+   * Supply {@link Automation.prompt}, `skills`, or a {@link Automation.reaction}
+   * script. Any one of the three is required for schedule triggers, event
+   * triggers with execution `"window"`, and Automations with no triggers
+   * (manual runs); an event trigger with execution `"turn"` may omit all three,
+   * since the incoming event is the content and a built-in default applies.
    */
   skills?: string[];
   /**

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -493,7 +493,7 @@ export const ManageAutomationsSchema = Type.Object(
       [
         Type.Literal("create", {
           description:
-            "Create an Automation. Put the task statement in `prompt` and reusable know-how in `skills`; either satisfies the instruction requirement, and an event trigger with execution 'turn' may omit both.",
+            "Create an Automation. Put the task statement in `prompt`, reusable know-how in `skills`, and/or a deterministic processing step in `reaction_script`; any one satisfies the instruction requirement, and an event trigger with execution 'turn' may omit all of them.",
         }),
         Type.Literal("list", { description: "List Automations." }),
         Type.Literal("update", { description: "Patch Automation config." }),
@@ -592,7 +592,7 @@ export const ManageAutomationsSchema = Type.Object(
     prompt: Type.Optional(
       Type.String({
         description:
-          "[create/create_version] Literal LLM instruction text for the Automation — the task statement, frozen into the version. No template expansion happens: the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Reusable know-how belongs in `skills` instead, which is delivered as readable files rather than pasted in here. A schedule trigger, an event trigger with execution 'window', and an Automation with no triggers each need an instruction source — supply `prompt`, `skills`, or both; an event trigger with execution 'turn' may omit both and use the built-in default.",
+          "[create/create_version] Literal LLM instruction text for the Automation — the task statement, frozen into the version. No template expansion happens: the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Reusable know-how belongs in `skills` instead, which is delivered as readable files rather than pasted in here. A schedule trigger, an event trigger with execution 'window', and an Automation with no triggers each need an instruction source — supply `prompt`, `skills`, or `reaction_script`; an event trigger with execution 'turn' may omit all three and use the built-in default.",
       })
     ),
     skills: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -493,7 +493,7 @@ export const ManageAutomationsSchema = Type.Object(
       [
         Type.Literal("create", {
           description:
-            "Create an Automation. Put the task statement in `prompt`, reusable know-how in `skills`, and/or a deterministic processing step in `reaction_script`; any one satisfies the instruction requirement, and an event trigger with execution 'turn' may omit all of them.",
+            "Create an Automation. Put the task statement in `prompt` and reusable know-how in `skills`; either satisfies the instruction requirement, and an event trigger with execution 'turn' may omit both.",
         }),
         Type.Literal("list", { description: "List Automations." }),
         Type.Literal("update", { description: "Patch Automation config." }),
@@ -592,7 +592,7 @@ export const ManageAutomationsSchema = Type.Object(
     prompt: Type.Optional(
       Type.String({
         description:
-          "[create/create_version] Literal LLM instruction text for the Automation — the task statement, frozen into the version. No template expansion happens: the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Reusable know-how belongs in `skills` instead, which is delivered as readable files rather than pasted in here. A schedule trigger, an event trigger with execution 'window', and an Automation with no triggers each need an instruction source — supply `prompt`, `skills`, or `reaction_script`; an event trigger with execution 'turn' may omit all three and use the built-in default.",
+          "[create/create_version] Literal LLM instruction text for the Automation — the task statement, frozen into the version. No template expansion happens: the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Reusable know-how belongs in `skills` instead, which is delivered as readable files rather than pasted in here. A schedule trigger, an event trigger with execution 'window', and an Automation with no triggers each need an instruction source — supply `prompt`, `skills`, or both; an event trigger with execution 'turn' may omit both and use the built-in default.",
       })
     ),
     skills: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-automations-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-automations-instruction-rule.test.ts
@@ -7,9 +7,9 @@
  * An event trigger with execution "turn" carries its own content and may omit
  * all three.
  *
- * create_version and set_reaction_script enforce the same rule when they write
- * instruction text: a version bump is validated against the group's reaction,
- * and clearing a reaction that was the sole instruction source is rejected.
+ * create_version and set_reaction_script enforce the same rule when they mutate
+ * instruction sources: a version bump is validated against the group's
+ * reaction, and clearing a sole-source reaction is rejected.
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
@@ -264,6 +264,83 @@ export default async function reaction(ctx, client) {
 			ownerCtx
 		)) as { version?: number };
 		expect(versioned.version).toBeGreaterThan(1);
+	});
+
+	it("update accepts a reaction-only Automation when its trigger becomes a schedule", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-updated",
+				agent_id: agentId,
+				reaction_script: REACTION_SCRIPT,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+
+		await expect(
+			executeTool(
+				"manage_automations",
+				{
+					action: "update",
+					automation_id: created.automation_id!,
+					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).resolves.toBeTruthy();
+	});
+
+	it("create_from_version preserves a reaction-only schedule Automation", async () => {
+		const rootEntity = await createTestEntity({
+			name: "IR Reaction Root",
+			organization_id: orgId,
+			created_by: ownerCtx.userId!,
+		});
+		const siblingEntity = await createTestEntity({
+			name: "IR Reaction Sibling",
+			organization_id: orgId,
+			created_by: ownerCtx.userId!,
+		});
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-cloned",
+				agent_id: agentId,
+				entity_id: rootEntity.id,
+				reaction_script: REACTION_SCRIPT,
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+
+		const sql = getTestDb();
+		const [root] = await sql`
+			SELECT current_version_id FROM automations
+			WHERE id = ${Number(created.automation_id)}
+		`;
+		const cloned = (await executeTool(
+			"manage_automations",
+			{
+				action: "create_from_version",
+				version_id: String(root.current_version_id),
+				entity_ids: [siblingEntity.id],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { created?: Array<{ automation_id: string }> };
+
+		expect(cloned.created?.[0]?.automation_id).toBeTruthy();
+		const siblingId = Number(cloned.created?.[0]?.automation_id);
+		const [sibling] = await sql`
+			SELECT reaction_script FROM automations WHERE id = ${siblingId}
+		`;
+		expect(sibling.reaction_script).toContain("resolve_duplicates");
 	});
 
 	it("rejects clearing the reaction script that was the sole instruction source", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-automations-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-automations-instruction-rule.test.ts
@@ -1,12 +1,15 @@
 /**
  * manage_automations — instruction-presence rule (issue #2320, thin Automations).
  *
- * An Automation needs at least one instruction source (`prompt` or pinned skills)
- * only for trigger shapes that run on it alone: schedule triggers, event
- * triggers with execution "window", and no triggers (manual). An event trigger
- * with execution "turn" carries its own content and may omit both.
+ * An Automation needs at least one instruction source (`prompt`, pinned skills,
+ * or a reaction script) only for trigger shapes that run on it alone: schedule
+ * triggers, event triggers with execution "window", and no triggers (manual).
+ * An event trigger with execution "turn" carries its own content and may omit
+ * all three.
  *
- * create_version enforces the same rule when it writes instruction text.
+ * create_version and set_reaction_script enforce the same rule when they write
+ * instruction text: a version bump is validated against the group's reaction,
+ * and clearing a reaction that was the sole instruction source is rejected.
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
@@ -189,6 +192,150 @@ describe("manage_automations — instruction-presence rule", () => {
 		`;
 		expect(v2.prompt).toBe("");
 		expect(v2.skills).toEqual(v1.skills);
+	});
+
+	const REACTION_SCRIPT = `export const input = {
+	type: "object",
+	properties: { summary: { type: "string" } },
+	required: ["summary"],
+	additionalProperties: false,
+};
+
+export default async function reaction(ctx, client) {
+	await client.entities.manage({ action: "resolve_duplicates", candidate_entity_ids: [1] });
+}`;
+
+	it("creates a schedule Automation from a reaction script without a prompt", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-only",
+				agent_id: agentId,
+				reaction_script: REACTION_SCRIPT,
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+		expect(created.automation_id).toBeTruthy();
+
+		const sql = getTestDb();
+		const [row] = await sql`
+			SELECT automation.reaction_script, automation.reaction_input_schema,
+			       version.prompt
+			FROM automations automation
+			JOIN automation_versions version ON version.id = automation.current_version_id
+			WHERE automation.id = ${Number(created.automation_id)}
+		`;
+		expect(row.prompt).toBe("");
+		expect(row.reaction_script).toContain("resolve_duplicates");
+		expect(row.reaction_input_schema).toEqual({
+			type: "object",
+			properties: { summary: { type: "string" } },
+			required: ["summary"],
+			additionalProperties: false,
+		});
+	});
+
+	it("create_version keeps a reaction-only schedule Automation valid when it blanks the prompt", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-versioned",
+				agent_id: agentId,
+				reaction_script: REACTION_SCRIPT,
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+
+		const versioned = (await executeTool(
+			"manage_automations",
+			{
+				action: "create_version",
+				automation_id: created.automation_id!,
+				prompt: "",
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+	});
+
+	it("rejects clearing the reaction script that was the sole instruction source", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-cleared",
+				agent_id: agentId,
+				reaction_script: REACTION_SCRIPT,
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+
+		await expect(
+			executeTool(
+				"manage_automations",
+				{
+					action: "set_reaction_script",
+					automation_id: created.automation_id!,
+					reaction_script: "",
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+
+		const sql = getTestDb();
+		const [row] = await sql`
+			SELECT reaction_script
+			FROM automations
+			WHERE id = ${Number(created.automation_id)}
+		`;
+		expect(row.reaction_script).toContain("resolve_duplicates");
+	});
+
+	it("allows clearing a reaction when the prompt alone satisfies the rule", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "ir-reaction-cleared-with-prompt",
+				agent_id: agentId,
+				prompt: "Daily digest instructions.",
+				reaction_script: REACTION_SCRIPT,
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { automation_id?: string };
+
+		const cleared = (await executeTool(
+			"manage_automations",
+			{
+				action: "set_reaction_script",
+				automation_id: created.automation_id!,
+				reaction_script: "",
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { has_script?: boolean };
+		expect(cleared.has_script).toBe(false);
+
+		const sql = getTestDb();
+		const [row] = await sql`
+			SELECT reaction_script
+			FROM automations
+			WHERE id = ${Number(created.automation_id)}
+		`;
+		expect(row.reaction_script).toBeNull();
 	});
 
 	it("create_version rejects blanking instructions on a schedule Automation, accepts real text", async () => {

--- a/packages/server/src/__tests__/unit/automation-instructions-rule.test.ts
+++ b/packages/server/src/__tests__/unit/automation-instructions-rule.test.ts
@@ -117,3 +117,33 @@ describe("assertAutomationInstructions", () => {
 		}
 	});
 });
+
+describe("validateReactionDefaultExport", () => {
+	// Lazy import to avoid module-level side effects in the test harness.
+	const loadValidator = () =>
+		import("../../automations/reaction-executor").then(
+			(m) => m.validateReactionDefaultExport,
+		);
+
+	test.skip("accepts a script with a default export (requires isolated-vm)", async () => {
+		const validate = await loadValidator();
+		const { compileReactionScript } = await import(
+			"../../automations/reaction-executor",
+		);
+		const source = 'export default async () => { return "ok"; }';
+		const compiled = await compileReactionScript(source);
+		await expect(validate(compiled)).resolves.toBeUndefined();
+	});
+
+	test.skip("rejects a script with only named exports (requires isolated-vm)", async () => {
+		const validate = await loadValidator();
+		const { compileReactionScript } = await import(
+			"../../automations/reaction-executor",
+		);
+		const source = 'export const input = { type: "object" }';
+		const compiled = await compileReactionScript(source);
+		await expect(validate(compiled)).rejects.toThrow(
+			/default async function/,
+		);
+	});
+});

--- a/packages/server/src/__tests__/unit/automation-instructions-rule.test.ts
+++ b/packages/server/src/__tests__/unit/automation-instructions-rule.test.ts
@@ -82,4 +82,38 @@ describe("assertAutomationInstructions", () => {
 		).not.toThrow();
 		expect(() => assertAutomationInstructions([], "Manual runbook.")).not.toThrow();
 	});
+
+	test("accepts a reaction script as the sole instruction source", () => {
+		const script =
+			"export default async (ctx, client) => { await client.automations.completeWindow({}); };";
+		for (const triggers of [
+			[schedule],
+			[eventWindow],
+			[workspaceEventDefault],
+			[] as AutomationTrigger[],
+		]) {
+			expect(() =>
+				assertAutomationInstructions(triggers, undefined, null, script)
+			).not.toThrow();
+		}
+	});
+
+	test("rejects a whitespace-only reaction script", () => {
+		expect(() =>
+			assertAutomationInstructions([schedule], undefined, null, "   ")
+		).toThrow(/needs instructions/);
+	});
+
+	test("still rejects the empty schedule/window/manual shape with a reaction absent", () => {
+		for (const triggers of [
+			[schedule],
+			[eventWindow],
+			[workspaceEventDefault],
+			[] as AutomationTrigger[],
+		]) {
+			expect(() =>
+				assertAutomationInstructions(triggers, undefined, null, null)
+			).toThrow(/needs instructions/);
+		}
+	});
 });

--- a/packages/server/src/automations/reaction-executor.ts
+++ b/packages/server/src/automations/reaction-executor.ts
@@ -168,3 +168,31 @@ export async function compileReactionScript(source: string): Promise<string> {
   });
   return result.compiledCode;
 }
+
+/**
+ * Validate that a compiled reaction module exposes a default handler.
+ *
+ * `compileReactionScript` only checks syntax; a script with named exports
+ * but no default export would pass compilation but fail at runtime inside
+ * `runScript`. This runs the compiled code in an isolate with extract mode
+ * to verify the default export exists without invoking the handler.
+ */
+export async function validateReactionDefaultExport(
+  compiledScript: string,
+): Promise<void> {
+  const result = await runScript({
+    source: compiledScript,
+    sdk: {} as unknown as Parameters<typeof runScript>[0]['sdk'],
+    allowCrossOrg: false,
+    context: {},
+    // Extract the default export without invoking it.
+    extractExport: 'default',
+    limits: { timeoutMs: 5_000 },
+  });
+  if (!result.success) {
+    throw new Error(
+      'Reaction script must export a default async function. ' +
+        (result.error?.message ?? 'No default export found.'),
+    );
+  }
+}

--- a/packages/server/src/automations/reaction-executor.ts
+++ b/packages/server/src/automations/reaction-executor.ts
@@ -189,7 +189,9 @@ export async function validateReactionDefaultExport(
     extractExport: 'default',
     limits: { timeoutMs: 5_000 },
   });
-  if (!result.success) {
+  // runScript returns success=true with returnValue=null when the default
+  // export is absent or not a function, so check both conditions.
+  if (!result.success || !result.returnValue) {
     throw new Error(
       'Reaction script must export a default async function. ' +
         (result.error?.message ?? 'No default export found.'),

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -282,23 +282,30 @@ export function assertAutomationOutputsUseWindowExecution(
  * values (inherited prompt/skills when omitted, resolved triggers after
  * write-merge).
  *
- * Either source satisfies the requirement on its own. They are no longer the
- * same field: skills used to be concatenated into `prompt` at save time, so one
- * check covered both, but pinned skills now remain separate from the stored
- * prompt. Requiring both would be stricter than the prior contract —
- * an Automation whose whole job is "run this skill" has nothing to put in a task
- * statement, and one that spells its task out inline needs no skill.
+ * Any one of the three sources satisfies the requirement on its own. Skills
+ * used to be concatenated into `prompt` at save time, so one check covered
+ * both, but pinned skills now remain separate from the stored prompt. A
+ * reaction script is the third independent source: it defines the window's
+ * extraction contract via its exported `input` schema (or falls back to
+ * free-form), and the worker runs the built-in default instruction when no
+ * prompt exists — so a reaction-only Automation is runnable exactly like a
+ * prompt-only one. Requiring any two would be stricter than the contract —
+ * an Automation whose whole job is "run this skill" has nothing to put in a
+ * task statement, one that spells its task out inline needs no skill, and one
+ * that runs entirely as code needs neither.
  */
 export function assertAutomationInstructions(
 	triggers: AutomationTrigger[],
 	instructions: string | null | undefined,
-	skills?: ReadonlyArray<{ name: string; content: string }> | null
+	skills?: ReadonlyArray<{ name: string; content: string }> | null,
+	reactionScript?: string | null
 ): void {
 	if (!automationRequiresInstructions(triggers)) return;
 	if (instructions?.trim()) return;
 	if (skills?.some((skill) => skill.content.trim())) return;
+	if (reactionScript?.trim()) return;
 	throw new ToolUserError(
-		"This Automation runs from a schedule, an analysis window, or manual runs, so it needs instructions: attach at least one skill or provide instruction text. Only event triggers with execution 'turn' may omit both."
+		"This Automation runs from a schedule, an analysis window, or manual runs, so it needs instructions: attach at least one skill, provide instruction text, or set a reaction script. Only event triggers with execution 'turn' may omit all three."
 	);
 }
 

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -242,8 +242,8 @@ export function resolveAutomationTriggerWrite(args: {
  * executing as "turn" carries its own content — the incoming message/event is
  * the input, and the built-in default instruction applies when the Automation
  * has none. Schedule triggers, event triggers with execution "window", and an
- * empty trigger set (manual runs) have no such content, so they need
- * instruction text.
+ * empty trigger set (manual runs) have no such content, so they need an
+ * instruction source.
  */
 export function automationRequiresInstructions(
 	triggers: AutomationTrigger[]
@@ -282,17 +282,11 @@ export function assertAutomationOutputsUseWindowExecution(
  * values (inherited prompt/skills when omitted, resolved triggers after
  * write-merge).
  *
- * Any one of the three sources satisfies the requirement on its own. Skills
- * used to be concatenated into `prompt` at save time, so one check covered
- * both, but pinned skills now remain separate from the stored prompt. A
- * reaction script is the third independent source: it defines the window's
- * extraction contract via its exported `input` schema (or falls back to
- * free-form), and the worker runs the built-in default instruction when no
- * prompt exists — so a reaction-only Automation is runnable exactly like a
- * prompt-only one. Requiring any two would be stricter than the contract —
- * an Automation whose whole job is "run this skill" has nothing to put in a
- * task statement, one that spells its task out inline needs no skill, and one
- * that runs entirely as code needs neither.
+ * Any one of the three sources satisfies the requirement on its own. Pinned
+ * skills remain separate from the stored prompt, while a reaction script
+ * supplies the extraction contract through its exported `input` schema or the
+ * free-form fallback. Dispatch provides the built-in extraction instruction
+ * when a reaction-only Automation has no authored prompt.
  */
 export function assertAutomationInstructions(
 	triggers: AutomationTrigger[],

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -543,7 +543,7 @@ export default async (_ctx, client) => {
 	},
 	"automations.create": {
 		summary:
-			"Create an Automation. Requires slug and agent_id; window/manual Automations also need prompt or skills. Declare named outputs as `{ entity, key, name? }` or `{ event }`, or omit outputs for a Canvas/reaction-only Automation. Event output rows are standard drafts with required content and optional title, metadata, author, source_url, occurred_at, parent_event_id, payload_type, and idempotency_key. Outputs require window execution. Each sources[] entry requires `name` and a read-only SELECT/WITH `query` projecting an `id` column; optional `context: true` marks the source as context-only. entity_id is optional for an org-scoped Automation.",
+			"Create an Automation. Requires slug and agent_id; window/manual Automations also need prompt, skills, or a reaction script. Declare named outputs as `{ entity, key, name? }` or `{ event }`, or omit outputs for a Canvas/reaction-only Automation. Event output rows are standard drafts with required content and optional title, metadata, author, source_url, occurred_at, parent_event_id, payload_type, and idempotency_key. Outputs require window execution. Each sources[] entry requires `name` and a read-only SELECT/WITH `query` projecting an `id` column; optional `context: true` marks the source as context-only. entity_id is optional for an org-scoped Automation.",
 		access: "admin",
 		throws: ["EntityNotFound"],
 		example:

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -679,6 +679,9 @@ const GUEST_RUNNER = `
 const EXTRACT_RUNNER = `
 (async () => {
   const __v = module.exports[__extract_name];
+  if (__extract_name === 'default') {
+    return typeof __v === 'function' ? '{"__valid":true}' : null;
+  }
   return __v === undefined || __v === null ? null : JSON.stringify(__v);
 })()
 `;

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -469,9 +469,15 @@ function buildAutomationProposal(
   }
   if (args.action === 'create') {
     if (!args.slug) throw new ToolUserError('slug is required for create action');
-    // An event-turn Automation may omit both instruction sources (built-in
-    // default); every other shape needs a prompt, pinned skills, or both.
-    assertAutomationInstructions(args.triggers ?? [], args.prompt, args.skills);
+    // An event-turn Automation may omit all three instruction sources (built-in
+    // default); every other shape needs a prompt, pinned skills, or a reaction
+    // script.
+    assertAutomationInstructions(
+      args.triggers ?? [],
+      args.prompt,
+      args.skills,
+      args.reaction_script
+    );
     if (!args.agent_id) {
       throw new ToolUserError(
         'agent_id is required to create an Automation (the agent that executes it).'

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -544,23 +544,12 @@ export async function handleUpdate(
     // with an empty current prompt must fail). Callers that need to change both
     // triggers and instructions atomically must use create_version with both
     // fields — lobu apply does that path.
-    //
-    // Wrapped in a TX-scoped advisory lock to re-read the group-shared
-    // reaction_script under the lock, ensuring we validate against the
-    // current state rather than a stale pre-lock snapshot.
-    await sql.begin(async (tx) => {
-      await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${Number(args.automation_id)})`;
-      const freshReactionRows = await tx`
-        SELECT reaction_script FROM automations WHERE id = ${args.automation_id}
-      `;
-      const freshReactionScript = (freshReactionRows[0]?.reaction_script as string | null) ?? null;
-      assertAutomationInstructions(
-        triggerWrite.triggers,
-        currentRow.current_prompt,
-        currentRow.current_skills,
-        freshReactionScript
-      );
-    });
+    assertAutomationInstructions(
+      triggerWrite.triggers,
+      currentRow.current_prompt,
+      currentRow.current_skills,
+      currentRow.reaction_script
+    );
   }
 
   // Executor matrix on the EFFECTIVE state (patch over the current row): an

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -53,6 +53,7 @@ import { DEFAULT_AUTOMATION_SOURCE_QUERY, automationSourcesFromPrompt, mergeProm
 import {
   compileReactionScript,
   extractReactionInputSchema,
+  validateReactionDefaultExport,
 } from '../../../automations/reaction-executor';
 import {
   assertAutomationInstructions,
@@ -285,6 +286,9 @@ export async function handleCreate(
   const reactionScriptCompiled = reactionScript
     ? await compileReactionScript(reactionScript)
     : null;
+  if (reactionScriptCompiled) {
+    await validateReactionDefaultExport(reactionScriptCompiled);
+  }
   const reactionInputSchema = reactionScript
     ? await extractReactionInputSchema(reactionScript)
     : null;

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -252,7 +252,7 @@ export async function handleCreate(
       )
     : null;
   const skills = args.skills ?? [];
-  assertAutomationInstructions(triggerWrite.triggers, args.prompt, skills);
+  assertAutomationInstructions(triggerWrite.triggers, args.prompt, skills, args.reaction_script);
   assertPromptSkillTokensPinned(args.prompt, skills);
   // v1 constraint: skill bodies resolve against ONE agent library at save
   // time — the Automation-level default executor when it is an agent.
@@ -498,7 +498,7 @@ export async function handleUpdate(
   const currentRows = await sql`
     SELECT w.organization_id, w.agent_id, w.schedule, w.timezone, w.triggers,
            w.device_worker_id::text AS device_worker_id, w.agent_kind,
-           w.delivery_target,
+           w.delivery_target, w.reaction_script,
            cv.prompt AS current_prompt, cv.skills AS current_skills,
            cv.outputs AS current_outputs
     FROM automations w
@@ -515,6 +515,7 @@ export async function handleUpdate(
     timezone: string | null;
     triggers: ManageAutomationsArgs['triggers'];
     delivery_target: ManageAutomationsArgs['delivery_target'];
+    reaction_script: string | null;
     current_prompt: string | null;
     current_skills: Array<{ name: string; content: string }> | null;
     current_outputs: Record<string, unknown> | null;
@@ -542,7 +543,8 @@ export async function handleUpdate(
     assertAutomationInstructions(
       triggerWrite.triggers,
       currentRow.current_prompt,
-      currentRow.current_skills
+      currentRow.current_skills,
+      currentRow.reaction_script
     );
   }
 
@@ -953,7 +955,8 @@ export async function handleCreateFromVersion(
         assertAutomationInstructions(
           (Array.isArray(cloneTriggers) ? cloneTriggers : []) as AutomationTrigger[],
           version.prompt as string | null | undefined,
-          version.skills as Array<{ name: string; content: string }> | null
+          version.skills as Array<{ name: string; content: string }> | null,
+          version.reaction_script as string | null | undefined
         );
         assertAutomationOutputsUseWindowExecution(
           (Array.isArray(cloneTriggers) ? cloneTriggers : []) as AutomationTrigger[],

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -544,12 +544,23 @@ export async function handleUpdate(
     // with an empty current prompt must fail). Callers that need to change both
     // triggers and instructions atomically must use create_version with both
     // fields — lobu apply does that path.
-    assertAutomationInstructions(
-      triggerWrite.triggers,
-      currentRow.current_prompt,
-      currentRow.current_skills,
-      currentRow.reaction_script
-    );
+    //
+    // Wrapped in a TX-scoped advisory lock to re-read the group-shared
+    // reaction_script under the lock, ensuring we validate against the
+    // current state rather than a stale pre-lock snapshot.
+    await sql.begin(async (tx) => {
+      await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${Number(args.automation_id)})`;
+      const freshReactionRows = await tx`
+        SELECT reaction_script FROM automations WHERE id = ${args.automation_id}
+      `;
+      const freshReactionScript = (freshReactionRows[0]?.reaction_script as string | null) ?? null;
+      assertAutomationInstructions(
+        triggerWrite.triggers,
+        currentRow.current_prompt,
+        currentRow.current_skills,
+        freshReactionScript
+      );
+    });
   }
 
   // Executor matrix on the EFFECTIVE state (patch over the current row): an

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -948,7 +948,7 @@ export async function handleCreateFromVersion(
         // cloneTriggers is computed once above (it does not depend on entity).
         // After stripping, the residual trigger shape must still satisfy the
         // instruction rule (chat-link-only sources become manual/empty triggers
-        // and require a non-empty prompt).
+        // and require a non-empty prompt, a pinned skill, or a reaction script).
         // The clone SHARES the source's automation_versions row, so its pinned
         // skills come along with it — they satisfy the rule here exactly as they
         // will at dispatch.

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -15,6 +15,7 @@ import {
 import {
   compileReactionScript,
   extractReactionInputSchema,
+  validateReactionDefaultExport,
 } from "../../../automations/reaction-executor";
 import { assertAutomationInstructions } from "../../../automations/triggers";
 import type { AutomationTrigger } from "@lobu/core/contracts/tools/manage-automations";
@@ -157,6 +158,7 @@ export async function handleSetReactionScript(
   }
 
   const compiledCode = await compileReactionScript(script);
+  await validateReactionDefaultExport(compiledCode);
   // Derive the reaction's extraction contract from its exported `input` schema,
   // so the worker is told the exact shape the reaction will Value.Parse. NULL
   // when the reaction declares no `input` (free-form `{ summary }` fallback).

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -106,45 +106,36 @@ export async function handleSetReactionScript(
     // final state (triggers per-assignment; prompt/skills group-shared through
     // the current version) and reject the clear if it would leave any
     // assignment invalid.
-    //
-    // Wrapped in a TX-scoped advisory lock (same key as create_version) so
-    // the read-validate-update is atomic against concurrent prompt/triggers
-    // mutations. The session-level lock from withAutomationGroupLock already
-    // serializes at the action level; this adds belt-and-suspenders safety
-    // for the instruction-source invariant.
-    await sql.begin(async (tx) => {
-      await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${groupId})`;
-      const groupState = await tx`
-        SELECT w.id, w.triggers, cv.prompt, cv.skills
-        FROM automations w
-        LEFT JOIN automation_versions cv ON cv.id = w.current_version_id
-        WHERE w.automation_group_id = ${groupId}
-      `;
-      for (const assignment of groupState) {
-        try {
-          assertAutomationInstructions(
-            (assignment.triggers ?? []) as AutomationTrigger[],
-            assignment.prompt as string | null | undefined,
-            (assignment.skills ?? null) as Array<{ name: string; content: string }> | null,
-            null
+    const groupState = await sql`
+      SELECT w.id, w.triggers, cv.prompt, cv.skills
+      FROM automations w
+      LEFT JOIN automation_versions cv ON cv.id = w.current_version_id
+      WHERE w.automation_group_id = ${groupId}
+    `;
+    for (const assignment of groupState) {
+      try {
+        assertAutomationInstructions(
+          (assignment.triggers ?? []) as AutomationTrigger[],
+          assignment.prompt as string | null | undefined,
+          (assignment.skills ?? null) as Array<{ name: string; content: string }> | null,
+          null
+        );
+      } catch (err) {
+        if (err instanceof ToolUserError) {
+          throw new ToolUserError(
+            `Cannot remove the reaction script: ${err.message}`,
+            422
           );
-        } catch (err) {
-          if (err instanceof ToolUserError) {
-            throw new ToolUserError(
-              `Cannot remove the reaction script: ${err.message}`,
-              422
-            );
-          }
-          throw err;
         }
+        throw err;
       }
-      await tx`
-        UPDATE automations
-        SET reaction_script = NULL, reaction_script_compiled = NULL,
-            reaction_input_schema = NULL
-        WHERE automation_group_id = ${groupId}
-      `;
-    });
+    }
+    await sql`
+      UPDATE automations
+      SET reaction_script = NULL, reaction_script_compiled = NULL,
+          reaction_input_schema = NULL
+      WHERE automation_group_id = ${groupId}
+    `;
     recordToolConfigChange(ctx, {
       resourceKind: "automation",
       resourceId: args.automation_id,

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -16,6 +16,8 @@ import {
   compileReactionScript,
   extractReactionInputSchema,
 } from "../../../automations/reaction-executor";
+import { assertAutomationInstructions } from "../../../automations/triggers";
+import type { AutomationTrigger } from "@lobu/core/contracts/tools/manage-automations";
 import type { ToolContext } from "../../registry";
 import { recordToolConfigChange } from "../helpers/config-audit";
 import { requireExists } from "../helpers/db-helpers";
@@ -97,6 +99,36 @@ export async function handleSetReactionScript(
   const script = args.reaction_script;
 
   if (!script || script.trim() === "") {
+    // Clearing the reaction can orphan a prompt-less Automation: removing the
+    // only instruction source leaves a schedule/window/manual Automation with
+    // nothing to run on. Re-run the instruction rule against every assignment's
+    // final state (triggers per-assignment; prompt/skills group-shared through
+    // the current version) and reject the clear if it would leave any
+    // assignment invalid.
+    const groupState = await sql`
+      SELECT w.id, w.triggers, cv.prompt, cv.skills
+      FROM automations w
+      LEFT JOIN automation_versions cv ON cv.id = w.current_version_id
+      WHERE w.automation_group_id = ${groupId}
+    `;
+    for (const assignment of groupState) {
+      try {
+        assertAutomationInstructions(
+          (assignment.triggers ?? []) as AutomationTrigger[],
+          assignment.prompt as string | null | undefined,
+          (assignment.skills ?? null) as Array<{ name: string; content: string }> | null,
+          null
+        );
+      } catch (err) {
+        if (err instanceof ToolUserError) {
+          throw new ToolUserError(
+            `Cannot remove the reaction script: ${err.message}`,
+            422
+          );
+        }
+        throw err;
+      }
+    }
     await sql`
       UPDATE automations
       SET reaction_script = NULL, reaction_script_compiled = NULL,

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -106,36 +106,45 @@ export async function handleSetReactionScript(
     // final state (triggers per-assignment; prompt/skills group-shared through
     // the current version) and reject the clear if it would leave any
     // assignment invalid.
-    const groupState = await sql`
-      SELECT w.id, w.triggers, cv.prompt, cv.skills
-      FROM automations w
-      LEFT JOIN automation_versions cv ON cv.id = w.current_version_id
-      WHERE w.automation_group_id = ${groupId}
-    `;
-    for (const assignment of groupState) {
-      try {
-        assertAutomationInstructions(
-          (assignment.triggers ?? []) as AutomationTrigger[],
-          assignment.prompt as string | null | undefined,
-          (assignment.skills ?? null) as Array<{ name: string; content: string }> | null,
-          null
-        );
-      } catch (err) {
-        if (err instanceof ToolUserError) {
-          throw new ToolUserError(
-            `Cannot remove the reaction script: ${err.message}`,
-            422
+    //
+    // Wrapped in a TX-scoped advisory lock (same key as create_version) so
+    // the read-validate-update is atomic against concurrent prompt/triggers
+    // mutations. The session-level lock from withAutomationGroupLock already
+    // serializes at the action level; this adds belt-and-suspenders safety
+    // for the instruction-source invariant.
+    await sql.begin(async (tx) => {
+      await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${groupId})`;
+      const groupState = await tx`
+        SELECT w.id, w.triggers, cv.prompt, cv.skills
+        FROM automations w
+        LEFT JOIN automation_versions cv ON cv.id = w.current_version_id
+        WHERE w.automation_group_id = ${groupId}
+      `;
+      for (const assignment of groupState) {
+        try {
+          assertAutomationInstructions(
+            (assignment.triggers ?? []) as AutomationTrigger[],
+            assignment.prompt as string | null | undefined,
+            (assignment.skills ?? null) as Array<{ name: string; content: string }> | null,
+            null
           );
+        } catch (err) {
+          if (err instanceof ToolUserError) {
+            throw new ToolUserError(
+              `Cannot remove the reaction script: ${err.message}`,
+              422
+            );
+          }
+          throw err;
         }
-        throw err;
       }
-    }
-    await sql`
-      UPDATE automations
-      SET reaction_script = NULL, reaction_script_compiled = NULL,
-          reaction_input_schema = NULL
-      WHERE automation_group_id = ${groupId}
-    `;
+      await tx`
+        UPDATE automations
+        SET reaction_script = NULL, reaction_script_compiled = NULL,
+            reaction_input_schema = NULL
+        WHERE automation_group_id = ${groupId}
+      `;
+    });
     recordToolConfigChange(ctx, {
       resourceKind: "automation",
       resourceId: args.automation_id,

--- a/packages/server/src/tools/admin/manage_automations/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_automations/version-actions.ts
@@ -254,7 +254,28 @@ export async function handleCreateVersion(
     );
   }
 
+  // Final-state instruction rule. The prompt version and the reaction script
+  // are both group-shared (cascade to every assignment), while triggers are
+  // per-assignment — so when set_as_current, validate the new prompt against
+  // every sibling's final trigger set (the targeted row uses
+  // triggerWrite.triggers). The reaction script is shared, so the same value
+  // satisfies (or fails) every sibling identically.
   const setAsCurrent = args.set_as_current !== false;
+  const reactionScript = automationRows[0].reaction_script as string | null;
+  if (setAsCurrent) {
+    for (const sibling of siblingRows) {
+      const siblingTriggers =
+        Number(sibling.id) === Number(args.automation_id)
+          ? triggerWrite.triggers
+          : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
+      assertAutomationInstructions(siblingTriggers, prompt, skills, reactionScript);
+      assertAutomationOutputsUseWindowExecution(siblingTriggers, outputs);
+    }
+  } else {
+    // Draft version only — triggers on the live row do not change.
+    assertAutomationInstructions(previousTriggers, prompt, skills, reactionScript);
+    assertAutomationOutputsUseWindowExecution(previousTriggers, outputs);
+  }
   // Both branches above write the SAME resolved prompt+skills pair, so the
   // chip/pin agreement is checked once here rather than inside either arm.
   // Unconditional, unlike the caller-supplied-only gates above: those consult
@@ -272,37 +293,6 @@ export async function handleCreateVersion(
     // tx-scoped (auto-released on commit/rollback) and keyed by group id,
     // so unrelated groups are unaffected.
     await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${groupId})`;
-
-    // Re-read the group-shared reaction script under the lock so we validate
-    // against the current state, not a stale pre-lock snapshot. The reaction
-    // script is shared across every assignment in the group; a concurrent
-    // set_reaction_script could clear it between our pre-lock read and here.
-    const freshReactionRows = await tx`
-      SELECT reaction_script FROM automations
-      WHERE automation_group_id = ${groupId} LIMIT 1
-    `;
-    const freshReactionScript = (freshReactionRows[0]?.reaction_script as string | null) ?? null;
-
-    // Final-state instruction rule. The prompt version and the reaction script
-    // are both group-shared (cascade to every assignment), while triggers are
-    // per-assignment — so when set_as_current, validate the new prompt against
-    // every sibling's final trigger set (the targeted row uses
-    // triggerWrite.triggers). The reaction script is shared, so the same value
-    // satisfies (or fails) every sibling identically.
-    if (setAsCurrent) {
-      for (const sibling of siblingRows) {
-        const siblingTriggers =
-          Number(sibling.id) === Number(args.automation_id)
-            ? triggerWrite.triggers
-            : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
-        assertAutomationInstructions(siblingTriggers, prompt, skills, freshReactionScript);
-        assertAutomationOutputsUseWindowExecution(siblingTriggers, outputs);
-      }
-    } else {
-      // Draft version only — triggers on the live row do not change.
-      assertAutomationInstructions(previousTriggers, prompt, skills, freshReactionScript);
-      assertAutomationOutputsUseWindowExecution(previousTriggers, outputs);
-    }
 
     // Re-resolve the latest id and version under the lock so we don't race
     // with a call that already committed while we were computing nextVersion.

--- a/packages/server/src/tools/admin/manage_automations/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_automations/version-actions.ts
@@ -254,28 +254,7 @@ export async function handleCreateVersion(
     );
   }
 
-  // Final-state instruction rule. The prompt version and the reaction script
-  // are both group-shared (cascade to every assignment), while triggers are
-  // per-assignment — so when set_as_current, validate the new prompt against
-  // every sibling's final trigger set (the targeted row uses
-  // triggerWrite.triggers). The reaction script is shared, so the same value
-  // satisfies (or fails) every sibling identically.
   const setAsCurrent = args.set_as_current !== false;
-  const reactionScript = automationRows[0].reaction_script as string | null;
-  if (setAsCurrent) {
-    for (const sibling of siblingRows) {
-      const siblingTriggers =
-        Number(sibling.id) === Number(args.automation_id)
-          ? triggerWrite.triggers
-          : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
-      assertAutomationInstructions(siblingTriggers, prompt, skills, reactionScript);
-      assertAutomationOutputsUseWindowExecution(siblingTriggers, outputs);
-    }
-  } else {
-    // Draft version only — triggers on the live row do not change.
-    assertAutomationInstructions(previousTriggers, prompt, skills, reactionScript);
-    assertAutomationOutputsUseWindowExecution(previousTriggers, outputs);
-  }
   // Both branches above write the SAME resolved prompt+skills pair, so the
   // chip/pin agreement is checked once here rather than inside either arm.
   // Unconditional, unlike the caller-supplied-only gates above: those consult
@@ -293,6 +272,37 @@ export async function handleCreateVersion(
     // tx-scoped (auto-released on commit/rollback) and keyed by group id,
     // so unrelated groups are unaffected.
     await tx`SELECT pg_advisory_xact_lock(hashtext('automation_create_version'), ${groupId})`;
+
+    // Re-read the group-shared reaction script under the lock so we validate
+    // against the current state, not a stale pre-lock snapshot. The reaction
+    // script is shared across every assignment in the group; a concurrent
+    // set_reaction_script could clear it between our pre-lock read and here.
+    const freshReactionRows = await tx`
+      SELECT reaction_script FROM automations
+      WHERE automation_group_id = ${groupId} LIMIT 1
+    `;
+    const freshReactionScript = (freshReactionRows[0]?.reaction_script as string | null) ?? null;
+
+    // Final-state instruction rule. The prompt version and the reaction script
+    // are both group-shared (cascade to every assignment), while triggers are
+    // per-assignment — so when set_as_current, validate the new prompt against
+    // every sibling's final trigger set (the targeted row uses
+    // triggerWrite.triggers). The reaction script is shared, so the same value
+    // satisfies (or fails) every sibling identically.
+    if (setAsCurrent) {
+      for (const sibling of siblingRows) {
+        const siblingTriggers =
+          Number(sibling.id) === Number(args.automation_id)
+            ? triggerWrite.triggers
+            : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
+        assertAutomationInstructions(siblingTriggers, prompt, skills, freshReactionScript);
+        assertAutomationOutputsUseWindowExecution(siblingTriggers, outputs);
+      }
+    } else {
+      // Draft version only — triggers on the live row do not change.
+      assertAutomationInstructions(previousTriggers, prompt, skills, freshReactionScript);
+      assertAutomationOutputsUseWindowExecution(previousTriggers, outputs);
+    }
 
     // Re-resolve the latest id and version under the lock so we don't race
     // with a call that already committed while we were computing nextVersion.

--- a/packages/server/src/tools/admin/manage_automations/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_automations/version-actions.ts
@@ -70,7 +70,8 @@ export async function handleCreateVersion(
   const automationRows = await sql`
     SELECT i.id, i.version, i.current_version_id, i.automation_group_id, i.sources, i.organization_id,
            i.entity_ids, i.schedule, i.timezone, i.triggers, i.agent_id,
-           i.device_worker_id::text AS device_worker_id, i.agent_kind
+           i.device_worker_id::text AS device_worker_id, i.agent_kind,
+           i.reaction_script
     FROM automations i WHERE i.id = ${args.automation_id}
   `;
   if (automationRows.length === 0) {
@@ -253,23 +254,26 @@ export async function handleCreateVersion(
     );
   }
 
-  // Final-state instruction rule. The prompt version is group-shared
-  // (cascades to every assignment), while triggers are per-assignment — so
-  // when set_as_current, validate the new prompt against every sibling's
-  // final trigger set (the targeted row uses triggerWrite.triggers).
+  // Final-state instruction rule. The prompt version and the reaction script
+  // are both group-shared (cascade to every assignment), while triggers are
+  // per-assignment — so when set_as_current, validate the new prompt against
+  // every sibling's final trigger set (the targeted row uses
+  // triggerWrite.triggers). The reaction script is shared, so the same value
+  // satisfies (or fails) every sibling identically.
   const setAsCurrent = args.set_as_current !== false;
+  const reactionScript = automationRows[0].reaction_script as string | null;
   if (setAsCurrent) {
     for (const sibling of siblingRows) {
       const siblingTriggers =
         Number(sibling.id) === Number(args.automation_id)
           ? triggerWrite.triggers
           : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
-      assertAutomationInstructions(siblingTriggers, prompt, skills);
+      assertAutomationInstructions(siblingTriggers, prompt, skills, reactionScript);
       assertAutomationOutputsUseWindowExecution(siblingTriggers, outputs);
     }
   } else {
     // Draft version only — triggers on the live row do not change.
-    assertAutomationInstructions(previousTriggers, prompt, skills);
+    assertAutomationInstructions(previousTriggers, prompt, skills, reactionScript);
     assertAutomationOutputsUseWindowExecution(previousTriggers, outputs);
   }
   // Both branches above write the SAME resolved prompt+skills pair, so the


### PR DESCRIPTION
## Summary
- A window/schedule/manual Automation can now be defined with a reaction script and **no prompt or skills** — the reaction's exported `input` schema is already the extraction contract and dispatch falls back to a built-in default instruction, so reaction-only Automations were runnable at runtime; only the save-time gate rejected them.
- Threads the reaction script through every `assertAutomationInstructions` call site (create, update, create_from_version, create_version, approval proposal) and guards `set_reaction_script('')` so clearing the sole instruction source is rejected instead of silently orphaning the Automation.
- UI (owletto): a "How does this run?" (Agent / Code / Agent+code) segmented control in the create form makes the codified-vs-agentic shape an explicit authoring choice; the mode is authoritative on create and additive on edit. Prompt `required` marker and verdict now account for a reaction script.
- CLI (lobu apply): the config preflight accepts the `reaction` marker as a third instruction source; `createAutomation` carries `reaction_script` in the same transaction; on update the reaction is pushed **before** `create_version` so a prompt-clearing transition validates against the attached reaction.

## Test plan
- [x] Server unit: `automation-instructions-rule.test.ts` (8 tests)
- [x] Server integration: `manage-automations-instruction-rule` (17 tests, incl. reaction-only create/version/update/clone + clear-guard cases), `manage-automations-approval-e2e` (11), `manage-automations-update-version-fields` (15), `automations-crud` + `automation-contract` (81)
- [x] Owletto: full suite 177 files / 1547 tests pass with `--testTimeout=20000` (default 5s times out slow route-mount tests under parallel load — pre-existing flakiness, unrelated files; my files pass at default timeout)
- [x] CLI: apply suite 336 tests, config define tests 12 — all green; `tsc --noEmit` clean
- [ ] `make pre-pr-remote` (deferred — depot queued behind another session's gate; background dispatcher runs ours when the field clears)

## Notes
- The reaction-satisfies-instructions semantic is deliberately loose (any non-empty script, per the "schema is optional" framing) rather than requiring an `input` export.
- No DB schema / API surface / ReactionContext change; channel-subscription routing untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automations can now use reaction scripts as their sole instruction source, alongside prompts and skills.
  * Reaction-script Automations are supported across creation, updates, cloning, versioning, trigger changes, and configuration application.
  * Reaction scripts are applied before related automation updates for more reliable deployments.

* **Bug Fixes**
  * Empty or invalid reaction scripts are rejected.
  * Removing the only instruction source is prevented.
  * Reaction scripts must provide a valid default handler before being saved.

* **Documentation**
  * Updated Automation guidance and validation messages to describe reaction scripts as an instruction option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->