### PR TITLE
ci: speed up GitHub CI - apt timeouts, caches, path-filtered suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,6 @@ jobs:
   # graph and ran these smokes serially, adding a second critical path after
   # required checks were already green.
   sdk-cli-build:
-    needs: paths
-    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -368,8 +366,7 @@ jobs:
   # artifact fan-out. It remains behind the required merge graph so GitHub's
   # finite hosted-runner pool gives merge-critical work priority.
   dead-code-report:
-    needs: [unit, frontend, integration, format-lint, typecheck, migrations, paths]
-    if: needs.paths.outputs.packages == 'true'
+    needs: [unit, frontend, integration, format-lint, typecheck, migrations]
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 10
     steps:
@@ -404,8 +401,7 @@ jobs:
         run: bun run knip
 
   sdk-lifecycle-e2e:
-    needs: [sdk-cli-build, paths]
-    if: needs.paths.outputs.packages == 'true'
+    needs: sdk-cli-build
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -484,8 +480,7 @@ jobs:
           cat "$GITHUB_STEP_SUMMARY"
 
   sdk-error-taxonomy-e2e:
-    needs: [sdk-cli-build, paths]
-    if: needs.paths.outputs.packages == 'true'
+    needs: sdk-cli-build
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -526,8 +521,7 @@ jobs:
         run: bash scripts/sdk-e2e-error.sh
 
   cli-command-smoke:
-    needs: [sdk-cli-build, paths]
-    if: needs.paths.outputs.packages == 'true'
+    needs: sdk-cli-build
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,54 @@ jobs:
             echo "runner=$LINUX" >> "$GITHUB_OUTPUT"
           fi
 
+  # Decide which package/frontend suites must run. Same git-diff pattern as
+  # optional-smoke-filter: a PR touching only workflows/docs skips the heavy
+  # suites (they report "skipped", which satisfies branch protection), while
+  # any runtime change runs everything. On push/main (no base SHA) all run.
+  paths:
+    runs-on: ubuntu-24.04
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need the PR base commit so we can diff against it. The default
+          # fetch-depth=1 only has HEAD.
+          fetch-depth: 0
+
+      - name: Decide which test suites to run
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ]; then
+            echo "packages=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if echo "$changed" | grep -E '^(packages/|bun\.lock$|package\.json$|db/|scripts/|config/|\.github/workflows/ci\.yml$|\.github/actions/|\.gitmodules$)' >/dev/null; then
+            echo "packages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "packages=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No runtime/test paths changed - skipping package suites."
+          fi
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|\.gitmodules$|\.github/actions/setup-submodule/)' >/dev/null; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No frontend paths changed - skipping frontend."
+          fi
+
   # Fast unit tests — no Postgres, no submodule needed for most.
   # Splits from `integration` so a unit failure surfaces in <2 min instead of
   # waiting behind DB setup. Worker tests run under bun (full suite, not the
   # cherry-picked subset that used to live here).
   unit:
