### PR TITLE
ci(staging): serve staging on the public lobu.ai host and close the bootstrap hole

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -137,7 +137,7 @@ jobs:
             # behind the ingress reads as http://<host> — OAuth metadata and the
             # MCP App asset URLs would both be stamped http and rejected by the
             # host's sandbox.
-            LOCK_ENV='- { name: PUBLIC_GATEWAY_URL, value: "https://staging.${{ vars.TAILNET_DOMAIN }}/lobu" }'
+            LOCK_ENV='- { name: PUBLIC_GATEWAY_URL, value: "https://${{ vars.STAGING_HOST || 'staging.lobu.ai' }}/lobu" }'
             echo "staging lock held by this PR - passwordless bootstrap disabled"
           fi
 
@@ -148,9 +148,9 @@ jobs:
           # Serve) injects Forwarded-* headers; tolerate them for this single-user
           # preview so /api/local-init sign-in works (peer is loopback via socat).
           # Set ONLY while this PR is tailnet-only. The `staging` label puts the
-          # same pod behind a public Funnel host, where the setting would let
+          # same pod behind the public staging host, where the setting would let
           # anyone on the internet mint an owner session (auth/routes.ts names
-          # Funnel as the case it refuses by default). staging.yml also strips
+          # public tunnels as the case it refuses by default). staging.yml also strips
           # the var when it acquires the lock; deciding it here as well is what
           # stops the next push to a locked PR from handing it back.
           # CHOKIDAR_USEPOLLING: the container's default nofile ulimit is 1024, and
@@ -165,6 +165,10 @@ jobs:
             namespace: $PREVIEW_NS
           spec:
             replicas: 1
+            # The namespace quota grants one pod's worth of CPU, so a rolling
+            # update can never schedule the surge replica: it stalls at "0 of 1
+            # updated" until the timeout. Replace the pod instead of surging.
+            strategy: { type: Recreate }
             selector:
               matchLabels: { app: $PREVIEW_NAME }
             template:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,6 +35,8 @@ jobs:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number || inputs.pr_number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number || inputs.pr_number }}
       PREVIEW_IMAGE: ghcr.io/${{ github.repository }}/preview
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v7
 
@@ -125,12 +127,29 @@ jobs:
           kubectl -n "$PREVIEW_NS" delete deployment "$PREVIEW_NAME" --ignore-not-found
           kubectl -n "$PREVIEW_NS" delete svc "$PREVIEW_NAME" --ignore-not-found
 
+          # Read the label here rather than from the event payload so a
+          # workflow_dispatch redeploy of a locked PR sees the lock too.
+          LOCAL_INIT_ENV='- { name: LOBU_LOCAL_INIT_ALLOW_PROXY, value: "1" }'
+          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
+            | grep -qx staging; then
+            # Expands to a whitespace-only line, which YAML reads as a blank
+            # line inside the sequence.
+            LOCAL_INIT_ENV=''
+            echo "staging lock held by this PR - passwordless bootstrap disabled"
+          fi
+
           # The embedded runner binds 127.0.0.1 (HOST below) so /api/local-init
           # sees a loopback peer. socat accepts external connections on 8788 and
           # forwards them over loopback to the app on 8787.
           # LOBU_LOCAL_INIT_ALLOW_PROXY: the private tailnet ingress (Tailscale
           # Serve) injects Forwarded-* headers; tolerate them for this single-user
           # preview so /api/local-init sign-in works (peer is loopback via socat).
+          # Set ONLY while this PR is tailnet-only. The `staging` label puts the
+          # same pod behind a public Funnel host, where the setting would let
+          # anyone on the internet mint an owner session (auth/routes.ts names
+          # Funnel as the case it refuses by default). staging.yml also strips
+          # the var when it acquires the lock; deciding it here as well is what
+          # stops the next push to a locked PR from handing it back.
           # CHOKIDAR_USEPOLLING: the container's default nofile ulimit is 1024, and
           # Vite's inotify watch fds blow through it at boot on a monorepo tree
           # (EMFILE crash, seen after the image grew). Polling uses stat() calls
