### PR TITLE
fix(server): seed device autowire connections from default_connection_config

### DIFF
--- a/packages/server/src/__tests__/integration/device-reconcile-config-seed.test.ts
+++ b/packages/server/src/__tests__/integration/device-reconcile-config-seed.test.ts
@@ -14,8 +14,9 @@
  * shape (and anything downstream that expects NULL) is untouched.
  */
 
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { reconcileDeviceCapabilities } from '../../worker-api/device-reconcile';
+import logger from '../../utils/logger';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
 
@@ -27,7 +28,11 @@ const VERSION = '1.0.0';
 
 const DEFAULT_CONFIG = { action_modes: { upload_file: 'auto' } };
 
-async function seedDefinition(orgId: string, defaultConfig: Record<string, unknown> | null) {
+async function seedDefinition(
+  orgId: string,
+  defaultConfig: Record<string, unknown> | null,
+  feedsSchema: Record<string, unknown> = {}
+) {
   await sql`
     INSERT INTO connector_definitions (
       organization_id, key, name, version, status, required_capability,
@@ -35,7 +40,7 @@ async function seedDefinition(orgId: string, defaultConfig: Record<string, unkno
       default_connection_config
     ) VALUES (
       ${orgId}, ${CONNECTOR}, 'Test Device Config Seed', ${VERSION}, 'active', ${CAPABILITY},
-      ${sql.json({ kind: 'device' })}, ${sql.json({})}, ${sql.json({})},
+      ${sql.json({ platforms: ['macos'] })}, ${sql.json(feedsSchema)}, ${sql.json({})},
       ${sql.json({})}, ${sql.json({})}, ${defaultConfig ? sql.json(defaultConfig) : null}
     )
   `;
@@ -49,6 +54,24 @@ async function seedDefinition(orgId: string, defaultConfig: Record<string, unkno
   `;
 }
 
+async function manifestFor(feeds: Record<string, unknown>): Promise<typeof MANIFEST> {
+  return {
+    key: CONNECTOR,
+    version: VERSION,
+    name: 'Test Device Config Seed',
+    required_capability: CAPABILITY,
+    runtime: { platforms: ['macos'] },
+    // Mirror the definition row the harness seeds so the manifest-matches-
+    // source check (and with it the ready fast path) can actually pass —
+    // without these the wildcard fields fall back to `{ methods: [...none] }`
+    // / null and no poll ever converges to the fast path.
+    auth_schema: {},
+    actions_schema: {},
+    options_schema: {},
+    feeds_schema: feeds,
+  };
+}
+
 const MANIFEST = {
   key: CONNECTOR,
   version: VERSION,
@@ -58,11 +81,16 @@ const MANIFEST = {
   feeds_schema: {},
 };
 
-async function seedWorker(userId: string, orgId: string): Promise<string> {
+async function seedWorker(
+  userId: string,
+  orgId: string,
+  feeds: Record<string, unknown> = {}
+): Promise<string> {
   const workerId = `mac-${Math.random().toString(36).slice(2, 10)}`;
+  const manifest = Object.keys(feeds).length > 0 ? await manifestFor(feeds) : MANIFEST;
   const manifests = {
     [CONNECTOR]: {
-      manifest: MANIFEST,
+      manifest,
       manifest_hash: `hash-${CONNECTOR}-${VERSION}`,
       received_at: new Date().toISOString(),
     },
@@ -177,5 +205,43 @@ describe('device reconcile config seeding', () => {
     `) as unknown as Array<{ config: unknown }>;
     expect(row).toBeDefined();
     expect(row.config).toBeNull();
+  });
+
+  it('converges without re-wiring when the definition default is wholly feed-scoped', async () => {
+    const FEEDS = {
+      main: {
+        configSchema: {
+          type: 'object',
+          properties: { lookback_days: { type: 'number' } },
+        },
+      },
+    };
+    await seedDefinition(orgId, { lookback_days: 30 }, FEEDS);
+    await seedWorker(userId, orgId, FEEDS);
+
+    const info = vi.spyOn(logger, 'info');
+    try {
+      await reconcileDeviceCapabilities(userId);
+      await reconcileDeviceCapabilities(userId);
+
+      const [row] = (await sql`
+        SELECT config FROM connections
+        WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR} AND deleted_at IS NULL
+      `) as unknown as Array<{ config: unknown }>;
+      // Feed-scoped defaults never belong on the connection row.
+      expect(row).toBeDefined();
+      expect(row.config).toBeNull();
+
+      const wired = info.mock.calls.filter(
+        (call) => call[1] === '[device-connectors] Wired device connector'
+      );
+      // Exactly one wire pass. A ready-gate that approximated "default exists"
+      // with the raw default instead of the seedable CONNECTION-scoped half
+      // spun forever here: NULL config + wholly feed-scoped default re-wired
+      // (and re-upserted the definition) on every single poll.
+      expect(wired).toHaveLength(1);
+    } finally {
+      info.mockRestore();
+    }
   });
 });

