### PR TITLE
feat: allow headless platform to mint child device tokens

### DIFF
--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/me/devices/mint-child-token must let a headless device register
+ * itself (platform: 'headless') from a device_worker:run bearer, and bind the
+ * device + child PAT to the user's personal org - the same contract as the
+ * chrome-extension Mac-bridge path, now open to server/VM devices (herdr).
+ */
+
+import { Hono } from 'hono';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { mintDeviceChildToken } from '../../worker-api/device-management';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+  RATE_LIMIT_ENABLED: 'false',
+} as unknown as Env;
+
+async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
+  const sql = getTestDb();
+  // Match personal-org-provisioning.ts: the marker lives in org metadata as
+  // plain JSON text (the read path casts with (metadata::jsonb)->>).
+  await sql`
+    UPDATE "organization"
+    SET metadata = ${JSON.stringify({ personal_org_for_user_id: userId })}
+    WHERE id = ${orgId}
+  `;
+}
+
+function mintApp(userId: string): Hono<{ Bindings: Env; Variables: { user: { id: string }; mcpAuthInfo: { scopes: string[] } | null } }> {
+  const app = new Hono<{ Bindings: Env; Variables: { user: { id: string }; mcpAuthInfo: { scopes: string[] } | null } }>();
+  app.post(
+    '/api/me/devices/mint-child-token',
+    async (c, next) => {
+      // Device-scoped bearer: device_worker:run scope, NO MCP resource audience.
+      c.set('user', { id: userId });
+      c.set('mcpAuthInfo', { scopes: ['device_worker:run'] });
+      await next();
+    },
+    (c) => mintDeviceChildToken(c)
+  );
+  return app;
+}
+
+describe('headless device mint (mint-child-token)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mints a headless device bound to the personal org with an owl_pat_ child token', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal' });
+    const user = await createTestUser({ email: 'headless-mint@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'headless', label: 'herdr-test' }),
+      },
+      TEST_ENV
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      worker_id: string;
+      access_token: string;
+      platform: string;
+      label: string;
+    };
+    expect(body.platform).toBe('headless');
+    expect(body.label).toBe('herdr-test');
+    expect(body.access_token.startsWith('owl_pat_')).toBe(true);
+
+    // The persisted device row is platform- and personal-org-bound.
+    const rows = (await sql`
+      SELECT platform, label, organization_id FROM device_workers
+      WHERE user_id = ${user.id} AND worker_id = ${body.worker_id}
+    `) as unknown as Array<{ platform: string; label: string; organization_id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].platform).toBe('headless');
+    expect(rows[0].label).toBe('herdr-test');
+    expect(rows[0].organization_id).toBe(personalOrg.id);
+  });
+
+  it('rejects a platform that is not eligible for child-token mint', async () => {
+    const user = await createTestUser({ email: 'headless-mint-reject@test.example.com' });
+    const personalOrg = await createTestOrganization({ name: 'Personal Reject' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'macos', label: 'should-fail' }),
+      },
+      TEST_ENV
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -204,9 +204,11 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'platform is required' }, 400);
   }
   // Only known device platforms can mint children — keeps the surface tight.
-  // Today: chrome-extension. (The Mac app calling for itself would just use
-  // its existing OAuth token; macos/ios don't need this path.)
-  if (platform !== 'chrome-extension' || !isKnownPlatform(platform)) {
+  // Today: chrome-extension (Mac bridge pairs the extension) and headless
+  // (a server/VM registers itself via a CLI session, then runs the worker
+  // daemon with the minted PAT). The Mac app calling for itself would just
+  // use its existing OAuth token; macos/ios don't need this path.
+  if ((platform !== 'chrome-extension' && platform !== 'headless') || !isKnownPlatform(platform)) {
     return c.json({ error: `platform '${platform}' is not eligible for child-token mint` }, 400);
   }
   const label = body.label?.toString().trim() || null;


### PR DESCRIPTION
## What

Completes the `headless` device platform (#2880): allows a `headless` platform to mint child device tokens via `POST /api/me/devices/mint-child-token`, so a server/VM (the herdr box) can register itself from a CLI session and then run the worker daemon with the minted PAT.

`device-management.ts`: the child-token mint gate now accepts `chrome-extension` (Mac bridge) **and** `headless`; still gated on `isKnownPlatform`, so unknown platforms are rejected.

## Proof

- `bunx tsc --noEmit` in packages/server clean after a forced core rebuild (initial errors were phantom stale-dist; fixed by rebuilding core per the package trap).
- Naming gate clean; banned vocab clean.
- Live E2E to follow post-merge: mint a headless device for herdr, run `connector-worker daemon --platform headless`, verify it appears online in the org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child tokens can now be minted for both Chrome extension and headless platforms.

* **Bug Fixes**
  * Existing validation and rejection behavior remains in place for unsupported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->