### PR TITLE
feat(review): support OpenCode as independent reviewer

### DIFF
--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -11,13 +11,13 @@ nothing runs locally besides the reviewer, reviews of different commits
 execute concurrently with no host-wide lock; a duplicate run of the same
 commit is refused so the `pi-review` status has exactly one owner per sha. Codex harnesses use Claude; other
 environments, including Claude Code, use Codex. Set
-`REVIEWER_CLI=codex|claude|pi` to override automatic selection (`pi` is
-never chosen by `auto`; it is the explicit third reviewer for when the
-codex/claude CLIs are out of quota or unauthenticated). The script
+`REVIEWER_CLI=codex|claude|pi|opencode` to override automatic selection (`pi` and
+`opencode` are never chosen by `auto`; they are explicit independent fallbacks
+when the default codex/claude CLIs are out of quota or unauthenticated). The script
 also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`,
 `CODEX_REVIEW_MODEL`, `PI_REVIEW_MODEL` (default `gpt-5.6-terra`; the
-ChatGPT account backend rejects `gpt-5.6-sol`), and
-`PI_REVIEW_PROVIDER` overrides. Claude reviews fail closed unless
+ChatGPT account backend rejects `gpt-5.6-sol`), `PI_REVIEW_PROVIDER`, and
+`OPENCODE_REVIEW_MODEL` (default `opencode-go/deepseek-v4-flash`) overrides. Claude reviews fail closed unless
 `CLAUDE_REVIEW_MODEL` is `fable`, `opus`, or a full `claude-opus-*` model ID;
 Sonnet, Haiku, empty, and arbitrary model values are rejected before the
 review starts. It posts a `pi-review` commit status

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -39,6 +39,8 @@ assert_auto_selected codex CODEX_CI=0
   fail "claude override was not honored"
 [ "$(review_select_reviewer pi)" = "pi" ] ||
   fail "pi override was not honored"
+[ "$(review_select_reviewer opencode)" = "opencode" ] ||
+  fail "opencode override was not honored"
 
 if review_select_reviewer invalid >/dev/null 2>&1; then
   fail "invalid reviewer override unexpectedly succeeded"
@@ -74,7 +76,7 @@ case "$failure_message" in
   *) fail "fail-closed message does not explain fallback policy" ;;
 esac
 case "$failure_message" in
-  *"REVIEWER_CLI=claude|codex|pi"*) ;;
+  *"REVIEWER_CLI=claude|codex|pi|opencode"*) ;;
   *) fail "fail-closed message does not explain the explicit override" ;;
 esac
 
@@ -108,6 +110,13 @@ if grep -E -- 'pi[^|]*--tools [^[:space:]]*(edit|write)' "$review_script"; then
   fail "pi reviewer arm must not carry edit/write tools"
 fi
 
+grep -Fq 'OPENCODE_REVIEW_MODEL="${OPENCODE_REVIEW_MODEL:-opencode-go/deepseek-v4-flash}"' "$review_script" ||
+  fail "OpenCode reviewer must default to DeepSeek v4 Flash"
+grep -Fq 'opencode run' "$review_script" ||
+  fail "review.sh must keep its OpenCode invocation arm"
+grep -Fq -- '--agent plan' "$review_script" ||
+  fail "OpenCode reviewer must use the non-writing plan agent"
+
 if grep -Eiq 'herdr|CLAUDE_REVIEW_HERDR' "$review_script"; then
   fail "review.sh must not reference Herdr (inline-only reviewer)"
 fi
@@ -138,6 +147,8 @@ grep -Eq -- '--tools [^[:space:]]*Edit[^[:space:]]*Write' "$review_fix_script" |
   fail "review-fix.sh claude arm must carry the Edit/Write tools that make it a fixer"
 grep -Fq -- '--tools "read,bash,edit,write"' "$review_fix_script" ||
   fail "review-fix.sh pi arm must carry the edit/write tools that make it a fixer"
+grep -Fq 'opencode run --pure --agent build --auto' "$review_fix_script" ||
+  fail "review-fix.sh OpenCode arm must use the explicit writing build agent"
 if grep -Fq 'command -v codex >/dev/null' "$review_fix_script"; then
   fail "review-fix.sh must not gate every run on codex being installed"
 fi

--- a/scripts/lib/review-reviewer.sh
+++ b/scripts/lib/review-reviewer.sh
@@ -15,11 +15,11 @@ review_select_reviewer() {
         printf 'codex\n'
       fi
       ;;
-    codex|claude|pi)
+    codex|claude|pi|opencode)
       printf '%s\n' "$1"
       ;;
     *)
-      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, claude, or pi)" >&2
+      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, claude, pi, or opencode)" >&2
       return 2
       ;;
   esac
@@ -43,6 +43,6 @@ review_should_retry_inline() {
 review_fail_closed_message() {
   local reviewer="$1"
   local detail="$2"
-  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex|pi only to explicitly select the intended independent reviewer.\n" \
+  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex|pi|opencode only to explicitly select the intended independent reviewer.\n" \
     "$reviewer" "$detail"
 }

--- a/scripts/review-fix.sh
+++ b/scripts/review-fix.sh
@@ -5,7 +5,7 @@
 # nothing. The driving agent inspects the edits (shown at the end), commits,
 # then runs `make review` once on the settled HEAD.
 #
-# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude|pi. This
+# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude|pi|opencode. This
 # step is mandated by AGENTS.md but is not a gate: unlike review.sh it posts no
 # status, so a reviewer outage here silently skips the fixer instead of failing
 # a check. Being hard-wired to one CLI therefore costs a whole quality pass
@@ -73,6 +73,7 @@ CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
 PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
 PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
+OPENCODE_REVIEW_MODEL="${OPENCODE_REVIEW_MODEL:-opencode-go/deepseek-v4-flash}"
 if [ "$FIXER_CLI" = "claude" ]; then
   review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
 fi
@@ -122,6 +123,11 @@ case "$FIXER_CLI" in
     fi
     env BASE_BRANCH="$BASE_BRANCH" \
       "${PI_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > "$LAST_MSG_FILE"
+    FIXER_EXIT=$?
+    ;;
+  opencode)
+    # Explicit writing fixer. The caller still inspects and stages the result.
+    env BASE_BRANCH="$BASE_BRANCH"       opencode run --pure --agent build --auto         --model "$OPENCODE_REVIEW_MODEL"         "$(cat "$PROMPT_FILE")" < /dev/null > "$LAST_MSG_FILE" 2> "$LAST_MSG_FILE.stderr"
     FIXER_EXIT=$?
     ;;
 esac

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -30,7 +30,7 @@
 # If there's no PR, the verdict still prints locally.
 #
 # Reviewer selection: Codex harnesses run Claude, while other environments
-# (including Claude Code) run Codex. Override with REVIEWER_CLI=codex|claude.
+# (including Claude Code) run Codex. Override with REVIEWER_CLI=codex|claude|pi|opencode.
 # Auth uses the operator's selected CLI auth for the local review verdict, and
 # `gh auth token` for GitHub (optional — missing auth just skips posting).
 # Commit statuses use the legacy Statuses API because `gh api check-runs`
@@ -92,6 +92,7 @@ CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
 # gpt-5.6-terra, so terra is the default; override with PI_REVIEW_MODEL.
 PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
 PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
+OPENCODE_REVIEW_MODEL="${OPENCODE_REVIEW_MODEL:-opencode-go/deepseek-v4-flash}"
 REVIEWER_CLI="${REVIEWER_CLI:-auto}"
 # light (default): skip the cross-harness reviewer for small safe-class diffs
 # (docs/renames/generated/root bun.lock/snapshots/additive-tests, exact model
@@ -299,6 +300,17 @@ run_reviewer_inline() {
         HEAD_SHA="$HEAD_SHA" \
         CI_CHECKS_FILE="$CI_CHECKS_FILE" \
         "${pi_args[@]}" "$(cat "$prompt_file")" < /dev/null > "$raw_file" 2> "$diagnostic_file"
+      ;;
+    opencode)
+      # Explicit independent reviewer. Plan mode keeps this pass non-writing;
+      # the final answer is still validated by the shared verdict schema.
+      local opencode_args=(
+        opencode run
+        --pure
+        --agent plan
+        --model "$OPENCODE_REVIEW_MODEL"
+      )
+      run_review_child env         BASE_BRANCH="$BASE_BRANCH"         HEAD_SHA="$HEAD_SHA"         CI_CHECKS_FILE="$CI_CHECKS_FILE"         "${opencode_args[@]}" "$(cat "$prompt_file")" < /dev/null > "$raw_file" 2> "$diagnostic_file"
       ;;
   esac
   REVIEWER_EXIT=$?


### PR DESCRIPTION
Adds OpenCode as an explicit first-class semantic reviewer/fixer backend while preserving the existing pi-review status, verdict schema, thresholds, caching, and fail-closed behavior. Defaults OpenCode review to opencode-go/deepseek-v4-flash. Reviewer uses plan mode; fixer uses explicit build/write mode. Reviewer selector tests and script syntax checks pass. Full make pre-pr is currently blocked in this fresh worktree by the local bun package postinstall environment, unrelated to this diff.