### PR TITLE
feat(cli): add field() shorthand for entity properties; route CI by trusted author

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ permissions:
 # CI_LINUX_RUNNER is an optional repository variable used for runner A/B tests.
 # Leaving it unset preserves GitHub-hosted execution; setting it changes only
 # the machine behind these jobs, not their names, events, secrets, or checks.
+# CI_K8S_RUNNER (e.g. "k8s-ci", an ARC self-hosted runner group) opts into the
+# self-hosted Kubernetes backend, gated to real pull_requests by a trusted
+# author (TRUSTED_AUTHORS, whitespace-separated). Pushes, workflow_dispatch,
+# and the `make pre-pr-remote` Depot gate are never routed to it.
 #
 # The `github.run_id` fallback exists for `depot ci run`, which `make
 # pre-pr-remote` uses to execute this same file against a local staged tree.
@@ -39,12 +43,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Resolve the Linux runner backend from the PR author. Trusted authors
+  # (TRUSTED_AUTHORS) may use the self-hosted Kubernetes runner when
+  # CI_K8S_RUNNER is set; every other event and author resolves to
+  # CI_LINUX_RUNNER (the A/B override) or GitHub-hosted ubuntu-24.04, so the
+  # `make pre-pr-remote` Depot gate never depends on a self-hosted runner.
+  check-author:
+    name: Resolve CI backend
+    runs-on: ubuntu-24.04
+    outputs:
+      runner: ${{ steps.route.outputs.runner }}
+    env:
+      AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      ACTOR: ${{ github.actor }}
+      TRUSTED: ${{ vars.TRUSTED_AUTHORS || 'buremba' }}
+      LINUX: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+      K8S: ${{ vars.CI_K8S_RUNNER }}
+    steps:
+      - name: Route runner backend
+        id: route
+        run: |
+          author="${AUTHOR:-$ACTOR}"
+          if [ -n "$K8S" ] && [ -n "$PR_NUMBER" ] && [ -n "$author" ] \
+            && echo "$TRUSTED" | tr '[:space:]' '\n' | grep -qxF "$author"; then
+            echo "runner=$K8S"
+          else
+            echo "runner=$LINUX"
+          fi
+
   # Fast unit tests — no Postgres, no submodule needed for most.
   # Splits from `integration` so a unit failure surfaces in <2 min instead of
   # waiting behind DB setup. Worker tests run under bun (full suite, not the
   # cherry-picked subset that used to live here).
   unit:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -217,7 +251,8 @@ jobs:
   # graph and ran these smokes serially, adding a second critical path after
   # required checks were already green.
   sdk-cli-build:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -248,8 +283,8 @@ jobs:
   # artifact fan-out. It remains behind the required merge graph so GitHub's
   # finite hosted-runner pool gives merge-critical work priority.
   dead-code-report:
-    needs: [unit, frontend, integration, format-lint, typecheck, migrations]
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: [check-author, unit, frontend, integration, format-lint, typecheck, migrations]
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -269,8 +304,8 @@ jobs:
         run: bun run knip
 
   sdk-lifecycle-e2e:
-    needs: sdk-cli-build
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: [check-author, sdk-cli-build]
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -336,8 +371,8 @@ jobs:
           cat "$GITHUB_STEP_SUMMARY"
 
   sdk-error-taxonomy-e2e:
-    needs: sdk-cli-build
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: [check-author, sdk-cli-build]
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -365,8 +400,8 @@ jobs:
         run: bash scripts/sdk-e2e-error.sh
 
   cli-command-smoke:
-    needs: sdk-cli-build
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: [check-author, sdk-cli-build]
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -422,7 +457,8 @@ jobs:
   # white-screen" packaging bugs. Build uses the same `bun run build` path as
   # docker/app/Dockerfile. Forks without the deploy key get a stub and skip.
   frontend:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
@@ -482,7 +518,8 @@ jobs:
   # closed unless every shard and Bun/Postgres suite succeeds.
   server-integration-vitest:
     name: integration-vitest (${{ matrix.shard }}/3)
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -607,7 +644,8 @@ jobs:
   # Vitest shards removes another ~2 minutes from the serial critical path.
   server-integration-bun:
     name: integration-bun
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     services:
       postgres:
@@ -760,7 +798,8 @@ jobs:
           test "$BUN_RESULT" = success
 
   format-lint:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -959,7 +998,8 @@ jobs:
           bash scripts/lib/__tests__/submodule-bump.test.sh
 
   typecheck:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -1060,7 +1100,7 @@ jobs:
     # Migration coverage and its required check name remain unchanged for
     # existing open PRs.
     if: ${{ !cancelled() }}
-    needs: format-lint
+    needs: [check-author, format-lint]
     # Catches the class of bug that has now broken prod twice in one
     # session: a migration file that's syntactically a SQL file but that the
     # migration runner rejects (missing -- migrate:up directive, constraint
@@ -1069,7 +1109,7 @@ jobs:
     # uses (scripts/migrate-up.mjs), so a migration that only the prod runner
     # can apply (e.g. transaction:false heal-DO + CONCURRENTLY) is validated
     # here instead of silently diverging from `dbmate up`.
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 10
     services:
       postgres:
@@ -1300,7 +1340,8 @@ jobs:
   # integer (the count of changed files), not a list — `contains()` over it
   # never matches. On push events there is no PR base, so both smokes run.
   optional-smoke-filter:
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: check-author
+    runs-on: ${{ needs.check-author.outputs.runner }}
     outputs:
       mac: ${{ steps.filter.outputs.mac }}
       connector: ${{ steps.filter.outputs.connector }}
@@ -1403,9 +1444,8 @@ jobs:
   # runConnectorRuntimeSelfCheck() over the same compile + default
   # SubprocessExecutor path.
   connector-parity-smoke:
-    needs: optional-smoke-filter
-    if: needs.optional-smoke-filter.outputs.connector == 'true'
-    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
+    needs: [check-author, optional-smoke-filter]
+    runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
           author="${AUTHOR:-$ACTOR}"
           if [ -n "$K8S" ] && [ -n "$PR_NUMBER" ] && [ -n "$author" ] \
             && echo "$TRUSTED" | tr '[:space:]' '\n' | grep -qxF "$author"; then
-            echo "runner=$K8S"
+            echo "runner=$K8S" >> "$GITHUB_OUTPUT"
           else
-            echo "runner=$LINUX"
+            echo "runner=$LINUX" >> "$GITHUB_OUTPUT"
           fi
 
   # Fast unit tests — no Postgres, no submodule needed for most.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1441,6 +1441,7 @@ jobs:
   # SubprocessExecutor path.
   connector-parity-smoke:
     needs: optional-smoke-filter
+    if: needs.optional-smoke-filter.outputs.connector == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 25
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,8 +251,7 @@ jobs:
   # graph and ran these smokes serially, adding a second critical path after
   # required checks were already green.
   sdk-cli-build:
-    needs: check-author
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -283,8 +282,8 @@ jobs:
   # artifact fan-out. It remains behind the required merge graph so GitHub's
   # finite hosted-runner pool gives merge-critical work priority.
   dead-code-report:
-    needs: [check-author, unit, frontend, integration, format-lint, typecheck, migrations]
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    needs: [unit, frontend, integration, format-lint, typecheck, migrations]
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -304,8 +303,8 @@ jobs:
         run: bun run knip
 
   sdk-lifecycle-e2e:
-    needs: [check-author, sdk-cli-build]
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    needs: sdk-cli-build
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -371,8 +370,8 @@ jobs:
           cat "$GITHUB_STEP_SUMMARY"
 
   sdk-error-taxonomy-e2e:
-    needs: [check-author, sdk-cli-build]
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    needs: sdk-cli-build
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -400,8 +399,8 @@ jobs:
         run: bash scripts/sdk-e2e-error.sh
 
   cli-command-smoke:
-    needs: [check-author, sdk-cli-build]
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    needs: sdk-cli-build
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -798,8 +797,7 @@ jobs:
           test "$BUN_RESULT" = success
 
   format-lint:
-    needs: check-author
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -998,8 +996,7 @@ jobs:
           bash scripts/lib/__tests__/submodule-bump.test.sh
 
   typecheck:
-    needs: check-author
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -1100,7 +1097,7 @@ jobs:
     # Migration coverage and its required check name remain unchanged for
     # existing open PRs.
     if: ${{ !cancelled() }}
-    needs: [check-author, format-lint]
+    needs: format-lint
     # Catches the class of bug that has now broken prod twice in one
     # session: a migration file that's syntactically a SQL file but that the
     # migration runner rejects (missing -- migrate:up directive, constraint
@@ -1109,7 +1106,7 @@ jobs:
     # uses (scripts/migrate-up.mjs), so a migration that only the prod runner
     # can apply (e.g. transaction:false heal-DO + CONCURRENTLY) is validated
     # here instead of silently diverging from `dbmate up`.
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 10
     services:
       postgres:
@@ -1340,8 +1337,7 @@ jobs:
   # integer (the count of changed files), not a list — `contains()` over it
   # never matches. On push events there is no PR base, so both smokes run.
   optional-smoke-filter:
-    needs: check-author
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     outputs:
       mac: ${{ steps.filter.outputs.mac }}
       connector: ${{ steps.filter.outputs.connector }}
@@ -1444,8 +1440,8 @@ jobs:
   # runConnectorRuntimeSelfCheck() over the same compile + default
   # SubprocessExecutor path.
   connector-parity-smoke:
-    needs: [check-author, optional-smoke-filter]
-    runs-on: ${{ needs.check-author.outputs.runner }}
+    needs: optional-smoke-filter
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7

--- a/examples/agent-community/lobu.config.ts
+++ b/examples/agent-community/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type DiscoursePostsConnector from "./discourse-posts.connector.ts";
 
