### PR TITLE
fix(server): keep the ACL-managed half of an inverse relationship pair

### DIFF
--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -11,6 +11,8 @@
  *   4. connector_definitions.description
  *   5. ACL-managed relationship types render a `read-only: access control` hint,
  *      on the same purpose-OR-slug test that link/unlink already 403 on
+ *   6. an inverse pair only collapses to one line when both halves share that
+ *      hint, so the ACL-managed half is never dropped by the name ordering
  *
  * Org guidance pinned here:
  *   - admin-authored `guidance` events render under "### Organization Context"
@@ -137,6 +139,42 @@ describe('buildWorkspaceInstructions render fixes', () => {
       WHERE organization_id = ${org.id} AND slug = 'grants_role'
     `;
 
+    // Two inverse pairs. The listing collapses a pair to one line, but the
+    // write rule is decided per type, so a pair whose halves disagree cannot be
+    // collapsed without losing one half's rule. `reports_to`/`has_report`
+    // disagree; `ships_to`/`shipped_from` agree and must still collapse.
+    //
+    // Written in this order deliberately: assertNotAuthorizationType refuses to
+    // pair a type that is ALREADY classified, so a straddling pair is reached
+    // by pairing while both halves are ordinary and letting the ACL sync
+    // classify one half afterwards — which is exactly what happens below.
+    await sql`
+      INSERT INTO entity_relationship_types (slug, name, description, organization_id)
+      VALUES
+        ('has_report', 'Has report', 'Reporting line, ordinary vocabulary', ${org.id}),
+        ('reports_to', 'Reports to', 'Reporting line synced from the IdP', ${org.id}),
+        ('shipped_from', 'Shipped from', 'Ordinary pair, both halves writable', ${org.id}),
+        ('ships_to', 'Ships to', 'Ordinary pair, both halves writable', ${org.id})
+    `;
+    await sql`
+      UPDATE entity_relationship_types a
+      SET inverse_type_id = b.id
+      FROM entity_relationship_types b
+      WHERE a.organization_id = ${org.id}
+        AND b.organization_id = ${org.id}
+        AND (a.slug, b.slug) IN (
+          ('has_report', 'reports_to'),
+          ('reports_to', 'has_report'),
+          ('shipped_from', 'ships_to'),
+          ('ships_to', 'shipped_from')
+        )
+    `;
+    await sql`
+      UPDATE entity_relationship_types
+      SET purpose = 'authorization'
+      WHERE organization_id = ${org.id} AND slug = 'reports_to'
+    `;
+
     // Org-scoped connector definition with a description + an active connection.
     await sql`
       INSERT INTO connector_definitions (key, name, description, actions_schema, organization_id, status)
@@ -215,6 +253,35 @@ describe('buildWorkspaceInstructions render fixes', () => {
     // Guards the other direction: ACL_MANAGED_TYPE_SQL uses IS NOT DISTINCT
     // FROM precisely so a NULL purpose does not sweep every type in.
     expect(out).not.toContain('- supplies (read-only: access control)');
+  });
+
+  it('keeps both halves of an inverse pair when only one is access-controlled', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    // A blanket collapse keeps whichever half `ORDER BY name ASC` reaches
+    // first, so `reports_to` — the half that 403s — can vanish from the
+    // vocabulary entirely, leaving the agent unaware the slug exists at all,
+    // let alone that it is read-only. Both halves are asserted, so this holds
+    // whichever way the ordering falls.
+    expect(out).toContain(
+      '- reports_to (inverse: has_report, read-only: access control) — Reporting line synced from the IdP'
+    );
+    expect(out).toContain('- has_report (inverse: reports_to) — Reporting line, ordinary vocabulary');
+  });
+
+  it('still collapses an inverse pair whose halves share the same write rule', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    // The other direction: keeping both halves unconditionally would double
+    // every ordinary pair in the listing for no gain.
+    // Asserted as "exactly one of the pair" rather than naming the winner:
+    // which half survives is decided by `ORDER BY name ASC` under whatever
+    // collation the database runs, and that is not the property under test.
+    const emitted = out!
+      .split('\n')
+      .filter((l) => l.startsWith('- ships_to') || l.startsWith('- shipped_from'));
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatch(
+      /^- (ships_to \(inverse: shipped_from\)|shipped_from \(inverse: ships_to\)) — Ordinary pair, both halves writable$/
+    );
   });
 
   it('renders connector definition descriptions', async () => {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -111,20 +111,31 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       return `- ${et.slug} ("${et.name}")${desc ? ` — ${desc}` : ''}${fields ? ` — fields: ${fields}` : ''}`;
     });
 