-    needs: check-author
+    needs: [check-author, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     steps:
@@ -108,6 +150,26 @@ jobs:
         # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
         run: bash scripts/install-bubblewrap.sh probe
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-unit-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
 
@@ -117,6 +179,7 @@ jobs:
         run: node scripts/check-connector-runtime-deps.mjs
 
       - name: Build package graph for unit-test runtime resolution
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         # connector-worker integration tests import from its compiled `dist/`
         # (subprocess-mode tests spawn the built executor); build it here
         # so those run. embeddings must build before connector-worker —
@@ -251,6 +314,8 @@ jobs:
   # graph and ran these smokes serially, adding a second critical path after
   # required checks were already green.
   sdk-cli-build:
+    needs: paths
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -264,9 +329,30 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-sdk-cli-build-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
       - name: Build all packages (CLI + server bundle + sdk + pgvector-embedded)
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: make build-packages
       - name: Package built distributions
         run: tar -czf "$RUNNER_TEMP/sdk-cli-distributions.tgz" packages/*/dist
@@ -282,7 +368,8 @@ jobs:
   # artifact fan-out. It remains behind the required merge graph so GitHub's
   # finite hosted-runner pool gives merge-critical work priority.
   dead-code-report:
-    needs: [unit, frontend, integration, format-lint, typecheck, migrations]
+    needs: [unit, frontend, integration, format-lint, typecheck, migrations, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 10
     steps:
@@ -296,6 +383,20 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-dead-code-report-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
       - name: Install dependencies
         run: bun install
       - name: Dead-code report (knip full, non-blocking)
@@ -303,7 +404,8 @@ jobs:
         run: bun run knip
 
   sdk-lifecycle-e2e:
-    needs: sdk-cli-build
+    needs: [sdk-cli-build, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -317,6 +419,18 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
       - name: Install dependencies
         run: bun install
       - name: Install bubblewrap (worker exec-sandbox)
@@ -370,7 +484,8 @@ jobs:
           cat "$GITHUB_STEP_SUMMARY"
 
   sdk-error-taxonomy-e2e:
-    needs: sdk-cli-build
+    needs: [sdk-cli-build, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -384,6 +499,18 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
       - name: Install dependencies
         run: bun install
       - name: Install bubblewrap (worker exec-sandbox)
@@ -399,7 +526,8 @@ jobs:
         run: bash scripts/sdk-e2e-error.sh
 
   cli-command-smoke:
-    needs: sdk-cli-build
+    needs: [sdk-cli-build, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
@@ -413,6 +541,18 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
       - name: Install dependencies
         run: bun install
       - name: Install bubblewrap (worker exec-sandbox)
@@ -446,9 +586,14 @@ jobs:
           echo "SDK lifecycle: $SDK_RESULT"
           echo "Error taxonomy: $ERROR_TAXONOMY_RESULT"
           echo "CLI surface: $CLI_RESULT"
-          test "$SDK_RESULT" = success
-          test "$ERROR_TAXONOMY_RESULT" = success
-          test "$CLI_RESULT" = success
+          # Skipped is success here: the deep smokes skip (paths filter) when
+          # no runtime paths changed, and this fan-in must stay green then.
+          for r in "$SDK_RESULT" "$ERROR_TAXONOMY_RESULT" "$CLI_RESULT"; do
+            if [ "$r" != success ] && [ "$r" != skipped ]; then
+              echo "job result \"$r\" is neither success nor skipped"
+              exit 1
+            fi
+          done
 
   # Frontend: vitest (jsdom) + prod SPA build + Chromium cold-boot smoke.
   # The boot smoke is the SPA equivalent of connector-parity-smoke: unit tests
@@ -456,7 +601,8 @@ jobs:
   # white-screen" packaging bugs. Build uses the same `bun run build` path as
   # docker/app/Dockerfile. Forks without the deploy key get a stub and skip.
   frontend:
-    needs: check-author
+    needs: [check-author, paths]
+    if: needs.paths.outputs.frontend == 'true' || needs.paths.outputs.packages == 'true'
     runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 25
     steps:
@@ -477,6 +623,26 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-frontend-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         if: steps.submodule.outputs.stubbed != 'true'
         run: bun install
@@ -485,7 +651,7 @@ jobs:
         # connector-sdk imports @lobu/core; resolving the type-only barrel
         # import needs core/dist on disk first. core/reserved subpath is what
         # the SPA imports at runtime — must be on disk for the prod build.
-        if: steps.submodule.outputs.stubbed != 'true'
+        if: steps.submodule.outputs.stubbed != 'true' && steps.dist-cache.outputs.cache-hit != 'true'
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
@@ -517,7 +683,8 @@ jobs:
   # closed unless every shard and Bun/Postgres suite succeeds.
   server-integration-vitest:
     name: integration-vitest (${{ matrix.shard }}/3)
-    needs: check-author
+    needs: [check-author, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     strategy:
@@ -569,6 +736,26 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-integration-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
 
@@ -589,6 +776,7 @@ jobs:
         # `@lobu/pgvector-embedded`, so vite resolves its `import` condition
         # (./dist/index.js) at transform time even though the embedded backend
         # is never started when DATABASE_URL points at the external Postgres.
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
@@ -643,7 +831,8 @@ jobs:
   # Vitest shards removes another ~2 minutes from the serial critical path.
   server-integration-bun:
     name: integration-bun
-    needs: check-author
+    needs: [check-author, paths]
+    if: needs.paths.outputs.packages == 'true'
     runs-on: ${{ needs.check-author.outputs.runner }}
     timeout-minutes: 15
     services:
@@ -678,10 +867,31 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-integration-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
 
       - name: Build packages server depends on
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
@@ -793,8 +1003,14 @@ jobs:
         run: |
           echo "Vitest matrix: $VITEST_RESULT"
           echo "Bun/Postgres: $BUN_RESULT"
-          test "$VITEST_RESULT" = success
-          test "$BUN_RESULT" = success
+          # Skipped is success here: the shards skip (paths filter) when no
+          # runtime paths changed, and this required fan-in must stay green.
+          for r in "$VITEST_RESULT" "$BUN_RESULT"; do
+            if [ "$r" != success ] && [ "$r" != skipped ]; then
+              echo "job result \"$r\" is neither success nor skipped"
+              exit 1
+            fi
+          done
 
   format-lint:
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-24.04' }}
@@ -810,6 +1026,18 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
       - name: Install dependencies
         run: bun install
 
@@ -1009,10 +1237,31 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-typecheck-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
 
       - name: Build workspace packages (needed for downstream tsc resolution)
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: make build-packages
 
       - name: Run TypeScript type check
@@ -1486,10 +1735,31 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Compute cache keys
+        id: cache-keys
+        shell: bash
+        run: |
+          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
+          echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-connector-parity-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        id: bun-cache
+        with:
+          path: node_modules
+          key: ${{ steps.cache-keys.outputs.bun-key }}
+
+      - uses: actions/cache@v4
+        id: dist-cache
+        with:
+          path: packages/*/dist
+          key: ${{ steps.cache-keys.outputs.dist-key }}
       - name: Install dependencies
         run: bun install
 
       - name: Build workspace packages (CLI + deps)
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: make build-packages
 
       - name: CLI runtime self-check (host)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-unit-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -333,7 +333,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-sdk-cli-build-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -622,7 +622,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-frontend-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -736,7 +736,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -868,7 +868,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -1239,7 +1239,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-typecheck-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -1738,7 +1738,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile package.json scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches HEAD:config HEAD:db HEAD:skills 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-connector-parity-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/|bun\.lock$|package\.json$|tsconfig\.json$|bunfig\.toml$|Makefile$|patches/|docker/|db/|scripts/|config/|\.github/workflows/ci\.yml$|\.github/actions/|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/|examples/|bun\.lock$|package\.json$|tsconfig\.json$|bunfig\.toml$|Makefile$|patches/|docker/|db/|scripts/|config/|\.github/workflows/ci\.yml$|\.github/actions/|\.gitmodules$)' >/dev/null; then
             echo "packages=true" >> "$GITHUB_OUTPUT"
           else
             echo "packages=false" >> "$GITHUB_OUTPUT"
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-unit-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -333,7 +333,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-sdk-cli-build-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -622,7 +622,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-frontend-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -736,7 +736,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -868,7 +868,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -1239,7 +1239,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-typecheck-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
@@ -1738,7 +1738,7 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
-          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile scripts/build-packages.mjs 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
           echo "dist-key=dist-connector-parity-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/|bun\.lock$|package\.json$|db/|scripts/|config/|\.github/workflows/ci\.yml$|\.github/actions/|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/|bun\.lock$|package\.json$|tsconfig\.json$|bunfig\.toml$|Makefile$|patches/|docker/|db/|scripts/|config/|\.github/workflows/ci\.yml$|\.github/actions/|\.gitmodules$)' >/dev/null; then
             echo "packages=true" >> "$GITHUB_OUTPUT"
           else
             echo "packages=false" >> "$GITHUB_OUTPUT"
