### PR TITLE
feat(server): expose device_workers through query_sql, owner-scoped

### DIFF
--- a/packages/server/src/__tests__/integration/device-workers-query-scope.test.ts
+++ b/packages/server/src/__tests__/integration/device-workers-query-scope.test.ts
@@ -1,0 +1,178 @@
+/**
+ * `device_workers` via query_sql must be OWNER-scoped, not org-scoped.
+ *
+ * The entry exists so an agent can find the UUID that
+ * `automations.device_worker_id` takes — previously it had to reconstruct that
+ * from a `device_created` lifecycle event. But the table is user-owned
+ * (`PRIMARY KEY (user_id, worker_id)`, nullable `organization_id`), and
+ * query_sql is member-safe, so scoping it the way every other allowlisted
+ * relation is scoped — on the org — would let any member enumerate every
+ * colleague's machines: `label` is normally a personal name and `last_seen_at`
+ * is a presence feed.
+ *
+ * This drives the real handler against real Postgres. The unit sibling
+ * (scoped-query-device-workers.test.ts) pins the emitted SQL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { querySql } from '../../tools/admin/query_sql';
+import type { ToolContext } from '../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
+
+interface Ctx {
+  organizationId: string;
+  alice: string;
+  bob: string;
+  aliceDeviceId: string;
+  bobDeviceId: string;
+  aliceUnattachedId: string;
+}
+
+let ctx: Ctx;
+
+function memberCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'member',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as unknown as ToolContext;
+}
+
+async function registerDevice(opts: {
+  userId: string;
+  workerId: string;
+  label: string;
+  organizationId: string | null;
+}): Promise<string> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id, agent_kinds)
+    VALUES (
+      ${opts.userId}, ${opts.workerId}, 'macos', ${sql.json({})}, ${opts.label},
+      ${opts.organizationId}, ${'{claude-code}'}::text[]
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(rows[0].id);
+}
+
+/** Run a query as one member and return the rows it could see. */
+async function runAs(
+  userId: string,
+  sqlText: string
+): Promise<Array<Record<string, unknown>>> {
+  const result = (await querySql(
+    { sql: sqlText },
+    {} as never,
+    memberCtx(ctx.organizationId, userId)
+  )) as { rows?: Array<Record<string, unknown>>; error?: string };
+  if (result.error) throw new Error(`query_sql failed: ${result.error}`);
+  return result.rows ?? [];
+}
+
+describe('device_workers through query_sql is owner-scoped', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Shared Device Org' });
+    const alice = await createTestUser({ email: 'alice-devices@test.example.com' });
+    const bob = await createTestUser({ email: 'bob-devices@test.example.com' });
+    // Both are ordinary members of the SAME workspace — the exact situation an
+    // org-only predicate would leak across.
+    await addUserToOrganization(alice.id, org.id, 'member');
+    await addUserToOrganization(bob.id, org.id, 'member');
+
+    ctx = {
+      organizationId: org.id,
+      alice: alice.id,
+      bob: bob.id,
+      aliceDeviceId: await registerDevice({
+        userId: alice.id,
+        workerId: 'alice-mac',
+        label: "Alice's MacBook Pro",
+        organizationId: org.id,
+      }),
+      bobDeviceId: await registerDevice({
+        userId: bob.id,
+        workerId: 'bob-mac',
+        label: "Bob's MacBook Pro",
+        organizationId: org.id,
+      }),
+      aliceUnattachedId: await registerDevice({
+        userId: alice.id,
+        workerId: 'alice-laptop',
+        label: "Alice's unattached laptop",
+        organizationId: null,
+      }),
+    };
+  });
+
+  it('shows a member only their own devices, never a colleague’s', async () => {
+    const rows = await runAs(ctx.alice, 'SELECT id, worker_id, label FROM device_workers');
+    const workerIds = rows.map((r) => String(r.worker_id)).sort();
+    expect(workerIds).toEqual(['alice-laptop', 'alice-mac']);
+
+    const serialized = JSON.stringify(rows);
+    expect(serialized).not.toContain('bob-mac');
+    expect(serialized).not.toContain("Bob's MacBook Pro");
+  });
+
+  it('is symmetric — Bob cannot see Alice either', async () => {
+    const rows = await runAs(ctx.bob, 'SELECT worker_id FROM device_workers');
+    expect(rows.map((r) => String(r.worker_id))).toEqual(['bob-mac']);
+  });
+
+  it('does not leak a colleague’s device even when asked for it by id', async () => {
+    // The filter has to be in the CTE, not merely in the caller's WHERE — a
+    // targeted lookup is exactly how an enumerating query would be written.
+    const rows = await runAs(
+      ctx.bob,
+      `SELECT id, label FROM device_workers WHERE id = '${ctx.aliceDeviceId}'`
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('exposes the id an Automation pin needs', async () => {
+    // The point of the entry: this UUID is what automations.device_worker_id
+    // takes, and it is the value the agent previously had to dig out of a
+    // lifecycle event.
+    const rows = await runAs(
+      ctx.alice,
+      "SELECT id, agent_kinds FROM device_workers WHERE worker_id = 'alice-mac'"
+    );
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].id)).toBe(ctx.aliceDeviceId);
+    expect(String(rows[0].agent_kinds)).toContain('claude-code');
+  });
+
+  it('includes the owner’s unattached device', async () => {
+    const rows = await runAs(
+      ctx.alice,
+      "SELECT id FROM device_workers WHERE worker_id = 'alice-laptop'"
+    );
+    expect(rows.map((r) => String(r.id))).toEqual([ctx.aliceUnattachedId]);
+  });
+
+  it('rejects the excluded columns rather than returning them', async () => {
+    // connector_manifests is not in the allowlist, so the query must fail
+    // closed at validation rather than silently projecting the column.
+    const result = (await querySql(
+      { sql: 'SELECT connector_manifests FROM device_workers' },
+      {} as never,
+      memberCtx(ctx.organizationId, ctx.alice)
+    )) as { error?: string; rows?: unknown[] };
+    expect(result.error).toBeTruthy();
+    expect(result.rows ?? []).toHaveLength(0);
+  });
+});

