### PR TITLE
docs(server): correct feed-scoped default comment in device auto-wire

### DIFF
--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -410,7 +410,7 @@ async function ensureDeviceConnectorWired(
       // the only creation path that previously skipped this, so a device swap
       // silently regressed action modes to descriptor fallbacks. Feed-scoped
       // default keys are dropped here — auto-wired feeds are minted with
-      // `config = NULL` (unchanged from prior behavior); the fast-path gate
+      // `config = NULL` (unchanged from the pre-seed path); the fast-path gate
       // accounts for this so a wholly feed-scoped default does not re-wire
       // forever.
       const defaultConnectionConfig =

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -409,7 +409,10 @@ async function ensureDeviceConnectorWired(
       // `default_connection_config` into the new row's config — auto-wire is
       // the only creation path that previously skipped this, so a device swap
       // silently regressed action modes to descriptor fallbacks. Feed-scoped
-      // default keys belong on feeds (wired below), never on the connection.
+      // default keys are dropped here — auto-wired feeds are minted with
+      // `config = NULL` (unchanged from prior behavior); the fast-path gate
+      // accounts for this so a wholly feed-scoped default does not re-wire
+      // forever.
       const defaultConnectionConfig =
         (await tx`
           SELECT default_connection_config


### PR DESCRIPTION
## Summary
Comment-only correction on a line shipped in #2841, flagged by the review: feed-scoped default keys on auto-wired connections are **dropped** (feeds are minted with `config = NULL`), not "wired below". The old wording implied the feed config is applied, which a future reader could "fix" wrongly.

## Test plan
- Comment-only change; pre-commit gates (biome + tsc) passed.
- No behavior change; CI re-runs to confirm.

## Notes
Closes out review nit on #2841.
