### PR TITLE
fix(server): let an org member use an agent they do not own

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-member-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-member-scope.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Agent history for an ORG MEMBER who does not own the agent.
+ *
+ * The same asymmetry as the chat surface (`agent-member-use.test.ts`): a member
+ * could read the agent's config org-wide but got 401 on every history read,
+ * because `getAuthorizedAgentScope` required an `agent_users` ownership row in
+ * the ambient workspace.
+ *
+ * Every thread route rebuilds the conversation id from `scope.userId`, so a
+ * member authorized this way reads only their OWN conversations. The two live
+ * worker-session proxies do not — they return whatever the agent is running
+ * right now, which for an org-shared agent may be a colleague's turn — so they
+ * stay owner-only.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { getDb } from "../../db/client.js";
+import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import { invalidateMembershipRoleCache } from "../../workspace/multi-tenant.js";
+import { UserAgentsStore } from "../auth/user-agents-store.js";
+import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const AGENT_ORG = "org-history-member-test";
+const AGENT_ID = "nasdaq-tracker";
+const AGENT_OWNER_ID = "user-history-owner";
+const MEMBER_ID = "user-history-member";
+const OUTSIDER_ID = "user-history-outsider";
+
+function sessionFor(userId: string) {
+  return { userId, platform: "external", exp: Date.now() + 60_000 };
+}
+
+async function seedMembership(userId: string, role: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, ${userId}, ${`${userId}@test`}, true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`m-${AGENT_ORG}-${userId}`}, ${AGENT_ORG}, ${userId}, ${role}, now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  invalidateMembershipRoleCache(AGENT_ORG, userId);
+}
+
+describe("agent history — org member who does not own the agent", () => {
+  let userAgentsStore: UserAgentsStore;
+  let app: Hono;
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 120_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    userAgentsStore = new UserAgentsStore();
+    await orgContext.run({ organizationId: AGENT_ORG }, async () => {
+      await seedAgentRow(AGENT_ID, {
+        organizationId: AGENT_ORG,
+        ownerPlatform: "external",
+        ownerUserId: AGENT_OWNER_ID,
+      });
+      await userAgentsStore.addAgent("external", AGENT_OWNER_ID, AGENT_ID);
+    });
+    await seedMembership(AGENT_OWNER_ID, "member");
+    await seedMembership(MEMBER_ID, "member");
+    invalidateMembershipRoleCache(AGENT_ORG, OUTSIDER_ID);
+
+    app = new Hono();
+    app.route(
+      "/api/v1/agents/:agentId/history",
+      createAgentHistoryRoutes({
+        userAgentsStore,
+        agentConfigStore: createPostgresAgentConfigStore() as never,
+      })
+    );
+  }, 60_000);
+
+  afterEach(() => {
+    setAuthProvider(null);
+  });
+
+  function request(path: string): Promise<Response> {
+    return orgContext.run({ organizationId: AGENT_ORG }, () =>
+      app.request(`/api/v1/agents/${AGENT_ID}/history${path}`, {
+        headers: { host: "localhost" },
+      })
+    );
+  }
+
+  test("a member may list their own threads (was 401)", async () => {
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const res = await request("/threads");
+    expect(res.status).toBe(200);
+    // Their own conversations only — they have none yet.
+    expect((await res.json()) as { threads: unknown[] }).toEqual({ threads: [] });
+  });
+
+  test("the owner still lists threads (regression)", async () => {
+    setAuthProvider(() => sessionFor(AGENT_OWNER_ID));
+    expect((await request("/threads")).status).toBe(200);
+  });
+
+  test("a non-member is still refused", async () => {
+    setAuthProvider(() => sessionFor(OUTSIDER_ID));
+    expect((await request("/threads")).status).toBe(401);
+  });
+
+  test("a member is refused the live worker-session proxies", async () => {
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    // These return the agent's CURRENT session — not this caller's
+    // conversation — so membership must not open them.
+    expect((await request("/session/messages")).status).toBe(401);
+    expect((await request("/session/stats")).status).toBe(401);
+  });
+});

--- a/packages/server/src/gateway/__tests__/agent-history-member-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-member-scope.test.ts
@@ -7,10 +7,12 @@
  * the ambient workspace.
  *
  * Every thread route rebuilds the conversation id from `scope.userId`, so a
- * member authorized this way reads only their OWN conversations. The two live
- * worker-session proxies do not — they return whatever the agent is running
- * right now, which for an org-shared agent may be a colleague's turn — so they
- * stay owner-only.
+ * member authorized this way reads only their OWN conversations. The routes
+ * that are NOT keyed on it are narrowed or refused for a member without org
+ * oversight: `?scope=all` falls back to the user-scoped list, and the
+ * automation transcripts plus the two live worker-session proxies — which
+ * return whatever the agent is running right now, possibly a colleague's turn
+ * — are refused. The agent's owner and org owner/admins keep all of them.
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
@@ -22,35 +24,24 @@ import { invalidateMembershipRoleCache } from "../../workspace/multi-tenant.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
+import { buildApiConversationId } from "../services/api-conversation-id.js";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
   seedAgentRow,
+  seedOrgMembership,
 } from "./helpers/db-setup.js";
 
 const AGENT_ORG = "org-history-member-test";
 const AGENT_ID = "nasdaq-tracker";
 const AGENT_OWNER_ID = "user-history-owner";
 const MEMBER_ID = "user-history-member";
+const ADMIN_ID = "user-history-admin";
 const OUTSIDER_ID = "user-history-outsider";
+const AUTOMATION_ID = 290001;
 
 function sessionFor(userId: string) {
   return { userId, platform: "external", exp: Date.now() + 60_000 };
-}
-
-async function seedMembership(userId: string, role: string): Promise<void> {
-  const sql = getDb();
-  await sql`
-    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
-    VALUES (${userId}, ${userId}, ${`${userId}@test`}, true, now(), now())
-    ON CONFLICT (id) DO NOTHING
-  `;
-  await sql`
-    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
-    VALUES (${`m-${AGENT_ORG}-${userId}`}, ${AGENT_ORG}, ${userId}, ${role}, now())
-    ON CONFLICT (id) DO NOTHING
-  `;
-  invalidateMembershipRoleCache(AGENT_ORG, userId);
 }
 
 describe("agent history — org member who does not own the agent", () => {
@@ -72,8 +63,9 @@ describe("agent history — org member who does not own the agent", () => {
       });
       await userAgentsStore.addAgent("external", AGENT_OWNER_ID, AGENT_ID);
     });
-    await seedMembership(AGENT_OWNER_ID, "member");
-    await seedMembership(MEMBER_ID, "member");
+    await seedOrgMembership(AGENT_ORG, AGENT_OWNER_ID, "member");
+    await seedOrgMembership(AGENT_ORG, MEMBER_ID, "member");
+    await seedOrgMembership(AGENT_ORG, ADMIN_ID, "admin");
     invalidateMembershipRoleCache(AGENT_ORG, OUTSIDER_ID);
 
     app = new Hono();
@@ -106,6 +98,102 @@ describe("agent history — org member who does not own the agent", () => {
     expect((await res.json()) as { threads: unknown[] }).toEqual({ threads: [] });
   });
 