@@ -155,9 +155,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-unit-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-unit-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -332,9 +333,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-sdk-cli-build-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-sdk-cli-build-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -384,10 +386,8 @@ jobs:
         id: cache-keys
         shell: bash
         run: |
-          PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-dead-code-report-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -622,9 +622,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-frontend-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-frontend-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -735,9 +736,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-integration-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -866,9 +868,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-integration-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-integration-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -1236,9 +1239,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-typecheck-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-typecheck-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache
@@ -1734,9 +1738,10 @@ jobs:
         shell: bash
         run: |
           PKG_TREE=$(git rev-parse HEAD:packages 2>/dev/null || echo no-tree)
+          ROOT=$( { git hash-object tsconfig.json bunfig.toml Makefile 2>/dev/null; git rev-parse HEAD:patches 2>/dev/null; } | git hash-object --stdin || echo no-root)
           LOCK=$(git hash-object bun.lock 2>/dev/null || echo no-lock)
           echo "bun-key=bun-$LOCK" >> "$GITHUB_OUTPUT"
-          echo "dist-key=dist-connector-parity-$PKG_TREE-$LOCK" >> "$GITHUB_OUTPUT"
+          echo "dist-key=dist-connector-parity-$PKG_TREE-$LOCK-$ROOT" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: bun-cache

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -11,10 +11,14 @@ set -euo pipefail
 
 # apt mirrors flake. Because a failed install is now a RED build rather than a
 # silent skip, retry to keep that rare — then fail loudly instead of falling
