### PR TITLE
ci: fail required fan-ins when an upstream gate job fails instead of passing on skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,23 +576,27 @@ jobs:
   # independently retryable and visible.
   sdk-cli-e2e:
     if: always()
-    needs: [sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke]
+    # `sdk-cli-build` is in `needs` on purpose: the three smokes `needs` it, so
+    # when it fails they report `skipped`, and a fan-in that accepted `skipped`
+    # turned a broken build into a green required check. None of these jobs
+    # has a paths filter, so every result must be an actual success.
+    needs: [sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke]
     runs-on: ubuntu-slim
     steps:
       - name: Require every deep smoke
         env:
+          BUILD_RESULT: ${{ needs.sdk-cli-build.result }}
           SDK_RESULT: ${{ needs.sdk-lifecycle-e2e.result }}
           ERROR_TAXONOMY_RESULT: ${{ needs.sdk-error-taxonomy-e2e.result }}
           CLI_RESULT: ${{ needs.cli-command-smoke.result }}
         run: |
+          echo "SDK/CLI build: $BUILD_RESULT"
           echo "SDK lifecycle: $SDK_RESULT"
           echo "Error taxonomy: $ERROR_TAXONOMY_RESULT"
           echo "CLI surface: $CLI_RESULT"
-          # Skipped is success here: the deep smokes skip (paths filter) when
-          # no runtime paths changed, and this fan-in must stay green then.
-          for r in "$SDK_RESULT" "$ERROR_TAXONOMY_RESULT" "$CLI_RESULT"; do
-            if [ "$r" != success ] && [ "$r" != skipped ]; then
-              echo "job result \"$r\" is neither success nor skipped"
+          for r in "$BUILD_RESULT" "$SDK_RESULT" "$ERROR_TAXONOMY_RESULT" "$CLI_RESULT"; do
+            if [ "$r" != success ]; then
+              echo "job result \"$r\" is not success (skipped means an upstream job failed)"
               exit 1
             fi
           done
@@ -993,7 +997,12 @@ jobs:
   # into a skipped required check.
   integration:
     if: always()
-    needs: [server-integration-vitest, server-integration-bun]
+    # `check-author` and `paths` are in `needs` on purpose: the shards `needs`
+    # them, so when either fails the shards report `skipped`, and a fan-in
+    # that accepted `skipped` unconditionally turned a broken gate job into a
+    # green required check. Skipped shards are only legitimate when the paths
+    # filter itself said no runtime paths changed.
+    needs: [check-author, paths, server-integration-vitest, server-integration-bun]
     # This compatibility context only evaluates two strings. Keep it on the
     # lightweight runner image while older open PRs still require the legacy
     # `integration` context; branch protection can move directly to the four
@@ -1003,18 +1012,30 @@ jobs:
     steps:
       - name: Require every backend integration job
         env:
+          AUTHOR_RESULT: ${{ needs.check-author.result }}
+          PATHS_RESULT: ${{ needs.paths.result }}
+          PACKAGES_CHANGED: ${{ needs.paths.outputs.packages }}
           VITEST_RESULT: ${{ needs.server-integration-vitest.result }}
           BUN_RESULT: ${{ needs.server-integration-bun.result }}
         run: |
+          echo "check-author: $AUTHOR_RESULT"
+          echo "paths: $PATHS_RESULT (packages=$PACKAGES_CHANGED)"
           echo "Vitest matrix: $VITEST_RESULT"
           echo "Bun/Postgres: $BUN_RESULT"
-          # Skipped is success here: the shards skip (paths filter) when no
-          # runtime paths changed, and this required fan-in must stay green.
-          for r in "$VITEST_RESULT" "$BUN_RESULT"; do
-            if [ "$r" != success ] && [ "$r" != skipped ]; then
-              echo "job result \"$r\" is neither success nor skipped"
+          for r in "$AUTHOR_RESULT" "$PATHS_RESULT"; do
+            if [ "$r" != success ]; then
+              echo "gate job result \"$r\" is not success"
               exit 1
             fi
