### PR TITLE
refactor(server): consolidate hand-rolled edge upserts into one batch writer

### DIFF
--- a/packages/server/src/__tests__/integration/authz/edge-writes-batch.test.ts
+++ b/packages/server/src/__tests__/integration/authz/edge-writes-batch.test.ts
@@ -1,0 +1,214 @@
+/** Contract for the shared batch edge writer. */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	ensureRelationshipType,
+	upsertEdges,
+} from "../../../utils/edge-writes";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestEntity,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const TYPE_SLUG = "batch_writer_probe";
+
+async function liveEdges(orgId: string, typeId: number) {
+	const sql = getTestDb();
+	return sql<
+		{
+			id: number;
+			source: string | null;
+			metadata: Record<string, unknown> | null;
+		}[]
+	>`
+    SELECT id, source, metadata
+    FROM entity_relationships
+    WHERE organization_id = ${orgId}
+      AND relationship_type_id = ${typeId}
+      AND deleted_at IS NULL
+    ORDER BY from_entity_id, to_entity_id
+  `;
+}
+
+describe("upsertEdges", () => {
+	let orgId: string;
+	let typeId: number;
+	let a: number;
+	let b: number;
+	let c: number;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Edge Writer Org" });
+		orgId = org.id;
+		const entity = (name: string) =>
+			createTestEntity({ organization_id: orgId, entity_type: "thing", name });
+		a = (await entity("A")).id;
+		b = (await entity("B")).id;
+		c = (await entity("C")).id;
+		typeId = await ensureRelationshipType({
+			organizationId: orgId,
+			slug: TYPE_SLUG,
+			name: "Batch writer probe",
+			description: "Fixture type",
+		});
+	});
+
+	it("survives two concurrent writers claiming the same pair", async () => {
+		const call = () =>
+			upsertEdges({
+				db: getTestDb(),
+				organizationId: orgId,
+				relationshipTypeId: typeId,
+				pairs: [{ fromEntityId: a, toEntityId: b }],
+				source: "feed",
+				confidence: 0.4,
+				onConflict: "ignore",
+			});
+
+		// Both run against the same live-triple index at once. Without a conflict
+		// clause one of these raises 23505 — that is the auto-linker bug.
+		const [first, second] = await Promise.all([call(), call()]);
+
+		expect(first.length + second.length).toBe(1);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
+	});
+
+	it("writes a batch and reports what it created", async () => {
+		const result = await upsertEdges({
+			db: getTestDb(),
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [
+				{ fromEntityId: a, toEntityId: b },
+				{ fromEntityId: a, toEntityId: c },
+			],
+			source: "feed",
+			confidence: 1.0,
+			onConflict: "ignore",
+		});
+
+		expect(result).toHaveLength(2);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(2);
+	});
+
+	it("reports no new rows on a re-run", async () => {
+		const params = {
+			db: getTestDb(),
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [{ fromEntityId: a, toEntityId: b }],
+			source: "feed",
+			confidence: 1.0,
+			onConflict: "ignore" as const,
+		};
+		await upsertEdges(params);
+		const again = await upsertEdges(params);
+
+		expect(again).toHaveLength(0);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
+	});
+
+	it("dedupes within one batch so DO UPDATE cannot hit a row twice", async () => {
+		// `ON CONFLICT DO UPDATE` refuses to affect the same row twice in one
+		// statement, so an un-deduped batch would raise 21000 here.
+		const result = await upsertEdges({
+			db: getTestDb(),
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [
+				{ fromEntityId: a, toEntityId: b },
+				{ fromEntityId: a, toEntityId: b },
+			],
+			source: "config",
+			confidence: 1.0,
+			metadata: { connection_id: "conn-1" },
+			onConflict: "update",
+		});
+
+		expect(result).toHaveLength(1);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
+	});
+
+	it("refreshes metadata and source on update, and leaves them alone on ignore", async () => {
+		const base = {
+			db: getTestDb(),
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [{ fromEntityId: a, toEntityId: b }],
+			confidence: 1.0,
+		};
+		await upsertEdges({
+			...base,
+			source: "config",
+			metadata: { connection_id: "conn-1" },
+			onConflict: "update",
+		});
+
+		await upsertEdges({
+			...base,
+			source: "manual",
+			metadata: { connection_id: "conn-2" },
+			onConflict: "update",
+		});
+		let rows = await liveEdges(orgId, typeId);
+		expect(rows[0].source).toBe("manual");
+		expect(rows[0].metadata).toMatchObject({ connection_id: "conn-2" });
+
+		await upsertEdges({
+			...base,
+			source: "feed",
+			metadata: { connection_id: "conn-3" },
+			onConflict: "ignore",
+		});
+		rows = await liveEdges(orgId, typeId);
+		expect(rows[0].source).toBe("manual");
+		expect(rows[0].metadata).toMatchObject({ connection_id: "conn-2" });
+	});
+
+	it("drops a self-edge without failing the rest of the batch", async () => {
+		const created = await upsertEdges({
+			db: getTestDb(),
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [
+				{ fromEntityId: a, toEntityId: a },
+				{ fromEntityId: a, toEntityId: b },
+			],
+			source: "feed",
+			confidence: 1.0,
+			onConflict: "ignore",
+		});
+
+		expect(created).toHaveLength(1);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
+	});
+
+	it("writes a fresh live row beside a tombstone rather than reviving it", async () => {
+		const sql = getTestDb();
+		const params = {
+			db: sql,
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: [{ fromEntityId: a, toEntityId: b }],
+			source: "config",
+			confidence: 1.0,
+			metadata: { connection_id: "conn-1" },
+			onConflict: "update" as const,
+		};
+		const first = await upsertEdges(params);
+		await sql`
+      UPDATE entity_relationships
+      SET deleted_at = current_timestamp
+      WHERE id = ${first[0]}
+    `;
+
+		// The conflict target is the PARTIAL live-triple index, so a tombstoned
+		// row is not a conflict at all and cannot be revived by the update branch.
+		const second = await upsertEdges(params);
+		expect(second).toHaveLength(1);
+		expect(second[0]).not.toBe(first[0]);
+		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
+	});
+});

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -45,6 +45,7 @@ import {
   patchEntityRows,
   withEntityWriteTransaction,
 } from '../utils/entity-management.js';
