### PR TITLE
feat: expose media attachments as MCP resources

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -1,16 +1,21 @@
 import { mkdtempSync, rmSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Context } from 'hono';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../../db/client';
 import {
   ArtifactStore,
   eventArtifactBinding,
   runArtifactBinding,
 } from '../../../gateway/files/artifact-store';
+import type { Env } from '../../../index';
+import * as lobuGateway from '../../../lobu/gateway';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { insertEvent } from '../../../utils/insert-event';
+import { completeActionRun, streamContent } from '../../../worker-api';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
@@ -21,6 +26,22 @@ import {
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (responseBody: unknown, status?: number) => {
+      captured = { body: responseBody, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
 
 describe('MCP media resources', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -91,37 +112,99 @@ describe('MCP media resources', () => {
     return sessionId!;
   }
 
-  it('returns durable event attachments as MCP resources', async () => {
+  it('materializes streamed media with connection-over-feed binding and reads its resource', async () => {
     const imageBytes = Buffer.from('durable-event-image');
-    const artifact = await artifactStore.publish({
-      buffer: imageBytes,
-      filename: 'memory-photo.webp',
-      contentType: 'image/webp',
-      publicGatewayUrl: 'http://localhost',
-      binding: eventArtifactBinding({
-        organizationId: org.id,
-        originId: 'mcp-media-event',
-      }),
-    });
-    const event = await insertEvent({
-      entityIds: [],
-      organizationId: org.id,
-      originId: 'mcp-media-event',
-      title: 'Memory photo',
-      payloadType: 'media',
-      content: '',
-      semanticType: 'photo',
-      attachments: [
+    const sql = getDb();
+    const [connection] = await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, status, visibility, slug, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'rss', 'active', 'org', 'mcp-media-stream', NOW(), NOW()
+      )
+      RETURNING id
+    `;
+    const connectionId = Number(connection!.id);
+    const [feed] = await sql`
+      INSERT INTO feeds (
+        organization_id, connection_id, feed_key, status, created_at, updated_at
+      ) VALUES (
+        ${org.id}, ${connectionId}, 'items', 'active', NOW(), NOW()
+      )
+      RETURNING id
+    `;
+    const feedId = Number(feed!.id);
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, feed_id, connection_id, connector_key,
+        connector_version, status, claimed_by, created_at
+      ) VALUES (
+        ${org.id}, 'sync', ${feedId}, ${connectionId}, 'rss', '1.0.0',
+        'running', 'worker-mcp-media', NOW()
+      )
+      RETURNING id
+    `;
+    const runId = Number(run!.id);
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: 'worker-mcp-media',
+      items: [
         {
-          kind: 'image',
-          filename: 'memory-photo.webp',
-          mime_type: 'image/webp',
-          artifact_id: artifact.artifactId,
-          download_url: artifact.downloadUrl,
-          size_bytes: imageBytes.length,
+          id: 'mcp-media-event',
+          title: 'Memory photo',
+          payload_text: 'A streamed photo',
+          payload_type: 'media',
+          occurred_at: new Date().toISOString(),
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'memory-photo.webp',
+              mime_type: 'image/webp',
+              data: imageBytes.toString('base64'),
+            },
+          ],
         },
       ],
     });
+    const coreServices = vi
+      .spyOn(lobuGateway, 'getLobuCoreServices')
+      .mockReturnValue({ getArtifactStore: () => artifactStore });
+    try {
+      await streamContent(ctx);
+    } finally {
+      coreServices.mockRestore();
+    }
+    expect(result()).toMatchObject({ status: 200, body: { total_items: 1 } });
+
+    const [event] = await sql`
+      SELECT id, attachments
+      FROM events
+      WHERE organization_id = ${org.id}
+        AND origin_id = 'mcp-media-event'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    const eventId = Number(event!.id);
+    const attachment = (event!.attachments as Array<Record<string, unknown>>)[0]!;
+    const artifactId = String(attachment.artifact_id);
+    expect(
+      await artifactStore.read(artifactId, {
+        binding: eventArtifactBinding({
+          organizationId: org.id,
+          connectionId,
+          feedId,
+          originId: 'mcp-media-event',
+        }),
+      })
+    ).toBeTruthy();
+    expect(
+      await artifactStore.read(artifactId, {
+        binding: eventArtifactBinding({
+          organizationId: org.id,
+          feedId,
+          originId: 'mcp-media-event',
+        }),
+      })
+    ).toBeNull();
 
     const sessionId = await initSession();
     const path = `/mcp/${org.slug}`;
@@ -133,7 +216,7 @@ describe('MCP media resources', () => {
         params: {
           name: 'run_sdk',
           arguments: {
-            script: `export default async (_ctx, client) => client.knowledge.read({ content_ids: [${event.id}] });`,
+            script: `export default async (_ctx, client) => client.knowledge.read({ content_ids: [${eventId}] });`,
           },
         },
       },
@@ -149,7 +232,7 @@ describe('MCP media resources', () => {
     expect(resource).toEqual(
       expect.objectContaining({
         type: 'resource_link',
-        uri: `lobu://event/${event.id}/attachment/0`,
+        uri: `lobu://event/${eventId}/attachment/0`,
         name: 'memory-photo.webp',
         mimeType: 'image/webp',
         size: imageBytes.length,
@@ -172,6 +255,39 @@ describe('MCP media resources', () => {
       mimeType: 'image/webp',
       blob: imageBytes.toString('base64'),
     });
+
+    const artifactsBeforeFailedInsert = (await readdir(artifactsDir)).sort();
+    const failedInsert = mockWorkerCtx({
+      run_id: runId,
+      worker_id: 'worker-mcp-media',
+      items: [
+        {
+          id: 'mcp-media-invalid-event',
+          title: 'Invalid streamed photo',
+          payload_text: 'This insert must fail',
+          payload_type: 'media',
+          occurred_at: 'not-a-timestamp',
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'invalid.webp',
+              mime_type: 'image/webp',
+              data: Buffer.from('must-be-cleaned').toString('base64'),
+            },
+          ],
+        },
+      ],
+    });
+    const failedInsertServices = vi
+      .spyOn(lobuGateway, 'getLobuCoreServices')
+      .mockReturnValue({ getArtifactStore: () => artifactStore });
+    try {
+      await streamContent(failedInsert.ctx);
+    } finally {
+      failedInsertServices.mockRestore();
+    }
+    expect(failedInsert.result().status).toBe(500);
+    expect((await readdir(artifactsDir)).sort()).toEqual(artifactsBeforeFailedInsert);
   });
 
   it('does not let a resource URI bypass workspace authorization', async () => {
@@ -225,6 +341,149 @@ describe('MCP media resources', () => {
     const body = await response.json();
     expect(body.result).toBeUndefined();
     expect(body.error?.message).toContain('Unknown resource');
+  });
+
+  it('fails safely for invalid, missing, and oversized resources', async () => {
+    const oversizedBytes = Buffer.alloc(20 * 1024 * 1024 + 1, 1);
+    const artifact = await artifactStore.publish({
+      buffer: oversizedBytes,
+      filename: 'oversized.bin',
+      contentType: 'application/octet-stream',
+      publicGatewayUrl: 'http://localhost',
+      binding: eventArtifactBinding({
+        organizationId: org.id,
+        originId: 'oversized-mcp-media-event',
+      }),
+    });
+    const event = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'oversized-mcp-media-event',
+      title: 'Oversized attachment',
+      payloadType: 'media',
+      content: '',
+      semanticType: 'file',
+      attachments: [
+        {
+          kind: 'file',
+          filename: 'oversized.bin',
+          mime_type: 'application/octet-stream',
+          artifact_id: artifact.artifactId,
+          size_bytes: oversizedBytes.length,
+        },
+      ],
+    });
+    const sessionId = await initSession();
+    const path = `/mcp/${org.slug}`;
+
+    for (const uri of [
+      'lobu://event/not-a-number/attachment/0',
+      `lobu://event/${event.id}/attachment/99`,
+    ]) {
+      const response = await post(path, {
+        body: {
+          jsonrpc: '2.0',
+          id: `invalid-${uri}`,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      const body = await response.json();
+      expect(body.result).toBeUndefined();
+      expect(body.error?.message).toContain('Unknown resource');
+    }
+
+    const oversizedResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'oversized-resource',
+        method: 'resources/read',
+        params: { uri: `lobu://event/${event.id}/attachment/0` },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const oversizedBody = await oversizedResponse.json();
+    expect(oversizedBody.result).toBeUndefined();
+    expect(oversizedBody.error?.message).toContain('limit 20971520');
+  });
+
+  it('cleans action artifacts when finalization rolls back or commits zero rows', async () => {
+    const sql = getDb();
+    const [rollbackRun, finalizedRun] = await Promise.all([
+      sql`
+        INSERT INTO runs (
+          organization_id, run_type, status, approval_status, claimed_by, action_key
+        ) VALUES (
+          ${org.id}, 'action', 'running', 'approved', 'worker-media-cleanup', 'capture'
+        )
+        RETURNING id
+      `.then((rows) => rows[0]),
+      sql`
+        INSERT INTO runs (
+          organization_id, run_type, status, approval_status, claimed_by, action_key
+        ) VALUES (
+          ${org.id}, 'action', 'completed', 'auto', 'worker-media-cleanup', 'capture'
+        )
+        RETURNING id
+      `.then((rows) => rows[0]),
+    ]);
+    const artifactsBefore = (await readdir(artifactsDir)).sort();
+    const coreServices = vi
+      .spyOn(lobuGateway, 'getLobuCoreServices')
+      .mockReturnValue({ getArtifactStore: () => artifactStore });
+
+    try {
+      const rollback = mockWorkerCtx({
+        run_id: Number(rollbackRun!.id),
+        worker_id: 'worker-media-cleanup',
+        status: 'success',
+        action_output: {
+          attachments: [
+            {
+              filename: 'rollback.jpg',
+              mime_type: 'image/jpeg',
+              data: Buffer.from('rollback-artifact').toString('base64'),
+            },
+          ],
+        },
+      });
+      await completeActionRun(rollback.ctx);
+      expect(rollback.result().status).toBe(500);
+      expect((rollback.result().body as { error?: string }).error).toContain(
+        'approval card is missing'
+      );
+
+      const zeroRows = mockWorkerCtx({
+        run_id: Number(finalizedRun!.id),
+        worker_id: 'worker-media-cleanup',
+        status: 'success',
+        action_output: {
+          attachments: [
+            {
+              filename: 'already-finalized.jpg',
+              mime_type: 'image/jpeg',
+              data: Buffer.from('zero-row-artifact').toString('base64'),
+            },
+          ],
+        },
+      });
+      await completeActionRun(zeroRows.ctx);
+      expect(zeroRows.result()).toMatchObject({
+        status: 200,
+        body: { success: false, reason: 'already_finalized' },
+      });
+    } finally {
+      coreServices.mockRestore();
+    }
+
+    expect((await readdir(artifactsDir)).sort()).toEqual(artifactsBefore);
+    const [runAfterRollback] = await sql`
+      SELECT status FROM runs WHERE id = ${Number(rollbackRun!.id)}
+    `;
+    expect(runAfterRollback!.status).toBe('running');
   });
 
   it('rejects an artifact grafted from another authorized resource', async () => {
@@ -306,8 +565,14 @@ describe('MCP media resources', () => {
       filename: 'candidate.jpg',
       contentType: 'image/jpeg',
       publicGatewayUrl: 'http://localhost',
+      ttlMs: -1,
       binding: runArtifactBinding(runId),
     });
+    const expiredToken = new URL(artifact.downloadUrl).searchParams.get('token');
+    expect(expiredToken).toBeTruthy();
+    expect(artifactStore.validateDownloadToken(expiredToken!, artifact.artifactId).valid).toBe(
+      false
+    );
     await sql`
       UPDATE runs
       SET action_output = ${sql.json({

--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
-import { ArtifactStore } from '../../../gateway/files/artifact-store';
+import {
+  ArtifactStore,
+  eventArtifactBinding,
+  runArtifactBinding,
+} from '../../../gateway/files/artifact-store';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { insertEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase } from '../../setup/test-db';
@@ -94,6 +98,10 @@ describe('MCP media resources', () => {
       filename: 'memory-photo.webp',
       contentType: 'image/webp',
       publicGatewayUrl: 'http://localhost',
+      binding: eventArtifactBinding({
+        organizationId: org.id,
+        originId: 'mcp-media-event',
+      }),
     });
     const event = await insertEvent({
       entityIds: [],
@@ -177,6 +185,10 @@ describe('MCP media resources', () => {
       filename: 'private.jpg',
       contentType: 'image/jpeg',
       publicGatewayUrl: 'http://localhost',
+      binding: eventArtifactBinding({
+        organizationId: otherOrg.id,
+        originId: 'other-mcp-media-event',
+      }),
     });
     const event = await insertEvent({
       entityIds: [],
@@ -215,37 +227,103 @@ describe('MCP media resources', () => {
     expect(body.error?.message).toContain('Unknown resource');
   });
 
+  it('rejects an artifact grafted from another authorized resource', async () => {
+    const otherOrg = await createTestOrganization({
+      name: 'Foreign Artifact Org',
+      slug: 'foreign-artifact-org',
+    });
+    const sql = getDb();
+    const [foreignRun, localRun] = await Promise.all([
+      sql`
+        INSERT INTO runs (organization_id, run_type, status, approval_status)
+        VALUES (${otherOrg.id}, 'action', 'completed', 'auto')
+        RETURNING id
+      `.then((rows) => rows[0]),
+      sql`
+        INSERT INTO runs (organization_id, run_type, status, approval_status)
+        VALUES (${org.id}, 'action', 'completed', 'auto')
+        RETURNING id
+      `.then((rows) => rows[0]),
+    ]);
+    const foreignRunId = Number(foreignRun!.id);
+    const localRunId = Number(localRun!.id);
+    const foreignBytes = Buffer.from('foreign-artifact-bytes');
+    const foreignArtifact = await artifactStore.publish({
+      buffer: foreignBytes,
+      filename: 'foreign.jpg',
+      contentType: 'image/jpeg',
+      publicGatewayUrl: 'http://localhost',
+      binding: runArtifactBinding(foreignRunId),
+    });
+    await sql`
+      UPDATE runs
+      SET action_output = ${sql.json({
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'foreign.jpg',
+            mime_type: 'image/jpeg',
+            artifact_id: foreignArtifact.artifactId,
+            size_bytes: foreignBytes.length,
+          },
+        ],
+      })}
+      WHERE id = ${localRunId}
+    `;
+
+    const sessionId = await initSession();
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'grafted-media',
+        method: 'resources/read',
+        params: { uri: `lobu://run/${localRunId}/attachment/0` },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error?.message).toContain('Unknown resource');
+  });
+
   it('returns operation attachments as stable resource links and serves their bytes', async () => {
     const imageBytes = Buffer.from('fake-image-bytes');
+    const sql = getDb();
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status
+      ) VALUES (
+        ${org.id}, 'action', 'completed', 'auto'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run!.id);
     const artifact = await artifactStore.publish({
       buffer: imageBytes,
       filename: 'candidate.jpg',
       contentType: 'image/jpeg',
       publicGatewayUrl: 'http://localhost',
+      binding: runArtifactBinding(runId),
     });
-
-    const sql = getDb();
-    const [run] = await sql`
-      INSERT INTO runs (
-        organization_id, run_type, status, approval_status, action_output
-      ) VALUES (
-        ${org.id}, 'action', 'completed', 'auto',
-        ${sql.json({
-          attachments: [
-            {
-              kind: 'image',
-              filename: 'candidate.jpg',
-              mime_type: 'image/jpeg',
-              artifact_id: artifact.artifactId,
-              download_url: artifact.downloadUrl,
-              size_bytes: imageBytes.length,
-            },
-          ],
-        })}
-      )
-      RETURNING id
+    await sql`
+      UPDATE runs
+      SET action_output = ${sql.json({
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'candidate.jpg',
+            mime_type: 'image/jpeg',
+            artifact_id: artifact.artifactId,
+            download_url: artifact.downloadUrl,
+            size_bytes: imageBytes.length,
+          },
+        ],
+      })}
+      WHERE id = ${runId}
     `;
-    const runId = Number(run!.id);
 
     const sessionId = await initSession();
     const path = `/mcp/${org.slug}`;

--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -1,0 +1,302 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { ArtifactStore } from '../../../gateway/files/artifact-store';
+import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+describe('MCP media resources', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let token: string;
+  let artifactStore: ArtifactStore;
+  let artifactsDir: string;
+  const previousArtifactsDir = process.env.LOBU_ARTIFACTS_DIR;
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  beforeAll(async () => {
+    artifactsDir = mkdtempSync(join(tmpdir(), 'lobu-mcp-media-'));
+    process.env.LOBU_ARTIFACTS_DIR = artifactsDir;
+    process.env.ENCRYPTION_KEY = Buffer.from(
+      '12345678901234567890123456789012'
+    ).toString('base64');
+    artifactStore = new ArtifactStore();
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({
+      name: 'MCP Media Org',
+      slug: 'mcp-media-org',
+    });
+    const owner = await createTestUser({ email: 'mcp-media-owner@test.example.com' });
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    const client = await createTestOAuthClient();
+    token = (
+      await createTestAccessToken(owner.id, org.id, client.client_id, {
+        scope: 'mcp:admin mcp:write mcp:read profile:read',
+      })
+    ).token;
+    clearInMemoryMcpSessionsForTests();
+  });
+
+  afterAll(() => {
+    if (previousArtifactsDir === undefined) delete process.env.LOBU_ARTIFACTS_DIR;
+    else process.env.LOBU_ARTIFACTS_DIR = previousArtifactsDir;
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    if (artifactsDir) rmSync(artifactsDir, { recursive: true, force: true });
+  });
+
+  async function initSession(): Promise<string> {
+    const path = `/mcp/${org.slug}`;
+    const initResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: '__test_init__',
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'lobu-mcp-media-test', version: '1.0' },
+        },
+      },
+      token,
+    });
+    const sessionId = initResponse.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    await post(path, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      headers: {
+        'mcp-session-id': sessionId!,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+    return sessionId!;
+  }
+
+  it('returns durable event attachments as MCP resources', async () => {
+    const imageBytes = Buffer.from('durable-event-image');
+    const artifact = await artifactStore.publish({
+      buffer: imageBytes,
+      filename: 'memory-photo.webp',
+      contentType: 'image/webp',
+      publicGatewayUrl: 'http://localhost',
+    });
+    const event = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'mcp-media-event',
+      title: 'Memory photo',
+      payloadType: 'media',
+      content: '',
+      semanticType: 'photo',
+      attachments: [
+        {
+          kind: 'image',
+          filename: 'memory-photo.webp',
+          mime_type: 'image/webp',
+          artifact_id: artifact.artifactId,
+          download_url: artifact.downloadUrl,
+          size_bytes: imageBytes.length,
+        },
+      ],
+    });
+
+    const sessionId = await initSession();
+    const path = `/mcp/${org.slug}`;
+    const response = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'event-media',
+        method: 'tools/call',
+        params: {
+          name: 'run_sdk',
+          arguments: {
+            script: `export default async (_ctx, client) => client.knowledge.read({ content_ids: [${event.id}] });`,
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const resource = body.result?.content?.find(
+      (item: { type?: string }) => item.type === 'resource_link'
+    );
+    expect(resource).toEqual(
+      expect.objectContaining({
+        type: 'resource_link',
+        uri: `lobu://event/${event.id}/attachment/0`,
+        name: 'memory-photo.webp',
+        mimeType: 'image/webp',
+        size: imageBytes.length,
+      })
+    );
+
+    const readResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'read-event-media',
+        method: 'resources/read',
+        params: { uri: resource.uri },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const readBody = await readResponse.json();
+    expect(readBody.result?.contents?.[0]).toEqual({
+      uri: resource.uri,
+      mimeType: 'image/webp',
+      blob: imageBytes.toString('base64'),
+    });
+  });
+
+  it('does not let a resource URI bypass workspace authorization', async () => {
+    const otherOrg = await createTestOrganization({
+      name: 'Other MCP Media Org',
+      slug: 'other-mcp-media-org',
+    });
+    const bytes = Buffer.from('other-workspace-image');
+    const artifact = await artifactStore.publish({
+      buffer: bytes,
+      filename: 'private.jpg',
+      contentType: 'image/jpeg',
+      publicGatewayUrl: 'http://localhost',
+    });
+    const event = await insertEvent({
+      entityIds: [],
+      organizationId: otherOrg.id,
+      originId: 'other-mcp-media-event',
+      title: 'Other workspace photo',
+      payloadType: 'media',
+      content: '',
+      semanticType: 'photo',
+      attachments: [
+        {
+          kind: 'image',
+          filename: 'private.jpg',
+          mime_type: 'image/jpeg',
+          artifact_id: artifact.artifactId,
+          size_bytes: bytes.length,
+        },
+      ],
+    });
+
+    const sessionId = await initSession();
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'cross-org-media',
+        method: 'resources/read',
+        params: { uri: `lobu://event/${event.id}/attachment/0` },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error?.message).toContain('Unknown resource');
+  });
+
+  it('returns operation attachments as stable resource links and serves their bytes', async () => {
+    const imageBytes = Buffer.from('fake-image-bytes');
+    const artifact = await artifactStore.publish({
+      buffer: imageBytes,
+      filename: 'candidate.jpg',
+      contentType: 'image/jpeg',
+      publicGatewayUrl: 'http://localhost',
+    });
+
+    const sql = getDb();
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, action_output
+      ) VALUES (
+        ${org.id}, 'action', 'completed', 'auto',
+        ${sql.json({
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'candidate.jpg',
+              mime_type: 'image/jpeg',
+              artifact_id: artifact.artifactId,
+              download_url: artifact.downloadUrl,
+              size_bytes: imageBytes.length,
+            },
+          ],
+        })}
+      )
+      RETURNING id
+    `;
+    const runId = Number(run!.id);
+
+    const sessionId = await initSession();
+    const path = `/mcp/${org.slug}`;
+    const response = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'operation-media',
+        method: 'tools/call',
+        params: {
+          name: 'run_sdk',
+          arguments: {
+            script: `export default async (_ctx, client) => client.operations.getRun(${runId});`,
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    const resource = body.result?.content?.find(
+      (item: { type?: string }) => item.type === 'resource_link'
+    );
+    expect(resource).toEqual(
+      expect.objectContaining({
+        type: 'resource_link',
+        uri: `lobu://run/${runId}/attachment/0`,
+        name: 'candidate.jpg',
+        mimeType: 'image/jpeg',
+        size: imageBytes.length,
+      })
+    );
+
+    const readResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'read-operation-media',
+        method: 'resources/read',
+        params: { uri: resource.uri },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect(readResponse.status).toBe(200);
+    const readBody = await readResponse.json();
+    expect(readBody.result?.contents?.[0]).toEqual({
+      uri: resource.uri,
+      mimeType: 'image/jpeg',
+      blob: imageBytes.toString('base64'),
+    });
+  });
+});

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -60,6 +60,7 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     const read = await env.artifactStore.read(artifactId);
     expect(read?.metadata.filename).toBe("note.txt");
   });
