### PR TITLE
fix(ci): fail closed when daytona CLI is present but unusable

### DIFF
--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -19,6 +19,8 @@
       "!**/.codex/**",
       "!**/.cli-smoke-run/**",
       "!**/.sdk-e2e-run/**",
+      "!**/.sdk-e2e-error-run/**",
+      "!**/.opencode/**",
       "!**/evals/**/last-run.json",
       "!**/.managed-e2e-run/**",
       "!**/dist/**",

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -300,6 +300,28 @@ MOCK
   grep -q -- '--cpu 4 ' <<<"$flat" || fail "daytona create must pass the default cpu"
   grep -q -- '--disk 10 ' <<<"$flat" || fail "daytona create must pass the default disk"
   rm -rf "$tmpbin" "$call_log"
+
+  # Tri-state provider resolution. A present-but-faulty CLI (list fails, i.e.
+  # not logged in) must fail closed under `auto` rather than silently falling
+  # back to local — that masking is the regression this guards against.
+  mkdir -p "$tmpbin"
+  cat > "$tmpbin/daytona" <<'MOCK_FAULTY'
+#!/usr/bin/env bash
+exit 1
+MOCK_FAULTY
+  chmod +x "$tmpbin/daytona"
+  if PATH="$tmpbin:$PATH" REMOTE_CI_PROVIDER=auto GATE_SKIP_SETTLED_CHECK=1 \
+      bash "$SCRIPT_DIR/../../run-remote-ci.sh" unit 2>/dev/null; then
+    fail "faulty (not logged in) daytona CLI was accepted under auto"
+  fi
+  out="$(PATH="$tmpbin:$PATH" REMOTE_CI_PROVIDER=auto GATE_SKIP_SETTLED_CHECK=1 \
+      bash "$SCRIPT_DIR/../../run-remote-ci.sh" unit 2>&1 || true)"
+  case "$out" in
+    *"refusing to silently"*) ;;
+    *) fail "faulty CLI did not fail closed with a clear message: $out" ;;
+  esac
+  rm -rf "$tmpbin"
+
   # Mocked SUCCESSFUL daytona lifecycle: create stores the generated name,
   # list reports it started (poll passes), exec emits the GATE_REMOTE_EXIT
   # sentinel, delete is called. Exercises polling, sentinel parsing, cleanup.

--- a/scripts/run-remote-ci.sh
+++ b/scripts/run-remote-ci.sh
@@ -53,25 +53,42 @@ DEFAULT_JOBS=(
 
 # ── provider resolution ────────────────────────────────────────────────────
 
-daytona_ready() {
-  command -v daytona >/dev/null 2>&1 || return 1
+# Daytona provider state: "ready" (usable), "absent" (CLI/jq not on PATH),
+# or "faulty" (CLI present but not usable — e.g. not logged in). The caller
+# decides: absent is a legitimate not-set-up case (fall back to local), but
+# faulty is a misconfiguration/regression that must not be silently masked.
+daytona_probe() {
+  command -v daytona >/dev/null 2>&1 || { echo absent; return; }
   # Sandbox polling pipes `daytona list --format json` through jq; without
-  # jq the run would fail mid-way, so fall back to local instead.
-  command -v jq >/dev/null 2>&1 || return 1
+  # jq the run would fail mid-way, so treat a missing jq as faulty too.
+  command -v jq >/dev/null 2>&1 || { echo faulty; return; }
   # `daytona list` fails when not logged in — that's the readiness probe.
-  daytona list >/dev/null 2>&1
+  if daytona list >/dev/null 2>&1; then echo ready; else echo faulty; fi
+}
+
+daytona_ready() {
+  [ "$(daytona_probe)" = "ready" ]
 }
 
 PROVIDER="${REMOTE_CI_PROVIDER:-auto}"
 case "$PROVIDER" in
   auto)
-    if daytona_ready; then
-      PROVIDER=daytona
-      echo ">> provider: daytona (ephemeral sandbox)"
-    else
-      PROVIDER=local
-      echo ">> provider: local (Daytona CLI not available — fallback; GitHub CI is canonical)"
-    fi
+    case "$(daytona_probe)" in
+      ready)
+        PROVIDER=daytona
+        echo ">> provider: daytona (ephemeral sandbox)"
+        ;;
+      absent)
+        PROVIDER=local
+        echo ">> provider: local (Daytona CLI not available — fallback; GitHub CI is canonical)"
+        ;;
+      faulty)
+        echo "Daytona CLI is installed but not usable (not logged in?) — refusing to silently" >&2
+        echo "fall back to local. Run 'daytona login', or force the local fallback with" >&2
+        echo "REMOTE_CI_PROVIDER=local." >&2
+        exit 2
+        ;;
+    esac
     ;;
   daytona)
     daytona_ready || {


### PR DESCRIPTION
## Summary
- `pr-full`'s `auto` provider silently fell back to local whenever the Daytona probe failed, masking an installed-but-not-logged-in CLI as "not available". A Daytona auth regression therefore ran local CI undetected.
- Split the probe into `ready` / `absent` / `faulty`: `absent` (CLI/jq not on PATH) still falls back to local; `faulty` (CLI present but `daytona list` fails, i.e. not logged in) now exits 2 with a clear message pointing at `daytona login` or `REMOTE_CI_PROVIDER=local`.
- Add a tri-state provider-resolution test proving the faulty CLI fails closed.
- Ignore `.sdk-e2e-error-run/` and `.opencode/` in biome so local dev artifacts no longer trip the repo-wide format gate (the former is the sibling of already-ignored `.sdk-e2e-run/`).

## Test plan
- [x] Focused shell test: `bash scripts/lib/__tests__/remote-ci.test.sh` → green
- [x] `make pre-pr` → all gates pass (typecheck, knip, biome, naming, LLM, entity-write, tests)
- [x] Pre-commit hook (biome + tsc) passes; committed diff is exactly the 3 intended files
- [x] Live check: with the user's CLI installed-but-not-logged-in, `pr-full` now fails closed with the clear message instead of silently running local