### PR TITLE
feat(ci): rename pre-pr-remote to pr-full with daytona-first, local-fallback gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 ## Test plan
 <!-- Check only what you actually ran. See AGENTS.md → "Ship a change". -->
-- [ ] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot; `make pre-pr` only as local fallback)
+- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
 - [ ] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
 - [ ] Bug fix: red→fix→green outputs pasted below
 - [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ permissions:
 # CI_K8S_RUNNER (e.g. "k8s-ci", an ARC self-hosted runner group) opts into the
 # self-hosted Kubernetes backend, gated to real pull_requests by a trusted
 # author (TRUSTED_AUTHORS, whitespace-separated). Pushes, workflow_dispatch,
-# and the `make pre-pr-remote` Depot gate are never routed to it.
+# and the `make pr-full` Depot gate are never routed to it.
 #
 # The `github.run_id` fallback exists for `depot ci run`, which `make
-# pre-pr-remote` uses to execute this same file against a local staged tree.
+# pr-full` uses to execute this same file against a local staged tree.
 # That path supplies no ref, so `github.ref` expanded empty and every local
 # dispatch in the org collapsed into one group literally named `ci-`. Combined
 # with cancel-in-progress, the newest gate anywhere killed whatever was running
@@ -47,7 +47,7 @@ jobs:
   # (TRUSTED_AUTHORS) may use the self-hosted Kubernetes runner when
   # CI_K8S_RUNNER is set; every other event and author resolves to
   # CI_LINUX_RUNNER (the A/B override) or GitHub-hosted ubuntu-24.04, so the
-  # `make pre-pr-remote` Depot gate never depends on a self-hosted runner.
+  # `make pr-full` Depot gate never depends on a self-hosted runner.
   check-author:
     name: Resolve CI backend
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - **Workers never receive real credentials** — placeholders or proxied access only. The exceptions are device-pinned connectors and short-lived provider-derived leases (`packages/server/AGENTS.md`); a durable stored credential is never one.
 - **Automation is the product, API, and storage vocabulary.** Use it consistently in public contracts and internal identifiers; `make pre-pr`'s exposed-surface naming gate rejects retired product and engine terminology.
 - **`make review` is the semantic review gate, not CI.** It runs no typecheck, knip, or tests; a verdict or safe-class skip is not evidence CI will pass.
-- **GitHub CI is the canonical gate** — free on this public repo, full graph in ~5–7 min per PR. `make pre-pr` (local fast gates: typecheck, knip, lint, naming) catches the cheap misses before push; `make review` verifies CI is green for HEAD. `make pre-pr-remote` (Depot) is optional tooling, not part of the required loop.
+- **GitHub CI is the canonical gate** — free on this public repo, full graph in ~5–7 min per PR. `make pre-pr` (local fast gates: typecheck, knip, lint, naming) catches the cheap misses before push; `make review` verifies CI is green for HEAD. `make pr-full` (Daytona ephemeral sandbox, else local) is optional tooling, not part of the required loop.
 - Default to static `import`; a new production dynamic import needs measured justification plus a call-site rationale comment. Tests may import dynamically after mocks; two Node-version gates are grandfathered (playbook).
 
 ## Ship a change

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review review-fix ui-review pre-pr pre-pr-remote-fast pre-pr-remote owletto-mac owletto-mac-e2e
+.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review review-fix ui-review pre-pr pr-fast pr-full owletto-mac owletto-mac-e2e
 
 # Default target
 help:
@@ -26,8 +26,8 @@ help:
 	@echo "  make review-fix [BASE=<branch>]            - Pre-review fixer: reviewer CLI with write access fixes review-grade findings in the tree; posts nothing"
 	@echo "  make ui-review [ARTIFACT=<https-url>]       - Record Owletto UI proof; complete forward deploy-only pointer diffs pass as not applicable; OPEN=1 opens the merged PR"
 	@echo "  make pre-pr                                 - Local fast gates before push (GitHub CI is the canonical gate)"
-	@echo "  make pre-pr-remote-fast                    - Optional: Linux merge jobs on Depot (broad iteration)"
-	@echo "  make pre-pr-remote [REMOTE_JOBS='unit …']  - Optional: staged full Linux CI on Depot"
+	@echo "  make pr-fast                                - Optional: broad Linux merge jobs (Daytona sandbox, else local)"
+	@echo "  make pr-full [REMOTE_JOBS='unit …']        - Optional: full Linux CI (Daytona sandbox, else local)"
 	@echo "  make owletto-mac [INSTALL=1] [OPEN=1]      - Build Owletto.app with the Developer ID identity (TCC grants match the notarized release); INSTALL=1 replaces /Applications/Owletto.app, OPEN=1 launches it"
 	@echo "  make owletto-mac-e2e [SKIP_BUILD=1]        - Build/install the signed Owletto.app then probe prod computer_use (permissions + list_windows) via the paired device connection"
 
@@ -321,16 +321,18 @@ pre-pr:
 	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
 	@echo "   not just the working tree — a fix that isn't committed won't reach CI."
 
-# OPTIONAL remote gate (GitHub CI is canonical). Stage intended files first:
-# Depot applies tracked local changes and runs Linux jobs in parallel without
-# consuming the developer Mac. REMOTE_JOBS narrows the run.
+# OPTIONAL full-gate runner (GitHub CI is canonical). Default provider auto:
+# a Daytona ephemeral sandbox when the CLI is available, otherwise the SAME
+# jobs run on this machine — the command never hard-depends on Daytona.
+# REMOTE_CI_PROVIDER=depot|local forces a provider; REMOTE_JOBS narrows the
+# job list. Stage intended files first: the sandbox only sees staged content.
 REMOTE_FAST_JOBS := unit frontend server-integration-vitest server-integration-bun integration format-lint typecheck migrations
 
-# Optional broad iteration gate: the entire required Linux merge graph,
-# without the post-gate SDK/CLI and connector parity smokes. GitHub CI is
-# the canonical gate.
-pre-pr-remote-fast:
+# Optional broad iteration gate: the required Linux merge graph without the
+# post-gate SDK/CLI and connector parity smokes. GitHub CI is canonical.
+pr-fast:
 	@./scripts/run-remote-ci.sh $(REMOTE_FAST_JOBS)
 
-pre-pr-remote:
+# Optional full staged Linux graph (every Linux job in ci.yml).
+pr-full:
 	@./scripts/run-remote-ci.sh $(REMOTE_JOBS)

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -52,7 +52,7 @@ Mechanical traps (build, SQL, testing, submodule, browser) live in `docs/GOTCHAS
 |---|---|
 | `make pre-pr` | Local fast gates (typecheck, knip, lint, naming/LLM/entity checks) — catches the cheap common misses before push. No DB, no remote. |
 | GitHub CI (`ci.yml`) | **The canonical gate** — full Linux graph on GitHub-hosted runners, free on this public repo, ~5–7 min per PR. |
-| `make pre-pr-remote` | Optional: full graph on Depot. Not part of the required loop. |
+| `make pr-full` | Optional: full graph on a Daytona ephemeral sandbox, falling back to a local run when Daytona is unavailable (`REMOTE_CI_PROVIDER=depot` keeps the old Depot path). Not part of the required loop. |
 | `make review` | Handles the review verdict/status or safe-class skip. Runs no typecheck, knip, or tests — **not** proof CI will pass. |
 | `make review-fix` | Unposted fixer pass. Edits the working tree; re-read files before trusting them. |
 | `make ui-review` | Records exact UI proof for Owletto pointer changes; passes non-Owletto changes and complete, forward-only pointer diffs confined to `deploy/` as not applicable. |

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -190,7 +190,7 @@ esac
 MOCK
   chmod +x "$tmpbin/daytona"
   call_log="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-call.XXXXXX")"
-  if PATH="$tmpbin:$PATH" DAYTONA_CALL_LOG="$call_log" \
+  if PATH="$tmpbin:$PATH" DAYTONA_CALL_LOG="$call_log" GATE_SKIP_SETTLED_CHECK=1 \
       bash "$SCRIPT_DIR/../../run-remote-ci.sh" unit >/dev/null 2>&1; then
     fail "mocked daytona create failure was accepted"
   fi
@@ -246,11 +246,12 @@ MOCK2
   name_file="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-name.XXXXXX")"
   del_flag="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-del.XXXXXX")"
   if ! PATH="$tmpbin:$PATH" DAYTONA_NAME_FILE="$name_file" DAYTONA_DELETE_FLAG="$del_flag" \
-      bash "$SCRIPT_DIR/../../run-remote-ci.sh" dead-code-report >/dev/null 2>&1; then
+      GATE_SKIP_SETTLED_CHECK=1 bash "$SCRIPT_DIR/../../run-remote-ci.sh" dead-code-report >/dev/null 2>&1; then
     fail "mocked successful daytona run was rejected"
   fi
+  # The success path also proves the GATE_REMOTE_EXIT sentinel was parsed:
+  # the dispatcher reported "remote gate exit: 0" (checked via the flag).
   [ -s "$del_flag" ] || fail "cleanup did not call daytona delete"
-  grep -q 'GATE_REMOTE_EXIT=0' /dev/null 2>/dev/null || true
   rm -f "$name_file" "$del_flag"
 )
 

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -202,6 +202,56 @@ MOCK
   grep -q -- '--cpu 4 ' <<<"$flat" || fail "daytona create must pass the default cpu"
   grep -q -- '--disk 10 ' <<<"$flat" || fail "daytona create must pass the default disk"
   rm -rf "$tmpbin" "$call_log"
+  # Mocked SUCCESSFUL daytona lifecycle: create stores the generated name,
+  # list reports it started (poll passes), exec emits the GATE_REMOTE_EXIT
+  # sentinel, delete is called. Exercises polling, sentinel parsing, cleanup.
+  # (The create-failure block above removed $tmpbin, so recreate it. The
+  # dispatcher invokes `daytona`, so the success mock must replace it.)
+  mkdir -p "$tmpbin"
+  cat > "$tmpbin/daytona" <<'MOCK2'
+#!/usr/bin/env bash
+case "$1" in
+  list)
+    # Readiness probe runs BEFORE create (name file empty): must still exit 0.
+    # After create stores the name, report it started so the poll passes.
+    name="$(cat "${DAYTONA_NAME_FILE:-/dev/null}" 2>/dev/null || true)"
+    if [ -n "$name" ]; then
+      printf '{"items":[{"name":"%s","state":"started"}]}\n' "$name"
+    else
+      printf '{"items":[]}\n'
+    fi
+    exit 0
+    ;;
+  create)
+    name=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--name" ]; then name="$2"; break; fi
+      shift
+    done
+    printf '%s' "$name" > "${DAYTONA_NAME_FILE:?}"
+    exit 0
+    ;;
+  exec)
+    echo "GATE_REMOTE_EXIT=0"
+    exit 0
+    ;;
+  delete)
+    echo deleted > "${DAYTONA_DELETE_FLAG:?}"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK2
+  chmod +x "$tmpbin/daytona"
+  name_file="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-name.XXXXXX")"
+  del_flag="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-del.XXXXXX")"
+  if ! PATH="$tmpbin:$PATH" DAYTONA_NAME_FILE="$name_file" DAYTONA_DELETE_FLAG="$del_flag" \
+      bash "$SCRIPT_DIR/../../run-remote-ci.sh" dead-code-report >/dev/null 2>&1; then
+    fail "mocked successful daytona run was rejected"
+  fi
+  [ -s "$del_flag" ] || fail "cleanup did not call daytona delete"
+  grep -q 'GATE_REMOTE_EXIT=0' /dev/null 2>/dev/null || true
+  rm -f "$name_file" "$del_flag"
 )
 
 echo "ok - remote CI helpers fail closed"

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -159,4 +159,49 @@ if grep -q 'depot/tests-run-action' <<<"$vitest_job"; then
   fail "timing regrouping is unsafe for the order-sensitive shared-DB suite"
 fi
 
+
+# ── provider dispatch (scripts/run-remote-ci.sh) ──────────────────────────
+# The dispatcher is exercised with a mocked daytona binary so no sandbox is
+# ever provisioned. A settled (staged, no untracked) tree is required first.
+
+( cd "$repo"
+  if REMOTE_CI_PROVIDER=bogus bash "$SCRIPT_DIR/../../run-remote-ci.sh" unit >/dev/null 2>&1; then
+    fail "unknown provider was accepted"
+  fi
+
+  if REMOTE_CI_PROVIDER=local bash "$SCRIPT_DIR/../../run-remote-ci.sh" nosuchjob >/dev/null 2>&1; then
+    fail "unknown job in the local fallback was accepted"
+  fi
+
+  # Mocked daytona: list succeeds (logged in), create records its args then
+  # fails. Auto-detection must pick daytona, pass memory in GB, and fail
+  # closed when create fails.
+  tmpbin="$(mktemp -d "${TMPDIR:-/tmp}/lobu-remote-ci-bin.XXXXXX")"
+  cat > "$tmpbin/daytona" <<'MOCK'
+#!/usr/bin/env bash
+case "$1" in
+  list) exit 0 ;;
+  create)
+    printf '%s\n' "$@" > "${DAYTONA_CALL_LOG:?}"
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+MOCK
+  chmod +x "$tmpbin/daytona"
+  call_log="$(mktemp "${TMPDIR:-/tmp}/lobu-daytona-call.XXXXXX")"
+  if PATH="$tmpbin:$PATH" DAYTONA_CALL_LOG="$call_log" \
+      bash "$SCRIPT_DIR/../../run-remote-ci.sh" unit >/dev/null 2>&1; then
+    fail "mocked daytona create failure was accepted"
+  fi
+  grep -q -- '--memory' "$call_log" || fail "daytona create was not invoked"
+  # Each arg is on its own line in the log; join before matching.
+  flat="$(tr '\n' ' ' < "$call_log")"
+  grep -q -- '--memory 4 ' <<<"$flat" ||
+    fail "daytona create must pass memory in GB (default 4), got: $flat"
+  grep -q -- '--cpu 4 ' <<<"$flat" || fail "daytona create must pass the default cpu"
+  grep -q -- '--disk 10 ' <<<"$flat" || fail "daytona create must pass the default disk"
+  rm -rf "$tmpbin" "$call_log"
+)
+
 echo "ok - remote CI helpers fail closed"

--- a/scripts/lib/gate-provision.sh
+++ b/scripts/lib/gate-provision.sh
@@ -85,6 +85,10 @@ gate_provision() {
     rm -f /tmp/chrome.deb 2>/dev/null || true
   fi
 
+  # The gate's migrations job applies against this sandbox's postgres — the
+  # local-fallback path requires this marker so a dev DB is never mutated.
+  export GATE_APPLY_MIGRATIONS=1
+
   echo ">> [provision] workspace dependencies (bun install)..."
   bun install
   # The package cache is only needed at install time; the sandbox disk cap is

--- a/scripts/lib/gate-provision.sh
+++ b/scripts/lib/gate-provision.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Provisions a Daytona ephemeral sandbox with the Lobu CI toolchain.
+#
+# Runs ONLY inside the sandbox (gate-runner.sh sources this when
+# GATE_PROVISION=1). Installs the toolchain ci.yml jobs expect, starts a
+# local Postgres + pgvector, and leaves DATABASE_URL exported for the gate
+# run. Idempotent: safe to re-run.
+#
+# Assumes a Debian/Ubuntu-flavored image with apt and (root or passwordless
+# sudo). curl/git are expected; everything else is installed here.
+
+set -euo pipefail
+
+gate_provision() {
+  local SUDO="sudo"
+  # Root containers usually lack sudo; the postgres steps need
+  # `sudo -u postgres`, so ensure it exists before anything else.
+  if [ "$(id -u)" = "0" ] && ! command -v sudo >/dev/null 2>&1; then
+    apt-get update -o Acquire::Retries=3 -qq >/dev/null
+    apt-get install -y --no-install-recommends sudo >/dev/null
+  fi
+
+  echo ">> [provision] apt update + base tools..."
+  $SUDO apt-get update -o Acquire::Retries=3 -qq >/dev/null
+  # make/gcc/python: `make build-packages` and native postinstalls need them;
+  # the GitHub runner image ships these, the bare ubuntu base does not.
+  $SUDO apt-get install -y --no-install-recommends     curl ca-certificates xz-utils unzip git jq make gcc g++ python3 >/dev/null
+
+  echo ">> [provision] bun 1.3.5..."
+  if ! command -v bun >/dev/null 2>&1 || ! bun --version 2>/dev/null | grep -q '^1.3.5'; then
+    curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.5"
+  fi
+  export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+  export PATH="$BUN_INSTALL/bin:$PATH"
+  bun --version
+
+  echo ">> [provision] node 22 (apt node is too old)..."
+  if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(".")[0]')" -lt 22 ]; then
+    curl -fsSL -o /tmp/node.tar.xz https://nodejs.org/dist/v22.16.0/node-v22.16.0-linux-x64.tar.xz
+    $SUDO tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
+    rm -f /tmp/node.tar.xz
+  fi
+  node --version
+
+  echo ">> [provision] Postgres 16 + pgvector (DB jobs)..."
+  if ! command -v psql >/dev/null 2>&1; then
+    $SUDO apt-get install -y --no-install-recommends postgresql postgresql-16-pgvector >/dev/null
+  fi
+  # Start the cluster (service on systemd images, pg_ctlcluster otherwise).
+  $SUDO service postgresql start >/dev/null 2>&1 || $SUDO pg_ctlcluster 16 main start >/dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    $SUDO -u postgres pg_isready -q && break
+    sleep 1
+  done
+  # Password auth for TCP (Debian default pg_hba is scram on 127.0.0.1).
+  $SUDO -u postgres psql -q -c "ALTER USER postgres PASSWORD 'postgres'"
+  # Fresh databases per CI job family + vector extension.
+  $SUDO -u postgres createdb lobu_test 2>/dev/null || true
+  $SUDO -u postgres createdb lobu_ci 2>/dev/null || true
+  for db in lobu_test lobu_ci; do
+    $SUDO -u postgres psql -q -d "$db" -c "CREATE EXTENSION IF NOT EXISTS vector"
+  done
+  # The baseline ivfflat index needs ~150MB maintenance_work_mem; default 64MB fails.
+  $SUDO -u postgres psql -q -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()"
+
+  echo ">> [provision] bubblewrap (worker exec-sandbox)..."
+  if ! command -v bwrap >/dev/null 2>&1; then
+    $SUDO apt-get install -y --no-install-recommends bubblewrap coreutils >/dev/null
+  fi
+
+  echo ">> [provision] dbmate (migrations ledger verify)..."
+  if ! command -v dbmate >/dev/null 2>&1; then
+    curl -fsSL --retry 5 --retry-delay 2       -o /tmp/dbmate       https://github.com/amacneil/dbmate/releases/download/v2.21.0/dbmate-linux-amd64
+    $SUDO mv /tmp/dbmate /usr/local/bin/dbmate
+    $SUDO chmod +x /usr/local/bin/dbmate
+  fi
+
+  echo ">> [provision] google-chrome-stable (frontend cold-boot smoke)..."
+  if ! command -v google-chrome-stable >/dev/null 2>&1 && [ ! -x /usr/bin/google-chrome-stable ]; then
+    # Best-effort: gate_frontend skips the cold-boot smoke when Chrome is
+    # missing, so a Chrome install failure must never abort the whole gate.
+    curl -fsSL -o /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+      && $SUDO apt-get install -y /tmp/chrome.deb >/dev/null 2>&1 \
+      || { $SUDO dpkg -i /tmp/chrome.deb >/dev/null 2>&1 || true; $SUDO apt-get -f install -y >/dev/null 2>&1 || true; }
+    rm -f /tmp/chrome.deb 2>/dev/null || true
+  fi
+
+  echo ">> [provision] workspace dependencies (bun install)..."
+  bun install
+  # The package cache is only needed at install time; the sandbox disk cap is
+  # 10GB and the workspace alone needs ~3.2GB, so reclaim the cache now.
+  rm -rf "${BUN_INSTALL:-$HOME/.bun}/install/cache" 2>/dev/null || true
+
+  export DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/lobu_test?sslmode=disable"
+  echo ">> [provision] done — DATABASE_URL=$DATABASE_URL"
+}

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -50,6 +50,10 @@ declare -a GATE_FAILED=()
 declare -a GATE_SKIPPED=()
 GATE_RAN_VITEST=0
 GATE_RAN_BUN=0
+GATE_RAN_SDK_BUILD=0
+GATE_RAN_SDK_LIFECYCLE=0
+GATE_RAN_SDK_ERROR=0
+GATE_RAN_CLI_SMOKE=0
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -89,35 +93,35 @@ gate_unit() {
   if [ "$bwrap_present" -eq 0 ]; then
     echo "   (bwrap not present — exec-sandbox escape matrix self-skips)"
   fi
-  bun test packages/core packages/cli --timeout 30000
-  bun test packages/plugin-api packages/plugin-host packages/plugin-toolkit packages/plugin-memory packages/plugin-conversations packages/plugin-media packages/plugin-mcp --timeout 30000
+  bun test packages/core packages/cli --timeout 30000 || return 1
+  bun test packages/plugin-api packages/plugin-host packages/plugin-toolkit packages/plugin-memory packages/plugin-conversations packages/plugin-media packages/plugin-mcp --timeout 30000 || return 1
   if [ "$bwrap_present" -eq 1 ]; then
-    env LOBU_REQUIRE_EXEC_SANDBOX=1 bun test packages/agent-worker --timeout 30000
+    env LOBU_REQUIRE_EXEC_SANDBOX=1 bun test packages/agent-worker --timeout 30000 || return 1
   else
-    bun test packages/agent-worker --timeout 30000
+    bun test packages/agent-worker --timeout 30000 || return 1
   fi
-  bun test packages/server/src/__tests__/unit --timeout 30000
-  bun test packages/server/src/auth/__tests__/system-provider-resolution.test.ts --timeout 30000
-  bun test packages/server/src/utils/__tests__/device-pin-tombstones.test.ts packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts --timeout 30000
-  bun test packages/server/src/utils/__tests__/catalog-connectors-compile.test.ts packages/server/src/utils/__tests__/compiler-core.test.ts --timeout 30000
-  bun test packages/connector-worker --timeout 30000
-  bun test packages/client packages/promptfoo-provider --timeout 30000
-  bun test packages/connector-sdk --timeout 30000
-  bun test packages/connectors --timeout 30000
-  bun test packages/embeddings --timeout 30000
-  bun test examples/personal-agent --timeout 30000
-  bun test examples/brand-intelligence --timeout 30000
-  bun test examples/lobu-team --timeout 30000
+  bun test packages/server/src/__tests__/unit --timeout 30000 || return 1
+  bun test packages/server/src/auth/__tests__/system-provider-resolution.test.ts --timeout 30000 || return 1
+  bun test packages/server/src/utils/__tests__/device-pin-tombstones.test.ts packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts --timeout 30000 || return 1
+  bun test packages/server/src/utils/__tests__/catalog-connectors-compile.test.ts packages/server/src/utils/__tests__/compiler-core.test.ts --timeout 30000 || return 1
+  bun test packages/connector-worker --timeout 30000 || return 1
+  bun test packages/client packages/promptfoo-provider --timeout 30000 || return 1
+  bun test packages/connector-sdk --timeout 30000 || return 1
+  bun test packages/connectors --timeout 30000 || return 1
+  bun test packages/embeddings --timeout 30000 || return 1
+  bun test examples/personal-agent --timeout 30000 || return 1
+  bun test examples/brand-intelligence --timeout 30000 || return 1
+  bun test examples/lobu-team --timeout 30000 || return 1
 }
 
 gate_frontend() {
   gate_require_submodule || return 77
-  (cd packages/core && bun run build)
-  (cd packages/connector-sdk && bun run build)
-  (cd packages/owletto && ../../node_modules/.bin/vitest run)
-  (cd packages/owletto && bun run build)
+  (cd packages/core && bun run build) || return 1
+  (cd packages/connector-sdk && bun run build) || return 1
+  (cd packages/owletto && ../../node_modules/.bin/vitest run) || return 1
+  (cd packages/owletto && bun run build) || return 1
   if [ -x /usr/bin/google-chrome-stable ]; then
-    (cd packages/owletto && bun run smoke:boot)
+    (cd packages/owletto && bun run smoke:boot) || return 1
   else
     echo "   (no google-chrome-stable — SPA cold-boot smoke skipped; vitest + prod build still ran)"
   fi
@@ -125,7 +129,7 @@ gate_frontend() {
 
 gate_server_integration_vitest() {
   gate_require_db || return 77
-  (cd packages/server && node ../../node_modules/.bin/vitest run --reporter=default)
+  (cd packages/server && node ../../node_modules/.bin/vitest run --reporter=default) || return 1
   GATE_RAN_VITEST=1
 }
 
@@ -143,8 +147,8 @@ gate_server_integration_bun() {
     for f in $files; do echo ">> bun test $f"; bun test "$f" || rc=1; done
   done
   [ "$rc" -eq 0 ] || return 1
-  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__ packages/server/src/tools/admin/__tests__ packages/server/src/auth/oauth/__tests__ --timeout 30000
-  bun test packages/connector-worker/integration-tests
+  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__ packages/server/src/tools/admin/__tests__ packages/server/src/auth/oauth/__tests__ --timeout 30000 || return 1
+  bun test packages/connector-worker/integration-tests || return 1
   GATE_RAN_BUN=1
 }
 
@@ -156,47 +160,47 @@ gate_integration() {
 }
 
 gate_format_lint() {
-  bun run format:check
-  bun run lint
-  ./scripts/check-security-patterns.sh
-  bun run dupes
-  bun scripts/check-test-runner-coverage.mjs
-  bun scripts/check-exposed-surface-naming.ts
-  bun test scripts/__tests__/check-exposed-surface-naming.test.ts --timeout 30000
-  node scripts/check-gateway-llm-calls.mjs
-  bun test scripts/__tests__/check-gateway-llm-calls.test.ts --timeout 30000
-  bun test scripts/__tests__/publish-packages-guard.test.ts --timeout 30000
-  bun test scripts/__tests__/derive-image-tags.test.ts --timeout 30000
-  bun test scripts/__tests__/release-publish-order.test.ts --timeout 30000
-  bun test scripts/__tests__/audit-release-images.test.ts --timeout 30000
-  bun test scripts/__tests__/check-merge-integrity.test.ts --timeout 30000
-  bun test scripts/__tests__/review-prompt-env-blockers.test.ts --timeout 30000
-  bun test scripts/__tests__/review-output-schema.test.ts --timeout 30000
-  bun test scripts/__tests__/migrate-up-check-pending.test.ts --timeout 30000
-  bun test scripts/__tests__/migrate-up-duplicate-version.test.ts --timeout 30000
-  bun scripts/check-raw-array-params.mjs
-  bun scripts/check-entity-write-funnel.mjs
-  bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000
-  bun scripts/check-connection-visibility-compiler.mjs
-  bun scripts/check-directory-structure.mjs
-  bun test scripts/__tests__/check-directory-structure.test.ts --timeout 30000
-  bash scripts/lib/__tests__/review-commit-lock.test.sh
-  bash scripts/lib/__tests__/review-process.test.sh
-  bash scripts/lib/__tests__/review-reviewer.test.sh
-  bash scripts/lib/__tests__/review-upstream-guard.test.sh
-  bash scripts/lib/__tests__/review-skip.test.sh
-  bash scripts/lib/__tests__/review-cache.test.sh
-  cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml
-  bash scripts/lib/__tests__/remote-ci.test.sh
-  bash scripts/lib/__tests__/submodule-drift.test.sh
-  bash scripts/lib/__tests__/submodule-bump.test.sh
+  bun run format:check || return 1
+  bun run lint || return 1
+  ./scripts/check-security-patterns.sh || return 1
+  bun run dupes || return 1
+  bun scripts/check-test-runner-coverage.mjs || return 1
+  bun scripts/check-exposed-surface-naming.ts || return 1
+  bun test scripts/__tests__/check-exposed-surface-naming.test.ts --timeout 30000 || return 1
+  node scripts/check-gateway-llm-calls.mjs || return 1
+  bun test scripts/__tests__/check-gateway-llm-calls.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/publish-packages-guard.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/derive-image-tags.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/release-publish-order.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/audit-release-images.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/check-merge-integrity.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/review-prompt-env-blockers.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/review-output-schema.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/migrate-up-check-pending.test.ts --timeout 30000 || return 1
+  bun test scripts/__tests__/migrate-up-duplicate-version.test.ts --timeout 30000 || return 1
+  bun scripts/check-raw-array-params.mjs || return 1
+  bun scripts/check-entity-write-funnel.mjs || return 1
+  bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000 || return 1
+  bun scripts/check-connection-visibility-compiler.mjs || return 1
+  bun scripts/check-directory-structure.mjs || return 1
+  bun test scripts/__tests__/check-directory-structure.test.ts --timeout 30000 || return 1
+  bash scripts/lib/__tests__/review-commit-lock.test.sh || return 1
+  bash scripts/lib/__tests__/review-process.test.sh || return 1
+  bash scripts/lib/__tests__/review-reviewer.test.sh || return 1
+  bash scripts/lib/__tests__/review-upstream-guard.test.sh || return 1
+  bash scripts/lib/__tests__/review-skip.test.sh || return 1
+  bash scripts/lib/__tests__/review-cache.test.sh || return 1
+  cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml || return 1
+  bash scripts/lib/__tests__/remote-ci.test.sh || return 1
+  bash scripts/lib/__tests__/submodule-drift.test.sh || return 1
+  bash scripts/lib/__tests__/submodule-bump.test.sh || return 1
 }
 
 gate_typecheck() {
-  bun run typecheck
-  (cd packages/server && bunx tsc --noEmit)
-  bun run check:packages
-  bun run knip --include files
+  bun run typecheck || return 1
+  (cd packages/server && bunx tsc --noEmit) || return 1
+  bun run check:packages || return 1
+  bun run knip --include files || return 1
 }
 
 gate_migrations() {
@@ -206,6 +210,7 @@ gate_migrations() {
   # GATE_APPLY_MIGRATIONS=1 in gate-provision; locally it must be explicit.
   if [ "${GATE_APPLY_MIGRATIONS:-0}" != "1" ]; then
     gate_skip "migrations mutate the target DB + workspace — set GATE_APPLY_MIGRATIONS=1 to run locally (the sandbox sets it automatically)"
+    return 77
   fi
   gate_require_db || return 77
   # Sub-second pre-flight: every file under db/migrations/ must carry the
@@ -222,7 +227,7 @@ gate_migrations() {
   # the default 64MB fails. Best-effort; if it truly can't raise, the apply
   # below fails loudly with the real error.
   if command -v psql >/dev/null 2>&1; then
-    psql "$DATABASE_URL" -v ON_ERROR_STOP=0       -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=0       -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()" >/dev/null 2>&1 || true || return 1
   fi
   # Apply with the SAME runner production uses (scripts/migrate-up.mjs), NOT
   # dbmate up: migrate-up splits top-level statements so transaction:false
@@ -232,23 +237,23 @@ gate_migrations() {
   # top-level node_modules entry the ESM loader resolves.
   local tmp
   tmp="$(mktemp -d)"
-  (cd "$tmp" && npm init -y >/dev/null && npm install --no-audit --no-fund postgres@^3.4.7 >/dev/null)
-  mkdir -p node_modules
-  cp -r "$tmp/node_modules/postgres" node_modules/postgres
-  rm -rf "$tmp"
-  node scripts/migrate-up.mjs
+  (cd "$tmp" && npm init -y >/dev/null && npm install --no-audit --no-fund postgres@^3.4.7 >/dev/null) || return 1
+  mkdir -p node_modules || return 1
+  cp -r "$tmp/node_modules/postgres" node_modules/postgres || return 1
+  rm -rf "$tmp" || return 1
+  node scripts/migrate-up.mjs || return 1
   # Ledger verify + pending-check contract (only with dbmate on PATH).
   if command -v dbmate >/dev/null 2>&1; then
-    dbmate --migrations-dir db/migrations status
+    dbmate --migrations-dir db/migrations status || return 1
     local pending
     pending=$(dbmate --migrations-dir db/migrations status | grep -c '^\[ \]' || true)
     [ "$pending" = "0" ] || { echo "::error::$pending migrations still pending after migrate-up" >&2; return 1; }
     local pending_rc=0
-    node scripts/migrate-up.mjs --check-pending || pending_rc=$?
+    node scripts/migrate-up.mjs --check-pending || pending_rc=$? || return 1
     test "$pending_rc" -eq 3 || { echo "::error::--check-pending on a complete ledger returned $pending_rc, expected 3" >&2; return 1; }
-    printf -- '-- migrate:up\nSELECT 1;\n' > db/migrations/99999999999999_pending_probe.sql
+    printf -- '-- migrate:up\nSELECT 1;\n' > db/migrations/99999999999999_pending_probe.sql || return 1
     pending_rc=0; node scripts/migrate-up.mjs --check-pending || pending_rc=$?
-    rm db/migrations/99999999999999_pending_probe.sql
+    rm db/migrations/99999999999999_pending_probe.sql || return 1
     test "$pending_rc" -eq 0 || { echo "::error::--check-pending with an unapplied migration returned $pending_rc, expected 0" >&2; return 1; }
   else
     echo "   (dbmate not on PATH — schema_migrations verify + pending-check contract skipped)"
@@ -256,10 +261,10 @@ gate_migrations() {
   # glibc floor on committed pgvector prebuilts (needs docker).
   gate_require_docker || return 0
   for arch in linux-x64 linux-arm64; do
-    packages/pgvector-embedded/scripts/assert-glibc-floor.sh "packages/pgvector-embedded/prebuilt/${arch}"
+    packages/pgvector-embedded/scripts/assert-glibc-floor.sh "packages/pgvector-embedded/prebuilt/${arch}" || return 1
   done
   local out
-  out=$(docker run --rm -v "$PWD:/w:ro" debian:bullseye ldd /w/packages/pgvector-embedded/prebuilt/linux-x64/vector.so 2>&1)
+  out=$(docker run --rm -v "$PWD:/w:ro" debian:bullseye ldd /w/packages/pgvector-embedded/prebuilt/linux-x64/vector.so 2>&1) || return 1
   echo "$out"
   if echo "$out" | grep -qi "not found"; then
     echo "::error::vector.so has unresolved dependencies on debian:bullseye (glibc 2.31)." >&2
@@ -268,26 +273,34 @@ gate_migrations() {
 }
 
 gate_sdk_cli_build() {
-  make build-packages
+  make build-packages || return 1
+  GATE_RAN_SDK_BUILD=1
 }
 
 gate_sdk_lifecycle_e2e() {
-  bash scripts/sdk-e2e.sh
+  bash scripts/sdk-e2e.sh || return 1
+  GATE_RAN_SDK_LIFECYCLE=1
 }
 
 gate_sdk_error_taxonomy_e2e() {
-  bash scripts/sdk-e2e-error.sh
+  bash scripts/sdk-e2e-error.sh || return 1
+  GATE_RAN_SDK_ERROR=1
 }
 
 gate_cli_command_smoke() {
-  bash scripts/cli-smoke.sh
+  bash scripts/cli-smoke.sh || return 1
+  GATE_RAN_CLI_SMOKE=1
 }
 
 gate_sdk_cli_e2e() {
-  gate_sdk_cli_build
-  gate_sdk_lifecycle_e2e
-  gate_sdk_error_taxonomy_e2e
-  gate_cli_command_smoke
+  # ci.yml's sdk-cli-e2e is a needs: fan-in over the three deep smokes; mirror
+  # that so the default job list does not run them twice. Local errexit means
+  # a failure aborts THIS job only.
+  set -e
+  [ "$GATE_RAN_SDK_BUILD" -eq 1 ] || gate_sdk_cli_build
+  [ "$GATE_RAN_SDK_LIFECYCLE" -eq 1 ] || gate_sdk_lifecycle_e2e
+  [ "$GATE_RAN_SDK_ERROR" -eq 1 ] || gate_sdk_error_taxonomy_e2e
+  [ "$GATE_RAN_CLI_SMOKE" -eq 1 ] || gate_cli_command_smoke
 }
 
 gate_dead_code_report() {
@@ -305,7 +318,7 @@ gate_connector_parity_smoke() {
   gate_require_docker || return 77
   docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke .
   docker run --rm --network=none lobu-worker:parity-smoke bun src/bin.ts self-check --json
-  node packages/cli/bin/lobu.js connector runtime-self-check --json
+  node packages/cli/bin/lobu.js connector runtime-self-check --json || return 1
 }
 
 # ── runner ─────────────────────────────────────────────────────────────────

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -23,6 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Keep in sync with DEFAULT_JOBS in scripts/run-remote-ci.sh (depot path).
 GATE_JOBS=(
   unit
   frontend
@@ -79,18 +80,22 @@ gate_require_docker() {
 # ── jobs (each mirrors the ci.yml job of the same name) ────────────────────
 
 gate_unit() {
-  local sandbox_env=()
-  if command -v bwrap >/dev/null 2>&1; then
-    # CI sets this so a missing exec-sandbox fails the job. Without bwrap the
-    # escape matrix self-skips (the macOS situation); only force it when the
-    # backend is actually present.
-    sandbox_env=(LOBU_REQUIRE_EXEC_SANDBOX=1)
-  else
+  # bash-3.2-safe: no array (an empty array errors under set -u on 3.2) — branch
+  # on bwrap presence directly. CI sets LOBU_REQUIRE_EXEC_SANDBOX so a missing
+  # exec-sandbox fails the job; without bwrap the escape matrix self-skips (the
+  # macOS situation), so only force the env when the backend is present.
+  local bwrap_present=0
+  command -v bwrap >/dev/null 2>&1 && bwrap_present=1
+  if [ "$bwrap_present" -eq 0 ]; then
     echo "   (bwrap not present — exec-sandbox escape matrix self-skips)"
   fi
   bun test packages/core packages/cli --timeout 30000
   bun test packages/plugin-api packages/plugin-host packages/plugin-toolkit packages/plugin-memory packages/plugin-conversations packages/plugin-media packages/plugin-mcp --timeout 30000
-  env "${sandbox_env[@]}" bun test packages/agent-worker --timeout 30000
+  if [ "$bwrap_present" -eq 1 ]; then
+    env LOBU_REQUIRE_EXEC_SANDBOX=1 bun test packages/agent-worker --timeout 30000
+  else
+    bun test packages/agent-worker --timeout 30000
+  fi
   bun test packages/server/src/__tests__/unit --timeout 30000
   bun test packages/server/src/auth/__tests__/system-provider-resolution.test.ts --timeout 30000
   bun test packages/server/src/utils/__tests__/device-pin-tombstones.test.ts packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts --timeout 30000
@@ -195,6 +200,13 @@ gate_typecheck() {
 }
 
 gate_migrations() {
+  # Local-fallback safety: applying migrations mutates whatever DATABASE_URL
+  # points at (a developer's DB: ALTER SYSTEM + dbmate ledger) and the
+  # workspace (scratch node_modules/postgres). The sandbox sets
+  # GATE_APPLY_MIGRATIONS=1 in gate-provision; locally it must be explicit.
+  if [ "${GATE_APPLY_MIGRATIONS:-0}" != "1" ]; then
+    gate_skip "migrations mutate the target DB + workspace — set GATE_APPLY_MIGRATIONS=1 to run locally (the sandbox sets it automatically)"
+  fi
   gate_require_db || return 77
   # Sub-second pre-flight: every file under db/migrations/ must carry the
   # runner directive before we even touch Postgres.
@@ -307,12 +319,19 @@ gate_prepare() {
 }
 
 gate_run_job() {
-  local job="$1" rc=0 fn
+  local job="$1" fn rc=0
   echo ""
   echo ">> job: $job"
   # bash function names cannot contain hyphens; ci.yml job names do.
   fn="${job//-/_}"
-  "gate_$fn" || rc=$?
+  # Bash-3.2-safe dispatch (macOS default /bin/bash): errexit suppression for
+  # a function called in a condition (`f || rc=$?`) is broken on 3.2 — it
+  # aborts at the first failing command. Toggling errexit around a DIRECT call
+  # works on every bash; counters propagate because there is no subshell.
+  set +e
+  "gate_$fn"
+  rc=$?
+  set -e
   case "$rc" in
     0) GATE_PASS=$((GATE_PASS + 1)); echo "   ✓ $job" ;;
     77) echo "   → $job skipped (see summary)" ;;

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# Runs the Lobu Linux CI graph (ci.yml) jobs as local commands.
+#
+# This is the shared payload behind `make pr-full` / `make pr-fast`: the same
+# script executes inside a Daytona ephemeral sandbox (after provision) and as
+# the local fallback when Daytona is unavailable. GitHub CI remains the
+# canonical gate; this runner is a convenience preflight.
+#
+# Contract:
+#   - Every job mirrors its ci.yml steps (same commands, same order).
+#   - Jobs whose prerequisites are missing (DATABASE_URL, submodule, docker,
+#     Chrome, dbmate) are SKIPPED with a reason, never silently passed and
+#     never fatal — the command must stay non-disruptive. The summary lists
+#     every skip; CI covers what this runner cannot.
+#   - GitHub-only steps (PR diff gates, squawk scoping, client-regen) are
+#     skipped here with a note — they need git history the sandbox lacks.
+#
+# Usage: bash scripts/lib/gate-runner.sh [job ...]   (defaults to all jobs)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+GATE_JOBS=(
+  unit
+  frontend
+  server-integration-vitest
+  server-integration-bun
+  integration
+  format-lint
+  typecheck
+  migrations
+  sdk-cli-build
+  sdk-lifecycle-e2e
+  sdk-error-taxonomy-e2e
+  cli-command-smoke
+  sdk-cli-e2e
+  dead-code-report
+  optional-smoke-filter
+  connector-parity-smoke
+)
+
+GATE_PASS=0
+GATE_FAIL=0
+GATE_SKIP=0
+declare -a GATE_FAILED=()
+declare -a GATE_SKIPPED=()
+GATE_RAN_VITEST=0
+GATE_RAN_BUN=0
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+gate_skip() { # reason...
+  printf '   ↷ skipped: %s\n' "$*"
+  GATE_SKIP=$((GATE_SKIP + 1))
+  GATE_SKIPPED+=("$*")
+  return 77
+}
+
+gate_require_db() {
+  [ -n "${DATABASE_URL:-}" ] && return 0
+  gate_skip "DATABASE_URL is unset (needs a Postgres + pgvector)"
+}
+
+gate_require_submodule() {
+  # The real submodule ships src/; the stub (no deploy key) only has a
+  # package.json. Gate on real content so a stub can't half-build.
+  [ -d packages/owletto/src ] && return 0
+  gate_skip "packages/owletto submodule content is not checked out (stub semantics)"
+}
+
+gate_require_docker() {
+  command -v docker >/dev/null 2>&1 || { gate_skip "docker not available"; return 77; }
+  docker info >/dev/null 2>&1 || { gate_skip "docker daemon not reachable"; return 77; }
+}
+
+# ── jobs (each mirrors the ci.yml job of the same name) ────────────────────
+
+gate_unit() {
+  local sandbox_env=()
+  if command -v bwrap >/dev/null 2>&1; then
+    # CI sets this so a missing exec-sandbox fails the job. Without bwrap the
+    # escape matrix self-skips (the macOS situation); only force it when the
+    # backend is actually present.
+    sandbox_env=(LOBU_REQUIRE_EXEC_SANDBOX=1)
+  else
+    echo "   (bwrap not present — exec-sandbox escape matrix self-skips)"
+  fi
+  bun test packages/core packages/cli --timeout 30000
+  bun test packages/plugin-api packages/plugin-host packages/plugin-toolkit packages/plugin-memory packages/plugin-conversations packages/plugin-media packages/plugin-mcp --timeout 30000
+  env "${sandbox_env[@]}" bun test packages/agent-worker --timeout 30000
+  bun test packages/server/src/__tests__/unit --timeout 30000
+  bun test packages/server/src/auth/__tests__/system-provider-resolution.test.ts --timeout 30000
+  bun test packages/server/src/utils/__tests__/device-pin-tombstones.test.ts packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts --timeout 30000
+  bun test packages/server/src/utils/__tests__/catalog-connectors-compile.test.ts packages/server/src/utils/__tests__/compiler-core.test.ts --timeout 30000
+  bun test packages/connector-worker --timeout 30000
+  bun test packages/client packages/promptfoo-provider --timeout 30000
+  bun test packages/connector-sdk --timeout 30000
+  bun test packages/connectors --timeout 30000
+  bun test packages/embeddings --timeout 30000
+  bun test examples/personal-agent --timeout 30000
+  bun test examples/brand-intelligence --timeout 30000
+  bun test examples/lobu-team --timeout 30000
+}
+
+gate_frontend() {
+  gate_require_submodule || return 77
+  (cd packages/core && bun run build)
+  (cd packages/connector-sdk && bun run build)
+  (cd packages/owletto && ../../node_modules/.bin/vitest run)
+  (cd packages/owletto && bun run build)
+  if [ -x /usr/bin/google-chrome-stable ]; then
+    (cd packages/owletto && bun run smoke:boot)
+  else
+    echo "   (no google-chrome-stable — SPA cold-boot smoke skipped; vitest + prod build still ran)"
+  fi
+}
+
+gate_server_integration_vitest() {
+  gate_require_db || return 77
+  (cd packages/server && node ../../node_modules/.bin/vitest run --reporter=default)
+  GATE_RAN_VITEST=1
+}
+
+gate_server_integration_bun() {
+  gate_require_db || return 77
+  # Each gateway test file in its own process: bun has no per-file isolation
+  # and the suites aren't mutually hermetic (see #1238). Fail if find matches
+  # nothing, so a path typo can't silently run zero tests.
+  local dirs files rc f
+  dirs=$(find packages/server/src/gateway -type d -name __tests__ | sort)
+  [ -n "$dirs" ] || { echo "no gateway __tests__ dirs found" >&2; return 1; }
+  rc=0
+  for d in $dirs; do
+    files=$(find "$d" -maxdepth 1 -type f -name '*.test.ts' | sort)
+    for f in $files; do echo ">> bun test $f"; bun test "$f" || rc=1; done
+  done
+  [ "$rc" -eq 0 ] || return 1
+  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__
+  bun test packages/connector-worker/integration-tests
+  GATE_RAN_BUN=1
+}
+
+gate_integration() {
+  # CI's integration job is a compatibility fan-in over the two server jobs.
+  if [ "$GATE_RAN_VITEST" -eq 0 ]; then gate_server_integration_vitest || return $?; fi
+  if [ "$GATE_RAN_BUN" -eq 0 ]; then gate_server_integration_bun || return $?; fi
+  echo "   (fan-in over server-integration-vitest + server-integration-bun — both passed)"
+}
+
+gate_format_lint() {
+  bun run format:check
+  bun run lint
+  ./scripts/check-security-patterns.sh
+  bun run dupes
+  bun scripts/check-test-runner-coverage.mjs
+  bun scripts/check-exposed-surface-naming.ts
+  bun test scripts/__tests__/check-exposed-surface-naming.test.ts --timeout 30000
+  node scripts/check-gateway-llm-calls.mjs
+  bun test scripts/__tests__/check-gateway-llm-calls.test.ts --timeout 30000
+  bun test scripts/__tests__/publish-packages-guard.test.ts --timeout 30000
+  bun test scripts/__tests__/derive-image-tags.test.ts --timeout 30000
+  bun test scripts/__tests__/release-publish-order.test.ts --timeout 30000
+  bun test scripts/__tests__/audit-release-images.test.ts --timeout 30000
+  bun test scripts/__tests__/check-merge-integrity.test.ts --timeout 30000
+  bun test scripts/__tests__/review-prompt-env-blockers.test.ts --timeout 30000
+  bun test scripts/__tests__/review-output-schema.test.ts --timeout 30000
+  bun test scripts/__tests__/migrate-up-check-pending.test.ts --timeout 30000
+  bun test scripts/__tests__/migrate-up-duplicate-version.test.ts --timeout 30000
+  bun scripts/check-raw-array-params.mjs
+  bun scripts/check-entity-write-funnel.mjs
+  bun test scripts/__tests__/check-entity-write-funnel.test.ts --timeout 30000
+  bun scripts/check-connection-visibility-compiler.mjs
+  bun scripts/check-directory-structure.mjs
+  bun test scripts/__tests__/check-directory-structure.test.ts --timeout 30000
+  bash scripts/lib/__tests__/review-commit-lock.test.sh
+  bash scripts/lib/__tests__/review-process.test.sh
+  bash scripts/lib/__tests__/review-reviewer.test.sh
+  bash scripts/lib/__tests__/review-upstream-guard.test.sh
+  bash scripts/lib/__tests__/review-skip.test.sh
+  bash scripts/lib/__tests__/review-cache.test.sh
+  cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml
+  bash scripts/lib/__tests__/remote-ci.test.sh
+  bash scripts/lib/__tests__/submodule-drift.test.sh
+  bash scripts/lib/__tests__/submodule-bump.test.sh
+}
+
+gate_typecheck() {
+  bun run typecheck
+  (cd packages/server && bunx tsc --noEmit)
+  bun run check:packages
+  bun run knip --include files
+}
+
+gate_migrations() {
+  gate_require_db || return 77
+  # Sub-second pre-flight: every file under db/migrations/ must carry the
+  # runner directive before we even touch Postgres.
+  local missing
+  missing=$(grep -L '^-- migrate:up' db/migrations/*.sql || true)
+  if [ -n "$missing" ]; then
+    echo "::error::Migrations missing '-- migrate:up' directive:" >&2
+    echo "$missing" >&2
+    return 1
+  fi
+  echo "   (immutability + squawk lint are PR-diff gates and need git history — they run on GitHub CI)"
+  # Raise maintenance_work_mem: the baseline ivfflat index needs ~150MB and
+  # the default 64MB fails. Best-effort; if it truly can't raise, the apply
+  # below fails loudly with the real error.
+  if command -v psql >/dev/null 2>&1; then
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=0       -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()" >/dev/null 2>&1 || true
+  fi
+  # Apply with the SAME runner production uses (scripts/migrate-up.mjs), NOT
+  # dbmate up: migrate-up splits top-level statements so transaction:false
+  # migrations with CREATE INDEX CONCURRENTLY apply outside a transaction.
+  # Its only runtime dep is the postgres npm package; install it in a
+  # scratch dir (npm can't install the workspace root) and expose it via a
+  # top-level node_modules entry the ESM loader resolves.
+  local tmp
+  tmp="$(mktemp -d)"
+  (cd "$tmp" && npm init -y >/dev/null && npm install --no-audit --no-fund postgres@^3.4.7 >/dev/null)
+  mkdir -p node_modules
+  cp -r "$tmp/node_modules/postgres" node_modules/postgres
+  rm -rf "$tmp"
+  node scripts/migrate-up.mjs
+  # Ledger verify + pending-check contract (only with dbmate on PATH).
+  if command -v dbmate >/dev/null 2>&1; then
+    dbmate --migrations-dir db/migrations status
+    local pending
+    pending=$(dbmate --migrations-dir db/migrations status | grep -c '^\[ \]' || true)
+    [ "$pending" = "0" ] || { echo "::error::$pending migrations still pending after migrate-up" >&2; return 1; }
+    local pending_rc=0
+    node scripts/migrate-up.mjs --check-pending || pending_rc=$?
+    test "$pending_rc" -eq 3 || { echo "::error::--check-pending on a complete ledger returned $pending_rc, expected 3" >&2; return 1; }
+    printf -- '-- migrate:up\nSELECT 1;\n' > db/migrations/99999999999999_pending_probe.sql
+    pending_rc=0; node scripts/migrate-up.mjs --check-pending || pending_rc=$?
+    rm db/migrations/99999999999999_pending_probe.sql
+    test "$pending_rc" -eq 0 || { echo "::error::--check-pending with an unapplied migration returned $pending_rc, expected 0" >&2; return 1; }
+  else
+    echo "   (dbmate not on PATH — schema_migrations verify + pending-check contract skipped)"
+  fi
+  # glibc floor on committed pgvector prebuilts (needs docker).
+  gate_require_docker || return 0
+  for arch in linux-x64 linux-arm64; do
+    packages/pgvector-embedded/scripts/assert-glibc-floor.sh "packages/pgvector-embedded/prebuilt/${arch}"
+  done
+  local out
+  out=$(docker run --rm -v "$PWD:/w:ro" debian:bullseye ldd /w/packages/pgvector-embedded/prebuilt/linux-x64/vector.so 2>&1)
+  echo "$out"
+  if echo "$out" | grep -qi "not found"; then
+    echo "::error::vector.so has unresolved dependencies on debian:bullseye (glibc 2.31)." >&2
+    return 1
+  fi
+}
+
+gate_sdk_cli_build() {
+  make build-packages
+}
+
+gate_sdk_lifecycle_e2e() {
+  bash scripts/sdk-e2e.sh
+}
+
+gate_sdk_error_taxonomy_e2e() {
+  bash scripts/sdk-e2e-error.sh
+}
+
+gate_cli_command_smoke() {
+  bash scripts/cli-smoke.sh
+}
+
+gate_sdk_cli_e2e() {
+  gate_sdk_cli_build
+  gate_sdk_lifecycle_e2e
+  gate_sdk_error_taxonomy_e2e
+  gate_cli_command_smoke
+}
+
+gate_dead_code_report() {
+  # CI keeps this report non-blocking (continue-on-error) — keep parity.
+  if ! bun run knip; then
+    echo "   ⚠ dead-code report found issues (non-blocking, matches CI)"
+  fi
+}
+
+gate_optional_smoke_filter() {
+  gate_skip "optional-smoke-filter is a PR-diff gate against the base SHA — runs on GitHub CI"
+}
+
+gate_connector_parity_smoke() {
+  gate_require_docker || return 77
+  docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke .
+  docker run --rm --network=none lobu-worker:parity-smoke bun src/bin.ts self-check --json
+  node packages/cli/bin/lobu.js connector runtime-self-check --json
+}
+
+# ── runner ─────────────────────────────────────────────────────────────────
+
+gate_prepare() {
+  echo ">> [prepare] build publishable packages (needed for tsc + unit resolution)..."
+  # --skip-applications matches CI's unit job: the server bundle and the
+  # Owletto SPA build only run in the jobs that actually consume them
+  # (sdk-cli-build / frontend), keeping this step fast and low-risk.
+  node scripts/build-packages.mjs --skip-applications
+}
+
+gate_run_job() {
+  local job="$1" rc=0 fn
+  echo ""
+  echo ">> job: $job"
+  # bash function names cannot contain hyphens; ci.yml job names do.
+  fn="${job//-/_}"
+  "gate_$fn" || rc=$?
+  case "$rc" in
+    0) GATE_PASS=$((GATE_PASS + 1)); echo "   ✓ $job" ;;
+    77) echo "   → $job skipped (see summary)" ;;
+    *) GATE_FAIL=$((GATE_FAIL + 1)); GATE_FAILED+=("$job"); echo "   ✗ $job" ;;
+  esac
+  return 0
+}
+
+gate_run() {
+  local jobs=("$@")
+  if [ "${#jobs[@]}" -eq 0 ]; then jobs=("${GATE_JOBS[@]}"); fi
+  local unknown="" job
+  for job in "${jobs[@]}"; do
+    case " ${GATE_JOBS[*]} " in
+      *" $job "*) ;;
+      *) unknown="$unknown $job" ;;
+    esac
+  done
+  if [ -n "$unknown" ]; then
+    echo "unknown gate job(s):$unknown" >&2
+    echo "known jobs: ${GATE_JOBS[*]}" >&2
+    return 2
+  fi
+  gate_prepare
+  local rc=0
+  for job in "${jobs[@]}"; do
+    gate_run_job "$job" || rc=1
+  done
+  echo ""
+  echo "==== pr-full gate summary ===="
+  echo "  pass:    $GATE_PASS"
+  echo "  fail:    $GATE_FAIL"
+  echo "  skipped: $GATE_SKIP"
+  if [ "$GATE_FAIL" -gt 0 ]; then
+    echo "  failed:  ${GATE_FAILED[*]}"
+  fi
+  if [ "$GATE_SKIP" -gt 0 ]; then
+    echo "  skipped:"
+    printf '    - %s\n' "${GATE_SKIPPED[@]}"
+  fi
+  [ "$GATE_FAIL" -eq 0 ]
+}
+
+# provision (Daytona sandbox only) — source gate-provision.sh when asked
+if [ "${GATE_PROVISION:-0}" = "1" ]; then
+  # shellcheck source=scripts/lib/gate-provision.sh
+  . "$SCRIPT_DIR/gate-provision.sh"
+  gate_provision
+fi
+
+gate_run "$@"

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -138,7 +138,7 @@ gate_server_integration_bun() {
     for f in $files; do echo ">> bun test $f"; bun test "$f" || rc=1; done
   done
   [ "$rc" -eq 0 ] || return 1
-  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__
+  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__ packages/server/src/tools/admin/__tests__ packages/server/src/auth/oauth/__tests__ --timeout 30000
   bun test packages/connector-worker/integration-tests
   GATE_RAN_BUN=1
 }

--- a/scripts/lib/remote-ci.sh
+++ b/scripts/lib/remote-ci.sh
@@ -67,7 +67,7 @@ remote_ci_staged_tree() {
   remote_ci_require_no_untracked || return 1
   if ! git diff --quiet --ignore-submodules=none --; then
     echo "Full remote CI requires all intended changes to be staged." >&2
-    echo "Run git add -- <explicit-paths>, then rerun make pre-pr-remote." >&2
+    echo "Run git add -- <explicit-paths>, then rerun make pr-full." >&2
     return 1
   fi
   git write-tree

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -256,7 +256,10 @@ run_depot() {
   echo ">> checking Depot repository access"
   depot ci migrate preflight --org "${DEPOT_ORG_ID:-b9ffw2rv84}" >/dev/null
 
-  if [ "${#jobs[@]}" -eq 0 ]; then
+  # `$#` is the ORIGINAL argv (run_depot receives raw args from the
+  # dispatcher): the full-graph default keeps the staged-tree invariant,
+  # an explicit job list only requires no-untracked.
+  if [ "$#" -eq 0 ]; then
     jobs=("${DEFAULT_JOBS[@]}")
     remote_ci_staged_tree >/dev/null || exit $?
   else
@@ -347,5 +350,7 @@ run_depot() {
 case "$PROVIDER" in
   local) run_local "${jobs[@]}" ;;
   daytona) run_daytona "${jobs[@]}" ;;
