### PR TITLE
feat(cli): prompt for token scope interactively

### DIFF
--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import postgres from "postgres";
+import { select } from "@inquirer/prompts";
 import { getToken, resolveContext } from "../internal/index.js";
 import { resolveApiClient } from "../internal/api-client.js";
 
@@ -56,7 +57,28 @@ export async function tokenCreateCommand(
   });
   const name =
     options.name?.trim() || `lobu-cli-${new Date().toISOString().slice(0, 10)}`;
-  const scope = options.scope?.trim() || "mcp:read mcp:write";
+
+  let scope = options.scope?.trim();
+  if (!scope && process.stdin.isTTY) {
+    scope = await select({
+      message: "Token scope:",
+      choices: [
+        {
+          value: "mcp:read mcp:write",
+          name: "Read + Write — typical for CI scripts and MCP clients",
+        },
+        {
+          value: "mcp:read mcp:write mcp:admin",
+          name: "Read + Write + Admin — full workspace access (agent CRUD, config patches)",
+        },
+        {
+          value: "mcp:read",
+          name: "Read only — search and query, no mutations",
+        },
+      ],
+    });
+  }
+  scope ??= "mcp:read mcp:write";
 
   const response = await client.post<{ token: CreatedPersonalAccessToken }>(
     `/api/${encodeURIComponent(orgSlug)}/tokens`,


### PR DESCRIPTION
When creating a PAT via `lobu token create`, the CLI now prompts the user to choose scope interactively instead of defaulting to `mcp:read mcp:write`.

- **TTY**: interactive select with 3 scope options (read+write, read+write+admin, read-only)
- **Non-TTY (CI)**: falls back to `mcp:read mcp:write`  
- `--scope` flag still works for scripted use

This fixes the issue where CLI users couldn't create agents because PATs didn't have `mcp:admin` scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive scope selector when creating tokens without a specified scope.
  * Users can choose read-only, read/write, or read/write/admin access.
  * Non-interactive usage continues with a default read/write scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->