### PR TITLE
feat(authz): govern soft delete with entity write rules

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
@@ -363,7 +363,7 @@ describe("an approved DELETE card is honoured despite the rule that escalated it
 			sql,
 		);
 
-		const [row] = await sql<{ deleted_at: Date | null }>`
+		const [row] = await sql<{ deleted_at: Date | null }[]>`
       SELECT deleted_at FROM entities WHERE id = ${invoice.id}
     `;
 		expect(row.deleted_at).not.toBeNull();

--- a/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
@@ -28,8 +28,15 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { compileEntityRule } from "../../../authz/entity-rule-executor";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
-import { createEntity, updateEntity } from "../../../utils/entity-management";
-import { applyEntityFieldChangeProposal } from "../../../tools/admin/entity-field-approval";
+import {
+	createEntity,
+	updateEntity,
+} from "../../../utils/entity-management";
+import {
+	applyEntityChangeProposal,
+	applyEntityFieldChangeProposal,
+	proposeEntityDelete,
+} from "../../../tools/admin/entity-field-approval";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import { initWorkspaceProvider } from "../../../workspace";
 import {
@@ -53,8 +60,18 @@ export default (row) => {
 };
 `;
 
+/** Escalates on the DELETE itself, so applying the card re-asks the same question. */
+const ESCALATE_ON_DELETE_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$deleted") && row.next.$deleted) {
+    row.escalate(["$deleted"], "deleting an invoice needs sign-off");
+  }
+};
+`;
+
 const TEST_ENV = {} as Env;
 let escalateOnSizeCompiled: string;
+let escalateOnDeleteCompiled: string;
 
 function ctxFor(
 	organizationId: string,
@@ -144,7 +161,10 @@ async function persistedProposal(organizationId: string): Promise<{
 describe("an escalated card applies atomically or not at all", () => {
 	beforeAll(async () => {
 		await initWorkspaceProvider();
-		escalateOnSizeCompiled = await compileEntityRule(ESCALATE_ON_SIZE_RULE);
+		[escalateOnSizeCompiled, escalateOnDeleteCompiled] = await Promise.all([
+			compileEntityRule(ESCALATE_ON_SIZE_RULE),
+			compileEntityRule(ESCALATE_ON_DELETE_RULE),
+		]);
 	}, 60_000);
 
 	beforeEach(async () => {
@@ -284,5 +304,68 @@ describe("an escalated card applies atomically or not at all", () => {
 		// check past escalated cards would strand this card instead.
 		expect(after.vendor).toBe("HUMAN");
 		expect(after.notes).toBe("n1");
+	}, 60_000);
+});
+
+/**
+ * A DELETE card is the same promise as an update card: what the human approved
+ * must be what applying it performs.
+ *
+ * Soft delete is now governed by write rules, so a rule may escalate on
+ * `$deleted`. Applying the card re-runs that rule against the same row, so
+ * without a grant it escalates a second time and throws — the card is minted, a
+ * human approves it, and the delete still never happens. That dead end is what
+ * this covers, end to end through the PERSISTED card rather than a hand-built
+ * proposal.
+ */
+describe("an approved DELETE card is honoured despite the rule that escalated it", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("applies the persisted delete card and tombstones the row", async () => {
+		const sql = getTestDb();
+		const { org, user, invoice } = await seed();
+
+		// The rule escalates on any delete of this type.
+		await sql`
+      UPDATE entity_types SET rules_compiled = ${escalateOnDeleteCompiled}
+      WHERE organization_id = ${org.id} AND slug = 'invoice'
+    `;
+
+		const ctx = ctxFor(org.id, { userId: user.id });
+		await proposeEntityDelete(ctx, {
+			entity_id: invoice.id,
+			entity_type: "invoice",
+			name: invoice.name,
+			force_delete_tree: false,
+		} as Parameters<typeof proposeEntityDelete>[1]);
+
+		// Read back what the card actually stored — a hand-built proposal would
+		// pass with the propose->persist->apply plumbing severed.
+		const [queued] = await sql<{ action_input: unknown }[]>`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${org.id}
+      ORDER BY id DESC LIMIT 1
+    `;
+		const proposal = (
+			typeof queued.action_input === "string"
+				? JSON.parse(queued.action_input)
+				: queued.action_input
+		) as Record<string, unknown>;
+		expect(proposal.entity_id).toBe(invoice.id);
+		expect(proposal.operation).toBe("delete");
+
+		await applyEntityChangeProposal(
+			proposal as never,
+			ctx,
+			TEST_ENV,
+			sql,
+		);
+
+		const [row] = await sql<{ deleted_at: Date | null }>`
+      SELECT deleted_at FROM entities WHERE id = ${invoice.id}
+    `;
+		expect(row.deleted_at).not.toBeNull();
 	}, 60_000);
 });

--- a/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
@@ -356,12 +356,15 @@ describe("an approved DELETE card is honoured despite the rule that escalated it
 		expect(proposal.entity_id).toBe(invoice.id);
 		expect(proposal.operation).toBe("delete");
 
-		await applyEntityChangeProposal(
-			proposal as never,
-			ctx,
-			TEST_ENV,
-			sql,
-		);
+		// Apply INSIDE a transaction, because that is what production does:
+		// approvals.ts wraps the whole claim+confirm+apply in `sql.begin` and
+		// hands `completeApproval` the tx. Passing the pool here would skip the
+		// one shape worth proving — `deleteEntity` opens its OWN transaction on a
+		// SECOND pooled connection while this one is still open, and takes
+		// `FOR UPDATE` on a row the outer tx has not locked.
+		await sql.begin(async (tx) => {
+			await applyEntityChangeProposal(proposal as never, ctx, TEST_ENV, tx);
+		});
 
 		const [row] = await sql<{ deleted_at: Date | null }[]>`
       SELECT deleted_at FROM entities WHERE id = ${invoice.id}

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -75,12 +75,22 @@ export default (row) => {
 };
 `;
 
+/** PROBE the grant's SCOPE: escalates a field the delete card never covered. */
+const ESCALATE_OTHER_FIELD_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$deleted") && row.next.$deleted) {
+    row.escalate(["status"], "confirm the status before deleting");
+  }
+};
+`;
+
 const TEST_ENV = {} as Env;
 
 // esbuild costs ~100ms per call, so compile each rule once for the whole file.
 let invoiceCompiled: string;
 let ticketCompiled: string;
 let escalateDeleteCompiled: string;
