### PR TITLE
ci: fail fast on the stalled apt mirror in install-bubblewrap.sh

### DIFF
--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -15,10 +15,17 @@ set -euo pipefail
 # apt FAILS fast: a stalled mirror (or dpkg lock) hangs the command until the
 # job timeout, so every apt call is wrapped in `timeout` — a stall becomes a
 # fast failure that the next attempt rides over.
+#
+# The GitHub runner's default azure.archive.ubuntu.com mirror stalls (~5min:
+# the update burns the whole 240s timeout on attempt 1, then a retry succeeds).
+# Per-request Acquire::http::Timeout makes a hanging mirror fail in seconds
+# instead, so apt falls through to the responsive mirror (archive.ubuntu.com)
+# on the SAME attempt — the retry loop stays for the genuinely-down case.
 installed=""
+APT_FLAGS="-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 -o Acquire::ftp::Timeout=15"
 for attempt in 1 2 3; do
-  if sudo timeout 240 apt-get update -o Acquire::Retries=3 \
-      && sudo timeout 300 apt-get install -y --no-install-recommends bubblewrap coreutils; then
+  if sudo timeout 240 apt-get update $APT_FLAGS \
+      && sudo timeout 300 apt-get install $APT_FLAGS -y --no-install-recommends bubblewrap coreutils; then
     installed=1
     break
   fi


### PR DESCRIPTION
## Summary
`cli-command-smoke` took **7m10s** on CI — measured breakdown from the job log:

| phase | duration |
|---|---|
| **`install-bubblewrap.sh`** | **313s (5m13s)** |
| `cli-smoke.sh` (the actual gate) | 83s |
| checkout + submodule + setup + bun install (cached) | ~30s |

The smoke itself is fast. The 313s is **apt-get update stalling on the runner's default `azure.archive.ubuntu.com` mirror** — the update burns the whole 240s outer `timeout` on attempt 1, then a retry succeeds.

## Fix
Per-request `Acquire::http::Timeout=15` (+https/ftp) on the update and install commands: a hanging mirror now fails in **seconds**, and apt falls through to the responsive `archive.ubuntu.com` mirror on the **same** attempt. The 3-attempt retry loop stays for the genuinely-down case.

Same stall caused the earlier `sdk-error-taxonomy-e2e` failures (all 3 attempts burned 240s+ → job timeout), so this also de-flakes those jobs.

## Test plan
- [x] Bash syntax check.
- [x] GitHub CI runs on this PR — expect `cli-command-smoke` to drop from ~7m to ~2m when the mirror stalls are gone.
