### PR TITLE
fix(notifications): stop approvals fanning out to every bound channel

### DIFF
--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -666,3 +666,111 @@ describe("resolveBotDeliveryTargets", () => {
     ]);
   });
 });
+
+/**
+ * Approvals must never ride the org-wide fan-out.
+ *
+ * An approval is a decision exactly one human makes; `notification_targets`
+ * already addresses the org's admins and the run parks behind its approval URL,
+ * so an unresolved chat target must deliver to NO channel rather than to every
+ * channel any agent in the org is bound to. Before `deliveryScope: "targeted"`,
+ * a Mac Shell `run` approval initiated over MCP (no chat coordinates at all)
+ * posted once into each of the org's bound channels — three per approval in
+ * prod.
+ */
+describe("resolveNotificationDeliveryPlan — targeted scope", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	async function seedTwoBoundChannels() {
+		const org = await createTestOrganization();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "crm",
+		});
+		await seedSlackConnection({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "conn-1",
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "conn-1",
+			channelId: "slack:C0LEADS",
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "conn-1",
+			channelId: "slack:C0OPS",
+		});
+		return org;
+	}
+
+	it("org scope still fans out to every bound channel with no target", async () => {
+		const org = await seedTwoBoundChannels();
+
+		const plan = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+		});
+
+		expect(plan.targets.map((t) => t.channelKey).sort()).toEqual([
+			"slack:C0LEADS",
+			"slack:C0OPS",
+		]);
+	});
+
+	it("targeted scope delivers to NO channel when no target is given", async () => {
+		const org = await seedTwoBoundChannels();
+
+		const plan = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			deliveryScope: "targeted",
+		});
+
+		expect(plan.targets).toEqual([]);
+	});
+
+	it("targeted scope still honours an explicit channel", async () => {
+		const org = await seedTwoBoundChannels();
+
+		const plan = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			channelId: "slack:C0OPS",
+			deliveryScope: "targeted",
+		});
+
+		expect(plan.targets.map((t) => t.channelKey)).toEqual(["slack:C0OPS"]);
+	});
+
+	it("targeted scope does not fall back org-wide when the target is unbound", async () => {
+		const org = await seedTwoBoundChannels();
+
+		const plan = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			channelId: "slack:C0DELETED",
+			deliveryScope: "targeted",
+		});
+
+		expect(plan.targets).toEqual([]);
+	});
+
+	it("org scope DOES fall back org-wide when the target is unbound", async () => {
+		const org = await seedTwoBoundChannels();
+
+		const plan = await resolveNotificationDeliveryPlan({
+			organizationId: org.id,
+			channelId: "slack:C0DELETED",
+		});
+
+		expect(plan.targets.map((t) => t.channelKey).sort()).toEqual([
+			"slack:C0LEADS",
+			"slack:C0OPS",
+		]);
+	});
+});

