### PR TITLE
feat(server): classify member_of as authorization-bearing

### DIFF
--- a/db/migrations/20260817020000_classify_member_of_authorization.sql
+++ b/db/migrations/20260817020000_classify_member_of_authorization.sql
@@ -1,0 +1,45 @@
+-- migrate:up
+
+-- Arms the authorization-edge trigger by classifying the one slug the ACL syncs
+-- own. This is the deliberate second release of the split that lobu#2825 began:
+-- that release added `purpose` and the trigger without backfilling, and made
+-- every ACL writer set the transaction-local `lobu.acl_write` flag first.
+--
+-- Keeping classification in this later release means every application version
+-- that can overlap this migration already supplies the flag, so the rolling
+-- deploy cannot leave an older pod writing guarded edges without it.
+--
+-- Classifies EVERY `member_of` row, not just the platform-created ones. A prod
+-- audit on 2026-08-16 found all four existing rows to be platform-created —
+-- `created_by` NULL, live edges only `source='feed'` — so no org's own
+-- vocabulary is being reclassified out from under it today. `created_by` must
+-- not be the filter regardless:
+-- `ensureMemberOfType` upserts on (organization_id, slug), so it ADOPTS an
+-- org-authored row as the ACL type, and that row keeps its non-NULL
+-- `created_by`. Filtering on it would leave a live ACL type unclassified — the
+-- trigger inert for exactly the org that authored its own row, which is the
+-- hole `purpose` exists to close.
+--
+-- No status or deletion filter: the current ACL reads select `member_of` by slug
+-- without a relationship-type lifecycle predicate. Any surviving edge attached
+-- to an archived row is still access-bearing and must be guarded too.
+--
+-- The `purpose IS NULL` predicate makes re-running a no-op instead of churning
+-- every row's `updated_at`.
+UPDATE entity_relationship_types
+SET purpose = 'authorization',
+    updated_at = current_timestamp
+WHERE slug = 'member_of'
+  AND purpose IS NULL;
+
+-- migrate:down
+
+-- Declassifying makes the trigger inert again. The current read gates still
+-- trust the slug during this rollout, so this widens who may write the edges
+-- without narrowing who may read them. The earlier migration owns removal of
+-- the `purpose` column and must be rolled back later, in reverse migration order.
+UPDATE entity_relationship_types
+SET purpose = NULL,
+    updated_at = current_timestamp
+WHERE slug = 'member_of'
+  AND purpose = 'authorization';

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -4,6 +4,7 @@ import type {
   InferenceModality,
 } from "../../../config/define.js";
 import { ValidationError } from "../../memory/_lib/errors.js";
+import { isPlatformOwnedRelationshipSlug } from "../platform-owned-types.js";
 import type {
   RemoteAgent,
   RemoteAuthProfile,
@@ -1102,25 +1103,13 @@ export const effectiveRelationshipTypeAfterApply = (
 });
 
 /**
- * Relationship types whose lifecycle the platform owns, not a config.
- *
  * `member_of` is minted and maintained by the connector ACL syncs. A config may
  * legitimately DECLARE it — `examples/personal-agent/lobu.config.ts` does — but
- * apply must not create, update, or delete it, declared or not. Once the server
- * classifies it as authorization-bearing, the schema surfaces refuse those
- * writes outright, so an apply that still attempted them would fail for every
- * such config.
- *
- * Keyed on the slug rather than the server's `purpose`, which the apply client
- * does not fetch. That is deliberate: the slug is reserved, and keying on it
- * covers the window BEFORE classification as well as after.
+ * apply must not create, update, or delete it, declared or not. `lobu memory
+ * seed` shares the rule and the same slug set.
  */
-const PLATFORM_OWNED_RELATIONSHIP_SLUGS = new Set(["member_of"]);
-
 function isPlatformOwnedRelationshipType(kind: string, slug: string): boolean {
-  return (
-    kind === "relationship-type" && PLATFORM_OWNED_RELATIONSHIP_SLUGS.has(slug)
-  );
+  return kind === "relationship-type" && isPlatformOwnedRelationshipSlug(slug);
 }
 
 /** Classify a remote-only definition without deleting unproven ownership. */

