### PR TITLE
feat(cli): execute an already-claimed device Automation via `lobu automation execute`

### DIFF
--- a/packages/cli/src/__tests__/automation-execute.test.ts
+++ b/packages/cli/src/__tests__/automation-execute.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import * as daemon from "@lobu/connector-worker/daemon";
+import { automationExecuteCommand } from "../commands/automation";
+import * as context from "../internal/context";
+
+/**
+ * `lobu automation execute` is a HANDOFF: a native bridge has already claimed
+ * the run, so exit status decides which side reports the outcome. Anything that
+ * inverts it leaves the run double-reported or silently unreported, so these
+ * pin the contract rather than the plumbing.
+ *
+ *   throws (non-zero exit) → nothing reported, caller still owns the run
+ *   returns (exit 0)       → this process owns the outcome, caller must not report
+ */
+
+const tmp = mkdtempSync(path.join(tmpdir(), "lobu-automation-cli-"));
+let seq = 0;
+
+function envelopeFile(
+  body: string = JSON.stringify({ run_id: 7, run_type: "automation" })
+): string {
+  const file = path.join(tmp, `envelope-${seq++}.json`);
+  writeFileSync(file, body);
+  return file;
+}
+
+function withEnv(token: string | undefined, fn: () => Promise<void>) {
+  const prior = process.env.WORKER_API_TOKEN;
+  if (token === undefined) delete process.env.WORKER_API_TOKEN;
+  else process.env.WORKER_API_TOKEN = token;
+  return fn().finally(() => {
+    if (prior === undefined) delete process.env.WORKER_API_TOKEN;
+    else process.env.WORKER_API_TOKEN = prior;
+  });
+}
+
+describe("lobu automation execute", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("reduces the context URL to the gateway ORIGIN, not the /api/v1 SDK path", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv("session-bearer", async () => {
+      await automationExecuteCommand({
+        workerId: "mac-abc",
+        jobFile: envelopeFile(),
+      });
+    });
+
+    // `/api/v1/api/workers/...` 404s — the worker API is mounted at the root.
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0]?.apiUrl).toBe("https://app.lobu.ai");
+    // The claimer's own bearer and worker id are passed straight through.
+    expect(execute.mock.calls[0]?.[0]?.workerId).toBe("mac-abc");
+    expect(execute.mock.calls[0]?.[0]?.authToken).toBe("session-bearer");
+  });
+
+  test("refuses a missing --worker-id before touching the run", async () => {
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv("session-bearer", async () => {
+      await expect(
+        automationExecuteCommand({ apiUrl: "https://app.lobu.ai" })
+      ).rejects.toThrow(/--worker-id is required/);
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("refuses a missing WORKER_API_TOKEN before touching the run", async () => {
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv(undefined, async () => {
+      await expect(
+        automationExecuteCommand({
+          apiUrl: "https://app.lobu.ai",
+          workerId: "mac-abc",
+        })
+      ).rejects.toThrow(/WORKER_API_TOKEN is required/);
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("a refusal carries exitCode 1 so the caller falls back to reporting", async () => {
+    await withEnv(undefined, async () => {
+      const error = await automationExecuteCommand({
+        apiUrl: "https://app.lobu.ai",
+        workerId: "mac-abc",
+      }).then(
+        () => null,
+        (err: unknown) => err
+      );
+      expect((error as { exitCode?: number } | null)?.exitCode).toBe(1);
+    });
+  });
+
+  test("a REPORTED failure exits 0 — the outcome is already delivered", async () => {
+    spyOn(daemon, "executeClaimedAutomationRun").mockResolvedValue({
+      itemsCollected: 0,
+      error: "agent CLI exited with non-zero status 1",
+    });
+
+    await withEnv("session-bearer", async () => {
+      // Resolves rather than throwing: throwing would exit non-zero and make
+      // the claiming bridge post a SECOND report for the same run.
+      await expect(
+        automationExecuteCommand({
+          apiUrl: "https://app.lobu.ai",
+          workerId: "mac-abc",
+          jobFile: envelopeFile(),
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  test("rejects a malformed envelope without reporting anything", async () => {
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv("session-bearer", async () => {
+      await expect(
+        automationExecuteCommand({
+          apiUrl: "https://app.lobu.ai",
+          workerId: "mac-abc",
+          jobFile: envelopeFile("not json"),
+        })
+      ).rejects.toThrow(/not valid JSON/);
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/automation-execute.test.ts
+++ b/packages/cli/src/__tests__/automation-execute.test.ts
@@ -137,6 +137,49 @@ describe("lobu automation execute", () => {
     });
   });
 
+  test("passes --default-agent-kind through for an Automation with no kind", async () => {
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv("session-bearer", async () => {
+      await automationExecuteCommand({
+        apiUrl: "https://app.lobu.ai",
+        workerId: "mac-abc",
+        jobFile: envelopeFile(),
+        defaultAgentKind: "claude-code",
+      });
+    });
+
+    expect(execute.mock.calls[0]?.[0]?.defaultAgentKind).toBe("claude-code");
+  });
+
+  test("rejects an unknown --default-agent-kind instead of ignoring it", async () => {
+    const execute = spyOn(
+      daemon,
+      "executeClaimedAutomationRun"
+    ).mockResolvedValue({
+      itemsCollected: 0,
+    });
+
+    await withEnv("session-bearer", async () => {
+      // Ignoring it would resurface much later as "no local agent executor
+      // configured", pointing at the Automation rather than the flag.
+      await expect(
+        automationExecuteCommand({
+          apiUrl: "https://app.lobu.ai",
+          workerId: "mac-abc",
+          jobFile: envelopeFile(),
+          defaultAgentKind: "claude",
+        })
+      ).rejects.toThrow(/is not a known agent/);
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   test("rejects a malformed envelope without reporting anything", async () => {
     const execute = spyOn(
       daemon,

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as daemonModule from "@lobu/connector-worker/daemon";
+import { daemonCommand } from "../commands/daemon";
+import { apiUrlToGatewayOrigin } from "../internal/context";
+import * as context from "../internal/context";
+
+/**
+ * Context URLs carry the SDK path (`https://app.lobu.ai/api/v1`) but the worker
+ * API is mounted at the app root, so handing the context URL straight to a
+ * device worker builds `/api/v1/api/workers/poll` and every call 404s. Only
+ * production contexts carry that path — a local context is a bare
+ * `http://localhost:<port>` — so the mismatch is invisible in dev and shows up
+ * only against prod.
+ */
+
+describe("apiUrlToGatewayOrigin", () => {
+  test("strips the /api/v1 SDK path from a production context URL", () => {
+    expect(apiUrlToGatewayOrigin("https://app.lobu.ai/api/v1")).toBe(
+      "https://app.lobu.ai"
+    );
+  });
+
+  test("leaves a bare local context origin alone, port included", () => {
+    expect(apiUrlToGatewayOrigin("http://localhost:8795")).toBe(
+      "http://localhost:8795"
+    );
+  });
+
+  test("hands back an unparseable value trimmed rather than throwing", () => {
+    // The user's first request then fails against the address they configured,
+    // which is a better error than a stack trace from URL parsing.
+    expect(apiUrlToGatewayOrigin("not a url/")).toBe("not a url");
+  });
+});
+
+describe("lobu daemon", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("auto-discovers the gateway ORIGIN, not the context's SDK path", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("https://app.lobu.ai");
+  });
+
+  test("an explicit --api-url is passed through untouched", async () => {
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+
+    expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("http://127.0.0.1:9564");
+  });
+});

--- a/packages/cli/src/commands/automation.ts
+++ b/packages/cli/src/commands/automation.ts
@@ -1,0 +1,114 @@
+import {
+  executeClaimedAutomationRun,
+  UnexecutableRunError,
+} from "@lobu/connector-worker/daemon";
+import { readFile } from "node:fs/promises";
+import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
+
+export interface AutomationExecuteOptions {
+  apiUrl?: string;
+  workerId?: string;
+  jobFile?: string;
+  context?: string;
+  debug?: boolean;
+}
+
+/** Read the whole of stdin. Rejects a TTY so an unpiped invocation fails fast. */
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new UnexecutableRunError(
+      "no run envelope on stdin: pipe the /api/workers/poll response body in, or pass --job-file <path>"
+    );
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * `lobu automation execute` — run one already-claimed device Automation.
+ *
+ * The device daemon (`lobu daemon`) claims and executes in one process. A
+ * native bridge cannot: the Owletto Mac app must keep its own poll loop for the
+ * platform connectors only it can serve, and a poll claims whatever the server
+ * returns — including Automation runs pinned to that device. Rather than a
+ * second poller racing the first on the same device row, the bridge stays the
+ * only claimer and pipes the run here.
+ *
+ * Exit status IS the handoff contract, because both sides can otherwise report
+ * the same run:
+ *   - 0  → this command owns the outcome. It posted the exit report, or
+ *          deliberately left an undeliverable one to the server's heartbeat
+ *          sweep. The caller must not report.
+ *   - !0 → nothing was reported and the run is untouched. The caller still owns
+ *          it and must post its own failure, or the run sits `running`.
+ * An older CLI without this command exits non-zero too ("unknown command"), so
+ * a version-skewed caller falls into the safe half of the contract.
+ */
+export async function automationExecuteCommand(
+  options: AutomationExecuteOptions
+): Promise<void> {
+  let apiUrl = options.apiUrl?.trim();
+  if (!apiUrl) {
+    try {
+      // The worker API is mounted at the ORIGIN, not under the context's
+      // `/api/v1` SDK path — see `apiUrlToGatewayOrigin`.
+      apiUrl = apiUrlToGatewayOrigin(
+        (await resolveContext(options.context)).url
+      );
+    } catch {
+      // No context configured — surface the explicit requirement below.
+    }
+  }
+  if (!apiUrl) {
+    throw new UnexecutableRunError(
+      "--api-url is required (or run `lobu login` to configure a context)"
+    );
+  }
+
+  const workerId = options.workerId?.trim();
+  if (!workerId) {
+    throw new UnexecutableRunError(
+      "--worker-id is required: it must be the id of the worker that claimed this run. " +
+        "/complete-automation authorizes on claimed_by, and a mismatch is dropped as an " +
+        "undelivered report rather than a failure, so the run would silently go unreported"
+    );
+  }
+
+  // The claiming caller's own bearer. Never discovered from disk: the run is
+  // authorized against the claim, so a different credential — even a valid one
+  // for the same user — would report against a claim it does not hold.
+  const authToken = process.env.WORKER_API_TOKEN?.trim();
+  if (!authToken) {
+    throw new UnexecutableRunError(
+      "WORKER_API_TOKEN is required: pass the same bearer the claiming worker polled with"
+    );
+  }
+
+  const raw = options.jobFile
+    ? await readFile(options.jobFile, "utf8")
+    : await readStdin();
+  let job: unknown;
+  try {
+    job = JSON.parse(raw);
+  } catch (error) {
+    throw new UnexecutableRunError(
+      `run envelope is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const result = await executeClaimedAutomationRun({
+    apiUrl,
+    workerId,
+    authToken,
+    job,
+    debug: options.debug === true,
+  });
+  // A reported failure is still a delivered outcome, so it must not become a
+  // non-zero exit — that would make the caller report the same run twice.
+  if (result.error) {
+    console.error(`  Automation run failed: ${result.error}`);
+  }
+}

--- a/packages/cli/src/commands/automation.ts
+++ b/packages/cli/src/commands/automation.ts
@@ -1,16 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { AGENT_KINDS } from "@lobu/core/contracts/worker/device-automation";
+import type { AgentKind } from "@lobu/core/contracts/worker/device-automation";
 import {
   executeClaimedAutomationRun,
   UnexecutableRunError,
 } from "@lobu/connector-worker/daemon";
-import { readFile } from "node:fs/promises";
 import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
 
 export interface AutomationExecuteOptions {
   apiUrl?: string;
   workerId?: string;
   jobFile?: string;
+  defaultAgentKind?: string;
   context?: string;
   debug?: boolean;
+}
+
+/**
+ * Which agent runs an Automation that names no `agent_kind`.
+ *
+ * The device owns this: `agent_kind` is optional on the wire and which CLIs are
+ * installed is a property of the machine. A caller passes its own user-facing
+ * pick (the Mac app's menubar default). Rejected loudly rather than ignored —
+ * silently falling through would surface much later as "no local agent
+ * executor configured", pointing at the Automation instead of the flag.
+ */
+function parseDefaultAgentKind(
+  value: string | undefined
+): AgentKind | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  if (!(AGENT_KINDS as readonly string[]).includes(trimmed)) {
+    throw new UnexecutableRunError(
+      `--default-agent-kind '${trimmed}' is not a known agent (${AGENT_KINDS.join(", ")})`
+    );
+  }
+  return trimmed as AgentKind;
 }
 
 /** Read the whole of stdin. Rejects a TTY so an unpiped invocation fails fast. */
@@ -87,6 +112,8 @@ export async function automationExecuteCommand(
     );
   }
 
+  const defaultAgentKind = parseDefaultAgentKind(options.defaultAgentKind);
+
   const raw = options.jobFile
     ? await readFile(options.jobFile, "utf8")
     : await readStdin();
@@ -104,6 +131,7 @@ export async function automationExecuteCommand(
     workerId,
     authToken,
     job,
+    ...(defaultAgentKind ? { defaultAgentKind } : {}),
     debug: options.debug === true,
   });
   // A reported failure is still a delivered outcome, so it must not become a

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,5 +1,5 @@
 import { startDaemonCommand } from "@lobu/connector-worker/daemon";
-import { resolveContext } from "../internal/context.js";
+import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
 
 export interface DaemonOptions {
   apiUrl?: string;
@@ -28,7 +28,9 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
   let apiUrl = options.apiUrl?.trim();
   if (!apiUrl) {
     try {
-      apiUrl = (await resolveContext()).url;
+      // The worker API is mounted at the ORIGIN, not under the context's
+      // `/api/v1` SDK path — see `apiUrlToGatewayOrigin`.
+      apiUrl = apiUrlToGatewayOrigin((await resolveContext()).url);
     } catch {
       // No context configured — surface the explicit requirement below.
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1206,6 +1206,10 @@ Memory:
         "Worker id that claimed the run (required; must match claimed_by)"
       )
       .option("--job-file <path>", "Read the run envelope from a file")
+      .option(
+        "--default-agent-kind <kind>",
+        "Agent to use when the Automation names no agent_kind"
+      )
       .option("--debug", "Log heartbeat/retry detail")
   ).action(async (options) => {
     const { automationExecuteCommand } = await import(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1186,6 +1186,34 @@ Memory:
       await daemonCommand(options);
     });
 
+  // ─── automation ─────────────────────────────────────────────────────
+  const automation = program
+    .command("automation")
+    .description("Device Automation execution");
+
+  withCommonOpts(
+    automation
+      .command("execute")
+      .description(
+        "Execute one already-claimed Automation run (envelope on stdin)"
+      )
+      .option(
+        "--api-url <url>",
+        "Gateway URL (defaults to your logged-in context)"
+      )
+      .option(
+        "--worker-id <id>",
+        "Worker id that claimed the run (required; must match claimed_by)"
+      )
+      .option("--job-file <path>", "Read the run envelope from a file")
+      .option("--debug", "Log heartbeat/retry detail")
+  ).action(async (options) => {
+    const { automationExecuteCommand } = await import(
+      "./commands/automation.js"
+    );
+    await automationExecuteCommand(options);
+  });
+
   // ─── doctor ─────────────────────────────────────────────────────────
   program
     .command("doctor")

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -448,6 +448,27 @@ function normalizeApiUrl(url: string): string {
   return end === url.length ? url : url.slice(0, end);
 }
 
+/**
+ * Reduce a context's API URL to the gateway ORIGIN the worker API is mounted on.
+ *
+ * Context URLs carry the SDK path (`https://app.lobu.ai/api/v1`) but
+ * `/api/workers/*` is mounted at the app root, so passing the context URL
+ * straight through builds `/api/v1/api/workers/poll` and every device call
+ * 404s. Only production contexts carry that path — a local context is a bare
+ * `http://localhost:<port>` — which is why the mismatch is invisible in dev.
+ * The Owletto Mac app already reduces the same way before polling
+ * (`LobuContextIdentity.origin(of:)`).
+ */
+export function apiUrlToGatewayOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    // Not a parseable absolute URL — hand it back trimmed and let the caller's
+    // first request fail with the address the user actually configured.
+    return normalizeApiUrl(url);
+  }
+}
+
 export async function findContextByUrl(
   apiUrl: string
 ): Promise<ResolvedContext | undefined> {

--- a/packages/connector-worker/src/__tests__/execute-claimed-run.test.ts
+++ b/packages/connector-worker/src/__tests__/execute-claimed-run.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import type { CompleteAutomationResponse, PollResponse } from '@lobu/core/contracts/worker/protocol';
+import {
+  executeClaimedAutomationRun,
+  UnexecutableRunError,
+} from '../daemon/execute-run.js';
+
+/**
+ * The one-shot handoff a native bridge uses: it has ALREADY claimed the run, so
+ * the contract under test is ownership. A refusal must reach the caller with
+ * nothing posted (the caller still has to report), and a delivered outcome must
+ * NOT surface as a refusal (or the run gets reported twice).
+ */
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'lobu-execute-claimed-'));
+const fakeBinary = path.join(tmp, 'pi');
+
+function automationJob(): PollResponse {
+  return {
+    run_id: 42,
+    run_type: 'automation',
+    organization_id: 'org_test',
+    payload: {
+      automation: {
+        id: 'beh_1',
+        name: 'Test',
+        slug: 'test',
+        agent_kind: 'pi',
+        prompt: 'do a thing',
+      },
+      event: { trigger_event_id: null, fired_at: '2026-07-30T00:00:00Z', payload: {} },
+      context: { device: { worker_id: 'wrk_1' }, user: { user_id: 'usr_1' } },
+    },
+  } as unknown as PollResponse;
+}
+
+let server: http.Server;
+let baseUrl: string;
+let requests: Array<{ path: string; auth: string | undefined; body: Record<string, unknown> }>;
+let script: CompleteAutomationResponse[];
+
+beforeAll(async () => {
+  writeFileSync(fakeBinary, '#!/bin/sh\necho "FAKE_OUTPUT"\nexit 0\n');
+  chmodSync(fakeBinary, 0o755);
+
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      requests.push({
+        path: req.url ?? '',
+        auth: req.headers.authorization,
+        body: raw ? JSON.parse(raw) : {},
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      if (req.url?.includes('/complete-automation')) {
+        res.end(JSON.stringify(script.shift() ?? { status: 'completed' }));
+        return;
+      }
+      res.end('{}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (addr == null || typeof addr === 'string') throw new Error('no server address');
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  requests = [];
+  script = [];
+});
+
+function opts(overrides: Record<string, unknown> = {}) {
+  return {
+    apiUrl: baseUrl,
+    workerId: 'wrk_1',
+    authToken: 'session_token_from_the_claimer',
+    job: automationJob(),
+    binaryOverrides: { pi: fakeBinary },
+    ...overrides,
+  } as Parameters<typeof executeClaimedAutomationRun>[0];
+}
+
+describe('executeClaimedAutomationRun', () => {
+  test('spawns the agent and posts the exit report as the CLAIMING worker', async () => {
+    const result = await executeClaimedAutomationRun(opts());
+
+    expect(result.error).toBeUndefined();
+    const completion = requests.find((r) => r.path.includes('/complete-automation'));
+    expect(completion).toBeDefined();
+    // worker_id must be the claimer's: /complete-automation authorizes on
+    // `runs.claimed_by`, and the live suite pins what a mismatch actually costs.
+    expect(completion?.body.worker_id).toBe('wrk_1');
+    expect(completion?.body.exit_code).toBe(0);
+    expect(String(completion?.body.output)).toContain('FAKE_OUTPUT');
+    // The caller's own bearer, verbatim — not a credential discovered on disk.
+    expect(completion?.auth).toBe('Bearer session_token_from_the_claimer');
+  });
+
+  test('a run that FAILS is still a delivered outcome, not a refusal', async () => {
+    // An agent_kind with no AgentSpec. Deliberately not a real-but-uninstalled
+    // kind like `codex`: the spec table would still resolve and the arm would
+    // spawn whatever is on this machine's PATH, so the test would pass or hang
+    // depending on the developer's laptop. The arm reports this through
+    // /complete-automation, so ownership has transferred and the caller must
+    // not report again.
+    const job = automationJob() as unknown as Record<string, unknown>;
+    (job.payload as { automation: { agent_kind: string } }).automation.agent_kind =
+      'not-a-real-agent';
+
+    const result = await executeClaimedAutomationRun(
+      opts({ job, binaryOverrides: undefined })
+    );
+
+    expect(result.error).toContain('no local agent executor configured');
+    const completion = requests.find((r) => r.path.includes('/complete-automation'));
+    expect(completion).toBeDefined();
+    expect(completion?.body.worker_id).toBe('wrk_1');
+  });
+
+  test('refuses a non-automation run without contacting the server', async () => {
+    const job = { ...automationJob(), run_type: 'sync' };
+    await expect(executeClaimedAutomationRun(opts({ job }))).rejects.toThrow(
+      UnexecutableRunError
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test('refuses a run with no run_id without contacting the server', async () => {
+    const job = automationJob() as unknown as Record<string, unknown>;
+    job.run_id = undefined;
+    await expect(executeClaimedAutomationRun(opts({ job }))).rejects.toThrow(
+      /run_id must be a positive number/
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test('refuses a non-object envelope without contacting the server', async () => {
+    await expect(executeClaimedAutomationRun(opts({ job: '[]' }))).rejects.toThrow(
+      /expected a JSON object/
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test('refuses a blank workerId — a non-claiming id loses the report silently', async () => {
+    await expect(executeClaimedAutomationRun(opts({ workerId: '  ' }))).rejects.toThrow(
+      /workerId is required/
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test('refuses a blank auth token', async () => {
+    await expect(executeClaimedAutomationRun(opts({ authToken: '' }))).rejects.toThrow(
+      /auth token is required/
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test('does NOT require a durable owl_pat_ token — a claimer polls with a session bearer', async () => {
+    const result = await executeClaimedAutomationRun(
+      opts({ authToken: 'oauth_session_token' })
+    );
+    expect(result.error).toBeUndefined();
+    const completion = requests.find((r) => r.path.includes('/complete-automation'));
+    expect(completion?.auth).toBe('Bearer oauth_session_token');
+  });
+
+  test('honours the server resume decision through the shared arm', async () => {
+    script = [
+      { status: 'resume', attempt: 2, max_attempts: 3, nudge: 'finalize it' },
+      { status: 'completed' },
+    ];
+    await executeClaimedAutomationRun(opts());
+    const completions = requests.filter((r) => r.path.includes('/complete-automation'));
+    expect(completions).toHaveLength(2);
+    expect(completions[1]?.body.finalize_attempt).toBe(2);
+  });
+});

--- a/packages/connector-worker/src/__tests__/execute-claimed-run.test.ts
+++ b/packages/connector-worker/src/__tests__/execute-claimed-run.test.ts
@@ -176,6 +176,47 @@ describe('executeClaimedAutomationRun', () => {
     expect(completion?.auth).toBe('Bearer oauth_session_token');
   });
 
+  test('falls back to defaultAgentKind when the Automation names none', async () => {
+    // The Mac app has always resolved an unset kind from the user's menubar
+    // pick. Without this the run fails on the device with "no local agent
+    // executor configured" — a regression the moment the Swift dispatcher is
+    // deleted in favour of this path.
+    const job = automationJob() as unknown as Record<string, unknown>;
+    (job.payload as { automation: { agent_kind?: string | null } }).automation.agent_kind =
+      null;
+
+    const result = await executeClaimedAutomationRun(
+      opts({ job, defaultAgentKind: 'pi' })
+    );
+
+    expect(result.error).toBeUndefined();
+    const completion = requests.find((r) => r.path.includes('/complete-automation'));
+    expect(String(completion?.body.output)).toContain('FAKE_OUTPUT');
+  });
+
+  test("an explicit agent_kind still WINS over the caller's default", async () => {
+    const result = await executeClaimedAutomationRun(
+      // Envelope says `pi`; the default names an agent with no binary override,
+      // so if the default won this would report "no local agent executor".
+      opts({ defaultAgentKind: 'not-a-real-agent' as never })
+    );
+
+    expect(result.error).toBeUndefined();
+    const completion = requests.find((r) => r.path.includes('/complete-automation'));
+    expect(String(completion?.body.output)).toContain('FAKE_OUTPUT');
+  });
+
+  test('no agent_kind and no default still reports through the server', async () => {
+    const job = automationJob() as unknown as Record<string, unknown>;
+    (job.payload as { automation: { agent_kind?: string | null } }).automation.agent_kind =
+      null;
+
+    const result = await executeClaimedAutomationRun(opts({ job }));
+
+    expect(result.error).toContain("agent_kind='(unset)'");
+    expect(requests.find((r) => r.path.includes('/complete-automation'))).toBeDefined();
+  });
+
   test('honours the server resume decision through the shared arm', async () => {
     script = [
       { status: 'resume', attempt: 2, max_attempts: 3, nudge: 'finalize it' },

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -56,6 +56,17 @@ export interface AutomationExecutorConfig {
   timeoutMs?: number;
   heartbeatIntervalMs?: number;
   /**
+   * Agent to use when the Automation names no `agent_kind`.
+   *
+   * The device, not the server, owns this choice: `agent_kind` is optional on
+   * the wire (`AutomationPollMetaSchema`), and which CLIs are actually
+   * installed is a property of the machine. The Mac app has always resolved it
+   * from the user's menubar pick; without it here, every Automation created
+   * without an explicit kind fails on the device with "no local agent executor
+   * configured".
+   */
+  defaultAgentKind?: AgentKind;
+  /**
    * Explicit per-agent binary paths (else PATH lookup). Lets an operator point
    * at a non-PATH CLI install, and is the injection seam the automation tests
    * use to drive a fake binary.
@@ -440,7 +451,9 @@ export async function executeAutomationRun(
     return { itemsCollected: 0, error: message };
   }
 
-  const kind = payload.automation.agent_kind ?? null;
+  // The Automation's explicit kind wins; the caller's device-level default is
+  // the fallback, matching how the Mac app has always resolved an unset kind.
+  const kind = payload.automation.agent_kind ?? cfg.defaultAgentKind ?? null;
   const spec = kind != null ? DEVICE_AGENT_SPECS_BY_KIND.get(kind as AgentKind) : undefined;
   if (!spec) {
     const message = `no local agent executor configured for agent_kind='${kind ?? '(unset)'}'`;

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -41,8 +41,27 @@ import type {
 } from '@lobu/core/contracts/worker/protocol';
 import type { ExecutorClient } from './client.js';
 import { WorkerDecodeError, WorkerHttpError } from './client.js';
-import type { ExecutorConfig } from './executor.js';
 import { log } from './log.js';
+
+/**
+ * The slice of the daemon's `ExecutorConfig` the automation arm reads.
+ *
+ * Declared narrowly so a caller that only executes automations — the one-shot
+ * `executeClaimedAutomationRun` entry point — does not have to fabricate
+ * connector-sync fields (`batchSize`, `generateEmbeddings`, `maxOldSpaceSize`)
+ * that this arm never touches. The daemon's full `ExecutorConfig` is
+ * structurally assignable to it.
+ */
+export interface AutomationExecutorConfig {
+  timeoutMs?: number;
+  heartbeatIntervalMs?: number;
+  /**
+   * Explicit per-agent binary paths (else PATH lookup). Lets an operator point
+   * at a non-PATH CLI install, and is the injection seam the automation tests
+   * use to drive a fake binary.
+   */
+  binaryOverrides?: Partial<Record<AgentKind, string>>;
+}
 
 /** Local-CLI run result, mirrored from the Mac app's `ExecutorResult`. */
 export interface ExecutorResult {
@@ -408,7 +427,7 @@ export interface AutomationRunIo {
 export async function executeAutomationRun(
   client: ExecutorClient,
   job: PollResponse,
-  cfg: ExecutorConfig
+  cfg: AutomationExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
   const runId = job.run_id;
   const payload = job.payload;

--- a/packages/connector-worker/src/daemon/execute-run.ts
+++ b/packages/connector-worker/src/daemon/execute-run.ts
@@ -1,0 +1,152 @@
+/**
+ * One-shot execution of an ALREADY-CLAIMED device Automation run.
+ *
+ * The daemon's poll loop claims and executes in one process. A native bridge
+ * cannot: the Owletto Mac app has to keep its own poll loop for the platform
+ * connectors only it can serve (HealthKit, Photos, Screen Time, computer use),
+ * and a poll claims whatever the server hands back — including automation runs
+ * pinned to that device. Splitting the claim across two pollers on one device
+ * row is what this avoids: the bridge stays the single claimer and hands the
+ * verbatim poll envelope here, so `executeAutomationRun` remains the single
+ * implementation of prompt building, MCP wiring, subprocess supervision, exit
+ * reporting and the finalize/resume loop.
+ *
+ * Ownership contract, which the caller depends on:
+ *   - returns normally → this call owns the run's outcome. It either delivered
+ *     an exit report to `/complete-automation`, or deliberately left the run
+ *     claimed for the server's heartbeat sweep (`dispatchAutomationResumeLoop`
+ *     does this when the report is undeliverable). The caller must NOT report.
+ *   - throws → nothing was reported and the run is untouched on the server. The
+ *     caller still owns it and must report the failure itself, or the run sits
+ *     `running` until the sweeper reclaims it.
+ */
+
+import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
+import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
+import { executeAutomationRun } from './automation.js';
+import { WorkerClient } from './client.js';
+import { log, setDebug } from './log.js';
+
+export interface ExecuteClaimedRunOptions {
+  /** Gateway base URL, e.g. `https://app.lobu.ai`. */
+  apiUrl: string;
+  /**
+   * The worker id that CLAIMED this run. `/complete-automation` authorizes on
+   * `runs.claimed_by` (`authorizeRunForWorker`), so a worker id that did not
+   * claim it is refused with a 403 — which the arm classifies as non-retriable
+   * and reports as an undelivered exit report, NOT as a run failure. The run
+   * then sits `running` until the heartbeat sweep reclaims it, and this call
+   * still returns without an error. So a wrong value here is lost silently:
+   * pass the claiming poller's own id, never a fresh one.
+   */
+  workerId: string;
+  /** Bearer the claiming poller authenticated with. */
+  authToken: string;
+  /** Verbatim `/api/workers/poll` response body for the claimed run. */
+  job: unknown;
+  timeoutMs?: number;
+  heartbeatIntervalMs?: number;
+  /** Explicit per-agent binary paths (else PATH lookup). Test injection seam. */
+  binaryOverrides?: Partial<Record<AgentKind, string>>;
+  debug?: boolean;
+}
+
+/**
+ * A refusal raised BEFORE any server contact, so the caller knows its run is
+ * still unreported. Carries `exitCode` so the CLI surfaces it as a non-zero
+ * exit — the signal a native bridge keys its own fallback report off.
+ */
+export class UnexecutableRunError extends Error {
+  readonly exitCode = 1;
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnexecutableRunError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate the envelope only as far as the arm's own error reporting cannot.
+ *
+ * `executeAutomationRun` already reports a missing `payload` through
+ * `/complete-automation`, so that stays its job — routing it here would create
+ * a second, divergent copy of the same failure text. What it CANNOT report is a
+ * missing `run_id` (there is no run to post against) or a non-automation run
+ * (it would build an agent prompt out of a connector sync job), so both are
+ * refusals here.
+ */
+function assertAutomationEnvelope(job: unknown): PollResponse {
+  if (!isRecord(job)) {
+    throw new UnexecutableRunError(
+      'expected a JSON object: the verbatim /api/workers/poll response body for the claimed run'
+    );
+  }
+  if (job.run_type !== 'automation') {
+    throw new UnexecutableRunError(
+      `run_type must be 'automation' (got ${JSON.stringify(job.run_type ?? null)}); ` +
+        'connector sync, action and auth runs are executed by the claiming worker, not here'
+    );
+  }
+  const runId = job.run_id;
+  if (typeof runId !== 'number' || !Number.isFinite(runId) || runId <= 0) {
+    throw new UnexecutableRunError(
+      `run_id must be a positive number (got ${JSON.stringify(runId ?? null)})`
+    );
+  }
+  return job as unknown as PollResponse;
+}
+
+/**
+ * Execute one already-claimed automation run and report its outcome.
+ *
+ * Deliberately does NOT require the durable `owl_pat_` token `startDaemonCommand`
+ * insists on. That check exists because a daemon runs for weeks off one
+ * snapshotted bearer, so a 24h OAuth session token would leave it polling 401
+ * forever. This call lives and dies inside a single run (600s by default) using
+ * the bearer its caller just polled with successfully, so the same rule would
+ * only reject working credentials.
+ */
+export async function executeClaimedAutomationRun(
+  opts: ExecuteClaimedRunOptions
+): Promise<{ itemsCollected: number; error?: string }> {
+  setDebug(opts.debug === true);
+
+  const apiUrl = opts.apiUrl.trim();
+  if (!apiUrl) throw new UnexecutableRunError('apiUrl is required');
+  const workerId = opts.workerId.trim();
+  if (!workerId) {
+    throw new UnexecutableRunError(
+      'workerId is required: it must be the id of the worker that claimed this run'
+    );
+  }
+  const authToken = opts.authToken.trim();
+  if (!authToken) {
+    throw new UnexecutableRunError(
+      'an auth token is required to post the run outcome to /complete-automation'
+    );
+  }
+
+  const job = assertAutomationEnvelope(opts.job);
+
+  // No capabilities and no platform: this client never polls, so it never
+  // registers a device row. It only heartbeats and posts the exit report, both
+  // of which authorize on (token, worker_id) against the existing claim.
+  const client = new WorkerClient({
+    apiUrl,
+    workerId,
+    authToken,
+    capabilities: {},
+  });
+
+  log.info(`[execute-run] Executing claimed automation run ${job.run_id}`);
+  return executeAutomationRun(client, job, {
+    ...(opts.timeoutMs != null ? { timeoutMs: opts.timeoutMs } : {}),
+    ...(opts.heartbeatIntervalMs != null
+      ? { heartbeatIntervalMs: opts.heartbeatIntervalMs }
+      : {}),
+    ...(opts.binaryOverrides ? { binaryOverrides: opts.binaryOverrides } : {}),
+  });
+}

--- a/packages/connector-worker/src/daemon/execute-run.ts
+++ b/packages/connector-worker/src/daemon/execute-run.ts
@@ -46,6 +46,11 @@ export interface ExecuteClaimedRunOptions {
   job: unknown;
   timeoutMs?: number;
   heartbeatIntervalMs?: number;
+  /**
+   * Agent to use when the Automation names no `agent_kind`. A native bridge
+   * passes the machine's own default here (the Mac app's menubar pick).
+   */
+  defaultAgentKind?: AgentKind;
   /** Explicit per-agent binary paths (else PATH lookup). Test injection seam. */
   binaryOverrides?: Partial<Record<AgentKind, string>>;
   debug?: boolean;
@@ -147,6 +152,7 @@ export async function executeClaimedAutomationRun(
     ...(opts.heartbeatIntervalMs != null
       ? { heartbeatIntervalMs: opts.heartbeatIntervalMs }
       : {}),
+    ...(opts.defaultAgentKind ? { defaultAgentKind: opts.defaultAgentKind } : {}),
     ...(opts.binaryOverrides ? { binaryOverrides: opts.binaryOverrides } : {}),
   });
 }

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -17,8 +17,4 @@ export { executeRun } from './executor.js';
 export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
 export { startDaemonCommand, type DaemonStartOptions } from './start.js';
-export {
-  executeClaimedAutomationRun,
-  UnexecutableRunError,
-  type ExecuteClaimedRunOptions,
-} from './execute-run.js';
+export { executeClaimedAutomationRun, UnexecutableRunError } from './execute-run.js';

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -17,3 +17,8 @@ export { executeRun } from './executor.js';
 export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
 export { startDaemonCommand, type DaemonStartOptions } from './start.js';
+export {
+  executeClaimedAutomationRun,
+  UnexecutableRunError,
+  type ExecuteClaimedRunOptions,
+} from './execute-run.js';

--- a/packages/server/src/__tests__/integration/automations/device-automation-resume-live.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-automation-resume-live.test.ts
@@ -19,7 +19,11 @@ import os from "node:os";
 import path from "node:path";
 import { serve } from "@hono/node-server";
 import { inferAutomationGranularityFromSchedule } from "@lobu/connector-sdk";
-import { executeRun, WorkerClient } from "@lobu/connector-worker/daemon";
+import {
+	executeClaimedAutomationRun,
+	executeRun,
+	WorkerClient,
+} from "@lobu/connector-worker/daemon";
 import type { PollResponse } from "@lobu/core/contracts/worker/protocol";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { generateSecureToken, hashToken } from "../../../auth/oauth/utils";
@@ -246,6 +250,82 @@ describe("device automation resume — live server round-trip", () => {
 		// The exit report the daemon actually posted is what stamped the run.
 		expect(run.exit_reason).toBe("ok");
 		expect(run.output_tail ?? "").toContain("forgot to finalize");
+		expect(result.error).toBeUndefined();
+	});
+
+	// The one-shot handoff a native bridge uses. Same real server, same real
+	// complete-automation handler — what differs is that the CLAIM happened
+	// elsewhere, so these pin that the entry point still stamps the row and that
+	// its one hard requirement (the claiming worker's id) is load-bearing.
+	it("executes an already-claimed run and stamps the row through the real handler", async () => {
+		const workerId = "live-resume-worker";
+		const { sql, workspace, runId, token } = await liveDeviceRun(workerId);
+
+		const result = await executeClaimedAutomationRun({
+			apiUrl: baseUrl,
+			workerId,
+			authToken: token,
+			job: automationJob(runId, workspace.org.id),
+			timeoutMs: 30_000,
+			heartbeatIntervalMs: 60_000,
+			binaryOverrides: { pi: fakeBinary },
+		});
+
+		// Identical outcome to the daemon's own dispatch above: the resume budget
+		// is the server's, so both entry points must land in the same place.
+		expect(invocations()).toHaveLength(2);
+		const [run] = (await sql`
+      SELECT status, approved_input->>'finalize_nudge_count' AS nudges,
+             exit_reason, output_tail
+      FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{
+			status: string;
+			nudges: string | null;
+			exit_reason: string | null;
+			output_tail: string | null;
+		}>;
+		expect(run.status).toBe("failed");
+		expect(Number(run.nudges)).toBe(1);
+		expect(run.exit_reason).toBe("ok");
+		expect(run.output_tail ?? "").toContain("forgot to finalize");
+		expect(result.error).toBeUndefined();
+	});
+
+	it("a worker id that did not claim the run loses the report SILENTLY", async () => {
+		const workerId = "live-resume-worker";
+		const { sql, workspace, runId, token } = await liveDeviceRun(workerId);
+
+		// A second registered device of the same user. Reporting as it is refused
+		// 403 (`authorizeRunForWorker` requires `claimed_by === worker_id`), which
+		// `isRetriableDeliveryFailure` classifies as non-retriable — so the arm
+		// gives up after ONE attempt, logs an undelivered exit report, and returns
+		// no error. The loss is invisible to the caller, which is why `workerId` is
+		// a hard requirement on the one-shot entry point rather than a default.
+		const otherWorkerId = "live-resume-worker-2";
+		await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label)
+      VALUES (${workspace.users.owner.id}, ${otherWorkerId}, 'macos', ${sql.json({})}, 'Other Mac')
+    `;
+
+		const result = await executeClaimedAutomationRun({
+			apiUrl: baseUrl,
+			workerId: otherWorkerId,
+			authToken: token,
+			job: automationJob(runId, workspace.org.id),
+			timeoutMs: 30_000,
+			heartbeatIntervalMs: 60_000,
+			binaryOverrides: { pi: fakeBinary },
+		});
+
+		// The agent still ran, once — the wrong id costs the REPORT, not the work,
+		// and the non-retriable 403 means no second delivery attempt either.
+		expect(invocations()).toHaveLength(1);
+		const [run] = (await sql`
+      SELECT status, exit_reason FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ status: string; exit_reason: string | null }>;
+		expect(run.status).toBe("running");
+		expect(run.exit_reason).toBeNull();
+		// And it reports no error, which is exactly what makes it silent.
 		expect(result.error).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `lobu automation execute` — a one-shot entry point that runs an **already-claimed** device Automation from the verbatim `/api/workers/poll` envelope. This is what lets the Owletto Mac app delete its 1220-line Swift `AutomationDispatcher` without putting a second poller on the same device row: the app stays the only claimer and hands the run to the CLI, where `executeAutomationRun` remains the single implementation.
- Fixes `lobu daemon`'s auto-discovered `--api-url`: it passed the context URL (`https://app.lobu.ai/api/v1`) straight through, but `/api/workers/*` is mounted at the origin — so it built `/api/v1/api/workers/poll`. Only production contexts carry that path, which is why it was invisible in dev. Both call sites now share `apiUrlToGatewayOrigin`, matching what the Mac app already does (`LobuContextIdentity.origin(of:)`).
- Narrows `executeAutomationRun`'s config parameter to the fields the arm reads, so a caller that only executes Automations need not fabricate connector-sync fields. The daemon's full `ExecutorConfig` still assigns structurally.

### Why the exit-code contract matters

Both sides can otherwise report the same run:

| exit | meaning |
|---|---|
| `0` | this command owns the outcome — it posted the exit report, or deliberately left an undeliverable one to the server's heartbeat sweep. The caller must **not** report. |
| non-zero | nothing was reported; the run is untouched. The caller still owns it and must report its own failure. |

An older CLI without the command exits non-zero too ("unknown command"), so a version-skewed caller lands in the safe half by construction.

### Why `--worker-id` is required rather than defaulted

`/complete-automation` authorizes on `runs.claimed_by` (`shared.ts:101`). A worker id that did not claim the run is refused **403**, which `isRetriableDeliveryFailure` classifies as non-retriable, so the arm gives up after one attempt, logs an undelivered exit report, and **returns no error**. The run then sits `running` until the sweep. The loss is invisible to the caller, so the id cannot be defaulted — and the live suite pins exactly that failure mode.

### Why the one-shot path does not require `owl_pat_`

`startDaemonCommand` rejects a non-durable token because a daemon runs for weeks off one snapshotted bearer, and a 24h OAuth session token would leave it polling 401 forever. This call lives inside a single run (600s default) using the bearer its caller just polled with successfully, so the same rule would only reject working credentials. Covered by a test that would fail if the gate were copied over.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (full Linux CI graph runs here on GitHub CI)
- [x] Tests run: targeted `bun test` + `bunx vitest run` — see below
- [x] Bug fix: red→fix→green pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval — n/a

**Unit (`bun test`)** — 9/9 `execute-claimed-run.test.ts`, 6/6 `automation-execute.test.ts`, 5/5 `daemon-gateway-origin.test.ts`. Full `packages/connector-worker` suite 102/102.

**Live server round-trip (`bunx vitest run device-automation-resume-live.test.ts`)** — 3/3. Two new cases drive the real Hono app on a real port over the real test Postgres, so the **real** `complete-automation` handler decides:
1. `executeClaimedAutomationRun` on an already-claimed run stamps the row identically to the daemon's own dispatch — same resume budget, `status=failed`, `finalize_nudge_count=1`, `exit_reason=ok`.
2. A worker id that did not claim the run leaves it `running` with `exit_reason` NULL and returns no error — the silent loss, pinned.

**Mutation-tested** (each mutation reverted after):
- remove the `run_type !== 'automation'` guard → non-automation test fails ✓
- remove the blank-`workerId` guard → that test fails ✓
- post a wrong `worker_id` → "posts as the CLAIMING worker" fails ✓
- drop `apiUrlToGatewayOrigin` in `automation.ts` → origin test fails ✓
- re-throw a *reported* failure (the double-report bug) → exit-0 test fails ✓
- revert the `lobu daemon` origin fix → daemon origin test fails ✓ (this is the red→green for the bug)
- hardcode the claiming worker id in `execute-run.ts` → live silent-loss test fails ✓ *(only after `bun run --cwd packages/connector-worker build` — server consumers resolve this package through `dist`, so the first attempt at this mutation was a false pass)*

`make review-fix` (Fable) made zero edits and reported no findings.

## Notes

Follow-up, in order: (1) publish the CLI, (2) an Owletto PR deleting `AutomationDispatcher.swift` + its golden-output tests (~1.9k Swift lines) in favour of a thin shim that spawns this command, (3) the submodule pointer bump. The app resolves the CLI via `locateLobuCLI()` and today lands on PATH for real users, so the version-skew case is real — the exit-code contract is what makes it fail loudly instead of silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `automation execute` CLI command for running already-claimed automation jobs from a file or piped input.
  * Added validation for job data, worker identity, authentication, and API connectivity.
  * Added automatic gateway URL discovery when starting the daemon.
  * Added support for reporting execution outcomes and resuming interrupted runs.

* **Tests**
  * Added comprehensive coverage for successful execution, failures, invalid inputs, URL handling, worker authorization, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->