### PR TITLE
feat(server,core): expose acl_managed on relationship rows

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1202,6 +1202,7 @@ export type ManageEntityResponses = {
           relationship_type_slug: string;
           relationship_type_name: string;
           is_symmetric: boolean;
+          acl_managed: boolean;
           from_entity_name?: string;
           from_entity_type?: string;
           to_entity_name?: string;
@@ -1229,6 +1230,7 @@ export type ManageEntityResponses = {
           relationship_type_slug: string;
           relationship_type_name: string;
           is_symmetric: boolean;
+          acl_managed: boolean;
           from_entity_name?: string;
           from_entity_type?: string;
           to_entity_name?: string;
@@ -1261,6 +1263,7 @@ export type ManageEntityResponses = {
           relationship_type_slug: string;
           relationship_type_name: string;
           is_symmetric: boolean;
+          acl_managed: boolean;
           from_entity_name?: string;
           from_entity_type?: string;
           to_entity_name?: string;

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -327,6 +327,20 @@ export const RelationshipRowSchema = Type.Object({
   relationship_type_slug: Type.String(),
   relationship_type_name: Type.String(),
   is_symmetric: Type.Boolean(),
+  // Server-derived: this edge cannot be created or removed through this
+  // surface — `unlink`/`update_link`/`link` all refuse it via
+  // assertNotAclManagedEdge, because ACL edges are what the access gates read.
+  // A client without this renders an unlink control that is guaranteed to 403.
+  //
+  // A derived flag rather than the raw `purpose`: the edge guard tests
+  // purpose OR slug, so an unclassified `member_of` (declared by a config
+  // before its first ACL sync) reads `purpose: null` and is still refused.
+  // Only the server can evaluate that pair, so it ships the answer.
+  //
+  // Required, not optional: an absent flag reads as writable, which is the
+  // dead affordance this exists to remove. Every producer projects it from
+  // the one shared RELATIONSHIP_SELECT, so no path needs to omit it.
+  acl_managed: Type.Boolean(),
   from_entity_name: Type.Optional(Type.String()),
   from_entity_type: Type.Optional(Type.String()),
   to_entity_name: Type.Optional(Type.String()),

--- a/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
+++ b/packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts
@@ -429,4 +429,83 @@ describe("authorization-bearing relationship types are not caller-writable", () 
 			),
 		).rejects.toThrow(/authorization-bearing/);
 	});
+
+	it("reports acl_managed on LIST_LINKS so a client can predict the unlink refusal", async () => {
+		await seedAclEdge();
+
+		const listed = (await manageEntity(
+			{ action: "list_links", entity_id: person },
+			env,
+			ctx(orgId, userId),
+		)) as { relationships: Array<Record<string, unknown>> };
+
+		const edge = listed.relationships.find(
+			(r) => r.relationship_type_slug === "member_of",
+		);
+		// toHaveProperty, not a truthiness check: an absent key is falsy too, so
+		// the loose form would keep passing if a handler stopped projecting the
+		// column — which is exactly the regression that revives the dead button.
+		expect(edge).toHaveProperty("acl_managed", true);
+	});
+
+	it("reports acl_managed BEFORE classification — purpose alone would say writable", async () => {
+		const edgeId = await seedAclEdge();
+		const sql = getTestDb();
+		await sql`
+      UPDATE entity_relationship_types SET purpose = NULL WHERE id = ${typeId}
+    `;
+
+		const listed = (await manageEntity(
+			{ action: "list_links", entity_id: person },
+			env,
+			ctx(orgId, userId),
+		)) as { relationships: Array<Record<string, unknown>> };
+
+		const edge = listed.relationships.find((r) => Number(r.id) === edgeId);
+		// The slug half of the guard: assertNotAclManagedEdge refuses on slug OR
+		// purpose, so unlink still 403s here (the test above covers the same
+		// window on the link side). The read path has to agree, or the client is
+		// told it may remove an edge the server will refuse.
+		expect(edge).toHaveProperty("acl_managed", true);
+	});
+
+	it("reports acl_managed false for ordinary domain vocabulary", async () => {
+		await manageEntitySchema(
+			{
+				schema_type: "relationship_type",
+				action: "create",
+				slug: "billed_to",
+				name: "Billed to",
+			},
+			env,
+			ctx(orgId, userId),
+		);
+		const linked = (await manageEntity(
+			{
+				action: "link",
+				from_entity_id: person,
+				to_entity_id: channel,
+				relationship_type_slug: "billed_to",
+			},
+			env,
+			ctx(orgId, userId),
+		)) as { relationship: Record<string, unknown> };
+		// `link` returns the same row shape, so cover that producer here too: a
+		// client switching on the flag must not see it appear and disappear
+		// across actions.
+		expect(linked.relationship).toHaveProperty("acl_managed", false);
+
+		const listed = (await manageEntity(
+			{ action: "list_links", entity_id: person },
+			env,
+			ctx(orgId, userId),
+		)) as { relationships: Array<Record<string, unknown>> };
+
+		const edge = listed.relationships.find(
+			(r) => r.relationship_type_slug === "billed_to",
+		);
+		// The other direction: a predicate that swept everything in would hide the
+		// unlink control on every ordinary edge in the product.
+		expect(edge).toHaveProperty("acl_managed", false);
+	});
 });

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -70,6 +70,7 @@ import {
 } from "../../utils/insert-event";
 import { resolveMemberSchemaFieldsFromSchema } from "../../utils/member-entity-type";
 import {
+	ACL_MANAGED_TYPE_SQL,
 	assertNotAclManagedEdge,
 	canonicalizeSymmetricEdge,
 	checkDuplicateEdge,
@@ -1471,6 +1472,7 @@ const RELATIONSHIP_SELECT = `
   rt.slug as relationship_type_slug,
   rt.name as relationship_type_name,
   rt.is_symmetric,
+  ${ACL_MANAGED_TYPE_SQL} as acl_managed,
   fe.name as from_entity_name,
   fet.slug as from_entity_type,
   te.name as to_entity_name,


### PR DESCRIPTION
## Summary
- `manage_entity` relationship rows now carry a server-derived `acl_managed: boolean`, so a client can tell which edges are refused by `assertNotAclManagedEdge` before it renders an unlink/edit control that is guaranteed to 403.
- The flag is derived, not the raw `purpose`, because the edge guard tests **purpose OR slug**: a `member_of` type declared by a config but not yet classified by an ACL sync reads `purpose: null` and is still refused. Only the server can evaluate that pair, so it ships the answer.
- Same predicate as the guard (`ACL_MANAGED_TYPE_SQL`), projected once from the shared `RELATIONSHIP_SELECT`, so every producer of a relationship row gets it.

Follows #2837 (purpose on the type read surface) and #2840 (`read-only: access control` in the agent's workspace instructions). This is the third and last blind surface from that program: the **edge** rows themselves.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Tests run: `packages/server/src/__tests__/integration/authz/authorization-type-guards.test.ts` — 17/17 pass
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed

Three tests added to the existing guard suite:
- `acl_managed` is `true` on `LIST_LINKS` for a classified authorization type
- `acl_managed` is `true` **before** classification (`purpose: null`, slug `member_of`) — this is the case a purpose-only field would get wrong
- `acl_managed` is `false` for ordinary domain vocabulary

Mutation-tested: swapping the projection to purpose-only fails the "before classification" test; hardcoding `true as acl_managed` fails the "ordinary domain vocabulary" test. File restored identical after each.

## Notes
`packages/client/src/generated/types.gen.ts` is regenerated output — produced by `bun run generate` in `packages/client` against a booted server, after confirming `acl_managed` was present in the served OpenAPI spec.

The field is required rather than optional: an absent flag reads as writable, which is the dead affordance this exists to remove. All three `sql.unsafe<RelationshipRow>` producers share `RELATIONSHIP_SELECT` + `RELATIONSHIP_JOINS`, which aliases the type table `rt`, so no path can omit it.

Follow-up not in this PR: Owletto still renders unlink controls without consulting the flag — that is a separate submodule change.