--- a/packages/cli/src/commands/_lib/platform-owned-types.ts
+++ b/packages/cli/src/commands/_lib/platform-owned-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Relationship slugs the platform owns outright.
+ *
+ * The ACL syncs create and maintain these types themselves, and once the server
+ * classifies one as authorization-bearing the schema surfaces refuse client
+ * writes to it. Any CLI command that would create or update a relationship type
+ * has to skip these, or it fails for every config that declares one.
+ *
+ * Keyed on the slug rather than the server's `purpose`, which no CLI command
+ * fetches. That is deliberate: the slug is reserved, so keying on it covers the
+ * window BEFORE classification as well as after.
+ */
+const PLATFORM_OWNED_RELATIONSHIP_SLUGS = new Set(["member_of"]);
+
+export function isPlatformOwnedRelationshipSlug(slug: string): boolean {
+  return PLATFORM_OWNED_RELATIONSHIP_SLUGS.has(slug);
+}

--- a/packages/cli/src/commands/memory/_lib/seed-cmd.ts
+++ b/packages/cli/src/commands/memory/_lib/seed-cmd.ts
@@ -6,6 +6,7 @@ import type {
   DesiredRelationshipType,
 } from "../../_lib/apply/desired-state.js";
 import { loadDesiredStateFromConfig } from "../../_lib/apply/desired-state.js";
+import { isPlatformOwnedRelationshipSlug } from "../../_lib/platform-owned-types.js";
 import { ApiError, ValidationError } from "./errors.js";
 import {
   getSessionForOrg,
@@ -536,9 +537,16 @@ export async function seedMemoryWorkspace(
     }
   }
 