+          done
+          # Skipped shards are success ONLY when the paths filter decided no
+          # runtime paths changed. With packages=true a skipped shard means an
+          # upstream dependency failed and must not pass as green.
+          for r in "$VITEST_RESULT" "$BUN_RESULT"; do
+            if [ "$r" = success ]; then continue; fi
+            if [ "$r" = skipped ] && [ "$PACKAGES_CHANGED" != true ]; then continue; fi
+            echo "job result \"$r\" is not acceptable (packages=$PACKAGES_CHANGED)"
+            exit 1
           done
 
   format-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1003,7 +1003,7 @@ jobs:
     # green required check. Skipped shards are only legitimate when the paths
     # filter itself said no runtime paths changed.
     needs: [check-author, paths, server-integration-vitest, server-integration-bun]
-    # This compatibility context only evaluates two strings. Keep it on the
+    # This compatibility context only evaluates a handful of strings. Keep it on the
     # lightweight runner image while older open PRs still require the legacy
     # `integration` context; branch protection can move directly to the four
     # worker contexts once those PRs refresh.

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -25,6 +25,17 @@ workflow_job() {
   ' "$workflow"
 }
 
+# Pull the body of a job's `run: |` block out of the YAML the caller already
+# extracted, so the tests below execute the real gate script instead of
+# re-stating it. Both fan-ins are shaped the same way, so they share this.
+job_run_script() {
+  awk '
+    /^        run: \|$/ { capture = 1; next }
+    capture && /^          / { print; next }
+    capture && NF { exit }
+  ' <<<"$1"
+}
+
 run_id="$(printf 'Org: test\nRun: bj0453b334\nWaiting...\n' | remote_ci_extract_run_id)"
 assert_eq "$run_id" "bj0453b334"
 
@@ -148,11 +159,7 @@ grep -q '^    needs: \[check-author, paths, server-integration-vitest, server-in
 # be EXECUTED rather than pattern-matched. A grep only proves the text is
 # present; running the real script from the workflow proves the decision. The
 # result vocabulary is GitHub's: success | failure | cancelled | skipped.
-integration_gate_script="$(awk '
-  /^        run: \|$/ { capture = 1; next }
-  capture && /^          / { print; next }
-  capture && NF { exit }
-' <<<"$integration_gate")"
+integration_gate_script="$(job_run_script "$integration_gate")"
 [ -n "$integration_gate_script" ] || fail "could not extract the integration fan-in script"
 
 # author paths packages vitest bun -> pass|fail
@@ -203,11 +210,7 @@ assert_gate fail success success true failure failure
 # Same treatment for the SDK fan-in: execute it, don't pattern-match it. None of
 # these jobs has a paths filter, so `skipped` can only mean a broken upstream —
 # there is no unaffected-PR exemption to carve out here.
