### PR TITLE
feat(devices): gate the automation claim lane on advertised agent kinds

### DIFF
--- a/db/migrations/20260819120000_device_agent_kinds.sql
+++ b/db/migrations/20260819120000_device_agent_kinds.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+
+-- Agent CLIs a device can actually spawn for an Automation run.
+--
+-- Devices advertise this on every poll (`agent_kinds` in the poll body, sent by
+-- the connector-worker daemon from the CLIs it can resolve on the machine), but
+-- the gateway dropped it — so the automation claim lane could hand a run to a
+-- device that has no `claude` installed. The device claims it and then fails it
+-- with "binary not found on PATH", which reads as a broken Automation rather
+-- than a machine missing a CLI.
+--
+-- NULL is deliberately distinct from '{}': NULL means "this device has never
+-- told us" (the Mac app and the Chrome bridge today, or an older daemon) and
+-- must stay claimable exactly as it is today. '{}' means "told us, and it can
+-- run nothing", which is a device the lane should skip.
+ALTER TABLE public.device_workers
+  ADD COLUMN IF NOT EXISTS agent_kinds text[];
+
+COMMENT ON COLUMN public.device_workers.agent_kinds IS
+  'Agent CLI kinds this device can spawn for Automation runs (claude-code, codex, …), as advertised on poll. NULL = never advertised (client does not send the field; claim unrestricted); empty array = advertised none.';
+
+-- migrate:down
+
+ALTER TABLE public.device_workers
+  DROP COLUMN IF EXISTS agent_kinds;