--- a/packages/server/src/__tests__/unit/scoped-query-device-workers.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-device-workers.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `device_workers` is the one allowlisted relation that is NOT org-scoped.
+ *
+ * Its PK is `(user_id, worker_id)` and `organization_id` is nullable — the org
+ * records where a device is ATTACHED, not who owns it. Scoping the CTE on the
+ * org alone would let any member of a shared workspace enumerate every
+ * colleague's machines: `label` is normally a personal name and `last_seen_at`
+ * is a presence feed. `query_sql` is member-safe, so the owner predicate is
+ * what makes this entry safe to expose at all.
+ *
+ * The integration sibling (device-workers-query-scope.test.ts) proves the rows
+ * really are filtered; this pins the emitted SQL so the predicate can't be
+ * loosened without a test noticing.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { buildScopedQuery } from '../../utils/execute-data-sources';
+import { SAFE_COLUMN_DEFS } from '../../utils/table-schema';
+
+/**
+ * Every user-facing caller (`query_sql`, metrics, member `client.query`)
+ * passes SAFE_COLUMN_DEFS; without it the CTE degrades to `dw.*` and every
+ * column-exclusion assertion below would pass vacuously. (System-context
+ * `client.query` omits it, but a system context has no principal, so the
+ * owner predicate already yields zero rows there.)
+ */
+const opts = { safeColumns: SAFE_COLUMN_DEFS };
+
+describe('buildScopedQuery device_workers CTE — owner scoping', () => {
+  it('filters on the requesting user, not just the organization', () => {
+    const { sql, params } = buildScopedQuery(
+      'SELECT id, label FROM device_workers',
+      ['device_workers'],
+      { organizationId: 'org_test', userId: 'user_a' },
+      opts
+    );
+
+    expect(sql).toContain('dw.user_id =');
+    expect(sql).toContain('public.device_workers');
+    // Both the owner and the org must be bound — the org arm alone is the leak.
+    expect(params).toContain('user_a');
+    expect(params).toContain('org_test');
+  });
+
+  it('admits an unattached device, since its owner may already pin it', () => {
+    // evaluateDeviceWorkerAccess lets an owner pin a device they own regardless
+    // of attachment, so hiding organization_id IS NULL rows would leave a device
+    // you can pin but cannot find.
+    const { sql } = buildScopedQuery(
+      'SELECT id FROM device_workers',
+      ['device_workers'],
+      { organizationId: 'org_test', userId: 'user_a' },
+      opts
+    );
+    expect(sql).toContain('dw.organization_id IS NULL');
+  });
+
+  it('binds a null principal rather than dropping the predicate', () => {
+    // A headless/service caller has no user. The predicate must still be
+    // emitted: `user_id = NULL` matches nothing, which is the fail-closed
+    // direction. Dropping it would make every device in the org readable.
+    const { sql, params } = buildScopedQuery(
+      'SELECT id FROM device_workers',
+      ['device_workers'],
+      { organizationId: 'org_test' },
+      opts
+    );
+    expect(sql).toContain('dw.user_id =');
+    expect(params).toContain(null);
+  });
+
+  it('never exposes connector_manifests or user_id', () => {
+    // connector_manifests is free-form jsonb the device writes verbatim — the
+    // same uncurated-write risk class that forced redaction onto
+    // connections.config. user_id is always the caller here, so projecting it
+    // only invites correlation.
+    const { sql } = buildScopedQuery(
+      'SELECT * FROM device_workers',
+      ['device_workers'],
+      { organizationId: 'org_test', userId: 'user_a' },
+      opts
+    );
+    const cte = sql.slice(sql.indexOf('"device_workers" AS'));
+    expect(cte).not.toContain('connector_manifests');
+    expect(cte.slice(0, cte.indexOf('FROM'))).not.toContain('user_id');
+  });
+
+  it('projects the id an Automation pin needs', () => {
+    // The whole point of the entry: automations.device_worker_id takes this
+    // UUID, and without it an agent has to reconstruct it from a lifecycle event.
+    const { sql } = buildScopedQuery(
+      'SELECT id FROM device_workers',
+      ['device_workers'],
+      { organizationId: 'org_test', userId: 'user_a' },
+      opts
+    );
+    expect(sql).toContain('"device_workers" AS (SELECT');
+    expect(sql).toMatch(/"device_workers" AS \(SELECT[^)]*\bid\b/);
+    // and the projection must be explicit, never a wildcard
+    expect(sql).not.toContain('dw.*');
+  });
+});

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -25,6 +25,8 @@ describe('QUERYABLE_TABLE_NAMES', () => {
       'connector_definitions',
       'entity_relationships',
       'entity_relationship_types',
+      // Owner-scoped, not org-scoped — see the CTE in execute-data-sources.
+      'device_workers',
     ];
     for (const t of expected) {
       expect(QUERYABLE_TABLE_NAMES.has(t)).toBe(true);
@@ -250,6 +252,12 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
       // outlives its QUERYABLE_SCHEMA entry until the phase-2 migration.
       'default_repair_agent_id',
     ]),
