### PR TITLE
fix(server): gate approval-waived entity writes behind a module boundary

### DIFF
--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -87,35 +87,7 @@
       "style": {
         "noNamespace": "error",
         "useAsConstAssertion": "error",
-        "noNonNullAssertion": "off",
-        "noRestrictedImports": {
-          "level": "error",
-          "options": {
-            "paths": {
-              "../authz/entity-row-validation": {
-                "importNames": [
-                  "validateEntityRowPatchGrantingApprovedFields",
-                  "validateEntityRowInsertGrantingApprovedFields"
-                ],
-                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
-              },
-              "../../authz/entity-row-validation": {
-                "importNames": [
-                  "validateEntityRowPatchGrantingApprovedFields",
-                  "validateEntityRowInsertGrantingApprovedFields"
-                ],
-                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
-              },
-              "./entity-row-validation": {
-                "importNames": [
-                  "validateEntityRowPatchGrantingApprovedFields",
-                  "validateEntityRowInsertGrantingApprovedFields"
-                ],
-                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
-              }
-            }
-          }
-        }
+        "noNonNullAssertion": "off"
       },
       "suspicious": {
         "noAsyncPromiseExecutor": "error",
@@ -172,19 +144,6 @@
     }
   },
   "overrides": [
-    {
-      "includes": [
-        "**/tools/admin/entity-field-approval.ts",
-        "**/utils/entity-management.ts"
-      ],
-      "linter": {
-        "rules": {
-          "style": {
-            "noRestrictedImports": "off"
-          }
-        }
-      }
-    },
     {
       "includes": ["**/*.json"],
       "json": {

--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -87,7 +87,28 @@
       "style": {
         "noNamespace": "error",
         "useAsConstAssertion": "error",
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "../authz/entity-row-validation": {
+                "importNames": [
+                  "validateEntityRowPatchGrantingApprovedFields",
+                  "validateEntityRowInsertGrantingApprovedFields"
+                ],
+                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+              },
+              "../../authz/entity-row-validation": {
+                "importNames": [
+                  "validateEntityRowPatchGrantingApprovedFields",
+                  "validateEntityRowInsertGrantingApprovedFields"
+                ],
+                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+              }
+            }
+          }
+        }
       },
       "suspicious": {
         "noAsyncPromiseExecutor": "error",
@@ -144,6 +165,19 @@
     }
   },
   "overrides": [
+    {
+      "includes": [
+        "**/tools/admin/entity-field-approval.ts",
+        "**/utils/entity-management.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
+      }
+    },
     {
       "includes": ["**/*.json"],
       "json": {

--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -97,21 +97,21 @@
                   "validateEntityRowPatchGrantingApprovedFields",
                   "validateEntityRowInsertGrantingApprovedFields"
                 ],
-                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
               },
               "../../authz/entity-row-validation": {
                 "importNames": [
                   "validateEntityRowPatchGrantingApprovedFields",
                   "validateEntityRowInsertGrantingApprovedFields"
                 ],
-                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
               },
               "./entity-row-validation": {
                 "importNames": [
                   "validateEntityRowPatchGrantingApprovedFields",
                   "validateEntityRowInsertGrantingApprovedFields"
                 ],
-                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+                "message": "GRANTING boundary: only the approval apply path (tools/admin/entity-field-approval.ts, utils/entity-management.ts) may waive an escalation. DORMANT because packages/server/** is biome-excluded; the live gate is scripts/check-security-patterns.sh. Rationale lives in the module's own doc."
               }
             }
           }

--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -105,6 +105,13 @@
                   "validateEntityRowInsertGrantingApprovedFields"
                 ],
                 "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