+import { ensureRelationshipType, upsertEdges } from '../utils/edge-writes.js';
 import { aclConnectionIdSql } from './acl-observability.js';
 import { ensureResourceEntityType } from './acl-resource-type.js';
 
@@ -101,20 +102,17 @@ async function ensurePersonEntityType(orgId: string): Promise<void> {
 	`;
 }
 
-/** Find-or-create the org-scoped `member_of` relationship type. */
-async function ensureMemberOfType(orgId: string): Promise<number> {
-  const sql = getDb();
-  const rows = await sql`
-		INSERT INTO entity_relationship_types
-			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
-		VALUES
-			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A member belongs to an ACL resource (channel, repo, …)', ${orgId},
-			 false, NULL, current_timestamp, current_timestamp)
-		ON CONFLICT (organization_id, slug) WHERE status = 'active'
-		DO UPDATE SET updated_at = EXCLUDED.updated_at
-		RETURNING id
-	`;
-  return Number(rows[0].id);
+/** Shared initializer for the org-scoped `member_of` relationship type.
+ *  Exported because the GitHub team graph writes the SAME slug in the SAME org
+ *  and so always shared this row; it used to keep a second copy of this
+ *  function with a different description. */
+export function ensureMemberOfType(orgId: string): Promise<number> {
+  return ensureRelationshipType({
+    organizationId: orgId,
+    slug: MEMBER_OF_TYPE_SLUG,
+    name: 'Member of',
+    description: 'A member belongs to an ACL resource (channel, repo, org, …)',
+  });
 }
 
 /**
@@ -488,7 +486,7 @@ export async function buildAccessGraph(params: {
 
   const memberEntityIds = new Set<number>();
   const currentMembersByResource = new Map<number, Set<number>>();
-  let createdEdges = 0;
+  const edgePairs: { fromEntityId: number; toEntityId: number }[] = [];
   for (let i = 0; i < resources.length; i++) {
     const resourceEntityId = resourceEntityIdByIndex.get(i);
     if (resourceEntityId === undefined) continue;
@@ -499,23 +497,23 @@ export async function buildAccessGraph(params: {
       if (memberEntityId === undefined) continue;
       memberEntityIds.add(memberEntityId);
       resourceMembers.add(memberEntityId);
-      const inserted = await sql<{ id: number }[]>`
-				INSERT INTO entity_relationships (
-					organization_id, from_entity_id, to_entity_id, relationship_type_id,
-					confidence, source, created_by, updated_by, created_at, updated_at
-				) VALUES (
-					${organizationId}, ${memberEntityId}, ${resourceEntityId}, ${typeId},
-					1.0, 'feed', ${creatorUserId}, ${creatorUserId},
-					current_timestamp, current_timestamp
-				)
-				ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
-					WHERE deleted_at IS NULL
-				DO NOTHING
-				RETURNING id
-			`;
-      if (inserted.length > 0) createdEdges += 1;
+      edgePairs.push({ fromEntityId: memberEntityId, toEntityId: resourceEntityId });
     }
   }
+
+  // One statement for the whole build. A resource's membership is re-affirmed
+  // rather than rewritten, so a steady-state resync creates nothing.
+  const created = await upsertEdges({
+    db: sql,
+    organizationId,
+    relationshipTypeId: typeId,
+    pairs: edgePairs,
+    source: 'feed',
+    confidence: 1.0,
+    createdBy: creatorUserId,
+    onConflict: 'ignore',
+  });
+  const createdEdges = created.length;
 
   // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
   // membership, so a `member_of` edge to a synced resource whose member is NOT

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -15,6 +15,7 @@ import {
 	pgBigintArray,
 	pgTextArray,
 } from "../db/client.js";
+import { upsertEdges } from "../utils/edge-writes.js";
 import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
 import { ensureResourceEntityType } from "./access-graph.js";
 import {
@@ -256,35 +257,39 @@ export async function resolveAboutEntityRefs(
 	return [...new Set([...ids, ...fromSlugs])];
 }
 
-async function upsertAboutEdge(opts: {
+/**
+ * Take ownership of one channel's `about` edges: create what is missing and
+ * re-stamp metadata/source on what already exists.
+ *
+ * The metadata is per-channel (it carries `channel_key`), so this is one batch
+ * per channel rather than one for the whole sync.
+ */
+async function upsertAboutEdges(opts: {
 	organizationId: string;
 	fromChannelEntityId: number;
-	toBusinessEntityId: number;
+	toBusinessEntityIds: number[];
 	source: string;
 	metadata: ChannelAboutMetadata;
 	userId: string | null | undefined;
 	typeId: number;
 	sql: DbClient;
 }): Promise<void> {
-	await opts.sql`
-    INSERT INTO entity_relationships (
-      organization_id, from_entity_id, to_entity_id, relationship_type_id,
-      metadata, confidence, source, created_by, updated_by, created_at, updated_at
-    ) VALUES (
-      ${opts.organizationId}, ${opts.fromChannelEntityId}, ${opts.toBusinessEntityId},
-      ${opts.typeId}, ${opts.sql.json(opts.metadata)}, 1.0, ${opts.source},
-      ${opts.userId ?? null}, ${opts.userId ?? null},
-      current_timestamp, current_timestamp
-    )
-    ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
-      WHERE deleted_at IS NULL
-    DO UPDATE SET
-      metadata = EXCLUDED.metadata,
-      source = EXCLUDED.source,
-      updated_by = EXCLUDED.updated_by,
-      updated_at = current_timestamp,
-      deleted_at = NULL
-  `;
+	// The partial conflict target only matches live rows; a tombstoned triple
+	// therefore gets a fresh live row, exactly as this path did before.
+	await upsertEdges({
+		db: opts.sql,
+		organizationId: opts.organizationId,
+		relationshipTypeId: opts.typeId,
+		pairs: opts.toBusinessEntityIds.map((toBusinessEntityId) => ({
+			fromEntityId: opts.fromChannelEntityId,
+			toEntityId: toBusinessEntityId,
+		})),
+		source: opts.source,
+		confidence: 1.0,
+		createdBy: opts.userId ?? null,
+		metadata: opts.metadata,
+		onConflict: 'update',
+	});
 }
 
 /**
@@ -338,20 +343,19 @@ export async function syncConnectionChannelAboutEdges(opts: {
 		};
 
 		for (const businessEntityId of channel.aboutEntityIds) {
-			const pairKey = `${channelEntityId}:${businessEntityId}`;
-			desiredPairs.add(pairKey);
-			await upsertAboutEdge({
-				organizationId: opts.organizationId,
-				fromChannelEntityId: channelEntityId,
-				toBusinessEntityId: businessEntityId,
-				source: EDGE_SOURCE_CONFIG,
-				metadata,
-				userId: opts.userId,
-				typeId,
-				sql,
-			});
-			linked += 1;
+			desiredPairs.add(`${channelEntityId}:${businessEntityId}`);
 		}
+		await upsertAboutEdges({
+			organizationId: opts.organizationId,
+			fromChannelEntityId: channelEntityId,
+			toBusinessEntityIds: channel.aboutEntityIds,
+			source: EDGE_SOURCE_CONFIG,
+			metadata,
+			userId: opts.userId,
+			typeId,
+			sql,
+		});
+		linked += channel.aboutEntityIds.length;
 	}
 
 	const existing = await sql<{
@@ -445,18 +449,16 @@ export async function setManualChannelAboutEdges(opts: {
     `;
 	}
 
