### PR TITLE
fix(scripts): prune the worktree registration before deleting its branch

### DIFF
--- a/scripts/__tests__/task-clean.test.ts
+++ b/scripts/__tests__/task-clean.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function command(cwd: string, args: string[], env?: Record<string, string>) {
+  return Bun.spawnSync(args, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function output(result: ReturnType<typeof Bun.spawnSync>) {
+  return new TextDecoder().decode(result.stdout) + new TextDecoder().decode(result.stderr);
+}
+
+describe("task-clean worktree removal", () => {
+  it("prunes stale metadata after Git rejects a submodule worktree removal", () => {
+    const root = mkdtempSync(join(tmpdir(), "lobu-task-clean-test-"));
+    temporaryDirectories.push(root);
+    const repo = join(root, "repo");
+    const worktree = join(repo, ".claude", "worktrees", "task-clean");
+    const bin = join(root, "bin");
+    mkdirSync(join(repo, "scripts", "lib"), { recursive: true });
+    mkdirSync(bin);
+    copyFileSync(resolve(import.meta.dir, "..", "task-clean.sh"), join(repo, "scripts", "task-clean.sh"));
+    copyFileSync(resolve(import.meta.dir, "..", "lib", "db-name.sh"), join(repo, "scripts", "lib", "db-name.sh"));
+
+    expect(command(root, ["git", "init", "-q", repo]).exitCode).toBe(0);
+    expect(command(repo, ["git", "config", "user.email", "test@example.com"]).exitCode).toBe(0);
+    expect(command(repo, ["git", "config", "user.name", "Test"]).exitCode).toBe(0);
+    expect(command(repo, ["git", "add", "scripts"]).exitCode).toBe(0);
+    expect(command(repo, ["git", "commit", "-qm", "fixture"]).exitCode).toBe(0);
+    expect(command(repo, ["git", "worktree", "add", "-b", "feat/task-clean", worktree]).exitCode).toBe(0);
+
+    // Older Git releases reject this operation before removing the registration.
+    const gitShim = join(bin, "git");
+    writeFileSync(
+      gitShim,
+      `#!/usr/bin/env bash
+if [[ " $* " == *" worktree remove "* ]]; then
+  printf '%s\\n' 'fatal: working trees containing submodules cannot be moved or removed' >&2
+  exit 1
+fi
+exec /usr/bin/git "$@"
+`
+    );
+    chmodSync(gitShim, 0o755);
+
+    const result = command(repo, ["bash", "scripts/task-clean.sh", "task-clean", "--force"], {
+      PATH: `${bin}:/usr/bin:/bin`,
+    });
+    expect(result.exitCode, output(result)).toBe(0);
+    expect(existsSync(worktree)).toBe(false);
+    expect(command(repo, ["git", "show-ref", "--verify", "--quiet", "refs/heads/feat/task-clean"]).exitCode).not.toBe(0);
+    expect(output(command(repo, ["git", "worktree", "list", "--porcelain"]))).not.toContain(
+      `worktree ${worktree}`
+    );
+  });
+});

--- a/scripts/__tests__/task-clean.test.ts
+++ b/scripts/__tests__/task-clean.test.ts
@@ -29,7 +29,10 @@ function command(cwd: string, args: string[], env?: Record<string, string>) {
 }
 
 function output(result: ReturnType<typeof Bun.spawnSync>) {
-  return new TextDecoder().decode(result.stdout) + new TextDecoder().decode(result.stderr);
+  return (
+    new TextDecoder().decode(result.stdout) +
+    new TextDecoder().decode(result.stderr)
+  );
 }
 
 describe("task-clean worktree removal", () => {
@@ -41,15 +44,35 @@ describe("task-clean worktree removal", () => {
     const bin = join(root, "bin");
     mkdirSync(join(repo, "scripts", "lib"), { recursive: true });
     mkdirSync(bin);
-    copyFileSync(resolve(import.meta.dir, "..", "task-clean.sh"), join(repo, "scripts", "task-clean.sh"));
-    copyFileSync(resolve(import.meta.dir, "..", "lib", "db-name.sh"), join(repo, "scripts", "lib", "db-name.sh"));
+    copyFileSync(
+      resolve(import.meta.dir, "..", "task-clean.sh"),
+      join(repo, "scripts", "task-clean.sh")
+    );
+    copyFileSync(
+      resolve(import.meta.dir, "..", "lib", "db-name.sh"),
+      join(repo, "scripts", "lib", "db-name.sh")
+    );
 
     expect(command(root, ["git", "init", "-q", repo]).exitCode).toBe(0);
-    expect(command(repo, ["git", "config", "user.email", "test@example.com"]).exitCode).toBe(0);
-    expect(command(repo, ["git", "config", "user.name", "Test"]).exitCode).toBe(0);
+    expect(
+      command(repo, ["git", "config", "user.email", "test@example.com"])
+        .exitCode
+    ).toBe(0);
+    expect(command(repo, ["git", "config", "user.name", "Test"]).exitCode).toBe(
+      0
+    );
     expect(command(repo, ["git", "add", "scripts"]).exitCode).toBe(0);
     expect(command(repo, ["git", "commit", "-qm", "fixture"]).exitCode).toBe(0);
-    expect(command(repo, ["git", "worktree", "add", "-b", "feat/task-clean", worktree]).exitCode).toBe(0);
+    expect(
+      command(repo, [
+        "git",
+        "worktree",
+        "add",
+        "-b",
+        "feat/task-clean",
+        worktree,
+      ]).exitCode
+    ).toBe(0);
 
     // Older Git releases reject this operation before removing the registration.
     const gitShim = join(bin, "git");
@@ -65,14 +88,26 @@ exec /usr/bin/git "$@"
     );
     chmodSync(gitShim, 0o755);
 
-    const result = command(repo, ["bash", "scripts/task-clean.sh", "task-clean", "--force"], {
-      PATH: `${bin}:/usr/bin:/bin`,
-    });
+    const result = command(
+      repo,
+      ["bash", "scripts/task-clean.sh", "task-clean", "--force"],
+      {
+        PATH: `${bin}:/usr/bin:/bin`,
+      }
+    );
     expect(result.exitCode, output(result)).toBe(0);
     expect(existsSync(worktree)).toBe(false);
-    expect(command(repo, ["git", "show-ref", "--verify", "--quiet", "refs/heads/feat/task-clean"]).exitCode).not.toBe(0);
-    expect(output(command(repo, ["git", "worktree", "list", "--porcelain"]))).not.toContain(
-      `worktree ${worktree}`
-    );
+    expect(
+      command(repo, [
+        "git",
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/feat/task-clean",
+      ]).exitCode
+    ).not.toBe(0);
+    expect(
+      output(command(repo, ["git", "worktree", "list", "--porcelain"]))
+    ).not.toContain(`worktree ${worktree}`);
   });
 });

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -120,6 +120,15 @@ else
   rm -rf "$worktree_dir" 2>/dev/null || true
 fi
 
+# Drop any registration still pointing at the path we just removed. Without
+# this, `git branch -D` below fails with "cannot delete branch ... used by
+# worktree at <path>" for a worktree whose directory no longer exists — git
+# keeps the admin files under .git/worktrees until pruned. The `rm -rf` branch
+# above guarantees that state, and `worktree remove` can leave it too when the
+# tree contains submodules ("working trees containing submodules cannot be
+# moved or removed"). Cheap and idempotent, so it runs unconditionally.
+git -C "$repo" worktree prune
+
 # Returns 0 if branch <b> in <gitdir> carries no local-only commits (its tip is
 # reachable from origin/main, or equals its pushed remote ref). Used to protect
 # the feat/<name> default below — we never auto-delete unpushed work.

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -114,7 +114,17 @@ fi
 
 echo "→ removing worktree $worktree_dir"
 if git -C "$repo" worktree list --porcelain 2>/dev/null | grep -qF "worktree $worktree_dir"; then
-  git -C "$repo" worktree remove "$worktree_dir" --force
+  if ! remove_error="$(git -C "$repo" worktree remove "$worktree_dir" --force 2>&1)"; then
+    # Keep locked worktrees and unexpected Git failures intact. Older Git
+    # versions reject any removal that contains a submodule, even when the
+    # worktree has passed the existing cleanliness and push guards.
+    if [[ "$remove_error" != *"containing submodules"* ]]; then
+      printf '%s\n' "$remove_error" >&2
+      exit 1
+    fi
+    printf '%s\n' "$remove_error" >&2
+    rm -rf "$worktree_dir"
+  fi
 else
   echo "→ worktree path already gone from git"
   rm -rf "$worktree_dir" 2>/dev/null || true
@@ -124,9 +134,7 @@ fi
 # this, `git branch -D` below fails with "cannot delete branch ... used by
 # worktree at <path>" for a worktree whose directory no longer exists — git
 # keeps the admin files under .git/worktrees until pruned. The `rm -rf` branch
-# above guarantees that state, and `worktree remove` can leave it too when the
-# tree contains submodules ("working trees containing submodules cannot be
-# moved or removed"). Cheap and idempotent, so it runs unconditionally.
+# above guarantees that state. Cheap and idempotent, so it runs unconditionally.
 git -C "$repo" worktree prune
 
 # Returns 0 if branch <b> in <gitdir> carries no local-only commits (its tip is


### PR DESCRIPTION
## Summary

`make task-clean` removed the worktree directory but left git's registration under `.git/worktrees`, so the branch delete immediately after failed:

```
→ removing worktree .../.claude/worktrees/<name>
→ worktree path already gone from git
→ deleting lobu branch feat/<name>
error: cannot delete branch 'feat/<name>' used by worktree at '.../.claude/worktrees/<name>'
make: *** [task-clean] Error 1
```

The caller was left to run `git worktree prune && git branch -D` by hand. Hit on three consecutive cleanups today.

Two paths reach that state, so the fix is unconditional rather than in one branch:

- the `rm -rf "$worktree_dir"` fallback (`task-clean.sh:120`) deletes the directory without ever telling git
- `git worktree remove` can fail outright when the tree contains submodules — every task worktree has `packages/owletto` — with *"working trees containing submodules cannot be moved or removed"*

`git worktree prune` is cheap and idempotent, so it runs in both cases.

## Test plan

**Red** — reproduce the exact failure, simulating the `rm -rf` path:

```
$ git worktree add -b tmp/prune-repro .claude/worktrees/zz-prune-repro origin/main
$ rm -rf .claude/worktrees/zz-prune-repro
$ git branch -D tmp/prune-repro
error: cannot delete branch 'tmp/prune-repro' used by worktree at '.../zz-prune-repro'
```

**Green** — the added step, in isolation:

```
$ git worktree prune
$ git branch -D tmp/prune-repro
Deleted branch tmp/prune-repro (was 70e5abae1).
```

**End-to-end with the patched script**, on a real `make task-setup` worktree (submodule and all):

```
$ ./scripts/task-clean.sh zz-e2e-prune --force
→ removing worktree .../.claude/worktrees/zz-e2e-prune
→ deleting lobu branch feat/zz-e2e-prune
Deleted branch feat/zz-e2e-prune (was 70e5abae1).
→ removed Lobu context 'zz-e2e-prune'
✓ cleaned up task 'zz-e2e-prune'

$ git branch --list feat/zz-e2e-prune   # empty
$ git worktree list | grep zz-e2e-prune # empty
```

No manual prune needed. Both throwaway worktrees cleaned up after themselves.

## Notes

The `--force` guard protecting unpushed work is untouched — this only changes what happens **after** removal is already sanctioned.

Gates could not run: Depot's trial has expired (#2873), so `make pre-pr-remote` cannot dispatch and `make review` refuses without it. Verified locally — pre-commit biome + tsc clean, plus the red/green above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of removed worktrees by pruning stale administrative metadata, including when worktrees contain submodules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->