### PR TITLE
fix(server): tell agents which relationship types refuse writes

### DIFF
--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -9,6 +9,8 @@
  *      top-level-keys bug: a real JSON Schema used to render "type, properties")
  *   3. entity_relationship_types.description
  *   4. connector_definitions.description
+ *   5. ACL-managed relationship types render a `read-only: access control` hint,
+ *      on the same purpose-OR-slug test that link/unlink already 403 on
  *
  * Org guidance pinned here:
  *   - admin-authored `guidance` events render under "### Organization Context"
@@ -115,6 +117,26 @@ describe('buildWorkspaceInstructions render fixes', () => {
       VALUES ('supplies', 'Supplies', 'Which company supplies which product', ${org.id})
     `;
 
+    // Two ACL-managed types, one per branch of the guard's purpose-OR-slug
+    // test, so a regression that narrows the predicate to either half alone
+    // still fails here. `grants_role` is classified but NOT the ACL slug;
+    // `member_of` is the ACL slug but NOT yet classified — the real window
+    // between a config declaring it and the first ACL sync running.
+    await sql`
+      INSERT INTO entity_relationship_types (slug, name, description, organization_id)
+      VALUES
+        ('grants_role', 'Grants role', 'Role grant synced from the IdP', ${org.id}),
+        ('member_of', 'Member of', 'Access-control membership', ${org.id})
+    `;
+    // Classify directly: `lobu_guard_authorization_edges` fires on
+    // entity_relationships, not on the type table, so setting `purpose` needs no
+    // `lobu.acl_write` privilege.
+    await sql`
+      UPDATE entity_relationship_types
+      SET purpose = 'authorization'
+      WHERE organization_id = ${org.id} AND slug = 'grants_role'
+    `;
+
     // Org-scoped connector definition with a description + an active connection.
     await sql`
       INSERT INTO connector_definitions (key, name, description, actions_schema, organization_id, status)
@@ -174,6 +196,25 @@ describe('buildWorkspaceInstructions render fixes', () => {
   it('renders relationship type descriptions', async () => {
     const out = await buildWorkspaceInstructions(org.id);
     expect(out).toContain('- supplies — Which company supplies which product');
+  });
+
+  it('marks a CLASSIFIED relationship type read-only so agents stop attempting 403 writes', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain('- grants_role (read-only: access control) — Role grant synced from the IdP');
+  });
+
+  it('marks the ACL slug read-only even before classification has run', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    // purpose IS NULL here, so a purpose-only predicate would render this as
+    // freely writable — the exact case assertNotAclManagedEdge still 403s.
+    expect(out).toContain('- member_of (read-only: access control) — Access-control membership');
+  });
+
+  it('does not mark ordinary relationship types read-only', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    // Guards the other direction: ACL_MANAGED_TYPE_SQL uses IS NOT DISTINCT
+    // FROM precisely so a NULL purpose does not sweep every type in.
+    expect(out).not.toContain('- supplies (read-only: access control)');
   });
 
   it('renders connector definition descriptions', async () => {

--- a/packages/server/src/utils/relationship-validation.ts
+++ b/packages/server/src/utils/relationship-validation.ts
@@ -44,8 +44,9 @@ const ACL_MANAGED_SLUG = 'member_of';
 
 /**
  * The same test as {@link isAclManagedRelationshipSlug}, in SQL, for statements
- * that select edges by their type. Expects the type table aliased `rt`. Static
- * text with no interpolation, so it is safe through `sql.unsafe`.
+ * that classify by relationship type — selecting edges, or listing the types
+ * themselves. Expects the type table aliased `rt`. Static text with no
+ * interpolation, so it is safe through `sql.unsafe`.
  *
  * `IS NOT DISTINCT FROM` rather than `=` so the negation is sound: `purpose` is
  * NULL on every unclassified type, and `NOT (NULL = 'authorization' OR …)`

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -9,6 +9,7 @@
 import { getDb } from '../db/client';
 import logger from './logger';
 import { loadOrgGuidanceBlock } from './org-guidance';
+import { ACL_MANAGED_TYPE_SQL } from './relationship-validation';
 
 /** Collapse whitespace/newlines so an authored description stays one line. */
 function singleLine(value: unknown): string {
@@ -84,8 +85,15 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
          ORDER BY name ASC`,
         [organizationId]
       ),
+      // `acl_managed` reuses the mutation guard's own predicate rather than a
+      // second copy of it: `link`/`unlink` refuse these types through
+      // assertNotAclManagedEdge, which is purpose-OR-slug, so a purpose-only
+      // test here would still promise the agent a write it cannot make during
+      // the window between a config declaring `member_of` and the first ACL
+      // sync classifying it.
       sql.unsafe(
-        `SELECT rt.slug, rt.name, rt.description, rt.is_symmetric, inv.slug as inverse_type_slug
+        `SELECT rt.slug, rt.name, rt.description, rt.is_symmetric, inv.slug as inverse_type_slug,
+                ${ACL_MANAGED_TYPE_SQL} AS acl_managed
          FROM entity_relationship_types rt
          LEFT JOIN entity_relationship_types inv ON rt.inverse_type_id = inv.id
          WHERE rt.status = 'active'
@@ -113,6 +121,10 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       const parts: string[] = [];
       if (rt.is_symmetric) parts.push('symmetric');
       if (inverseSlug) parts.push(`inverse: ${inverseSlug}`);
+      // Annotated rather than filtered out: reading these edges is legitimate,
+      // so hiding the type would blind the agent to real schema. Only the WRITE
+      // is refused, so say exactly that.
+      if (rt.acl_managed) parts.push('read-only: access control');
       const meta = parts.length > 0 ? ` (${parts.join(', ')})` : '';
       const desc = singleLine(rt.description);
       relTypeLines.push(`- ${slug}${meta}${desc ? ` — ${desc}` : ''}`);


### PR DESCRIPTION
## What

Workspace instructions now mark ACL-managed relationship types as non-writable:

```
- member_of (read-only: access control) — Access-control membership
```

## Why

Arming the ACL guard made every write on an authorization-bearing relationship type 403. The settings UI stopped offering those writes in owletto#881 / #2839, but the **agent-facing** instruction text was still blind — it rendered these types with no hint, so agents kept attempting `link`/`unlink` calls that cannot succeed.

Types are **annotated, not filtered out**. Reading these edges is legitimate, so hiding the type would make the agent blind to real schema. Only the write is refused, so the line says exactly that — the same choice owletto#881 made in the UI.

## The predicate

Reuses `ACL_MANAGED_TYPE_SQL`, the mutation guard's own test, rather than a second copy that can drift. `link`/`unlink` refuse through `assertNotAclManagedEdge`, which is **purpose-OR-slug**. A purpose-only test here would still promise a write the server rejects, during the window between a config declaring `member_of` (as `examples/personal-agent/lobu.config.ts` does) and the first ACL sync classifying it.

The helper's docstring said "for statements that select edges by their type"; widened to cover listing the types themselves.

## Tests

Three cases, one per branch of the OR, so narrowing either half fails the suite:

| mutation | result |
|---|---|
| predicate → purpose-only | ✗ `marks the ACL slug read-only even before classification has run` |
| predicate → slug-only | ✗ `marks a CLASSIFIED relationship type read-only` |
| annotation removed | ✗ both |
| unmutated | ✓ 29/29 |

```
Test Files  1 passed (1)
     Tests  29 passed (29)
```

Depot gate `nb2dxn2tl8` passed.

## Not in scope

The **edge** surface is still blind: `RelationshipRowSchema` carries no predictor, so *unlink* buttons on an entity's relationships can still 403. That needs a derived boolean on a public contract and is pending owner sign-off.

Separately, `review-fix` surfaced a harness bug worth its own branch: `global-setup.ts` provides `databaseUrl` via `provide()`, but `test-db.ts:95` still reads `process.env.DATABASE_URL` and never calls `inject()`. Under CPU load that becomes "DATABASE_URL is required" and a silent 29-test **skip** rather than a failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace instructions now identify access-controlled relationships as read-only.
  - Access-controlled relationships remain available for viewing while clearly indicating their restrictions.

- **Tests**
  - Added coverage for classified and unclassified access-controlled relationships.
  - Confirmed ordinary relationships are not incorrectly marked as access-controlled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->