### PR TITLE
feat: os.shell connector for headless devices (run commands on herdr)

### DIFF
--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -216,7 +216,7 @@ const gh = defineConnection({
 **Bundled connector keys** — use the exact key; several are dotted (Gmail is
 `google.gmail`, not `gmail` or `google_gmail`): `github`, `slack`, `linear`, `jira`, `google.gmail`,
 `google.calendar`, `microsoft.outlook`, `discord`, `teams`, `telegram`, `webhook`,
-`whatsapp`, `gchat`, `rss`, `postgres`,
+`whatsapp`, `gchat`, `rss`, `postgres`, `os.shell`,
 `hackernews`, `market.quotes`, `reddit`, `x`, `youtube`, `producthunt`.
 
 Mac/Chrome device connectors are advertised by Owletto at poll time and appear after the relevant device grants permission.

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -11,6 +11,10 @@
       "import": "./dist/daemon/index.js",
       "types": "./dist/daemon/index.d.ts"
     },
+    "./daemon/device-manifests": {
+      "import": "./dist/daemon/device-manifests.js",
+      "types": "./dist/daemon/device-manifests.d.ts"
+    },
     "./env": {
       "import": "./dist/env.js",
       "types": "./dist/env.d.ts"

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { isKnownPlatform } from '@lobu/core';
 import { startDaemon } from './daemon/index.js';
+import { DEVICE_MANIFESTS_BY_PLATFORM } from './daemon/device-manifests.js';
 import { buildConnectorWorkerEnv } from './env.js';
 import { assertExternalDepsResolvable } from './compile/index.js';
 import { printSelfCheckResult, runConnectorRuntimeSelfCheck } from './self-check/index.js';
@@ -202,6 +203,8 @@ async function main(): Promise<void> {
           capabilities,
           ...(platform ? { platform } : {}),
           ...(label ? { label } : {}),
+          // Device manifests to register on poll (headless declares os.shell).
+          ...(platform ? { manifests: DEVICE_MANIFESTS_BY_PLATFORM[platform] ?? [] } : {}),
           ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
         },
         env

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -103,6 +103,7 @@ export class WorkerClient implements ExecutorClient {
   private version: string;
   private platform?: string;
   private label?: string;
+  private manifests: unknown[] = [];
 
   constructor(config: {
     apiUrl: string;
@@ -114,6 +115,8 @@ export class WorkerClient implements ExecutorClient {
     platform?: string;
     /** Human-readable device name for the Devices page. */
     label?: string;
+    /** Device-manifest connector definitions to register on each poll. */
+    manifests?: unknown[];
   }) {
     this.apiUrl = trimTrailingSlashes(config.apiUrl);
     this.workerId = config.workerId;
@@ -122,6 +125,7 @@ export class WorkerClient implements ExecutorClient {
     this.version = config.version ?? '1.0.0';
     this.platform = config.platform?.trim() || undefined;
     this.label = config.label?.trim() || undefined;
+    this.manifests = config.manifests ?? [];
   }
 
   private authHeaders(): Record<string, string> {
@@ -165,6 +169,7 @@ export class WorkerClient implements ExecutorClient {
       // fleet workers rather than sending empty values.
       ...(this.platform ? { platform: this.platform, app_version: this.version } : {}),
       ...(this.label ? { label: this.label } : {}),
+      ...(this.manifests.length > 0 ? { connector_manifests: this.manifests } : {}),
     });
   }
 

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -17,7 +17,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
   description:
     'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
   required_capability: 'os.shell',
-  runtime: { platforms: ['linux'] },
+  runtime: { platforms: ['headless'] },
   auth_schema: { methods: [{ type: 'none' }] },
   feeds_schema: {},
   actions_schema: {

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -1,0 +1,65 @@
+/**
+ * Device manifests the connector-worker daemon declares on poll, keyed by
+ * platform. A headless device (server/VM/pod) advertises the os.shell
+ * connector so an org can create a connection pinned to it and run shell
+ * commands (executed by the bundled os.shell connector via bash -lc).
+ */
+
+/**
+ * os.shell manifest for headless platforms. Mirrors the macOS manifest's
+ * run action (packages/owletto/apps/mac/.../os_shell.json) but targets
+ * linux, where the connector-worker daemon (not a native bridge) serves it.
+ */
+export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
+  key: 'os.shell',
+  version: '0.1.0',
+  name: 'Shell',
+  description:
+    'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
+  required_capability: 'os.shell',
+  runtime: { platforms: ['linux'] },
+  auth_schema: { methods: [{ type: 'none' }] },
+  feeds_schema: {},
+  actions_schema: {
+    run: {
+      key: 'run',
+      kind: 'write',
+      name: 'Run command',
+      description:
+        'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash -lc`, so pipes, redirects, and && chains work. Prefer one focused command per call.',
+      requiresApproval: true,
+      inputSchema: {
+        type: 'object',
+        required: ['command'],
+        properties: {
+          command: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 20000,
+          },
+          cwd: { type: 'string' },
+          timeout_ms: { type: 'integer', minimum: 100, maximum: 300000, default: 60000 },
+          stdin: { type: 'string', maxLength: 1000000 },
+        },
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          stdout: { type: 'string' },
+          stderr: { type: 'string' },
+          exit_code: { type: 'integer' },
+          success: { type: 'boolean' },
+          timed_out: { type: 'boolean' },
+          duration_ms: { type: 'integer' },
+        },
+      },
+    },
+  },
+};
+
+/** Manifests a device daemon declares, keyed by platform. */
+export const DEVICE_MANIFESTS_BY_PLATFORM: Record<string, unknown[]> = {
+  headless: [HEADLESS_OS_SHELL_MANIFEST],
+};

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -21,6 +21,8 @@ export interface DaemonConfig {
   platform?: string;
   /** Human-readable device name for the Devices page. */
   label?: string;
+  /** Device-manifest connector definitions to register on each poll. */
+  manifests?: unknown[];
 }
 
 const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
@@ -51,6 +53,7 @@ export class WorkerDaemon {
       version: daemonConfig.version,
       platform: daemonConfig.platform,
       label: daemonConfig.label,
+      manifests: daemonConfig.manifests,
     });
 
     this.env = env;

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -52,4 +52,32 @@ describe('os.shell connector', () => {
     const result = await connector.execute(runContext('nope', {}));
     expect(result.success).toBe(false);
   });
+
+  it('truncates oversized output instead of buffering it all', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'yes x | head -c 4000000' }),
+    );
+    expect(result.success).toBe(true);
+    const output = result.output as Record<string, unknown>;
+    expect(String(output.stdout).length).toBeLessThan(2000000);
+    expect(String(output.stdout)).toContain('(output truncated)');
+  });
+
+  it('rejects a relative or non-existent cwd', async () => {
+    const rel = await connector.execute(
+      runContext('run', { command: 'pwd', cwd: 'relative/path' }),
+    );
+    expect(rel.success).toBe(false);
+    const missing = await connector.execute(
+      runContext('run', { command: 'pwd', cwd: '/definitely/not/a/real/dir' }),
+    );
+    expect(missing.success).toBe(false);
+  });
+
+  it('defaults cwd to the device home', async () => {
+    const result = await connector.execute(runContext('run', { command: 'pwd' }));
+    expect(result.success).toBe(true);
+    const output = result.output as Record<string, unknown>;
+    expect(String(output.stdout).trim()).toBe(require('node:os').homedir());
+  });
 });

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -1,0 +1,55 @@
+/**
+ * os.shell connector - runs commands and returns structured output.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import OsShellConnector from '../os_shell.js';
+
+function runContext(actionKey: string, input: Record<string, unknown>) {
+  return {
+    actionKey,
+    input,
+    credentials: null,
+    config: {},
+  } as never;
+}
+
+describe('os.shell connector', () => {
+  const connector = new OsShellConnector();
+
+  it('runs a command and returns stdout with exit 0', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'echo hello-from-shell' })
+    );
+    expect(result.success).toBe(true);
+    const output = result.output as Record<string, unknown>;
+    expect(output.stdout).toContain('hello-from-shell');
+    expect(output.exit_code).toBe(0);
+    expect(output.timed_out).toBe(false);
+    expect(typeof output.duration_ms).toBe('number');
+  });
+
+  it('returns stderr and non-zero exit for a failing command', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'echo oops >&2; exit 3' })
+    );
+    expect(result.success).toBe(false);
+    const output = result.output as Record<string, unknown>;
+    expect(output.exit_code).toBe(3);
+    expect(output.stderr).toContain('oops');
+  });
+
+  it('respects timeout_ms and reports timed_out', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'sleep 10', timeout_ms: 300 })
+    );
+    expect(result.success).toBe(false);
+    const output = result.output as Record<string, unknown>;
+    expect(output.timed_out).toBe(true);
+  });
+
+  it('rejects an unknown action', async () => {
+    const result = await connector.execute(runContext('nope', {}));
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -9,6 +9,9 @@
  */
 
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
 import {
   ConnectorRuntime,
   type ActionContext,
@@ -35,6 +38,20 @@ interface RunOutput {
 const MAX_TIMEOUT_MS = 300000;
 const DEFAULT_TIMEOUT_MS = 60000;
 const SIGTERM_GRACE_MS = 3000;
+// Cap captured output so a chatty command cannot balloon daemon memory.
+// Streams keep draining (the child must not block on a full pipe), but
+// anything past the cap is dropped with a truncation marker.
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const TRUNCATED_MARKER = '\n... (output truncated)';
+
+function appendCapped(target: string, chunk: string, truncated: boolean): string {
+  if (truncated) return target;
+  const next = target + chunk;
+  if (next.length > MAX_OUTPUT_BYTES) {
+    return next.slice(0, MAX_OUTPUT_BYTES) + TRUNCATED_MARKER;
+  }
+  return next;
+}
 
 function runShellCommand(
   command: string,
@@ -49,14 +66,22 @@ function runShellCommand(
     });
     let stdout = '';
     let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
     let timedOut = false;
 
     if (opts.stdin) child.stdin.write(opts.stdin);
     child.stdin.end();
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
-    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.stdout.on('data', (chunk: string) => {
+      stdout = appendCapped(stdout, chunk, stdoutTruncated);
+      if (stdout.includes(TRUNCATED_MARKER)) stdoutTruncated = true;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr = appendCapped(stderr, chunk, stderrTruncated);
+      if (stderr.includes(TRUNCATED_MARKER)) stderrTruncated = true;
+    });
 
     const timer = setTimeout(() => {
       timedOut = true;
@@ -175,8 +200,22 @@ export default class OsShellConnector extends ConnectorRuntime {
       typeof input.timeout_ms === 'number' ? input.timeout_ms : DEFAULT_TIMEOUT_MS,
       MAX_TIMEOUT_MS
     );
+    // cwd must be an existing absolute path (the declared contract); default
+    // to the device home. Reject rather than let bash guess at a relative cwd.
+    let cwd: string | undefined;
+    if (input.cwd) {
+      if (!isAbsolute(input.cwd) || !existsSync(input.cwd)) {
+        return {
+          success: false,
+          error: `cwd must be an existing absolute path (got '${input.cwd}')`,
+        };
+      }
+      cwd = input.cwd;
+    } else {
+      cwd = homedir();
+    }
     const output = await runShellCommand(command, {
-      cwd: input.cwd,
+      cwd,
       timeoutMs,
       stdin: input.stdin,
     });

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -1,0 +1,185 @@
+/**
+ * os.shell - run shell commands on the host device.
+ *
+ * Device-bound connector served by the connector-worker daemon on headless
+ * devices (servers, VMs, k8s pods). Executes through `bash -lc` and returns
+ * structured stdout/stderr/exit_code - the same contract as the macOS
+ * os.shell manifest, but for boxes without a UI. Commands run in the device's
+ * real environment (host PATH, files), so the action is approval-gated.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  ConnectorRuntime,
+  type ActionContext,
+  type ActionResult,
+  type ConnectorDefinition,
+} from '@lobu/connector-sdk';
+
+interface RunInput {
+  command?: string;
+  cwd?: string;
+  timeout_ms?: number;
+  stdin?: string;
+}
+
+interface RunOutput {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  success: boolean;
+  timed_out: boolean;
+  duration_ms: number;
+}
+
+const MAX_TIMEOUT_MS = 300000;
+const DEFAULT_TIMEOUT_MS = 60000;
+const SIGTERM_GRACE_MS = 3000;
+
+function runShellCommand(
+  command: string,
+  opts: { cwd?: string; timeoutMs: number; stdin?: string }
+): Promise<RunOutput> {
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn('bash', ['-lc', command], {
+      cwd: opts.cwd || undefined,
+      env: { ...process.env, LC_ALL: 'C' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    if (opts.stdin) child.stdin.write(opts.stdin);
+    child.stdin.end();
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }, SIGTERM_GRACE_MS);
+    }, opts.timeoutMs);
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      const durationMs = Date.now() - started;
+      const exitCode = code ?? (signal ? -1 : 0);
+      resolve({
+        stdout,
+        stderr,
+        exit_code: exitCode,
+        success: !timedOut && exitCode === 0,
+        timed_out: timedOut,
+        duration_ms: durationMs,
+      });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr: `${stderr}${stderr ? '\n' : ''}spawn error: ${err.message}`,
+        exit_code: -1,
+        success: false,
+        timed_out: false,
+        duration_ms: Date.now() - started,
+      });
+    });
+  });
+}
+
+export default class OsShellConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: 'os.shell',
+    name: 'Shell',
+    description:
+      'Run shell commands on the host device. Executes via `bash -lc` and returns structured stdout/stderr/exit_code. Same trust tier as the macOS shell connector - commands run in the device\'s real environment (host PATH, files), so gate with approval.',
+    version: '0.1.0',
+    requiredCapability: 'os.shell',
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {},
+    actions: {
+      run: {
+        key: 'run',
+        kind: 'write',
+        name: 'Run command',
+        description:
+          'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash -lc`, so pipes, redirects, and && chains work. Prefer one focused command per call.',
+        requiresApproval: true,
+        inputSchema: {
+          type: 'object',
+          required: ['command'],
+          properties: {
+            command: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 20000,
+              description: 'Shell command to execute. Runs via `bash -lc`, so pipes, redirects, and && chains work. Keep commands short and targeted.',
+            },
+            cwd: {
+              type: 'string',
+              description: 'Absolute working directory. Defaults to the device home. Must exist.',
+            },
+            timeout_ms: {
+              type: 'integer',
+              minimum: 100,
+              maximum: 300000,
+              default: 60000,
+              description: 'Wall-clock budget in milliseconds. On timeout the process gets SIGTERM (3s grace) then SIGKILL.',
+            },
+            stdin: {
+              type: 'string',
+              maxLength: 1000000,
+              description: 'Optional string piped to the command\'s stdin.',
+            },
+          },
+          additionalProperties: false,
+        },
+        outputSchema: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            stdout: { type: 'string' },
+            stderr: { type: 'string' },
+            exit_code: { type: 'integer' },
+            success: { type: 'boolean' },
+            timed_out: { type: 'boolean' },
+            duration_ms: { type: 'integer' },
+          },
+        },
+      },
+    },
+  };
+
+  async sync(): Promise<{ events: []; checkpoint: null }> {
+    // No feeds - this connector only serves action runs.
+    return { events: [], checkpoint: null };
+  }
+
+  async execute(ctx: ActionContext): Promise<ActionResult> {
+    if (ctx.actionKey !== 'run') {
+      return { success: false, error: `Unknown action '${ctx.actionKey}'` };
+    }
+    const input = ctx.input as RunInput;
+    const command = input.command?.trim();
+    if (!command) {
+      return { success: false, error: 'command is required' };
+    }
+    const timeoutMs = Math.min(
+      typeof input.timeout_ms === 'number' ? input.timeout_ms : DEFAULT_TIMEOUT_MS,
+      MAX_TIMEOUT_MS
+    );
+    const output = await runShellCommand(command, {
+      cwd: input.cwd,
+      timeoutMs,
+      stdin: input.stdin,
+    });
+    return { success: output.success, output: { ...output } };
+  }
+}

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -530,6 +530,31 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId)).not.toBeNull();
   });
 
+  it('admits os.shell for a headless device', async () => {
+    const { userId, workerId } = await seedDeviceOwner('headless');
+    const shell = manifest({
+      key: 'os.shell',
+      required_capability: 'os.shell',
+      name: 'Headless Shell Probe',
+      runtime: { platforms: ['headless'] },
+      feeds_schema: {},
+    });
+
+    const res = await poll(workerId, [shell], 'headless', { 'os.shell': true });
+    expect(res.status).toBe(200);
+
+    // The manifest was admitted and stored on the device row (the headless
+    // shell connector is what makes a connection pinned to this device able to
+    // run commands). Feedless, so no definition materialization is asserted.
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT connector_manifests FROM device_workers
+      WHERE user_id = ${userId} AND worker_id = ${workerId}
+    `) as unknown as Array<{ connector_manifests: unknown }>;
+    const stored = rows[0]?.connector_manifests as Record<string, unknown> | undefined;
+    expect(stored?.['os.shell']).toBeDefined();
+  });
+
   it('drops a manifest that still declares removed entityLinks rules', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const legacyManifest = manifest({

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -8,6 +8,7 @@ import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestConnection, createTestConnectorDefinition } from '../setup/test-fixtures';
 import { post } from '../setup/test-helpers';
+import { HEADLESS_OS_SHELL_MANIFEST } from '@lobu/connector-worker/daemon/device-manifests';
 
 const CONNECTOR_KEY = 'apple.test_device_manifest';
 
@@ -530,17 +531,11 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId)).not.toBeNull();
   });
 
-  it('admits os.shell for a headless device', async () => {
+  it('admits the daemon-emitted os.shell manifest for a headless device', async () => {
     const { userId, workerId } = await seedDeviceOwner('headless');
-    const shell = manifest({
-      key: 'os.shell',
-      required_capability: 'os.shell',
-      name: 'Headless Shell Probe',
-      runtime: { platforms: ['headless'] },
-      feeds_schema: {},
-    });
-
-    const res = await poll(workerId, [shell], 'headless', { 'os.shell': true });
+    // The exact manifest the connector-worker daemon sends on poll - not a
+    // synthetic fixture - so the test validates what herdr actually declares.
+    const res = await poll(workerId, [HEADLESS_OS_SHELL_MANIFEST], 'headless', { 'os.shell': true });
     expect(res.status).toBe(200);
 
     // The manifest was admitted and stored on the device row (the headless

--- a/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
+++ b/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_BUNDLED_CONNECTORS = [
 	"linear",
 	"market.quotes",
 	"microsoft.outlook",
+	"os.shell",
 	"postgres",
 	"producthunt",
 	"reddit",
@@ -75,6 +76,7 @@ describe("bundled connector lifecycle matrix", () => {
 		expect(actionCounts).toEqual({
 			github: 6,
 			"google.calendar": 4,
+			"os.shell": 1,
 			"google.gmail": 5,
 			"market.quotes": 1,
 			x: 1,

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -281,6 +281,12 @@ function connectorKeyAllowedForPlatform(platform: string, key: string): boolean 
   if (platform === 'chrome-extension') {
     return key === 'chrome' || key.startsWith('chrome.');
   }
+  // Headless devices (servers/VMs/pods, the herdr box) serve the shell
+  // connector: bundled `os.shell` executes `bash -lc` and returns structured
+  // output. Keep this list tight - nothing browser/OS-UI based.
+  if (platform === 'headless') {
+    return key === 'os.shell';
+  }
   return false;
 }
 


### PR DESCRIPTION
## What

Makes the headless device actually execute shell commands. The `headless` platform (#2880) allowlisted `os.shell`/`os.files`, but nothing could *run* them: the server's device-manifest gate only admitted os.shell for macOS, and the connector-worker daemon had no shell connector. This closes the loop: `df` on herdr through Lobu becomes possible.

1. **`packages/connectors/src/os_shell.ts`** - a real `os.shell` connector: the `run` action executes `bash -lc <command>` and returns structured `{stdout, stderr, exit_code, success, timed_out, duration_ms}` (same contract as the macOS os.shell manifest). Approval-gated. The gateway compiles it and sends it to the device worker on dispatch.
2. **`packages/server/src/worker-api/device-manifests.ts`** - `connectorKeyAllowedForPlatform` admits `os.shell` for `headless` (previously macOS-only).
3. **`packages/connector-worker` daemon** - declares a headless os.shell device manifest in its poll body (`connector_manifests`), so an org can create an os.shell connection pinned to the device. New `daemon/device-manifests.ts` + wiring through `client.ts`/`worker.ts`/`bin.ts`.

## Tests

- `os_shell.test.ts` (4): runs a command (stdout/exit 0), failing command (stderr/exit 3), timeout (timed_out), unknown action.
- `device-connector-manifests.test.ts` (+1): headless poll with an os.shell manifest is accepted and stored on the device row (16/16 total).

## After merge

- Create an `os.shell` connection pinned to the herdr device (worker 80af0ff2) in lobu-team.
- Dispatch `run { command: "df" }` - herdr's daemon claims it, executes, returns output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for headless Linux devices to run approved shell commands through the new `os.shell` connector.
  - Commands support working directories, optional input, configurable timeouts, and structured results including output, errors, exit status, and duration.
  - Headless devices now automatically advertise the available shell connector capabilities.
- **Bug Fixes**
  - Improved handling and reporting of failed, timed-out, or unavailable command executions.
  - Restricted headless device connector access to the supported shell connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->