### PR TITLE
fix(server): serialize ACL syncs per connection and fence the projection

### DIFF
--- a/db/migrations/20260817010000_org_acl_generation.sql
+++ b/db/migrations/20260817010000_org_acl_generation.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+
+-- An org-scoped ACL invalidation counter.
+--
+-- The freshness fence in `markAclFresh` compared
+-- `authz_source_acl_state.updated_at < syncStartedAt`, which orders STATEMENT
+-- timestamps, not commit visibility. An unmerge could stamp `updated_at` at T1
+-- and commit at T3; a sync starting at T2 (T1 < T2 < T3) never saw the unmerge
+-- in its snapshot, yet the fence read T1 < T2 and blessed the connection
+-- `fresh` on membership that predates the revocation.
+--
+-- A counter closes it: the sync reads the generation before it reads or
+-- reconciles membership, and the stamp refuses unless it is still unchanged.
+-- An invalidation that commits mid-sync bumps it and the stamp is skipped.
+--
+-- It lives on `organization` rather than `authz_source_acl_state` because an
+-- entity-graph invalidation can affect every connection and must also fence the
+-- INSERT path: a sync that began before the invalidation can create a brand-new
+-- state row afterward, and a per-row counter cannot guard a row that did not
+-- exist to be bumped.
+ALTER TABLE public.organization
+  ADD COLUMN IF NOT EXISTS acl_generation bigint NOT NULL DEFAULT 0;
+
+-- migrate:down
+
+ALTER TABLE public.organization
+  DROP COLUMN IF EXISTS acl_generation;

--- a/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
@@ -404,10 +404,9 @@ describe("authorization edges have one enforcement point", () => {
 		expect(rows[0].freshness_state).toBe("stale");
 	});
 
