### PR TITLE
fix(server): thread the caller's handle through entity-write helpers

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-write-pool-starvation.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-write-pool-starvation.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Entity-write transactions must never ask the POOL for a second connection.
+ *
+ * `withEntityWriteTransaction` holds ONE pooled connection for the whole write.
+ * A helper inside it that reaches for `getDb()` instead of the caller's handle
+ * needs a SECOND connection while still holding the first, so `DB_POOL_MAX`
+ * concurrent writers each hold a slot and each wait for a slot only another
+ * writer can free. Session waits are unbounded, so the pool is dead for the life
+ * of the process — the #2818 hang, whose signature is exactly `DB_POOL_MAX`
+ * sessions `idle in transaction` on the same statement.
+ *
+ * Same one-directional-dependency rule `getLockDb()` already documents for
+ * session advisory locks, applied to the entity write path.
+ *
+ * These assert the INVARIANT (every statement of a write goes through the
+ * caller's handle) rather than staging the deadlock itself. Staging it means
+ * shrinking the shared singleton pool, and that singleton is process-wide across
+ * every file in a Vitest worker — an earlier draft did exactly that and left a
+ * later file in the same shard with a closed pool. The invariant is also the
+ * stronger check: it fails on a reintroduced `getDb()` directly, without
+ * depending on how many writers happen to be concurrent.
+ *
+ * The fourth fixed site, `ensureResourceEntityType`, needs no case here: its
+ * handle parameter is required, so a regression is a compile error.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { DbClient } from "../../../db/client";
+import {
+	applyEventAttributions,
+	clearEntityLinkRulesCache,
+	loadAttributionRuleByType,
+	resolveSenderIdentity,
+} from "../../../utils/entity-link-upsert";
+import { ensureMemberEntityType } from "../../../utils/member-entity-type";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const connectorKey = "pool-starvation";
+const feedKey = "messages";
+
+/**
+ * Wraps a handle so every tagged-template statement issued THROUGH it is
+ * recorded. A helper that bypasses it by calling `getDb()` leaves no trace here,
+ * which is precisely the defect.
+ */
+function recordingHandle(handle: DbClient): {
+	handle: DbClient;
+	statements: string[];
+} {
+	const statements: string[] = [];
+	const proxy = new Proxy(handle, {
+		apply(target, thisArg, args) {
+			const strings = args[0] as TemplateStringsArray | undefined;
+			if (strings && Array.isArray(strings.raw))
+				statements.push(strings.raw.join(" ? "));
+			return Reflect.apply(target as never, thisArg, args);
+		},
+	});
+	return { handle: proxy as DbClient, statements };
+}
+
+const matched = (statements: string[], pattern: RegExp): boolean =>
+	statements.some((statement) => pattern.test(statement));
+
+describe("entity write transactions never reach for a pooled connection", () => {
+	let orgId: string;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		// Both caches answer a HIT without any query at all, so a warm entry would
+		// hide the very reads under test.
+		clearEntityLinkRulesCache();
+		const org = await createTestOrganization({ name: "Pool Starvation Org" });
+		orgId = org.id;
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, orgId, "owner");
+		await ensureMemberEntityType(orgId);
+		await getTestDb()`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${orgId}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+	});
+
+	it("resolves the creator through the caller's transaction, not the pool", async () => {
+		// The handle has to be a REAL transaction, not the pool: given a pool,
+		// `withEntityWriteTransaction` opens its own and the write runs on that one
+		// instead of anything this test can observe.
+		const { entityId, statements } = await getTestDb().begin(async (tx) => {
+			// The #2818 site exactly: the sender miss opens a transaction, resolves an
+			// org member to attribute the mint to, then runs the identity lookup.
+			const recorded = recordingHandle(tx);
+			const resolved = await resolveSenderIdentity(recorded.handle, {
+				orgId,
+				connectorKey,
+				mintEntityType: "person",
+				title: "Unknown Sender",
+				identities: [
+					{
+						namespace: "pool_starvation_user_id",
+						identifier: "U_STARVE_1",
+						matchOnly: false,
+						primary: true,
+					},
+				],
+			});
+			return { entityId: resolved, statements: recorded.statements };
+		});
+
+		// The mint must actually have happened, or the write never reached the
+		// statements below and the assertion would pass vacuously.
+		expect(typeof entityId).toBe("number");
+		expect(matched(statements, /FROM "member"/)).toBe(true);
+	});
+
+	it("loads attribution rules through the caller's transaction, not the pool", async () => {
+		await createTestConnectorDefinition({
+			key: connectorKey,
+			name: "Pool Starvation Connector",
+			organization_id: orgId,
+			feeds_schema: {
+				[feedKey]: {
+					eventKinds: {
+						message: {
+							attributions: [
+								{
+									role: "authored_by",
+									target: {
+										entityType: "person",
+										autoCreate: true,
+										titlePath: "metadata.author_name",
+										identities: [
+											{
+												namespace: "pool_starvation_user_id",
+												eventPath: "metadata.author_id",
+												primary: true,
+											},
+										],
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		});
+		clearEntityLinkRulesCache();
+
+		// Both rule loaders are covered here: `loadAttributionRuleByType` is what the
+		// GitHub webhook path calls, `loadEventAttributionRules` is what
+		// `applyEventAttributions` calls. A caller-supplied handle may already be an
+		// open transaction (the sync dry-run path threads its rolled-back one), so a
+		// rule read on the pool would hold that transaction's connection while
+		// waiting for a second one.
+		const { byTypeRule, statements } = await getTestDb().begin(async (tx) => {
+			const recorded = recordingHandle(tx);
+			const rule = await loadAttributionRuleByType(recorded.handle, {
+				connectorKey,
+				orgId,
+				entityType: "person",
+				role: "authored_by",
+			});
+			await applyEventAttributions(
+				{
+					connectorKey,
+					feedKey,
+					orgId,
+					items: [
+						{
+							origin_type: "message",
+							metadata: {
+								author_id: "U_STARVE_2",
+								author_name: "Rules Sender",
+							},
+						},
+					],
+				},
+				recorded.handle,
+			);
+			return { byTypeRule: rule, statements: recorded.statements };
+		});
+
+		// Liveness: the rule really resolved, so the reads asserted below are the
+		// real ones rather than an early bail-out.
+		expect(byTypeRule).not.toBeNull();
+		expect(
+			statements.filter((statement) =>
+				/FROM connector_definitions/.test(statement),
+			).length,
+		).toBeGreaterThanOrEqual(2);
+		expect(matched(statements, /FROM "member"/)).toBe(true);
+	});
+});

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -375,7 +375,7 @@ export async function buildAccessGraph(params: {
     return EMPTY_RESULT;
   }
 
-  await ensureResourceEntityType(organizationId);
+  await ensureResourceEntityType(getDb(), organizationId);
   await ensurePersonEntityType(organizationId);
 
   // ACL state uses a runtime connection id, while identity provenance references

--- a/packages/server/src/authz/acl-resource-type.ts
+++ b/packages/server/src/authz/acl-resource-type.ts
@@ -4,14 +4,22 @@
  */
 
 import { ACL_RESOURCE_TYPE } from '@lobu/connector-sdk';
-import { getDb } from '../db/client.js';
+import type { DbClient } from '../db/client.js';
 
 /**
  * Find-or-create the org-scoped `$resource` entity type. Idempotent; empty
  * metadata schema (graph anchor only).
+ *
+ * The handle is REQUIRED rather than defaulted to `getDb()`: attribution
+ * auto-create calls this from inside `withEntityWriteTransaction`, where a
+ * pooled query would hold the transaction's connection while waiting for a
+ * second one — the pool deadlock behind #2818. Requiring it means the next call
+ * site has to answer the same question instead of inheriting the pool silently.
  */
-export async function ensureResourceEntityType(orgId: string): Promise<void> {
-  const sql = getDb();
+export async function ensureResourceEntityType(
+  sql: DbClient,
+  orgId: string
+): Promise<void> {
   await sql`
     INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
     VALUES (

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -148,7 +148,9 @@ export async function ensureChannelResourceEntity(opts: {
 		opts.teamId,
 		opts.channelId,
 	);
-	await ensureResourceEntityType(opts.organizationId);
+	// `sql`, never `getDb()` — the caller may have handed us its transaction, and
+	// a pooled query inside one starves the pool (#2818).
+	await ensureResourceEntityType(sql, opts.organizationId);
 
 	const resolved = await resolveEventAttributionsForItems(
 		{

--- a/packages/server/src/gateway/routes/public/github-webhook-actor.ts
+++ b/packages/server/src/gateway/routes/public/github-webhook-actor.ts
@@ -9,7 +9,7 @@ import {
 	GITHUB_IDENTITY,
 	normalizeGithubLogin,
 } from "@lobu/connectors/github-identity";
-import type { DbClient } from "../../../db/client.js";
+import { type DbClient, getDb } from "../../../db/client.js";
 import {
 	loadAttributionRuleByType,
 	resolveEventAttributionsForItems,
@@ -117,7 +117,10 @@ export async function resolveGithubWebhookActor(params: {
 	// The person entity-link rule is read from the connector definition (same
 	// source the poll path uses) — not mirrored here. Absent def/rule → no
 	// attribution (best-effort).
-	const rule = await loadAttributionRuleByType({
+	// Raw-webhook winners pass their open transaction here; a pooled read would
+	// hold that transaction's connection while waiting for a second one (#2818).
+	const sql = params.sql ?? getDb();
+	const rule = await loadAttributionRuleByType(sql, {
 		connectorKey: "github",
 		orgId: params.organizationId,
 		entityType: "person",
@@ -150,7 +153,7 @@ export async function resolveGithubWebhookActor(params: {
 			items: [item],
 			rules: { [kind]: [rule] },
 		},
-		params.sql,
+		sql,
 	);
 
 	const entityIds = resolved.get(0) ?? [];

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -89,9 +89,17 @@ const RULES_CACHE_TTL_MS = 60_000;
 const rulesCache = new TtlCache<RuleMap>(RULES_CACHE_TTL_MS);
 const creatorCache = new TtlCache<string | null>(RULES_CACHE_TTL_MS);
 
-async function resolveOrgCreator(orgId: string): Promise<string | null> {
+/**
+ * Takes the caller's handle rather than reaching for `getDb()`, because both
+ * call sites run INSIDE `withEntityWriteTransaction`. A pooled query there asks
+ * for a second connection while still holding the transaction's own, so
+ * `DB_POOL_MAX` concurrent writers deadlock the pool permanently — #2818.
+ *
+ * A cache hit performs no query at all; racing misses each query through their
+ * own caller-owned handle.
+ */
+async function resolveOrgCreator(sql: DbClient, orgId: string): Promise<string | null> {
   return creatorCache.getOrSet(orgId, async () => {
-    const sql = getDb();
     const rows = await sql<{ userId: string }>`
       SELECT "userId"
       FROM "member"
@@ -113,14 +121,16 @@ function randomSlug(entityType: string): string {
   return `${prefix}-${randomBytes(5).toString('hex')}`;
 }
 
-async function loadEventAttributionRules(params: {
-  connectorKey: string;
-  feedKey: string;
-  orgId: string;
-}): Promise<RuleMap> {
+async function loadEventAttributionRules(
+  sql: DbClient,
+  params: {
+    connectorKey: string;
+    feedKey: string;
+    orgId: string;
+  }
+): Promise<RuleMap> {
   const cacheKey = `${params.orgId}:${params.connectorKey}:${params.feedKey}`;
   return rulesCache.getOrSet(cacheKey, async () => {
-    const sql = getDb();
     const rows = await sql`
       SELECT feeds_schema
       FROM connector_definitions
@@ -155,16 +165,18 @@ async function loadEventAttributionRules(params: {
  * pass the role the caller actually wants ('authored_by' for a webhook actor)
  * rather than relying on declaration order.
  */
-export async function loadAttributionRuleByType(params: {
-  connectorKey: string;
-  orgId: string;
-  entityType: string;
-  role?: EventAttributionRule['role'];
-}): Promise<ResolvedEventAttributionRule | null> {
+export async function loadAttributionRuleByType(
+  sql: DbClient,
+  params: {
+    connectorKey: string;
+    orgId: string;
+    entityType: string;
+    role?: EventAttributionRule['role'];
+  }
+): Promise<ResolvedEventAttributionRule | null> {
   const roleKey = params.role ?? '__any__';
   const cacheKey = `${params.orgId}:${params.connectorKey}:__bytype__:${params.entityType}:${roleKey}`;
   const map = await rulesCache.getOrSet(cacheKey, async () => {
-    const sql = getDb();
     const rows = await sql`
       SELECT feeds_schema
       FROM connector_definitions
@@ -468,7 +480,7 @@ async function createEntityWithIdentities(
     // Platform ACL type is ensured on the fly so event attribution can race
     // ahead of the first ACL sync without failing closed on a missing type.
     if (params.entityType === ACL_RESOURCE_TYPE_SLUG) {
-      await ensureResourceEntityType(params.orgId);
+      await ensureResourceEntityType(sql, params.orgId);
       typeRow = await sql<{ id: number; backing_sql: string | null }>`
         SELECT et.id, et.backing_sql
         FROM entity_types et
@@ -660,14 +672,17 @@ export async function applyEventAttributions(
 ): Promise<void> {
   if (!params.feedKey || params.items.length === 0) return;
 
-  const rulesByKind = await loadEventAttributionRules({
+  // Resolved BEFORE the rule load: the sync dry-run path supplies its
+  // rolled-back transaction, and reading rules on the pool while that is open is
+  // the starvation this file exists to avoid (#2818).
+  const db = sql ?? getDb();
+
+  const rulesByKind = await loadEventAttributionRules(db, {
     connectorKey: params.connectorKey,
     feedKey: params.feedKey,
     orgId: params.orgId,
   });
   if (Object.keys(rulesByKind).length === 0) return;
-
-  const db = sql ?? getDb();
   await withEntityWriteTransaction(db, (tx) =>
     resolveLinksByKind(
       {
@@ -750,7 +765,7 @@ async function resolveLinksByKind(
 
   // entities.created_by is NOT NULL; resolve an org owner/admin once per batch
   // so auto-created entities attribute to a real member rather than a seed user.
-  const creatorUserId = await resolveOrgCreator(params.orgId);
+  const creatorUserId = await resolveOrgCreator(sql, params.orgId);
 
   // rule -> per-item extracted link, carrying the source item + index (the
   // caller recovers the resolved entity per item; metadata is stamped onto the
@@ -1062,7 +1077,7 @@ async function resolveSenderIdentityInTransaction(
   if (hit !== null) return hit;
 
   // 2) Mint. The only remaining gate is a real org member to attribute to.
-  const creatorUserId = await resolveOrgCreator(params.orgId);
+  const creatorUserId = await resolveOrgCreator(sql, params.orgId);
   if (!creatorUserId) return null;
 
   const created = await createEntityWithIdentities(sql, {


### PR DESCRIPTION
## Summary
- `withEntityWriteTransaction` holds ONE pooled connection for the whole write. Four helpers inside it called `getDb()` instead of the caller's handle, so each asked for a SECOND connection while holding the first. At `DB_POOL_MAX` concurrent writers every slot is held and every writer waits for a slot only another writer can free — session waits are unbounded, so the pool is dead for the life of the process.
- Signature in `pg_stat_activity`: exactly `DB_POOL_MAX` sessions `idle in transaction`, `wait_event_type = ClientRead`, all showing the SAME last query — the statement immediately before the offending call. Everything downstream (the blocked `TRUNCATE`, the 15-minute job cap reporting as `cancelled`) is a consequence, not the bug.
- `ensureResourceEntityType` now takes a **required** handle rather than a defaulted one, so the next call site has to answer the question instead of inheriting the pool silently. A regression there is a compile error.
- The caches hide it: `TtlCache.getOrSet` stores the resolved value, so a hit costs no query. It only bites on cold cache — fresh orgs in tests, or a pod handling many orgs in prod. This is a real prod hazard, not a CI-only flake.
- `db/client.ts` already documents this exact one-directional-dependency rule for `getLockDb()`; the entity write path just never applied it.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (19/19 Depot jobs, first attempt, no retries)
- [x] Tests run: targeted `bunx vitest run src/__tests__/integration/entities/entity-write-pool-starvation.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### Red → green at lane scale
Full gateway lane 2 on one machine, baseline run on the unpatched tree vs. patched:

```
baseline (all hunks reverted):  71 failures / 67 lock timeouts
with the fix:                    0 failures /  0 lock timeouts, 1117 tests in 48.27s
```

### New regression test

```
✓ resolves the creator through the caller's transaction, not the pool
✓ loads attribution rules through the caller's transaction, not the pool
Tests  2 passed (2)
```

Mutation test — all three testable sites reverted to `getDb()` in one pass:

```
Tests  2 failed (2)
```

The test asserts the INVARIANT (every statement of a write goes through the caller's handle) via a recording Proxy, rather than staging the deadlock. Staging it means shrinking the shared singleton pool, and that singleton is process-wide across every file in a Vitest worker — an earlier draft did exactly that and left a later file in the same shard with a closed pool. The invariant is also the stronger check: it fails on a reintroduced `getDb()` directly, without depending on how many writers happen to be concurrent.

## Notes
Closes #2818. Unblocks the ACL generation-counter branch, whose gate was failing on this and not on its own diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of entity creation and event attribution when database transactions are under heavy load.
  * Ensured related database operations consistently use the active transaction, reducing connection pool starvation risks.
  * Improved GitHub webhook attribution and resource initialization within ongoing transactions.

* **Tests**
  * Added integration coverage for transaction handling, sender resolution, attribution rules, and connector configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->