### PR TITLE
test(server): widen the late-claim margin in device-action-wait

### DIFF
--- a/packages/server/src/__tests__/integration/device-action-wait.test.ts
+++ b/packages/server/src/__tests__/integration/device-action-wait.test.ts
@@ -15,7 +15,8 @@
  *      (status='running' AND claimed_by=worker_id guard) must reject
  *      the worker write so the gateway's verdict stands.
  *
- * The test stubs `setTimeout` to keep poll loops fast.
+ * The tests use real timers; the poll loops stay fast because the budgets are
+ * shrunk, not because the clock is stubbed.
  *
  * The abort path calls the production helper directly. The longer phase and
  * race tests use a budget-parameterized mirror so they complete in
@@ -213,6 +214,17 @@ async function claim(runId: number, workerId: string): Promise<void> {
 }
 
 const FAST_BUDGETS = { queueMs: 400, postClaimMs: 600, pollMs: 30 };
+
+// The late-claim test deliberately schedules its claim near the QUEUE deadline,
+// so unlike the tests above its margin has to absorb the claim's round trip to
+// Postgres, not just timer drift. Under FAST_BUDGETS that margin was 80ms,
+// which a contended CI database blows through: the claim commits after the poll
+// that already observed `now >= queueDeadline`, so the wait returns 'timeout'
+// and the test reds with `expected 'timeout' to be 'completed'`. These budgets
+// keep the claim late in relative terms while widening that margin to 400ms.
+// To re-verify, prefix `claim()` with `await sql`SELECT pg_sleep(0.2)``: that is
+// 3/3 red on the old 80ms margin and 3/3 green on this one (still green at 0.35).
+const LATE_CLAIM_BUDGETS = { queueMs: 1200, postClaimMs: 1800, pollMs: 30 };
 const WORKER_ID = 'worker-test';
 
 describe('waitForDeviceActionRun', () => {
@@ -282,16 +294,24 @@ describe('waitForDeviceActionRun', () => {
     const connId = await insertChromeConnection(org.id);
     const runId = await insertPendingActionRun(org.id, connId, {});
 
-    // Claim near the end of the queue budget; ensure the post-claim
-    // budget kicks in and we don't timeout immediately.
-    setTimeout(() => void claim(runId, WORKER_ID), FAST_BUDGETS.queueMs - 80);
+    // Claim late in the queue budget, then complete AFTER the queue deadline
+    // has already passed. Only the post-claim budget can carry the wait that
+    // far, so a 'completed' verdict is what proves the phase switch happened.
+    setTimeout(
+      () => void claim(runId, WORKER_ID),
+      LATE_CLAIM_BUDGETS.queueMs - 400,
+    );
     setTimeout(
       () =>
         void workerCompleteAction(runId, WORKER_ID, 'success', { ok: true }),
-      FAST_BUDGETS.queueMs + 100,
+      LATE_CLAIM_BUDGETS.queueMs + 300,
     );
 
-    const out = await waitForDeviceActionRunForTest(runId, org.id, FAST_BUDGETS);
+    const out = await waitForDeviceActionRunForTest(
+      runId,
+      org.id,
+      LATE_CLAIM_BUDGETS,
+    );
     expect(out.status).toBe('completed');
   });
 


### PR DESCRIPTION
## What

The `honors POST_CLAIM_BUDGET_MS after claim` case scheduled its claim 80ms before the queue deadline (`FAST_BUDGETS.queueMs - 80`). That window had to absorb the claim's round trip to Postgres, not just timer drift. A contended CI database blows through it: the claim commits after the poll that already observed `now >= queueDeadline`, the wait returns `timeout`, and the test reds.

This is what reddened `integration-vitest (3/3)` and the `integration` fan-in on `main` at `75f675ff` (the 15.0.0 release, which changed zero runtime code — version strings only). `87e9f6945` before it was green, so it is newly exposed under load, not a regression.

Gives the late-claim case its own `LATE_CLAIM_BUDGETS` with a 400ms margin, keeping the claim late in relative terms (two thirds through the queue budget) so the property under test is unchanged: completion still lands after the queue deadline, so only the post-claim budget can carry the wait that far.

## Reproduce red

CPU load does **not** reproduce it — load avg 47 on 14 cores, 6/6 green. Starving the event loop delays the poll timer and the claim timer equally. Only **DB latency** separates them.

Prefixing `claim()` with `await sql\`SELECT pg_sleep(0.2)\``:

```
run 1: FAIL  expected 'timeout' to be 'completed'
run 2: FAIL  expected 'timeout' to be 'completed'
run 3: FAIL  expected 'timeout' to be 'completed'
SLOW-DB (200ms) + 80ms margin: pass=0 fail=3
```

## Prove green

Same injected latency, new budgets:

```
run 1: PASS
run 2: PASS
run 3: PASS
FIXED + SLOW-DB(200ms): pass=3 fail=0
```

Still green at `pg_sleep(0.35)` (2/2). Harness removed; `grep pg_sleep` matches only the comment that documents how to re-run it.

Settled tree, no injection:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

`bunx tsc --noEmit` exit 0. Full Depot preflight green (19 jobs, tree `22bf12d6`).

## Class check

`grep` for other tests racing a scheduled write against a budget deadline returns nothing outside this file. Within the file, the other claim-racing tests carry a 320ms margin and survive the same injected latency (full file 10/10 green with `pg_sleep(0.2)` active), so the late-claim case was the only instance. Not widening them speculatively.

## Also

Corrects the file header, which claimed "The test stubs `setTimeout`". It never has — verified no `useFakeTimers`/timer stubbing anywhere in the file. The poll loops are fast because the budgets are shrunk.

## Residual risk

The fix is proven against 4.4x the latency that breaks the old margin, but CI's worst-case DB stall is unbounded — if a single `UPDATE` ever exceeds ~400ms this reds again. A structurally deterministic version (await the claim, then assert the phase switch) would remove timing from the test entirely; that is a redesign beyond this branch.

Separately noted, not addressed: `waitForDeviceActionRunForTest` is a hand-maintained **mirror** of the production helper, so these cases exercise a copy rather than `waitForDeviceActionRun` itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test timing to use real timers.
  * Added coverage for late task claiming and completion after the queue deadline.
  * Adjusted timing allowances to better account for database response latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->