### PR TITLE
fix(notifications): make the approval chat-origin tier work for preview orgs

### DIFF
--- a/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tier 1 of approval delivery: the conversation that asked.
+ *
+ * The sharp case is the hosted-preview binding — a channel this org reaches
+ * through a connection that lives in a DIFFERENT org. Any reachability check
+ * scoped to the notifying org's own `connections` finds no row and reports the
+ * channel unreachable, so every preview-served org silently loses tier 1 and
+ * answers a channel question in the asker's DM instead. Found in prod: the org
+ * whose only binding is preview-served resolved to no chat origin at all.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { resolveApprovalChatOrigin } from "../../../tools/admin/approval-delivery";
+import type { ToolContext } from "../../../tools/registry";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import { createTestAutomationSubscription } from "../../setup/automation-subscriptions";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+	insertChatConnectionRow,
+} from "../../setup/test-fixtures";
+
+const TEAM = "T_ORIGIN";
+
+function ctxFor(opts: {
+	organizationId: string;
+	agentId: string | null;
+	connectionId?: string;
+	channelId?: string;
+}): ToolContext {
+	return {
+		organizationId: opts.organizationId,
+		userId: "user-asker",
+		agentId: opts.agentId,
+		memberRole: null,
+		isAuthenticated: true,
+		tokenType: "oauth",
+		scopedToOrg: true,
+		sourceContext:
+			opts.connectionId && opts.channelId
+				? {
+						platform: "slack",
+						connectionId: opts.connectionId,
+						channelId: opts.channelId,
+						conversationId: opts.channelId,
+						teamId: TEAM,
+						userId: "U_ASKER",
+					}
+				: null,
+	} as unknown as ToolContext;
+}
+
+async function seedBinding(opts: {
+	organizationId: string;
+	agentId: string;
+	connectionId: string;
+	channelId: string;
+}): Promise<void> {
+	const configuredBy = await createTestUser();
+	await addUserToOrganization(configuredBy.id, opts.organizationId, "owner");
+	await createTestAutomationSubscription({
+		organizationId: opts.organizationId,
+		agentId: opts.agentId,
+		connectionSlug: `agentconn-${opts.connectionId}`,
+		platform: "slack",
+		channelId: opts.channelId,
+		teamId: TEAM,
+		configuredBy: configuredBy.id,
+	});
+}
+
+describe("resolveApprovalChatOrigin", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("resolves the originating channel for an own-connection binding", async () => {
+		const org = await createTestOrganization();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "crm",
+		});
+		await insertChatConnectionRow({
+			id: "conn-own",
+			organizationId: org.id,
+			agentId: agent.agentId,
+			platform: "slack",
+			status: "active",
+			settings: {},
+			metadata: {},
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "conn-own",
+			channelId: "slack:C0ASKED",
+		});
+
+		const target = await resolveApprovalChatOrigin(
+			ctxFor({
+				organizationId: org.id,
+				agentId: agent.agentId,
+				connectionId: "conn-own",
+				channelId: "slack:C0ASKED",
+			}),
+		);
+
+		expect(target).toEqual({
+			connectionId: "conn-own",
+			channelId: "slack:C0ASKED",
+			teamId: TEAM,
+		});
+	});
+
+	// The regression this file exists for.
+	it("resolves the originating channel for a hosted-preview cross-org binding", async () => {
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
+		const tenantAgent = await createTestAgent({
+			organizationId: tenantOrg.id,
+			agentId: "product-ops",
+		});
+		// The connection lives in the HOST org; the binding belongs to the tenant.
+		await insertChatConnectionRow({
+			id: "preview-conn",
+			organizationId: hostOrg.id,
+			agentId: "concierge",
+			platform: "slack",
+			status: "active",
+			settings: { previewMode: true },
+			metadata: {},
+		});
+		await seedBinding({
+			organizationId: tenantOrg.id,
+			agentId: tenantAgent.agentId,
+			connectionId: "preview-conn",
+			channelId: "slack:C0PREVIEW",
+		});
+
+		const target = await resolveApprovalChatOrigin(
+			ctxFor({
+				organizationId: tenantOrg.id,
+				agentId: tenantAgent.agentId,
+				connectionId: "preview-conn",
+				channelId: "slack:C0PREVIEW",
+			}),
+		);
+
+		expect(target).toEqual({
+			connectionId: "preview-conn",
+			channelId: "slack:C0PREVIEW",
+			teamId: TEAM,
+		});
+	});
+
+	it("returns no target for a channel the agent is not bound to", async () => {
+		const org = await createTestOrganization();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "crm",
+		});
+		await insertChatConnectionRow({
+			id: "conn-own",
+			organizationId: org.id,
+			agentId: agent.agentId,
+			platform: "slack",
+			status: "active",
+			settings: {},
+			metadata: {},
+		});
+		await seedBinding({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			connectionId: "conn-own",
+			channelId: "slack:C0ASKED",
+		});
+
+		const target = await resolveApprovalChatOrigin(
+			ctxFor({
+				organizationId: org.id,
+				agentId: agent.agentId,
+				connectionId: "conn-own",
+				channelId: "slack:C0SOMEWHERE_ELSE",
+			}),
+		);
+
+		expect(target).toEqual({
+			connectionId: null,
+			channelId: null,
+			teamId: null,
+		});
+	});
+
+	it("returns no target for an agentless turn", async () => {
+		const org = await createTestOrganization();
+
+		const target = await resolveApprovalChatOrigin(
+			ctxFor({
+				organizationId: org.id,
+				agentId: null,
+				connectionId: "conn-own",
+				channelId: "slack:C0ASKED",
+			}),
+		);
+
+		expect(target.channelId).toBeNull();
+	});
+
+	it("returns no target when the turn carries no chat source", async () => {
+		const org = await createTestOrganization();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "crm",
+		});
+
+		const target = await resolveApprovalChatOrigin(
+			ctxFor({ organizationId: org.id, agentId: agent.agentId }),
+		);
+
+		expect(target.channelId).toBeNull();
+	});
+});