@@ -162,7 +181,7 @@ jobs:
                       - { name: NODE_ENV, value: "development" }
                       - { name: CHOKIDAR_USEPOLLING, value: "true" }
                       - { name: ENCRYPTION_KEY, valueFrom: { secretKeyRef: { name: preview-encryption, key: key } } }
-                      - { name: LOBU_LOCAL_INIT_ALLOW_PROXY, value: "1" }
+                      ${LOCAL_INIT_ENV}
                     ports:
                       - { containerPort: 8787 }
                     readinessProbe:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -129,9 +129,15 @@ jobs:
 
           # Read the label here rather than from the event payload so a
           # workflow_dispatch redeploy of a locked PR sees the lock too.
+          #
+          # The gh call gets its own line on purpose. Piped straight into grep
+          # the step would take grep's status, and this shell has no pipefail:
+          # a rate limit or 5xx would read as "not labelled" and redeploy with
+          # passwordless bootstrap enabled while the staging ingress still
+          # points the public host at this pod. As an assignment, `-e` aborts.
+          PR_LABELS="$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')"
           LOCK_ENV='- { name: LOBU_LOCAL_INIT_ALLOW_PROXY, value: "1" }'
-          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
-            | grep -qx staging; then
+          if printf '%s\n' "$PR_LABELS" | grep -qx staging; then
             # Drop the passwordless bootstrap (see above) and pin the public
             # origin. resolvePublicOrigin falls back to the request URL, which
             # behind the ingress reads as http://<host> — OAuth metadata and the

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -129,12 +129,15 @@ jobs:
 
           # Read the label here rather than from the event payload so a
           # workflow_dispatch redeploy of a locked PR sees the lock too.
-          LOCAL_INIT_ENV='- { name: LOBU_LOCAL_INIT_ALLOW_PROXY, value: "1" }'
+          LOCK_ENV='- { name: LOBU_LOCAL_INIT_ALLOW_PROXY, value: "1" }'
           if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
             | grep -qx staging; then
-            # Expands to a whitespace-only line, which YAML reads as a blank
-            # line inside the sequence.
-            LOCAL_INIT_ENV=''
+            # Drop the passwordless bootstrap (see above) and pin the public
+            # origin. resolvePublicOrigin falls back to the request URL, which
+            # behind the ingress reads as http://<host> — OAuth metadata and the
+            # MCP App asset URLs would both be stamped http and rejected by the
+            # host's sandbox.
+            LOCK_ENV='- { name: PUBLIC_GATEWAY_URL, value: "https://staging.${{ vars.TAILNET_DOMAIN }}/lobu" }'
             echo "staging lock held by this PR - passwordless bootstrap disabled"
           fi
 
@@ -181,7 +184,7 @@ jobs:
                       - { name: NODE_ENV, value: "development" }
                       - { name: CHOKIDAR_USEPOLLING, value: "true" }
                       - { name: ENCRYPTION_KEY, valueFrom: { secretKeyRef: { name: preview-encryption, key: key } } }
-                      ${LOCAL_INIT_ENV}
+                      ${LOCK_ENV}
                     ports:
                       - { containerPort: 8787 }
                     readinessProbe:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -93,13 +93,37 @@ jobs:
             fi
           done
 
+          # Staging is PUBLIC (Tailscale Funnel, below), so the passwordless
+          # bootstrap endpoint must not be reachable through it. preview.yml
+          # sets LOBU_LOCAL_INIT_ALLOW_PROXY=1 because a plain preview is
+          # tailnet-only; behind Funnel that same setting would let anyone on
+          # the internet mint an owner session (auth/routes.ts names Funnel as
+          # the case it refuses by default). Strip it before the host goes
+          # public. The rollout restarts the pod, and the preview's data volume
+          # is an emptyDir — so bootstrap AFTER the lock, from inside the pod
+          # where the peer really is loopback:
+          #   kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \
+          #     curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' \
+          #     http://127.0.0.1:8787/api/local-init
+          kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
+            LOBU_LOCAL_INIT_ALLOW_PROXY-
+          kubectl -n "$PREVIEW_NS" rollout status "deploy/$PREVIEW_NAME" --timeout=600s
+
           # Pin the staging ingress to this PR's preview.
