### PR TITLE
feat(server): classify member_of as authorization-bearing

### DIFF
--- a/db/migrations/20260816020000_relationship_type_purpose.sql
+++ b/db/migrations/20260816020000_relationship_type_purpose.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+
+-- Authorization-bearing relationship types get an explicit, system-controlled
+-- classification.
+--
+-- The hole this closes: `member_of` is simultaneously an ACL primitive and
+-- ordinary domain vocabulary, and `ensureMemberOfType` does not create-or-fail —
+-- it does `ON CONFLICT (organization_id, slug) DO UPDATE`, so it ADOPTS a
+-- pre-existing active row. An org defining `member_of` in its own `lobu apply`
+-- schema for domain modelling would have that type silently promoted into the
+-- ACL path. `created_by` cannot distinguish origin: it is NULL on the platform
+-- path, and it also becomes NULL when a user is deleted.
+--
+-- Once ACL reads require this column (a SEPARATE, later deploy — see below), a
+-- type that is not classified can never grant access, so forgetting to classify
+-- fails CLOSED rather than opening a hole.
+ALTER TABLE entity_relationship_types
+  ADD COLUMN IF NOT EXISTS purpose text;
+
+-- DROP first so a partially applied migration can be retried safely. NOT VALID
+-- avoids validating under the ADD's stronger table lock; the separate VALIDATE
+-- permits normal reads and writes while it checks the existing rows.
+ALTER TABLE entity_relationship_types
+  DROP CONSTRAINT IF EXISTS entity_relationship_types_purpose_check;
+
+ALTER TABLE entity_relationship_types
+  ADD CONSTRAINT entity_relationship_types_purpose_check
+  CHECK (purpose IS NULL OR purpose = 'authorization') NOT VALID;
+
+ALTER TABLE entity_relationship_types
+  VALIDATE CONSTRAINT entity_relationship_types_purpose_check;
+
+-- DELIBERATELY NOT BACKFILLED HERE. Classification is what arms the trigger, and
+-- arming it in this deploy would break the ACL syncs running on pods that have
+-- not yet restarted: they write member_of edges without the transaction-local
+-- flag, so the trigger would reject them until the rollout drained. Every
+-- trusted path that may touch ACL edges learns to set the flag while nothing is
+-- classified and the trigger is inert. A follow-up deploy backfills the purpose,
+-- by which point every live pod already sets the flag.
+
+-- ROLLOUT ORDER IS LOAD-BEARING. This migration and the ACL writers that set the
+-- transaction-local flag must be fully deployed BEFORE classification is
+-- backfilled or ACL reads require it. During a rolling deploy an old pod can
+-- still create an unclassified `member_of`; if new readers already demanded the
+-- classification, that org's members would lose access until the next sync.
+
+-- migrate:down
+
+-- Dropping the column removes the classification the ACL reads will depend on.
+-- Safe only in the direction it is written: the follow-up that adds
+-- `AND rt.purpose = 'authorization'` to the three visibility gates must be rolled
+-- back FIRST, or those gates match nothing and every member loses access.
+ALTER TABLE entity_relationship_types
+  DROP CONSTRAINT IF EXISTS entity_relationship_types_purpose_check;
+
+ALTER TABLE entity_relationship_types
+  DROP COLUMN IF EXISTS purpose;

--- a/db/migrations/20260816030000_acl_edge_chokepoint.sql
+++ b/db/migrations/20260816030000_acl_edge_chokepoint.sql
@@ -1,0 +1,78 @@
+-- migrate:up
+
+-- A single enforcement point for authorization-bearing edges.
+--
+-- INERT ON ARRIVAL, deliberately. The trigger only fires for a type whose
+-- `purpose` is 'authorization', and no row carries that yet — the companion
+-- migration adds the column without backfilling it. This deploy therefore
+-- teaches every ACL writer to set the transaction-local flag while enforcement
+-- is still off. A follow-up deploy classifies `member_of`, at which point every
+-- live pod already sets the flag and enforcement begins without a window in
+-- which older pods' ACL syncs are rejected.
+--
+-- Why not call-site guards: `entity_relationships` is written by caller tools,
+-- batch materializers, reconcilers, merge/unmerge, and force-delete paths.
+-- Guarding a subset only ever means the NEXT writer added is the bypass, so the
+-- check has to live where a caller cannot route around it.
+--
+-- Why not `source`: the ACL syncs write source='feed', and 'feed' is ALSO in the
+-- caller-settable enum, so a caller can mint an edge that is byte-identical to a
+-- sync's. Source cannot carry this boundary.
+--
+-- The flag is transaction-local, so it cannot leak across pooled connections
+-- the way a session GUC would.
+
+CREATE OR REPLACE FUNCTION lobu_guard_authorization_edges()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  type_id bigint;
+BEGIN
+  -- An UPDATE must protect both sides. Checking only NEW would let a caller move
+  -- an authorization edge onto an ordinary type and thereby evade the guard.
+  IF TG_OP = 'INSERT' THEN
+    SELECT id INTO type_id
+    FROM entity_relationship_types
+    WHERE id = NEW.relationship_type_id AND purpose = 'authorization';
+  ELSIF TG_OP = 'DELETE' THEN
+    SELECT id INTO type_id
+    FROM entity_relationship_types
+    WHERE id = OLD.relationship_type_id AND purpose = 'authorization';
+  ELSE
+    SELECT id INTO type_id
+    FROM entity_relationship_types
+    WHERE id IN (OLD.relationship_type_id, NEW.relationship_type_id)
+      AND purpose = 'authorization'
+    LIMIT 1;
+  END IF;
+
+  IF type_id IS NULL THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+
+  -- Only the ACL materializers set this, and only for the duration of their own
+  -- transaction. Anything else touching a classified edge is a caller.
+  IF COALESCE(current_setting('lobu.acl_write', true), '') <> 'on' THEN
+    RAISE EXCEPTION
+      'relationship type % is authorization-bearing; edges on it are maintained only by the ACL syncs', type_id
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Re-runnable if deployment is interrupted after the function is installed.
+DROP TRIGGER IF EXISTS lobu_guard_authorization_edges ON entity_relationships;
+
+CREATE TRIGGER lobu_guard_authorization_edges
+BEFORE INSERT OR UPDATE OR DELETE ON entity_relationships
+FOR EACH ROW EXECUTE FUNCTION lobu_guard_authorization_edges();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS lobu_guard_authorization_edges ON entity_relationships;
+DROP FUNCTION IF EXISTS lobu_guard_authorization_edges();