--- a/packages/server/src/tools/admin/approval-delivery.ts
+++ b/packages/server/src/tools/admin/approval-delivery.ts
@@ -6,9 +6,9 @@
  * module resolves the one legitimate chat destination, in precedence order:
  *
  *   1. The conversation that ASKED — the turn's `sourceContext`, when the caller
- *      came in through a chat trigger and the acting agent is authorized to post
- *      there. Same trust check the scheduled-delivery path uses, so a turn can
- *      never name a channel its agent may not reach.
+ *      came in through a chat trigger and the acting agent is bound to that
+ *      channel. Resolved through `resolveBoundChannelRows`, so a turn can never
+ *      name a channel its agent may not reach.
  *   2. The requesting human's DM — handled downstream by the notification
  *      service's `ownerUserId` tier; the trigger passes the user id.
  *   3. Nothing. The durable inbox already targets the org's admins and the run
@@ -18,10 +18,14 @@
  * is why tier 2 exists: those approvals used to fall through to the org-wide
  * broadcast.
  */
+import { getDb } from "../../db/client";
+import {
+	resolveBoundChannelRows,
+	stripPlatformPrefix,
+} from "../../gateway/channels/bound-channels";
 import {
 	isDeliverableChatPlatform,
 	type ScheduledDeliveryContext,
-	validateDeliveryAuthorization,
 } from "../../scheduled/scheduled-jobs-service";
 import type { ToolContext, ToolSourceContext } from "../registry";
 import logger from "../../utils/logger";