-	it("costs an ERP-only tenant nothing — there is no ACL state to invalidate", async () => {
-		// The availability cost only lands where ACL is actually onboarded. An org
-		// that has never graphed a connection has no row, so the statement matches
-		// nothing and no visibility is lost.
+	it("does not change visibility for an ERP-only tenant with no ACL state", async () => {
+		// The generation still advances, but an org that has never graphed a
+		// connection has no state row to mark stale, so no visibility changes.
 		const sql = getTestDb();
 		await applyMerge(
 			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },

--- a/packages/server/src/__tests__/integration/authz/acl-generation-fence.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-generation-fence.test.ts
@@ -55,6 +55,14 @@ describe("ACL generation fence", () => {
 		return { loserId: loser.id, winnerId: winner.id };
 	}
 
+	/** Stamp with a fence captured right now — the ordinary uncontended case. */
+	async function stampFresh(): Promise<void> {
+		await markAclFresh(orgId, connectionId, {
+			startedAt: await syncCutoff(),
+			generation: await observeGeneration(),
+		});
+	}
+
 	async function syncCutoff(): Promise<string> {
 		const sql = getDb();
 		const rows = await sql<{ now: string }>`
@@ -84,7 +92,7 @@ describe("ACL generation fence", () => {
 	it("stamps fresh when nothing invalidated mid-sync", async () => {
 		const generation = await observeGeneration();
 		const cutoff = await syncCutoff();
-		await markAclFresh(orgId, connectionId, cutoff, generation);
+		await markAclFresh(orgId, connectionId, { startedAt: cutoff, generation });
 		expect(await freshnessState()).toBe("fresh");
 	});
 
@@ -97,12 +105,12 @@ describe("ACL generation fence", () => {
 		await getDb().begin(async (tx) => {
 			await bumpAclGeneration(tx, orgId);
 		});
-		await markAclFresh(orgId, connectionId, cutoff, generation);
+		await markAclFresh(orgId, connectionId, { startedAt: cutoff, generation });
 		expect(await freshnessState()).toBeNull();
 	});
 
 	it("refuses to UPDATE an existing row to fresh when a bump landed mid-sync", async () => {
-		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		await stampFresh();
 		const sql = getDb();
 		await sql`
       UPDATE authz_source_acl_state SET freshness_state = 'stale'
@@ -114,12 +122,12 @@ describe("ACL generation fence", () => {
 		await getDb().begin(async (tx) => {
 			await bumpAclGeneration(tx, orgId);
 		});
-		await markAclFresh(orgId, connectionId, cutoff, generation);
+		await markAclFresh(orgId, connectionId, { startedAt: cutoff, generation });
 		expect(await freshnessState()).toBe("stale");
 	});
 
 	it("refuses a revocation whose write timestamp precedes the sync but commits afterward", async () => {
-		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		await stampFresh();
 		const generation = await observeGeneration();
 
 		let signalInvalidationWritten!: (writtenAt: string) => void;
@@ -156,7 +164,7 @@ describe("ACL generation fence", () => {
 		const [{ cutoff }] = await getDb()<{ cutoff: string }>`
       SELECT (${invalidatedAtWrite}::timestamptz + interval '1 microsecond')::text AS cutoff
     `;
-		const stamping = markAclFresh(orgId, connectionId, cutoff, generation);
+		const stamping = markAclFresh(orgId, connectionId, { startedAt: cutoff, generation });
 		let blockingError: unknown;
 		try {
 			await waitForBlockedGenerationRead();
@@ -183,12 +191,12 @@ describe("ACL generation fence", () => {
 		});
 		const generation = await observeGeneration();
 		const cutoff = await syncCutoff();
-		await markAclFresh(orgId, connectionId, cutoff, generation);
+		await markAclFresh(orgId, connectionId, { startedAt: cutoff, generation });
 		expect(await freshnessState()).toBe("fresh");
 	});
 
 	it("invalidates an in-flight sync when another ACL sync fails", async () => {
-		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		await stampFresh();
 		const generation = await observeGeneration();
 		await markConnectionAclFailed(orgId, connectionId, "generation fence test");
 		expect(Number(await observeGeneration())).toBeGreaterThan(Number(generation));
@@ -203,7 +211,7 @@ describe("ACL generation fence", () => {
 
 		it("invalidates on merge", async () => {
 			const { loserId, winnerId } = await seedMergePair();
-			await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+			await stampFresh();
 			const before = await generation();
 			await applyMerge(
 				{ orgId, loserId, winnerId, mergedBy: "generation-test" },
@@ -219,7 +227,7 @@ describe("ACL generation fence", () => {
 				{ orgId, loserId, winnerId, mergedBy: "generation-test" },
 				getDb(),
 			);
-			await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+			await stampFresh();
 			const before = await generation();
 			await applyUnmerge({ orgId, loserId, unmergedBy: "generation-test" }, getDb());
 			expect(await generation()).toBeGreaterThan(before);
@@ -227,17 +235,22 @@ describe("ACL generation fence", () => {
 		});
 	});
 
-	it("keeps stamping for a synthetic org with no organization row", async () => {
-		// Standalone graph tests use synthetic org ids. NULL observed against a
-		// missing row must compare equal, or the materializer silently stops
-		// stamping for every one of them.
+	it("refuses to stamp when the organization row is missing", async () => {
+		// No organization row means no generation to compare, so there is no fence
+		// to satisfy. Publishing anyway would bless a projection whose freshness
+		// cannot be verified, so this fails closed instead. `connections` cascades
+		// from `organization`, so in production this is an orphaned state row or a
+		// job racing org deletion — never a live connection.
 		const syntheticOrg = "org_does_not_exist_generation";
-		await markAclFresh(syntheticOrg, connectionId, await syncCutoff(), null);
+		await markAclFresh(syntheticOrg, connectionId, {
+			startedAt: await syncCutoff(),
+			generation: null,
+		});
 		const sql = getDb();
 		const rows = await sql<{ freshness_state: string }>`
       SELECT freshness_state FROM authz_source_acl_state
       WHERE organization_id = ${syntheticOrg} AND connection_id = ${connectionId}
     `;
-		expect(rows[0]?.freshness_state).toBe("fresh");
+		expect(rows).toHaveLength(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/authz/acl-generation-fence.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-generation-fence.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The org-scoped ACL generation fence.
+ *
+ * The timestamp fence it supplements orders STATEMENT timestamps, not commit
+ * visibility: an invalidation can stamp `updated_at` before a sync's cutoff yet
+ * become visible after it, so the sync blesses membership the invalidation had
+ * already contradicted. These cases pin the generation half, which is read in
+ * the sync's own snapshot and therefore cannot be fooled that way.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { bumpAclGeneration } from "../../../authz/acl-generation";
+import { markAclFresh } from "../../../authz/access-graph";
+import { markConnectionAclFailed } from "../../../authz/acl-observability";
+import { getDb } from "../../../db/client";
+import { applyMerge, applyUnmerge } from "../../../utils/entity-merge";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import { createTestEntity, createTestOrganization } from "../../setup/test-fixtures";
+
+describe("ACL generation fence", () => {
+	let orgId: string;
+	const connectionId = "conn-acl-generation";
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Generation Org" });
+		orgId = org.id;
+	});
+
+	/** The generation a sync would have observed when it began. */
+	async function observeGeneration(): Promise<string | null> {
+		const sql = getDb();
+		const rows = await sql<{ acl_generation: string | null }>`
+      SELECT acl_generation::text AS acl_generation
+      FROM organization WHERE id = ${orgId}
+    `;
+		return rows.length > 0 ? rows[0].acl_generation : null;
+	}
+
+	async function freshnessState(): Promise<string | null> {
+		const sql = getDb();
+		const rows = await sql<{ freshness_state: string }>`
+      SELECT freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${orgId} AND connection_id = ${connectionId}
+    `;
+		return rows.length > 0 ? rows[0].freshness_state : null;
+	}
+
+	/** Two `person` entities, the second of which can be merged into the first. */
+	async function seedMergePair(): Promise<{ loserId: number; winnerId: number }> {
+		const mk = (name: string) =>
+			createTestEntity({ organization_id: orgId, entity_type: "person", name });
+		const loser = await mk("Loser");
+		const winner = await mk("Winner");
+		return { loserId: loser.id, winnerId: winner.id };
+	}
+
+	async function syncCutoff(): Promise<string> {
+		const sql = getDb();
+		const rows = await sql<{ now: string }>`
+      SELECT clock_timestamp()::text AS now
+    `;
+		return rows[0].now;
+	}
+
+	async function waitForBlockedGenerationRead(timeoutMs = 10_000): Promise<void> {
+		const sql = getDb();
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			const [{ n }] = await sql<{ n: number }>`
+        SELECT count(*)::int AS n
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%SELECT acl_generation::text AS acl_generation%'
+          AND query ILIKE '%FOR SHARE%'
+      `;
+			if (n > 0) return;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		throw new Error("markAclFresh never blocked on the uncommitted generation bump");
+	}
+
+	it("stamps fresh when nothing invalidated mid-sync", async () => {
+		const generation = await observeGeneration();
+		const cutoff = await syncCutoff();
+		await markAclFresh(orgId, connectionId, cutoff, generation);
+		expect(await freshnessState()).toBe("fresh");
+	});
+
+	it("refuses to INSERT a fresh row when a bump landed mid-sync", async () => {
+		// The path the timestamp fence cannot guard at all: with no existing row,
+		// `ON CONFLICT … WHERE` never runs, so a sync that began before the
+		// invalidation would create a brand-new `fresh` row after it.
+		const generation = await observeGeneration();
+		const cutoff = await syncCutoff();
+		await getDb().begin(async (tx) => {
+			await bumpAclGeneration(tx, orgId);
+		});
+		await markAclFresh(orgId, connectionId, cutoff, generation);
+		expect(await freshnessState()).toBeNull();
+	});
+
+	it("refuses to UPDATE an existing row to fresh when a bump landed mid-sync", async () => {
+		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		const sql = getDb();
+		await sql`
+      UPDATE authz_source_acl_state SET freshness_state = 'stale'
+      WHERE organization_id = ${orgId} AND connection_id = ${connectionId}
+    `;
+
+		const generation = await observeGeneration();
+		const cutoff = await syncCutoff();
+		await getDb().begin(async (tx) => {
+			await bumpAclGeneration(tx, orgId);
+		});
+		await markAclFresh(orgId, connectionId, cutoff, generation);
+		expect(await freshnessState()).toBe("stale");
+	});
+
+	it("refuses a revocation whose write timestamp precedes the sync but commits afterward", async () => {
+		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		const generation = await observeGeneration();
+
+		let signalInvalidationWritten!: (writtenAt: string) => void;
+		const invalidationWritten = new Promise<string>((resolve) => {
+			signalInvalidationWritten = resolve;
+		});
+		let releaseInvalidation!: () => void;
+		const mayCommit = new Promise<void>((resolve) => {
+			releaseInvalidation = resolve;
+		});
+
+		const invalidating = getDb().begin(async (tx) => {
+			await bumpAclGeneration(tx, orgId);
+			const [{ updated_at: invalidatedAt }] = await tx<{ updated_at: string }>`
+        UPDATE authz_source_acl_state
+        SET freshness_state = 'stale', updated_at = clock_timestamp()
+        WHERE organization_id = ${orgId} AND connection_id = ${connectionId}
+        RETURNING updated_at::text AS updated_at
+      `;
+			signalInvalidationWritten(invalidatedAt);
+			await mayCommit;
+			return invalidatedAt;
+		});
+
+		const invalidatedAtWrite = await invalidationWritten;
+		// The invalidation is still uncommitted, so this sync sees the old
+		// generation even though its cutoff is later than the stale-row write.
+		expect(await observeGeneration()).toBe(generation);
+		// DERIVED from the invalidation's own write timestamp rather than read
+		// from the clock. The point of the cutoff is to sit strictly after that
+		// write while the invalidation is still uncommitted — reading
+		// `clock_timestamp()` from the shared pool only usually produces that
+		// ordering, which made this assertion flaky under parallel load.
+		const [{ cutoff }] = await getDb()<{ cutoff: string }>`
+      SELECT (${invalidatedAtWrite}::timestamptz + interval '1 microsecond')::text AS cutoff
+    `;
+		const stamping = markAclFresh(orgId, connectionId, cutoff, generation);
+		let blockingError: unknown;
+		try {
+			await waitForBlockedGenerationRead();
+		} catch (error) {
+			blockingError = error;
+		} finally {
+			releaseInvalidation();
+		}
+		await invalidating;
+		await stamping;
+		if (blockingError) throw blockingError;
+
+		// The whole point: the stamp had a cutoff LATER than the revocation's
+		// write, so the timestamp fence alone would have blessed it fresh. The
+		// generation is what keeps it stale.
+		expect(await freshnessState()).toBe("stale");
+	});
+
+	it("stamps fresh once the sync observes the NEW generation", async () => {
+		// The fence must not wedge the connection permanently: the next sync reads
+		// the bumped generation and is allowed through.
+		await getDb().begin(async (tx) => {
+			await bumpAclGeneration(tx, orgId);
+		});
+		const generation = await observeGeneration();
+		const cutoff = await syncCutoff();
+		await markAclFresh(orgId, connectionId, cutoff, generation);
+		expect(await freshnessState()).toBe("fresh");
+	});
+
+	it("invalidates an in-flight sync when another ACL sync fails", async () => {
+		await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+		const generation = await observeGeneration();
+		await markConnectionAclFailed(orgId, connectionId, "generation fence test");
+		expect(Number(await observeGeneration())).toBeGreaterThan(Number(generation));
+		expect(await freshnessState()).toBe("failed");
+	});
+
+	/** Merge and unmerge both mutate authorization state outside an ACL sync. */
+	describe("entity merge invalidation", () => {
+		async function generation(): Promise<number> {
+			return Number(await observeGeneration());
+		}
+
+		it("invalidates on merge", async () => {
+			const { loserId, winnerId } = await seedMergePair();
+			await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+			const before = await generation();
+			await applyMerge(
+				{ orgId, loserId, winnerId, mergedBy: "generation-test" },
+				getDb(),
+			);
+			expect(await generation()).toBeGreaterThan(before);
+			expect(await freshnessState()).toBe("stale");
+		});
+
+		it("invalidates on unmerge", async () => {
+			const { loserId, winnerId } = await seedMergePair();
+			await applyMerge(
+				{ orgId, loserId, winnerId, mergedBy: "generation-test" },
+				getDb(),
+			);
+			await markAclFresh(orgId, connectionId, await syncCutoff(), await observeGeneration());
+			const before = await generation();
+			await applyUnmerge({ orgId, loserId, unmergedBy: "generation-test" }, getDb());
+			expect(await generation()).toBeGreaterThan(before);
+			expect(await freshnessState()).toBe("stale");
+		});
+	});
+
+	it("keeps stamping for a synthetic org with no organization row", async () => {
+		// Standalone graph tests use synthetic org ids. NULL observed against a
+		// missing row must compare equal, or the materializer silently stops
+		// stamping for every one of them.
+		const syntheticOrg = "org_does_not_exist_generation";
+		await markAclFresh(syntheticOrg, connectionId, await syncCutoff(), null);
+		const sql = getDb();
+		const rows = await sql<{ freshness_state: string }>`
+      SELECT freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${syntheticOrg} AND connection_id = ${connectionId}
+    `;
+		expect(rows[0]?.freshness_state).toBe("fresh");
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -306,8 +306,8 @@ describe("acl observability", () => {
       `;
 			expect(repeatConn?.updated_at).toEqual(new Date(SENTINEL));
 			// Unlike the shared connection row, ACL state must record every failure.
-			// `markAclFresh` compares this timestamp with its snapshot start, so an
-			// older in-flight sync cannot overwrite a newer repeated failure.
+			// The timestamp and generation fences keep an older in-flight sync from
+			// overwriting a newer repeated failure.
 			expect(repeatState?.updated_at).not.toEqual(new Date(SENTINEL));
 
 			// A genuinely different reason still lands — the guard suppresses

--- a/packages/server/src/__tests__/integration/authz/acl-sync-lock.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-sync-lock.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-connection ACL sync serialization.
+ *
+ * The generation fence covers the fresh STAMP, never the edge writes that
+ * precede it, so two overlapping syncs of ONE connection can publish a leak the
+ * fence cannot detect: the loser's stamp is refused, but its edges are already
+ * in the graph under the winner's `fresh` state. These cases pin the ordering
+ * that makes that interleaving impossible.
+ */
+
+import { describe, expect, it } from "vitest";
+import { withAclConnectionSyncLock } from "../../../authz/acl-sync-lock";
+import { cleanupTestDatabase } from "../../setup/test-db";
+
+const connectionId = "conn-acl-sync-lock";
+
+/** Resolves once `signal` fires, so a holder can be pinned open deterministically. */
+function deferred(): { promise: Promise<void>; release: () => void } {
+	let release!: () => void;
+	const promise = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	return { promise, release };
+}
+
+describe("per-connection ACL sync lock", () => {
+	it("runs the body and reports that it ran", async () => {
+		await cleanupTestDatabase();
+		const outcome = await withAclConnectionSyncLock(connectionId, async () => 42);
+		expect(outcome.ran).toBe(true);
+		expect(outcome.value).toBe(42);
+	});
+
+	it("skips a second sync of the SAME connection while one is in flight", async () => {
+		const held = deferred();
+		let secondRan = false;
+
+		const holder = withAclConnectionSyncLock(connectionId, async () => {
+			await held.promise;
+			return "first";
+		});
+
+		// The holder is inside its body only once the lock is taken; poll for the
+		// contended outcome rather than sleeping a fixed interval.
+		let contended = await withAclConnectionSyncLock(connectionId, async () => {
+			secondRan = true;
+			return "second";
+		});
+		for (let i = 0; i < 100 && contended.ran; i++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			contended = await withAclConnectionSyncLock(connectionId, async () => {
+				secondRan = true;
+				return "second";
+			});
+		}
+
+		held.release();
+		const first = await holder;
+
+		expect(first.ran).toBe(true);
+		expect(first.value).toBe("first");
+		// The decisive assertion: the second sync did not merely fail to stamp, it
+		// never ran its body at all, so it wrote no edges.
+		expect(contended.ran).toBe(false);
+		expect(secondRan).toBe(false);
+	});
+
+	it("does not serialize DIFFERENT connections", async () => {
+		const held = deferred();
+		const holder = withAclConnectionSyncLock(`${connectionId}-a`, async () => {
+			await held.promise;
+			return "a";
+		});
+
+		const other = await withAclConnectionSyncLock(`${connectionId}-b`, async () => "b");
+
+		held.release();
+		await holder;
+
+		expect(other.ran).toBe(true);
+		expect(other.value).toBe("b");
+	});
+
+	it("releases the lock when the body throws", async () => {
+		await expect(
+			withAclConnectionSyncLock(connectionId, async () => {
+				throw new Error("sync exploded");
+			}),
+		).rejects.toThrow("sync exploded");
+
+		// A leaked session lock would wedge this connection until the pod restarted.
+		const after = await withAclConnectionSyncLock(connectionId, async () => "recovered");
+		expect(after.ran).toBe(true);
+		expect(after.value).toBe("recovered");
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
+++ b/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
@@ -321,6 +321,15 @@ describe("authorization-bearing relationship types are not caller-writable", () 
     `;
 		expect(before).toHaveLength(1);
 
+		const [{ acl_generation: generationBefore }] = await sql<{
+			acl_generation: string;
+		}>`SELECT acl_generation::text AS acl_generation FROM organization WHERE id = ${orgId}`;
+		await sql`
+      INSERT INTO authz_source_acl_state
+        (organization_id, connection_id, acl_support, freshness_state)
+      VALUES (${orgId}, 'force-delete-generation', 'full', 'fresh')
+    `;
+
 		await deleteEntity(person, true, env, ctx(orgId, userId));
 
 		const live = await sql`
@@ -328,6 +337,19 @@ describe("authorization-bearing relationship types are not caller-writable", () 
       WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
     `;
 		expect(live).toHaveLength(0);
+
+		// Dropping the grant must also invalidate any sync already in flight, or it
+		// can stamp the connection fresh over a projection it never saw.
+		const [{ acl_generation: generationAfter }] = await sql<{
+			acl_generation: string;
+		}>`SELECT acl_generation::text AS acl_generation FROM organization WHERE id = ${orgId}`;
+		expect(Number(generationAfter)).toBeGreaterThan(Number(generationBefore));
+		const [{ freshness_state: freshnessAfter }] = await sql<{ freshness_state: string }>`
+      SELECT freshness_state
+      FROM authz_source_acl_state
+      WHERE organization_id = ${orgId} AND connection_id = 'force-delete-generation'
+    `;
+		expect(freshnessAfter).toBe("stale");
 	});
 
 	it("refuses member_of by slug before it is classified", async () => {

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -134,8 +134,8 @@ export function ensureMemberOfType(orgId: string): Promise<number> {
  * NOT a general concurrency fix: overlapping syncs can still interleave their
  * EDGE writes, which this cannot see. That race predates this fence (on
  * `origin/main` the stamp was unconditional) and closing it properly needs one
- * graph build per connection plus a real snapshot generation — a separate
- * change, deliberately not smuggled in here.
+ * graph build per connection or a per-build snapshot id — a separate change,
+ * deliberately not smuggled in here.
  *
  * Exported because the stamp is CONNECTION-wide while a build is per-resource-
  * set: a caller that reconciles one connection across several source scopes
@@ -148,6 +148,7 @@ export async function markAclFresh(
   orgId: string,
   connectionId: string,
   syncStartedAt: string,
+  aclGeneration: string | null,
 ): Promise<void> {
   const sql = getDb();
   await sql.begin(async (tx) => {
@@ -167,6 +168,35 @@ export async function markAclFresh(
     `;
     if (connections.length > 0 && connections.every((row) => row.deleted_at != null)) return;
 
+    // Lock the org generation before touching ACL state. An invalidation takes
+    // the same locks in the same order: if it began first, this waits and then
+    // observes the new generation; if this began first, the invalidation waits
+    // and makes the state stale after this transaction commits.
+    const generationRows = await tx<{ acl_generation: string }>`
+      SELECT acl_generation::text AS acl_generation
+      FROM organization
+      WHERE id = ${orgId}
+      FOR SHARE
+    `;
+    const currentGeneration = generationRows[0]?.acl_generation ?? null;
+    if (currentGeneration !== aclGeneration) return;
+
+    // Two fences, and both are load-bearing.
+    //
+    // The generation is the real one: it was captured before this sync read or
+    // reconciled membership, so an invalidation that COMMITTED mid-sync fails
+    // the comparison even though its statement timestamp precedes
+    // `syncStartedAt`. It also guards the INSERT, which the timestamp cannot —
+    // `ON CONFLICT … WHERE` never runs when there is no conflicting row, so a
+    // sync that began pre-invalidation could otherwise create a brand-new
+    // `fresh` row afterward.
+    //
+    // The timestamp fence stays for the same-generation case: two concurrent
+    // syncs of one connection, where the later-starting one must not be
+    // overwritten by an older snapshot finishing after it.
+    //
+    // A missing organization row maps to null so standalone graph tests with a
+    // synthetic org keep the historical materializer semantics.
     await tx`
 		INSERT INTO authz_source_acl_state
 			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
@@ -340,11 +370,14 @@ export async function buildAccessGraph(params: {
   memberIdentities: AccessIdentitySpec[];
   resources: AccessResource[];
   /**
-   * Database time captured before the source snapshot began. A newer ACL-state
-   * write means that snapshot lost a revocation race and must not mark the
-   * connection fresh.
+   * Database time and org generation captured together before the source
+   * snapshot began. A caller that captures its own remote snapshot supplies
+   * this pair; otherwise the graph builder captures it before reconciliation.
    */
-  syncStartedAt?: string;
+  syncFence?: {
+    startedAt: string;
+    generation: string | null;
+  };
   /**
    * Whether this build may stamp the connection fresh. Default true — one build
    * IS the whole connection for a single-scope source (GitHub). A caller that
@@ -358,13 +391,23 @@ export async function buildAccessGraph(params: {
   const resources = params.resources.filter((r) => r.key);
   if (resources.length === 0) return EMPTY_RESULT;
 
-  const syncStartedAt =
-    params.syncStartedAt ??
-    (
-      await getDb()<{ sync_started_at: string }>`
-        SELECT clock_timestamp()::text AS sync_started_at
-      `
-    )[0].sync_started_at;
+  // Read the cutoff and generation in one statement so an invalidation cannot
+  // land between the two observations and produce an incoherent fence.
+  let syncFence = params.syncFence;
+  if (!syncFence) {
+    const [observed] = await getDb()<{
+      sync_started_at: string;
+      acl_generation: string | null;
+    }>`
+      SELECT clock_timestamp()::text AS sync_started_at,
+             (SELECT o.acl_generation::text FROM organization o WHERE o.id = ${organizationId})
+               AS acl_generation
+    `;
+    syncFence = {
+      startedAt: observed.sync_started_at,
+      generation: observed.acl_generation ?? null,
+    };
+  }
 
   const creatorUserId = await resolveOrgCreator(organizationId);
   if (!creatorUserId) {
@@ -560,7 +603,12 @@ export async function buildAccessGraph(params: {
   );
 
   if (params.markFresh !== false) {
-    await markAclFresh(organizationId, connectionId, syncStartedAt);
+    await markAclFresh(
+      organizationId,
+      connectionId,
+      syncFence.startedAt,
+      syncFence.generation,
+    );
   }
 
   logger.info(

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -48,6 +48,7 @@ import {
 import { ensureRelationshipType, upsertEdges } from '../utils/edge-writes.js';
 import { withAclEdgeWrite } from '../utils/relationship-validation.js';
 import { aclConnectionIdSql } from './acl-observability.js';
+import { type AclSyncFence, captureAclSyncFence } from './acl-generation.js';
 import { ensureResourceEntityType } from './acl-resource-type.js';
 
 const logger = createLogger('access-graph');
@@ -131,11 +132,12 @@ export function ensureMemberOfType(orgId: string): Promise<number> {
  * already contradicted. Skipping the stamp leaves the row `stale`, the gate
  * fails closed, and the next sync rebuilds from current membership.
  *
- * NOT a general concurrency fix: overlapping syncs can still interleave their
- * EDGE writes, which this cannot see. That race predates this fence (on
- * `origin/main` the stamp was unconditional) and closing it properly needs one
- * graph build per connection or a per-build snapshot id — a separate change,
- * deliberately not smuggled in here.
+ * This fence covers the STAMP only. It cannot see an EDGE write, so on its own
+ * it does not stop two overlapping syncs of one connection from interleaving:
+ * the loser's stamp is refused, but its edges are already written. That half is
+ * closed by `withAclConnectionSyncLock`, which orders syncs of a connection so
+ * the interleaving cannot arise; this fence then covers the case no
+ * per-connection lock can order — an invalidation racing a sync.
  *
  * Exported because the stamp is CONNECTION-wide while a build is per-resource-
  * set: a caller that reconciles one connection across several source scopes
@@ -147,11 +149,32 @@ export function ensureMemberOfType(orgId: string): Promise<number> {
 export async function markAclFresh(
   orgId: string,
   connectionId: string,
-  syncStartedAt: string,
-  aclGeneration: string | null,
+  fence: AclSyncFence,
 ): Promise<void> {
+  const { startedAt: syncStartedAt, generation: aclGeneration } = fence;
   const sql = getDb();
   await sql.begin(async (tx) => {
+    // ORGANIZATION FIRST, and the order is the whole point.
+    //
+    // Every writer here takes organization -> connections -> ACL state. That
+    // matches the one path that already locks in that order and cannot be
+    // changed: deleting an organization locks the org row, then its
+    // `ON DELETE CASCADE` deletes the connections beneath it
+    // (`connections_organization_id_fkey`). Locking the connection first and
+    // then waiting for the org row would invert that and deadlock a stamp
+    // against a concurrent org deletion.
+    //
+    // Holding it as FOR SHARE also fences the comparison: an invalidation's
+    // `UPDATE organization` conflicts with the share lock, so if it began first
+    // this waits and then reads the NEW generation, and if this began first the
+    // invalidation waits and applies after this transaction commits.
+    const generationRows = await tx<{ acl_generation: string }>`
+      SELECT acl_generation::text AS acl_generation
+      FROM organization
+      WHERE id = ${orgId}
+      FOR SHARE
+    `;
+
     // Serialize the state stamp with the connection tombstone. A sync can spend
     // seconds fetching a remote membership snapshot after the scheduler selected
     // the row; without this lock, deletion can remove the old ACL state and the
@@ -168,18 +191,14 @@ export async function markAclFresh(
     `;
     if (connections.length > 0 && connections.every((row) => row.deleted_at != null)) return;
 
-    // Lock the org generation before touching ACL state. An invalidation takes
-    // the same locks in the same order: if it began first, this waits and then
-    // observes the new generation; if this began first, the invalidation waits
-    // and makes the state stale after this transaction commits.
-    const generationRows = await tx<{ acl_generation: string }>`
-      SELECT acl_generation::text AS acl_generation
-      FROM organization
-      WHERE id = ${orgId}
-      FOR SHARE
-    `;
-    const currentGeneration = generationRows[0]?.acl_generation ?? null;
-    if (currentGeneration !== aclGeneration) return;
+    // A missing organization row is not a fence we can evaluate: there is no
+    // generation to compare, so refuse the stamp rather than publish a
+    // projection whose freshness cannot be verified. `connections` has an
+    // ON DELETE CASCADE FK to `organization`, so a live connection cannot
+    // outlive its org — this fires only for an orphaned state row or a job
+    // racing org deletion, and both must fail closed.
+    if (generationRows.length === 0) return;
+    if (generationRows[0].acl_generation !== aclGeneration) return;
 
     // Two fences, and both are load-bearing.
     //
@@ -195,8 +214,6 @@ export async function markAclFresh(
     // syncs of one connection, where the later-starting one must not be
     // overwritten by an older snapshot finishing after it.
     //
-    // A missing organization row maps to null so standalone graph tests with a
-    // synthetic org keep the historical materializer semantics.
     await tx`
 		INSERT INTO authz_source_acl_state
 			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
@@ -374,10 +391,7 @@ export async function buildAccessGraph(params: {
    * snapshot began. A caller that captures its own remote snapshot supplies
    * this pair; otherwise the graph builder captures it before reconciliation.
    */
-  syncFence?: {
-    startedAt: string;
-    generation: string | null;
-  };
+  syncFence?: AclSyncFence;
   /**
    * Whether this build may stamp the connection fresh. Default true — one build
    * IS the whole connection for a single-scope source (GitHub). A caller that
@@ -391,23 +405,12 @@ export async function buildAccessGraph(params: {
   const resources = params.resources.filter((r) => r.key);
   if (resources.length === 0) return EMPTY_RESULT;
 
-  // Read the cutoff and generation in one statement so an invalidation cannot
-  // land between the two observations and produce an incoherent fence.
-  let syncFence = params.syncFence;
-  if (!syncFence) {
-    const [observed] = await getDb()<{
-      sync_started_at: string;
-      acl_generation: string | null;
-    }>`
-      SELECT clock_timestamp()::text AS sync_started_at,
-             (SELECT o.acl_generation::text FROM organization o WHERE o.id = ${organizationId})
-               AS acl_generation
-    `;
-    syncFence = {
-      startedAt: observed.sync_started_at,
-      generation: observed.acl_generation ?? null,
-    };
-  }
+  // A caller that reads a remote snapshot BEFORE calling this must capture its
+  // own fence first and pass it — capturing here would observe a generation an
+  // invalidation had already bumped during that read, so the stale snapshot
+  // would satisfy its own fence. Both production syncs do exactly that; this
+  // fallback serves direct callers that build from data already in hand.
+  const syncFence = params.syncFence ?? (await captureAclSyncFence(organizationId));
 
   const creatorUserId = await resolveOrgCreator(organizationId);
   if (!creatorUserId) {
@@ -603,12 +606,7 @@ export async function buildAccessGraph(params: {
   );
 
   if (params.markFresh !== false) {
-    await markAclFresh(
-      organizationId,
-      connectionId,
-      syncFence.startedAt,
-      syncFence.generation,
-    );
+    await markAclFresh(organizationId, connectionId, syncFence);
   }
 
   logger.info(

--- a/packages/server/src/authz/acl-generation.ts
+++ b/packages/server/src/authz/acl-generation.ts
@@ -1,0 +1,28 @@
+import type { DbClient } from '../db/client.js';
+
+/**
+ * Invalidate in-flight ACL syncs for an organization.
+ *
+ * This must share the transaction that mutates the projection. Committing the
+ * bump separately could let a sync observe it without the mutation it fences.
+ */
+export async function bumpAclGeneration(tx: DbClient, orgId: string): Promise<void> {
+  await tx`
+    UPDATE organization
+    SET acl_generation = acl_generation + 1
+    WHERE id = ${orgId}
+  `;
+}
+
+/** Fail closed every ACL projection whose entity graph changed outside a sync. */
+export async function invalidateOrgAcl(tx: DbClient, orgId: string): Promise<void> {
+  // Lock the generation before ACL-state rows. `markAclFresh` uses the same
+  // order, so its comparison cannot read an old generation and then wait behind
+  // the invalidation's state-row lock.
+  await bumpAclGeneration(tx, orgId);
+  await tx`
+    UPDATE authz_source_acl_state
+    SET freshness_state = 'stale', updated_at = clock_timestamp()
+    WHERE organization_id = ${orgId}
+  `;
+}

--- a/packages/server/src/authz/acl-generation.ts
+++ b/packages/server/src/authz/acl-generation.ts
@@ -1,4 +1,40 @@
-import type { DbClient } from '../db/client.js';
+import { type DbClient, getDb } from '../db/client.js';
+
+/**
+ * The pair a sync must capture BEFORE it reads anything — provider snapshot or
+ * membership — and carry through to its fresh stamp.
+ */
+export interface AclSyncFence {
+  /** Cutoff for the secondary same-generation ordering fence. */
+  startedAt: string;
+  /** Null only when the organization row is absent. */
+  generation: string | null;
+}
+
+/**
+ * Capture the cutoff and the generation in ONE statement.
+ *
+ * Two statements would let an invalidation land between them and produce an
+ * incoherent fence: a generation from before it paired with a cutoff from
+ * after, which passes both checks while describing neither state.
+ */
+export async function captureAclSyncFence(
+  orgId: string,
+  sql: DbClient = getDb()
+): Promise<AclSyncFence> {
+  const [observed] = await sql<{
+    sync_started_at: string;
+    acl_generation: string | null;
+  }>`
+    SELECT clock_timestamp()::text AS sync_started_at,
+           (SELECT o.acl_generation::text FROM organization o WHERE o.id = ${orgId})
+             AS acl_generation
+  `;
+  return {
+    startedAt: observed.sync_started_at,
+    generation: observed.acl_generation ?? null,
+  };
+}
 
 /**
  * Invalidate in-flight ACL syncs for an organization.
@@ -11,6 +47,29 @@ export async function bumpAclGeneration(tx: DbClient, orgId: string): Promise<vo
     UPDATE organization
     SET acl_generation = acl_generation + 1
     WHERE id = ${orgId}
+  `;
+}
+
+/**
+ * Take the organization row FIRST, before a transaction locks any row beneath
+ * it that will later bump the generation.
+ *
+ * Organization deletion locks the org row and then cascades into `entities`,
+ * `connections`, and the rest. A transaction that locks entity or connection
+ * rows first and only afterwards updates `organization` inverts that order and
+ * deadlocks against a concurrent delete. Every invalidating transaction —
+ * merge, unmerge, force-delete, approval-driven merge — therefore claims the
+ * parent up front.
+ */
+export async function lockOrgForAclInvalidation(
+  tx: DbClient,
+  orgId: string
+): Promise<void> {
+  await tx`
+    SELECT 1
+    FROM organization
+    WHERE id = ${orgId}
+    FOR UPDATE
   `;
 }
 

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -6,6 +6,7 @@
  */
 
 import { type DbClient, getDb } from "../db/client.js";
+import { bumpAclGeneration } from "./acl-generation.js";
 
 const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
 
@@ -52,8 +53,8 @@ export function aclConnectionIdSql(tableAlias?: "c"): string {
  * `ChatInstanceManager` hydrates chat adapters against (`rowVersion`), so a
  * repeated identical failure would otherwise tear down and rehydrate
  * otherwise-working Slack instances for the length of the outage. The ACL
- * state's own timestamp still advances on every failure: `markAclFresh` uses it
- * as a fence so an older in-flight snapshot cannot overwrite a newer failure.
+ * state's own timestamp and the org generation still advance on every failure,
+ * so an older in-flight snapshot cannot overwrite a newer failure.
  */
 export async function markConnectionAclFailed(
 	organizationId: string,
@@ -64,9 +65,9 @@ export async function markConnectionAclFailed(
 	const message = formatAclErrorMessage(reason);
 	await sql.begin(async (tx) => {
 		// Lock the live connection row FIRST and UNCONDITIONALLY. Two reasons:
-		// (1) lock order is connections → ACL state, matching connection deletion
-		// and fresh-state stamping, so a failing sync cannot deadlock against a
-		// concurrent delete; (2) the message UPDATE below is conditional, so a
+		// (1) lock order begins with connections, matching connection deletion and
+		// fresh-state stamping, so a failing sync cannot deadlock against a concurrent
+		// delete; (2) the message UPDATE below is conditional, so a
 		// repeated identical failure would take no row lock at all and could
 		// interleave with `clearConnectionAclError`.
 		await tx`
@@ -89,6 +90,8 @@ export async function markConnectionAclFailed(
         )
         AND error_message IS DISTINCT FROM ${message}
     `;
+		// Take the generation lock before ACL state, matching `markAclFresh`.
+		await bumpAclGeneration(tx, organizationId);
 		await tx`
       UPDATE authz_source_acl_state
       SET freshness_state = 'failed', updated_at = clock_timestamp()

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -64,12 +64,15 @@ export async function markConnectionAclFailed(
 	const sql = getDb();
 	const message = formatAclErrorMessage(reason);
 	await sql.begin(async (tx) => {
-		// Lock the live connection row FIRST and UNCONDITIONALLY. Two reasons:
-		// (1) lock order begins with connections, matching connection deletion and
-		// fresh-state stamping, so a failing sync cannot deadlock against a concurrent
-		// delete; (2) the message UPDATE below is conditional, so a
-		// repeated identical failure would take no row lock at all and could
-		// interleave with `clearConnectionAclError`.
+		// ORGANIZATION FIRST, then connections, then ACL state — the same order as
+		// `markAclFresh` and as organization deletion, whose `ON DELETE CASCADE`
+		// reaches connections while already holding the org row. Bumping after the
+		// connection lock would invert that and deadlock against a concurrent org
+		// delete.
+		await bumpAclGeneration(tx, organizationId);
+		// Then lock the live connection row UNCONDITIONALLY: the message UPDATE
+		// below is conditional, so a repeated identical failure would take no row
+		// lock at all and could interleave with `clearConnectionAclError`.
 		await tx`
       SELECT 1
       FROM connections
@@ -90,8 +93,6 @@ export async function markConnectionAclFailed(
         )
         AND error_message IS DISTINCT FROM ${message}
     `;
-		// Take the generation lock before ACL state, matching `markAclFresh`.
-		await bumpAclGeneration(tx, organizationId);
 		await tx`
       UPDATE authz_source_acl_state
       SET freshness_state = 'failed', updated_at = clock_timestamp()

--- a/packages/server/src/authz/acl-sync-lock.ts
+++ b/packages/server/src/authz/acl-sync-lock.ts
@@ -1,0 +1,79 @@
+/**
+ * Serializes ACL syncs per connection.
+ *
+ * The generation counter fences the FRESH STAMP, not the edge writes that
+ * precede it — `buildAccessGraph` reconciles membership in one transaction and
+ * stamps in another. Two syncs of the SAME connection can therefore interleave
+ * into a published leak that no generation check can see:
+ *
+ *   1. sync A captures generation 0, holding a snapshot that still contains a
+ *      since-revoked member U
+ *   2. an unmerge commits generation 1, drops U's edges, marks the state stale
+ *   3. sync B captures generation 1, reconciles U away, stamps fresh — its
+ *      generation still matches, so the stamp is correct
+ *   4. A writes U's `member_of` edge back; nothing fences an edge WRITE
+ *   5. A's stamp is refused (0 != 1), which is too late
+ *
+ * The connection ends at generation 1, `fresh`, with U's revoked edge live, and
+ * the gate serves U. Ordering the two syncs removes step 4 entirely.
+ *
+ * The counter still earns its place: it covers an invalidation racing a sync of
+ * a DIFFERENT connection, which no per-connection lock can order. There the
+ * refused stamp leaves the state stale, which fails closed.
+ */
+
+import { getLockDb } from "../db/client.js";
+
+const ACL_SYNC_LOCK_NS = "acl_connection_sync";
+
+export type AclSyncLockOutcome<T> =
+	| { ran: true; value: T }
+	| { ran: false; value?: undefined };
+
+/**
+ * Run an entire ACL sync for one connection under a SESSION advisory lock.
+ *
+ * Session-scoped rather than `pg_advisory_xact_lock`: a sync spans several
+ * transactions on the main pool (graph build, edge reconcile, fresh stamp), and
+ * a transaction-scoped lock would release at the first commit — reopening the
+ * window this closes. Acquire and release happen on ONE reserved connection so
+ * the session identity is stable; any other connection serving the unlock makes
+ * Postgres raise `you don't own a lock of type ExclusiveLock`.
+ *
+ * The reserved connection comes from the DEDICATED lock pool. A holder camps on
+ * a connection for the whole sync while the sync's own queries run on the main
+ * pool; camping on the main pool instead would let `DB_POOL_MAX` concurrent
+ * syncs consume every slot and starve the very queries they are waiting on —
+ * the permanent pool-wide deadlock `getLockDb` exists to prevent.
+ *
+ * TRY, not wait. A caller that cannot get the lock is a redundant sync of a
+ * connection already being synced, and the holder is producing a fresher result
+ * from a newer snapshot. Queueing would add a stale second pass and needs a
+ * `lock_timeout` to bound it; skipping needs neither.
+ *
+ * Returns `{ ran: false }` when another sync held the lock. Callers MUST NOT
+ * report that as success — a skipped sync has published nothing, so treating it
+ * as done would suppress the retry that a genuinely failed sync deserves.
+ */
+export async function withAclConnectionSyncLock<T>(
+	connectionId: string,
+	fn: () => Promise<T>,
+): Promise<AclSyncLockOutcome<T>> {
+	const reserved = await getLockDb().reserve();
+	try {
+		const [acquisition] = await reserved<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${ACL_SYNC_LOCK_NS}), hashtext(${connectionId}))
+        AS acquired
+    `;
+		if (!acquisition?.acquired) return { ran: false };
+		try {
+			return { ran: true, value: await fn() };
+		} finally {
+			await reserved`
+        SELECT pg_advisory_unlock(hashtext(${ACL_SYNC_LOCK_NS}), hashtext(${connectionId}))
+      `;
+		}
+	} finally {
+		reserved.release();
+	}
+}

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -29,6 +29,8 @@ import {
   markConnectionAclFailed,
 } from './acl-observability.js';
 import { buildAccessGraph } from './access-graph.js';
+import { captureAclSyncFence } from './acl-generation.js';
+import { withAclConnectionSyncLock } from './acl-sync-lock.js';
 
 const logger = createLogger('github-acl-sync');
 
@@ -52,6 +54,12 @@ export interface GithubAclSyncDeps {
 
 export interface GithubAclSyncResult {
   ok: boolean;
+  /**
+   * True when another sync already held this connection and this call published
+   * nothing. Distinct from `ok: false`: a skip is not a failure and must NOT
+   * mark the connection failed, but nothing was reconciled either.
+   */
+  skipped?: boolean;
   reposSynced: number;
 }
 
@@ -64,7 +72,31 @@ export async function syncGithubConnectionAcl(
   deps: GithubAclSyncDeps,
   params: { connectionId: string; organizationId: string },
 ): Promise<GithubAclSyncResult> {
+  const outcome = await withAclConnectionSyncLock(params.connectionId, () =>
+    syncGithubConnectionAclLocked(deps, params),
+  );
+  if (!outcome.ran) {
+    logger.info('GitHub ACL sync skipped: another sync holds this connection', {
+      organization_id: params.organizationId,
+      connection_id: params.connectionId,
+    });
+    return { ok: false, skipped: true, reposSynced: 0 };
+  }
+  return outcome.value;
+}
+
+async function syncGithubConnectionAclLocked(
+  deps: GithubAclSyncDeps,
+  params: { connectionId: string; organizationId: string },
+): Promise<GithubAclSyncResult> {
   const { connectionId, organizationId } = params;
+
+  // Captured BEFORE any provider read. Capturing it inside `buildAccessGraph`
+  // instead — after every collaborator fetch — would observe a generation that
+  // an invalidation had already bumped while this snapshot was being taken, so
+  // the stale snapshot would then satisfy its own fence. Slack captures its
+  // fence in the same position, before its channel fetches.
+  const syncFence = await captureAclSyncFence(organizationId);
 
   const repos = await deps.listRepos({ organizationId, connectionId });
   if (repos.length === 0) {
@@ -90,6 +122,7 @@ export async function syncGithubConnectionAcl(
       resourceNamespace: githubAclSource.resourceNamespace,
       memberIdentities: githubAclSource.memberIdentities,
       resources: githubReposToResources(repoInputs),
+      syncFence,
     });
     await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, reposSynced: repoInputs.length };
@@ -194,15 +227,25 @@ export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<
 
   let ok = 0;
   let failed = 0;
+  let skipped = 0;
   for (const conn of connections) {
     const result = await syncGithubConnectionAcl(deps, {
       connectionId: conn.id,
       organizationId: conn.organization_id,
     });
     if (result.ok) ok += 1;
+    // A skip means another sync of this connection is in flight and will
+    // publish; counting it as failed would make an overlapping tick look like
+    // an outage.
+    else if (result.skipped) skipped += 1;
     else failed += 1;
   }
-  logger.info('GitHub ACL sync tick complete', { connections: connections.length, ok, failed });
+  logger.info('GitHub ACL sync tick complete', {
+    connections: connections.length,
+    ok,
+    failed,
+    skipped,
+  });
 }
 
 /** Resolve an org's GitHub App installation token (collaborator-capable), minted

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -51,7 +51,8 @@ import {
   markConnectionAclFailed,
 } from './acl-observability.js';
 import { buildAccessGraph, markAclFresh } from './access-graph.js';
-import { bumpAclGeneration } from './acl-generation.js';
+import { bumpAclGeneration, captureAclSyncFence } from './acl-generation.js';
+import { withAclConnectionSyncLock } from './acl-sync-lock.js';
 
 const logger = createLogger('slack-acl-sync');
 
@@ -138,6 +139,13 @@ export interface SlackAclSyncDeps {
 export interface SlackAclSyncResult {
   /** True when every bound Slack channel was fetched and graphed. */
   ok: boolean;
+  /**
+   * True when another sync already held this connection and this call published
+   * nothing. Distinct from `ok: false`: a skip is not a failure and must NOT
+   * mark the connection failed, but it is not success either — nothing was
+   * reconciled, so the tick must not count it as a completed sync.
+   */
+  skipped?: boolean;
   teamsSynced: number;
   channelsSynced: number;
 }
@@ -148,6 +156,23 @@ export interface SlackAclSyncResult {
  * the file header for the fail-closed contract.
  */
 export async function syncSlackConnectionAcl(
+  deps: SlackAclSyncDeps,
+  params: { connectionId: string; organizationId: string },
+): Promise<SlackAclSyncResult> {
+  const outcome = await withAclConnectionSyncLock(params.connectionId, () =>
+    syncSlackConnectionAclLocked(deps, params),
+  );
+  if (!outcome.ran) {
+    logger.info('Slack ACL sync skipped: another sync holds this connection', {
+      organization_id: params.organizationId,
+      connection_id: params.connectionId,
+    });
+    return { ok: false, skipped: true, teamsSynced: 0, channelsSynced: 0 };
+  }
+  return outcome.value;
+}
+
+async function syncSlackConnectionAclLocked(
   deps: SlackAclSyncDeps,
   params: { connectionId: string; organizationId: string },
 ): Promise<SlackAclSyncResult> {
@@ -218,14 +243,7 @@ export async function syncSlackConnectionAcl(
    * snapshot — a per-team cutoff would let a late team bless membership the
    * revocation had already contradicted for an earlier one.
    */
-  const [{ sync_started_at: syncStartedAt, acl_generation: aclGeneration }] = await sql<{
-    sync_started_at: string;
-    acl_generation: string | null;
-  }>`
-		SELECT clock_timestamp()::text AS sync_started_at,
-		       (SELECT o.acl_generation::text FROM organization o WHERE o.id = ${organizationId})
-		         AS acl_generation
-	`;
+  const syncFence = await captureAclSyncFence(organizationId, sql);
   try {
     for (const [teamId, channelIds] of byTeam) {
       const identity = await deps.resolveBotIdentity({ organizationId, teamId, connectionId });
@@ -309,7 +327,7 @@ export async function syncSlackConnectionAcl(
         resourceNamespace: slackAclSource.resourceNamespace,
         memberIdentities: slackAclSource.memberIdentities,
         resources: slackChannelsToResources(teamId, channels),
-        syncFence: { startedAt: syncStartedAt, generation: aclGeneration },
+        syncFence,
         // The stamp is connection-wide; this loop is per-workspace. See below.
         markFresh: false,
       });
@@ -326,7 +344,7 @@ export async function syncSlackConnectionAcl(
      * out of the loop to the catch below, which marks the connection failed
      * instead, so a partial reconcile can never be blessed fresh.
      */
-    await markAclFresh(organizationId, connectionId, syncStartedAt, aclGeneration);
+    await markAclFresh(organizationId, connectionId, syncFence);
     await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, teamsSynced, channelsSynced };
   } catch (error) {
@@ -538,13 +556,23 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
 
   let ok = 0;
   let failed = 0;
+  let skipped = 0;
   for (const conn of connections) {
     const result = await syncSlackConnectionAcl(deps, {
       connectionId: conn.id,
       organizationId: conn.organization_id,
     });
     if (result.ok) ok += 1;
+    // A skip means another sync of this connection is in flight and will
+    // publish; counting it as failed would make an overlapping tick look like
+    // an outage.
+    else if (result.skipped) skipped += 1;
     else failed += 1;
   }
-  logger.info('Slack ACL sync tick complete', { connections: connections.length, ok, failed });
+  logger.info('Slack ACL sync tick complete', {
+    connections: connections.length,
+    ok,
+    failed,
+    skipped,
+  });
 }

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -51,6 +51,7 @@ import {
   markConnectionAclFailed,
 } from './acl-observability.js';
 import { buildAccessGraph, markAclFresh } from './access-graph.js';
+import { bumpAclGeneration } from './acl-generation.js';
 
 const logger = createLogger('slack-acl-sync');
 
@@ -63,9 +64,9 @@ const logger = createLogger('slack-acl-sync');
  * first-sync race: a connection that has never been graphed has no row, the
  * revocation matches nothing, and the sync already holding a pre-departure
  * snapshot then INSERTs `fresh` — blessing exactly the membership Slack just
- * told us was gone. Writing the row makes the departure visible to
- * `markAclFresh`'s freshness fence, which refuses to bless a snapshot older
- * than it.
+ * told us was gone. Writing the stale row fails closed immediately; bumping the
+ * org generation in the same transaction prevents that older sync from
+ * overwriting or bypassing it.
  *
  * Writing the row DOES change enforcement, and that is the point: any existing
  * `authz_source_acl_state` row moves the connection from `not-graphed` (legacy
@@ -80,17 +81,15 @@ export async function invalidateSlackConnectionAcl(params: {
   organizationId: string;
   connectionId: string;
 }): Promise<{ aclSupport: string }> {
-  /*
-   * `clock_timestamp()`, not `current_timestamp`. The sync's freshness fence
-   * (`markAclFresh`) refuses to re-mark a connection fresh when this row was
-   * written after the snapshot began, and it captures that cutoff with
-   * `clock_timestamp()`. `current_timestamp` is TRANSACTION start time, so a
-   * revocation whose transaction opened before the cutoff but committed after
-   * it would record an `updated_at` below the cutoff, slip under the fence, and
-   * be overwritten as fresh — the precise race the fence exists to stop. Both
-   * sides have to measure the same clock.
-   */
-  const rows = await getDb()<{ acl_support: string }>`
+  // `clock_timestamp()`, not transaction-start `current_timestamp`, preserves
+  // the secondary ordering fence between syncs in the same generation. The
+  // `markAclFresh` generation comparison handles commit visibility across
+  // invalidations.
+  // The stale write and the generation bump commit together: a sync observing
+  // one without the other would see an inconsistent invalidation.
+  const rows = await getDb().begin(async (tx) => {
+    await bumpAclGeneration(tx, params.organizationId);
+    const stamped = await tx<{ acl_support: string }>`
 		INSERT INTO authz_source_acl_state
 			(organization_id, connection_id, acl_support, freshness_state, updated_at)
 		VALUES (${params.organizationId}, ${params.connectionId}, 'none', 'stale', clock_timestamp())
@@ -98,6 +97,8 @@ export async function invalidateSlackConnectionAcl(params: {
 		DO UPDATE SET freshness_state = 'stale', updated_at = clock_timestamp()
 		RETURNING acl_support
 	`;
+    return stamped;
+  });
   // The upsert always yields a row, so a boolean "did it work" would be a
   // constant. Report the resulting support level instead — 'full' means an
   // already-enforcing connection went stale, 'none' means this revocation is
@@ -217,10 +218,13 @@ export async function syncSlackConnectionAcl(
    * snapshot — a per-team cutoff would let a late team bless membership the
    * revocation had already contradicted for an earlier one.
    */
-  const [{ sync_started_at: syncStartedAt }] = await sql<{
+  const [{ sync_started_at: syncStartedAt, acl_generation: aclGeneration }] = await sql<{
     sync_started_at: string;
+    acl_generation: string | null;
   }>`
-		SELECT clock_timestamp()::text AS sync_started_at
+		SELECT clock_timestamp()::text AS sync_started_at,
+		       (SELECT o.acl_generation::text FROM organization o WHERE o.id = ${organizationId})
+		         AS acl_generation
 	`;
   try {
     for (const [teamId, channelIds] of byTeam) {
@@ -305,7 +309,7 @@ export async function syncSlackConnectionAcl(
         resourceNamespace: slackAclSource.resourceNamespace,
         memberIdentities: slackAclSource.memberIdentities,
         resources: slackChannelsToResources(teamId, channels),
-        syncStartedAt,
+        syncFence: { startedAt: syncStartedAt, generation: aclGeneration },
         // The stamp is connection-wide; this loop is per-workspace. See below.
         markFresh: false,
       });
@@ -322,7 +326,7 @@ export async function syncSlackConnectionAcl(
      * out of the loop to the catch below, which marks the connection failed
      * instead, so a partial reconcile can never be blessed fresh.
      */
-    await markAclFresh(organizationId, connectionId, syncStartedAt);
+    await markAclFresh(organizationId, connectionId, syncStartedAt, aclGeneration);
     await clearConnectionAclError(organizationId, connectionId);
     return { ok: true, teamsSynced, channelsSynced };
   } catch (error) {

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -12,6 +12,7 @@ import {
 	resolveWritePolicyDecision,
 	automationIdFromPrincipalId,
 } from "../../../../authz/entity-policy";
+import { lockOrgForAclInvalidation } from "../../../../authz/acl-generation";
 import { type DbClient, getDb, parsePgNumberArray, pgTextArray } from "../../../../db/client";
 import { lockResolutionCandidate, wasResolutionRejected } from "../../../../entity-resolution/rejection";
 import { droppedEvidence } from "../../../../entity-resolution/evidence-strength";
@@ -1050,6 +1051,11 @@ async function tryApproveEntityChangeRun(
 	if (pendingOperation === "merge") {
 		try {
 			return await sql.begin(async (tx) => {
+				// The merge below bumps the org ACL generation, so claim the org
+				// row before the approval-run and candidate entity rows —
+				// organization deletion locks the parent and cascades downward, and
+				// the reverse order deadlocks against it.
+				await lockOrgForAclInvalidation(tx, ctx.organizationId);
 				const claimed = await claimEntityChangeRun(
 					args.run_id,
 					ctx.organizationId,

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -41,6 +41,7 @@ import { ToolUserError } from "./errors";
 import logger from "./logger";
 import { requireWriteAccess } from "./organization-access";
 import { RESERVED_ENTITY_TYPE_SLUGS } from "./reserved";
+import { invalidateOrgAcl } from "../authz/acl-generation";
 import { withAclPrivilege } from "./relationship-validation";
 
 /** Minimal type shape needed to count stored vs derived entity rows. */
@@ -1357,6 +1358,10 @@ export async function deleteEntity(
              OR to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
         `;
       });
+      // Fail closed until a sync based on the post-delete graph completes. The
+      // generation also fences an older sync that has resolved, but not yet
+      // written, a grant involving one of the deleted entities.
+      await invalidateOrgAcl(tx, ctx.organizationId);
 
       // Canvas-on-events: window_id link rows carry canvas root event ids, so
       // key the cleanup on the denormalized automation_id.

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -41,7 +41,10 @@ import { ToolUserError } from "./errors";
 import logger from "./logger";
 import { requireWriteAccess } from "./organization-access";
 import { RESERVED_ENTITY_TYPE_SLUGS } from "./reserved";
-import { invalidateOrgAcl } from "../authz/acl-generation";
+import {
+	invalidateOrgAcl,
+	lockOrgForAclInvalidation,
+} from "../authz/acl-generation";
 import { withAclPrivilege } from "./relationship-validation";
 
 /** Minimal type shape needed to count stored vs derived entity rows. */
@@ -1343,6 +1346,10 @@ export async function deleteEntity(
     // and lets the GIN index on entity_ids drive the scan instead of a
     // full-table pass.
     await sql.begin(async (tx) => {
+      // Parent row first: this locks the entity tree below and then bumps the
+      // org generation, the reverse of organization deletion's parent-then-
+      // cascade order unless the org is claimed up front.
+      await lockOrgForAclInvalidation(tx, ctx.organizationId);
       // Force-delete removes ACL edges along with everything else. That is
       // correct — the entity is gone, so its membership projection must go too —
       // but the `entity_relationships` trigger refuses authorization-bearing

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -25,7 +25,10 @@
  */
 
 import { isDeepStrictEqual } from "node:util";
-import { invalidateOrgAcl } from "../authz/acl-generation";
+import {
+	invalidateOrgAcl,
+	lockOrgForAclInvalidation,
+} from "../authz/acl-generation";
 import { type DbClient, getDb, pgBigintArray } from "../db/client";
 import { mergeEntityState } from "../entity-resolution/merge-state";
 import {
@@ -102,6 +105,12 @@ export async function applyMergeGroupInTransaction(
 		throw new Error("applyMergeGroup: canonical entity is also a duplicate");
   }
 
+  // The organization outranks the entities: this transaction bumps the org
+  // generation after locking entity rows, while organization deletion locks the
+  // org and then cascades into `entities`. Claim the parent first or the two
+  // deadlock.
+  await lockOrgForAclInvalidation(tx, params.orgId);
+
   // Lock the whole group in one global order before applying any member. Pairwise
   // locking inside the loop is not sufficient: overlapping groups with different
   // winners can otherwise each hold one entity while waiting for the other.
@@ -143,6 +152,11 @@ export async function applyMergeGroupInTransaction(
     movedIdentities += result.movedIdentities;
     repointedEdges += result.repointedEdges;
   }
+  // ONCE for the whole group, not once per loser. The invalidation is org-wide
+  // and idempotent within a transaction, so a 100-loser group doing 100 bumps
+  // and 100 org-wide state updates buys nothing and multiplies the write cost
+  // and the row-lock hold time by 100.
+  await invalidateOrgAcl(tx, params.orgId);
   return { mergedEntityIds: loserIds, movedIdentities, repointedEdges };
 }
 
@@ -156,7 +170,15 @@ export async function applyMerge(
   params: ApplyMergeParams,
   db: DbClient = getDb(),
 ): Promise<ApplyMergeResult> {
-	return db.begin((tx) => applyMergeInTransaction(params, tx));
+	// Invalidation lives with the transaction OWNER, not inside
+	// `applyMergeInTransaction`, so the group path can invalidate once for all its
+	// losers instead of once each.
+	return db.begin(async (tx) => {
+		await lockOrgForAclInvalidation(tx, params.orgId);
+		const result = await applyMergeInTransaction(params, tx);
+		await invalidateOrgAcl(tx, params.orgId);
+		return result;
+	});
 }
 
 async function applyMergeInTransaction(
@@ -329,11 +351,6 @@ async function applyMergeInTransaction(
         AND (r.from_entity_id = ${loserId} OR r.to_entity_id = ${loserId})
     `;
   });
-  // Keep the projection untrusted until a post-merge sync completes. Merely
-  // skipping an older sync's stamp is insufficient when the existing state row
-  // is already fresh.
-  await invalidateOrgAcl(tx, orgId);
-
   // 3. Tombstone loser edges that would become self-loops or collide with an
   //    existing winner edge. This must happen before repointing: the live-edge
   //    unique index rejects the collision during UPDATE, before a later cleanup
@@ -534,6 +551,7 @@ export async function applyUnmerge(
   const { orgId, loserId, unmergedBy } = params;
 
   return db.begin(async (tx) => {
+    await lockOrgForAclInvalidation(tx, orgId);
     // Discover the winner WITHOUT locking first: we can't name the winner until
     // we read merged_into, but taking the loser's lock here would grab the
     // loser's row before the winner's — inverting applyMerge's lowest-id-first

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -25,6 +25,7 @@
  */
 
 import { isDeepStrictEqual } from "node:util";
+import { invalidateOrgAcl } from "../authz/acl-generation";
 import { type DbClient, getDb, pgBigintArray } from "../db/client";
 import { mergeEntityState } from "../entity-resolution/merge-state";
 import {
@@ -328,6 +329,10 @@ async function applyMergeInTransaction(
         AND (r.from_entity_id = ${loserId} OR r.to_entity_id = ${loserId})
     `;
   });
+  // Keep the projection untrusted until a post-merge sync completes. Merely
+  // skipping an older sync's stamp is insufficient when the existing state row
+  // is already fresh.
+  await invalidateOrgAcl(tx, orgId);
 
   // 3. Tombstone loser edges that would become self-loops or collide with an
   //    existing winner edge. This must happen before repointing: the live-edge
@@ -812,10 +817,9 @@ export async function applyUnmerge(
 		// Dropping the edges is not enough on its own: a sync that resolved the
 		// loser's provider identity to the WINNER before this transaction can
 		// still be in flight and would write that already-resolved grant back
-		// moments after we commit. Marking the ACL state stale closes that race
-		// from both ends — the gate stops trusting the snapshot, and the in-flight
-		// sync's own `fresh` stamp is suppressed because it only applies while
-		// `updated_at < syncStartedAt`, which this write invalidates.
+		// moments after we commit. Marking the ACL state stale makes the gate stop
+		// trusting the snapshot; bumping the generation below prevents that sync
+		// from marking it fresh again after this transaction commits.
 		//
 		// NOT gated on having dropped anything, which is the subtle part. The race
 		// this exists for is exactly the case where the drop finds nothing: the
@@ -823,30 +827,16 @@ export async function applyUnmerge(
 		// written the edge, so counting dropped rows would skip the invalidation
 		// in precisely the window that needs it.
 		//
-		// Marking unconditionally is cheap where it does not apply: the statement
-		// matches no rows for an org that has never onboarded an ACL connection,
-		// so an ERP-only tenant pays nothing. Where it does match, `stale` FAILS
-		// CLOSED for every enforced connection until the next sync — an
+		// Marking unconditionally is harmless where it does not apply: the state
+		// update matches no rows for an org that has never onboarded an ACL
+		// connection. Where it does match, `stale` FAILS CLOSED for every enforced
+		// connection until the next sync — an
 		// availability cost taken deliberately on a rare, admin-initiated action,
 		// because the alternative is serving access the provider never granted.
 		//
-		// `clock_timestamp()` rather than `current_timestamp` is load-bearing for
-		// the same reason it is in `slack-acl-sync.ts`: the latter is
-		// transaction-START time, which would record a cutoff below an in-flight
-		// sync's and slip under the fence.
-		//
-		// KNOWN RESIDUAL, narrower than what it replaces: a sync that starts after
-		// this statement executes but before the transaction commits reads the old
-		// identity mapping and can still satisfy `updated_at < syncStartedAt`,
-		// because that predicate orders statement timestamps, not commit
-		// visibility. Closing it needs a generation counter observed at sync start
-		// rather than a timestamp. Today unmerge invalidates nothing at all, so the
-		// winner keeps the grant indefinitely; this is strictly better.
-		await tx`
-      UPDATE authz_source_acl_state
-      SET freshness_state = 'stale', updated_at = clock_timestamp()
-      WHERE organization_id = ${orgId}
-    `;
+		// `clock_timestamp()` remains the secondary fence for two syncs within one
+		// generation; the counter covers commit visibility across invalidations.
+		await invalidateOrgAcl(tx, orgId);
 
 		// 1. Restore every identity this operation moved, including identities an
 		//    inner merge had already placed on the loser. Legacy operations have no


### PR DESCRIPTION
## Summary
- The freshness fence compared `authz_source_acl_state.updated_at < syncStartedAt`, which orders **statement** timestamps, not **commit visibility**. An invalidation could stamp `updated_at` at T1 and commit at T3; a sync starting at T2 (T1 < T2 < T3) never saw it in its snapshot, read T1 < T2, and blessed the connection `fresh` on membership the provider had already revoked.
- The timestamp also cannot guard the INSERT path: `ON CONFLICT … WHERE` never runs when there is no conflicting row, so a sync that began pre-invalidation could create a brand-new `fresh` row afterward. A per-row counter cannot guard a row that did not exist to be bumped, which is why the counter is org-scoped.

**Two mechanisms, because neither is sufficient alone.** This was the central finding of the design review: a generation counter fences the *stamp*, never the *edge writes* that precede it — `buildAccessGraph` reconciles membership in one transaction and stamps in another. Two overlapping syncs of one connection therefore publish a leak no generation check can see:

1. sync A captures generation 0, holding a snapshot that still contains revoked member U
2. an unmerge commits generation 1, drops U's edges, marks the state stale
3. sync B captures generation 1, reconciles U away, stamps fresh — correctly, its generation matches
4. A writes U's `member_of` edge back; **nothing fences an edge write**
5. A's stamp is refused (0 ≠ 1) — too late

Final state: generation 1, `fresh`, with U's revoked edge live. So:

- `withAclConnectionSyncLock` serializes syncs of one connection on a **session** advisory lock from the dedicated lock pool. Session-scoped because a sync spans several transactions and a tx-scoped lock would release at the first commit. `pg_try_advisory_lock`, so a redundant sync **skips** rather than queues — the holder is already producing a fresher result, and skipping needs no `lock_timeout` to bound it. This removes step 4 entirely.
- The **org-scoped generation counter** covers what no per-connection lock can order: an invalidation racing a sync. There the refused stamp leaves the state stale, which fails closed.

Also fixed:
- **GitHub captured its fence after the remote snapshot** — every collaborator fetch happened before `buildAccessGraph`, where the default capture lived, so a stale snapshot satisfied its own fence. Now captured before `listRepos`, matching Slack.
- **Lock order is uniformly `organization → children → ACL state`** across all seven writers. Organization deletion holds the org row and cascades into `connections` and `entities` (`connections_organization_id_fkey ON DELETE CASCADE`), so any transaction locking those first and bumping the generation afterward deadlocked against a concurrent delete. Five invalidating transactions now claim the parent up front via `lockOrgForAclInvalidation`.
- **Merge groups bumped once per loser** — a 100-loser group did 100 bumps and 100 org-wide state updates. Now once per group.
- **A missing organization row let the stamp proceed** (`null !== null` is false). It now fails closed; the test asserts the refusal rather than the old fail-open.
- **A skipped sync returns `skipped: true`**, distinct from `ok: false`. `markAclFresh` returns `void`, so a superseded build would otherwise report success and suppress the retry a genuinely failed sync deserves.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `cr58dq4tcp` passed, no retries)
- [x] Tests run: `bunx vitest run src/__tests__/integration/authz/ src/__tests__/integration/entities/ src/__tests__/integration/operations/`
- [x] Bug fix: red→green below

### Green

```
Test Files  27 passed (27)
     Tests  218 passed (218)
```

### Mutation test

Forcing the lock to never skip (`if (false && !acquisition?.acquired)`):

```
✓ runs the body and reports that it ran
× skips a second sync of the SAME connection while one is in flight
✓ does not serialize DIFFERENT connections
✓ releases the lock when the body throws
```

Exactly the serialization assertion, and only that one. Restored → green.

## Notes
Known residual, stated rather than hidden: there is no test that stages the full five-step interleaving end to end, nor one that stages a concurrent org-delete deadlock. Both are argued structurally.

Deliberately not included:
- **Moving the counter off `organization` into its own table.** That needs schema sign-off. The write volume is also far lower than a first reading suggests — only `force=true` tree deletes invalidate, and merges now bump once per group — so this is worth measuring before adding a table.
- **Suppressing invalidation on a no-op merge** (an idempotent re-run of an already-merged loser). A real availability win, but an optimization rather than a correctness fix.
- **Inert-then-arm rollout staging.** The change is additive: the column has a default, old pods ignore it, and no new code rejects an old pod's write. During a rolling deploy an old `markAclFresh` behaves exactly as it does today, so the mixed-version window is no worse than the status quo it replaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved access-control synchronization to prevent stale permissions after changes, failures, merges, unmerges, and deletions.
  * Prevented overlapping synchronization attempts for the same connection while allowing separate connections to sync concurrently.
  * Added safeguards to ensure synchronization results remain consistent during concurrent updates.

* **Monitoring**
  * Synchronization reporting now distinguishes skipped operations from failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->