--- a/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
+++ b/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The device advertises the agent CLIs it can actually spawn, not the list its
+ * build knows about.
+ *
+ * The gateway withholds an Automation run whose `agent_kind` is missing from
+ * `device_workers.agent_kinds`. If the client advertised the static
+ * `AGENT_KINDS` table, that gate would only ever distinguish client versions —
+ * every device would claim every kind and then fail locally with "binary not
+ * found on PATH", which is the exact failure the gate exists to prevent.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import * as agentBinaries from "../daemon/agent-binaries";
+import { resolveRunnableAgentKinds } from "../daemon/agent-binaries";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * A bin dir holding exactly the named executables. Passed to the resolver
+ * explicitly: the real discovery list includes absolute prefixes like
+ * /opt/homebrew/bin, so a PATH-only stub would still see the developer's own
+ * CLIs and make the assertion machine-dependent.
+ */
+function binDirWith(names: string[]): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agent-bins-"));
+  tempDirs.push(dir);
+  for (const name of names) {
+    const file = path.join(dir, name);
+    writeFileSync(file, "#!/bin/sh\nexit 0\n");
+    chmodSync(file, 0o755);
+  }
+  return dir;
+}
+
+describe("resolveRunnableAgentKinds", () => {
+  test("reports only kinds whose binary resolves, in spec order", () => {
+    // `claude` → claude-code, `pi` → pi. codex/opencode/agy are absent.
+    const dirs = [binDirWith(["pi", "claude"])];
+    expect(resolveRunnableAgentKinds(undefined, dirs)).toEqual(["claude-code", "pi"]);
+  });
+
+  test("no local CLI at all reports an empty set, not the static table", () => {
+    expect(resolveRunnableAgentKinds(undefined, [binDirWith([])])).toEqual([]);
+  });
+
+  test("a binary override counts even when the search dirs are empty", () => {
+    const dir = binDirWith(["my-codex"]);
+    expect(
+      resolveRunnableAgentKinds({ codex: path.join(dir, "my-codex") }, [binDirWith([])])
+    ).toEqual(["codex"]);
+  });
+
+  test("a dangling override does not — the device would fail to launch it", () => {
+    const dir = binDirWith([]);
+    expect(
+      resolveRunnableAgentKinds({ codex: path.join(dir, "gone") }, [binDirWith([])])
+    ).toEqual([]);
+  });
+});
+
+describe("poll body agent_kinds", () => {
+  /**
+   * Stub the discovery sweep, then import the client fresh so it binds the
+   * stub. Returns the captured poll bodies and the discovery call count (the
+   * TTL assertion needs it).
+   *
+   * bun's `mock.module` is process-global, so everything except the sweep is
+   * re-exported from the real module — the automation-arm tests in this
+   * package resolve binaries through `locateBinary` and must keep seeing the
+   * real one.
+   */
+  async function pollWith(
+    kinds: string[][],
+    config: { platform?: string } = {}
+  ): Promise<{ bodies: Array<Record<string, unknown>>; discoveries: number }> {
+    let discoveries = 0;
+    mock.module("../daemon/agent-binaries", () => ({
+      ...agentBinaries,
+      resolveRunnableAgentKinds: () => kinds[Math.min(discoveries++, kinds.length - 1)],
+    }));
+
+    const bodies: Array<Record<string, unknown>> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+      return new Response(JSON.stringify({ next_poll_seconds: 5 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    try {
+      const { WorkerClient } = await import("../daemon/client");
+      const client = new WorkerClient({
+        apiUrl: "https://app.example.com",
+        workerId: "w-kinds",
+        capabilities: {},
+        ...config,
+      });
+      await client.poll();
+      await client.poll();
+      return { bodies, discoveries };
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  }
+
+  test("a device worker forwards exactly what discovery returned", async () => {
+    const { bodies } = await pollWith([["claude-code"]], { platform: "macos" });
+    expect(bodies[0].agent_kinds).toEqual(["claude-code"]);
+  });
+
+  test("a device with no CLIs still sends the key, so the server stores [] not NULL", async () => {
+    // NULL means "never advertised" and stays unrestricted server-side; a
+    // device that genuinely runs nothing has to say so explicitly.
+    const { bodies } = await pollWith([[]], { platform: "macos" });
+    expect(bodies[0]).toHaveProperty("agent_kinds");
+    expect(bodies[0].agent_kinds).toEqual([]);
+  });
+
+  test("a fleet worker (no platform) advertises nothing — it runs no Automations", async () => {
+    const { bodies } = await pollWith([["claude-code"]]);
+    expect(bodies[0]).not.toHaveProperty("agent_kinds");
+  });
+
+  test("discovery runs once per TTL, not once per poll", async () => {
+    // Two polls back to back are well inside the 60s window, so the second
+    // must reuse the first sweep rather than re-stat the filesystem.
+    const { bodies, discoveries } = await pollWith([["claude-code"], ["pi"]], {
+      platform: "macos",
+    });
+    expect(discoveries).toBe(1);
+    expect(bodies[1].agent_kinds).toEqual(["claude-code"]);
+  });
+});

--- a/packages/connector-worker/src/daemon/agent-binaries.ts
+++ b/packages/connector-worker/src/daemon/agent-binaries.ts
@@ -1,0 +1,67 @@
+/**
+ * Local agent CLI discovery.
+ *
+ * Two consumers:
+ *   - the automation arm, which resolves the binary it is about to spawn;
+ *   - the poll loop, which advertises `agent_kinds` so the gateway can withhold
+ *     an Automation run from a device that cannot execute it.
+ *
+ * Those have to agree. Advertising the static `AGENT_KINDS` list would say
+ * "this build knows about five CLIs", not "this machine has them" — the run
+ * would still be claimed and then fail locally with "binary not found on PATH",
+ * which is exactly the outcome the gateway gate exists to prevent.
+ */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
+import { DEVICE_AGENT_SPECS } from '@lobu/core/contracts/worker/device-automation';
+
+/** Search prefixes for CLI discovery — mirrors the Mac app's detector list. */
+export function searchDirs(): string[] {
+  const home = homedir();
+  return [
+    `${home}/.local/bin`,
+    `${home}/.bun/bin`,
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ];
+}
+
+/**
+ * `dirs` overrides the discovery path. Production never passes it — the default
+ * is the fixed prefixes plus `$PATH`, because a GUI-launched daemon inherits a
+ * minimal `$PATH` that omits every one of them.
+ */
+export function locateBinary(name: string, dirs?: string[]): string | null {
+  const search = dirs ?? [
+    ...searchDirs(),
+    ...(process.env.PATH ?? '').split(':').filter(Boolean),
+  ];
+  for (const dir of search) {
+    const candidate = path.join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The agent kinds this machine can actually spawn right now, in
+ * `DEVICE_AGENT_SPECS` order.
+ *
+ * `overrides` is the executor's `binaryOverrides` map: an explicit path wins
+ * over PATH discovery, matching how the arm resolves the binary at spawn time,
+ * but it still has to exist — an override pointing at a deleted file must not
+ * make the device claim runs it will fail.
+ */
+export function resolveRunnableAgentKinds(
+  overrides?: Partial<Record<AgentKind, string>>,
+  dirs?: string[]
+): AgentKind[] {
+  return DEVICE_AGENT_SPECS.filter((spec) => {
+    const override = overrides?.[spec.kind];
+    if (override) return existsSync(override);
+    return locateBinary(spec.binaryName, dirs) !== null;
+  }).map((spec) => spec.kind);
+}

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -24,7 +24,7 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Readable } from 'node:stream';
 import {
@@ -39,6 +39,7 @@ import type {
   PollResponse,
   WorkerExitReason,
 } from '@lobu/core/contracts/worker/protocol';
+import { locateBinary, searchDirs } from './agent-binaries.js';
 import type { ExecutorClient } from './client.js';
 import { WorkerDecodeError, WorkerHttpError } from './client.js';
 import type { ExecutorConfig } from './executor.js';
@@ -67,29 +68,6 @@ class ExecutableNotFoundError extends Error {
     super(`${name} binary not found on PATH`);
     this.name = 'ExecutableNotFoundError';
   }
-}
-
-/** Search prefixes for CLI discovery — mirrors the Mac app's detector list. */
-function searchDirs(): string[] {
-  const home = homedir();
-  return [
-    `${home}/.local/bin`,
-    `${home}/.bun/bin`,
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-  ];
-}
-
-function locateBinary(name: string): string | null {
-  const dirs = [
-    ...searchDirs(),
-    ...(process.env.PATH ?? '').split(':').filter(Boolean),
-  ];
-  for (const dir of dirs) {
-    const candidate = path.join(dir, name);
-    if (existsSync(candidate)) return candidate;
-  }
-  return null;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -103,7 +103,8 @@ import type {
   PollResponse,
   StreamBatch,
 } from "@lobu/core/contracts/worker/protocol";
-import { AGENT_KINDS } from "@lobu/core/contracts/worker/device-automation";
+import type { AgentKind } from "@lobu/core/contracts/worker/device-automation";
+import { resolveRunnableAgentKinds } from "./agent-binaries.js";
 
 /** Capability strings the worker advertises, keyed by name (e.g. `browser.debugger`). */
 export type WorkerCapabilities = Record<string, boolean>;
@@ -131,6 +132,9 @@ export class WorkerDecodeError extends Error {
   }
 }
 
+/** How long a local CLI discovery sweep is reused before re-running. */
+const AGENT_KIND_DISCOVERY_TTL_MS = 60_000;
+
 /**
  * Worker API Client
  */
@@ -143,6 +147,8 @@ export class WorkerClient implements ExecutorClient {
   private platform?: string;
   private label?: string;
   private manifests: unknown[] = [];
+  private binaryOverrides?: Partial<Record<AgentKind, string>>;
+  private agentKindsCache: { kinds: AgentKind[]; at: number } | null = null;
 
   constructor(config: {
     apiUrl: string;
@@ -156,6 +162,8 @@ export class WorkerClient implements ExecutorClient {
     label?: string;
     /** Device-manifest connector definitions to register on each poll. */
     manifests?: unknown[];
+    /** Executor binary overrides, so advertised kinds match what the arm spawns. */
+    binaryOverrides?: Partial<Record<AgentKind, string>>;
   }) {
     this.apiUrl = trimTrailingSlashes(config.apiUrl);
     this.workerId = config.workerId;
@@ -165,6 +173,23 @@ export class WorkerClient implements ExecutorClient {
     this.platform = config.platform?.trim() || undefined;
     this.label = config.label?.trim() || undefined;
     this.manifests = config.manifests ?? [];
+    this.binaryOverrides = config.binaryOverrides;
+  }
+
+  /**
+   * Agent kinds this machine can spawn, re-discovered at most every
+   * `AGENT_KIND_DISCOVERY_TTL_MS`. Installing a CLI mid-session must start
+   * attracting runs without a daemon restart, but a filesystem sweep on every
+   * poll (default 10s) buys nothing.
+   */
+  private runnableAgentKinds(): AgentKind[] {
+    const now = Date.now();
+    if (this.agentKindsCache && now - this.agentKindsCache.at < AGENT_KIND_DISCOVERY_TTL_MS) {
+      return this.agentKindsCache.kinds;
+    }
+    const kinds = resolveRunnableAgentKinds(this.binaryOverrides);
+    this.agentKindsCache = { kinds, at: now };
+    return kinds;
   }
 
   private authHeaders(): Record<string, string> {
@@ -211,7 +236,7 @@ export class WorkerClient implements ExecutorClient {
         ? {
             platform: this.platform,
             app_version: this.version,
-            agent_kinds: AGENT_KINDS,
+            agent_kinds: this.runnableAgentKinds(),
           }
         : {}),
       ...(this.label ? { label: this.label } : {}),

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -55,6 +55,9 @@ export class WorkerDaemon {
       platform: daemonConfig.platform,
       label: daemonConfig.label,
       manifests: daemonConfig.manifests,
+      // The poll advertisement and the spawn path must resolve the same
+      // binaries, or the device advertises a kind it then fails to launch.
+      binaryOverrides: daemonConfig.executor?.binaryOverrides,
     });
 
     this.env = env;

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -398,9 +398,10 @@ export type AutomationDeliveryTarget = Static<
  * configured", so accepting an arbitrary string here only defers the failure
  * to a place nobody is watching (#2504).
  *
- * Adding a CLI means adding an `AgentSpec` there AND a literal here — a device
- * advertises its kinds on poll (`agent_kinds`), but the gateway does not yet
- * persist them, so the server still has no way to derive this list.
+ * Adding a CLI means adding an `AgentSpec` there AND a literal here. The gateway
+ * persists what a device advertises on poll (`device_workers.agent_kinds`) and
+ * uses it to withhold runs from devices that can't execute them, but that is a
+ * per-device set, not the product-wide vocabulary this list defines.
  */
 const DEVICE_AGENT_KIND_LITERALS = [
   Type.Literal("claude-code"),

--- a/packages/core/src/contracts/worker/device-automation.ts
+++ b/packages/core/src/contracts/worker/device-automation.ts
@@ -24,7 +24,7 @@ import type { AutomationPollPayload } from "./protocol.js";
 /** Local CLI runtimes a device-pinned Automation can name in `agent_kind`. */
 export type AgentKind = "claude-code" | "codex" | "opencode" | "pi" | "agy";
 
-/** Every kind the device executors advertise. Order is the UI/routing order. */
+/** Every kind a device-pinned Automation can name. Order is the UI/routing order. */
 export const AGENT_KINDS: readonly AgentKind[] = [
   "claude-code",
   "codex",

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -107,9 +107,13 @@ export const PollRequestSchema = Type.Object({
   connector_manifests: Type.Optional(Type.Unknown()),
   /**
    * Agent kinds this device can run for Automations (e.g. `["claude-code"]`).
-   * Advertised by device executors that ship a local CLI spawner. Advisory
-   * until the gateway persists it per-device — it is the eventual replacement
-   * for the hand-synced `DEVICE_AGENT_KIND_LITERALS` list on the write side.
+   * Advertised by the connector-worker daemon, derived from the binaries
+   * actually resolvable on that machine — not the build's static kind table,
+   * which would make the gate below inert. The gateway
+   * persists it on `device_workers.agent_kinds` and withholds device-pinned
+   * runs whose `agent_kind` the device did not advertise. Omit the field
+   * entirely when the client runs no CLIs and should stay unrestricted; send
+   * `[]` to claim no Automation runs at all.
    */
   agent_kinds: Type.Optional(Type.Array(Type.String())),
 });

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -113,7 +113,8 @@ export const PollRequestSchema = Type.Object({
    * persists it on `device_workers.agent_kinds` and withholds device-pinned
    * runs whose `agent_kind` the device did not advertise. Omit the field
    * entirely when the client runs no CLIs and should stay unrestricted; send
-   * `[]` to claim no Automation runs at all.
+   * `[]` to claim no Automation runs at all — including runs that name no
+   * `agent_kind`, since a device that runs nothing has no default either.
    */
   agent_kinds: Type.Optional(Type.Array(Type.String())),
 });

--- a/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration test for the device `agent_kinds` advertisement and the
+ * automation claim lane that gates on it (POST /api/workers/poll).
+ *
+ * A device-pinned Automation names the local CLI it needs in
+ * `approved_input.agent_kind`. Before this gate the automation lane was
+ * capability-blind, so a device with no executor for that kind still claimed
+ * the run and then failed it locally with "no local agent executor configured"
+ * — indistinguishable, from the UI, from a broken Automation.
+ *
+ * Verifies:
+ *   - poll persists the advertised kinds onto device_workers, and a later poll
+ *     that omits the field does not erase them.
+ *   - advertised kind matches the run's agent_kind → claimed.
+ *   - advertised kinds don't include it → not claimed, run stays pending, and
+ *     the same device claims it once it advertises the kind.
+ *   - advertising nothing at all (a client that does not send the field)
+ *     stays unrestricted; advertising `[]` claims nothing.
+ *   - a run naming no agent_kind is claimable by an advertising device.
+ *   - GET /api/me/devices reports the advertised kinds, keeping null distinct
+ *     from [].
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { listDeviceWorkers } from '../../../worker-api/device-management';
+import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
+import { parsePgTextArray } from '../../../db/client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+/** Mint a PAT bound to a device worker_id, as the Mac app / daemon holds. */
+async function createWorkerBoundPat(
+  userId: string,
+  organizationId: string,
+  workerId: string
+): Promise<string> {
+  const sql = getTestDb();
+  const token = `owl_pat_${generateSecureToken(24)}`;
+  await sql`
+    INSERT INTO personal_access_tokens (
+      token_hash, token_prefix, user_id, organization_id, name, scope, worker_id,
+      created_at, updated_at
+    ) VALUES (
+      ${hashToken(token)}, ${token.substring(0, 12)}, ${userId}, ${organizationId},
+      ${`Test worker PAT (${workerId})`}, 'device_worker:run', ${workerId},
+      NOW(), NOW()
+    )
+  `;
+  return token;
+}
+
+interface GateCtx {
+  sql: ReturnType<typeof getTestDb>;
+  organizationId: string;
+  userId: string;
+  workerId: string;
+  token: string;
+  deviceWorkerId: string;
+  automationId: number;
+}
+
+/**
+ * Register a device worker plus an Automation pinned to it. `agentKind: null`
+ * leaves the pin without a named CLI, which the device resolves against its own
+ * default.
+ */
+async function setup(opts: {
+  workerId: string;
+  agentKind: string | null;
+}): Promise<GateCtx> {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({ name: 'Agent Kinds Org' });
+  const userId = workspace.users.owner.id;
+  const organizationId = workspace.org.id;
+
+  const inserted = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+    VALUES (${userId}, ${opts.workerId}, 'macos', ${sql.json({})}, 'Mac Test', ${organizationId})
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  const deviceWorkerId = String(inserted[0].id);
+
+  const entity = await createTestEntity({
+    name: 'Gate Entity',
+    organization_id: organizationId,
+    created_by: userId,
+  });
+  const agent = await createTestAgent({
+    organizationId,
+    ownerUserId: userId,
+    agentId: 'gate-agent',
+    name: 'Gate Agent',
+  });
+  const automation = (await workspace.owner.automations.create({
+    entity_id: entity.id,
+    slug: 'gate-automation',
+    name: 'Gate Automation',
+    prompt: 'Summarize {{entities}}.',
+    triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+    agent_id: agent.agentId,
+  })) as { automation_id: string };
+  const automationId = Number(automation.automation_id);
+
+  // AutomationCreateInput doesn't expose device_worker_id / agent_kind; set
+  // them directly, as manual-trigger.test.ts does.
+  await sql`
+    UPDATE automations
+    SET device_worker_id = ${deviceWorkerId}::uuid,
+        agent_kind = ${opts.agentKind}
+    WHERE id = ${automationId}
+  `;
+
+  const token = await createWorkerBoundPat(userId, organizationId, opts.workerId);
+  return { sql, organizationId, userId, workerId: opts.workerId, token, deviceWorkerId, automationId };
+}
+
+/** Queue a pending run via the manual-trigger endpoint the device owns. */
+async function trigger(ctx: GateCtx): Promise<number> {
+  const res = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, {
+    token: ctx.token,
+  });
+  expect(res.status).toBe(200);
+  const json = (await res.json()) as { run_id: number };
+  return json.run_id;
+}
+
+/** Poll as the device. `agentKinds: undefined` omits the field entirely. */
+async function poll(
+  ctx: GateCtx,
+  agentKinds?: string[]
+): Promise<{ run_id?: number; run_type?: string; next_poll_seconds?: number }> {
+  const body: Record<string, unknown> = { worker_id: ctx.workerId, capabilities: {} };
+  if (agentKinds !== undefined) body.agent_kinds = agentKinds;
+  const res = await post('/api/workers/poll', { token: ctx.token, body });
+  expect(res.status).toBe(200);
+  return (await res.json()) as { run_id?: number; run_type?: string };
+}
+
+/** Invoke the session-authenticated devices listing without the auth plumbing. */
+async function callListDevices(
+  userId: string
+): Promise<Array<{ worker_id: string; agent_kinds: string[] | null }>> {
+  const res = await listDeviceWorkers({
+    var: { user: { id: userId } },
+    json: (body: unknown, status = 200) => Response.json(body, { status }),
+  } as unknown as Context<{ Bindings: Env }>);
+  expect(res.status).toBe(200);
+  const json = (await res.json()) as {
+    devices: Array<{ worker_id: string; agent_kinds: string[] | null }>;
+  };
+  return json.devices;
+}
+
+async function runStatus(ctx: GateCtx, runId: number): Promise<string> {
+  const [row] = await ctx.sql`SELECT status FROM runs WHERE id = ${runId}`;
+  return String(row.status);
+}
+
+describe('device agent_kinds advertisement + automation claim gate', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('persists advertised kinds, and a later poll omitting them does not erase them', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-persist', agentKind: 'claude-code' });
+
+    await poll(ctx, ['claude-code', ' pi ', 'claude-code', '']);
+    const [afterAdvertise] = await ctx.sql`
+      SELECT agent_kinds FROM device_workers WHERE id = ${ctx.deviceWorkerId}::uuid
+    `;
+    // Trimmed, de-duplicated, blanks dropped.
+    // The driver returns text[] as a raw '{a,b}' literal, hence parsePgTextArray.
+    expect(parsePgTextArray(afterAdvertise.agent_kinds)).toEqual(['claude-code', 'pi']);
+
+    // A downgraded client omits the field; COALESCE must keep what the
+    // capable client already told us.
+    await poll(ctx);
+    const [afterOmit] = await ctx.sql`
+      SELECT agent_kinds FROM device_workers WHERE id = ${ctx.deviceWorkerId}::uuid
+    `;
+    expect(parsePgTextArray(afterOmit.agent_kinds)).toEqual(['claude-code', 'pi']);
+  });
+
+  it('claims a run whose agent_kind the device advertised', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-match', agentKind: 'claude-code' });
+    const runId = await trigger(ctx);
+
+    const job = await poll(ctx, ['claude-code', 'pi']);
+    expect(job.run_type).toBe('automation');
+    expect(job.run_id).toBe(runId);
+    expect(await runStatus(ctx, runId)).toBe('running');
+  });
+
+  it('withholds a run whose agent_kind the device cannot run, then hands it over once advertised', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-miss', agentKind: 'claude-code' });
+    const runId = await trigger(ctx);
+
+    const miss = await poll(ctx, ['pi']);
+    expect(miss.run_id).toBeUndefined();
+    expect(await runStatus(ctx, runId)).toBe('pending');
+
+    // The user installs the CLI; the next poll's discovery sweep picks it up
+    // and the same still-pending run is claimed — nothing had to be re-queued.
+    const hit = await poll(ctx, ['pi', 'claude-code']);
+    expect(hit.run_id).toBe(runId);
+    expect(await runStatus(ctx, runId)).toBe('running');
+  });
+
+  it('claims nothing when the device advertises an empty kind set', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-empty', agentKind: 'claude-code' });
+    const runId = await trigger(ctx);
+
+    const job = await poll(ctx, []);
+    expect(job.run_id).toBeUndefined();
+    expect(await runStatus(ctx, runId)).toBe('pending');
+
+    const [row] = await ctx.sql`
+      SELECT agent_kinds FROM device_workers WHERE id = ${ctx.deviceWorkerId}::uuid
+    `;
+    // Advertised-none is stored as [], not NULL — that's what makes it a gate
+    // rather than a legacy no-op.
+    expect(row.agent_kinds).not.toBeNull();
+    expect(parsePgTextArray(row.agent_kinds)).toEqual([]);
+  });
+
+  it('leaves a device that never advertised unrestricted', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-legacy', agentKind: 'claude-code' });
+    const runId = await trigger(ctx);
+
+    const job = await poll(ctx);
+    expect(job.run_id).toBe(runId);
+    expect(await runStatus(ctx, runId)).toBe('running');
+
+    const [row] = await ctx.sql`
+      SELECT agent_kinds FROM device_workers WHERE id = ${ctx.deviceWorkerId}::uuid
+    `;
+    expect(row.agent_kinds).toBeNull();
+  });
+
+  it('reports advertised kinds on GET /api/me/devices, null distinct from []', async () => {
+    const advertised = await setup({ workerId: 'mac-kinds-listed', agentKind: 'claude-code' });
+    await poll(advertised, ['claude-code']);
+
+    // A second device on the same user that has only ever polled without the
+    // field — the listing must not flatten it to "runs nothing".
+    await advertised.sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+      VALUES (${advertised.userId}, 'mac-kinds-silent', 'macos', ${advertised.sql.json({})},
+              'Silent Mac', ${advertised.organizationId})
+    `;
+
+    const listed = await callListDevices(advertised.userId);
+    const byWorker = new Map(listed.map((d) => [d.worker_id, d.agent_kinds]));
+    expect(byWorker.get('mac-kinds-listed')).toEqual(['claude-code']);
+    expect(byWorker.get('mac-kinds-silent')).toBeNull();
+  });
+
+  it('claims a run that names no agent_kind even when the device advertises kinds', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-unpinned', agentKind: null });
+    const runId = await trigger(ctx);
+
+    const job = await poll(ctx, ['pi']);
+    expect(job.run_id).toBe(runId);
+    expect(await runStatus(ctx, runId)).toBe('running');
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
@@ -16,7 +16,8 @@
  *     the same device claims it once it advertises the kind.
  *   - advertising nothing at all (a client that does not send the field)
  *     stays unrestricted; advertising `[]` claims nothing.
- *   - a run naming no agent_kind is claimable by an advertising device.
+ *   - a run naming no agent_kind is claimable by an advertising device, but not
+ *     by one advertising `[]`.
  *   - GET /api/me/devices reports the advertised kinds, keeping null distinct
  *     from [].
  */
@@ -257,6 +258,17 @@ describe('device agent_kinds advertisement + automation claim gate', () => {
     const byWorker = new Map(listed.map((d) => [d.worker_id, d.agent_kinds]));
     expect(byWorker.get('mac-kinds-listed')).toEqual(['claude-code']);
     expect(byWorker.get('mac-kinds-silent')).toBeNull();
+  });
+
+  it('withholds an unnamed-agent_kind run from a device that advertises nothing runnable', async () => {
+    // The empty set is the one case where "no agent_kind" is not permissive:
+    // the device would resolve it against its own default, and it has none.
+    const ctx = await setup({ workerId: 'mac-kinds-empty-unnamed', agentKind: null });
+    const runId = await trigger(ctx);
+
+    const job = await poll(ctx, []);
+    expect(job.run_id).toBeUndefined();
+    expect(await runStatus(ctx, runId)).toBe('pending');
   });
 
   it('claims a run that names no agent_kind even when the device advertises kinds', async () => {

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -15,7 +15,7 @@ import type { Context } from 'hono';
 import { createAuth } from '../auth';
 import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
 import { PersonalAccessTokenService } from '../auth/tokens';
-import { getDb, pgBigintArray } from '../db/client';
+import { getDb, parsePgTextArray, pgBigintArray } from '../db/client';
 import type { Env } from '../index';
 import { captureServerError } from '../sentry';
 import { errorMessage } from '../utils/errors';
@@ -53,6 +53,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         dw.platform,
         dw.app_version,
         dw.capabilities,
+        dw.agent_kinds,
         dw.label,
         dw.last_seen_at,
         (dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS online,
@@ -99,6 +100,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
       platform: string | null;
       app_version: string | null;
       capabilities: string[];
+      agent_kinds: string | string[] | null;
       label: string | null;
       last_seen_at: string;
       online: boolean;
@@ -123,6 +125,12 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         platform: r.platform,
         app_version: r.app_version,
         capabilities: Array.isArray(r.capabilities) ? r.capabilities : [],
+        // null (never advertised) is distinct from [] (advertised none): the
+        // automation lane leaves the former unrestricted and withholds every run
+        // from the latter, so the UI must be able to tell "unknown" from "runs
+        // nothing". The driver hands text[] back as a raw '{a,b}' literal, so it
+        // needs parsing, not Array.isArray.
+        agent_kinds: r.agent_kinds == null ? null : parsePgTextArray(r.agent_kinds),
         label: r.label,
         last_seen_at: r.last_seen_at,
         online: r.online,

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -643,9 +643,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             --     it queued until a device that can run it polls.
             --     A device that advertised nothing (agentKinds IS NULL: the Mac
             --     app and Chrome bridge today, or an older daemon) is deliberately
-            --     unrestricted, and
-            --     so is a run that names no agent_kind — the device resolves that
-            --     one against its own default.
+            --     unrestricted. A run that names no agent_kind is claimable too —
+            --     the device resolves it against its own default — but only by a
+            --     device that advertised at least one kind: a device that told us
+            --     it can run nothing has no default to resolve against either.
             OR (
               ${isUserScopedWorker}
               AND r.run_type = 'automation'
@@ -655,8 +656,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
               AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
               AND (
                 ${agentKindsParam}::text[] IS NULL
-                OR NULLIF(r.approved_input->>'agent_kind', '') IS NULL
-                OR r.approved_input->>'agent_kind' = ANY(${agentKindsParam}::text[])
+                OR CASE
+                  WHEN NULLIF(r.approved_input->>'agent_kind', '') IS NULL
+                    THEN cardinality(${agentKindsParam}::text[]) > 0
+                  ELSE r.approved_input->>'agent_kind' = ANY(${agentKindsParam}::text[])
+                END
               )
               AND NOT EXISTS (
                 SELECT 1

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -36,7 +36,7 @@ import { supersedeActionEvent } from '../tools/admin/approval-events';
 import logger from '../utils/logger';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import { isCloudMode } from '../utils/cloud-mode';
-import { normalizeAdvertisedCapabilities } from './shared';
+import { normalizeAdvertisedCapabilities, normalizeAgentKinds } from './shared';
 import { storedManifestMap, validateDeviceConnectorManifests } from './device-manifests';
 import type { RunOutcome } from '../runs/run-outcome';
 
@@ -157,6 +157,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   let label: string | null = null;
   let connectorManifestsProvided = false;
   let connectorManifestsRaw: unknown;
+  // Agent CLIs this device can spawn. `null` is NOT the same as `[]`: null means
+  // the client never told us (today that is every client except the
+  // connector-worker daemon — the Mac app, the Chrome bridge, older daemons)
+  // and must stay as claimable as it is today, while `[]` means it told us and
+  // can run nothing.
+  let agentKinds: string[] | null = null;
   try {
     const body = await c.req.json<PollRequest>();
     worker_id = body.worker_id;
@@ -166,9 +172,15 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     label = body.label ?? null;
     connectorManifestsProvided = Object.hasOwn(body, 'connector_manifests');
     connectorManifestsRaw = body.connector_manifests;
+    agentKinds = normalizeAgentKinds(body.agent_kinds);
   } catch {
     return c.json({ error: 'Invalid or missing JSON body' }, 400);
   }
+
+  // postgres.js renders a bound JS array as a bare comma list, which Postgres
+  // rejects for text[]; the repo's array params go through pgTextArray. NULL
+  // must stay NULL — that's the "never advertised" case the lane keys on.
+  const agentKindsParam = agentKinds === null ? null : pgTextArray(agentKinds);
   const sql = getDb();
   // Capability set the worker advertised, used to filter on
   // connector_definitions.required_capability.
@@ -336,7 +348,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       // registration from a routine poll-update so we only emit the
       // `device:created` lifecycle event once per device.
       const upserted = (await sql`
-        INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id, connector_manifests)
+        INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id, connector_manifests, agent_kinds)
         VALUES (
           ${registrationUserId}, ${worker_id}, ${platform}, ${app_version},
           ${sql.json(incomingCaps)}, ${label},
@@ -344,7 +356,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             ${registrationOrgId}::text,
             (SELECT id FROM organization WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${registrationUserId} LIMIT 1)
           ),
-          ${sql.json(connectorManifestMap ?? {})}
+          ${sql.json(connectorManifestMap ?? {})},
+          ${agentKindsParam}::text[]
         )
         ON CONFLICT (user_id, worker_id) DO UPDATE SET
           -- platform is set-once: COALESCE preserves the original value,
@@ -361,6 +374,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests
             ELSE device_workers.connector_manifests
           END,
+          -- Only overwrite when the device actually advertised. A client that
+          -- stops sending the field (a downgraded build) must not erase what a
+          -- capable client already told us.
+          agent_kinds = COALESCE(EXCLUDED.agent_kinds, device_workers.agent_kinds),
           last_seen_at = now()
         RETURNING id, organization_id, (xmax = 0) AS inserted
       `) as unknown as Array<{
@@ -611,11 +628,24 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             )
             -- (2) Automation lane: an automation run with approved_input.device_worker_id
             --     matching this device. Automations don't carry a connection_id and
-            --     don't gate on capabilities — the matching device's local CLI
-            --     executor handles the work (Owletto's AutomationDispatcher routes
-            --     by approved_input.agent_kind). The server-side dispatcher
-            --     (#802) already refuses to claim rows with this pin set, so
-            --     this branch is the only legal claim path for them.
+            --     don't gate on the connector capability set — the matching device's
+            --     local CLI executor handles the work, routing by
+            --     approved_input.agent_kind. The server-side dispatcher (#802)
+            --     already refuses to claim rows with this pin set, so this branch
+            --     is the only legal claim path for them.
+            --
+            --     It DOES gate on the agent kinds the device advertised on this
+            --     poll, which the daemon derives from the CLIs it can actually
+            --     resolve on the machine. Without that, a run pinned to a device
+            --     with no claude binary on PATH is still claimed and then fails with
+            --     "binary not found on PATH" — which reads as a broken Automation
+            --     rather than a machine missing a CLI. Leaving it unclaimed keeps
+            --     it queued until a device that can run it polls.
+            --     A device that advertised nothing (agentKinds IS NULL: the Mac
+            --     app and Chrome bridge today, or an older daemon) is deliberately
+            --     unrestricted, and
+            --     so is a run that names no agent_kind — the device resolves that
+            --     one against its own default.
             OR (
               ${isUserScopedWorker}
               AND r.run_type = 'automation'
@@ -623,6 +653,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
               AND r.approved_input ? 'device_worker_id'
               AND r.approved_input->>'device_worker_id' = ${deviceWorkerId}::text
               AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
+              AND (
+                ${agentKindsParam}::text[] IS NULL
+                OR NULLIF(r.approved_input->>'agent_kind', '') IS NULL
+                OR r.approved_input->>'agent_kind' = ANY(${agentKindsParam}::text[])
+              )
               AND NOT EXISTS (
                 SELECT 1
                 FROM runs active

--- a/packages/server/src/worker-api/shared.ts
+++ b/packages/server/src/worker-api/shared.ts
@@ -5,8 +5,8 @@
  * complete-automation, complete-action, and complete-auth to verify the caller
  * owns the run it's acting on.
  *
- * `normalizeAdvertisedCapabilities` — sanitises the raw capabilities map the
- * device sends on poll.
+ * `normalizeAdvertisedCapabilities` / `normalizeAgentKinds` — sanitise the raw
+ * capabilities map and agent-kind list the device sends on poll.
  */
 
 import type { Context } from 'hono';
@@ -25,6 +25,34 @@ export function normalizeAdvertisedCapabilities(capabilities: Record<string, boo
         .map(([key]) => key)
     )
   );
+}
+
+/**
+ * Agent CLI kinds a device advertised on poll, or `null` when it advertised
+ * nothing at all.
+ *
+ * The null/empty distinction is load-bearing and must survive to the DB: a
+ * client that never sends the field (the Mac app and the Chrome bridge today,
+ * or an older daemon) has to stay exactly as claimable as it is today, while a
+ * client that sends `[]` is telling us it can run nothing.
+ * Collapsing the two would either strand every legacy device or hand runs to
+ * devices that cannot execute them.
+ *
+ * Values are client-supplied, so this trims, de-duplicates, and caps length
+ * and count — but does not validate them against the gateway's own `AgentKind`
+ * union, because that list ships with the device client's core build and may
+ * legitimately run ahead of the server.
+ */
+export function normalizeAgentKinds(kinds: unknown): string[] | null {
+  if (!Array.isArray(kinds)) return null;
+  return Array.from(
+    new Set(
+      kinds
+        .filter((kind): kind is string => typeof kind === 'string')
+        .map((kind) => kind.trim())
+        .filter((kind) => kind.length > 0 && kind.length <= 64)
+    )
+  ).slice(0, 32);
 }
 
 /**


### PR DESCRIPTION
## Summary
- A device-pinned Automation names the CLI it needs in `approved_input.agent_kind`, but the automation claim lane never checked whether the polling device could run it — the device claimed the run and then failed it with "binary not found on PATH", indistinguishable in the UI from a broken Automation.
- The daemon now advertises the kinds it can **actually resolve** (it sent the static `AGENT_KINDS` table before, which would have made the gate inert), and the gateway persists them on `device_workers.agent_kinds` and withholds runs the device cannot execute, leaving them pending for a device that can.
- `NULL` is deliberately distinct from `{}`. `NULL` = the client never told us (the Mac app and Chrome bridge both land there today) and stays exactly as claimable as before; `{}` = it told us and can run nothing. A poll that omits the field does not erase what a capable client already stored.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, strict typecheck, knip, biome, naming, gateway-LLM, entity-write gates — all green)
- [x] Tests run:
  - `packages/server` → `bunx vitest run src/__tests__/integration/automations/device-agent-kinds-gate.test.ts` → **7/7 pass** (real Hono app, embedded Postgres, new migration applied)
  - `packages/connector-worker` → `bun test` → **109/109 pass across 21 files** (incl. the new `advertised-agent-kinds.test.ts`)
  - Regression sweep: `src/__tests__/integration/automations`, `browser-affinity-poll-claim`, `device-management-{delete,mint}` → **326/326 pass**
- [x] Mutation-tested — every new test is load-bearing:

| mutation | result |
|---|---|
| delete the SQL `agent_kind` predicate from the automation lane | `withholds…` + `claims nothing when… empty kind set` red (2 failed / 4 passed) |
| `agent_kinds = COALESCE(EXCLUDED…, device_workers…)` → `EXCLUDED.agent_kinds` | `persists advertised kinds…` red |
| `normalizeAgentKinds` returns `[]` instead of `null` for a non-array | `persists…` + `leaves a device that never advertised unrestricted` red |
| `Array.isArray(r.agent_kinds)` instead of `parsePgTextArray` in the listing | `reports advertised kinds on GET /api/me/devices` red |
| client advertises the static `AGENT_KINDS` table | 3 poll-body cases red |
| drop the discovery TTL cache | `discovery runs once per TTL` red |
| `if (override) return true` (skip the `existsSync` check) | `a dangling override does not` red |

## Notes
Two bugs found while building this, both fixed here:
- `postgres.js` renders a bound JS array as a bare comma list, which Postgres rejects for `text[]` (`malformed array literal: "claude-code,pi"`). The param goes through the repo's `pgTextArray` helper, with `NULL` preserved as `NULL`.
- The driver hands `text[]` **back** as a raw `'{a,b}'` literal, so `GET /api/me/devices` needs `parsePgTextArray`, not `Array.isArray` — the naive version would have reported `null` for every device.

Follow-up, out of scope here: the Mac app is the primary device executor and does not send `agent_kinds` at all, so it stays in the NULL/unrestricted bucket and keeps the old failure mode until the Swift side advertises. That's an `packages/owletto` change.

DB: additive nullable `text[]` column on `device_workers`, `ADD COLUMN IF NOT EXISTS`, no backfill, reversible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Devices now advertise which agent types they can run.
  - Automation runs are assigned only to compatible devices.
  - Device listings show whether agent capabilities are unavailable, empty, or configured.
  - Agent discovery supports executable detection, configured overrides, and cached polling results.

- **Bug Fixes**
  - Prevented unsupported device-pinned automation runs from being claimed.
  - Added normalization for advertised capabilities, including trimming, deduplication, and invalid-entry filtering.

- **Documentation**
  - Clarified agent capability advertisement and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->