### PR TITLE
fix(review): end teardown when a process group cannot be signalled

### DIFF
--- a/scripts/lib/__tests__/review-process.test.sh
+++ b/scripts/lib/__tests__/review-process.test.sh
@@ -89,7 +89,53 @@ test_late_grandchild_is_killed_with_process_group() {
   fi
 }
 
+# A process group we lack permission to signal must end teardown, not crash it
+# and not spin on it. `group_alive` reports such a group as alive, so a denied
+# signal that raised would surface as a Python traceback replacing the
+# reviewer's real error, and one that was merely swallowed would hang the
+# escalation loop against a group it can never kill.
+test_denied_signal_ends_teardown() {
+  python3 - "$repo_root/scripts/lib/review-process-supervisor.py" "$tmp/denied-control" <<'PY' ||
+import importlib.util
+import signal
+import sys
+
+# Importing by path would otherwise leave a __pycache__ beside the tracked
+# script, and nothing in the repo ignores it.
+sys.dont_write_bytecode = True
+
+spec = importlib.util.spec_from_file_location("supervisor", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+calls = []
+
+
+def denied(process_group, sig):
+    calls.append(sig)
+    raise PermissionError(1, "Operation not permitted")
+
+
+module.os.killpg = denied
+
+# Every killpg is denied, so the supervisor sees a group that stays alive and
+# never becomes signallable — exactly the shape that spins a retrying teardown.
+signal.alarm(20)
+sys.argv = ["supervisor", "--control-dir", sys.argv[2], "--", sys.executable, "-c", ""]
+status = module.main()
+signal.alarm(0)
+
+if status != 0:
+    raise SystemExit(f"supervisor returned {status} for a command that exited 0")
+# The liveness probe from group_alive, then the single TERM that ends teardown.
+if calls != [0, signal.SIGTERM]:
+    raise SystemExit(f"unexpected killpg sequence: {calls}")
+PY
+    fail "denied process-group signal did not end teardown cleanly"
+}
+
 test_signal_during_spawn_does_not_orphan_command
 test_late_grandchild_is_killed_with_process_group
+test_denied_signal_ends_teardown
 
 echo "review process tests passed"

--- a/scripts/lib/review-process-supervisor.py
+++ b/scripts/lib/review-process-supervisor.py
@@ -26,13 +26,21 @@ def group_alive(process_group: int) -> bool:
         return True
 
 
-def signal_group(process_group: Optional[int], sig: signal.Signals) -> None:
+def signal_group(process_group: Optional[int], sig: signal.Signals) -> bool:
+    """Signal the group. False means we cannot reap it — gone, or not ours.
+
+    `group_alive` reports a group we lack permission to signal as alive, so a
+    caller that retried on a denied signal would spin forever. Returning the
+    outcome lets the teardown path stop instead of escalating against a group
+    it will never be able to kill.
+    """
     if process_group is None:
-        return
+        return False
     try:
         os.killpg(process_group, sig)
-    except ProcessLookupError:
-        pass
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
 
 
 def wait_for_group_exit(
@@ -103,12 +111,11 @@ def main() -> int:
     # A command may exit while leaving workers behind, or a TERM handler may
     # fork one last cleanup child after the first group signal. Keep supervising
     # the session until it is empty; escalate only after the grace period.
-    if group_alive(process_group):
-        signal_group(process_group, signal.SIGTERM)
+    if group_alive(process_group) and signal_group(process_group, signal.SIGTERM):
         if not wait_for_group_exit(child, process_group, grace):
-            signal_group(process_group, signal.SIGKILL)
-            while not wait_for_group_exit(child, process_group, 0.5):
-                signal_group(process_group, signal.SIGKILL)
+            while signal_group(process_group, signal.SIGKILL):
+                if wait_for_group_exit(child, process_group, 0.5):
+                    break
 
     if child_exit is None:
         child_exit = child.wait()


### PR DESCRIPTION
## Summary
- `make review REVIEWER_CLI=claude` reported a Python traceback instead of the reviewer's actual error. The real message was `Fable 5 requires usage credits` (129 bytes, the whole reviewer output) — the crash hid it and sent a live debugging session down the wrong path.
- Cause: `group_alive()` treats a group it lacks permission to signal as alive (`except PermissionError: return True`), but `signal_group()` caught only `ProcessLookupError`. A denied `os.killpg` raised straight out of teardown.
- Swallowing the error alone would be **worse than the crash**: with `group_alive` still returning `True`, the SIGKILL escalation loop `while not wait_for_group_exit(...)` never terminates. A hang instead of a traceback.

Fix: `signal_group` returns whether the group can be reaped (False = gone, or not ours), and teardown stops escalating against a group it will never be able to kill.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bash scripts/lib/__tests__/review-process.test.sh`
- [x] Bug fix: red→fix→green pasted below
- [ ] If bot runtime changed: N/A

**Red** — reproduces the exact traceback seen in the live review run:

```
File "scripts/lib/review-process-supervisor.py", line 33, in signal_group
    os.killpg(process_group, sig)
PermissionError: [Errno 1] Operation not permitted
```

**Green**:

```
review process tests passed
```

Both pre-existing cases (`test_signal_during_spawn_does_not_orphan_command`, `test_late_grandchild_is_killed_with_process_group`) still pass, so the SIGKILL escalation path is behaviourally unchanged where permissions are normal. `make pre-pr`: all 7 gates clean.

## Notes
The new test asserts the exact `killpg` sequence (`[SIGTERM, 0]`) rather than a call count — `group_alive` issues its own signal-0 probe, and an assertion that ignored that would have passed for the wrong reason.

`make review` cannot run on this PR either, for the same reason it documents: both reviewer backends are out of credits (Codex until Aug 20; Fable 5 needs credits).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup when permission to signal a process group is denied.
  * Prevented unnecessary retry and force-termination attempts for process groups that cannot be signaled.
  * Teardown now continues safely while preserving accurate process-group status reporting.

* **Tests**
  * Added regression coverage for denied process-group signals during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->