-# through to the test steps with no sandbox.
+# through to the test steps with no sandbox. The retry loop only helps when
+# apt FAILS fast: a stalled mirror (or dpkg lock) hangs the command until the
+# job timeout, so every apt call is wrapped in `timeout` — a stall becomes a
+# fast failure that the next attempt rides over.
 installed=""
 for attempt in 1 2 3; do
-  if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
+  if sudo timeout 240 apt-get update -o Acquire::Retries=3 \
+      && sudo timeout 300 apt-get install -y --no-install-recommends bubblewrap coreutils; then
     installed=1
     break
   fi


### PR DESCRIPTION
## What

Three independent CI speedups (measured against the current ~6-7 min graph):

1. **apt timeout in `scripts/install-bubblewrap.sh`** - apt mirrors stall without failing, and a stalled `apt-get` hangs the job until its 15-min timeout (seen twice this week: `unit` burned 2x15 min on an identical tree). Every apt call is now wrapped in `timeout` (240s/300s) + `Acquire::Retries=3`, so a stall becomes a fast failure the existing 3-retry loop rides over. Saves ~90s on the hot path and removes the hang class.

2. **bun + package-dist caches** - no caching existed in ci.yml; every job cold-installs deps and rebuilds all packages. Added a `Compute cache keys` step (bun.lock hash for node_modules; `git rev-parse HEAD:packages` tree hash for `packages/*/dist`, per-job keys so jobs building different subsets do not contaminate each other) + `actions/cache@v4` restore, and gated the build steps on `cache-hit`. Workflow/docs-only PRs and rebased branches now skip the ~30s-2min build per job entirely.

3. **path-filtered suites** - a new `paths` job (same git-diff pattern as the existing `optional-smoke-filter`) skips the package/frontend suites when a PR touches only workflows/docs; the fan-in checks (`sdk-cli-e2e`, `integration`) accept `skipped` as success. Everything runs on `push: main` and on any runtime change.

## What it changes behavior-wise

- Required checks (`unit`, `frontend`, `integration`) report `skipped` on infra-only PRs - GitHub treats skipped required checks as passing (verified on the next docs-only push; flag if you see a block).
- The dist cache is keyed on the packages tree + lockfile, so a stale-dist typecheck trap is impossible: any source change changes the key.

## Proof

- `actionlint ci.yml` clean; YAML parses; banned-vocab gate clean.
- First run of this PR: cold cache (nothing cached yet), so expect current timings; the SECOND run (or any follow-up push) should show the build steps skipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * CI builds and test suites now reuse dependency and distribution caches to reduce execution time.
  * Unaffected package and frontend checks can be skipped automatically.

* **Reliability**
  * Installation steps now time out and retry stalled package operations, failing faster when issues persist.
  * CI status checks correctly handle intentionally skipped jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->