-  if (relationshipTypes.length > 0) {
-    printText(`\nRelationship types (${relationshipTypes.length}):`);
-    for (const rel of relationshipTypes) {
+  // Platform-owned slugs are skipped for the same reason apply skips them: the
+  // create returns "already exists", the fallback issues an update, and the
+  // schema surface rejects that outright once the type is classified as
+  // authorization-bearing — aborting the whole seed for any config declaring one.
+  const seedableRelationshipTypes = relationshipTypes.filter(
+    (rel) => !isPlatformOwnedRelationshipSlug(rel.slug)
+  );
+  if (seedableRelationshipTypes.length > 0) {
+    printText(`\nRelationship types (${seedableRelationshipTypes.length}):`);
+    for (const rel of seedableRelationshipTypes) {
       await seedRelationshipType(rel, ctx);
     }
   }

--- a/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-edge-chokepoint.test.ts
@@ -36,17 +36,7 @@ describe("authorization edges have one enforcement point", () => {
 		alice = (await mk("person", "Alice")).id;
 		bob = (await mk("person", "Bob")).id;
 		channel = (await mk("channel", "#secrets")).id;
-		await classifyMemberOf();
 	});
-
-	/** The follow-up deployment classifies this in production; these tests arm it. */
-	async function classifyMemberOf(): Promise<void> {
-		const sql = getTestDb();
-		await sql`
-      UPDATE entity_relationship_types SET purpose = 'authorization'
-      WHERE id = ${typeId}
-    `;
-	}
 
 	async function seedGrant(person: number): Promise<number> {
 		return withAclEdgeWrite(getTestDb(), async (tx) => {
@@ -328,7 +318,7 @@ describe("authorization edges have one enforcement point", () => {
 			{ orgId, winnerId: bob, loserId: alice, mergedBy: "chokepoint-test" },
 			sql,
 		);
-		// The follow-up deploy classifies the type the ledger already references.
+		// Simulate classifying the type after the ledger already references it.
 		await sql`
       UPDATE entity_relationship_types SET purpose = 'authorization'
       WHERE id = ${legacyTypeId}

--- a/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
+++ b/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
@@ -67,7 +67,6 @@ describe("authorization-bearing relationship types are not caller-writable", () 
 				name: "#secrets",
 			})
 		).id;
-		await classifyMemberOf();
 	});
 
 	/**
@@ -87,15 +86,6 @@ describe("authorization-bearing relationship types are not caller-writable", () 
       `;
 			return Number(rows[0].id);
 		});
-	}
-
-	/** The follow-up deployment classifies this in production; these tests arm it. */
-	async function classifyMemberOf(): Promise<void> {
-		const sql = getTestDb();
-		await sql`
-      UPDATE entity_relationship_types SET purpose = 'authorization'
-      WHERE id = ${typeId}
-    `;
 	}
 
 	it("refuses to LINK on an authorization type — creating one would mint access", async () => {
@@ -152,10 +142,9 @@ describe("authorization-bearing relationship types are not caller-writable", () 
 	});
 
 	it("allows a config to declare member_of while it is unclassified", async () => {
-		// `lobu apply` configs legitimately declare member_of — and must, or prune
-		// flags it removed and aborts the apply (examples/personal-agent). Refusing
-		// the TYPE surface would break apply today. Declaring a type grants nobody
-		// access; only an edge on it does, and that surface stays closed.
+		// Legacy and direct config paths can declare member_of before the first ACL
+		// sync creates it. Declaring a type grants nobody access; only an edge on it
+		// does, and that surface stays closed.
 		const sql = getTestDb();
 		await sql`
       UPDATE entity_relationship_types
@@ -353,8 +342,8 @@ describe("authorization-bearing relationship types are not caller-writable", () 
 	});
 
 	it("refuses member_of by slug before it is classified", async () => {
-		// During the staged rollout, ACL reads still trust the slug while `purpose`
-		// is null. The temporary slug guard keeps that interval fail-closed.
+		// ACL reads still trust the slug during the staged cutover. The slug guard
+		// keeps a newly declared row fail-closed before its first sync classifies it.
 		const sql = getTestDb();
 		await sql`
       UPDATE entity_relationship_types SET purpose = NULL WHERE id = ${typeId}

--- a/packages/server/src/__tests__/integration/authz/relationship-type-purpose.test.ts
+++ b/packages/server/src/__tests__/integration/authz/relationship-type-purpose.test.ts
@@ -5,12 +5,10 @@
  * `ensureMemberOfType` upserts on (organization_id, slug) — so it ADOPTS a
  * pre-existing row rather than create-or-failing.
  *
- * This deploy ships the classification MECHANISM without classifying anything:
- * stamping `member_of` is what arms the trigger, and arming it while older pods
- * still write ACL edges without the transaction-local flag would reject their
- * writes until the rollout drained. So these tests drive `ensureRelationshipType`
- * with an explicit purpose and pin the rollout invariant that
- * `ensureMemberOfType` does not yet classify.
+ * lobu#2825 shipped the classification mechanism inert, after making every ACL
+ * writer set the transaction-local flag. This follow-up stamps `member_of`, so
+ * the tests pin both the shared helper's repair path and the initializer
+ * that now arms the trigger for each organization.
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -50,13 +48,31 @@ describe('relationship type purpose', () => {
     expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
   });
 
-  it('does not classify member_of before every pod sets the flag', async () => {
-    // Guards the rollout seam. If a later change makes `ensureMemberOfType`
-    // stamp the purpose, it arms the trigger org-by-org as pods restart, and
-    // ACL syncs on not-yet-restarted pods start failing. Flipping this test is
-    // the deliberate follow-up deployment step.
+  it('classifies member_of at initialization', async () => {
+    // #2825 established the writer flag in the earlier release. Reverting this
+    // initializer to omit the purpose would now leave an org's ACL type
+    // unguarded from its next sync onward.
     await ensureMemberOfType(orgId);
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
+  });
+
+  it('repairs an unclassified member_of it adopts on the next sync', async () => {
+    // The backfill classifies rows that exist when it runs. This covers the
+    // other source of unclassified rows: one created during the deploy window by
+    // a pod still running the pre-classification code. Without this repair such
+    // a row is a live ACL type the trigger ignores — permanently, since nothing
+    // else revisits it.
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_relationship_types
+        (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+      VALUES ('member_of', 'Member of', 'pre-classification row', ${orgId}, false, NULL,
+              current_timestamp, current_timestamp)
+    `;
     expect(await purposeOf(orgId, 'member_of')).toBeNull();
+
+    await ensureMemberOfType(orgId);
+    expect(await purposeOf(orgId, 'member_of')).toBe('authorization');
   });
 
   it('repairs an unclassified row it adopts', async () => {

--- a/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
@@ -16,6 +16,7 @@
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getTestDb } from "../../setup/test-db";
+import { withAclEdgeWrite } from "../../../utils/relationship-validation";
 import { createTestConnection } from "../../setup/test-fixtures";
 import { TestWorkspace } from "../../setup/test-mcp-client";
 import {
@@ -50,7 +51,11 @@ describe("streaming feed as an automation @feed source", () => {
     const sql = getTestDb();
     await sql`DELETE FROM channel_messages WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${orgId}`;
-    await sql`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    // `member_of` is authorization-bearing, so the edge trigger refuses this
+    // teardown from outside a sync — a DELETE is guarded exactly like an INSERT.
+    await withAclEdgeWrite(sql, async (tx) => {
+      await tx`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    });
     await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM feeds WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
@@ -270,13 +275,18 @@ describe("streaming feed as an automation @feed source", () => {
       WHERE organization_id = ${orgId} AND slug = 'member_of' AND status = 'active'
       LIMIT 1
     `;
-    await sql`
-      INSERT INTO entity_relationships (
-        organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
-      ) VALUES (
-        ${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW()
-      )
-    `;
+    // Seeded under the ACL-write privilege because `member_of` is classified
+    // authorization-bearing: the chokepoint trigger refuses a grant minted
+    // outside a sync, which is the property this fixture is standing in for.
+    await withAclEdgeWrite(sql, async (tx) => {
+      await tx`
+        INSERT INTO entity_relationships (
+          organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
+        ) VALUES (
+          ${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW()
+        )
+      `;
+    });
 
     const rows = (await readAsAutomationSource(readerUserId)) as Array<{ text: string }>;
     expect(rows.length).toBe(2);

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -32,6 +32,7 @@ import type { Env } from "../../../index";
 import { slugToRuntimeConnectionId } from "../../../lobu/stores/connections-projection";
 import { materializeDueFeeds } from "../../../scheduled/check-due-feeds";
 import { ensureMemberEntity } from "../../../utils/member-entity";
+import { withAclEdgeWrite } from "../../../utils/relationship-validation";
 import { getTestDb } from "../../setup/test-db";
 import { createTestAgent, createTestConnection } from "../../setup/test-fixtures";
 import { TestWorkspace } from "../../setup/test-mcp-client";
@@ -97,7 +98,11 @@ describe("channel streaming feeds", () => {
     await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
     // ACL/graph state the membership-gate test materializes.
     await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${orgId}`;
-    await sql`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    // `member_of` is authorization-bearing, so the edge trigger refuses this
+    // teardown from outside a sync — a DELETE is guarded exactly like an INSERT.
+    await withAclEdgeWrite(sql, async (tx) => {
+      await tx`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    });
     await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
     await sql`
       DELETE FROM entities
@@ -484,11 +489,16 @@ describe("channel streaming feeds", () => {
       WHERE organization_id = ${orgId} AND slug = 'member_of' AND status = 'active'
       LIMIT 1
     `;
-    await sql`
-      INSERT INTO entity_relationships (
-        organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
-      ) VALUES (${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW())
-    `;
+    // Seeded under the ACL-write privilege because `member_of` is classified
+    // authorization-bearing: the chokepoint trigger refuses a grant minted
+    // outside a sync, which is the property this fixture is standing in for.
+    await withAclEdgeWrite(sql, async (tx) => {
+      await tx`
+        INSERT INTO entity_relationships (
+          organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
+        ) VALUES (${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW())
+      `;
+    });
 
     const allowed = (await workspace.owner.feeds.manage({
       action: "read_feed",

--- a/packages/server/src/__tests__/integration/migrations/classify-member-of-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/classify-member-of-migration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The backfill half of the ACL classification rollout.
+ *
+ * lobu#2825 added `purpose` and the authorization-edge trigger but deliberately
+ * classified nothing, so the trigger shipped inert. This migration arms it. The
+ * cases below pin the choices that are easy to get wrong when re-reading it: it
+ * classifies EVERY `member_of` row regardless of author or lifecycle state,
+ * leaves every other slug alone, and does not churn rows on a re-run.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import {
+  executeMigrationSection,
+  loadMigrationDown,
+  loadMigrationUp,
+  type MigrationSection,
+} from '../../../db/migration-loader';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const CLASSIFY_MIGRATION = '20260817020000_classify_member_of_authorization.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+async function executeSection(section: MigrationSection): Promise<void> {
+  await executeMigrationSection((statement) => getDb().unsafe(statement), section);
+}
+
+async function purposeOf(orgId: string, slug: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = await sql<{ purpose: string | null }[]>`
+    SELECT purpose FROM entity_relationship_types
+    WHERE organization_id = ${orgId} AND slug = ${slug}
+    LIMIT 1
+  `;
+  return rows.length > 0 ? rows[0].purpose : null;
+}
+
+async function rowVersionOf(orgId: string, slug: string): Promise<string> {
+  const sql = getDb();
+  const rows = await sql<{ row_version: string }[]>`
+    SELECT xmin::text AS row_version FROM entity_relationship_types
+    WHERE organization_id = ${orgId} AND slug = ${slug}
+    LIMIT 1
+  `;
+  return rows[0].row_version;
+}
+
+async function seedType(
+  orgId: string,
+  slug: string,
+  createdBy: string | null
+): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO entity_relationship_types
+      (slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at, purpose)
+    VALUES (${slug}, ${slug}, 'seeded by migration test', ${orgId}, false, ${createdBy},
+            current_timestamp, current_timestamp, NULL)
+  `;
+}
+
+describe('classify member_of migration', () => {
+  let up: MigrationSection;
+  let down: MigrationSection;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    const dir = resolveMigrationsDir();
+    up = loadMigrationUp(dir, CLASSIFY_MIGRATION);
+    down = loadMigrationDown(dir, CLASSIFY_MIGRATION);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('classifies a platform-created member_of', async () => {
+    const org = await createTestOrganization({ name: 'Backfill platform' });
+    await seedType(org.id, 'member_of', null);
+    expect(await purposeOf(org.id, 'member_of')).toBeNull();
+
+    await executeSection(up);
+
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+  });
+
+  it('classifies an ORG-AUTHORED member_of too', async () => {
+    // The load-bearing case. `ensureMemberOfType` upserts on
+    // (organization_id, slug), so it adopts a row a config authored — and that
+    // row keeps its non-NULL `created_by`. Filtering the backfill on
+    // `created_by IS NULL` would leave that live ACL type unclassified, i.e. the
+    // trigger inert for precisely the org that wrote its own row.
+    const org = await createTestOrganization({ name: 'Backfill org-authored' });
+    const author = await createTestUser();
+    await seedType(org.id, 'member_of', author.id);
+
+    await executeSection(up);
+
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+  });
+
+  it('classifies an archived member_of', async () => {
+    const org = await createTestOrganization({ name: 'Backfill archived' });
+    await seedType(org.id, 'member_of', null);
+    const sql = getDb();
+    await sql`
+      UPDATE entity_relationship_types
+      SET status = 'archived', deleted_at = current_timestamp
+      WHERE organization_id = ${org.id} AND slug = 'member_of'
+    `;
+
+    await executeSection(up);
+
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+  });
+
+  it('leaves ordinary domain vocabulary alone', async () => {
+    const org = await createTestOrganization({ name: 'Backfill domain' });
+    const author = await createTestUser();
+    await seedType(org.id, 'billed_to', author.id);
+
+    await executeSection(up);
+
+    expect(await purposeOf(org.id, 'billed_to')).toBeNull();
+  });
+
+  it('is idempotent', async () => {
+    const org = await createTestOrganization({ name: 'Backfill idempotent' });
+    await seedType(org.id, 'member_of', null);
+
+    await executeSection(up);
+    const firstVersion = await rowVersionOf(org.id, 'member_of');
+    await executeSection(up);
+
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+    expect(await rowVersionOf(org.id, 'member_of')).toBe(firstVersion);
+  });
+
+  it('declassifies on down, disarming the trigger rather than blocking reads', async () => {
+    const org = await createTestOrganization({ name: 'Backfill rollback' });
+    await seedType(org.id, 'member_of', null);
+
+    await executeSection(up);
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+
+    await executeSection(down);
+    expect(await purposeOf(org.id, 'member_of')).toBeNull();
+
+    // Re-applying up after down must classify again — a down that left the row
+    // in a state up could not re-stamp would strand a rolled-back deploy. No
+    // cleanup depends on this: afterAll only truncates.
+    await executeSection(up);
+    expect(await purposeOf(org.id, 'member_of')).toBe('authorization');
+  });
+});

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -46,7 +46,10 @@ import {
   withEntityWriteTransaction,
 } from '../utils/entity-management.js';
 import { ensureRelationshipType, upsertEdges } from '../utils/edge-writes.js';
-import { withAclEdgeWrite } from '../utils/relationship-validation.js';
+import {
+  PURPOSE_AUTHORIZATION,
+  withAclEdgeWrite,
+} from '../utils/relationship-validation.js';
 import { aclConnectionIdSql } from './acl-observability.js';
 import { type AclSyncFence, captureAclSyncFence } from './acl-generation.js';
 import { ensureResourceEntityType } from './acl-resource-type.js';
@@ -114,12 +117,14 @@ export function ensureMemberOfType(orgId: string): Promise<number> {
     slug: MEMBER_OF_TYPE_SLUG,
     name: 'Member of',
     description: 'A member belongs to an ACL resource (channel, repo, org, …)',
-    // NOT classified in this deploy, and the omission is load-bearing rather
-    // than an oversight. Stamping `purpose` here would arm the trigger for an
-    // org the moment one new pod ran its sync, while older pods still writing
-    // that org's member_of edges without the flag would start being rejected.
-    // The follow-up deploy adds `purpose: PURPOSE_AUTHORIZATION` here together
-    // with the backfill, once every live pod sets the flag.
+    // lobu#2825 made every ACL writer set `lobu.acl_write` while leaving
+    // classification inert. This later release can therefore stamp the type
+    // without a rolling-deploy window in which an older pod's sync is rejected.
+    //
+    // This also REPAIRS: the upsert adopts a pre-existing `member_of` row, so an
+    // org whose type predates the backfill is classified on its next sync rather
+    // than staying an unguarded ACL type forever.
+    purpose: PURPOSE_AUTHORIZATION,
   });
 }
 
@@ -557,7 +562,7 @@ export async function buildAccessGraph(params: {
   // A resource's membership is re-affirmed rather than rewritten, so a
   // steady-state resync creates nothing.
   // Grants and departures commit together under the ACL write flag. The trigger
-  // starts requiring it once the follow-up deploy classifies `member_of`.
+  // requires it now that `member_of` is classified.
   // Enforcement lives in the database rather than at each call site because
   // this table has several writers, and `source='feed'` cannot mark a write as
   // ours — it is caller-settable too.

--- a/packages/server/src/gateway/routes/public/github-team-graph.ts
+++ b/packages/server/src/gateway/routes/public/github-team-graph.ts
@@ -291,8 +291,8 @@ export async function buildGithubTeamGraph(params: {
 	const typeId = await ensureMemberOfType(params.organizationId);
 	// person -> company. Idempotent on the live-triple unique index; a re-bind
 	// re-affirms the edge without duplicating it.
-	// Set the ACL write flag now; the trigger starts requiring it when the
-	// follow-up deploy classifies `member_of` as authorization-bearing.
+	// The classified `member_of` type makes the trigger require the ACL write
+	// flag for this edge.
 	const created = await withAclEdgeWrite(getDb(), (tx) =>
 		upsertEdges({
 			db: tx,

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -1130,11 +1130,11 @@ async function rtHandleUpdate(
 ): Promise<ManageEntitySchemaResult> {
   const { typeId, sql } = await requireRelationshipType(args.slug, 'update', ctx);
 
-  // Before purpose is backfilled, config may still declare member_of and update
-  // its harmless fields. It may not archive the type: the materializer upserts
-  // against active slugs, so archiving would make the next sync create a second
-  // type while existing grants remain attached to the old one and stop being
-  // reconciled.
+  // A config can declare member_of before its first ACL sync classifies the row,
+  // and may update harmless fields while it is still unclassified. It may not
+  // archive the type: the materializer upserts against active slugs, so the next
+  // sync would create a second type while existing grants remain attached to the
+  // old one and stop being reconciled.
   if (
     isAclManagedRelationshipSlug(args.slug ?? '') &&
     args.status === 'archived'

--- a/packages/server/src/utils/relationship-validation.ts
+++ b/packages/server/src/utils/relationship-validation.ts
@@ -20,7 +20,7 @@ export const EDGE_SOURCE_MANUAL = 'manual';
 /**
  * System-controlled classification of what a relationship type is FOR.
  *
- * `authorization` marks a type for ACL reads in the follow-up deployment. It is
+ * `authorization` marks a type for the purpose-based ACL-read cutover. It is
  * deliberately not caller-settable: the whole point is that the platform, not
  * a caller or connector manifest, decides which vocabulary grants access.
  */
@@ -28,13 +28,13 @@ export type RelationshipTypePurpose = 'authorization';
 export const PURPOSE_AUTHORIZATION: RelationshipTypePurpose = 'authorization';
 
 /**
- * Relationship slugs whose EDGES the ACL engine owns. Configs legitimately
- * declare the `member_of` type and may update its harmless fields before
- * classification; caller-created edges on it are never allowed.
+ * Relationship slugs whose EDGES the ACL engine owns. A config can declare the
+ * `member_of` type before its first ACL sync classifies it; caller-created edges
+ * on it are never allowed.
  *
- * `purpose` is the durable enforcement boundary. During the staged rollout the
- * mutation guard also checks this ACL-managed slug, because ACL reads trust it
- * before the classification backfill lands.
+ * `purpose` is the durable enforcement boundary. Until ACL reads switch fully
+ * to it, the mutation guard also checks the slug so a newly declared,
+ * not-yet-classified row cannot be used to mint access.
  */
 export function isAclManagedRelationshipSlug(slug: string): boolean {
   return slug === ACL_MANAGED_SLUG;
@@ -126,10 +126,10 @@ export function assertNotAuthorizationType(
  * Stricter variant for the EDGE surfaces: also refuses the ACL-managed slug, not
  * just a classified type.
  *
- * That gap is the entire pre-classification window. Until the backfill lands
- * every live `member_of` row is unclassified while the ACL reads already trust
- * the slug, so a purpose-only guard would leave callers free to mint or revoke
- * grants and the backfill would then bless whatever they left behind.
+ * ACL reads still trust the slug during the staged cutover. A config can create
+ * a new unclassified `member_of` row after the one-time backfill and before its
+ * first ACL sync; a purpose-only guard would leave callers free to mint or
+ * revoke grants on that row.
  *
  * Deliberately NOT used on the relationship-TYPE surfaces: configs legitimately
  * declare `member_of` (`examples/personal-agent/lobu.config.ts`), and refusing

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -142,6 +142,17 @@ expect_fail_grep() {
   else softfail "$desc (expected non-zero exit + '$marker', got exit=$RC) [lobu $*]"; fi
 }
 
+# expect_grep_absent <desc> <present> <absent> <cwd> <args...>  -> succeeds, and
+# the output carries <present> but NOT <absent>. The positive half is required:
+# without it a command that produced nothing at all would pass vacuously.
+expect_grep_absent() {
+  local desc="$1" present="$2" absent="$3" cwd="$4"; shift 4
+  runlobu "$cwd" "$@"
+  if [ "$RC" -eq 0 ] && grep -qF -- "$present" "$OUT" \
+     && ! grep -qF -- "$absent" "$OUT"; then pass "$desc"
+  else softfail "$desc (exit=$RC, want '$present' without '$absent') [lobu $*]"; fi
+}
+
 # expect_exit <desc> <code> <cwd> <args...>  -> exact exit code
 expect_exit() {
   local desc="$1" code="$2" cwd="$3"; shift 3
@@ -420,12 +431,29 @@ expect_grep "lobu memory org current -c local" "org:" "$PROJ" memory org current
 expect_grep "lobu memory org set -c local" "memory org" "$PROJ" memory org set "$ORG" -c local
 # memory seed needs a config with `org` set -- use a dedicated minimal project.
 SEEDPROJ="$RUN_DIR/seedproj"; mkdir -p "$SEEDPROJ"
+# It declares `member_of` on purpose: that slug is platform-owned, and seeding
+# it would 409-then-403 against a server that classifies it as
+# authorization-bearing. Seed must skip it while still seeding ordinary types.
 cat > "$SEEDPROJ/lobu.config.ts" <<TS
-import { defineConfig, defineEntityType } from "@lobu/cli/config";
+import {
+  defineConfig,
+  defineEntityType,
+  defineRelationshipType,
+} from "@lobu/cli/config";
 const note = defineEntityType({ key: "note", name: "Note" });
-export default defineConfig({ org: "$ORG", agents: [], entities: [note] });
+const mentions = defineRelationshipType({ key: "mentions", name: "Mentions" });
+const memberOf = defineRelationshipType({ key: "member_of", name: "Member of" });
+export default defineConfig({
+  org: "$ORG",
+  agents: [],
+  entities: [note],
+  relationships: [mentions, memberOf],
+});
 TS
 expect_grep "lobu memory seed --dry-run" "Dry run" "$SEEDPROJ" memory seed --dry-run -c local
+expect_grep_absent "lobu memory seed skips platform-owned member_of" \
+  "relationship_type: mentions" "relationship_type: member_of" \
+  "$SEEDPROJ" memory seed --dry-run -c local
 # memory exec -- run a trivial ClientSDK script.
 echo 'export default async () => "cli-smoke-exec-ok";' > "$RUN_DIR/exec.ts"
 expect_ok "lobu memory exec (ClientSDK script)" "$PROJ" memory exec "$RUN_DIR/exec.ts" -c local


### PR DESCRIPTION
## Summary
- Second half of the split lobu#2825 began. That release added `entity_relationship_types.purpose`, the `entity_relationships` chokepoint trigger, and `withAclEdgeWrite`/`withAclPrivilege` at every ACL writer — all **inert**, because nothing was classified. This release classifies `member_of`, which arms the trigger.
- The split exists because *classification*, not the trigger, is what a rolling deploy can break: an older pod that does not set `lobu.acl_write` would have its ACL sync rejected. `git merge-base --is-ancestor 629b5314 acb9c262e` → true, so #2825 is live on every prod pod and the flag is universally supplied before this migration lands.
- `ensureMemberOfType` now passes `purpose: PURPOSE_AUTHORIZATION`. That is the only production code change, and it doubles as the repair path: the upsert on `(organization_id, slug)` adopts a pre-existing `member_of` row, so an org whose type predates the backfill gets classified on its next sync instead of staying an unguarded ACL type forever.

### Two migration predicates that are deliberately absent
- **No `created_by` filter.** A prod audit (2026-08-16) found all four existing `member_of` rows platform-created, so nothing is being reclassified out from under an org today. But `created_by` must not be the filter regardless: `ensureMemberOfType` adopts an org-authored row, which keeps its non-NULL `created_by`. Filtering on it would leave the trigger inert for exactly the org that authored its own row — the hole `purpose` exists to close.
- **No status/deleted filter.** The ACL read gates select `member_of` by slug with no relationship-type lifecycle predicate (`resource-visibility.ts:100`, `channel-visibility.ts:187`), so an archived type's surviving edges are still access-bearing and must be guarded.

Each absence is pinned by a test, and each was mutation-tested: adding `AND created_by IS NULL` kills the org-authored case; adding `AND status = 'active'` kills the archived case, and nothing else.

### Cascade audit — arming a `BEFORE DELETE` trigger
The trigger is `BEFORE INSERT OR UPDATE OR DELETE`, so every FK cascade into `entity_relationships` fires it. All four (`baseline.sql` ~4845-4873) are clean:
- `from_entity_id` / `to_entity_id` → force-delete removes edges under `withAclPrivilege` first, so the cascade finds none; the other four `hardDeleteEntityRows` callers each drop a row created in the same transaction after losing an identity race, explicitly relationship-less.
- `organization_id` → no production org-delete path exists (`DELETE FROM organization` greps empty outside tests).
- `relationship_type_id` → no production type-delete path; `assertNotAuthorizationType` guards the schema surface.

The slug fallback (`isAclManagedRelationshipSlug`, the `OR rt.slug` half of `ACL_MANAGED_TYPE_SQL`) is intentionally kept: a config can create a new unclassified `member_of` row after this one-time backfill and before its first sync classifies it. Removing it is a follow-up.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Full `packages/server/src/__tests__/integration/` tree: 331 files, 2421 passed, 2 skipped, 0 failed
- [x] Mutation-tested both migration predicates (each mutation killed exactly its one intended test)
- [x] `tsc --noEmit` clean · CLI apply 65/65 · squawk clean · `check-exposed-surface-naming` clean

The first gate run on this branch failed and is fully explained: a banned-vocabulary word in a comment (cascading to `migrations`, which only gates on `FORMAT_LINT_RESULT`), and two vitest shards where test fixtures wrote/deleted `entity_relationships` with raw SQL. A `DELETE` in teardown fires the guard exactly like an `INSERT`; both sites in each file now use `withAclEdgeWrite`. Those two files live in `automations/` and `connectors/`, which is why a topical subset run went green — a change that arms a database-level guard needs the whole integration tree.

## Notes
Rolling-deploy safe in both directions: the down migration declassifies, making the trigger inert again, and the read gates still trust the slug during this rollout, so a rollback widens who may write these edges without narrowing who may read them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization-related `member_of` relationships are now automatically classified and repaired when needed.
  * Added a database migration to apply or roll back this classification safely.

* **Bug Fixes**
  * Ensured authorization relationship changes use the required access controls.
  * Prevented unrelated relationship types from being modified during migration.

* **Tests**
  * Added coverage for migration behavior, rollback, idempotency, archived records, and existing classifications.
  * Updated authorization and integration tests for the active classification workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->