-	for (const businessEntityId of desired) {
-		await upsertAboutEdge({
-			organizationId: opts.organizationId,
-			fromChannelEntityId: channelEntityId,
-			toBusinessEntityId: businessEntityId,
-			source: EDGE_SOURCE_MANUAL,
-			metadata,
-			userId: opts.userId,
-			typeId,
-			sql,
-		});
-	}
+	await upsertAboutEdges({
+		organizationId: opts.organizationId,
+		fromChannelEntityId: channelEntityId,
+		toBusinessEntityIds: [...desired],
+		source: EDGE_SOURCE_MANUAL,
+		metadata,
+		userId: opts.userId,
+		typeId,
+		sql,
+	});
 }
 
 export interface ChannelAboutEntity {

--- a/packages/server/src/gateway/routes/public/github-team-graph.ts
+++ b/packages/server/src/gateway/routes/public/github-team-graph.ts
@@ -36,12 +36,13 @@
 import { getDb } from "../../../db/client.js";
 import { createLogger } from "@lobu/core";
 import { GITHUB_IDENTITY } from "@lobu/connectors/github-identity";
+import { ensureMemberOfType } from "../../../authz/access-graph.js";
+import { upsertEdges } from "../../../utils/edge-writes.js";
 import { resolveEventAttributionsForItems } from "../../../utils/entity-link-upsert.js";
 
 const logger = createLogger("github-team-graph");
 
 const GITHUB_CONNECTOR_KEY = "github";
-const MEMBER_OF_TYPE_SLUG = "member_of";
 
 /** A GitHub org member as the org-members API reports it. */
 export interface GithubOrgMember {
@@ -197,22 +198,6 @@ async function ensureOrgCompany(params: {
 	return ids.length > 0 ? ids[0] : null;
 }
 
-/** Find-or-create the org-scoped `member_of` relationship type. */
-async function ensureMemberOfType(orgId: string): Promise<number> {
-	const sql = getDb();
-	const rows = await sql`
-		INSERT INTO entity_relationship_types
-			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
-		VALUES
-			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization', ${orgId},
-			 false, NULL, current_timestamp, current_timestamp)
-		ON CONFLICT (organization_id, slug) WHERE status = 'active'
-		DO UPDATE SET updated_at = EXCLUDED.updated_at
-		RETURNING id
-	`;
-	return Number(rows[0].id);
-}
-
 /**
  * Build the team graph for a GitHub App install: upsert the org `company`,
  * resolve each member to a `person`, and write `member_of` edges. Injectable
@@ -303,27 +288,22 @@ export async function buildGithubTeamGraph(params: {
 	}
 
 	const typeId = await ensureMemberOfType(params.organizationId);
-	const sql = getDb();
-	let createdEdges = 0;
-	for (const memberId of uniqueMemberIds) {
-		// person -> company. Idempotent on the live-triple unique index; a re-bind
-		// re-affirms the edge without duplicating it.
-		const inserted = await sql<{ id: number }[]>`
-			INSERT INTO entity_relationships (
-				organization_id, from_entity_id, to_entity_id, relationship_type_id,
-				confidence, source, created_by, updated_by, created_at, updated_at
-			) VALUES (
-				${params.organizationId}, ${memberId}, ${companyEntityId}, ${typeId},
-				1.0, 'feed', ${creatorUserId}, ${creatorUserId},
-				current_timestamp, current_timestamp
-			)
-			ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
-				WHERE deleted_at IS NULL
-			DO NOTHING
-			RETURNING id
-		`;
-		if (inserted.length > 0) createdEdges += 1;
-	}
+	// person -> company. Idempotent on the live-triple unique index; a re-bind
+	// re-affirms the edge without duplicating it.
+	const created = await upsertEdges({
+		db: getDb(),
+		organizationId: params.organizationId,
+		relationshipTypeId: typeId,
+		pairs: uniqueMemberIds.map((memberId) => ({
+			fromEntityId: memberId,
+			toEntityId: companyEntityId,
+		})),
+		source: "feed",
+		confidence: 1.0,
+		createdBy: creatorUserId,
+		onConflict: "ignore",
+	});
+	const createdEdges = created.length;
 
 	logger.info(
 		{

--- a/packages/server/src/utils/auto-linker.ts
+++ b/packages/server/src/utils/auto-linker.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDb } from '../db/client';
+import { ensureRelationshipType, upsertEdges } from './edge-writes';
 import logger from './logger';
 
 interface AutoLinkParams {
@@ -54,19 +55,13 @@ async function getOrgEntities(organizationId: string): Promise<EntityCandidate[]
   return entities;
 }
 
-async function ensureMentionsType(organizationId: string): Promise<number> {
-  const sql = getDb();
-  const rows = await sql`
-    INSERT INTO entity_relationship_types
-      (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
-    VALUES
-      ('mentions', 'Mentions', 'Auto-discovered content reference', ${organizationId},
-       false, NULL, current_timestamp, current_timestamp)
-    ON CONFLICT (organization_id, slug) WHERE status = 'active'
-    DO UPDATE SET updated_at = EXCLUDED.updated_at
-    RETURNING id
-  `;
-  return Number(rows[0].id);
+function ensureMentionsType(organizationId: string): Promise<number> {
+  return ensureRelationshipType({
+    organizationId,
+    slug: 'mentions',
+    name: 'Mentions',
+    description: 'Auto-discovered content reference',
+  });
 }
 
 /**
@@ -104,36 +99,23 @@ export async function autoLinkEvent(params: AutoLinkParams): Promise<void> {
 
   if (candidates.length === 0) return;
 
-  const sql = getDb();
   const typeId = await ensureMentionsType(organizationId);
-  let created = 0;
 
-  for (const { fromId, toId } of candidates) {
-    const { from, to } = { from: fromId, to: toId };
-
-    // `mentions` is directional. Only skip when the same directional type already exists.
-    const existing = await sql`
-      SELECT id FROM entity_relationships
-      WHERE from_entity_id = ${from} AND to_entity_id = ${to}
-        AND relationship_type_id = ${typeId}
-        AND organization_id = ${organizationId}
-        AND deleted_at IS NULL
-      LIMIT 1
-    `;
-    if (existing.length > 0) continue;
-
-    await sql`
-      INSERT INTO entity_relationships (
-        organization_id, from_entity_id, to_entity_id, relationship_type_id,
-        confidence, source, created_by, updated_by, created_at, updated_at
-      ) VALUES (
-        ${organizationId}, ${from}, ${to}, ${typeId},
-        0.4, 'feed', NULL, NULL,
-        current_timestamp, current_timestamp
-      )
-    `;
-    created++;
-  }
+  // `mentions` is directional, so an existing edge only blocks the same
+  // direction — which is exactly what the live-triple unique index keys on.
+  const createdIds = await upsertEdges({
+    db: getDb(),
+    organizationId,
+    relationshipTypeId: typeId,
+    pairs: candidates.map(({ fromId, toId }) => ({
+      fromEntityId: fromId,
+      toEntityId: toId,
+    })),
+    source: 'feed',
+    confidence: 0.4,
+    onConflict: 'ignore',
+  });
+  const created = createdIds.length;
 
   if (created > 0) {
     logger.debug(

--- a/packages/server/src/utils/edge-writes.ts
+++ b/packages/server/src/utils/edge-writes.ts
@@ -1,0 +1,119 @@
+/**
+ * Conflict-safe batch edge writes for first-party materializers.
+ *
+ * Four call sites had hand-rolled the same statement one round trip per edge.
+ * Three agreed; `auto-linker` had copied it WITHOUT the conflict clause and put
+ * a `SELECT` in front instead, so two concurrent linkers could both pass the
+ * check and the second raise `23505`.
+ *
+ * Not a replacement for `relationship-validation.ts`, which guards the
+ * caller-facing `manage_entity` surface: its `validateSource` accepts only
+ * `ui|llm|feed|api` and would reject the `config`/`manual` sources reconcilers
+ * own, and its `checkDuplicateEdge` raises a 409 where a materializer wants an
+ * idempotent no-op.
+ *
+ * Not a general edge kernel either: `entity-merge`'s repoint/tombstone and
+ * `force_delete_tree`'s hard delete stay where they are, because their SQL is
+ * ordering-dependent and set-based.
+ */
+
+import { type DbClient, getDb, pgBigintArray } from '../db/client';
+
+interface EdgePair {
+  fromEntityId: number;
+  toEntityId: number;
+}
+
+interface UpsertEdgesParams {
+  db: DbClient;
+  organizationId: string;
+  relationshipTypeId: number;
+  pairs: EdgePair[];
+  source: string;
+  confidence?: number | null;
+  createdBy?: string | null;
+  metadata?: object | null;
+  onConflict: 'ignore' | 'update';
+}
+
+/**
+ * Find-or-create an org-scoped relationship type.
+ *
+ * `description` only lands on first create; an existing type keeps its current
+ * description.
+ */
+export async function ensureRelationshipType(params: {
+  organizationId: string;
+  slug: string;
+  name: string;
+  description: string;
+}): Promise<number> {
+  const sql = getDb();
+  const rows = await sql<{ id: number }>`
+    INSERT INTO entity_relationship_types
+      (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+    VALUES
+      (${params.slug}, ${params.name}, ${params.description}, ${params.organizationId},
+       false, NULL, current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE status = 'active'
+    DO UPDATE SET updated_at = EXCLUDED.updated_at
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+/**
+ * Write directed edges of one type in a single statement. In `ignore` mode the
+ * returned ids are newly created rows; in `update` mode they are created or
+ * refreshed rows.
+ */
+export async function upsertEdges(params: UpsertEdgesParams): Promise<number[]> {
+  const { db, organizationId, relationshipTypeId, source, onConflict } = params;
+
+  // `ON CONFLICT DO UPDATE` cannot affect the same row twice in one statement.
+  // Self-edges are dropped rather than written: identity resolution can collapse
+  // two source keys onto one entity, and a self-loop is meaningless for every
+  // type written here.
+  const seen = new Set<string>();
+  const pairs: EdgePair[] = [];
+  for (const pair of params.pairs) {
+    if (pair.fromEntityId === pair.toEntityId) continue;
+    const key = `${pair.fromEntityId}:${pair.toEntityId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    pairs.push(pair);
+  }
+  if (pairs.length === 0) return [];
+
+  const froms = pairs.map((p) => p.fromEntityId);
+  const tos = pairs.map((p) => p.toEntityId);
+
+  const conflictAction =
+    onConflict === 'update'
+      ? db`DO UPDATE SET
+            metadata = EXCLUDED.metadata,
+            source = EXCLUDED.source,
+            updated_by = EXCLUDED.updated_by,
+            updated_at = current_timestamp`
+      : db`DO NOTHING`;
+
+  const written = await db<{ id: number }>`
+    INSERT INTO entity_relationships (
+      organization_id, from_entity_id, to_entity_id, relationship_type_id,
+      metadata, confidence, source, created_by, updated_by, created_at, updated_at
+    )
+    SELECT
+      ${organizationId}, v.f, v.t, ${relationshipTypeId},
+      ${params.metadata == null ? null : db.json(params.metadata)},
+      ${params.confidence ?? null}, ${source},
+      ${params.createdBy ?? null}, ${params.createdBy ?? null},
+      current_timestamp, current_timestamp
+    FROM unnest(${pgBigintArray(froms)}::bigint[], ${pgBigintArray(tos)}::bigint[]) AS v(f, t)
+    ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
+      WHERE deleted_at IS NULL
+    ${conflictAction}
+    RETURNING id
+  `;
+
+  return written.map((row) => Number(row.id));
+}


### PR DESCRIPTION
## Summary
- Four materializers (`access-graph`, `channel-about`, `github-team-graph`, `auto-linker`) had each hand-rolled the same `INSERT INTO entity_relationships`, one round trip per edge. `upsertEdges` writes the whole batch in one statement.
- **This fixes a real bug.** Three of the four agreed on the statement; `auto-linker` had copied it *without* the `ON CONFLICT` clause and put a `SELECT` in front instead, so two concurrent linkers could both pass the check and the second raise `23505` against `idx_entity_relationships_live_triple`.
- Net −38 lines across the call sites; `github-team-graph`'s duplicate local `ensureMemberOfType` is deleted in favour of the one in `access-graph`.

## Scope — what this deliberately does not touch
Not a replacement for `relationship-validation.ts`, which guards the caller-facing `manage_entity` surface: its `validateSource` accepts only `ui|llm|feed|api` and would reject the `config`/`manual` sources these reconcilers own, and `checkDuplicateEdge` raises a 409 where a materializer wants an idempotent no-op.

Not a general edge kernel either — `entity-merge`'s repoint/tombstone and `force_delete_tree`'s hard delete stay where they are, because their SQL is ordering-dependent and set-based.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `v7jg6h0sf2`, zero failed jobs, full remote preflight recorded for tree `59fc7fd8`)
- [x] Tests run: `bunx vitest run` in `packages/server` — 448/448 green on the full sweep; 7 new contract tests in `edge-writes-batch.test.ts`
- [x] Bug fix: red→fix→green below

### red → green
Both failure modes were mutation-proved rather than asserted.

Removing the `ON CONFLICT` clause (the `auto-linker` bug, reproduced):

```
duplicate key value violates unique constraint "idx_entity_relationships_live_triple"
  × survives two concurrent writers claiming the same pair
```

Removing the in-batch dedupe:

```
ON CONFLICT DO UPDATE command cannot affect row a second time
  × dedupes within one batch so DO UPDATE cannot hit a row twice
```

With both in place: `7 passed (7)`.

## Notes
The tombstone test pins behaviour worth stating explicitly: the conflict target is the **partial** live-triple index, so a soft-deleted row is not a conflict and cannot be revived by the update branch — a re-assertion writes a fresh live row beside the tombstone.

Self-edges are dropped rather than written. Identity resolution can collapse two source keys onto one entity (see #2798), and a self-loop is meaningless for every relationship type written on these paths.