@@ -48,26 +49,10 @@ const match = defineEntityType({
   description:
     "A suggested introduction between two members with reasons and confidence",
   properties: {
-    member_a: {
-      type: "string",
-      "x-table-label": "Member A",
-      "x-table-column": true,
-    },
-    member_b: {
-      type: "string",
-      "x-table-label": "Member B",
-      "x-table-column": true,
-    },
-    reason: {
-      type: "string",
-      "x-table-label": "Reason",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
+    member_a: field("Member A", { optional: true }),
+    member_b: field("Member B", { optional: true }),
+    reason: field("Reason", { optional: true }),
+    status: field("Status", { optional: true }),
   },
 });
 
@@ -77,22 +62,10 @@ const post = defineEntityType({
   description:
     "A blog post, newsletter, or public writing by a community member",
   properties: {
-    title: { type: "string", "x-table-label": "Title", "x-table-column": true },
-    source: {
-      type: "string",
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
-    author: {
-      type: "string",
-      "x-table-label": "Author",
-      "x-table-column": true,
-    },
-    topics: {
-      type: "string",
-      "x-table-label": "Topics",
-      "x-table-column": true,
-    },
+    title: field("Title", { optional: true }),
+    source: field("Source", { optional: true }),
+    author: field("Author", { optional: true }),
+    topics: field("Topics", { optional: true }),
   },
 });
 
@@ -102,22 +75,10 @@ const topic = defineEntityType({
   description:
     "A durable interest or subject area used for member matching and discovery",
   properties: {
-    topic_name: {
-      type: "string",
-      "x-table-label": "Topic",
-      "x-table-column": true,
-    },
-    evidence: {
-      type: "string",
-      "x-table-label": "Evidence",
-      "x-table-column": true,
-    },
-    member_count: {
-      type: "string",
-      "x-table-label": "Members",
-      "x-table-column": true,
-    },
-    relevance: { type: "string", "x-table-label": "Relevance" },
+    topic_name: field("Topic", { optional: true }),
+    evidence: field("Evidence", { optional: true }),
+    member_count: field("Members", { optional: true }),
+    relevance: field("Relevance", { column: false, optional: true }),
   },
 });
 

--- a/examples/context-layer/lobu.config.ts
+++ b/examples/context-layer/lobu.config.ts
@@ -17,6 +17,8 @@ import {
   defineConfig,
   defineConnection,
   defineEntityType,
+  field,
+  Type,
 } from "@lobu/cli/config";
 import { CHURN_ROLLUP_SQL } from "./scripts/lib/env.ts";
 
@@ -98,16 +100,11 @@ const businessEvent = defineEntityType({
     "pricing change. Before explaining any movement in a metric, check the " +
     "business events overlapping that period; if one exists, cite it (with its " +
     "source_link) instead of speculating.",
-  required: ["event_date", "event_type"],
   properties: {
-    event_date: {
-      type: "string",
+    event_date: field("Date", {
       description: "ISO date (YYYY-MM-DD) the event took effect.",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    event_type: {
-      type: "string",
+    }),
+    event_type: field("Type", {
       enum: [
         "data_incident",
         "definition_change",
@@ -116,40 +113,41 @@ const businessEvent = defineEntityType({
         "pricing_change",
       ],
       description:
-        "What kind of why this is. data_incident = the numbers are wrong " +
-        "(exclude/repair them); definition_change = the metric's meaning moved; " +
-        "external_shock = the numbers are right but the cause is external and " +
-        "temporary; campaign/pricing_change = self-inflicted, expected shifts.",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    affected_metrics: {
-      type: "array",
-      items: { type: "string" },
-      description:
-        "Metric slugs this event distorts or shifts (must match a " +
-        "metric-definition entity's metric slug, e.g. churn_rate).",
-      "x-table-label": "Affects",
-      "x-table-column": true,
-    },
-    expected_effect: {
-      type: "string",
-      description:
-        "Operative instruction for anyone reading the affected metrics: what " +
-        "the series will look like and how to treat it (e.g. 'exclude 2026-03 " +
-        "from churn trend — rows are migration artifacts, not real churn').",
-    },
-    owner: {
-      type: "string",
+        "What kind of why this is. data_incident = the numbers are wrong (exclude/repair them); definition_change = the metric's meaning moved; external_shock = the numbers are right but the cause is external and temporary; campaign/pricing_change = self-inflicted, expected shifts.",
+    }),
+    affected_metrics: Type.Optional(
+      Type.Unsafe({
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Metric slugs this event distorts or shifts (must match a " +
+          "metric-definition entity's metric slug, e.g. churn_rate).",
+        "x-table-label": "Affects",
+        "x-table-column": true,
+      })
+    ),
+    expected_effect: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Operative instruction for anyone reading the affected metrics: what " +
+          "the series will look like and how to treat it (e.g. 'exclude 2026-03 " +
+          "from churn trend — rows are migration artifacts, not real churn').",
+      })
+    ),
+    owner: field("Owner", {
       description: "Person or team accountable for this record being correct.",
-      "x-table-label": "Owner",
-    },
-    source_link: {
-      type: "string",
-      description:
-        "Deep link to the source of truth — incident ticket, decision doc, or " +
-        "Slack thread. Always cite this when the event is used in an answer.",
-    },
+      column: false,
+      optional: true,
+    }),
+    source_link: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Deep link to the source of truth — incident ticket, decision doc, or " +
+          "Slack thread. Always cite this when the event is used in an answer.",
+      })
+    ),
   },
 });
 
@@ -172,30 +170,31 @@ const metricDefinition = defineEntityType({
     "when a month straddles a definition change, say which version was in " +
     "effect. metadata.aliases carries the metric slug so observation events " +
     "resolve to this entity.",
-  required: ["metric"],
   properties: {
-    metric: {
-      type: "string",
+    metric: field("Metric", {
       description: "Stable metric slug, e.g. churn_rate.",
-      "x-table-label": "Metric",
-      "x-table-column": true,
-    },
-    unit: {
-      type: "string",
-      description: "Unit of the metric's readings (e.g. cancellations/month).",
-    },
-    owner: {
-      type: "string",
+    }),
+    unit: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Unit of the metric's readings (e.g. cancellations/month).",
+      })
+    ),
+    owner: field("Owner", {
       description: "Team that owns this metric's definition.",
-      "x-table-label": "Owner",
-    },
-    aliases: {
-      type: "array",
-      items: { type: "string" },
-      description:
-        "Alias strings observation events use to resolve to this entity — an " +
-        "observation's metadata.metric must equal one of these.",
-    },
+      column: false,
+      optional: true,
+    }),
+    aliases: Type.Optional(
+      Type.Unsafe({
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Alias strings observation events use to resolve to this entity — an " +
+          "observation's metadata.metric must equal one of these.",
+      })
+    ),
   },
   eventKinds: {
     definition: {
@@ -286,38 +285,34 @@ const verifiedQuery = defineEntityType({
     "ad-hoc SQL when one matches the question. If the drift check reports a " +
     "mismatch, treat the pinned answer as stale and flag it for " +
     "re-verification — do not silently quote either side.",
-  required: ["question", "sql"],
   properties: {
-    question: {
-      type: "string",
+    question: field("Question", {
       description: "The business question this query answers, verbatim.",
-      "x-table-label": "Question",
-      "x-table-column": true,
-    },
+    }),
     sql: {
       type: "string",
       description:
         "The exact read-only SQL that produced the approved answer. Runs " +
         "against the warehouse connection (same query the virtual feed uses).",
     },
-    approved_answer: {
-      type: "array",
-      items: { type: "object" },
-      description:
-        "The result rows pinned at approval time. The drift canary diffs live " +
-        "results against these.",
-    },
-    approved_by: {
-      type: "string",
+    approved_answer: Type.Optional(
+      Type.Unsafe({
+        type: "array",
+        items: { type: "object" },
+        description:
+          "The result rows pinned at approval time. The drift canary diffs live " +
+          "results against these.",
+      })
+    ),
+    approved_by: field("Approved by", {
       description: "Who verified and approved the answer.",
-      "x-table-label": "Approved by",
-    },
-    approved_at: {
-      type: "string",
+      column: false,
+      optional: true,
+    }),
+    approved_at: field("Approved", {
       description: "ISO date of approval.",
-      "x-table-label": "Approved",
-      "x-table-column": true,
-    },
+      optional: true,
+    }),
   },
 });
 

--- a/examples/delivery/lobu.config.ts
+++ b/examples/delivery/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type ShopifyOrdersConnector from "./shopify-orders.connector.ts";
 
@@ -47,26 +48,10 @@ const blocker = defineEntityType({
   name: "Blocker",
   description: "A dependency or issue that is blocking project progress",
   properties: {
-    blocker_description: {
-      type: "string",
-      "x-table-label": "Blocker",
-      "x-table-column": true,
-    },
-    owned_by: {
-      type: "string",
-      "x-table-label": "Owner",
-      "x-table-column": true,
-    },
-    impact: {
-      type: "string",
-      "x-table-label": "Impact",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
+    blocker_description: field("Blocker", { optional: true }),
+    owned_by: field("Owner", { optional: true }),
+    impact: field("Impact", { optional: true }),
+    status: field("Status", { optional: true }),
   },
 });
 
@@ -75,26 +60,10 @@ const document = defineEntityType({
   name: "Document",
   description: "A project artifact, review, or reference document",
   properties: {
-    document_name: {
-      type: "string",
-      "x-table-label": "Document",
-      "x-table-column": true,
-    },
-    document_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    linked_project: {
-      type: "string",
-      "x-table-label": "Project",
-      "x-table-column": true,
-    },
-    last_updated: {
-      type: "string",
-      "x-table-label": "Updated",
-      "x-table-column": true,
-    },
+    document_name: field("Document", { optional: true }),
+    document_type: field("Type", { optional: true }),
+    linked_project: field("Project", { optional: true }),
+    last_updated: field("Updated", { optional: true }),
   },
 });
 
@@ -103,26 +72,10 @@ const milestone = defineEntityType({
   name: "Milestone",
   description: "A key deliverable or phase gate within a project",
   properties: {
-    milestone_name: {
-      type: "string",
-      "x-table-label": "Milestone",
-      "x-table-column": true,
-    },
-    lifecycle_state: {
-      type: "string",
-      "x-table-label": "State",
-      "x-table-column": true,
-    },
-    target_date: {
-      type: "string",
-      "x-table-label": "Target Date",
-      "x-table-column": true,
-    },
-    parent_project: {
-      type: "string",
-      "x-table-label": "Project",
-      "x-table-column": true,
-    },
+    milestone_name: field("Milestone", { optional: true }),
+    lifecycle_state: field("State", { optional: true }),
+    target_date: field("Target Date", { optional: true }),
+    parent_project: field("Project", { optional: true }),
   },
 });
 
@@ -131,10 +84,10 @@ const stakeholder = defineEntityType({
   name: "Stakeholder",
   description: "A person who owns or is responsible for part of a project",
   properties: {
-    name: { type: "string", "x-table-label": "Name", "x-table-column": true },
-    role: { type: "string", "x-table-label": "Role", "x-table-column": true },
-    owns: { type: "string", "x-table-label": "Owns", "x-table-column": true },
-    contact: { type: "string", "x-table-label": "Contact" },
+    name: field("Name", { optional: true }),
+    role: field("Role", { optional: true }),
+    owns: field("Owns", { optional: true }),
+    contact: field("Contact", { column: false, optional: true }),
   },
 });
 

--- a/examples/ecommerce/lobu.config.ts
+++ b/examples/ecommerce/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type StripeChargesConnector from "./stripe-charges.connector.ts";
 
@@ -48,22 +49,10 @@ const customer = defineEntityType({
   description:
     "A customer with subscriptions, orders, and communication preferences",
   properties: {
-    full_name: {
-      type: "string",
-      "x-table-label": "Name",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    plan: { type: "string", "x-table-label": "Plan", "x-table-column": true },
-    communication_preference: {
-      type: "string",
-      "x-table-label": "Preference",
-      "x-table-column": true,
-    },
+    full_name: field("Name", { optional: true }),
+    status: field("Status", { optional: true }),
+    plan: field("Plan", { optional: true }),
+    communication_preference: field("Preference", { optional: true }),
   },
 });
 
@@ -72,26 +61,10 @@ const order = defineEntityType({
   name: "Order",
   description: "A customer order with fulfillment status and delivery details",
   properties: {
-    order_number: {
-      type: "string",
-      "x-table-label": "Order",
-      "x-table-column": true,
-    },
-    product: {
-      type: "string",
-      "x-table-label": "Product",
-      "x-table-column": true,
-    },
-    fulfillment_status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    customer: {
-      type: "string",
-      "x-table-label": "Customer",
-      "x-table-column": true,
-    },
+    order_number: field("Order", { optional: true }),
+    product: field("Product", { optional: true }),
+    fulfillment_status: field("Status", { optional: true }),
+    customer: field("Customer", { optional: true }),
   },
 });
 
@@ -100,22 +73,10 @@ const product = defineEntityType({
   name: "Product",
   description: "A product in the catalog linked to subscriptions and orders",
   properties: {
-    product_name: {
-      type: "string",
-      "x-table-label": "Product",
-      "x-table-column": true,
-    },
-    plan_tier: {
-      type: "string",
-      "x-table-label": "Tier",
-      "x-table-column": true,
-    },
-    delivery_frequency: {
-      type: "string",
-      "x-table-label": "Delivery",
-      "x-table-column": true,
-    },
-    price: { type: "string", "x-table-label": "Price", "x-table-column": true },
+    product_name: field("Product", { optional: true }),
+    plan_tier: field("Tier", { optional: true }),
+    delivery_frequency: field("Delivery", { optional: true }),
+    price: field("Price", { optional: true }),
   },
 });
 
@@ -125,26 +86,10 @@ const subscription = defineEntityType({
   description:
     "A recurring subscription plan with billing cycle and pending changes",
   properties: {
-    plan_name: {
-      type: "string",
-      "x-table-label": "Plan",
-      "x-table-column": true,
-    },
-    frequency: {
-      type: "string",
-      "x-table-label": "Frequency",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    pending_changes: {
-      type: "string",
-      "x-table-label": "Pending",
-      "x-table-column": true,
-    },
+    plan_name: field("Plan", { optional: true }),
+    frequency: field("Frequency", { optional: true }),
+    status: field("Status", { optional: true }),
+    pending_changes: field("Pending", { optional: true }),
   },
 });
 

--- a/examples/finance/lobu.config.ts
+++ b/examples/finance/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type QuickBooksTransactionsConnector from "./quickbooks-transactions.connector.ts";
 
@@ -48,26 +49,10 @@ const account = defineEntityType({
   description:
     "A financial account that holds balances, transactions, and reconciliation state",
   properties: {
-    account_name: {
-      type: "string",
-      "x-table-label": "Account",
-      "x-table-column": true,
-    },
-    account_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    balance: {
-      type: "string",
-      "x-table-label": "Balance",
-      "x-table-column": true,
-    },
-    reconciliation_status: {
-      type: "string",
-      "x-table-label": "Reconciliation",
-      "x-table-column": true,
-    },
+    account_name: field("Account", { optional: true }),
+    account_type: field("Type", { optional: true }),
+    balance: field("Balance", { optional: true }),
+    reconciliation_status: field("Reconciliation", { optional: true }),
   },
 });
 
@@ -77,26 +62,10 @@ const report = defineEntityType({
   description:
     "A financial report or summary generated from account and transaction data",
   properties: {
-    report_name: {
-      type: "string",
-      "x-table-label": "Report",
-      "x-table-column": true,
-    },
-    period: {
-      type: "string",
-      "x-table-label": "Period",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    exceptions_count: {
-      type: "string",
-      "x-table-label": "Exceptions",
-      "x-table-column": true,
-    },
+    report_name: field("Report", { optional: true }),
+    period: field("Period", { optional: true }),
+    status: field("Status", { optional: true }),
+    exceptions_count: field("Exceptions", { optional: true }),
   },
 });
 
@@ -105,22 +74,10 @@ const transaction = defineEntityType({
   name: "Transaction",
   description: "A financial transaction that affects account balances",
   properties: {
-    description: {
-      type: "string",
-      "x-table-label": "Description",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
-    date: { type: "string", "x-table-label": "Date", "x-table-column": true },
-    category: {
-      type: "string",
-      "x-table-label": "Category",
-      "x-table-column": true,
-    },
+    description: field("Description", { optional: true }),
+    amount: field("Amount", { optional: true }),
+    date: field("Date", { optional: true }),
+    category: field("Category", { optional: true }),
   },
 });
 
@@ -130,26 +87,10 @@ const variance = defineEntityType({
   description:
     "A discrepancy or anomaly identified during reconciliation or reporting",
   properties: {
-    variance_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
-    source_account: {
-      type: "string",
-      "x-table-label": "Account",
-      "x-table-column": true,
-    },
-    explanation: {
-      type: "string",
-      "x-table-label": "Explanation",
-      "x-table-column": true,
-    },
+    variance_type: field("Type", { optional: true }),
+    amount: field("Amount", { optional: true }),
+    source_account: field("Account", { optional: true }),
+    explanation: field("Explanation", { optional: true }),
   },
 });
 

--- a/examples/leadership/lobu.config.ts
+++ b/examples/leadership/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type LinearCyclesConnector from "./linear-cycles.connector.ts";
 
@@ -48,26 +49,10 @@ const decision = defineEntityType({
   description:
     "A leadership decision extracted from a document with its approval status",
   properties: {
-    subject: {
-      type: "string",
-      "x-table-label": "Subject",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    source_document: {
-      type: "string",
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
-    decision_date: {
-      type: "string",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
+    subject: field("Subject", { optional: true }),
+    status: field("Status", { optional: true }),
+    source_document: field("Source", { optional: true }),
+    decision_date: field("Date", { optional: true }),
   },
 });
 
@@ -77,22 +62,10 @@ const document = defineEntityType({
   description:
     "A source document such as a board memo, strategy brief, or executive report",
   properties: {
-    document_name: {
-      type: "string",
-      "x-table-label": "Document",
-      "x-table-column": true,
-    },
-    document_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    date: { type: "string", "x-table-label": "Date", "x-table-column": true },
-    decisions_count: {
-      type: "string",
-      "x-table-label": "Decisions",
-      "x-table-column": true,
-    },
+    document_name: field("Document", { optional: true }),
+    document_type: field("Type", { optional: true }),
+    date: field("Date", { optional: true }),
+    decisions_count: field("Decisions", { optional: true }),
   },
 });
 
@@ -102,22 +75,10 @@ const region = defineEntityType({
   description:
     "A geographic region referenced in strategic decisions or expansion plans",
   properties: {
-    region_name: {
-      type: "string",
-      "x-table-label": "Region",
-      "x-table-column": true,
-    },
-    decision_context: {
-      type: "string",
-      "x-table-label": "Context",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    budget_approved: { type: "string", "x-table-label": "Budget" },
+    region_name: field("Region", { optional: true }),
+    decision_context: field("Context", { optional: true }),
+    status: field("Status", { optional: true }),
+    budget_approved: field("Budget", { column: false, optional: true }),
   },
 });
 
@@ -127,18 +88,10 @@ const risk = defineEntityType({
   description:
     "A blocker or dependency that is holding up a decision or initiative",
   properties: {
-    blocker: {
-      type: "string",
-      "x-table-label": "Blocker",
-      "x-table-column": true,
-    },
-    affects: {
-      type: "string",
-      "x-table-label": "Affects",
-      "x-table-column": true,
-    },
-    state: { type: "string", "x-table-label": "State", "x-table-column": true },
-    owner: { type: "string", "x-table-label": "Owner", "x-table-column": true },
+    blocker: field("Blocker", { optional: true }),
+    affects: field("Affects", { optional: true }),
+    state: field("State", { optional: true }),
+    owner: field("Owner", { optional: true }),
   },
 });
 
@@ -148,22 +101,10 @@ const task = defineEntityType({
   description:
     "An assigned follow-up action extracted from a leadership document or meeting",
   properties: {
-    action: {
-      type: "string",
-      "x-table-label": "Action",
-      "x-table-column": true,
-    },
-    owner: { type: "string", "x-table-label": "Owner", "x-table-column": true },
-    deadline: {
-      type: "string",
-      "x-table-label": "Deadline",
-      "x-table-column": true,
-    },
-    source: {
-      type: "string",
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
+    action: field("Action", { optional: true }),
+    owner: field("Owner", { optional: true }),
+    deadline: field("Deadline", { optional: true }),
+    source: field("Source", { optional: true }),
   },
 });
 

--- a/examples/legal/lobu.config.ts
+++ b/examples/legal/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type DocuSignEnvelopesConnector from "./docusign-envelopes.connector.ts";
 
@@ -48,26 +49,10 @@ const clause = defineEntityType({
   description:
     "A specific provision or section within a contract that defines terms or obligations",
   properties: {
-    clause_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    section: {
-      type: "string",
-      "x-table-label": "Section",
-      "x-table-column": true,
-    },
-    risk_level: {
-      type: "string",
-      "x-table-label": "Risk Level",
-      "x-table-column": true,
-    },
-    language_summary: {
-      type: "string",
-      "x-table-label": "Summary",
-      "x-table-column": true,
-    },
+    clause_type: field("Type", { optional: true }),
+    section: field("Section", { optional: true }),
+    risk_level: field("Risk Level", { optional: true }),
+    language_summary: field("Summary", { optional: true }),
   },
 });
 
@@ -77,27 +62,11 @@ const contract = defineEntityType({
   description:
     "A legal agreement between parties with defined terms, obligations, and conditions",
   properties: {
-    contract_type: {
-      type: "string",
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    effective_date: {
-      type: "string",
-      "x-table-label": "Effective Date",
-      "x-table-column": true,
-    },
-    counterparty_name: {
-      type: "string",
-      "x-table-label": "Counterparty",
-      "x-table-column": true,
-    },
-    governing_law: { type: "string", "x-table-label": "Governing Law" },
+    contract_type: field("Type", { optional: true }),
+    status: field("Status", { optional: true }),
+    effective_date: field("Effective Date", { optional: true }),
+    counterparty_name: field("Counterparty", { optional: true }),
+    governing_law: field("Governing Law", { column: false, optional: true }),
   },
 });
 
@@ -106,26 +75,10 @@ const counterparty = defineEntityType({
   name: "Counterparty",
   description: "An external party involved in a contract or legal agreement",
   properties: {
-    organization_name: {
-      type: "string",
-      "x-table-label": "Organization",
-      "x-table-column": true,
-    },
-    jurisdiction: {
-      type: "string",
-      "x-table-label": "Jurisdiction",
-      "x-table-column": true,
-    },
-    contact_person: {
-      type: "string",
-      "x-table-label": "Contact",
-      "x-table-column": true,
-    },
-    relationship_status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
+    organization_name: field("Organization", { optional: true }),
+    jurisdiction: field("Jurisdiction", { optional: true }),
+    contact_person: field("Contact", { optional: true }),
+    relationship_status: field("Status", { optional: true }),
   },
 });
 
@@ -135,26 +88,10 @@ const risk = defineEntityType({
   description:
     "A legal risk identified in a contract or clause that requires attention or mitigation",
   properties: {
-    severity: {
-      type: "string",
-      "x-table-label": "Severity",
-      "x-table-column": true,
-    },
-    category: {
-      type: "string",
-      "x-table-label": "Category",
-      "x-table-column": true,
-    },
-    mitigation: {
-      type: "string",
-      "x-table-label": "Mitigation",
-      "x-table-column": true,
-    },
-    source_clause: {
-      type: "string",
-      "x-table-label": "Source Clause",
-      "x-table-column": true,
-    },
+    severity: field("Severity", { optional: true }),
+    category: field("Category", { optional: true }),
+    mitigation: field("Mitigation", { optional: true }),
+    source_clause: field("Source Clause", { optional: true }),
   },
 });
 

--- a/examples/lobu-crm/lobu.config.ts
+++ b/examples/lobu-crm/lobu.config.ts
@@ -12,6 +12,8 @@ import {
   reactionFromFile,
   secret,
   skillFromFile,
+  field,
+  Type,
 } from "@lobu/cli/config";
 import type NpmDownloadsConnector from "./npm-downloads.connector.ts";
 import type funnelDigestReaction from "./funnel-digest.reaction.ts";
@@ -71,50 +73,29 @@ const lead = defineEntityType({
   name: "Lead",
   description:
     "A person who has shown a signal toward Lobu — starred, engaged, asked, or talked to us",
-  required: ["name", "source", "stage"],
   properties: {
-    name: { type: "string", "x-table-label": "Name", "x-table-column": true },
-    company: {
-      type: "string",
-      "x-table-label": "Company",
-      "x-table-column": true,
-    },
-    stage: {
-      type: "string",
+    name: field("Name"),
+    company: field("Company", { optional: true }),
+    source: field("Source", {
+      description:
+        'Where they first showed up — "github:stargazer", "x:mention", "github:issue-comment", "demo-form", "intro", etc.',
+    }),
+    stage: field("Stage", {
       enum: ["signal", "trial", "conversation", "pilot", "customer", "cold"],
-      "x-table-label": "Stage",
-      "x-table-column": true,
       // Board layout is deliberate for the CRM pipeline — the stage enum IS
       // the board column set. Declared explicitly so the pipeline defaults to
       // Board; a status/state/stage name alone no longer implies a board.
       "x-lobu": { role: "workflowState" },
-    },
-    source: {
-      type: "string",
-      description:
-        'Where they first showed up — "github:stargazer", "x:mention", "github:issue-comment", "demo-form", "intro", etc.',
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
-    github_handle: {
-      type: "string",
-      "x-table-label": "GitHub",
-      "x-table-column": true,
-    },
-    x_handle: { type: "string", "x-table-label": "X" },
-    email: { type: "string", "x-table-label": "Email" },
-    last_touch: {
-      type: "string",
+    }),
+    github_handle: field("GitHub", { optional: true }),
+    x_handle: field("X", { column: false, optional: true }),
+    email: field("Email", { column: false, optional: true }),
+    last_touch: field("Last touch", {
       description: "ISO date of the most recent interaction",
-      "x-table-label": "Last touch",
-      "x-table-column": true,
-    },
-    next_action: {
-      type: "string",
-      "x-table-label": "Next action",
-      "x-table-column": true,
-    },
-    notes: { type: "string" },
+      optional: true,
+    }),
+    next_action: field("Next action", { optional: true }),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -123,45 +104,25 @@ const pilot = defineEntityType({
   name: "Pilot",
   description:
     "A paid pilot — a company running Lobu for their team under a time-boxed agreement",
-  required: ["company", "status"],
   properties: {
-    company: {
-      type: "string",
-      "x-table-label": "Company",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
-      enum: ["active", "won", "lost", "paused"],
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    seats: {
-      type: "integer",
-      "x-table-label": "Seats",
-      "x-table-column": true,
-    },
-    mrr: {
-      type: "string",
+    company: field("Company"),
+    status: field("Status", { enum: ["active", "won", "lost", "paused"] }),
+    seats: Type.Optional(field(Type.Integer(), "Seats")),
+    mrr: field("MRR", {
       description: 'Monthly recurring revenue for the pilot, e.g. "$750"',
-      "x-table-label": "MRR",
-      "x-table-column": true,
-    },
-    start_date: {
-      type: "string",
-      "x-table-label": "Start",
-      "x-table-column": true,
-    },
-    success_metric: {
-      type: "string",
+      optional: true,
+    }),
+    start_date: field("Start", { optional: true }),
+    success_metric: field("Success metric", {
       description: "The one metric agreed up front that defines pilot success",
-      "x-table-label": "Success metric",
-      "x-table-column": true,
-    },
-    lead_id: {
-      type: "string",
-      description: "The lead entity this pilot converted from",
-    },
+      optional: true,
+    }),
+    lead_id: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "The lead entity this pilot converted from",
+      })
+    ),
   },
 });
 

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -11,6 +11,8 @@ import {
   reactionFromFile,
   secret,
   skillFromFile,
+  field,
+  Type,
 } from "@lobu/cli/config";
 import type DeliverooConnector from "./deliveroo.connector.ts";
 import type lunchDeliverooReaction from "./lunch-deliveroo.reaction.ts";
@@ -70,62 +72,48 @@ const lunchRun = defineEntityType({
   name: "Lunch run",
   description:
     "One day's office lunch order — who's in, what they ordered, the restaurant, the basket link, and where it ended up",
-  required: ["date", "channel", "status"],
   properties: {
-    date: {
-      type: "string",
+    date: field("Date", {
       description: "ISO date of the run (one run per day)",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    channel: {
-      type: "string",
+    }),
+    channel: field("Channel", {
       description: "The chat channel/conversation the run happened in",
-      "x-table-label": "Channel",
-    },
-    status: {
-      type: "string",
-      enum: ["collecting", "done", "cancelled"],
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    restaurant: {
-      type: "string",
-      "x-table-label": "Restaurant",
-      "x-table-column": true,
-    },
-    thread_ref: {
-      type: "string",
-      // Adopted verbatim from the live lobu-team schema so `lobu apply`
-      // converges instead of blocking on undeclared drift — "lunch-finalize"
-      // is the remote wording, not a typo for the Automation slug.
-      description:
-        "Reference to the thread/message where the run is happening — lunch-finalize uses this to find the conversation",
-    },
-    items: {
-      type: "array",
-      description: "Per-person order lines",
-      items: {
-        type: "object",
-        properties: {
-          person: { type: "string" },
-          item: { type: "string" },
-          price: { type: "number" },
-          notes: { type: "string" },
+      column: false,
+    }),
+    status: field("Status", { enum: ["collecting", "done", "cancelled"] }),
+    restaurant: field("Restaurant", { optional: true }),
+    thread_ref: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+
+        description:
+          "Reference to the thread/message where the run is happening — lunch-finalize uses this to find the conversation",
+      })
+    ),
+    items: Type.Optional(
+      Type.Unsafe({
+        type: "array",
+        description: "Per-person order lines",
+        items: {
+          type: "object",
+          properties: {
+            person: { type: "string" },
+            item: { type: "string" },
+            price: { type: "number" },
+            notes: { type: "string" },
+          },
         },
-      },
-    },
-    subtotal: {
-      type: "number",
-      "x-table-label": "Subtotal",
-      "x-table-column": true,
-    },
-    basket_url: {
-      type: "string",
-      description:
-        "Deliveroo group-order / basket link handed to a human, or null if placed manually",
-    },
-    notes: { type: "string" },
+      })
+    ),
+    subtotal: Type.Optional(field(Type.Number(), "Subtotal")),
+    basket_url: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Deliveroo group-order / basket link handed to a human, or null if placed manually",
+      })
+    ),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 

--- a/examples/market/lobu.config.ts
+++ b/examples/market/lobu.config.ts
@@ -8,6 +8,8 @@ import {
   defineSkill,
   every,
   secret,
+  field,
+  Type,
 } from "@lobu/cli/config";
 import type ExaNewsFeedConnector from "./exa-news-feed.connector.ts";
 
@@ -57,8 +59,7 @@ const organization = defineEntityType({
   description:
     "Canonical public identity for an organization. Roles are represented by organization_type and relationships, not separate entity types.",
   properties: {
-    organization_type: {
-      type: "string",
+    organization_type: field("Organization Type", {
       enum: [
         "operating_company",
         "investment_firm",
@@ -68,46 +69,57 @@ const organization = defineEntityType({
         "government",
         "other",
       ],
-      "x-table-column": true,
-      "x-table-label": "Organization Type",
-    },
-    domain: {
-      type: "string",
+      optional: true,
+    }),
+    domain: field("Domain", {
       description: "Normalized public domain",
       "x-identity-namespace": {
         namespace: "hosted_domain",
         normalize: "lowercase",
       },
-      "x-table-column": true,
-      "x-table-label": "Domain",
-    },
-    link: { type: "string", format: "uri" },
-    one_liner: { type: "string" },
-    description: { type: "string" },
-    categories: { type: "array", items: { type: "string" } },
-    location: { type: "string" },
-    stage: {
-      type: "string",
-      enum: [
-        "idea",
-        "pre-seed",
-        "seed",
-        "series-a",
-        "series-b",
-        "series-c",
-        "growth",
-        "public",
-      ],
-    },
-    operating_status: {
-      type: "string",
-      enum: ["active", "acquired", "inactive", "closed"],
-    },
-    stage_focus: { type: "array", items: { type: "string" } },
-    sector_focus: { type: "array", items: { type: "string" } },
-    portfolio_url: { type: "string", format: "uri" },
-    canonical_path: { type: "string" },
-    indexability: { type: "string", enum: ["noindex", "index"] },
+      optional: true,
+    }),
+    link: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
+    one_liner: Type.Optional(Type.Unsafe({ type: "string" })),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
+    categories: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    location: Type.Optional(Type.Unsafe({ type: "string" })),
+    stage: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: [
+          "idea",
+          "pre-seed",
+          "seed",
+          "series-a",
+          "series-b",
+          "series-c",
+          "growth",
+          "public",
+        ],
+      })
+    ),
+    operating_status: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["active", "acquired", "inactive", "closed"],
+      })
+    ),
+    stage_focus: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    sector_focus: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    portfolio_url: Type.Optional(
+      Type.Unsafe({ type: "string", format: "uri" })
+    ),
+    canonical_path: Type.Optional(Type.Unsafe({ type: "string" })),
+    indexability: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["noindex", "index"] })
+    ),
   },
 });
 
@@ -117,15 +129,19 @@ const person = defineEntityType({
   description:
     "Canonical public identity for a real-world person. Founder, employee, executive, and investor are relationship roles.",
   properties: {
-    full_name: { type: "string" },
-    headline: { type: "string" },
-    role: { type: "string" },
-    specialties: { type: "array", items: { type: "string" } },
-    background: { type: "string" },
-    linkedin_url: { type: "string", format: "uri" },
-    twitter_handle: { type: "string" },
-    canonical_path: { type: "string" },
-    indexability: { type: "string", enum: ["noindex", "index"] },
+    full_name: Type.Optional(Type.Unsafe({ type: "string" })),
+    headline: Type.Optional(Type.Unsafe({ type: "string" })),
+    role: Type.Optional(Type.Unsafe({ type: "string" })),
+    specialties: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    background: Type.Optional(Type.Unsafe({ type: "string" })),
+    linkedin_url: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
+    twitter_handle: Type.Optional(Type.Unsafe({ type: "string" })),
+    canonical_path: Type.Optional(Type.Unsafe({ type: "string" })),
+    indexability: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["noindex", "index"] })
+    ),
   },
 });
 
@@ -135,15 +151,21 @@ const product = defineEntityType({
   description:
     "Distinct product or platform. Pricing plans and commercial offers remain sourced events, not product entities.",
   properties: {
-    product_type: { type: "string" },
-    tagline: { type: "string" },
-    description: { type: "string" },
-    link: { type: "string", format: "uri" },
-    categories: { type: "array", items: { type: "string" } },
-    key_features: { type: "array", items: { type: "string" } },
-    availability: { type: "string" },
-    canonical_path: { type: "string" },
-    indexability: { type: "string", enum: ["noindex", "index"] },
+    product_type: Type.Optional(Type.Unsafe({ type: "string" })),
+    tagline: Type.Optional(Type.Unsafe({ type: "string" })),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
+    link: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
+    categories: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    key_features: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    availability: Type.Optional(Type.Unsafe({ type: "string" })),
+    canonical_path: Type.Optional(Type.Unsafe({ type: "string" })),
+    indexability: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["noindex", "index"] })
+    ),
   },
 });
 
@@ -153,8 +175,7 @@ const fundingRound = defineEntityType({
   description:
     "Non-indexed materialized projection of an append-only financing event. Participant and lead roles are represented through participated_in relationships.",
   properties: {
-    round_type: {
-      type: "string",
+    round_type: field("Round Type", {
       enum: [
         "preseed",
         "seed",
@@ -165,30 +186,37 @@ const fundingRound = defineEntityType({
         "growth",
         "ipo",
       ],
-      "x-table-column": true,
-      "x-table-label": "Round Type",
-    },
-    amount_usd: {
-      type: "number",
-      "x-table-column": true,
-      "x-table-label": "Amount (USD)",
-    },
-    currency: { type: "string" },
-    announced_at: { type: "string", format: "date-time" },
-    status: {
-      type: "string",
-      enum: ["announced", "closed", "cancelled", "rumoured"],
-    },
-    source_urls: {
-      type: "array",
-      items: { type: "string", format: "uri" },
-    },
-    projection_kind: { type: "string", enum: ["financing_event"] },
-    projection_status: {
-      type: "string",
-      enum: ["materialized", "superseded", "disputed"],
-    },
-    indexability: { type: "string", enum: ["noindex", "index"] },
+      optional: true,
+    }),
+    amount_usd: Type.Optional(field(Type.Number(), "Amount (USD)")),
+    currency: Type.Optional(Type.Unsafe({ type: "string" })),
+    announced_at: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date-time" })
+    ),
+    status: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["announced", "closed", "cancelled", "rumoured"],
+      })
+    ),
+    source_urls: Type.Optional(
+      Type.Unsafe({
+        type: "array",
+        items: { type: "string", format: "uri" },
+      })
+    ),
+    projection_kind: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["financing_event"] })
+    ),
+    projection_status: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["materialized", "superseded", "disputed"],
+      })
+    ),
+    indexability: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["noindex", "index"] })
+    ),
   },
 });
 