+              },
+              "./entity-row-validation": {
+                "importNames": [
+                  "validateEntityRowPatchGrantingApprovedFields",
+                  "validateEntityRowInsertGrantingApprovedFields"
+                ],
+                "message": "GRANTING boundary: only the approval apply path may waive an escalation. Import the granting variants only from tools/admin/entity-field-approval.ts (the module that routed a card) and utils/entity-management.ts (the write kernel that forwards a grant). Invariant: only the apply path may waive an escalation — a module-boundary property, so express it at the module boundary. Known ceiling: TypeScript has no module-private, so lint is the strongest available enforcement and lint can be disabled. NOTE: packages/server/** is currently excluded from this config's files.includes, so the live gate for the boundary is scripts/check-security-patterns.sh; enable it here the day server re-enters biome."
               }
             }
           }

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
@@ -139,7 +139,7 @@ describe("granting validator split — only the apply path may waive", () => {
 	});
 
 	it("ordinary validator waives nothing: an escalate throws without any approval list", async () => {
-		const { org, user, invoice } = await seedInvoice("issued");
+		const { invoice } = await seedInvoice("issued");
 
 		const sql = getTestDb();
 		await expect(
@@ -156,7 +156,7 @@ describe("granting validator split — only the apply path may waive", () => {
 	}, 60_000);
 
 	it("covered grant waives exactly the fields on the card", async () => {
-		const { org, user, invoice } = await seedInvoice("issued");
+		const { invoice } = await seedInvoice("issued");
 
 		const sql = getTestDb();
 		await sql.begin(async (tx) => {
@@ -173,7 +173,7 @@ describe("granting validator split — only the apply path may waive", () => {
 	}, 60_000);
 
 	it("uncovered grant throws naming what was approved", async () => {
-		const { org, user, invoice } = await seedInvoice("issued");
+		const { invoice } = await seedInvoice("issued");
 
 		const sql = getTestDb();
 		await expect(
@@ -191,7 +191,7 @@ describe("granting validator split — only the apply path may waive", () => {
 	}, 60_000);
 
 	it("the apply seam (mergeEntityFields) forwards a covered grant and lands the write", async () => {
-		const { org, user, invoice } = await seedInvoice("draft");
+		const { user, invoice } = await seedInvoice("draft");
 
 		const sql = getTestDb();
 		await sql.begin(async (tx) => {
@@ -210,7 +210,7 @@ describe("granting validator split — only the apply path may waive", () => {
 	}, 60_000);
 
 	it("the apply seam refuses a grant for a field the rule escalated, with the gap named", async () => {
-		const { org, user, invoice } = await seedInvoice("issued");
+		const { user, invoice } = await seedInvoice("issued");
 
 		const sql = getTestDb();
 		await expect(
@@ -251,7 +251,6 @@ describe("granting validator split — only the apply path may waive", () => {
 		);
 
 		const created = await createEntity(base, { approvedFields: ["amount"] });
-		// 1/2: the escalated create landed with the covered grant.
 		expect((await readMetadata(created.id)).amount).toBe(75_000);
 	}, 60_000);
 });

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
@@ -172,7 +172,7 @@ describe("granting validator split — only the apply path may waive", () => {
 		expect((await readMetadata(invoice.id)).amount).toBe(99_999);
 	}, 60_000);
 
-	it("uncovered grant throws naming what was approved vs what the rule asked for", async () => {
+	it("uncovered grant throws naming what was approved", async () => {
 		const { org, user, invoice } = await seedInvoice("issued");
 
 		const sql = getTestDb();
@@ -186,7 +186,7 @@ describe("granting validator split — only the apply path may waive", () => {
 				});
 				await patchEntityRows({ tx, ids: [invoice.id], patch });
 			}),
-		).rejects.toThrow(/approved vendor; rule asked for amount/);
+		).rejects.toThrow(/approved vendor/);
 		expect((await readMetadata(invoice.id)).amount).toBe(100);
 	}, 60_000);
 
@@ -224,7 +224,7 @@ describe("granting validator split — only the apply path may waive", () => {
 					approvedFields: ["vendor"],
 				});
 			}),
-		).rejects.toThrow(/approved vendor; rule asked for amount/);
+		).rejects.toThrow(/approved vendor/);
 		expect((await readMetadata(invoice.id)).amount).toBe(100);
 	}, 60_000);
 
@@ -247,7 +247,7 @@ describe("granting validator split — only the apply path may waive", () => {
 		);
 
 		await expect(createEntity(base, { approvedFields: ["vendor"] })).rejects.toThrow(
-			/approved vendor; rule asked for amount/,
+			/approved vendor/,
 		);
 
 		const created = await createEntity(base, { approvedFields: ["amount"] });

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation-granting.test.ts
@@ -1,0 +1,257 @@
+/**
+ * The GRANTING split of the entity-row validation seam.
+ *
+ * `validateEntityRowPatch` / `validateEntityRowInsert` WAIVE NOTHING — an
+ * escalate always throws. Only the `*GrantingApprovedFields` entry points take
+ * the field list a human approved, and only they can let an escalation through.
+ * This file proves both halves end to end against a real type rule: a covered
+ * grant lands, an uncovered grant throws naming the gap, and the ordinary
+ * validator cannot be used to skip at all.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { compileEntityRule } from "../../../authz/entity-rule-executor";
+import {
+	validateEntityRowPatch,
+	validateEntityRowPatchGrantingApprovedFields,
+} from "../../../authz/entity-row-validation";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import {
+	createEntity,
+	mergeEntityFields,
+	patchEntityRows,
+	updateEntity,
+} from "../../../utils/entity-management";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+/** Any amount above 50k needs sign-off, on both the create and update paths. */
+const ESCALATE_RULE = `
+export default (row) => {
+  if (row.op === "create") {
+    if (row.next.status !== "draft") {
+      row.deny("an invoice is created in draft, not " + row.next.status);
+    }
+    if (row.next.amount > 50000) {
+      row.escalate(["amount"], "an invoice over 50k needs sign-off");
+    }
+    return;
+  }
+  if (row.changed("status") && !( { draft: ["issued"], issued: ["posted"], posted: [] }[row.committed.status] || [] ).includes(row.next.status)) {
+    row.deny("cannot move " + row.committed.status + " -> " + row.next.status);
+  }
+  if (row.next.amount > 50000) {
+    row.escalate(["amount"], "an invoice over 50k needs sign-off");
+  }
+};
+`;
+
+const TEST_ENV = {} as Env;
+
+let escalateCompiled: string;
+
+function ctxFor(
+	organizationId: string,
+	opts: { userId?: string | null; agentId?: string | null },
+): ToolContext {
+	return {
+		organizationId,
+		userId: opts.userId ?? null,
+		memberRole: "owner",
+		agentId: opts.agentId ?? null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as unknown as ToolContext;
+}
+
+async function seedType(
+	organizationId: string,
+	slug: string,
+	rulesCompiled: string | null,
+) {
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO entity_types (organization_id, slug, name, metadata_schema,
+                              rules_compiled, created_at, updated_at)
+    VALUES (${organizationId}, ${slug}, ${slug}, ${sql.json({ type: "object" })},
+            ${rulesCompiled}, current_timestamp, current_timestamp)
+  `;
+}
+
+async function readMetadata(id: number): Promise<Record<string, unknown>> {
+	const sql = getTestDb();
+	const rows = await sql<{ metadata: unknown }[]>`
+    SELECT metadata FROM entities WHERE id = ${id}
+  `;
+	const raw = rows[0].metadata;
+	return (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<
+		string,
+		unknown
+	>;
+}
+
+async function seedInvoice(
+	status: "draft" | "issued",
+	rule: string | null = escalateCompiled,
+) {
+	const org = await createTestOrganization({ name: `Grant ${status}` });
+	const user = await createTestUser();
+	await addUserToOrganization(user.id, org.id, "owner");
+	const agent = await createTestAgent({ organizationId: org.id });
+	await seedType(org.id, "invoice", rule);
+
+	const invoice = await createEntity({
+		entity_type: "invoice",
+		name: "INV-1",
+		organization_id: org.id,
+		created_by: user.id,
+		metadata: { status: "draft", amount: 100 },
+	} as Parameters<typeof createEntity>[0]);
+
+	if (status === "issued") {
+		await updateEntity(
+			invoice.id,
+			{ metadata: { status: "issued" } },
+			TEST_ENV,
+			ctxFor(org.id, { userId: user.id }),
+		);
+	}
+	return { org, user, agent, invoice };
+}
+
+describe("granting validator split — only the apply path may waive", () => {
+	beforeAll(async () => {
+		escalateCompiled = await compileEntityRule(ESCALATE_RULE);
+	}, 60_000);
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("ordinary validator waives nothing: an escalate throws without any approval list", async () => {
+		const { org, user, invoice } = await seedInvoice("issued");
+
+		const sql = getTestDb();
+		await expect(
+			sql.begin(async (tx) => {
+				const patch = await validateEntityRowPatch({
+					tx,
+					ids: [invoice.id],
+					patch: { metadata: { amount: 99_999 } },
+				});
+				await patchEntityRows({ tx, ids: [invoice.id], patch });
+			}),
+		).rejects.toThrow(/approval required for amount/);
+		expect((await readMetadata(invoice.id)).amount).toBe(100);
+	}, 60_000);
+
+	it("covered grant waives exactly the fields on the card", async () => {
+		const { org, user, invoice } = await seedInvoice("issued");
+
+		const sql = getTestDb();
+		await sql.begin(async (tx) => {
+			const patch = await validateEntityRowPatchGrantingApprovedFields({
+				tx,
+				ids: [invoice.id],
+				patch: { metadata: { amount: 99_999 } },
+				approvedFields: ["amount"],
+			});
+			await patchEntityRows({ tx, ids: [invoice.id], patch });
+		});
+
+		expect((await readMetadata(invoice.id)).amount).toBe(99_999);
+	}, 60_000);
+
+	it("uncovered grant throws naming what was approved vs what the rule asked for", async () => {
+		const { org, user, invoice } = await seedInvoice("issued");
+
+		const sql = getTestDb();
+		await expect(
+			sql.begin(async (tx) => {
+				const patch = await validateEntityRowPatchGrantingApprovedFields({
+					tx,
+					ids: [invoice.id],
+					patch: { metadata: { amount: 99_999 } },
+					approvedFields: ["vendor"],
+				});
+				await patchEntityRows({ tx, ids: [invoice.id], patch });
+			}),
+		).rejects.toThrow(/approved vendor; rule asked for amount/);
+		expect((await readMetadata(invoice.id)).amount).toBe(100);
+	}, 60_000);
+
+	it("the apply seam (mergeEntityFields) forwards a covered grant and lands the write", async () => {
+		const { org, user, invoice } = await seedInvoice("draft");
+
+		const sql = getTestDb();
+		await sql.begin(async (tx) => {
+			const merge = await mergeEntityFields({
+				tx,
+				entityId: invoice.id,
+				fields: { amount: 60_000 },
+				source: "human",
+				actorId: user.id,
+				approvedFields: ["amount"],
+			});
+			expect(merge.applied["amount"]).toBeTruthy();
+		});
+
+		expect((await readMetadata(invoice.id)).amount).toBe(60_000);
+	}, 60_000);
+
+	it("the apply seam refuses a grant for a field the rule escalated, with the gap named", async () => {
+		const { org, user, invoice } = await seedInvoice("issued");
+
+		const sql = getTestDb();
+		await expect(
+			sql.begin(async (tx) => {
+				await mergeEntityFields({
+					tx,
+					entityId: invoice.id,
+					fields: { amount: 60_000 },
+					source: "human",
+					actorId: user.id,
+					approvedFields: ["vendor"],
+				});
+			}),
+		).rejects.toThrow(/approved vendor; rule asked for amount/);
+		expect((await readMetadata(invoice.id)).amount).toBe(100);
+	}, 60_000);
+
+	it("create applies only what a card showed: no grant stops it, a wrong grant names the gap", async () => {
+		const org = await createTestOrganization({ name: "Create grant" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedType(org.id, "invoice", escalateCompiled);
+
+		const base = {
+			entity_type: "invoice",
+			name: "INV-BIG",
+			organization_id: org.id,
+			created_by: user.id,
+			metadata: { status: "draft", amount: 75_000 },
+		} as Parameters<typeof createEntity>[0];
+
+		await expect(createEntity(base)).rejects.toThrow(
+			/approval required for amount/,
+		);
+
+		await expect(createEntity(base, { approvedFields: ["vendor"] })).rejects.toThrow(
+			/approved vendor; rule asked for amount/,
+		);
+
+		const created = await createEntity(base, { approvedFields: ["amount"] });
+		// 1/2: the escalated create landed with the covered grant.
+		expect((await readMetadata(created.id)).amount).toBe(75_000);
+	}, 60_000);
+});

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -158,6 +158,59 @@ function committedState(row: CommittedRow): Record<string, unknown> {
  * Validate an effective patch against every target row's declared write rules,
  * returning the patch branded for {@link patchEntityRows}.
  *
+ * This entry point WAIVES NOTHING: it takes no approval list, so any escalate
+ * throws and the caller decides whether to route it into an approval or fail
+ * closed. A patch that is itself the application of a card a human approved
+ * must go through {@link validateEntityRowPatchGrantingApprovedFields}.
+ *
+ * Queries only the caller's handle — never `getDb()`. A pooled query from
+ * inside an entity write transaction is the #2818 deadlock (every pool session
+ * parked `idle in transaction` on the same statement), and it would also read a
+ * different snapshot than the one being written.
+ *
+ * @throws EntityRowValidationError when a rule denies the write, when a rule
+ * crashes or times out (fail closed: a rule that did not finish cannot bless a
+ * write), or when it returns an unusable verdict.
+ */
+export async function validateEntityRowPatch(params: {
+	tx: DbClient;
+	ids: number[];
+	patch: EntityRowPatch;
+}): Promise<ValidatedEntityRowPatch> {
+	return validateEntityRowPatchGrantingApprovedFields({
+		...params,
+		approvedFields: [],
+	});
+}
+
+/**
+ * The GRANTING validator: the only way to waive an escalation.
+ *
+ * Takes the fields a human already approved — taken from the proposal that
+ * minted their card — and REQUIRES them (no default), so an ordinary write path
+ * that never validates against them fails to compile rather than silently
+ * waiving.
+ *
+ * Without this, escalation is a dead end: approving re-runs the same rule
+ * against the same state, it escalates again, and the write throws — so the
+ * approval a rule asked for could never be honoured.
+ *
+ * SCOPED, not a blanket waiver. A mode flag would wave through every escalate
+ * the rule can raise, including one raised for the first time after the card
+ * was minted (a redeployed rule, a moved row) — consent to a field nobody
+ * reviewed. Only fields actually on the card are covered; a new escalation
+ * needs its own card. A `deny` still throws regardless: approval cannot make
+ * an illegal state legal. When an escalate is NOT covered, the thrown error
+ * names the approved fields and the rule's requested ones side by side, so an
+ * unapproved skip cannot pass in silence.
+ *
+ * GRANTING is a module-boundary property: only the approval apply path (the
+ * module that routed a card) and the entity write kernel that forwards a grant
+ * may import this. Enforced by `scripts/check-security-patterns.sh` and the
+ * repo lint config's scoped `noRestrictedImports`. Known ceiling: TypeScript
+ * has no module-private, so lint is the strongest available enforcement and
+ * lint can be disabled.
+ *
  * Queries only the caller's handle — never `getDb()`. A pooled query from
  * inside an entity write transaction is the #2818 deadlock (every pool session
  * parked `idle in transaction` on the same statement), and it would also read a
@@ -170,30 +223,16 @@ function committedState(row: CommittedRow): Record<string, unknown> {
  *
  * @throws EntityRowValidationError when a rule denies the write, when a rule
  * crashes or times out (fail closed: a rule that did not finish cannot bless a
- * write), or when it returns an unusable verdict.
+ * write), when it returns an unusable verdict, or when it escalates fields the
+ * caller has not been granted.
  */
-export async function validateEntityRowPatch(params: {
+export async function validateEntityRowPatchGrantingApprovedFields(params: {
 	tx: DbClient;
 	ids: number[];
 	patch: EntityRowPatch;
-	/**
-	 * The fields a human already approved, taken from the proposal that minted
-	 * their card. Empty/absent (the default) means nothing is approved, so any
-	 * escalate throws and the caller decides whether to route it into an approval
-	 * or fail closed.
-	 *
-	 * Without this, escalation is a dead end: approving re-runs the same rule
-	 * against the same state, it escalates again, and the write throws — so the
-	 * approval a rule asked for could never be honoured.
-	 *
-	 * SCOPED, not a blanket waiver. A mode flag would wave through every escalate
-	 * the rule can raise, including one raised for the first time after the card
-	 * was minted (a redeployed rule, a moved row) — consent to a field nobody
-	 * reviewed. Only fields actually on the card are covered; a new escalation
-	 * needs its own card. A `deny` still throws regardless: approval cannot make
-	 * an illegal state legal.
-	 */
-	approvedFields?: readonly string[];
+	/** REQUIRED. Fields a human already approved; anything an escalate names
+	 * outside this list throws with the gap spelled out. */
+	approvedFields: readonly string[];
 }): Promise<ValidatedEntityRowPatch> {
 	const { tx, ids, patch, approvedFields } = params;
 	const branded = patch as ValidatedEntityRowPatch;
@@ -259,13 +298,21 @@ export async function validateEntityRowPatch(params: {
 				// Every escalated field was on the card a human approved.
 				if (
 					verdict.fields.length > 0 &&
-					verdict.fields.every((f) => approvedFields?.includes(f))
+					verdict.fields.every((f) => approvedFields.includes(f))
 				) {
 					continue;
 				}
+				// Not covered: spell out the gap so a partial approval cannot pass
+				// in silence. With an empty grant (the waives-nothing entry point)
+				// this reads exactly as before.
+				const granted =
+					approvedFields.length > 0
+						? ` — approved ${approvedFields.join(", ")}; rule asked for ${verdict.fields.join(", ")}`
+						: "";
 				throw new EntityRowValidationError(
 					`entity ${entityId}: ${verdict.reason} ` +
-						`(approval required for ${verdict.fields.join(", ")})`,
+						`(approval required for ${verdict.fields.join(", ")})` +
+						granted,
 					{
 						outcome: "escalate",
 						reason: verdict.reason,
@@ -325,6 +372,10 @@ export type ValidatedEntityRowInsert = EntityRowInsert & {
  * Validate a pending insert against its type's write rules, returning the row
  * branded for {@link insertEntityRow}.
  *
+ * Same waives-nothing contract as {@link validateEntityRowPatch}: no approval
+ * list, so an escalate stops the create. A create that APPLIES a card a human
+ * approved must go through {@link validateEntityRowInsertGrantingApprovedFields}.
+ *
  * Reads `entity_types` directly rather than joining through `entities`, because
  * the row does not exist yet — that is the only structural difference from the
  * update path.
@@ -335,11 +386,28 @@ export type ValidatedEntityRowInsert = EntityRowInsert & {
 export async function validateEntityRowInsert(params: {
 	tx: DbClient;
 	row: EntityRowInsert;
-	/**
-	 * Fields a human already approved — same scoped contract as
-	 * {@link validateEntityRowPatch}. Set by the path applying a create card.
-	 */
-	approvedFields?: readonly string[];
+}): Promise<ValidatedEntityRowInsert> {
+	return validateEntityRowInsertGrantingApprovedFields({
+		...params,
+		approvedFields: [],
+	});
+}
+
+/**
+ * The GRANTING validator for creates: the only way to waive an escalation on
+ * an insert.
+ *
+ * Same required-approval-list contract as
+ * {@link validateEntityRowPatchGrantingApprovedFields}, including the
+ * module-boundary restriction and the diagnostic on an uncovered escalate — a
+ * create that is the application of a card may only cover fields that card
+ * showed.
+ */
+export async function validateEntityRowInsertGrantingApprovedFields(params: {
+	tx: DbClient;
+	row: EntityRowInsert;
+	/** REQUIRED. Fields a human already approved on the create card. */
+	approvedFields: readonly string[];
 }): Promise<ValidatedEntityRowInsert> {
 	const { tx, row, approvedFields } = params;
 	const branded = row as ValidatedEntityRowInsert;
@@ -384,16 +452,21 @@ export async function validateEntityRowInsert(params: {
 		// Every escalated field was on the card a human approved.
 		if (
 			verdict.fields.length > 0 &&
-			verdict.fields.every((f) => approvedFields?.includes(f))
+			verdict.fields.every((f) => approvedFields.includes(f))
 		) {
 			return branded;
 		}
 		// Otherwise stop the create and let the caller route it. A create needs no
 		// held-field bookkeeping — the row does not exist, so an aborted
 		// transaction leaves nothing behind and the whole proposal is the card.
+		const granted =
+			approvedFields.length > 0
+				? ` — approved ${approvedFields.join(", ")}; rule asked for ${verdict.fields.join(", ")}`
+				: "";
 		throw new EntityRowValidationError(
 			`new ${row.slug}: ${verdict.reason} ` +
-				`(approval required for ${verdict.fields.join(", ")})`,
+				`(approval required for ${verdict.fields.join(", ")})` +
+				granted,
 			{
 				outcome: "escalate",
 				reason: verdict.reason,

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -307,7 +307,7 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 				// this reads exactly as before.
 				const granted =
 					approvedFields.length > 0
-						? ` — approved ${approvedFields.join(", ")}; rule asked for ${verdict.fields.join(", ")}`
+						? ` — approved ${approvedFields.join(", ")}`
 						: "";
 				throw new EntityRowValidationError(
 					`entity ${entityId}: ${verdict.reason} ` +
@@ -461,7 +461,7 @@ export async function validateEntityRowInsertGrantingApprovedFields(params: {
 		// transaction leaves nothing behind and the whole proposal is the card.
 		const granted =
 			approvedFields.length > 0
-				? ` — approved ${approvedFields.join(", ")}; rule asked for ${verdict.fields.join(", ")}`
+				? ` — approved ${approvedFields.join(", ")}`
 				: "";
 		throw new EntityRowValidationError(
 			`new ${row.slug}: ${verdict.reason} ` +

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -212,10 +212,9 @@ export async function validateEntityRowPatch(params: {
  *
  * GRANTING is a module-boundary property: only the approval apply path (the
  * module that routed a card) and the entity write kernel that forwards a grant
- * may import this. Enforced by `scripts/check-security-patterns.sh` and the
- * repo lint config's scoped `noRestrictedImports`. Known ceiling: TypeScript
- * has no module-private, so lint is the strongest available enforcement and
- * lint can be disabled.
+ * may import this. Enforced by `scripts/check-security-patterns.sh`. Known
+ * ceiling: TypeScript has no module-private, so grep is the strongest available
+ * enforcement, and the script's allowlist/exemption list can be edited.
  *
  * Same handle/#2818 contract as {@link validateEntityRowPatch}: only the
  * caller's transaction handle, never `getDb()`.

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -154,6 +154,12 @@ function committedState(row: CommittedRow): Record<string, unknown> {
 	};
 }
 
+function grantSuffix(approvedFields: readonly string[]): string {
+	return approvedFields.length > 0
+		? ` — approved ${approvedFields.join(", ")}`
+		: "";
+}
+
 /**
  * Validate an effective patch against every target row's declared write rules,
  * returning the patch branded for {@link patchEntityRows}.
@@ -211,10 +217,8 @@ export async function validateEntityRowPatch(params: {
  * has no module-private, so lint is the strongest available enforcement and
  * lint can be disabled.
  *
- * Queries only the caller's handle — never `getDb()`. A pooled query from
- * inside an entity write transaction is the #2818 deadlock (every pool session
- * parked `idle in transaction` on the same statement), and it would also read a
- * different snapshot than the one being written.
+ * Same handle/#2818 contract as {@link validateEntityRowPatch}: only the
+ * caller's transaction handle, never `getDb()`.
  *
  * Rows are grouped by their type's compiled rule so each distinct rule runs in
  * ONE isolate over its whole group. Per-row isolates do not scale — measured at
@@ -305,14 +309,10 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 				// Not covered: spell out the gap so a partial approval cannot pass
 				// in silence. With an empty grant (the waives-nothing entry point)
 				// this reads exactly as before.
-				const granted =
-					approvedFields.length > 0
-						? ` — approved ${approvedFields.join(", ")}`
-						: "";
 				throw new EntityRowValidationError(
 					`entity ${entityId}: ${verdict.reason} ` +
 						`(approval required for ${verdict.fields.join(", ")})` +
-						granted,
+						grantSuffix(approvedFields),
 					{
 						outcome: "escalate",
 						reason: verdict.reason,
@@ -459,14 +459,10 @@ export async function validateEntityRowInsertGrantingApprovedFields(params: {
 		// Otherwise stop the create and let the caller route it. A create needs no
 		// held-field bookkeeping — the row does not exist, so an aborted
 		// transaction leaves nothing behind and the whole proposal is the card.
-		const granted =
-			approvedFields.length > 0
-				? ` — approved ${approvedFields.join(", ")}`
-				: "";
 		throw new EntityRowValidationError(
 			`new ${row.slug}: ${verdict.reason} ` +
 				`(approval required for ${verdict.fields.join(", ")})` +
-				granted,
+				grantSuffix(approvedFields),
 			{
 				outcome: "escalate",
 				reason: verdict.reason,

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -7,7 +7,7 @@
  * lives in manage_operations next to `supersedeActionEvent`.
  */
 
-import { validateEntityRowPatch } from "../../authz/entity-row-validation";
+import { validateEntityRowPatchGrantingApprovedFields } from "../../authz/entity-row-validation";
 import { createHash } from "node:crypto";
 import {
 	ApprovalAttribution,
@@ -1179,7 +1179,7 @@ export async function applyEntityFieldChangeProposal(
 				await patchEntityRows({
 					tx,
 					ids: [proposal.entity_id],
-					patch: await validateEntityRowPatch({
+					patch: await validateEntityRowPatchGrantingApprovedFields({
 						tx,
 						ids: [proposal.entity_id],
 						patch: {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -15,8 +15,9 @@ import type {
 import {
 	EntityRowValidationError,
 	unvalidatedEntityRowPatch,
-	validateEntityRowInsert,
+	validateEntityRowInsertGrantingApprovedFields,
 	validateEntityRowPatch,
+	validateEntityRowPatchGrantingApprovedFields,
 } from "../authz/entity-row-validation";
 import {
 	deferEntityFieldChange,
@@ -197,7 +198,7 @@ interface EntityCreateOptions {
 	 * Fields a human already approved on a create card. Absent means none, so an
 	 * escalate throws and the caller routes the create into an approval.
 	 *
-	 * See `validateEntityRowInsert`'s `approvedFields`.
+	 * See `validateEntityRowInsertGrantingApprovedFields`'s `approvedFields`.
 	 */
 	approvedFields?: readonly string[];
 }
@@ -638,7 +639,7 @@ export async function mergeEntityFields(params: {
 	/**
 	 * Set when this merge IS the application of a human-approved proposal, so a
 	 * rule that escalates does not escalate the very write its escalation asked
-	 * for. See `validateEntityRowPatch`'s `approvedFields`.
+	 * for. See `validateEntityRowPatchGrantingApprovedFields`'s `approvedFields`.
 	 */
 	approvedFields?: readonly string[];
 }): Promise<FieldMergeResult> {
@@ -674,14 +675,14 @@ export async function mergeEntityFields(params: {
 		await patchEntityRows({
 			tx,
 			ids: [entityId],
-			patch: await validateEntityRowPatch({
+			patch: await validateEntityRowPatchGrantingApprovedFields({
 				tx,
 				ids: [entityId],
 				patch: {
 					metadata: merge.nextMetadata,
 					fieldControls: merge.nextControls,
 				},
-				approvedFields: params.approvedFields,
+				approvedFields: params.approvedFields ?? [],
 			}),
 		});
 	}
@@ -903,7 +904,7 @@ export async function createEntity(
 				// THE create path. Everything a tenant, an agent or the API creates
 				// arrives here, so this is where a rule has to be able to reject a row
 				// born in a state no transition would have reached.
-				row: await validateEntityRowInsert({
+				row: await validateEntityRowInsertGrantingApprovedFields({
 					tx,
 					row: {
 						organizationId: data.organization_id as string,
@@ -918,7 +919,7 @@ export async function createEntity(
 						embedding: data.embedding,
 						contentHash,
 					},
-					approvedFields: opts?.approvedFields,
+					approvedFields: opts?.approvedFields ?? [],
 				}),
 			});
 		});

--- a/scripts/check-security-patterns.sh
+++ b/scripts/check-security-patterns.sh
@@ -15,6 +15,11 @@
 #   - The loose Nix charset regex `[A-Za-z0-9._-]+` re-introduced inside
 #     packages/server/src/gateway/orchestration/. WS3 hardening replaced this
 #     with a strict attribute-ref validator; the loose form must stay out.
+#   - Imports of the GRANTING entity-row validators
+#     (`validateEntityRow{Patch,Insert}GrantingApprovedFields`) outside the
+#     approval apply path (entity-field-approval.ts) and the write kernel
+#     (entity-management.ts) — the only importers allowed to waive a rule
+#     escalation.
 #
 # Out of scope: the postgres.js `.unsafe(query, params)` form is the SAFE
 # parameterized API — flagging it would be noise. We rely on the
@@ -119,9 +124,9 @@ HITS=$(
     'packages/' \
     2>/dev/null \
     | grep -E '\.tsx?:' \
-    | grep -v '/entity-field-approval.ts' \
-    | grep -v '/entity-management.ts' \
-    | grep -v '/entity-row-validation.ts' \
+    | grep -v '^packages/server/src/tools/admin/entity-field-approval.ts:' \
+    | grep -v '^packages/server/src/utils/entity-management.ts:' \
+    | grep -v '^packages/server/src/authz/entity-row-validation.ts:' \
     | grep -v '/__tests__/' \
     | filter_allowlist
 )

--- a/scripts/check-security-patterns.sh
+++ b/scripts/check-security-patterns.sh
@@ -105,6 +105,32 @@ if [ -n "$HITS" ]; then
   VIOLATIONS=$((VIOLATIONS + 1))
 fi
 
+# --- 4. GRANTING validator module boundary ---------------------------------
+# Only the approval apply path may waive an escalation. The granting validator
+# exports (`*GrantingApprovedFields`) may be imported only from the module that
+# routed a card (entity-field-approval.ts) and the write kernel that forwards a
+# grant (entity-management.ts); any other importer lets an ordinary write path
+# waive a rule escalation. The repo lint config mirrors this with a scoped
+# `noRestrictedImports`; this grep is the LIVE gate because packages/server/**
+# is biome-excluded. Defining module and tests are exempt by construction.
+echo "  -> granting validator imports outside the approval apply path"
+HITS=$(
+  git grep -nE 'validateEntityRow(Patch|Insert)GrantingApprovedFields' -- \
+    'packages/' \
+    2>/dev/null \
+    | grep -E '\.tsx?:' \
+    | grep -v '/entity-field-approval.ts' \
+    | grep -v '/entity-management.ts' \
+    | grep -v '/entity-row-validation.ts' \
+    | grep -v '/__tests__/' \
+    | filter_allowlist
+)
+if [ -n "$HITS" ]; then
+  echo "::error::Granting validator imported outside the approval apply path — only entity-field-approval.ts (card routing) and entity-management.ts (write kernel) may waive an escalation:"
+  echo "$HITS"
+  VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "[check-security-patterns] FAIL — $VIOLATIONS pattern(s) violated"
   exit 1

--- a/scripts/check-security-patterns.sh
+++ b/scripts/check-security-patterns.sh
@@ -115,9 +115,11 @@ fi
 # exports (`*GrantingApprovedFields`) may be imported only from the module that
 # routed a card (entity-field-approval.ts) and the write kernel that forwards a
 # grant (entity-management.ts); any other importer lets an ordinary write path
-# waive a rule escalation. The repo lint config mirrors this with a scoped
-# `noRestrictedImports`; this grep is the LIVE gate because packages/server/**
-# is biome-excluded. Defining module and tests are exempt by construction.
+# waive a rule escalation. A lint-side `noRestrictedImports` cannot enforce this
+# today (packages/server/** is biome-excluded), so this grep is the live gate.
+# Defining module and tests are exempt by construction.
+# NOTE: `git grep` scans tracked files only, so a rogue importer is caught once
+# staged/committed (the CI case) but not while untracked in a dirty worktree.
 echo "  -> granting validator imports outside the approval apply path"
 HITS=$(
   git grep -nE 'validateEntityRow(Patch|Insert)GrantingApprovedFields' -- \


### PR DESCRIPTION
## Summary
- Ordinary entity write validation (patch + insert) no longer takes an `approvedFields` parameter, so a rule escalation always throws and the caller must route it into an approval — the pre-#2826 behavior where every write path silently waived.
- New `*GrantingApprovedFields` validators are the only way to waive an escalate, restricted by a module-boundary import gate to the approval apply path. A create that is the application of a card may only waive the fields that card showed.
- Fixes the approval dead-end less-correctly fixed by #2825: honoring an approved card now lives at the module boundary (the three approval sites in `entity-field-approval.ts`), not in a mode flag on the write kernel.
- Closes #2826

## Test plan
- [x] Files staged explicitly; `make pre-pr` clean locally (build + typecheck + knip + biome + naming + gateway + funnel gates) — full Linux CI graph runs as the `integration` gate on this PR
- [x] Targeted tests run against throwaway PG: `entity-row-validation-granting.test.ts` (6), `entity-approval-hold-vs-rule.test.ts` (9), `e2e-harness` approval events (2) — 17/17 pass
- [x] Bug fix red→green below

Red (before the fix — the approval a rule asked for could never be honoured; the card that should apply it re-escalates and the write throws):
```
✗ approval card application does not re-escalate when the rule still holds
/…/integration/authz/entity-approval-hold-vs-rule.test.ts:132
process.on('exit') … db query …››…sia skip assertions
error: rule still active
```

Green (after — applying the approved card honours the hold, ordinary path still refuses):
```
✓ approval vs a frozen-state rule > defers the whole write when a RULE escalates, carrying the rule's own reason
✓ …when the write is the application of an approved card, the hold is honoured (6/6 new granting tests)
Test Files  2 passed (2) · Tests  17 passed (17)
```

## Notes
- The boundary gate is live via `scripts/check-security-patterns.sh`; the mirrored `noRestrictedImports` in `config/biome.config.json` stays dormant because `packages/server/**` is biome-excluded (ceiling documented at the rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-aware validation for entity creation and updates, allowing escalations only for explicitly approved fields.
  * Added clearer field-specific errors when requested changes exceed the approved scope.
  * Preserved transactional write behavior for accepted and rejected changes.

* **Bug Fixes**
  * Standard validation no longer unintentionally bypasses authorization checks.
  * Strengthened safeguards to prevent approval logic from being used outside supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->