+
   test("enforces immutable internal bindings and supports cleanup", async () => {
     const binding = runArtifactBinding(42);
     const { artifactId } = await env.artifactStore.publish({
@@ -78,5 +79,4 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     await env.artifactStore.delete(artifactId);
     expect(await env.artifactStore.read(artifactId)).toBeNull();
   });
-
 });

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runArtifactBinding } from "../files/artifact-store.js";
 import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
 
 describe("ArtifactStore.buildDownloadUrl", () => {
@@ -59,4 +60,23 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     const read = await env.artifactStore.read(artifactId);
     expect(read?.metadata.filename).toBe("note.txt");
   });
+  test("enforces immutable internal bindings and supports cleanup", async () => {
+    const binding = runArtifactBinding(42);
+    const { artifactId } = await env.artifactStore.publish({
+      buffer: Buffer.from("bound"),
+      filename: "bound.txt",
+      contentType: "text/plain",
+      publicGatewayUrl: "http://localhost:8954/lobu",
+      binding,
+    });
+
+    expect(await env.artifactStore.read(artifactId, { binding })).toBeTruthy();
+    expect(
+      await env.artifactStore.read(artifactId, { binding: runArtifactBinding(43) })
+    ).toBeNull();
+
+    await env.artifactStore.delete(artifactId);
+    expect(await env.artifactStore.read(artifactId)).toBeNull();
+  });
+
 });

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -20,6 +20,8 @@ interface StoredArtifactMetadata {
   contentType: string;
   size: number;
   createdAt: number;
+  /** Immutable Lobu resource identity allowed to read this artifact internally. */
+  binding?: string;
 }
 
 interface PublishArtifactResult {
@@ -33,6 +35,25 @@ interface PublishArtifactResult {
 function sanitizeFilename(filename: string): string {
   const safe = path.basename(filename).trim();
   return safe || "download";
+}
+
+export function runArtifactBinding(runId: number): string {
+  return `run:${runId}`;
+}
+
+export function eventArtifactBinding(params: {
+  organizationId: string;
+  connectionId?: number | null;
+  feedId?: number | null;
+  originId: string;
+}): string {
+  const sourceScope =
+    params.connectionId != null
+      ? `connection:${params.connectionId}`
+      : params.feedId != null
+        ? `feed:${params.feedId}`
+        : "unscoped";
+  return `event:${params.organizationId}:${sourceScope}:${params.originId}`;
 }
 
 function normalizeBaseUrl(publicGatewayUrl: string): string {
@@ -68,6 +89,7 @@ export class ArtifactStore {
     contentType?: string;
     publicGatewayUrl: string;
     ttlMs?: number;
+    binding?: string;
   }): Promise<PublishArtifactResult> {
     const artifactId = randomUUID();
     const filename = sanitizeFilename(params.filename);
@@ -89,6 +111,7 @@ export class ArtifactStore {
           contentType,
           size: params.buffer.length,
           createdAt,
+          ...(params.binding ? { binding: params.binding } : {}),
         } satisfies StoredArtifactMetadata,
         null,
         2
@@ -112,19 +135,28 @@ export class ArtifactStore {
     };
   }
 
-  async read(artifactId: string): Promise<{
+  async read(
+    artifactId: string,
+    options?: { binding?: string }
+  ): Promise<{
     metadata: StoredArtifactMetadata;
     filePath: string;
   } | null> {
     try {
       const raw = await fs.readFile(this.metadataPath(artifactId), "utf8");
       const metadata = JSON.parse(raw) as StoredArtifactMetadata;
+      if (options?.binding && metadata.binding !== options.binding) return null;
       const filePath = this.artifactFilePath(artifactId, metadata.filename);
       await fs.access(filePath);
       return { metadata, filePath };
     } catch {
       return null;
     }
+  }
+
+  async delete(artifactId: string): Promise<void> {
+    await fs.rm(this.artifactDir(artifactId), { recursive: true, force: true });
+    logger.info(`Deleted artifact ${artifactId}`);
   }
 
   createDownloadToken(artifactId: string, ttlMs = this.defaultTtlMs): string {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -50,12 +50,14 @@ import {
 } from './mcp-session-state';
 import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
 import { LOBU_SKILL_MARKDOWN } from './skills/lobu-skill.generated';
+import { readMcpAttachmentResource } from './mcp-media-resources';
 import {
   type AuthContext,
   executeTool,
   extractAuthContext,
   isSoftErrorResult,
 } from './tools/execute';
+import { getMcpResultContent } from './tools/mcp-result-content';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
 import { toMcpPublicSdkScriptResult } from './tools/sdk_run';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
@@ -383,6 +385,8 @@ function createServerForContext(
   // resources/read — return the built bundle HTML for a `ui://` app resource.
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const uri = request.params.uri;
+    const mediaResource = await readMcpAttachmentResource(uri, env, authCtx);
+    if (mediaResource) return mediaResource;
     const skill = MCP_SKILL_RESOURCES[uri];
     if (skill) {
       return {
@@ -463,6 +467,8 @@ function createServerForContext(
         await touchAgentLastUsed(authCtx.organizationId, authCtx.agentId);
       }
 
+      const attachedContent = getMcpResultContent(result) ?? [];
+
       // executeTool has already passed the rich SDK result through the internal
       // audit seam. Do not expose logs, stacks, org traversal, or call traces to
       // MCP clients.
@@ -523,7 +529,7 @@ function createServerForContext(
         const structured = validateToolResult(tool.outputSchema, publicResult);
         if (structured !== null) {
           return {
-            content: [{ type: 'text' as const, text }],
+            content: [{ type: 'text' as const, text }, ...attachedContent],
             structuredContent: structured as Record<string, unknown>,
             _meta: resultMeta,
             ...(softError ? { isError: true } : {}),
@@ -531,7 +537,7 @@ function createServerForContext(
         }
       }
       return {
-        content: [{ type: 'text' as const, text }],
+        content: [{ type: 'text' as const, text }, ...attachedContent],
         _meta: resultMeta,
         ...(softError ? { isError: true } : {}),
       };

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,0 +1,226 @@
+import { readFile } from 'node:fs/promises';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ArtifactStore } from './gateway/files/artifact-store';
+import type { Env } from './index';
+import { type AuthContext, executeTool } from './tools/execute';
+
+const MAX_MCP_RESOURCE_BYTES = 20 * 1024 * 1024;
+
+type ResourceLink = Extract<
+  CallToolResult['content'][number],
+  { type: 'resource_link' }
+>;
+
+type AttachmentRecord = {
+  artifact_id?: unknown;
+  filename?: unknown;
+  mime_type?: unknown;
+  size_bytes?: unknown;
+};
+
+type ResourceRef =
+  | { kind: 'run'; id: number; index: number }
+  | { kind: 'event'; id: number; index: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : null;
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+export function runAttachmentResourceUri(runId: number, index: number): string {
+  return `lobu://run/${runId}/attachment/${index}`;
+}
+
+export function eventAttachmentResourceUri(eventId: number, index: number): string {
+  return `lobu://event/${eventId}/attachment/${index}`;
+}
+
+function resourceLinksForAttachments(
+  uriForIndex: (index: number) => string,
+  attachments: unknown
+): ResourceLink[] {
+  if (!Array.isArray(attachments)) return [];
+
+  return attachments.flatMap((raw, index) => {
+    if (!isRecord(raw)) return [];
+    const attachment = raw as AttachmentRecord;
+    if (
+      typeof attachment.artifact_id !== 'string' ||
+      typeof attachment.mime_type !== 'string'
+    ) {
+      return [];
+    }
+    const name =
+      typeof attachment.filename === 'string' && attachment.filename.trim()
+        ? attachment.filename
+        : `attachment-${index + 1}`;
+    const size = nonNegativeInteger(attachment.size_bytes);
+    return [
+      {
+        type: 'resource_link' as const,
+        uri: uriForIndex(index),
+        name,
+        mimeType: attachment.mime_type,
+        ...(size !== null ? { size } : {}),
+      },
+    ];
+  });
+}
+
+function resourceLinksForRunOutput(runId: number, output: unknown): ResourceLink[] {
+  if (!isRecord(output)) return [];
+  return resourceLinksForAttachments(
+    (index) => runAttachmentResourceUri(runId, index),
+    output.attachments
+  );
+}
+
+function resourceLinksForKnowledgeRead(value: Record<string, unknown>): ResourceLink[] {
+  if (!Array.isArray(value.content)) return [];
+
+  return value.content.flatMap((raw) => {
+    if (!isRecord(raw)) return [];
+    const eventId = positiveInteger(raw.id);
+    if (eventId === null) return [];
+    return resourceLinksForAttachments(
+      (index) => eventAttachmentResourceUri(eventId, index),
+      raw.attachments
+    );
+  });
+}
+
+/**
+ * Recognize resource-bearing ClientSDK return values and expose materialized
+ * attachments as MCP resource links. Links use Lobu-owned stable ids, never
+ * ephemeral signed download URLs.
+ */
+export function mcpResourceLinksForSdkReturnValue(value: unknown): ResourceLink[] {
+  if (!isRecord(value)) return [];
+
+  if (value.action === 'execute' && value.status === 'completed') {
+    const runId = positiveInteger(value.run_id);
+    return runId === null ? [] : resourceLinksForRunOutput(runId, value.output);
+  }
+
+  if (value.action === 'get_run' && isRecord(value.run)) {
+    const runId = positiveInteger(value.run.id);
+    return runId === null
+      ? []
+      : resourceLinksForRunOutput(runId, value.run.output);
+  }
+
+  return resourceLinksForKnowledgeRead(value);
+}
+
+function parseAttachmentUri(uri: string): ResourceRef | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'lobu:') return null;
+  const kind = parsed.hostname;
+  if (kind !== 'run' && kind !== 'event') return null;
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  if (parts.length !== 3 || parts[1] !== 'attachment') return null;
+  const id = Number(parts[0]);
+  const index = Number(parts[2]);
+  if (!Number.isSafeInteger(id) || id <= 0) return null;
+  if (!Number.isSafeInteger(index) || index < 0) return null;
+  return { kind, id, index };
+}
+
+async function loadResourceAttachment(
+  ref: ResourceRef,
+  env: Env,
+  authCtx: AuthContext
+): Promise<Record<string, unknown> | null> {
+  if (ref.kind === 'run') {
+    const result = await executeTool(
+      'manage_operations',
+      { action: 'get_run', run_id: ref.id },
+      env,
+      authCtx
+    );
+    if (!isRecord(result) || result.action !== 'get_run' || !isRecord(result.run)) {
+      return null;
+    }
+    const output = result.run.output;
+    if (!isRecord(output) || !Array.isArray(output.attachments)) return null;
+    const raw = output.attachments[ref.index];
+    return isRecord(raw) ? raw : null;
+  }
+
+  const result = await executeTool(
+    'read_knowledge',
+    { content_ids: [ref.id], limit: 50 },
+    env,
+    authCtx
+  );
+  if (!isRecord(result) || !Array.isArray(result.content)) return null;
+  const item = result.content.find(
+    (raw) => isRecord(raw) && positiveInteger(raw.id) === ref.id
+  );
+  if (!isRecord(item) || !Array.isArray(item.attachments)) return null;
+  const raw = item.attachments[ref.index];
+  return isRecord(raw) ? raw : null;
+}
+
+/**
+ * Resolve a stable Lobu attachment URI through the same permission-aware
+ * readers used by SDK/MCP tools, then return its bytes as an MCP blob.
+ */
+export async function readMcpAttachmentResource(
+  uri: string,
+  env: Env,
+  authCtx: AuthContext
+): Promise<
+  | {
+      contents: Array<{
+        uri: string;
+        mimeType: string;
+        blob: string;
+      }>;
+    }
+  | null
+> {
+  const ref = parseAttachmentUri(uri);
+  if (!ref) return null;
+
+  const attachment = await loadResourceAttachment(ref, env, authCtx);
+  if (!attachment || typeof attachment.artifact_id !== 'string') {
+    throw new Error(`Unknown resource: ${uri}`);
+  }
+
+  const artifactStore = new ArtifactStore();
+  const stored = await artifactStore.read(attachment.artifact_id);
+  if (!stored) throw new Error(`Unknown resource: ${uri}`);
+  if (stored.metadata.size > MAX_MCP_RESOURCE_BYTES) {
+    throw new Error(
+      `MCP resource is too large to inline (${stored.metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
+    );
+  }
+
+  const data = await readFile(stored.filePath);
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: stored.metadata.contentType,
+        blob: data.toString('base64'),
+      },
+    ],
+  };
+}

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -42,11 +42,11 @@ function nonNegativeInteger(value: unknown): number | null {
     : null;
 }
 
-export function runAttachmentResourceUri(runId: number, index: number): string {
+function runAttachmentResourceUri(runId: number, index: number): string {
   return `lobu://run/${runId}/attachment/${index}`;
 }
 
-export function eventAttachmentResourceUri(eventId: number, index: number): string {
+function eventAttachmentResourceUri(eventId: number, index: number): string {
   return `lobu://event/${eventId}/attachment/${index}`;
 }
 

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,6 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ArtifactStore } from './gateway/files/artifact-store';
+import {
+  ArtifactStore,
+  eventArtifactBinding,
+  runArtifactBinding,
+} from './gateway/files/artifact-store';
 import type { Env } from './index';
 import { type AuthContext, executeTool } from './tools/execute';
 
@@ -146,7 +150,7 @@ async function loadResourceAttachment(
   ref: ResourceRef,
   env: Env,
   authCtx: AuthContext
-): Promise<Record<string, unknown> | null> {
+): Promise<{ attachment: Record<string, unknown>; binding: string } | null> {
   if (ref.kind === 'run') {
     const result = await executeTool(
       'manage_operations',
@@ -160,7 +164,9 @@ async function loadResourceAttachment(
     const output = result.run.output;
     if (!isRecord(output) || !Array.isArray(output.attachments)) return null;
     const raw = output.attachments[ref.index];
-    return isRecord(raw) ? raw : null;
+    return isRecord(raw)
+      ? { attachment: raw, binding: runArtifactBinding(ref.id) }
+      : null;
   }
 
   const result = await executeTool(
@@ -175,7 +181,18 @@ async function loadResourceAttachment(
   );
   if (!isRecord(item) || !Array.isArray(item.attachments)) return null;
   const raw = item.attachments[ref.index];
-  return isRecord(raw) ? raw : null;
+  if (!isRecord(raw) || !authCtx.organizationId) return null;
+  const originId = typeof item.origin_id === 'string' ? item.origin_id : '';
+  if (!originId) return null;
+  return {
+    attachment: raw,
+    binding: eventArtifactBinding({
+      organizationId: authCtx.organizationId,
+      connectionId: positiveInteger(item.connection_id),
+      feedId: positiveInteger(item.feed_id),
+      originId,
+    }),
+  };
 }
 
 /**
@@ -199,13 +216,16 @@ export async function readMcpAttachmentResource(
   const ref = parseAttachmentUri(uri);
   if (!ref) return null;
 
-  const attachment = await loadResourceAttachment(ref, env, authCtx);
-  if (!attachment || typeof attachment.artifact_id !== 'string') {
+  const loaded = await loadResourceAttachment(ref, env, authCtx);
+  const attachment = loaded?.attachment;
+  if (!loaded || !attachment || typeof attachment.artifact_id !== 'string') {
     throw new Error(`Unknown resource: ${uri}`);
   }
 
   const artifactStore = new ArtifactStore();
-  const stored = await artifactStore.read(attachment.artifact_id);
+  const stored = await artifactStore.read(attachment.artifact_id, {
+    binding: loaded.binding,
+  });
   if (!stored) throw new Error(`Unknown resource: ${uri}`);
   if (stored.metadata.size > MAX_MCP_RESOURCE_BYTES) {
     throw new Error(

--- a/packages/server/src/tools/mcp-result-content.ts
+++ b/packages/server/src/tools/mcp-result-content.ts
@@ -1,0 +1,32 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const MCP_RESULT_CONTENT = Symbol('lobu.mcp-result-content');
+
+export type McpResultContentBlock = CallToolResult['content'][number];
+
+type ResultWithMcpContent = {
+  [MCP_RESULT_CONTENT]?: McpResultContentBlock[];
+};
+
+/**
+ * Attach host-only MCP content blocks without making them part of the tool's
+ * structured result, formatted text, audit payload, or output-schema contract.
+ */
+export function attachMcpResultContent<T extends object>(
+  result: T,
+  content: McpResultContentBlock[]
+): T {
+  if (content.length === 0) return result;
+  Object.defineProperty(result, MCP_RESULT_CONTENT, {
+    value: content,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return result;
+}
+
+export function getMcpResultContent(result: unknown): McpResultContentBlock[] | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  return (result as ResultWithMcpContent)[MCP_RESULT_CONTENT];
+}

--- a/packages/server/src/tools/mcp-result-content.ts
+++ b/packages/server/src/tools/mcp-result-content.ts
@@ -2,7 +2,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 const MCP_RESULT_CONTENT = Symbol('lobu.mcp-result-content');
 
-export type McpResultContentBlock = CallToolResult['content'][number];
+type McpResultContentBlock = CallToolResult['content'][number];
 
 type ResultWithMcpContent = {
   [MCP_RESULT_CONTENT]?: McpResultContentBlock[];

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -8,6 +8,8 @@ import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
 import { MAX_SCRIPT_TIMEOUT_MS, runScript } from "../sandbox/run-script";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
+import { mcpResourceLinksForSdkReturnValue } from "../mcp-media-resources";
+import { attachMcpResultContent } from "./mcp-result-content";
 import { attachMcpResultMeta } from "./mcp-result-meta";
 
 const SCRIPT_FIELDS = {
@@ -387,6 +389,8 @@ async function runSandbox(
     // never appear under dry_run:false.
     dry_run: dryRun,
   };
+  const resourceLinks = mcpResourceLinksForSdkReturnValue(result.returnValue);
+  const mcpOutput = attachMcpResultContent(output, resourceLinks);
   const challengeRequestUrl = ctx.requestUrl ?? ctx.baseUrl;
   // Only a failed run carries the challenge: the MCP handler flips any result
   // holding one to isError, and a script that caught the denial and still
@@ -398,7 +402,7 @@ async function runSandbox(
     (ctx.tokenType === "oauth" || ctx.tokenType === "pat") &&
     challengeRequestUrl
   ) {
-    return attachMcpResultMeta(output, {
+    return attachMcpResultMeta(mcpOutput, {
       "mcp/www_authenticate": [
         buildMcpBearerChallenge(challengeRequestUrl, {
           error: "insufficient_scope",
@@ -409,7 +413,7 @@ async function runSandbox(
       ],
     });
   }
-  return output;
+  return mcpOutput;
 }
 
 export const runSdkScript = withValidatedArgs(

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -2,11 +2,12 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ArtifactStore,
   runArtifactBinding,
 } from '../../gateway/files/artifact-store';
+import * as lobuGateway from '../../lobu/gateway';
 import {
   deleteMaterializedArtifacts,
   materializeActionOutputAttachments,
@@ -23,9 +24,13 @@ describe('materializeActionOutputAttachments', () => {
       '12345678901234567890123456789012'
     ).toString('base64');
     artifactStore = new ArtifactStore(artifactsDir);
+    vi.spyOn(lobuGateway, 'getLobuCoreServices').mockReturnValue({
+      getArtifactStore: () => artifactStore,
+    });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
     else process.env.ENCRYPTION_KEY = previousEncryptionKey;
     rmSync(artifactsDir, { recursive: true, force: true });
@@ -46,8 +51,7 @@ describe('materializeActionOutputAttachments', () => {
             size_bytes: bytes.length,
           },
         ],
-      },
-      artifactStore
+      }
     );
 
     expect(output.asset_local_id).toBe('photo-123');
@@ -71,6 +75,7 @@ describe('materializeActionOutputAttachments', () => {
     expect(stored).toBeTruthy();
     expect(await readFile(stored!.filePath)).toEqual(bytes);
   });
+
   it('deletes partial publishes when a later attachment publish fails', async () => {
     let publishCalls = 0;
     let firstArtifactId: string | undefined;
@@ -84,6 +89,9 @@ describe('materializeActionOutputAttachments', () => {
       },
       delete: (artifactId: string) => artifactStore.delete(artifactId),
     };
+    vi.mocked(lobuGateway.getLobuCoreServices).mockReturnValue({
+      getArtifactStore: () => flakyStore,
+    });
 
     await expect(
       materializeActionOutputAttachments(
@@ -103,8 +111,7 @@ describe('materializeActionOutputAttachments', () => {
               data: Buffer.from('second').toString('base64'),
             },
           ],
-        },
-        flakyStore
+        }
       )
     ).rejects.toThrow('second publish failed');
 
@@ -124,14 +131,12 @@ describe('materializeActionOutputAttachments', () => {
             data: Buffer.from('abandoned').toString('base64'),
           },
         ],
-      },
-      artifactStore
+      }
     );
     expect(publishedArtifactIds).toHaveLength(1);
     expect(await artifactStore.read(publishedArtifactIds[0])).toBeTruthy();
 
-    await deleteMaterializedArtifacts(publishedArtifactIds, artifactStore);
+    await deleteMaterializedArtifacts(publishedArtifactIds);
     expect(await artifactStore.read(publishedArtifactIds[0])).toBeNull();
   });
-
 });

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -3,8 +3,14 @@ import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ArtifactStore } from '../../gateway/files/artifact-store';
-import { materializeActionOutputAttachments } from '../inline-attachments';
+import {
+  ArtifactStore,
+  runArtifactBinding,
+} from '../../gateway/files/artifact-store';
+import {
+  deleteMaterializedArtifacts,
+  materializeActionOutputAttachments,
+} from '../inline-attachments';
 
 describe('materializeActionOutputAttachments', () => {
   let artifactsDir: string;
@@ -27,7 +33,7 @@ describe('materializeActionOutputAttachments', () => {
 
   it('reuses connector attachment materialization for device action media', async () => {
     const bytes = Buffer.from('device-photo-bytes');
-    const output = await materializeActionOutputAttachments(
+    const { output, publishedArtifactIds } = await materializeActionOutputAttachments(
       42,
       {
         asset_local_id: 'photo-123',
@@ -45,6 +51,7 @@ describe('materializeActionOutputAttachments', () => {
     );
 
     expect(output.asset_local_id).toBe('photo-123');
+    expect(publishedArtifactIds).toHaveLength(1);
     const attachment = (output.attachments as Array<Record<string, unknown>>)[0];
     expect(attachment).toEqual(
       expect.objectContaining({
@@ -58,8 +65,73 @@ describe('materializeActionOutputAttachments', () => {
     );
     expect(attachment).not.toHaveProperty('data');
 
-    const stored = await artifactStore.read(String(attachment.artifact_id));
+    const stored = await artifactStore.read(String(attachment.artifact_id), {
+      binding: runArtifactBinding(42),
+    });
     expect(stored).toBeTruthy();
     expect(await readFile(stored!.filePath)).toEqual(bytes);
   });
+  it('deletes partial publishes when a later attachment publish fails', async () => {
+    let publishCalls = 0;
+    let firstArtifactId: string | undefined;
+    const flakyStore = {
+      publish: async (params: Parameters<ArtifactStore['publish']>[0]) => {
+        publishCalls += 1;
+        if (publishCalls === 2) throw new Error('second publish failed');
+        const published = await artifactStore.publish(params);
+        firstArtifactId = published.artifactId;
+        return published;
+      },
+      delete: (artifactId: string) => artifactStore.delete(artifactId),
+    };
+
+    await expect(
+      materializeActionOutputAttachments(
+        77,
+        {
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'first.jpg',
+              mime_type: 'image/jpeg',
+              data: Buffer.from('first').toString('base64'),
+            },
+            {
+              kind: 'image',
+              filename: 'second.jpg',
+              mime_type: 'image/jpeg',
+              data: Buffer.from('second').toString('base64'),
+            },
+          ],
+        },
+        flakyStore
+      )
+    ).rejects.toThrow('second publish failed');
+
+    expect(firstArtifactId).toBeTruthy();
+    expect(await artifactStore.read(firstArtifactId!)).toBeNull();
+  });
+
+  it('deletes materialized action artifacts when finalization is abandoned', async () => {
+    const { publishedArtifactIds } = await materializeActionOutputAttachments(
+      88,
+      {
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'abandoned.jpg',
+            mime_type: 'image/jpeg',
+            data: Buffer.from('abandoned').toString('base64'),
+          },
+        ],
+      },
+      artifactStore
+    );
+    expect(publishedArtifactIds).toHaveLength(1);
+    expect(await artifactStore.read(publishedArtifactIds[0])).toBeTruthy();
+
+    await deleteMaterializedArtifacts(publishedArtifactIds, artifactStore);
+    expect(await artifactStore.read(publishedArtifactIds[0])).toBeNull();
+  });
+
 });

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ArtifactStore } from '../../gateway/files/artifact-store';
+import { materializeActionOutputAttachments } from '../inline-attachments';
+
+describe('materializeActionOutputAttachments', () => {
+  let artifactsDir: string;
+  let artifactStore: ArtifactStore;
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    artifactsDir = mkdtempSync(join(tmpdir(), 'lobu-action-attachments-'));
+    process.env.ENCRYPTION_KEY = Buffer.from(
+      '12345678901234567890123456789012'
+    ).toString('base64');
+    artifactStore = new ArtifactStore(artifactsDir);
+  });
+
+  afterEach(() => {
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    rmSync(artifactsDir, { recursive: true, force: true });
+  });
+
+  it('reuses connector attachment materialization for device action media', async () => {
+    const bytes = Buffer.from('device-photo-bytes');
+    const output = await materializeActionOutputAttachments(
+      42,
+      {
+        asset_local_id: 'photo-123',
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'photo.jpg',
+            mime_type: 'image/jpeg',
+            data: bytes.toString('base64'),
+            size_bytes: bytes.length,
+          },
+        ],
+      },
+      artifactStore
+    );
+
+    expect(output.asset_local_id).toBe('photo-123');
+    const attachment = (output.attachments as Array<Record<string, unknown>>)[0];
+    expect(attachment).toEqual(
+      expect.objectContaining({
+        kind: 'image',
+        filename: 'photo.jpg',
+        mime_type: 'image/jpeg',
+        artifact_id: expect.any(String),
+        download_url: expect.any(String),
+        size_bytes: bytes.length,
+      })
+    );
+    expect(attachment).not.toHaveProperty('data');
+
+    const stored = await artifactStore.read(String(attachment.artifact_id));
+    expect(stored).toBeTruthy();
+    expect(await readFile(stored!.filePath)).toEqual(bytes);
+  });
+});

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -89,7 +89,6 @@ function publicGatewayUrl(): string {
  */
 export async function materializeInlineAttachments<T extends StreamItemLike>(
   items: T[],
-  artifactStoreOverride?: Pick<ArtifactStore, "publish" | "delete">,
   bindingForItem?: (item: T) => string | undefined
 ): Promise<{
   items: T[];
@@ -97,7 +96,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
   publishedArtifactIds: string[];
 }> {
   const coreServices = getLobuCoreServices();
-  const artifactStore = artifactStoreOverride ?? coreServices?.getArtifactStore?.();
+  const artifactStore = coreServices?.getArtifactStore?.();
   if (!artifactStore) {
     return { items, pendingTranscriptions: [], publishedArtifactIds: [] };
   }
@@ -198,8 +197,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
 /** Materialize connector-style attachments returned by a device action. */
 export async function materializeActionOutputAttachments(
   runId: number,
-  actionOutput: Record<string, unknown>,
-  artifactStoreOverride?: Pick<ArtifactStore, "publish" | "delete">
+  actionOutput: Record<string, unknown>
 ): Promise<{
   output: Record<string, unknown>;
   publishedArtifactIds: string[];
@@ -209,7 +207,6 @@ export async function materializeActionOutputAttachments(
   }
   const { items, publishedArtifactIds } = await materializeInlineAttachments(
     [{ id: `action:${runId}`, attachments: actionOutput.attachments }],
-    artifactStoreOverride,
     () => runArtifactBinding(runId)
   );
   return {
@@ -218,13 +215,10 @@ export async function materializeActionOutputAttachments(
   };
 }
 
-export async function deleteMaterializedArtifacts(
-  artifactIds: string[],
-  artifactStoreOverride?: Pick<ArtifactStore, "delete">
-): Promise<void> {
+export async function deleteMaterializedArtifacts(artifactIds: string[]): Promise<void> {
   if (artifactIds.length === 0) return;
   const coreServices = getLobuCoreServices();
-  const artifactStore = artifactStoreOverride ?? coreServices?.getArtifactStore?.();
+  const artifactStore = coreServices?.getArtifactStore?.();
   if (!artifactStore) return;
   const results = await Promise.allSettled(
     artifactIds.map((artifactId) => artifactStore.delete(artifactId))

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -23,6 +23,7 @@
 import { readFile } from "node:fs/promises";
 import { getDb } from "../db/client";
 import { getLobuCoreServices } from "../lobu/gateway";
+import type { ArtifactStore } from "../gateway/files/artifact-store";
 import { resolvePublicGatewayUrl } from "./public-origin";
 import { insertEvent } from "./insert-event";
 import logger from "./logger";
@@ -84,10 +85,11 @@ function publicGatewayUrl(): string {
  * an existing artifact).
  */
 export async function materializeInlineAttachments<T extends StreamItemLike>(
-  items: T[]
+  items: T[],
+  artifactStoreOverride?: Pick<ArtifactStore, "publish">
 ): Promise<{ items: T[]; pendingTranscriptions: AudioTranscriptionPending[] }> {
   const coreServices = getLobuCoreServices();
-  const artifactStore = coreServices?.getArtifactStore?.();
+  const artifactStore = artifactStoreOverride ?? coreServices?.getArtifactStore?.();
   if (!artifactStore) {
     return { items, pendingTranscriptions: [] };
   }
@@ -172,6 +174,20 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
   }
 
   return { items: out, pendingTranscriptions };
+}
+
+/** Materialize connector-style attachments returned by a device action. */
+export async function materializeActionOutputAttachments(
+  runId: number,
+  actionOutput: Record<string, unknown>,
+  artifactStoreOverride?: Pick<ArtifactStore, "publish">
+): Promise<Record<string, unknown>> {
+  if (!Array.isArray(actionOutput.attachments)) return actionOutput;
+  const { items } = await materializeInlineAttachments(
+    [{ id: `action:${runId}`, attachments: actionOutput.attachments }],
+    artifactStoreOverride
+  );
+  return { ...actionOutput, attachments: items[0]?.attachments ?? [] };
 }
 
 function inferKindFromMime(mime: string): string {

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -23,7 +23,10 @@
 import { readFile } from "node:fs/promises";
 import { getDb } from "../db/client";
 import { getLobuCoreServices } from "../lobu/gateway";
-import type { ArtifactStore } from "../gateway/files/artifact-store";
+import {
+  runArtifactBinding,
+  type ArtifactStore,
+} from "../gateway/files/artifact-store";
 import { resolvePublicGatewayUrl } from "./public-origin";
 import { insertEvent } from "./insert-event";
 import logger from "./logger";
@@ -86,16 +89,22 @@ function publicGatewayUrl(): string {
  */
 export async function materializeInlineAttachments<T extends StreamItemLike>(
   items: T[],
-  artifactStoreOverride?: Pick<ArtifactStore, "publish">
-): Promise<{ items: T[]; pendingTranscriptions: AudioTranscriptionPending[] }> {
+  artifactStoreOverride?: Pick<ArtifactStore, "publish" | "delete">,
+  bindingForItem?: (item: T) => string | undefined
+): Promise<{
+  items: T[];
+  pendingTranscriptions: AudioTranscriptionPending[];
+  publishedArtifactIds: string[];
+}> {
   const coreServices = getLobuCoreServices();
   const artifactStore = artifactStoreOverride ?? coreServices?.getArtifactStore?.();
   if (!artifactStore) {
-    return { items, pendingTranscriptions: [] };
+    return { items, pendingTranscriptions: [], publishedArtifactIds: [] };
   }
 
   const baseUrl = publicGatewayUrl();
   const pendingTranscriptions: AudioTranscriptionPending[] = [];
+  const publishedArtifactIds: string[] = [];
   const out: T[] = [];
 
   for (const item of items) {
@@ -142,12 +151,22 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
         continue;
       }
 
-      const published = await artifactStore.publish({
-        buffer,
-        filename,
-        contentType: mime,
-        publicGatewayUrl: baseUrl,
-      });
+      let published: Awaited<ReturnType<ArtifactStore["publish"]>>;
+      try {
+        published = await artifactStore.publish({
+          buffer,
+          filename,
+          contentType: mime,
+          publicGatewayUrl: baseUrl,
+          binding: bindingForItem?.(item),
+        });
+        publishedArtifactIds.push(published.artifactId);
+      } catch (error) {
+        await Promise.allSettled(
+          publishedArtifactIds.map((artifactId) => artifactStore.delete(artifactId))
+        );
+        throw error;
+      }
 
       const materialized: MaterializedAttachment = {
         kind,
@@ -173,21 +192,50 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
     out.push({ ...item, attachments: rewritten });
   }
 
-  return { items: out, pendingTranscriptions };
+  return { items: out, pendingTranscriptions, publishedArtifactIds };
 }
 
 /** Materialize connector-style attachments returned by a device action. */
 export async function materializeActionOutputAttachments(
   runId: number,
   actionOutput: Record<string, unknown>,
-  artifactStoreOverride?: Pick<ArtifactStore, "publish">
-): Promise<Record<string, unknown>> {
-  if (!Array.isArray(actionOutput.attachments)) return actionOutput;
-  const { items } = await materializeInlineAttachments(
+  artifactStoreOverride?: Pick<ArtifactStore, "publish" | "delete">
+): Promise<{
+  output: Record<string, unknown>;
+  publishedArtifactIds: string[];
+}> {
+  if (!Array.isArray(actionOutput.attachments)) {
+    return { output: actionOutput, publishedArtifactIds: [] };
+  }
+  const { items, publishedArtifactIds } = await materializeInlineAttachments(
     [{ id: `action:${runId}`, attachments: actionOutput.attachments }],
-    artifactStoreOverride
+    artifactStoreOverride,
+    () => runArtifactBinding(runId)
   );
-  return { ...actionOutput, attachments: items[0]?.attachments ?? [] };
+  return {
+    output: { ...actionOutput, attachments: items[0]?.attachments ?? [] },
+    publishedArtifactIds,
+  };
+}
+
+export async function deleteMaterializedArtifacts(
+  artifactIds: string[],
+  artifactStoreOverride?: Pick<ArtifactStore, "delete">
+): Promise<void> {
+  if (artifactIds.length === 0) return;
+  const coreServices = getLobuCoreServices();
+  const artifactStore = artifactStoreOverride ?? coreServices?.getArtifactStore?.();
+  if (!artifactStore) return;
+  const results = await Promise.allSettled(
+    artifactIds.map((artifactId) => artifactStore.delete(artifactId))
+  );
+  const failed = results.filter((result) => result.status === "rejected").length;
+  if (failed > 0) {
+    logger.warn(
+      { artifact_count: artifactIds.length, failed },
+      "[inline-attachments] failed to delete some uncommitted artifacts"
+    );
+  }
 }
 
 function inferKindFromMime(mime: string): string {

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -33,6 +33,7 @@ import { materializeConnectorAutomationSignal } from "../automations/connector-s
 import { feedBackoff } from "../connectors/feed-backoff";
 import { maybeEmitFeedAutoPausedAfterFailure } from "../automations/platform-events";
 import { getDb, parsePgNumberArray } from "../db/client";
+import { eventArtifactBinding } from "../gateway/files/artifact-store";
 import { emit } from "../events/emitter";
 import { parseJsonBody } from "../gateway/routes/shared/helpers";
 import type { Env } from "../index";
@@ -51,6 +52,7 @@ import { applyEventAttributions } from "../utils/entity-link-upsert";
 import { errorMessage } from "../utils/errors";
 import { validateConnectorEventSemanticType } from "../utils/event-kind-validation";
 import {
+	deleteMaterializedArtifacts,
 	materializeActionOutputAttachments,
 	materializeInlineAttachments,
 	triggerAudioTranscriptions,
@@ -311,7 +313,17 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			>["pendingTranscriptions"] = [];
 			if (!isDry) {
 				const { items: materializedItems, pendingTranscriptions: pending } =
-					await materializeInlineAttachments(batch.items);
+					await materializeInlineAttachments(
+						batch.items,
+						undefined,
+						(item) =>
+							eventArtifactBinding({
+								organizationId: run.organization_id,
+								connectionId: run.connection_id,
+								feedId: run.feed_id,
+								originId: item.id,
+							})
+					);
 				batch.items = materializedItems as typeof batch.items;
 				pendingTranscriptions = pending;
 			}
@@ -1899,6 +1911,7 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
  * Worker signals action run completion (for async high-risk actions).
  */
 export async function completeActionRun(c: Context<{ Bindings: Env }>) {
+	let publishedActionArtifactIds: string[] = [];
 	try {
 		const req = await c.req.json<CompleteActionRequest>();
 
@@ -1909,9 +1922,12 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
-		const actionOutput = req.action_output
+		const materializedActionOutput = req.action_output
 			? await materializeActionOutputAttachments(req.run_id, req.action_output)
 			: undefined;
+		const actionOutput = materializedActionOutput?.output;
+		publishedActionArtifactIds =
+			materializedActionOutput?.publishedArtifactIds ?? [];
 
 		// Atomic terminal-state transition with the shared F2 guard (see
 		// finalizeRun) AND, for approval-gated runs, the card supersede in ONE
@@ -1966,6 +1982,8 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 			return rows;
 		});
 		if (updatedRuns.length === 0) {
+			await deleteMaterializedArtifacts(publishedActionArtifactIds);
+			publishedActionArtifactIds = [];
 			// Either the run was already finalized (timeout race) or the
 			// worker isn't the claimant. authorizeRunForWorker already gated
 			// ownership, so this is almost always the timeout race; return
@@ -1981,6 +1999,8 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 			return c.json({ success: false, reason: "already_finalized" });
 		}
 
+		// The transaction committed; from here these artifacts are durable run output.
+		publishedActionArtifactIds = [];
 		const organizationId = (updatedRuns[0] as any)?.organization_id;
 
 		if (organizationId) {
@@ -1993,6 +2013,7 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		);
 		return c.json({ success: true });
 	} catch (err: unknown) {
+		await deleteMaterializedArtifacts(publishedActionArtifactIds);
 		logger.error({ error: errorMessage(err) }, "[completeActionRun] Error");
 		return c.json({ error: errorMessage(err) }, 500);
 	}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -51,6 +51,7 @@ import { applyEventAttributions } from "../utils/entity-link-upsert";
 import { errorMessage } from "../utils/errors";
 import { validateConnectorEventSemanticType } from "../utils/event-kind-validation";
 import {
+	materializeActionOutputAttachments,
 	materializeInlineAttachments,
 	triggerAudioTranscriptions,
 } from "../utils/inline-attachments";
@@ -1908,6 +1909,9 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
+		const actionOutput = req.action_output
+			? await materializeActionOutputAttachments(req.run_id, req.action_output)
+			: undefined;
 
 		// Atomic terminal-state transition with the shared F2 guard (see
 		// finalizeRun) AND, for approval-gated runs, the card supersede in ONE
@@ -1926,7 +1930,7 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 				workerId: req.worker_id,
 				status: req.status === "success" ? "completed" : "failed",
 				extraSet: tx`,
-					action_output = ${req.action_output ? tx.json(req.action_output) : null},
+					action_output = ${actionOutput ? tx.json(actionOutput) : null},
 					error_message = ${req.error_message ?? null}`,
 				returning: tx`organization_id, action_key, approval_status`,
 			});
@@ -1948,7 +1952,7 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 						? `Action completed: ${actionKey}`
 						: `Action failed: ${actionKey}${req.error_message ? ` — ${req.error_message}` : ""}`,
 					req.status === "success"
-						? { action_output: req.action_output }
+						? { action_output: actionOutput }
 						: { error_message: req.error_message },
 					null,
 					tx,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -298,35 +298,10 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		// applyEventAttributions opens one bounded transaction for this batch's
 		// entity attribution writes. The dry path passes a tx that is rolled back.
 		const ingestBatch = async (db: DbClient) => {
-			// Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
-			// come over the wire as base64 in `attachment.data`. Materialize each into
-			// the ArtifactStore before the row hits events.attachments — the events
-			// table is not a binary store. Audio attachments are queued for async
-			// transcription after insert.
-			//
-			// ESCAPES THE TX: this uploads a blob to the ArtifactStore, which no
-			// Postgres rollback can retract. Because the blob is written before the
-			// row that would reference it, a dry run doing this would leave an
-			// orphaned artifact behind — storage that quietly accumulates.
+			// Audio attachments are queued only after their event insert commits.
 			let pendingTranscriptions: Awaited<
 				ReturnType<typeof materializeInlineAttachments>
 			>["pendingTranscriptions"] = [];
-			if (!isDry) {
-				const { items: materializedItems, pendingTranscriptions: pending } =
-					await materializeInlineAttachments(
-						batch.items,
-						undefined,
-						(item) =>
-							eventArtifactBinding({
-								organizationId: run.organization_id,
-								connectionId: run.connection_id,
-								feedId: run.feed_id,
-								originId: item.id,
-							})
-					);
-				batch.items = materializedItems as typeof batch.items;
-				pendingTranscriptions = pending;
-			}
 
 			// Resolve or create entities declared via eventKinds[kind].attributions
 			// before inserting events. One query per (entityType, matchField) per
@@ -375,7 +350,9 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 				);
 			}
 
-			for (const item of batch.items) {
+			for (let item of batch.items) {
+				let publishedArtifactIds: string[] = [];
+				let artifactCommitted = false;
 			try {
 				const itemOriginType = item.origin_type ?? null;
 				const itemSemanticType =
@@ -421,6 +398,26 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 						"[stream] Skipping event with empty payload_text and title"
 					);
 					continue;
+				}
+
+				let itemPendingTranscriptions: typeof pendingTranscriptions = [];
+				if (!isDry) {
+					// ESCAPES THE TX: publish only after validation, immediately before
+					// the event insert. The finally block deletes this item's artifacts
+					// unless insertEvent wrote a row that references them.
+					const materialized = await materializeInlineAttachments(
+						[item],
+						() =>
+							eventArtifactBinding({
+								organizationId: run.organization_id,
+								connectionId: run.connection_id,
+								feedId: run.feed_id,
+								originId: item.id,
+							})
+					);
+					item = materialized.items[0] as typeof item;
+					itemPendingTranscriptions = materialized.pendingTranscriptions;
+					publishedArtifactIds = materialized.publishedArtifactIds;
 				}
 
 				const activations: AutomationActivationResult[] = [];
@@ -512,6 +509,13 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 						},
 					}
 				);
+				// `unchanged` reuses the pre-existing row, which still points at the
+				// artifacts published by an earlier sync — the ones we just published
+				// were never referenced by any row, so the finally block reclaims them.
+				if (inserted.change !== "unchanged") {
+					artifactCommitted = true;
+					pendingTranscriptions.push(...itemPendingTranscriptions);
+				}
 				// ESCAPES THE TX: this dispatches real Automation runs to the worker
 				// fleet. The activation ROWS roll back with the tx, but a dispatched
 				// agent run has already left the database — it would run against, and
@@ -559,12 +563,16 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			} catch (err) {
 				console.error("[stream] Insert failed for item", item.id, ":", err);
 				throw err;
+			} finally {
+				if (!artifactCommitted) {
+					await deleteMaterializedArtifacts(publishedArtifactIds);
+				}
 			}
 		}
 
 			// ESCAPES THE TX: transcription is an external, paid API call, and it
 			// is fired detached so nothing awaits it. `pendingTranscriptions` is
-			// already empty on a dry run (nothing was materialized above), but the
+			// already empty on a dry run (nothing was materialized), but the
 			// guard stays so this cannot start costing money if materialization
 			// ever grows a dry path.
 			if (!isDry) {
@@ -1983,7 +1991,6 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		});
 		if (updatedRuns.length === 0) {
 			await deleteMaterializedArtifacts(publishedActionArtifactIds);
-			publishedActionArtifactIds = [];
 			// Either the run was already finalized (timeout race) or the
 			// worker isn't the claimant. authorizeRunForWorker already gated
 			// ownership, so this is almost always the timeout race; return


### PR DESCRIPTION
## Summary
- expose durable event and operation attachments as native MCP resource links
- serve binary attachment data through permission-aware `resources/read`
- materialize device action attachments through the existing connector attachment pipeline

## Why
Lobu already stores first-class media attachments and its internal agents can read images, but the MCP transport flattened tool results to text plus structured JSON. External MCP clients therefore received attachment metadata / expiring signed URLs rather than a stable MCP-native media path.

This adds stable Lobu resource URIs such as `lobu://event/<id>/attachment/<index>` and `lobu://run/<id>/attachment/<index>`. Resource reads reuse Lobu's canonical `read_knowledge` and `manage_operations/get_run` authorization paths before reading the existing ArtifactStore, so the URI itself does not widen access.

Device actions now reuse `materializeInlineAttachments()` before persisting `action_output`. A device connector such as Apple Photos can return the existing connector attachment shape and automatically get an ArtifactStore-backed result that MCP clients can read without adding a separate media protocol.

The resource mechanism is MIME-generic, so it also applies to video, audio, and files. MCP blob reads are capped at 20 MB to avoid unbounded inline responses.

## Tests
- `make pre-pr`
- `bunx vitest run src/__tests__/integration/operation-device-routing-lifecycle.test.ts src/__tests__/integration/mcp/mcp-media-resources.test.ts src/utils/__tests__/inline-attachments.test.ts --reporter=dot`
- integration coverage includes durable event media, real `client.operations.getRun()` media, binary `resources/read`, and cross-workspace denial

## Follow-up
Apple Photos still needs its device-side read action to resolve `asset_local_id` into a vision-sized attachment. This PR provides the reusable server/MCP path that action can use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP tool results now expose media attachments as downloadable resource links.
  - Authorized attachment resources can be read as base64-encoded content.
  - Action-output attachments are stored with metadata and download access.
  - Attachment storage now supports secure association with runs and events, plus cleanup.

- **Bug Fixes**
  - Unauthorized, missing, invalid, or oversized media resources are rejected safely.
  - Failed attachment publishing no longer leaves abandoned artifacts behind.

- **Tests**
  - Added coverage for secure resource access, encrypted storage, attachment links, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->