@@ -197,35 +225,49 @@ const jobPosting = defineEntityType({
   name: "Job Posting",
   description: "Public job posting associated with an organization",
   properties: {
-    title: { type: "string", "x-table-column": true, "x-table-label": "Title" },
-    company_id: {
-      type: "integer",
-      description: "FK to Market organization",
-      "x-table-column": true,
-      "x-table-label": "Organization",
-      "x-link-entity-type": "company",
-    },
-    posted_by_person_id: {
-      type: "integer",
-      description: "FK to canonical public person",
-      "x-link-entity-type": "person",
-    },
-    posted_by_member_id: {
-      type: "integer",
-      description: "FK to authenticated workspace member",
-      "x-link-entity-type": "$member",
-    },
-    city_id: {
-      type: "integer",
-      description: "FK to local Market city",
-      "x-table-column": true,
-      "x-table-label": "City",
-      "x-link-entity-type": "city",
-    },
-    description: { type: "string" },
-    status: { type: "string", enum: ["open", "filled", "closed"] },
-    posted_at: { type: "string", format: "date-time" },
-    expires_at: { type: "string", format: "date-time" },
+    title: field("Title", { optional: true }),
+    company_id: Type.Optional(
+      field(
+        Type.Integer({
+          description: "FK to Market organization",
+          "x-link-entity-type": "company",
+        }),
+        "Organization"
+      )
+    ),
+    posted_by_person_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to canonical public person",
+        "x-link-entity-type": "person",
+      })
+    ),
+    posted_by_member_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to authenticated workspace member",
+        "x-link-entity-type": "$member",
+      })
+    ),
+    city_id: Type.Optional(
+      field(
+        Type.Integer({
+          description: "FK to local Market city",
+          "x-link-entity-type": "city",
+        }),
+        "City"
+      )
+    ),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
+    status: Type.Optional(
+      Type.Unsafe({ type: "string", enum: ["open", "filled", "closed"] })
+    ),
+    posted_at: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date-time" })
+    ),
+    expires_at: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date-time" })
+    ),
   },
 });
 
