### PR TITLE
fix(automations): contain a write-rule escalate to its promoted row

### DIFF
--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -24,6 +24,7 @@ import type { AuthContext } from '../../../tools/execute';
 import { executeTool } from '../../../tools/execute';
 import { createAutomationRun } from '../../../runs/queue-service';
 import { computePendingWindow } from '../../../utils/window-utils';
+import { compileEntityRule } from '../../../authz/entity-rule-executor';
 import { promoteAutomationEntityOutput } from '../../../utils/promote-keyed-entities';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
@@ -1323,5 +1324,507 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect((feedback[0].metadata as Record<string, unknown>).reason).toBe(
       'severity should stay high'
     );
+  });
+
+  /**
+   * A write rule is a per-ROW verdict. Every case that mints a card ends the
+   * same way — approve, and the change lands — because that round trip is the
+   * only thing that proves the card is CLEARABLE. A card can be minted, carry
+   * the right fields, and still be dead: the apply path replays the write, so a
+   * grant that does not cover what the rule escalates makes the write throw and
+   * `applyFailure` resets the run to pending, forever. The last case mints no
+   * card at all, for the same reason: a write the rule denies has no approval
+   * that could rescue it.
+   */
+  describe('a rule escalate is contained to its row', () => {
+    const escalatingType = async (ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>, source: string) => {
+      const compiled = await compileEntityRule(source);
+      await ctx.sql`
+        UPDATE entity_types SET rules_compiled = ${compiled}
+        WHERE organization_id = ${ctx.workspace.org.id} AND slug = 'topic'
+      `;
+    };
+
+    const metaFor = async (ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>, stableKey: string) => {
+      const [row] = await ctx.sql`
+        SELECT e.metadata FROM entities e
+        JOIN entity_identities ei ON ei.entity_id = e.id
+        WHERE ei.namespace = 'automation_key'
+          AND ei.identifier = ${topicIdentity(ctx.automationId, stableKey)}
+      `;
+      return row.metadata as Record<string, unknown>;
+    };
+
+    const pendingCard = async (ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>) => {
+      const rows = await ctx.sql`
+        SELECT id, action_input FROM runs
+        WHERE organization_id = ${ctx.workspace.org.id}
+          AND run_type = 'internal'
+          AND action_key = 'entity_field_change'
+          AND approval_status = 'pending'
+      `;
+      return rows;
+    };
+
+    const approve = async (ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>, runId: number) => {
+      const res = (await executeTool(
+        'manage_operations',
+        { action: 'approve', run_id: runId },
+        TEST_ENV,
+        ownerAuthCtx(ctx.workspace.org.id, ctx.workspace.users.owner.id)
+      )) as { approved?: boolean };
+      expect(res.approved).toBe(true);
+      const [settled] = await ctx.sql`
+        SELECT status, approval_status FROM runs WHERE id = ${runId}
+      `;
+      expect(settled.status).toBe('completed');
+      expect(settled.approval_status).toBe('approved');
+    };
+
+    it('holds the escalating row only, and the card clears', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing and loading slowly.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', severity: 'low' },
+            { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+          ],
+        },
+      });
+
+      // The rule is deployed AFTER the automation is already promoting rows.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && row.next.severity === "critical") {
+    row.escalate(["severity"], "a critical topic needs sign-off");
+  }
+};`
+      );
+
+      let windowError: unknown = null;
+      try {
+        await ctx.api.automations.completeWindow({
+          automation_id: String(ctx.automationId),
+          window_token: token,
+          run_metadata: { automation_run_id: runId },
+          extracted_data: {
+            problems: [
+              { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+              { category: 'Performance', name: 'Slow Loading', severity: 'medium' },
+            ],
+          },
+        });
+      } catch (err) {
+        windowError = err;
+      }
+
+      // Letting a per-row verdict escape rolls back the WHOLE completion — every
+      // promoted row and every declared output — and it recurs on every retry.
+      expect(windowError).toBeNull();
+      expect((await metaFor(ctx, SLOW_LOADING_KEY)).severity).toBe('medium');
+      expect((await metaFor(ctx, APP_CRASHES_KEY)).severity).toBe('low');
+
+      const cards = await pendingCard(ctx);
+      expect(cards.length).toBe(1);
+      const proposal = cards[0].action_input as {
+        escalated_fields?: string[];
+        fields: Record<string, unknown>;
+      };
+      expect(proposal.escalated_fields).toEqual(['severity']);
+      expect(proposal.fields.severity).toBe('critical');
+
+      await approve(ctx, Number(cards[0].id));
+      expect((await metaFor(ctx, APP_CRASHES_KEY)).severity).toBe('critical');
+    });
+
+    it('holds the row whole when the rule gates on COMMITTED state', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'ops', summary: 'first' },
+          ],
+        },
+      });
+
+      // `row.next` is `{...committed, ...patch}`, so this reads the MERGED owner
+      // and keeps firing however much a write drops. Anything that tried to
+      // satisfy it by shrinking the patch would never terminate — or would fail
+      // the row closed with no card at all.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && row.next.owner) {
+    row.escalate(["owner", "reviewed_by"], "an owned topic needs sign-off");
+  }
+};`
+      );
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'security', summary: 'second' },
+          ],
+        },
+      });
+
+      // Nothing applies: the rule judged this write as one unit, so no subset of
+      // it may commit on its own.
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({
+        owner: 'ops',
+        summary: 'first',
+      });
+
+      const cards = await pendingCard(ctx);
+      expect(cards.length).toBe(1);
+      const proposal = cards[0].action_input as {
+        escalated_fields?: string[];
+        fields: Record<string, unknown>;
+      };
+      // The grant is the rule's OWN list — including `reviewed_by`, which this
+      // row never proposes. The replay demands the grant cover every field the
+      // VERDICT names, so trimming it to the proposed subset mints a dead card.
+      expect(proposal.escalated_fields).toEqual(['owner', 'reviewed_by']);
+      expect(proposal.fields).toMatchObject({ owner: 'security', summary: 'second' });
+
+      await approve(ctx, Number(cards[0].id));
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({
+        owner: 'security',
+        summary: 'second',
+      });
+    });
+
+    it('clears when the rule escalates from more than one branch', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            {
+              category: 'Stability',
+              name: 'App Crashes',
+              severity: 'low',
+              owner: 'ops',
+            },
+          ],
+        },
+      });
+
+      // Two branches both fire. The executor UNIONS repeated `escalate()` calls
+      // (#2910), so one verdict carries both field sets and both reasons — and
+      // because the card replays the same write the verdict judged, the replay
+      // agrees with it.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && row.changed("severity")) {
+    row.escalate(["severity"], "a severity change needs sign-off");
+  }
+  if (row.op === "update" && row.changed("owner")) {
+    row.escalate(["owner"], "reassigning an owner needs sign-off");
+  }
+};`
+      );
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            {
+              category: 'Stability',
+              name: 'App Crashes',
+              severity: 'critical',
+              owner: 'security',
+            },
+          ],
+        },
+      });
+
+      const cards = await pendingCard(ctx);
+      expect(cards.length).toBe(1);
+      const proposal = cards[0].action_input as {
+        escalated_fields?: string[];
+        reason?: string;
+      };
+      expect([...(proposal.escalated_fields ?? [])].sort()).toEqual(['owner', 'severity']);
+      // Every field the card holds is explained: a grant naming a field whose
+      // reason was dropped tells the approver nothing about why it is held.
+      expect(proposal.reason).toContain('reassigning an owner needs sign-off');
+      expect(proposal.reason).toContain('a severity change needs sign-off');
+
+      // The decisive assertion: BOTH fields land. Approving replays the whole
+      // write, so the severity branch is satisfied by the same grant.
+      await approve(ctx, Number(cards[0].id));
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({
+        severity: 'critical',
+        owner: 'security',
+      });
+    });
+
+    it('grants what the rule says about the CARD, not about the residual write', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'ops', summary: 'first' },
+          ],
+        },
+      });
+
+      // A human owns `owner`, so the automation's proposal for it is held by
+      // FIELD OWNERSHIP before any rule runs — the write the rule sees is a
+      // strict subset of the write the card will replay.
+      const [row] = await ctx.sql`
+        SELECT e.id FROM entities e
+        JOIN entity_identities ei ON ei.entity_id = e.id
+        WHERE ei.namespace = 'automation_key'
+          AND ei.identifier = ${topicIdentity(ctx.automationId, APP_CRASHES_KEY)}
+      `;
+      await ctx.workspace.owner.entities.update({
+        entity_id: Number(row.id),
+        metadata: { owner: 'sec-team' },
+        field_note: 'assigned by hand',
+      });
+
+      // Two branches, and only the FIRST can fire on the residual: the held
+      // `owner` never reaches `row.next`, so the residual answers about
+      // `summary` while the card's own write answers about `owner`.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && row.next.summary) {
+    row.escalate(["summary"], "a summary needs sign-off");
+  }
+  if (row.op === "update" && row.next.owner === "ops") {
+    row.escalate(["owner"], "handing a topic back to ops needs sign-off");
+  }
+};`
+      );
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'ops', summary: 'second' },
+          ],
+        },
+      });
+
+      const cards = await pendingCard(ctx);
+      expect(cards.length).toBe(1);
+      const proposal = cards[0].action_input as {
+        escalated_fields?: string[];
+        fields: Record<string, unknown>;
+      };
+      expect(proposal.fields).toMatchObject({ owner: 'ops', summary: 'second' });
+      // The residual's verdict names only `summary` — the held `owner` never
+      // reaches `row.next`, so its branch cannot fire there. The card replays
+      // `owner` too, so a grant copied off the residual is short by exactly the
+      // field the replay escalates on, and approval could never clear it.
+      expect([...(proposal.escalated_fields ?? [])].sort()).toEqual(['owner', 'summary']);
+
+      await approve(ctx, Number(cards[0].id));
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({
+        owner: 'ops',
+        summary: 'second',
+      });
+    });
+
+    it('fails the row closed when the rule denies the write the card would replay', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'ops', summary: 'first' },
+          ],
+        },
+      });
+
+      const [row] = await ctx.sql`
+        SELECT e.id FROM entities e
+        JOIN entity_identities ei ON ei.entity_id = e.id
+        WHERE ei.namespace = 'automation_key'
+          AND ei.identifier = ${topicIdentity(ctx.automationId, APP_CRASHES_KEY)}
+      `;
+      await ctx.workspace.owner.entities.update({
+        entity_id: Number(row.id),
+        metadata: { owner: 'sec-team' },
+        field_note: 'assigned by hand',
+      });
+
+      // The residual only ever reaches the escalate; the write the card would
+      // replay hits the deny. Carding it would mint a proposal that throws the
+      // moment anyone approves it.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && row.next.owner === "ops") {
+    row.deny("a topic cannot be handed back to ops");
+  }
+  if (row.op === "update" && row.next.summary) {
+    row.escalate(["summary"], "a summary needs sign-off");
+  }
+};`
+      );
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', owner: 'ops', summary: 'second' },
+          ],
+        },
+      });
+
+      expect(await pendingCard(ctx)).toEqual([]);
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({
+        owner: 'sec-team',
+        summary: 'first',
+      });
+    });
+
+    it('cards with NO grant when the rule escalates the residual but allows the whole write', async () => {
+      const ctx = await setupKeyedAutomation();
+      const { sql, workspace } = ctx;
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+      const token = await readWindowToken(ctx);
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', severity: 'low', summary: 'first' },
+          ],
+        },
+      });
+
+      // A human owns `severity`, so the merge strips it and the rule sees a
+      // residual with no severity at all.
+      const [entity] = await sql`
+        SELECT e.id FROM entities e
+        JOIN entity_identities ei ON ei.entity_id = e.id
+        WHERE ei.namespace = 'automation_key'
+          AND ei.identifier = ${topicIdentity(ctx.automationId, APP_CRASHES_KEY)}
+      `;
+      await sql`
+        UPDATE entities
+        SET field_controls = ${sql.json({ severity: { set_by: workspace.users.owner.id } })}
+        WHERE id = ${entity.id}
+      `;
+
+      // `changed()` is what separates the residual from the whole write:
+      // `row.next` merges committed state, so severity LOOKS present either way,
+      // but only the whole write actually changes it. The rule therefore
+      // escalates the residual and allows the whole write — `fullProposalVerdict`
+      // returns null and the card is held by OWNERSHIP, not by the rule.
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update" && !row.changed("severity")) {
+    row.escalate(["summary"], "a topic that leaves severity alone needs sign-off");
+  }
+};`
+      );
+
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [
+            { category: 'Stability', name: 'App Crashes', severity: 'high', summary: 'second' },
+          ],
+        },
+      });
+
+      const cards = await pendingCard(ctx);
+      expect(cards.length).toBe(1);
+      // No grant and no rule reason: neither describes why THIS card exists —
+      // the rule is satisfied by the write the card replays.
+      const proposal = cards[0].action_input as { escalated_fields?: string[] };
+      expect(proposal.escalated_fields ?? []).toEqual([]);
+
+      // And it still clears, which is the point: a grantless card is only safe
+      // because the replayed write is one the rule allows.
+      await approve(ctx, Number(cards[0].id));
+      expect((await metaFor(ctx, APP_CRASHES_KEY)).severity).toBe('high');
+    });
   });
 });

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -55,11 +55,12 @@ export interface EntityRowValidationVerdict {
  * Thrown when a patch would produce an illegal state.
  *
  * Throwing rather than returning a verdict is deliberate: it makes failing
- * closed the DEFAULT for every caller. Only `updateEntity` has approval
- * machinery to route an escalation into, and it opts in by catching this and
- * reading {@link verdict}. Merge, link auto-create and eval scaffolding have
- * nowhere to queue a card, so for them a rule that asked for review must stop
- * the write — which is exactly what an uncaught throw does.
+ * closed the DEFAULT for every caller. Only a caller with approval machinery to
+ * route an escalation into opts in by catching this and reading {@link verdict}
+ * — `updateEntity`, and automation promotion (`promote-keyed-entities`). Merge,
+ * link auto-create and eval scaffolding have nowhere to queue a card, so for
+ * them a rule that asked for review must stop the write — which is exactly what
+ * an uncaught throw does.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -689,7 +689,12 @@ export async function mergeEntityFields(params: {
 	return merge;
 }
 
-function parseEntityJsonObject(value: unknown): Record<string, unknown> {
+/**
+ * Tolerant metadata/controls parse. Exported for `promote-keyed-entities`,
+ * which reads live metadata inside a rule-containment catch — a throw there
+ * would escape the catch and roll back the window completion it exists to save.
+ */
+export function parseEntityJsonObject(value: unknown): Record<string, unknown> {
 	if (value == null) return {};
 	if (typeof value === "string") {
 		try {
@@ -724,8 +729,11 @@ function parseEntityJsonObject(value: unknown): Record<string, unknown> {
  *
  * A rule that crashes or times out reads as a deny, so a broken rule surfaces as
  * an error rather than an unanswerable approval.
+ *
+ * Exported for automation promotion, whose merge strips human-owned and
+ * policy-gated fields before validating and so faces the same split.
  */
-async function fullProposalVerdict(params: {
+export async function fullProposalVerdict(params: {
 	tx: DbClient;
 	entityId: number;
 	patch: EntityRowPatch;

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -49,11 +49,13 @@ import type { DbClient } from '../db/client';
 import type { EntityOutput } from '../types/automations';
 import type { AppliedChange, BlockedChange } from './entity-field-merge';
 import {
+  fullProposalVerdict,
   hardDeleteEntityRows,
   insertEntityRow,
   mergeEntityFields,
+  parseEntityJsonObject,
 } from './entity-management';
-import { validateEntityRowInsert } from '../authz/entity-row-validation';
+import { EntityRowValidationError, validateEntityRowInsert } from '../authz/entity-row-validation';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
 import { resolveEntityCreator } from './resolve-entity-creator';
@@ -298,6 +300,14 @@ async function upsertKeyedEntity(params: {
   applied: Record<string, AppliedChange>;
   blockedCreate: boolean;
   deniedUpdate?: true;
+  /**
+   * Set when a write RULE escalates the write the card will replay. The card
+   * must carry that verdict's field list verbatim: the replay checks
+   * `verdict.fields.every(f => approvedFields.includes(f))`, so a grant built
+   * from anything else — the fields this row happened to propose, the verdict
+   * on some subset of the write — mints a card no approval can ever clear.
+   */
+  escalated?: { fields: string[]; reason: string };
 }> {
   const { tx, organizationId, identifier } = params;
 
@@ -354,21 +364,101 @@ async function upsertKeyedEntity(params: {
       };
     }
     const requireApproval = [...decision.requireApproval];
-    const merge = await mergeEntityFields({
-      tx,
-      entityId,
-      fields: params.fieldValues,
-      source: 'automation',
-      actorId: null,
-      requireApproval,
-    });
-    return {
-      entityId,
-      created: false,
-      blocked: merge.blocked,
-      applied: merge.applied,
-      blockedCreate: false,
-    };
+    try {
+      const merge = await mergeEntityFields({
+        tx,
+        entityId,
+        fields: params.fieldValues,
+        source: 'automation',
+        actorId: null,
+        requireApproval,
+      });
+      return {
+        entityId,
+        created: false,
+        blocked: merge.blocked,
+        applied: merge.applied,
+        blockedCreate: false,
+      };
+    } catch (err) {
+      if (!(err instanceof EntityRowValidationError)) throw err;
+      // A write rule is a per-ROW verdict, so it must not escape this row.
+      // Letting it propagate rolls back the whole window completion — every
+      // promoted row and every declared output — and it recurs on every retry,
+      // so one escalating rule permanently poison-pills the automation.
+      //
+      // A deny is a refusal, not a request for review: fail the row closed,
+      // like the policy deny above.
+      if (err.verdict.outcome !== 'escalate') {
+        return {
+          entityId,
+          created: false,
+          blocked: {},
+          applied: {},
+          blockedCreate: false,
+          deniedUpdate: true,
+        };
+      }
+      // Hold the row WHOLE, and ask the rule about that same whole write.
+      //
+      // The caught verdict judged the RESIDUAL — `mergeEntityFields` strips
+      // human-owned and policy-gated fields before it validates, so the write
+      // the rule answered about can be a strict subset of the one the card
+      // replays. The replay demands `verdict.fields.every(f =>
+      // approvedFields.includes(f))`, so a grant copied off the residual mints
+      // a card no approval can ever clear: approving re-runs the rule against
+      // the full write, it names a field nobody granted, and the write throws.
+      // (`updateEntity` re-asks for the same reason — same helper.)
+      const [live] = await tx<{ metadata: unknown }>`
+        SELECT metadata FROM entities WHERE id = ${entityId}
+      `;
+      // Tolerant parse on purpose: this runs INSIDE the containment catch, so a
+      // throw here would escape it and roll back the very window completion the
+      // catch exists to save.
+      const current = parseEntityJsonObject(live?.metadata);
+      const held: Record<string, BlockedChange> = {};
+      for (const [field, proposed] of Object.entries(params.fieldValues)) {
+        held[field] = { current: current[field] ?? null, proposed };
+      }
+      // `fieldControls` is ungoverned, so a metadata-only patch asks the rule
+      // the whole question the card's replay will ask it.
+      const whole = await fullProposalVerdict({
+        tx,
+        entityId,
+        patch: { metadata: { ...current, ...params.fieldValues } },
+      });
+      // Stated in the terms the card proposes, not the residual's. A deny on
+      // the whole write is the same dead end as an uncovered escalate, so fail
+      // the row closed rather than card a proposal approval cannot rescue.
+      if (whole?.verdict.outcome === 'deny') {
+        return {
+          entityId,
+          created: false,
+          blocked: {},
+          applied: {},
+          blockedCreate: false,
+          deniedUpdate: true,
+        };
+      }
+      // A whole write the rule finds legal still needs the card — those fields
+      // are held by ownership or policy, not by the rule — but no grant, and
+      // no rule reason: neither describes why THIS card exists.
+      return {
+        entityId,
+        created: false,
+        blocked: held,
+        applied: {},
+        blockedCreate: false,
+        ...(whole?.verdict.outcome === 'escalate'
+          ? {
+              escalated: {
+                fields: whole.verdict.fields,
+                reason: whole.verdict.reason,
+              },
+            }
+          : {}),
+      };
+    }
   }
 
   // Org policy holds creates of this type for approval — no insert, no identity
@@ -598,7 +688,15 @@ export async function promoteAutomationEntityOutput(
     };
 
     try {
-      const { created, blocked, applied, entityId, blockedCreate, deniedUpdate } = await tx.savepoint((sp) =>
+      const {
+        created,
+        blocked,
+        applied,
+        entityId,
+        blockedCreate,
+        deniedUpdate,
+        escalated,
+      } = await tx.savepoint((sp) =>
         upsertKeyedEntity({
           tx: sp,
           organizationId,
@@ -620,7 +718,7 @@ export async function promoteAutomationEntityOutput(
       if (deniedUpdate) {
         logger.warn(
           { automationId, organizationId, windowId, stableKey, entityId },
-          '[promote-keyed-entities] mutation gate denied update — row skipped'
+          '[promote-keyed-entities] update denied by the mutation gate or a write rule — row skipped'
         );
         continue;
       }
@@ -669,6 +767,10 @@ export async function promoteAutomationEntityOutput(
             fields: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].proposed])),
             current: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].current])),
             attribution: ApprovalAttribution.Automation,
+            // A rule-held row carries the rule's own grant and reason: the apply
+            // path replays the write, so an empty grant re-escalates, the write
+            // throws, and `applyFailure` resets the run to pending — forever.
+            ...(escalated ? { escalatedFields: escalated.fields, reason: escalated.reason } : {}),
             automationId,
             windowId,
           })


### PR DESCRIPTION
## Summary
- A write rule is a per-**row** verdict, but an `escalate` on a promoted row escaped the row and rolled back the whole `complete_window` transaction — every promoted row and every declared output — recurring on every retry. One escalating rule permanently poison-pilled the automation, so rules and automations could not be run together at all.
- Contain it at the merge: hold the row **whole**, then ask the rule about that same whole write and take the card's grant from *that* verdict.
- Reuses `updateEntity`'s existing `fullProposalVerdict` (now exported) rather than adding a second copy of the same reasoning.

## Why the grant must come from a second ask
`computeFieldMerge` strips human-owned and policy-gated fields **before** it builds `nextMetadata` (`entity-field-merge.ts:137-142` — the `continue`), so the verdict thrown by `mergeEntityFields` judges a **residual** write, while the card replays the **whole** one. The replay checks `verdict.fields.every(f => approvedFields.includes(f))`, so a grant copied off the residual mints a card no approval can ever clear: approving re-runs the rule against the full write, it names a field nobody granted, and the write throws — `applyFailure` then resets the run to `pending`, forever.

This is exactly the invariant `updateEntity` already encodes ("the card replays the FULL proposal — so the full proposal is what has to be legal"), which is why this shares its helper instead of reimplementing it.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] Tests run: `promote-keyed-entities` 20/20 · `integration/automations` + `integration/authz` 523/523
- [x] Bug fix: red→fix→green outputs pasted below

**Red (grant taken off the residual verdict):**
```
× grants what the rule says about the CARD, not about the residual write
  → expected [ 'summary' ] to deeply equal [ 'owner' ]
```
and with that assertion removed, approve confirms the card is dead, not merely mislabeled:
```
expect(res.approved).toBe(true)  → expected undefined to be true   // reset to pending
```

**Green:** `Tests  20 passed (20)`

**Mutation tests** — each guard isolated, each failing only its own test:
```
rethrow the escalate (no containment) → 3 fail: window rolled back
grant off the residual verdict        → expected ['summary'] to equal ['owner']
never fail closed on a whole-write deny → expected [{id:31,…}] to equal []
apply the legal subset inline         → 2 fail: rule escalates AGAIN on the residual write
```
The last one is the argument for holding the row whole: applying a subset makes the rule re-fire on a patch it never judged.

## Notes
Behaviour is unchanged for every path that doesn't throw — no rules configured, ownership holds, policy defer/deny, and `allow` all take the original code path. The blast radius is orgs with a rule that fires on promoted rows, where `main` today produces zero working rows.

Follow-ups, not in this PR:
- Creates are the other half of this class and are handled in a stacked PR.
- Duplicate cards: the idempotency key carries `windowId`, so each window mints a fresh card for the same logical change. Proven with a byte-identical payload across two windows. Pre-existing on `main`; this PR increases card size (whole row), not card count.
