### PR TITLE
feat(server,connector-sdk): scope entity identities per connection when declared

### DIFF
--- a/db/migrations/20260818000000_entity_identity_connection_scope.sql
+++ b/db/migrations/20260818000000_entity_identity_connection_scope.sql
@@ -1,0 +1,68 @@
+-- migrate:up
+
+-- Identity scope: does an identifier mean the same thing across connections?
+--
+-- `idx_entity_identities_live_unique` is `(organization_id, namespace,
+-- identifier)`, so two connections in the same org that share a namespace
+-- collapse onto one entity. Namespaces come from connector manifests, not from
+-- anything the platform controls: two ERP connections against two different
+-- tenants both declaring `erp_customer` resolve `CARI-001` in tenant A to the
+-- entity minted for `CARI-001` in tenant B. Nothing errors — the second
+-- connection's attribution silently accretes traits onto the first's entity.
+--
+-- The fix is NOT to add `connection_id` to the index. That column is
+-- PROVENANCE: it records which connection first wrote the row, and it is set on
+-- every connector-written identity including ones that are legitimately
+-- org-wide. Indexing it would split identities that must stay collapsed — in
+-- production today one organization shares `slack_channel_id` across three
+-- connections and `slack_user_id` across two, and the same Slack user seen
+-- through two connections must remain ONE person.
+--
+-- So scope gets its own column, written only when the connector declares the
+-- namespace connection-scoped. NULL means org-wide, which is every row that
+-- exists today.
+--
+-- Deliberately NO foreign key, unlike the sibling `connection_id`
+-- (`entity_identities_connection_id_fkey`, ON DELETE SET NULL). That column is
+-- provenance, so nulling it on a deleted connection loses nothing. This one is
+-- part of the uniqueness key: SET NULL would silently PROMOTE a
+-- connection-scoped identity to org-wide — the exact collapse the column
+-- prevents — and could collide with a legitimately org-wide row for the same
+-- (org, namespace, identifier), aborting the connection delete on a unique
+-- violation. CASCADE would delete identity rows, taking their entities'
+-- attribution with them. Leaving the id dangling is inert instead: `connections.id`
+-- is a bigserial and never reused, so the orphaned row simply stops matching.
+ALTER TABLE entity_identities
+  ADD COLUMN IF NOT EXISTS scope_connection_id bigint;
+
+-- COALESCE to a sentinel rather than indexing the nullable column directly: in
+-- a UNIQUE index NULLs are distinct, so a bare `scope_connection_id` would stop
+-- deduplicating the org-wide rows entirely — every re-sync would insert another
+-- copy. 0 is safe as the sentinel because `connections.id` is a bigserial and
+-- never 0.
+--
+-- Existing rows all have NULL, so they collapse on exactly the key they
+-- collapse on today: this migration is behaviour-preserving on its own, and
+-- only a connector declaring `scope: 'connection'` changes any outcome.
+DROP INDEX IF EXISTS idx_entity_identities_live_unique;
+
+CREATE UNIQUE INDEX idx_entity_identities_live_unique
+  ON entity_identities (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
+  WHERE deleted_at IS NULL;
+
+-- migrate:down
+
+-- Reversible only while no connection-scoped identities exist. Once two
+-- connections hold the same (org, namespace, identifier) under different
+-- scopes, restoring the narrower index makes them duplicates and the CREATE
+-- fails — which is the correct failure: silently collapsing two different
+-- tenants' customers onto one entity is the defect this column exists to
+-- prevent, and the rollback must not perform it.
+DROP INDEX IF EXISTS idx_entity_identities_live_unique;
+
+CREATE UNIQUE INDEX idx_entity_identities_live_unique
+  ON entity_identities (organization_id, namespace, identifier)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE entity_identities
+  DROP COLUMN IF EXISTS scope_connection_id;

--- a/db/migrations/20260818000000_entity_identity_connection_scope.sql
+++ b/db/migrations/20260818000000_entity_identity_connection_scope.sql
@@ -1,4 +1,4 @@
--- migrate:up
+-- migrate:up transaction:false
 
 -- Identity scope: does an identifier mean the same thing across connections?
 --
@@ -30,11 +30,21 @@
 -- prevents — and could collide with a legitimately org-wide row for the same
 -- (org, namespace, identifier), aborting the connection delete on a unique
 -- violation. CASCADE would delete identity rows, taking their entities'
--- attribution with them. Leaving the id dangling is inert instead: `connections.id`
--- is a bigserial and never reused, so the orphaned row simply stops matching.
+-- attribution with them. The dangling id is inert for matching; the entity
+-- duplication that follows a reconnect is tracked separately (#2849).
+--
+-- Nullable with no default, so this is a metadata-only catalog update: no table
+-- rewrite and no lingering ACCESS EXCLUSIVE hold.
 ALTER TABLE entity_identities
   ADD COLUMN IF NOT EXISTS scope_connection_id bigint;
 
+-- The replacement arbiter is built CONCURRENTLY under a NEW name and the old
+-- one retired afterwards, so uniqueness is never absent and neither statement
+-- takes ACCESS EXCLUSIVE for the duration of a build. The same name cannot be
+-- reused while the old index still exists, and that is fine: `ON CONFLICT`
+-- infers its arbiter by matching the target EXPRESSION against available
+-- indexes, never by name.
+--
 -- COALESCE to a sentinel rather than indexing the nullable column directly: in
 -- a UNIQUE index NULLs are distinct, so a bare `scope_connection_id` would stop
 -- deduplicating the org-wide rows entirely — every re-sync would insert another
@@ -44,25 +54,65 @@ ALTER TABLE entity_identities
 -- Existing rows all have NULL, so they collapse on exactly the key they
 -- collapse on today: this migration is behaviour-preserving on its own, and
 -- only a connector declaring `scope: 'connection'` changes any outcome.
-DROP INDEX IF EXISTS idx_entity_identities_live_unique;
+--
+-- The INVALID-carcass heal is inlined rather than split into its own migration
+-- so it re-runs on every retry: a crashed CONCURRENTLY build leaves an INVALID
+-- same-named index, and `CREATE ... IF NOT EXISTS` would then silently no-op
+-- over it and record this migration as applied with a NON-ENFORCING arbiter —
+-- a silent uniqueness hole on identity claims. Same structure as
+-- 20260721120020_connector_versions_org_unique.sql.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_entity_identities_live_unique_scoped'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_entity_identities_live_unique_scoped';
+  END IF;
+END
+$heal$;
 
-CREATE UNIQUE INDEX idx_entity_identities_live_unique
-  ON entity_identities (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_entity_identities_live_unique_scoped
+  ON public.entity_identities (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
   WHERE deleted_at IS NULL;
 
--- migrate:down
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_entity_identities_live_unique;
+
+-- migrate:down transaction:false
 
 -- Reversible only while no connection-scoped identities exist. Once two
 -- connections hold the same (org, namespace, identifier) under different
--- scopes, restoring the narrower index makes them duplicates and the CREATE
+-- scopes, rebuilding the narrower arbiter makes them duplicates and the CREATE
 -- fails — which is the correct failure: silently collapsing two different
 -- tenants' customers onto one entity is the defect this column exists to
--- prevent, and the rollback must not perform it.
-DROP INDEX IF EXISTS idx_entity_identities_live_unique;
+-- prevent, and the rollback must not perform it. A failed CONCURRENTLY build
+-- leaves an INVALID carcass, healed on the next attempt by the block above.
+DO $heal_down$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_entity_identities_live_unique'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_entity_identities_live_unique';
+  END IF;
+END
+$heal_down$;
 
-CREATE UNIQUE INDEX idx_entity_identities_live_unique
-  ON entity_identities (organization_id, namespace, identifier)
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_entity_identities_live_unique
+  ON public.entity_identities (organization_id, namespace, identifier)
   WHERE deleted_at IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_entity_identities_live_unique_scoped;
 
 ALTER TABLE entity_identities
   DROP COLUMN IF EXISTS scope_connection_id;

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -588,7 +588,8 @@ export interface EventAttributionRule {
 /**
  * Normalized identifier that uniquely names an entity within a namespace.
  * Stored as a row in `entity_identities` with UNIQUE on
- * (organization_id, namespace, identifier) — matching, creation races, and
+ * (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
+ * — matching, creation races, and
  * accrete all collapse onto this constraint.
  */
 export interface EntityIdentitySpec {
@@ -617,6 +618,29 @@ export interface EntityIdentitySpec {
    * matched by ANY of them — cross-channel WhatsApp/email matching relies on this).
    */
   primary?: boolean;
+  /**
+   * Does this identifier mean the same thing across connections?
+   *
+   * - `organization` (default) — globally meaningful within the org. A Slack
+   *   user id names the same person no matter which connection observed it, so
+   *   two connections seeing it must converge on ONE entity.
+   * - `connection` — only meaningful inside the connection that produced it.
+   *   `erp_customer` `CARI-001` is a different customer in two different ERP
+   *   tenants, so two connections seeing it must stay SEPARATE entities.
+   *
+   * Only the connector knows which it is: the namespace string is declared by
+   * the manifest, and nothing about `invoice_no` or `customer_code` tells the
+   * platform whether it is globally unique. Declaring it wrong in the
+   * `connection` direction fragments one entity into several; declaring it
+   * wrong in the `organization` direction merges two tenants' records, so the
+   * default is the conservative one only for connectors whose namespaces really
+   * are global.
+   *
+   * Distinct from the deleted `uniquePerOrg` flag, which was CARDINALITY — does
+   * this value name one entity or many (`email_domain` names many). Scope is
+   * orthogonal: `email_domain` is many-per-org yet globally meaningful.
+   */
+  scope?: 'organization' | 'connection';
 }
 
 /**

--- a/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
@@ -1,7 +1,7 @@
 /**
  * Identity scope: does an identifier mean the same thing across connections?
  *
- * `idx_entity_identities_live_unique` keys on
+ * `idx_entity_identities_live_unique_scoped` keys on
  * `(organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))`.
  * A connector declares `scope` per identity namespace, because only it knows
  * whether its namespace is globally meaningful:

--- a/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Identity scope: does an identifier mean the same thing across connections?
+ *
+ * `idx_entity_identities_live_unique` keys on
+ * `(organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))`.
+ * A connector declares `scope` per identity namespace, because only it knows
+ * whether its namespace is globally meaningful:
+ *
+ *   - `scope: 'connection'` — `erp_customer` `CARI-001` is a DIFFERENT customer
+ *     in two different ERP tenants, so two connections must stay separate.
+ *   - default (`organization`) — a Slack user id names the same person no
+ *     matter which connection observed it, so two connections must collapse.
+ *
+ * Both directions are pinned here: getting either one wrong is a data defect,
+ * and they fail in opposite directions (fragmenting one entity vs merging two
+ * tenants' records).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyEventAttributions, clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { ensureMemberEntityType } from '../../../utils/member-entity-type';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const connectorKey = 'erp-scope-contract';
+const feedKey = 'customers';
+
+/**
+ * One connector, two namespaces on the same rule: `erp_customer` is
+ * connection-scoped, `email` is not. A mixed rule is the interesting case — it
+ * proves scope is resolved per identity rather than per rule or per call.
+ */
+async function seed() {
+  await cleanupTestDatabase();
+  clearEntityLinkRulesCache();
+
+  const org = await createTestOrganization({ name: 'Identity Scope Org' });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  await ensureMemberEntityType(org.id);
+
+  await createTestConnectorDefinition({
+    key: connectorKey,
+    name: 'ERP Scope Contract',
+    organization_id: org.id,
+    feeds_schema: {
+      [feedKey]: {
+        eventKinds: {
+          customer: {
+            attributions: [
+              {
+                role: 'about',
+                autoCreate: true,
+                target: {
+                  entityType: '$member',
+                  titlePath: 'metadata.name',
+                  identities: [
+                    {
+                      namespace: 'erp_customer',
+                      eventPath: 'metadata.customer_code',
+                      scope: 'connection',
+                    },
+                    { namespace: 'email', eventPath: 'metadata.email' },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  });
+
+  const tenantA = await createTestConnection({
+    organization_id: org.id,
+    connector_key: connectorKey,
+    display_name: 'ERP Tenant A',
+    createDefaultFeed: false,
+  });
+  const tenantB = await createTestConnection({
+    organization_id: org.id,
+    connector_key: connectorKey,
+    display_name: 'ERP Tenant B',
+    createDefaultFeed: false,
+  });
+
+  clearEntityLinkRulesCache();
+  return { org, tenantA, tenantB };
+}
+
+function customerEvent(code: string, name: string, email?: string) {
+  return {
+    origin_type: 'customer',
+    metadata: { customer_code: code, name, ...(email ? { email } : {}) },
+  };
+}
+
+async function memberCount(orgId: string): Promise<number> {
+  const sql = getTestDb();
+  const rows = await sql<{ n: string }[]>`
+    SELECT count(*) AS n
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = '$member' AND e.deleted_at IS NULL
+  `;
+  return Number(rows[0].n);
+}
+
+describe('connector identity scope', () => {
+  beforeEach(() => {
+    clearEntityLinkRulesCache();
+  });
+
+  it('keeps a connection-scoped identifier separate across two connections', async () => {
+    const { org, tenantA, tenantB } = await seed();
+    const sql = getTestDb();
+
+    // Same customer_code, two ERP tenants, no other identifier to link them.
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      connectionId: tenantA.id,
+      items: [customerEvent('CARI-001', 'Acme A')],
+    });
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      connectionId: tenantB.id,
+      items: [customerEvent('CARI-001', 'Beta B')],
+    });
+
+    expect(await memberCount(org.id)).toBe(2);
+
+    const rows = await sql<{ identifier: string; scope_connection_id: string | null }[]>`
+      SELECT identifier, scope_connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'erp_customer' AND deleted_at IS NULL
+      ORDER BY scope_connection_id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => Number(r.scope_connection_id)).sort((a, b) => a - b)).toEqual(
+      [tenantA.id, tenantB.id].sort((a, b) => a - b)
+    );
+  });
+
+  it('still collapses an org-scoped identifier across the same two connections', async () => {
+    const { org, tenantA, tenantB } = await seed();
+    const sql = getTestDb();
+
+    // Distinct customer codes so `erp_customer` cannot be what links them —
+    // only the shared, org-scoped `email` can.
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      connectionId: tenantA.id,
+      items: [customerEvent('CARI-001', 'Dana', 'dana@example.com')],
+    });
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      connectionId: tenantB.id,
+      items: [customerEvent('CARI-999', 'Dana', 'dana@example.com')],
+    });
+
+    // One person, seen through two connections. This is the case a blanket
+    // `connection_id` in the unique index would have broken.
+    expect(await memberCount(org.id)).toBe(1);
+
+    const emails = await sql<{ scope_connection_id: string | null }[]>`
+      SELECT scope_connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'email' AND deleted_at IS NULL
+    `;
+    expect(emails).toHaveLength(1);
+    expect(emails[0].scope_connection_id).toBeNull();
+  });
+
+  it('falls back to org scope when there is no ingesting connection', async () => {
+    const { org } = await seed();
+    const sql = getTestDb();
+
+    // The webhook and manual paths pass no connectionId. Inventing a scope
+    // there would strand the identity in a bucket nothing can ever match.
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [customerEvent('CARI-777', 'Orphan')],
+    });
+
+    const rows = await sql<{ scope_connection_id: string | null }[]>`
+      SELECT scope_connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'erp_customer' AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scope_connection_id).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/identity-connection-scope.test.ts
@@ -185,6 +185,37 @@ describe('connector identity scope', () => {
     expect(emails[0].scope_connection_id).toBeNull();
   });
 
+  it('is idempotent when the same connection re-syncs a scoped identifier', async () => {
+    const { org, tenantA } = await seed();
+    const sql = getTestDb();
+
+    // The ON CONFLICT DO UPDATE path with a NON-NULL scope_connection_id — the
+    // conflict target is an expression index, so a re-sync is where a
+    // mismatched inference would surface as a duplicate row rather than an
+    // error.
+    for (let i = 0; i < 2; i++) {
+      await applyEventAttributions({
+        connectorKey,
+        feedKey,
+        orgId: org.id,
+        connectionId: tenantA.id,
+        items: [customerEvent('CARI-042', 'Repeat Customer')],
+      });
+    }
+
+    expect(await memberCount(org.id)).toBe(1);
+    const rows = await sql<{ scope_connection_id: string | null }[]>`
+      SELECT scope_connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id}
+        AND namespace = 'erp_customer'
+        AND identifier = 'CARI-042'
+        AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].scope_connection_id)).toBe(tenantA.id);
+  });
+
   it('falls back to org scope when there is no ingesting connection', async () => {
     const { org } = await seed();
     const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/events/save-content-member-claim-heal.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-member-claim-heal.test.ts
@@ -68,7 +68,7 @@ describe('saveContent > $member auth_user_id claim heals poison source', () => {
         (organization_id, entity_id, namespace, identifier, source_connector)
       VALUES
         (${org.id}, ${memberId}, 'auth_user_id', ${user.id}, 'save_content')
-      ON CONFLICT (organization_id, namespace, identifier)
+      ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
         WHERE deleted_at IS NULL
       DO NOTHING
     `;

--- a/packages/server/src/__tests__/integration/events/save-content-member-claim-heal.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-member-claim-heal.test.ts
@@ -5,7 +5,7 @@
  * The authz channel-visibility gate resolves a user to their $member via an
  * entity_identities row with namespace `auth_user_id` AND
  * `source_connector='auth:signup'`. save_content used to write that claim with
- * `source_connector='save_content'`; because idx_entity_identities_live_unique
+ * `source_connector='save_content'`; because idx_entity_identities_live_unique_scoped
  * is on (org, namespace, identifier), the wrong-source row BLOCKED the correct
  * auth:signup insert forever — a permanent poison the member-claim-drift
  * detector reports but cannot repair. The fix writes `auth:signup` and heals

--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -1005,7 +1005,7 @@ export async function linkSlackIdentityInGraph(opts: {
     ) VALUES (
       ${opts.organizationId}, ${memberEntityId}, 'slack_user_id', ${identifier}, 'auth:signup'
     )
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO NOTHING
   `;
 }

--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -45,7 +45,8 @@ type Sql = ReturnType<typeof getDb>;
 
 /**
  * Insert (or no-op on conflict) entity_identities rows pointing at the given
- * member entity. The unique index on (organization_id, namespace, identifier)
+ * member entity. The unique index on (organization_id, namespace, identifier,
+ * COALESCE(scope_connection_id, 0))
  * WHERE deleted_at IS NULL guards against duplicates.
  */
 async function writeIdentities(
@@ -62,7 +63,7 @@ async function writeIdentities(
       ) VALUES (
         ${organizationId}, ${memberEntityId}, ${row.namespace}, ${row.identifier}, ${source}
       )
-      ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+      ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
       DO NOTHING
     `;
 	}
@@ -73,8 +74,10 @@ async function writeIdentities(
  * from a `person` entity when one already owns it.
  *
  * Why an UPDATE and not another INSERT: `entity_identities` has a live-unique
- * index on `(organization_id, namespace, identifier)`, so the claim exists at
- * most once. `writeIdentities`' `ON CONFLICT DO NOTHING` therefore SILENTLY LOSES
+ * index on `(organization_id, namespace, identifier,
+ * COALESCE(scope_connection_id, 0))`, so the claim exists at most once —
+ * auth-written identities are always org-scoped (NULL). `writeIdentities`'
+ * `ON CONFLICT DO NOTHING` therefore SILENTLY LOSES
  * whenever the ACL sync minted a `person` for this workspace user before the
  * human ever signed in — which is the normal ordering, since channel sync runs
  * on a timer and sign-in is a one-off. The gate only ever resolves a `$member`
@@ -109,7 +112,7 @@ async function adoptSlackIdentityOntoMember(
     ) VALUES (
       ${organizationId}, ${memberEntityId}, ${SLACK_IDENTITY.USER_ID}, ${identifier}, 'auth:signup'
     )
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO NOTHING
     RETURNING id
   `;

--- a/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
@@ -79,7 +79,7 @@ async function linkSlackUser(teamId: string): Promise<void> {
     ) VALUES
       (${ORG_ID}, ${entityId}, 'auth_user_id', ${USER_ID}, 'auth:signup'),
       (${ORG_ID}, ${entityId}, 'slack_user_id', ${`${teamId.toUpperCase()}:${SLACK_USER_ID.toUpperCase()}`}, 'auth:signup')
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO NOTHING
   `;
 }

--- a/packages/server/src/gateway/connections/__tests__/sender-identity.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/sender-identity.test.ts
@@ -54,6 +54,11 @@ describe("buildSenderIdentity", () => {
         identifier: normalizeSlackUserId(TEAM, USER) as string,
         matchOnly: false,
         primary: false,
+        // Org-scoped, and asserted rather than omitted: a Slack user id already
+        // carries its workspace, so it names the same person through every
+        // connection that observes it. Scoping it per connection would fork one
+        // person into one entity per connection.
+        scopeConnectionId: null,
       },
     ]);
   });

--- a/packages/server/src/gateway/connections/sender-identity.ts
+++ b/packages/server/src/gateway/connections/sender-identity.ts
@@ -50,6 +50,10 @@ export function buildSenderIdentity(sender: RawChatSender): SenderIdentitySpec |
             identifier: slackId,
             matchOnly: false,
             primary: false,
+            // Org-scoped: a Slack user id already carries its workspace
+            // (`T…:U…`), so it names the same person through every connection
+            // that observes it — which is exactly the collapse we want.
+            scopeConnectionId: null,
           },
         ],
         mintEntityType: 'person',

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -20,7 +20,8 @@
  *
  * Identity is the (source run, case key) pair, claimed in `entity_identities`
  * under the `eval_case` namespace. The partial unique index
- * `idx_entity_identities_live_unique (organization_id, namespace, identifier)
+ * `idx_entity_identities_live_unique (organization_id, namespace, identifier,
+ * COALESCE(scope_connection_id, 0))
  * WHERE deleted_at IS NULL` is the multi-replica lock, so two operators
  * promoting the same run concurrently resolve to one case rather than two.
  */
@@ -566,7 +567,7 @@ async function claimEvalCaseIdentity(
       ${organizationId}, ${entityId}, ${EVAL_CASE_NAMESPACE}, ${identifier},
       current_timestamp
     )
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO UPDATE SET entity_id = EXCLUDED.entity_id, updated_at = current_timestamp
     WHERE EXISTS (
       SELECT 1 FROM entities de

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -20,7 +20,7 @@
  *
  * Identity is the (source run, case key) pair, claimed in `entity_identities`
  * under the `eval_case` namespace. The partial unique index
- * `idx_entity_identities_live_unique (organization_id, namespace, identifier,
+ * `idx_entity_identities_live_unique_scoped (organization_id, namespace, identifier,
  * COALESCE(scope_connection_id, 0))
  * WHERE deleted_at IS NULL` is the multi-replica lock, so two operators
  * promoting the same run concurrently resolve to one case rather than two.

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -440,8 +440,9 @@ async function saveContentImpl(
     // guard); this call is a verified signed-in user resolved to their own
     // member, so it IS that trusted tier. save_content historically wrote the
     // claim with source 'save_content', which — because the live-unique index
-    // is on (org, namespace, identifier) — permanently blocks the correct
-    // insert and poisons the member for the authz gate. Only that legacy source
+    // is on (org, namespace, identifier, COALESCE(scope_connection_id, 0)) and
+    // this claim is org-scoped (NULL) — permanently blocks the correct insert
+    // and poisons the member for the authz gate. Only that legacy source
     // is eligible for promotion: upgrading an arbitrary conflicting source
     // would defeat the gate's anti-hijack boundary.
     if (memberRows.length > 0 && authId) {
@@ -452,7 +453,7 @@ async function saveContentImpl(
         ) VALUES (
           ${ctx.organizationId}, ${memberId}, 'auth_user_id', ${authId}, 'auth:signup'
         )
-        ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+        ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
         DO UPDATE SET
           source_connector = 'auth:signup',
           entity_id = EXCLUDED.entity_id

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -9,7 +9,7 @@
  *
  * Identity: a lazy per-automation "canvas" entity claimed via `entity_identities`
  * (namespace `automation_canvas`, identifier = `<automationId>`), anchoring the chain
- * via `entity_ids`. The partial unique index `idx_entity_identities_live_unique`
+ * via `entity_ids`. The partial unique index `idx_entity_identities_live_unique_scoped`
  * (org, namespace, identifier WHERE deleted_at IS NULL) is the multi-replica lock.
  *
  * Invariants (enforced by DB indexes, not in-memory state):

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -142,7 +142,7 @@ export async function ensureCanvasEntity(params: {
     ) VALUES (
       ${organizationId}, ${entityId}, ${AUTOMATION_CANVAS_NAMESPACE}, ${identifier}, 'automation'
     )
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO NOTHING
     RETURNING entity_id
   `;

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -421,7 +421,7 @@ function extractLink(
  * Resolve identity keys to their owning entity — TYPE-AGNOSTIC.
  *
  * An identity value belongs to at most ONE entity within its scope (the
- * `idx_entity_identities_live_unique` index on
+ * `idx_entity_identities_live_unique_scoped` index on
  * `(org, namespace, identifier, COALESCE(scope_connection_id, 0))`), so a key
  * resolves to a single entity of ANY type. Org-scoped identities carry a NULL
  * scope and therefore still resolve org-wide, which is every identity a

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -6,7 +6,8 @@
  * The ingestion pipeline:
  *   1) Extracts + normalizes identifiers from each event.
  *   2) Looks them up in the normalized `entity_identities` table
- *      (UNIQUE per (org, namespace, identifier)).
+ *      (UNIQUE per (org, namespace, identifier, COALESCE(scope_connection_id, 0))
+ *       — see EntityIdentitySpec.scope).
  *   3) Links to the matched entity, creates on miss (when autoCreate=true),
  *      logs a merge candidate when one event's identifiers resolve to
  *      multiple distinct entities.
@@ -225,6 +226,69 @@ export type ResolvedIdentity = {
   identifier: string;
   matchOnly: boolean;
   primary: boolean;
+  /**
+   * Uniqueness scope, resolved once at extraction from the spec's `scope` and
+   * the ingesting connection. `null` = org-wide, which is every identity a
+   * connector has not explicitly declared connection-scoped.
+   *
+   * Carried on the identity rather than read from params at each use site so
+   * matching and insertion cannot disagree: `lookupMatches` and
+   * `insertIdentities` both key on this value, and a rule that scopes one of
+   * its namespaces but not another produces a mixed array here.
+   *
+   * OPTIONAL, and `undefined` is treated exactly as `null`. Callers outside the
+   * attribution path (`resolveSenderIdentity`, tests) hand-build identities and
+   * legitimately mean org scope; requiring the field would break them without
+   * the compiler noticing, because the server tsconfig excludes `__tests__`.
+   * Omission is safe in the only direction that matters: it can never
+   * accidentally CLAIM a connection scope, only decline one.
+   */
+  scopeConnectionId?: number | null;
+};
+
+/**
+ * The sentinel the unique index COALESCEs a NULL scope to. `connections.id` is
+ * a bigserial, so 0 can never collide with a real connection.
+ *
+ * Every `ON CONFLICT` below writes this sentinel as a LITERAL `0`, never as a
+ * bound parameter: conflict inference matches the target expression against the
+ * index's, and a Param node never equals the index's Const node — a
+ * parameterized `COALESCE(scope_connection_id, $n)` fails with "there is no
+ * unique or exclusion constraint matching the ON CONFLICT specification". If
+ * this value ever changes, the SQL literals must be updated by hand.
+ */
+const ORG_SCOPE_SENTINEL = 0;
+
+/** Index-shaped scope value: mirrors `COALESCE(scope_connection_id, 0)`. */
+function scopeKeyOf(identity: { scopeConnectionId?: number | null }): number {
+  return identity.scopeConnectionId ?? ORG_SCOPE_SENTINEL;
+}
+
+/**
+ * Match key for an identity. Includes the scope so a connection-scoped
+ * `erp_customer:CARI-001` never resolves to another connection's row — the
+ * whole point of the scope column.
+ */
+function identityKey(identity: {
+  namespace: string;
+  identifier: string;
+  scopeConnectionId?: number | null;
+}): string {
+  // NUL separator, as the pre-scope key used: a namespace or identifier may
+  // contain any printable character, so only a byte that cannot appear in
+  // either is a safe delimiter.
+  return `${identity.namespace}\u0000${identity.identifier}\u0000${scopeKeyOf(identity)}`;
+}
+
+/**
+ * An identity row that actually landed on the entity. Structurally a
+ * `ResolvedIdentity` minus the extraction-time tier flags, and it carries the
+ * scope so `identityKey` can be rebuilt from it.
+ */
+type AttachedIdentity = {
+  namespace: string;
+  identifier: string;
+  scopeConnectionId: number | null;
 };
 
 type ExtractedLink = {
@@ -307,7 +371,22 @@ function normalizeIdentityValue(namespace: string, raw: string): string | null {
   return normalizeIdentifier(namespace, raw);
 }
 
-function extractLink(item: BatchItem, rule: ResolvedEventAttributionRule): ExtractedLink | null {
+/**
+ * Extraction is the one place scope is decided. Everything downstream —
+ * matching, creation, insertion — reads `scopeConnectionId` off the identity
+ * rather than consulting the spec again, so there is no way for the lookup and
+ * the write to disagree about which row they mean.
+ *
+ * `scope: 'connection'` with no ingesting connection falls back to org scope:
+ * the webhook and manual paths pass `connectionId: null`, and inventing a
+ * scope there would strand those identities in a bucket nothing else can ever
+ * match.
+ */
+function extractLink(
+  item: BatchItem,
+  rule: ResolvedEventAttributionRule,
+  connectionId: number | null
+): ExtractedLink | null {
   const identities: ExtractedLink['identities'] = [];
   for (const spec of rule.identities) {
     const raw = getValueAtPath(item, spec.eventPath);
@@ -319,6 +398,7 @@ function extractLink(item: BatchItem, rule: ResolvedEventAttributionRule): Extra
       identifier: normalized,
       matchOnly: spec.matchOnly === true,
       primary: spec.primary === true,
+      scopeConnectionId: spec.scope === 'connection' ? connectionId : null,
     });
   }
   if (identities.length === 0) return null;
@@ -340,9 +420,12 @@ function extractLink(item: BatchItem, rule: ResolvedEventAttributionRule): Extra
 /**
  * Resolve identity keys to their owning entity — TYPE-AGNOSTIC.
  *
- * An identity value belongs to at most ONE entity org-wide (the
- * `idx_entity_identities_live_unique` index on `(org, namespace, identifier)`),
- * so a key resolves to a single entity of ANY type. We deliberately do NOT
+ * An identity value belongs to at most ONE entity within its scope (the
+ * `idx_entity_identities_live_unique` index on
+ * `(org, namespace, identifier, COALESCE(scope_connection_id, 0))`), so a key
+ * resolves to a single entity of ANY type. Org-scoped identities carry a NULL
+ * scope and therefore still resolve org-wide, which is every identity a
+ * connector has not declared `scope: 'connection'`. We deliberately do NOT
  * filter by the rule's target `entityType`: a `slack_user_id` owned by a
  * signed-in `$member` must resolve to that `$member` even when a `person`-typed
  * rule looks it up, so attribution and ACL converge on one entity instead of
@@ -357,35 +440,60 @@ async function lookupMatches(
     identities: ExtractedLink['identities'][];
   }
 ): Promise<Map<string, number>> {
-  const keys = new Set<string>();
+  // Deduplicated by the SCOPED key, so the same (namespace, identifier) under
+  // two different scopes stays two lookups instead of collapsing back into the
+  // collision this exists to prevent.
+  const wanted = new Map<string, ResolvedIdentity>();
   for (const arr of params.identities) {
-    for (const id of arr) keys.add(`${id.namespace}\u0000${id.identifier}`);
+    for (const id of arr) wanted.set(identityKey(id), id);
   }
-  if (keys.size === 0) return new Map();
+  if (wanted.size === 0) return new Map();
 
   const namespaces: string[] = [];
   const identifiers: string[] = [];
-  for (const key of keys) {
-    const [ns, ident] = key.split('\u0000');
-    namespaces.push(ns);
-    identifiers.push(ident);
+  const scopes: number[] = [];
+  for (const id of wanted.values()) {
+    namespaces.push(id.namespace);
+    identifiers.push(id.identifier);
+    scopes.push(scopeKeyOf(id));
   }
 
-  const rows = await sql<{ entity_id: number | string; namespace: string; identifier: string }>`
-    SELECT ei.entity_id, ei.namespace, ei.identifier
+  const rows = await sql<{
+    entity_id: number | string;
+    namespace: string;
+    identifier: string;
+    scope_key: number | string;
+  }>`
+    SELECT ei.entity_id, ei.namespace, ei.identifier,
+           COALESCE(ei.scope_connection_id, 0) AS scope_key
     FROM entity_identities ei
     JOIN entities e ON e.id = ei.entity_id
     WHERE ei.organization_id = ${params.orgId}
       AND ei.deleted_at IS NULL
       AND e.deleted_at IS NULL
-      AND (ei.namespace, ei.identifier) IN (
-        SELECT ns, ident FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS u(ns, ident)
+      AND (ei.namespace, ei.identifier, COALESCE(ei.scope_connection_id, 0)) IN (
+        SELECT ns, ident, scope
+        FROM unnest(
+          ${pgTextArray(namespaces)}::text[],
+          ${pgTextArray(identifiers)}::text[],
+          ${pgBigintArray(scopes)}::bigint[]
+        ) AS u(ns, ident, scope)
       )
   `;
 
   const out = new Map<string, number>();
   for (const row of rows) {
-    out.set(`${row.namespace}\u0000${row.identifier}`, Number(row.entity_id));
+    out.set(
+      identityKey({
+        namespace: row.namespace,
+        identifier: row.identifier,
+        // COALESCE already collapsed NULL to the sentinel; map it back so the
+        // key built from a DB row matches the key built from an extracted
+        // identity, whose org scope is null.
+        scopeConnectionId: Number(row.scope_key) || null,
+      }),
+      Number(row.entity_id)
+    );
   }
   return out;
 }
@@ -421,7 +529,7 @@ function resolveIdentityTier(
   const governing = primaries.length > 0 ? primaries : identities;
   const hits = new Set<number>();
   for (const id of governing) {
-    const h = matches.get(`${id.namespace}\u0000${id.identifier}`);
+    const h = matches.get(identityKey(id));
     if (h !== undefined) hits.add(h);
   }
   if (hits.size > 1) return 'ambiguous';
@@ -434,7 +542,7 @@ function firstIdentityHit(
   matches: Map<string, number>
 ): number | null {
   for (const id of identities) {
-    const hit = matches.get(`${id.namespace}\u0000${id.identifier}`);
+    const hit = matches.get(identityKey(id));
     if (hit !== undefined) return hit;
   }
   return null;
@@ -452,7 +560,7 @@ async function createEntityWithIdentities(
     traits: Map<string, unknown>;
     creatorUserId: string;
   }
-): Promise<{ entityId: number; attached: Array<{ namespace: string; identifier: string }> } | null> {
+): Promise<{ entityId: number; attached: AttachedIdentity[] } | null> {
   const persisted = params.identities.filter((i) => !i.matchOnly);
   if (persisted.length === 0) return null;
 
@@ -554,10 +662,14 @@ async function createEntityWithIdentities(
 }
 
 /**
- * Insert identities for `entityId`, RETURNING the `(namespace, identifier)` rows
- * attached to that entity. Re-observing a legacy row fills missing connection
- * provenance; a row owned by another entity is not returned, so the caller will
- * not mis-claim it.
+ * Insert identities for `entityId`, RETURNING the rows attached to that entity.
+ * Re-observing a legacy row fills missing connection provenance; a row owned by
+ * another entity is not returned, so the caller will not mis-claim it.
+ *
+ * The scope is RETURNED, not just written, because callers key the in-memory
+ * claim map on it. Returning `(namespace, identifier)` alone would let a
+ * connection-scoped identity be re-keyed as org-scoped on the way back, and the
+ * rest of the batch would then resolve it to the wrong entity.
  */
 async function insertIdentities(
   sql: DbClient,
@@ -568,25 +680,46 @@ async function insertIdentities(
     connectionId?: number | null;
     identities: ExtractedLink['identities'];
   }
-): Promise<Array<{ namespace: string; identifier: string }>> {
+): Promise<AttachedIdentity[]> {
   if (params.identities.length === 0) return [];
   const namespaces = params.identities.map((i) => i.namespace);
   const identifiers = params.identities.map((i) => i.identifier);
-  const attached = await sql<{ namespace: string; identifier: string }>`
+  // NULL, not the sentinel: the sentinel exists only inside the index
+  // expression. Storing 0 would make the row claim connection 0.
+  // `?? null` collapses undefined into null BEFORE serialization. Without it an
+  // omitted scope reached the array literal as String(undefined) === "undefined",
+  // which Postgres rejects with `invalid input syntax for type bigint`.
+  const scopes = params.identities.map((i) => i.scopeConnectionId ?? null);
+  const attached = await sql<{
+    namespace: string;
+    identifier: string;
+    scope_connection_id: number | string | null;
+  }>`
     INSERT INTO entity_identities (
-      organization_id, entity_id, namespace, identifier, source_connector, connection_id
+      organization_id, entity_id, namespace, identifier, source_connector, connection_id,
+      scope_connection_id
     )
     SELECT ${params.orgId}, ${params.entityId}, v.ns, v.ident,
-           ${`connector:${params.connectorKey}`}, ${params.connectionId ?? null}
-    FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS v(ns, ident)
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+           ${`connector:${params.connectorKey}`}, ${params.connectionId ?? null},
+           v.scope
+    FROM unnest(
+      ${pgTextArray(namespaces)}::text[],
+      ${pgTextArray(identifiers)}::text[],
+      ${pgTextArray(scopes.map((v) => (v === null ? null : String(v))))}::bigint[]
+    ) AS v(ns, ident, scope)
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0))
+      WHERE deleted_at IS NULL
     DO UPDATE SET connection_id = EXCLUDED.connection_id
     WHERE entity_identities.entity_id = EXCLUDED.entity_id
       AND entity_identities.connection_id IS NULL
       AND EXCLUDED.connection_id IS NOT NULL
-    RETURNING namespace, identifier
+    RETURNING namespace, identifier, scope_connection_id
   `;
-  return attached.map((r) => ({ namespace: r.namespace, identifier: r.identifier }));
+  return attached.map((r) => ({
+    namespace: r.namespace,
+    identifier: r.identifier,
+    scopeConnectionId: r.scope_connection_id === null ? null : Number(r.scope_connection_id),
+  }));
 }
 
 async function applyTraits(
@@ -707,7 +840,8 @@ export async function applyEventAttributions(
  * per item (keyed by `items` array index) so the caller can write
  * `events.entity_ids` (a webhook row is read by id, not via a feed-time JOIN).
  * `rules` is keyed by event kind (origin_type). Tenant-scoped on `orgId`;
- * entity_identities are UNIQUE per (org, namespace, identifier), so resolution
+ * entity_identities are UNIQUE per
+ * (org, namespace, identifier, COALESCE(scope_connection_id, 0)), so resolution
  * never crosses organizations.
  */
 export async function resolveEventAttributionsForItems(
@@ -780,7 +914,7 @@ async function resolveLinksByKind(
     const rules = params.rulesByKind[kind];
     if (!rules) return;
     for (const rule of rules) {
-      const link = extractLink(item, rule);
+      const link = extractLink(item, rule, params.connectionId ?? null);
       if (!link) continue;
       // Metadata stamping is deferred to post-resolution (below) — only
       // attached identifiers are stamped, so a stale one (e.g. a vacated
@@ -869,7 +1003,7 @@ async function resolveLinksByKind(
       // only ever claim THESE in the in-memory matches map below — an identifier
       // that ON CONFLICT-skipped because another entity already owns it stays
       // with that entity, so the map must not mis-claim it for this one.
-      let attached: Array<{ namespace: string; identifier: string }> = [];
+      let attached: AttachedIdentity[] = [];
       if (entityId !== null) {
         // Matched an existing entity: accrete the non-matchOnly identities; the
         // identifier(s) we matched on already belong to this entity.
@@ -894,8 +1028,12 @@ async function resolveLinksByKind(
         // The matched identifiers themselves are this entity's even if a
         // re-insert was a no-op (they were how we found it), so claim them too.
         for (const id of link.identities) {
-          if (matches.get(`${id.namespace}\u0000${id.identifier}`) === entityId) {
-            attached.push({ namespace: id.namespace, identifier: id.identifier });
+          if (matches.get(identityKey(id)) === entityId) {
+            attached.push({
+              namespace: id.namespace,
+              identifier: id.identifier,
+              scopeConnectionId: id.scopeConnectionId ?? null,
+            });
           }
         }
       } else if (rule.autoCreate && passesCreateWhen(rule.createWhen, item)) {
@@ -942,8 +1080,12 @@ async function resolveLinksByKind(
           if (typeof winnerTier === 'number') {
             entityId = winnerTier;
             for (const id of link.identities) {
-              if (winner.get(`${id.namespace}\u0000${id.identifier}`) === entityId) {
-                attached.push({ namespace: id.namespace, identifier: id.identifier });
+              if (winner.get(identityKey(id)) === entityId) {
+                attached.push({
+                  namespace: id.namespace,
+                  identifier: id.identifier,
+                  scopeConnectionId: id.scopeConnectionId ?? null,
+                });
               }
             }
           }
@@ -971,7 +1113,7 @@ async function resolveLinksByKind(
       // claim is exactly what that re-read returned — `lookupMatches` is
       // type-agnostic and an identity belongs to at most one entity org-wide.
       for (const id of attached) {
-        const key = `${id.namespace}\u0000${id.identifier}`;
+        const key = identityKey(id);
         for (const ruleMatches of matchesByRule.values()) ruleMatches.set(key, entityId);
       }
 

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -277,10 +277,13 @@ async function applyMergeInTransaction(
     FOR UPDATE OF r
   `;
 
-  // 1. Move the loser's LIVE identities to the winner. A live loser↔live winner
-  //    collision on the SAME (org, namespace, identifier) is impossible — the
-  //    global unique index `idx_entity_identities_live_unique` forbids two live
-  //    rows for one value org-wide — so the move can never hit the index. Stamp
+  // 1. Move the loser's LIVE identities to the winner. The move can never hit
+  //    `idx_entity_identities_live_unique`: `entity_id` is not part of that
+  //    index, so repointing a row leaves its key
+  //    (org, namespace, identifier, COALESCE(scope_connection_id, 0))
+  //    untouched. That holds even when loser and winner both claim the same
+  //    (namespace, identifier) under DIFFERENT connection scopes, which the
+  //    index legitimately permits as two live rows. Stamp
   //    origin with COALESCE so an identity that already carries a marker (moved
   //    here by an EARLIER merge, e.g. L→W then W→V) keeps its INNERMOST origin —
 	//    the outer operation ledger can then put it back on W without losing L's

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -278,7 +278,7 @@ async function applyMergeInTransaction(
   `;
 
   // 1. Move the loser's LIVE identities to the winner. The move can never hit
-  //    `idx_entity_identities_live_unique`: `entity_id` is not part of that
+  //    `idx_entity_identities_live_unique_scoped`: `entity_id` is not part of that
   //    index, so repointing a row leaves its key
   //    (org, namespace, identifier, COALESCE(scope_connection_id, 0))
   //    untouched. That holds even when loser and winner both claim the same

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -143,7 +143,7 @@ export async function ensureMemberEntity(params: EnsureMemberEntityParams): Prom
       ) VALUES (
         ${params.organizationId}, ${memberEntityId}, 'auth_user_id', ${params.userId}, 'auth:signup'
       )
-      ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+      ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
       DO NOTHING
     `;
   }

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -8,7 +8,8 @@
  * typed key tuple; the full tuple remains in entity metadata for inspection,
  * so a re-run — or a second replica racing the same window — resolves to the
  * existing entity instead of creating a duplicate. The partial unique index
- * `idx_entity_identities_live_unique (organization_id, namespace, identifier)
+ * `idx_entity_identities_live_unique (organization_id, namespace, identifier,
+ * COALESCE(scope_connection_id, 0))
  * WHERE deleted_at IS NULL` is the lock.
  *
  * Origin provenance (the window that first produced the entity, its stable key,
@@ -247,7 +248,9 @@ async function insertEntityWithUniqueSlug(params: {
 /**
  * Upsert a child entity by stable key. Returns its id and whether it was newly
  * created. Idempotent across re-runs / concurrent replicas via the
- * `entity_identities` live-unique index on (org, namespace, identifier). Slug
+ * `entity_identities` live-unique index on
+ * (org, namespace, identifier, COALESCE(scope_connection_id, 0)) — automation
+ * keys are org-scoped, so that column is always NULL here. Slug
  * collisions are disambiguated by `insertEntityWithUniqueSlug` (the stable key,
  * not the slug, is the identity).
  */
@@ -390,7 +393,7 @@ async function upsertKeyedEntity(params: {
     ) VALUES (
       ${organizationId}, ${entityId}, ${AUTOMATION_KEY_NAMESPACE}, ${identifier}, 'automation'
     )
-    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    ON CONFLICT (organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL
     DO NOTHING
     RETURNING entity_id
   `;

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -8,7 +8,7 @@
  * typed key tuple; the full tuple remains in entity metadata for inspection,
  * so a re-run — or a second replica racing the same window — resolves to the
  * existing entity instead of creating a duplicate. The partial unique index
- * `idx_entity_identities_live_unique (organization_id, namespace, identifier,
+ * `idx_entity_identities_live_unique_scoped (organization_id, namespace, identifier,
  * COALESCE(scope_connection_id, 0))
  * WHERE deleted_at IS NULL` is the lock.
  *


### PR DESCRIPTION
## Summary
- Two connections in one org that share an identity namespace collapsed onto one entity. `erp_customer` `CARI-001` in ERP tenant A resolved to the entity minted for `CARI-001` in tenant B, and the second connection's attribution silently accreted its traits onto the first's entity. Nothing errored.
- Scope is now **declared per identity namespace**: `EntityIdentitySpec.scope?: 'organization' | 'connection'`, defaulting to `organization`. Only the connector knows whether its namespace is globally meaningful — nothing about `invoice_no` or `customer_code` tells the platform.
- `entity_identities` gains a nullable `scope_connection_id`, written only when a connector declares connection scope. The live-unique index becomes `(organization_id, namespace, identifier, COALESCE(scope_connection_id, 0)) WHERE deleted_at IS NULL`.

Reopens and closes #2798, which was auto-closed as COMPLETED by release-please when #2718 merged (issue closed `16:35:41Z`, release PR merged `16:35:40Z`) — it swept up the reference from #2817's changelog text. Nothing had shipped.

### Why not `connection_id` in the index (issue option 1)

That column is **provenance** — it records which connection first wrote the row, and it is set on every connector-written identity including legitimately org-wide ones. Indexing it splits identities that must stay collapsed. In production today:

| namespace | distinct connections | rows |
|---|---|---|
| `slack_channel_id` | 3 | 9 |
| `slack_user_id` | 2 | 8 |

Those collisions are **correct** — the same Slack user seen through two connections must remain one person. Option 1 would split that person into 2 entities and that channel into 3. The prod data argues for the declared-property design rather than merely permitting it.

Distinct from the `uniquePerOrg` flag deleted in #2817, which was **cardinality** (does this value name one entity or many — `email_domain` names many). Scope is orthogonal: `email_domain` is many-per-org yet globally meaningful, so scoping it per connection would be backwards.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (Depot run `3jqr1glq60` passed)
- [x] Tests run: new `identity-connection-scope.test.ts` **4/4**; `entity-write-pool-starvation` 2/2; bun `sender-identity` 5/5; 1772 vitest across connectors/events/auth/utils
- [x] Bug fix: red→green below

### red → green

I wrote the fix before the test, so there was no natural red run — the defect is "an intent the manifest could not express." Red is demonstrated by mutation instead, one mutation per direction, each killing exactly one test:

```
### MUTATION 1: ignore spec.scope (== origin/main behavior for this path)
   × keeps a connection-scoped identifier separate across two connections
      Tests  1 failed | 2 passed (3)
### MUTATION 2: scope EVERYTHING per connection
   × still collapses an org-scoped identifier across the same two connections
      Tests  1 failed | 2 passed (3)
### RESTORED
      Tests  3 passed (3)
```

Mutation 1 reproduces the exact #2798 collision: two ERP tenants, one entity.

The transcript above is from when the suite had 3 tests. A fourth (`falls back to org scope when there is no ingesting connection`) was added afterwards and no mutation targets it; the suite is 4/4 green on the merged HEAD.

### Two defects the gate caught that local runs did not

1. `scopeConnectionId: undefined` (not `null`) reached the array literal as `String(undefined)`, and Postgres rejected it with `invalid input syntax for type bigint: "undefined"`. Callers outside the attribution path (`resolveSenderIdentity`, tests) hand-build identities and legitimately mean org scope. The field is now optional, with `undefined` treated as org scope — safe in the only direction that matters, since omission can decline a connection scope but never accidentally claim one. The compiler did not catch this because the server tsconfig excludes `__tests__`.
2. A `toEqual` shape assertion in the **bun** suite `sender-identity.test.ts`, which a vitest-only local sweep never runs.

## Notes

**Blast radius.** Changing the unique index breaks every `ON CONFLICT` naming the old column list — they no longer match any index. That was **10 sites**, only one of which was in the file being edited: `save_content`, `subject-identities` (x2), `canvas-events`, `promote-keyed-entities`, `member-entity`, `eval-cases`, plus 3 in test fixtures.

**The sentinel must be a SQL literal.** Conflict-target inference compares parse trees, so an interpolated `COALESCE(scope_connection_id, $n)` never matches the index's `Const` and fails with *"there is no unique or exclusion constraint matching the ON CONFLICT specification"* — non-deterministically across suites, which reads exactly like test-isolation flake.

**No foreign key on `scope_connection_id`, deliberately.** `ON DELETE SET NULL` would silently promote a connection-scoped identity to org-wide — the exact collapse the column prevents — and could collide with a legitimately org-wide row. `CASCADE` would delete identity rows and take their entities' attribution with them.

**`entity-merge.ts` documented an invariant this change falsifies.** It claimed a live loser↔winner collision on the same `(org, namespace, identifier)` was impossible because the index forbids two live rows for one value org-wide. Two scopes now make two live rows legal. The conclusion survives for a different reason — the merge UPDATE sets only `entity_id`/`merged_from_entity_id`/`updated_at`, none of which are in the index — so the comment is corrected rather than the code.

**Behaviour-preserving on its own.** Every existing row has `scope_connection_id IS NULL` and collapses on exactly the key it collapses on today. Only a connector declaring `scope: 'connection'` changes any outcome, and none do yet.

### Known gaps, filed separately

- Scope is declared per *usage*, not per namespace: a connector declaring the same namespace in two event kinds with different scopes silently produces two entities. No validation.
- No story for changing a namespace's scope after rows exist — the identifier forks.
- Deleting and re-creating a connection changes `connections.id`, stranding connection-scoped rows so the new connection re-mints its entities. Reconnecting is routine, so this is the one that produces bad prod data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connection-scoped connector identities.
  * Identities can now be unique per connection or across the organization.
  * Connection-scoped identities remain separate, while organization-scoped identities continue to merge across connections.
  * Identities without connection context fall back to organization scope.
* **Bug Fixes**
  * Updated identity resolution, linking, and conflict handling to respect the selected scope.
  * Preserved organization-wide behavior for existing integrations and Slack identities.
* **Tests**
  * Added coverage for scoped identity separation, organization-level merging, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