@@ -234,17 +276,21 @@ const industry = defineEntityType({
   name: "Industry",
   description: "Local reference taxonomy for organizations and products",
   properties: {
-    parent_id: {
-      type: "integer",
-      description: "FK to parent Market industry",
-      "x-link-entity-type": "industry",
-    },
-    taxonomy_source: {
-      type: "string",
-      enum: ["NAICS", "BICS", "custom"],
-    },
-    code: { type: "string" },
-    description: { type: "string" },
+    parent_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to parent Market industry",
+        "x-link-entity-type": "industry",
+      })
+    ),
+    taxonomy_source: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["NAICS", "BICS", "custom"],
+      })
+    ),
+    code: Type.Optional(Type.Unsafe({ type: "string" })),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -253,10 +299,14 @@ const country = defineEntityType({
   name: "Country",
   description: "Local reference identity for a sovereign country",
   properties: {
-    iso2: { type: "string", minLength: 2, maxLength: 2 },
-    iso3: { type: "string", minLength: 3, maxLength: 3 },
-    currency: { type: "string" },
-    official_name: { type: "string" },
+    iso2: Type.Optional(
+      Type.Unsafe({ type: "string", minLength: 2, maxLength: 2 })
+    ),
+    iso3: Type.Optional(
+      Type.Unsafe({ type: "string", minLength: 3, maxLength: 3 })
+    ),
+    currency: Type.Optional(Type.Unsafe({ type: "string" })),
+    official_name: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -265,12 +315,14 @@ const region = defineEntityType({
   name: "Region",
   description: "Local reference identity for an administrative region",
   properties: {
-    country_id: {
-      type: "integer",
-      description: "FK to local Market country",
-      "x-link-entity-type": "country",
-    },
-    iso_3166_2: { type: "string" },
+    country_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to local Market country",
+        "x-link-entity-type": "country",
+      })
+    ),
+    iso_3166_2: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -279,17 +331,21 @@ const city = defineEntityType({
   name: "City",
   description: "Local reference identity for a city, town, or metro area",
   properties: {
-    country_id: {
-      type: "integer",
-      description: "FK to local Market country",
-      "x-link-entity-type": "country",
-    },
-    region_id: {
-      type: "integer",
-      description: "FK to local Market region",
-      "x-link-entity-type": "region",
-    },
-    timezone: { type: "string" },
+    country_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to local Market country",
+        "x-link-entity-type": "country",
+      })
+    ),
+    region_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to local Market region",
+        "x-link-entity-type": "region",
+      })
+    ),
+    timezone: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -299,9 +355,9 @@ const technology = defineEntityType({
   description:
     "Local reference identity for a technology, framework, library, or platform",
   properties: {
-    category: { type: "string" },
-    homepage_url: { type: "string", format: "uri" },
-    open_source: { type: "boolean" },
+    category: Type.Optional(Type.Unsafe({ type: "string" })),
+    homepage_url: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
+    open_source: Type.Optional(Type.Unsafe({ type: "boolean" })),
   },
 });
 
@@ -310,17 +366,21 @@ const university = defineEntityType({
   name: "University",
   description: "Local reference identity for a higher-education institution",
   properties: {
-    country_id: {
-      type: "integer",
-      description: "FK to local Market country",
-      "x-link-entity-type": "country",
-    },
-    city_id: {
-      type: "integer",
-      description: "FK to local Market city",
-      "x-link-entity-type": "city",
-    },
-    homepage_url: { type: "string", format: "uri" },
+    country_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to local Market country",
+        "x-link-entity-type": "country",
+      })
+    ),
+    city_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "FK to local Market city",
+        "x-link-entity-type": "city",
+      })
+    ),
+    homepage_url: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
   },
 });
 

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -11,6 +11,8 @@ import {
   defineSkill,
   every,
   reactionFromFile,
+  field,
+  Type,
 } from "@lobu/cli/config";
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type HackerNewsConnector from "./hackernews.connector.ts";
@@ -75,94 +77,104 @@ const person = defineEntityType({
   // Trait names must match connector EventAttributionRule.traits keys.
   // Identity join keys live on entity identities/aliases, not as required props.
   properties: {
-    // X (packages/connectors x.ts + twitter takeout)
-    x_handle: {
-      type: "string",
+    x_handle: field("X", {
       description:
         "X/Twitter @handle without @. Mutable secondary identity; primary join is x_user_id.",
-      "x-table-label": "X",
-      "x-table-column": true,
-    },
-    x_display_name: {
-      type: "string",
-      description: "Display name from X profile/posts.",
-    },
-    last_x_interaction_at: {
-      type: "string",
+      optional: true,
+    }),
+    x_display_name: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Display name from X profile/posts.",
+      })
+    ),
+    last_x_interaction_at: field("Last X", {
       format: "date-time",
       description:
         "Most recent X post/like/bookmark/reply involving this person.",
-      "x-table-label": "Last X",
-      "x-table-column": true,
-    },
-    last_x_dm_at: {
-      type: "string",
-      format: "date-time",
-      description: "Most recent X DM with this person.",
-    },
-    // WhatsApp
-    push_name: {
-      type: "string",
+      optional: true,
+    }),
+    last_x_dm_at: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date-time",
+        description: "Most recent X DM with this person.",
+      })
+    ),
+    push_name: field("WA name", {
       description: "WhatsApp push name.",
-      "x-table-label": "WA name",
-      "x-table-column": true,
-    },
-    last_seen_at: {
-      type: "string",
-      format: "date-time",
-      description: "Most recent WhatsApp message time for this contact.",
-    },
-    // LinkedIn
-    linkedin_url: {
-      type: "string",
-      description:
-        "LinkedIn profile URL (display trait; identity is linkedin_slug).",
-    },
-    position: {
-      type: "string",
-      description: "LinkedIn headline/position.",
-    },
-    company: {
-      type: "string",
+      optional: true,
+    }),
+    last_seen_at: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date-time",
+        description: "Most recent WhatsApp message time for this contact.",
+      })
+    ),
+    linkedin_url: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "LinkedIn profile URL (display trait; identity is linkedin_slug).",
+      })
+    ),
+    position: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "LinkedIn headline/position.",
+      })
+    ),
+    company: field("Company", {
       description: "Company / employer (LinkedIn connection + manual).",
-      "x-table-label": "Company",
-      "x-table-column": true,
-    },
-    last_linkedin_message_at: {
-      type: "string",
-      format: "date-time",
-      description: "Most recent LinkedIn message with this person.",
-    },
-    // Instagram takeout
-    ig_username: {
-      type: "string",
-      description: "Instagram username.",
-    },
-    instagram_profile_url: {
-      type: "string",
-      description: "Instagram profile URL.",
-    },
-    // Gmail (match-only; traits accrete when identity already exists)
-    from_name: {
-      type: "string",
-      description: "Name as seen on inbound email.",
-    },
-    last_email_at: {
-      type: "string",
-      format: "date-time",
-      description: "Most recent email from/to this address.",
-    },
-    // Optional human-curated (email is also an identity namespace)
-    email: {
-      type: "string",
-      description: "Email address (also an identity namespace).",
-    },
-    first_name: { type: "string" },
-    last_name: { type: "string" },
-    role: {
-      type: "string",
-      description: "Freeform role or relationship note (not a CRM enum).",
-    },
+      optional: true,
+    }),
+    last_linkedin_message_at: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date-time",
+        description: "Most recent LinkedIn message with this person.",
+      })
+    ),
+    ig_username: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Instagram username.",
+      })
+    ),
+    instagram_profile_url: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Instagram profile URL.",
+      })
+    ),
+    from_name: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Name as seen on inbound email.",
+      })
+    ),
+    last_email_at: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date-time",
+        description: "Most recent email from/to this address.",
+      })
+    ),
+    email: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Email address (also an identity namespace).",
+      })
+    ),
+    first_name: Type.Optional(Type.Unsafe({ type: "string" })),
+    last_name: Type.Optional(Type.Unsafe({ type: "string" })),
+    role: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Freeform role or relationship note (not a CRM enum).",
+      })
+    ),
   },
   // WhatsApp + X identity metrics. Declared here so `apply` preserves them
   // rather than pruning — persons alias connector identities (wa_jid, x_handle).
@@ -239,57 +251,93 @@ const company = defineEntityType({
     "An organization the user cares about — own company, employer, customer, partner, or portfolio company. Link people via works_at.",
   metadata: { icon: "building", color: "#2563eb" },
   properties: {
-    // Core identity / positioning
-    domain: { type: "string", description: "Primary web domain" },
-    one_liner: { type: "string", description: "One-line description" },
-    location: { type: "string" },
-    market: { type: "string", description: "Primary market vertical" },
-    main_market: { type: "string" },
-    platform_type: { type: "string" },
-    linkedin_url: { type: "string", format: "uri" },
-    founding_year: { type: "integer", maximum: 2030, minimum: 1900 },
-    team_size: { type: "integer", minimum: 0 },
-    // Optional growth / funding fields (portfolio / competitive tracking)
-    stage: {
-      type: "string",
-      enum: [
-        "preseed",
-        "seed",
-        "series_a",
-        "series_b",
-        "series_c",
-        "growth",
-        "public",
-      ],
-      description: "Current funding stage when relevant",
-    },
-    mrr: { type: "number", description: "Monthly recurring revenue in USD" },
-    revenue: { type: "number", description: "Annual revenue in USD" },
-    valuation: { type: "number", description: "Last known valuation in USD" },
-    growth_rate: { type: "number", description: "YoY growth rate as decimal" },
-    funding_raised: {
-      type: "number",
-      description: "Total funding raised in USD",
-    },
-    thesis: { type: "string", description: "Investment or relationship notes" },
-    traction_score: {
-      type: "number",
-      maximum: 100,
-      minimum: 0,
-      description: "Computed traction score",
-    },
-    traction_signals: {
-      type: "object",
-      properties: {
-        hiring: { type: "number" },
-        last_updated: { type: "string", format: "date-time" },
-        news_coverage: { type: "number" },
-        github_velocity: { type: "number" },
-        social_mentions: { type: "number" },
-        app_store_growth: { type: "number" },
-        review_sentiment: { type: "number" },
-      },
-    },
+    domain: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Primary web domain" })
+    ),
+    one_liner: Type.Optional(
+      Type.Unsafe({ type: "string", description: "One-line description" })
+    ),
+    location: Type.Optional(Type.Unsafe({ type: "string" })),
+    market: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Primary market vertical" })
+    ),
+    main_market: Type.Optional(Type.Unsafe({ type: "string" })),
+    platform_type: Type.Optional(Type.Unsafe({ type: "string" })),
+    linkedin_url: Type.Optional(Type.Unsafe({ type: "string", format: "uri" })),
+    founding_year: Type.Optional(
+      Type.Unsafe({ type: "integer", maximum: 2030, minimum: 1900 })
+    ),
+    team_size: Type.Optional(Type.Unsafe({ type: "integer", minimum: 0 })),
+    stage: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: [
+          "preseed",
+          "seed",
+          "series_a",
+          "series_b",
+          "series_c",
+          "growth",
+          "public",
+        ],
+        description: "Current funding stage when relevant",
+      })
+    ),
+    mrr: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description: "Monthly recurring revenue in USD",
+      })
+    ),
+    revenue: Type.Optional(
+      Type.Unsafe({ type: "number", description: "Annual revenue in USD" })
+    ),
+    valuation: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description: "Last known valuation in USD",
+      })
+    ),
+    growth_rate: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description: "YoY growth rate as decimal",
+      })
+    ),
+    funding_raised: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description: "Total funding raised in USD",
+      })
+    ),
+    thesis: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Investment or relationship notes",
+      })
+    ),
+    traction_score: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        maximum: 100,
+        minimum: 0,
+        description: "Computed traction score",
+      })
+    ),
+    traction_signals: Type.Optional(
+      Type.Unsafe({
+        type: "object",
+        properties: {
+          hiring: { type: "number" },
+          last_updated: { type: "string", format: "date-time" },
+          news_coverage: { type: "number" },
+          github_velocity: { type: "number" },
+          social_mentions: { type: "number" },
+          app_store_growth: { type: "number" },
+          review_sentiment: { type: "number" },
+        },
+      })
+    ),
   },
 });
 