--- a/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
@@ -1,0 +1,472 @@
+/**
+ * The database-level chokepoint for authorization-bearing edges.
+ *
+ * Call-site checks are not enough because a new or overlooked SQL writer could
+ * route around them. These cases cover every mutation shape plus the privileged
+ * materializer and merge lifecycle.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { ensureMemberOfType } from "../../../authz/access-graph";
+import { applyMerge, applyUnmerge } from "../../../utils/entity-merge";
+import {
+	withAclEdgeWrite,
+	withAclPrivilege,
+} from "../../../utils/relationship-validation";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestEntity,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+describe("authorization edges have one enforcement point", () => {
+	let orgId: string;
+	let typeId: number;
+	let alice: number;
+	let bob: number;
+	let channel: number;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Chokepoint Org" });
+		orgId = org.id;
+		typeId = await ensureMemberOfType(orgId);
+		const mk = (type: string, name: string) =>
+			createTestEntity({ organization_id: orgId, entity_type: type, name });
+		alice = (await mk("person", "Alice")).id;
+		bob = (await mk("person", "Bob")).id;
+		channel = (await mk("channel", "#secrets")).id;
+		await classifyMemberOf();
+	});
+
+	/** The follow-up deployment classifies this in production; these tests arm it. */
+	async function classifyMemberOf(): Promise<void> {
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types SET purpose = 'authorization'
+      WHERE id = ${typeId}
+    `;
+	}
+
+	async function seedGrant(person: number): Promise<number> {
+		return withAclEdgeWrite(getTestDb(), async (tx) => {
+			const rows = await tx<{ id: number }[]>`
+        INSERT INTO entity_relationships
+          (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+           source, created_at, updated_at)
+        VALUES (${orgId}, ${person}, ${channel}, ${typeId}, 'feed',
+                current_timestamp, current_timestamp)
+        RETURNING id
+      `;
+			return Number(rows[0].id);
+		});
+	}
+
+	it("the ACL sync itself still works", async () => {
+		const id = await seedGrant(alice);
+		expect(id).toBeGreaterThan(0);
+	});
+
+	it("blocks a raw INSERT that impersonates the sync's own source value", async () => {
+		// `source='feed'` is what the ACL syncs write AND is caller-settable, so
+		// source can never carry this boundary. The flag can.
+		const sql = getTestDb();
+		await expect(
+			sql`
+        INSERT INTO entity_relationships
+          (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+           source, created_at, updated_at)
+        VALUES (${orgId}, ${bob}, ${channel}, ${typeId}, 'feed',
+                current_timestamp, current_timestamp)
+      `
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("blocks the repoint an entity MERGE performs", async () => {
+		await seedGrant(alice);
+		const sql = getTestDb();
+		await expect(
+			sql`
+        UPDATE entity_relationships
+        SET from_entity_id = ${bob}, updated_at = current_timestamp
+        WHERE relationship_type_id = ${typeId} AND from_entity_id = ${alice}
+      `
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("blocks the tombstone an unlink or merge-collision performs", async () => {
+		const id = await seedGrant(alice);
+		const sql = getTestDb();
+		await expect(
+			sql`
+        UPDATE entity_relationships
+        SET deleted_at = current_timestamp
+        WHERE id = ${id}
+      `
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("blocks a hard DELETE that is not the ACL sync's own", async () => {
+		const id = await seedGrant(alice);
+		const sql = getTestDb();
+		await expect(
+			sql`DELETE FROM entity_relationships WHERE id = ${id}`
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("lets the sync tombstone its own edge when a member leaves", async () => {
+		const id = await seedGrant(alice);
+		await withAclEdgeWrite(getTestDb(), async (tx) => {
+			await tx`
+        UPDATE entity_relationships
+        SET deleted_at = current_timestamp
+        WHERE id = ${id}
+      `;
+		});
+		const sql = getTestDb();
+		const live = await sql`
+      SELECT id FROM entity_relationships WHERE id = ${id} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("does not touch ordinary domain edges", async () => {
+		const sql = getTestDb();
+		const t = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_types
+        (slug, name, organization_id, created_at, updated_at)
+      VALUES ('billed_to', 'Billed to', ${orgId}, current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		const billedTo = Number(t[0].id);
+
+		const edge = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationships
+        (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+         source, created_at, updated_at)
+      VALUES (${orgId}, ${alice}, ${channel}, ${billedTo}, 'feed',
+              current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		expect(edge).toHaveLength(1);
+
+		// …and every mutation shape stays open on it.
+		await sql`
+      UPDATE entity_relationships SET confidence = 0.5 WHERE id = ${edge[0].id}
+    `;
+		await sql`DELETE FROM entity_relationships WHERE id = ${edge[0].id}`;
+	});
+
+	it("blocks moving an edge either onto or off an authorization type", async () => {
+		const protectedEdgeId = await seedGrant(alice);
+		const sql = getTestDb();
+		const types = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_types
+        (slug, name, organization_id, created_at, updated_at)
+      VALUES ('ordinary', 'Ordinary', ${orgId}, current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		const ordinaryTypeId = Number(types[0].id);
+		const ordinaryEdges = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationships
+        (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+         source, created_at, updated_at)
+      VALUES (${orgId}, ${bob}, ${channel}, ${ordinaryTypeId}, 'api',
+              current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+
+		await expect(
+			sql`
+        UPDATE entity_relationships
+        SET relationship_type_id = ${ordinaryTypeId}
+        WHERE id = ${protectedEdgeId}
+      `,
+		).rejects.toThrow(/authorization-bearing/);
+		await expect(
+			sql`
+        UPDATE entity_relationships
+        SET relationship_type_id = ${typeId}
+        WHERE id = ${ordinaryEdges[0].id}
+      `,
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("a MERGE drops the loser's grants instead of transferring them", async () => {
+		// The vulnerability this closes: Alice is in #secrets, Bob is not. Merging
+		// Alice into Bob must not hand Bob her access. ACL edges are a projection
+		// of provider membership, so the correct outcome is to drop and re-derive.
+		await seedGrant(alice);
+
+		const sql = getTestDb();
+		const before = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND from_entity_id = ${alice}
+        AND deleted_at IS NULL
+    `;
+		expect(before).toHaveLength(1);
+
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const bobGrants = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND from_entity_id = ${bob}
+        AND deleted_at IS NULL
+    `;
+		const aliceGrants = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND from_entity_id = ${alice}
+        AND deleted_at IS NULL
+    `;
+
+		// Neither party holds the grant afterwards: the next sync decides.
+		expect(bobGrants).toHaveLength(0);
+		expect(aliceGrants).toHaveLength(0);
+	});
+
+	it("an UNMERGE after that merge neither crashes nor restores the grant", async () => {
+		// The undo ledger replays an exact prior state, but access is whatever the
+		// provider says NOW. If authorization edges were in the ledger, unmerge
+		// would both resurrect a revoked grant AND hit the trigger on the UPDATE.
+		await seedGrant(alice);
+		const sql = getTestDb();
+
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const live = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("an UNMERGE drops a grant the sync created for the winner mid-merge", async () => {
+		// Merge moves the loser's identities onto the winner, so an ACL sync that
+		// runs while they are merged resolves the loser's provider identity to the
+		// WINNER and grants the winner access. Splitting them again would leave
+		// that grant pointing at someone the provider never granted it to, and no
+		// ledger entry describes it — it was created after the merge. The only
+		// answer that cannot invent access is to drop it and re-derive.
+		const sql = getTestDb();
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		// The intervening sync, writing exactly as the materializer does.
+		await seedGrant(bob);
+
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const live = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("an UNMERGE of a legacy merge also drops grants created mid-merge", async () => {
+		const sql = getTestDb();
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		await seedGrant(bob);
+		// Simulate an entity merged before the durable operation ledger existed.
+		await sql`
+      DELETE FROM entity_merge_operations
+      WHERE organization_id = ${orgId} AND loser_entity_id = ${alice}
+    `;
+
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const live = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("an UNMERGE survives a ledger written BEFORE the type was classified", async () => {
+		// Reproduces the pre-upgrade ledger: the merge happened while the type was
+		// ordinary, so the edge was repointed and RECORDED for undo. Classifying it
+		// afterwards would make the trigger reject that restore — permanently
+		// stranding every historical merge — unless unmerge skips it.
+		const sql = getTestDb();
+		const legacy = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_types
+        (slug, name, organization_id, created_at, updated_at)
+      VALUES ('legacy_grant', 'Legacy grant', ${orgId},
+              current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		const legacyTypeId = Number(legacy[0].id);
+		await sql`
+      INSERT INTO entity_relationships
+        (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+         source, created_at, updated_at)
+      VALUES (${orgId}, ${alice}, ${channel}, ${legacyTypeId}, 'feed',
+              current_timestamp, current_timestamp)
+    `;
+
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		// The follow-up deploy classifies the type the ledger already references.
+		await sql`
+      UPDATE entity_relationship_types SET purpose = 'authorization'
+      WHERE id = ${legacyTypeId}
+    `;
+
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const live = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${legacyTypeId} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("an UNMERGE marks the ACL snapshot stale so an in-flight sync cannot bless it", async () => {
+		// Dropping the edges alone loses a race with a sync that already resolved
+		// the loser's identity to the winner and writes moments after we commit.
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO authz_source_acl_state
+        (organization_id, connection_id, acl_support, freshness_state,
+         last_synced_at, created_at, updated_at)
+      VALUES (${orgId}, 'conn-under-test', 'full', 'fresh',
+              current_timestamp, current_timestamp, current_timestamp)
+    `;
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		// The in-flight sync's grant, resolved to the winner while they were merged.
+		await seedGrant(bob);
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const rows = await sql<{ freshness_state: string }[]>`
+      SELECT freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${orgId}
+    `;
+		expect(rows[0].freshness_state).toBe("stale");
+	});
+
+	it("an UNMERGE invalidates even when it dropped NOTHING", async () => {
+		// The race is exactly this ordering: the sync has resolved the identity to
+		// the winner but has not yet written the edge, so there is nothing to drop.
+		// Counting dropped rows and skipping the invalidation would therefore skip
+		// it in precisely the window that needs it.
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO authz_source_acl_state
+        (organization_id, connection_id, acl_support, freshness_state,
+         last_synced_at, created_at, updated_at)
+      VALUES (${orgId}, 'conn-under-test', 'full', 'fresh',
+              current_timestamp, current_timestamp, current_timestamp)
+    `;
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const rows = await sql<{ freshness_state: string }[]>`
+      SELECT freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${orgId}
+    `;
+		expect(rows[0].freshness_state).toBe("stale");
+	});
+
+	it("costs an ERP-only tenant nothing — there is no ACL state to invalidate", async () => {
+		// The availability cost only lands where ACL is actually onboarded. An org
+		// that has never graphed a connection has no row, so the statement matches
+		// nothing and no visibility is lost.
+		const sql = getTestDb();
+		await applyMerge(
+			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
+			sql,
+		);
+		await applyUnmerge(
+			{ orgId, loserId: alice, unmergedBy: "chokepoint-test" },
+			sql,
+		);
+
+		const rows = await sql`
+      SELECT 1 FROM authz_source_acl_state WHERE organization_id = ${orgId}
+    `;
+		expect(rows).toHaveLength(0);
+	});
+
+	it("does not leave the ACL privilege set for the rest of the transaction", async () => {
+		// Regression: a bare `set_config(...)` with no reset made every later
+		// statement in the merge transaction privileged, so the trigger could no
+		// longer refuse a repoint of an authorization edge the first statement
+		// had not matched.
+		const sql = getTestDb();
+
+		await expect(
+			sql.begin(async (tx) => {
+				await withAclPrivilege(tx as never, async () => {
+					await tx`
+            INSERT INTO entity_relationships
+              (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+               source, created_at, updated_at)
+            VALUES (${orgId}, ${alice}, ${channel}, ${typeId}, 'feed',
+                    current_timestamp, current_timestamp)
+          `;
+				});
+				// Same transaction, privilege dropped — must now be refused.
+				await tx`
+          INSERT INTO entity_relationships
+            (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+             source, created_at, updated_at)
+          VALUES (${orgId}, ${bob}, ${channel}, ${typeId}, 'feed',
+                  current_timestamp, current_timestamp)
+        `;
+			}),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("does not leak the flag to the next transaction on a pooled connection", async () => {
+		// SET LOCAL is transaction-scoped. If it leaked, a later caller write on the
+		// same pooled connection would silently pass.
+		await seedGrant(alice);
+		const sql = getTestDb();
+		await expect(
+			sql`
+        INSERT INTO entity_relationships
+          (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+           source, created_at, updated_at)
+        VALUES (${orgId}, ${bob}, ${channel}, ${typeId}, 'feed',
+                current_timestamp, current_timestamp)
+      `
+		).rejects.toThrow(/authorization-bearing/);
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/acl-trigger-cost.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-trigger-cost.test.ts
@@ -1,0 +1,109 @@
+/**
+ * What the chokepoint trigger costs on the common (unclassified) path.
+ *
+ * It fires per row on every `entity_relationships` write, and `upsertEdges`
+ * writes whole batches in one statement, so "one PK lookup" is multiplied by
+ * batch size. Measured rather than assumed: an unclassified type pays the
+ * lookup and returns early, which is the common path for every domain edge in
+ * the system.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { upsertEdges } from "../../../utils/edge-writes";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestEntity,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const BATCH = 500;
+
+describe("chokepoint trigger cost", () => {
+	let orgId: string;
+	let typeId: number;
+	let hub: number;
+	let spokes: number[];
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Cost Org" });
+		orgId = org.id;
+		const sql = getTestDb();
+		const t = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_types
+        (slug, name, organization_id, created_at, updated_at)
+      VALUES ('perf_probe', 'Perf probe', ${orgId}, current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		typeId = Number(t[0].id);
+		hub = (
+			await createTestEntity({
+				organization_id: orgId,
+				entity_type: "thing",
+				name: "hub",
+			})
+		).id;
+		spokes = [];
+		for (let i = 0; i < BATCH; i++) {
+			spokes.push(
+				(
+					await createTestEntity({
+						organization_id: orgId,
+						entity_type: "thing",
+						name: `spoke-${i}`,
+					})
+				).id,
+			);
+		}
+	});
+
+	async function timeBatch(): Promise<number> {
+		const sql = getTestDb();
+		await sql`DELETE FROM entity_relationships WHERE relationship_type_id = ${typeId}`;
+		const started = process.hrtime.bigint();
+		await upsertEdges({
+			db: sql,
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs: spokes.map((s) => ({ fromEntityId: hub, toEntityId: s })),
+			source: "feed",
+			onConflict: "ignore",
+		});
+		return Number(process.hrtime.bigint() - started) / 1e6;
+	}
+
+	it(`writes ${BATCH} unclassified edges through the trigger`, async () => {
+		const sql = getTestDb();
+
+		// Warm, then measure with the trigger in place.
+		await timeBatch();
+		const withTrigger = Math.min(await timeBatch(), await timeBatch());
+
+		let without: number;
+		try {
+			await sql`DROP TRIGGER IF EXISTS lobu_guard_authorization_edges ON entity_relationships`;
+			await timeBatch();
+			without = Math.min(await timeBatch(), await timeBatch());
+		} finally {
+			// Restore even if the measurement throws. Without the finally a
+			// failure here silently disarms the chokepoint for every test that
+			// runs after it in the same database.
+			await sql`
+        CREATE TRIGGER lobu_guard_authorization_edges
+        BEFORE INSERT OR UPDATE OR DELETE ON entity_relationships
+        FOR EACH ROW EXECUTE FUNCTION lobu_guard_authorization_edges()
+      `;
+		}
+
+		const overheadPct = ((withTrigger - without) / without) * 100;
+		// eslint-disable-next-line no-console
+		console.log(
+			`${BATCH} edges — with trigger ${withTrigger.toFixed(1)}ms, ` +
+				`without ${without.toFixed(1)}ms, overhead ${overheadPct.toFixed(0)}%`,
+		);
+
+		// Wall-clock noise makes this threshold deliberately broad; it only fails a
+		// catastrophic regression of roughly an order of magnitude.
+		expect(withTrigger).toBeLessThan(without * 10 + 50);
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
+++ b/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Caller surfaces refuse authorization-bearing relationship types.
+ *
+ * Classifying `member_of` makes the ACL gates depend on those rows. That is only
+ * a trust boundary if the rows stop being generically writable — otherwise
+ * anyone holding the entity-link surface could mint access by creating an edge,
+ * or revoke it by soft-deleting one. These tests drive the real tool, not the
+ * validation helpers, because the tool is the surface a caller reaches.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { ensureMemberOfType } from "../../../authz/access-graph";
+import { manageEntity } from "../../../tools/admin/manage_entity";
+import { manageEntitySchema } from "../../../tools/admin/manage_entity_schema";
+import type { ToolContext } from "../../../tools/registry";
+import { deleteEntity } from "../../../utils/entity-management";
+import { withAclEdgeWrite } from "../../../utils/relationship-validation";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const env = {} as Env;
+
+function ctx(orgId: string, userId: string): ToolContext {
+	return {
+		organizationId: orgId,
+		userId,
+		memberRole: "owner",
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+	} as ToolContext;
+}
+
+describe("authorization-bearing relationship types are not caller-writable", () => {
+	let orgId: string;
+	let userId: string;
+	let typeId: number;
+	let person: number;
+	let channel: number;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "Guard Org" });
+		orgId = org.id;
+		const user = await createTestUser();
+		userId = user.id;
+		await addUserToOrganization(userId, orgId, "owner");
+
+		typeId = await ensureMemberOfType(orgId);
+		person = (
+			await createTestEntity({
+				organization_id: orgId,
+				entity_type: "person",
+				name: "Ada",
+			})
+		).id;
+		channel = (
+			await createTestEntity({
+				organization_id: orgId,
+				entity_type: "channel",
+				name: "#secrets",
+			})
+		).id;
+		await classifyMemberOf();
+	});
+
+	/**
+	 * Seeds the edge the way the ACL sync does — under the write flag. A raw
+	 * INSERT is now rejected by the database trigger, which is the point: the
+	 * fixture has to impersonate a sync because nothing else may write these.
+	 */
+	async function seedAclEdge(): Promise<number> {
+		return withAclEdgeWrite(getTestDb(), async (tx) => {
+			const rows = await tx<{ id: number }[]>`
+        INSERT INTO entity_relationships
+          (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+           source, created_at, updated_at)
+        VALUES (${orgId}, ${person}, ${channel}, ${typeId}, 'feed',
+                current_timestamp, current_timestamp)
+        RETURNING id
+      `;
+			return Number(rows[0].id);
+		});
+	}
+
+	/** The follow-up deployment classifies this in production; these tests arm it. */
+	async function classifyMemberOf(): Promise<void> {
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types SET purpose = 'authorization'
+      WHERE id = ${typeId}
+    `;
+	}
+
+	it("refuses to LINK on an authorization type — creating one would mint access", async () => {
+		await expect(
+			manageEntity(
+				{
+					action: "link",
+					from_entity_id: person,
+					to_entity_id: channel,
+					relationship_type_slug: "member_of",
+				},
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+
+		const sql = getTestDb();
+		const rows = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(0);
+	});
+
+	it("refuses to UNLINK an authorization edge — removing one revokes access", async () => {
+		const edgeId = await seedAclEdge();
+
+		await expect(
+			manageEntity(
+				{ action: "unlink", relationship_id: edgeId },
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+
+		const sql = getTestDb();
+		const rows = await sql`
+      SELECT id FROM entity_relationships
+      WHERE id = ${edgeId} AND deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(1);
+	});
+
+	it("refuses to UPDATE_LINK an authorization edge", async () => {
+		const edgeId = await seedAclEdge();
+
+		await expect(
+			manageEntity(
+				{ action: "update_link", relationship_id: edgeId, confidence: 0.1 },
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("allows a config to declare member_of while it is unclassified", async () => {
+		// `lobu apply` configs legitimately declare member_of — and must, or prune
+		// flags it removed and aborts the apply (examples/personal-agent). Refusing
+		// the TYPE surface would break apply today. Declaring a type grants nobody
+		// access; only an edge on it does, and that surface stays closed.
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types
+      SET purpose = NULL, status = 'archived', deleted_at = current_timestamp
+      WHERE id = ${typeId}
+    `;
+
+		await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "member_of",
+				name: "Member of",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+		await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "update",
+				slug: "member_of",
+				description: "declared by config",
+			} as never,
+			env,
+			ctx(orgId, userId),
+		);
+
+		// …but an EDGE on it is still refused in that same window.
+		await expect(
+			manageEntity(
+				{
+					action: "link",
+					from_entity_id: person,
+					to_entity_id: channel,
+					relationship_type_slug: "member_of",
+				} as never,
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("refuses to ARCHIVE an authorization type — that revokes an org wholesale", async () => {
+		await expect(
+			manageEntitySchema(
+				{ schema_type: "relationship_type", action: "delete", slug: "member_of" },
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+
+		const sql = getTestDb();
+		const rows = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE id = ${typeId} AND status = 'active' AND deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(1);
+	});
+
+	it("refuses to archive member_of before classification", async () => {
+		const edgeId = await seedAclEdge();
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types SET purpose = NULL WHERE id = ${typeId}
+    `;
+
+		await expect(
+			manageEntitySchema(
+				{
+					schema_type: "relationship_type",
+					action: "update",
+					slug: "member_of",
+					status: "archived",
+				},
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/ACL-managed.*cannot be archived/);
+
+		const types = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE id = ${typeId} AND status = 'active'
+    `;
+		const edges = await sql`
+      SELECT id FROM entity_relationships
+      WHERE id = ${edgeId} AND deleted_at IS NULL
+    `;
+		expect(types).toHaveLength(1);
+		expect(edges).toHaveLength(1);
+	});
+
+	it("still allows ordinary domain vocabulary through every surface", async () => {
+		// The guard must key on the CLASSIFICATION, not on being a relationship
+		// type. Ordinary domain vocabulary — an ERP invoice's `billed_to` — is
+		// exactly what this whole programme exists to keep writable.
+		await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "billed_to",
+				name: "Billed to",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+
+		const linked = (await manageEntity(
+			{
+				action: "link",
+				from_entity_id: person,
+				to_entity_id: channel,
+				relationship_type_slug: "billed_to",
+			},
+			env,
+			ctx(orgId, userId),
+		)) as { action: string; relationship: { id: number } };
+
+		expect(linked.action).toBe("link");
+		expect(linked.relationship.id).toBeGreaterThan(0);
+	});
+
+	it("refuses remove_rule on an authorization type", async () => {
+		// remove_rule resolves by rule_id, so it never passes through the
+		// slug-based guard add_rule uses.
+		const sql = getTestDb();
+		const rule = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_type_rules
+        (relationship_type_id, source_entity_type_slug, target_entity_type_slug,
+         created_at, updated_at)
+      VALUES (${typeId}, 'person', 'channel', current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+		await expect(
+			manageEntitySchema({
+				schema_type: "relationship_type",
+				action: "remove_rule",
+				rule_id: Number(rule[0].id),
+			} as never, env, ctx(orgId, userId)),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("refuses to pair a caller's own type with an authorization type as its inverse", async () => {
+		await expect(
+			manageEntitySchema({
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "owns_membership",
+				name: "Owns membership",
+				inverse_type_slug: "member_of",
+			} as never, env, ctx(orgId, userId)),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+
+	it("lets force-delete remove an entity holding a grant", async () => {
+		// Force-delete deliberately claims the ACL privilege, so exercise that path
+		// as well as the unprivileged DELETE refusal.
+		const sql = getTestDb();
+		await seedAclEdge();
+		const before = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(before).toHaveLength(1);
+
+		await deleteEntity(person, true, env, ctx(orgId, userId));
+
+		const live = await sql`
+      SELECT id FROM entity_relationships
+      WHERE relationship_type_id = ${typeId} AND deleted_at IS NULL
+    `;
+		expect(live).toHaveLength(0);
+	});
+
+	it("refuses member_of by slug before it is classified", async () => {
+		// During the staged rollout, ACL reads still trust the slug while `purpose`
+		// is null. The temporary slug guard keeps that interval fail-closed.
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types SET purpose = NULL WHERE id = ${typeId}
+    `;
+
+		await expect(
+			manageEntity(
+				{
+					action: "link",
+					from_entity_id: person,
+					to_entity_id: channel,
+					relationship_type_slug: "member_of",
+				},
+				env,
+				ctx(orgId, userId),
+			),
+		).rejects.toThrow(/authorization-bearing/);
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/relationship-type-purpose.test.ts
+++ b/packages/server/src/__tests__/integration/authz/relationship-type-purpose.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Authorization-purpose classification contract.
+ *
+ * `member_of` is both an ACL primitive and ordinary domain vocabulary, and
+ * `ensureMemberOfType` upserts on (organization_id, slug) — so it ADOPTS a
+ * pre-existing row rather than create-or-failing.
+ *
+ * This deploy ships the classification MECHANISM without classifying anything:
+ * stamping `member_of` is what arms the trigger, and arming it while older pods
+ * still write ACL edges without the transaction-local flag would reject their
+ * writes until the rollout drained. So these tests drive `ensureRelationshipType`
+ * with an explicit purpose and pin the rollout invariant that
+ * `ensureMemberOfType` does not yet classify.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ensureMemberOfType } from '../../../authz/access-graph';
+import { ensureRelationshipType } from '../../../utils/edge-writes';
+import { PURPOSE_AUTHORIZATION } from '../../../utils/relationship-validation';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+async function purposeOf(orgId: string, slug: string): Promise<string | null> {
+  const sql = getTestDb();
+  const rows = await sql<{ purpose: string | null }[]>`
+    SELECT purpose FROM entity_relationship_types
+    WHERE organization_id = ${orgId} AND slug = ${slug} AND status = 'active'
+    LIMIT 1
+  `;
+  return rows.length > 0 ? rows[0].purpose : null;
+}
+
+describe('relationship type purpose', () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Purpose Org' });
+    orgId = org.id;
+  });
+
+  it('stamps authorization when a caller supplies the purpose at create', async () => {
+    await ensureRelationshipType({
+      organizationId: orgId,
+      slug: 'member_of',
+      name: 'Member of',
+      description: 'ACL membership',
+      purpose: PURPOSE_AUTHORIZATION,
+    });
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
+  });
+
+  it('does not classify member_of before every pod sets the flag', async () => {
+    // Guards the rollout seam. If a later change makes `ensureMemberOfType`
+    // stamp the purpose, it arms the trigger org-by-org as pods restart, and
+    // ACL syncs on not-yet-restarted pods start failing. Flipping this test is
+    // the deliberate follow-up deployment step.
+    await ensureMemberOfType(orgId);
+    expect(await purposeOf(orgId, 'member_of')).toBeNull();
+  });
+
+  it('repairs an unclassified row it adopts', async () => {
+    // The rolling-deploy case: an older pod created `member_of` without the
+    // classification. Because this statement upserts rather than create-or-fails,
+    // it lands on that row — and leaving it unclassified would drop every
+    // member's access once the ACL reads require the stamp.
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_relationship_types
+        (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+      VALUES ('member_of', 'Member of', 'legacy row', ${orgId}, false, NULL,
+              current_timestamp, current_timestamp)
+    `;
+    expect(await purposeOf(orgId, 'member_of')).toBeNull();
+
+    await ensureRelationshipType({
+      organizationId: orgId,
+      slug: 'member_of',
+      name: 'Member of',
+      description: 'ACL membership',
+      purpose: PURPOSE_AUTHORIZATION,
+    });
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
+  });
+
+  it('is idempotent across repeated syncs', async () => {
+    const opts = {
+      organizationId: orgId,
+      slug: 'member_of',
+      name: 'Member of',
+      description: 'ACL membership',
+      purpose: PURPOSE_AUTHORIZATION,
+    };
+    const first = await ensureRelationshipType(opts);
+    const second = await ensureRelationshipType(opts);
+    expect(second).toBe(first);
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
+  });
+
+  it('does not clear an existing classification when a caller omits purpose', async () => {
+    // `mentions` and `member_of` share this function. An unclassified upsert must
+    // never strip a stamp, or the auto-linker would silently declassify the ACL
+    // type on every run.
+    await ensureRelationshipType({
+      organizationId: orgId,
+      slug: 'member_of',
+      name: 'Member of',
+      description: 'ACL membership',
+      purpose: PURPOSE_AUTHORIZATION,
+    });
+    await ensureRelationshipType({
+      organizationId: orgId,
+      slug: 'member_of',
+      name: 'Member of',
+      description: 'no purpose supplied',
+    });
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
+  });
+
+  it('leaves ordinary domain types unclassified', async () => {
+    await ensureRelationshipType({
+      organizationId: orgId,
+      slug: 'billed_to',
+      name: 'Billed to',
+      description: 'ERP vocabulary',
+    });
+    expect(await purposeOf(orgId, 'billed_to')).toBeNull();
+  });
+
+  it('rejects a purpose value outside the enum at the database', async () => {
+    const sql = getTestDb();
+    await expect(
+      sql`
+        INSERT INTO entity_relationship_types
+          (slug, name, organization_id, created_at, updated_at, purpose)
+        VALUES ('bogus', 'Bogus', ${orgId}, current_timestamp, current_timestamp, 'superuser')
+      `
+    ).rejects.toThrow(/entity_relationship_types_purpose_check/);
+  });
+});

--- a/packages/server/src/__tests__/unit/scoped-query-schema-rejection.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-schema-rejection.test.ts
@@ -9,7 +9,7 @@
  * the @polyglot-sql/sdk migration's first cut used `ast.getTables`, which only
  * returns the first FROM table — a schema-qualified table in a JOIN or subquery
  * slipped past and leaked. These reproducers were RED then; the raw-AST
- * recursion in extractTableRefs makes them GREEN.
+ * walk in extractTableRefs makes them GREEN.
  */
 
 import { describe, expect, it } from 'bun:test';
@@ -133,6 +133,15 @@ describe('validateAndScopeQuery — member table restriction (auth/identity admi
  * prefix guard + the complete (union) table walk + the CTE-collision guard.
  */
 describe('validateAndScopeQuery — parser-bypass regressions', () => {
+  it('rejects session-setting functions even in tableless SELECTs', () => {
+    expect(() => scope("SELECT set_config('lobu.acl_write', 'on', false)")).toThrow(
+      /Function 'set_config'.*not allowed/i
+    );
+    expect(() =>
+      scope("SELECT pg_catalog.\"set_config\"('lobu.acl_write', 'on', false)")
+    ).toThrow(/Function 'set_config'.*not allowed/i);
+  });
+
   it('rejects the PostgreSQL `TABLE <name>` shorthand (member)', () => {
     expect(() => scopeAsMember('TABLE oauth_tokens')).toThrow(/SELECT \/ WITH/i);
   });

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -46,6 +46,7 @@ import {
   withEntityWriteTransaction,
 } from '../utils/entity-management.js';
 import { ensureRelationshipType, upsertEdges } from '../utils/edge-writes.js';
+import { withAclEdgeWrite } from '../utils/relationship-validation.js';
 import { aclConnectionIdSql } from './acl-observability.js';
 import { ensureResourceEntityType } from './acl-resource-type.js';
 
@@ -112,6 +113,12 @@ export function ensureMemberOfType(orgId: string): Promise<number> {
     slug: MEMBER_OF_TYPE_SLUG,
     name: 'Member of',
     description: 'A member belongs to an ACL resource (channel, repo, org, …)',
+    // NOT classified in this deploy, and the omission is load-bearing rather
+    // than an oversight. Stamping `purpose` here would arm the trigger for an
+    // org the moment one new pod ran its sync, while older pods still writing
+    // that org's member_of edges without the flag would start being rejected.
+    // The follow-up deploy adds `purpose: PURPOSE_AUTHORIZATION` here together
+    // with the backfill, once every live pod sets the flag.
   });
 }
 
@@ -501,31 +508,42 @@ export async function buildAccessGraph(params: {
     }
   }
 
-  // One statement for the whole build. A resource's membership is re-affirmed
-  // rather than rewritten, so a steady-state resync creates nothing.
-  const created = await upsertEdges({
-    db: sql,
-    organizationId,
-    relationshipTypeId: typeId,
-    pairs: edgePairs,
-    source: 'feed',
-    confidence: 1.0,
-    createdBy: creatorUserId,
-    onConflict: 'ignore',
-  });
-  const createdEdges = created.length;
+  // A resource's membership is re-affirmed rather than rewritten, so a
+  // steady-state resync creates nothing.
+  // Grants and departures commit together under the ACL write flag. The trigger
+  // starts requiring it once the follow-up deploy classifies `member_of`.
+  // Enforcement lives in the database rather than at each call site because
+  // this table has several writers, and `source='feed'` cannot mark a write as
+  // ours — it is caller-settable too.
+  //
+  // The transaction is also a correctness fix in its own right: these used to be
+  // separate autocommits, so a crash between them left grants written and
+  // departures unreconciled — i.e. access that should have been revoked.
+  const { createdEdges, removedEdges } = await withAclEdgeWrite(
+    sql,
+    async (tx) => {
+      const created = await upsertEdges({
+        db: tx,
+        organizationId,
+        relationshipTypeId: typeId,
+        pairs: edgePairs,
+        source: 'feed',
+        confidence: 1.0,
+        createdBy: creatorUserId,
+        onConflict: 'ignore',
+      });
 
-  // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
-  // membership, so a `member_of` edge to a synced resource whose member is NOT
-  // in the current set means that person left: soft-delete it so they lose
-  // access immediately. Scoped to `to_entity_id` = a resource we just synced, so
-  // edges to OTHER resource types (a different source's graph) are never touched.
-  // An empty member set deletes all of that resource's edges — the caller must
-  // not pass empty-on-fetch-error.
-  let removedEdges = 0;
-  for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
-    const keep = [...resourceMembers];
-    const removed = await sql<{ id: number }[]>`
+      // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
+      // membership, so a `member_of` edge to a synced resource whose member is NOT
+      // in the current set means that person left: soft-delete it so they lose
+      // access immediately. Scoped to `to_entity_id` = a resource we just synced, so
+      // edges to OTHER resource types (a different source's graph) are never touched.
+      // An empty member set deletes all of that resource's edges — the caller must
+      // not pass empty-on-fetch-error.
+      let removedEdges = 0;
+      for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
+        const keep = [...resourceMembers];
+        const removed = await tx<{ id: number }[]>`
 			UPDATE entity_relationships
 			SET deleted_at = current_timestamp, updated_at = current_timestamp
 			WHERE organization_id = ${organizationId}
@@ -535,8 +553,11 @@ export async function buildAccessGraph(params: {
 			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
 			RETURNING id
 		`;
-    removedEdges += removed.length;
-  }
+        removedEdges += removed.length;
+      }
+      return { createdEdges: created.length, removedEdges };
+    },
+  );
 
   if (params.markFresh !== false) {
     await markAclFresh(organizationId, connectionId, syncStartedAt);

--- a/packages/server/src/gateway/routes/public/github-team-graph.ts
+++ b/packages/server/src/gateway/routes/public/github-team-graph.ts
@@ -39,6 +39,7 @@ import { GITHUB_IDENTITY } from "@lobu/connectors/github-identity";
 import { ensureMemberOfType } from "../../../authz/access-graph.js";
 import { upsertEdges } from "../../../utils/edge-writes.js";
 import { resolveEventAttributionsForItems } from "../../../utils/entity-link-upsert.js";
+import { withAclEdgeWrite } from "../../../utils/relationship-validation.js";
 
 const logger = createLogger("github-team-graph");
 
@@ -290,19 +291,23 @@ export async function buildGithubTeamGraph(params: {
 	const typeId = await ensureMemberOfType(params.organizationId);
 	// person -> company. Idempotent on the live-triple unique index; a re-bind
 	// re-affirms the edge without duplicating it.
-	const created = await upsertEdges({
-		db: getDb(),
-		organizationId: params.organizationId,
-		relationshipTypeId: typeId,
-		pairs: uniqueMemberIds.map((memberId) => ({
-			fromEntityId: memberId,
-			toEntityId: companyEntityId,
-		})),
-		source: "feed",
-		confidence: 1.0,
-		createdBy: creatorUserId,
-		onConflict: "ignore",
-	});
+	// Set the ACL write flag now; the trigger starts requiring it when the
+	// follow-up deploy classifies `member_of` as authorization-bearing.
+	const created = await withAclEdgeWrite(getDb(), (tx) =>
+		upsertEdges({
+			db: tx,
+			organizationId: params.organizationId,
+			relationshipTypeId: typeId,
+			pairs: uniqueMemberIds.map((memberId) => ({
+				fromEntityId: memberId,
+				toEntityId: companyEntityId,
+			})),
+			source: "feed",
+			confidence: 1.0,
+			createdBy: creatorUserId,
+			onConflict: "ignore",
+		}),
+	);
 	const createdEdges = created.length;
 
 	logger.info(

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -70,6 +70,7 @@ import {
 } from "../../utils/insert-event";
 import { resolveMemberSchemaFieldsFromSchema } from "../../utils/member-entity-type";
 import {
+	assertNotAclManagedEdge,
 	canonicalizeSymmetricEdge,
 	checkDuplicateEdge,
 	validateConfidence,
@@ -1512,17 +1513,19 @@ interface EdgeAuditRow {
 	confidence: number | null;
 	source: string | null;
 	relationship_type_slug: string | null;
+	purpose: string | null;
 }
 
 async function lockEdgeForMutation(
 	tx: DbClient,
 	relationshipId: number,
 	organizationId: string,
+	action: string,
 ): Promise<EdgeAuditRow> {
 	const rows = await tx<EdgeAuditRow>`
     SELECT r.id, r.organization_id, r.from_entity_id, r.to_entity_id,
            r.relationship_type_id, r.metadata, r.confidence, r.source,
-           rt.slug AS relationship_type_slug
+           rt.slug AS relationship_type_slug, rt.purpose
     FROM entity_relationships r
     LEFT JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
     WHERE r.id = ${relationshipId} AND r.deleted_at IS NULL
@@ -1538,6 +1541,13 @@ async function lockEdgeForMutation(
 			403,
 		);
 	}
+	// Both callers of this loader (unlink, update_link) mutate the edge, so the
+	// authorization guard belongs here rather than in each of them. Soft-deleting
+	// an ACL edge revokes access exactly as surely as creating one grants it.
+	assertNotAclManagedEdge(
+		{ slug: rows[0].relationship_type_slug, purpose: rows[0].purpose },
+		action,
+	);
 	return rows[0];
 }
 
@@ -1564,7 +1574,7 @@ async function handleLink(
 	// public-uk-finance without registering a local copy. Tenant-local types
 	// win when both exist.
 	const typeRows = await sql`
-    SELECT rt.id, rt.is_symmetric
+    SELECT rt.id, rt.is_symmetric, rt.slug, rt.purpose
     FROM entity_relationship_types rt
     LEFT JOIN organization o ON o.id = rt.organization_id
     WHERE rt.slug = ${args.relationship_type_slug}
@@ -1582,6 +1592,11 @@ async function handleLink(
 			404,
 		);
   }
+  // An authorization-bearing type is what the ACL gates read. Minting one of its
+  // edges here would be minting access, so this surface refuses them outright —
+  // classification is only a trust boundary if the classified rows stop being
+  // generically writable.
+  assertNotAclManagedEdge(typeRows[0], 'link');
   const typeId = Number(typeRows[0].id);
   const isSymmetric = Boolean(typeRows[0].is_symmetric);
 
@@ -1684,6 +1699,7 @@ async function handleUnlink(
 			tx,
 			args.relationship_id!,
 			ctx.organizationId,
+			"unlink",
 		);
 		await tx`
       UPDATE entity_relationships
@@ -1732,6 +1748,7 @@ async function handleUpdateLink(
 			tx,
 			args.relationship_id!,
 			ctx.organizationId,
+			"update_link",
 		);
 		validateConfidence(args.confidence);
 		validateSource(args.source);

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -29,6 +29,10 @@ import {
   executeDataSources,
 } from '../../utils/execute-data-sources';
 import { isAdminOrOwnerRole, isInProcessSystemCall } from '../access-control';
+import {
+  assertNotAuthorizationType,
+  isAclManagedRelationshipSlug,
+} from '../../utils/relationship-validation';
 import { measureColumns } from '../../utils/infer-measures';
 import type { Env } from '../../index';
 import logger from '../../utils/logger';
@@ -861,12 +865,18 @@ async function requireRelationshipType(
   // unscoped lookup that fell back to a foreign row and threw 'Access denied'
   // leaked the slug's existence in another org. Absent an own row → 'not found'.
   const existing = await sql`
-    SELECT id FROM entity_relationship_types
+    SELECT id, slug, purpose FROM entity_relationship_types
     WHERE slug = ${slug} AND deleted_at IS NULL
       AND organization_id = ${ctx.organizationId}
     LIMIT 1
   `;
   if (existing.length === 0) throw new ToolUserError(`Relationship type "${slug}" not found`, 404);
+
+  // Every write action (update, delete, add_rule, …) funnels through here, so
+  // one guard covers the schema lifecycle. Archiving an authorization type would
+  // revoke an org's access wholesale, and renaming or re-ruling one would move
+  // the boundary the ACL gates read — neither belongs on a caller surface.
+  assertNotAuthorizationType(existing[0], action);
 
   return { typeId: Number(existing[0].id), sql };
 }
@@ -887,7 +897,7 @@ async function resolveInverseType(
   ctx: ToolContext
 ): Promise<{ id: number; ownedByCaller: boolean }> {
   const rows = await sql`
-    SELECT rt.id, (rt.organization_id = ${ctx.organizationId}) AS owned
+    SELECT rt.id, rt.slug, rt.purpose, (rt.organization_id = ${ctx.organizationId}) AS owned
     FROM entity_relationship_types rt
     LEFT JOIN organization o ON o.id = rt.organization_id
     WHERE rt.slug = ${inverseSlug}
@@ -899,6 +909,13 @@ async function resolveInverseType(
   if (rows.length === 0) {
     throw new ToolUserError(`Inverse relationship type "${inverseSlug}" not found`, 404);
   }
+  // Refuse to pair a caller's type with an authorization type. The inverse is a
+  // declared equivalence between two vocabularies, so allowing it would let a
+  // caller attach their own freely-writable type to the one the ACL gates read.
+  assertNotAuthorizationType(
+    { slug: String(rows[0].slug ?? inverseSlug), purpose: rows[0].purpose as string | null },
+    'inverse_type_slug'
+  );
   return { id: Number(rows[0].id), ownedByCaller: Boolean(rows[0].owned) };
 }
 
@@ -1113,6 +1130,21 @@ async function rtHandleUpdate(
 ): Promise<ManageEntitySchemaResult> {
   const { typeId, sql } = await requireRelationshipType(args.slug, 'update', ctx);
 
+  // Before purpose is backfilled, config may still declare member_of and update
+  // its harmless fields. It may not archive the type: the materializer upserts
+  // against active slugs, so archiving would make the next sync create a second
+  // type while existing grants remain attached to the old one and stop being
+  // reconciled.
+  if (
+    isAclManagedRelationshipSlug(args.slug ?? '') &&
+    args.status === 'archived'
+  ) {
+    throw new ToolUserError(
+      `Relationship type '${args.slug}' is ACL-managed and cannot be archived`,
+      403
+    );
+  }
+
   // `is_symmetric` is create-only (contract: `[relationship_type: create]`).
   // It's load-bearing for relationship canonicalization/dedup at write time
   // (manage_entity.ts canonicalizes a→b / b→a as one edge when symmetric), so
@@ -1321,7 +1353,7 @@ async function rtHandleRemoveRule(
   const sql = getDb();
 
   const ruleRows = await sql`
-    SELECT r.id, rt.organization_id, rt.slug AS relationship_type_slug
+    SELECT r.id, rt.organization_id, rt.slug AS relationship_type_slug, rt.purpose
     FROM entity_relationship_type_rules r
     JOIN entity_relationship_types rt ON r.relationship_type_id = rt.id
     WHERE r.id = ${args.rule_id} AND r.deleted_at IS NULL
@@ -1333,6 +1365,18 @@ async function rtHandleRemoveRule(
   if (ruleOrgId && ruleOrgId !== ctx.organizationId) {
     throw new ToolUserError('Access denied: rule belongs to another organization', 403);
   }
+
+  // This handler resolves by rule_id, so unlike add_rule it never passes through
+  // `requireRelationshipType` and needs its own check: the type-pair rules of an
+  // authorization type constrain which entity kinds it may connect, and dropping
+  // them widens the access vocabulary.
+  assertNotAuthorizationType(
+    {
+      slug: String(ruleRows[0].relationship_type_slug ?? ''),
+      purpose: ruleRows[0].purpose as string | null,
+    },
+    'remove_rule'
+  );
 
   await sql`
     UPDATE entity_relationship_type_rules

--- a/packages/server/src/utils/edge-writes.ts
+++ b/packages/server/src/utils/edge-writes.ts
@@ -18,6 +18,7 @@
  */
 
 import { type DbClient, getDb, pgBigintArray } from '../db/client';
+import type { RelationshipTypePurpose } from './relationship-validation';
 
 interface EdgePair {
   fromEntityId: number;
@@ -41,22 +42,33 @@ interface UpsertEdgesParams {
  *
  * `description` only lands on first create; an existing type keeps its current
  * description.
+ *
+ * `purpose` classifies the type for the ACL readers. Passing it also REPAIRS an
+ * existing row, which matters because this statement adopts rather than
+ * create-or-fails: without the repair, a row that predates the classification
+ * (or that an older pod created mid-rollout) would stay unclassified forever and
+ * its members would lose access once reads require it. Omitting `purpose` never
+ * clears an existing one — `mentions` and `member_of` share this function, and a
+ * mentions upsert must not strip an authorization stamp.
  */
 export async function ensureRelationshipType(params: {
   organizationId: string;
   slug: string;
   name: string;
   description: string;
+  purpose?: RelationshipTypePurpose;
 }): Promise<number> {
   const sql = getDb();
   const rows = await sql<{ id: number }>`
     INSERT INTO entity_relationship_types
-      (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+      (slug, name, description, organization_id, is_symmetric, created_by, purpose, created_at, updated_at)
     VALUES
       (${params.slug}, ${params.name}, ${params.description}, ${params.organizationId},
-       false, NULL, current_timestamp, current_timestamp)
+       false, NULL, ${params.purpose ?? null}, current_timestamp, current_timestamp)
     ON CONFLICT (organization_id, slug) WHERE status = 'active'
-    DO UPDATE SET updated_at = EXCLUDED.updated_at
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at,
+      purpose = COALESCE(EXCLUDED.purpose, entity_relationship_types.purpose)
     RETURNING id
   `;
   return Number(rows[0].id);

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -41,6 +41,7 @@ import { ToolUserError } from "./errors";
 import logger from "./logger";
 import { requireWriteAccess } from "./organization-access";
 import { RESERVED_ENTITY_TYPE_SLUGS } from "./reserved";
+import { withAclPrivilege } from "./relationship-validation";
 
 /** Minimal type shape needed to count stored vs derived entity rows. */
 export type EntityTypeCountInput = {
@@ -1341,11 +1342,21 @@ export async function deleteEntity(
     // and lets the GIN index on entity_ids drive the scan instead of a
     // full-table pass.
     await sql.begin(async (tx) => {
-      await tx`
-        DELETE FROM entity_relationships
-        WHERE from_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
-           OR to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
-      `;
+      // Force-delete removes ACL edges along with everything else. That is
+      // correct — the entity is gone, so its membership projection must go too —
+      // but the `entity_relationships` trigger refuses authorization-bearing
+      // writes from outside a sync, so the intent is declared explicitly here
+      // rather than the delete failing. The next sync re-derives membership for
+      // whatever entities remain.
+      // Scoped to this statement: the rest of the delete cascade must not run
+      // with the ACL-write privilege still granted.
+      await withAclPrivilege(tx, async () => {
+        await tx`
+          DELETE FROM entity_relationships
+          WHERE from_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
+             OR to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
+        `;
+      });
 
       // Canvas-on-events: window_id link rows carry canvas root event ids, so
       // key the cleanup on the denormalized automation_id.

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -34,6 +34,7 @@ import {
 import { assertResolutionFingerprintCurrent } from "../entity-resolution/staleness";
 import { transitionEntityMergeRows } from "./entity-management";
 import logger from "./logger";
+import { withAclPrivilege } from "./relationship-validation";
 
 export interface MergeResolutionProvenance {
 	decision: "auto_merge" | "human";
@@ -233,13 +234,22 @@ async function applyMergeInTransaction(
 		to_entity_id: number;
 		deleted_at: Date | string | null;
 	}>`
-    SELECT id, from_entity_id, to_entity_id, deleted_at
-    FROM entity_relationships
-    WHERE organization_id = ${orgId}
-      AND deleted_at IS NULL
-      AND (from_entity_id = ${loserId} OR to_entity_id = ${loserId})
-    ORDER BY id
-    FOR UPDATE
+    SELECT r.id, r.from_entity_id, r.to_entity_id, r.deleted_at
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${orgId}
+      AND r.deleted_at IS NULL
+      AND (r.from_entity_id = ${loserId} OR r.to_entity_id = ${loserId})
+      -- Authorization edges are deliberately absent from the undo ledger. Step
+      -- 2b drops rather than repoints them, and an unmerge must not put a
+      -- revoked grant back: the ledger replays an exact prior state, but access
+      -- is whatever the provider says NOW. Leaving them out means the next ACL
+      -- sync decides, which is the same fail-closed rule the merge followed.
+      -- It also keeps unmerge's UPDATE off rows the trigger would refuse.
+      AND rt.purpose IS DISTINCT FROM 'authorization'
+      AND rt.slug <> 'member_of'
+    ORDER BY r.id
+    FOR UPDATE OF r
   `;
 
   // 1. Move the loser's LIVE identities to the winner. A live loser↔live winner
@@ -289,6 +299,33 @@ async function applyMergeInTransaction(
 	if (updatedWinnerIds.length !== 1) {
 		throw new Error("applyMerge: canonical entity changed after locking");
 	}
+
+  // 2b. DROP the loser's authorization-bearing edges instead of repointing them.
+  //
+  //     An ACL edge is a projection of the provider's membership, not authored
+  //     data, so "which of these two people keeps the channel grant" has no
+  //     correct answer to guess — repointing silently transfers one person's
+  //     access to another. Tombstoning lets the next sync re-derive the truth,
+  //     which fails closed and self-heals. Once classified, the database trigger
+  //     would reject the repoint anyway; this makes the intent explicit rather
+  //     than crashing the merge.
+  //
+  //     The privilege is dropped again immediately: steps 3 and 4 below repoint
+  //     ordinary edges, and if the flag stayed set for the rest of this
+  //     transaction the trigger could no longer refuse a repoint of an
+  //     authorization edge this statement did not match.
+  await withAclPrivilege(tx, async () => {
+    await tx`
+      UPDATE entity_relationships r
+      SET deleted_at = current_timestamp, updated_at = current_timestamp
+      FROM entity_relationship_types rt
+      WHERE rt.id = r.relationship_type_id
+        AND (rt.purpose = 'authorization' OR rt.slug = 'member_of')
+        AND r.organization_id = ${orgId}
+        AND r.deleted_at IS NULL
+        AND (r.from_entity_id = ${loserId} OR r.to_entity_id = ${loserId})
+    `;
+  });
 
   // 3. Tombstone loser edges that would become self-loops or collide with an
   //    existing winner edge. This must happen before repointing: the live-edge
@@ -657,19 +694,35 @@ export async function applyUnmerge(
 							from_entity_id: number;
 							to_entity_id: number;
 							deleted_at: Date | string | null;
+							acl_managed: boolean;
 						}>`
-            SELECT id, from_entity_id, to_entity_id, deleted_at
-            FROM entity_relationships
-            WHERE organization_id = ${orgId}
-              AND id = ANY(${pgBigintArray(relationshipIds)}::bigint[])
-            ORDER BY id
-            FOR UPDATE
+            SELECT r.id, r.from_entity_id, r.to_entity_id, r.deleted_at,
+                   (rt.purpose = 'authorization' OR rt.slug = 'member_of')
+                     AS acl_managed
+            FROM entity_relationships r
+            JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+            WHERE r.organization_id = ${orgId}
+              AND r.id = ANY(${pgBigintArray(relationshipIds)}::bigint[])
+            ORDER BY r.id
+            FOR UPDATE OF r
           `
 					: [];
 			const currentById = new Map(
 				currentRelationships.map((row) => [Number(row.id), row]),
 			);
+			// A ledger written BEFORE this feature can contain `member_of` rows:
+			// back then merge repointed them like any other edge. Restoring one
+			// now would resurrect a revoked grant, and once the type is classified
+			// the trigger would reject the write outright — which would make every
+			// historical merge permanently un-undoable. Skip them in both the
+			// exactness check and the restore; the cleanup below drops them.
+			const aclManagedIds = new Set(
+				currentRelationships
+					.filter((row) => row.acl_managed)
+					.map((row) => Number(row.id)),
+			);
 			for (const item of ledger.relationships) {
+				if (aclManagedIds.has(item.id)) continue;
 				const current = currentById.get(item.id);
 				const currentDeletedAt =
 					current?.deleted_at == null
@@ -688,6 +741,7 @@ export async function applyUnmerge(
 			}
 
 			for (const item of ledger.relationships) {
+				if (aclManagedIds.has(item.id)) continue;
 				await tx`
           UPDATE entity_relationships
           SET from_entity_id = ${item.before.fromEntityId},
@@ -697,6 +751,7 @@ export async function applyUnmerge(
           WHERE organization_id = ${orgId} AND id = ${item.id}
         `;
 			}
+
 			const redirectedEntityIds = ledger.redirectedEntityIds ?? [];
 			if (redirectedEntityIds.length > 0) {
 				const restoredRedirects = await transitionEntityMergeRows({
@@ -728,6 +783,68 @@ export async function applyUnmerge(
 				);
 			}
 		}
+
+		// Authorization edges on EITHER entity are dropped, not restored. This is
+		// required for ledger-backed and legacy merges alike: while the identities
+		// were folded onto the winner, an ACL sync could have resolved the loser's
+		// provider identity there and granted the winner access. Splitting them
+		// again would leave that grant on someone the provider never granted it to.
+		// The only answer that cannot invent access is to drop both sides and let
+		// the next sync re-derive from the provider.
+		await withAclPrivilege(tx, async () => {
+			await tx`
+        UPDATE entity_relationships r
+        SET deleted_at = current_timestamp, updated_at = current_timestamp
+        FROM entity_relationship_types rt
+        WHERE rt.id = r.relationship_type_id
+          AND (rt.purpose = 'authorization' OR rt.slug = 'member_of')
+          AND r.organization_id = ${orgId}
+          AND r.deleted_at IS NULL
+          AND (
+            r.from_entity_id IN (${loserId}, ${winnerId})
+            OR r.to_entity_id IN (${loserId}, ${winnerId})
+          )
+      `;
+		});
+
+		// Dropping the edges is not enough on its own: a sync that resolved the
+		// loser's provider identity to the WINNER before this transaction can
+		// still be in flight and would write that already-resolved grant back
+		// moments after we commit. Marking the ACL state stale closes that race
+		// from both ends — the gate stops trusting the snapshot, and the in-flight
+		// sync's own `fresh` stamp is suppressed because it only applies while
+		// `updated_at < syncStartedAt`, which this write invalidates.
+		//
+		// NOT gated on having dropped anything, which is the subtle part. The race
+		// this exists for is exactly the case where the drop finds nothing: the
+		// sync has already resolved the identity to the winner but has not yet
+		// written the edge, so counting dropped rows would skip the invalidation
+		// in precisely the window that needs it.
+		//
+		// Marking unconditionally is cheap where it does not apply: the statement
+		// matches no rows for an org that has never onboarded an ACL connection,
+		// so an ERP-only tenant pays nothing. Where it does match, `stale` FAILS
+		// CLOSED for every enforced connection until the next sync — an
+		// availability cost taken deliberately on a rare, admin-initiated action,
+		// because the alternative is serving access the provider never granted.
+		//
+		// `clock_timestamp()` rather than `current_timestamp` is load-bearing for
+		// the same reason it is in `slack-acl-sync.ts`: the latter is
+		// transaction-START time, which would record a cutoff below an in-flight
+		// sync's and slip under the fence.
+		//
+		// KNOWN RESIDUAL, narrower than what it replaces: a sync that starts after
+		// this statement executes but before the transaction commits reads the old
+		// identity mapping and can still satisfy `updated_at < syncStartedAt`,
+		// because that predicate orders statement timestamps, not commit
+		// visibility. Closing it needs a generation counter observed at sync start
+		// rather than a timestamp. Today unmerge invalidates nothing at all, so the
+		// winner keeps the grant indefinitely; this is strictly better.
+		await tx`
+      UPDATE authz_source_acl_state
+      SET freshness_state = 'stale', updated_at = clock_timestamp()
+      WHERE organization_id = ${orgId}
+    `;
 
 		// 1. Restore every identity this operation moved, including identities an
 		//    inner merge had already placed on the loser. Legacy operations have no

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -69,6 +69,7 @@ export interface DataSourceContext {
 
 /** Operations that bypass READ ONLY transactions or have side-effects. */
 const FORBIDDEN_OPS = /\b(COPY|IMPORT|PRAGMA|CALL)\b/i;
+const FORBIDDEN_QUERY_FUNCTIONS = new Set(['set_config']);
 const MAX_ROWS = 1000;
 const QUERY_TIMEOUT_MS = 5000;
 
@@ -96,6 +97,36 @@ function identName(value: unknown): string | null {
     if (o.this) return identName(o.this);
   }
   return null;
+}
+
+/**
+ * Reject functions that mutate the database session even inside a read-only
+ * transaction. `set_config` can persist a custom GUC on a pooled connection;
+ * that would let caller SQL forge server-only transaction flags used by database
+ * triggers on a later request.
+ */
+function assertNoForbiddenFunctions(root: unknown): void {
+  const seen = new Set<object>();
+  const stack: unknown[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || typeof node !== 'object') continue;
+    if (seen.has(node as object)) continue;
+    seen.add(node as object);
+    if (Array.isArray(node)) {
+      for (const child of node) stack.push(child);
+      continue;
+    }
+
+    const record = node as Record<string, unknown>;
+    const functionNode = record.function as Record<string, unknown> | undefined;
+    const methodNode = record.method_call as Record<string, unknown> | undefined;
+    const name = identName(functionNode?.name) ?? identName(methodNode?.method);
+    if (name && FORBIDDEN_QUERY_FUNCTIONS.has(name.toLowerCase())) {
+      throw new Error(`Function '${name}' is not allowed in read-only queries.`);
+    }
+    for (const child of Object.values(record)) stack.push(child);
+  }
 }
 
 /**
@@ -272,6 +303,8 @@ function extractTableRefs(query: string): string[] {
     throw new Error('Multiple SQL statements are not allowed; provide a single query.');
   }
   const root = statements[0] as SqlNode;
+
+  assertNoForbiddenFunctions(root);
 
   // Reject schema-qualified references anywhere in the tree (joins, subqueries,
   // CTE bodies, UNION branches) — they bypass the org-scoping CTEs.

--- a/packages/server/src/utils/relationship-validation.ts
+++ b/packages/server/src/utils/relationship-validation.ts
@@ -17,6 +17,135 @@ const CALLER_SETTABLE_SOURCES = ['ui', 'llm', 'feed', 'api'] as const;
 export const EDGE_SOURCE_CONFIG = 'config';
 export const EDGE_SOURCE_MANUAL = 'manual';
 
+/**
+ * System-controlled classification of what a relationship type is FOR.
+ *
+ * `authorization` marks a type for ACL reads in the follow-up deployment. It is
+ * deliberately not caller-settable: the whole point is that the platform, not
+ * a caller or connector manifest, decides which vocabulary grants access.
+ */
+export type RelationshipTypePurpose = 'authorization';
+export const PURPOSE_AUTHORIZATION: RelationshipTypePurpose = 'authorization';
+
+/**
+ * Relationship slugs whose EDGES the ACL engine owns. Configs legitimately
+ * declare the `member_of` type and may update its harmless fields before
+ * classification; caller-created edges on it are never allowed.
+ *
+ * `purpose` is the durable enforcement boundary. During the staged rollout the
+ * mutation guard also checks this ACL-managed slug, because ACL reads trust it
+ * before the classification backfill lands.
+ */
+export function isAclManagedRelationshipSlug(slug: string): boolean {
+  return slug === 'member_of';
+}
+
+/**
+ * Run `fn` with the transaction-local flag the ACL edge trigger requires for a
+ * classified relationship type.
+ *
+ * Enforcement of "only the ACL syncs write authorization edges" lives in a
+ * database trigger, not in call-site checks, because `entity_relationships` has
+ * several write paths and guarding a subset only ever means the next writer is
+ * the bypass. `source` cannot carry the boundary either: the syncs write
+ * `source='feed'`, which is also caller-settable, so a caller-minted edge is
+ * byte-identical to a sync-minted one.
+ *
+ * `set_config(..., true)` is transaction-LOCAL. On a pooled connection a session
+ * GUC would leak the privilege to whatever ran next; this cannot.
+ *
+ * This opens a top-level transaction. A writer that is already inside a
+ * transaction uses `withAclPrivilege` instead. The privilege is released
+ * explicitly so the grant is bounded by `fn`, not by the rest of the caller's
+ * transaction.
+ */
+export async function withAclEdgeWrite<T>(
+  db: DbClient,
+  fn: (tx: DbClient) => Promise<T>
+): Promise<T> {
+  return db.begin((tx: DbClient) => withAclPrivilege(tx, () => fn(tx))) as Promise<T>;
+}
+
+/**
+ * Grant the ACL-write privilege for exactly `fn`, inside a transaction the
+ * caller already owns.
+ *
+ * `withAclEdgeWrite` opens its own transaction; this is for a writer that is
+ * already mid-transaction and must drop the privilege again before its
+ * remaining statements run. Merge is the motivating case: it tombstones
+ * authorization edges early and then repoints ordinary ones, and if the flag
+ * stayed set for the rest of that transaction the trigger could no longer
+ * refuse a repoint of any authorization edge the first statement missed.
+ *
+ * The reset is best-effort: if `fn` failed with a database error the
+ * transaction is already aborted and every later statement — including this
+ * one — will fail, so swallowing keeps the caller's original error rather than
+ * masking it with `current transaction is aborted`. Nothing leaks in that case
+ * because the whole transaction rolls back.
+ */
+export async function withAclPrivilege<T>(tx: DbClient, fn: () => Promise<T>): Promise<T> {
+  await tx`SELECT set_config('lobu.acl_write', 'on', true)`;
+  try {
+    return await fn();
+  } finally {
+    await tx`SELECT set_config('lobu.acl_write', 'off', true)`.catch(() => {});
+  }
+}
+
+/**
+ * Refuse a caller-driven mutation of an authorization-bearing relationship type.
+ *
+ * Once a type is classified, its schema lifecycle is platform-owned: callers
+ * cannot archive it, change its rules, or attach it as another type's inverse.
+ * Edge mutations use the stricter pre-classification guard below.
+ */
+export function assertNotAuthorizationType(
+  type: { slug?: string | null; purpose?: string | null },
+  action: string
+): void {
+  if (type.purpose !== PURPOSE_AUTHORIZATION) return;
+  throw new ToolUserError(
+    `Relationship type '${type.slug ?? 'unknown'}' is authorization-bearing and cannot be modified via ${action}. ` +
+      'Access-granting edges are maintained by the connector ACL syncs.',
+    403
+  );
+}
+
+/**
+ * Refuse a caller-driven mutation of an EDGE on an ACL-managed relationship type.
+ *
+ * Stricter than `assertNotAuthorizationType`: it also refuses the ACL-managed slug,
+ * not just a classified type. That gap matters for the whole window between the
+ * deploy that adds this mechanism and the deploy that backfills `purpose` —
+ * during it every live `member_of` row is unclassified while the ACL reads
+ * already trust the slug, so a purpose-only guard would leave callers free to
+ * mint or revoke grants and the backfill would then bless whatever they left
+ * behind.
+ *
+ * Deliberately not applied wholesale to relationship-type surfaces before
+ * classification. Configs legitimately declare `member_of`
+ * (`examples/personal-agent/lobu.config.ts`) and declaring a type grants nobody
+ * access; creating an edge on it does. The schema handler separately blocks the
+ * unsafe archive transition. Once classified, the purpose guard above protects
+ * the rest of its schema lifecycle as well.
+ */
+export function assertNotAclManagedEdge(
+  type: { slug?: string | null; purpose?: string | null },
+  action: string
+): void {
+  if (
+    type.purpose !== PURPOSE_AUTHORIZATION &&
+    !isAclManagedRelationshipSlug(type.slug ?? '')
+  ) {
+    return;
+  }
+  throw new ToolUserError(
+    `Relationship type '${type.slug ?? 'unknown'}' is authorization-bearing and cannot be modified via ${action}. ` +
+      'Access-granting edges are maintained by the connector ACL syncs.',
+    403
+  );
+}
+
 /** Source values used to select edges during reconciliation. */
 const RECONCILED_SOURCES = [EDGE_SOURCE_CONFIG, EDGE_SOURCE_MANUAL] as const;
 

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -758,7 +758,8 @@ export const QUERYABLE_SCHEMA = {
         'deleted_at',
         'created_at',
         'updated_at',
-        'metadata'
+        'metadata',
+        'purpose'
       ),
     },
   ],


### PR DESCRIPTION
## Summary
- Second half of the split lobu#2825 began. That release added `entity_relationship_types.purpose`, the `entity_relationships` chokepoint trigger, and `withAclEdgeWrite`/`withAclPrivilege` at every ACL writer — all **inert**, because nothing was classified. This release classifies `member_of`, which arms the trigger.
- The split exists because *classification*, not the trigger, is what a rolling deploy can break: an older pod that does not set `lobu.acl_write` would have its ACL sync rejected. `git merge-base --is-ancestor 629b5314 acb9c262e` → true, so #2825 is live on every prod pod and the flag is universally supplied before this migration lands.
- `ensureMemberOfType` now passes `purpose: PURPOSE_AUTHORIZATION`. That is the only production code change, and it doubles as the repair path: the upsert on `(organization_id, slug)` adopts a pre-existing `member_of` row, so an org whose type predates the backfill gets classified on its next sync instead of staying an unguarded ACL type forever.

### Two migration predicates that are deliberately absent
- **No `created_by` filter.** A prod audit (2026-08-16) found all four existing `member_of` rows platform-created, so nothing is being reclassified out from under an org today. But `created_by` must not be the filter regardless: `ensureMemberOfType` adopts an org-authored row, which keeps its non-NULL `created_by`. Filtering on it would leave the trigger inert for exactly the org that authored its own row — the hole `purpose` exists to close.
- **No status/deleted filter.** The ACL read gates select `member_of` by slug with no relationship-type lifecycle predicate (`resource-visibility.ts:100`, `channel-visibility.ts:187`), so an archived type's surviving edges are still access-bearing and must be guarded.

Each absence is pinned by a test, and each was mutation-tested: adding `AND created_by IS NULL` kills the org-authored case; adding `AND status = 'active'` kills the archived case, and nothing else.

### Cascade audit — arming a `BEFORE DELETE` trigger
The trigger is `BEFORE INSERT OR UPDATE OR DELETE`, so every FK cascade into `entity_relationships` fires it. All four (`baseline.sql` ~4845-4873) are clean:
- `from_entity_id` / `to_entity_id` → force-delete removes edges under `withAclPrivilege` first, so the cascade finds none; the other four `hardDeleteEntityRows` callers each drop a row created in the same transaction after losing an identity race, explicitly relationship-less.
- `organization_id` → no production org-delete path exists (`DELETE FROM organization` greps empty outside tests).
- `relationship_type_id` → no production type-delete path; `assertNotAuthorizationType` guards the schema surface.

The slug fallback (`isAclManagedRelationshipSlug`, the `OR rt.slug` half of `ACL_MANAGED_TYPE_SQL`) is intentionally kept: a config can create a new unclassified `member_of` row after this one-time backfill and before its first sync classifies it. Removing it is a follow-up.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Full `packages/server/src/__tests__/integration/` tree: 331 files, 2421 passed, 2 skipped, 0 failed
- [x] Mutation-tested both migration predicates (each mutation killed exactly its one intended test)
- [x] `tsc --noEmit` clean · CLI apply 65/65 · squawk clean · `check-exposed-surface-naming` clean

The first gate run on this branch failed and is fully explained: a banned-vocabulary word in a comment (cascading to `migrations`, which only gates on `FORMAT_LINT_RESULT`), and two vitest shards where test fixtures wrote/deleted `entity_relationships` with raw SQL. A `DELETE` in teardown fires the guard exactly like an `INSERT`; both sites in each file now use `withAclEdgeWrite`. Those two files live in `automations/` and `connectors/`, which is why a topical subset run went green — a change that arms a database-level guard needs the whole integration tree.

## Notes
Rolling-deploy safe in both directions: the down migration declassifies, making the trigger inert again, and the read gates still trust the slug during this rollout, so a rollback widens who may write these edges without narrowing who may read them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization-purpose classification for relationship types.
  * Protected authorization-managed relationships from unauthorized linking, unlinking, updating, archiving, and deletion.
  * Ensured ACL changes occur through controlled, atomic transactions.
  * Improved entity merge, unmerge, deletion, and membership handling to prevent accidental grant restoration or transfer.
* **Bug Fixes**
  * Blocked attempts to bypass ACL protections through inverse, slug-based, or raw database writes.
  * Prevented privilege leakage between transactions and pooled connections.
* **Security**
  * Rejected forbidden SQL configuration calls, including in read-only queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->