### PR TITLE
fix(automations): record a refused promote in the run change set

### DIFF
--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -544,6 +544,26 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
         AND identifier LIKE ${`${automationId}::%`}
     `;
     expect(Number(promoted[0].c)).toBe(0);
+
+    // Policy is the other decider, and its refusals need the same record: with
+    // nothing created and nothing carded, the run's change set is all there is.
+    const [changeSet] = await sql`
+      SELECT metadata FROM current_event_records
+      WHERE run_id = ${runId}
+        AND organization_id = ${workspace.org.id}
+        AND semantic_type = 'change_set'
+    `;
+    expect(changeSet).toBeDefined();
+    const meta = changeSet.metadata as Record<string, unknown>;
+    expect(Number(meta.created_count)).toBe(0);
+    expect(Number(meta.denied_count)).toBeGreaterThan(0);
+    const changes = meta.changes as Array<{
+      kind: string;
+      denied?: { source: string; reason: string };
+    }>;
+    expect(changes.every((c) => c.kind === 'denied')).toBe(true);
+    expect(changes.every((c) => c.denied?.source === 'policy')).toBe(true);
+    expect(changes.every((c) => (c.denied?.reason ?? '').length > 0)).toBe(true);
   });
 
   it('is idempotent across a same-window replay — no duplicate entities', async () => {
@@ -1752,6 +1772,75 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       });
     });
 
+    it('records a rule DENY in the run change set, not just a log line', async () => {
+      const ctx = await setupKeyedAutomation();
+      await createTestEvent({
+        entity_id: ctx.parentEntityId,
+        organization_id: ctx.workspace.org.id,
+        content: 'Users report the app crashing.',
+        occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const token = await readWindowToken(ctx);
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: await queueRunningRun(ctx) },
+        extracted_data: {
+          problems: [{ category: 'Stability', name: 'App Crashes', summary: 'first' }],
+        },
+      });
+
+      await escalatingType(
+        ctx,
+        `export default (row) => {
+  if (row.op === "update") {
+    row.deny("this topic is frozen for the quarter");
+  }
+};`
+      );
+
+      // Its OWN run: the change set is idempotent per run, so a denial folded
+      // into the create's run would be swallowed by the existing event.
+      const denyRunId = await queueRunningRun(ctx);
+      await ctx.api.automations.completeWindow({
+        automation_id: String(ctx.automationId),
+        window_token: token,
+        run_metadata: { automation_run_id: denyRunId },
+        extracted_data: {
+          problems: [{ category: 'Stability', name: 'App Crashes', summary: 'second' }],
+        },
+      });
+
+      // A deny is a refusal, not a request for review: nothing written, nothing
+      // carded — which is exactly why the run event is the only record left.
+      expect(await metaFor(ctx, APP_CRASHES_KEY)).toMatchObject({ summary: 'first' });
+      expect(await pendingCard(ctx)).toEqual([]);
+
+      const [changeSet] = await ctx.sql`
+        SELECT title, metadata, entity_ids
+        FROM current_event_records
+        WHERE run_id = ${denyRunId}
+          AND organization_id = ${ctx.workspace.org.id}
+          AND semantic_type = 'change_set'
+      `;
+      expect(changeSet).toBeDefined();
+      const meta = changeSet.metadata as Record<string, unknown>;
+      expect(Number(meta.created_count)).toBe(0);
+      expect(Number(meta.updated_count)).toBe(0);
+      expect(Number(meta.denied_count)).toBe(1);
+      expect(String(changeSet.title)).toContain('1 denied');
+      const changes = meta.changes as Array<{
+        kind: string;
+        denied?: { source: string; reason: string };
+      }>;
+      expect(changes).toHaveLength(1);
+      expect(changes[0].kind).toBe('denied');
+      expect(changes[0].denied).toEqual({
+        source: 'rule',
+        reason: 'this topic is frozen for the quarter',
+      });
+    });
+
     it('cards with NO grant when the rule escalates the residual but allows the whole write', async () => {
       const ctx = await setupKeyedAutomation();
       const { sql, workspace } = ctx;
@@ -1958,6 +2047,40 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       expect(windowError).toBeNull();
       expect(await findEntity(ctx, APP_CRASHES_KEY)).toEqual([]);
       expect(await pendingAnyCard(ctx)).toEqual([]);
+
+      // No entity and no card means the run's change set is the ONLY record
+      // that this row was seen and refused. A refused create has no id, so it
+      // is recorded under the name the automation proposed.
+      const [changeSet] = await ctx.sql`
+        SELECT title, metadata, entity_ids
+        FROM current_event_records
+        WHERE run_id = ${runId}
+          AND organization_id = ${ctx.workspace.org.id}
+          AND semantic_type = 'change_set'
+      `;
+      expect(changeSet).toBeDefined();
+      const meta = changeSet.metadata as Record<string, unknown>;
+      expect(Number(meta.created_count)).toBe(0);
+      expect(Number(meta.denied_count)).toBe(1);
+      // A row that was never written must not be linked as an entity — and in
+      // particular must not link the `0` placeholder a refused create carries.
+      // An event with no links stores NULL; a linked one comes back as a raw PG
+      // array literal (`{0}` if the placeholder ever leaked through).
+      expect(changeSet.entity_ids ?? null).toBeNull();
+      const changes = meta.changes as Array<{
+        kind: string;
+        name: string;
+        denied?: { source: string; reason: string };
+      }>;
+      expect(changes).toHaveLength(1);
+      expect(changes[0].kind).toBe('denied');
+      // The readable promoted name, not the stable key — the refusal has to be
+      // legible to whoever reads the run.
+      expect(changes[0].name).toBe('Stability · App Crashes');
+      expect(changes[0].denied).toEqual({
+        source: 'rule',
+        reason: 'this type is closed to new rows',
+      });
     });
   });
 });

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -825,8 +825,9 @@ export async function handleCompleteWindow(
     const entityChanges = [] as Array<{
       entityId: number;
       name: string;
-      kind: 'created' | 'updated';
+      kind: 'created' | 'updated' | 'denied';
       applied: Record<string, unknown>;
+      denied?: { source: 'policy' | 'rule'; reason: string };
     }>;
     const subscribedWorkspaceEventTypes = await findSubscribedWorkspaceEventTypes(
       automationOrgId,
@@ -894,8 +895,13 @@ export async function handleCompleteWindow(
 
     // One run-level change set covers every entity output.
     if (entityChanges.length > 0 && automationRunId && Number.isFinite(automationRunId)) {
+      // Count each kind explicitly. Deriving one by subtraction silently
+      // mislabels every kind added later — `denied` would have counted as
+      // `updated`, reporting a refusal as a write.
       const createdCount = entityChanges.filter((c) => c.kind === 'created').length;
-      const updatedCount = entityChanges.length - createdCount;
+      const updatedCount = entityChanges.filter((c) => c.kind === 'updated').length;
+      const deniedCount = entityChanges.filter((c) => c.kind === 'denied').length;
+      const deniedSuffix = deniedCount > 0 ? ` + ${deniedCount} denied` : '';
       const changeSetIdempotencyKey = `automation:${automationId}:run:${automationRunId}:change_set`;
       const findChangeSet = () => tx<{ id: number }>`
         SELECT id FROM events