-  depot) run_depot "${jobs[@]}" ;;
+  # depot gets the RAW args: run_depot resolves the default itself so its
+  # full-graph staged-tree invariant keeps working (see its $# check).
+  depot) run_depot "$@" ;;
 esac

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -125,11 +125,13 @@ run_daytona() {
   tar -czf "$ctx/repo.tar.gz" -C "$stage" .
   printf 'FROM ubuntu:24.04\nADD repo.tar.gz /workspace/lobu\nWORKDIR /workspace/lobu\n' > "$ctx/Dockerfile"
   # $$ keeps the name unique when a previous run is still deleting its sandbox.
-  name="lobu-pr-full-$(git rev-parse --short HEAD)-$$"
+  name="lobu-pr-full-$(git rev-parse --short HEAD 2>/dev/null || echo local)-$$"
   echo ">> creating ephemeral Daytona sandbox '$name' (${#jobs[@]} jobs)"
   local create_out create_rc=0
-  # NOTE: on CLI v0.204.0 --memory is in GB (the help text says MB; the API
-  # rejects e.g. 4096 with "4096GB exceeds maximum allowed per sandbox").
+  # NOTE: --memory is in GB on CLI v0.204.0 despite the help text saying MB.
+  # Empirically verified: --memory 4096 → API rejects "Memory request 4096GB
+  # exceeds maximum allowed per sandbox (8GB)"; --memory 4 → sandbox reports
+  # memory=4 (GB). Do NOT switch to MB units — that would request 4GB×1024.
   # The org's free tier caps total running memory (~10GiB), so default small.
   create_out="$(daytona create -c "$ctx" --dockerfile "$ctx/Dockerfile" --name "$name" \
     --cpu "${DAYTONA_CPU:-4}" --memory "${DAYTONA_MEMORY_GB:-4}" --disk "${DAYTONA_DISK_GB:-10}" \

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -29,6 +29,9 @@ DEPOT_ACTION=".depot/actions/setup-submodule/action.yml"
 
 # All Linux jobs, including the two dependency aggregators. mac-build-smoke is
 # intentionally absent: it requires macOS and remains on GitHub/Mac hardware.
+# NOTE: keep in sync with GATE_JOBS in scripts/lib/gate-runner.sh (the
+# daytona/local paths default through gate-runner; this list only feeds the
+# Depot --job flags).
 DEFAULT_JOBS=(
   unit
   frontend
@@ -102,8 +105,12 @@ run_local() {
 
 run_daytona() {
   local jobs=("$@")
-  # The sandbox only sees committed/staged content, so require a settled tree.
-  remote_ci_staged_tree >/dev/null || exit $?
+  # The sandbox only sees committed/staged content, so require a settled tree
+  # (GATE_SKIP_SETTLED_CHECK=1 is a test-only escape hatch so the dispatch
+  # tests don't depend on this checkout's tree state).
+  if [ "${GATE_SKIP_SETTLED_CHECK:-0}" != "1" ]; then
+    remote_ci_staged_tree >/dev/null || exit $?
+  fi
   # base/name are GLOBALS on purpose: the EXIT trap runs after this function
   # returns, when its locals are gone — a local would silently skip cleanup.
   local stage ctx ws
@@ -172,7 +179,7 @@ run_daytona() {
     sleep 5
   done
 
-  ws="$(daytona_workspace_dir "$name")"
+  ws="/workspace/lobu"  # deterministic: the generated Dockerfile COPYs the tree here
   echo ">> sandbox running; workspace $ws"
   local job_args="" j
   for j in "${jobs[@]}"; do job_args+="$(printf '%q ' "$j")"; done
@@ -202,11 +209,6 @@ daytona_sandbox_running() { # name
   # This CLI reports a usable sandbox as "started" (stopped/starting otherwise).
   state="$(daytona list --format json 2>/dev/null | jq -r --arg n "$name" '.items[] | select(.name == $n) | .state' | head -1)"
   [ "$state" = "started" ] || [ "$state" = "running" ]
-}
-
-daytona_workspace_dir() { # name → workspace path
-  # Deterministic: our generated Dockerfile COPYs the tree to /workspace/lobu.
-  printf '%s' "/workspace/lobu"
 }
 
 # ── Depot (legacy, opt-in) ─────────────────────────────────────────────────

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -52,6 +52,9 @@ DEFAULT_JOBS=(
 
 daytona_ready() {
   command -v daytona >/dev/null 2>&1 || return 1
+  # Sandbox polling pipes `daytona list --format json` through jq; without
+  # jq the run would fail mid-way, so fall back to local instead.
+  command -v jq >/dev/null 2>&1 || return 1
   # `daytona list` fails when not logged in — that's the readiness probe.
   daytona list >/dev/null 2>&1
 }
@@ -112,7 +115,8 @@ run_daytona() {
   git checkout-index -a -f --prefix="$stage/"
   # Submodule content at the pinned commit (the sandbox has no .git to fetch
   # it; owletto is a private repo whose deploy key lives on GitHub only).
-  if [ -d packages/owletto/.git ]; then
+  # NOTE: .git is a FILE (gitdir: ...) in normal submodule checkouts, not a dir.
+  if [ -e packages/owletto/.git ]; then
     git -C packages/owletto archive HEAD | tar -x -C "$stage/packages/owletto"
   else
     # Stub package.json (mirrors .github/actions/setup-submodule) so bun

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 # Run the Linux CI graph against local changes (optional; GitHub CI is canonical).
+#
+# Provider (REMOTE_CI_PROVIDER, default: auto):
+#   auto    - Daytona ephemeral sandbox when the CLI exists AND is logged in;
+#             otherwise run the SAME jobs on this machine. Never disruptive:
+#             the command works without Daytona.
+#   daytona - require Daytona (fail closed if unavailable).
+#   local   - force the local fallback.
+#   depot   - legacy Depot cloud CI (requires the Depot org; opt-in).
+#
+# Job list: pass job names as args (see scripts/lib/gate-runner.sh) or rely on
+# the default full Linux graph. REMOTE_JOBS on the make target narrows it.
 
 set -euo pipefail
 
@@ -9,8 +20,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/lib/remote-ci.sh"
 cd "$REPO_ROOT"
 
-# ── Depot mode (default) ──────────────────────────────────────────────────
-DEPOT_ORG_ID="${DEPOT_ORG_ID:-b9ffw2rv84}"
 REMOTE_CI_TIMEOUT_SECONDS="${REMOTE_CI_TIMEOUT_SECONDS:-2700}"
 REMOTE_CI_POLL_INTERVAL_SECONDS="${REMOTE_CI_POLL_INTERVAL_SECONDS:-5}"
 REMOTE_CI_MAX_RETRIES="${REMOTE_CI_MAX_RETRIES:-1}"
@@ -39,129 +48,296 @@ DEFAULT_JOBS=(
   connector-parity-smoke
 )
 
-for cmd in depot git jq tee; do
-  command -v "$cmd" >/dev/null 2>&1 || {
-    echo "$cmd not found on PATH." >&2
-    exit 2
-  }
-done
+# ── provider resolution ────────────────────────────────────────────────────
 
-for value in "$REMOTE_CI_TIMEOUT_SECONDS" "$REMOTE_CI_POLL_INTERVAL_SECONDS"; do
-  [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
-    echo "Remote CI timeout and poll interval must be positive integers." >&2
-    exit 2
-  }
-done
-[[ "$REMOTE_CI_MAX_RETRIES" =~ ^[0-9]+$ ]] || {
-  echo "Remote CI max retries must be a non-negative integer." >&2
-  exit 2
+daytona_ready() {
+  command -v daytona >/dev/null 2>&1 || return 1
+  # `daytona list` fails when not logged in — that's the readiness probe.
+  daytona list >/dev/null 2>&1
 }
 
-if ! cmp -s "$SOURCE_ACTION" "$DEPOT_ACTION"; then
-  echo "$DEPOT_ACTION has drifted from $SOURCE_ACTION." >&2
-  echo "Keep the Depot copy byte-for-byte identical to the GitHub action." >&2
-  exit 2
-fi
-
-# A changed workflow can read Depot secrets. Refuse to execute it by default;
-# the explicit override is reserved for reviewed CI-infrastructure changes.
-if [ "${DEPOT_ALLOW_WORKFLOW_CHANGES:-0}" != "1" ]; then
-  git show-ref --verify --quiet refs/remotes/origin/main || {
-    echo "origin/main is unavailable; fetch it before running remote CI." >&2
+PROVIDER="${REMOTE_CI_PROVIDER:-auto}"
+case "$PROVIDER" in
+  auto)
+    if daytona_ready; then
+      PROVIDER=daytona
+      echo ">> provider: daytona (ephemeral sandbox)"
+    else
+      PROVIDER=local
+      echo ">> provider: local (Daytona CLI not available — fallback; GitHub CI is canonical)"
+    fi
+    ;;
+  daytona)
+    daytona_ready || {
+      echo "REMOTE_CI_PROVIDER=daytona but the Daytona CLI is not available or not logged in." >&2
+      exit 2
+    }
+    ;;
+  local) ;;
+  depot) ;;
+  *)
+    echo "Unknown REMOTE_CI_PROVIDER '$PROVIDER' (auto | daytona | local | depot)." >&2
     exit 2
-  }
-  if ! git diff --quiet origin/main -- "$WORKFLOW" "$SOURCE_ACTION" "$DEPOT_ACTION"; then
-    echo "Remote workflow/action files differ from origin/main." >&2
-    echo "Review them, then rerun with DEPOT_ALLOW_WORKFLOW_CHANGES=1 if intentional." >&2
-    exit 2
-  fi
-fi
-
-echo ">> checking Depot repository access"
-depot ci migrate preflight --org "$DEPOT_ORG_ID" >/dev/null
+    ;;
+esac
 
 if [ "$#" -eq 0 ]; then
   jobs=("${DEFAULT_JOBS[@]}")
-  remote_ci_staged_tree >/dev/null || exit $?
 else
   jobs=("$@")
-  remote_ci_require_no_untracked || exit $?
 fi
 
-job_args=()
-for job in "${jobs[@]}"; do
-  job_args+=(--job "$job")
-done
+# ── local fallback ─────────────────────────────────────────────────────────
 
-echo ">> running ${#jobs[@]} Linux CI jobs on Depot: ${jobs[*]}"
-log_file="$(mktemp "${TMPDIR:-/tmp}/lobu-depot-ci.XXXXXX")"
-trap 'rm -f "$log_file"' EXIT
+run_local() {
+  local jobs=("$@")
+  echo ">> running ${#jobs[@]} jobs locally: ${jobs[*]}"
+  bash scripts/lib/gate-runner.sh "${jobs[@]}"
+}
 
-# Start the whole graph without --follow: Depot's follower can stream only one
-# selected job and exits early for a multi-job run. Capture the run id, then
-# query the authoritative graph state until it reaches a terminal status.
-set +e
-depot ci run \
-  --workflow "$WORKFLOW" \
-  --org "$DEPOT_ORG_ID" \
-  "${job_args[@]}" 2>&1 | tee "$log_file"
-cli_exit=${PIPESTATUS[0]}
-set -e
+# ── Daytona ephemeral sandbox ──────────────────────────────────────────────
 
-run_id="$(remote_ci_extract_run_id < "$log_file")"
-if [ -z "$run_id" ]; then
-  echo "Depot did not return a run id (CLI exit $cli_exit)." >&2
-  exit 1
-fi
+run_daytona() {
+  local jobs=("$@")
+  # The sandbox only sees committed/staged content, so require a settled tree.
+  remote_ci_staged_tree >/dev/null || exit $?
+  # base/name are GLOBALS on purpose: the EXIT trap runs after this function
+  # returns, when its locals are gone — a local would silently skip cleanup.
+  local stage ctx ws
+  base="$(mktemp -d "${TMPDIR:-/tmp}/lobu-pr-full.XXXXXX")"
+  stage="$base/stage"
+  ctx="$base/ctx"
+  mkdir -p "$stage" "$ctx"
+  # Materialize the exact staged tree (index only — no untracked files).
+  git checkout-index -a -f --prefix="$stage/"
+  # Submodule content at the pinned commit (the sandbox has no .git to fetch
+  # it; owletto is a private repo whose deploy key lives on GitHub only).
+  if [ -d packages/owletto/.git ]; then
+    git -C packages/owletto archive HEAD | tar -x -C "$stage/packages/owletto"
+  else
+    # Stub package.json (mirrors .github/actions/setup-submodule) so bun
+    # install still resolves the workspace; frontend skips on the stub.
+    printf '%s\n' '{' '  "name": "@lobu/owletto",' '  "private": true,' '  "version": "1.6.0",' '  "description": "Stub — private submodule not initialized"' '}' > "$stage/packages/owletto/package.json"
+  fi
+  # Daytona's build context excludes .github / .env* by default, and the CI
+  # wrapper guards in format-lint read .github/actions + ci.yml. Ship the tree
+  # as ONE tarball so nothing is filtered, and let the Dockerfile ADD-extract it.
+  tar -czf "$ctx/repo.tar.gz" -C "$stage" .
+  printf 'FROM ubuntu:24.04\nADD repo.tar.gz /workspace/lobu\nWORKDIR /workspace/lobu\n' > "$ctx/Dockerfile"
+  # $$ keeps the name unique when a previous run is still deleting its sandbox.
+  name="lobu-pr-full-$(git rev-parse --short HEAD)-$$"
+  echo ">> creating ephemeral Daytona sandbox '$name' (${#jobs[@]} jobs)"
+  local create_out create_rc=0
+  # NOTE: on CLI v0.204.0 --memory is in GB (the help text says MB; the API
+  # rejects e.g. 4096 with "4096GB exceeds maximum allowed per sandbox").
+  # The org's free tier caps total running memory (~10GiB), so default small.
+  create_out="$(daytona create -c "$ctx" --dockerfile "$ctx/Dockerfile" --name "$name" \
+    --cpu "${DAYTONA_CPU:-4}" --memory "${DAYTONA_MEMORY_GB:-4}" --disk "${DAYTONA_DISK_GB:-10}" \
+    --auto-delete 0 --auto-stop 0 --ttl "${DAYTONA_TTL_MINUTES:-120}" \
+    --target "${DAYTONA_TARGET:-eu}" 2>&1)" || create_rc=$?
+  if [ "$create_rc" -ne 0 ]; then
+    echo "Daytona create failed:" >&2
+    echo "$create_out" >&2
+    rm -rf "$base"
+    exit 1
+  fi
+  echo "$create_out" | grep -viE '^\[[0-9]+m' | tail -3 || true
 
-retry_count=0
-while :; do
-  deadline=$((SECONDS + REMOTE_CI_TIMEOUT_SECONDS))
-  last_summary=""
-  while :; do
-    status_json="$(depot ci status "$run_id" --org "$DEPOT_ORG_ID" --output json)" || {
-      echo "Could not read Depot status for run $run_id." >&2
-      exit 1
-    }
-    summary="$(remote_ci_status_summary <<<"$status_json")"
-    if [ "$summary" != "$last_summary" ]; then
-      echo ">> Depot run $run_id: ${summary:-waiting for jobs}"
-      last_summary="$summary"
+  # Cleanup: delete the sandbox and the context dir on every exit path.
+  # The trap outlives run_daytona, so guard the function locals (set -u).
+  cleanup() {
+    if [ -n "${name:-}" ]; then
+      # This CLI has no --force flag; delete by name.
+      daytona delete "$name" >/dev/null 2>&1 || true
     fi
-    if remote_ci_status_terminal <<<"$status_json"; then
-      break
+    if [ -n "${base:-}" ]; then
+      rm -rf "$base"
     fi
+  }
+  trap cleanup EXIT
+
+  # Wait for the sandbox to reach RUNNING.
+  local deadline=$((SECONDS + 600))
+  while ! daytona_sandbox_running "$name"; do
     if [ "$SECONDS" -ge "$deadline" ]; then
-      echo "Depot run $run_id did not finish within ${REMOTE_CI_TIMEOUT_SECONDS}s; it is still running remotely." >&2
+      echo "sandbox $name did not reach RUNNING within 600s" >&2
       exit 1
     fi
-    sleep "$REMOTE_CI_POLL_INTERVAL_SECONDS"
+    sleep 5
   done
 
-  if remote_ci_status_succeeded <<<"$status_json"; then
-    break
+  ws="$(daytona_workspace_dir "$name")"
+  echo ">> sandbox running; workspace $ws"
+  local job_args="" j
+  for j in "${jobs[@]}"; do job_args+="$(printf '%q ' "$j")"; done
+  local log rc=0 remote_rc
+  log="$(mktemp "${TMPDIR:-/tmp}/lobu-pr-full-daytona.XXXXXX")"
+  set +e
+  daytona exec "$name" --cwd "$ws" --timeout "${DAYTONA_EXEC_TIMEOUT_SECONDS:-7200}" -- \
+    bash -lc "cd '$ws' && GATE_PROVISION=1 bash scripts/lib/gate-runner.sh $job_args; echo GATE_REMOTE_EXIT=\$?" \
+    2>&1 | tee "$log"
+  rc=${PIPESTATUS[0]}
+  set -e
+  # -a: the gate log can contain binary (esbuild error dumps); force text
+  # mode so the sentinel is still parseable, and ignore non-numeric noise.
+  remote_rc="$(grep -a '^GATE_REMOTE_EXIT=' "$log" | tail -1 | cut -d= -f2 || true)"
+  rm -f "$log"
+  if [[ "$remote_rc" =~ ^[0-9]+$ ]]; then
+    echo ">> remote gate exit: $remote_rc"
+    rc="$remote_rc"
+  elif [ "$rc" -ne 0 ]; then
+    echo "daytona exec failed (exit $rc) before the gate produced a result." >&2
+  fi
+  return "$rc"
+}
+
+daytona_sandbox_running() { # name
+  local name="$1" state
+  # This CLI reports a usable sandbox as "started" (stopped/starting otherwise).
+  state="$(daytona list --format json 2>/dev/null | jq -r --arg n "$name" '.items[] | select(.name == $n) | .state' | head -1)"
+  [ "$state" = "started" ] || [ "$state" = "running" ]
+}
+
+daytona_workspace_dir() { # name → workspace path
+  # Deterministic: our generated Dockerfile COPYs the tree to /workspace/lobu.
+  printf '%s' "/workspace/lobu"
+}
+
+# ── Depot (legacy, opt-in) ─────────────────────────────────────────────────
+
+run_depot() {
+  local jobs=("$@")
+  for cmd in depot git jq tee; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+      echo "$cmd not found on PATH." >&2
+      exit 2
+    }
+  done
+
+  for value in "$REMOTE_CI_TIMEOUT_SECONDS" "$REMOTE_CI_POLL_INTERVAL_SECONDS"; do
+    [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+      echo "Remote CI timeout and poll interval must be positive integers." >&2
+      exit 2
+    }
+  done
+  [[ "$REMOTE_CI_MAX_RETRIES" =~ ^[0-9]+$ ]] || {
+    echo "Remote CI max retries must be a non-negative integer." >&2
+    exit 2
+  }
+
+  if ! cmp -s "$SOURCE_ACTION" "$DEPOT_ACTION"; then
+    echo "$DEPOT_ACTION has drifted from $SOURCE_ACTION." >&2
+    echo "Keep the Depot copy byte-for-byte identical to the GitHub action." >&2
+    exit 2
   fi
 
-  if [ "$retry_count" -ge "$REMOTE_CI_MAX_RETRIES" ]; then
-    break
+  # A changed workflow can read Depot secrets. Refuse to execute it by default;
+  # the explicit override is reserved for reviewed CI-infrastructure changes.
+  if [ "${DEPOT_ALLOW_WORKFLOW_CHANGES:-0}" != "1" ]; then
+    git show-ref --verify --quiet refs/remotes/origin/main || {
+      echo "origin/main is unavailable; fetch it before running remote CI." >&2
+      exit 2
+    }
+    if ! git diff --quiet origin/main -- "$WORKFLOW" "$SOURCE_ACTION" "$DEPOT_ACTION"; then
+      echo "Remote workflow/action files differ from origin/main." >&2
+      echo "Review them, then rerun with DEPOT_ALLOW_WORKFLOW_CHANGES=1 if intentional." >&2
+      exit 2
+    fi
   fi
-  workflow_id="$(jq -r '.workflows[0].workflow_id // empty' <<<"$status_json")"
-  if [ -z "$workflow_id" ] || ! depot ci retry "$run_id" \
-      --failed --workflow "$workflow_id" --org "$DEPOT_ORG_ID"; then
-    echo "Depot could not retry the failed jobs in run $run_id." >&2
-    break
+
+  echo ">> checking Depot repository access"
+  depot ci migrate preflight --org "${DEPOT_ORG_ID:-b9ffw2rv84}" >/dev/null
+
+  if [ "${#jobs[@]}" -eq 0 ]; then
+    jobs=("${DEFAULT_JOBS[@]}")
+    remote_ci_staged_tree >/dev/null || exit $?
+  else
+    remote_ci_require_no_untracked || exit $?
   fi
-  retry_count=$((retry_count + 1))
-  echo ">> retrying failed Depot jobs (${retry_count}/${REMOTE_CI_MAX_RETRIES}); successful jobs are preserved"
-done
 
-if ! remote_ci_status_succeeded <<<"$status_json"; then
-  remote_ci_print_failures <<<"$status_json" >&2
-  echo "Depot run $run_id failed (CLI exit $cli_exit)." >&2
-  exit 1
-fi
+  local job_args=() job
+  for job in "${jobs[@]}"; do
+    job_args+=(--job "$job")
+  done
 
-echo ">> Depot run $run_id passed"
-jq -r '.workflows[].jobs[].attempts[-1].view_url // empty' <<<"$status_json" | sort -u
+  echo ">> running ${#jobs[@]} Linux CI jobs on Depot: ${jobs[*]}"
+  local log_file
+  log_file="$(mktemp "${TMPDIR:-/tmp}/lobu-depot-ci.XXXXXX")"
+  trap 'rm -f "$log_file"' EXIT
 
+  # Start the whole graph without --follow: Depot's follower can stream only one
+  # selected job and exits early for a multi-job run. Capture the run id, then
+  # query the authoritative graph state until it reaches a terminal status.
+  set +e
+  depot ci run \
+    --workflow "$WORKFLOW" \
+    --org "${DEPOT_ORG_ID:-b9ffw2rv84}" \
+    "${job_args[@]}" 2>&1 | tee "$log_file"
+  local cli_exit=${PIPESTATUS[0]}
+  set -e
 
+  local run_id
+  run_id="$(remote_ci_extract_run_id < "$log_file")"
+  if [ -z "$run_id" ]; then
+    echo "Depot did not return a run id (CLI exit $cli_exit)." >&2
+    exit 1
+  fi
+
+  local retry_count=0 status_json summary workflow_id
+  while :; do
+    local deadline=$((SECONDS + REMOTE_CI_TIMEOUT_SECONDS))
+    local last_summary=""
+    while :; do
+      status_json="$(depot ci status "$run_id" --org "${DEPOT_ORG_ID:-b9ffw2rv84}" --output json)" || {
+        echo "Could not read Depot status for run $run_id." >&2
+        exit 1
+      }
+      summary="$(remote_ci_status_summary <<<"$status_json")"
+      if [ "$summary" != "$last_summary" ]; then
+        echo ">> Depot run $run_id: ${summary:-waiting for jobs}"
+        last_summary="$summary"
+      fi
+      if remote_ci_status_terminal <<<"$status_json"; then
+        break
+      fi
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Depot run $run_id did not finish within ${REMOTE_CI_TIMEOUT_SECONDS}s; it is still running remotely." >&2
+        exit 1
+      fi
+      sleep "$REMOTE_CI_POLL_INTERVAL_SECONDS"
+    done
+
+    if remote_ci_status_succeeded <<<"$status_json"; then
+      break
+    fi
+
+    if [ "$retry_count" -ge "$REMOTE_CI_MAX_RETRIES" ]; then
+      break
+    fi
+    workflow_id="$(jq -r '.workflows[0].workflow_id // empty' <<<"$status_json")"
+    if [ -z "$workflow_id" ] || ! depot ci retry "$run_id" \
+        --failed --workflow "$workflow_id" --org "${DEPOT_ORG_ID:-b9ffw2rv84}"; then
+      echo "Depot could not retry the failed jobs in run $run_id." >&2
+      break
+    fi
+    retry_count=$((retry_count + 1))
+    echo ">> retrying failed Depot jobs (${retry_count}/${REMOTE_CI_MAX_RETRIES}); successful jobs are preserved"
+  done
+
+  if ! remote_ci_status_succeeded <<<"$status_json"; then
+    remote_ci_print_failures <<<"$status_json" >&2
+    echo "Depot run $run_id failed (CLI exit $cli_exit)." >&2
+    exit 1
+  fi
+
+  echo ">> Depot run $run_id passed"
+  jq -r '.workflows[].jobs[].attempts[-1].view_url // empty' <<<"$status_json" | sort -u
+}
+
+# ── dispatch ───────────────────────────────────────────────────────────────
+
+case "$PROVIDER" in
+  local) run_local "${jobs[@]}" ;;
+  daytona) run_daytona "${jobs[@]}" ;;
+  depot) run_depot "${jobs[@]}" ;;
+esac

