### PR TITLE
fix(ci): exempt Owletto build scripts from ui-review hosted proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>] [ARTIFACT=<url>] - Lightweight pointer PR + required statuses (skips bun install, .env, ports)"
 	@echo "  make review [BASE=<branch>]                - Run the cross-harness LLM reviewer against the local diff (deterministic suites run in CI); posts pi-review status and PR comment"
 	@echo "  make review-fix [BASE=<branch>]            - Pre-review fixer: reviewer CLI with write access fixes review-grade findings in the tree; posts nothing"
-	@echo "  make ui-review [ARTIFACT=<https-url>]       - Record Owletto UI proof; complete forward deploy-only pointer diffs pass as not applicable; OPEN=1 opens the merged PR"
+	@echo "  make ui-review [ARTIFACT=<https-url>]       - Record Owletto UI proof; complete forward pointer diffs touching no hosted surface pass as not applicable; OPEN=1 opens the merged PR"
 	@echo "  make pre-pr                                 - Local fast gates before push (GitHub CI is the canonical gate)"
 	@echo "  make pr-fast                                - Optional: broad Linux merge jobs (Daytona sandbox, else local)"
 	@echo "  make pr-full [REMOTE_JOBS='unit …']        - Optional: full Linux CI (Daytona sandbox, else local)"

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -198,6 +198,19 @@ describe("UI review proof", () => {
     ).toBe(false);
     // Fail closed on an apps/ tree that is NOT on the allowlist.
     expect(isUnhostedRange([{ filename: "apps/web/index.tsx" }])).toBe(false);
+    // Build/post-build checks run in CI and are never served, so there is no
+    // URL to compare — the same reason deploy/ and the packaged apps qualify.
+    expect(
+      isUnhostedRange([{ filename: "scripts/check-mcp-app-bundle.mjs" }])
+    ).toBe(true);
+    // ...but the prefix must not swallow a hosted tree that merely contains
+    // a scripts/ directory, nor a sibling whose name it merely starts.
+    expect(isUnhostedRange([{ filename: "src/scripts/widget.tsx" }])).toBe(
+      false
+    );
+    expect(
+      isUnhostedRange([{ filename: "scripts-archive/old-widget.tsx" }])
+    ).toBe(false);
 
     // The unhosted prefixes are path prefixes, not substrings.
     expect(isUnhostedRange([{ filename: "src/deploy/widget.tsx" }])).toBe(

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -159,6 +159,7 @@ export const COMPARE_FILE_CAP = 300;
  *   deploy/      k8s manifests — nothing user-visible
  *   apps/chrome/ the browser extension — distributed as a Web Store zip
  *   apps/mac/    the native Mac app — distributed as a signed build
+ *   scripts/     build and post-build checks — run in CI, never served
  *
  * The extension and the Mac app do have their own UI (the Owletto side panel,
  * for one), and this exemption deliberately does NOT claim otherwise. It says
@@ -171,7 +172,12 @@ export const COMPARE_FILE_CAP = 300;
  * gate stays fail-closed: a future hosted tree (say apps/web/) correctly
  * demands proof instead of inheriting an exemption nobody revisited.
  */
-export const UNHOSTED_PREFIXES = ["deploy/", "apps/chrome/", "apps/mac/"];
+export const UNHOSTED_PREFIXES = [
+  "deploy/",
+  "apps/chrome/",
+  "apps/mac/",
+  "scripts/",
+];
 
 const isUnhostedPath = (path: string) =>
   UNHOSTED_PREFIXES.some((prefix) => path.startsWith(prefix));


### PR DESCRIPTION
## Problem

#2905 established the principle: hosted before/after proof is the wrong *instrument* for an Owletto tree with no URL to compare, and allowlisted `deploy/`, `apps/chrome/`, `apps/mac/`.

`scripts/` belongs in the same class and was missed. Those files are build and post-build checks — they run in CI and are never served, so a hosted comparison renders nothing.

Hit live on #2915. Its pointer range `59d35eea...f671b0af` is 25 files:

```
deploy/       6   already exempt
apps/chrome/ 16   already exempt
apps/mac/     2   already exempt
scripts/      1   scripts/check-mcp-app-bundle.mjs  <- the only reason the gate fires
```

`--admin` is not an escape either — `enforce_admins` is `true` on `main`, so GitHub refuses the merge while a required check is `errored`:

```
GraphQL: Required status check "ui-review" is errored. (mergePullRequest)
```

That left exactly two alternatives: publish a screenshot of a build script changing nothing (the unverifiable artifact the proof mechanism exists to reject), or loosen branch protection repo-wide. Neither is right; the allowlist is.

## Change

```ts
export const UNHOSTED_PREFIXES = [
  "deploy/",
  "apps/chrome/",
  "apps/mac/",
  "scripts/",
];
```

Plus the `Makefile:27` help line, which still said "deploy-only" after #2905's rename — flagged by that PR's own review and now doubly wrong.

## Verification

`bun test scripts/__tests__/ui-review-proof.test.ts` → 9/9; `make pre-pr` clean (all 7 gates).

Mutation-tested, each fails the suite:

| mutation | result |
|---|---|
| drop `"scripts/"` from the allowlist | `(fail) accepts only a complete unhosted endpoint diff` |
| weaken it to `"scripts"` (no trailing slash) | `(fail) accepts only a complete unhosted endpoint diff` |

The second one caught a real gap in my first draft of the test: without a `scripts-archive/old-widget.tsx` case, the slashless prefix passed. `startsWith` makes the trailing slash load-bearing, so it now has a test that says so.

Keeps #2905's two deliberate calls intact — an explicit allowlist rather than "anything that isn't `src/`", so a future hosted tree fails closed, and no claim that these trees lack UI, only that hosted proof cannot express it.