### PR TITLE
feat(server,core): report relationship-type purpose on list and get

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1739,6 +1739,7 @@ export type ManageEntitySchemaResponses = {
           updated_at: string;
           deleted_at?: string | null;
           relationship_count?: number;
+          purpose?: string | null;
         }>;
         list_scope: "accessible" | "organization";
         organization_id: string;
@@ -1768,6 +1769,7 @@ export type ManageEntitySchemaResponses = {
           updated_at: string;
           deleted_at?: string | null;
           relationship_count?: number;
+          purpose?: string | null;
         } | null;
       }
     | {
@@ -1795,6 +1797,7 @@ export type ManageEntitySchemaResponses = {
           updated_at: string;
           deleted_at?: string | null;
           relationship_count?: number;
+          purpose?: string | null;
         };
       }
     | {
@@ -1822,6 +1825,7 @@ export type ManageEntitySchemaResponses = {
           updated_at: string;
           deleted_at?: string | null;
           relationship_count?: number;
+          purpose?: string | null;
         };
       }
     | {

--- a/packages/core/src/contracts/tools/manage-entity-schema.ts
+++ b/packages/core/src/contracts/tools/manage-entity-schema.ts
@@ -291,6 +291,18 @@ export const RelationshipTypeRowSchema = Type.Object({
   updated_at: Type.String(),
   deleted_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   relationship_count: Type.Optional(Type.Integer()),
+  /**
+   * System-controlled classification; `authorization` marks the vocabulary the
+   * ACL gates read. On the read paths because it is exactly what makes every
+   * write action on the TYPE 403 (`assertNotAuthorizationType`): `member_of` is
+   * org-owned, so without it a client cannot separate one from ordinary
+   * vocabulary and renders edit affordances guaranteed to fail. It does not
+   * cover the EDGE surfaces, which also refuse the ACL-managed slug while a
+   * freshly declared row is still unclassified. An open string, not a literal
+   * union, so a server that learns a new purpose still satisfies the result
+   * schema an older client validates against.
+   */
+  purpose: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });
 export type RelationshipTypeRow = Static<typeof RelationshipTypeRowSchema>;
 

--- a/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
+++ b/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
@@ -341,6 +341,73 @@ describe("authorization-bearing relationship types are not caller-writable", () 
 		expect(freshnessAfter).toBe("stale");
 	});
 