--- a/packages/server/src/__tests__/unit/approval-dm-target.test.ts
+++ b/packages/server/src/__tests__/unit/approval-dm-target.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Approval delivery precedence: conversation → requester DM → inbox.
+ *
+ * `deliverToBotConnections` tries the DM tier BEFORE the channel tier and
+ * returns on success, so feeding the requester into that tier unconditionally
+ * would send an approval asked for in a channel to the asker's DM instead —
+ * inverting the order. This pins the seam where that inversion lives.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { resolveApprovalDmTarget } from "../../notifications/triggers";
+
+describe("resolveApprovalDmTarget", () => {
+	it("routes to the field owner even when a chat origin resolved", () => {
+		expect(
+			resolveApprovalDmTarget({
+				ownerUserId: "user-owner",
+				requesterUserId: "user-asker",
+				connectionId: "conn-1",
+				channelId: "slack:C0OPS",
+			}),
+		).toBe("user-owner");
+	});
+
+	it("routes to the field owner over the requester with no chat origin", () => {
+		expect(
+			resolveApprovalDmTarget({
+				ownerUserId: "user-owner",
+				requesterUserId: "user-asker",
+			}),
+		).toBe("user-owner");
+	});
+
+	it("does NOT DM the requester when the approval has a chat origin", () => {
+		expect(
+			resolveApprovalDmTarget({
+				requesterUserId: "user-asker",
+				connectionId: "conn-1",
+				channelId: "slack:C0OPS",
+			}),
+		).toBeNull();
+	});
+
+	it("does NOT DM the requester when only a connection resolved", () => {
+		expect(
+			resolveApprovalDmTarget({
+				requesterUserId: "user-asker",
+				connectionId: "conn-1",
+			}),
+		).toBeNull();
+	});
+
+	it("DMs the requester when there is no chat origin (the MCP case)", () => {
+		expect(
+			resolveApprovalDmTarget({ requesterUserId: "user-asker" }),
+		).toBe("user-asker");
+	});
+
+	it("returns null when there is no owner and no requester", () => {
+		expect(resolveApprovalDmTarget({})).toBeNull();
+	});
+});

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -46,8 +46,26 @@ interface CreateNotificationParams {
 	/** Optional workspace/team guard for channel-scoped delivery. */
 	teamId?: string | null;
 	/**
-	 * Lobu user who owns the change under review (field-change approvals).
-	 * When set, bot delivery tries the owner's Slack DM FIRST — resolved via
+	 * Who the chat fan-out may reach when no explicit target resolves.
+	 *
+	 * `"org"` (the default) keeps the org-wide broadcast every informational
+	 * notification relies on: with no target, post into every channel any of the
+	 * org's agents is bound to. `"targeted"` fails CLOSED — an unresolved target
+	 * delivers to NO channel rather than everywhere.
+	 *
+	 * Approvals are `"targeted"`. An approval is a decision exactly one human
+	 * makes, and `notification_targets` already addresses precisely the org's
+	 * admins, so the durable inbox loses nothing when chat delivery is skipped —
+	 * the run stays pending behind its approval URL either way. Broadcasting the
+	 * operation name and a review link into every bound channel is pure noise
+	 * plus needless disclosure.
+	 */
+	deliveryScope?: "targeted" | "org";
+	/**
+	 * Lobu user whose Slack DM is the first chat destination — the owner of the
+	 * change under review (field-change approvals), or the requester of an
+	 * approval that has no chat origin. When set, bot delivery tries their DM
+	 * FIRST — resolved via
 	 * the owner's workspace-scoped Slack identity — and only falls back
 	 * to the configured-target/org-wide channel chain when the owner has no
 	 * Slack identity or the DM fails. In-app inbox targeting is unaffected.
@@ -198,6 +216,8 @@ export async function resolveNotificationDeliveryPlan(params: {
 	connectionId?: string | null;
 	channelId?: string | null;
 	teamId?: string | null;
+	/** See `CreateNotificationParams.deliveryScope`. Defaults to `"org"`. */
+	deliveryScope?: "targeted" | "org";
 }): Promise<{ strictAutomationTarget: boolean; targets: BotDeliveryTarget[] }> {
 	const configuredAutomationTarget =
 		params.automationId == null
@@ -221,15 +241,38 @@ export async function resolveNotificationDeliveryPlan(params: {
 		};
 	}
 
+	const targeted = params.deliveryScope === "targeted";
+	const hasExplicitTarget = Boolean(
+		params.connectionId || params.channelId || params.teamId,
+	);
+	// Targeted with nothing to target: skip the resolve entirely. Calling the
+	// org-wide resolver here and discarding the rows would read as an oversight
+	// the next time someone edits this branch.
+	if (targeted && !hasExplicitTarget) {
+		return { strictAutomationTarget: false, targets: [] };
+	}
+
 	let targets = await resolveBotDeliveryTargets(params.organizationId, {
 		connectionId: params.connectionId,
 		channelId: params.channelId,
 		teamId: params.teamId,
 	});
-	if (
-		targets.length === 0 &&
-		(params.connectionId || params.channelId || params.teamId)
-	) {
+	if (targets.length === 0 && hasExplicitTarget) {
+		if (targeted) {
+			// A stale/unbound target on a targeted notification means "nobody",
+			// never "everybody" — the org-wide fallback below would turn a
+			// deleted channel into an org-wide broadcast of an approval.
+			logger.warn(
+				{
+					organizationId: params.organizationId,
+					connectionId: params.connectionId,
+					channelId: params.channelId,
+					teamId: params.teamId,
+				},
+				"[Notifications] Targeted delivery resolved to no bound channels — skipping chat delivery",
+			);
+			return { strictAutomationTarget: false, targets: [] };
+		}
 		logger.warn(
 			{
 				organizationId: params.organizationId,
@@ -420,6 +463,7 @@ async function deliverToBotConnections(
 		connectionId: params.connectionId,
 		channelId: params.channelId,
 		teamId: params.teamId,
+		deliveryScope: params.deliveryScope,
 	});
 	if (deliveryPlan.strictAutomationTarget && deliveryPlan.targets.length === 0) {
 		logger.error(

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -493,6 +493,30 @@ async function notifyOrgAdmins(
 	await sendNotification(orgId, adminIds, build(orgSlug));
 }
 
+/**
+ * Which user, if any, should get the approval as a Slack DM.
+ *
+ * `deliverToBotConnections` tries the DM tier BEFORE the channel tier and
+ * returns on success, so this is a real precedence decision and not a
+ * preference: hand it the requester while a chat origin is also set and an
+ * approval asked for in a channel silently lands in the asker's DM instead,
+ * inverting the documented conversation → DM → inbox order.
+ *
+ * A field owner always wins — they own the change under review, and routing it
+ * to them is the point of the tier. The requester is the fallback that gives an
+ * MCP-initiated approval (no chat coordinates at all) somewhere to go.
+ */
+export function resolveApprovalDmTarget(params: {
+	ownerUserId?: string | null;
+	requesterUserId?: string | null;
+	connectionId?: string | null;
+	channelId?: string | null;
+}): string | null {
+	if (params.ownerUserId) return params.ownerUserId;
+	if (params.connectionId || params.channelId) return null;
+	return params.requesterUserId ?? null;
+}
+
 export async function notifyActionApprovalNeeded(params: {
 	orgId: string;
 	runId: number;
@@ -505,6 +529,13 @@ export async function notifyActionApprovalNeeded(params: {
 	teamId?: string | null;
 	/** Field owner — routes the Slack card to their DM before the channel tier. */
 	ownerUserId?: string | null;
+	/**
+	 * The human whose turn queued this approval. Used as the DM tier when there
+	 * is no field owner AND no chat origin — an MCP-initiated approval (Claude
+	 * Code, claude.ai) carries no chat coordinates at all, so without this it
+	 * would have no chat destination and land in the inbox alone.
+	 */
+	requesterUserId?: string | null;
 	mcpActivity?: McpActivityAttribution | null;
 	details?: ActionApprovalDetails;
 }): Promise<void> {
@@ -539,7 +570,11 @@ export async function notifyActionApprovalNeeded(params: {
 			connectionId: params.connectionId,
 			channelId: params.channelId,
 			teamId: params.teamId,
-			ownerUserId: params.ownerUserId,
+			// Never org-wide. An approval with no resolved chat target reaches its
+			// admins through the inbox + approval URL; broadcasting it into every
+			// bound channel is noise, not reach. See CreateNotificationParams.
+			deliveryScope: "targeted",
+			ownerUserId: resolveApprovalDmTarget(params),
 			mcpActivity: params.mcpActivity,
 		};
 	});

--- a/packages/server/src/tools/admin/approval-delivery.ts
+++ b/packages/server/src/tools/admin/approval-delivery.ts
@@ -1,0 +1,106 @@
+/**
+ * Where an approval card should be posted in chat.
+ *
+ * An approval is a decision exactly ONE human makes, so it must never ride the
+ * org-wide notification fan-out (every channel any agent is bound to). This
+ * module resolves the one legitimate chat destination, in precedence order:
+ *
+ *   1. The conversation that ASKED — the turn's `sourceContext`, when the caller
+ *      came in through a chat trigger and the acting agent is authorized to post
+ *      there. Same trust check the scheduled-delivery path uses, so a turn can
+ *      never name a channel its agent may not reach.
+ *   2. The requesting human's DM — handled downstream by the notification
+ *      service's `ownerUserId` tier; the trigger passes the user id.
+ *   3. Nothing. The durable inbox already targets the org's admins and the run
+ *      parks behind its approval URL, so skipping chat costs no reachability.
+ *
+ * MCP callers (Claude Code, claude.ai) carry no chat coordinates at all, which
+ * is why tier 2 exists: those approvals used to fall through to the org-wide
+ * broadcast.
+ */
+import {
+	isDeliverableChatPlatform,
+	type ScheduledDeliveryContext,
+	validateDeliveryAuthorization,
+} from "../../scheduled/scheduled-jobs-service";
+import type { ToolContext, ToolSourceContext } from "../registry";
+import logger from "../../utils/logger";
+
+/** Chat coordinates a notification can actually be delivered into. */
+interface ApprovalDeliveryTarget {
+	connectionId: string | null;
+	channelId: string | null;
+	teamId: string | null;
+}
+
+const NO_APPROVAL_DELIVERY_TARGET: ApprovalDeliveryTarget = {
+	connectionId: null,
+	channelId: null,
+	teamId: null,
+};
+
+/**
+ * The turn's chat origin as a delivery context, or null when there isn't one.
+ *
+ * Only platforms the delivery path can actually post into; an unsupported or
+ * partial source yields null rather than a dead target that silently never
+ * posts. Shared with `manage_schedules`, which stores the same shape as a
+ * scheduled job's `delivery_context`.
+ */
+export function sourceToDeliveryContext(
+	source: ToolSourceContext | null | undefined,
+): ScheduledDeliveryContext | null {
+	if (!source?.platform || !isDeliverableChatPlatform(source.platform)) {
+		return null;
+	}
+	if (!source.connectionId || !source.channelId || !source.conversationId) {
+		return null;
+	}
+	return {
+		platform: source.platform,
+		conversationId: source.conversationId,
+		channelId: source.channelId,
+		teamId: source.teamId ?? null,
+		connectionId: source.connectionId,
+		userId: source.userId ?? null,
+	};
+}
+
+/**
+ * Tier 1 of the precedence above: the originating conversation, if the acting
+ * agent is authorized to deliver there. Returns all-nulls otherwise — the
+ * caller pairs this with `requesterUserId` so tier 2 takes over.
+ *
+ * Authorization is NOT optional: `sourceContext` is stamped from a verified
+ * worker token, but the binding it names can be revoked between the trigger and
+ * the approval, so the live connection + binding rows are re-checked here
+ * exactly as the scheduled fire-time path does.
+ */
+export async function resolveApprovalChatOrigin(
+	ctx: ToolContext,
+): Promise<ApprovalDeliveryTarget> {
+	const delivery = sourceToDeliveryContext(ctx.sourceContext);
+	if (!delivery) return NO_APPROVAL_DELIVERY_TARGET;
+	// No acting agent means no binding to validate against — an agentless turn
+	// (a human in the web app) has no channel it "belongs" to.
+	if (!ctx.agentId) return NO_APPROVAL_DELIVERY_TARGET;
+
+	const result = await validateDeliveryAuthorization({
+		organizationId: ctx.organizationId,
+		agentId: ctx.agentId,
+		delivery,
+	}).catch((err) => {
+		logger.warn(
+			{ err, organizationId: ctx.organizationId, agentId: ctx.agentId },
+			"[Approvals] Chat-origin authorization check failed — falling back to requester DM",
+		);
+		return { authorized: false as const, reason: "connection-missing" as const };
+	});
+	if (!result.authorized) return NO_APPROVAL_DELIVERY_TARGET;
+
+	return {
+		connectionId: delivery.connectionId,
+		channelId: delivery.channelId,
+		teamId: delivery.teamId ?? null,
+	};
+}

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -14,6 +14,7 @@ import {
 	type ApprovalAttribution as ApprovalAttributionType,
 } from "@lobu/core/contracts/interaction-envelope";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
+import { resolveApprovalChatOrigin } from "./approval-delivery";
 import { type DbClient, getDb, pgBigintArray } from "../../db/client";
 import {
 	type EntityResolutionAssessment,
@@ -1014,7 +1015,14 @@ export async function proposeEntityChange(
 		fieldPath:
 			updateProposal && fieldKeys.length === 1 ? (fieldKeys[0] ?? null) : null,
 	});
-	const deliveryTarget = approvalPolicy.deliveryTarget;
+	// The policy's configured channel wins; otherwise the conversation that asked.
+	// Either way this is a targeted delivery — the trigger never falls back to the
+	// org-wide fan-out.
+	const deliveryTarget =
+		approvalPolicy.deliveryTarget.connectionId ||
+		approvalPolicy.deliveryTarget.channelId
+			? approvalPolicy.deliveryTarget
+			: await resolveApprovalChatOrigin(ctx);
 
 	notifyActionApprovalNeeded({
 		orgId: ctx.organizationId,
@@ -1027,6 +1035,7 @@ export async function proposeEntityChange(
 		channelId: deliveryTarget.channelId,
 		teamId: deliveryTarget.teamId,
 		ownerUserId: updateProposal?.owner_user_id ?? null,
+		requesterUserId: ctx.userId ?? null,
 		mcpActivity: currentMcpActivityAttribution(ctx),
 		details:
 			operation === "update"

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -51,6 +51,7 @@ import {
 } from '../../lobu/model-config';
 import { isValidAgentId } from '../../lobu/stores/postgres-stores';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
+import { resolveApprovalChatOrigin } from './approval-delivery';
 import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import {
@@ -755,6 +756,8 @@ async function queueWriteForApproval(
     settingsReviewUrl ??
     buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
 
+  // One destination, never the org-wide fan-out — see resolveApprovalChatOrigin.
+  const chatOrigin = await resolveApprovalChatOrigin(ctx);
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,
     runId,
@@ -762,6 +765,10 @@ async function queueWriteForApproval(
     connectionName: label,
     eventId,
     approvalUrl,
+    connectionId: chatOrigin.connectionId,
+    channelId: chatOrigin.channelId,
+    teamId: chatOrigin.teamId,
+    requesterUserId: ctx.userId ?? null,
     mcpActivity: currentMcpActivityAttribution(ctx),
   }).catch((error) =>
     logger.error(error, 'Failed to send manage_agents approval notification')

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -39,6 +39,7 @@ import {
   currentMcpActivityEventMetadata,
 } from '../../lobu/stores/mcp-client-conversations';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
+import { resolveApprovalChatOrigin } from './approval-delivery';
 import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import { buildResourcePermalink, buildAutomationSettingsUrl } from '../../utils/url-builder';
@@ -806,6 +807,8 @@ async function queueAutomationWriteForApproval(
   const approvalUrl =
     settingsReviewUrl ?? buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
 
+  // One destination, never the org-wide fan-out — see resolveApprovalChatOrigin.
+  const chatOrigin = await resolveApprovalChatOrigin(ctx);
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,
     runId,
@@ -813,6 +816,10 @@ async function queueAutomationWriteForApproval(
     connectionName: label,
     eventId,
     approvalUrl,
+    connectionId: chatOrigin.connectionId,
+    channelId: chatOrigin.channelId,
+    teamId: chatOrigin.teamId,
+    requesterUserId: ctx.userId ?? null,
     mcpActivity: currentMcpActivityAttribution(ctx),
   }).catch((error) => logger.error(error, 'Failed to send manage_automations approval notification'));
 

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -12,6 +12,7 @@ import type { Env } from "../../../../index";
 import { currentMcpActivityAttribution, currentMcpActivityEventMetadata } from "../../../../lobu/stores/mcp-client-conversations";
 import { callTool as callProxyTool } from "../../../../mcp-proxy/client";
 import { notifyActionApprovalNeeded } from "../../../../notifications/triggers";
+import { resolveApprovalChatOrigin } from "../../approval-delivery";
 import { resolveActionMode } from "../../../../operations/action-modes";
 import { getOperationForConnection } from "../../../../operations/connector-operations";
 import { executeHttpOperation } from "../../../../operations/execute-http-operation";
@@ -747,6 +748,9 @@ export async function handleExecute(
 			baseUrl,
 		);
 
+		// One destination, never the org-wide fan-out: the conversation that asked
+		// when there is one, else the requesting human's DM, else the inbox alone.
+		const chatOrigin = await resolveApprovalChatOrigin(ctx);
 		notifyActionApprovalNeeded({
 			orgId: ctx.organizationId,
 			runId,
@@ -754,6 +758,10 @@ export async function handleExecute(
 			connectionName: connection.display_name ?? connection.connector_key,
 			eventId,
 			approvalUrl,
+			connectionId: chatOrigin.connectionId,
+			channelId: chatOrigin.channelId,
+			teamId: chatOrigin.teamId,
+			requesterUserId: visibilityUserId ?? ctx.userId ?? null,
 			mcpActivity: currentMcpActivityAttribution(ctx),
 		}).catch((error) =>
 			logger.error(error, "Failed to send operation approval notification"),

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -33,7 +33,6 @@ import {
   type DeliveryAuthzDenyReason,
   deleteScheduledJob,
   getScheduledJob,
-  isDeliverableChatPlatform,
   listScheduledJobs,
   pauseScheduledJob,
   type ScheduledDeliveryContext,
@@ -41,7 +40,8 @@ import {
   updateScheduledJob,
   validateDeliveryAuthorization,
 } from '../../scheduled/scheduled-jobs-service';
-import type { ToolContext, ToolSourceContext } from '../registry';
+import type { ToolContext } from '../registry';
+import { sourceToDeliveryContext } from './approval-delivery';
 import logger from '../../utils/logger';
 import { nextRunAt as nextCronTickAt, validateTimezone } from '../../utils/cron';
 import { getErrorMessage } from "@lobu/core";
@@ -260,24 +260,6 @@ function actionArgsForPayload(
     ...(payload.body !== undefined ? { body: payload.body } : {}),
     ...(payload.recipients !== undefined ? { recipients: payload.recipients } : {}),
     ...(payload.resource_url !== undefined ? { resource_url: payload.resource_url } : {}),
-  };
-}
-
-function sourceToDeliveryContext(
-  source: ToolSourceContext | null | undefined
-): ScheduledDeliveryContext | null {
-  // Only platforms the fire-time dispatch can actually deliver into; an
-  // unsupported source platform stores no delivery_context (api fallback)
-  // rather than a dead one that silently never posts.
-  if (!source?.platform || !isDeliverableChatPlatform(source.platform)) return null;
-  if (!source.connectionId || !source.channelId || !source.conversationId) return null;
-  return {
-    platform: source.platform,
-    conversationId: source.conversationId,
-    channelId: source.channelId,
-    teamId: source.teamId ?? null,
-    connectionId: source.connectionId,
-    userId: source.userId ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- An approval is a decision exactly one human makes, but 3 of the 4 `notifyActionApprovalNeeded` call sites passed no delivery target, and `resolveNotificationDeliveryPlan` resolves "no target" to **every channel any agent in the org is bound to**. Prod: one Mac Shell `run` approval posted into 3 Slack channels, operation name + review link broadcast org-wide each time.
- `write_approval_policies.approval_channel_id` looks like the existing answer but is dead scaffolding — both HTTP routes upsert with `preserveDelivery: true` and nothing writes it. Prod holds 1 policy row, 0 with a channel, so entity approvals were fanning out too.
- Delivery is now targeted: originating conversation → field owner / requester DM → inbox only. Never org-wide.

## Evidence

Prod, before (`8dc12bdd…`, 4 bound channels):

```
SELECT id, title, jsonb_array_length(metadata->'delivery') AS delivered
  FROM events WHERE metadata->>'notification_type'='action_approval_needed' …

5264864 | Action "search" needs approval | 3
5226067 | Action "run" needs approval    | 3
5209281 | Action "close_user_tabs" …     | 3
```

Those runs carry `client_id = mcp_client_…` and an `mcp_session_id` — MCP-initiated, so they have no chat origin to route to at all. That is why the requester-DM tier exists.

Dead config confirmed in prod:

```
resource_class | rows | with_channel
entity         |   1  |      0
```

## Design

`deliveryScope: "targeted"` makes an unresolved target mean *nobody* rather than *everybody*, including when a configured channel goes stale. The org-wide fallback stays for informational notifications, which rely on it.

Precedence, resolved in `tools/admin/approval-delivery.ts`:

1. **The conversation that asked** — `ctx.sourceContext`, re-validated against the live connection + binding rows via the same `validateDeliveryAuthorization` the scheduled-delivery path uses, so a turn can never name a channel its agent may not reach.
2. **Field owner's DM, else the requester's DM** — the service tries the DM tier *before* the channel tier and returns on success, so the requester is only used when no chat origin resolved (`resolveApprovalDmTarget`).
3. **Nothing.** `notification_targets` already addresses the org's admins and the run parks behind its approval URL, so skipping chat costs no reachability.

`sourceToDeliveryContext` moves out of `manage_schedules` into the shared module so both callers resolve a chat origin identically.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (build, strict typecheck, knip, biome, naming, gateway-LLM, entity-write gates)
- [x] Tests run: `bunx vitest run src/__tests__/integration/notifications/ src/__tests__/integration/tools/` → 25 files, 235 passed. `bun test src/__tests__/unit/approval-dm-target.test.ts` → 6 passed. `bun test src/tools/admin/__tests__/manage-schedules-delivery.test.ts` → 7 passed (the refactored helper). `bunx vitest run src/__tests__/integration/authz/` → 201 passed.
- [x] Bug fix: red→fix→green below

### red → green

New coverage mutation-tested. Neutering the fail-closed branch (`const targeted = false`) kills exactly the two assertions that pin it and leaves the org-scope controls green:

```
✓ org scope still fans out to every bound channel with no target
× targeted scope delivers to NO channel when no target is given
✓ targeted scope still honours an explicit channel
× targeted scope does not fall back org-wide when the target is unbound
```

Restored → `21 passed (21)`, with the log proving both branches:

```
[Notifications] Targeted delivery resolved to no bound channels — skipping chat delivery
[Notifications] Configured delivery target resolved to no bound channels — falling back to org-wide delivery
```

Neutering the DM precedence guard kills exactly its two assertions:

```
(fail) does NOT DM the requester when the approval has a chat origin
(fail) does NOT DM the requester when only a connection resolved
 4 pass, 2 fail
```

Restored → `6 pass`.

## Notes
Not fixed here, and worth its own PR: connector-op approval cards render with **no Approve/Reject buttons**. `notifyActionApprovalNeeded` passes no `inputSchema`, so `buildActionApprovalCard` returns `undefined` and the post is bare markdown. That is currently honest — `interaction-bridge.ts` filters `action_key = ANY(ENTITY_CHANGE_ACTION_KEYS)`, so a connector run clicked from Slack would answer *"This approval can't be completed from Slack yet"*. Giving connector approvals real buttons needs the env-safe execution path that file's comment already calls for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval notifications now route to the originating chat when available.
  * Notifications support targeted delivery, preventing unintended organization-wide broadcasts.
  * Approval DMs prioritize the responsible owner, with requester fallback when appropriate.
  * Delivery checks validate the destination and authorization before sending.

* **Bug Fixes**
  * Stale or unbound targets no longer trigger broad notification fan-out.
  * Approvals without a chat origin can now reach the appropriate owner via direct message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->