### PR TITLE
fix(mcp): bind MCP resource to the host the client actually called

### DIFF
--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -174,4 +174,63 @@ describe('MCP OAuth resource indicators', () => {
     });
     expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
   });
+
+  // Prod chain: the lobu.ai Cloudflare Pages worker proxies to app.lobu.ai and
+  // sets both `x-forwarded-host: lobu.ai` and `x-forwarded-for-origin`, but
+  // Traefik in front of the pod overwrites `x-forwarded-host` with its own
+  // request host. Only the non-standard header survives, so a token bound to
+  // `https://lobu.ai/mcp` is compared against `https://app.lobu.ai/mcp` and
+  // every MCP call 401s.
+  test('publicMcpRequestUrl honours x-forwarded-for-origin when a proxy rewrote the forwarded host', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://app.lobu.ai/mcp', {
+      headers: {
+        host: 'app.lobu.ai',
+        'x-forwarded-host': 'app.lobu.ai',
+        'x-forwarded-for-origin': 'https://lobu.ai',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
+    expect(buildMcpBearerChallenge(publicMcpRequestUrl(request))).toContain(
+      'resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp"'
+    );
+  });
+
+  test('publicMcpRequestUrl rejects an x-forwarded-for-origin outside the trusted zone', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    for (const spoofed of ['https://evil.example', 'not-a-url', 'http://lobu.ai']) {
+      const request = new Request('https://app.lobu.ai/mcp', {
+        headers: {
+          host: 'app.lobu.ai',
+          'x-forwarded-host': 'app.lobu.ai',
+          'x-forwarded-for-origin': spoofed,
+          'x-forwarded-proto': 'https',
+        },
+      });
+      expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/mcp');
+    }
+  });
+
+  test('publicMcpRequestUrl ignores x-forwarded-for-origin when no zone is configured', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    delete process.env.AUTH_COOKIE_DOMAIN;
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://app.lobu.ai/mcp', {
+      headers: {
+        host: 'app.lobu.ai',
+        'x-forwarded-host': 'app.lobu.ai',
+        'x-forwarded-for-origin': 'https://lobu.ai',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/mcp');
+  });
 });

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   buildMcpBearerChallenge,
   canonicalizeMcpResource,
+  getMcpResourceForRequest,
   getProtectedResourceMetadataUrl,
   publicMcpRequestUrl,
 } from '../../auth/oauth/resource-indicator.js';
@@ -175,12 +176,10 @@ describe('MCP OAuth resource indicators', () => {
     expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
   });
 