--- a/packages/server/src/__tests__/integration/device-reconcile-config-seed.test.ts
+++ b/packages/server/src/__tests__/integration/device-reconcile-config-seed.test.ts
@@ -1,0 +1,181 @@
+/**
+ * reconcileDeviceCapabilities — auto-wired device connections must seed
+ * `default_connection_config` exactly like manage_connections create/connect do.
+ *
+ * Auto-wire was the only connection creation path that skipped the merge, so a
+ * device swap (old row tombstoned, new device polls in) minted a connection with
+ * `config = NULL` and effective action modes silently fell back to raw descriptor
+ * `requires_approval`. Prod 2026-08: org 8dc12bdd, chrome rows 369 (upload_file
+ * auto, tombstoned) / 432 / 479 (new device, config NULL, requires approval).
+ *
+ * The same pass must (a) seed new rows from the org definition default, (b) heal
+ * a surviving NULL-config row once a default exists, and (c) never clobber an
+ * explicit per-connection config. No default → keep writing NULL, so the legacy
+ * shape (and anything downstream that expects NULL) is untouched.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { reconcileDeviceCapabilities } from '../../worker-api/device-reconcile';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+
+const CONNECTOR = 'test.device_config_seed';
+const CAPABILITY = 'test_device_config_seed';
+const VERSION = '1.0.0';
+
+const DEFAULT_CONFIG = { action_modes: { upload_file: 'auto' } };
+
+async function seedDefinition(orgId: string, defaultConfig: Record<string, unknown> | null) {
+  await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, status, required_capability,
+      runtime, feeds_schema, auth_schema, actions_schema, options_schema,
+      default_connection_config
+    ) VALUES (
+      ${orgId}, ${CONNECTOR}, 'Test Device Config Seed', ${VERSION}, 'active', ${CAPABILITY},
+      ${sql.json({ kind: 'device' })}, ${sql.json({})}, ${sql.json({})},
+      ${sql.json({})}, ${sql.json({})}, ${defaultConfig ? sql.json(defaultConfig) : null}
+    )
+  `;
+  // device-manifest connectors install `connector_versions` through
+  // upsertConnectorDefinitionRecords; the ready-gate version_key check needs
+  // the match present, exactly as the pin-guard harness does.
+  await sql`
+    INSERT INTO connector_versions (organization_id, connector_key, version)
+    VALUES (${orgId}, ${CONNECTOR}, ${VERSION})
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+const MANIFEST = {
+  key: CONNECTOR,
+  version: VERSION,
+  name: 'Test Device Config Seed',
+  required_capability: CAPABILITY,
+  runtime: { platforms: ['macos'] },
+  feeds_schema: {},
+};
+
+async function seedWorker(userId: string, orgId: string): Promise<string> {
+  const workerId = `mac-${Math.random().toString(36).slice(2, 10)}`;
+  const manifests = {
+    [CONNECTOR]: {
+      manifest: MANIFEST,
+      manifest_hash: `hash-${CONNECTOR}-${VERSION}`,
+      received_at: new Date().toISOString(),
+    },
+  };
+  const [row] = (await sql`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, capabilities, label, organization_id,
+      last_seen_at, connector_manifests
+    ) VALUES (
+      ${userId}, ${workerId}, 'macos', ${sql.json([CAPABILITY])},
+      'Mac mini', ${orgId}, NOW(), ${sql.json(manifests)}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(row.id);
+}
+
+async function seedConn(
+  orgId: string,
+  userId: string,
+  config: Record<string, unknown> | null | undefined
+): Promise<number> {
+  const slug = `conn-${Math.random().toString(36).slice(2, 8)}`;
+  const [row] = (await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      auth_profile_id, created_by, visibility, config
+    ) VALUES (
+      ${orgId}, ${CONNECTOR}, ${slug}, 'Test Device Config Seed', 'active',
+      NULL, ${userId}, 'private', ${config === undefined ? null : config ? sql.json(config) : null}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function configOf(id: number): Promise<Record<string, unknown> | null> {
+  const [row] = (await sql`
+    SELECT config FROM connections WHERE id = ${id}
+  `) as unknown as Array<{ config: unknown }>;
+  if (row == null || row.config == null) return null;
+  return typeof row.config === 'string' ? JSON.parse(row.config) : (row.config as Record<string, unknown>);
+}
+
+async function setUpOrg(): Promise<{ orgId: string; userId: string }> {
+  const user = await createTestUser();
+  const org = await createTestOrganization();
+  await sql`
+    UPDATE "organization"
+    SET metadata = ${JSON.stringify({ personal_org_for_user_id: user.id })}
+    WHERE id = ${org.id}
+  `;
+  return { orgId: org.id, userId: user.id };
+}
+
+describe('device reconcile config seeding', () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ orgId, userId } = await setUpOrg());
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('creates a connection whose config is seeded from the definition default', async () => {
+    await seedDefinition(orgId, DEFAULT_CONFIG);
+    await seedWorker(userId, orgId);
+
+    await reconcileDeviceCapabilities(userId);
+
+    const [row] = (await sql`
+      SELECT id, config FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR} AND deleted_at IS NULL
+    `) as unknown as Array<{ id: number; config: unknown }>;
+    expect(row).toBeDefined();
+    expect(row.config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('seeds an existing NULL-config connection once the definition has a default', async () => {
+    await seedDefinition(orgId, DEFAULT_CONFIG);
+    await seedWorker(userId, orgId);
+    const id = await seedConn(orgId, userId, null);
+
+    await reconcileDeviceCapabilities(userId);
+
+    expect(await configOf(id)).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('never clobbers an explicit per-connection config', async () => {
+    await seedDefinition(orgId, DEFAULT_CONFIG);
+    await seedWorker(userId, orgId);
+    const explicit = { action_modes: { upload_file: 'approval' } };
+    const id = await seedConn(orgId, userId, explicit);
+
+    await reconcileDeviceCapabilities(userId);
+
+    expect(await configOf(id)).toEqual(explicit);
+  });
+
+  it('keeps config NULL when the definition has no default', async () => {
+    await seedDefinition(orgId, null);
+    await seedWorker(userId, orgId);
+
+    await reconcileDeviceCapabilities(userId);
+
+    const [row] = (await sql`
+      SELECT config FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR} AND deleted_at IS NULL
+    `) as unknown as Array<{ config: unknown }>;
+    expect(row).toBeDefined();
+    expect(row.config).toBeNull();
+  });
+});

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -297,9 +297,19 @@ async function ensureDeviceConnectorWired(
     // leave it resolving against raw descriptor fallbacks. `conn_config` is the
     // raw jsonb value (`null` only when the column is SQL NULL), so an empty
     // explicit `{}` still counts as configured. Seeded in wireOnce below.
+    // The predicate gates on the CONNECTION-scoped half of the default
+    // (`splitConfigByFeedScope(…).connectionConfig`), the exact value seeding
+    // can write: a wholly feed-scoped default must not keep a NULL-config
+    // connection spinning the wire path forever. `def_feeds_schema` equals the
+    // manifest feeds on this path (definitionMatchesSource above), so the split
+    // here mirrors the one wireOnce performs; don't re-split against a
+    // different feeds schema, or the gate and the seed stop agreeing.
     const needsDefaultConfigSeed =
       existingReady[0]?.conn_config == null &&
-      Object.keys(parseJsonObject(existingReady[0]?.def_default_config)).length > 0;
+      splitConfigByFeedScope(
+        parseJsonObject(existingReady[0]?.def_default_config),
+        (existingReady[0]?.def_feeds_schema as Record<string, FeedDefinition> | null) ?? null,
+      ).connectionConfig != null;
     const ready =
       readyConnectionId != null &&
       existingReady[0]?.version_key != null &&

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -9,8 +9,10 @@
  * creating runs nothing can claim.
  */
 