@@ -311,60 +359,47 @@ const task = defineEntityType({
   description:
     "An actionable item collaboratively managed by Burak and his personal agent.",
   metadata: { icon: "check-square", color: "#10B981" },
-  required: [
-    "action",
-    "status",
-    "source_scope",
-    "source_origin_id",
-    "task_key",
-  ],
   properties: {
-    action: {
-      type: "string",
+    action: field("Action", {
       minLength: 1,
       description: "Concrete action to perform",
-      "x-table-label": "Action",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
+    }),
+    status: field("Status", {
       enum: ["backlog", "active", "done", "dismissed"],
       description: "Collaborative task state",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    owner: {
-      type: "string",
+    }),
+    owner: field("Owner", {
       description: "Person or agent responsible",
-      "x-table-label": "Owner",
-      "x-table-column": true,
-    },
-    priority: {
-      type: "string",
+      optional: true,
+    }),
+    priority: field("Priority", {
       enum: ["high", "medium", "low"],
       description: "Execution priority",
-      "x-table-label": "Priority",
-      "x-table-column": true,
-    },
-    due_date: {
-      type: "string",
+      optional: true,
+    }),
+    due_date: field("Due", {
       format: "date-time",
       description: "Due time when known",
-      "x-table-label": "Due",
-      "x-table-column": true,
-    },
-    source: {
-      type: "string",
-      description: "Where this task came from",
-    },
-    rationale: {
-      type: "string",
-      description: "Why this task is worth doing",
-    },
-    source_event_id: {
-      type: "integer",
-      description: "Originating Lobu event id (provenance, not identity)",
-    },
+      optional: true,
+    }),
+    source: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Where this task came from",
+      })
+    ),
+    rationale: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Why this task is worth doing",
+      })
+    ),
+    source_event_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "Originating Lobu event id (provenance, not identity)",
+      })
+    ),
     source_scope: {
       type: "string",
       minLength: 1,
@@ -489,14 +524,18 @@ const account = defineEntityType({
     "A financial account used as the stable grain for account-level transaction metrics.",
   metadata: { icon: "landmark", color: "#10B981" },
   properties: {
-    is_active: {
-      type: "boolean",
-      description: "Whether this account is active",
-      "x-table-column": true,
-      "x-table-label": "Active",
-    },
-    institution: { type: "string", description: "Financial institution" },
-    account_type: { type: "string", description: "Account classification" },
+    is_active: Type.Optional(
+      field(
+        Type.Boolean({ description: "Whether this account is active" }),
+        "Active"
+      )
+    ),
+    institution: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Financial institution" })
+    ),
+    account_type: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Account classification" })
+    ),
   },
   // Governed spend metrics over the Revolut transaction stream. The eventSet
   // resolves a transaction to an account by matching its `currency` against the
@@ -640,55 +679,57 @@ const subscription = defineEntityType({
   metadata: { icon: "🔄", color: "#EF4444" },
   backing: { sql: subscriptionBackingSql },
   properties: {
-    amount: {
-      type: "number",
-      description: "Current charge amount",
-      "x-table-column": true,
-      "x-table-label": "Amount",
-    },
-    status: {
-      type: "string",
+    amount: Type.Optional(
+      field(Type.Number({ description: "Current charge amount" }), "Amount")
+    ),
+    status: field("Status", {
       enum: ["active", "cancelled", "changed"],
       description: "Current status",
-      "x-table-column": true,
-      "x-table-label": "Status",
-    },
-    category: {
-      type: "string",
-      enum: ["subscription", "bill", "insurance", "membership"],
-      description: "Type of expense",
-    },
-    currency: { type: "string", description: "Currency code" },
-    frequency: {
-      type: "string",
-      enum: ["monthly", "annual", "periodic"],
-      description: "How often charged",
-    },
-    last_seen: {
-      type: "string",
-      format: "date",
-      "x-table-column": true,
-      "x-table-label": "Last Seen",
-    },
-    first_seen: { type: "string", format: "date" },
-    billing_day: {
-      type: "number",
-      description: "Day of month typically charged",
-    },
-    total_spent: {
-      type: "number",
-      description:
-        "Total charged over the tracked period, in the charge currency",
-      "x-table-column": true,
-      "x-table-label": "Total",
-    },
-    total_spent_gbp: {
-      type: "number",
-      description:
-        "Total in GBP: exact where known (native GBP + Revolut-booked GBP counterpart), and pocket charges (USD/EUR) valued at the user's own realised conversion rate",
-    },
-    charge_count: { type: "integer" },
-    active_months: { type: "integer" },
+      optional: true,
+    }),
+    category: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["subscription", "bill", "insurance", "membership"],
+        description: "Type of expense",
+      })
+    ),
+    currency: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Currency code" })
+    ),
+    frequency: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["monthly", "annual", "periodic"],
+        description: "How often charged",
+      })
+    ),
+    last_seen: field("Last Seen", { format: "date", optional: true }),
+    first_seen: Type.Optional(Type.Unsafe({ type: "string", format: "date" })),
+    billing_day: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description: "Day of month typically charged",
+      })
+    ),
+    total_spent: Type.Optional(
+      field(
+        Type.Number({
+          description:
+            "Total charged over the tracked period, in the charge currency",
+        }),
+        "Total"
+      )
+    ),
+    total_spent_gbp: Type.Optional(
+      Type.Unsafe({
+        type: "number",
+        description:
+          "Total in GBP: exact where known (native GBP + Revolut-booked GBP counterpart), and pocket charges (USD/EUR) valued at the user's own realised conversion rate",
+      })
+    ),
+    charge_count: Type.Optional(Type.Unsafe({ type: "integer" })),
+    active_months: Type.Optional(Type.Unsafe({ type: "integer" })),
   },
 });
 
@@ -700,26 +741,14 @@ const trip = defineEntityType({
   description: "Travel derived from passport stamps",
   metadata: { icon: "✈️", color: "#F59E0B" },
   properties: {
-    destination: {
-      type: "string",
+    destination: field("Destination", {
       description: "Destination of the trip",
-      "x-table-column": true,
-      "x-table-label": "Destination",
-    },
-    start_date: {
-      type: "string",
-      format: "date",
-      "x-table-column": true,
-      "x-table-label": "Start",
-    },
-    end_date: {
-      type: "string",
-      format: "date",
-      "x-table-column": true,
-      "x-table-label": "End",
-    },
-    event_type: { type: "string" },
-    notes: { type: "string" },
+      optional: true,
+    }),
+    start_date: field("Start", { format: "date", optional: true }),
+    end_date: field("End", { format: "date", optional: true }),
+    event_type: Type.Optional(Type.Unsafe({ type: "string" })),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
   eventSets: {
     transactions: {
@@ -758,39 +787,41 @@ const goal = defineEntityType({
     "A personal objective the agent tracks and helps make progress on",
   metadata: { icon: "🎯", color: "#0EA5E9" },
   properties: {
-    status: {
-      type: "string",
+    status: field("Status", {
       enum: ["active", "achieved", "paused", "abandoned"],
       description: "Current status",
-      "x-table-column": true,
-      "x-table-label": "Status",
-    },
-    category: {
-      type: "string",
-      description:
-        "Area of life (finance, health, career, travel, learning, …)",
-    },
-    target_date: {
-      type: "string",
+      optional: true,
+    }),
+    category: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Area of life (finance, health, career, travel, learning, …)",
+      })
+    ),
+    target_date: field("Target", {
       format: "date",
       description: "When the user wants to reach it",
-      "x-table-column": true,
-      "x-table-label": "Target",
-    },
-    progress: {
-      type: "number",
-      minimum: 0,
-      maximum: 100,
-      description: "Percent complete (0–100)",
-      "x-table-column": true,
-      "x-table-label": "Progress",
-    },
-    metric: {
-      type: "string",
-      description:
-        "How progress is measured — ideally a declared metric (e.g. account.spend) the agent can query",
-    },
-    description: { type: "string" },
+      optional: true,
+    }),
+    progress: Type.Optional(
+      field(
+        Type.Number({
+          minimum: 0,
+          maximum: 100,
+          description: "Percent complete (0–100)",
+        }),
+        "Progress"
+      )
+    ),
+    metric: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "How progress is measured — ideally a declared metric (e.g. account.spend) the agent can query",
+      })
+    ),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -801,31 +832,26 @@ const learning = defineEntityType({
     "Something the agent has learned about the user or their world worth retaining",
   metadata: { icon: "💡", color: "#A855F7" },
   properties: {
-    topic: {
-      type: "string",
+    topic: field("Topic", {
       description: "What the learning is about",
-      "x-table-column": true,
-      "x-table-label": "Topic",
-    },
-    source: {
-      type: "string",
-      description:
-        "Where it was learned (conversation, Automation, observation)",
-    },
-    learned_date: {
-      type: "string",
-      format: "date",
-      "x-table-column": true,
-      "x-table-label": "Date",
-    },
-    confidence: {
-      type: "string",
+      optional: true,
+    }),
+    source: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Where it was learned (conversation, Automation, observation)",
+      })
+    ),
+    learned_date: field("Date", { format: "date", optional: true }),
+    confidence: field("Confidence", {
       enum: ["low", "medium", "high"],
-      "x-table-column": true,
-      "x-table-label": "Confidence",
-    },
-    tags: { type: "array", items: { type: "string" } },
-    description: { type: "string" },
+      optional: true,
+    }),
+    tags: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    description: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -1110,36 +1136,33 @@ const voiceProfile = defineEntityType({
     "How the member sounds (mode=voice) or what they engage with (mode=taste) on one channel. Human analogue of agent identity/soul.",
   metadata: { icon: "🎙️", color: "#F59E0B" },
   properties: {
-    mode: {
-      type: "string",
-      enum: ["voice", "taste"],
-      "x-table-label": "Mode",
-      "x-table-column": true,
-    },
-    channel: {
-      type: "string",
+    mode: field("Mode", { enum: ["voice", "taste"], optional: true }),
+    channel: field("Channel", {
       enum: ["core", "x", "linkedin", "reddit", "instagram"],
-      "x-table-label": "Channel",
-      "x-table-column": true,
-    },
-    summary: { type: "string" },
-    themes: { type: "array", items: { type: "string" } },
-    prefers: { type: "array", items: { type: "string" } },
-    avoids: { type: "array", items: { type: "string" } },
-    confidence: {
-      type: "string",
+      optional: true,
+    }),
+    summary: Type.Optional(Type.Unsafe({ type: "string" })),
+    themes: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    prefers: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    avoids: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "string" } })
+    ),
+    confidence: field("Confidence", {
       enum: ["low", "medium", "high"],
-      "x-table-label": "Confidence",
-      "x-table-column": true,
-    },
-    evidence_count: {
-      type: "number",
-      "x-table-label": "Evidence",
-      "x-table-column": true,
-    },
-    evidence_from: { type: "string", format: "date" },
-    evidence_to: { type: "string", format: "date" },
-    sample_event_ids: { type: "array", items: { type: "number" } },
+      optional: true,
+    }),
+    evidence_count: Type.Optional(field(Type.Number(), "Evidence")),
+    evidence_from: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    evidence_to: Type.Optional(Type.Unsafe({ type: "string", format: "date" })),
+    sample_event_ids: Type.Optional(
+      Type.Unsafe({ type: "array", items: { type: "number" } })
+    ),
   },
 });
 
@@ -1164,7 +1187,9 @@ const socialSignal = defineEntityType({
       minLength: 1,
       description: 'Post author (never "unknown")',
     },
-    snippet: { type: "string", description: "Excerpt of the post" },
+    snippet: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Excerpt of the post" })
+    ),
     why: {
       type: "string",
       minLength: 1,
@@ -1175,11 +1200,15 @@ const socialSignal = defineEntityType({
       type: "string",
       description: "Stable events.origin_id of the source post",
     },
-    source_event_id: {
-      type: "integer",
-      description: "Originating event id (unstable across re-sync)",
-    },
-    suggested_action: { type: "string", description: "Concrete next step" },
+    source_event_id: Type.Optional(
+      Type.Unsafe({
+        type: "integer",
+        description: "Originating event id (unstable across re-sync)",
+      })
+    ),
+    suggested_action: Type.Optional(
+      Type.Unsafe({ type: "string", description: "Concrete next step" })
+    ),
   },
   required: ["platform", "author", "why", "priority", "source_origin_id"],
 });

--- a/examples/personal-finance/lobu.config.ts
+++ b/examples/personal-finance/lobu.config.ts
@@ -7,6 +7,8 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
+  Type,
 } from "@lobu/cli/config";
 
 const gmailTxSkill = defineSkill({
@@ -47,16 +49,11 @@ const account = defineEntityType({
   name: "Account",
   description:
     "A bank, savings, brokerage, pension, mortgage, or business account. Owner is always set via the owned_by relationship (or co_owned_by for joint accounts) — never inferred from context.",
-  required: ["provider", "wrapper"],
   properties: {
-    provider: {
-      type: "string",
+    provider: field("Provider", {
       description: 'Bank or broker name (e.g. "Monzo", "Hargreaves Lansdown")',
-      "x-table-label": "Provider",
-      "x-table-column": true,
-    },
-    wrapper: {
-      type: "string",
+    }),
+    wrapper: field("Wrapper", {
       enum: [
         "current",
         "savings",
@@ -75,32 +72,34 @@ const account = defineEntityType({
       ],
       description:
         "Account class. Drives tax treatment (ISA = no SA reporting, GIA = CGT applies, etc.).",
-      "x-table-label": "Wrapper",
-      "x-table-column": true,
-    },
-    currency: {
-      type: "string",
+    }),
+    currency: field("Ccy", {
       description: "ISO 4217 currency code",
       default: "GBP",
-      "x-table-label": "Ccy",
-      "x-table-column": true,
-    },
-    account_number_last4: {
-      type: "string",
-      description: "Last 4 digits, for matching against statements",
-    },
-    sort_code: { type: "string" },
-    iban: {
-      type: "string",
-      description:
-        "For non-UK accounts; preferred over sort_code+account_number when known",
-    },
-    opening_balance: {
-      type: "string",
-      description: 'Decimal string, e.g. "1234.56"',
-    },
-    closing_balance: { type: "string" },
-    notes: { type: "string" },
+      optional: true,
+    }),
+    account_number_last4: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Last 4 digits, for matching against statements",
+      })
+    ),
+    sort_code: Type.Optional(Type.Unsafe({ type: "string" })),
+    iban: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "For non-UK accounts; preferred over sort_code+account_number when known",
+      })
+    ),
+    opening_balance: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: 'Decimal string, e.g. "1234.56"',
+      })
+    ),
+    closing_balance: Type.Optional(Type.Unsafe({ type: "string" })),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -109,10 +108,8 @@ const allowance_window = defineEntityType({
   name: "Allowance Window",
   description:
     'A materialized accumulator for one tax allowance over one tax year. Lets the agent answer "how much ISA budget left this year?" or "how much pension annual allowance can I still use?" instantly without recomputing across all underlying transactions/contributions every time.',
-  required: ["kind", "cap", "used"],
   properties: {
-    kind: {
-      type: "string",
+    kind: field("Allowance", {
       enum: [
         "isa_subscription",
         "dividend_allowance",
@@ -124,46 +121,42 @@ const allowance_window = defineEntityType({
         "personal_allowance",
       ],
       description: "Which HMRC-defined allowance this window tracks",
-      "x-table-label": "Allowance",
-      "x-table-column": true,
-    },
-    cap: {
-      type: "string",
+    }),
+    cap: field("Cap", {
       description:
         'Decimal GBP. The statutory limit for this allowance in this year (e.g. "20000" for ISA, "60000" for pension AA).',
-      "x-table-label": "Cap",
-      "x-table-column": true,
-    },
-    used: {
-      type: "string",
+    }),
+    used: field("Used", {
       description:
         "Decimal GBP consumed so far. Updated on every relevant transaction/contribution write.",
-      "x-table-label": "Used",
-      "x-table-column": true,
-    },
-    remaining: {
-      type: "string",
+    }),
+    remaining: field("Remaining", {
       description:
         "Decimal GBP. cap minus used minus carry_forward used. May go negative if a tapered allowance applies (the agent surfaces this).",
-      "x-table-label": "Remaining",
-      "x-table-column": true,
-    },
-    carry_forward_in: {
-      type: "string",
-      description:
-        "For pension AA — unused allowance carried in from the prior 3 years.",
-    },
-    carry_forward_out: {
-      type: "string",
-      description:
-        "Unused this year, available to carry forward (subject to the allowance's rules).",
-    },
-    last_recomputed_at: {
-      type: "string",
-      format: "date-time",
-      description:
-        "When the agent last recomputed used/remaining from underlying entities.",
-    },
+      optional: true,
+    }),
+    carry_forward_in: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "For pension AA — unused allowance carried in from the prior 3 years.",
+      })
+    ),
+    carry_forward_out: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Unused this year, available to carry forward (subject to the allowance's rules).",
+      })
+    ),
+    last_recomputed_at: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date-time",
+        description:
+          "When the agent last recomputed used/remaining from underlying entities.",
+      })
+    ),
   },
 });
 