+	it("reports purpose on LIST so callers can predict the refusal", async () => {
+		// A refusal a caller cannot anticipate becomes a dead button: `member_of`
+		// is org-owned, so ownership alone cannot separate it from an ordinary
+		// type, and the UI renders edit affordances that are guaranteed to 403.
+		const ordinary = await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "mentions",
+				name: "Mentions",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+		// `toHaveProperty` and not `?? null`: an absent key reads as null too, so
+		// the loose form still passes once a handler stops selecting the column —
+		// and on a missing row, `bySlug.get(…)?.purpose ?? null` would as well.
+		expect(ordinary.relationship_type).toHaveProperty("purpose", null);
+
+		const listed = await manageEntitySchema(
+			{ schema_type: "relationship_type", action: "list" },
+			env,
+			ctx(orgId, userId),
+		);
+		const bySlug = new Map(
+			(listed.relationship_types ?? []).map((rt) => [rt.slug, rt]),
+		);
+		expect(bySlug.get("member_of")).toHaveProperty("purpose", "authorization");
+		expect(bySlug.get("mentions")).toHaveProperty("purpose", null);
+	});
+
+	it("reports purpose on UPDATE too — the row shape does not vary by action", async () => {
+		// update refuses a classified type, so this path can only ever report
+		// null. It still carries the key: a client switching on `purpose` must
+		// not see the field appear and disappear across actions.
+		await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "mentions",
+				name: "Mentions",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+		const updated = await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "update",
+				slug: "mentions",
+				name: "Mentioned in",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+		expect(updated.relationship_type).toHaveProperty("purpose", null);
+	});
+
+	it("reports purpose on GET too", async () => {
+		const got = await manageEntitySchema(
+			{ schema_type: "relationship_type", action: "get", slug: "member_of" },
+			env,
+			ctx(orgId, userId),
+		);
+		expect(got.relationship_type?.purpose).toBe("authorization");
+	});
+
 	it("refuses member_of by slug before it is classified", async () => {
 		// ACL reads still trust the slug during the staged cutover. The slug guard
 		// keeps a newly declared row fail-closed before its first sync classifies it.

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -940,7 +940,7 @@ async function rtHandleList(
       rt.id, rt.slug, rt.name, rt.description, rt.organization_id, rt.created_by,
       rt.metadata_schema, rt.metadata, rt.is_symmetric, rt.inverse_type_id,
       inv.slug as inverse_type_slug,
-      rt.status, rt.created_at, rt.updated_at, rt.deleted_at,
+      rt.status, rt.purpose, rt.created_at, rt.updated_at, rt.deleted_at,
       o.slug AS organization_slug,
       COALESCE(rc.relationship_count, 0) as relationship_count
     FROM entity_relationship_types rt
@@ -988,7 +988,7 @@ async function rtHandleGet(
       rt.id, rt.slug, rt.name, rt.description, rt.organization_id, rt.created_by,
       rt.metadata_schema, rt.metadata, rt.is_symmetric, rt.inverse_type_id,
       inv.slug as inverse_type_slug,
-      rt.status, rt.created_at, rt.updated_at, rt.deleted_at,
+      rt.status, rt.purpose, rt.created_at, rt.updated_at, rt.deleted_at,
       o.slug AS organization_slug
     FROM entity_relationship_types rt
     LEFT JOIN entity_relationship_types inv ON rt.inverse_type_id = inv.id
@@ -1103,7 +1103,7 @@ async function rtHandleCreate(
       rt.id, rt.slug, rt.name, rt.description, rt.organization_id, rt.created_by,
       rt.metadata_schema, rt.metadata, rt.is_symmetric, rt.inverse_type_id,
       inv.slug as inverse_type_slug,
-      rt.status, rt.created_at, rt.updated_at
+      rt.status, rt.purpose, rt.created_at, rt.updated_at
     FROM entity_relationship_types rt
     LEFT JOIN entity_relationship_types inv ON rt.inverse_type_id = inv.id
     WHERE rt.id = ${typeId}
@@ -1195,7 +1195,7 @@ async function rtHandleUpdate(
       rt.id, rt.slug, rt.name, rt.description, rt.organization_id, rt.created_by,
       rt.metadata_schema, rt.metadata, rt.is_symmetric, rt.inverse_type_id,
       inv.slug as inverse_type_slug,
-      rt.status, rt.created_at, rt.updated_at
+      rt.status, rt.purpose, rt.created_at, rt.updated_at
     FROM entity_relationship_types rt
     LEFT JOIN entity_relationship_types inv ON rt.inverse_type_id = inv.id
     WHERE rt.id = ${typeId}


### PR DESCRIPTION
## What

Classifying `member_of` as authorization-bearing (#2833) made every write action on it 403 via `assertNotAuthorizationType`. Nothing on a **read** path said so.

`rtHandleList` and `rtHandleGet` select explicit column lists that omitted `rt.purpose` — it was selected only on guard/write paths (`:868`, `:900`, `:916`, `:1356`, `:1376`). So a client could not distinguish an authorization-bearing type from an ordinary org-owned one, and `member_of` **is** org-owned, so ownership alone cannot separate them. Owletto rendered Delete and Add Rule on it, both guaranteed to fail.

## How

Adds `purpose` to `list` and `get`, and also to `create` and `update` so the row shape does not vary by action — a client switching on the field must not see it appear and disappear.

Contract field is optional and nullable, so an older client is unaffected. Left an open string rather than a literal union so a server that learns a new purpose does not fail contract validation against a cached client schema.

Owletto companion: lobu-ai/owletto#881 (hold until this is green, then merge, then repin).

## Verification

```
authorization-type-guards.test.ts    Tests  14 passed (14)
packages/server tsc --noEmit         exit 0
packages/core   tsc --noEmit         exit 0
Depot full remote preflight          passed (tree f007771f)
```

Three new cases, each **mutation-tested**:

| mutation | result |
|---|---|
| drop `rt.purpose` from LIST select | `reports purpose on LIST` fails — `expected undefined to be 'authorization'` |
| drop `rt.purpose` from GET select | `reports purpose on GET too` fails — same |
| drop from create+update selects | LIST + UPDATE fail (2 failed / 12 passed) |

Assertions use `toHaveProperty("purpose", null)` rather than `?? null` — the loose form still passes once a handler stops selecting the column, so it would not have caught the regression.

## Generated client

Regenerated against the booted server, not hand-edited:

```
cd packages/client && LOBU_OPENAPI_URL=http://127.0.0.1:9533/lobu/api/docs/openapi.json bun run generate
```

Delta is exactly `purpose?: string | null;` at all four emitted `RelationshipTypeRow` sites. `[client-regen-not-needed]` does **not** apply — the emitted schema genuinely changes.

## Known gap, deliberately not in scope

The **edge** surface still has the same problem: `RelationshipRowSchema` (`manage-entity.ts:321`) carries `relationship_type_slug` but no purpose, so a client listing an entity's relationships still cannot predict which unlink buttons 403. That needs a shape decision rather than a column — `purpose` alone is the wrong predictor there, because the edge guard is slug-**OR**-purpose, and a freshly declared unclassified `member_of` reads `purpose: null` and still refuses. A derived boolean is probably right. Separate PR.

Same class, different contract: `workspace-instructions.ts:88` renders relationship types into agent prompt text with no purpose, so an agent will still attempt writes that 403.