@@ -908,11 +914,15 @@ export async function handleCompleteWindow(
           await tx.savepoint((sp) =>
             insertEvent(
               {
-                entityIds: entityChanges.map((c) => c.entityId),
+                // A denial can carry no entity (a refused CREATE never got an
+                // id), so the timeline links only the rows that exist.
+                entityIds: entityChanges.map((c) => c.entityId).filter((id) => id > 0),
                 organizationId: automationOrgId,
                 originId: `run_${automationRunId}_changeset`,
-                title: `Automation applied ${createdCount} new + ${updatedCount} updated`,
-                content: `This run created ${createdCount} and updated ${updatedCount} entities.`,
+                title: `Automation applied ${createdCount} new + ${updatedCount} updated${deniedSuffix}`,
+                content: `This run created ${createdCount} and updated ${updatedCount} entities${
+                  deniedCount > 0 ? `; ${deniedCount} denied` : ''
+                }.`,
                 semanticType: 'change_set',
                 runId: automationRunId,
                 automationId: Number(automationId),
@@ -924,6 +934,7 @@ export async function handleCompleteWindow(
                   automation_id: Number(automationId),
                   created_count: createdCount,
                   updated_count: updatedCount,
+                  denied_count: deniedCount,
                   changes: entityChanges,
                 },
                 createdBy: automationCreatedBy,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -105,10 +105,20 @@ export interface PromoteKeyedEntitiesParams {
 export interface PromotedEntityChange {
   entityId: number;
   name: string;
-  /** `created` = brand-new entity; `updated` = existing entity whose fields changed. */
-  kind: 'created' | 'updated';
-  /** For `updated`, the fields written inline (old→new). Empty for `created`. */
+  /**
+   * `created` = brand-new entity; `updated` = existing entity whose fields
+   * changed; `denied` = the write was REFUSED and nothing was written.
+   *
+   * A denial belongs in the run's change set for the same reason a write does:
+   * containing a per-row refusal keeps the window alive, so this event is the
+   * only durable record that the row was seen and turned down. Without it a
+   * refusal is indistinguishable from a row the automation never emitted.
+   */
+  kind: 'created' | 'updated' | 'denied';
+  /** For `updated`, the fields written inline (old→new). Empty otherwise. */
   applied: Record<string, AppliedChange>;
+  /** Why the write was refused, and by which decider. Set only for `denied`. */
+  denied?: { source: 'policy' | 'rule'; reason: string };
 }
 
 export interface PromoteKeyedEntitiesResult {
@@ -299,7 +309,15 @@ async function upsertKeyedEntity(params: {
   /** Fields the automation actually wrote inline (auto-applied), old→new. */
   applied: Record<string, AppliedChange>;
   blockedCreate: boolean;
-  deniedUpdate?: true;
+  /**
+   * Set when the write was REFUSED here: every rule deny, plus a policy deny on
+   * an UPDATE. A policy deny on a CREATE is decided by the type-wide gate before
+   * this runs, so it returns as a plain `blockedCreate` and the caller derives
+   * that one. Carries the reason so the run's change set can record WHY, not
+   * just that a row was skipped: containment means the window survives, so
+   * nothing else marks it.
+   */
+  denied?: { source: 'policy' | 'rule'; reason: string };
   /**
    * Set when a write RULE escalates the write the card will replay. The card
    * must carry that verdict's field list verbatim: the replay checks
@@ -360,7 +378,7 @@ async function upsertKeyedEntity(params: {
         blocked: {},
         applied: {},
         blockedCreate: false,
-        deniedUpdate: true,
+        denied: { source: 'policy', reason: decision.reason },
       };
     }
     const requireApproval = [...decision.requireApproval];
@@ -396,7 +414,7 @@ async function upsertKeyedEntity(params: {
           blocked: {},
           applied: {},
           blockedCreate: false,
-          deniedUpdate: true,
+          denied: { source: 'rule', reason: err.verdict.reason },
         };
       }
       // Hold the row WHOLE, and ask the rule about that same whole write.
@@ -437,7 +455,7 @@ async function upsertKeyedEntity(params: {
           blocked: {},
           applied: {},
           blockedCreate: false,
-          deniedUpdate: true,
+          denied: { source: 'rule', reason: whole.verdict.reason },
         };
       }
       // A whole write the rule finds legal still needs the card — those fields
@@ -492,21 +510,15 @@ async function upsertKeyedEntity(params: {
     // Validation runs INSIDE the savepoint and throws before `insertEntityRow`,
     // so the savepoint has already unwound — there is no partial row to undo.
     if (err.verdict.outcome !== 'escalate') {
-      logger.warn(
-        {
-          automationId: params.automationId,
-          organizationId,
-          identifier,
-          reason: err.verdict.reason,
-        },
-        '[promote-keyed-entities] a write rule denied this create — row skipped'
-      );
+      // The refusal is logged and recorded by the caller, which knows the op and
+      // the window this row came from.
       return {
         entityId: 0,
         created: false,
         blocked: {},
         applied: {},
         blockedCreate: true,
+        denied: { source: 'rule', reason: err.verdict.reason },
       };
     }
     // Unlike the update path, this verdict needs no second ask. A create has no
@@ -735,7 +747,7 @@ export async function promoteAutomationEntityOutput(
         applied,
         entityId,
         blockedCreate,
-        deniedUpdate,
+        denied,
         escalated,
       } = await tx.savepoint((sp) =>
         upsertKeyedEntity({
@@ -756,20 +768,42 @@ export async function promoteAutomationEntityOutput(
           createNeedsApproval,
         })
       );
-      if (deniedUpdate) {
+      // A refusal, on either op and from either decider. Every rule deny — and a
+      // policy deny on an UPDATE — arrives as `denied`. A policy deny on a CREATE
+      // carries no such marker: it returns early as a plain blocked create, so
+      // read it off the type-wide gate decision instead. The two can never
+      // disagree, because that early return happens before the insert the rule
+      // runs inside.
+      const refusal =
+        denied ??
+        (blockedCreate && createGate.outcome === 'deny'
+          ? ({ source: 'policy', reason: createGate.reason } as const)
+          : null);
+      if (refusal) {
         logger.warn(
-          { automationId, organizationId, windowId, stableKey, entityId },
-          '[promote-keyed-entities] update denied by the mutation gate or a write rule — row skipped'
+          {
+            automationId,
+            organizationId,
+            windowId,
+            stableKey,
+            entityId,
+            op: blockedCreate ? 'create' : 'update',
+            deniedBy: refusal.source,
+            reason: refusal.reason,
+          },
+          '[promote-keyed-entities] write denied — row skipped'
         );
+        // A log line is not an audit record. Put the refusal in the run's change
+        // set so it is queryable next to the writes that DID land. A refused
+        // CREATE has no id, so it is recorded under the name the automation
+        // proposed — the only handle a reader has on a row never written.
+        result.changes.push({ entityId, name, kind: 'denied', applied: {}, denied: refusal });
         continue;
       }
       if (blockedCreate) {
         // A create is carded when POLICY defers it or when a write RULE
-        // escalated it. A 'deny' from either is fail-closed — the row is skipped
-        // entirely (no create, no approval card), because approval cannot
-        // launder a refusal into a write. A rule deny needs no separate signal:
-        // it can only be reached once policy already said 'allow', because a
-        // policy defer returns before the insert the rule runs inside.
+        // escalated it. A deny from either was already recorded and skipped
+        // above, because approval cannot launder a refusal into a write.
         if (createGate.outcome === 'defer' || escalated) {
           const createProposal = {
             entity_type: entityTypeSlug,


### PR DESCRIPTION
## Problem

Containing a per-row write-rule verdict (#2923, #2924) keeps the automation window alive — but the refused row was left with only a `logger.warn`. A denied write became indistinguishable from a row the automation never emitted. Containment is right; trading a durable failure for a log line was not.

This is the audit half of that pair, and it also covers the pre-existing policy-deny paths, which were silently skipped the same way.

## Change

- `deniedUpdate?: true` → `denied?: { source: 'policy' | 'rule'; reason: string }` at every deny site, so the record says *who* refused and *why*.
- One refusal path in the caller covers **both ops and both deciders**. A refused CREATE has no id, so it is recorded under the name the automation proposed and is **not** linked as an entity.
- The refusal is written to the run's existing append-only `change_set` event — the same mechanism the writes already use. **No new table, no migration.**
- Counting each kind explicitly is part of the fix, not tidying: the old `updatedCount = length - createdCount` reports a refusal as a *write*.

## Testing

`bunx vitest run src/__tests__/integration/automations/promote-keyed-entities.test.ts` → **24/24 pass**.
Suites: automations + authz + entities → **588/588 pass** (68 files). `make pre-pr` clean.

Four mutations, each reverted, each red for its own reason:

| mutation | fails with |
|---|---|
| drop `result.changes.push({kind:'denied'})` | 3 tests — `expected undefined to be defined` |
| `updatedCount = length - createdCount` | `expected 1 to be +0` — the denial counted as an **update** |
| `refusal = denied ?? null` (drop the policy arm) | the create=deny policy test only |
| drop `.filter((id) => id > 0)` on `entityIds` | `expected '{0}' to be null` — a dangling link to a nonexistent entity 0 |

All four branches of `refusal` (policy-update, rule-update, rule-create, policy-create) are exercised against a real DB.

## Not in this PR

- **The card does not render denials yet.** That is owletto#896, already merged; it ships when the submodule pointer lands, which is a separate bump PR (the pointer range touches `src/`, so it owes a hosted `ui-review` artifact).
- The same "a deny is only a log line" shape plausibly exists on other entity-write paths. Widening it here would break one-branch-one-concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation runs now clearly report promotions denied by policies or rules, including the denial source and reason.
  * Change-set summaries include denied counts and readable details for refused creations.
  * Invalid entity links are excluded from automation event records.

* **Bug Fixes**
  * Corrected automation promotion tracking so denied changes are recorded without creating or updating entities.
  * Preserved deferred approvals for eligible policy deferrals and rule escalations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->