### PR TITLE
fix(gateway): deliver terminal thread_response locally on the final attempt

### DIFF
--- a/packages/server/src/__tests__/integration/thread-response-owner-gate-fallback.test.ts
+++ b/packages/server/src/__tests__/integration/thread-response-owner-gate-fallback.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The `thread_response` owner-gate uses attempt exhaustion as its drop policy:
+ * a replica that does not hold the client's SSE throws to re-queue, and after
+ * TERMINAL_DELIVERY_SEND_OPTS.retryLimit claims the row dead-letters.
+ *
+ * Dropping the row also drops the renderer's DURABLE side effects — above all
+ * `resolveAutomationRunsByMessageIds`, without which an Automation run never
+ * reaches a terminal state and hangs until the 2h stale sweep (observed in
+ * prod: run 989823 on 2026-08-16, plus 20 other dead-letters since 07-28).
+ *
+ * This drives the REAL RunsQueue against Postgres to prove the two halves that
+ * the unit tests cannot: the queue hands the handler its attempt budget, and
+ * the budget it hands over lines up with the dead-letter rule in `runHandler`
+ * (attempts + 1 >= max_attempts), so the consumer's final-attempt fallback
+ * fires on exactly the claim before the drop.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { RunsQueue } from "../../gateway/infrastructure/queue/runs-queue";
+import type { QueueJob } from "../../gateway/infrastructure/queue/types";
+import { getDb } from "../../db/client";
+import { cleanupTestDatabase } from "../setup/test-db";
+
+const QUEUE = "thread_response";
+
+describe("thread_response attempt budget reaches the handler", () => {
+  const queue = new RunsQueue();
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await queue.start();
+    await queue.createQueue(QUEUE);
+  });
+
+  afterAll(async () => {
+    await queue.stop();
+  });
+
+  it("exposes attempt/maxAttempts and marks the pre-drop claim as final", async () => {
+    const seen: Array<{ attempt?: number; maxAttempts?: number }> = [];
+    const retryLimit = 3;
+
+    let settle: () => void;
+    const exhausted = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+
+    await queue.work(QUEUE, async (job: QueueJob<unknown>) => {
+      seen.push({ attempt: job.attempt, maxAttempts: job.maxAttempts });
+      if (seen.length >= retryLimit) settle();
+      // Mirror the owner-gate: throw so the row consumes its budget.
+      throw new Error("no SSE owner on this replica");
+    });
+
+    const runId = await queue.send(
+      QUEUE,
+      {
+        messageId: "m-budget-1",
+        conversationId: "conv-budget-1",
+        userId: "u-budget",
+        teamId: "api",
+        processedMessageIds: ["m-budget-1"],
+        platformMetadata: { source: "direct-api" },
+      },
+      { retryLimit, retryDelay: 1 },
+    );
+
+    await exhausted;
+    // Let runHandler finish marking the last attempt failed.
+    await new Promise((r) => setTimeout(r, 750));
+
+    // Every claim carries the budget...
+    expect(seen.length).toBeGreaterThanOrEqual(retryLimit);
+    for (const s of seen) {
+      expect(s.maxAttempts).toBe(retryLimit);
+      expect(typeof s.attempt).toBe("number");
+    }
+    // ...counting up from 0, so the LAST claim satisfies the same
+    // `attempt + 1 >= maxAttempts` test the consumer uses.
+    expect(seen[0]!.attempt).toBe(0);
+    const last = seen[retryLimit - 1]!;
+    expect(last.attempt! + 1).toBeGreaterThanOrEqual(last.maxAttempts!);
+    // ...and no earlier claim looked final.
+    for (const s of seen.slice(0, retryLimit - 1)) {
+      expect(s.attempt! + 1).toBeLessThan(s.maxAttempts!);
+    }
+
+    // The row really did dead-letter after the budget ran out.
+    const rows = await getDb()<{ status: string; attempts: number }>`
+      SELECT status, attempts FROM public.runs WHERE id = ${Number(runId)}
+    `;
+    expect(rows[0]?.status).toBe("failed");
+  }, 30_000);
+});

--- a/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
+++ b/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
@@ -378,6 +378,98 @@ describe("UnifiedThreadResponseConsumer headless owner-gate exemption", () => {
   });
 });
 