+          #
+          # Funnel, not Serve: the whole point of the staging URL is a stable
+          # endpoint third-party services can reach — an MCP host (claude.ai,
+          # ChatGPT) resolves and calls /mcp from its own backend, not from the
+          # operator's browser, so a tailnet-only name is unreachable to it and
+          # the connector fails at discovery.
           kubectl apply -f - <<EOF
           apiVersion: networking.k8s.io/v1
           kind: Ingress
           metadata:
             name: $STAGING_INGRESS
             namespace: $PREVIEW_NS
+            annotations:
+              tailscale.com/funnel: "true"
           spec:
             ingressClassName: tailscale
             tls:
@@ -121,6 +145,13 @@ jobs:
             "- **App**: https://$STAGING_HOST" \
             "- **MCP endpoint**: https://$STAGING_HOST/mcp" \
             "" \
-            "Removing the \`staging\` label releases the lock.")
+            "This host is served over Tailscale **Funnel** — publicly reachable, so a cloud MCP host can call it. Passwordless bootstrap is disabled on it; sign in once from inside the pod:" \
+            "" \
+            "\`\`\`" \
+            "kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \\" \
+            "  curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' http://127.0.0.1:8787/api/local-init" \
+            "\`\`\`" \
+            "" \
+            "Removing the \`staging\` label releases the lock and takes the public host down.")
           gh pr comment "$PR_NUM" --body "$STAGING_BODY"
           echo "staging locked to PR #$PR_NUM at https://$STAGING_HOST"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           # Only release if THIS PR holds the lock (scoped to this namespace).
           kubectl delete ingress "$STAGING_INGRESS" -n "$PREVIEW_NS" --ignore-not-found
+          # The preview keeps running on its own private host; hand back the
+          # settings the public host required.
+          kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
+            PUBLIC_GATEWAY_URL- LOBU_LOCAL_INIT_ALLOW_PROXY=1 2>/dev/null || true
           echo "staging lock released (staging.${{ vars.TAILNET_DOMAIN }} no longer mapped)"
 
       - name: Acquire lock (labeled)
@@ -105,8 +109,12 @@ jobs:
           #   kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \
           #     curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' \
           #     http://127.0.0.1:8787/api/local-init
+          # PUBLIC_GATEWAY_URL: resolvePublicOrigin otherwise falls back to the
+          # request URL, which behind the ingress reads as http://<host>; OAuth
+          # metadata and the MCP App asset URLs would both be stamped http.
           kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
-            LOBU_LOCAL_INIT_ALLOW_PROXY-
+            LOBU_LOCAL_INIT_ALLOW_PROXY- \
+            "PUBLIC_GATEWAY_URL=https://$STAGING_HOST/lobu"
           kubectl -n "$PREVIEW_NS" rollout status "deploy/$PREVIEW_NAME" --timeout=600s
 
           # Pin the staging ingress to this PR's preview.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,6 @@
 name: Staging lock
 
-# The 'staging' label pins the rolling staging URL (staging.<tailnet>) to one PR.
+# The 'staging' label pins the rolling staging URL (STAGING_HOST, public) to one PR.
 # Adding the label acquires the lock (strips it from other open PRs, moves the
 # staging ingress to this PR's namespace); removing it releases the lock.
 # Also dispatchable manually (workflow_dispatch) for manual lock control.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,7 +41,15 @@ jobs:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number || inputs.pr_number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number || inputs.pr_number }}
       STAGING_INGRESS: lobu-staging
