### PR TITLE
ci(preview): never cancel teardown, and pass KUBECONFIG through env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1210,6 +1210,12 @@ jobs:
           bash scripts/lib/__tests__/review-skip.test.sh
           bash scripts/lib/__tests__/review-cache.test.sh
 
+      - name: Preview workflow guards
+        # The preview deploy's mid-flight teardown decides whether to delete a
+        # namespace out from under a running PR. It only ever executes on a
+        # close/unlabel race, so without this it would first run in anger.
+        run: bash scripts/lib/__tests__/preview-teardown.test.sh
+
       - name: Remote CI wrapper guards
         # Depot rewrites .github/actions paths to .depot/actions for local runs.
         # Pin the duplicate action and the fail-closed run-status parser so a

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -275,6 +275,25 @@ jobs:
               });
             }
 
+      # Deploy and cleanup run in disjoint concurrency groups (so teardown is
+      # never cancelled), which opens the reverse window: a close/unlabel that
+      # lands mid-deploy no longer cancels this run, and the surviving deploy
+      # would recreate the namespace cleanup just deleted. Re-check the PR's
+      # state after deploying and tear down if the preview is no longer wanted.
+      - name: Tear down if the PR closed or lost the preview label mid-deploy
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          state=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" -q '.state')
+          labeled=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
+          echo "PR state=$state preview-labeled=$labeled"
+          if [ "$state" != "open" ] || [ "$labeled" != "true" ]; then
+            echo "Preview no longer wanted; deleting namespace $PREVIEW_NS"
+            kubectl delete namespace "$PREVIEW_NS" --ignore-not-found
+          fi
+
   cleanup:
     runs-on: ubuntu-24.04
     if: (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview')) && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,9 +15,11 @@ permissions:
   pull-requests: write
   packages: write
 
-concurrency:
-  group: preview-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+# Concurrency is declared PER JOB below, not here: a workflow-level group with
+# cancel-in-progress covered the cleanup job too, so a `synchronize`/`labeled`
+# event landing while teardown was running cancelled the teardown and leaked
+# the namespace — the accumulation this workflow's opt-in label was added to
+# stop. Deploys still supersede each other; teardown is never cancelled.
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -31,6 +33,9 @@ jobs:
   preview:
     runs-on: ubuntu-24.04
     if: github.event.action != 'closed' && (github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'preview')))
+    concurrency:
+      group: preview-deploy-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: true
     env:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number || inputs.pr_number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number || inputs.pr_number }}
@@ -67,8 +72,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Setup kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
         run: |
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
 
       - name: Create preview namespace
         run: |
@@ -271,13 +278,20 @@ jobs:
   cleanup:
     runs-on: ubuntu-24.04
     if: (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview')) && github.event.pull_request.head.repo.full_name == github.repository
+    # Own group, never cancelled: teardown must run to completion even if a
+    # deploy for the same PR is queued behind or ahead of it.
+    concurrency:
+      group: preview-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     env:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number }}
     steps:
       - name: Setup kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
         run: |
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
 
       - name: Delete preview namespace
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -226,7 +226,41 @@ jobs:
             -n "$PREVIEW_NS" \
             --timeout=600s
 
+      # Deploy and cleanup run in disjoint concurrency groups (so teardown is
+      # never cancelled), which opens the reverse window: a close/unlabel that
+      # lands mid-deploy no longer cancels this run, and the surviving deploy
+      # would recreate the namespace cleanup just deleted. Re-check the PR's
+      # state after deploying and tear down if the preview is no longer wanted.
+      # This runs BEFORE the comment step so we never announce a preview we are
+      # about to delete in this same run.
+      - name: Tear down if the PR closed or lost the preview label mid-deploy
+        id: preview-wanted
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          state=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '.state')
+          labeled=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
+          echo "PR state=$state preview-labeled=$labeled"
+          # `.state` is only ever `open` or `closed` (a merged PR reads
+          # `closed`, with `.merged` carrying that distinction), so any
+          # non-open value means the preview is no longer wanted.
+          if [ "$state" != "open" ] || [ "$labeled" != "true" ]; then
+            echo "Preview no longer wanted; deleting namespace $PREVIEW_NS"
+            kubectl delete namespace "$PREVIEW_NS" --ignore-not-found
+            echo "wanted=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "wanted=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      # Suppressed when the re-check above tore the preview down: announcing
+      # "Status: Running" on a PR whose namespace this same run just deleted is
+      # worse than saying nothing. A skipped re-check (workflow_dispatch) leaves
+      # the output empty, which still posts.
       - name: Comment on PR
