### PR TITLE
fix(mcp): rehydrate approval apps after reload

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -780,11 +780,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
   });
 
-  it('keeps the standalone GET SSE channel available for server notifications', async () => {
+  it('keeps the standalone GET SSE channel available when Accept is omitted', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await get(`/mcp/${org.slug}`, {
       headers: {
-        Accept: 'text/event-stream',
         'mcp-session-id': sessionId,
         'mcp-protocol-version': MCP_PROTOCOL_VERSION,
       },

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -273,7 +273,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps prior external aliases on the external template they originally referenced', async () => {
+  it('serves every external-mapped alias from the external template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v3.html',

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -7,6 +7,7 @@ import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { buildClientSDK } from '../../../sandbox/client-sdk';
+import { LOBU_INTERACTION_RESOURCE_URI } from '../../../tools/mcp_app';
 import type { ToolContext } from '../../../tools/registry';
 import { insertEvent } from '../../../utils/insert-event';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -273,25 +274,23 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('serves every external-mapped alias from the external template', async () => {
+  it('keeps v3-v6 and every v30-and-later retired URI on the external template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
-    for (const uri of [
-      'ui://lobu/interaction/v3.html',
-      'ui://lobu/interaction/v4.html',
-      'ui://lobu/interaction/v5.html',
-      'ui://lobu/interaction/v6.html',
-      'ui://lobu/interaction/v30.html',
-      'ui://lobu/interaction/v31.html',
-      'ui://lobu/interaction/v32.html',
-      'ui://lobu/interaction/v33.html',
-      'ui://lobu/interaction/v34.html',
-      'ui://lobu/interaction/v35.html',
-      'ui://lobu/interaction/v36.html',
-      'ui://lobu/interaction/v37.html',
-      'ui://lobu/interaction/v38.html',
-      'ui://lobu/interaction/v39.html',
-      'ui://lobu/interaction/v40.html',
-    ]) {
+    // Derive the retired range from the live constant so a bump that forgets
+    // to alias the URI it replaced fails here instead of in a live chat.
+    const currentVersion = Number(
+      LOBU_INTERACTION_RESOURCE_URI.match(/\/v(\d+)\.html$/)?.[1]
+    );
+    expect(currentVersion).toBeGreaterThan(30);
+    const externalAliases = [
+      3,
+      4,
+      5,
+      6,
+      ...Array.from({ length: currentVersion - 30 }, (_, index) => 30 + index),
+    ].map((version) => `ui://lobu/interaction/v${version}.html`);
+
+    for (const uri of externalAliases) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
@@ -743,6 +742,58 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(receipt).not.toHaveProperty(key);
     }
     expect(JSON.stringify(receipt)).not.toContain('nested-sdk-save-body-must-stay-headless');
+  });
+
+  it('returns tools/call as JSON when an Inspector-style client accepts JSON and SSE', async () => {
+    const accept = 'application/json, text/event-stream';
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      headers: { Accept: accept },
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'inspector-get-approval',
+        method: 'tools/call',
+        params: {
+          name: 'get_approval',
+          arguments: { run_id: 999_999_999 },
+        },
+      },
+      headers: {
+        Accept: accept,
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+
+    // Inspector keeps a standalone GET SSE channel for server notifications.
+    // Ordinary POST request/response traffic must complete in-band as JSON;
+    // a finite POST-SSE response leaves Inspector waiting out its request
+    // timeout while a reconnecting GET stream collides with the SDK's
+    // one-standalone-stream session guard (handleGetRequest → 409).
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = await response.json();
+    expect(body.id).toBe('inspector-get-approval');
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
+  });
+
+  it('keeps the standalone GET SSE channel available for server notifications', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await get(`/mcp/${org.slug}`, {
+      headers: {
+        Accept: 'text/event-stream',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    await response.body?.cancel();
   });
 
   it('returns the viewer member role on every app-rendered result and nowhere else', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -184,14 +184,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(await initSession(`/mcp/${org.slug}`)).toBeTruthy();
   });
 
-  it('serves the external v35 interaction bundle over resources/read', async () => {
+  it('serves the external v36 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v35.html' },
+        params: { uri: 'ui://lobu/interaction/v36.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -200,7 +200,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v35.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v36.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-external-stub');
     expect(content?.text).not.toContain('mcp-app-embedded-stub');
@@ -273,7 +273,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps v3 through v6 aliases on the external template they originally referenced', async () => {
+  it('keeps prior external aliases on the external template they originally referenced', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v3.html',
@@ -285,6 +285,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       'ui://lobu/interaction/v32.html',
       'ui://lobu/interaction/v33.html',
       'ui://lobu/interaction/v34.html',
+      'ui://lobu/interaction/v35.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -371,7 +372,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v35.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v36.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -420,10 +421,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v35.html',
+            resourceUri: 'ui://lobu/interaction/v36.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v35.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v36.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -438,10 +439,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v35.html',
+            resourceUri: 'ui://lobu/interaction/v36.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v35.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v36.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -527,7 +528,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v35.html',
+        resourceUri: 'ui://lobu/interaction/v36.html',
         visibility: ['model', 'app'],
       })
     );
@@ -590,7 +591,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain('payload_data');
     expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
     expect(body.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v35.html'
+      'ui://lobu/interaction/v36.html'
     );
   });
 
@@ -1134,7 +1135,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(capability.length).toBeGreaterThan(40);
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');
     expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v35.html'
+      'ui://lobu/interaction/v36.html'
     );
     expect(JSON.stringify(view)).not.toContain(capability);
     expect(renderBody.result?.content?.[0]?.text).not.toContain(capability);

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -184,14 +184,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(await initSession(`/mcp/${org.slug}`)).toBeTruthy();
   });
 
-  it('serves the external v36 interaction bundle over resources/read', async () => {
+  it('serves the external v41 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v36.html' },
+        params: { uri: 'ui://lobu/interaction/v41.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -200,7 +200,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v36.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v41.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-external-stub');
     expect(content?.text).not.toContain('mcp-app-embedded-stub');
@@ -286,6 +286,11 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       'ui://lobu/interaction/v33.html',
       'ui://lobu/interaction/v34.html',
       'ui://lobu/interaction/v35.html',
+      'ui://lobu/interaction/v36.html',
+      'ui://lobu/interaction/v37.html',
+      'ui://lobu/interaction/v38.html',
+      'ui://lobu/interaction/v39.html',
+      'ui://lobu/interaction/v40.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -372,7 +377,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v36.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v41.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -421,10 +426,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v36.html',
+            resourceUri: 'ui://lobu/interaction/v41.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v36.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v41.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -439,10 +444,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v36.html',
+            resourceUri: 'ui://lobu/interaction/v41.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v36.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v41.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -528,7 +533,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v36.html',
+        resourceUri: 'ui://lobu/interaction/v41.html',
         visibility: ['model', 'app'],
       })
     );
@@ -591,7 +596,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain('payload_data');
     expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
     expect(body.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v36.html'
+      'ui://lobu/interaction/v41.html'
     );
   });
 