-      STAGING_HOST: staging.${{ vars.TAILNET_DOMAIN }}
+      # Public DNS, not the tailnet name: an MCP host (claude.ai, ChatGPT)
+      # resolves and calls /mcp from its own backend, so a tailnet-only name
+      # is unreachable to it and the connector fails at discovery.
+      STAGING_HOST: ${{ vars.STAGING_HOST || 'staging.lobu.ai' }}
+      # cert-manager issues the *.lobu.ai wildcard into the prod namespace;
+      # the staging ingress lives in the preview namespace and needs its own
+      # copy of that secret.
+      WILDCARD_TLS_NS: summaries-prod
+      WILDCARD_TLS_SECRET: wildcard-lobu-ai-tls
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
       # labeled = acquire, unlabeled = release (label event or manual dispatch)
@@ -60,7 +68,7 @@ jobs:
           # settings the public host required.
           kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
             PUBLIC_GATEWAY_URL- LOBU_LOCAL_INIT_ALLOW_PROXY=1 2>/dev/null || true
-          echo "staging lock released (staging.${{ vars.TAILNET_DOMAIN }} no longer mapped)"
+          echo "staging lock released ($STAGING_HOST no longer mapped)"
 
       - name: Acquire lock (labeled)
         if: env.STAGING_ACTION == 'labeled'
@@ -97,13 +105,13 @@ jobs:
             fi
           done
 
-          # Staging is PUBLIC (Tailscale Funnel, below), so the passwordless
-          # bootstrap endpoint must not be reachable through it. preview.yml
-          # sets LOBU_LOCAL_INIT_ALLOW_PROXY=1 because a plain preview is
-          # tailnet-only; behind Funnel that same setting would let anyone on
-          # the internet mint an owner session (auth/routes.ts names Funnel as
-          # the case it refuses by default). Strip it before the host goes
-          # public. The rollout restarts the pod, and the preview's data volume
+          # Staging is PUBLIC (the ingress below), so the passwordless bootstrap
+          # endpoint must not be reachable through it. preview.yml sets
+          # LOBU_LOCAL_INIT_ALLOW_PROXY=1 because a plain preview is
+          # tailnet-only; on a public host that same setting would let anyone on
+          # the internet mint an owner session (auth/routes.ts names public
+          # tunnels as the case it refuses by default). Strip it before the host
+          # goes public. The rollout restarts the pod, and the preview's data volume
           # is an emptyDir — so bootstrap AFTER the lock, from inside the pod
           # where the peer really is loopback:
           #   kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \
@@ -117,25 +125,26 @@ jobs:
             "PUBLIC_GATEWAY_URL=https://$STAGING_HOST/lobu"
           kubectl -n "$PREVIEW_NS" rollout status "deploy/$PREVIEW_NAME" --timeout=600s
 
-          # Pin the staging ingress to this PR's preview.
-          #
-          # Funnel, not Serve: the whole point of the staging URL is a stable
-          # endpoint third-party services can reach — an MCP host (claude.ai,
-          # ChatGPT) resolves and calls /mcp from its own backend, not from the
-          # operator's browser, so a tailnet-only name is unreachable to it and
-          # the connector fails at discovery.
+          # The wildcard cert lives in the prod namespace; a TLS secret is only
+          # readable from its own namespace, so copy it next to the ingress.
+          kubectl -n "$WILDCARD_TLS_NS" get secret "$WILDCARD_TLS_SECRET" -o json \
+            | jq --arg ns "$PREVIEW_NS" \
+                '{apiVersion, kind, type, data, metadata: {name: .metadata.name, namespace: $ns}}' \
+            | kubectl apply -f -
+
+          # Pin the staging ingress to this PR's preview, on the public
+          # (traefik) class rather than the tailnet one.
           kubectl apply -f - <<EOF
           apiVersion: networking.k8s.io/v1
           kind: Ingress
           metadata:
             name: $STAGING_INGRESS
             namespace: $PREVIEW_NS
-            annotations:
-              tailscale.com/funnel: "true"
           spec:
-            ingressClassName: tailscale
+            ingressClassName: traefik
             tls:
               - hosts: ["$STAGING_HOST"]
+                secretName: $WILDCARD_TLS_SECRET
             rules:
               - host: $STAGING_HOST
                 http:
@@ -153,7 +162,7 @@ jobs:
             "- **App**: https://$STAGING_HOST" \
             "- **MCP endpoint**: https://$STAGING_HOST/mcp" \
             "" \