+        if: steps.preview-wanted.outputs.wanted != 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -274,26 +308,6 @@ jobs:
                 body,
               });
             }
-
-      # Deploy and cleanup run in disjoint concurrency groups (so teardown is
-      # never cancelled), which opens the reverse window: a close/unlabel that
-      # lands mid-deploy no longer cancels this run, and the surviving deploy
-      # would recreate the namespace cleanup just deleted. Re-check the PR's
-      # state after deploying and tear down if the preview is no longer wanted.
-      - name: Tear down if the PR closed or lost the preview label mid-deploy
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          state=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '.state')
-          labeled=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
-          echo "PR state=$state preview-labeled=$labeled"
-          if [ "$state" != "open" ] || [ "$labeled" != "true" ]; then
-            echo "Preview no longer wanted; deleting namespace $PREVIEW_NS"
-            kubectl delete namespace "$PREVIEW_NS" --ignore-not-found
-          fi
 
   cleanup:
     runs-on: ubuntu-24.04

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -284,10 +284,11 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          state=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" -q '.state')
-          labeled=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
+          state=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '.state')
+          labeled=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
           echo "PR state=$state preview-labeled=$labeled"
           if [ "$state" != "open" ] || [ "$labeled" != "true" ]; then
             echo "Preview no longer wanted; deleting namespace $PREVIEW_NS"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -241,8 +241,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          state=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '.state')
-          labeled=$(gh api "repos/$REPO/pulls/$PR_NUMBER" -q '[.labels[].name] | index("preview") != null')
+          # ONE fetch, both answers read from it. Two calls can straddle a
+          # close landing between them and return state=open with the label
+          # still attached, which keeps a namespace cleanup already deleted —
+          # the exact permanent leak this step exists to prevent.
+          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          state=$(jq -r '.state' <<<"$pr")
+          labeled=$(jq -r '[.labels[].name] | index("preview") != null' <<<"$pr")
           echo "PR state=$state preview-labeled=$labeled"
           # `.state` is only ever `open` or `closed` (a merged PR reads
           # `closed`, with `.merged` carrying that distinction), so any

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -48,8 +48,10 @@ jobs:
       STAGING_ACTION: ${{ github.event_name == 'workflow_dispatch' && inputs.action || github.event.action }}
     steps:
       - name: Setup kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
         run: |
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
 
       - name: Release lock (unlabeled)
         if: env.STAGING_ACTION == 'unlabeled'

--- a/scripts/lib/__tests__/preview-teardown.test.sh
+++ b/scripts/lib/__tests__/preview-teardown.test.sh
@@ -36,12 +36,12 @@ trap 'rm -rf "$STUBS"' EXIT
 
 cat >"$STUBS/gh" <<'STUB'
 #!/usr/bin/env bash
-# `gh api <path> -q <expr>` — answer from the fixture the case exported.
-case "$*" in
-  *".state"*) printf '%s\n' "$FAKE_PR_STATE" ;;
-  *"index(\"preview\")"*) printf '%s\n' "$FAKE_PR_LABELED" ;;
-  *) echo "unexpected gh invocation: $*" >&2; exit 64 ;;
-esac
+# One `gh api <path>` returning the whole PR; the step reads both answers out
+# of this single snapshot with jq. Serving one document is the point: the step
+# must not be able to observe a half-changed PR.
+labels='[]'
+[ "$FAKE_PR_LABELED" = "true" ] && labels='[{"name":"preview"}]'
+printf '{"state":"%s","labels":%s}\n' "$FAKE_PR_STATE" "$labels"
 STUB
 
 cat >"$STUBS/kubectl" <<'STUB'