+import { parseJsonObject } from '@lobu/core';
 import { getDb, pgTextArray } from '../db/client';
 import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
+import { splitConfigByFeedScope, type FeedDefinition } from '../tools/admin/helpers/feed-helpers';
 import {
   type BundledDeviceConnector,
   bundledConnectorSourcePath,
@@ -33,6 +35,10 @@ const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
  * Install + wire a bundled device connector into the user's personal org:
  * connector definition (idempotent), a no-auth connection, the first feed, and
  * re-activate the feed if a previous "capability went away" pass had paused it.
+ * New connections are seeded with the org definition's `default_connection_config`
+ * (connection-scoped keys only), and surviving NULL-config rows are healed the
+ * same way — mirroring manage_connections create/connect — so device swaps
+ * don't silently regress action modes to descriptor fallbacks.
  * Called by {@link reconcileDeviceCapabilities} for each device connector whose
  * `requiredCapability` is currently advertised by the user's fleet — which
  * connectors those are is read from the catalog, never hardcoded here.
@@ -201,6 +207,8 @@ async function ensureDeviceConnectorWired(
         cd.favicon_domain AS def_favicon_domain,
         cd.required_capability AS def_required_capability,
         cd.runtime AS def_runtime,
+        cd.default_connection_config AS def_default_config,
+        c.config AS conn_config,
         -- jsonb_agg, not array_agg: postgres.js (fetch_types:false) returns a
         -- text[] result column as the literal string "{a,b}", which would make
         -- the fast-path feed check below silently always miss. jsonb arrays are
@@ -251,6 +259,8 @@ async function ensureDeviceConnectorWired(
       def_favicon_domain: string | null;
       def_required_capability: string | null;
       def_runtime: unknown;
+      def_default_config: unknown;
+      conn_config: unknown;
       active_feed_keys: string[] | null;
     }>;
     // Device-manifest connectors carry their full metadata in-hand (`source`),
@@ -282,10 +292,19 @@ async function ensureDeviceConnectorWired(
     };
     const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
     const readyConnectionId = existingReady[0]?.connection_id;
+    // A ready connection whose config is SQL NULL while the org definition
+    // carries a default needs the default seeded — the fast path must not
+    // leave it resolving against raw descriptor fallbacks. `conn_config` is the
+    // raw jsonb value (`null` only when the column is SQL NULL), so an empty
+    // explicit `{}` still counts as configured. Seeded in wireOnce below.
+    const needsDefaultConfigSeed =
+      existingReady[0]?.conn_config == null &&
+      Object.keys(parseJsonObject(existingReady[0]?.def_default_config)).length > 0;
     const ready =
       readyConnectionId != null &&
       existingReady[0]?.version_key != null &&
       definitionMatchesSource(existingReady[0]) &&
+      !needsDefaultConfigSeed &&
       // userManaged-only connectors (e.g. local.directory, browser/*) report
       // declaredFeedKeys=[]. Once the connection + definition are installed,
       // every subsequent poll has nothing to verify — fast-path out.
@@ -375,6 +394,27 @@ async function ensureDeviceConnectorWired(
         versionScope: source ? 'organization' : 'shared',
       });
 
+      // Seed new/repaired auto-wired connections from the org's definition
+      // default, exactly like manage_connections create/connect merge
+      // `default_connection_config` into the new row's config — auto-wire is
+      // the only creation path that previously skipped this, so a device swap
+      // silently regressed action modes to descriptor fallbacks. Feed-scoped
+      // default keys belong on feeds (wired below), never on the connection.
+      const defaultConnectionConfig =
+        (await tx`
+          SELECT default_connection_config
+          FROM connector_definitions
+          WHERE organization_id = ${organizationId}
+            AND key = ${connectorKey}
+            AND status = 'active'
+          LIMIT 1
+        `) as unknown as Array<{ default_connection_config: unknown }>;
+      const splitConfig = splitConfigByFeedScope(
+        parseJsonObject(defaultConnectionConfig[0]?.default_connection_config),
+        (metadata.feeds as unknown as Record<string, FeedDefinition>) ?? null,
+      );
+      const seedConfig = splitConfig.connectionConfig;
+
       // 3. Reuse or create the connection (no-auth, active, private). Match on
       //    (org, connector, no auth_profile) — the device-connector identity —
       //    rather than created_by, so orphan rows (created_by IS NULL, or
@@ -398,6 +438,18 @@ async function ensureDeviceConnectorWired(
           UPDATE connections
           SET created_by = ${userId}, updated_at = NOW()
           WHERE id = ${connectionId} AND created_by IS NULL
+        `;
+      }
+      if (connectionId && seedConfig) {
+        // Heal a surviving connection whose config is still SQL NULL (a row
+        // created before the definition default existed, or by the old
+        // no-seed path): seed the same default now. Guarded by `config IS NULL`
+        // so an explicit per-connection config is never clobbered. Idempotent —
+        // once seeded, this UPDATE stops matching.
+        await tx`
+          UPDATE connections
+          SET config = ${sql.json(seedConfig)}, updated_at = NOW()
+          WHERE id = ${connectionId} AND config IS NULL AND deleted_at IS NULL
         `;
       }
       if (!connectionId) {
@@ -430,7 +482,7 @@ async function ensureDeviceConnectorWired(
             auth_profile_id, app_auth_profile_id, config, created_by, visibility
           ) VALUES (
             ${organizationId}, ${connectorKey}, ${slug}, ${metadata.name}, 'active',
-            NULL, NULL, NULL, ${userId}, 'private'
+            NULL, NULL, ${seedConfig ? sql.json(seedConfig) : null}, ${userId}, 'private'
           )
           RETURNING id
         `) as unknown as Array<{ id: number }>;


### PR DESCRIPTION
## Summary

Device-auto-wire connections stopped inheriting the connector's default config: `device-reconcile` created connections with `config = NULL`, silently dropping the org's intended `action_modes` (all `auto`). This broke `upload_file` and the other chrome ops on every device connection created after the tombstone/rewire.

- `device-reconcile.ts` now seeds new connections from `connector_definitions.default_connection_config` at create time — the same contract used by `connect`, `crud`, and social-login provisioning paths (no layered runtime resolution, no retroactive semantics).
- Pre-existing NULL-config rows are mechanically healed on the next reconcile poll; explicit per-connection configs are never clobbered.
- Fast-path readiness check leaves dependencies untouched when the connection already has a config and no default is set.

## Test plan

- [x] **Bug fix red→fix→green pasted below**
- [x] Targeted `bunx vitest run` in `packages/server` — **42/42 passed**: `device-reconcile-config-seed` (4, new) + `device-pin-owner-guard` (3) + `device-reconcile-slug-race` (2) + `device-action-wait` (10) + `operations-list-available-lifecycle` (19) + `operations-execute-capability-readiness` (4). Plus 46/46 device/operations cluster on the base.
- Pre-commit gates (biome + root tsc) ran on commit; `tsc --noEmit` clean for touched files.
- **`make pre-pr-remote` (Depot full Linux CI graph) and `make review` are NOT run in this PR** — the Depot CLI + org auth are provisioned in the managed worktree environment, not this approval-review checkout. They are the outstanding org-managed gates before merge.

### Red (on parent `a5e818dc`, fix absent)

```
FAIL device-reconcile-config-seed.test.ts
AssertionError: expected null to deeply equal { action_modes: { upload_file: "auto", ... } }
```

Reproduces the reported incident (connection created with `config = NULL`, `action_modes` not auto).

### Green (with fix)

```
✓ device-reconcile-config-seed.test.ts (4 tests)
✓ device-pin-owner-guard.test.ts (3 tests)
✓ device-reconcile-slug-race.test.ts (2 tests)
✓ device-action-wait.test.ts (10 tests)
✓ operations-list-available-lifecycle.test.ts (19 tests)
✓ operations-execute-capability-readiness.test.ts (4 tests)
Test Files  6 passed (6)      Tests  42 passed (42)
```

## Notes

- No prod rows were manually migrated; recovery is mechanical once the org's connector default is set (`update_connector_default_config`) — 479/377 self-heal on their next device poll.
- Follow-up (separate submodule, not this repo): Owletto has no affordance to write connector-level defaults for device connectors; pairing this server fix with that UI surface closes the product gap.