@@ -1135,7 +1140,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(capability.length).toBeGreaterThan(40);
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');
     expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v36.html'
+      'ui://lobu/interaction/v41.html'
     );
     expect(JSON.stringify(view)).not.toContain(capability);
     expect(renderBody.result?.content?.[0]?.text).not.toContain(capability);

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -1254,6 +1254,13 @@ function createSessionTransport(
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
+    // Keep request/response traffic in-band. Inspector and other clients keep
+    // one standalone GET SSE stream open for server notifications; finite
+    // POST-SSE responses can strand a tools/call until the client timeout when
+    // that stream reconnects through a proxy and hits the SDK's one-GET-stream
+    // session guard. JSON responses avoid that split delivery path while the
+    // standalone GET stream remains available for notifications.
+    enableJsonResponse: true,
     onsessioninitialized: (id) => {
       // The per-session authCtx object is shared by every request on this
       // session, so stamping once here threads the session id into each

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -192,6 +192,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v34.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
+  [
+    'ui://lobu/interaction/v35.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -196,6 +196,8 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v35.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
+  // v36-v40 were issued to live ChatGPT preview apps while this reload fix
+  // was iterated. ChatGPT caches these immutable URIs, so keep them readable.
   [
     'ui://lobu/interaction/v36.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -196,6 +196,26 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v35.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
+  [
+    'ui://lobu/interaction/v36.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v37.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v38.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v39.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v40.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -1186,7 +1186,11 @@ async function handleAndMaybeConvert(
 ): Promise<Response> {
   const rawJson = req.headers.get('x-mcp-format')?.toLowerCase() === 'json';
   const response = await mcpRequestFormat.run({ rawJson }, () => transport.handleRequest(req));
-  if (!wantsSSE && response.headers.get('content-type')?.includes('text/event-stream')) {
+  if (
+    req.method === 'POST' &&
+    !wantsSSE &&
+    response.headers.get('content-type')?.includes('text/event-stream')
+  ) {
     return sseToJson(response);
   }
   // Inject SSE heartbeat pings to keep the stream alive through proxies.

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v35.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v36.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v36.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v41.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,6 +18,9 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
+// Every bump must also add the retired URI to `MCP_APP_RESOURCE_ALIASES` in
+// mcp-handler.ts — already-rendered apps keep fetching the URI they were built
+// with, and an unmapped one fails `resources/read` for the life of that chat.
 export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v41.html';
 
 const TITLE_MAX_LENGTH = 200;


### PR DESCRIPTION
## Summary

- pin Owletto [#880](https://github.com/lobu-ai/owletto/pull/880), which makes approval cards recover server-authored state after ChatGPT reloads, preserves form state, and safely refreshes expired approval capabilities without duplicate writes
- bump the immutable ChatGPT MCP App resource from `v40` to `v41`
- retain external-template aliases for every retired `v30`-and-later URI so cached conversations continue loading
- return Streamable HTTP POST request/response traffic in-band as JSON while retaining standalone GET SSE for notifications, preventing Inspector-style clients from hanging on `tools/call`
- keep ordinary MCP data tools headless; the deleted public `render_lobu_view`, `save_lobu_app_state`, and `restore_lobu_app_result` helpers are not restored

## Test plan

- [x] Reproduced the broken cached approval state, host-recovery path, and Inspector `tools/call` timeout
- [x] Owletto focused MCP App suites: 32 passed
- [x] All Owletto MCP App suites: 132 passed
- [x] Owletto TypeScript, Biome, and `build:mcp-apps` passed; bundle verified as `v41`
- [x] Server MCP App resource integration: 29 passed
- [x] Full server MCP integration directory: 155 passed / 2 skipped
- [x] Server TypeScript passed
- [x] Official MCP Inspector against Mac-mini preview: initialize, exact 8-tool list, App-info, resources/list, v41 resources/read, and completed `get_approval` all passed
- [x] Native ChatGPT reload proof: final v41 completed card rehydrated with persisted fields and no loading state
- [x] Earlier preview interaction proof: approval form submitted exactly once, emitted the automatic continuation message, completed, and survived a second native reload
- [ ] Fresh first-click ChatGPT mutation on the final hardening commit: blocked by the test account's weekly ChatGPT usage limit until August 20; no credits were purchased
- [ ] Final `make pre-pr-remote`, semantic review, UI review, merge, and production rollout proof

Red reproduction:

```text
openai-compat: incomplete cached Lobu view was treated as authoritative
host bridge: explicit approval recovery was not requested
expired capability path could retry an ambiguous write
Inspector App-info/get_approval: POST-SSE response remained loading and timed out while GET SSE reconnect hit 409
```

Green proof:

```text
Owletto MCP App suites: 132 passed
Server MCP App resource integration: 29 passed
Server MCP integration: 155 passed, 2 skipped
Official Inspector CLI: all required calls exit 0; exact 8 tools; v41 App resource; completed run 873 with persisted values
MCP App bundle/resource: v41
```

## Notes

No database, public MCP tool, API, or SDK schema is added. Production verification will gate on the squash commit and use the existing harmless pending approval test run.