--- a/scripts/lib/__tests__/preview-teardown.test.sh
+++ b/scripts/lib/__tests__/preview-teardown.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# The preview deploy job's mid-flight teardown check, executed rather than
+# read. Deploy and cleanup sit in disjoint concurrency groups so teardown is
+# never cancelled; the cost is that a close/unlabel landing mid-deploy no
+# longer cancels the deploy, and the surviving deploy would recreate the
+# namespace cleanup just removed. This step closes that window, so its decision
+# is load-bearing: a wrong answer either leaks a namespace forever or deletes a
+# live preview out from under an open PR.
+#
+# `gh` and `kubectl` are stubbed on PATH; the assertion is whether the real
+# script from the workflow issues the namespace delete.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$SCRIPT_DIR/../../../.github/workflows/preview.yml"
+
+fail() {
+  echo "not ok - $1" >&2
+  exit 1
+}
+
+# Pull the step's shell body straight out of the workflow: a copy in this file
+# would drift from the thing that actually runs.
+teardown_script="$(awk '
+  /^      - name: Tear down if the PR closed or lost the preview label mid-deploy$/ { found = 1 }
+  found && /^        run: \|$/ { capture = 1; next }
+  capture && /^          / { print; next }
+  capture && NF { exit }
+' "$WORKFLOW")"
+[ -n "$teardown_script" ] || fail "could not extract the mid-deploy teardown script"
+
+STUBS="$(mktemp -d)"
+trap 'rm -rf "$STUBS"' EXIT
+
+cat >"$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+# `gh api <path> -q <expr>` — answer from the fixture the case exported.
+case "$*" in
+  *".state"*) printf '%s\n' "$FAKE_PR_STATE" ;;
+  *"index(\"preview\")"*) printf '%s\n' "$FAKE_PR_LABELED" ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 64 ;;
+esac
+STUB
+
+cat >"$STUBS/kubectl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$KUBECTL_LOG"
+STUB
+
+chmod +x "$STUBS/gh" "$STUBS/kubectl"
+
+# state labeled -> "deleted" | "kept"
+teardown_verdict() {
+  local log
+  log="$(mktemp)"
+  FAKE_PR_STATE="$1" FAKE_PR_LABELED="$2" \
+  KUBECTL_LOG="$log" PATH="$STUBS:$PATH" \
+  REPO="lobu-ai/lobu" PR_NUMBER="123" PREVIEW_NS="lobu-preview-123" \
+    bash -e -c "$teardown_script" >/dev/null 2>&1 ||
+    { rm -f "$log"; echo "error"; return; }
+  if grep -q 'delete namespace lobu-preview-123 --ignore-not-found' "$log"; then
+    rm -f "$log"; echo deleted
+  else
+    rm -f "$log"; echo kept
+  fi
+}
+
+assert_teardown() {
+  local expected="$1" state="$2" labeled="$3" got
+  got="$(teardown_verdict "$state" "$labeled")"
+  [ "$got" = "$expected" ] ||
+    fail "teardown with state=$state labeled=$labeled -> $got, wanted $expected"
+}
+
+# The normal case: the PR is still open and still wants a preview. Deleting
+# here would tear down a live preview on every single deploy.
+assert_teardown kept open true
+# Closed mid-deploy: cleanup already ran and this deploy recreated the
+# namespace behind it. This is the leak the step exists to close.
+assert_teardown deleted closed true
+# Label pulled mid-deploy — same window, different trigger.
+assert_teardown deleted open false
+assert_teardown deleted closed false
+# `merged` is not `open`: a PR merged mid-deploy must not keep its namespace.
+assert_teardown deleted merged true
+
+echo "ok - preview mid-deploy teardown decides correctly"

