### PR TITLE
feat(ci): let ui-review skip the screenshot when a range has no UI surface

### DIFF
--- a/prompts/ui-review-agent-output-schema.json
+++ b/prompts/ui-review-agent-output-schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "description": "Verdict on whether an Owletto diff range has any user-visible UI surface, for the ui-review gate's agent-judged not-applicable path.",
+  "additionalProperties": false,
+  "required": ["has_ui_surface", "reasoning", "verification_summary"],
+  "properties": {
+    "has_ui_surface": {
+      "type": "boolean",
+      "description": "True if the range touches ANYTHING a human could see rendered: templates, HTML/CSS, images/icons, extension popup/sidepanel/UI components, SwiftUI/AppKit views, user-visible copy shown in a rendered surface (not just an internal log or error message), layout, or asset files. When genuinely unsure or the range is large/mixed, answer true — this gate fails closed."
+    },
+    "reasoning": {
+      "type": "string",
+      "description": "Concrete justification citing the actual changed files and why they do or do not have UI surface. Must name specific files, not a general claim."
+    },
+    "verification_summary": {
+      "type": "string",
+      "description": "How the change was otherwise verified (tests run, pass/fail counts, manual reproduction) — cite specifics from the diff/PR content, not a restatement of the reasoning."
+    }
+  }
+}

--- a/prompts/ui-review-agent-prompt.md
+++ b/prompts/ui-review-agent-prompt.md
@@ -1,0 +1,36 @@
+# Owletto UI-surface classification
+
+The `ui-review` gate normally requires a hosted before/after screenshot
+comparison for any Owletto pointer change that isn't confined to `deploy/`.
+That requirement exists to catch visual regressions — but a change with no
+visual surface at all has nothing for a screenshot to show, and demanding one
+anyway just teaches people to fabricate or skip the gate.
+
+Your job: read the diff below (file list + unified diffs) and the merged
+Owletto PR's own description (its test plan, if any), then judge whether this
+EXACT range introduces or changes ANYTHING a human would see rendered:
+
+- Chrome extension: popup, sidepanel, options page, injected page UI,
+  notifications, icons/badges, any HTML/CSS.
+- Mac app: SwiftUI/AppKit views, menu bar UI, window layouts, icons, copy
+  shown in a window or menu.
+- Any user-visible string surfaced in a rendered UI (not a log line, not an
+  internal error message, not a tool/action description an LLM reads).
+
+This is a fail-closed gate: `has_ui_surface` must be `true` whenever there is
+real ambiguity, the range is large or mixed, or you cannot fully account for
+every changed file's effect. Answering `false` incorrectly means a real visual
+regression ships without a human ever looking at it — that is the failure
+mode this exists to prevent. Only answer `false` when you can point at every
+changed file and say concretely why it has no rendered surface.
+
+`reasoning` must name the actual changed files and explain the call per file
+(or per small group), not a general summary. `verification_summary` must cite
+concrete evidence already in the diff/PR content (specific test files, pass
+counts, what was run) — never invent evidence that isn't there; if none is
+cited in the source material, say so rather than filling it in.
+
+Final output is exactly one JSON object matching the provided schema. No
+prose, no Markdown fences, no commentary before or after.
+
+## Range under review