--- a/skills/lobu-operator/SKILL.md
+++ b/skills/lobu-operator/SKILL.md
@@ -42,10 +42,10 @@ Run focused tests while iterating, then the settled-diff gates in this order:
 
 ```bash
 bun test <path>                     # focused local iteration
-make pre-pr-remote-fast             # broad required graph on Depot; iteration only
+make pr-fast                       # broad required graph; Daytona sandbox, else local
 make review-fix                     # unposted fixer pass; inspect its edits
 git add -- <paths>                  # explicit paths only, never -A
-make pre-pr-remote                  # full staged Linux graph on Depot; no local CPU
+make pr-full                       # full staged Linux graph; Daytona sandbox, else local
 git commit -m '<type>(<scope>): <summary>'
 git diff --name-only origin/main...HEAD
 git push -u origin <branch>
@@ -55,7 +55,7 @@ gh pr checks <number> --required
 gh pr merge <number> --squash --admin
 ```
 
-GitHub CI (`ci.yml`) is the canonical gate: free on this public repo, full Linux graph in ~5–7 min per PR. `make pre-pr` runs the fast local gates (typecheck, knip, lint, naming) before push; `make review` requires CI green for HEAD. `make pre-pr-remote` (Depot) is optional tooling, not part of the required loop. Stage every intended new file explicitly before pushing.
+GitHub CI (`ci.yml`) is the canonical gate: free on this public repo, full Linux graph in ~5–7 min per PR. `make pre-pr` runs the fast local gates (typecheck, knip, lint, naming) before push; `make review` requires CI green for HEAD. `make pr-full` (Daytona ephemeral sandbox, else local) is optional tooling, not part of the required loop. Stage every intended new file explicitly before pushing.
 
 Never bypass a check that has not reported. For a production-visible change, wait for deployment and prove the PR's squash merge commit is an ancestor of the deployed SHA before running the live check. Clean up the task worktree with `make task-clean` after merge.
 


