### PR TITLE
feat: add headless device platform for server/VM workers

### DIFF
--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -32,7 +32,7 @@ Options:
   --api-url <url>    Backend API URL (required for daemon)
   --worker-id <id>   Worker ID (required in device mode; fleet default: UUID)
   --version <ver>    Worker version (default: 1.0.0)
-  --platform <name>  Run as a device worker on this host platform (e.g. macos)
+  --platform <name>  Run as a device worker on this host platform (e.g. macos, headless)
                      instead of a cloud-fleet worker. Requires a durable
                      personal access token in WORKER_API_TOKEN — mint one with
                      \`lobu token create --raw\`. Note \`lobu whoami --json\`

--- a/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
+++ b/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
@@ -47,4 +47,23 @@ describe("platform allowlist lookups ignore inherited keys", () => {
       "os.files"
     );
   });
+
+  test("headless devices authorize shell+files but nothing browser-ish", () => {
+    // A server/VM device (herdr) advertises the shell/files it actually has;
+    // browser and UI capabilities must be dropped, never silently granted.
+    expect(isKnownPlatform("headless")).toBe(true);
+    const authorized = authorizeCapabilities("headless", [
+      "os.shell",
+      "os.files",
+      "os.notifications",
+      "browser.tabs",
+      "computer_use",
+    ]);
+    expect(authorized.authorized.sort()).toEqual(["os.files", "os.shell"]);
+    expect(authorized.dropped.sort()).toEqual([
+      "browser.tabs",
+      "computer_use",
+      "os.notifications",
+    ]);
+  });
 });

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -53,6 +53,15 @@ export const MAC_DEVICE_CAPABILITIES = [
   "computer_use",
 ] as const;
 
+// A server/VM with no UI or browser (the herdr box, a CI node, a k8s pod).
+// The device daemon can run agent work and touch a shell/files, but has no
+// browser to drive and no screen to notify. Keep this set small and honest -
+// add strings here only as headless connectors actually land.
+export const HEADLESS_CAPABILITIES = [
+  "os.shell",
+  "os.files",
+] as const;
+
 const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {
   macos: [
     ...OS_CAPABILITIES,
@@ -61,6 +70,7 @@ const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {
   ],
   ios: IOS_CAPABILITIES,
   "chrome-extension": BROWSER_CAPABILITIES,
+  headless: HEADLESS_CAPABILITIES,
 };
 
 export interface CapabilityAuthorizationResult {

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -57,10 +57,7 @@ export const MAC_DEVICE_CAPABILITIES = [
 // The device daemon can run agent work and touch a shell/files, but has no
 // browser to drive and no screen to notify. Keep this set small and honest -
 // add strings here only as headless connectors actually land.
-export const HEADLESS_CAPABILITIES = [
-  "os.shell",
-  "os.files",
-] as const;
+export const HEADLESS_CAPABILITIES = ["os.shell", "os.files"] as const;
 
 const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {
   macos: [


### PR DESCRIPTION
## What

Adds a **`headless`** device platform so a server/VM without a UI or browser (the herdr box, a CI node, a k8s pod) can register as a first-class Lobu device worker, exactly like the Mac app / Chrome extension do.

- `packages/core/src/capabilities.ts`: new `HEADLESS_CAPABILITIES` (`os.shell`, `os.files` - the honest capability set of a headless box; no browser/notification/ios/mac strings) registered in `PLATFORM_ALLOWLIST`.
- Test: headless is a known platform, authorizes shell+files, drops browser/UI capabilities.
- `packages/connector-worker/src/bin.ts`: help text mentions `headless` as a `--platform` option.

## Why this shape

- **`sandbox`** was rejected as the platform id: the product already uses "sandbox" for runtime providers (`lobu sandbox`, the `sandboxes` table, the vercel provider) - a different concept from a device daemon polling `/api/workers/*`.
- **`container`** was rejected: it describes packaging, not the device role.
- The platform drives server-side capability authorization at `/api/workers/poll` (unknown platforms get an empty allowlist), so headless devices can never claim browser/UI capabilities.

## Follow-ups (not in this PR)

- Devices-page label: the owletto UI falls back to the raw platform string ("headless"); a "Server" label needs an owletto change.
- `connectorKeyAllowedForPlatform` returns false for headless, so headless devices cannot register device-connector manifests yet (safe default; revisit when a headless connector lands).

## Proof

- `bun test packages/core/src/__tests__/capabilities-prototype-keys.test.ts` -> 12 pass (incl. new headless case).
- actionlint clean; banned-vocab gate clean.