+describe("UnifiedThreadResponseConsumer owner-gate last-attempt fallback", () => {
+  function makeApiConsumer() {
+    const queue = {
+      start: mock(async () => undefined),
+      stop: mock(async () => undefined),
+      createQueue: mock(async () => undefined),
+      work: mock(async () => undefined),
+    };
+    const renderer = {
+      handleCompletion: mock(async () => undefined),
+      handleError: mock(async () => undefined),
+    };
+    const sseManager = {
+      broadcast: mock(() => undefined),
+      hasActiveConnection: mock(() => false),
+    };
+    const platformRegistry = {
+      get: mock(() => ({ getResponseRenderer: () => renderer })),
+    };
+    const consumer = new UnifiedThreadResponseConsumer(
+      queue as any,
+      platformRegistry as any,
+      sseManager as any
+    ) as any;
+    return { consumer, renderer };
+  }
+
+  const directApiTerminal = {
+    messageId: "m-d-1",
+    channelId: "api_u1",
+    conversationId: "conv-d-1",
+    userId: "u1",
+    teamId: "api",
+    timestamp: 99,
+    processedMessageIds: ["m-d-1"],
+    platformMetadata: { source: "direct-api" },
+  };
+
+  test("success row delivers locally on the final attempt instead of dropping the reply", async () => {
+    const { consumer, renderer } = makeApiConsumer();
+
+    await consumer.handleThreadResponse({
+      id: "job-final-ok",
+      attempt: 29,
+      maxAttempts: 30,
+      data: { ...directApiTerminal, finalText: "the answer" },
+    });
+
+    expect(renderer.handleCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  test("error row delivers locally on the final attempt so the run still resolves", async () => {
+    const { consumer, renderer } = makeApiConsumer();
+
+    await consumer.handleThreadResponse({
+      id: "job-final-err",
+      attempt: 29,
+      maxAttempts: 30,
+      data: {
+        ...directApiTerminal,
+        processedMessageIds: undefined,
+        error: "The agent didn't finish responding in time.",
+      },
+    });
+
+    expect(renderer.handleError).toHaveBeenCalledTimes(1);
+    expect(renderer.handleCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  test("still re-queues while attempts remain", async () => {
+    const { consumer, renderer } = makeApiConsumer();
+
+    await expect(
+      consumer.handleThreadResponse({
+        id: "job-mid",
+        attempt: 28,
+        maxAttempts: 30,
+        data: directApiTerminal,
+      })
+    ).rejects.toThrow(/not owned by this gateway instance/);
+    expect(renderer.handleCompletion).not.toHaveBeenCalled();
+  });
+
+  test("re-queues when the queue supplies no attempt budget", async () => {
+    const { consumer } = makeApiConsumer();
+
+    await expect(
+      consumer.handleThreadResponse({ id: "job-nobudget", data: directApiTerminal })
+    ).rejects.toThrow(/not owned by this gateway instance/);
+  });
+});
+
 describe("UnifiedThreadResponseConsumer dead-letters instead of silent drops", () => {
   test("missing platform adapter throws so the row retries then dead-letters", async () => {
     const queue = {

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -638,6 +638,8 @@ export class RunsQueue implements IMessageQueue {
       id: String(claimed.runId),
       data: claimed.payload,
       name: worker.queueName,
+      attempt: claimed.attempts,
+      maxAttempts: claimed.maxAttempts,
     };
     const heartbeat = setInterval(() => {
       void this.heartbeatClaim(claimed.runId);

--- a/packages/server/src/gateway/infrastructure/queue/types.ts
+++ b/packages/server/src/gateway/infrastructure/queue/types.ts
@@ -11,6 +11,18 @@ export interface QueueJob<T = any> {
   id: string;
   data: T;
   name?: string;
+  /**
+   * Attempts already consumed by this row, and the budget they run against.
+   * Both are present only for handlers invoked by `RunsQueue`; a handler must
+   * treat `undefined` as "budget unknown" and keep its normal retry policy.
+   *
+   * A handler whose drop policy IS attempt exhaustion (the `thread_response`
+   * owner-gate, see TERMINAL_DELIVERY_SEND_OPTS) reads these to recognise its
+   * LAST claim and degrade to a local, best-effort delivery instead of letting
+   * the row dead-letter with its side effects unrun.
+   */
+  attempt?: number;
+  maxAttempts?: number;
 }
 
 export interface QueueOptions {
@@ -35,8 +47,11 @@ export interface QueueOptions {
  * A short FIXED retry delay (not the default exponential backoff, which would
  * span hours) plus a raised retry limit gives a ~30s re-claim window. That
  * covers both the cross-pod hand-off and the client's POST→connect gap at the
- * small replica counts we run. After the budget is exhausted the row is
- * dropped (the client is genuinely gone).
+ * small replica counts we run. On the LAST claim the consumer stops re-queueing
+ * and renders locally instead (see the owner-gate in unified-thread-consumer):
+ * the client may well be gone, but the terminal row's durable side effects —
+ * Automation run resolution above all — must still run, and dead-lettering the
+ * row skipped them.
  *
  * Non-terminal rows (deltas/status) are NOT owner-gated, so they don't need
  * this and keep the default send options.

--- a/packages/server/src/gateway/metrics/__tests__/registered-counters.test.ts
+++ b/packages/server/src/gateway/metrics/__tests__/registered-counters.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `incrementCounter` fails SILENTLY: an unregistered name logs a warning and
+ * returns, so the metric never reaches /metrics and any alert built on it is
+ * dead on arrival. Nothing at build time catches the mismatch — a counter can
+ * be incremented on a hot path for months while reading as "no events".
+ *
+ * This walks every `incrementCounter("literal")` call in the server source and
+ * asserts the name was registered, so adding a counter without registering it
+ * fails here instead of in production silence.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+// Importing the module runs its own initializeMetrics() (prometheus.ts:282).
+import { getMetricsText } from "../prometheus";
+
+const SRC_ROOT = join(import.meta.dir, "../../..");
+const CALL_RE = /incrementCounter\(\s*"([a-z_0-9]+)"/g;
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (full.endsWith(".ts")) yield full;
+  }
+}
+
+function usedCounterNames(): string[] {
+  const names = new Set<string>();
+  for (const file of walk(SRC_ROOT)) {
+    if (file.includes("__tests__")) continue;
+    const src = readFileSync(file, "utf8");
+    for (const m of src.matchAll(CALL_RE)) names.add(m[1]!);
+  }
+  return [...names].sort();
+}
+
+describe("prometheus counter registration", () => {
+  test("every incremented counter is registered", () => {
+    const exported = getMetricsText();
+    const used = usedCounterNames();
+
+    // Guard the guard: a regex that silently matches nothing would make this
+    // test vacuously green.
+    expect(used.length).toBeGreaterThan(0);
+
+    const unregistered = used.filter((name) => !exported.includes(name));
+    expect(unregistered).toEqual([]);
+  });
+});

--- a/packages/server/src/gateway/metrics/prometheus.ts
+++ b/packages/server/src/gateway/metrics/prometheus.ts
@@ -123,6 +123,15 @@ function initializeMetrics() {
     "SSE events skipped from fan-out for exceeding the NOTIFY payload cap",
     "counter"
   );
+  // Terminal rows whose owner never claimed them inside the retry budget. Each
+  // increment is a turn the client did not receive live; before the local
+  // fallback these were dropped outright, so a rising rate here is the signal
+  // that owner-routing is failing (pod affinity, rollout churn, long turns).
+  registerMetric(
+    "lobu_sse_owner_gate_final_attempt_total",
+    "Terminal thread_response rows rendered locally after the owner-gate retry budget was exhausted",
+    "counter"
+  );
 
   // Scheduler + Automation health. These back the prod alerting rules
   // (charts/lobu PrometheusRule): a silent scheduler / failing Automation tick is

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -16,6 +16,7 @@ import type {
 } from "../infrastructure/queue/index.js";
 import { TERMINAL_DELIVERY_SEND_OPTS } from "../infrastructure/queue/index.js";
 import type { InteractionService } from "../interactions.js";
+import { incrementCounter } from "../metrics/prometheus.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { SseManager } from "../services/sse-manager.js";
 import { AUTOMATION_RUN_SOURCE } from "../automation-run-session.js";
@@ -188,6 +189,14 @@ export class UnifiedThreadResponseConsumer {
     job: QueueJob<ThreadResponsePayload>
   ): Promise<void> {
     const data = job.data;
+    // Last claim before `RunsQueue.runHandler` dead-letters this row (its
+    // rule: attempts + 1 >= max_attempts). The owner-gate below uses the
+    // exhausted budget as its drop policy, so it needs to know when dropping
+    // is the only remaining outcome.
+    const isFinalAttempt =
+      typeof job.attempt === "number" &&
+      typeof job.maxAttempts === "number" &&
+      job.attempt + 1 >= job.maxAttempts;
 
     if (!data?.messageId) {
       logger.error(`Invalid thread response data: ${JSON.stringify(data)}`);
@@ -227,7 +236,12 @@ export class UnifiedThreadResponseConsumer {
       }
       if (await this.chatResponseBridge?.ensureDeliverable(data)) {
         const sessionKey = `${data.userId}:${data.originalMessageId || data.messageId}`;
-        await this.routeToRenderer(this.chatResponseBridge!, data, sessionKey);
+        await this.routeToRenderer(
+          this.chatResponseBridge!,
+          data,
+          sessionKey,
+          isFinalAttempt
+        );
         return;
       }
       if (chatConnectionId) {
@@ -272,7 +286,7 @@ export class UnifiedThreadResponseConsumer {
         `Processing thread response for platform=${platformName}, message=${data.messageId}, session=${sessionKey}`
       );
 
-      await this.routeToRenderer(renderer, data, sessionKey);
+      await this.routeToRenderer(renderer, data, sessionKey, isFinalAttempt);
     } catch (error) {
       logger.error(
         `Error processing thread response for message ${data.messageId}:`,
@@ -368,7 +382,8 @@ export class UnifiedThreadResponseConsumer {
   private async routeToRenderer(
     renderer: ResponseRenderer,
     data: ThreadResponsePayload,
-    sessionKey: string
+    sessionKey: string,
+    isFinalAttempt = false
   ): Promise<void> {
     // Owner-routing for API/SSE TERMINAL delivery (success completion OR
     // error). The SseManager is per-pod and in-memory, so a terminal event
@@ -482,17 +497,40 @@ export class UnifiedThreadResponseConsumer {
         sseKey &&
         !this.sseManager.hasActiveConnection(sseKey)
       ) {
-        throw new Error(
-          `API SSE session ${sseKey} not owned by this gateway instance; re-queueing for owner delivery`
+        // Budget exhausted: this claim is the row's last, so re-queueing again
+        // would dead-letter it and drop the terminal event entirely. Dropping
+        // was the original policy ("the client is genuinely gone"), but it also
+        // discards the renderer's DURABLE side effects — most critically
+        // `resolveAutomationRunsByMessageIds`, without which an Automation run
+        // never reaches a terminal state and hangs until the 2h stale sweep.
+        // A completed reply is lost the same way, even though the worker
+        // produced it.
+        //
+        // So on the final attempt we deliver here instead. The broadcast is
+        // best-effort: `SseManager.broadcast` still fans out to peer replicas
+        // over LISTEN/NOTIFY, so a small event reaches the owning pod anyway;
+        // an oversized one (>7000B, see SseFanout) stays local and the client
+        // recovers it from the transcript snapshot on reload. Either way the
+        // durable side effects run exactly where they otherwise would not.
+        if (!isFinalAttempt) {
+          throw new Error(
+            `API SSE session ${sseKey} not owned by this gateway instance; re-queueing for owner delivery`
+          );
+        }
+        logger.warn(
+          `API SSE session ${sseKey} still unowned on the final delivery attempt; rendering locally so terminal side effects are not dropped`
         );
+        incrementCounter("lobu_sse_owner_gate_final_attempt_total");
       }
     }
 
     // Output-stage guardrails for the API/SSE path (see `outputGuardrail`).
     // Scoped to API rows — chat rows route through ChatResponseBridge, which
     // owns their output scanning, so scanning them here would double-enforce.
-    // Runs on the owning pod (terminal rows are owner-gated above), so the
-    // authoritative finalText scan is replica-safe.
+    // Runs on the owning pod (terminal rows are owner-gated above) — or, on a
+    // row's final attempt, on whichever pod renders it locally. Either way the
+    // authoritative finalText scan is replica-safe: it scans the WHOLE terminal
+    // text in one place, so unlike a delta it cannot be split across pods.
     if (isApiRow && this.outputGuardrail.enabled) {
       const md = readPlatformMetadata(data.platformMetadata);
       const agentId = md.agentId;


### PR DESCRIPTION
## Summary
- The API owner-gate re-queues a terminal `thread_response` row when no pod holds the client's SSE. `RunsQueue` treats that throw as an ordinary error, so after the budget (30 claims / ~31s) it `markFailed`s the row and the terminal event is gone — along with the renderer's **durable** side effects.
- The worst casualty is `resolveAutomationRunsByMessageIds`: without it an Automation run never reaches a terminal state and hangs until the 2h stale sweep. A completed reply is discarded the same way, even though the worker produced it.
- The gate stays (it is load-bearing: a terminal payload >7000B can't ride the `SseFanout` NOTIFY and genuinely needs the owning pod). Only the **last** claim changes: render locally instead of re-queueing into a drop.

**Prod evidence:** 21 dead-lettered `thread_response` rows since 07-28, 5 of them on 08-18; 7 carried a real `finalText`. Automation run 989823 (08-16) started 02:45, its terminal row dead-lettered at 03:34, and the run sat unresolved until the sweep timed it out at 04:45.

```
   id    |   source    |      code           | has_final
 1034536 | direct-api  | WORKER_UNRESPONSIVE | f
  990281 | watcher-run | WORKER_UNRESPONSIVE | f     <- automation run 989823
  919372 | direct-api  |                     | t     <- reply discarded
  919212 | direct-api  |                     | t     <- reply discarded
```

`RunsQueue` already read `attempts`/`max_attempts` when claiming and threw them away; they are now handed to the handler so it can recognise the claim before the drop, using the same `attempt + 1 >= maxAttempts` rule `runHandler` applies. A handler with no budget supplied keeps the old re-queue-always semantics.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates; `pre-pr-remote` unavailable — see Notes)
- [x] Tests run: full vitest graph **449 files / 4090 passed, 0 failed**; full gateway suite **0 failures**; `runs-queue` 13; `automation-contract` + `headless-card-delivery-e2e` 53
- [x] Bug fix: red→fix→green outputs pasted below

### red (before the fix)
```
(fail) owner-gate last-attempt fallback > success row delivers locally on the final attempt
error: API SSE session conv-d-1 not owned by this gateway instance; re-queueing for owner delivery
      at routeToRenderer (unified-thread-consumer.ts:485:19)
 31 pass, 2 fail
```

### green (after)
```
 33 pass
 0 fail
 73 expect() calls
```

### integration — real Postgres, proves the wiring isn't inert
```
✓ thread_response attempt budget reaches the handler
  > exposes attempt/maxAttempts and marks the pre-drop claim as final  2891ms
 Test Files  1 passed (1)
```
Asserts the queue hands over `attempt` counting 0,1,2 against `maxAttempts: 3`, that **only** the last claim satisfies `attempt + 1 >= maxAttempts`, and that the row really does land in `failed`.

### full graph
```
 Test Files  449 passed (449)
      Tests  4090 passed | 2 skipped (4092)
```

## Notes
Guard tests pin the behaviour that must *not* change: a non-final attempt (`attempt: 28, maxAttempts: 30`) and a handler invoked with no budget both still re-queue, so the ~30s owner-routing window is untouched.

Also corrected two comments this makes false — `TERMINAL_DELIVERY_SEND_OPTS` claiming the row "is dropped" after the budget, and the guardrail note claiming the terminal scan only ever runs on the owning pod (it now also runs on the pod that renders a final attempt; still replica-safe, since it scans the whole terminal text in one place rather than a splittable delta).

`make review-fix` could not run: the cross-harness reviewer is out of credits until Aug 20 (`You've hit your usage limit`). It made zero edits. Flagging so the `pi-review` status is not assumed to have been exercised.

Follow-ups this does not cover:
- The five `developer` turns on 08-18 are a separate upstream worker-hang bug (5 distinct `messageId`s, all `WORKER_UNRESPONSIVE` at the same instant).
- No alerting exists on `queue_name='thread_response' AND status='failed'`; this burned silently for three weeks.