-    const emittedRelSlugs = new Set<string>();
+    // An inverse pair renders as one line, but `acl_managed` is decided per
+    // type, so the halves can disagree: pairing is only refused against an
+    // ALREADY-classified type, and classification later sets `purpose` without
+    // touching `inverse_type_id`, so it lands on one half of a live pair.
+    // Collapsing regardless drops whichever half loses the name ordering, and
+    // when that is the ACL-managed half the agent never learns the slug exists,
+    // let alone that writing it 403s. So collapse a pair only when both halves
+    // carry the same rule. A slug not yet emitted maps to `undefined`, which
+    // never equals a boolean — that is what keeps the first half of a pair (and
+    // a type whose inverse is inactive, hence absent here) from skipping itself.
+    const emittedRelAclManaged = new Map<string, boolean>();
     const relTypeLines: string[] = [];
     for (const rt of relationshipTypes) {
       const slug = rt.slug as string;
       const inverseSlug = rt.inverse_type_slug as string | null;
-      if (inverseSlug && emittedRelSlugs.has(inverseSlug)) continue;
-      emittedRelSlugs.add(slug);
+      const aclManaged = Boolean(rt.acl_managed);
+      if (inverseSlug && emittedRelAclManaged.get(inverseSlug) === aclManaged) continue;
+      emittedRelAclManaged.set(slug, aclManaged);
       const parts: string[] = [];
       if (rt.is_symmetric) parts.push('symmetric');
       if (inverseSlug) parts.push(`inverse: ${inverseSlug}`);
       // Annotated rather than filtered out: reading these edges is legitimate,
       // so hiding the type would blind the agent to real schema. Only the WRITE
       // is refused, so say exactly that.
-      if (rt.acl_managed) parts.push('read-only: access control');
+      if (aclManaged) parts.push('read-only: access control');
       const meta = parts.length > 0 ? ` (${parts.join(', ')})` : '';
       const desc = singleLine(rt.description);
       relTypeLines.push(`- ${slug}${meta}${desc ? ` — ${desc}` : ''}`);


### PR DESCRIPTION
## Summary
- The agent's relationship-type listing collapses an inverse pair to one line, but `acl_managed` is decided **per type**. When the halves disagree, the collapse drops whichever half loses `ORDER BY name ASC` — and if that's the ACL-managed half, the agent never learns the slug exists, let alone that writing it 403s.
- Collapse now happens only when both halves carry the same write rule. Ordinary pairs still collapse; a straddling pair renders both lines, each with its own annotation.
- Follows #2840, which added the `read-only: access control` hint this fix keeps from being silently discarded.

**This is a listing defect, not an ACL bypass.** `inverse_type_id` is read by exactly four places — schema CRUD, this listing, `table-schema.ts`, and one test — and by no edge-write path. `manage_entity.ts` never mentions `inverse`, so writing one half never materializes the other, and ACL reads key on the edge's own `relationship_type_id`.

How a straddling pair is reached: `resolveInverseType` (`manage_entity_schema.ts:915`) calls `assertNotAuthorizationType`, so you cannot pair against an *already-classified* type. But that guard is purpose-only, so the pair can be formed while both halves are ordinary and classified afterwards — classification sets `purpose` and never touches `inverse_type_id`. The fixture is ordered to match that sequence.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean
- [x] Tests run: `packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts` — 31/31
- [x] Bug fix: red→fix→green outputs pasted below

**Red** (new tests against unfixed code — note the collapse-guard is already green, so only the bug is red):
```
 ❯ src/__tests__/integration/tools/workspace-instructions.test.ts:257:17
   expect(out).toContain('- reports_to (inverse: has_report, read-only: access control) — …')
 Tests  1 failed | 30 passed (31)
```

**Green**:
```
 ✓ src/__tests__/integration/tools/workspace-instructions.test.ts (31 tests) 1106ms
 Tests  31 passed (31)
```

**Mutation-tested, one failure each, neither test vacuous**:
```
### MUTATION 1: unconditional collapse (the original bug)
   × keeps both halves of an inverse pair when only one is access-controlled
      Tests  1 failed | 30 passed (31)
### MUTATION 2: no collapse at all
   × still collapses an inverse pair whose halves share the same write rule
      Tests  1 failed | 30 passed (31)
### RESTORED
      Tests  31 passed (31)
```

## Notes
Reachability: prod has 103 active relationship types and **0** with `inverse_type_id` set, so this branch is currently dead there — latent-bug hygiene, not an incident. It is agent-reachable, though: `manage_entity_schema` accepts `inverse_type_slug` on create/update and back-links the pair.

A slug not yet emitted maps to `undefined`, which never equals a boolean. That is what keeps the first half of a pair from skipping itself, and also what makes a type whose inverse is inactive (the `inv` LEFT JOIN carries no status filter, unlike the outer `rt`) fail toward being shown rather than hidden.

The collapse test asserts *exactly one of the pair survives* rather than naming the winner — which half wins depends on the database's collation, and that isn't the property under test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace instructions for inverse relationships with differing access rules.
  * Ensured both relationship directions are shown when their access settings differ.
  * Continued consolidating inverse relationships with matching access rules.
  * Clearly marks access-controlled relationships as read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->