+    // user_id: always the caller under the CTE's owner filter, so projecting it
+    // adds nothing but a correlation handle.
+    // connector_manifests: free-form jsonb the device writes verbatim — the
+    // same uncurated-write risk class that forced redaction onto
+    // connections.config, and nothing needs it to pin an Automation.
+    device_workers: new Set(['user_id', 'connector_manifests']),
     oauth_clients: new Set(['client_secret', 'client_secret_expires_at']),
     oauth_tokens: new Set(['token_hash']),
     // repair_*/last_repair_*: same retired repair-agent subsystem, awaiting the

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -464,6 +464,20 @@ export function buildScopedQuery(
   };
   if (tableRefs.length > 0) bindOrganization();
 
+  // Requesting user, bound lazily like the org. Cast because a null principal
+  // (headless/service caller) gives postgres no type to infer — and `user_id =
+  // NULL` is never true, so those callers see zero owner-scoped rows, which is
+  // the fail-closed direction.
+  let principalP: string | undefined;
+  const bindPrincipal = (): string => {
+    if (!principalP) {
+      idx++;
+      params.push(context.userId ?? null);
+      principalP = `$${idx}::text`;
+    }
+    return principalP;
+  };
+
   // Run every query through the same context-placeholder compiler. Parameter
   // allocation stays lazy so tableless SELECTs bind only values they reference.
   let processedQuery = userQuery;