+let escalateOtherFieldCompiled: string;
 
 function ctxFor(
 	organizationId: string,
@@ -198,10 +208,16 @@ async function seedEscalatingDoc() {
 
 describe("entity row validation at the physical writer", () => {
 	beforeAll(async () => {
-		[invoiceCompiled, ticketCompiled, escalateDeleteCompiled] = await Promise.all([
+		[
+			invoiceCompiled,
+			ticketCompiled,
+			escalateDeleteCompiled,
+			escalateOtherFieldCompiled,
+		] = await Promise.all([
 			compileEntityRule(INVOICE_RULE),
 			compileEntityRule(TICKET_RULE),
 			compileEntityRule(ESCALATE_DELETE_RULE),
+			compileEntityRule(ESCALATE_OTHER_FIELD_RULE),
 		]);
 	}, 60_000);
 
@@ -488,8 +504,35 @@ describe("entity row validation at the physical writer", () => {
 			expect(await readDeletedAt(invoice.id)).toBeNull();
 		}, 60_000);
 
-		/** The grant is SCOPED: it covers `$deleted` and nothing else. */
+		/**
+		 * The grant is SCOPED to `$deleted`. A rule that escalates some OTHER field
+		 * while judging the delete is asking about something nobody reviewed, so the
+		 * delete card cannot cover it — the apply must still stop. This is the
+		 * property that makes the grant a scoped waiver rather than a mode flag.
+		 */
 		it("does not let a delete grant waive an escalate on another field", async () => {
+			const { org, user } = await seedOrg("Escalates elsewhere");
+			await seedType(org.id, "doc", escalateOtherFieldCompiled);
+			const doc = await createEntity({
+				entity_type: "doc",
+				name: "DOC-OTHER",
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: { status: "open" },
+			} as Parameters<typeof createEntity>[0]);
+
+			// Even WITH the delete card's grant in hand, `status` is not covered.
+			await expect(
+				deleteEntity(doc.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id }), {
+					approvedFields: ["$deleted"],
+				}),
+			).rejects.toThrow(/status/);
+
+			expect(await readDeletedAt(doc.id)).toBeNull();
+		}, 60_000);
+
+		/** A grant waives an ESCALATE. It may never launder a DENY. */
+		it("does not let a delete grant launder a deny", async () => {
 			const { org, user, invoice } = await seedInvoice("posted");
 
 			// The invoice rule DENIES this delete. A grant may not launder a deny —

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -449,6 +449,45 @@ describe("entity row validation at the physical writer", () => {
 			expect(await readDeletedAt(doc.id)).not.toBeNull();
 		}, 60_000);
 
+		/**
+		 * A dry run exists to answer "may I delete this?" before committing. Once
+		 * the rule governs the delete, a preview that ignores the rule answers the
+		 * wrong question — and answers it optimistically, which is the worst way to
+		 * be wrong here.
+		 */
+		it("reports the rule verdict in a dry run instead of promising the delete", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			const preview = await deleteEntity(
+				invoice.id,
+				false,
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+				{ dryRun: true },
+			);
+
+			expect(preview.message).toMatch(/would NOT be deleted/);
+			expect(preview.message).toMatch(/posted is frozen: \$deleted is not writable/);
+			expect(preview.deleted).toBe(0);
+			// A dry run mutates nothing, verdict or no verdict.
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+
+		it("still promises the delete in a dry run the rule permits", async () => {
+			const { org, user, invoice } = await seedInvoice("draft");
+
+			const preview = await deleteEntity(
+				invoice.id,
+				false,
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+				{ dryRun: true },
+			);
+
+			expect(preview.message).toBe("Dry run: entity would be soft-deleted");
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+
 		/** The grant is SCOPED: it covers `$deleted` and nothing else. */
 		it("does not let a delete grant waive an escalate on another field", async () => {
 			const { org, user, invoice } = await seedInvoice("posted");

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -485,6 +485,9 @@ describe("entity row validation at the physical writer", () => {
 			expect(preview.message).toMatch(/would NOT be deleted/);
 			expect(preview.message).toMatch(/posted is frozen: \$deleted is not writable/);
 			expect(preview.deleted).toBe(0);
+			// Structured, so `manage_entity` can suppress its "would be queued for
+			// approval" suffix without pattern-matching the prose.
+			expect(preview.refused).toBe(true);
 			// A dry run mutates nothing, verdict or no verdict.
 			expect(await readDeletedAt(invoice.id)).toBeNull();
 		}, 60_000);
@@ -501,6 +504,7 @@ describe("entity row validation at the physical writer", () => {
 			);
 
 			expect(preview.message).toBe("Dry run: entity would be soft-deleted");
+			expect(preview.refused).toBeUndefined();
 			expect(await readDeletedAt(invoice.id)).toBeNull();
 		}, 60_000);
 

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -4,16 +4,21 @@
  *
  * These run the REAL path: an author's rule source is compiled exactly as the
  * apply path would store it, written to `entity_types.rules_compiled`, and then
- * exercised through `updateEntity` — not through the validator in isolation. A
- * rule that is never reached would pass a unit test of the evaluator and fail
- * here, which is the failure mode worth catching.
+ * exercised through the real CRUD entry points (`createEntity`, `updateEntity`,
+ * `deleteEntity`) — not through the validator in isolation. A rule that is never
+ * reached would pass a unit test of the evaluator and fail here, which is the
+ * failure mode worth catching.
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { compileEntityRule } from "../../../authz/entity-rule-executor";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
-import { createEntity, updateEntity } from "../../../utils/entity-management";
+import {
+	createEntity,
+	deleteEntity,
+	updateEntity,
+} from "../../../utils/entity-management";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	addUserToOrganization,
@@ -61,11 +66,21 @@ export default (row) => {
 };
 `;
 
+/** PROBE: a rule that asks for review of the delete itself. */
+const ESCALATE_DELETE_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$deleted") && row.next.$deleted) {
+    row.escalate(["$deleted"], "a delete needs a second pair of eyes");
+  }
+};
+`;
+
 const TEST_ENV = {} as Env;
 
 // esbuild costs ~100ms per call, so compile each rule once for the whole file.
 let invoiceCompiled: string;
 let ticketCompiled: string;
+let escalateDeleteCompiled: string;
 
 function ctxFor(
 	organizationId: string,
@@ -109,6 +124,14 @@ async function readMetadata(id: number): Promise<Record<string, unknown>> {
 		string,
 		unknown
 	>;
+}
+
+async function readDeletedAt(id: number): Promise<Date | null> {
+	const sql = getTestDb();
+	const rows = await sql<{ deleted_at: Date | null }[]>`
+    SELECT deleted_at FROM entities WHERE id = ${id}
+  `;
+	return rows[0].deleted_at;
 }
 
 async function seedOrg(name: string) {
@@ -159,11 +182,26 @@ async function seedInvoice(
 	return { org, user, agent, invoice };
 }
 
+/** A doc whose type asks for review of any delete. */
+async function seedEscalatingDoc() {
+	const { org, user } = await seedOrg("Escalating delete");
+	await seedType(org.id, "doc", escalateDeleteCompiled);
+	const doc = await createEntity({
+		entity_type: "doc",
+		name: "DOC-1",
+		organization_id: org.id,
+		created_by: user.id,
+		metadata: {},
+	} as Parameters<typeof createEntity>[0]);
+	return { org, user, doc };
+}
+
 describe("entity row validation at the physical writer", () => {
 	beforeAll(async () => {
-		[invoiceCompiled, ticketCompiled] = await Promise.all([
+		[invoiceCompiled, ticketCompiled, escalateDeleteCompiled] = await Promise.all([
 			compileEntityRule(INVOICE_RULE),
 			compileEntityRule(TICKET_RULE),
+			compileEntityRule(ESCALATE_DELETE_RULE),
 		]);
 	}, 60_000);
 
@@ -314,4 +352,116 @@ describe("entity row validation at the physical writer", () => {
 			updateEntity(ticket.id, { metadata: { state: "open" } }, TEST_ENV, ctx),
 		).rejects.toThrow(/closed ticket cannot be reopened/);
 	}, 60_000);
+
+	describe("soft delete", () => {
+		/**
+		 * A rule sees a soft delete as `$deleted: false -> true`, so the SAME
+		 * frozen-field clause that stops an edit stops the delete. That is the point
+		 * of routing it through the seam: freezing a row has to mean the row cannot
+		 * be tombstoned out from under the rule, not merely that its fields resist
+		 * editing.
+		 */
+		it("denies deleting a frozen row, and the row stays live", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			await expect(
+				deleteEntity(invoice.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id })),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			// The verdict has to have stopped the WRITE, not merely produced an error
+			// after it. Read the tombstone column itself rather than trusting the throw.
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+
+		it("denies an AGENT the same delete — validation has no principal in it", async () => {
+			const { org, agent, invoice } = await seedInvoice("posted");
+
+			await expect(
+				deleteEntity(invoice.id, false, TEST_ENV, ctxFor(org.id, { agentId: agent.agentId })),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+
+		/**
+		 * The complement, and the reason the test above is not vacuous: the seam has
+		 * to stop the delete the rule objects to WITHOUT stopping delete generally.
+		 */
+		it("allows deleting a row the rule does not freeze", async () => {
+			const { org, user, invoice } = await seedInvoice("draft");
+
+			await deleteEntity(invoice.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id }));
+
+			expect(await readDeletedAt(invoice.id)).not.toBeNull();
+		}, 60_000);
+
+		/**
+		 * Deleting twice is a no-op, not an error: the lock finds no live row, so
+		 * there is nothing for a rule to judge and nothing to write.
+		 */
+		it("is a no-op on an already-tombstoned row", async () => {
+			const { org, user, invoice } = await seedInvoice("draft");
+			const ctx = ctxFor(org.id, { userId: user.id });
+
+			await deleteEntity(invoice.id, false, TEST_ENV, ctx);
+			const first = await readDeletedAt(invoice.id);
+
+			await deleteEntity(invoice.id, false, TEST_ENV, ctx);
+			expect(await readDeletedAt(invoice.id)).toEqual(first);
+		}, 60_000);
+
+		/** A type with no rule at all must not pay for the seam existing. */
+		it("allows deleting a row whose type declares no rule", async () => {
+			const { org, user, invoice } = await seedInvoice("posted", null);
+
+			await deleteEntity(invoice.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id }));
+
+			expect(await readDeletedAt(invoice.id)).not.toBeNull();
+		}, 60_000);
+
+		/**
+		 * An escalate on the delete stops an ORDINARY delete: there is no grant, so
+		 * the write kernel refuses exactly as it does for a field edit nobody
+		 * approved.
+		 */
+		it("stops an unapproved delete when the rule escalates", async () => {
+			const { org, user, doc } = await seedEscalatingDoc();
+
+			await expect(
+				deleteEntity(doc.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id })),
+			).rejects.toThrow(/second pair of eyes \(approval required for \$deleted\)/);
+
+			expect(await readDeletedAt(doc.id)).toBeNull();
+		}, 60_000);
+
+		/**
+		 * ...and the SAME rule must not block the delete a human then approved.
+		 * Without the grant the card is a dead end: applying it re-runs the rule,
+		 * escalates again, and throws — the approval could never be honoured.
+		 */
+		it("honours an approved delete the rule escalated", async () => {
+			const { org, user, doc } = await seedEscalatingDoc();
+
+			await deleteEntity(doc.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id }), {
+				approvedFields: ["$deleted"],
+			});
+
+			expect(await readDeletedAt(doc.id)).not.toBeNull();
+		}, 60_000);
+
+		/** The grant is SCOPED: it covers `$deleted` and nothing else. */
+		it("does not let a delete grant waive an escalate on another field", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			// The invoice rule DENIES this delete. A grant may not launder a deny —
+			// only an escalate — so the delete still fails with the grant present.
+			await expect(
+				deleteEntity(invoice.id, false, TEST_ENV, ctxFor(org.id, { userId: user.id }), {
+					approvedFields: ["$deleted"],
+				}),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+	});
 });

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -228,7 +228,13 @@ export async function validateEntityRowPatch(params: {
  * enforcement, and the script's allowlist/exemption list can be edited.
  *
  * Same handle/#2818 contract as {@link validateEntityRowPatch}: only the
- * caller's transaction handle, never `getDb()`.
+ * caller's transaction handle, never `getDb()` — because a read on one pooled
+ * connection followed by a write on another can be overtaken in between.
+ *
+ * The single exception is a caller that WRITES NOTHING: `deleteEntity`'s dry
+ * run passes the pool deliberately, because a preview enforces nothing and so
+ * has no check for a concurrent write to overtake. If a call can commit, it
+ * owes this function a transaction.
  *
  * Rows are grouped by their type's compiled rule so each distinct rule runs in
  * ONE isolate over its whole group. Per-row isolates do not scale — measured at

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -61,6 +61,12 @@ export interface EntityRowValidationVerdict {
  * link auto-create and eval scaffolding have nowhere to queue a card, so for
  * them a rule that asked for review must stop the write — which is exactly what
  * an uncaught throw does.
+ *
+ * Soft-delete (`deleteEntity`) DOES have somewhere to route one: the mutation
+ * gate queues a delete card, and applying it grants `$deleted` — the one field a
+ * delete card can be said to have approved. So an escalate on `$deleted` stops
+ * an ordinary delete and is waived for the approved one, while a `deny` stops
+ * both. A hard delete never reaches this seam at all.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;
@@ -80,9 +86,9 @@ export class EntityRowValidationError extends Error {
  *
  * The complement (`metadata`, `name`, `slug`, `parentId`, `content`,
  * `softDelete`) IS governed: freezing a document has to stop a rename, not
- * merely a metadata edit. `softDelete` is governed by this seam but no
- * soft-delete caller routes through it yet — see the KNOWN GAP in
- * `deleteEntity`.
+ * merely a metadata edit, and it has to stop the row being tombstoned out from
+ * under the rule that froze it. (A hard delete removes the row without a patch,
+ * so it never passes through here — see `deleteEntity`.)
  */
 const UNGOVERNED_COLUMNS: ReadonlySet<string> = new Set([
 	"currentViewTemplateVersionId",

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -62,11 +62,15 @@ export interface EntityRowValidationVerdict {
  * them a rule that asked for review must stop the write — which is exactly what
  * an uncaught throw does.
  *
- * Soft-delete (`deleteEntity`) DOES have somewhere to route one: the mutation
- * gate queues a delete card, and applying it grants `$deleted` — the one field a
- * delete card can be said to have approved. So an escalate on `$deleted` stops
- * an ordinary delete and is waived for the approved one, while a `deny` stops
- * both. A hard delete never reaches this seam at all.
+ * Soft-delete (`deleteEntity`) is the in-between case, and the distinction is
+ * WHO asked for the review. The POLICY gate can queue a delete card, and
+ * applying that card grants `$deleted` — the one field a delete card can be said
+ * to have approved — so a rule escalating on `$deleted` no longer dead-ends an
+ * approval a human already gave. But a rule escalate does not itself mint a
+ * card: `manage_entity`'s delete path has no `EntityRowValidationError` catch
+ * (only its CREATE path does), so an escalate with no policy card behind it
+ * fails closed like merge and link auto-create. A `deny` stops the delete either
+ * way, and a hard delete never reaches this seam at all.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;

--- a/packages/server/src/authz/entity-rule-executor.ts
+++ b/packages/server/src/authz/entity-rule-executor.ts
@@ -67,10 +67,12 @@ export interface EntityRuleBatch {
 	compiled: string;
 	rows: EntityRuleRow[];
 	/**
-	 * `delete` is deliberately absent: soft-delete is the only delete that
-	 * reaches this seam, and every soft-delete caller is currently exempted (see
-	 * the KNOWN GAP in `deleteEntity`). Offering an op a rule can never observe
-	 * would be a contract we do not honour.
+	 * `delete` is deliberately absent: a soft delete reaches this seam as an
+	 * ordinary patch whose one governed column is `$deleted` flipping to true, so
+	 * a rule judges it as an `update` and `changed("$deleted")` is what tells it
+	 * apart. A hard delete (`force_delete_tree`) removes the row outright and
+	 * never reaches this seam at all, so a `delete` op would be a contract only
+	 * half the deletes could honour.
 	 */
 	op: "create" | "update";
 	timeoutMs?: number;

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -1378,10 +1378,17 @@ export async function applyEntityChangeProposal(
 		return applyMergeGroupInTransaction(params, db);
 	}
 	const deleteProposal = asDeleteProposal(proposal);
+	// The grant comes from the write this card REPLAYS. A delete card's entire
+	// content is the delete, so `$deleted` — and only `$deleted` — is what the
+	// human approved. Without it a rule that escalates on the delete is a dead
+	// end: the card is minted, a human approves, and applying re-runs the rule,
+	// escalates again, and throws. An escalate naming anything else is still not
+	// covered and still stops the apply, which is the point of a scoped grant.
 	return deleteEntity(
 		deleteProposal.entity_id,
 		deleteProposal.force_delete_tree ?? false,
 		env,
 		ctx,
+		{ approvedFields: ["$deleted"] },
 	);
 }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -1463,8 +1463,12 @@ async function handleDelete(
 		return {
 			action: "delete",
 			success: true,
+			// A rule refusal outranks the policy gate here. Telling someone their
+			// delete "would be queued for approval" when a rule already refused it
+			// promises a review that cannot help: approval waives an escalate, and
+			// it can never launder a deny.
 			message:
-				deleteDecision.outcome === "defer"
+				deleteDecision.outcome === "defer" && !preview.refused
 					? `${preview.message} (a real delete would be queued for approval)`
 					: preview.message,
 			deleted_count: 0,

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1801,6 +1801,28 @@ export async function deleteEntity(
   }
 
   if (opts?.dryRun) {
+    // Preview the RULE too, or the preview lies. Soft delete is rule-governed
+    // now, so reporting "would be soft-deleted" for a row a rule refuses is
+    // exactly backwards for the one caller who asked before committing.
+    //
+    // A pool read is right HERE, and only here: a dry run enforces nothing, so
+    // there is no check for a concurrent write to overtake. The verdict is
+    // advisory by construction — the real delete below re-asks it under lock.
+    try {
+      await validateEntityRowPatchGrantingApprovedFields({
+        tx: sql,
+        ids: [entityId],
+        patch: { softDelete: true },
+        approvedFields: opts?.approvedFields ?? [],
+      });
+    } catch (err) {
+      if (!(err instanceof EntityRowValidationError)) throw err;
+      return {
+        message: `Dry run: entity would NOT be deleted — ${err.verdict.reason}`,
+        deleted: 0,
+        dry_run: true,
+      };
+    }
     return {
       message: 'Dry run: entity would be soft-deleted',
       deleted: 0,

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -14,7 +14,6 @@ import type {
 } from "../authz/entity-row-validation";
 import {
 	EntityRowValidationError,
-	unvalidatedEntityRowPatch,
 	validateEntityRowInsertGrantingApprovedFields,
 	validateEntityRowPatch,
 	validateEntityRowPatchGrantingApprovedFields,
@@ -1517,7 +1516,18 @@ export async function deleteEntity(
 	force: boolean = false,
 	env: Env,
 	ctx: ToolContext,
-	opts?: { skipHooks?: boolean; dryRun?: boolean },
+	opts?: {
+		skipHooks?: boolean;
+		dryRun?: boolean;
+		/**
+		 * Set only when this call IS the application of a delete a human already
+		 * approved, so a rule that escalates on the delete does not escalate the
+		 * very delete its escalation asked for — the dead end
+		 * `validateEntityRowPatchGrantingApprovedFields` exists to prevent for
+		 * field edits. An ordinary caller passes nothing and an escalate stops it.
+		 */
+		approvedFields?: readonly string[];
+	},
 ): Promise<{
   message: string;
   deleted: number;
@@ -1797,21 +1807,45 @@ export async function deleteEntity(
       dry_run: true,
     };
   }
-  // Soft delete: stamp deleted_at. Stays a single pool-level statement, so the
-  // semantic layer's existing transaction boundary is unchanged.
-  // KNOWN GAP: state rules do not cover soft-delete. Validating here would mean
-  // reading and writing on the same POOL handle (this path is deliberately a
-  // single pool-level statement, not a transaction), so the check could be
-  // overtaken between read and write. A racy check that looks like enforcement
-  // is worse than an honest exemption; closing this needs a transaction
-  // boundary, which is a separate change.
-  await patchEntityRows({
-    tx: sql,
-    ids: [entityId],
-    patch: unvalidatedEntityRowPatch({
-      patch: { softDelete: true },
-      reason: 'soft-delete runs outside a transaction; see KNOWN GAP above',
-    }),
+  // Soft delete: stamp deleted_at, governed by the type's write rules.
+  //
+  // The rule sees `$deleted` flip to true, so freezing a row stops it being
+  // tombstoned and not merely edited. This closes the KNOWN GAP that used to sit
+  // here: the check was skipped because a pool-level read-then-write could be
+  // overtaken between the two, and a racy check that looks like enforcement is
+  // worse than an honest exemption. The transaction boundary is what makes it
+  // honest — the `FOR UPDATE` below holds the row from the moment the rule judges
+  // it until the tombstone commits, so no concurrent write can change the state
+  // the verdict was based on.
+  //
+  // Scope is the soft-delete path only. `force` above hard-deletes the tree
+  // through `hardDeleteEntityRows`, which no rule sees: freezing a row does not
+  // survive a force delete.
+  //
+  // A deny throws rather than returning: approval cannot launder an illegal
+  // state into a legal one. An escalate throws too UNLESS this call is the
+  // application of a delete a human already approved — see `approvedFields`.
+  await withEntityWriteTransaction(sql, async (tx) => {
+    // Lock first: the rule must judge the state that will actually be deleted.
+    const locked = await tx<{ id: number }>`
+      SELECT id FROM entities
+      WHERE id = ${entityId} AND deleted_at IS NULL
+      FOR UPDATE
+    `;
+    // Already tombstoned. `patchEntityRows` would no-op on its own
+    // `deleted_at IS NULL` guard, exactly as the unlocked statement did; stopping
+    // here also keeps a tenant rule from judging a row this call cannot write.
+    if (locked.length === 0) return;
+    await patchEntityRows({
+      tx,
+      ids: [entityId],
+      patch: await validateEntityRowPatchGrantingApprovedFields({
+        tx,
+        ids: [entityId],
+        patch: { softDelete: true },
+        approvedFields: opts?.approvedFields ?? [],
+      }),
+    });
   });
 
   return {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1533,6 +1533,12 @@ export async function deleteEntity(
   deleted: number;
   dry_run?: boolean;
   tree?: ForceDeleteTreeReport;
+  /**
+   * Dry run only: a write rule refuses this delete. Structured rather than left
+   * for the caller to sniff out of `message`, because a caller that pattern-
+   * matched the prose would silently start lying the day the wording changed.
+   */
+  refused?: true;
 }> {
   const pgSql = createDbClientFromEnv(env);
   const sql = getDb();
@@ -1821,6 +1827,7 @@ export async function deleteEntity(
         message: `Dry run: entity would NOT be deleted — ${err.verdict.reason}`,
         deleted: 0,
         dry_run: true,
+        refused: true,
       };
     }
     return {


### PR DESCRIPTION
## Summary

- A type's write rules governed every field edit but not the delete. Freezing a row stopped a rename and stopped a metadata write, then the row could be tombstoned anyway. `$deleted` was already a reserved column the seam *claimed* to govern; no caller routed through it.
- The gap was documented with a reason: soft delete ran as one pool-level statement, so a check there would read and write on different connections and could be overtaken in between. The comment named the fix — a transaction boundary — as "a separate change". This is that change.
- Fixing it surfaced a second problem: the mutation gate already queues deletes for approval, so a rule escalating on `$deleted` became a dead end — card minted, human approves, apply re-runs the rule, escalates again, throws. The apply path now grants `$deleted`.

## What is NOT in scope

Both are pre-existing and now *stated* rather than implied:

- **Hard delete** (`force_delete_tree`) removes the row outright through `hardDeleteEntityRows`. There is no patch to judge, so it never reaches the seam. Closing it needs either a `delete` op in the rule context or an explicit declared exemption — a contract decision, not a refactor.
- **Merge / unmerge** are untouched. `transitionEntityMergeRows`' own note explains why: a topology change is not a field edit, so `committed`/`patch` cannot describe it and a field-shaped rule could not judge it. That needs a merge-shaped verdict.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-LLM, entity-write-funnel)
- [x] Tests run: targeted vitest, then a 42-file regression sweep over every suite touching delete or the seam — **389 passed**
- [x] Bug fix: red→fix→green pasted below
- [ ] Bot runtime unchanged, no eval needed

### Red (against the pre-fix tree)

```
× soft delete > denies deleting a frozen row, and the row stays live
  → promise resolved "{ …(2) }" instead of rejecting
× soft delete > denies an AGENT the same delete — validation has no principal in it
  → promise resolved "{ …(2) }" instead of rejecting
✓ soft delete > allows deleting a row the rule does not freeze
✓ soft delete > allows deleting a row whose type declares no rule
  Tests  2 failed | 11 passed (13)
```

Red for the claimed reason — the delete *succeeded*. The two allow-cases pass on both sides, which is what makes them a control rather than noise.

### Green (after)

```
  Tests  17 passed (17)   # entity-row-validation.test.ts
  Tests   4 passed (4)    # entity-approval-atomic-apply.test.ts

Test Files  42 passed (42)
     Tests  389 passed (389)   # full sweep incl. all-tools-e2e, entity-history-contract,
                               # eval-case-promote, promote-keyed-entities, entity-schema
```

The rule really evaluates — real deny verdicts in the run log, not a stubbed validator:

```
{"module":"entity-rules","entityId":10,"outcome":"deny","reason":"posted is frozen: $deleted is not writable"}
{"module":"entity-rules","entityId":11,"outcome":"deny","reason":"posted is frozen: $deleted is not writable"}
```

### Mutation testing

| Mutation | Result |
|---|---|
| `ids: []` at the validator call | ✗ both deny tests — `promise resolved instead of rejecting` |
| drop the grant in `deleteEntity` | ✗ `honours an approved delete the rule escalated` — `approval required for $deleted` |
| drop the grant in `applyEntityChangeProposal` | ✗ the persisted-card e2e — `deleting an invoice needs sign-off` |
| drop `FOR UPDATE` | **passed** — see Notes |

### End-to-end through the persisted card

`entity-approval-atomic-apply.test.ts` proposes a real delete, reads the proposal back out of `runs.action_input`, and applies *that* through `applyEntityChangeProposal`. A hand-built proposal would pass with the propose→persist→apply plumbing severed, so it reads the stored row instead.

## Notes

**One honest coverage gap.** Dropping `FOR UPDATE` leaves all tests green, so the lock is not covered by a test. It is not decorative — it is the whole reason the check is non-racy, and it is why this could be closed at all. But discriminating it needs an interleaving where a concurrent transaction commits between the rule's read and the tombstone's write, which means instrumenting production code with a delay. I judged that not worth it and am flagging it rather than claiming coverage. The lock is correct by construction (standard `SELECT … FOR UPDATE` ahead of a read-then-write) and the comment says so.

**Pre-existing, untouched:** `deleteEntity` still reports `deleted: 1` on a repeat delete that wrote nothing. It predates this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for soft deletes before changes are applied.
  * Dry-run deletes now report validation denials without modifying data.
  * Soft deletes safely handle concurrent updates.

* **Bug Fixes**
  * Approved delete requests no longer trigger duplicate escalation.
  * Fixed rollback for stale escalated changes.
  * Ensured approved deletes correctly mark entities as deleted.
  * Preserved non-escalated field updates when other changes require approval.

* **Documentation**
  * Clarified soft-delete validation, approval, escalation, and hard-delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->