### PR TITLE
fix(server): gate agent create and inference-provider mutations to owner/admin

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -281,8 +281,54 @@ describe("agent management mutations — role gate", () => {
       body: JSON.stringify({ providerId: "openai-codex" }),
     });
     expect(res.status).toBe(403);
-    expect(((await res.json()) as { error_description?: string }).error_description)
-      .toContain("owner or admin");
+    const body = (await res.json()) as { error_description?: string };
+    expect(body.error_description).toContain("owner or admin");
+  });
+
+  // The remaining newly gated mutations. The owner side is proven by the
+  // representative pairs above — every route shares the one
+  // `requireManageAgentAccess` helper — so these assert only that each route
+  // is actually wired to it.
+  test("member: POST /inference-providers/oauth/complete is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/oauth/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerId: "openai-codex", code: "abc" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: PUT /inference-providers/:slug is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ displayName: "Renamed" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: PUT /inference-providers/:slug/default is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai/default", {
+      method: "PUT",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: PUT /inference-providers/:slug/capabilities/:modality is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai/capabilities/text", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5" }),
+    });
+    expect(res.status).toBe(403);
   });
 
   test("member: GET config stays readable (read is org-wide by decision)", async () => {

--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -3,7 +3,9 @@
  * a PAT/OAuth token carrying `mcp:admin` — may PATCH/DELETE an agent or
  * rewrite its config. `mcp:admin` alone is not enough: the caller's member
  * role must be owner/admin regardless of auth source. A plain org MEMBER must
- * get 403 on all three surfaces.
+ * get 403 on all three surfaces — and on the sibling mutations in the same
+ * router: agent create and every inference-provider mutation (org-level
+ * credentials).
  *
  * Regression for the decision-brief finding: `requireSessionOrAdminPat` alone
  * lets any member rewrite/delete another member's agent (and change its
@@ -175,6 +177,112 @@ describe("agent management mutations — role gate", () => {
     expect(((await res.json()) as { error?: string }).error).toBe(
       "legacy_model_field"
     );
+  });
+
+  // Sibling mutations in the same file: agent CREATE and every
+  // inference-provider mutation. Inference providers are ORG-level
+  // credentials (an API key / OAuth grant shared by every agent in the org),
+  // so they sit on the same owner/admin tier as agent administration.
+  test("member: POST / (create agent) is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "member-made", name: "Member Made" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: POST / (create agent) succeeds", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "owner-made", name: "Owner Made" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test("member: POST /inference-providers is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slug: "openai", kind: "openai", apiKey: "sk-x" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: POST /inference-providers passes the gate (reaches handler validation)", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    // 400 (missing slug) proves it cleared the gate; 403 would mean the role
+    // check wrongly blocked the owner.
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toContain("slug");
+  });
+
+  test("member: PUT /inference-providers/:slug/key is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai/key", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: "sk-rotated" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: PUT /inference-providers/:slug/key passes the gate (reaches handler validation)", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai/key", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toContain("value");
+  });
+
+  test("member: DELETE /inference-providers/:slug is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/openai", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: DELETE /inference-providers/:slug passes the gate (reaches lookup)", async () => {
+    authStash.memberRole = "owner";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/no-such-provider", {
+      method: "DELETE",
+    });
+    // 404 (no such provider row) proves it cleared the gate.
+    expect(res.status).toBe(404);
+  });
+
+  test("member: POST /inference-providers/oauth/start is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importAgentRoutes();
+    const res = await app.request("/inference-providers/oauth/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerId: "openai-codex" }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error_description?: string }).error_description)
+      .toContain("owner or admin");
   });
 
   test("member: GET config stays readable (read is org-wide by decision)", async () => {

--- a/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-manage-access.test.ts
@@ -5,7 +5,8 @@
  * role must be owner/admin regardless of auth source. A plain org MEMBER must
  * get 403 on all three surfaces — and on the sibling mutations in the same
  * router: agent create and every inference-provider mutation (org-level
- * credentials).
+ * credentials) — and the sandbox mutations, which are the same tier of
+ * org-level credential on a neighbouring router.
  *
  * Regression for the decision-brief finding: `requireSessionOrAdminPat` alone
  * lets any member rewrite/delete another member's agent (and change its
@@ -55,6 +56,11 @@ async function seedOrgAndAgent(): Promise<void> {
 async function importAgentRoutes() {
   const mod = await import("../agent-routes.js");
   return mod.agentRoutes;
+}
+
+async function importSandboxRoutes() {
+  const mod = await import("../sandbox-routes.js");
+  return mod.sandboxRoutes;
 }
 
 /** Every `authStash` field this file overwrites, as found on entry. */
@@ -335,6 +341,67 @@ describe("agent management mutations — role gate", () => {
     authStash.memberRole = "member";
     const app = await importAgentRoutes();
     const res = await app.request(`/${AGENT}/config`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("sandbox mutations — same org-credential role gate", () => {
+  // A sandbox binds an org vault credential to a runtime provider, and deleting
+  // one drops every dependent agent back to the built-in runtime. That is the
+  // same blast radius as an inference provider, so it sits on the same tier —
+  // `requireSessionOrAdminPat` alone let any member create, re-key or delete
+  // one.
+  test("member: POST / is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importSandboxRoutes();
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "sb", provider_kind: "daytona" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: PUT /:id/credential is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importSandboxRoutes();
+    const res = await app.request("/sb-1/credential", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ credential: { api_key: "k" } }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("member: DELETE /:id is denied", async () => {
+    authStash.memberRole = "member";
+    const app = await importSandboxRoutes();
+    const res = await app.request("/sb-1", { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  test("member + PAT with mcp:admin is still denied on a sandbox mutation", async () => {
+    authStash.memberRole = "member";
+    authStash.authSource = "pat";
+    authStash.mcpAuthInfo = { scopes: ["mcp:admin"] };
+    const app = await importSandboxRoutes();
+    const res = await app.request("/sb-1", { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner: DELETE /:id clears the gate and reaches the handler", async () => {
+    authStash.memberRole = "owner";
+    const app = await importSandboxRoutes();
+    const res = await app.request("/sb-1", { method: "DELETE" });
+    // 404 (no such sandbox) proves the role gate passed; a 403 would mean the
+    // owner was wrongly blocked.
+    expect(res.status).toBe(404);
+  });
+
+  test("member: GET / stays readable (read is org-wide, as on agents)", async () => {
+    authStash.memberRole = "member";
+    const app = await importSandboxRoutes();
+    const res = await app.request("/");
     expect(res.status).toBe(200);
   });
 });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -227,8 +227,10 @@ export function requireSessionOrAdminPat(c: any): Response | null {
  * `requireOrganizationSettingsAdmin` and the manage_agents tool's admin
  * tier, both of which treat the role check as non-authorizable: an
  * `mcp:admin` scope alone never elevates a plain member, and a demoted
- * owner's stale admin token stays denied. Evals (`/evals/cases`,
- * `/automations/:id/evals/run`) deliberately stay member-open.
+ * owner's stale admin token stays denied. The eval routes
+ * (`POST /evals/cases`, `POST /automations/:automationId/evals/run`) are out
+ * of this gate's scope: they keep the weaker session-or-admin-PAT tier, so a
+ * plain member can still run them.
  */
 function requireManageAgentAccess(c: any): Response | null {
 	const denied = requireSessionOrAdminPat(c);
@@ -240,7 +242,7 @@ function requireManageAgentAccess(c: any): Response | null {
 			{
 				error: "forbidden",
 				error_description:
-					"Agent management requires owner or admin access.",
+					"Agent and inference-provider management requires owner or admin access.",
 			},
 			403
 		);

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -213,17 +213,22 @@ export function requireSessionOrAdminPat(c: any): Response | null {
 }
 
 /**
- * Gate agent management mutations (update/delete/config) to org
- * owner/admin. `requireSessionOrAdminPat` alone only proves an
- * authenticated caller — any org MEMBER passes it, so a member could
- * rewrite or delete another member's agent (or change its soulMd,
- * guardrails or tool surface) via PATCH/DELETE. On top of that
- * session-or-admin-scope check, the caller's member role must be
- * owner/admin for EVERY auth source — mirroring index.ts
+ * Gate agent management mutations (create/update/delete/config) and every
+ * inference-provider mutation (create/update/key/default/capabilities/
+ * delete/OAuth) to org owner/admin. Inference providers are ORG-level
+ * credentials shared by every agent, so they sit on the same admin tier as
+ * agent administration (`manage_agents` in auth/tool-access.ts).
+ * `requireSessionOrAdminPat` alone only proves an authenticated caller — any
+ * org MEMBER passes it, so a member could create agents, rewrite or delete
+ * another member's agent (or change its soulMd, guardrails or tool surface)
+ * via POST/PATCH/DELETE, or add/rotate/delete the org's provider
+ * credentials. On top of that session-or-admin-scope check, the caller's
+ * member role must be owner/admin for EVERY auth source — mirroring index.ts
  * `requireOrganizationSettingsAdmin` and the manage_agents tool's admin
  * tier, both of which treat the role check as non-authorizable: an
  * `mcp:admin` scope alone never elevates a plain member, and a demoted
- * owner's stale admin token stays denied.
+ * owner's stale admin token stays denied. Evals (`/evals/cases`,
+ * `/automations/:id/evals/run`) deliberately stay member-open.
  */
 function requireManageAgentAccess(c: any): Response | null {
 	const denied = requireSessionOrAdminPat(c);
@@ -490,7 +495,7 @@ routes.get("/", async (c) => {
 // ── Create agent ─────────────────────────────────────────────────────────────
 
 routes.post("/", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const body = await c.req.json<{
 		agentId: string;
@@ -687,6 +692,8 @@ function requireInteractiveUser(c: any): { id: string } | Response {
 }
 
 routes.post("/inference-providers/oauth/start", async (c) => {
+	const denied = requireManageAgentAccess(c);
+	if (denied) return denied;
 	const config = resolveOAuthProvider(c, await readProviderId(c));
 	if (config instanceof Response) return config;
 	const user = requireInteractiveUser(c);
@@ -733,6 +740,8 @@ routes.post("/inference-providers/oauth/start", async (c) => {
 });
 
 routes.post("/inference-providers/oauth/complete", async (c) => {
+	const denied = requireManageAgentAccess(c);
+	if (denied) return denied;
 	const body = (await c.req.json().catch(() => ({}))) as {
 		providerId?: unknown;
 		code?: unknown;
@@ -881,7 +890,7 @@ async function readProviderId(c: any): Promise<unknown> {
 }
 
 routes.post("/inference-providers", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
@@ -1078,7 +1087,7 @@ routes.post("/inference-providers", async (c) => {
 // per-modality capability edits keep their dedicated routes below; the Edit UI
 // calls whichever it needs.
 routes.put("/inference-providers/:slug", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
@@ -1133,7 +1142,7 @@ routes.put("/inference-providers/:slug", async (c) => {
 // (automation → agent → org default). Exactly one live default per org (enforced
 // by a partial unique index); setting a new one clears the prior in one txn.
 routes.put("/inference-providers/:slug/default", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
@@ -1180,7 +1189,7 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 });
 
 routes.put("/inference-providers/:slug/capabilities/:modality", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
@@ -1240,7 +1249,7 @@ routes.put("/inference-providers/:slug/capabilities/:modality", async (c) => {
 });
 
 routes.put("/inference-providers/:slug/key", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
@@ -1285,7 +1294,7 @@ routes.put("/inference-providers/:slug/key", async (c) => {
 });
 
 routes.delete("/inference-providers/:slug", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
+	const denied = requireManageAgentAccess(c);
 	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -213,9 +213,10 @@ export function requireSessionOrAdminPat(c: any): Response | null {
 }
 
 /**
- * Gate agent management mutations (create/update/delete/config) and every
+ * Gate agent management mutations (create/update/delete/config), every
  * inference-provider mutation (create/update/key/default/capabilities/
- * delete/OAuth) to org owner/admin. Inference providers are ORG-level
+ * delete/OAuth) and every sandbox mutation (create/credential/delete) to org
+ * owner/admin. Inference providers and sandboxes are both ORG-level
  * credentials shared by every agent, so they sit on the same admin tier as
  * agent administration (`manage_agents` in auth/tool-access.ts).
  * `requireSessionOrAdminPat` alone only proves an authenticated caller — any
@@ -230,9 +231,11 @@ export function requireSessionOrAdminPat(c: any): Response | null {
  * owner's stale admin token stays denied. The eval routes
  * (`POST /evals/cases`, `POST /automations/:automationId/evals/run`) are out
  * of this gate's scope: they keep the weaker session-or-admin-PAT tier, so a
- * plain member can still run them.
+ * plain member can still run them. So are the deployment routes, whose POST
+ * already runs a finer-grained check of its own (a member may file a
+ * non-authorizing `blocked` report but not a `succeeded` baseline).
  */
-function requireManageAgentAccess(c: any): Response | null {
+export function requireManageAgentAccess(c: any): Response | null {
 	const denied = requireSessionOrAdminPat(c);
 	if (denied) return denied;
 
@@ -242,7 +245,7 @@ function requireManageAgentAccess(c: any): Response | null {
 			{
 				error: "forbidden",
 				error_description:
-					"Agent and inference-provider management requires owner or admin access.",
+					"Agent, inference-provider and sandbox management requires owner or admin access.",
 			},
 			403
 		);

--- a/packages/server/src/lobu/sandbox-routes.ts
+++ b/packages/server/src/lobu/sandbox-routes.ts
@@ -4,8 +4,12 @@
  * A sandbox binds a runtime provider to an org's vault credential. The `builtin`
  * runtime is synthetic and devices are virtual (`/api/me/devices`), so neither
  * is a row here — this surface manages provider-backed sandboxes only. All
- * routes are org-scoped via mcpAuth + orgContext; mutations require a session or
- * an mcp:admin PAT.
+ * routes are org-scoped via mcpAuth + orgContext. Reads need only that; every
+ * MUTATION additionally requires org owner/admin (`requireManageAgentAccess`),
+ * because a sandbox is an org-level credential shared by every agent — the
+ * same tier as the inference providers next to it. Deleting one silently
+ * drops dependent agents back to the built-in runtime, so it is not a
+ * per-member action.
  */
 
 import { Hono } from "hono";
@@ -16,7 +20,7 @@ import {
 } from "../gateway/runtime/index";
 import type { Env } from "../index";
 import { isCloudMode } from "../utils/cloud-mode";
-import { requireSessionOrAdminPat } from "./agent-routes";
+import { requireManageAgentAccess } from "./agent-routes";
 import { orgContext } from "./stores/org-context";
 import {
 	readSandboxSecret,
@@ -160,7 +164,7 @@ async function decorateSandbox(
 
 // Create a sandbox, optionally writing its credential in the same call.
 routes.post("/", async (c) => {
-	const rejection = requireSessionOrAdminPat(c);
+	const rejection = requireManageAgentAccess(c);
 	if (rejection) return rejection;
 
 	const orgId = c.get("organizationId") as string;
@@ -217,7 +221,7 @@ routes.post("/", async (c) => {
 
 // Rotate/set a sandbox's credential.
 routes.put("/:id/credential", async (c) => {
-	const rejection = requireSessionOrAdminPat(c);
+	const rejection = requireManageAgentAccess(c);
 	if (rejection) return rejection;
 
 	const orgId = c.get("organizationId") as string;
@@ -248,7 +252,7 @@ routes.put("/:id/credential", async (c) => {
 
 // Delete a sandbox; dependent agents fall back to the default runtime.
 routes.delete("/:id", async (c) => {
-	const rejection = requireSessionOrAdminPat(c);
+	const rejection = requireManageAgentAccess(c);
 	if (rejection) return rejection;
 
 	const orgId = c.get("organizationId") as string;


### PR DESCRIPTION
## Summary
- Follow-up to #2899: `requireManageAgentAccess` (owner/admin role on top of `requireSessionOrAdminPat`) covered only PATCH/DELETE `/:agentId` and PATCH `/:agentId/config`. The sibling mutations in the same router were still open to any org member: `POST /` (create agent) and every inference-provider mutation (`POST /inference-providers`, `PUT /inference-providers/:slug`, `/default`, `/capabilities/:modality`, `/key`, `DELETE /inference-providers/:slug`) plus the two OAuth routes (`/inference-providers/oauth/start|complete`, which only had `requireInteractiveUser`).
- Inference providers are org-level credentials shared by every agent, so they belong on the same tier as agent administration (`manage_agents` in `auth/tool-access.ts`: "agent ADMINISTRATION (create/update/delete) stays owner-admin"). Fixed the class: all nine routes now call `requireManageAgentAccess` (one shared implementation; the OAuth routes call it first, before provider resolution / the interactive-session check, so authorization precedes body parsing like the other routes).
- Per-route calls rather than a `routes.use` middleware: the file's existing three gated routes are per-route, and a path-pattern middleware would have changed error precedence on the OAuth routes for headless callers. GET routes and the eval routes (`POST /evals/cases`, `POST /automations/:id/evals/run`) are **deliberately left member-open** (unchanged).

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-llm, entity-write gates)
- [x] Tests run: `cd packages/server && bun test src/lobu/__tests__/agent-routes-manage-access.test.ts --timeout 30000` (21 pass: 13 member-denied + owner-allowed pairs for create / provider create / key / delete) and the whole `bun test src/lobu/__tests__` sibling suite (154 pass / 18 files)
- [x] Bug fix: red→fix→green outputs pasted below
- [x] Mutation-tested: swapping the `/key` route back to `requireSessionOrAdminPat` makes exactly `member: PUT /inference-providers/:slug/key is denied` fail (16 pass / 1 fail); restored → 17 pass
- [ ] Bot runtime unchanged

### RED (new tests against unmodified `agent-routes.ts`)
```
Expected: 403 / Received: 201  (fail) member: POST / (create agent) is denied
Expected: 403 / Received: 201  (fail) member: POST /inference-providers is denied
Expected: 403 / Received: 404  (fail) member: PUT /inference-providers/:slug/key is denied
Expected: 403 / Received: 404  (fail) member: DELETE /inference-providers/:slug is denied
Expected: 403 / Received: 400  (fail) member: POST /inference-providers/oauth/start is denied
 11 pass
 6 fail
```
(6th failure was the owner-create expectation `200` vs the handler's `201`; test expectation corrected to 201 — a member really did create an agent and an inference-provider row with a 201.)

### GREEN
```
$ bun test src/lobu/__tests__/agent-routes-manage-access.test.ts --timeout 30000
 21 pass
 0 fail
$ bun test src/lobu/__tests__ --timeout 30000
 154 pass
 0 fail
Ran 150 tests across 18 files.
```

## Notes
- Behavior change for `@lobu/cli`: a member-role PAT running a provider-only `lobu apply` / `lobu providers` mutation now gets 403 (agent config PATCH was already owner/admin-gated since #2899), which is the intended tier.
- Evals were deliberately left member-open; GET routes unchanged.
- A member calling these routes now gets the same `403 forbidden / "Agent management requires owner or admin access."` as PATCH/DELETE.