-sdk_gate_script="$(awk '
-  /^        run: \|$/ { capture = 1; next }
-  capture && /^          / { print; next }
-  capture && NF { exit }
-' <<<"$sdk_gate")"
+sdk_gate_script="$(job_run_script "$sdk_gate")"
 [ -n "$sdk_gate_script" ] || fail "could not extract the sdk-cli-e2e gate script"
 
 sdk_gate_verdict() {

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -141,6 +141,14 @@ done
 sdk_gate="$(workflow_job "$workflow" sdk-cli-e2e)"
 grep -q '^    needs: \[sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke\]$' <<<"$sdk_gate" ||
   fail "sdk-cli-e2e does not aggregate every deep smoke"
+integration_gate="$(workflow_job "$workflow" integration)"
+grep -q '^    needs: \[check-author, paths, server-integration-vitest, server-integration-bun\]$' <<<"$integration_gate" ||
+  fail "integration fan-in does not gate on check-author/paths"
+grep -q 'PACKAGES_CHANGED" != true' <<<"$integration_gate" ||
+  fail "integration fan-in accepts skipped shards unconditionally"
+grep -q '^    needs: \[sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke\]$' <<<"$sdk_gate" &&
+  ! grep -q '"$r" != skipped' <<<"$sdk_gate" ||
+  fail "sdk-cli-e2e accepts skipped smokes"
 dead_code="$(workflow_job "$workflow" dead-code-report)"
 [ -n "$dead_code" ] || fail "advisory dead-code report was dropped during SDK fan-out"
 grep -q '^    needs: \[unit, frontend, integration, format-lint, typecheck, migrations\]$' <<<"$dead_code" ||

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -139,7 +139,7 @@ for smoke in sdk-lifecycle-e2e sdk-error-taxonomy-e2e cli-command-smoke; do
     fail "$smoke does not restore the built distributions"
 done
 sdk_gate="$(workflow_job "$workflow" sdk-cli-e2e)"
-grep -q '^    needs: \[sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke\]$' <<<"$sdk_gate" ||
+grep -q '^    needs: \[sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke\]$' <<<"$sdk_gate" ||
   fail "sdk-cli-e2e does not aggregate every deep smoke"
 dead_code="$(workflow_job "$workflow" dead-code-report)"
 [ -n "$dead_code" ] || fail "advisory dead-code report was dropped during SDK fan-out"

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -144,11 +144,98 @@ grep -q '^    needs: \[sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e,
 integration_gate="$(workflow_job "$workflow" integration)"
 grep -q '^    needs: \[check-author, paths, server-integration-vitest, server-integration-bun\]$' <<<"$integration_gate" ||
   fail "integration fan-in does not gate on check-author/paths"
-grep -q 'PACKAGES_CHANGED" != true' <<<"$integration_gate" ||
-  fail "integration fan-in accepts skipped shards unconditionally"
-grep -q '^    needs: \[sdk-cli-build, sdk-lifecycle-e2e, sdk-error-taxonomy-e2e, cli-command-smoke\]$' <<<"$sdk_gate" &&
-  ! grep -q '"$r" != skipped' <<<"$sdk_gate" ||
-  fail "sdk-cli-e2e accepts skipped smokes"
+# The fan-in decision is pure shell over the `needs.*.result` strings, so it can
+# be EXECUTED rather than pattern-matched. A grep only proves the text is
+# present; running the real script from the workflow proves the decision. The
+# result vocabulary is GitHub's: success | failure | cancelled | skipped.
+integration_gate_script="$(awk '
+  /^        run: \|$/ { capture = 1; next }
+  capture && /^          / { print; next }
+  capture && NF { exit }
+' <<<"$integration_gate")"
+[ -n "$integration_gate_script" ] || fail "could not extract the integration fan-in script"
+
+# author paths packages vitest bun -> pass|fail
+gate_verdict() {
+  if AUTHOR_RESULT="$1" PATHS_RESULT="$2" PACKAGES_CHANGED="$3" \
+     VITEST_RESULT="$4" BUN_RESULT="$5" \
+     bash -e -c "$integration_gate_script" >/dev/null 2>&1; then
+    echo pass
+  else
+    echo fail
+  fi
+}
+
+assert_gate() {
+  local expected="$1"; shift
+  local got
+  got="$(gate_verdict "$@")"
+  [ "$got" = "$expected" ] ||
+    fail "integration fan-in: author=$1 paths=$2 packages=$3 vitest=$4 bun=$5 -> $got, wanted $expected"
+}
+
+# Everything green passes, whether or not runtime paths changed.
+assert_gate pass success success true success success
+assert_gate pass success success false success success
+# THE REGRESSION: a shard reports `skipped` when its own dependency broke. With
+# packages=true that is a broken gate, not an unaffected PR, and must be red.
+assert_gate fail success success true skipped success
+assert_gate fail success success true success skipped
+assert_gate fail success success true skipped skipped
+# ...but a genuinely unaffected PR still passes on skipped shards.
+assert_gate pass success success false skipped skipped
+# An unset `packages` output is not the string "true", so it reads as unaffected.
+assert_gate pass success success "" skipped skipped
+# A gate job that did not succeed is fatal however it ended — this is the hole
+# `check-author`/`paths` were added to `needs` to close.
+assert_gate fail failure success true success success
+assert_gate fail skipped success true success success
+assert_gate fail cancelled success true success success
+assert_gate fail success failure true success success
+assert_gate fail success skipped true success success
+assert_gate fail success cancelled false skipped skipped
+# `cancelled` is not `skipped`: it never gets the unaffected-PR exemption.
+assert_gate fail success success false cancelled success
+assert_gate fail success success false success cancelled
+# An outright shard failure is red regardless of the paths filter.
+assert_gate fail success success false failure success
+assert_gate fail success success true failure failure
+# Same treatment for the SDK fan-in: execute it, don't pattern-match it. None of
+# these jobs has a paths filter, so `skipped` can only mean a broken upstream —
+# there is no unaffected-PR exemption to carve out here.
+sdk_gate_script="$(awk '
+  /^        run: \|$/ { capture = 1; next }
+  capture && /^          / { print; next }
+  capture && NF { exit }
+' <<<"$sdk_gate")"
+[ -n "$sdk_gate_script" ] || fail "could not extract the sdk-cli-e2e gate script"
+
+sdk_gate_verdict() {
+  if BUILD_RESULT="$1" SDK_RESULT="$2" ERROR_TAXONOMY_RESULT="$3" CLI_RESULT="$4" \
+     bash -e -c "$sdk_gate_script" >/dev/null 2>&1; then
+    echo pass
+  else
+    echo fail
+  fi
+}
+
+assert_sdk_gate() {
+  local expected="$1"; shift
+  local got
+  got="$(sdk_gate_verdict "$@")"
+  [ "$got" = "$expected" ] ||
+    fail "sdk-cli-e2e: build=$1 sdk=$2 taxonomy=$3 cli=$4 -> $got, wanted $expected"
+}
+
+assert_sdk_gate pass success success success success
+# A skipped smoke means sdk-cli-build broke underneath it — never green.
+assert_sdk_gate fail success skipped success success
+assert_sdk_gate fail success success skipped success
+assert_sdk_gate fail success success success skipped
+assert_sdk_gate fail skipped skipped skipped skipped
+assert_sdk_gate fail failure skipped skipped skipped
+assert_sdk_gate fail success cancelled success success
+assert_sdk_gate fail success failure success success
 dead_code="$(workflow_job "$workflow" dead-code-report)"
 [ -n "$dead_code" ] || fail "advisory dead-code report was dropped during SDK fan-out"
 grep -q '^    needs: \[unit, frontend, integration, format-lint, typecheck, migrations\]$' <<<"$dead_code" ||

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -227,7 +227,7 @@ gate_migrations() {
   # the default 64MB fails. Best-effort; if it truly can't raise, the apply
   # below fails loudly with the real error.
   if command -v psql >/dev/null 2>&1; then
-    psql "$DATABASE_URL" -v ON_ERROR_STOP=0       -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()" >/dev/null 2>&1 || true || return 1
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=0       -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()" >/dev/null 2>&1 || true
   fi
   # Apply with the SAME runner production uses (scripts/migrate-up.mjs), NOT
   # dbmate up: migrate-up splits top-level statements so transaction:false


### PR DESCRIPTION
## Summary
- `integration` and `sdk-cli-e2e` accepted `skipped` shard results unconditionally. Shards only skip because an upstream job failed or filtered (`paths`/`check-author` for the integration shards; `sdk-cli-build` for the SDK smokes), so a broken gate job produced a **green required check with zero tests run** — and `make review`'s `ci_run_green_for_head` then trusted that run.
- `integration`: add `check-author` + `paths` to `needs`, require both `success`, and accept a skipped shard only when `paths.outputs.packages != true`.
- `sdk-cli-e2e`: add `sdk-cli-build` to `needs` and require every result to be `success`. None of these jobs has a paths filter, so the comment claiming one was wrong.
- `scripts/lib/gate-runner.sh`: drop the unreachable `|| return 1` after `|| true`.

Follow-up to #2875 (path-filtered suites). Found while auditing the last 3 days of merges.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate for this PR)
- [x] `actionlint .github/workflows/ci.yml` clean; YAML parses
- [ ] Not a bug-fix with a runtime repro — the behaviour is in the GitHub Actions `needs`/`if: always()` semantics. Verification is this PR's own CI run: `integration` and `sdk-cli-e2e` must still report green here (packages=true path, all shards success).

## Notes
- Push-to-main runs have no `BASE_SHA`, so `paths` emits `packages=true` there and the stricter branch (no skipped shards) applies — same as before for real failures, stricter for upstream-gate failures.