### PR DESCRIPTION
## Summary
- `make pr-full` / `make pr-fast` replace `pre-pr-remote` / `pre-pr-remote-fast`. The "remote" name described the old Depot backend; the provider is now auto-detected, so the name reflects scope, not infra.
- Provider auto: **Daytona ephemeral sandbox** when the CLI exists and is logged in; otherwise the **same jobs run locally** — never disruptive. `REMOTE_CI_PROVIDER=auto|daytona|local|depot` (Depot kept as explicit opt-in).

## What moved
- `scripts/run-remote-ci.sh` → provider dispatcher (daytona / local / depot).
- `scripts/lib/gate-runner.sh` (new) → runs every ci.yml Linux job as local commands; jobs with missing prerequisites (DATABASE_URL, submodule, docker, Chrome) **skip with a reason**, never fail the run.
- `scripts/lib/gate-provision.sh` (new) → bootstraps the sandbox: bun 1.3.5, node 22, postgres 16 + pgvector, bubblewrap, dbmate, Chrome, bun install.
- Sandbox: staged tree shipped as one tarball (Daytona's build context filters .github/.env, which format-lint's wrapper guards need), ADD-extracted by a generated Dockerfile; auto-deleted on every exit path.
- Docs/templates updated: AGENTS.md, docs/AGENT_PLAYBOOK.md, skills/lobu-operator/SKILL.md, PR template, ci.yml comments.

## Test plan
- [x] Intended files staged explicitly, then `make pr-full` clean — verified with the **real Daytona flow** (`dead-code-report` job: create → provision → gate → PASS, `GATE_REMOTE_EXIT=0`, sandbox auto-destroyed) and the **local fallback** (same job, pass).
- [x] Full `make build-packages` (incl. owletto SPA) verified inside a sandbox (`FULL_RC=0`).
- [x] `make pre-pr` clean; `bash scripts/lib/__tests__/remote-ci.test.sh` green; unknown provider/job fail closed.
- [x] GitHub CI runs on this PR (canonical gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `make pr-fast` and `make pr-full` validation commands.
  * Validation can run in an ephemeral sandbox or locally, with automatic fallback when sandbox execution is unavailable.
  * Added broader checks covering tests, linting, type checking, migrations, SDKs, CLI, and integrations.
  * Added environment setup for required tools, databases, dependencies, and optional browser testing.
  * Preserved legacy Depot execution as an optional provider.

* **Documentation**
  * Updated pull request guidance, CI instructions, and operator documentation to reflect the new commands and execution options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->