@@ -68,35 +72,54 @@ export function sourceToDeliveryContext(
 
 /**
  * Tier 1 of the precedence above: the originating conversation, if the acting
- * agent is authorized to deliver there. Returns all-nulls otherwise — the
- * caller pairs this with `requesterUserId` so tier 2 takes over.
+ * agent can actually reach it. Returns all-nulls otherwise — the caller pairs
+ * this with `requesterUserId` so tier 2 takes over.
  *
- * Authorization is NOT optional: `sourceContext` is stamped from a verified
- * worker token, but the binding it names can be revoked between the trigger and
- * the approval, so the live connection + binding rows are re-checked here
- * exactly as the scheduled fire-time path does.
+ * Re-checking is NOT optional: `sourceContext` is stamped from a verified worker
+ * token, but the binding it names can be revoked between the trigger and the
+ * approval, so the live binding rows decide.
+ *
+ * The check runs through `resolveBoundChannelRows` — THE single source of truth
+ * for "which channels can this org/agent reach", and the same resolver the
+ * delivery plan itself uses. That matters for a case a connection-scoped check
+ * gets wrong: a hosted-preview binding is served by a connection living in a
+ * DIFFERENT org, so any lookup scoped to the notifying org's `connections` finds
+ * no row and reports the channel unreachable. Every preview-served org would
+ * silently lose tier 1 and answer a channel question in a DM instead.
+ * `resolveBoundChannelRows` covers the own-connection AND preview branches, and
+ * is still scoped to `agentId` so an agent cannot address another agent's
+ * channel.
  */
 export async function resolveApprovalChatOrigin(
 	ctx: ToolContext,
 ): Promise<ApprovalDeliveryTarget> {
 	const delivery = sourceToDeliveryContext(ctx.sourceContext);
 	if (!delivery) return NO_APPROVAL_DELIVERY_TARGET;
-	// No acting agent means no binding to validate against — an agentless turn
+	// No acting agent means no binding to check against — an agentless turn
 	// (a human in the web app) has no channel it "belongs" to.
 	if (!ctx.agentId) return NO_APPROVAL_DELIVERY_TARGET;
 
-	const result = await validateDeliveryAuthorization({
+	const rows = await resolveBoundChannelRows(getDb(), {
 		organizationId: ctx.organizationId,
 		agentId: ctx.agentId,
-		delivery,
+		connectionId: delivery.connectionId,
 	}).catch((err) => {
 		logger.warn(
 			{ err, organizationId: ctx.organizationId, agentId: ctx.agentId },
-			"[Approvals] Chat-origin authorization check failed — falling back to requester DM",
+			"[Approvals] Chat-origin binding check failed — falling back to requester DM",
 		);
-		return { authorized: false as const, reason: "connection-missing" as const };
+		return [];
 	});
-	if (!result.authorized) return NO_APPROVAL_DELIVERY_TARGET;
+
+	// Bindings store either the bare id or the platform-prefixed one, so compare
+	// on the native id — a legacy row must not read as "unreachable".
+	const wanted = stripPlatformPrefix(delivery.platform, delivery.channelId);
+	const reachable = rows.some(
+		(row) =>
+			row.platform === delivery.platform &&
+			stripPlatformPrefix(row.platform, row.channel_id) === wanted,
+	);
+	if (!reachable) return NO_APPROVAL_DELIVERY_TARGET;
 
 	return {
 		connectionId: delivery.connectionId,


### PR DESCRIPTION
## Summary
Follow-up to #2906, found while trying to verify its chat-origin tier end-to-end in prod.

#2906 resolved the originating conversation through `validateDeliveryAuthorization`, which scopes the connection lookup to the **notifying** org:

```sql
SELECT ... FROM connections WHERE organization_id = ${organizationId} AND slug = ...
```

A hosted-preview binding is served by a connection living in a **different** org (`bound-channels.ts` branch B exists precisely for this), so that lookup finds no row and reports the channel unreachable. Every preview-served org silently lost tier 1 and answered a channel question in the asker's DM.

## Evidence

Prod binding topology — the `same_org` column is the whole story:

```
organization_id   | connection_organization_id | same_org | channel
UdNAH1bb3csC84…   | org_lobucrm                |    f     | slack:C0BPWNXR0MP
8dc12bdd-5d8c…    | org_lobucrm                |    f     | slack:D0BEQTB3WFN
8dc12bdd-5d8c…    | 8dc12bdd-5d8c…             |    t     | slack:C0BRALUTFLY
org_z5HBxkx3UT8   | org_lobucrm                |    f     | slack:D095U1QV667
```

`UdNAH…` and `org_z5HBxkx3UT8` are preview-served only — tier 1 was unreachable for them by construction.

## Fix

Resolve through `resolveBoundChannelRows`, THE single source of truth for "which channels can this org/agent reach" and the same resolver the delivery plan itself uses. It covers the own-connection **and** preview branches, and still takes `agentId`, so an agent cannot address another agent's channel. `validateDeliveryAuthorization` keeps its scheduled-delivery callers unchanged.

## Behaviour tightening — please read

The mutation run surfaced a second bug in the old path. `validateDeliveryAuthorization` short-circuits:

```ts
if (connection.agent_id) {
  return connection.agent_id === agentId ? { authorized: true } : { … };
}
```

It returns authorized whenever the BYO connection's `agent_id` matches the acting agent, **without checking that a binding exists for that channel**. So a turn originating in an unbound channel was routed to a channel the targeted delivery plan then filtered out — landing in the inbox alone, with the DM tier suppressed because `connectionId` was set.

It now falls through to the requester DM. Not a leak either way (targeted scope filtered it downstream), but the old behaviour was silently worse. Bound DMs are unaffected — prod holds `slack:D095U1QV667` and `slack:D0BEQTB3WFN` as real binding rows.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Tests run: `bunx vitest run src/__tests__/integration/notifications/` → 6 files, 61 passed. `bun test src/tools/admin/__tests__/manage-schedules-delivery.test.ts` → 7 passed (the shared helper's other caller). `bun test src/__tests__/unit/approval-dm-target.test.ts` → 6 passed.
- [x] Bug fix: red→fix→green below

### red → green

New file against the **shipped** `origin/main` implementation:

```
✓ resolves the originating channel for an own-connection binding
× resolves the originating channel for a hosted-preview cross-org binding
× returns no target for a channel the agent is not bound to
✓ returns no target for an agentless turn
✓ returns no target when the turn carries no chat source
  Tests  2 failed | 3 passed (5)
```

Both failures are the two defects above. With the fix: `5 passed (5)`, and the whole notifications suite `61 passed`.

## Notes
Why this wasn't caught live: I could not drive tier 1 end-to-end from here. In the org my MCP is bound to, tier 1 is unreachable by construction (preview-only binding — this bug); in the org where it works, the MCP isn't bound and the Slack app isn't installed on those workspaces. The integration test is the durable substitute and outlives a one-off prod poke.

The requester-DM tier (#2906 tier 2) **was** verified live in prod: delivery record moved from `channelKey: "slack:C0BPWNXR0MP"` to `channelKey: "dm"`.