@@ -172,35 +165,22 @@ const asset_lot = defineEntityType({
   name: "Asset Lot",
   description:
     "An acquisition lot used for s.104 share-pool / matching rules. One lot per buy event.",
-  required: ["acquisition_date", "quantity", "cost_basis"],
   properties: {
-    pool_id: {
-      type: "string",
+    pool_id: field("Pool", {
       description: "Identifier for the s.104 pool (typically the ticker/ISIN)",
-      "x-table-label": "Pool",
-      "x-table-column": true,
-    },
-    acquisition_date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Acquired",
-      "x-table-column": true,
-    },
-    quantity: {
-      type: "string",
-      "x-table-label": "Quantity",
-      "x-table-column": true,
-    },
-    cost_basis: {
-      type: "string",
+      optional: true,
+    }),
+    acquisition_date: field("Acquired", { format: "date" }),
+    quantity: field("Quantity"),
+    cost_basis: field("Cost", {
       description: "Total cost for this lot, decimal GBP",
-      "x-table-label": "Cost",
-      "x-table-column": true,
-    },
-    quantity_remaining: {
-      type: "string",
-      description: "After partial disposals",
-    },
+    }),
+    quantity_remaining: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "After partial disposals",
+      })
+    ),
   },
 });
 
@@ -209,20 +189,9 @@ const cgt_event = defineEntityType({
   name: "CGT Event",
   description:
     "A capital-gains disposal — sale, gift, or other event triggering CGT (SA108).",
-  required: [
-    "asset_description",
-    "asset_class",
-    "disposal_date",
-    "disposal_proceeds",
-  ],
   properties: {
-    asset_description: {
-      type: "string",
-      "x-table-label": "Asset",
-      "x-table-column": true,
-    },
-    asset_class: {
-      type: "string",
+    asset_description: field("Asset"),
+    asset_class: field("Class", {
       enum: [
         "listed_shares",
         "unlisted_shares",
@@ -231,32 +200,27 @@ const cgt_event = defineEntityType({
         "crypto",
         "other",
       ],
-      "x-table-label": "Class",
-      "x-table-column": true,
-    },
-    acquisition_date: { type: "string", format: "date" },
-    acquisition_cost: {
-      type: "string",
-      description: "Total acquisition cost, decimal string GBP",
-    },
-    disposal_date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Disposal",
-      "x-table-column": true,
-    },
-    disposal_proceeds: {
-      type: "string",
+    }),
+    acquisition_date: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    acquisition_cost: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Total acquisition cost, decimal string GBP",
+      })
+    ),
+    disposal_date: field("Disposal", { format: "date" }),
+    disposal_proceeds: field("Proceeds", {
       description: "Total proceeds, decimal string GBP",
-      "x-table-label": "Proceeds",
-      "x-table-column": true,
-    },
-    incidental_costs: {
-      type: "string",
-      description: "Legal, broker, SDLT on acquisition, enhancement",
-    },
-    relief_claimed: {
-      type: "string",
+    }),
+    incidental_costs: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Legal, broker, SDLT on acquisition, enhancement",
+      })
+    ),
+    relief_claimed: field("Relief", {
       enum: [
         "none",
         "PRR",
@@ -267,14 +231,15 @@ const cgt_event = defineEntityType({
         "SEIS_deferral",
       ],
       default: "none",
-      "x-table-label": "Relief",
-      "x-table-column": true,
-    },
-    residential_60day_return_ref: {
-      type: "string",
-      description:
-        "HMRC reference if a 60-day residential CGT return was already filed",
-    },
+      optional: true,
+    }),
+    residential_60day_return_ref: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "HMRC reference if a 60-day residential CGT return was already filed",
+      })
+    ),
   },
 });
 
@@ -283,15 +248,9 @@ const company = defineEntityType({
   name: "Company",
   description:
     "A legal entity that can hold accounts, file tax returns, employ people, or be owned. Covers Ltd, PLC, LLP, sole-trader, partnership, trust, and charity. Discriminate by company_type.",
-  required: ["legal_name", "company_type"],
   properties: {
-    legal_name: {
-      type: "string",
-      "x-table-label": "Name",
-      "x-table-column": true,
-    },
-    company_type: {
-      type: "string",
+    legal_name: field("Name"),
+    company_type: field("Type", {
       enum: [
         "ltd",
         "plc",
@@ -302,43 +261,51 @@ const company = defineEntityType({
         "charity",
         "foreign",
       ],
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    incorporation_date: { type: "string", format: "date" },
-    registered_address: { type: "string" },
-    accounting_period_start: {
-      type: "string",
-      format: "date",
-      description:
-        "Start of the company's accounting reference period (CT600 / SA800 anchor)",
-    },
-    accounting_period_end: { type: "string", format: "date" },
-    vat_registered: {
-      type: "boolean",
-      default: false,
-      "x-table-label": "VAT",
-      "x-table-column": true,
-    },
-    vat_scheme: {
-      type: "string",
-      enum: [
-        "standard",
-        "flat_rate",
-        "cash_accounting",
-        "annual_accounting",
-        "none",
-      ],
-      default: "none",
-    },
-    is_personal_service_company: {
-      type: "boolean",
-      default: false,
-      description: "Marks PSCs (relevant for IR35 / off-payroll-working rules)",
-    },
-    dormant_flag: { type: "boolean", default: false },
-    ceased_date: { type: "string", format: "date" },
-    notes: { type: "string" },
+    }),
+    incorporation_date: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    registered_address: Type.Optional(Type.Unsafe({ type: "string" })),
+    accounting_period_start: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date",
+        description:
+          "Start of the company's accounting reference period (CT600 / SA800 anchor)",
+      })
+    ),
+    accounting_period_end: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    vat_registered: Type.Optional(
+      field(Type.Boolean({ default: false }), "VAT")
+    ),
+    vat_scheme: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: [
+          "standard",
+          "flat_rate",
+          "cash_accounting",
+          "annual_accounting",
+          "none",
+        ],
+        default: "none",
+      })
+    ),
+    is_personal_service_company: Type.Optional(
+      Type.Unsafe({
+        type: "boolean",
+        default: false,
+        description:
+          "Marks PSCs (relevant for IR35 / off-payroll-working rules)",
+      })
+    ),
+    dormant_flag: Type.Optional(
+      Type.Unsafe({ type: "boolean", default: false })
+    ),
+    ceased_date: Type.Optional(Type.Unsafe({ type: "string", format: "date" })),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -347,39 +314,22 @@ const contribution = defineEntityType({
   name: "Contribution",
   description:
     "A pension or charitable contribution affecting tax (Gift Aid, SIPP, etc.).",
-  required: ["scheme", "mechanism", "amount", "date"],
   properties: {
-    scheme: {
-      type: "string",
-      description: "Provider/charity name",
-      "x-table-label": "Scheme",
-      "x-table-column": true,
-    },
-    mechanism: {
-      type: "string",
+    scheme: field("Scheme", { description: "Provider/charity name" }),
+    mechanism: field("Mechanism", {
       enum: ["relief_at_source", "net_pay", "salary_sacrifice", "gift_aid"],
       description:
         "Pension relief mechanism, or gift_aid for charitable donations",
-      "x-table-label": "Mechanism",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
-      description: "Net amount paid, decimal GBP",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
-    date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    carry_back_to_prior_year: {
-      type: "boolean",
-      default: false,
-      description: "Gift Aid carry-back election",
-    },
+    }),
+    amount: field("Amount", { description: "Net amount paid, decimal GBP" }),
+    date: field("Date", { format: "date" }),
+    carry_back_to_prior_year: Type.Optional(
+      Type.Unsafe({
+        type: "boolean",
+        default: false,
+        description: "Gift Aid carry-back election",
+      })
+    ),
   },
 });
 
@@ -388,10 +338,8 @@ const document = defineEntityType({
   name: "Document",
   description:
     "A source document — P60, P45, P11D, SA302, broker contract note, mortgage statement, bank statement — that other entities are parsed from.",
-  required: ["doc_type", "source"],
   properties: {
-    doc_type: {
-      type: "string",
+    doc_type: field("Type", {
       enum: [
         "P60",
         "P45",
@@ -407,25 +355,24 @@ const document = defineEntityType({
         "receipt",
         "other",
       ],
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    source: {
-      type: "string",
-      enum: ["gmail", "whatsapp_upload", "manual"],
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
-    download_url: {
-      type: "string",
-      format: "uri",
-      description: "Signed gateway artifact URL",
-    },
-    payer_or_employer: {
-      type: "string",
-      description: "Counterparty named on the document",
-    },
-    captured_at: { type: "string", format: "date-time" },
+    }),
+    source: field("Source", { enum: ["gmail", "whatsapp_upload", "manual"] }),
+    download_url: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "uri",
+        description: "Signed gateway artifact URL",
+      })
+    ),
+    payer_or_employer: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Counterparty named on the document",
+      })
+    ),
+    captured_at: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date-time" })
+    ),
   },
 });
 
@@ -433,10 +380,8 @@ const expense = defineEntityType({
   key: "expense",
   name: "Expense",
   description: "An allowable expense against a trade or property.",
-  required: ["category", "amount", "date"],
   properties: {
-    category: {
-      type: "string",
+    category: field("Category", {
       enum: [
         "cost_of_goods",
         "travel",
@@ -452,28 +397,18 @@ const expense = defineEntityType({
         "agent_fees",
         "other",
       ],
-      "x-table-label": "Category",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
-      description: "Decimal GBP",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
-    date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    notes: { type: "string" },
-    is_capital: {
-      type: "boolean",
-      default: false,
-      description:
-        "Capital vs revenue (capital expenses go to capital_allowances, not expenses)",
-    },
+    }),
+    amount: field("Amount", { description: "Decimal GBP" }),
+    date: field("Date", { format: "date" }),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
+    is_capital: Type.Optional(
+      Type.Unsafe({
+        type: "boolean",
+        default: false,
+        description:
+          "Capital vs revenue (capital expenses go to capital_allowances, not expenses)",
+      })
+    ),
   },
 });
 
@@ -482,16 +417,8 @@ const filing_obligation = defineEntityType({
   name: "Filing Obligation",
   description:
     "A required tax return or filing the user (or one of their companies) must submit by a deadline. Captures SA100, CT600, SA800, SA900, VAT101, P11D, etc. Lets the agent surface deadlines proactively and reconcile against actual filings.",
-  required: [
-    "return_form",
-    "period_start",
-    "period_end",
-    "deadline_type",
-    "due_date",
-  ],
   properties: {
-    return_form: {
-      type: "string",
+    return_form: field("Form", {
       enum: [
         "SA100",
         "SA800",
@@ -502,13 +429,10 @@ const filing_obligation = defineEntityType({
         "PAYE_RTI",
         "confirmation_statement",
       ],
-      "x-table-label": "Form",
-      "x-table-column": true,
-    },
+    }),
     period_start: { type: "string", format: "date" },
     period_end: { type: "string", format: "date" },
-    deadline_type: {
-      type: "string",
+    deadline_type: field("Deadline", {
       enum: [
         "paper_filing",
         "online_filing",
@@ -520,27 +444,22 @@ const filing_obligation = defineEntityType({
         "vat_payment",
         "registration",
       ],
-      "x-table-label": "Deadline",
-      "x-table-column": true,
-    },
-    due_date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Due",
-      "x-table-column": true,
-    },
-    status: {
-      type: "string",
+    }),
+    due_date: field("Due", { format: "date" }),
+    status: field("Status", {
       enum: ["upcoming", "reminded", "overdue", "filed", "paid", "waived"],
       default: "upcoming",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    completed_date: { type: "string", format: "date" },
-    hmrc_reference: {
-      type: "string",
-      description: "HMRC submission receipt or reference number, once filed.",
-    },
+      optional: true,
+    }),
+    completed_date: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    hmrc_reference: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "HMRC submission receipt or reference number, once filed.",
+      })
+    ),
   },
 });
 
@@ -549,31 +468,19 @@ const goal = defineEntityType({
   name: "Goal",
   description:
     "A personal financial goal (emergency fund, deposit, retirement target, etc.).",
-  required: ["name", "target_amount", "category"],
   properties: {
-    name: { type: "string", "x-table-label": "Goal", "x-table-column": true },
-    target_amount: {
-      type: "string",
-      description: "Decimal GBP",
-      "x-table-label": "Target",
-      "x-table-column": true,
-    },
-    target_date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "By",
-      "x-table-column": true,
-    },
-    category: {
-      type: "string",
+    name: field("Goal"),
+    target_amount: field("Target", { description: "Decimal GBP" }),
+    target_date: field("By", { format: "date", optional: true }),
+    category: field("Category", {
       enum: ["emergency_fund", "deposit", "retirement", "debt_payoff", "other"],
-      "x-table-label": "Category",
-      "x-table-column": true,
-    },
-    current_amount: {
-      type: "string",
-      description: "Optional snapshot, decimal GBP",
-    },
+    }),
+    current_amount: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Optional snapshot, decimal GBP",
+      })
+    ),
   },
 });
 
@@ -581,31 +488,18 @@ const holding = defineEntityType({
   key: "holding",
   name: "Holding",
   description: "A current security position in a brokerage account.",
-  required: ["ticker", "quantity", "as_of_date"],
   properties: {
-    ticker: {
-      type: "string",
-      "x-table-label": "Ticker",
-      "x-table-column": true,
-    },
-    isin: { type: "string" },
-    quantity: {
-      type: "string",
-      description: "Decimal string",
-      "x-table-label": "Quantity",
-      "x-table-column": true,
-    },
-    avg_cost: {
-      type: "string",
-      description: "Average cost per unit (s.104 pool), decimal string",
-    },
-    currency: { type: "string", default: "GBP" },
-    as_of_date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "As of",
-      "x-table-column": true,
-    },
+    ticker: field("Ticker"),
+    isin: Type.Optional(Type.Unsafe({ type: "string" })),
+    quantity: field("Quantity", { description: "Decimal string" }),
+    avg_cost: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "Average cost per unit (s.104 pool), decimal string",
+      })
+    ),
+    currency: Type.Optional(Type.Unsafe({ type: "string", default: "GBP" })),
+    as_of_date: field("As of", { format: "date" }),
   },
 });
 