-  // Prod chain: the lobu.ai Cloudflare Pages worker proxies to app.lobu.ai and
-  // sets both `x-forwarded-host: lobu.ai` and `x-forwarded-for-origin`, but
-  // Traefik in front of the pod overwrites `x-forwarded-host` with its own
-  // request host. Only the non-standard header survives, so a token bound to
-  // `https://lobu.ai/mcp` is compared against `https://app.lobu.ai/mcp` and
-  // every MCP call 401s.
+  // Prod chain: only `x-forwarded-for-origin` survives the edge → Traefik hop
+  // (see `forwardedPublicOrigin`), so the audience check must resolve the same
+  // origin the client called — otherwise a token bound to `https://lobu.ai/mcp`
+  // is compared against `https://app.lobu.ai/mcp` and every MCP call 401s.
   test('publicMcpRequestUrl honours x-forwarded-for-origin when a proxy rewrote the forwarded host', () => {
     process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
     process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
@@ -195,6 +194,8 @@ describe('MCP OAuth resource indicators', () => {
       },
     });
     expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
+    // The resource the audience check compares the token's `resource` against.
+    expect(getMcpResourceForRequest(publicMcpRequestUrl(request))).toBe('https://lobu.ai/mcp');
     expect(buildMcpBearerChallenge(publicMcpRequestUrl(request))).toContain(
       'resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp"'
     );
@@ -205,7 +206,9 @@ describe('MCP OAuth resource indicators', () => {
     process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
     __resetPublicOriginCachesForTests();
 
-    for (const spoofed of ['https://evil.example', 'not-a-url', 'http://lobu.ai']) {
+    // `file:///` parses but yields the opaque origin string `null`, which is
+    // not itself a URL — it must be rejected, not thrown on.
+    for (const spoofed of ['https://evil.example', 'not-a-url', 'http://lobu.ai', 'file:///']) {
       const request = new Request('https://app.lobu.ai/mcp', {
         headers: {
           host: 'app.lobu.ai',
@@ -216,6 +219,21 @@ describe('MCP OAuth resource indicators', () => {
       });
       expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/mcp');
     }
+  });
+
+  test('publicMcpRequestUrl falls back when a forwarded proto yields an opaque origin', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://app.lobu.ai/mcp', {
+      headers: {
+        host: 'app.lobu.ai',
+        'x-forwarded-host': 'lobu.ai',
+        'x-forwarded-proto': 'file',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/mcp');
   });
 
   test('publicMcpRequestUrl ignores x-forwarded-for-origin when no zone is configured', () => {

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -221,6 +221,24 @@ describe('MCP OAuth resource indicators', () => {
     }
   });
 
+  // Tenant orgs are subdomains of this same zone, so admitting the whole zone
+  // would let any caller reaching the pod directly present a sibling org's host
+  // and pass the audience check for a token bound to it. Only the apex host the
+  // edge worker actually fronts is accepted.
+  test('publicMcpRequestUrl rejects an in-zone sibling host in x-forwarded-for-origin', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+
+    const request = new Request('https://app.lobu.ai/mcp', {
+      headers: {
+        host: 'app.lobu.ai',
+        'x-forwarded-for-origin': 'https://buremba.lobu.ai',
+      },
+    });
+    expect(publicMcpRequestUrl(request)).toBe('https://app.lobu.ai/mcp');
+  });
+
   test('publicMcpRequestUrl falls back when a forwarded proto yields an opaque origin', () => {
     process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
     process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -207,8 +207,20 @@ describe('MCP OAuth resource indicators', () => {
     __resetPublicOriginCachesForTests();
 
     // `file:///` parses but yields the opaque origin string `null`, which is
-    // not itself a URL — it must be rejected, not thrown on.
-    for (const spoofed of ['https://evil.example', 'not-a-url', 'http://lobu.ai', 'file:///']) {
+    // not itself a URL — it must be rejected, not thrown on. The trailing four
+    // cover the bare-origin guard (path/query/fragment) and the port arm, so
+    // removing either check fails here rather than silently widening what the
+    // audience comparison will accept.
+    for (const spoofed of [
+      'https://evil.example',
+      'not-a-url',
+      'http://lobu.ai',
+      'file:///',
+      'https://lobu.ai/mcp',
+      'https://lobu.ai?x=1',
+      'https://lobu.ai#f',
+      'https://lobu.ai:444',
+    ]) {
       const request = new Request('https://app.lobu.ai/mcp', {
         headers: {
           host: 'app.lobu.ai',

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -10,7 +10,7 @@ import {
   getConfiguredPublicOrigin,
   getConfiguredSubdomainZone,
 } from '../../utils/public-origin';
-import { resolveBaseUrl } from '../base-url';
+import { resolveBaseUrl, safeParseUrl } from '../base-url';
 import { DEFAULT_SCOPES_STRING } from './scopes';
 
 /**
@@ -54,30 +54,30 @@ export function publicMcpRequestUrl(request: Request): string {
  *
  * A request that skips the edge can set the header itself, so it is honoured
  * only after `isTrustedPublicOrigin` — the same gate the standard forwarded
- * host clears. That confines it to the configured zone, which is one resource
- * server under one operator, so it can never name a foreign resource server.
+ * host clears. With an origin or zone configured, that gate confines it to one
+ * operator's hosts, so it can never name a foreign resource server; a
+ * deployment that configures neither trusts this header exactly as much as it
+ * already trusts `x-forwarded-host`.
  */
 function forwardedPublicOrigin(request: Request): string | null {
   const raw = request.headers.get('x-forwarded-for-origin')?.trim();
-  if (!raw) return null;
-  let origin: string;
-  try {
-    const parsed = new URL(raw);
-    // Origin only: a path, query, or fragment means this is not a bare origin
-    // and we should not guess at what the client called.
-    if (parsed.pathname !== '/' || parsed.search || parsed.hash) return null;
-    origin = parsed.origin;
-  } catch {
-    return null;
-  }
-  return isTrustedPublicOrigin(origin) ? origin : null;
+  const parsed = raw ? safeParseUrl(raw) : null;
+  if (!parsed) return null;
+  // Origin only: a path, query, or fragment means this is not a bare origin
+  // and we should not guess at what the client called.
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) return null;
+  return isTrustedPublicOrigin(parsed.origin) ? parsed.origin : null;
 }
 
 function isTrustedPublicOrigin(
   candidateOrigin: string,
   configuredOrigin = getConfiguredPublicOrigin()
 ): boolean {
-  const candidate = new URL(candidateOrigin);
+  // Client-supplied headers reach here: `x-forwarded-proto: file` makes
+  // `resolveBaseUrl` return the opaque origin string `null`, which is not a
+  // parseable URL. Fail closed instead of throwing a 500 on every such call.
+  const candidate = safeParseUrl(candidateOrigin);
+  if (!candidate) return false;
   const zone = getConfiguredSubdomainZone();
   if (!configuredOrigin) {
     return !zone || candidate.hostname === zone || candidate.hostname.endsWith(`.${zone}`);

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -52,12 +52,14 @@ export function publicMcpRequestUrl(request: Request): string {
  * `https://app.lobu.ai/mcp` and every MCP call 401s — the failure mode this
  * function exists to prevent.
  *
- * A request that skips the edge can set the header itself, so it is honoured
- * only after `isTrustedPublicOrigin` — the same gate the standard forwarded
- * host clears. With an origin or zone configured, that gate confines it to one
- * operator's hosts, so it can never name a foreign resource server; a
- * deployment that configures neither trusts this header exactly as much as it
- * already trusts `x-forwarded-host`.
+ * A request that skips the edge can set the header itself, so it is accepted
+ * only when it names the apex zone host — the one host the edge worker fronts
+ * (`lobu.ai/mcp` -> `app.lobu.ai/mcp`). Admitting the whole zone the way the
+ * standard forwarded host does would let any caller reaching the pod directly
+ * relocate the MCP resource onto a sibling in-zone host and satisfy the RFC
+ * 8707 audience check for a token bound to that host. Tenant orgs are
+ * themselves subdomains of this zone, so the apex restriction is what keeps
+ * audience binding meaningful between them.
  */
 function forwardedPublicOrigin(request: Request): string | null {
   const raw = request.headers.get('x-forwarded-for-origin')?.trim();
@@ -66,6 +68,8 @@ function forwardedPublicOrigin(request: Request): string | null {
   // Origin only: a path, query, or fragment means this is not a bare origin
   // and we should not guess at what the client called.
   if (parsed.pathname !== '/' || parsed.search || parsed.hash) return null;
+  const zone = getConfiguredSubdomainZone();
+  if (!zone || parsed.hostname !== zone) return null;
   return isTrustedPublicOrigin(parsed.origin) ? parsed.origin : null;
 }
 

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -32,11 +32,45 @@ export function publicMcpRequestUrl(request: Request): string {
   // WWW-Authenticate stay bound to the URL the client called.
   const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
   const configuredOrigin = getConfiguredPublicOrigin();
-  const origin = isTrustedPublicOrigin(servingOrigin, configuredOrigin)
-    ? servingOrigin
-    : (configuredOrigin ?? new URL(request.url).origin);
+  const origin =
+    forwardedPublicOrigin(request) ??
+    (isTrustedPublicOrigin(servingOrigin, configuredOrigin)
+      ? servingOrigin
+      : (configuredOrigin ?? new URL(request.url).origin));
   const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
   return `${origin}${pathname}`;
+}
+
+/**
+ * Public origin recovered from `x-forwarded-for-origin`.
+ *
+ * The `lobu.ai` Cloudflare Pages worker proxies `/mcp` to `app.lobu.ai` and
+ * sets `x-forwarded-host` AND this header to the host the client actually
+ * called. Traefik in front of the pod then overwrites `x-forwarded-host` with
+ * its own request host, so only this header survives the hop. Without reading
+ * it, a token bound to `https://lobu.ai/mcp` is audience-checked against
+ * `https://app.lobu.ai/mcp` and every MCP call 401s — the failure mode this
+ * function exists to prevent.
+ *
+ * A request that skips the edge can set the header itself, so it is honoured
+ * only after `isTrustedPublicOrigin` — the same gate the standard forwarded
+ * host clears. That confines it to the configured zone, which is one resource
+ * server under one operator, so it can never name a foreign resource server.
+ */
+function forwardedPublicOrigin(request: Request): string | null {
+  const raw = request.headers.get('x-forwarded-for-origin')?.trim();
+  if (!raw) return null;
+  let origin: string;
+  try {
+    const parsed = new URL(raw);
+    // Origin only: a path, query, or fragment means this is not a bare origin
+    // and we should not guess at what the client called.
+    if (parsed.pathname !== '/' || parsed.search || parsed.hash) return null;
+    origin = parsed.origin;
+  } catch {
+    return null;
+  }
+  return isTrustedPublicOrigin(origin) ? origin : null;
 }
 
 function isTrustedPublicOrigin(


### PR DESCRIPTION
## Summary
- claude.ai's MCP connector at `https://lobu.ai/mcp` 401'd on **every** call. Prod logs show `user-agent: Claude-User` retrying and failing 73 times in one window, surfaced in the UI as "Authorization with the MCP server failed."
- Root cause: the `lobu.ai` Cloudflare Pages worker proxies `/mcp` to `app.lobu.ai` and correctly sets `x-forwarded-host: lobu.ai` **and** `x-forwarded-for-origin`, but Traefik in front of the pod overwrites `x-forwarded-host` with its own request host. Only the non-standard header survives the hop.
- `publicMcpRequestUrl` read the standard header only, resolving the request resource to `https://app.lobu.ai/mcp` while the client's RFC 8707 token is bound to `https://lobu.ai/mcp` — the resource `lobu.ai` advertises in its own protected-resource metadata. The strict audience compare at `multi-tenant.ts:423` then returned `401 invalid_token` every time.

Fix: prefer `x-forwarded-for-origin` when present, gated through the existing `isTrustedPublicOrigin` check so a request that bypasses the edge cannot name an origin outside the configured zone (`AUTH_COOKIE_DOMAIN`).

### Evidence

Headers as the pod actually receives them — I sent `x-forwarded-host: lobu.ai` straight at `app.lobu.ai` and it arrived rewritten, while the custom header passed through:

```
host                   = app.lobu.ai
x-forwarded-host       = app.lobu.ai      <- sent "lobu.ai"; Traefik overwrote it
x-forwarded-for-origin = https://lobu.ai  <- survived
x-forwarded-server     = traefik-59b7647586-k76z9
```

Prod env confirms the zone gate accepts `lobu.ai`: `AUTH_COOKIE_DOMAIN=.lobu.ai`, `PUBLIC_GATEWAY_URL=https://app.lobu.ai/lobu`.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; Depot not used)
- [x] Tests run: targeted `bun test packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts` plus the oauth/mcp/base-url unit files
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: N/A

**Red** (before the fix, new test reproducing the prod header shape):

```
197 |     expect(publicMcpRequestUrl(request)).toBe('https://lobu.ai/mcp');
                                               ^
error: expect(received).toBe(expected)
Expected: "https://lobu.ai/mcp"
Received: "https://app.lobu.ai/mcp"
(fail) publicMcpRequestUrl honours x-forwarded-for-origin when a proxy rewrote the forwarded host
 13 pass
 1 fail
```

**Green** (after):

```
bun test v1.3.5
 14 pass
 0 fail
 29 expect() calls
```

Surrounding suites (`oauth-resource-indicator`, `oauth-scope-filter`, `connect-base-url`, `mcp-conversation-context`):

```
 35 pass
 0 fail
 83 expect() calls
```

`make pre-pr`: all 7 gates clean (typecheck, knip, biome, naming, gateway-llm, entity-write, tests 19 pass / 0 fail).

## Notes
Three new tests cover the spoofing boundary: an origin outside the zone, a malformed value, and a protocol downgrade are all ignored; the header is also ignored entirely when no zone is configured.

`make review-fix` could not run — the Codex backend is out of usage credits until Aug 20. It made no edits to the tree.

Follow-up, not in this PR: a page on `claude.ai` cannot reach `app.lobu.ai` at all because `isAllowedCorsOrigin` rejects the origin (`OPTIONS /mcp` with `Origin: https://claude.ai` returns 403). That does not affect MCP tool calls, which are server-to-server, but it would block any browser-side app surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth request URL handling for requests routed through forwarded hosts.
  * Valid, trusted forwarded origins are now used when configured, including supported sibling-zone hosts.
  * Invalid, untrusted, opaque, or unsupported-protocol forwarded origins are safely rejected.
  * Forwarded origins are ignored when no cookie domain is configured, improving request security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->