### PR TITLE
feat(sdk): expose the caller's devices as client.devices

### DIFF
--- a/packages/server/src/__tests__/integration/sdk-devices-namespace.test.ts
+++ b/packages/server/src/__tests__/integration/sdk-devices-namespace.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `client.devices.list()` through the REAL ClientSDK against real Postgres.
+ *
+ * The unit sibling (sandbox/namespaces/__tests__/devices-namespace.test.ts)
+ * mocks the query to pin delegation and the no-principal guard. This one wires
+ * the actual surface: buildClientSDK → the namespace → queryDeviceWorkers →
+ * Postgres, because a namespace that is never constructed by the real builder
+ * is a feature that does not exist.
+ *
+ * The property under test is owner scoping. `device_workers` is keyed
+ * `(user_id, worker_id)` with a nullable `organization_id` that records where a
+ * device is ATTACHED, not who owns it — so two members of ONE org must not see
+ * each other's machines through the SDK.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { buildClientSDK } from '../../sandbox/client-sdk';
+import type { ToolContext } from '../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
+
+const env = { ENVIRONMENT: 'test' } as Env;
+
+let organizationId: string;
+let aliceId: string;
+let bobId: string;
+let aliceDeviceId: string;
+
+function sdkFor(userId: string | null) {
+  return buildClientSDK(
+    {
+      organizationId,
+      userId,
+      memberRole: 'member',
+      isAuthenticated: true,
+      scopes: ['mcp:read', 'mcp:write'],
+    } as unknown as ToolContext,
+    env
+  );
+}
+
+async function registerDevice(opts: {
+  userId: string;
+  workerId: string;
+  label: string;
+  organizationId: string | null;
+}): Promise<string> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id, agent_kinds)
+    VALUES (
+      ${opts.userId}, ${opts.workerId}, 'macos', ${sql.json({})}, ${opts.label},
+      ${opts.organizationId}, ${'{claude-code}'}::text[]
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(rows[0].id);
+}
+
+describe('client.devices.list() is owner-scoped', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'SDK Device Org' });
+    const alice = await createTestUser({ email: 'alice-sdk-dev@test.example.com' });
+    const bob = await createTestUser({ email: 'bob-sdk-dev@test.example.com' });
+    await addUserToOrganization(alice.id, org.id, 'member');
+    await addUserToOrganization(bob.id, org.id, 'member');
+
+    organizationId = org.id;
+    aliceId = alice.id;
+    bobId = bob.id;
+    aliceDeviceId = await registerDevice({
+      userId: alice.id,
+      workerId: 'alice-mac',
+      label: "Alice's MacBook Pro",
+      organizationId: org.id,
+    });
+    await registerDevice({
+      userId: bob.id,
+      workerId: 'bob-mac',
+      label: "Bob's MacBook Pro",
+      organizationId: org.id,
+    });
+    // Attached to NO workspace: still Alice's, and still pinnable by her, so the
+    // list must include it rather than hide a device she can pin.
+    await registerDevice({
+      userId: alice.id,
+      workerId: 'alice-laptop',
+      label: "Alice's unattached laptop",
+      organizationId: null,
+    });
+  });
+
+  it('exposes a devices namespace on the real SDK object', () => {
+    // Guards the wiring itself: buildClientSDK must actually construct it.
+    const sdk = sdkFor(aliceId);
+    expect(typeof sdk.devices?.list).toBe('function');
+  });
+
+  it("returns only the caller's devices, never a colleague's", async () => {
+    const devices = await sdkFor(aliceId).devices.list();
+    expect(devices.map((d) => d.worker_id).sort()).toEqual([
+      'alice-laptop',
+      'alice-mac',
+    ]);
+    const serialized = JSON.stringify(devices);
+    expect(serialized).not.toContain('bob-mac');
+    expect(serialized).not.toContain("Bob's MacBook Pro");
+  });
+
+  it('is symmetric — Bob sees only his own', async () => {
+    const devices = await sdkFor(bobId).devices.list();
+    expect(devices.map((d) => d.worker_id)).toEqual(['bob-mac']);
+  });
+
+  it('surfaces the id and agent_kinds an Automation pin needs', async () => {
+    const devices = await sdkFor(aliceId).devices.list();
+    const mac = devices.find((d) => d.worker_id === 'alice-mac');
+    // This id is the whole point: automations.device_worker_id takes it.
+    expect(mac?.id).toBe(aliceDeviceId);
+    expect(mac?.agent_kinds).toEqual(['claude-code']);
+  });
+
+  it('returns nothing for a context with no principal', async () => {
+    // A system/service caller owns no devices; returning none is fail-closed.
+    expect(await sdkFor(null).devices.list()).toEqual([]);
+  });
+});

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -39,6 +39,7 @@ import {
 	buildClassifiersNamespace,
 	buildConnectionsNamespace,
 	buildConversationsNamespace,
+	buildDevicesNamespace,
 	buildEntitiesNamespace,
 	buildEntitySchemaNamespace,
 	buildFeedsNamespace,
@@ -56,6 +57,7 @@ import type { CatalogNamespace } from "./namespaces/catalog";
 import type { ClassifiersNamespace } from "./namespaces/classifiers";
 import type { ConnectionsNamespace } from "./namespaces/connections";
 import type { ConversationsNamespace } from "./namespaces/conversations";
+import type { DevicesNamespace } from "./namespaces/devices";
 import type { EntitiesNamespace } from "./namespaces/entities";
 import type { EntitySchemaNamespace } from "./namespaces/entity-schema";
 import type { FeedsNamespace } from "./namespaces/feeds";
@@ -84,6 +86,7 @@ export interface ClientSDK {
 	knowledge: KnowledgeNamespace;
 	metrics: MetricsNamespace;
 	notifications: NotificationsNamespace;
+	devices: DevicesNamespace;
 	organizations: OrganizationsNamespace;
 	schedules: SchedulesNamespace;
 
@@ -207,6 +210,7 @@ export function buildClientSDK(
 		knowledge: buildKnowledgeNamespace(ctx, env),
 		metrics: buildMetricsNamespace(ctx, env),
 		notifications: buildNotificationsNamespace(ctx, env),
+		devices: buildDevicesNamespace(ctx),
 		organizations: buildOrganizationsNamespace(ctx),
 		schedules: buildSchedulesNamespace(ctx, env),
 	};

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -52,6 +52,14 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
 		example: "const org = await client.organizations.current();",
 	},
 
+	// devices
+	"devices.list": {
+		summary:
+			"List the caller's own registered devices, most-recently-seen first. Each carries the `id` that `automations.device_worker_id` and `connections.device_worker_id` take when pinning work to a machine, plus `agent_kinds` (which agent CLIs it advertised — null means it never advertised, so the Automation lane leaves it unrestricted), `capabilities`, `online`, and the workspace it is attached to. Owner-scoped: devices are user-owned, so this never lists a colleague's machines.",
+		access: "read",
+		example: "const devices = await client.devices.list();",
+	},
+
 	// entities
 	"entities.manage": {
 		summary: "Raw manage_entity action wrapper. Prefer named methods.",

--- a/packages/server/src/sandbox/namespaces/__tests__/devices-namespace.test.ts
+++ b/packages/server/src/sandbox/namespaces/__tests__/devices-namespace.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `devices` SDK namespace — owner scoping and the no-principal case.
+ *
+ * The namespace exists so a script can discover the `id` that
+ * `automations.device_worker_id` / `connections.device_worker_id` take. Two
+ * things must hold and neither is obvious from the two-line implementation:
+ *
+ *  1. It delegates to `queryDeviceWorkers` — the SAME function behind
+ *     `GET /api/me/devices` — rather than issuing its own query. A second query
+ *     would drift from the route's shape silently.
+ *  2. A context with no principal (system/service caller) gets an empty list,
+ *     NOT every device. `device_workers` is user-owned, so there is no sensible
+ *     "all devices" answer; returning none is the fail-closed direction.
+ *
+ * Uses vi.doMock + vi.resetModules + dynamic import (NOT hoisted vi.mock), for
+ * the reason documented in conversations-namespace.test.ts: the integration
+ * suite shares a module registry across files.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "../../../tools/registry";
+
+const DEVICE = {
+	id: "11111111-2222-3333-4444-555555555555",
+	worker_id: "macos:my-laptop",
+	agent_kinds: ["claude-code"],
+};
+
+/** Register the query mock, then dynamic-import the namespace against it. */
+async function loadNamespaceWith(query: (userId: string) => Promise<unknown>) {
+	vi.resetModules();
+	vi.doMock("../../../worker-api/device-management", () => ({
+		queryDeviceWorkers: query,
+	}));
+	const { buildDevicesNamespace } = await import("../devices");
+	return buildDevicesNamespace;
+}
+
+afterEach(() => {
+	vi.resetModules();
+	vi.doUnmock("../../../worker-api/device-management");
+});
+
+describe("devices namespace", () => {
+	it("delegates to queryDeviceWorkers with the caller's own user id", async () => {
+		const seen: string[] = [];
+		const build = await loadNamespaceWith(async (userId) => {
+			seen.push(userId);
+			return [DEVICE];
+		});
+
+		const devices = await build({
+			organizationId: "org_a",
+			userId: "user_a",
+		} as ToolContext).list();
+
+		// The principal — never the org — is what scopes this read.
+		expect(seen).toEqual(["user_a"]);
+		expect(devices).toEqual([DEVICE]);
+	});
+
+	it("returns nothing when the context carries no principal", async () => {
+		let called = false;
+		const build = await loadNamespaceWith(async () => {
+			called = true;
+			return [DEVICE];
+		});
+
+		const devices = await build({
+			organizationId: "org_a",
+			userId: null,
+		} as ToolContext).list();
+
+		expect(devices).toEqual([]);
+		// Fail closed: it must not fall through to an unscoped query.
+		expect(called).toBe(false);
+	});
+});

--- a/packages/server/src/sandbox/namespaces/devices.ts
+++ b/packages/server/src/sandbox/namespaces/devices.ts
@@ -1,0 +1,42 @@
+/**
+ * ClientSDK `devices` namespace.
+ *
+ * Lets a script find the caller's own registered devices — most importantly the
+ * `id`, which is the value `automations.device_worker_id` and
+ * `connections.device_worker_id` take when pinning work to a machine. Without
+ * it an agent could pin a device but never discover one, and had to recover the
+ * id from whatever already referenced it.
+ *
+ * A read-only wrapper over `queryDeviceWorkers`, the same function behind
+ * `GET /api/me/devices` — one query, two transports, so the shapes cannot drift.
+ */
+
+import type { ToolContext } from "../../tools/registry";
+import {
+	type DeviceWorkerSummary,
+	queryDeviceWorkers,
+} from "../../worker-api/device-management";
+
+export interface DevicesNamespace {
+	/**
+	 * The caller's registered devices, most-recently-seen first.
+	 *
+	 * Owner-scoped, not org-scoped: `device_workers` is keyed
+	 * `(user_id, worker_id)` and its `organization_id` records where a device is
+	 * attached, not who owns it. Devices attached to another workspace — or to
+	 * none — are still the caller's and still listed.
+	 */
+	list(): Promise<DeviceWorkerSummary[]>;
+}
+
+export function buildDevicesNamespace(ctx: ToolContext): DevicesNamespace {
+	return {
+		async list() {
+			// A system/service context carries no principal. Devices are owned by a
+			// user, so there is no sensible "all devices" answer here — return none
+			// rather than widen the query, which is the fail-closed direction.
+			if (!ctx.userId) return [];
+			return queryDeviceWorkers(ctx.userId);
+		},
+	};
+}

--- a/packages/server/src/sandbox/namespaces/index.ts
+++ b/packages/server/src/sandbox/namespaces/index.ts
@@ -9,6 +9,7 @@ export { buildCatalogNamespace } from "./catalog";
 export { buildClassifiersNamespace } from "./classifiers";
 export { buildConnectionsNamespace } from "./connections";
 export { buildConversationsNamespace } from "./conversations";
+export { buildDevicesNamespace } from "./devices";
 export { buildEntitiesNamespace } from "./entities";
 export { buildEntitySchemaNamespace } from "./entity-schema";
 export { buildFeedsNamespace } from "./feeds";

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -30,13 +30,124 @@ import { getWorkspaceRole } from '../utils/organization-access';
 import { parseJsonBody } from '../gateway/routes/shared/helpers';
 import { buildAutomationUrl, getPublicWebUrl } from '../utils/url-builder';
 
+/** One of the caller's registered devices, as both readers return it. */
+export interface DeviceWorkerSummary {
+  id: string;
+  worker_id: string;
+  platform: string | null;
+  app_version: string | null;
+  capabilities: string[];
+  agent_kinds: string[] | null;
+  label: string | null;
+  last_seen_at: string;
+  online: boolean;
+  organization_id: string | null;
+  organization_name: string | null;
+  organization_slug: string | null;
+  connector_count: number;
+  connector_error_count: number;
+  last_sync_at: string | null;
+  connectors: Array<{
+    connection_id: number;
+    connector_key: string;
+    display_name: string;
+    status: string;
+    organization_slug: string | null;
+  }>;
+}
+
+/**
+ * The caller's registered devices, most-recently-seen first.
+ *
+ * Owner-scoped on `user_id`, never on the org: `device_workers` is keyed
+ * `(user_id, worker_id)` and `organization_id` records where a device is
+ * ATTACHED, not who owns it — so an org filter would both hide a user's own
+ * unattached devices and expose colleagues' machines (`label` is typically a
+ * personal name, `last_seen_at` a presence feed).
+ *
+ * Shared deliberately: `GET /api/me/devices` and the ClientSDK `devices`
+ * namespace are two transports over this one query, so a column added here
+ * reaches both and neither can drift.
+ */
+export async function queryDeviceWorkers(
+  userId: string
+): Promise<DeviceWorkerSummary[]> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT
+      dw.id,
+      dw.worker_id,
+      dw.platform,
+      dw.app_version,
+      dw.capabilities,
+      dw.agent_kinds,
+      dw.label,
+      dw.last_seen_at,
+      (dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS online,
+      dw.organization_id,
+      o.name AS organization_name,
+      o.slug AS organization_slug,
+      (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL)::int AS connector_count,
+      (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL AND cn.status = 'error')::int AS connector_error_count,
+      (
+        SELECT max(f.last_sync_at) FROM feeds f
+        JOIN connections cn ON cn.id = f.connection_id
+        WHERE cn.device_worker_id = dw.id AND f.deleted_at IS NULL
+      ) AS last_sync_at,
+      (
+        SELECT coalesce(
+          json_agg(
+            json_build_object(
+              'connection_id', cn.id,
+              'connector_key', cn.connector_key,
+              'display_name', coalesce(cd.name, cn.connector_key),
+              'status', cn.status,
+              'organization_slug', cno.slug
+            )
+            ORDER BY cn.created_at
+          ),
+          '[]'::json
+        )
+        FROM connections cn
+        LEFT JOIN organization cno ON cno.id = cn.organization_id
+        LEFT JOIN LATERAL (
+          SELECT name FROM connector_definitions
+          WHERE key = cn.connector_key AND status = 'active' AND organization_id = cn.organization_id
+          ORDER BY updated_at DESC LIMIT 1
+        ) cd ON TRUE
+        WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL
+      ) AS connectors
+    FROM device_workers dw
+    LEFT JOIN organization o ON o.id = dw.organization_id
+    WHERE dw.user_id = ${userId}
+    ORDER BY dw.last_seen_at DESC
+  `) as unknown as Array<
+    Omit<DeviceWorkerSummary, 'agent_kinds'> & { agent_kinds: string | string[] | null }
+  >;
+
+  return rows.map((r) => ({
+    ...r,
+    capabilities: Array.isArray(r.capabilities) ? r.capabilities : [],
+    // null (never advertised) is distinct from [] (advertised none): the
+    // automation lane leaves the former unrestricted and withholds every run
+    // from the latter, so a reader must be able to tell "unknown" from "runs
+    // nothing". The driver hands text[] back as a raw '{a,b}' literal, so it
+    // needs parsing, not Array.isArray.
+    agent_kinds: r.agent_kinds == null ? null : parsePgTextArray(r.agent_kinds),
+    connector_count: r.connector_count ?? 0,
+    connector_error_count: r.connector_error_count ?? 0,
+    connectors: Array.isArray(r.connectors) ? r.connectors : [],
+  }));
+}
+
 /**
  * GET /api/me/devices
  *
- * Returns the calling user's registered device workers, each with its surrogate
- * id (used as `device_worker_id` when pinning a connection), the workspace the
- * device is attached to, how many connections are pinned to it (and how many of
- * those are erroring), and when its feeds last synced.
+ * Thin transport over `queryDeviceWorkers`. Returns the calling user's
+ * registered device workers, each with its surrogate id (used as
+ * `device_worker_id` when pinning a connection or an Automation), the workspace
+ * the device is attached to, how many connections are pinned to it (and how
+ * many of those are erroring), and when its feeds last synced.
  * Requires session / PAT / OAuth authentication (mcpAuth).
  */
 export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
@@ -45,104 +156,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
   try {
-    const sql = getDb();
-    const rows = (await sql`
-      SELECT
-        dw.id,
-        dw.worker_id,
-        dw.platform,
-        dw.app_version,
-        dw.capabilities,
-        dw.agent_kinds,
-        dw.label,
-        dw.last_seen_at,
-        (dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS online,
-        dw.organization_id,
-        o.name AS organization_name,
-        o.slug AS organization_slug,
-        (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL)::int AS connector_count,
-        (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL AND cn.status = 'error')::int AS connector_error_count,
-        (
-          SELECT max(f.last_sync_at) FROM feeds f
-          JOIN connections cn ON cn.id = f.connection_id
-          WHERE cn.device_worker_id = dw.id AND f.deleted_at IS NULL
-        ) AS last_sync_at,
-        (
-          SELECT coalesce(
-            json_agg(
-              json_build_object(
-                'connection_id', cn.id,
-                'connector_key', cn.connector_key,
-                'display_name', coalesce(cd.name, cn.connector_key),
-                'status', cn.status,
-                'organization_slug', cno.slug
-              )
-              ORDER BY cn.created_at
-            ),
-            '[]'::json
-          )
-          FROM connections cn
-          LEFT JOIN organization cno ON cno.id = cn.organization_id
-          LEFT JOIN LATERAL (
-            SELECT name FROM connector_definitions
-            WHERE key = cn.connector_key AND status = 'active' AND organization_id = cn.organization_id
-            ORDER BY updated_at DESC LIMIT 1
-          ) cd ON TRUE
-          WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL
-        ) AS connectors
-      FROM device_workers dw
-      LEFT JOIN organization o ON o.id = dw.organization_id
-      WHERE dw.user_id = ${userId}
-      ORDER BY dw.last_seen_at DESC
-    `) as unknown as Array<{
-      id: string;
-      worker_id: string;
-      platform: string | null;
-      app_version: string | null;
-      capabilities: string[];
-      agent_kinds: string | string[] | null;
-      label: string | null;
-      last_seen_at: string;
-      online: boolean;
-      organization_id: string | null;
-      organization_name: string | null;
-      organization_slug: string | null;
-      connector_count: number;
-      connector_error_count: number;
-      last_sync_at: string | null;
-      connectors: Array<{
-        connection_id: number;
-        connector_key: string;
-        display_name: string;
-        status: string;
-        organization_slug: string | null;
-      }>;
-    }>;
-    return c.json({
-      devices: rows.map((r) => ({
-        id: r.id,
-        worker_id: r.worker_id,
-        platform: r.platform,
-        app_version: r.app_version,
-        capabilities: Array.isArray(r.capabilities) ? r.capabilities : [],
-        // null (never advertised) is distinct from [] (advertised none): the
-        // automation lane leaves the former unrestricted and withholds every run
-        // from the latter, so the UI must be able to tell "unknown" from "runs
-        // nothing". The driver hands text[] back as a raw '{a,b}' literal, so it
-        // needs parsing, not Array.isArray.
-        agent_kinds: r.agent_kinds == null ? null : parsePgTextArray(r.agent_kinds),
-        label: r.label,
-        last_seen_at: r.last_seen_at,
-        online: r.online,
-        organization_id: r.organization_id,
-        organization_name: r.organization_name,
-        organization_slug: r.organization_slug,
-        connector_count: r.connector_count ?? 0,
-        connector_error_count: r.connector_error_count ?? 0,
-        last_sync_at: r.last_sync_at,
-        connectors: Array.isArray(r.connectors) ? r.connectors : [],
-      })),
-    });
+    return c.json({ devices: await queryDeviceWorkers(userId) });
   } catch (err: unknown) {
     logger.error({ error: errorMessage(err) }, '[listDeviceWorkers] Error');
     captureServerError(c, err, 'listDeviceWorkers');


### PR DESCRIPTION
## Summary
- An agent could **pin** an Automation or connection to a device (`device_worker_id`) but had no way to **discover** one. The sandbox SDK's 17 namespaces had nothing for devices, and `GET /api/me/devices` is a plain Hono route absent from the generated client, so `run_sdk` couldn't reach it — the id had to be recovered from whatever already referenced it.
- Rather than add a second query, this **extracts the existing one**. `listDeviceWorkers` had a ~100-line query inlined; that query and its row mapping move to `queryDeviceWorkers(userId)` and the handler becomes a thin transport. The new namespace calls the same function, so `GET /api/me/devices` and `client.devices.list()` are two transports over one implementation and can't drift.
- **Owner-scoped, never org-scoped.** `device_workers` is keyed `(user_id, worker_id)`; `organization_id` records where a device is *attached*, not who owns it. An org filter would both hide a user's own unattached devices and expose colleagues' machines (`label` is typically a personal name, `last_seen_at` a presence feed). No principal ⇒ empty list, not an unscoped query.
- Follows #2918 (`agent_kinds`) and #2922 (`device_workers` in `query_sql`): `query_sql` closed raw discovery, this gives the same data a typed, shaped read.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, strict typecheck, knip, biome "Checked 567 files… No fixes applied", naming, gateway-LLM, entity-write; 19 pass / 0 fail). Also ran `scripts/check-security-patterns.sh` → **OK** (CI-only gate, not in pre-pr).
- [x] `bunx vitest run src/__tests__/integration/sdk-devices-namespace.test.ts` → **5 pass**
- [x] `bunx vitest run src/sandbox/namespaces/__tests__/devices-namespace.test.ts` → **2 pass**
- [x] Existing device suites (`device-management-delete`, `device-management-mint`, `device-agent-kinds-gate`, `device-connector-manifests`, `device-liveness-window`) → **35 pass**, proving the extraction is behavior-preserving
- [x] Sandbox metadata gates: `src/__tests__/unit/sandbox/` **149 pass**, `access-model-cross-check` **4 pass**
- [ ] Bug fix: n/a — missing capability, not a regression

### What the tests prove
`sdk-devices-namespace.test.ts` drives the **real `buildClientSDK`** against real Postgres with two ordinary members of the **same** org and three devices (alice-mac attached, bob-mac attached, alice-laptop unattached):

- the `devices` namespace is actually constructed by the real builder (a namespace the builder never wires is a feature that doesn't exist)
- a member sees only their own; the serialized result contains neither `bob-mac` nor `Bob's MacBook Pro`
- symmetric for Bob
- `id` + `agent_kinds` come back for the row an Automation pin needs
- no principal ⇒ `[]`

### Mutation testing
| mutation | result |
|---|---|
| drop the `if (!ctx.userId) return []` guard | only the no-principal test fails |
| scope on `ctx.organizationId` instead of `ctx.userId` | only the delegation test fails |
| widen the shared query's `WHERE` to admit any org-attached row | exactly the 2 leak tests fail; 3 positive tests still pass |
| remove the `devices.list` METHOD_METADATA entry | `has metadata for every namespace method` fails, naming `devices.list` |

## Notes
SDK-surface addition, confirmed with the owner before implementation.

`METHOD_METADATA` is bidirectionally gated (every runtime method needs metadata; every metadata key needs a method), and `sdk_search` / `sdk-manifest` derive from it, so `devices` surfaces to discovery automatically.

Deliberately read-only. Device mutation (rename, re-attach, delete) stays on the REST routes behind `mcpAuth`; nothing here needs it to pin work to a machine.