### PR TITLE
fix(server): gate agent management mutations to owner/admin

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -1,14 +1,16 @@
 /**
- * Agent management-mutation access: only org owner/admin (web session) — or a
- * PAT/OAuth token carrying `mcp:admin` — may PATCH/DELETE an agent or rewrite
- * its config. A plain org MEMBER must get 403 on all three surfaces.
+ * Agent management-mutation access: only org owner/admin — a web session, or
+ * a PAT/OAuth token carrying `mcp:admin` — may PATCH/DELETE an agent or
+ * rewrite its config. `mcp:admin` alone is not enough: the caller's member
+ * role must be owner/admin regardless of auth source. A plain org MEMBER must
+ * get 403 on all three surfaces.
  *
  * Regression for the decision-brief finding: `requireSessionOrAdminPat` alone
  * lets any member rewrite/delete another member's agent (and change its
  * soulMd/guardrails/tool surface) via the REST routes.
  */
 
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
@@ -23,6 +25,8 @@ installRouteTestMocks();
 
 const ORG = "org-manage-access";
 const AGENT = "manage-access-agent";
+/** Mirrors the `authStash` default in ./helpers/route-test-mocks. */
+const DEFAULT_MEMBER_ROLE = "owner";
 
 async function seedOrgAndAgent(): Promise<void> {
   const { getDb } = await import("../../db/client.js");
@@ -30,6 +34,14 @@ async function seedOrgAndAgent(): Promise<void> {
   await sql`
     INSERT INTO organization (id, name, slug)
     VALUES (${ORG}, ${ORG}, ${ORG}) ON CONFLICT (id) DO NOTHING
+  `;
+  // The metadata PATCH fires a config-audit event whose `created_by` references
+  // `user.id` (events_created_by_fkey); seed the caller so that insert lands
+  // instead of logging a dropped audit row.
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES ('u1', 'Test', 'u1@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
   `;
   await sql`
     INSERT INTO agents (id, organization_id, name)
@@ -59,12 +71,26 @@ beforeEach(async () => {
   authStash.organizationId = ORG;
   authStash.authSource = "session";
   authStash.mcpAuthInfo = null;
-  authStash.memberRole = "member";
+  // `authStash` is process-wide and shared by every src/lobu route test (see
+  // the helper's header): bun runs all files in ONE process, so a file that
+  // leaves a non-default value here breaks whichever sibling runs next and
+  // relies on the default. `deployment-routes.test.ts` already save/restores
+  // around its own override. So reset to the helper default (`owner`) here,
+  // let each test opt into `member` explicitly, and restore in `afterAll` —
+  // otherwise the last test's role leaks out of this file.
+  authStash.memberRole = DEFAULT_MEMBER_ROLE;
   coreServicesStash.services = null;
 }, 30_000);
 
+afterAll(() => {
+  authStash.memberRole = DEFAULT_MEMBER_ROLE;
+  authStash.authSource = "session";
+  authStash.mcpAuthInfo = null;
+});
+
 describe("agent management mutations — role gate", () => {
   test("member: PATCH /config is denied", async () => {
+    authStash.memberRole = "member";
     const app = await importAgentRoutes();
     const res = await app.request(`/${AGENT}/config`, {
       method: "PATCH",
@@ -75,6 +101,7 @@ describe("agent management mutations — role gate", () => {
   });
 
   test("member: PATCH /:agentId (metadata) is denied", async () => {
+    authStash.memberRole = "member";
     const app = await importAgentRoutes();
     const res = await app.request(`/${AGENT}`, {
       method: "PATCH",
@@ -85,6 +112,7 @@ describe("agent management mutations — role gate", () => {
   });
 
   test("member: DELETE /:agentId is denied", async () => {
+    authStash.memberRole = "member";
     const app = await importAgentRoutes();
     const res = await app.request(`/${AGENT}`, { method: "DELETE" });
     expect(res.status).toBe(403);
@@ -117,7 +145,7 @@ describe("agent management mutations — role gate", () => {
     expect(res.status).toBe(200);
   });
 
-  test("member + PAT with mcp:admin keeps the admin delegation", async () => {
+  test("member + PAT with mcp:admin is still denied (role is not authorizable by scope)", async () => {
     authStash.memberRole = "member";
     authStash.authSource = "pat";
     authStash.mcpAuthInfo = { scopes: ["mcp:admin"] };
@@ -127,7 +155,20 @@ describe("agent management mutations — role gate", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ defaultModel: "openai/gpt-5" }),
     });
-    // Same 400-legacy-field marker: the mcp:admin token passes the gate.
+    expect(res.status).toBe(403);
+  });
+
+  test("owner + PAT with mcp:admin passes the gate", async () => {
+    authStash.memberRole = "owner";
+    authStash.authSource = "pat";
+    authStash.mcpAuthInfo = { scopes: ["mcp:admin"] };
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultModel: "openai/gpt-5" }),
+    });
+    // Same 400-legacy-field marker: the owner's mcp:admin token passes the gate.
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error?: string }).error).toBe(
       "legacy_model_field"
@@ -135,6 +176,7 @@ describe("agent management mutations — role gate", () => {
   });
 
   test("member: GET config stays readable (read is org-wide by decision)", async () => {
+    authStash.memberRole = "member";
     const app = await importAgentRoutes();
     const res = await app.request(`/${AGENT}/config`);
     expect(res.status).toBe(200);

--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -55,7 +55,11 @@ async function importAgentRoutes() {
   return mod.agentRoutes;
 }
 
+/** Every `authStash` field this file overwrites, as found on entry. */
+let stashOnEntry: typeof authStash;
+
 beforeAll(async () => {
+  stashOnEntry = { ...authStash };
   await ensureDbForGatewayTests();
 }, 60_000);
 
@@ -76,16 +80,14 @@ beforeEach(async () => {
   // leaves a non-default value here breaks whichever sibling runs next and
   // relies on the default. `deployment-routes.test.ts` already save/restores
   // around its own override. So reset to the helper default (`owner`) here,
-  // let each test opt into `member` explicitly, and restore in `afterAll` —
-  // otherwise the last test's role leaks out of this file.
+  // let each test opt into `member` explicitly, and put the whole stash back
+  // in `afterAll` — otherwise this file's role, org and user leak out of it.
   authStash.memberRole = DEFAULT_MEMBER_ROLE;
   coreServicesStash.services = null;
 }, 30_000);
 
 afterAll(() => {
-  authStash.memberRole = DEFAULT_MEMBER_ROLE;
-  authStash.authSource = "session";
-  authStash.mcpAuthInfo = null;
+  Object.assign(authStash, stashOnEntry);
 });
 
 describe("agent management mutations — role gate", () => {

--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent management-mutation access: only org owner/admin (web session) — or a
+ * PAT/OAuth token carrying `mcp:admin` — may PATCH/DELETE an agent or rewrite
+ * its config. A plain org MEMBER must get 403 on all three surfaces.
+ *
+ * Regression for the decision-brief finding: `requireSessionOrAdminPat` alone
+ * lets any member rewrite/delete another member's agent (and change its
+ * soulMd/guardrails/tool surface) via the REST routes.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import {
+  authStash,
+  coreServicesStash,
+  installRouteTestMocks,
+} from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const ORG = "org-manage-access";
+const AGENT = "manage-access-agent";
+
+async function seedOrgAndAgent(): Promise<void> {
+  const { getDb } = await import("../../db/client.js");
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG}) ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agents (id, organization_id, name)
+    VALUES (${AGENT}, ${ORG}, 'Manage Access Agent')
+    ON CONFLICT (organization_id, id) DO NOTHING
+  `;
+}
+
+async function importAgentRoutes() {
+  const mod = await import("../agent-routes.js");
+  return mod.agentRoutes;
+}
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  await seedOrgAndAgent();
+  authStash.user = {
+    id: "u1",
+    name: "Test",
+    email: "u1@test",
+    emailVerified: true,
+  };
+  authStash.organizationId = ORG;
+  authStash.authSource = "session";
+  authStash.mcpAuthInfo = null;
+  authStash.memberRole = "member";
+  coreServicesStash.services = null;
+}, 30_000);
+
+describe("agent management mutations — role gate", () => {
+  test("member: PATCH /config is denied", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ soulMd: "override" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: PATCH /:agentId (metadata) is denied", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Renamed" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: DELETE /:agentId is denied", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}`, { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: PATCH /config passes the gate (reaches handler validation)", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultModel: "openai/gpt-5" }),
+    });
+    // 400 (legacy field rejected by the handler) proves it cleared the gate;
+    // a 403 would mean the role check wrongly blocked the owner.
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "legacy_model_field"
+    );
+  });
+
+  test("owner: PATCH /:agentId (metadata) succeeds", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Renamed" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("member + PAT with mcp:admin keeps the admin delegation", async () => {
+    authStash.memberRole = "member";
+    authStash.authSource = "pat";
+    authStash.mcpAuthInfo = { scopes: ["mcp:admin"] };
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultModel: "openai/gpt-5" }),
+    });
+    // Same 400-legacy-field marker: the mcp:admin token passes the gate.
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "legacy_model_field"
+    );
+  });
+
+  test("member: GET config stays readable (read is org-wide by decision)", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -217,28 +217,28 @@ export function requireSessionOrAdminPat(c: any): Response | null {
  * owner/admin. `requireSessionOrAdminPat` alone only proves an
  * authenticated caller — any org MEMBER passes it, so a member could
  * rewrite or delete another member's agent (or change its soulMd,
- * guardrails or tool surface) via PATCH/DELETE. Role check mirrors
- * index.ts `requireOrganizationSettingsAdmin`: a web session needs
- * owner/admin; a PAT/OAuth token keeps passing only with `mcp:admin`
- * scope (an explicit admin delegation, the same rule the manage_agents
- * tool's write gate applies).
+ * guardrails or tool surface) via PATCH/DELETE. On top of that
+ * session-or-admin-scope check, the caller's member role must be
+ * owner/admin for EVERY auth source — mirroring index.ts
+ * `requireOrganizationSettingsAdmin` and the manage_agents tool's admin
+ * tier, both of which treat the role check as non-authorizable: an
+ * `mcp:admin` scope alone never elevates a plain member, and a demoted
+ * owner's stale admin token stays denied.
  */
 function requireManageAgentAccess(c: any): Response | null {
 	const denied = requireSessionOrAdminPat(c);
 	if (denied) return denied;
 
-	if (c.get("authSource") === "session") {
-		const memberRole = c.get("memberRole") as string | null | undefined;
-		if (memberRole !== "owner" && memberRole !== "admin") {
-			return c.json(
-				{
-					error: "forbidden",
-					error_description:
-						"Agent management requires owner or admin access.",
-				},
-				403
-			);
-		}
+	const memberRole = c.get("memberRole") as string | null | undefined;
+	if (memberRole !== "owner" && memberRole !== "admin") {
+		return c.json(
+			{
+				error: "forbidden",
+				error_description:
+					"Agent management requires owner or admin access.",
+			},
+			403
+		);
 	}
 	return null;
 }

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -213,6 +213,37 @@ export function requireSessionOrAdminPat(c: any): Response | null {
 }
 
 /**
+ * Gate agent management mutations (update/delete/config) to org
+ * owner/admin. `requireSessionOrAdminPat` alone only proves an
+ * authenticated caller — any org MEMBER passes it, so a member could
+ * rewrite or delete another member's agent (or change its soulMd,
+ * guardrails or tool surface) via PATCH/DELETE. Role check mirrors
+ * index.ts `requireOrganizationSettingsAdmin`: a web session needs
+ * owner/admin; a PAT/OAuth token keeps passing only with `mcp:admin`
+ * scope (an explicit admin delegation, the same rule the manage_agents
+ * tool's write gate applies).
+ */
+function requireManageAgentAccess(c: any): Response | null {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+
+	if (c.get("authSource") === "session") {
+		const memberRole = c.get("memberRole") as string | null | undefined;
+		if (memberRole !== "owner" && memberRole !== "admin") {
+			return c.json(
+				{
+					error: "forbidden",
+					error_description:
+						"Agent management requires owner or admin access.",
+				},
+				403
+			);
+		}
+	}
+	return null;
+}
+
+/**
  * Emit a config-audit event for a mutation handled in this file. Thin wrapper
  * binding `recordConfigChangeEvent` (fire-and-forget, redacts internally) to
  * the request's apply/actor context.
@@ -1466,7 +1497,7 @@ routes.get("/:agentId", async (c) => {
 // ── Update agent metadata ────────────────────────────────────────────────────
 
 routes.patch("/:agentId", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const { agentId } = c.req.param();
 	const body = await c.req.json<{ name?: string; description?: string }>();
@@ -1492,7 +1523,7 @@ routes.patch("/:agentId", async (c) => {
 // ── Delete agent ─────────────────────────────────────────────────────────────
 
 routes.delete("/:agentId", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const { agentId } = c.req.param();
 
@@ -1922,7 +1953,7 @@ export function validateSkillsConfig(value: unknown): string | null {
 }
 
 routes.patch("/:agentId/config", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const { agentId } = c.req.param();
 	const updates = await c.req.json();


### PR DESCRIPTION
## Summary
- Any authenticated org **member** could `PATCH`/`DELETE` another member's agent and rewrite its entire config (`soulMd`, `identityMd`, `guardrails`, `preApprovedTools`, `toolsConfig`) through the REST agent routes. `requireSessionOrAdminPat` only proves *an authenticated caller* — it never consulted org role.
- Adds `requireManageAgentAccess` on `PATCH /:agentId`, `DELETE /:agentId` and `PATCH /:agentId/config`: a web session must be `owner`/`admin`; a PAT/OAuth token keeps its existing `mcp:admin` admin delegation (the same rule the `manage_agents` write gate applies).
- Read stays org-wide on purpose — `GET /:agentId/config` is unchanged, and a test pins that.

This is item #5 of the agent-access decision brief (the "is `manage_agents` write really open to any member?" question, which turned out to be yes for the REST surface).

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate for this PR)
- [x] Tests run: `bun test ./packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

**RED** — same new test file run in a clean worktree at `origin/main` (`packages/server/src/lobu/agent-routes.ts` verified byte-identical to `origin/main`), packages built:

```
(fail) agent management mutations — role gate > member: PATCH /config is denied
(fail) agent management mutations — role gate > member: PATCH /:agentId (metadata) is denied
  Expected: 403 / Received: 200
(fail) agent management mutations — role gate > member: DELETE /:agentId is denied
  Expected: 403 / Received: 200

 4 pass
 3 fail
Ran 7 tests across 1 file. [3.79s]
```

The three failures are exactly the member-denial cases, and the audit log emitted during the red run confirms the member's writes actually landed on main:

```
"summary":"Agent 'Renamed' metadata updated","resourceKind":"agent","op":"updated"
"summary":"Agent 'manage-access-agent' deleted","resourceKind":"agent","op":"deleted"
```

The 4 passing tests are the owner / `mcp:admin`-PAT / member-GET-read cases — unchanged behaviour before and after, so they hold on both sides.

**GREEN** — same file on this branch:

```
 8 pass
 0 fail
 10 expect() calls
Ran 8 tests across 1 file. [3.53s]
```

(The 8th case pins the follow-up commit's rule: an `mcp:admin` PAT held by a
plain member is denied too — role is not authorizable by scope.)

## Notes
- Follow-ups from the same brief, deliberately **not** in this branch (one branch = one concern): the member-*use* gate on the agent chat/session surface (a member is currently 403'd from chatting with an agent they can fully read), multi-org ownership disambiguation via `x-lobu-org`, and the Owletto composer gate that stops rendering a chat box the server will 403.