@@ -614,10 +508,8 @@ const income_source = defineEntityType({
   name: "Income Source",
   description:
     "A recurring origin of income (employer, trade, dividend payer, interest payer, rental property, pension, foreign source).",
-  required: ["type"],
   properties: {
-    type: {
-      type: "string",
+    type: field("Type", {
       enum: [
         "employment",
         "self_employment",
@@ -627,39 +519,43 @@ const income_source = defineEntityType({
         "pension",
         "foreign",
       ],
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    payer_name: {
-      type: "string",
-      "x-table-label": "Payer",
-      "x-table-column": true,
-    },
-    country: {
-      type: "string",
-      description: "ISO 3166-1 alpha-2; non-GB triggers SA106",
-    },
-    foreign_tax_paid: {
-      type: "string",
-      description:
-        "Decimal — total foreign tax withheld at source for the tax year, in foreign_tax_currency. Drives Foreign Tax Credit Relief (FTCR) on SA106.",
-    },
-    foreign_tax_currency: {
-      type: "string",
-      description:
-        "ISO 4217 of the foreign_tax_paid amount. Usually matches the income currency.",
-    },
-    withholding_jurisdiction: {
-      type: "string",
-      description:
-        "ISO 3166-1 alpha-2 of the country that withheld the tax. May differ from `country` (e.g. US dividends paid via a UK broker — withheld in US, paid to UK).",
-    },
-    treaty_rate_applied: {
-      type: "string",
-      description:
-        'Decimal — treaty withholding rate already applied at source (e.g. "0.15" for the 15% US/UK treaty rate on dividends). Used to flag over-withholding that may be recoverable from the source country.',
-    },
-    notes: { type: "string" },
+    }),
+    payer_name: field("Payer", { optional: true }),
+    country: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "ISO 3166-1 alpha-2; non-GB triggers SA106",
+      })
+    ),
+    foreign_tax_paid: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Decimal — total foreign tax withheld at source for the tax year, in foreign_tax_currency. Drives Foreign Tax Credit Relief (FTCR) on SA106.",
+      })
+    ),
+    foreign_tax_currency: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "ISO 4217 of the foreign_tax_paid amount. Usually matches the income currency.",
+      })
+    ),
+    withholding_jurisdiction: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "ISO 3166-1 alpha-2 of the country that withheld the tax. May differ from `country` (e.g. US dividends paid via a UK broker — withheld in US, paid to UK).",
+      })
+    ),
+    treaty_rate_applied: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          'Decimal — treaty withholding rate already applied at source (e.g. "0.15" for the 15% US/UK treaty rate on dividends). Used to flag over-withholding that may be recoverable from the source country.',
+      })
+    ),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -668,29 +564,12 @@ const payment = defineEntityType({
   name: "Payment",
   description:
     "A payment to or from HMRC — balancing payments, payments on account, corporation tax, VAT remittances, refunds. Distinct from generic transactions because it ties to filing_obligation and tax_assessment for reconciliation.",
-  required: ["amount", "currency", "date", "direction", "kind"],
   properties: {
-    amount: {
-      type: "string",
-      description: "Decimal — always positive",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
+    amount: field("Amount", { description: "Decimal — always positive" }),
     currency: { type: "string", default: "GBP" },
-    date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    direction: {
-      type: "string",
-      enum: ["to_hmrc", "from_hmrc"],
-      "x-table-label": "Direction",
-      "x-table-column": true,
-    },
-    kind: {
-      type: "string",
+    date: field("Date", { format: "date" }),
+    direction: field("Direction", { enum: ["to_hmrc", "from_hmrc"] }),
+    kind: field("Kind", {
       enum: [
         "balancing_payment",
         "poa1",
@@ -702,24 +581,26 @@ const payment = defineEntityType({
         "penalty",
         "interest",
       ],
-      "x-table-label": "Kind",
-      "x-table-column": true,
-    },
-    reference: {
-      type: "string",
-      description:
-        "HMRC payment reference (UTR + K, or CT-specific accounting reference)",
-    },
-    method: {
-      type: "string",
-      enum: [
-        "bank_transfer",
-        "direct_debit",
-        "debit_card",
-        "cheque",
-        "paye_coding",
-      ],
-    },
+    }),
+    reference: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "HMRC payment reference (UTR + K, or CT-specific accounting reference)",
+      })
+    ),
+    method: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: [
+          "bank_transfer",
+          "direct_debit",
+          "debit_card",
+          "cheque",
+          "paye_coding",
+        ],
+      })
+    ),
   },
 });
 
@@ -728,21 +609,12 @@ const property = defineEntityType({
   name: "Property",
   description:
     "Real estate. Use for primary residences (PRR on disposal), let properties (SA105/SA106), holiday lets (FHL), and commercial real estate. Owner is set via owned_by or co_owned_by; never put owner in metadata.",
-  required: ["address", "type", "use"],
   properties: {
-    address: {
-      type: "string",
-      "x-table-label": "Address",
-      "x-table-column": true,
-    },
-    type: {
-      type: "string",
+    address: field("Address"),
+    type: field("Type", {
       enum: ["residential", "commercial", "mixed_use", "land"],
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    use: {
-      type: "string",
+    }),
+    use: field("Use", {
       description:
         "How the property is used. Drives tax treatment more than physical type does.",
       enum: [
@@ -753,25 +625,31 @@ const property = defineEntityType({
         "mixed_use",
         "investment_held",
       ],
-      "x-table-label": "Use",
-      "x-table-column": true,
-    },
-    country: {
-      type: "string",
-      description: "ISO 3166-1 alpha-2; non-GB triggers SA106",
-      default: "GB",
-    },
-    rental_income_allowance_claimed: {
-      type: "boolean",
-      default: false,
-      description: "£1,000 property income allowance flag",
-    },
-    purchase_date: { type: "string", format: "date" },
-    purchase_cost: {
-      type: "string",
-      description:
-        "Decimal GBP — useful for PRR calculation on eventual disposal",
-    },
+    }),
+    country: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "ISO 3166-1 alpha-2; non-GB triggers SA106",
+        default: "GB",
+      })
+    ),
+    rental_income_allowance_claimed: Type.Optional(
+      Type.Unsafe({
+        type: "boolean",
+        default: false,
+        description: "£1,000 property income allowance flag",
+      })
+    ),
+    purchase_date: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date" })
+    ),
+    purchase_cost: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Decimal GBP — useful for PRR calculation on eventual disposal",
+      })
+    ),
   },
 });
 
@@ -780,10 +658,8 @@ const relief_claim = defineEntityType({
   name: "Relief Claim",
   description:
     "A tax relief or allowance claim (Gift Aid, marriage allowance, EIS/SEIS, BADR, PRR).",
-  required: ["type"],
   properties: {
-    type: {
-      type: "string",
+    type: field("Type", {
       enum: [
         "gift_aid",
         "marriage_allowance",
@@ -794,16 +670,12 @@ const relief_claim = defineEntityType({
         "investors_relief",
         "foreign_tax_credit",
       ],
-      "x-table-label": "Type",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
+    }),
+    amount: field("Amount", {
       description: "Decimal GBP if applicable",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
-    notes: { type: "string" },
+      optional: true,
+    }),
+    notes: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -812,10 +684,8 @@ const tax_assessment = defineEntityType({
   name: "Tax Assessment",
   description:
     "A computed or HMRC-issued tax position for one tax year, one subject. Captures SA302 outputs (HMRC's view) + agent-computed projections (our view) so we can reconcile and surface differences.",
-  required: ["source", "total_tax_due", "computed_at"],
   properties: {
-    source: {
-      type: "string",
+    source: field("Source", {
       enum: [
         "agent_projection",
         "hmrc_sa302",
@@ -824,34 +694,38 @@ const tax_assessment = defineEntityType({
       ],
       description:
         "Where this assessment came from. agent_projection = our running estimate; hmrc_* = the authority's number.",
-      "x-table-label": "Source",
-      "x-table-column": true,
-    },
-    total_income: {
-      type: "string",
-      description: "Decimal GBP — sum of all income sources before allowances",
-    },
-    total_tax_due: {
-      type: "string",
+    }),
+    total_income: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Decimal GBP — sum of all income sources before allowances",
+      })
+    ),
+    total_tax_due: field("Tax due", {
       description: "Decimal GBP — final tax liability for the year",
-      "x-table-label": "Tax due",
-      "x-table-column": true,
-    },
-    tax_paid_at_source: {
-      type: "string",
-      description: "PAYE + dividend tax withheld + foreign tax credit",
-    },
-    balancing_owed: {
-      type: "string",
-      description: "total_tax_due - tax_paid_at_source - poa_paid",
-    },
-    allowances_used: {
-      type: "object",
-      description:
-        "Per-allowance breakdown (personal_allowance, dividend_allowance, psa, cgt_aea, etc.)",
-    },
+    }),
+    tax_paid_at_source: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "PAYE + dividend tax withheld + foreign tax credit",
+      })
+    ),
+    balancing_owed: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description: "total_tax_due - tax_paid_at_source - poa_paid",
+      })
+    ),
+    allowances_used: Type.Optional(
+      Type.Unsafe({
+        type: "object",
+        description:
+          "Per-allowance breakdown (personal_allowance, dividend_allowance, psa, cgt_aea, etc.)",
+      })
+    ),
     computed_at: { type: "string", format: "date-time" },
-    hmrc_reference: { type: "string" },
+    hmrc_reference: Type.Optional(Type.Unsafe({ type: "string" })),
   },
 });
 
@@ -860,14 +734,8 @@ const tax_year = defineEntityType({
   name: "Tax Year",
   description:
     "A UK fiscal year (6 April to 5 April) — the container all reportable activity is anchored to.",
-  required: ["year_label", "start", "end"],
   properties: {
-    year_label: {
-      type: "string",
-      description: 'Year label, e.g. "2025-26"',
-      "x-table-label": "Year",
-      "x-table-column": true,
-    },
+    year_label: field("Year", { description: 'Year label, e.g. "2025-26"' }),
     start: {
       type: "string",
       format: "date",
@@ -878,16 +746,15 @@ const tax_year = defineEntityType({
       format: "date",
       description: "Inclusive end, e.g. 2026-04-05",
     },
-    filing_status: {
-      type: "string",
+    filing_status: field("Status", {
       enum: ["in_progress", "assembled", "filed"],
       description: "Where the user is in the cycle",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    filed_at: { type: "string", format: "date-time" },
-    residence_status: {
-      type: "string",
+      optional: true,
+    }),
+    filed_at: Type.Optional(
+      Type.Unsafe({ type: "string", format: "date-time" })
+    ),
+    residence_status: field("Residence", {
       enum: [
         "uk_resident",
         "non_resident",
@@ -897,19 +764,22 @@ const tax_year = defineEntityType({
       ],
       description:
         "UK tax residence for THIS year. Recorded per-tax_year because residence\ncan change (someone moving in/out of the UK has different status year\nto year). Drives SA109 routing.\n",
-      "x-table-label": "Residence",
-      "x-table-column": true,
-    },
-    arrival_date: {
-      type: "string",
-      format: "date",
-      description: "For split-year arrivers — date residence began",
-    },
-    departure_date: {
-      type: "string",
-      format: "date",
-      description: "For split-year leavers — date residence ended",
-    },
+      optional: true,
+    }),
+    arrival_date: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date",
+        description: "For split-year arrivers — date residence began",
+      })
+    ),
+    departure_date: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        format: "date",
+        description: "For split-year leavers — date residence ended",
+      })
+    ),
   },
 });
 
@@ -917,64 +787,61 @@ const transaction = defineEntityType({
   key: "transaction",
   name: "Transaction",
   description: "A single debit or credit on an account.",
-  required: ["date", "amount", "currency"],
   properties: {
-    date: {
-      type: "string",
-      format: "date",
-      "x-table-label": "Date",
-      "x-table-column": true,
-    },
-    amount: {
-      type: "string",
+    date: field("Date", { format: "date" }),
+    amount: field("Amount", {
       description: "Decimal string. Positive = credit, negative = debit.",
-      "x-table-label": "Amount",
-      "x-table-column": true,
-    },
+    }),
     currency: { type: "string", default: "GBP" },
-    description: {
-      type: "string",
-      "x-table-label": "Description",
-      "x-table-column": true,
-    },
-    merchant_raw: {
-      type: "string",
-      description:
-        "Verbatim merchant text from the statement; resolved/categorised later.",
-    },
-    tax_relevance: {
-      type: "string",
+    description: field("Description", { optional: true }),
+    merchant_raw: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Verbatim merchant text from the statement; resolved/categorised later.",
+      })
+    ),
+    tax_relevance: field("Tax", {
       enum: ["none", "income", "expense", "cgt"],
       description: "Whether this transaction matters for the SA return.",
-      "x-table-label": "Tax",
-      "x-table-column": true,
-    },
-    expense_category: {
-      type: "string",
-      description:
-        "HMRC-aligned category for allowable expenses (cost_of_goods, travel, premises, repairs, admin, advertising, interest, professional_fees, wages, other).",
-    },
-    is_personal: { type: "boolean", default: true },
-    native_amount: {
-      type: "string",
-      description:
-        "Decimal amount in the foreign currency, when currency != GBP. Keep alongside `amount` so the agent can show both numbers and recompute if rates need correcting.",
-    },
-    native_currency: {
-      type: "string",
-      description:
-        'ISO 4217 currency code of native_amount (e.g. "USD", "EUR"). When set, the `currency` field on this transaction is GBP and native_currency is the original.',
-    },
-    fx_rate_to_gbp: {
-      type: "string",
-      description:
-        "Decimal — the FX rate snapshot used to convert native_amount to amount (GBP). Source the rate from the transaction date. Required when native_currency is set so HMRC-aligned conversion is auditable.",
-    },
-    fx_rate_source: {
-      type: "string",
-      description:
-        'Where the FX rate came from (e.g. "hmrc_monthly", "broker_statement", "ecb_daily"). Helps reconcile if HMRC\'s published rate differs.',
-    },
+      optional: true,
+    }),
+    expense_category: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "HMRC-aligned category for allowable expenses (cost_of_goods, travel, premises, repairs, admin, advertising, interest, professional_fees, wages, other).",
+      })
+    ),
+    is_personal: Type.Optional(Type.Unsafe({ type: "boolean", default: true })),
+    native_amount: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Decimal amount in the foreign currency, when currency != GBP. Keep alongside `amount` so the agent can show both numbers and recompute if rates need correcting.",
+      })
+    ),
+    native_currency: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          'ISO 4217 currency code of native_amount (e.g. "USD", "EUR"). When set, the `currency` field on this transaction is GBP and native_currency is the original.',
+      })
+    ),
+    fx_rate_to_gbp: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          "Decimal — the FX rate snapshot used to convert native_amount to amount (GBP). Source the rate from the transaction date. Required when native_currency is set so HMRC-aligned conversion is auditable.",
+      })
+    ),
+    fx_rate_source: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        description:
+          'Where the FX rate came from (e.g. "hmrc_monthly", "broker_statement", "ecb_daily"). Helps reconcile if HMRC\'s published rate differs.',
+      })
+    ),
   },
 });
 

--- a/examples/sales/lobu.config.ts
+++ b/examples/sales/lobu.config.ts
@@ -8,6 +8,7 @@ import {
   defineAutomation,
   every,
   secret,
+  field,
 } from "@lobu/cli/config";
 import type SalesforcePipelineConnector from "./salesforce-pipeline.connector.ts";
 
@@ -51,18 +52,10 @@ const organization = defineEntityType({
   description:
     "A customer account or prospect being tracked by the revenue team",
   properties: {
-    company_name: {
-      type: "string",
-      "x-table-label": "Company",
-      "x-table-column": true,
-    },
-    stage: { type: "string", "x-table-label": "Stage", "x-table-column": true },
-    arr: { type: "string", "x-table-label": "ARR", "x-table-column": true },
-    renewal_date: {
-      type: "string",
-      "x-table-label": "Renewal Date",
-      "x-table-column": true,
-    },
+    company_name: field("Company", { optional: true }),
+    stage: field("Stage", { optional: true }),
+    arr: field("ARR", { optional: true }),
+    renewal_date: field("Renewal Date", { optional: true }),
   },
 });
 