@@ -768,6 +782,35 @@ export function buildScopedQuery(
         `"${safeName}" AS (SELECT ${sel(table, 'u')} FROM public."user" u ` +
           `JOIN public.member m ON m."userId" = u.id ` +
           `WHERE m."organizationId" = ${orgP})`
+      );
+    } else if (table === 'device_workers') {
+      // NOT an org-scoped table. The PK is (user_id, worker_id) and
+      // `organization_id` is nullable — it records where a device is ATTACHED,
+      // not who owns it. Scoping on the org alone would let any member of a
+      // shared org enumerate every colleague's machines: `label` is typically a
+      // personal name, and `last_seen_at` is a presence feed. That is the leak
+      // class that keeps `user` in ADMIN_ONLY_QUERYABLE_TABLES, so the owner
+      // filter — not the org — is what makes this member-safe.
+      //
+      // The owner predicate is the one `listDeviceWorkers`
+      // (worker-api/device-management.ts) already uses for the typed device
+      // list. The org arm still admits devices with NO org, because
+      // `evaluateDeviceWorkerAccess` already lets an owner pin a device they own
+      // regardless of attachment; hiding those would leave a device you can pin
+      // but cannot find, which is the gap this entry exists to close. It cannot
+      // widen exposure: the owner predicate is ANDed first.
+      //
+      // Deliberately narrower than the pin policy in two places: an owner's
+      // device attached to ANOTHER org is not this org's data, and the
+      // owner/admin arm of `evaluateDeviceWorkerAccess` is not mirrored because
+      // DataSourceContext carries no member role. Both still resolve through
+      // the typed device list, which is owner-scoped and cross-org.
+      const principalP = bindPrincipal();
+      // security-allowed: see block comment above the for-loop
+      ctes.push(
+        `"${safeName}" AS (SELECT ${sel(table, 'dw')} FROM public.device_workers dw ` +
+          `WHERE dw.user_id = ${principalP} ` +
+          `AND (dw.organization_id = ${orgP} OR dw.organization_id IS NULL))`
       );
     } else if (table === 'feeds') {
       // Every feed derives from a connection (`connection_id` NOT NULL), so a

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -741,6 +741,31 @@ export const QUERYABLE_SCHEMA = {
         'updated_at'
       ),
     },