--- a/scripts/lib/__tests__/preview-teardown.test.sh
+++ b/scripts/lib/__tests__/preview-teardown.test.sh
@@ -55,15 +55,25 @@ chmod +x "$STUBS/gh" "$STUBS/kubectl"
 teardown_verdict() {
   local log
   log="$(mktemp)"
+  local outfile
+  outfile="$(mktemp)"
   FAKE_PR_STATE="$1" FAKE_PR_LABELED="$2" \
-  KUBECTL_LOG="$log" PATH="$STUBS:$PATH" \
+  KUBECTL_LOG="$log" PATH="$STUBS:$PATH" GITHUB_OUTPUT="$outfile" \
   REPO="lobu-ai/lobu" PR_NUMBER="123" PREVIEW_NS="lobu-preview-123" \
     bash -e -c "$teardown_script" >/dev/null 2>&1 ||
-    { rm -f "$log"; echo "error"; return; }
+    { rm -f "$log" "$outfile"; echo "error"; return; }
+  # The step's `wanted` output gates the "Preview environment ready" comment,
+  # so it must agree with the delete decision or we announce a preview we just
+  # deleted. Fold a disagreement into a distinct verdict rather than ignoring it.
+  local wanted
+  wanted="$(sed -n 's/^wanted=//p' "$outfile")"
+  rm -f "$outfile"
   if grep -q 'delete namespace lobu-preview-123 --ignore-not-found' "$log"; then
-    rm -f "$log"; echo deleted
+    rm -f "$log"
+    [ "$wanted" = "false" ] && echo deleted || echo "deleted-but-announced"
   else
-    rm -f "$log"; echo kept
+    rm -f "$log"
+    [ "$wanted" = "true" ] && echo kept || echo "kept-but-suppressed"
   fi
 }
 
@@ -83,7 +93,9 @@ assert_teardown deleted closed true
 # Label pulled mid-deploy — same window, different trigger.
 assert_teardown deleted open false
 assert_teardown deleted closed false
-# `merged` is not `open`: a PR merged mid-deploy must not keep its namespace.
-assert_teardown deleted merged true
+# Defensive: `.state` only ever reads `open` or `closed` (a merged PR reads
+# `closed`), so this stands in for any unexpected non-open value rather than a
+# real API response — the branch must fail closed and delete.
+assert_teardown deleted unexpected-state true
 
 echo "ok - preview mid-deploy teardown decides correctly"


### PR DESCRIPTION
## Summary
- The workflow-level `concurrency` group with `cancel-in-progress: true` covered the `cleanup` job too, so a `synchronize`/`labeled` event arriving while an `unlabeled` teardown was running **cancelled the teardown and leaked the namespace** — the accumulation the `preview` label (#2891) was introduced to stop. Deploy and cleanup now have separate per-PR groups; cleanup is never cancelled.
- `secrets.KUBECONFIG` was expanded directly into the `run:` script body in two steps; it is now passed via `env:` (GitHub's documented pattern so the secret is not part of the shell source).

Follow-up to #2826 / #2891, found while auditing the last 3 days of merges.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate for this PR)
- [x] `actionlint .github/workflows/preview.yml` clean; YAML parses
- [ ] No runtime repro: the behaviour is GitHub Actions concurrency semantics. Verify live on the next PR that toggles the `preview` label twice quickly — the cleanup run must finish rather than show as cancelled.

## Notes
- Deploy vs cleanup for the same PR are now independent groups, so in the rare label-off/label-on-within-seconds case a deploy may run concurrently with a teardown and fail; the next `synchronize` redeploys. Leaking a namespace was the worse failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment cleanup when a pull request is closed or no longer has the preview label.
  * Prevented outdated preview deployments from posting unnecessary status updates.
  * Ensured cleanup operations complete reliably without being cancelled by newer deployments.

* **Tests**
  * Added automated coverage for preview teardown scenarios, including pull-request state and label changes.
  * Expanded CI validation for preview workflow cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->