-            "This host is served over Tailscale **Funnel** — publicly reachable, so a cloud MCP host can call it. Passwordless bootstrap is disabled on it; sign in once from inside the pod:" \
+            "This host is publicly reachable, so a cloud MCP host can call it. Passwordless bootstrap is disabled on it; sign in once from inside the pod:" \
             "" \
             "\`\`\`" \
             "kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \\" \


### PR DESCRIPTION
## Why

The staging lock already advertises an MCP endpoint in the comment it posts:

```
- **MCP endpoint**: https://staging.<tailnet>.ts.net/mcp
```

That cannot work today. The ingress it applies is plain Tailscale **Serve**, so the name only resolves inside the tailnet — and an MCP host (claude.ai, ChatGPT) resolves and calls `/mcp` from its own backend, not from the operator's browser. Public DNS returns nothing for the host, so the connector fails at discovery and the URL is unusable for the one thing it was created for.

Found while trying to test an MCP Apps rendering fix (#2915) end to end against staging.

## What changed

**`staging.yml`** — the staging ingress gets `tailscale.com/funnel: "true"`. Previews stay private; only the single PR holding the lock is exposed.

**Both workflows** — `LOBU_LOCAL_INIT_ALLOW_PROXY` is now conditional on the lock.

This is the load-bearing half. `preview.yml` sets that var because a plain preview is tailnet-only, and `auth/routes.ts` refuses proxied `/api/local-init` by default for exactly this reason:

```ts
// Tailscale Serve / local reverse proxies connect to 127.0.0.1 (peer is
// loopback) but inject Forwarded-*. Public tunnels (Funnel, ngrok) look the
// same — refuse by default so a misconfigured public frontend can't mint
// passwordless sessions.
```

Behind Funnel, leaving it set means anyone on the internet can `POST /api/local-init` with an `X-Lobu-Client` header and become owner of the instance — which by then holds OAuth clients registered by real MCP hosts. So:

- `preview.yml` reads the label (via `gh`, not the event payload, so a `workflow_dispatch` redeploy sees the lock too) and omits the var when the PR holds staging.
- `staging.yml` strips it again on acquire, covering a label applied to an already-running preview.

Both halves are needed: without the first, the next push to a locked PR hands the var back; without the second, labelling a running preview leaves it set.

**Bootstrap moves inside the pod**, where the peer really is loopback and no `Forwarded-*` headers exist. The comment the lock posts now carries the command:

```
kubectl -n <ns> exec deploy/<name> -- \
  curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' http://127.0.0.1:8787/api/local-init
```

## Verification

Rendering the Deployment heredoc both ways and parsing the result as YAML — the empty expansion has to stay valid, since it becomes a whitespace-only line inside a sequence:

```
preview          -> ['PORT', 'HOST', 'DATABASE_URL', 'NODE_ENV', 'CHOKIDAR_USEPOLLING', 'ENCRYPTION_KEY', 'LOBU_LOCAL_INIT_ALLOW_PROXY']
staging-locked   -> ['PORT', 'HOST', 'DATABASE_URL', 'NODE_ENV', 'CHOKIDAR_USEPOLLING', 'ENCRYPTION_KEY']
```

Both workflow files parse. `make pre-pr` clean.

## Note for review

This deliberately exposes one environment to the public internet. That is the point of the change, and it is the narrowest form I could find: one label, one host, one PR at a time, torn down when the label is removed, with the passwordless path closed before the host goes public. If Funnel is not permitted for `tag:k8s` in the tailnet policy the ingress will simply fail to publish, which is a safe failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview environments can now be accessed through a configurable public staging host.
  * Staging deployments automatically configure public gateway access and HTTPS certificates.
  * Deployment comments provide public access details and an in-environment bootstrap command.

* **Bug Fixes**
  * Improved deployment reliability by waiting for rollout completion and handling command failures correctly.
  * Preview environments now correctly adjust proxy access based on staging status.
  * Deployment settings and lock-related configuration are restored correctly when releasing the lock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->