+    // device_workers — the caller's OWN registered devices.
+    //
+    // Excludes `user_id` (always the caller under the CTE's owner filter, so it
+    // only invites correlation) and `connector_manifests` (free-form jsonb the
+    // device writes verbatim, the same "written by the write path, not curated
+    // for secrecy" risk class that forced redactedConfigColumn onto
+    // connections.config; nothing needs it to pin an Automation).
+    //
+    // `id` is the point of the entry: it is the UUID that
+    // `automations.device_worker_id` / `connections.device_worker_id` take, and
+    // without it an agent had to reconstruct it from a device lifecycle event.
+    {
+      name: 'device_workers',
+      columns: cols(
+        'id',
+        'worker_id',
+        'platform',
+        'app_version',
+        'capabilities',
+        'label',
+        'last_seen_at',
+        'organization_id',
+        'agent_kinds'
+      ),
+    },
     // entity_relationship_types — local and public-catalog edge definitions.
     {
       name: 'entity_relationship_types',


### PR DESCRIPTION
## Summary
- An agent creating an Automation can pin it to a device via `automations.device_worker_id`, but there was no allowlisted way to **discover** that UUID — in the live demo the agent had to reconstruct it from a `device_created` lifecycle event. This adds `device_workers` to `QUERYABLE_SCHEMA`.
- `device_workers` is **user-owned, not org-owned**: PK `(user_id, worker_id)`, nullable `organization_id` recording where a device is *attached*, not who owns it. Scoping the CTE on the org — the way every other allowlisted relation is scoped — would let any member of a shared workspace enumerate every colleague's machines (`label` is normally a personal name, `last_seen_at` is a presence feed). So the CTE filters on the requesting principal and ANDs the org arm.
- The org arm still admits unattached devices (`organization_id IS NULL`), because `evaluateDeviceWorkerAccess` already lets an owner pin a device they own regardless of attachment — hiding them would leave a device you can pin but cannot find, which is the gap this closes. It cannot widen exposure: the owner predicate is ANDed first.
- `user_id` and `connector_manifests` are registered in the drift test's `INTENTIONALLY_OMITTED` set — the former is always the caller under the owner filter, the latter is free-form jsonb the device writes verbatim (the same uncurated-write risk class that forced redaction onto `connections.config`).

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build + strict typecheck + knip + biome "Checked 567 files, No fixes applied" + naming + gateway-LLM + entity-write gates, 19 pass / 0 fail)
- [x] Tests run: `bun test src/__tests__/unit/scoped-query-device-workers.test.ts` → **5 pass / 0 fail**; `bunx vitest run src/__tests__/integration/device-workers-query-scope.test.ts src/utils/__tests__/table-schema.test.ts` → **32 pass / 0 fail**
- [ ] Bug fix: n/a — this is a missing-capability gap, not a regression
- [ ] Bot runtime unchanged

### What the tests actually prove
`device-workers-query-scope.test.ts` drives the **real `querySql` handler against real Postgres** with two ordinary members (alice, bob) of the **same** org and three device rows (alice-mac attached, bob-mac attached, alice-laptop unattached):

- a member sees only their own devices, and the serialized result contains neither `bob-mac` nor `Bob's MacBook Pro`
- symmetric in the other direction
- a **targeted** `WHERE id = '<alice's uuid>'` run as Bob returns 0 rows — the filter has to live in the CTE, not merely in the caller's `WHERE`, since a targeted lookup is exactly how an enumerating query would be written
- `id` + `agent_kinds` come back for the row an Automation pin needs
- the unattached device is included
- `SELECT connector_manifests` fails closed with an error and 0 rows

`scoped-query-device-workers.test.ts` pins the emitted SQL so the predicate cannot be loosened silently. It threads `SAFE_COLUMN_DEFS` through every `buildScopedQuery` call — without it the CTE degrades to `dw.*` and every column-exclusion assertion would pass **vacuously**.

### Mutation testing
| mutation | result |
|---|---|
| neutralise the owner guard (`dw.user_id IS NOT NULL OR $p IS NULL` — param-consuming so arity stays valid) | exactly the 3 leak tests fail; the 3 positive tests still pass |
| drop the `organization_id IS NULL` arm | 2 fail (`shows a member only their own devices`, `includes the owner's unattached device`) |
| add `connector_manifests` to the column list | 1 integration + 1 unit test fail |

## Notes
Follows #2918 (`agent_kinds` persistence + automation-lane gate), which is what makes `agent_kinds` worth projecting here: an agent can now read a device's advertised kinds before pinning, instead of pinning blind and getting a claimed-then-failed run.

Deliberately narrower than `evaluateDeviceWorkerAccess` in two places, documented at the CTE: an owner's device attached to **another** org is not this org's data, and the owner/admin arm is not mirrored because `DataSourceContext` carries no member role. Both still resolve through the typed device list, which is owner-scoped and cross-org. Closing the gap would mean threading a role flag into `DataSourceContext` (touching `query_sql`, `metric_series`, `client.query`) — out of scope for one branch.