@@ -71,26 +64,10 @@ const product = defineEntityType({
   name: "Product",
   description: "A product rollout or pilot being tracked at a customer account",
   properties: {
-    product_name: {
-      type: "string",
-      "x-table-label": "Product",
-      "x-table-column": true,
-    },
-    pilot_status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    owner_team: {
-      type: "string",
-      "x-table-label": "Owner",
-      "x-table-column": true,
-    },
-    account: {
-      type: "string",
-      "x-table-label": "Account",
-      "x-table-column": true,
-    },
+    product_name: field("Product", { optional: true }),
+    pilot_status: field("Status", { optional: true }),
+    owner_team: field("Owner", { optional: true }),
+    account: field("Account", { optional: true }),
   },
 });
 
@@ -99,22 +76,10 @@ const region = defineEntityType({
   name: "Region",
   description: "A geographic region where an account is expanding or operating",
   properties: {
-    region_name: {
-      type: "string",
-      "x-table-label": "Region",
-      "x-table-column": true,
-    },
-    expansion_status: {
-      type: "string",
-      "x-table-label": "Status",
-      "x-table-column": true,
-    },
-    parent_account: {
-      type: "string",
-      "x-table-label": "Account",
-      "x-table-column": true,
-    },
-    market_size: { type: "string", "x-table-label": "Market Size" },
+    region_name: field("Region", { optional: true }),
+    expansion_status: field("Status", { optional: true }),
+    parent_account: field("Account", { optional: true }),
+    market_size: field("Market Size", { column: false, optional: true }),
   },
 });
 
@@ -124,26 +89,10 @@ const renewalRisk = defineEntityType({
   description:
     "A commercial signal or concern that affects an upcoming renewal or expansion",
   properties: {
-    signal: {
-      type: "string",
-      "x-table-label": "Signal",
-      "x-table-column": true,
-    },
-    severity: {
-      type: "string",
-      "x-table-label": "Severity",
-      "x-table-column": true,
-    },
-    affects: {
-      type: "string",
-      "x-table-label": "Affects",
-      "x-table-column": true,
-    },
-    next_step: {
-      type: "string",
-      "x-table-label": "Next Step",
-      "x-table-column": true,
-    },
+    signal: field("Signal", { optional: true }),
+    severity: field("Severity", { optional: true }),
+    affects: field("Affects", { optional: true }),
+    next_step: field("Next Step", { optional: true }),
   },
 });
 
@@ -153,18 +102,10 @@ const team = defineEntityType({
   description:
     "An internal team or customer function that owns a pilot or initiative",
   properties: {
-    team_name: {
-      type: "string",
-      "x-table-label": "Team",
-      "x-table-column": true,
-    },
-    role: { type: "string", "x-table-label": "Role", "x-table-column": true },
-    owns: { type: "string", "x-table-label": "Owns", "x-table-column": true },
-    account: {
-      type: "string",
-      "x-table-label": "Account",
-      "x-table-column": true,
-    },
+    team_name: field("Team", { optional: true }),
+    role: field("Role", { optional: true }),
+    owns: field("Owns", { optional: true }),
+    account: field("Account", { optional: true }),
   },
 });
 

--- a/packages/cli/src/config/__tests__/define.test.ts
+++ b/packages/cli/src/config/__tests__/define.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Kind, OptionalKind, Type } from "@sinclair/typebox";
 import {
   type Agent,
   type AuthProfile,
@@ -14,6 +15,7 @@ import {
   defineRelationshipType,
   type EntityType,
   every,
+  field,
   on,
   reactionFromFile,
 } from "../define.js";
@@ -171,6 +173,126 @@ describe("authoring producers", () => {
     expect(context("SELECT id, name FROM entities")).toEqual({
       query: "SELECT id, name FROM entities",
       context: true,
+    });
+  });
+
+  test("field() emits a TypeBox string column with display metadata", () => {
+    const f = field("Name");
+    expect(f[Kind]).toBe("String");
+    expect(JSON.parse(JSON.stringify(f))).toEqual({
+      type: "string",
+      "x-table-label": "Name",
+      "x-table-column": true,
+    });
+  });
+
+  test("field() opts: enum passthrough, column opt-out, optional wrapper", () => {
+    const withEnum = field("Stage", { enum: ["a", "b"] });
+    expect(JSON.parse(JSON.stringify(withEnum))).toEqual({
+      type: "string",
+      enum: ["a", "b"],
+      "x-table-label": "Stage",
+      "x-table-column": true,
+    });
+
+    const noColumn = field("X", { column: false });
+    expect(JSON.parse(JSON.stringify(noColumn))).toEqual({
+      type: "string",
+      "x-table-label": "X",
+    });
+
+    const opt = field("Email", { optional: true });
+    expect(opt[OptionalKind]).toBe("Optional");
+    // the Optional marker is a symbol: serialized schema stays plain JSON Schema
+    expect(JSON.parse(JSON.stringify(opt))).toEqual({
+      type: "string",
+      "x-table-label": "Email",
+      "x-table-column": true,
+    });
+  });
+
+  test("field() accepts any TypeBox schema for non-string columns", () => {
+    const seats = field(Type.Integer(), "Seats");
+    expect(JSON.parse(JSON.stringify(seats))).toEqual({
+      type: "integer",
+      "x-table-label": "Seats",
+      "x-table-column": true,
+    });
+  });
+
+  test("defineEntityType derives required from field() optionality", () => {
+    const lead = defineEntityType({
+      key: "lead",
+      properties: {
+        name: field("Name"),
+        company: field("Company", { optional: true }),
+        stage: field("Stage", { enum: ["a", "b"] }),
+        email: field("Email", { column: false, optional: true }),
+      },
+    });
+    expect(lead.required).toEqual(["name", "stage"]);
+    expect(lead.properties?.name).toHaveProperty("x-table-label", "Name");
+    // symbols are stripped: stored properties are pure JSON Schema
+    expect(
+      Object.getOwnPropertySymbols(lead.properties?.company ?? {})
+    ).toEqual([]);
+    expect(JSON.parse(JSON.stringify(lead.properties))).toEqual({
+      name: { type: "string", "x-table-label": "Name", "x-table-column": true },
+      company: {
+        type: "string",
+        "x-table-label": "Company",
+        "x-table-column": true,
+      },
+      stage: {
+        type: "string",
+        enum: ["a", "b"],
+        "x-table-label": "Stage",
+        "x-table-column": true,
+      },
+      email: { type: "string", "x-table-label": "Email" },
+    });
+  });
+
+  test("defineEntityType: explicit required wins; raw JSON keeps all-optional", () => {
+    const explicit = defineEntityType({
+      key: "x",
+      required: ["name"],
+      properties: {
+        name: field("Name"),
+        email: field("Email", { optional: true }),
+      },
+    });
+    expect(explicit.required).toEqual(["name"]);
+
+    // no field()/TypeBox → today's default: no derived required list
+    const raw = defineEntityType({
+      key: "y",
+      properties: { name: { type: "string" }, email: { type: "string" } },
+    });
+    expect(raw.required).toBeUndefined();
+  });
+
+  test("field() schemas compose inside Type.Object", () => {
+    const schema = Type.Object({
+      name: field("Name"),
+      email: field("Email", { optional: true }),
+    });
+    expect(schema.required).toEqual(["name"]);
+    expect(JSON.parse(JSON.stringify(schema))).toEqual({
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          "x-table-label": "Name",
+          "x-table-column": true,
+        },
+        email: {
+          type: "string",
+          "x-table-label": "Email",
+          "x-table-column": true,
+        },
+      },
+      required: ["name"],
     });
   });
 

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -23,6 +23,15 @@ import type {
   ReactionContext,
   Segment,
 } from "@lobu/connector-sdk";
+import {
+  Kind,
+  OptionalKind,
+  Type,
+  type StringOptions,
+  type TOptional,
+  type TSchema,
+  type TString,
+} from "@sinclair/typebox";
 import type { SecretRef } from "./secret.js";
 
 /** A connector referenced by its key, or by the class produced by `defineConnector`. */
@@ -96,9 +105,15 @@ export interface EntityType {
   key: string;
   name?: string;
   description?: string;
-  /** Required property names for the entity's metadata. */
+  /** Required property names for the entity's metadata. Omit when the properties
+   * use `field()`/TypeBox — the required list is then derived from which fields
+   * are not marked `optional`. An explicit list always wins. */
   required?: string[];
-  /** JSON Schema properties for the entity's metadata. */
+  /**
+   * JSON Schema properties for the entity's metadata. Author with the `field()`
+   * shorthand (or bare TypeBox `Type.*` schemas) for labels, table-column
+   * placement, and per-field optionality; raw JSON Schema objects stay valid.
+   */
   properties?: Record<string, unknown>;
   /**
    * Event kinds (semantic types) valid for events linked to this entity type,
@@ -155,8 +170,125 @@ export interface EntityType {
   segments?: Record<string, Segment>;
 }
 
+/**
+ * Entity property shorthand — a JSON Schema field with Lobu's display metadata
+ * attached. Emits a TypeBox schema, so it composes with `Type.*` and
+ * `Type.Object({...})` and survives `JSON.stringify` as a plain JSON Schema
+ * object.
+ *
+ * The common case is a string column shown in the admin table — just the label:
+ *
+ * ```ts
+ * properties: {
+ *   name: field("Name"),                                     // string column
+ *   stage: field("Stage", { enum: ["signal", "trial", "customer"] }),
+ *   seats: field(Type.Integer(), "Seats"),                   // non-string column
+ *   x_handle: field("X", { column: false }),                 // labeled, not a column
+ *   email: field("Email", { optional: true }),               // optional (derived required)
+ *   notes: Type.String(),                                    // bare TypeBox stays valid
+ * }
+ * ```
+ *
+ * `opts` are TypeBox string-schema options plus `column` (show as a table
+ * column; default true) and `optional` (wrap in `Type.Optional`, which marks
+ * the field optional in the entity's derived `required` array).
+ */
+export function field(
+  label: string,
+  opts: FieldOptions & { optional: true }
+): TOptional<TString>;
+export function field(
+  label: string,
+  opts?: FieldOptions & { optional?: false }
+): TString;
+export function field(
+  label: string,
+  opts: FieldOptions
+): TString | TOptional<TString>;
+/** Any TypeBox schema as a labeled table column — `field(Type.Integer(), "Seats")`. */
+export function field<T extends TSchema>(schema: T, label: string): T;
+export function field(
+  labelOrSchema: string | TSchema,
+  labelOrOpts?: string | FieldOptions
+): TSchema {
+  if (typeof labelOrSchema === "string") {
+    const label = labelOrSchema;
+    const opts = (labelOrOpts ?? {}) as FieldOptions;
+    const { column, optional, ...schemaOpts } = opts;
+    const base = Type.String({
+      "x-table-label": label,
+      ...(column !== false ? { "x-table-column": true } : {}),
+      ...schemaOpts,
+    });
+    return optional ? Type.Optional(base) : base;
+  }
+  return {
+    ...labelOrSchema,
+    "x-table-label": String(labelOrOpts),
+    "x-table-column": true,
+  } as TSchema;
+}
+
+export interface FieldOptions extends StringOptions {
+  /** Show this field as a column in the admin table. Default true. */
+  column?: boolean;
+  /** Make the field optional. Default false. Emits `Type.Optional(...)`. */
+  optional?: boolean;
+}
+
+function isTypeBoxSchema(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { [Kind]?: unknown })[Kind] !== undefined
+  );
+}
+
+function isOptionalSchema(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { [OptionalKind]?: unknown })[OptionalKind] !== undefined
+  );
+}
+
+/**
+ * Derive the entity's `required` list from its property schemas when the author
+ * uses `field()`/TypeBox and supplies no explicit list: every field not wrapped
+ * in `Type.Optional` is required. An explicit `required` always wins, and raw
+ * JSON-Schema properties (no TypeBox types) keep today's all-optional default.
+ */
+function deriveRequired(
+  required: string[] | undefined,
+  properties: Record<string, unknown> | undefined
+): string[] | undefined {
+  if (required || !properties) return required;
+  const usesTypeBox = Object.values(properties).some(isTypeBoxSchema);
+  if (!usesTypeBox) return undefined;
+  const derived = Object.entries(properties)
+    .filter(([, schema]) => !isOptionalSchema(schema))
+    .map(([key]) => key);
+  return derived.length > 0 ? derived : undefined;
+}
+
 export function defineEntityType(config: Omit<EntityType, "kind">): EntityType {
-  return { ...config, kind: "entityType" };
+  const { required, properties, ...rest } = config;
+  const resolvedRequired = deriveRequired(required, properties);
+  return {
+    ...rest,
+    kind: "entityType",
+    ...(properties !== undefined
+      ? { properties: stripSymbols(properties) }
+      : {}),
+    ...(resolvedRequired ? { required: resolvedRequired } : {}),
+  };
+}
+
+/** Deep JSON round-trip drops TypeBox symbol keys (`Kind`, `Optional`), so the
+ * stored properties stay pure JSON Schema and the apply diff against the remote
+ * metadata_schema never churns on invisible symbol keys. */
+function stripSymbols(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 export interface RelationshipType {


### PR DESCRIPTION
## Summary
- **`field()` shorthand for entity `properties`** — a TypeBox-native way to author labels, table-column placement, and per-field optionality in one call, with `required` derived from `Type.Optional()` instead of a hand-maintained parallel list:
  ```ts
  properties: {
    name: field("Name"),
    stage: field("Stage", { enum: [...] }),
    seats: field(Type.Integer(), "Seats"),
    x_handle: field("X", { column: false }),
    email: field("Email", { optional: true }),
  }
  ```
  `defineEntityType` JSON-normalizes properties (strips TypeBox symbol keys) so the apply diff never churns, and derives `required` when TypeBox schemas are present (raw JSON-Schema properties keep today's all-optional default).
- **All 13 example configs converted** to `field()`/TypeBox — ~240 label/column properties, `required` arrays removed. **Proven semantically identical** via the real loader: every example's desired-state entity types (77 across 15 projects) match the pre-conversion snapshot exactly.
- **CI runner routing** — a `check-author` job resolves the Linux runner from the PR author: trusted authors (`vars.TRUSTED_AUTHORS`, default `buremba`) get the self-hosted K8s backend (`vars.CI_K8S_RUNNER`, e.g. `k8s-ci`) when it's configured; everyone else and all non-PR events (pushes, `workflow_dispatch`, the `make pre-pr-remote` Depot gate) resolve to `vars.CI_LINUX_RUNNER || 'ubuntu-24.04'`, so Depot dispatch never depends on a runner it can't satisfy.

## Test plan
- [x] `bun test packages/cli/src/config` — 19 pass (8 new `field()`/derivation tests)
- [x] CLI `tsc` clean; biome clean on all changed files
- [x] Loader proof: all 15 example configs load with entity types byte-identical to pre-conversion (required compared as sets)
- [x] `actionlint .github/workflows/ci.yml` clean; YAML parses (18 jobs)

## Notes
- `field()` is additive — raw JSON-Schema properties and explicit `required` arrays remain fully supported.
- The two concerns (feature + CI routing) are separate commits on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a streamlined configuration helper for defining labeled, optional, typed, and table-visible entity fields.
  - Required fields are now inferred automatically when explicit requirements are not provided.
  - Supports custom schemas, enums, nested types, and column visibility settings.

- **Examples**
  - Updated sample applications to use the new field configuration style while preserving existing labels, validation, metadata, and table behavior.

- **Tests**
  - Added coverage for field definitions, optionality, serialization, schema composition, and required-field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->