+  test("scope=all does not widen a member beyond their own web threads", async () => {
+    const sql = getDb();
+    const ownKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: MEMBER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "member-own",
+    });
+    const ownerKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: AGENT_OWNER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "owner-private",
+    });
+    await sql`
+      INSERT INTO conversations
+        (organization_id, agent_id, platform, conversation_id, thread_id,
+         kind, user_id, title, last_activity_at)
+      VALUES
+        (${AGENT_ORG}, ${AGENT_ID}, 'web', ${ownKey}, 'member-own',
+         'owned', ${MEMBER_ID}, 'Member own', now()),
+        (${AGENT_ORG}, ${AGENT_ID}, 'web', ${ownerKey}, 'owner-private',
+         'owned', ${AGENT_OWNER_ID}, 'Owner private', now())
+    `;
+    await sql`
+      INSERT INTO automations
+        (id, organization_id, agent_id, created_by, automation_group_id,
+         name, status, min_cooldown_seconds, last_run_completed_at,
+         created_at, updated_at)
+      VALUES
+        (${AUTOMATION_ID}, ${AGENT_ORG}, ${AGENT_ID}, ${AGENT_OWNER_ID}, 0,
+         'Owner automation', 'active', 0, now(), now(), now())
+    `;
+
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const res = await request("/threads?scope=all");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      threads: Array<{ id: string; conversationId: string }>;
+    };
+    expect(body.threads).toEqual([
+      expect.objectContaining({ id: "member-own", conversationId: ownKey }),
+    ]);
+  });
+
+  test("a member cannot read an org automation transcript; an admin can", async () => {
+    const sql = getDb();
+    await sql`
+      INSERT INTO automations
+        (id, organization_id, agent_id, created_by, automation_group_id,
+         name, status, min_cooldown_seconds, created_at, updated_at)
+      VALUES
+        (${AUTOMATION_ID}, ${AGENT_ORG}, ${AGENT_ID}, ${AGENT_OWNER_ID}, 0,
+         'Private automation', 'active', 0, now(), now())
+    `;
+    const [run] = await sql<{ id: number }[]>`
+      INSERT INTO runs
+        (run_type, status, organization_id, automation_id, approval_status,
+         run_metadata, created_at, completed_at)
+      VALUES
+        ('automation', 'completed', ${AGENT_ORG}, ${AUTOMATION_ID}, 'auto',
+         ${sql.json({ prompt_rendered: "owner automation secret" })}, now(), now())
+      RETURNING id
+    `;
+    const conversationId = `${AGENT_ID}_automation_${AUTOMATION_ID}_run_${run!.id}`;
+    const snapshot =
+      '{"type":"message","message":{"role":"assistant","content":"secret result"}}\n';
+    await sql`
+      INSERT INTO agent_transcript_snapshot
+        (organization_id, agent_id, conversation_id, run_id, snapshot_jsonl,
+         byte_size, terminal_status)
+      VALUES
+        (${AGENT_ORG}, ${AGENT_ID}, ${conversationId}, ${run!.id}, ${snapshot},
+         ${Buffer.byteLength(snapshot)}, 'completed')
+    `;
+
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    expect(
+      (await request(`/automations/${AUTOMATION_ID}/thread`)).status
+    ).toBe(401);
+
+    setAuthProvider(() => sessionFor(ADMIN_ID));
+    const admin = await request(`/automations/${AUTOMATION_ID}/thread`);
+    expect(admin.status).toBe(200);
+    const body = (await admin.json()) as {
+      runs: Array<{ runId: number; task: string | null }>;
+    };
+    expect(body.runs).toEqual([
+      expect.objectContaining({
+        runId: Number(run!.id),
+        task: "owner automation secret",
+      }),
+    ]);
+  });
+
   test("the owner still lists threads (regression)", async () => {
     setAuthProvider(() => sessionFor(AGENT_OWNER_ID));
     expect((await request("/threads")).status).toBe(200);
@@ -113,6 +201,11 @@ describe("agent history — org member who does not own the agent", () => {
 
   test("a non-member is still refused", async () => {
     setAuthProvider(() => sessionFor(OUTSIDER_ID));
+    expect((await request("/threads")).status).toBe(401);
+  });
+
+  test("an agent-scoped session cannot borrow human membership", async () => {
+    setAuthProvider(() => ({ ...sessionFor(MEMBER_ID), agentId: AGENT_ID }));
     expect((await request("/threads")).status).toBe(401);
   });
 

--- a/packages/server/src/gateway/__tests__/agent-member-use.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-member-use.test.ts
@@ -31,10 +31,10 @@ import { Hono } from "hono";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import type { SettingsTokenPayload } from "../auth/settings/token-service.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
-import { getDb } from "../../db/client.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { invalidateMembershipRoleCache } from "../../workspace/multi-tenant.js";
+import { buildApiConversationId } from "../services/api-conversation-id.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
 import type { ThreadSession } from "../session.js";
@@ -42,6 +42,7 @@ import {
   ensureDbForGatewayTests,
   resetTestDatabase,
   seedAgentRow,
+  seedOrgMembership,
 } from "./helpers/db-setup.js";
 
 const AGENT_ORG = "org-agent-use-test";
@@ -60,28 +61,6 @@ function sessionFor(userId: string): SettingsTokenPayload {
   // Mirrors the embedded authProvider: better-auth user → external identity,
   // no oauthUserId, so the lookup key is `userId`.
   return { userId, platform: "external", exp: Date.now() + 60_000 };
-}
-
-async function seedUser(userId: string): Promise<void> {
-  await getDb()`
-    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
-    VALUES (${userId}, ${userId}, ${`${userId}@test`}, true, now(), now())
-    ON CONFLICT (id) DO NOTHING
-  `;
-}
-
-async function seedMembership(
-  orgId: string,
-  userId: string,
-  role: string
-): Promise<void> {
-  await seedUser(userId);
-  await getDb()`
-    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
-    VALUES (${`m-${orgId}-${userId}`}, ${orgId}, ${userId}, ${role}, now())
-    ON CONFLICT (id) DO NOTHING
-  `;
-  invalidateMembershipRoleCache(orgId, userId);
 }
 
 function makeSessionManager() {
@@ -191,13 +170,19 @@ describe("POST /api/v1/agents — org member using an agent they don't own", () 
     await seedAgentRow("placeholder-outsider", {
       organizationId: OUTSIDER_ORG,
     });
+    await seedAgentRow(AGENT_ID, {
+      organizationId: OUTSIDER_ORG,
+      ownerPlatform: "external",
+      ownerUserId: OUTSIDER_ID,
+    });
 
     // The agent's owner is deliberately a plain member: `use` follows
     // membership, `manage` follows role, and the two are independent.
-    await seedMembership(AGENT_ORG, AGENT_OWNER_ID, "member");
-    await seedMembership(AGENT_ORG, MEMBER_ID, "member");
-    await seedMembership(AGENT_ORG, ADMIN_ID, "admin");
-    await seedMembership(OUTSIDER_ORG, OUTSIDER_ID, "owner");
+    await seedOrgMembership(AGENT_ORG, AGENT_OWNER_ID, "member");
+    await seedOrgMembership(AGENT_ORG, MEMBER_ID, "member");
+    await seedOrgMembership(AGENT_ORG, ADMIN_ID, "admin");
+    await seedOrgMembership(OUTSIDER_ORG, OUTSIDER_ID, "owner");
+    await seedOrgMembership(OUTSIDER_ORG, MEMBER_ID, "member");
     // The outsider must not be a member of the agent's org.
     invalidateMembershipRoleCache(AGENT_ORG, OUTSIDER_ID);
   }, 60_000);
@@ -221,11 +206,68 @@ describe("POST /api/v1/agents — org member using an agent they don't own", () 
     );
 
     expect(res.status).toBe(201);
+    const expectedKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: MEMBER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "member-thread",
+    });
+    expect(((await res.json()) as { agentId: string }).agentId).toBe(
+      expectedKey
+    );
     const stored = sessions.getStored();
     // Stamped with the AGENT's org (not the caller's ambient default), and with
     // the authenticated human — the field the own-conversation check reads.
     expect(stored?.organizationId).toBe(AGENT_ORG);
     expect(stored?.createdByUserId).toBe(MEMBER_ID);
+    expect(stored?.conversationId).toBe(expectedKey);
+    expect(sessions.store.get(expectedKey)).toBe(stored);
+  });
+
+  test("the same agent id remains isolated across organizations", async () => {
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const shared = makeSessionManager();
+    const { app } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+
+    const inAgentOrg = await postCreate(
+      app,
+      { thread: "same-thread" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+    const inOutsiderOrg = await postCreate(
+      app,
+      { thread: "same-thread" },
+      { "x-lobu-org": OUTSIDER_ORG }
+    );
+
+    expect(inAgentOrg.status).toBe(201);
+    expect(inOutsiderOrg.status).toBe(201);
+    const agentOrgKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: MEMBER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "same-thread",
+    });
+    const outsiderOrgKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: MEMBER_ID,
+      organizationId: OUTSIDER_ORG,
+      threadId: "same-thread",
+    });
+    expect(((await inAgentOrg.json()) as { agentId: string }).agentId).toBe(
+      agentOrgKey
+    );
+    expect(((await inOutsiderOrg.json()) as { agentId: string }).agentId).toBe(
+      outsiderOrgKey
+    );
+    expect(shared.store.get(agentOrgKey)?.organizationId).toBe(AGENT_ORG);
+    expect(shared.store.get(outsiderOrgKey)?.organizationId).toBe(OUTSIDER_ORG);
+    expect(shared.store.size).toBe(2);
   });
 
   test("the agent's owner is still authorized (regression)", async () => {
@@ -258,6 +300,27 @@ describe("POST /api/v1/agents — org member using an agent they don't own", () 
 
     expect(res.status).toBe(403);
     expect(sessions.getStored()).toBeNull();
+  });
+
+  test("a Bearer request cannot borrow a settings cookie's membership", async () => {
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const { app, sessions } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      AGENT_ORG
+    );
+
+    const res = await postCreate(
+      app,
+      { thread: "mixed-auth" },
+      {
+        "x-lobu-org": AGENT_ORG,
+        Authorization: "Bearer pat-or-oauth-token",
+      }
+    );
+
+    expect(res.status).toBe(403);
+    expect(sessions.store.size).toBe(0);
   });
 
   test("a non-member naming the workspace is still denied", async () => {
@@ -377,8 +440,60 @@ describe("POST /api/v1/agents — org member using an agent they don't own", () 
       { "x-lobu-org": AGENT_ORG }
     );
     expect(clobber.status).toBe(403);
-    // The owner's session is untouched.
-    expect(shared.getStored()?.createdByUserId).toBe(AGENT_OWNER_ID);
+    const ownerKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: AGENT_OWNER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "shared-thread",
+    });
+    // The owner's exact session is untouched.
+    expect(shared.store.get(ownerKey)?.createdByUserId).toBe(AGENT_OWNER_ID);
+  });
+
+  test("a member cannot resume or replace an unstamped legacy session", async () => {
+    const shared = makeSessionManager();
+    const legacyKey = buildApiConversationId({
+      agentId: AGENT_ID,
+      userId: AGENT_OWNER_ID,
+      organizationId: AGENT_ORG,
+      threadId: "legacy-thread",
+    });
+    const legacySession: ThreadSession = {
+      conversationId: legacyKey,
+      channelId: `api_${AGENT_OWNER_ID}`,
+      userId: AGENT_OWNER_ID,
+      threadCreator: AGENT_OWNER_ID,
+      lastActivity: 123,
+      createdAt: 100,
+      status: "active",
+      agentId: AGENT_ID,
+      organizationId: AGENT_ORG,
+    };
+    shared.store.set(legacyKey, legacySession);
+
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const member = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    const body = { userId: AGENT_OWNER_ID, thread: "legacy-thread" };
+
+    expect(
+      (await postCreate(member.app, body, { "x-lobu-org": AGENT_ORG })).status
+    ).toBe(403);
+    expect(
+      (
+        await postCreate(
+          member.app,
+          { ...body, forceNew: true },
+          { "x-lobu-org": AGENT_ORG }
+        )
+      ).status
+    ).toBe(403);
+    expect(shared.store.get(legacyKey)).toBe(legacySession);
+    expect(shared.store.size).toBe(1);
   });
 
   test("an org admin keeps oversight of a member's session", async () => {

--- a/packages/server/src/gateway/__tests__/agent-member-use.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-member-use.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Surface B (agent chat) authorizes an ORG MEMBER, not only the agent's owner.
+ *
+ * Prod repro (org `umit-unal`, agent `nasdaq-tracker`): a fellow member could
+ * `GET /api/<org>/agents/<id>/config` → 200 (soulMd, guardrails, tools) but got
+ * `POST /lobu/api/v1/agents` → 403, because chat authorized on the per-user
+ * `agent_users` ownership mapping while everything else authorized on org
+ * membership. The composer rendered anyway, so every send failed.
+ *
+ * An agent is an org-level object, so a member may USE it. `manage` stays
+ * owner/admin on the org-scoped REST routes (`lobu/agent-routes.ts`), and this
+ * file pins the two halves that make member-use safe:
+ *   1. membership is verified against a PROVEN org (the `x-lobu-org` workspace
+ *      the request names, or the existing session's org) — never the caller's
+ *      ambient default org, and the agent must exist in that org;
+ *   2. a member reaches only their OWN conversation: session keys are guessable
+ *      (`agentId_userId_org_thread`) and the `userId` half is caller-supplied,
+ *      so without the `createdByUserId` check one member could attach to a
+ *      colleague's stream, message into their thread, or clobber it.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { Hono } from "hono";
+import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
+import type { SettingsTokenPayload } from "../auth/settings/token-service.js";
+import { UserAgentsStore } from "../auth/user-agents-store.js";
+import { getDb } from "../../db/client.js";
+import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import { invalidateMembershipRoleCache } from "../../workspace/multi-tenant.js";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+import type { ThreadSession } from "../session.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const AGENT_ORG = "org-agent-use-test";
+// The SPA pins the ambient org to the caller's DEFAULT org, which is not where
+// the agent lives — the workspace comes in as `x-lobu-org`.
+const CALLER_DEFAULT_ORG = "org-caller-default-use-test";
+const OUTSIDER_ORG = "org-outsider-use-test";
+
+const AGENT_ID = "nasdaq-tracker";
+const AGENT_OWNER_ID = "user-agent-owner-use";
+const MEMBER_ID = "user-plain-member-use";
+const ADMIN_ID = "user-org-admin-use";
+const OUTSIDER_ID = "user-outsider-use";
+
+function sessionFor(userId: string): SettingsTokenPayload {
+  // Mirrors the embedded authProvider: better-auth user → external identity,
+  // no oauthUserId, so the lookup key is `userId`.
+  return { userId, platform: "external", exp: Date.now() + 60_000 };
+}
+
+async function seedUser(userId: string): Promise<void> {
+  await getDb()`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, ${userId}, ${`${userId}@test`}, true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function seedMembership(
+  orgId: string,
+  userId: string,
+  role: string
+): Promise<void> {
+  await seedUser(userId);
+  await getDb()`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`m-${orgId}-${userId}`}, ${orgId}, ${userId}, ${role}, now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  invalidateMembershipRoleCache(orgId, userId);
+}
+
+function makeSessionManager() {
+  const store = new Map<string, ThreadSession>();
+  let lastStored: ThreadSession | null = null;
+  return {
+    mgr: {
+      async getSession(key: string) {
+        return store.get(key) ?? null;
+      },
+      async setSession(session: ThreadSession) {
+        store.set(session.conversationId, session);
+        lastStored = session;
+      },
+      async touchSession() {},
+      async deleteSession(key: string) {
+        store.delete(key);
+      },
+    } as never,
+    getStored: () => lastStored,
+    store,
+  };
+}
+
+/**
+ * One app instance per test, sharing a session store so a follow-up request can
+ * resolve the row an earlier POST created. Reproduces the production ambient
+ * org-context (`createLobuOrgContextMiddleware` sets it AND wraps the request
+ * in `orgContext.run`).
+ */
+function makeApp(
+  userAgentsStore: UserAgentsStore,
+  agentMetadataStore: AgentMetadataStore,
+  ambientOrg: string,
+  sessions = makeSessionManager()
+) {
+  const agentApi = createAgentApi({
+    queueProducer: {} as never,
+    sessionManager: sessions.mgr,
+    sseManager: { hasActiveConnection: () => false } as never,
+    publicGatewayUrl: "http://localhost:8787",
+    artifactStore: {} as never,
+    userAgentsStore,
+    agentMetadataStore: agentMetadataStore as never,
+  });
+
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("organizationId", ambientOrg);
+    return orgContext.run({ organizationId: ambientOrg }, () => next());
+  });
+  app.route("/", agentApi);
+
+  return { app, sessions };
+}
+
+async function postCreate(
+  app: Hono,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return app.request("/api/v1/agents", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({ agentId: AGENT_ID, ...body }),
+  });
+}
+
+function getStatus(app: Hono, sessionKey: string): Promise<Response> {
+  return app.request(`/api/v1/agents/${encodeURIComponent(sessionKey)}`, {
+    method: "GET",
+  });
+}
+
+function deleteSession(app: Hono, sessionKey: string): Promise<Response> {
+  return app.request(`/api/v1/agents/${encodeURIComponent(sessionKey)}`, {
+    method: "DELETE",
+  });
+}
+
+describe("POST /api/v1/agents — org member using an agent they don't own", () => {
+  let userAgentsStore: UserAgentsStore;
+  let agentMetadataStore: AgentMetadataStore;
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 120_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    const configStore = createPostgresAgentConfigStore();
+    agentMetadataStore = new AgentMetadataStore(configStore);
+    userAgentsStore = new UserAgentsStore();
+
+    // The agent + its per-user owner mapping live in AGENT_ORG only.
+    await orgContext.run({ organizationId: AGENT_ORG }, async () => {
+      await seedAgentRow(AGENT_ID, {
+        organizationId: AGENT_ORG,
+        ownerPlatform: "external",
+        ownerUserId: AGENT_OWNER_ID,
+      });
+      await userAgentsStore.addAgent("external", AGENT_OWNER_ID, AGENT_ID);
+    });
+    await seedAgentRow("placeholder-default", {
+      organizationId: CALLER_DEFAULT_ORG,
+    });
+    await seedAgentRow("placeholder-outsider", {
+      organizationId: OUTSIDER_ORG,
+    });
+
+    // The agent's owner is deliberately a plain member: `use` follows
+    // membership, `manage` follows role, and the two are independent.
+    await seedMembership(AGENT_ORG, AGENT_OWNER_ID, "member");
+    await seedMembership(AGENT_ORG, MEMBER_ID, "member");
+    await seedMembership(AGENT_ORG, ADMIN_ID, "admin");
+    await seedMembership(OUTSIDER_ORG, OUTSIDER_ID, "owner");
+    // The outsider must not be a member of the agent's org.
+    invalidateMembershipRoleCache(AGENT_ORG, OUTSIDER_ID);
+  }, 60_000);
+
+  afterEach(() => {
+    setAuthProvider(null);
+  });
+
+  test("a plain member naming the workspace is authorized (was 403)", async () => {
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const { app, sessions } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await postCreate(
+      app,
+      { thread: "member-thread" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+
+    expect(res.status).toBe(201);
+    const stored = sessions.getStored();
+    // Stamped with the AGENT's org (not the caller's ambient default), and with
+    // the authenticated human — the field the own-conversation check reads.
+    expect(stored?.organizationId).toBe(AGENT_ORG);
+    expect(stored?.createdByUserId).toBe(MEMBER_ID);
+  });
+
+  test("the agent's owner is still authorized (regression)", async () => {
+    setAuthProvider(() => sessionFor(AGENT_OWNER_ID));
+    const { app, sessions } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await postCreate(app, { thread: "owner-thread" });
+
+    expect(res.status).toBe(201);
+    expect(sessions.getStored()?.organizationId).toBe(AGENT_ORG);
+    expect(sessions.getStored()?.createdByUserId).toBe(AGENT_OWNER_ID);
+  });
+
+  test("a member is denied without a workspace selector — no proven org", async () => {
+    // No `x-lobu-org` and no Bearer: nothing authoritative names the org the
+    // membership would be checked against, and the ambient default org is the
+    // caller's own, not the agent's. Declining is the only tenant-safe answer.
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const { app, sessions } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await postCreate(app, { thread: "no-workspace" });
+
+    expect(res.status).toBe(403);
+    expect(sessions.getStored()).toBeNull();
+  });
+
+  test("a non-member naming the workspace is still denied", async () => {
+    setAuthProvider(() => sessionFor(OUTSIDER_ID));
+    const { app, sessions } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      OUTSIDER_ORG
+    );
+
+    const res = await postCreate(
+      app,
+      { thread: "outsider-thread" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+
+    expect(res.status).toBe(403);
+    expect(sessions.getStored()).toBeNull();
+  });
+
+  test("a member is denied an agent id that does not exist in the named workspace", async () => {
+    // Membership alone must not authorize: the same agent id string can exist
+    // in every org, so the row has to be pinned to the named workspace.
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const { app } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await app.request("/api/v1/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-lobu-org": AGENT_ORG },
+      body: JSON.stringify({ agentId: "not-in-this-org", thread: "t" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("a member may drive their OWN session but not another member's", async () => {
+    const shared = makeSessionManager();
+
+    // The agent's owner opens a conversation.
+    setAuthProvider(() => sessionFor(AGENT_OWNER_ID));
+    const owner = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    const ownerCreate = await postCreate(owner.app, { thread: "owners-own" });
+    expect(ownerCreate.status).toBe(201);
+    const ownerKey = ((await ownerCreate.json()) as { agentId: string }).agentId;
+
+    // The member opens their own conversation with the same agent.
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const member = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    const memberCreate = await postCreate(
+      member.app,
+      { thread: "members-own" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+    expect(memberCreate.status).toBe(201);
+    const memberKey = ((await memberCreate.json()) as { agentId: string })
+      .agentId;
+
+    // Their own session: fine.
+    expect((await getStatus(member.app, memberKey)).status).toBe(200);
+
+    // The owner's session: denied, even though the member may use the agent.
+    expect((await getStatus(member.app, ownerKey)).status).toBe(403);
+    expect((await deleteSession(member.app, ownerKey)).status).toBe(403);
+    // …and the denial did not delete it.
+    expect(shared.store.has(ownerKey)).toBe(true);
+  });
+
+  test("a member cannot hijack another member's thread by naming their userId", async () => {
+    // `conversationId` is `agentId_userId_org_thread` and the `userId` half
+    // comes from the request body, so the session key is forgeable. The
+    // createdBy check is what stops a resume (which hands back a worker token
+    // scoped to that conversation) and a `forceNew` clobber.
+    const shared = makeSessionManager();
+
+    setAuthProvider(() => sessionFor(AGENT_OWNER_ID));
+    const owner = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    expect(
+      (await postCreate(owner.app, { thread: "shared-thread" })).status
+    ).toBe(201);
+
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const member = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    const resume = await postCreate(
+      member.app,
+      { userId: AGENT_OWNER_ID, thread: "shared-thread" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+    expect(resume.status).toBe(403);
+
+    const clobber = await postCreate(
+      member.app,
+      { userId: AGENT_OWNER_ID, thread: "shared-thread", forceNew: true },
+      { "x-lobu-org": AGENT_ORG }
+    );
+    expect(clobber.status).toBe(403);
+    // The owner's session is untouched.
+    expect(shared.getStored()?.createdByUserId).toBe(AGENT_OWNER_ID);
+  });
+
+  test("an org admin keeps oversight of a member's session", async () => {
+    const shared = makeSessionManager();
+
+    setAuthProvider(() => sessionFor(MEMBER_ID));
+    const member = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+    const created = await postCreate(
+      member.app,
+      { thread: "member-thread" },
+      { "x-lobu-org": AGENT_ORG }
+    );
+    expect(created.status).toBe(201);
+    const memberKey = ((await created.json()) as { agentId: string }).agentId;
+
+    setAuthProvider(() => sessionFor(ADMIN_ID));
+    const admin = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG,
+      shared
+    );
+
+    expect((await getStatus(admin.app, memberKey)).status).toBe(200);
+  });
+});

--- a/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
@@ -91,7 +91,7 @@ function makeSessionManager() {
  * Mount `createAgentApi` behind a wrapper that reproduces the production
  * ambient org-context: `createLobuOrgContextMiddleware` calls
  * `c.set("organizationId", <default org>)` AND wraps the request in
- * `orgContext.run()`. The early tenant guard in `requireAgentOwnership` reads
+ * `orgContext.run()`. The early tenant guard in `resolveAgentAccess` reads
  * `c.get("organizationId")`, so the bug is only reproducible when that ambient
  * value is set on the Hono context — not merely present in AsyncLocalStorage.
  */
@@ -318,7 +318,7 @@ describe("POST /api/v1/agents — owner of a non-default-org agent", () => {
     const res = await postCreate(app, {
       // A non-worker, non-OAuth Bearer (PAT-shaped). The settings-session
       // provider authenticates the user; the Bearer's presence is what makes
-      // the ambient org authoritative in requireAgentOwnership.
+      // the ambient org authoritative in resolveAgentAccess.
       Authorization: "Bearer owl_pat_test_token",
     });
 

--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -190,7 +190,7 @@ describe("POST /api/v1/agents — agent resolution + cross-tenant isolation", ()
     // Set up: orgA creates a session via POST /api/v1/agents, then orgB
     // tries to GET that exact session URL. Both orgs nominally "own"
     // agentId `owletto-default` (the global constant) — without the
-    // tenant guard in requireAgentOwnership, orgB would pass the
+    // tenant guard in resolveAgentAccess, orgB would pass the
     // (platform, userId, agentId) check and read orgA's session row.
     const orgA = "org-A";
     const orgB = "org-B";
@@ -265,7 +265,7 @@ describe("POST /api/v1/agents — agent resolution + cross-tenant isolation", ()
 
     // Real test: orgB tries the same URL. Ownership check would otherwise
     // pass (orgB also owns agent `owletto-default`) — the tenant guard
-    // inside requireAgentOwnership refuses based on session.organizationId
+    // inside resolveAgentAccess refuses based on session.organizationId
     // (orgA) ≠ caller orgId (orgB).
     const denied = await app.request(
       "/api/v1/agents/owletto-default_owletto-default_org-A",
@@ -283,7 +283,7 @@ describe("POST /api/v1/agents — agent resolution + cross-tenant isolation", ()
     // the up-front tenant guard catches their cross-tenant attempts (the test
     // above). The settings-session COOKIE path populates only a userId —
     // callerOrgId stays undefined and that guard is a no-op. This exercises the
-    // resolved-org fallback inside requireAgentOwnership: verifyOwnedAgentAccess
+    // resolved-org fallback inside resolveAgentAccess: verifyOwnedAgentAccess
     // authorizes orgB's cookie user (they own their own `owletto-default`) but
     // resolves their org to orgB, which must NOT match orgA's session. Without
     // the fallback this GET would return 200 and leak orgA's session.

--- a/packages/server/src/gateway/__tests__/helpers/db-setup.ts
+++ b/packages/server/src/gateway/__tests__/helpers/db-setup.ts
@@ -24,6 +24,7 @@ import {
   closeTestDb,
   setupTestDatabase,
 } from "../../../__tests__/setup/test-db.js";
+import { invalidateMembershipRoleCache } from "../../../workspace/multi-tenant.js";
 
 let initPromise: Promise<void> | null = null;
 let backend: EmbeddedBackend | null = null;
@@ -139,6 +140,30 @@ export async function seedAgentRow(
     ON CONFLICT (organization_id, id) DO NOTHING
   `;
   return orgId;
+}
+
+/**
+ * Seed a `member` row (and the `user` it references) for an org, then drop the
+ * membership-role cache entry so the next `getCachedMembershipRole` reads it.
+ * Without that invalidation a role seeded after a prior lookup stays invisible.
+ */
+export async function seedOrgMembership(
+  organizationId: string,
+  userId: string,
+  role: string
+): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, ${userId}, ${`${userId}@test`}, true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`m-${organizationId}-${userId}`}, ${organizationId}, ${userId}, ${role}, now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  invalidateMembershipRoleCache(organizationId, userId);
 }
 
 /**

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -32,7 +32,6 @@ import {
 } from "../../services/agent-thread-list.js";
 import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
 import { getCachedMembershipRole } from "../../../workspace/multi-tenant.js";
-import { agentExistsInOrganization } from "../../../lobu/stores/postgres-stores.js";
 import { buildApiConversationId } from "../../services/api-conversation-id.js";
 import { findConversationById } from "../../services/conversations-store.js";
 import { readAutomationRunThreads } from "../../services/automation-run-thread.js";
@@ -41,6 +40,10 @@ import {
 	resolveSettingsLookupUserId,
 	sessionMatchesMetadataOwner,
 } from "../shared/agent-ownership.js";
+import {
+	authorizeOrgAgentMemberInProvenOrg,
+	isRestrictedOrgAgentMember,
+} from "../shared/org-agent-access.js";
 import { errorResponse } from "../shared/helpers.js";
 import { verifySettingsSession } from "./settings-auth.js";
 
@@ -408,14 +411,17 @@ export function createAgentHistoryRoutes(deps: {
 		userId: string;
 		isAdmin: boolean;
 		/**
-		 * True when the caller does not OWN the agent and was authorized by org
-		 * membership alone. Every route below is already keyed on
-		 * `scope.userId` (thread ids are rebuilt from it), so a member reads
-		 * only their own conversations — except the two live worker-session
-		 * proxies, which expose whoever is driving the agent right now and are
-		 * therefore refused for this scope.
+		 * The caller's org role, set ONLY when they do not OWN the agent and were
+		 * authorized by org membership alone; undefined on the ownership path.
+		 *
+		 * Every route below is already keyed on `scope.userId` (thread ids are
+		 * rebuilt from it), so a member reads only their own conversations. The
+		 * routes that are NOT so keyed — the widened `?scope=all` list, the
+		 * automation transcripts, and the two live worker-session proxies, which
+		 * expose whoever is driving the agent right now — are narrowed or refused
+		 * for a member without org oversight (`isRestrictedOrgAgentMember`).
 		 */
-		viaMembership?: boolean;
+		memberRole?: string;
 	} | null> {
 		const session = await verifySettingsSession(c);
 		if (!session) return null;
@@ -456,37 +462,22 @@ export function createAgentHistoryRoutes(deps: {
 					isAdmin: false,
 				};
 			}
-			// Not the owner: an org MEMBER may read their OWN conversations with
-			// an org's agent (they may now chat with it — see
-			// `authorizeOrgMemberUse` in routes/public/agent.ts). The agent must
-			// exist in this membership-verified org: the same agent id string can
-			// exist in every org, so membership alone would authorize the wrong
-			// tenant's agent.
-			try {
-				const memberRole = await getCachedMembershipRole(
-					ambientOrgId,
-					userId,
-				);
-				if (
-					memberRole &&
-					(await agentExistsInOrganization(ambientOrgId, agentId))
-				) {
-					return {
-						agentId,
-						organizationId: ambientOrgId,
-						userId,
-						isAdmin: false,
-						viaMembership: true,
-					};
-				}
-			} catch (error) {
-				// Fail closed: an unreachable membership lookup denies (401 below)
-				// rather than surfacing a 500 from an authorization path.
-				logger.warn("member history authorization lookup failed — denying", {
-					error,
+			// An agent-scoped settings session is bound to its own ownership rule;
+			// it must not borrow the underlying human's org membership.
+			if (session.agentId) return null;
+			const member = await authorizeOrgAgentMemberInProvenOrg({
+				organizationId: ambientOrgId,
+				agentId,
+				userId,
+			});
+			if (member) {
+				return {
 					agentId,
-					organizationId: ambientOrgId,
-				});
+					organizationId: member.organizationId,
+					userId: member.userId,
+					isAdmin: false,
+					memberRole: member.role,
+				};
 			}
 			return null;
 		}
@@ -667,7 +658,12 @@ export function createAgentHistoryRoutes(deps: {
 
 		// `?scope=all` widens the list to every conversation for the agent across
 		// platforms (Slack, Telegram, …), not just the requesting user's threads.
-		const listScope = c.req.query("scope") === "all" ? "all" : "user";
+		// A member without org oversight never gets that widening: their `use`
+		// grant covers their own conversations, so the query param is ignored
+		// rather than refused (the narrowed list is still a valid answer).
+		const restrictedMember = isRestrictedOrgAgentMember(scope.memberRole);
+		const listScope =
+			!restrictedMember && c.req.query("scope") === "all" ? "all" : "user";
 		// DM conversations gate on explicit admin access, not channel membership.
 		// Resolve the org-role half only for the widened list; the existing
 		// platform-admin bypass is already carried on the authorized scope.
@@ -675,7 +671,11 @@ export function createAgentHistoryRoutes(deps: {
 			listScope === "all" && scope.organizationId
 				? scope.isAdmin ||
 					isAdminOrOwnerRole(
-						await getCachedMembershipRole(scope.organizationId, scope.userId),
+						scope.memberRole ??
+							(await getCachedMembershipRole(
+								scope.organizationId,
+								scope.userId,
+							)),
 					)
 				: false;
 		const threads = await listAgentThreads({
@@ -932,6 +932,13 @@ export function createAgentHistoryRoutes(deps: {
 	app.get("/automations/:automationId/thread", async (c) => {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
+		// An automation belongs to the org, not to the caller: its runs are keyed
+		// on automationId alone, with no `scope.userId` half to confine them. A
+		// member without org oversight would read a colleague's automation
+		// transcripts wholesale, so this route stays owner/admin.
+		if (isRestrictedOrgAgentMember(scope.memberRole)) {
+			return errorResponse(c, "Unauthorized", 401);
+		}
 		if (!scope.organizationId) return c.json({ runs: [] });
 
 		const automationId = Number(c.req.param("automationId"));
@@ -993,9 +1000,12 @@ export function createAgentHistoryRoutes(deps: {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
 		// The live worker session belongs to whoever is driving the agent right
-		// now, which for an org-shared agent need not be this caller. Owners
-		// keep it; a member reads their own threads through /threads/* instead.
-		if (scope.viaMembership) return errorResponse(c, "Unauthorized", 401);
+		// now, which for an org-shared agent need not be this caller. The agent's
+		// owner and org owner/admins keep it; a member without oversight reads
+		// their own threads through /threads/* instead.
+		if (isRestrictedOrgAgentMember(scope.memberRole)) {
+			return errorResponse(c, "Unauthorized", 401);
+		}
 
 		const cursor = c.req.query("cursor") || "";
 		const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 200);
@@ -1027,7 +1037,9 @@ export function createAgentHistoryRoutes(deps: {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
 		// Same live-session reasoning as /session/messages above.
-		if (scope.viaMembership) return errorResponse(c, "Unauthorized", 401);
+		if (isRestrictedOrgAgentMember(scope.memberRole)) {
+			return errorResponse(c, "Unauthorized", 401);
+		}
 
 		const result = await proxyOrFallback(
 			scope.agentId,

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -32,6 +32,7 @@ import {
 } from "../../services/agent-thread-list.js";
 import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
 import { getCachedMembershipRole } from "../../../workspace/multi-tenant.js";
+import { agentExistsInOrganization } from "../../../lobu/stores/postgres-stores.js";
 import { buildApiConversationId } from "../../services/api-conversation-id.js";
 import { findConversationById } from "../../services/conversations-store.js";
 import { readAutomationRunThreads } from "../../services/automation-run-thread.js";
@@ -406,6 +407,15 @@ export function createAgentHistoryRoutes(deps: {
 		organizationId: string | undefined;
 		userId: string;
 		isAdmin: boolean;
+		/**
+		 * True when the caller does not OWN the agent and was authorized by org
+		 * membership alone. Every route below is already keyed on
+		 * `scope.userId` (thread ids are rebuilt from it), so a member reads
+		 * only their own conversations — except the two live worker-session
+		 * proxies, which expose whoever is driving the agent right now and are
+		 * therefore refused for this scope.
+		 */
+		viaMembership?: boolean;
 	} | null> {
 		const session = await verifySettingsSession(c);
 		if (!session) return null;
@@ -445,6 +455,38 @@ export function createAgentHistoryRoutes(deps: {
 					userId,
 					isAdmin: false,
 				};
+			}
+			// Not the owner: an org MEMBER may read their OWN conversations with
+			// an org's agent (they may now chat with it — see
+			// `authorizeOrgMemberUse` in routes/public/agent.ts). The agent must
+			// exist in this membership-verified org: the same agent id string can
+			// exist in every org, so membership alone would authorize the wrong
+			// tenant's agent.
+			try {
+				const memberRole = await getCachedMembershipRole(
+					ambientOrgId,
+					userId,
+				);
+				if (
+					memberRole &&
+					(await agentExistsInOrganization(ambientOrgId, agentId))
+				) {
+					return {
+						agentId,
+						organizationId: ambientOrgId,
+						userId,
+						isAdmin: false,
+						viaMembership: true,
+					};
+				}
+			} catch (error) {
+				// Fail closed: an unreachable membership lookup denies (401 below)
+				// rather than surfacing a 500 from an authorization path.
+				logger.warn("member history authorization lookup failed — denying", {
+					error,
+					agentId,
+					organizationId: ambientOrgId,
+				});
 			}
 			return null;
 		}
@@ -950,6 +992,10 @@ export function createAgentHistoryRoutes(deps: {
 	app.get("/session/messages", async (c) => {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
+		// The live worker session belongs to whoever is driving the agent right
+		// now, which for an org-shared agent need not be this caller. Owners
+		// keep it; a member reads their own threads through /threads/* instead.
+		if (scope.viaMembership) return errorResponse(c, "Unauthorized", 401);
 
 		const cursor = c.req.query("cursor") || "";
 		const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 200);
@@ -980,6 +1026,8 @@ export function createAgentHistoryRoutes(deps: {
 	app.get("/session/stats", async (c) => {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
+		// Same live-session reasoning as /session/messages above.
+		if (scope.viaMembership) return errorResponse(c, "Unauthorized", 401);
 
 		const result = await proxyOrFallback(
 			scope.agentId,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -20,7 +20,12 @@ import {
   type RouteSpec,
 } from "../shared/define-route.js";
 import { getDb } from "../../../db/client.js";
-import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
+import {
+  getCachedMembershipRole,
+  getCachedOrgBySlug,
+} from "../../../workspace/multi-tenant.js";
+import { agentExistsInOrganization } from "../../../lobu/stores/postgres-stores.js";
+import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import { listPendingToolsForConversation } from "../../auth/mcp/pending-tool-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
@@ -49,7 +54,10 @@ import { buildAutomationRunWorkerAccess } from "../../services/automation-run-wo
 import { resolveAgentOptions } from "../../services/platform-helpers.js";
 import type { SseManager } from "../../services/sse-manager.js";
 import type { ISessionManager, ThreadSession } from "../../session.js";
-import { verifyOwnedAgentAccess } from "../shared/agent-ownership.js";
+import {
+  resolveSettingsLookupUserId,
+  verifyOwnedAgentAccess,
+} from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import { errorResponses } from "../shared/openapi-responses.js";
 import { verifySettingsSessionOrToken } from "./settings-auth.js";
@@ -59,6 +67,25 @@ import {
 } from "../../../tools/admin/manage_operations/activity-feed.js";
 
 const logger = createLogger("agent-api");
+
+/**
+ * What one request is allowed to do with one agent.
+ *
+ * `organizationId` is the tenant the agent was authorized under (resolved from
+ * `agent_users` for an owner, from the request's workspace scope for a
+ * member) — never the caller's ambient default org.
+ *
+ * `callerUserId` / `orgMemberRole` are populated only for a HUMAN web-session
+ * caller. `orgMemberRole` being set means the caller does NOT own the agent and
+ * was authorized by org membership alone, which grants `use`, not `manage`
+ * (agent management lives on the org-scoped REST routes and is gated
+ * owner/admin there).
+ */
+interface AgentAccessGrant {
+  organizationId?: string;
+  callerUserId?: string;
+  orgMemberRole?: string;
+}
 
 // =============================================================================
 // Constants
@@ -439,15 +466,78 @@ export function createAgentApi(config: AgentApiConfig): Hono {
   }
 
   /**
-   * Authorize access to an agent via per-user ownership. Workers (a worker
-   * IS its own agent) always take the ownership path. Returns a denial
-   * Response, or the resolved access ({ organizationId }).
+   * Authorize a HUMAN web-session caller to USE an agent they do not own,
+   * because they are a member of the org the agent lives in.
+   *
+   * An agent is an org-level object: it is stored `(organization_id, id)`,
+   * listed org-wide and its config is readable org-wide. Chat was the one
+   * surface still keyed on per-user ownership (`agent_users`), so a fellow
+   * member could read an agent's whole prompt and tool surface yet got 403 on
+   * `POST /api/v1/agents`. This closes that asymmetry for `use` only.
+   *
+   * Tenant safety rests on `candidateOrgId` being a PROVEN org, never the
+   * caller's ambient default org: it is either the workspace the SPA named via
+   * `x-lobu-org` (resolved by slug at the call site) or the org stamped on the
+   * existing session row. Membership in THAT org is then verified against the
+   * `member` table, and the agent must actually exist in it — the same agent id
+   * string can exist in every org, so proving membership without pinning the
+   * row would authorize the wrong tenant's agent.
+   *
+   * Returns null (caller keeps its ownership denial) rather than a Response, so
+   * the response shape stays the uniform `Forbidden` with no oracle for which
+   * check failed.
+   */
+  async function authorizeOrgMemberUse(
+    session: SettingsTokenPayload,
+    agentId: string,
+    candidateOrgId: string | undefined
+  ): Promise<{ organizationId: string; role: string; userId: string } | null> {
+    if (!candidateOrgId) return null;
+    // An agent-scoped session (worker/self) is bound to its own agent and must
+    // not borrow its human's org membership.
+    if (session.agentId) return null;
+    const callerUserId = resolveSettingsLookupUserId(session);
+    if (!callerUserId) return null;
+    try {
+      const role = await getCachedMembershipRole(candidateOrgId, callerUserId);
+      if (!role) return null;
+      if (!(await agentExistsInOrganization(candidateOrgId, agentId))) {
+        return null;
+      }
+      return { organizationId: candidateOrgId, role, userId: callerUserId };
+    } catch (error) {
+      // Fail closed: an unreachable membership lookup must deny (the caller
+      // keeps its ownership denial), never turn an authorization decision into
+      // a 500 that hides which answer the gate would have given.
+      logger.warn(
+        { err: error, agentId, organizationId: candidateOrgId },
+        "member-use authorization lookup failed — denying"
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Authorize access to an agent: per-user ownership first, then org
+   * membership for a human web-session caller (`use`, not `manage`). Workers
+   * (a worker IS its own agent) always take the ownership path. Returns a
+   * denial Response, or the resolved `AgentAccessGrant`.
    */
   async function authorizeAgentAccess(
     c: Context,
     agentId: string,
-    sessionForTenantCheck?: { organizationId?: string } | null
-  ): Promise<Response | { organizationId?: string }> {
+    sessionForTenantCheck?: {
+      organizationId?: string;
+      /**
+       * Present only when the value IS an existing session row (every
+       * ThreadSession has one). The create route passes a bare
+       * `{ organizationId }` workspace scope instead, and must not be read as
+       * a session — there is no session to be a member of yet.
+       */
+      conversationId?: string;
+      createdByUserId?: string;
+    } | null
+  ): Promise<Response | AgentAccessGrant> {
     const bearer = tokenFromHeader(c);
     // Authoritative auth-method-bound org (mirrors requireAgentOwnership): set
     // only by token auth (worker/external-OAuth `authContext`, or a PAT's pinned
@@ -468,12 +558,30 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     }
     const owned = await requireAgentOwnership(c, agentId, sessionForTenantCheck);
     if (owned instanceof Response) return owned;
-    return { organizationId: owned.organizationId };
+
+    // Own-conversation restriction for the member path. A member authorized by
+    // org membership may USE the agent, which does not extend to reading
+    // another member's conversation: these routes take a sessionKey, so
+    // without this any member could attach to a colleague's SSE stream, send
+    // messages into their thread or delete their session. Org owner/admins keep
+    // oversight, and the ownership path is untouched. `createdByUserId` is
+    // stamped at create time for every human caller; a session without one
+    // predates that (owner-created, since members could not create any before
+    // this change) and stays member-inaccessible.
+    if (owned.orgMemberRole && sessionForTenantCheck?.conversationId) {
+      const isOversight = isAdminOrOwnerRole(owned.orgMemberRole);
+      if (
+        !isOversight &&
+        sessionForTenantCheck.createdByUserId !== owned.callerUserId
+      ) {
+        return c.json({ success: false, error: "Forbidden" }, 403);
+      }
+    }
+    return owned;
   }
 
   /**
-   * Verify that the caller is authorized to act on `resolvedAgentId` via
-   * per-user ownership.
+   * Verify that the caller is authorized to act on `resolvedAgentId`.
    *
    * The agent API middleware accepts three auth methods (worker token,
    * external OAuth, settings session). Each needs its own ownership rule:
@@ -481,7 +589,9 @@ export function createAgentApi(config: AgentApiConfig): Hono {
    *   - worker token         → scoped to its own agentId
    *   - settings session     → verifyOwnedAgentAccess (handles admin bypass,
    *                            agent-scoped sessions, and UserAgentsStore
-   *                            / AgentMetadataStore lookups)
+   *                            / AgentMetadataStore lookups), then
+   *                            `authorizeOrgMemberUse` for a member of the
+   *                            workspace the request names
    *   - external OAuth       → treated as an external-platform identity and
    *                            run through verifyOwnedAgentAccess
    *
@@ -496,7 +606,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     c: Context,
     resolvedAgentId: string,
     sessionForTenantCheck?: { organizationId?: string } | null
-  ): Promise<Response | { organizationId?: string }> {
+  ): Promise<Response | AgentAccessGrant> {
     const deny = () =>
       c.json({ success: false, error: "Forbidden" }, 403) as Response;
 
@@ -617,7 +727,31 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         resolvedAgentId,
         ownershipAccessConfig
       );
-      return authorizeOwnership(access);
+      const owned = authorizeOwnership(access);
+      if (!(owned instanceof Response)) {
+        return {
+          organizationId: owned.organizationId,
+          callerUserId: resolveSettingsLookupUserId(settingsSession) || undefined,
+        };
+      }
+
+      // Not an owner — fall back to the org-membership USE path. Scoped to a
+      // PROVEN org: the workspace the request named (`x-lobu-org`, resolved by
+      // the create route) or the existing session's org, never the caller's
+      // ambient default org. Bearer callers keep the ownership rule: a PAT or
+      // third-party OAuth token is not a person acting in the web app, and its
+      // own tier (`mcp:*` scopes) is enforced elsewhere.
+      const member = await authorizeOrgMemberUse(
+        settingsSession,
+        resolvedAgentId,
+        sessionForTenantCheck?.organizationId ?? authoritativeCallerOrgId
+      );
+      if (!member) return owned;
+      return {
+        organizationId: member.organizationId,
+        callerUserId: member.userId,
+        orgMemberRole: member.role,
+      };
     }
 
     if (!bearer) return deny();
@@ -885,13 +1019,30 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       };
     };
 
-    // Try to resume existing session (unless forceNew is requested).
-    // Refuse cross-tenant resume defensively: even though the userId fallback
-    // above is per-org-unique for the default-agent path, a future caller that
-    // bypasses the auth bridge or passes a colliding requestedUserId would
-    // otherwise resume another tenant's session and leak its worker token.
+    // Read the session this request would resume or overwrite once, then run
+    // both guards over it.
+    const existing = await sessMgr.getSession(conversationId);
+
+    // A human may only resume — or overwrite with `forceNew` — a session they
+    // created themselves. Org members can now USE an agent they do not own, and
+    // the `userId` half of the conversationId is caller-supplied (request body),
+    // so without this a member could name a colleague's userId to resume their
+    // thread (receiving a worker token scoped to it) or clobber it outright.
+    // Bearer/automation callers have no `callerUserId` and are unaffected.
+    if (
+      access.callerUserId &&
+      existing?.createdByUserId &&
+      existing.createdByUserId !== access.callerUserId
+    ) {
+      return c.json({ success: false, error: "Forbidden" }, 403);
+    }
+
+    // Resume (unless forceNew). Refuse cross-tenant resume defensively: even
+    // though the userId fallback above is per-org-unique for the default-agent
+    // path, a future caller that bypasses the auth bridge or passes a colliding
+    // requestedUserId would otherwise resume another tenant's session and leak
+    // its worker token.
     if (!effectiveForceNew) {
-      const existing = await sessMgr.getSession(conversationId);
       if (
         existing &&
         existing.organizationId &&
@@ -945,6 +1096,9 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       nixConfig,
       agentId,
       ...(tokenOrganizationId ? { organizationId: tokenOrganizationId } : {}),
+      ...(access.callerUserId
+        ? { createdByUserId: access.callerUserId }
+        : {}),
       dryRun: effectiveDryRun,
       intent: automationIntent ?? undefined,
       ...(automationExecutionMode

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -20,12 +20,7 @@ import {
   type RouteSpec,
 } from "../shared/define-route.js";
 import { getDb } from "../../../db/client.js";
-import {
-  getCachedMembershipRole,
-  getCachedOrgBySlug,
-} from "../../../workspace/multi-tenant.js";
-import { agentExistsInOrganization } from "../../../lobu/stores/postgres-stores.js";
-import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
+import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import { listPendingToolsForConversation } from "../../auth/mcp/pending-tool-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
@@ -58,6 +53,10 @@ import {
   resolveSettingsLookupUserId,
   verifyOwnedAgentAccess,
 } from "../shared/agent-ownership.js";
+import {
+  authorizeOrgAgentMemberInProvenOrg,
+  isRestrictedOrgAgentMember,
+} from "../shared/org-agent-access.js";
 import { errorResponse } from "../shared/helpers.js";
 import { errorResponses } from "../shared/openapi-responses.js";
 import { verifySettingsSessionOrToken } from "./settings-auth.js";
@@ -75,17 +74,24 @@ const logger = createLogger("agent-api");
  * `agent_users` for an owner, from the request's workspace scope for a
  * member) — never the caller's ambient default org.
  *
- * `callerUserId` / `orgMemberRole` are populated only for a HUMAN web-session
- * caller. `orgMemberRole` being set means the caller does NOT own the agent and
- * was authorized by org membership alone, which grants `use`, not `manage`
- * (agent management lives on the org-scoped REST routes and is gated
- * owner/admin there).
+ * `kind` is the authorization route, and it gates what the grant may reach:
+ * `"membership"` is a cookie-only human authorized through the proven
+ * workspace rather than agent ownership (token callers never enter that
+ * branch), and a member without org oversight is confined to conversations
+ * they created themselves — see `isRestrictedOrgAgentMember`.
  */
-interface AgentAccessGrant {
-  organizationId?: string;
-  callerUserId?: string;
-  orgMemberRole?: string;
-}
+type AgentAccessGrant =
+  | {
+      kind: "ownership";
+      organizationId?: string;
+      callerUserId?: string;
+    }
+  | {
+      kind: "membership";
+      organizationId: string;
+      callerUserId: string;
+      memberRole: string;
+    };
 
 // =============================================================================
 // Constants
@@ -466,58 +472,6 @@ export function createAgentApi(config: AgentApiConfig): Hono {
   }
 
   /**
-   * Authorize a HUMAN web-session caller to USE an agent they do not own,
-   * because they are a member of the org the agent lives in.
-   *
-   * An agent is an org-level object: it is stored `(organization_id, id)`,
-   * listed org-wide and its config is readable org-wide. Chat was the one
-   * surface still keyed on per-user ownership (`agent_users`), so a fellow
-   * member could read an agent's whole prompt and tool surface yet got 403 on
-   * `POST /api/v1/agents`. This closes that asymmetry for `use` only.
-   *
-   * Tenant safety rests on `candidateOrgId` being a PROVEN org, never the
-   * caller's ambient default org: it is either the workspace the SPA named via
-   * `x-lobu-org` (resolved by slug at the call site) or the org stamped on the
-   * existing session row. Membership in THAT org is then verified against the
-   * `member` table, and the agent must actually exist in it — the same agent id
-   * string can exist in every org, so proving membership without pinning the
-   * row would authorize the wrong tenant's agent.
-   *
-   * Returns null (caller keeps its ownership denial) rather than a Response, so
-   * the response shape stays the uniform `Forbidden` with no oracle for which
-   * check failed.
-   */
-  async function authorizeOrgMemberUse(
-    session: SettingsTokenPayload,
-    agentId: string,
-    candidateOrgId: string | undefined
-  ): Promise<{ organizationId: string; role: string; userId: string } | null> {
-    if (!candidateOrgId) return null;
-    // An agent-scoped session (worker/self) is bound to its own agent and must
-    // not borrow its human's org membership.
-    if (session.agentId) return null;
-    const callerUserId = resolveSettingsLookupUserId(session);
-    if (!callerUserId) return null;
-    try {
-      const role = await getCachedMembershipRole(candidateOrgId, callerUserId);
-      if (!role) return null;
-      if (!(await agentExistsInOrganization(candidateOrgId, agentId))) {
-        return null;
-      }
-      return { organizationId: candidateOrgId, role, userId: callerUserId };
-    } catch (error) {
-      // Fail closed: an unreachable membership lookup must deny (the caller
-      // keeps its ownership denial), never turn an authorization decision into
-      // a 500 that hides which answer the gate would have given.
-      logger.warn(
-        { err: error, agentId, organizationId: candidateOrgId },
-        "member-use authorization lookup failed — denying"
-      );
-      return null;
-    }
-  }
-
-  /**
    * Authorize access to an agent: per-user ownership first, then org
    * membership for a human web-session caller (`use`, not `manage`). Workers
    * (a worker IS its own agent) always take the ownership path. Returns a
@@ -538,25 +492,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       createdByUserId?: string;
     } | null
   ): Promise<Response | AgentAccessGrant> {
-    const bearer = tokenFromHeader(c);
-    // Authoritative auth-method-bound org (mirrors requireAgentOwnership): set
-    // only by token auth (worker/external-OAuth `authContext`, or a PAT's pinned
-    // org via the bearer-gated ambient read). Undefined for the cookie session
-    // (SPA), which has no org binding and is gated by the membership/role check
-    // below. A bearer/token caller MUST NOT escape its bound org via a
-    // client-supplied workspace scope (x-lobu-org) or session org — deny on
-    // conflict before resolving ownership.
-    const authoritativeCallerOrgId =
-      c.get("authContext")?.organizationId ??
-      (bearer ? (c.get("organizationId") as string | undefined) : undefined);
-    if (
-      sessionForTenantCheck?.organizationId &&
-      authoritativeCallerOrgId &&
-      sessionForTenantCheck.organizationId !== authoritativeCallerOrgId
-    ) {
-      return c.json({ success: false, error: "Forbidden" }, 403);
-    }
-    const owned = await requireAgentOwnership(c, agentId, sessionForTenantCheck);
+    const owned = await resolveAgentAccess(c, agentId, sessionForTenantCheck);
     if (owned instanceof Response) return owned;
 
     // Own-conversation restriction for the member path. A member authorized by
@@ -568,12 +504,12 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     // stamped at create time for every human caller; a session without one
     // predates that (owner-created, since members could not create any before
     // this change) and stays member-inaccessible.
-    if (owned.orgMemberRole && sessionForTenantCheck?.conversationId) {
-      const isOversight = isAdminOrOwnerRole(owned.orgMemberRole);
-      if (
-        !isOversight &&
-        sessionForTenantCheck.createdByUserId !== owned.callerUserId
-      ) {
+    if (
+      owned.kind === "membership" &&
+      isRestrictedOrgAgentMember(owned.memberRole) &&
+      sessionForTenantCheck?.conversationId
+    ) {
+      if (sessionForTenantCheck.createdByUserId !== owned.callerUserId) {
         return c.json({ success: false, error: "Forbidden" }, 403);
       }
     }
@@ -590,19 +526,19 @@ export function createAgentApi(config: AgentApiConfig): Hono {
    *   - settings session     → verifyOwnedAgentAccess (handles admin bypass,
    *                            agent-scoped sessions, and UserAgentsStore
    *                            / AgentMetadataStore lookups), then
-   *                            `authorizeOrgMemberUse` for a member of the
-   *                            workspace the request names
+   *                            org membership in the proven workspace
    *   - external OAuth       → treated as an external-platform identity and
    *                            run through verifyOwnedAgentAccess
    *
-   * Returns a Response when the caller is not authorized (the handler
-   * should early-return it). On success returns `{ organizationId }` — the
-   * org the agent was authorized under (resolved from `agent_users`, NOT the
-   * caller's ambient org-context), so the handler can stamp the worker token
-   * and session with the agent's real tenant. `organizationId` may be
-   * undefined for auth paths that don't resolve one (worker token / admin).
+   * Returns a Response when the caller is not authorized (the handler should
+   * early-return it). On success returns the `AgentAccessGrant` naming the org
+   * the agent was authorized under — from `agent_users` on the ownership path,
+   * from the proven workspace on the membership path, NEVER the caller's
+   * ambient org-context — so the handler can stamp the worker token and session
+   * with the agent's real tenant. On the ownership path `organizationId` may be
+   * undefined for auth methods that resolve none (worker token / admin).
    */
-  async function requireAgentOwnership(
+  async function resolveAgentAccess(
     c: Context,
     resolvedAgentId: string,
     sessionForTenantCheck?: { organizationId?: string } | null
@@ -679,7 +615,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     const authorizeOwnership = (access: {
       authorized: boolean;
       organizationId?: string;
-    }): Response | { organizationId?: string } => {
+    }): Response | Extract<AgentAccessGrant, { kind: "ownership" }> => {
       if (!access.authorized) return deny();
 
       // Cross-tenant guard #1: a caller with an AUTHORITATIVE org (token/PAT)
@@ -712,7 +648,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       ) {
         return deny();
       }
-      return { organizationId: access.organizationId };
+      return { kind: "ownership", organizationId: access.organizationId };
     };
 
     // 1. Settings session cookie (or injected auth provider for embedded mode),
@@ -727,30 +663,39 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         resolvedAgentId,
         ownershipAccessConfig
       );
+      const callerUserId = resolveSettingsLookupUserId(settingsSession);
       const owned = authorizeOwnership(access);
       if (!(owned instanceof Response)) {
-        return {
-          organizationId: owned.organizationId,
-          callerUserId: resolveSettingsLookupUserId(settingsSession) || undefined,
-        };
+        return { ...owned, callerUserId: callerUserId || undefined };
       }
 
-      // Not an owner — fall back to the org-membership USE path. Scoped to a
+      // Not an owner — fall back to the org-membership USE path, scoped to a
       // PROVEN org: the workspace the request named (`x-lobu-org`, resolved by
       // the create route) or the existing session's org, never the caller's
-      // ambient default org. Bearer callers keep the ownership rule: a PAT or
-      // third-party OAuth token is not a person acting in the web app, and its
-      // own tier (`mcp:*` scopes) is enforced elsewhere.
-      const member = await authorizeOrgMemberUse(
-        settingsSession,
-        resolvedAgentId,
-        sessionForTenantCheck?.organizationId ?? authoritativeCallerOrgId
-      );
+      // ambient default org.
+      //
+      // Two callers are excluded even though they carry a settings session:
+      //   - a Bearer request keeps its PAT/OAuth/worker rules even when a
+      //     cookie is also present — a token is not a person acting in the web
+      //     app, and its own tier (`mcp:*` scopes) is enforced elsewhere;
+      //   - an agent-scoped session (worker/self) is bound to its own agent and
+      //     must not borrow its human's org membership.
+      const candidateOrgId =
+        sessionForTenantCheck?.organizationId ?? authoritativeCallerOrgId;
+      const member =
+        !bearer && !settingsSession.agentId && candidateOrgId && callerUserId
+          ? await authorizeOrgAgentMemberInProvenOrg({
+              organizationId: candidateOrgId,
+              agentId: resolvedAgentId,
+              userId: callerUserId,
+            })
+          : null;
       if (!member) return owned;
       return {
+        kind: "membership",
         organizationId: member.organizationId,
         callerUserId: member.userId,
-        orgMemberRole: member.role,
+        memberRole: member.role,
       };
     }
 
@@ -769,7 +714,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       }
       const workerAgentId = workerData.agentId || workerData.userId;
       return workerAgentId && workerAgentId === resolvedAgentId
-        ? { organizationId: workerData.organizationId }
+        ? { kind: "ownership", organizationId: workerData.organizationId }
         : deny();
     }
 
@@ -1029,12 +974,22 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     // so without this a member could name a colleague's userId to resume their
     // thread (receiving a worker token scoped to it) or clobber it outright.
     // Bearer/automation callers have no `callerUserId` and are unaffected.
-    if (
-      access.callerUserId &&
-      existing?.createdByUserId &&
-      existing.createdByUserId !== access.callerUserId
-    ) {
-      return c.json({ success: false, error: "Forbidden" }, 403);
+    //
+    // A session with NO `createdByUserId` predates that stamp, so it can only
+    // be the owner's (members could not create one before this change). It
+    // stays closed to a member without oversight, who would otherwise resume
+    // or `forceNew`-clobber it on the strength of an absent field.
+    if (access.callerUserId && existing) {
+      const creatorMismatch =
+        existing.createdByUserId !== undefined &&
+        existing.createdByUserId !== access.callerUserId;
+      const unstampedAndNotOursToTake =
+        existing.createdByUserId === undefined &&
+        access.kind === "membership" &&
+        isRestrictedOrgAgentMember(access.memberRole);
+      if (creatorMismatch || unstampedAndNotOursToTake) {
+        return c.json({ success: false, error: "Forbidden" }, 403);
+      }
     }
 
     // Resume (unless forceNew). Refuse cross-tenant resume defensively: even

--- a/packages/server/src/gateway/routes/shared/org-agent-access.ts
+++ b/packages/server/src/gateway/routes/shared/org-agent-access.ts
@@ -1,0 +1,70 @@
+import { createLogger } from "@lobu/core";
+import { agentExistsInOrganization } from "../../../lobu/stores/postgres-stores.js";
+import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
+import { getCachedMembershipRole } from "../../../workspace/multi-tenant.js";
+
+const logger = createLogger("org-agent-access");
+
+interface OrgAgentMembershipGrant {
+  organizationId: string;
+  userId: string;
+  role: string;
+}
+
+/**
+ * Authorize a human to USE an org's agent through MEMBERSHIP rather than
+ * ownership. Grants `use`, never `manage` (agent management stays owner/admin
+ * on the org-scoped REST routes).
+ *
+ * `organizationId` MUST already be a PROVEN tenant — the workspace the request
+ * named (`x-lobu-org`, resolved by slug) or the org stamped on an existing
+ * session row — never the caller's ambient default org. Membership in THAT org
+ * is verified against `member`, and the agent must actually exist in it: the
+ * same agent id string can exist in every org, so membership alone would
+ * authorize the wrong tenant's agent.
+ *
+ * Returns null (the caller keeps its ownership denial) rather than a Response,
+ * so the response shape stays uniform with no oracle for which check failed.
+ * An unreachable lookup denies rather than turning authorization into a 500.
+ */
+export async function authorizeOrgAgentMemberInProvenOrg(args: {
+  organizationId: string;
+  agentId: string;
+  userId: string;
+}): Promise<OrgAgentMembershipGrant | null> {
+  try {
+    const role = await getCachedMembershipRole(
+      args.organizationId,
+      args.userId
+    );
+    if (!role) return null;
+    if (!(await agentExistsInOrganization(args.organizationId, args.agentId))) {
+      return null;
+    }
+    return {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      role,
+    };
+  } catch (error) {
+    logger.warn(
+      {
+        err: error,
+        agentId: args.agentId,
+        organizationId: args.organizationId,
+      },
+      "org-agent membership lookup failed — denying"
+    );
+    return null;
+  }
+}
+
+/**
+ * True for a membership-authorized caller WITHOUT org oversight. Org
+ * owner/admins keep oversight of their members' agent conversations; a plain
+ * member is confined to their own. `undefined` means the caller reached the
+ * agent by OWNERSHIP, which this restriction never applies to.
+ */
+export function isRestrictedOrgAgentMember(role: string | undefined): boolean {
+  return role !== undefined && !isAdminOrOwnerRole(role);
+}

--- a/packages/server/src/gateway/session.ts
+++ b/packages/server/src/gateway/session.ts
@@ -45,6 +45,15 @@ export interface ThreadSession {
    * the session itself was created cleanly.
    */
   organizationId?: string;
+  /**
+   * The authenticated HUMAN who created this session, when one did (web
+   * settings session). Distinct from `userId`, which is only a routing key for
+   * `buildApiConversationId` and may be supplied by the caller — so it proves
+   * nothing about identity. Org members may USE an agent they do not own
+   * (see `authorizeAgentAccess`), and this field is what keeps one member out
+   * of another member's conversation.
+   */
+  createdByUserId?: string;
   /** Process without persisting history */
   dryRun?: boolean;
   /** Internal automation intent for one-shot system sessions. */


### PR DESCRIPTION
## Summary
- An agent is an org-level object — stored `(organization_id, id)`, listed org-wide, config readable org-wide — but **chat** was the one surface still keyed on the per-user `agent_users` ownership mapping. So a fellow org member could read an agent's entire `soulMd`, `guardrails` and tool surface (200) and still get **403** on `POST /lobu/api/v1/agents`, plus **401** on every history read. The composer rendered anyway, so every send failed (two dead threads in prod: `b360c643695e`, `afc4818fb41a`).
- Authorizes an org **member** to `use` an agent in their workspace: `authorizeOrgMemberUse` (chat) and the membership branch of `getAuthorizedAgentScope` (history). `manage` is unchanged and stays owner/admin on the org-scoped REST routes (#2899).
- Two guards keep it tenant- and member-safe:
  - membership is verified against a **proven** org — the workspace the request named via `x-lobu-org`, or the existing session's org, never the caller's ambient default org — and the agent must exist in that org (the same agent id string can exist in every org);
  - a member reaches only their **own** conversation. Session keys are derivable (`agentId_userId_org_thread`) and the `userId` half is caller-supplied, so `createdByUserId` is now stamped from the authenticated human at create time and checked on every session-scoped route. Org owners/admins keep oversight; the ownership path is untouched.
- Also closes the multi-org decline for the SPA: a user who owns the same agent id in two orgs used to be denied (`orgs.length !== 1`) because the route carried no org selector. With `x-lobu-org` naming the workspace, that caller now resolves through membership instead of declining.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate for this PR)
- [x] Tests run: `bun test src/gateway/__tests__/agent-member-use.test.ts src/gateway/__tests__/agent-history-member-scope.test.ts`, plus the neighbouring suites (`agent-session-create*`, `agent-history-*`, `agent-ownership`, `multi-tenant-isolation-reproducers`) and the full `src/gateway/__tests__` directory
- [x] Bug fix: red→fix→green outputs pasted below

**RED** — both new files run in a clean worktree checked out at `origin/main` (`agent.ts`, `session.ts` and `agent-history.ts` verified byte-identical to `origin/main`, packages built):

```
Expected: 201 / Received: 403
(fail) org member using an agent they don't own > a plain member naming the workspace is authorized (was 403)
Expected: "user-agent-owner-use" / Received: undefined
(fail) org member using an agent they don't own > the agent's owner is still authorized (regression)
Expected: 201 / Received: 403
(fail) org member using an agent they don't own > a member may drive their OWN session but not another member's
Expected: "user-agent-owner-use" / Received: undefined
(fail) org member using an agent they don't own > a member cannot hijack another member's thread by naming their userId
Expected: 201 / Received: 403
(fail) org member using an agent they don't own > an org admin keeps oversight of a member's session

 3 pass
 5 fail
```

```
Expected: 200 / Received: 401
(fail) agent history — org member who does not own the agent > a member may list their own threads (was 401)

 3 pass
 1 fail
```

The five chat failures are exactly the prod symptom (member → 403 where the owner gets 201) plus the missing `createdByUserId` stamp. The passing cases are the denials — non-member, no workspace selector, wrong org, thread hijack — which must hold on **both** sides, and they do.

**GREEN** — same files on this branch:

```
 8 pass / 0 fail   agent-member-use.test.ts
 4 pass / 0 fail   agent-history-member-scope.test.ts
```

## Notes
Deliberately **not** in this branch (one branch = one concern):
- **Owletto** must stop offering `manage` controls (agent settings / delete) to a plain member now that #2899 403s them — submodule change, needs the pointer-bump flow.
- Bearer callers (PAT / third-party OAuth) keep the ownership rule: a token is not a person acting in the web app, and its tier is enforced by its own scopes.
- The two live worker-session proxies (`/history/session/messages`, `/history/session/stats`) stay owner-only — they return whatever the agent is running right now, which for an org-shared agent may be a colleague's turn.
- Per-agent human exceptions (`write_approval_policies` with a human principal kind) remain a proposal: it needs a DB CHECK change plus the `resolveWriteEffect` / `upsertEntityApprovalPolicy` user short-circuits, i.e. explicit sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization members can use agents within verified workspaces.
  - Members can access their own conversation history, while owners and administrators retain appropriate broader access.
  - Sessions now track the human who created them.

- **Bug Fixes**
  - Prevented unauthorized viewing, modification, deletion, or resumption of other users’ sessions.
  - Restricted live session messages, statistics, and automation transcripts for limited member access.
  - Improved denial behavior when workspace membership or agent access cannot be verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->