--- a/scripts/__tests__/ui-review-command.test.ts
+++ b/scripts/__tests__/ui-review-command.test.ts
@@ -362,7 +362,7 @@ describe("ui-review command", () => {
     // The exemption is judged over the whole pointer range, so the range is what
     // the human-readable note must name.
     expect(finalState.comments[parentEndpoint]?.[0]?.body).toContain(
-      `\`${"1".repeat(40)}...${"2".repeat(40)}\` changes only \`deploy/\` (2 files, through Owletto #712).`
+      `\`${"1".repeat(40)}...${"2".repeat(40)}\` changes only unhosted trees (2 files, through Owletto #712).`
     );
     expect(finalState.opened).toBe(
       "https://github.com/lobu-ai/owletto/pull/712"
@@ -427,7 +427,7 @@ describe("ui-review command", () => {
       UI_REVIEW_AGENT: "1",
       UI_REVIEW_AGENT_SCRIPT: agentScript,
       MOCK_OWLETTO_FILES: JSON.stringify([
-        { filename: "apps/chrome/tools.js" },
+        { filename: "src/lib/api-client.ts" },
       ]),
     });
 
@@ -465,7 +465,7 @@ describe("ui-review command", () => {
       UI_REVIEW_AGENT: "1",
       UI_REVIEW_AGENT_SCRIPT: agentScript,
       MOCK_OWLETTO_FILES: JSON.stringify([
-        { filename: "apps/chrome/sidepanel.html" },
+        { filename: "src/components/shell/responsive-app-shell.tsx" },
       ]),
     });
 
@@ -486,7 +486,7 @@ describe("ui-review command", () => {
       UI_REVIEW_AGENT: "1",
       UI_REVIEW_AGENT_SCRIPT: join(fixture.repo, "does-not-exist.sh"),
       MOCK_OWLETTO_FILES: JSON.stringify([
-        { filename: "apps/chrome/sidepanel.html" },
+        { filename: "src/components/shell/responsive-app-shell.tsx" },
       ]),
     });
 
@@ -513,7 +513,7 @@ describe("ui-review command", () => {
       UI_REVIEW_AGENT: "1",
       UI_REVIEW_AGENT_SCRIPT: agentScript,
       MOCK_OWLETTO_FILES: JSON.stringify([
-        { filename: "apps/chrome/tools.js" },
+        { filename: "src/lib/api-client.ts" },
       ]),
     });
     expectExit(first, 0);
@@ -521,7 +521,7 @@ describe("ui-review command", () => {
     const second = runUiReview(fixture, {
       ARTIFACT: "https://claude.ai/code/artifact/override",
       MOCK_OWLETTO_FILES: JSON.stringify([
-        { filename: "apps/chrome/tools.js" },
+        { filename: "src/lib/api-client.ts" },
       ]),
     });
     expectExit(second, 0);

--- a/scripts/__tests__/ui-review-command.test.ts
+++ b/scripts/__tests__/ui-review-command.test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { buildProofBody, UNHOSTED_PREFIXES } from "../lib/ui-review-proof";
+import { buildProofBody } from "../lib/ui-review-proof";
 
 const UI_REVIEW_SCRIPT = resolve(import.meta.dir, "..", "ui-review.ts");
 const BASE_POINTER = "1".repeat(40);
@@ -194,6 +194,23 @@ await Bun.write(stateFile, JSON.stringify(state));
   return { repo, bin, stateFile, head };
 }
 
+/**
+ * A fake ui-review-agent.sh standing in for a real reviewer CLI: writes the
+ * given verdict straight to the out-file, ignoring the context it's handed.
+ * Command tests exercise the plumbing (does ui-review.ts call it, parse its
+ * output, and record the right proof kind) — not reviewer judgment quality,
+ * which the standalone script + real CLI cover separately.
+ */
+function createFakeAgentScript(root: string, verdict: object): string {
+  const path = join(root, "fake-agent.ts");
+  writeFileSync(
+    path,
+    `#!/usr/bin/env bun\nawait Bun.write(process.argv[3], ${JSON.stringify(JSON.stringify(verdict))});\n`
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
 function runUiReview(
   fixture: ReturnType<typeof createFixture>,
   environment: Record<string, string> = {}
@@ -209,6 +226,11 @@ function runUiReview(
       MOCK_BASE_POINTER: BASE_POINTER,
       MOCK_HEAD_POINTER: HEAD_POINTER,
       MOCK_PRODUCT_POINTER: PRODUCT_POINTER,
+      // Every existing test exercises the ARTIFACT-required path, not the
+      // agent-classification one — default it off so a missing ARTIFACT
+      // falls straight to "proof missing" instead of spawning a real
+      // reviewer CLI mid test-run. Tests of the agent path override this.
+      UI_REVIEW_AGENT: "0",
       ...environment,
     },
     stdout: "pipe",
@@ -300,7 +322,7 @@ describe("ui-review command", () => {
     });
   });
 
-  it("passes a complete unhosted PR and clears stale parent proof copy", () => {
+  it("passes a complete deploy-only PR and clears stale parent proof copy", () => {
     const fixture = createFixture();
     const state = readState(fixture.stateFile);
     const parentEndpoint = "repos/lobu-ai/lobu/issues/2500/comments";
@@ -334,13 +356,13 @@ describe("ui-review command", () => {
       context: "ui-review",
       state: "success",
       description:
-        "Owletto 111111111...222222222 ships no hosted surface; no URL to prove",
+        "Owletto 111111111...222222222 is deploy-only; no UI to prove",
       target_url: "https://github.com/lobu-ai/owletto/pull/712",
     });
     // The exemption is judged over the whole pointer range, so the range is what
     // the human-readable note must name.
     expect(finalState.comments[parentEndpoint]?.[0]?.body).toContain(
-      `\`${"1".repeat(40)}...${"2".repeat(40)}\` touches no hosted surface (2 files under ${UNHOSTED_PREFIXES.join(", ")}, through Owletto #712).`
+      `\`${"1".repeat(40)}...${"2".repeat(40)}\` changes only \`deploy/\` (2 files, through Owletto #712).`
     );
     expect(finalState.opened).toBe(
       "https://github.com/lobu-ai/owletto/pull/712"
@@ -388,6 +410,130 @@ describe("ui-review command", () => {
       state: "error",
       description: "UI proof missing; rerun make ui-review with ARTIFACT=...",
     });
+  });
+
+  it("records an agent no-ui-surface proof when no ARTIFACT is given and the reviewer agrees", () => {
+    const fixture = createFixture();
+    const agentScript = createFakeAgentScript(fixture.repo, {
+      has_ui_surface: false,
+      reasoning:
+        "Only tools.js (static import cleanup) and MacShellActionService.swift changed; neither renders anything.",
+      verification_summary:
+        "vitest 249/254 pass; Swift logic compiled and run, 9/9 assertions pass.",
+      reviewer: "claude",
+    });
+
+    const result = runUiReview(fixture, {
+      UI_REVIEW_AGENT: "1",
+      UI_REVIEW_AGENT_SCRIPT: agentScript,
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "apps/chrome/tools.js" },
+      ]),
+    });
+
+    expectExit(result, 0);
+    const state = readState(fixture.stateFile);
+    const proofComments =
+      state.comments["repos/lobu-ai/owletto/issues/712/comments"];
+    expect(proofComments?.[0]?.body).toContain("no UI surface");
+    expect(proofComments?.[0]?.body).toContain("claude");
+    expect(proofComments?.[0]?.body).toContain("Only tools.js");
+
+    const status = state.calls
+      .filter((call) => call.endpoint.includes("/statuses/"))
+      .at(-1);
+    expect(status?.payload).toMatchObject({
+      context: "ui-review",
+      state: "success",
+    });
+
+    const parentComment =
+      state.comments["repos/lobu-ai/lobu/issues/2500/comments"]?.[0];
+    expect(parentComment?.body).toContain("**UI review recorded**");
+  });
+
+  it("still requires ARTIFACT when the reviewer finds real UI surface", () => {
+    const fixture = createFixture();
+    const agentScript = createFakeAgentScript(fixture.repo, {
+      has_ui_surface: true,
+      reasoning: "sidepanel.html copy and new icon assets changed.",
+      verification_summary: "no screenshots in the source material.",
+      reviewer: "claude",
+    });
+
+    const result = runUiReview(fixture, {
+      UI_REVIEW_AGENT: "1",
+      UI_REVIEW_AGENT_SCRIPT: agentScript,
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "apps/chrome/sidepanel.html" },
+      ]),
+    });
+
+    expectExit(result, 2);
+    const status = readState(fixture.stateFile)
+      .calls.filter((call) => call.endpoint.includes("/statuses/"))
+      .at(-1);
+    expect(status?.payload).toMatchObject({
+      context: "ui-review",
+      state: "error",
+      description: "UI proof missing; rerun make ui-review with ARTIFACT=...",
+    });
+  });
+
+  it("still requires ARTIFACT when the reviewer is unavailable (fails closed)", () => {
+    const fixture = createFixture();
+    const result = runUiReview(fixture, {
+      UI_REVIEW_AGENT: "1",
+      UI_REVIEW_AGENT_SCRIPT: join(fixture.repo, "does-not-exist.sh"),
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "apps/chrome/sidepanel.html" },
+      ]),
+    });
+
+    expectExit(result, 2);
+    const status = readState(fixture.stateFile)
+      .calls.filter((call) => call.endpoint.includes("/statuses/"))
+      .at(-1);
+    expect(status?.payload).toMatchObject({
+      context: "ui-review",
+      state: "error",
+      description: "UI proof missing; rerun make ui-review with ARTIFACT=...",
+    });
+  });
+
+  it("prefers an explicit ARTIFACT over an existing agent no-ui-surface proof", () => {
+    const fixture = createFixture();
+    const agentScript = createFakeAgentScript(fixture.repo, {
+      has_ui_surface: false,
+      reasoning: "no surface",
+      verification_summary: "tests pass",
+      reviewer: "claude",
+    });
+    const first = runUiReview(fixture, {
+      UI_REVIEW_AGENT: "1",
+      UI_REVIEW_AGENT_SCRIPT: agentScript,
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "apps/chrome/tools.js" },
+      ]),
+    });
+    expectExit(first, 0);
+
+    const second = runUiReview(fixture, {
+      ARTIFACT: "https://claude.ai/code/artifact/override",
+      MOCK_OWLETTO_FILES: JSON.stringify([
+        { filename: "apps/chrome/tools.js" },
+      ]),
+    });
+    expectExit(second, 0);
+
+    const state = readState(fixture.stateFile);
+    const proofComments =
+      state.comments["repos/lobu-ai/owletto/issues/712/comments"];
+    expect(proofComments).toHaveLength(1);
+    expect(proofComments?.[0]?.body).toContain(
+      "https://claude.ai/code/artifact/override"
+    );
+    expect(proofComments?.[0]?.body).not.toContain("no UI surface");
   });
 
   it("keeps its own proof when another Lobu PR pins the same Owletto commit", () => {

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+  type AgentUiReviewProof,
   buildProofBody,
   COMPARE_FILE_CAP,
   findProofComment,
-  isUnhostedRange,
+  isArtifactProof,
+  isDeployOnlyRange,
   isHttpsArtifact,
   parseProof,
   permittedFluxTailParent,
@@ -154,9 +156,9 @@ describe("UI review proof", () => {
     }
   });
 
-  it("accepts only a complete unhosted endpoint diff", () => {
+  it("accepts only a complete deploy-only endpoint diff", () => {
     expect(
-      isUnhostedRange([
+      isDeployOnlyRange([
         { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
         { filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" },
       ])
@@ -165,62 +167,18 @@ describe("UI review proof", () => {
     // The range spans several merged PRs. A surviving UI change from an earlier
     // commit must still demand proof when the head PR is deploy-only on its own.
     expect(
-      isUnhostedRange([
+      isDeployOnlyRange([
         { filename: "src/components/shell/responsive-app-shell.tsx" },
         { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
       ])
     ).toBe(false);
 
-    // An extension-only or Mac-only range has no hosted URL to compare, so it
-    // is exempt from proof the same way a deploy-only range is.
-    expect(
-      isUnhostedRange([
-        { filename: "apps/chrome/watch.js" },
-        { filename: "apps/chrome/sidepanel.html" },
-      ])
-    ).toBe(true);
-    expect(isUnhostedRange([{ filename: "apps/mac/Owletto/App.swift" }])).toBe(
-      true
-    );
-    // Mixed unhosted trees still qualify — none of them is hosted.
-    expect(
-      isUnhostedRange([
-        { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
-        { filename: "apps/chrome/manifest.json" },
-      ])
-    ).toBe(true);
-    // A hosted change anywhere in the range still demands proof.
-    expect(
-      isUnhostedRange([
-        { filename: "apps/chrome/watch.js" },
-        { filename: "src/components/shell/responsive-app-shell.tsx" },
-      ])
-    ).toBe(false);
-    // Fail closed on an apps/ tree that is NOT on the allowlist.
-    expect(isUnhostedRange([{ filename: "apps/web/index.tsx" }])).toBe(false);
-    // Build/post-build checks run in CI and are never served, so there is no
-    // URL to compare — the same reason deploy/ and the packaged apps qualify.
-    expect(
-      isUnhostedRange([{ filename: "scripts/check-mcp-app-bundle.mjs" }])
-    ).toBe(true);
-    // ...but the prefix must not swallow a hosted tree that merely contains
-    // a scripts/ directory, nor a sibling whose name it merely starts.
-    expect(isUnhostedRange([{ filename: "src/scripts/widget.tsx" }])).toBe(
+    // `deploy/` is a path prefix, not a substring.
+    expect(isDeployOnlyRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
       false
     );
     expect(
-      isUnhostedRange([{ filename: "scripts-archive/old-widget.tsx" }])
-    ).toBe(false);
-
-    // The unhosted prefixes are path prefixes, not substrings.
-    expect(isUnhostedRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
-      false
-    );
-    expect(isUnhostedRange([{ filename: "src/apps/chrome/panel.tsx" }])).toBe(
-      false
-    );
-    expect(
-      isUnhostedRange([
+      isDeployOnlyRange([
         {
           filename: "deploy/k8s/archived-app.tsx",
           previous_filename: "src/app.tsx",
@@ -230,9 +188,9 @@ describe("UI review proof", () => {
 
     // Fail closed when the compare response tells us nothing, and when it may
     // have been truncated at the cap.
-    expect(isUnhostedRange([])).toBe(false);
+    expect(isDeployOnlyRange([])).toBe(false);
     expect(
-      isUnhostedRange(
+      isDeployOnlyRange(
         Array.from({ length: COMPARE_FILE_CAP }, (_, index) => ({
           filename: `deploy/k8s/generated/${index}.yaml`,
         }))
@@ -246,6 +204,65 @@ describe("UI review proof", () => {
     );
     expect(isHttpsArtifact("http://localhost:9284/proof.html")).toBe(false);
     expect(isHttpsArtifact("/tmp/proof.html")).toBe(false);
+  });
+
+  it("round-trips an agent no-ui-surface proof alongside an artifact proof", () => {
+    const agentProof: AgentUiReviewProof = {
+      version: 1,
+      lobu_repo: "lobu-ai/lobu",
+      lobu_pr: 2920,
+      lobu_base_owletto_sha: BASE_SHA,
+      owletto_sha: HEAD_SHA,
+      owletto_pr: 892,
+      no_ui_surface: true,
+      reviewer: "codex",
+      reasoning:
+        "Only apps/chrome/tools.js (static import cleanup) and apps/mac/Owletto/MacShellActionService.swift (a stderr-text heuristic) changed; neither renders anything a user sees.",
+      verification_summary:
+        "bunx vitest run apps/chrome — 249/254 pass (5 pre-existing unrelated failures); Swift logic compiled and run on Linux via a stub harness, 9/9 assertions pass.",
+    };
+
+    expect(isArtifactProof(agentProof)).toBe(false);
+    expect(isArtifactProof(proof)).toBe(true);
+
+    const body = buildProofBody(agentProof);
+    expect(parseProof(body)).toEqual(agentProof);
+    expect(body).toContain(agentProof.reasoning);
+    expect(body).toContain(agentProof.verification_summary);
+    expect(body).toContain(HEAD_SHA);
+
+    // Sharing findProofComment/proofMatches with the artifact variant is the
+    // point — a Lobu PR owns at most one proof regardless of which kind it is.
+    const comment: UiReviewComment = {
+      body,
+      created_at: "2026-08-19T16:00:00Z",
+      html_url: "https://github.com/lobu-ai/owletto/pull/892#agent-proof",
+      user: { login: "agent" },
+    };
+    expect(findProofComment([comment], "lobu-ai/lobu", 2920)).toBe(comment);
+    expect(
+      proofMatches(agentProof, "lobu-ai/lobu", BASE_SHA, HEAD_SHA, 2920, 892)
+    ).toBe(true);
+  });
+
+  it("rejects a malformed agent proof (missing reasoning/verification)", () => {
+    const malformed = {
+      version: 1,
+      lobu_repo: "lobu-ai/lobu",
+      lobu_pr: 2920,
+      lobu_base_owletto_sha: BASE_SHA,
+      owletto_sha: HEAD_SHA,
+      owletto_pr: 892,
+      no_ui_surface: true,
+      reviewer: "codex",
+      reasoning: "",
+      verification_summary: "",
+    };
+    expect(
+      parseProof(
+        `<!-- lobu-ui-review-proof ${Buffer.from(JSON.stringify(malformed)).toString("base64url")} -->\nbody`
+      )
+    ).toBeNull();
   });
 
   it("matches only the exact repo/base/head/PR tuple a proof carries", () => {

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -5,7 +5,7 @@ import {
   COMPARE_FILE_CAP,
   findProofComment,
   isArtifactProof,
-  isDeployOnlyRange,
+  isUnhostedRange,
   isHttpsArtifact,
   parseProof,
   permittedFluxTailParent,
@@ -156,9 +156,9 @@ describe("UI review proof", () => {
     }
   });
 
-  it("accepts only a complete deploy-only endpoint diff", () => {
+  it("accepts only a complete unhosted-tree endpoint diff", () => {
     expect(
-      isDeployOnlyRange([
+      isUnhostedRange([
         { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
         { filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" },
       ])
@@ -167,18 +167,18 @@ describe("UI review proof", () => {
     // The range spans several merged PRs. A surviving UI change from an earlier
     // commit must still demand proof when the head PR is deploy-only on its own.
     expect(
-      isDeployOnlyRange([
+      isUnhostedRange([
         { filename: "src/components/shell/responsive-app-shell.tsx" },
         { filename: "deploy/k8s/clusters/lobu-prod/apps.yaml" },
       ])
     ).toBe(false);
 
     // `deploy/` is a path prefix, not a substring.
-    expect(isDeployOnlyRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
+    expect(isUnhostedRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
       false
     );
     expect(
-      isDeployOnlyRange([
+      isUnhostedRange([
         {
           filename: "deploy/k8s/archived-app.tsx",
           previous_filename: "src/app.tsx",
@@ -188,9 +188,29 @@ describe("UI review proof", () => {
 
     // Fail closed when the compare response tells us nothing, and when it may
     // have been truncated at the cap.
-    expect(isDeployOnlyRange([])).toBe(false);
+    // Every unhosted tree keeps its exemption — the agent classifier is an
+    // ADDITION for hosted ranges, not a replacement for these. An extension- or
+    // Mac-only range has no hosted URL to compare, so demanding ARTIFACT here
+    // would be unsatisfiable rather than strict.
     expect(
-      isDeployOnlyRange(
+      isUnhostedRange([
+        { filename: "apps/chrome/src/sidepanel/index.ts" },
+        { filename: "apps/mac/Owletto/AppDelegate.swift" },
+        { filename: "scripts/check-manifest.mjs" },
+      ])
+    ).toBe(true);
+
+    // A hosted path anywhere in the range still demands proof.
+    expect(
+      isUnhostedRange([
+        { filename: "apps/chrome/src/sidepanel/index.ts" },
+        { filename: "src/components/shell/responsive-app-shell.tsx" },
+      ])
+    ).toBe(false);
+
+    expect(isUnhostedRange([])).toBe(false);
+    expect(
+      isUnhostedRange(
         Array.from({ length: COMPARE_FILE_CAP }, (_, index) => ({
           filename: `deploy/k8s/generated/${index}.yaml`,
         }))

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -1,13 +1,39 @@
 import { Buffer } from "node:buffer";
 
-export interface UiReviewProof {
+interface UiReviewProofBase {
   version: 1;
   lobu_repo: string;
   lobu_pr: number;
   lobu_base_owletto_sha: string;
   owletto_sha: string;
   owletto_pr: number;
+}
+
+/** Screenshot-based proof: a hosted before/after comparison a human reviews. */
+export interface ArtifactUiReviewProof extends UiReviewProofBase {
   artifact_url: string;
+}
+
+/**
+ * Agent-judged proof: an independent reviewer CLI (the same one `make review`
+ * uses) concluded the range has no user-visible UI surface at all, so a
+ * screenshot comparison would have nothing to show. Recorded with its
+ * reasoning and how the change was otherwise verified — evidence, not
+ * assertion — so a human can audit the call same as a screenshot.
+ */
+export interface AgentUiReviewProof extends UiReviewProofBase {
+  no_ui_surface: true;
+  reviewer: string;
+  reasoning: string;
+  verification_summary: string;
+}
+
+export type UiReviewProof = ArtifactUiReviewProof | AgentUiReviewProof;
+
+export function isArtifactProof(
+  proof: UiReviewProof
+): proof is ArtifactUiReviewProof {
+  return "artifact_url" in proof;
 }
 
 export interface UiReviewComment {
@@ -38,9 +64,7 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const FLUX_AUTHOR_EMAIL = "fluxcd@lobu.ai";
 const FLUX_SUBJECT = "chore: update images";
 
-function isProof(value: unknown): value is UiReviewProof {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Partial<UiReviewProof>;
+function isProofBase(candidate: Partial<UiReviewProofBase>): boolean {
   return (
     candidate.version === 1 &&
     typeof candidate.lobu_repo === "string" &&
@@ -52,7 +76,27 @@ function isProof(value: unknown): value is UiReviewProof {
     typeof candidate.owletto_sha === "string" &&
     SHA_PATTERN.test(candidate.owletto_sha) &&
     Number.isInteger(candidate.owletto_pr) &&
-    (candidate.owletto_pr ?? 0) > 0 &&
+    (candidate.owletto_pr ?? 0) > 0
+  );
+}
+
+function isProof(value: unknown): value is UiReviewProof {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<
+    ArtifactUiReviewProof & AgentUiReviewProof
+  >;
+  if (!isProofBase(candidate)) return false;
+  if (candidate.no_ui_surface === true) {
+    return (
+      typeof candidate.reviewer === "string" &&
+      candidate.reviewer.length > 0 &&
+      typeof candidate.reasoning === "string" &&
+      candidate.reasoning.length > 0 &&
+      typeof candidate.verification_summary === "string" &&
+      candidate.verification_summary.length > 0
+    );
+  }
+  return (
     typeof candidate.artifact_url === "string" &&
     isHttpsArtifact(candidate.artifact_url)
   );
@@ -71,7 +115,8 @@ export function buildProofBody(proof: UiReviewProof): string {
     "base64url"
   );
   const marker = `${PROOF_MARKER}${encoded} -->`;
-  return `${marker}
+  if (isArtifactProof(proof)) {
+    return `${marker}
 ## UI proof
 
 Visual evidence for the Owletto version proposed by ${proof.lobu_repo}#${proof.lobu_pr}.
@@ -82,6 +127,24 @@ Visual evidence for the Owletto version proposed by ${proof.lobu_repo}#${proof.l
 
 The comparison is captured from one booted instance against the same data on
 both sides. A later pointer change that needs visual proof republishes it.`;
+  }
+  return `${marker}
+## UI review: no UI surface
+
+Independent review (\`${proof.reviewer}\`) for the Owletto version proposed by
+${proof.lobu_repo}#${proof.lobu_pr} found no user-visible UI surface in this
+range, so a screenshot comparison would have nothing to show.
+
+- Before: \`${proof.lobu_base_owletto_sha}\`
+- After: \`${proof.owletto_sha}\`
+
+**Reasoning:** ${proof.reasoning}
+
+**Verification:** ${proof.verification_summary}
+
+A later pointer change that touches UI surface still needs a real screenshot
+comparison — this classification is scoped to this exact range and republishes
+whenever the range changes.`;
 }
 
 export function parseProof(body: string): UiReviewProof | null {
@@ -148,49 +211,19 @@ export function selectOwlettoPullRequest(
  * The pointer can span several merged PRs, so inspect its endpoint diff rather
  * than only the head PR. GitHub caps comparison files at COMPARE_FILE_CAP and
  * reports no total, so empty and cap-sized responses fail closed. Renames must
- * stay inside the unhosted prefixes at both ends.
+ * stay under `deploy/` at both ends.
  */
 export const COMPARE_FILE_CAP = 300;
 
-/**
- * Owletto trees that ship no hosted web surface, so a before/after URL cannot
- * exist for them:
- *
- *   deploy/      k8s manifests — nothing user-visible
- *   apps/chrome/ the browser extension — distributed as a Web Store zip
- *   apps/mac/    the native Mac app — distributed as a signed build
- *   scripts/     build and post-build checks — run in CI, never served
- *
- * The extension and the Mac app do have their own UI (the Owletto side panel,
- * for one), and this exemption deliberately does NOT claim otherwise. It says
- * only that hosted proof is the wrong instrument for them: there is no URL to
- * compare, and the sole way to satisfy the gate would be a screenshot, which
- * is exactly the unverifiable artifact the proof mechanism exists to reject.
- * Their content review belongs to the Owletto repo's own PR review.
- *
- * Kept as an explicit allowlist rather than "anything that isn't src/" so the
- * gate stays fail-closed: a future hosted tree (say apps/web/) correctly
- * demands proof instead of inheriting an exemption nobody revisited.
- */
-export const UNHOSTED_PREFIXES = [
-  "deploy/",
-  "apps/chrome/",
-  "apps/mac/",
-  "scripts/",
-];
-
-const isUnhostedPath = (path: string) =>
-  UNHOSTED_PREFIXES.some((prefix) => path.startsWith(prefix));
-
-export function isUnhostedRange(
+export function isDeployOnlyRange(
   files: Array<{ filename: string; previous_filename?: string }>
 ): boolean {
   if (files.length === 0 || files.length >= COMPARE_FILE_CAP) return false;
   return files.every(
     (file) =>
-      isUnhostedPath(file.filename) &&
+      file.filename.startsWith("deploy/") &&
       (file.previous_filename === undefined ||
-        isUnhostedPath(file.previous_filename))
+        file.previous_filename.startsWith("deploy/"))
   );
 }
 

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -211,19 +211,56 @@ export function selectOwlettoPullRequest(
  * The pointer can span several merged PRs, so inspect its endpoint diff rather
  * than only the head PR. GitHub caps comparison files at COMPARE_FILE_CAP and
  * reports no total, so empty and cap-sized responses fail closed. Renames must
- * stay under `deploy/` at both ends.
+ * stay inside the unhosted prefixes at both ends.
  */
 export const COMPARE_FILE_CAP = 300;
 
-export function isDeployOnlyRange(
+/**
+ * Owletto trees that ship no hosted web surface, so a before/after URL cannot
+ * exist for them:
+ *
+ *   deploy/      k8s manifests — nothing user-visible
+ *   apps/chrome/ the browser extension — distributed as a Web Store zip
+ *   apps/mac/    the native Mac app — distributed as a signed build
+ *   scripts/     build and post-build checks — run in CI, never served
+ *
+ * The extension and the Mac app do have their own UI (the Owletto side panel,
+ * for one), and this exemption deliberately does NOT claim otherwise. It says
+ * only that hosted proof is the wrong instrument for them: there is no URL to
+ * compare, and the sole way to satisfy the gate would be a screenshot, which
+ * is exactly the unverifiable artifact the proof mechanism exists to reject.
+ * Their content review belongs to the Owletto repo's own PR review.
+ *
+ * This list is NOT made redundant by the agent classifier below it. The two
+ * answer different questions: this one says hosted proof is unobtainable in
+ * principle, the agent says a specific range happens to render nothing. Only
+ * the first holds when no reviewer CLI is reachable — dropping it would leave
+ * an extension-only range with no free path AND no satisfiable fallback, since
+ * the ARTIFACT it would demand cannot exist.
+ *
+ * Kept as an explicit allowlist rather than "anything that isn't src/" so the
+ * gate stays fail-closed: a future hosted tree (say apps/web/) correctly
+ * demands proof instead of inheriting an exemption nobody revisited.
+ */
+export const UNHOSTED_PREFIXES = [
+  "deploy/",
+  "apps/chrome/",
+  "apps/mac/",
+  "scripts/",
+];
+
+const isUnhostedPath = (path: string) =>
+  UNHOSTED_PREFIXES.some((prefix) => path.startsWith(prefix));
+
+export function isUnhostedRange(
   files: Array<{ filename: string; previous_filename?: string }>
 ): boolean {
   if (files.length === 0 || files.length >= COMPARE_FILE_CAP) return false;
   return files.every(
     (file) =>
-      file.filename.startsWith("deploy/") &&
+      isUnhostedPath(file.filename) &&
       (file.previous_filename === undefined ||
-        file.previous_filename.startsWith("deploy/"))
+        isUnhostedPath(file.previous_filename))
   );
 }
 

--- a/scripts/ui-review-agent.sh
+++ b/scripts/ui-review-agent.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ui-review-agent.sh <context-file> <out-file>
+#
+# Independent reviewer verdict on whether an Owletto pointer range has any
+# user-visible UI surface. Called by ui-review.ts as an alternative to a
+# hosted screenshot comparison, ONLY for a range that is not deploy-only.
+# Reuses the same reviewer CLI selection as `make review` (scripts/review.sh)
+# so this is the same independent-agent trust model, not self-attestation by
+# whoever wrote the change.
+#
+# <context-file> is the caller-prepared prompt body: changed file list,
+# unified diffs, and the source PR's own description (which carries its test
+# plan). <out-file> receives the raw JSON verdict on success.
+#
+# Fails closed: any error, empty output, or a verdict that fails the schema
+# leaves <out-file> unwritten and exits non-zero. The caller must then fall
+# back to requiring a real ARTIFACT — never treat a failure here as "no UI
+# surface" by default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/review-reviewer.sh"
+
+CONTEXT_FILE="${1:?usage: ui-review-agent.sh <context-file> <out-file>}"
+OUT_FILE="${2:?usage: ui-review-agent.sh <context-file> <out-file>}"
+
+REVIEWER_CLI="${REVIEWER_CLI:-auto}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
+CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
+SCHEMA_FILE="$SCRIPT_DIR/../prompts/ui-review-agent-output-schema.json"
+PROMPT_FILE="$SCRIPT_DIR/../prompts/ui-review-agent-prompt.md"
+SCHEMA_JQ='(.has_ui_surface | type == "boolean") and (.reasoning | type == "string" and length > 0) and (.verification_summary | type == "string" and length > 0)'
+
+[ -f "$SCHEMA_FILE" ] || { echo "schema not found: $SCHEMA_FILE" >&2; exit 2; }
+[ -f "$PROMPT_FILE" ] || { echo "prompt not found: $PROMPT_FILE" >&2; exit 2; }
+
+REVIEWER_CLI_SELECTED="$(review_select_reviewer "$REVIEWER_CLI")"
+if [ "$REVIEWER_CLI_SELECTED" = "claude" ]; then
+  review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
+fi
+command -v "$REVIEWER_CLI_SELECTED" >/dev/null 2>&1 || {
+  review_fail_closed_message "$REVIEWER_CLI_SELECTED" "command not found on PATH" >&2
+  exit 2
+}
+
+FULL_PROMPT_FILE="$(mktemp /tmp/lobu-ui-review-agent-prompt.XXXXXX)"
+trap 'rm -f "$FULL_PROMPT_FILE"' EXIT
+cat "$PROMPT_FILE" "$CONTEXT_FILE" > "$FULL_PROMPT_FILE"
+printf '\n\nEmit only the JSON verdict.\n' >> "$FULL_PROMPT_FILE"
+
+RAW_FILE="$(mktemp /tmp/lobu-ui-review-agent-"${REVIEWER_CLI_SELECTED}".XXXXXX)"
+DIAGNOSTIC_FILE="${RAW_FILE}.stderr"
+trap 'rm -f "$FULL_PROMPT_FILE" "$RAW_FILE" "$DIAGNOSTIC_FILE"' EXIT
+
+set +e
+case "$REVIEWER_CLI_SELECTED" in
+  claude)
+    claude -p "$(cat "$FULL_PROMPT_FILE")" \
+      --model "$CLAUDE_REVIEW_MODEL" \
+      --effort "$CLAUDE_REVIEW_EFFORT" \
+      --json-schema "$(cat "$SCHEMA_FILE")" \
+      --output-format text \
+      --no-session-persistence \
+      --tools Read,Grep,LS \
+      --permission-mode bypassPermissions < /dev/null > "$RAW_FILE" 2> "$DIAGNOSTIC_FILE"
+    ;;
+  codex)
+    codex_args=(codex exec --sandbox read-only --output-schema "$SCHEMA_FILE" --output-last-message "$RAW_FILE" --ephemeral)
+    [ -n "$CODEX_REVIEW_MODEL" ] && codex_args+=(--model "$CODEX_REVIEW_MODEL")
+    "${codex_args[@]}" "$(cat "$FULL_PROMPT_FILE")" < /dev/null > /dev/null 2> "$DIAGNOSTIC_FILE"
+    ;;
+  pi)
+    pi_args=(pi -p --no-session --tools "read")
+    [ -n "${PI_REVIEW_PROVIDER:-}" ] && pi_args+=(--provider "$PI_REVIEW_PROVIDER")
+    [ -n "${PI_REVIEW_MODEL:-}" ] && pi_args+=(--model "$PI_REVIEW_MODEL")
+    "${pi_args[@]}" "$(cat "$FULL_PROMPT_FILE")" < /dev/null > "$RAW_FILE" 2> "$DIAGNOSTIC_FILE"
+    ;;
+esac
+REVIEWER_EXIT=$?
+set -e
+
+RAW="$(cat "$RAW_FILE" 2>/dev/null || true)"
+if [ "$REVIEWER_EXIT" -ne 0 ]; then
+  echo "ui-review-agent: reviewer '$REVIEWER_CLI_SELECTED' exited $REVIEWER_EXIT" >&2
+  [ -s "$DIAGNOSTIC_FILE" ] && cat "$DIAGNOSTIC_FILE" >&2
+  exit 1
+fi
+if [ -z "$(printf '%s' "$RAW" | tr -d '[:space:]')" ]; then
+  echo "ui-review-agent: empty verdict from '$REVIEWER_CLI_SELECTED'" >&2
+  exit 1
+fi
+if ! printf '%s' "$RAW" | jq -e "$SCHEMA_JQ" >/dev/null 2>&1; then
+  echo "ui-review-agent: verdict failed schema check: $RAW" >&2
+  exit 1
+fi
+
+printf '%s' "$RAW" | jq --arg reviewer "$REVIEWER_CLI_SELECTED" '. + {reviewer: $reviewer}' > "$OUT_FILE"

--- a/scripts/ui-review.ts
+++ b/scripts/ui-review.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env bun
 
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
+  type AgentUiReviewProof,
   buildProofBody,
   findProofComment,
-  isUnhostedRange,
-  UNHOSTED_PREFIXES,
+  isArtifactProof,
+  isDeployOnlyRange,
   isHttpsArtifact,
   permittedFluxTailParent,
   type OwlettoPullRequest,
@@ -15,6 +20,8 @@ import {
   type UiReviewComment,
   type UiReviewProof,
 } from "./lib/ui-review-proof";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 const STATUS_CONTEXT = "ui-review";
 const PARENT_MARKER = "<!-- lobu-ui-review-marker -->";
@@ -226,6 +233,94 @@ function parentCommentBody(
 - Proof: ${proofUrl}`;
 }
 
+interface CompareResponse {
+  status?: string;
+  files?: Array<{
+    filename: string;
+    previous_filename?: string;
+    status?: string;
+    patch?: string;
+  }>;
+  commits?: Array<{ commit: { message: string } }>;
+}
+
+interface AgentVerdict {
+  has_ui_surface: boolean;
+  reasoning: string;
+  verification_summary: string;
+  reviewer: string;
+}
+
+function buildAgentContext(
+  comparison: CompareResponse,
+  basePointer: string,
+  headPointer: string
+): string {
+  const files = comparison.files ?? [];
+  const lines: string[] = [
+    `## Range ${basePointer}...${headPointer}`,
+    "",
+    "### Changed files",
+    ...files.map((f) => `- ${f.status ?? "modified"}: ${f.filename}`),
+    "",
+    "### Commit messages (squash PR bodies)",
+    ...(comparison.commits ?? []).map((c) => `---\n${c.commit.message}`),
+    "",
+    "### Unified diffs",
+  ];
+  for (const file of files) {
+    if (!file.patch) continue;
+    lines.push(`--- ${file.filename} ---`, file.patch, "");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Ask an independent reviewer CLI (the same one `make review` uses — see
+ * ui-review-agent.sh) whether this range has any user-visible UI surface at
+ * all. Returns null on ANY failure (reviewer unavailable, non-zero exit,
+ * invalid verdict) so the caller falls back to requiring a real ARTIFACT —
+ * this must never be the thing that silently waves through a real UI change.
+ * UI_REVIEW_AGENT_SCRIPT overrides the script path — test-only, so a command
+ * test can point this at a fake without spawning a real reviewer CLI.
+ */
+function tryAgentClassification(
+  comparison: CompareResponse,
+  basePointer: string,
+  headPointer: string
+): AgentVerdict | null {
+  if (process.env.UI_REVIEW_AGENT === "0") return null;
+  const dir = mkdtempSync(join(tmpdir(), "lobu-ui-review-agent-"));
+  try {
+    const contextFile = join(dir, "context.md");
+    const outFile = join(dir, "verdict.json");
+    writeFileSync(
+      contextFile,
+      buildAgentContext(comparison, basePointer, headPointer)
+    );
+    const agentScript =
+      process.env.UI_REVIEW_AGENT_SCRIPT ??
+      join(SCRIPT_DIR, "ui-review-agent.sh");
+    const result = spawnSync(agentScript, [contextFile, outFile], {
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      console.log(
+        `ui-review: agent classification unavailable (${(result.stderr || result.stdout || "").trim().slice(0, 300)})`
+      );
+      return null;
+    }
+    return JSON.parse(readFileSync(outFile, "utf8")) as AgentVerdict;
+  } catch (error) {
+    console.log(
+      `ui-review: agent classification failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function main(): number {
   const options = parseOptions(process.argv.slice(2));
   const localHead = run("git", ["rev-parse", "HEAD"]);
@@ -304,30 +399,29 @@ function main(): number {
     );
   }
 
-  const comparison = ghApi<{
-    status?: string;
-    files?: Array<{ filename: string; previous_filename?: string }>;
-  }>(`repos/${owlettoRepo}/compare/${basePointer}...${headPointer}`);
+  const comparison = ghApi<CompareResponse>(
+    `repos/${owlettoRepo}/compare/${basePointer}...${headPointer}`
+  );
   const rangeFiles = comparison.files ?? [];
-  if (comparison.status === "ahead" && isUnhostedRange(rangeFiles)) {
+  if (comparison.status === "ahead" && isDeployOnlyRange(rangeFiles)) {
     const parentComment = findComment(lobuRepo, parentPr.number, PARENT_MARKER);
     if (parentComment) {
       ghApi(`repos/${lobuRepo}/issues/comments/${parentComment.id}`, "PATCH", {
         body: `${PARENT_MARKER}
 **UI review not applicable** for Lobu head \`${localHead}\`.
 
-\`${basePointer}...${headPointer}\` touches no hosted surface (${rangeFiles.length} files under ${UNHOSTED_PREFIXES.join(", ")}, through Owletto #${owlettoPr.number}).`,
+\`${basePointer}...${headPointer}\` changes only \`deploy/\` (${rangeFiles.length} files, through Owletto #${owlettoPr.number}).`,
       });
     }
     postStatus(
       lobuRepo,
       localHead,
       "success",
-      `Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} ships no hosted surface; no URL to prove`,
+      `Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} is deploy-only; no UI to prove`,
       owlettoPr.html_url
     );
     console.log(
-      `ui-review: not applicable; Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} touches no hosted surface (${rangeFiles.length} files)`
+      `ui-review: not applicable; Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} changes only deploy/ (${rangeFiles.length} files)`
     );
     if (options.open) openPullRequest(owlettoPr.html_url);
     return 0;
@@ -349,39 +443,75 @@ function main(): number {
       owlettoPr.number
     );
 
+  const currentArtifactUrl =
+    currentProof && isArtifactProof(currentProof)
+      ? currentProof.artifact_url
+      : undefined;
+
   if (
     !exactProof ||
-    (options.artifactUrl && currentProof?.artifact_url !== options.artifactUrl)
+    (options.artifactUrl && currentArtifactUrl !== options.artifactUrl)
   ) {
     if (!options.artifactUrl) {
-      postStatus(
-        lobuRepo,
-        localHead,
-        "error",
-        "UI proof missing; rerun make ui-review with ARTIFACT=...",
-        owlettoPr.html_url
+      // No screenshot supplied — ask an independent reviewer whether this
+      // range has any UI surface at all before demanding one. Fails closed:
+      // any classification failure, or a `true` verdict, falls through to
+      // the existing ARTIFACT-required error unchanged.
+      const verdict = tryAgentClassification(
+        comparison,
+        basePointer,
+        headPointer
       );
-      if (options.open) openPullRequest(owlettoPr.html_url);
-      throw new Error(
-        `No current proof on ${owlettoPr.html_url}. Rerun with ARTIFACT=<hosted HTTPS comparison>.`
+      if (verdict && verdict.has_ui_surface === false) {
+        const agentProof: AgentUiReviewProof = {
+          version: 1,
+          lobu_repo: lobuRepo,
+          lobu_pr: parentPr.number,
+          lobu_base_owletto_sha: basePointer,
+          owletto_sha: headPointer,
+          owletto_pr: owlettoPr.number,
+          no_ui_surface: true,
+          reviewer: verdict.reviewer,
+          reasoning: verdict.reasoning,
+          verification_summary: verdict.verification_summary,
+        };
+        currentProof = agentProof;
+        proofComment = writeComment(
+          owlettoRepo,
+          owlettoPr.number,
+          proofComment,
+          buildProofBody(agentProof)
+        );
+      } else {
+        postStatus(
+          lobuRepo,
+          localHead,
+          "error",
+          "UI proof missing; rerun make ui-review with ARTIFACT=...",
+          owlettoPr.html_url
+        );
+        if (options.open) openPullRequest(owlettoPr.html_url);
+        throw new Error(
+          `No current proof on ${owlettoPr.html_url}. Rerun with ARTIFACT=<hosted HTTPS comparison>.`
+        );
+      }
+    } else {
+      currentProof = {
+        version: 1,
+        lobu_repo: lobuRepo,
+        lobu_pr: parentPr.number,
+        lobu_base_owletto_sha: basePointer,
+        owletto_sha: headPointer,
+        owletto_pr: owlettoPr.number,
+        artifact_url: options.artifactUrl,
+      };
+      proofComment = writeComment(
+        owlettoRepo,
+        owlettoPr.number,
+        proofComment,
+        buildProofBody(currentProof)
       );
     }
-
-    currentProof = {
-      version: 1,
-      lobu_repo: lobuRepo,
-      lobu_pr: parentPr.number,
-      lobu_base_owletto_sha: basePointer,
-      owletto_sha: headPointer,
-      owletto_pr: owlettoPr.number,
-      artifact_url: options.artifactUrl,
-    };
-    proofComment = writeComment(
-      owlettoRepo,
-      owlettoPr.number,
-      proofComment,
-      buildProofBody(currentProof)
-    );
   }
 
   if (!currentProof || !proofComment) {

--- a/scripts/ui-review.ts
+++ b/scripts/ui-review.ts
@@ -10,7 +10,7 @@ import {
   buildProofBody,
   findProofComment,
   isArtifactProof,
-  isDeployOnlyRange,
+  isUnhostedRange,
   isHttpsArtifact,
   permittedFluxTailParent,
   type OwlettoPullRequest,
@@ -403,14 +403,14 @@ function main(): number {
     `repos/${owlettoRepo}/compare/${basePointer}...${headPointer}`
   );
   const rangeFiles = comparison.files ?? [];
-  if (comparison.status === "ahead" && isDeployOnlyRange(rangeFiles)) {
+  if (comparison.status === "ahead" && isUnhostedRange(rangeFiles)) {
     const parentComment = findComment(lobuRepo, parentPr.number, PARENT_MARKER);
     if (parentComment) {
       ghApi(`repos/${lobuRepo}/issues/comments/${parentComment.id}`, "PATCH", {
         body: `${PARENT_MARKER}
 **UI review not applicable** for Lobu head \`${localHead}\`.
 
-\`${basePointer}...${headPointer}\` changes only \`deploy/\` (${rangeFiles.length} files, through Owletto #${owlettoPr.number}).`,
+\`${basePointer}...${headPointer}\` changes only unhosted trees (${rangeFiles.length} files, through Owletto #${owlettoPr.number}).`,
       });
     }
     postStatus(
@@ -421,7 +421,7 @@ function main(): number {
       owlettoPr.html_url
     );
     console.log(
-      `ui-review: not applicable; Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} changes only deploy/ (${rangeFiles.length} files)`
+      `ui-review: not applicable; Owletto ${basePointer.slice(0, 9)}...${headPointer.slice(0, 9)} changes only unhosted trees (${rangeFiles.length} files)`
     );
     if (options.open) openPullRequest(owlettoPr.html_url);
     return 0;


### PR DESCRIPTION
## Summary
- Every non-deploy-only Owletto pointer bump requires a hosted before/after screenshot — even when the range is purely backend logic/tests with nothing rendered for a screenshot to show. That surfaced directly on #2920: `owletto#889`/`#890`/`#892` have zero UI surface, but the pointer range also carried an unrelated, already-merged real UI change (`owletto#885`, a toolbar-icon/sidepanel rework) that genuinely needed a screenshot. The all-or-nothing gate meant either fabricating "proof" for the non-visual PRs or `--admin`-overriding the one check that exists to catch real visual regressions.
- Adds an agent-judged path: before demanding `ARTIFACT`, ask an independent reviewer CLI (the same selection `make review` already uses — see `review_select_reviewer` in `lib/review-reviewer.sh`) whether the range touches any user-visible UI surface at all, given its diff + commit messages. It must cite concrete file-by-file reasoning and existing verification (test names, pass counts) — never invented evidence.
- Fails closed on every axis: reviewer CLI unavailable, non-zero exit, invalid/malformed verdict, or an honest `has_ui_surface: true` — all fall straight through to the existing "UI proof missing" error, unchanged. Only a clean `false` verdict records a proof. An explicit `ARTIFACT` always overrides an existing agent proof (a human's screenshot wins).
- `ui-review-proof.ts`'s `UiReviewProof` is now a discriminated union (`ArtifactUiReviewProof | AgentUiReviewProof`) so both proof kinds share the same marker/dedup/matching logic and PR comment rendering.
- `UI_REVIEW_AGENT=0` disables the path entirely; `UI_REVIEW_AGENT_SCRIPT` overrides the script path (test-only escape hatch).

## Test plan
- [x] `bun test scripts/__tests__/ui-review-proof.test.ts scripts/__tests__/ui-review-command.test.ts` — 25/25 pass, including 5 new tests: agent proof round-trip + malformed-proof rejection (proof.test.ts), and command-level coverage for "agent agrees → proof recorded", "agent finds real UI surface → still requires ARTIFACT", "reviewer unavailable → fails closed", and "explicit ARTIFACT overrides an existing agent proof" (command.test.ts). All *existing* tests default `UI_REVIEW_AGENT=0` so they don't spawn a real reviewer CLI mid test-run.
- [x] Ran the standalone `scripts/ui-review-agent.sh` logic against the **actual** `lobu#2920` pointer range (`59d35eea..1d9972ea`) with a real reviewer CLI: correctly returned `has_ui_surface: true`, citing the exact sidepanel copy/icon/badge-removal changes from `owletto#885` — proving it doesn't rubber-stamp large/mixed ranges.
- [x] Ran the same script against `owletto#892` alone (`6bd764ff..1d9972ea`, the connector-manifest-hash fix): correctly returned `has_ui_surface: false`.
- [x] `make pre-pr` (build + typecheck + knip + biome + naming) — clean.
- [x] `bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)