### PR TITLE
perf(server): memoize compiled sandbox sources by content hash

### DIFF
--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -16,9 +16,24 @@
  * `isolated-vm` so the regression cannot ship again.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ClientSDK } from "../../../sandbox/client-sdk";
 import { runScript } from "../../../sandbox/run-script";
+
+// Counts compiles so the memo is asserted by call count rather than by
+// wall-clock timing, which is unassertable at the ~3ms scale a warm run costs.
+// The spy delegates to the real compiler, so every test in this file still
+// exercises genuine esbuild + isolated-vm.
+vi.mock("../../../utils/compiler-core", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../../utils/compiler-core")>();
+  return { ...actual, compileSource: vi.fn(actual.compileSource) };
+});
+
+async function compileCallCount(): Promise<number> {
+  const { compileSource } = await import("../../../utils/compiler-core");
+  return vi.mocked(compileSource).mock.calls.length;
+}
 
 describe("sandbox runtime", () => {
   it("loads isolated-vm and runs a trivial script", async () => {
@@ -240,6 +255,62 @@ describe("sandbox runtime", () => {
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("TimeoutError");
     expect(result.sdkCalls).toBe(1);
+  });
+});
+
+describe("compiled-source memo", () => {
+  const stub = stubSDK();
+
+  /** Unique per run so a previous test cannot have warmed the entry. */
+  const uniqueSource = (tag: string) =>
+    `// ${tag}\nexport default async () => ${tag.length};`;
+
+  it("re-running identical source skips compilation", async () => {
+    const source = uniqueSource(`memo_hit_${process.pid}`);
+
+    const before = await compileCallCount();
+    const first = await runScript({ source, sdk: stub });
+    const afterCold = await compileCallCount();
+    const second = await runScript({ source, sdk: stub });
+    const afterWarm = await compileCallCount();
+
+    expect(first.success).toBe(true);
+    expect(second.returnValue).toBe(first.returnValue);
+    expect(afterCold - before).toBe(1);
+    expect(afterWarm - afterCold).toBe(0);
+  });
+
+  it("different source is compiled separately, not served from the memo", async () => {
+    const before = await compileCallCount();
+    const a = await runScript({
+      source: uniqueSource(`memo_a_${process.pid}`),
+      sdk: stub,
+    });
+    const b = await runScript({
+      source: uniqueSource(`memo_bb_${process.pid}`),
+      sdk: stub,
+    });
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect((await compileCallCount()) - before).toBe(2);
+    // Return values are derived from the tag length, so a collision here would
+    // mean one entry was served for both sources.
+    expect(a.returnValue).not.toBe(b.returnValue);
+  });
+
+  it("a compile error is not cached as a success", async () => {
+    const broken = `export default async () => { this is not valid ts`;
+    const before = await compileCallCount();
+    const first = await runScript({ source: broken, sdk: stub });
+    const second = await runScript({ source: broken, sdk: stub });
+
+    expect(first.success).toBe(false);
+    expect(first.error?.name).toBe("CompileError");
+    expect(second.success).toBe(false);
+    expect(second.error?.name).toBe("CompileError");
+    // A failed compile leaves no entry, so the retry recompiles.
+    expect((await compileCallCount()) - before).toBe(2);
   });
 });
 

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -686,6 +686,19 @@ const EXTRACT_RUNNER = `
 })()
 `;
 
+/**
+ * Compiled-output memo, keyed by a hash of the source text. Insertion-ordered
+ * `Map` used as an LRU: a hit re-inserts, an overflow evicts the oldest key.
+ *
+ * Bounded by bytes as well as by entries, because an entry is a whole bundle:
+ * ~1 KB for an import-free script but ~530 KB for one importing `npm:zod`
+ * (measured), so an entry-only cap would let 256 heavy scripts pin >100 MB.
+ */
+const compiledSourceCache = new Map<string, { code: string; bytes: number }>();
+const COMPILED_SOURCE_CACHE_MAX_ENTRIES = 256;
+const COMPILED_SOURCE_CACHE_MAX_BYTES = 32 * 1024 * 1024;
+let compiledSourceCacheBytes = 0;
+
 export async function runScript(
 	options: RunScriptOptions,
 ): Promise<RunScriptResult> {
@@ -859,18 +872,61 @@ export async function runScript(
 
 	let compiled: string;
 	try {
-		const { compileSource } = await import("../utils/compiler-core");
-		const result = await compileSource(options.source, {
-			tmpPrefix: ".execute-compile-",
-			label: "ExecuteCompiler",
-			buildOptions: {
-				format: "cjs",
-				target: "esnext",
-				platform: "node",
-				external: [],
-			},
-		});
-		compiled = result.compiledCode;
+		// Deferred: `compiler-core` pulls in esbuild and resolves the connector
+		// SDK entry at module scope, neither of which a run-free process needs.
+		const { compileSource, computeCodeHash } = await import(
+			"../utils/compiler-core"
+		);
+		// Compilation is `mkdtemp` + `writeFile` + a full esbuild bundle + read
+		// back — filesystem I/O and a bundler per call. Measured locally, a cold
+		// `runScript` costs 6–25ms end to end where a memo hit costs ~3ms, so
+		// compilation, not the isolate, is the bulk of a short run. That was
+		// affordable while the only callers were automation reactions (once per
+		// window) and `sdk_run` (once per agent turn); anything that runs per
+		// entity write would pay it on every write.
+		//
+		// Source text is the whole compile input, so its hash is a total cache
+		// key. Process-local by design: this memoizes a pure function, it does
+		// not hold shared state, so replicas diverging is not a correctness
+		// concern (cf. AGENTS.md on Postgres-mediated state).
+		const cacheKey = computeCodeHash(options.source);
+		const cached = compiledSourceCache.get(cacheKey);
+		if (cached !== undefined) {
+			// Refresh LRU recency.
+			compiledSourceCache.delete(cacheKey);
+			compiledSourceCache.set(cacheKey, cached);
+			compiled = cached.code;
+		} else {
+			const result = await compileSource(options.source, {
+				tmpPrefix: ".execute-compile-",
+				label: "ExecuteCompiler",
+				buildOptions: {
+					format: "cjs",
+					target: "esnext",
+					platform: "node",
+					external: [],
+				},
+			});
+			compiled = result.compiledCode;
+			const bytes = Buffer.byteLength(compiled, "utf8");
+			// Two concurrent runs of one new source both compile and both land
+			// here; without discounting the entry the loser already stored, the
+			// byte counter would over-count permanently and eventually evict on
+			// every insert.
+			compiledSourceCacheBytes -=
+				compiledSourceCache.get(cacheKey)?.bytes ?? 0;
+			compiledSourceCache.set(cacheKey, { code: compiled, bytes });
+			compiledSourceCacheBytes += bytes;
+			while (
+				compiledSourceCache.size > COMPILED_SOURCE_CACHE_MAX_ENTRIES ||
+				compiledSourceCacheBytes > COMPILED_SOURCE_CACHE_MAX_BYTES
+			) {
+				const oldest = compiledSourceCache.entries().next();
+				if (oldest.done) break;
+				compiledSourceCache.delete(oldest.value[0]);
+				compiledSourceCacheBytes -= oldest.value[1].bytes;
+			}
+		}
 	} catch (err) {
 		clearTimeout(abortTimer);
 		const e = err as Error & {


### PR DESCRIPTION
## Summary
- `runScript` called `compileSource` on **every** invocation — `mkdtemp` + `writeFile` + a full esbuild bundle + read back — with no cache. Invisible while the only callers were automation reactions (once per window) and `sdk_run` (once per agent turn); not viable for anything per-write. `reaction-executor.ts` was additionally passing already-compiled JS that got recompiled on every fire.
- Memoized by `computeCodeHash(source)` (already in `compiler-core`). Source text is the whole compile input, so the hash is a total key. Process-local by design: memoizes a **pure function** and holds no shared state, so replicas caching different subsets cannot diverge — this is not the kind of state AGENTS.md requires to be Postgres-mediated.
- Bounded by **bytes (32MB)** as well as entries (256): an entry is a whole bundle, measured at **1,003 bytes** for an import-free script vs **542,893 bytes** for one importing `zod`, so an entry-only cap would allow >100MB of retained code.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean — Depot run `3xcb6hb8m1`, 19/19 jobs passed
- [x] Tests run: `test:sandbox-runtime` 35/35 (was 32, +3 new)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

### Before / after (node 22, local)
```
before:  p50 9.2ms   min 7.4ms   p95 114ms     <- esbuild every call
after:   p50 3.2ms   min 1.5ms   p95 5.2ms     <- memo hit
cold (first esbuild in a process): ~100ms, paid once per source
```

### Mutation test
Removing the `compiledSourceCache.set(...)` fails the memo-hit test:
```
× compiled-source memo > re-running identical source skips compilation
  → expected 1 to be +0 // Object.is equality
```
Restored → 35/35 green.

### Bundle-size measurement behind the byte cap
```
bare:     1,003 bytes
with zod: 542,893 bytes
```

## Notes
- Tests assert **compile call counts**, not wall-clock timing. A warm run costs ~3ms, so a timing assertion fails on normal CI jitter — same class as the `device-action-wait` 80ms flake.
- `make review-fix` could not run under codex (usage limit until Aug 20) or fable (credit limit); it ran under `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus`. Its findings were verified independently rather than taken on faith: the flaky-assertion catch, the bundle-size numbers, and the mutation kill are all reproduced above.
- **Not covered by a committed test:** the LRU eviction path. Verified only by a throwaway probe (`MAX_BYTES` temporarily at 2000 produced the exact predicted `A1:compiled A2:hit B1:compiled A3:compiled A4:hit` sequence). Testing it in-suite needs either ~257 compiles or exporting the cache; flagging rather than hiding it.
- Follow-up: `compileReactionScript` (`automations/reaction-executor.ts:155`) also compiles per call, but it is save-time pre-validation rather than a hot path, so it is deliberately left alone.