### PR TITLE
fix(server): reuse headless device identity on child-token re-mint

### DIFF
--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -17,9 +17,10 @@
  *
  * Unlike connector children (which inherit a small system-env allowlist), the
  * spawned agent CLI must run as the user: it inherits the daemon's environment
- * (PATH, HOME, the user's CLI credentials) minus `WORKER_API_TOKEN`, which the
- * CLI must never see — it authenticates through its own `~/.config/lobu`
- * credentials or the MCP bearer wired per-spec.
+ * (PATH, HOME, the user's CLI credentials) minus the `WORKER_API_TOKEN` env
+ * var, so the child cannot act as the worker/poll loop — it authenticates
+ * through its own `~/.config/lobu` credentials or the MCP bearer wired
+ * per-spec (deliberately the daemon's own bearer, as in the Mac dispatcher).
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -276,8 +277,11 @@ async function runCli(
     const args = buildArguments(spec, prompt, config, mcpArgs, timeoutMs / 1000);
     const started = Date.now();
 
-    // Inherit the user's environment (PATH, HOME, CLI credentials) but never
-    // leak the daemon's worker token into the spawned agent.
+    // Inherit the user's environment (PATH, HOME, CLI credentials) but drop
+    // WORKER_API_TOKEN so the child cannot act as the worker/poll loop itself.
+    // The same bearer is still wired into the child's MCP config on purpose
+    // (buildMcp above) — that is how the spawned CLI reaches Lobu tools, same
+    // as the Mac `AutomationDispatcher`; what we withhold is the daemon role.
     const env: NodeJS.ProcessEnv = { ...process.env };
     delete env.WORKER_API_TOKEN;
     for (const [key, value] of Object.entries(mcpEnv)) env[key] = value;

--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -93,6 +93,99 @@ describe('headless device mint (mint-child-token)', () => {
     expect(rows[0].organization_id).toBe(personalOrg.id);
   });
 
+  it('reuses a headless worker_id on re-mint and revokes the previous child PAT', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Reuse' });
+    const user = await createTestUser({ email: 'headless-mint-reuse@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    const app = mintApp(user.id);
+
+    const first = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'headless', label: 'herdr-reuse' }),
+      },
+      TEST_ENV
+    );
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { worker_id: string; access_token: string };
+
+    // Re-register with the stored worker_id (what a headless daemon does on
+    // restart): identity must stay stable and the previous PAT must be revoked.
+    const second = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'headless', worker_id: firstBody.worker_id }),
+      },
+      TEST_ENV
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { worker_id: string; access_token: string };
+    expect(secondBody.worker_id).toBe(firstBody.worker_id);
+    expect(secondBody.access_token).not.toBe(firstBody.access_token);
+
+    const deviceRows = (await sql`
+      SELECT worker_id, platform FROM device_workers WHERE user_id = ${user.id}
+    `) as unknown as Array<{ worker_id: string; platform: string }>;
+    expect(deviceRows).toHaveLength(1);
+    expect(deviceRows[0].worker_id).toBe(firstBody.worker_id);
+    expect(deviceRows[0].platform).toBe('headless');
+
+    const pats = (await sql`
+      SELECT revoked_at FROM personal_access_tokens
+      WHERE user_id = ${user.id} AND worker_id = ${firstBody.worker_id}
+      ORDER BY id ASC
+    `) as unknown as Array<{ revoked_at: Date | null }>;
+    expect(pats).toHaveLength(2);
+    expect(pats[0].revoked_at).not.toBeNull();
+    expect(pats[1].revoked_at).toBeNull();
+  });
+
+  it('does not reuse a chrome-extension worker_id when re-minting as headless', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Cross' });
+    const user = await createTestUser({ email: 'headless-mint-cross@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    const app = mintApp(user.id);
+
+    const chrome = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'chrome-extension', label: 'chrome' }),
+      },
+      TEST_ENV
+    );
+    expect(chrome.status).toBe(200);
+    const chromeBody = (await chrome.json()) as { worker_id: string };
+
+    const headless = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'headless', worker_id: chromeBody.worker_id }),
+      },
+      TEST_ENV
+    );
+    expect(headless.status).toBe(200);
+    const headlessBody = (await headless.json()) as { worker_id: string };
+    expect(headlessBody.worker_id).not.toBe(chromeBody.worker_id);
+
+    const rows = (await sql`
+      SELECT worker_id, platform FROM device_workers WHERE user_id = ${user.id} ORDER BY platform ASC
+    `) as unknown as Array<{ worker_id: string; platform: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.platform)).toEqual(['chrome-extension', 'headless']);
+  });
+
   it('rejects a platform that is not eligible for child-token mint', async () => {
     const user = await createTestUser({ email: 'headless-mint-reject@test.example.com' });
     const personalOrg = await createTestOrganization({ name: 'Personal Reject' });

--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -184,6 +184,21 @@ describe('headless device mint (mint-child-token)', () => {
     `) as unknown as Array<{ worker_id: string; platform: string }>;
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.platform)).toEqual(['chrome-extension', 'headless']);
+
+    // The sharp edge of the old hardcoded predicate: the reuse branch matched
+    // the chrome row even though 'headless' was requested, so the re-mint
+    // revoked every other PAT on that worker_id — killing the live extension's
+    // credential and leaving a headless-named PAT bound to a row whose stored
+    // platform stayed 'chrome-extension'. Both devices must keep a live token.
+    const pats = (await sql`
+      SELECT worker_id, revoked_at FROM personal_access_tokens
+      WHERE user_id = ${user.id} AND worker_id IS NOT NULL
+    `) as unknown as Array<{ worker_id: string; revoked_at: string | null }>;
+    expect(pats).toHaveLength(2);
+    expect(pats.every((p) => p.revoked_at === null)).toBe(true);
+    expect(new Set(pats.map((p) => p.worker_id))).toEqual(
+      new Set([chromeBody.worker_id, headlessBody.worker_id])
+    );
   });
 
   it('rejects a platform that is not eligible for child-token mint', async () => {

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -236,22 +236,26 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       );
     }
 
-    // Identity reuse: when the sibling forwards its existing worker_id AND it
-    // already belongs to this user as a chrome-extension device, keep that
-    // identity stable — re-mint the PAT bound to the same worker_id (revoking
-    // the previous child PAT first) and reuse the existing device_workers row.
-    // This is what stops each Mac-bridge re-pair from minting a fresh uuid and
-    // orphaning the previous row (the source of the duplicate "chrome" entries
-    // on the Devices page). Falls through to a fresh mint for the first-ever
-    // pair, a stale/garbage id, or an id owned by another user/platform — i.e.
-    // any case where reuse would be unsafe or a no-op.
+    // Identity reuse: when the caller forwards its existing worker_id AND it
+    // already belongs to this user as a device of the SAME platform being
+    // requested, keep that identity stable — re-mint the PAT bound to the same
+    // worker_id (revoking the previous child PAT first) and reuse the existing
+    // device_workers row. This is what stops each re-register (Mac-bridge
+    // re-pair, headless daemon restart) from minting a fresh uuid and orphaning
+    // the previous row plus its still-live PAT (the source of the duplicate
+    // "chrome" entries on the Devices page). Matching on the requested platform
+    // rather than a fixed one keeps cross-platform reuse refused: a
+    // chrome-extension worker_id cannot be re-minted as headless or vice versa.
+    // Falls through to a fresh mint for the first-ever register, a
+    // stale/garbage id, or an id owned by another user/platform — i.e. any case
+    // where reuse would be unsafe or a no-op.
     let workerId: string;
     if (requestedWorkerId) {
       const existing = (await sql`
         SELECT worker_id FROM device_workers
         WHERE user_id = ${userId}
           AND worker_id = ${requestedWorkerId}
-          AND platform = 'chrome-extension'
+          AND platform = ${platform}
         LIMIT 1
       `) as unknown as Array<{ worker_id: string }>;
       workerId = existing[0]?.worker_id ?? crypto.randomUUID();

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -190,10 +190,12 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     platform?: string;
     label?: string;
     /**
-     * Optional: the sibling's existing worker_id. When the Mac bridge forwards
-     * the extension's already-stored id we reuse that device identity (re-mint
-     * the bound PAT, keep the same row) instead of minting a fresh one, so
-     * native re-pairs don't churn the device id and accumulate orphaned
+     * Optional: the caller's previously-stored worker_id — the Mac bridge
+     * forwarding the extension's id, or a headless daemon re-registering after
+     * a restart. Reused only when that id already belongs to this user on the
+     * SAME platform being requested, in which case we keep the device identity
+     * (re-mint the bound PAT, keep the same row) instead of minting a fresh
+     * one, so a re-register doesn't churn the device id and accumulate orphaned
      * `device_workers` rows. See the reuse branch below.
      */
     worker_id?: string;
@@ -212,9 +214,9 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     return c.json({ error: `platform '${platform}' is not eligible for child-token mint` }, 400);
   }
   const label = body.label?.toString().trim() || null;
-  // The sibling's previously-stored worker_id, if the Mac bridge forwarded it.
-  // Trimmed; validated against ownership + platform in the reuse branch below,
-  // so a stale/garbage value just falls through to a fresh mint.
+  // The caller's previously-stored worker_id, if it forwarded one. Trimmed;
+  // validated against ownership + the requested platform in the reuse branch
+  // below, so a stale/garbage value just falls through to a fresh mint.
   const requestedWorkerId = (body.worker_id ?? '').trim();
 
   try {


### PR DESCRIPTION
## Summary
- Follow-up to #2884. `mintDeviceChildToken` accepts `platform` in `{chrome-extension, headless}`, but the identity-reuse SELECT was hard-coded `AND platform = 'chrome-extension'`. A headless device re-registering with its stored `worker_id` never matched, so every restart minted a fresh `worker_id`, orphaned the previous `device_workers` row and left its durable child PAT live — exactly the churn the reuse branch exists to prevent. The same hole also let a chrome-extension `worker_id` forwarded with `platform: 'headless'` be reused cross-platform.
- Fix: match on the requested platform (`AND platform = ${platform}`); comment made platform-neutral.
- Comment-only: `connector-worker` automation arm's `runCli` said it "never leaks the daemon's worker token into the spawned agent" while `buildMcp` deliberately wires that bearer into the MCP config. Reworded (env-var deletion withholds the worker/poll-loop role; the MCP bearer is on purpose, same as the Mac `AutomationDispatcher`). No behavior change.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (typecheck, knip, biome, naming, gateway-llm, entity-write gates)
- [x] Tests run: `DATABASE_URL=postgres://…:5418/lobu_test vitest run src/__tests__/integration/device-management-mint.test.ts` (4 tests)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

**RED** (new tests against unmodified handler):
```
× reuses a headless worker_id on re-mint and revokes the previous child PAT
  → expected '9deef937-…' to be '26a8827c-…' // Object.is equality   (line 129: secondBody.worker_id === firstBody.worker_id)
× does not reuse a chrome-extension worker_id when re-minting as headless
  → expected '87fa5181-…' not to be '87fa5181-…'                      (line 180: cross-platform reuse happened)
Tests  2 failed | 2 passed (4)
```

**GREEN** (after the fix):
```
✓ src/__tests__/integration/device-management-mint.test.ts (4 tests) 255ms
Tests  4 passed (4)
```

## Notes
The negative test surfaced that the old code did reuse a chrome-extension identity when asked for `headless` (the SELECT only checked the stored platform, not the requested one). Both directions are now refused.
