### PR TITLE
refactor(events): give every audit writer one <subject>.<op> vocabulary

### DIFF
--- a/packages/server/src/__tests__/integration/events/audit-event-type-stamp.test.ts
+++ b/packages/server/src/__tests__/integration/events/audit-event-type-stamp.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Every audit writer speaks ONE `<subject>.<op>` vocabulary.
+ *
+ * The four `record*` writers each hold the pair under their own key
+ * (`entity_type`, `resource_kind`, a bare `op`, or free-form caller metadata),
+ * so classifying a row per writer would mean special-casing each. The funnel
+ * (`insertConnectionlessAuditEvent`) REQUIRES the pair and stamps
+ * `_lobu_event_type` itself, so:
+ *   - a new writer that omits it is a compile error, not a silently
+ *     unclassifiable row, and
+ *   - a new event type costs no code here — pass a new `subject`.
+ *
+ * `_lobu_` matters: that namespace is stripped from caller input in
+ * save_content.ts, so a member cannot forge an event type through save_memory.
+ * Deriving the type from `category`/`entity_type` instead — both caller-writable
+ * — would have been spoofable.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import {
+  formatAuditEventType,
+  insertConnectionlessAuditEvent,
+} from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+let organizationId: string;
+
+async function stampedTypeFor(originId: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT metadata->>'_lobu_event_type' AS event_type
+    FROM events
+    WHERE organization_id = ${organizationId} AND origin_id = ${originId}
+    LIMIT 1
+  `) as unknown as Array<{ event_type: string | null }>;
+  return rows[0]?.event_type ?? null;
+}
+
+describe('audit events carry a uniform _lobu_event_type', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    organizationId = (await createTestOrganization({ name: 'Audit Type Org' })).id;
+  });
+
+  it('formats the pair as dotted <subject>.<op>', () => {
+    // Dotted + past tense, matching feed.auto_paused / message.created — NOT the
+    // underscored origin_type audit tag.
+    expect(formatAuditEventType({ subject: 'device', op: 'created' })).toBe(
+      'device.created'
+    );
+  });
+
+  it('stamps the type onto the persisted row', async () => {
+    const originId = `audit_type_${Date.now()}`;
+    await insertConnectionlessAuditEvent(
+      {
+        entityIds: [],
+        organizationId,
+        originId,
+        title: 'Device registered',
+        semanticType: 'change',
+        metadata: { category: 'lifecycle' },
+      },
+      { subject: 'device', op: 'created' }
+    );
+    expect(await stampedTypeFor(originId)).toBe('device.created');
+  });
+
+  it('stamps over caller metadata that carries the same key', async () => {
+    // The funnel's own stamp is applied after the caller's metadata spread, so
+    // a writer passing `_lobu_event_type` itself cannot override the declared
+    // pair. (save_content separately strips every `_lobu_*` key from member
+    // input, so save_memory cannot reach this key at all.)
+    const originId = `audit_forge_${Date.now()}`;
+    await insertConnectionlessAuditEvent(
+      {
+        entityIds: [],
+        organizationId,
+        originId,
+        title: 'Attempted forge',
+        semanticType: 'change',
+        metadata: { _lobu_event_type: 'device.created' },
+      },
+      { subject: 'entity', op: 'updated' }
+    );
+    expect(await stampedTypeFor(originId)).toBe('entity.updated');
+  });
+
+  it('keeps a distinct type per subject so one vocabulary covers every writer', async () => {
+    const cases: Array<{ subject: string; op: string; expected: string }> = [
+      { subject: 'connection', op: 'deleted', expected: 'connection.deleted' },
+      { subject: 'relationship', op: 'linked', expected: 'relationship.linked' },
+      { subject: 'member', op: 'created', expected: 'member.created' },
+    ];
+    for (const c of cases) {
+      const originId = `audit_${c.expected}_${Date.now()}`;
+      await insertConnectionlessAuditEvent(
+        {
+          entityIds: [],
+          organizationId,
+          originId,
+          title: c.expected,
+          semanticType: 'change',
+        },
+        { subject: c.subject, op: c.op }
+      );
+      expect(await stampedTypeFor(originId)).toBe(c.expected);
+    }
+  });
+});

--- a/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
@@ -40,8 +40,8 @@ describe('insertConnectionlessAuditEvent idempotency', () => {
       },
     };
 
-    const first = await insertConnectionlessAuditEvent(params);
-    const second = await insertConnectionlessAuditEvent(params);
+    const first = await insertConnectionlessAuditEvent(params, { subject: 'member', op: 'created' });
+    const second = await insertConnectionlessAuditEvent(params, { subject: 'member', op: 'created' });
 
     expect(second.change).toBe('unchanged');
     expect(second.id).toBe(first.id);
@@ -76,9 +76,9 @@ describe('insertConnectionlessAuditEvent idempotency', () => {
     };
 
     const results = await Promise.all([
-      insertConnectionlessAuditEvent(params),
-      insertConnectionlessAuditEvent(params),
-      insertConnectionlessAuditEvent(params),
+      insertConnectionlessAuditEvent(params, { subject: 'member', op: 'created' }),
+      insertConnectionlessAuditEvent(params, { subject: 'member', op: 'created' }),
+      insertConnectionlessAuditEvent(params, { subject: 'member', op: 'created' }),
     ]);
     const ids = new Set(results.map((r) => r.id));
     expect(ids.size).toBe(1);

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -739,6 +739,11 @@ export async function handleDelete(
           recordChangeEvent({
             entityIds: entityIds.map(Number),
             organizationId: automation.organization_id as string,
+            subject: 'automation',
+            // `deleted`, not `archived`: the lifecycle and config writers for
+            // this same action below already stamp `automation.deleted`, and
+            // one action must not fork the shared vocabulary.
+            op: 'deleted',
             title: `Automation archived: ${automation.name || automationId}`,
             content: `Automation "${automation.name || automationId}" (id: ${automationId}) was archived.`,
             metadata: {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2301,6 +2301,8 @@ export async function handleDelete(
   recordChangeEvent({
     entityIds: entityIds.map(Number),
     organizationId,
+    subject: 'connection',
+    op: 'deleted',
     title: `Connection deleted: ${connName}`,
     content: `Connection "${connName}" (id: ${args.connection_id}, connector: ${conn.connector_key}) was deleted.`,
     metadata: {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -632,6 +632,8 @@ async function handleUpdate(
 		recordChangeEvent({
 			entityIds: [entityId],
 			organizationId: ctx.organizationId,
+			subject: "entity",
+			op: "updated",
 			title: `Entity updated: ${changes.map((c) => c.field).join(", ")}`,
 			content: `Entity "${entityDetails.name}" (id: ${entityId}) updated:\n${contentLines.join("\n")}`,
 			metadata: { changes },

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -948,6 +948,8 @@ async function handleDeleteFeed(
   recordChangeEvent({
     entityIds: feedEntityIds.map(Number),
     organizationId,
+    subject: 'feed',
+    op: 'deleted',
     title: `Feed deleted: ${feed.feed_key}`,
     content: `Feed "${feed.feed_key}" (id: ${args.feed_id}) was deleted.`,
     metadata: {

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -676,11 +676,51 @@ export async function insertEvent(
 interface ChangeEventParams {
   entityIds: number[];
   organizationId: string;
+  /**
+   * What changed, as the shared `<subject>.<op>` vocabulary. Explicit here
+   * because this writer's `metadata` is caller-shaped free-form jsonb — unlike
+   * its siblings it carries no structured field the funnel could classify from.
+   */
+  subject: string;
+  op: string;
   title: string;
   content: string;
   metadata: Record<string, unknown>;
   createdBy?: string | null;
   clientId?: string | null;
+}
+
+/**
+ * What happened, as one `<subject>.<op>` pair — the single vocabulary every
+ * audit writer speaks.
+ *
+ * Required by the funnel rather than optional so a new writer cannot introduce
+ * an untyped audit row by omission: leaving it out is a compile error, not a
+ * silently unclassifiable event. The four `record*` helpers below each supply
+ * it from data they already hold, so adding a new event type costs no code
+ * here — pass a new `subject`.
+ *
+ * Dotted and past-tense to match the event-type vocabulary already in use
+ * (`feed.auto_paused`, `message.created`), NOT the underscored `origin_type`
+ * audit tag, which stays an internal provenance field.
+ */
+export interface AuditEventType {
+  /**
+   * The domain object: `device`, `connection`, `entity`, `relationship`, …
+   *
+   * Free-form so a new subject costs no code here. State-change writers pass
+   * their existing `AuditResourceKind` slugs, which are hyphenated and
+   * sometimes compound (`agent-settings`, `auth-profile`) — kept as-is rather
+   * than renamed, since those slugs are already the dashboard's pivot.
+   */
+  subject: string;
+  /** Past-tense transition: `created`, `updated`, `deleted`, `linked`, … */
+  op: string;
+}
+
+/** `{subject:'device', op:'created'}` -> `'device.created'`. */
+export function formatAuditEventType(type: AuditEventType): string {
+  return `${type.subject}.${type.op}`;
 }
 
 const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
@@ -696,12 +736,14 @@ const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
  * winner instead of appending a duplicate.
  */
 export async function insertConnectionlessAuditEvent(
-  params: InsertEventParams
+  params: InsertEventParams,
+  eventType: AuditEventType
 ): Promise<InsertedEvent> {
   const idempotencyKey = `audit:${params.originId}`;
   const metadata: Record<string, unknown> = {
     ...(params.metadata ?? {}),
     _lobu_idempotency_key: idempotencyKey,
+    _lobu_event_type: formatAuditEventType(eventType),
   };
 
   try {
@@ -770,7 +812,8 @@ export function recordChangeEvent(params: ChangeEventParams): void {
         metadata: params.metadata,
         createdBy: params.createdBy ?? null,
         clientId: params.clientId ?? null,
-      }),
+      },
+      { subject: params.subject, op: params.op }),
     AUDIT_EVENT_RETRY
   ).catch((err) => {
     logger.error(
@@ -854,7 +897,10 @@ export function recordEdgeChangeEvent(params: EdgeChangeEventParams): void {
         },
         createdBy: params.createdBy ?? null,
         clientId: params.clientId ?? null,
-      }),
+      },
+      // `verb` not `op`: the stored op is imperative (link/unlink/update_link)
+      // while the shared vocabulary is past-tense.
+      { subject: 'relationship', op: verb }),
     AUDIT_EVENT_RETRY
   ).catch((err) => {
     logger.error(
@@ -990,7 +1036,8 @@ function recordStateChangeEvent(
         },
         createdBy: params.createdBy ?? null,
         clientId: params.clientId ?? null,
-      }),
+      },
+      { subject: params.resourceKind, op: params.op }),
     AUDIT_EVENT_RETRY
   ).catch((err) => {
     logger.error(
@@ -1042,7 +1089,8 @@ export function recordLifecycleEvent(params: LifecycleEventParams): void {
           ...(params.extra ? { extra: params.extra } : {}),
         },
         createdBy: params.createdBy ?? null,
-      }),
+      },
+      { subject: params.entityType, op: params.op }),
     AUDIT_EVENT_RETRY
   ).catch((err) => {
     logger.error(


### PR DESCRIPTION
## Summary
Stage A of three for making lifecycle events subscribable by Automations. This one is **structural only** — no behavior change beyond one extra metadata key — so the shape change is reviewable apart from the seam work that follows.

Four audit writers funnel through `insertConnectionlessAuditEvent`, carrying **three different shapes**:

| writer | sites | shape |
|---|---|---|
| `recordLifecycleEvent` | 16 | structured — `entityType` + `op` |
| `recordStateChangeEvent` (config/workspace) | ~16 | structured — `resourceKind` + `op` (same pair, different key) |
| `recordEdgeChangeEvent` | 3 | partial — `op` only, no subject |
| `recordChangeEvent` | 4 | **unstructured** — free-form caller metadata |

So classifying an audit row meant special-casing per writer, and a new writer could introduce an unclassifiable row with nothing noticing.

The funnel now **requires** an `AuditEventType` (`{subject, op}`) and stamps `_lobu_event_type` itself:
- required, not optional → omitting it is a **compile error**, which is how the 4 `recordChangeEvent` sites were found
- stamped at the funnel, not per helper → a new event type costs **zero code**; pass a new `subject`

## Why `_lobu_event_type` and not `origin_type` or derived metadata
- **Dotted + past tense** (`device.created`) matches the vocabulary already in use — `feed.auto_paused`, `message.created`. `origin_type` is underscored (`device_created`), already overloaded as an audit provenance tag, and would put two naming conventions in one trigger field.
- **`_lobu_` is load-bearing.** That namespace is stripped from caller input at `save_content.ts:573`, so a member cannot forge an event type via `save_memory`. Deriving from `category`/`entity_type` — both caller-writable — would have been **spoofable**; the code comment at `recordStateChangeEvent` already warns that "`category` alone is NOT a safe gate."
- No schema change: `metadata` is jsonb.

## Test plan
- [x] Intended files staged explicitly, `make pre-pr` clean (build, strict typecheck, knip, biome "Checked 570 files… No fixes applied", naming, gateway-LLM, entity-write; 19 pass / 0 fail). Also ran `scripts/check-security-patterns.sh` → **OK** (CI-only gate).
- [x] `bunx vitest run src/__tests__/integration/events/ src/__tests__/integration/entities/entity-history-contract.test.ts` → **221 pass across 46 suites**
- [x] New suite `audit-event-type-stamp.test.ts` → **4 pass**
- [ ] Bug fix: n/a — structural refactor

### Mutation testing
| mutation | result |
|---|---|
| let caller metadata override the funnel's stamp | exactly the forge test fails; other 3 pass |
| omit `subject`/`op` at any `recordChangeEvent` site | compile error — this is how all 4 sites were located |

## Notes
**Nothing reads `_lobu_event_type` yet.** Stage B teaches the workspace matcher and GIN needle the new key and relaxes the producer gate so events without an `automation_id` load as roots (still inert). Stage C opens the seam from `afterPersist` and threads causality.

**Known, pre-existing, and unchanged by this PR:** one user action can emit several audit rows sharing a type — a connection delete writes via `recordChangeEvent`, `recordLifecycleEvent`, and a config-change writer, all now stamping `connection.deleted`. The stamp makes them uniform, not deduplicated; stage C has to decide whether subscribers see one activation or three.

Subject vocabulary is intentionally free-form: state-change writers pass existing `AuditResourceKind` slugs (`agent-settings`, `auth-profile`), kept as-is rather than renamed since those slugs are already the dashboard's pivot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit events now use consistent subject-and-action labels, making activity records easier to interpret.
  * Updates, deletions, lifecycle changes, and relationship activity now receive clearer event types.

* **Bug Fixes**
  * Audit metadata can no longer be unintentionally overridden when events are recorded.
  * Repeated actions continue to produce a single audit record, improving reliability and preventing duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->