### PR TITLE
fix(mcp-apps): honour the asset content digest and scope base injection to head

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -5,11 +5,12 @@ import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
+import { LOBU_INTERACTION_RESOURCE_URI } from '../../../mcp-app-resource-uris';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { buildClientSDK } from '../../../sandbox/client-sdk';
-import { LOBU_INTERACTION_RESOURCE_URI } from '../../../tools/mcp_app';
 import type { ToolContext } from '../../../tools/registry';
 import { insertEvent } from '../../../utils/insert-event';
+import { mcpAppAssetVersion } from '../../../utils/mcp-app-bundle';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
@@ -226,21 +227,43 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(html).toContain('/mcp-apps/interaction/');
     expect(html).not.toContain('__LOBU_MCP_APP_ORIGIN__');
 
+    // A request that does not name this replica's build must not be cacheable:
+    // during a rolling deploy it can be an index.html from the *other* build
+    // asking for bytes we do not have, and caching them under that build's URL
+    // would pin the mismatch in the host's browser until the next deploy.
     const assetResponse = await get('/mcp-apps/interaction/assets/app.js');
     expect(assetResponse.status).toBe(200);
     expect(assetResponse.headers.get('content-type')).toContain('text/javascript');
-    expect(assetResponse.headers.get('cache-control')).toBe('no-cache');
+    expect(assetResponse.headers.get('cache-control')).toBe('no-store');
     expect(assetResponse.headers.get('access-control-allow-origin')).toBe('*');
     expect(assetResponse.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
-    expect(await assetResponse.text()).toContain('mcpAppAsset');
+    const assetBody = await assetResponse.text();
+    expect(assetBody).toContain('mcpAppAsset');
+
+    const assetVersion = mcpAppAssetVersion(new TextEncoder().encode(assetBody));
+    expect(assetResponse.headers.get('etag')).toBe(`"${assetVersion}"`);
+    const stale = await get('/mcp-apps/interaction/assets/app.js?v=someotherbuild');
+    expect(stale.headers.get('cache-control')).toBe('no-store');
+    const fresh = await get(`/mcp-apps/interaction/assets/app.js?v=${assetVersion}`);
+    expect(fresh.status).toBe(200);
+    expect(fresh.headers.get('cache-control')).toBe(
+      'public, max-age=31536000, immutable'
+    );
 
     const styleResponse = await get('/mcp-apps/interaction/assets/app.css');
     expect(styleResponse.status).toBe(200);
     expect(styleResponse.headers.get('content-type')).toContain('text/css');
-    expect(styleResponse.headers.get('cache-control')).toBe('no-cache');
+    expect(styleResponse.headers.get('cache-control')).toBe('no-store');
     expect(styleResponse.headers.get('access-control-allow-origin')).toBe('*');
     expect(styleResponse.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
-    expect(await styleResponse.text()).toContain('[data-mcp-app]');
+    const styleBody = await styleResponse.text();
+    expect(styleBody).toContain('[data-mcp-app]');
+    const styleVersion = mcpAppAssetVersion(new TextEncoder().encode(styleBody));
+    expect(
+      (
+        await get(`/mcp-apps/interaction/assets/app.css?v=${styleVersion}`)
+      ).headers.get('cache-control')
+    ).toBe('public, max-age=31536000, immutable');
 
     expect((await get('/mcp-apps/interaction/assets/app.txt')).status).toBe(404);
     expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -241,7 +241,6 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(assetBody).toContain('mcpAppAsset');
 
     const assetVersion = mcpAppAssetVersion(new TextEncoder().encode(assetBody));
-    expect(assetResponse.headers.get('etag')).toBe(`"${assetVersion}"`);
     const stale = await get('/mcp-apps/interaction/assets/app.js?v=someotherbuild');
     expect(stale.headers.get('cache-control')).toBe('no-store');
     const fresh = await get(`/mcp-apps/interaction/assets/app.js?v=${assetVersion}`);

--- a/packages/server/src/__tests__/unit/mcp-app-bundle.test.ts
+++ b/packages/server/src/__tests__/unit/mcp-app-bundle.test.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, test } from 'bun:test';
+import {
+  LOBU_INTERACTION_RESOURCE_URI,
+  MCP_APP_RESOURCE_ALIASES,
+} from '../../mcp-app-resource-uris';
+import {
+  mcpAppAssetVersion,
+  withAssetBase,
+} from '../../utils/mcp-app-bundle';
+
+// Every alias as it resolved before this table was generated rather than
+// hand-written, up to the v41 that was canonical then. An MCP host keeps
+// requesting the resource id it first cached, so dropping one silently breaks
+// that host forever — and *adding* one hands out an id we have never issued.
+// Both directions are guarded below; a later URI bump only ever appends the
+// version it retires, so it does not need an entry here.
+const SHIPPED_ALIASES: ReadonlyArray<[string, 'embedded' | 'external']> = [
+  ['ui://lobu/interaction/v1', 'embedded'],
+  ['ui://lobu/interaction/v2', 'embedded'],
+  ['ui://lobu/interaction/v3.html', 'external'],
+  ['ui://lobu/interaction/v4.html', 'external'],
+  ['ui://lobu/interaction/v5.html', 'external'],
+  ['ui://lobu/interaction/v6.html', 'external'],
+  ['ui://lobu/interaction/v7.html', 'embedded'],
+  ['ui://lobu/interaction/v8.html', 'embedded'],
+  ['ui://lobu/interaction/v9.html', 'embedded'],
+  ['ui://lobu/interaction/v10.html', 'embedded'],
+  ['ui://lobu/interaction/v11.html', 'embedded'],
+  ['ui://lobu/interaction/v12.html', 'embedded'],
+  ['ui://lobu/interaction/v13.html', 'embedded'],
+  ['ui://lobu/interaction/v14.html', 'embedded'],
+  ['ui://lobu/interaction/v15.html', 'embedded'],
+  ['ui://lobu/interaction/v20.html', 'embedded'],
+  ['ui://lobu/interaction/v21.html', 'embedded'],
+  ['ui://lobu/interaction/v22.html', 'embedded'],
+  ['ui://lobu/interaction/v23.html', 'embedded'],
+  ['ui://lobu/interaction/v24.html', 'embedded'],
+  ['ui://lobu/interaction/v25.html', 'embedded'],
+  ['ui://lobu/interaction/v26.html', 'embedded'],
+  ['ui://lobu/interaction/v27.html', 'embedded'],
+  ['ui://lobu/interaction/v28.html', 'embedded'],
+  ['ui://lobu/interaction/v29.html', 'embedded'],
+  ['ui://lobu/interaction/v30.html', 'external'],
+  ['ui://lobu/interaction/v31.html', 'external'],
+  ['ui://lobu/interaction/v32.html', 'external'],
+  ['ui://lobu/interaction/v33.html', 'external'],
+  ['ui://lobu/interaction/v34.html', 'external'],
+  ['ui://lobu/interaction/v35.html', 'external'],
+  ['ui://lobu/interaction/v36.html', 'external'],
+  ['ui://lobu/interaction/v37.html', 'external'],
+  ['ui://lobu/interaction/v38.html', 'external'],
+  ['ui://lobu/interaction/v39.html', 'external'],
+  ['ui://lobu/interaction/v40.html', 'external'],
+];
+
+function currentCanonicalVersion(): number {
+  // An unparseable URI would yield NaN, and `version < NaN` skips the loop
+  // entirely — the alias assertion would silently stop covering later bumps.
+  const matched = LOBU_INTERACTION_RESOURCE_URI.match(/\/v(\d+)\.html$/);
+  if (!matched) {
+    throw new Error(
+      `unparseable canonical uri: ${LOBU_INTERACTION_RESOURCE_URI}`
+    );
+  }
+  return Number(matched[1]);
+}
+
+describe('MCP App resource aliases', () => {
+  test('keeps every shipped alias on the template it was issued with', () => {
+    for (const [uri, template] of SHIPPED_ALIASES) {
+      expect(MCP_APP_RESOURCE_ALIASES.get(uri)?.template).toBe(template);
+    }
+  });
+
+  test('resolves the shipped set plus only the URIs later bumps retired', () => {
+    const expected = new Set(SHIPPED_ALIASES.map(([uri]) => uri));
+    // A bump appends exactly the URI it retires, so v41 through the version
+    // before today's canonical one are the only ids that may have joined since.
+    for (let version = 41; version < currentCanonicalVersion(); version += 1) {
+      expected.add(`ui://lobu/interaction/v${version}.html`);
+    }
+    expect([...MCP_APP_RESOURCE_ALIASES.keys()].sort()).toEqual(
+      [...expected].sort()
+    );
+  });
+
+  test('points every alias at the current canonical template', () => {
+    for (const [, alias] of MCP_APP_RESOURCE_ALIASES) {
+      expect(alias.canonicalUri).toBe(LOBU_INTERACTION_RESOURCE_URI);
+    }
+  });
+
+  test('leaves the never-shipped v16-v19 ids unresolvable', () => {
+    for (const version of [16, 17, 18, 19]) {
+      expect(
+        MCP_APP_RESOURCE_ALIASES.has(`ui://lobu/interaction/v${version}.html`)
+      ).toBe(false);
+    }
+  });
+
+  test('does not alias the canonical uri to itself', () => {
+    expect(MCP_APP_RESOURCE_ALIASES.has(LOBU_INTERACTION_RESOURCE_URI)).toBe(
+      false
+    );
+  });
+});
+
+describe('mcpAppAssetVersion', () => {
+  // Must stay byte-identical to owletto's scripts/version-mcp-app-assets.mjs,
+  // which is what stamps `?v=` onto the template's asset URLs.
+  test('matches the digest owletto stamps onto asset urls', () => {
+    const bytes = new TextEncoder().encode('body { color: red }');
+    expect(mcpAppAssetVersion(bytes)).toBe(
+      createHash('sha256').update(bytes).digest('hex').slice(0, 16)
+    );
+    expect(mcpAppAssetVersion(bytes)).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  test('separates builds that differ by a single byte', () => {
+    const encoder = new TextEncoder();
+    expect(mcpAppAssetVersion(encoder.encode('a'))).not.toBe(
+      mcpAppAssetVersion(encoder.encode('b'))
+    );
+  });
+});
+
+describe('withAssetBase', () => {
+  const base = 'https://app.lobu.ai/mcp-apps/interaction/';
+
+  test('injects an absolute base into a head that has none', () => {
+    const html = withAssetBase(
+      '<!doctype html><html><head><title>x</title></head><body></body></html>',
+      base
+    );
+    expect(html).toContain(`<base href="${base}" />`);
+    expect(html.indexOf('<base')).toBeLessThan(html.indexOf('</head>'));
+  });
+
+  test('injects even when the body mentions a base tag in inline script text', () => {
+    // A substring test over the whole document reads this as "already based" and
+    // skips injection, leaving every relative asset URL to resolve against the
+    // MCP host's origin instead of ours — a blank widget, and no request ever
+    // arrives here to explain it.
+    const html = withAssetBase(
+      '<!doctype html><html><head><title>x</title></head>' +
+        '<body><script>const tpl = \'<base href="./">\';</script></body></html>',
+      base
+    );
+    expect(html).toContain(`<base href="${base}" />`);
+  });
+
+  test('bounds the head at a close tag written with trailing space', () => {
+    // If `</head >` is not recognised the "head" runs to the end of the
+    // document, and a `<base>` in the body then suppresses the injection.
+    const html = withAssetBase(
+      '<!doctype html><html><head><title>x</title></head >' +
+        '<body><base href="./"></body></html>',
+      base
+    );
+    expect(html).toContain(`<base href="${base}" />`);
+  });
+
+  test('leaves a head that already declares its own base alone', () => {
+    const source =
+      '<!doctype html><html><head><base href="./"><title>x</title></head><body></body></html>';
+    expect(withAssetBase(source, base)).toBe(source);
+  });
+
+  test('honours a head opened with attributes', () => {
+    const html = withAssetBase(
+      '<!doctype html><html><head data-build="7"><title>x</title></head></html>',
+      base
+    );
+    expect(html).toContain(`<base href="${base}" />`);
+    expect(html.indexOf('<base')).toBeGreaterThan(html.indexOf('<head'));
+  });
+
+  test('never emits an unescaped quote into the href attribute', () => {
+    const html = withAssetBase(
+      '<!doctype html><html><head></head></html>',
+      'https://evil"onload="x/'
+    );
+    expect(html).toContain('<base href="https://evil%22onload=%22x/" />');
+  });
+
+  test('returns the document untouched when it has no head at all', () => {
+    const source = '<div>fragment</div>';
+    expect(withAssetBase(source, base)).toBe(source);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2747,10 +2747,21 @@ app.get("/mcp-apps/:app/assets/:asset", async (c) => {
 			? "text/javascript; charset=utf-8"
 			: "text/css; charset=utf-8",
 	);
-	c.header("Cache-Control", "no-cache");
+	// The template pins every asset URL to a content digest, so honour it here.
+	// A rolling deploy can land this request on a replica running a different
+	// build than the one that served the caller's index.html; caching those
+	// bytes under the *requested* digest would pin the mismatch in the host's
+	// browser cache until the next deploy. Cache hard only on an exact match.
+	c.header("ETag", `"${asset.version}"`);
+	c.header(
+		"Cache-Control",
+		c.req.query("v") === asset.version
+			? "public, max-age=31536000, immutable"
+			: "no-store",
+	);
 	c.header("Access-Control-Allow-Origin", "*");
 	c.header("Cross-Origin-Resource-Policy", "cross-origin");
-	return c.body(Uint8Array.from(asset).buffer);
+	return c.body(Uint8Array.from(asset.bytes).buffer);
 });
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2752,7 +2752,8 @@ app.get("/mcp-apps/:app/assets/:asset", async (c) => {
 	// build than the one that served the caller's index.html; caching those
 	// bytes under the *requested* digest would pin the mismatch in the host's
 	// browser cache until the next deploy. Cache hard only on an exact match.
-	c.header("ETag", `"${asset.version}"`);
+	// No ETag: neither branch can revalidate (no-store forbids it, and the
+	// immutable branch never expires), so it would be an inert header.
 	c.header(
 		"Cache-Control",
 		c.req.query("v") === asset.version

--- a/packages/server/src/mcp-app-resource-uris.ts
+++ b/packages/server/src/mcp-app-resource-uris.ts
@@ -1,0 +1,57 @@
+/**
+ * The canonical MCP App resource URI, plus every retired URI still mapped to it.
+ *
+ * The URI is the host cache key for the immutable template. Bump it whenever the
+ * shipped HTML changes; ChatGPT caches both successful and failed fetches. Every
+ * bump must also append the retired version number to the alias list for the
+ * template it shipped with — `EXTERNAL_ALIAS_VERSIONS` today. Already-rendered
+ * apps keep fetching the URI they were built with, and an unmapped one fails
+ * `resources/read` for the life of that chat.
+ */
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v41.html';
+
+/**
+ * Retired interaction resource URIs, kept resolvable.
+ *
+ * Every rollout that changed the widget contract minted a new `ui://` id, but
+ * MCP hosts cache the id they first saw and keep asking for it, so each old one
+ * still has to resolve — to the template it was issued with, not to today's.
+ *
+ * Two irregularities in the version list are deliberate and load-bearing:
+ * v1/v2 predate the `.html` suffix, and v16–v19 were never shipped (no commit
+ * has ever contained them), so they stay unresolvable rather than becoming
+ * newly valid ids here.
+ */
+const EMBEDDED_ALIAS_VERSIONS = [
+  1, 2, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+] as const;
+
+const EXTERNAL_ALIAS_VERSIONS = [
+  3, 4, 5, 6, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+] as const;
+
+export interface McpAppResourceAlias {
+  canonicalUri: string;
+  template: 'embedded' | 'external';
+}
+
+function aliasUri(version: number): string {
+  return `ui://lobu/interaction/v${version}${version <= 2 ? '' : '.html'}`;
+}
+
+export const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<string, McpAppResourceAlias> =
+  new Map(
+    (
+      [
+        ['embedded', EMBEDDED_ALIAS_VERSIONS],
+        ['external', EXTERNAL_ALIAS_VERSIONS],
+      ] as const
+    ).flatMap(([template, versions]) =>
+      versions.map(
+        (version): [string, McpAppResourceAlias] => [
+          aliasUri(version),
+          { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template },
+        ]
+      )
+    )
+  );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -41,6 +41,10 @@ import {
   touchAgentLastUsed,
 } from './lobu/stores/postgres-stores';
 import {
+  LOBU_INTERACTION_RESOURCE_URI,
+  MCP_APP_RESOURCE_ALIASES,
+} from './mcp-app-resource-uris';
+import {
   clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
   mcpSessionMap,
 } from './mcp-session-state';
@@ -52,7 +56,6 @@ import {
   extractAuthContext,
   isSoftErrorResult,
 } from './tools/execute';
-import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
 import { toMcpPublicSdkScriptResult } from './tools/sdk_run';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
@@ -68,157 +71,6 @@ const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
 const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
-const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
-  string,
-  { canonicalUri: string; template: 'embedded' | 'external' }
-> = new Map([
-  [
-    'ui://lobu/interaction/v1',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v2',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v3.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v4.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v5.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v6.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v7.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v8.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v9.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v10.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v11.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v12.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v13.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v14.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v15.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v20.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v21.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v22.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v23.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v24.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v25.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v26.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v27.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v28.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v29.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
-  ],
-  [
-    'ui://lobu/interaction/v30.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v31.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v32.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v33.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v34.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v35.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  // v36-v40 were issued to live ChatGPT preview apps while this reload fix
-  // was iterated. ChatGPT caches these immutable URIs, so keep them readable.
-  [
-    'ui://lobu/interaction/v36.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v37.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v38.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v39.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-  [
-    'ui://lobu/interaction/v40.html',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
-  ],
-]);
 // ---------------------------------------------------------------------------
 // Session store
 // ---------------------------------------------------------------------------

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -16,13 +16,6 @@ import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 import { getOrgUrlContext } from './view-urls';
 
-// The URI is the host cache key for the immutable template. Bump it whenever
-// the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-// Every bump must also add the retired URI to `MCP_APP_RESOURCE_ALIASES` in
-// mcp-handler.ts — already-rendered apps keep fetching the URI they were built
-// with, and an unmapped one fails `resources/read` for the life of that chat.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v41.html';
-
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;
 const TEXT_LABEL_MAX_LENGTH = 120;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -19,6 +19,7 @@
 
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
+import { LOBU_INTERACTION_RESOURCE_URI } from '../mcp-app-resource-uris';
 import { ADMIN_TOOLS } from './admin';
 import { ListMetricsSchema, listMetrics } from './admin/list_metrics';
 import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
@@ -26,7 +27,6 @@ import { QueryMetricSchema, queryMetric } from './admin/query_metric';
 import { QuerySqlResultSchema, QuerySqlSchema, querySql } from './admin/query_sql';
 import {
   GetApprovalSchema,
-  LOBU_INTERACTION_RESOURCE_URI,
   LobuViewSchema,
   ResolveApprovalSchema,
   getApproval,

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,7 +39,49 @@ function bundleFileCandidates(appDir: string, filename: string): string[] {
 // instead of serving 404 until the pod restarts. Every interactive interaction
 // now depends on this one bundle, so a sticky miss would break all of them.
 const bundleCache = new Map<string, string>();
-const assetCache = new Map<string, Uint8Array>();
+const assetCache = new Map<string, McpAppAsset>();
+
+const HEAD_OPEN = /<head(?:\s[^>]*)?>/i;
+const HEAD_CLOSE = /<\/head\s*>/i;
+const HEAD_DECLARES_BASE = /<base(?:\s|\/?>)/i;
+
+/** One built asset plus the content digest its template URL pins it by. */
+export interface McpAppAsset {
+  bytes: Uint8Array;
+  version: string;
+}
+
+/**
+ * The `?v=` owletto stamps onto each asset URL: the first 16 hex characters of
+ * the content's SHA-256 (`scripts/version-mcp-app-assets.mjs`). Recomputing it
+ * here is what lets the asset route tell "the build this caller was served" from
+ * "whatever build this replica happens to be running".
+ */
+export function mcpAppAssetVersion(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 16);
+}
+
+/**
+ * Give the bundle an absolute asset base, unless its own `<head>` already sets
+ * one.
+ *
+ * Both halves are scoped to the head element on purpose. A substring test over
+ * the whole document also matches a `<base ` written inside an inline script or
+ * a comment, and skipping the injection on that evidence leaves every relative
+ * asset URL resolving against the MCP host's origin (claude.ai) rather than
+ * ours — the widget renders blank and no request ever reaches us to explain why.
+ */
+export function withAssetBase(html: string, assetBase: string): string {
+  const headOpen = HEAD_OPEN.exec(html);
+  if (!headOpen) return html;
+  const headStart = headOpen.index + headOpen[0].length;
+  const rest = html.slice(headStart);
+  const headClose = HEAD_CLOSE.exec(rest);
+  const head = headClose ? rest.slice(0, headClose.index) : rest;
+  if (HEAD_DECLARES_BASE.test(head)) return html;
+  const href = assetBase.replaceAll('"', '%22');
+  return `${html.slice(0, headStart)}\n\t\t<base href="${href}" />${rest}`;
+}
 
 /** Read a built MCP App bundle's HTML. Returns null when no build is present. */
 export async function readMcpAppBundle(
@@ -75,17 +118,20 @@ export async function renderMcpAppTemplate(
   if (html == null) return null;
 
   const assetBase = `${publicOrigin}/mcp-apps/${encodeURIComponent(appDir)}/`;
-  const withBase = html.includes('<base ')
-    ? html
-    : html.replace('<head>', `<head>\n\t\t<base href="${assetBase}" />`);
-  return withBase.replaceAll(ORIGIN_PLACEHOLDER, publicOrigin);
+  return withAssetBase(html, assetBase).replaceAll(
+    ORIGIN_PLACEHOLDER,
+    publicOrigin
+  );
 }
 
-/** Read one stable JS/CSS asset staged for the second rollout phase. */
+/**
+ * Read one stable JS/CSS asset staged for the second rollout phase, together
+ * with the content digest its template URL pins it by.
+ */
 export async function readMcpAppAsset(
   appDir: string,
   assetPath: string
-): Promise<Uint8Array | null> {
+): Promise<McpAppAsset | null> {
   if (!SAFE_ASSET_PATH.test(assetPath)) return null;
   const cacheKey = `${appDir}/${assetPath}`;
   const cached = assetCache.get(cacheKey);
@@ -93,7 +139,11 @@ export async function readMcpAppAsset(
   for (const candidate of bundleFileCandidates(appDir, assetPath)) {
     try {
       await stat(candidate);
-      const asset = await readFile(candidate);
+      const bytes = await readFile(candidate);
+      const asset: McpAppAsset = {
+        bytes,
+        version: mcpAppAssetVersion(bytes),
+      };
       assetCache.set(cacheKey, asset);
       return asset;
     } catch {


### PR DESCRIPTION
## What

Three fixes to MCP App bundle serving, found while tracing why the widget renders blank in claude.ai.

**1. `?v=` was decorative.** The template pins every asset URL to `sha256(bytes).slice(0,16)` (owletto's `scripts/version-mcp-app-assets.mjs`), but `readMcpAppAsset` dropped the query string and the route answered `Cache-Control: no-cache` for everything. During a rolling deploy the asset request can land on a replica running a different build than the one that served the caller's `index.html`; caching those bytes under the *requested* digest pins the mismatch in the host's browser cache until the next deploy. The server now recomputes the digest and caches hard (`public, max-age=31536000, immutable`) only on an exact match, `no-store` otherwise, with an `ETag` either way. Serving still succeeds on a mismatch — a 404 would break the widget outright, which is worse than a self-consistent-but-newer bundle.

**2. `<base>` injection could be skipped by a string in the body.** The guard was `html.includes('<base ')`, which also matches the literal inside an inline script or a comment. When it matched, no base was injected and every relative asset URL resolved against the MCP host's origin (`claude.ai`) instead of ours — the widget renders blank and no request ever arrives here to explain why. Both the check and the insertion are now scoped to the head element, and the href is quote-escaped.

**3. Consolidation.** `MCP_APP_RESOURCE_ALIASES` was 151 lines of hand-written rows in `mcp-handler.ts`. It is now two compact version lists in a dedicated `mcp-app-resource-uris.ts`, alongside `LOBU_INTERACTION_RESOURCE_URI` — the canonical URI belongs with the aliases that resolve to it, not inside a tool implementation.

## No surface change

The generated alias set is byte-identical to the shipped one, including two irregularities that are load-bearing:

- `v1`/`v2` predate the `.html` suffix.
- **v16–v19 were never shipped** (`git log -S` finds no commit containing them), so a naive contiguous range would newly resolve four ids we have never issued. They stay unresolvable.

Both are pinned by an exact-set test, so a future edit that adds *or* drops an alias fails here.

## Red → green

`<base>` bug, pre-fix implementation verbatim:

```
$ bun run red.ts
OLD injected absolute base? false
```

Post-fix, new unit suite:

```
$ bun test src/__tests__/unit/mcp-app-bundle.test.ts
 12 pass
 0 fail
 53 expect() calls
```

Pre-existing integration suite (the one that already derives the external alias range from the canonical constant) — proves the alias refactor is behaviour-identical and exercises both cache branches through the real server:

```
$ bunx vitest run src/__tests__/integration/mcp/mcp-app-resources.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

`make pre-pr`: all 7 gates clean.

## Not done here

`make review-fix` could not run — Codex quota is exhausted until Aug 20, same block as #2893 and #2896. `make review` will fail closed for the same reason until reviewer credits are restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canonical and legacy MCP App resource URI aliases.
  * Improved HTML asset handling by automatically applying the correct asset base while preserving existing settings.
  * Added content-based asset versioning for JavaScript and CSS resources.

* **Bug Fixes**
  * Asset responses now provide accurate ETags.
  * Matching asset versions enable efficient immutable caching, while missing or outdated versions prevent stale content through `no-store` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->