### PR TITLE
fix(automations): contain a write-rule verdict on a promoted CREATE

### DIFF
--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -1826,5 +1826,138 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       await approve(ctx, Number(cards[0].id));
       expect((await metaFor(ctx, APP_CRASHES_KEY)).severity).toBe('high');
     });
+
+    /**
+     * Creates are the other half of the class. `validateEntityRowInsert` throws
+     * on an uncovered escalate, and the caller only ever queued a create card
+     * for a POLICY defer — so a rule escalate on create reached the outer catch
+     * and rolled the whole completion back, on every retry.
+     */
+    // A create card carries `entity_change`, not the update path's
+    // `entity_field_change`, so it needs its own lookup.
+    const pendingAnyCard = async (ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>) =>
+      await ctx.sql`
+        SELECT id, action_key, action_input FROM runs
+        WHERE organization_id = ${ctx.workspace.org.id}
+          AND run_type = 'internal'
+          AND approval_status = 'pending'
+      `;
+
+    const findEntity = async (
+      ctx: Awaited<ReturnType<typeof setupKeyedAutomation>>,
+      stableKey: string
+    ) =>
+      await ctx.sql`
+        SELECT id, slug, metadata FROM entities
+        WHERE organization_id = ${ctx.workspace.org.id}
+          AND metadata->>'stable_key' = ${stableKey}
+      `;
+
+    it('cards a CREATE the rule escalated instead of failing the window', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "create") {
+    row.escalate(["severity"], "a new topic needs sign-off");
+  }
+};`
+      );
+
+      let windowError: unknown = null;
+      try {
+        await ctx.api.automations.completeWindow({
+          automation_id: String(ctx.automationId),
+          window_token: await readWindowToken(ctx),
+          run_metadata: { automation_run_id: runId },
+          extracted_data: {
+            problems: [{ category: 'Stability', name: 'App Crashes', severity: 'critical' }],
+          },
+        });
+      } catch (err) {
+        windowError = err;
+      }
+
+      expect(windowError).toBeNull();
+      // No row: a create has no held-field bookkeeping, because the aborted
+      // savepoint leaves nothing behind and the whole proposal is the card.
+      expect(await findEntity(ctx, APP_CRASHES_KEY)).toEqual([]);
+
+      const cards = await pendingAnyCard(ctx);
+      expect(cards.length).toBe(1);
+      expect(cards[0].action_key).toBe('entity_change');
+      // The verdict needs no second ask here: a create strips nothing before
+      // the rule runs, so the judged write and the replayed write are the same.
+      expect((cards[0].action_input as { escalated_fields?: string[] }).escalated_fields).toEqual([
+        'severity',
+      ]);
+
+      await approve(ctx, Number(cards[0].id));
+      const created = await findEntity(ctx, APP_CRASHES_KEY);
+      expect(created.length).toBe(1);
+      expect(created[0].metadata as Record<string, unknown>).toMatchObject({
+        severity: 'critical',
+      });
+
+      // The automation_key identity is claimed on the NEXT promotion, not at
+      // approval — so re-promoting must adopt the approved row, not fork it.
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: await readWindowToken(ctx),
+        run_metadata: { automation_run_id: runId },
+        extracted_data: {
+          problems: [{ category: 'Stability', name: 'App Crashes', severity: 'critical' }],
+        },
+      });
+      expect((await findEntity(ctx, APP_CRASHES_KEY)).length).toBe(1);
+    });
+
+    it('skips a CREATE the rule denied, and mints no card for it', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const runId = await queueRunningRun(ctx);
+
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "create") {
+    row.deny("this type is closed to new rows");
+  }
+};`
+      );
+
+      let windowError: unknown = null;
+      try {
+        await ctx.api.automations.completeWindow({
+          automation_id: String(ctx.automationId),
+          window_token: await readWindowToken(ctx),
+          run_metadata: { automation_run_id: runId },
+          extracted_data: {
+            problems: [{ category: 'Stability', name: 'App Crashes', severity: 'low' }],
+          },
+        });
+      } catch (err) {
+        windowError = err;
+      }
+
+      // Fail the ROW closed, not the window — and mint nothing, because
+      // approval cannot launder a deny into a write.
+      expect(windowError).toBeNull();
+      expect(await findEntity(ctx, APP_CRASHES_KEY)).toEqual([]);
+      expect(await pendingAnyCard(ctx)).toEqual([]);
+    });
   });
 });

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -470,17 +470,58 @@ async function upsertKeyedEntity(params: {
 
   // 2. Create the entity (sequence-allocated id — multi-replica safe),
   //    tolerating a slug collision so promotion can never poison-pill the window.
-  const entityId = await insertEntityWithUniqueSlug({
-    tx,
-    organizationId,
-    entityTypeId: params.entityTypeId,
-    parentEntityId: params.parentEntityId,
-    name: params.name,
-    baseSlug: params.baseSlug,
-    identifier,
-    metadata: params.metadata,
-    createdBy: params.createdBy,
-  });
+  let entityId: number;
+  try {
+    entityId = await insertEntityWithUniqueSlug({
+      tx,
+      organizationId,
+      entityTypeId: params.entityTypeId,
+      parentEntityId: params.parentEntityId,
+      name: params.name,
+      baseSlug: params.baseSlug,
+      identifier,
+      metadata: params.metadata,
+      createdBy: params.createdBy,
+    });
+  } catch (err) {
+    if (!(err instanceof EntityRowValidationError)) throw err;
+    // Same containment as the update path above, and for the same reason: a
+    // rule verdict is per-ROW, so letting it escape rolls back the whole window
+    // completion and recurs on every retry.
+    //
+    // Validation runs INSIDE the savepoint and throws before `insertEntityRow`,
+    // so the savepoint has already unwound — there is no partial row to undo.
+    if (err.verdict.outcome !== 'escalate') {
+      logger.warn(
+        {
+          automationId: params.automationId,
+          organizationId,
+          identifier,
+          reason: err.verdict.reason,
+        },
+        '[promote-keyed-entities] a write rule denied this create — row skipped'
+      );
+      return {
+        entityId: 0,
+        created: false,
+        blocked: {},
+        applied: {},
+        blockedCreate: true,
+      };
+    }
+    // Unlike the update path, this verdict needs no second ask. A create has no
+    // committed row and so no held fields — nothing is stripped before the rule
+    // runs — and the card replays the same `entity_data` that was just judged.
+    // The verdict and the replay are already about the same write.
+    return {
+      entityId: 0,
+      created: false,
+      blocked: {},
+      applied: {},
+      blockedCreate: true,
+      escalated: { fields: err.verdict.fields, reason: err.verdict.reason },
+    };
+  }
 
   // 3. Claim the stable key. ON CONFLICT DO NOTHING against the live-unique
   //    index: if a concurrent completion already claimed it, our insert is a
@@ -723,9 +764,13 @@ export async function promoteAutomationEntityOutput(
         continue;
       }
       if (blockedCreate) {
-        // Only a 'defer' outcome queues an approval; a 'deny' is fail-closed —
-        // the row is skipped entirely (no create, no approval card).
-        if (createGate.outcome === 'defer') {
+        // A create is carded when POLICY defers it or when a write RULE
+        // escalated it. A 'deny' from either is fail-closed — the row is skipped
+        // entirely (no create, no approval card), because approval cannot
+        // launder a refusal into a write. A rule deny needs no separate signal:
+        // it can only be reached once policy already said 'allow', because a
+        // policy defer returns before the insert the rule runs inside.
+        if (createGate.outcome === 'defer' || escalated) {
           const createProposal = {
             entity_type: entityTypeSlug,
             name,
@@ -742,6 +787,11 @@ export async function promoteAutomationEntityOutput(
               },
               proposal: createProposal,
               attribution: ApprovalAttribution.Automation,
+              // A rule-held create carries the rule's own grant and reason: the
+              // apply path replays the insert, so an empty grant re-escalates.
+              ...(escalated
+                ? { escalatedFields: escalated.fields, reason: escalated.reason }
+                : {}),
               automationId,
               windowId,
             })


### PR DESCRIPTION
## Summary
- Creates are the other half of the class #2923 fixes for updates. `validateEntityRowInsert` throws on an uncovered `escalate`, and the caller only ever queued a create card for a **policy** defer — so a rule escalate on create reached the outer catch, rolled back the whole `complete_window` transaction, and recurred on every retry.
- Contain it at the insert: the whole proposal is the card, carrying the rule's grant and reason so approval can actually clear it.
- A rule **deny** skips the row, matching the policy deny above it.

**Stacked on #2923** — review that first; this PR's own commit is the create path only.

## Why this needs no second verdict
The update path has to re-ask the rule (`fullProposalVerdict`) because `computeFieldMerge` strips held fields before validating, so the verdict judges a residual. A create has no committed row and therefore no held fields — nothing is stripped before the rule runs, and the card replays the same `entity_data` that was just judged. Verdict and replay already describe the same write.

Two details worth stating, both verified rather than assumed:
- Validation runs **inside** the savepoint and throws before `insertEntityRow`, so the savepoint has already unwound — there is no partial row to undo.
- A rule deny needs no separate signal: it can only be reached once policy already said `allow`, because a policy defer returns at `:440`, before the insert the rule runs inside at `:448`. I added such a signal first, proved it unreachable, and removed it rather than ship defensive dead code.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] Tests run: `promote-keyed-entities` 22/22 · `integration/automations` + `authz` + `entities` 580/580
- [x] Bug fix: red→fix→green outputs pasted below

**Red (containment removed — the escalate escapes the row):**
```
→ expected EntityRowValidationError: new stability-a… { verdict: {…} } to be null
Tests  2 failed | 20 passed (22)
```

**Green:** `Tests  22 passed (22)`

**Mutation tests** — each guard isolated:
```
rethrow the create escalate  → 2 fail: window rolled back
drop the grant from the card → expected undefined to equal ['severity']
card a rule-DENIED create    → expected [{id:35,…}] to equal []
```

The escalate test also asserts the full round trip: approve → the row is created → **re-promoting adopts it rather than forking a second entity**. The automation-key identity is claimed on the next promotion, not at approval, so that adoption is the actual contract and is now pinned.

## Notes
Known limitation, **pre-existing on `main` and not introduced here** — two windows can each mint a create card for the same logical row before either is decided, because the idempotency key carries `windowId`. Proved with a byte-identical payload across two windows:

```
PROBE cards= 2
outcomes= ["approved=true status=completed/approved",
           "approved=undefined status=pending/pending err=Entity already exists with this name/domain"]
entities= [{"id":3,"slug":"stability-app-crashes"}]
```

No duplicate entity is created (org-wide name uniqueness catches it), but the second card can never clear and resets to `pending` on every approval click. The policy-defer route mints cards the same way, so this is reachable on `main` today; this PR adds a second route to it. Fix belongs with card supersession, tracked separately.
