### PR TITLE
fix(deploy): enforce the promotions pause server-side, not just in the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -996,7 +996,7 @@ jobs:
         # src/lobu/__tests__ specifically rather than the whole src/lobu tree.
         working-directory: packages/server
         run: |
-          bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__ --coverage --timeout 30000
+          bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__ src/utils/__tests__/deployment-pause.test.ts --coverage --timeout 30000
           mv coverage/lcov.info coverage/server-postgres-other.lcov.info
 
       - name: Upload server Bun/Postgres coverage

--- a/db/migrations/20260820120000_events_org_origin_index.sql
+++ b/db/migrations/20260820120000_events_org_origin_index.sql
@@ -1,0 +1,32 @@
+-- migrate:up transaction:false
+
+-- The promotions-pause gate verifies a claimed rollback by probing for the
+-- deployment it says it is undoing:
+--
+--   SELECT 1 FROM events
+--   WHERE organization_id = $1 AND origin_id = 'deployment_<apply_id>'
+--
+-- That runs on a REQUEST path (utils/deployment-pause.ts, reached from the
+-- auth funnel and from executeTool), and `events` only grows. The one existing
+-- (organization_id, origin_id) index is PARTIAL —
+-- idx_events_live_suggestion_origin is predicated on
+-- `superseded_by IS NULL AND interaction_type = 'suggestion'` — so a
+-- deployment row matches neither clause and the probe cannot use it, leaving
+-- an organization-wide scan that degrades with history.
+--
+-- Non-partial deliberately. A predicate narrowed to deployment rows (e.g.
+-- origin_id LIKE 'deployment\_%') would be smaller, but Postgres does not
+-- prove that an equality on origin_id implies a LIKE predicate, so the planner
+-- would only use it if every call site repeated the LIKE clause verbatim — an
+-- invariant nothing enforces and the next caller silently breaks. This index
+-- also serves any other org-scoped origin_id lookup, which is the shape
+-- cross-sync identity already keys on (see root AGENTS.md on origin_id).
+--
+-- CONCURRENTLY + transaction:false: `events` is the largest table and cannot
+-- take a writes-blocking build.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_org_origin
+  ON public.events (organization_id, origin_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_org_origin;

--- a/db/migrations/20260820130000_events_org_origin_index.sql
+++ b/db/migrations/20260820130000_events_org_origin_index.sql
@@ -1,4 +1,5 @@
 -- migrate:up transaction:false
+-- lobu:no-quiesce
 
 -- The promotions-pause gate verifies a claimed rollback by probing for the
 -- deployment it says it is undoing:
@@ -23,7 +24,24 @@
 -- cross-sync identity already keys on (see root AGENTS.md on origin_id).
 --
 -- CONCURRENTLY + transaction:false: `events` is the largest table and cannot
--- take a writes-blocking build.
+-- take a writes-blocking build. Heal an INVALID same-named carcass inline so
+-- an interrupted concurrent build is repaired on retry before IF NOT EXISTS.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_events_org_origin'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_events_org_origin';
+  END IF;
+END
+$heal$;
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_org_origin
   ON public.events (organization_id, origin_id);
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/deployment.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/deployment.test.ts
@@ -211,4 +211,32 @@ describe("ApplyClient x-lobu-apply-id threading", () => {
     await client.getAgentSettings("a1").catch(() => undefined);
     expect(sawHeader).toBeNull();
   });
+
+  test("a rollback threads both workflow identifiers through every request", async () => {
+    let seen: Headers | null = null;
+    const fetchImpl = (async (_input: any, init?: RequestInit) => {
+      seen = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const applyId = mintApplyId();
+    const rollbackOf = mintApplyId();
+    const client = new ApplyClient(
+      {
+        apiBaseUrl: "http://api.test",
+        orgSlug: "acme",
+        token: "t",
+        applyId,
+        rollbackOf,
+      },
+      fetchImpl
+    );
+    await client.patchAgentSettings("a1", {});
+
+    expect(seen?.get("x-lobu-apply-id")).toBe(applyId);
+    expect(seen?.get("x-lobu-rollback-of")).toBe(rollbackOf);
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
@@ -5,11 +5,14 @@
  * secret (or the literal sentinel) anywhere.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { REDACTED_SENTINEL } from "@lobu/core";
+import * as clientModule from "../client.js";
 import { buildDeploymentManifest } from "../deployment.js";
 import type { DesiredState } from "../desired-state.js";
-import { sanitizeSnapshotState } from "../rollback-cmd.js";
+import { rollbackCommand, sanitizeSnapshotState } from "../rollback-cmd.js";
+
+afterEach(() => mock.restore());
 
 function stateWithSecrets(): DesiredState {
   return {
@@ -141,5 +144,86 @@ describe("sanitizeSnapshotState", () => {
     expect(droppedSlugs).toEqual(["hn-main"]);
     expect(JSON.stringify(pinned.state)).not.toContain(REDACTED_SENTINEL);
     expect(JSON.stringify(dropped.state)).not.toContain(REDACTED_SENTINEL);
+  });
+});
+
+describe("rollback pause ordering", () => {
+  function emptyState(): DesiredState {
+    return {
+      agents: [],
+      prune: false,
+      memorySchema: { entityTypes: [], relationshipTypes: [] },
+      automations: [],
+      connectors: { definitions: [], authProfiles: [], connections: [] },
+      providers: [],
+      requiredSecrets: [],
+    };
+  }
+
+  function rollbackClient(opts: { pauseFails?: boolean } = {}) {
+    const calls: string[] = [];
+    const record = (name: string) => calls.push(name);
+    const client = {
+      getDeployment: mock(async () => ({
+        applyId: "apl_11111111-2222-3333-4444-555555555555",
+        status: "succeeded",
+        createdAt: null,
+        gitSha: null,
+        manifest: {
+          version: 1,
+          state: emptyState(),
+          connector_versions: { "zz.probe": "1.0.0" },
+        },
+      })),
+      listConnectors: mock(async () => [
+        { key: "zz.probe", installed: true, version: "2.0.0" },
+      ]),
+      listAgents: mock(async () => []),
+      listEntityTypes: mock(async () => []),
+      listRelationshipTypes: mock(async () => []),
+      listAutomations: mock(async () => []),
+      listInferenceProviders: mock(async () => []),
+      setDeploymentPause: mock(async () => {
+        record("pause");
+        if (opts.pauseFails) throw new Error("pause unavailable");
+      }),
+      rollbackConnectorVersion: mock(async () => record("mutation")),
+      listOrgs: mock(async () => [{ id: "org_1", slug: "acme" }]),
+      postDeploymentSummary: mock(async () => record("summary")),
+    };
+    spyOn(clientModule, "resolveApplyClient").mockResolvedValue({
+      client: client as never,
+      apiBaseUrl: "http://api.test",
+      orgSlug: "acme",
+    });
+    return { calls, client };
+  }
+
+  test("sets the server pause before the first rollback mutation", async () => {
+    const { calls } = rollbackClient();
+
+    await rollbackCommand({
+      applyId: "apl_11111111-2222-3333-4444-555555555555",
+      cwd: "/",
+      yes: true,
+    });
+
+    expect(calls).toEqual(["pause", "mutation", "summary"]);
+  });
+
+  test("fails closed without mutating when the pause cannot be set", async () => {
+    const { calls, client } = rollbackClient({ pauseFails: true });
+
+    await expect(
+      rollbackCommand({
+        applyId: "apl_11111111-2222-3333-4444-555555555555",
+        cwd: "/",
+        yes: true,
+      })
+    ).rejects.toThrow("pause unavailable");
+
+    expect(calls).toEqual(["pause"]);
+    expect(client.rollbackConnectorVersion).not.toHaveBeenCalled();
+    expect(client.postDeploymentSummary).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -376,6 +376,16 @@ interface ApplyClientConfig {
   token: string;
   /** Sent as `x-lobu-apply-id` on every request so the server can group this run's config-audit events into one deployment. */
   applyId?: string;
+  /**
+   * The deployment this run is restoring, sent as `x-lobu-rollback-of`. Set by
+   * `lobu rollback` only. The server refuses mutating apply-run requests while
+   * promotions are paused; rollbacks are exempt, because rolling back FURTHER is
+   * the main thing an operator does while paused — and a rollback sets the pause
+   * AFTER posting its summary, so without this a second rollback would be
+   * blocked by the pause the first one created. The server verifies the named
+   * deployment exists in the org rather than trusting the header.
+   */
+  rollbackOf?: string;
 }
 
 /**
@@ -391,12 +401,10 @@ export class ApplyClient {
 
   constructor(cfg: ApplyClientConfig, fetchImpl: typeof fetch = fetch) {
     this.orgSlug = cfg.orgSlug;
-    this.http = new ApiClient(
-      cfg.apiBaseUrl,
-      cfg.token,
-      fetchImpl,
-      cfg.applyId ? { "x-lobu-apply-id": cfg.applyId } : {}
-    );
+    this.http = new ApiClient(cfg.apiBaseUrl, cfg.token, fetchImpl, {
+      ...(cfg.applyId ? { "x-lobu-apply-id": cfg.applyId } : {}),
+      ...(cfg.rollbackOf ? { "x-lobu-rollback-of": cfg.rollbackOf } : {}),
+    });
   }
 
   /**
@@ -1759,6 +1767,8 @@ export async function resolveApplyClient(opts: {
   url?: string;
   org?: string;
   applyId?: string;
+  /** Set by `lobu rollback` — exempts the run from the promotions pause. */
+  rollbackOf?: string;
   fetchImpl?: typeof fetch;
 }): Promise<ResolvedClient> {
   const { token, apiBaseUrl, orgSlug } = await resolveApiClient({
@@ -1767,7 +1777,13 @@ export async function resolveApplyClient(opts: {
     fetchImpl: opts.fetchImpl,
   });
   const client = new ApplyClient(
-    { apiBaseUrl, orgSlug, token, applyId: opts.applyId },
+    {
+      apiBaseUrl,
+      orgSlug,
+      token,
+      applyId: opts.applyId,
+      rollbackOf: opts.rollbackOf,
+    },
     opts.fetchImpl
   );
   return { client, apiBaseUrl, orgSlug };

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -380,10 +380,10 @@ interface ApplyClientConfig {
    * The deployment this run is restoring, sent as `x-lobu-rollback-of`. Set by
    * `lobu rollback` only. The server refuses mutating apply-run requests while
    * promotions are paused; rollbacks are exempt, because rolling back FURTHER is
-   * the main thing an operator does while paused — and a rollback sets the pause
-   * AFTER posting its summary, so without this a second rollback would be
-   * blocked by the pause the first one created. The server verifies the named
-   * deployment exists in the org rather than trusting the header.
+   * the main thing an operator does while paused. A rollback sets the pause
+   * BEFORE its first mutation, so without this it would be blocked by its own
+   * pause. The server verifies the named deployment is a restorable snapshot in
+   * the org rather than trusting the header.
    */
   rollbackOf?: string;
 }

--- a/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
@@ -147,6 +147,11 @@ export async function rollbackCommand(opts: RollbackOptions): Promise<void> {
     url: opts.url,
     org: opts.org,
     applyId: newApplyId,
+    // Declares this run a rollback for the whole of its lifetime, so the
+    // server's promotions-pause gate lets its writes through. Rolling back
+    // further is exactly what an operator does while paused, and the pause a
+    // previous rollback set would otherwise block this one.
+    rollbackOf: opts.applyId,
     fetchImpl: opts.fetchImpl,
   });
   printText(chalk.dim(`Org: ${orgSlug}`));

--- a/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
@@ -273,6 +273,15 @@ export async function rollbackCommand(opts: RollbackOptions): Promise<void> {
     return;
   }
 
+  // Close the re-promotion window BEFORE the first rollback mutation. The
+  // client carries x-lobu-rollback-of, so this rollback remains allowed while
+  // ordinary applies stop at the server gate. If pausing fails, do not perform
+  // a rollback that CI could immediately overwrite.
+  await client.setDeploymentPause({
+    applyId: newApplyId,
+    rollbackOf: opts.applyId,
+  });
+
   // ── Execute: pins first (catalog correctness for everything after) ────────
   let rollbackErr: unknown;
   try {
@@ -374,28 +383,18 @@ export async function rollbackCommand(opts: RollbackOptions): Promise<void> {
     );
   }
 
-  if (!rollbackErr) {
-    try {
-      await client.setDeploymentPause({
-        applyId: newApplyId,
-        rollbackOf: opts.applyId,
-      });
-      printText(
-        [
-          "",
-          chalk.yellow("Deployments are now PAUSED for this org."),
-          "Reconcile your config repo (e.g. `git revert` the bad change), then run:",
-          "  lobu apply --resume",
-        ].join("\n")
-      );
-    } catch (err) {
-      printText(
-        chalk.yellow(
-          `Warning: could not pause deployments (${err instanceof Error ? err.message : String(err)}) — a CI apply may re-promote the rolled-back config.`
-        )
-      );
-    }
-  }
+  printText(
+    [
+      "",
+      chalk.yellow(
+        rollbackErr
+          ? "Deployments remain PAUSED after the incomplete rollback."
+          : "Deployments are now PAUSED for this org."
+      ),
+      "Reconcile your config repo (e.g. `git revert` the bad change), then run:",
+      "  lobu apply --resume",
+    ].join("\n")
+  );
 
   if (rollbackErr) throw rollbackErr;
 }

--- a/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
@@ -82,6 +82,14 @@ const HEAL_MIGRATIONS = [
         ON events (id)
     `,
 	},
+	{
+		files: ["20260820130000_events_org_origin_index.sql"],
+		index: "idx_events_org_origin",
+		seedSql: `
+      CREATE INDEX IF NOT EXISTS idx_events_org_origin
+        ON events (id)
+    `,
+	},
 ] as const;
 
 function resolveMigrationsDir(): string {

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -611,6 +611,18 @@ describe('checkToolAccess', () => {
     // actions — these go through SDK wrappers / action-router, gated by policy.
     expect(requiresOwnerAdmin('manage_entity_schema', { action: 'create' }, false)).toBe(true);
   });
+
+  it('returns the exact access tier that was authorized', () => {
+    const owner = {
+      ...baseAuth,
+      memberRole: 'owner',
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    };
+
+    expect(checkToolAccess('manage_entity_schema', { action: 'list' }, owner)).toBe('read');
+    expect(checkToolAccess('save_memory', {}, owner)).toBe('write');
+    expect(checkToolAccess('manage_entity_schema', { action: 'create' }, owner)).toBe('admin');
+  });
 });
 
 describe('first-party tool-name coverage', () => {

--- a/packages/server/src/lobu/__tests__/deployment-routes.test.ts
+++ b/packages/server/src/lobu/__tests__/deployment-routes.test.ts
@@ -485,6 +485,15 @@ describe('deployment snapshots + promotions pause (lobu rollback)', () => {
   test('pause lifecycle: unpaused → PUT → paused (org-scoped) → DELETE → unpaused', async () => {
     const app = await importDeploymentRoutes();
 
+    const target = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(
+        summaryBody({ manifest: { version: 1, state: {} } })
+      ),
+    });
+    expect(target.status).toBe(201);
+
     const initial = (await (await app.request('/pause')).json()) as {
       paused: boolean;
     };
@@ -514,6 +523,29 @@ describe('deployment snapshots + promotions pause (lobu rollback)', () => {
     expect(cleared.status).toBe(200);
     const after = (await (await app.request('/pause')).json()) as { paused: boolean };
     expect(after.paused).toBe(false);
+  });
+
+  test('pause setter rejects malformed ids and a non-restorable target', async () => {
+    const app = await importDeploymentRoutes();
+    const malformed = await app.request('/pause', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ apply_id: 'bad', rollback_of: APPLY_ID }),
+    });
+    expect(malformed.status).toBe(400);
+
+    const missing = await app.request('/pause', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        apply_id: 'apl_99999999-8888-7777-6666-555555555555',
+        rollback_of: APPLY_ID,
+      }),
+    });
+    expect(missing.status).toBe(400);
+
+    const state = (await (await app.request('/pause')).json()) as { paused: boolean };
+    expect(state.paused).toBe(false);
   });
 });
 

--- a/packages/server/src/lobu/deployment-routes.ts
+++ b/packages/server/src/lobu/deployment-routes.ts
@@ -24,6 +24,7 @@ import {
 	type ConfigResourceKind,
 	isConfigResourceKind,
 } from "../utils/config-redaction";
+import { isRestorableDeployment } from "../utils/deployment-pause";
 import { insertEvent } from "../utils/insert-event";
 import { requireSessionOrAdminPat } from "./agent-routes";
 import { orgContext } from "./stores/org-context";
@@ -406,6 +407,21 @@ routes.put("/pause", async (c) => {
 	const rollbackOf = parseApplyId(
 		typeof body.rollback_of === "string" ? body.rollback_of : null,
 	);
+	if (!applyId || !rollbackOf) {
+		return c.json(
+			{ error: "apply_id and rollback_of must each match apl_<id>" },
+			400,
+		);
+	}
+	if (!(await isRestorableDeployment(organizationId, rollbackOf))) {
+		return c.json(
+			{
+				error:
+					"rollback_of must name a restorable deployment in this organization",
+			},
+			400,
+		);
+	}
 	const applyCtx = getApplyContext(c);
 
 	const sql = getDb();

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -14,6 +14,7 @@ import {
   hasRequiredMcpScope,
   isPublicReadable,
   SCOPE_CHECK_NOT_APPLICABLE,
+  type ToolAccessLevel,
 } from '../auth/tool-access';
 import type { Env } from '../index';
 import { recordMcpConversationActivity } from '../lobu/stores/mcp-client-conversations';
@@ -171,7 +172,11 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
  */
 const ORG_AGNOSTIC_TOOLS = new Set(['list_organizations']);
 
-export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthContext): void {
+export function checkToolAccess(
+  toolName: string,
+  args: unknown,
+  authCtx: AuthContext
+): ToolAccessLevel {
   if (ORG_AGNOSTIC_TOOLS.has(toolName)) {
     if (!authCtx.isAuthenticated) {
       throw new Error('Authentication required.');
@@ -183,7 +188,7 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
         'This MCP session does not include read access. Reconnect with read access to list organizations.'
       );
     }
-    return;
+    return 'read';
   }
 
   if (!authCtx.organizationId) {
@@ -239,6 +244,7 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
     adminScope:
       'This MCP session does not include admin access. Reconnect with admin access after an owner grants the role.',
   });
+  return requiredAccess;
 }
 
 /**
@@ -256,27 +262,20 @@ export async function executeTool(
   env: Env,
   authCtx: AuthContext
 ): Promise<unknown> {
-  checkToolAccess(toolName, args, authCtx);
+  const requiredAccess = checkToolAccess(toolName, args, authCtx);
 
   // Promotions pause, enforced where config is actually mutated. `lobu apply`
   // writes through these tools, so this is the chokepoint that binds every
   // caller — including a CI job posting straight at the API with a PAT, which
   // the CLI-side check never could. Read-tier calls and non-apply traffic pass
-  // through untouched; see `assertDeploymentsNotPaused`.
-  const pauseTool = getTool(toolName);
-  if (pauseTool && !ORG_AGNOSTIC_TOOLS.has(toolName)) {
-    await assertDeploymentsNotPaused({
-      organizationId: authCtx.organizationId,
-      applyId: authCtx.applyId ?? null,
-      rollbackOf: authCtx.rollbackOf ?? null,
-      isReadOnly:
-        getRequiredAccessLevel(
-          toolName,
-          args,
-          isAuthorizationReadOnly(pauseTool)
-        ) === 'read',
-    });
-  }
+  // through untouched, which also covers the org-agnostic tools below (they
+  // are read-tier by construction); see `assertDeploymentsNotPaused`.
+  await assertDeploymentsNotPaused({
+    organizationId: authCtx.organizationId,
+    applyId: authCtx.applyId ?? null,
+    rollbackOf: authCtx.rollbackOf ?? null,
+    isReadOnly: requiredAccess === 'read',
+  });
 
   // Org-agnostic tools get a minimal context with just userId
   if (ORG_AGNOSTIC_TOOLS.has(toolName)) {

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -19,6 +19,7 @@ import type { Env } from '../index';
 import { recordMcpConversationActivity } from '../lobu/stores/mcp-client-conversations';
 import { trackMCPToolCall } from '../sentry';
 import { parseApplyId } from '../utils/apply-context';
+import { assertDeploymentsNotPaused } from '../utils/deployment-pause';
 import { ToolNotRegisteredError, ToolUserError } from '../utils/errors';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { enforceRoleScopeAccess } from './access-control';
@@ -74,6 +75,14 @@ export interface AuthContext {
   instructions?: string;
   /** `x-lobu-apply-id` when the call belongs to a `lobu apply` run. */
   applyId?: string | null;
+  /**
+   * `x-lobu-rollback-of` when the run is a `lobu rollback` restoring the named
+   * deployment. Lets a rollback proceed while promotions are paused — rolling
+   * back further is the main thing an operator does while paused. Claimed by
+   * the client, VERIFIED server-side against a real deployment in this org
+   * (see `assertDeploymentsNotPaused`); never trusted on shape alone.
+   */
+  rollbackOf?: string | null;
   /**
    * Per-turn LIMIT on which tools may execute admin-tier actions. Carried on
    * the worker token (see
@@ -147,6 +156,7 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     scopedToOrg,
     allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
     applyId: parseApplyId(c.req.header('x-lobu-apply-id')),
+    rollbackOf: parseApplyId(c.req.header('x-lobu-rollback-of')),
     // Admin-tool LIMIT: only the verified worker token's per-turn allowlist
     // (an admin-tools run) carries this. External
     // `mcp:admin` callers need no grant — every tool is reachable uniformly
@@ -247,6 +257,26 @@ export async function executeTool(
   authCtx: AuthContext
 ): Promise<unknown> {
   checkToolAccess(toolName, args, authCtx);
+
+  // Promotions pause, enforced where config is actually mutated. `lobu apply`
+  // writes through these tools, so this is the chokepoint that binds every
+  // caller — including a CI job posting straight at the API with a PAT, which
+  // the CLI-side check never could. Read-tier calls and non-apply traffic pass
+  // through untouched; see `assertDeploymentsNotPaused`.
+  const pauseTool = getTool(toolName);
+  if (pauseTool && !ORG_AGNOSTIC_TOOLS.has(toolName)) {
+    await assertDeploymentsNotPaused({
+      organizationId: authCtx.organizationId,
+      applyId: authCtx.applyId ?? null,
+      rollbackOf: authCtx.rollbackOf ?? null,
+      isReadOnly:
+        getRequiredAccessLevel(
+          toolName,
+          args,
+          isAuthorizationReadOnly(pauseTool)
+        ) === 'read',
+    });
+  }
 
   // Org-agnostic tools get a minimal context with just userId
   if (ORG_AGNOSTIC_TOOLS.has(toolName)) {

--- a/packages/server/src/utils/__tests__/deployment-pause.test.ts
+++ b/packages/server/src/utils/__tests__/deployment-pause.test.ts
@@ -4,9 +4,10 @@
  * This guard sits in the auth funnel, so a wrong answer either freezes a
  * product that should still be editable, or waves through the CI re-promotion
  * the pause exists to stop. Both failures are silent, so every branch of the
- * decision gets a case here — including the two exemptions that are easy to
- * lose in a refactor: the tool proxy owns its own read/write signal, and
- * `--resume` must be able to clear the pause it is exiting.
+ * decision gets a case here — including the three exemptions that are easy to
+ * lose in a refactor: the tool proxy owns its own read/write signal, the
+ * audit-summary POST records a refused run, and `--resume` must be able to
+ * clear the pause it is exiting.
  */
 
 import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
@@ -50,8 +51,13 @@ async function seedDeployment(applyId: string): Promise<void> {
   const sql = getDb();
   await sql`
     INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
-    VALUES (${ORG}, ${`deployment_${applyId}`}, 'change', '{}'::jsonb,
-            ${JSON.stringify({ category: 'deployment' })}::jsonb)
+    VALUES (${ORG}, ${`deployment_${applyId}`}, 'change',
+            ${sql.json({ manifest: { state: {} } })},
+            ${sql.json({
+              category: 'deployment',
+              apply_id: applyId,
+              status: 'succeeded',
+            })})
   `;
 }
 
@@ -129,6 +135,21 @@ describe('promotions pause — the funnel decision', () => {
     ).toBe('allowed');
     // …but a DELETE anywhere else is still a mutation.
     expect(await verdict(ctx({ method: 'DELETE' }))).toBe('blocked');
+    expect(
+      await verdict(
+        ctx({ method: 'DELETE', path: '/api/org-pause-gate/agents/deployments/pause' })
+      )
+    ).toBe('blocked');
+  });
+
+  test('allows only the exact audit-summary POST after a blocked apply', async () => {
+    await pauseOrg();
+    expect(
+      await verdict(ctx({ method: 'POST', path: '/api/org-pause-gate/deployments' }))
+    ).toBe('allowed');
+    expect(
+      await verdict(ctx({ method: 'POST', path: '/api/org-pause-gate/agents/deployments' }))
+    ).toBe('blocked');
   });
 
   test('lets a genuine rollback through while paused', async () => {
@@ -146,6 +167,52 @@ describe('promotions pause — the funnel decision', () => {
     ).toBe('blocked');
   });
 
+  test('rejects a malformed rollback claim', async () => {
+    await pauseOrg();
+    expect(
+      await verdict(ctx({ method: 'POST', rollbackOf: 'deployment_apl_not-valid' }))
+    ).toBe('blocked');
+  });
+
+  test('rejects a matching origin id that is not a restorable deployment', async () => {
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    await sql`
+      INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
+      VALUES (${ORG}, ${`deployment_${ROLLED_BACK}`}, 'change', '{}'::jsonb,
+              ${JSON.stringify({ category: 'config', apply_id: ROLLED_BACK })}::jsonb)
+    `;
+    await pauseOrg();
+
+    expect(await verdict(ctx({ method: 'POST', rollbackOf: ROLLED_BACK }))).toBe('blocked');
+  });
+
+  test('rejects blocked and snapshot-less deployment targets', async () => {
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    await sql`
+      INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
+      VALUES
+        (${ORG}, 'deployment_apl_blocked', 'change',
+         ${sql.json({ manifest: { state: {} } })},
+         ${sql.json({
+           category: 'deployment',
+           apply_id: 'apl_blocked',
+           status: 'blocked',
+         })}),
+        (${ORG}, 'deployment_apl_snapshotless', 'change', '{}'::jsonb,
+         ${sql.json({
+           category: 'deployment',
+           apply_id: 'apl_snapshotless',
+           status: 'succeeded',
+         })})
+    `;
+    await pauseOrg();
+
+    expect(await verdict(ctx({ method: 'POST', rollbackOf: 'apl_blocked' }))).toBe('blocked');
+    expect(await verdict(ctx({ method: 'POST', rollbackOf: 'apl_snapshotless' }))).toBe('blocked');
+  });
+
   test('rejects a rollback claim naming another org’s deployment', async () => {
     const { getDb } = await import('../../db/client.js');
     const sql = getDb();
@@ -155,8 +222,13 @@ describe('promotions pause — the funnel decision', () => {
     `;
     await sql`
       INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
-      VALUES ('org-other', ${`deployment_${ROLLED_BACK}`}, 'change', '{}'::jsonb,
-              ${JSON.stringify({ category: 'deployment' })}::jsonb)
+      VALUES ('org-other', ${`deployment_${ROLLED_BACK}`}, 'change',
+              ${sql.json({ manifest: { state: {} } })},
+              ${sql.json({
+                category: 'deployment',
+                apply_id: ROLLED_BACK,
+                status: 'succeeded',
+              })})
     `;
     await pauseOrg();
     expect(await verdict(ctx({ method: 'POST', rollbackOf: ROLLED_BACK }))).toBe('blocked');
@@ -188,6 +260,50 @@ describe('promotions pause — the funnel decision', () => {
     ).not.toBeNull();
   });
 
+  test('the real tool executor refuses a classified mutation before its handler', async () => {
+    await pauseOrg();
+    const { executeTool } = await import('../../tools/execute.js');
+    const { DeploymentsPausedError } = await import('../deployment-pause.js');
+
+    let caught: unknown;
+    try {
+      await executeTool(
+        'manage_entity_schema',
+        { action: 'create', schema_type: 'entity_type', slug: 'must-not-exist' },
+        {} as never,
+        {
+          organizationId: ORG,
+          tokenOrganizationId: ORG,
+          userId: 'u1',
+          memberRole: 'owner',
+          agentId: null,
+          requestedAgentId: null,
+          isAuthenticated: true,
+          clientId: 'pause-test',
+          scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+          tokenType: 'pat',
+          requestUrl: 'http://test.local/api/org-pause-gate/manage_entity_schema',
+          baseUrl: 'http://test.local',
+          scopedToOrg: true,
+          allowCrossOrg: false,
+          applyId: RUNNING_APPLY,
+          rollbackOf: null,
+        }
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(DeploymentsPausedError);
+    const { getDb } = await import('../../db/client.js');
+    const [row] = await getDb()`
+      SELECT count(*)::int AS count
+      FROM entity_types
+      WHERE organization_id = ${ORG} AND slug = 'must-not-exist'
+    `;
+    expect(row?.count).toBe(0);
+  });
+
   test('ignores traffic that is not part of an apply run', async () => {
     await pauseOrg();
     const { getBlockingPause } = await import('../deployment-pause.js');
@@ -201,5 +317,76 @@ describe('promotions pause — the funnel decision', () => {
         isReadOnly: false,
       })
     ).toBeNull();
+  });
+
+  test('treats a malformed apply id as non-apply traffic', async () => {
+    await pauseOrg();
+    const { checkApplyPause } = await import('../deployment-pause.js');
+
+    expect(
+      await checkApplyPause(ctx({ method: 'POST' }) as never, 'not-an-apply-id', null)
+    ).toBeNull();
+  });
+
+  test('never blocks when authentication resolved no organization', async () => {
+    await pauseOrg();
+    expect(await verdict(ctx({ method: 'POST', organizationId: null }))).toBe('allowed');
+  });
+
+  test('normalizes the database timestamp at the in-process boundary', async () => {
+    await pauseOrg();
+    const { getBlockingPause } = await import('../deployment-pause.js');
+    const pause = await getBlockingPause({
+      organizationId: ORG,
+      applyId: RUNNING_APPLY,
+      rollbackOf: null,
+      isReadOnly: false,
+    });
+
+    expect(typeof pause?.pausedAt).toBe('string');
+    expect(pause?.pausedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('rollback verification has a non-partial index-backed plan', async () => {
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    const [catalog] = await sql`
+      SELECT i.indpred IS NULL AS non_partial
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'idx_events_org_origin'
+    `;
+    expect(catalog?.non_partial).toBe(true);
+
+    const plans = await sql.begin(async (tx) => {
+      await tx`SET LOCAL enable_seqscan = off`;
+      const production = await tx`
+        EXPLAIN (FORMAT JSON)
+        SELECT 1
+        FROM events
+        WHERE organization_id = ${ORG}
+          AND origin_id = ${`deployment_${ROLLED_BACK}`}
+          AND semantic_type = 'change'
+          AND metadata->>'category' = 'deployment'
+          AND metadata->>'apply_id' = ${ROLLED_BACK}
+          AND metadata->>'status' IN ('succeeded', 'partial_failure')
+          AND jsonb_typeof(payload_data->'manifest') = 'object'
+          AND jsonb_typeof(payload_data->'manifest'->'state') = 'object'
+        LIMIT 1
+      `;
+      const orgOrigin = await tx`
+        EXPLAIN (FORMAT JSON)
+        SELECT 1
+        FROM events
+        WHERE organization_id = ${ORG}
+          AND origin_id = ${`deployment_${ROLLED_BACK}`}
+        LIMIT 1
+      `;
+      return { production, orgOrigin };
+    });
+    expect(JSON.stringify(plans.production)).toContain('Index Scan');
+    expect(JSON.stringify(plans.production)).not.toContain('Seq Scan');
+    expect(JSON.stringify(plans.orgOrigin)).toContain('idx_events_org_origin');
   });
 });

--- a/packages/server/src/utils/__tests__/deployment-pause.test.ts
+++ b/packages/server/src/utils/__tests__/deployment-pause.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The promotions-pause decision, executed rather than asserted about.
+ *
+ * This guard sits in the auth funnel, so a wrong answer either freezes a
+ * product that should still be editable, or waves through the CI re-promotion
+ * the pause exists to stop. Both failures are silent, so every branch of the
+ * decision gets a case here — including the two exemptions that are easy to
+ * lose in a refactor: the tool proxy owns its own read/write signal, and
+ * `--resume` must be able to clear the pause it is exiting.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup.js';
+
+const ORG = 'org-pause-gate';
+const PAUSED_BY_APPLY = 'apl_aaaaaaaa-1111-2222-3333-444444444444';
+const ROLLED_BACK = 'apl_bbbbbbbb-1111-2222-3333-444444444444';
+const RUNNING_APPLY = 'apl_cccccccc-1111-2222-3333-444444444444';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug) VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+});
+
+async function pauseOrg(): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO deployment_pause (organization_id, apply_id, rollback_of, paused_by)
+    VALUES (${ORG}, ${PAUSED_BY_APPLY}, ${ROLLED_BACK}, 'u1')
+    ON CONFLICT (organization_id) DO UPDATE SET rollback_of = EXCLUDED.rollback_of
+  `;
+}
+
+/** A deployment the CLI could legitimately claim to be rolling back. */
+async function seedDeployment(applyId: string): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
+    VALUES (${ORG}, ${`deployment_${applyId}`}, 'change', '{}'::jsonb,
+            ${JSON.stringify({ category: 'deployment' })}::jsonb)
+  `;
+}
+
+/** Minimal stand-in for the Hono context the funnel hands the guard. */
+function ctx(opts: {
+  method: string;
+  path?: string;
+  rollbackOf?: string;
+  organizationId?: string | null;
+}) {
+  const headers: Record<string, string> = {};
+  if (opts.rollbackOf) headers['x-lobu-rollback-of'] = opts.rollbackOf;
+  return {
+    req: {
+      method: opts.method,
+      path: opts.path ?? '/api/org-pause-gate/agents',
+      header: (name: string) => headers[name.toLowerCase()],
+    },
+    get: (key: string) =>
+      key === 'organizationId'
+        ? opts.organizationId === undefined
+          ? ORG
+          : opts.organizationId
+        : null,
+    json: (body: unknown, status: 409) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+  };
+}
+
+/** "blocked" | "allowed" — what the funnel would actually do. */
+async function verdict(
+  c: ReturnType<typeof ctx>,
+  toolName: string | null = null
+): Promise<'blocked' | 'allowed'> {
+  const { checkApplyPause } = await import('../deployment-pause.js');
+  const res = await checkApplyPause(c as never, RUNNING_APPLY, toolName);
+  if (!res) return 'allowed';
+  expect(res.status).toBe(409);
+  return 'blocked';
+}
+
+describe('promotions pause — the funnel decision', () => {
+  test('blocks a mutating apply-run request while paused', async () => {
+    await pauseOrg();
+    expect(await verdict(ctx({ method: 'POST' }))).toBe('blocked');
+    expect(await verdict(ctx({ method: 'PATCH' }))).toBe('blocked');
+    expect(await verdict(ctx({ method: 'PUT' }))).toBe('blocked');
+  });
+
+  test('allows everything when the org is not paused', async () => {
+    expect(await verdict(ctx({ method: 'POST' }))).toBe('allowed');
+  });
+
+  test('never blocks a read, so the diff and --dry-run survive a pause', async () => {
+    await pauseOrg();
+    expect(await verdict(ctx({ method: 'GET' }))).toBe('allowed');
+    expect(await verdict(ctx({ method: 'HEAD' }))).toBe('allowed');
+  });
+
+  test('leaves the tool proxy to its own guard', async () => {
+    await pauseOrg();
+    // Apply's READS go through the proxy as POSTs. Deciding here on the method
+    // would classify them as mutations and break `--dry-run` against a paused
+    // org — the proxy reads intent from the tool args instead.
+    expect(await verdict(ctx({ method: 'POST' }), 'manage_entity_schema')).toBe('allowed');
+  });
+
+  test('never blocks the DELETE that --resume uses to clear the pause', async () => {
+    await pauseOrg();
+    expect(
+      await verdict(ctx({ method: 'DELETE', path: '/api/org-pause-gate/deployments/pause' }))
+    ).toBe('allowed');
+    // …but a DELETE anywhere else is still a mutation.
+    expect(await verdict(ctx({ method: 'DELETE' }))).toBe('blocked');
+  });
+
+  test('lets a genuine rollback through while paused', async () => {
+    await pauseOrg();
+    await seedDeployment(ROLLED_BACK);
+    expect(await verdict(ctx({ method: 'POST', rollbackOf: ROLLED_BACK }))).toBe('allowed');
+  });
+
+  test('rejects a rollback claim naming a deployment that does not exist', async () => {
+    await pauseOrg();
+    // Shape-valid but fabricated: without the existence check the header would
+    // be a one-line bypass for anyone who can spell `apl_`.
+    expect(
+      await verdict(ctx({ method: 'POST', rollbackOf: 'apl_dddddddd-9999-9999-9999-999999999999' }))
+    ).toBe('blocked');
+  });
+
+  test('rejects a rollback claim naming another org’s deployment', async () => {
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    await sql`
+      INSERT INTO organization (id, name, slug) VALUES ('org-other', 'other', 'org-other')
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
+      VALUES ('org-other', ${`deployment_${ROLLED_BACK}`}, 'change', '{}'::jsonb,
+              ${JSON.stringify({ category: 'deployment' })}::jsonb)
+    `;
+    await pauseOrg();
+    expect(await verdict(ctx({ method: 'POST', rollbackOf: ROLLED_BACK }))).toBe('blocked');
+  });
+
+  test('lets a read-tier tool call through while paused', async () => {
+    await pauseOrg();
+    const { getBlockingPause } = await import('../deployment-pause.js');
+    // The proxy path decides read-vs-write from the tool args and passes the
+    // answer in. This is apply's MAIN read path — `manage_*` list/get calls are
+    // POSTs — so losing this branch breaks `--dry-run` against a paused org
+    // even though the HTTP-method rule above still looks correct.
+    expect(
+      await getBlockingPause({
+        organizationId: ORG,
+        applyId: RUNNING_APPLY,
+        rollbackOf: null,
+        isReadOnly: true,
+      })
+    ).toBeNull();
+    // …and the same call at write tier is refused.
+    expect(
+      await getBlockingPause({
+        organizationId: ORG,
+        applyId: RUNNING_APPLY,
+        rollbackOf: null,
+        isReadOnly: false,
+      })
+    ).not.toBeNull();
+  });
+
+  test('ignores traffic that is not part of an apply run', async () => {
+    await pauseOrg();
+    const { getBlockingPause } = await import('../deployment-pause.js');
+    // No apply header at all: Owletto edits and one-off API calls are never
+    // gated, or a paused org would be a frozen product.
+    expect(
+      await getBlockingPause({
+        organizationId: ORG,
+        applyId: null,
+        rollbackOf: null,
+        isReadOnly: false,
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/server/src/utils/deployment-pause.ts
+++ b/packages/server/src/utils/deployment-pause.ts
@@ -14,20 +14,23 @@
  * The seam is the apply header. `x-lobu-apply-id` marks a request as part of a
  * `lobu apply` run, so gating on it freezes promotions without freezing the
  * product: interactive edits from Owletto and one-off API calls carry no such
- * header and are unaffected.
+ * header and are unaffected. This is deliberately a workflow guard, not an
+ * authorization credential: it stops cooperating `lobu apply` clients from
+ * accidentally re-promoting, but an otherwise-authorized caller can omit the
+ * header and remains free to make an ordinary one-off edit.
  *
  * Read-tier calls stay allowed. `lobu apply` reads current config to compute
  * its diff, and `--dry-run` is how an operator inspects what a resume would do;
  * blocking reads would make a paused org undiagnosable.
  *
  * Rollbacks stay allowed. Rolling back FURTHER, because the first rollback did
- * not fix it, is the main thing an operator does while paused — and
- * `rollback-cmd` posts its summary BEFORE setting the pause, so a blanket block
- * would strand the escape hatch behind the pause its own predecessor created.
- * A rollback declares itself with `x-lobu-rollback-of`, which is VERIFIED
- * against a real deployment in this org rather than trusted: a forged header
- * has to name a deployment that actually exists, and permanently mislabels the
- * run as a rollback in the audit log.
+ * not fix it, is the main thing an operator does while paused. `rollback-cmd`
+ * sets the pause before its first mutation to close the re-promotion window, so
+ * a blanket block would strand the rollback behind the pause it just created.
+ * A rollback declares itself with `x-lobu-rollback-of`, which is checked
+ * against a real, restorable deployment in the already-authorized org. The
+ * header classifies a CLI workflow; it is not an authentication credential and
+ * never chooses the user or organization.
  */
 
 import { getDb } from '../db/client';
@@ -38,6 +41,28 @@ export interface DeploymentPauseState {
   applyId: string | null;
   rollbackOf: string | null;
   pausedBy: string | null;
+}
+
+/** Whether this org owns a deployment snapshot the rollback CLI can restore. */
+export async function isRestorableDeployment(
+  organizationId: string,
+  applyId: string
+): Promise<boolean> {
+  const sql = getDb();
+  const target = await sql`
+    SELECT 1
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND origin_id = ${`deployment_${applyId}`}
+      AND semantic_type = 'change'
+      AND metadata->>'category' = 'deployment'
+      AND metadata->>'apply_id' = ${applyId}
+      AND metadata->>'status' IN ('succeeded', 'partial_failure')
+      AND jsonb_typeof(payload_data->'manifest') = 'object'
+      AND jsonb_typeof(payload_data->'manifest'->'state') = 'object'
+    LIMIT 1
+  `;
+  return target.length > 0;
 }
 
 /** Thrown when a paused org receives a mutating apply-run request. */
@@ -83,22 +108,19 @@ export async function getBlockingPause(params: {
   if (rows.length === 0) return null;
 
   // A rollback may proceed, but only if its claim checks out: the deployment it
-  // says it is undoing has to exist in THIS org. Shape validation alone would
-  // make the header a bypass for anyone who can spell `apl_`.
-  if (rollbackOf) {
-    const target = await sql`
-      SELECT 1
-      FROM events
-      WHERE organization_id = ${organizationId}
-        AND origin_id = ${`deployment_${rollbackOf}`}
-      LIMIT 1
-    `;
-    if (target.length > 0) return null;
-  }
+  // says it is undoing has to be a restorable deployment in THIS org. An event
+  // with a colliding origin_id, a blocked drift report, or a pre-snapshot
+  // deployment is not a rollback target and must not turn into an exemption.
+  if (rollbackOf && (await isRestorableDeployment(organizationId, rollbackOf))) return null;
 
   const row = rows[0];
   return {
-    pausedAt: row.paused_at ?? null,
+    pausedAt:
+      row.paused_at instanceof Date
+        ? row.paused_at.toISOString()
+        : typeof row.paused_at === 'string'
+          ? row.paused_at
+          : null,
     applyId: row.apply_id ?? null,
     rollbackOf: row.rollback_of ?? null,
     pausedBy: row.paused_by ?? null,
@@ -117,7 +139,7 @@ export async function assertDeploymentsNotPaused(
  * Hono-side pause check for the auth funnel. Returns a 409 to short-circuit, or
  * null to let the request through.
  *
- * Two exemptions carry the design and must travel together:
+ * Three exemptions carry the design:
  *
  *  - Tool-proxy calls are left to `executeTool`'s own guard. Apply's READS go
  *    through that proxy as POSTs (`manage_entity_schema` list, `manage_feeds`
@@ -125,6 +147,9 @@ export async function assertDeploymentsNotPaused(
  *    and break `--dry-run` against a paused org — the exact carve-out the
  *    feature promises. The proxy decides read-vs-write from the tool args, which
  *    is the only signal that is actually correct there.
+ *  - `POST /deployments` records the outcome after the apply has stopped. It is
+ *    audit-only (the route independently validates admin authority and the
+ *    summary body), so blocking it would erase the evidence of a refused run.
  *  - `DELETE /deployments/pause` is how `lobu apply --resume` clears the pause.
  *    Gating it would make the pause unexitable.
  *
@@ -146,8 +171,10 @@ export async function checkApplyPause(
   const method = c.req.method.toUpperCase();
   if (method === 'GET' || method === 'HEAD') return null;
 
-  // `--resume` has to be able to clear the pause it is exiting.
-  if (method === 'DELETE' && c.req.path.endsWith('/deployments/pause')) return null;
+  // These are exact routes, not suffix matches: an unrelated endpoint named
+  // `*/deployments/pause` must not inherit either escape hatch.
+  if (method === 'POST' && /^\/api\/[^/]+\/deployments\/?$/.test(c.req.path)) return null;
+  if (method === 'DELETE' && /^\/api\/[^/]+\/deployments\/pause\/?$/.test(c.req.path)) return null;
 
   const pause = await getBlockingPause({
     organizationId: (c.get('organizationId') as string | null) ?? null,

--- a/packages/server/src/utils/deployment-pause.ts
+++ b/packages/server/src/utils/deployment-pause.ts
@@ -1,0 +1,170 @@
+/**
+ * Server-side enforcement of the promotions pause.
+ *
+ * A `lobu rollback` pauses promotions for the org so a later `lobu apply`
+ * cannot silently re-push the config that was just rolled back. The pause row
+ * has lived server-side since #2068, but only the CLI ever honoured it
+ * (`apply-cmd.ts` asked, then refused locally), so anything posting straight at
+ * the API — CI holding a PAT, or a client predating the check — walked through
+ * the exact gate the feature was built to close. Gating the deployment SUMMARY
+ * route would not have helped: that record is written after `executePlan` has
+ * already mutated the org, and the CLI swallows its failure, so rejecting it
+ * blocks nothing and only destroys the audit trail of the offending apply.
+ *
+ * The seam is the apply header. `x-lobu-apply-id` marks a request as part of a
+ * `lobu apply` run, so gating on it freezes promotions without freezing the
+ * product: interactive edits from Owletto and one-off API calls carry no such
+ * header and are unaffected.
+ *
+ * Read-tier calls stay allowed. `lobu apply` reads current config to compute
+ * its diff, and `--dry-run` is how an operator inspects what a resume would do;
+ * blocking reads would make a paused org undiagnosable.
+ *
+ * Rollbacks stay allowed. Rolling back FURTHER, because the first rollback did
+ * not fix it, is the main thing an operator does while paused — and
+ * `rollback-cmd` posts its summary BEFORE setting the pause, so a blanket block
+ * would strand the escape hatch behind the pause its own predecessor created.
+ * A rollback declares itself with `x-lobu-rollback-of`, which is VERIFIED
+ * against a real deployment in this org rather than trusted: a forged header
+ * has to name a deployment that actually exists, and permanently mislabels the
+ * run as a rollback in the audit log.
+ */
+
+import { getDb } from '../db/client';
+import { parseApplyId } from './apply-context';
+
+export interface DeploymentPauseState {
+  pausedAt: string | null;
+  applyId: string | null;
+  rollbackOf: string | null;
+  pausedBy: string | null;
+}
+
+/** Thrown when a paused org receives a mutating apply-run request. */
+export class DeploymentsPausedError extends Error {
+  readonly pause: DeploymentPauseState;
+
+  constructor(pause: DeploymentPauseState) {
+    super(
+      `Deployments are paused for this organization — a rollback restored deployment ${
+        pause.rollbackOf ?? '?'
+      }. Applying now would re-promote the config that was just rolled back. Reconcile your config repo, then run \`lobu apply --resume\`.`
+    );
+    this.name = 'DeploymentsPausedError';
+    this.pause = pause;
+  }
+}
+
+/**
+ * The pause blocking this request, or null if it may proceed. A no-op for every
+ * caller that is not a mutating apply-run request — see the module note for why
+ * each carve-out exists.
+ */
+export async function getBlockingPause(params: {
+  organizationId: string | null | undefined;
+  applyId: string | null;
+  rollbackOf: string | null;
+  isReadOnly: boolean;
+}): Promise<DeploymentPauseState | null> {
+  const { organizationId, applyId, rollbackOf, isReadOnly } = params;
+
+  // Not part of an apply run: UI and one-off API edits are never gated.
+  if (!organizationId || !applyId) return null;
+  // The diff and `--dry-run` must keep working while paused.
+  if (isReadOnly) return null;
+
+  const sql = getDb();
+  const rows = await sql`
+    SELECT paused_at, apply_id, rollback_of, paused_by
+    FROM deployment_pause
+    WHERE organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+
+  // A rollback may proceed, but only if its claim checks out: the deployment it
+  // says it is undoing has to exist in THIS org. Shape validation alone would
+  // make the header a bypass for anyone who can spell `apl_`.
+  if (rollbackOf) {
+    const target = await sql`
+      SELECT 1
+      FROM events
+      WHERE organization_id = ${organizationId}
+        AND origin_id = ${`deployment_${rollbackOf}`}
+      LIMIT 1
+    `;
+    if (target.length > 0) return null;
+  }
+
+  const row = rows[0];
+  return {
+    pausedAt: row.paused_at ?? null,
+    applyId: row.apply_id ?? null,
+    rollbackOf: row.rollback_of ?? null,
+    pausedBy: row.paused_by ?? null,
+  };
+}
+
+/** Throwing form, for the tool funnel where a thrown error is the idiom. */
+export async function assertDeploymentsNotPaused(
+  params: Parameters<typeof getBlockingPause>[0]
+): Promise<void> {
+  const pause = await getBlockingPause(params);
+  if (pause) throw new DeploymentsPausedError(pause);
+}
+
+/**
+ * Hono-side pause check for the auth funnel. Returns a 409 to short-circuit, or
+ * null to let the request through.
+ *
+ * Two exemptions carry the design and must travel together:
+ *
+ *  - Tool-proxy calls are left to `executeTool`'s own guard. Apply's READS go
+ *    through that proxy as POSTs (`manage_entity_schema` list, `manage_feeds`
+ *    get, …), so the method-based rule below would classify them as mutations
+ *    and break `--dry-run` against a paused org — the exact carve-out the
+ *    feature promises. The proxy decides read-vs-write from the tool args, which
+ *    is the only signal that is actually correct there.
+ *  - `DELETE /deployments/pause` is how `lobu apply --resume` clears the pause.
+ *    Gating it would make the pause unexitable.
+ *
+ * For everything else the HTTP method is the signal: every direct read the CLI
+ * issues is a GET, every direct mutation is POST/PATCH/PUT/DELETE.
+ */
+export async function checkApplyPause(
+  c: {
+    req: { method: string; path: string; header: (name: string) => string | undefined };
+    get: (key: string) => unknown;
+    json: (body: unknown, status: 409) => Response;
+  },
+  applyId: string,
+  requestedToolName: string | null
+): Promise<Response | null> {
+  // The tool proxy gates itself, with an args-aware read/write signal.
+  if (requestedToolName) return null;
+
+  const method = c.req.method.toUpperCase();
+  if (method === 'GET' || method === 'HEAD') return null;
+
+  // `--resume` has to be able to clear the pause it is exiting.
+  if (method === 'DELETE' && c.req.path.endsWith('/deployments/pause')) return null;
+
+  const pause = await getBlockingPause({
+    organizationId: (c.get('organizationId') as string | null) ?? null,
+    applyId: parseApplyId(applyId),
+    rollbackOf: parseApplyId(c.req.header('x-lobu-rollback-of')),
+    isReadOnly: false,
+  });
+  if (!pause) return null;
+
+  return c.json(
+    {
+      error: new DeploymentsPausedError(pause).message,
+      paused: true,
+      pausedAt: pause.pausedAt,
+      rollbackOf: pause.rollbackOf,
+      pausedBy: pause.pausedBy,
+    },
+    409
+  );
+}

--- a/packages/server/src/workspace/__tests__/multi-tenant-pause-gate.test.ts
+++ b/packages/server/src/workspace/__tests__/multi-tenant-pause-gate.test.ts
@@ -15,29 +15,55 @@
 
 import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { Hono } from 'hono';
+import { serializeSigned } from 'hono/utils/cookie';
+import { clearAuthCacheForTests } from '../../auth/index.js';
+import { sessionCookieName } from '../../auth/session-cookie-scope.js';
+import type { Env } from '../../index.js';
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
 } from '../../gateway/__tests__/helpers/db-setup.js';
+import { getConfiguredPublicOrigin } from '../../utils/public-origin.js';
 
 const ORG = 'org-pause-wiring';
+const OTHER_ORG = 'org-pause-wiring-other';
 const USER = 'u-pause-wiring';
 const APPLY_ID = 'apl_dddddddd-1111-2222-3333-444444444444';
 const ROLLED_BACK = 'apl_eeeeeeee-1111-2222-3333-444444444444';
 
 let token = '';
+let oauthToken = '';
+let sessionCookie = '';
+
+function requestOrigin(): string {
+  return getConfiguredPublicOrigin() ?? 'http://test.local';
+}
+
+const testEnv: Env = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+};
 
 beforeAll(async () => {
   await ensureDbForGatewayTests();
+  testEnv.DATABASE_URL = process.env.DATABASE_URL;
 }, 60_000);
 
 beforeEach(async () => {
   await resetTestDatabase();
+  // The auth instance is cached by organization across requests. Keep this
+  // harness independent of any auth suite that ran earlier in the worker.
+  clearAuthCacheForTests();
   const { getDb } = await import('../../db/client.js');
   const sql = getDb();
 
   await sql`
     INSERT INTO organization (id, name, slug) VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO organization (id, name, slug) VALUES (${OTHER_ORG}, ${OTHER_ORG}, ${OTHER_ORG})
     ON CONFLICT (id) DO NOTHING
   `;
   await sql`
@@ -50,6 +76,11 @@ beforeEach(async () => {
     VALUES ('m-pause-wiring', ${ORG}, ${USER}, 'owner', now())
     ON CONFLICT (id) DO NOTHING
   `;
+  await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES ('m-pause-wiring-other', ${OTHER_ORG}, ${USER}, 'owner', now())
+    ON CONFLICT (id) DO NOTHING
+  `;
 
   // Both caches are module-level and survive resetTestDatabase, so a prior
   // test's slug→id and org:user→role entries would outlive the rows.
@@ -57,18 +88,57 @@ beforeEach(async () => {
     '../multi-tenant.js'
   );
   invalidateOrgSlugCache(ORG);
+  invalidateOrgSlugCache(OTHER_ORG);
   invalidateMembershipRoleCache(ORG, USER);
+  invalidateMembershipRoleCache(OTHER_ORG, USER);
 
   const { PersonalAccessTokenService } = await import('../../auth/tokens.js');
   token = (await new PersonalAccessTokenService(sql).create(USER, ORG, 'pause-wiring')).token;
+
+  const { generateAccessToken, hashToken } = await import('../../auth/oauth/utils.js');
+  oauthToken = generateAccessToken();
+  await sql`
+    INSERT INTO oauth_clients (id, redirect_uris, client_name)
+    VALUES ('pause-wiring-client', ARRAY['http://localhost/callback'], 'Pause Wiring')
+  `;
+  await sql`
+    INSERT INTO oauth_tokens (
+      id, token_type, token_hash, client_id, user_id, organization_id,
+      scope, expires_at
+    ) VALUES (
+      'pause-wiring-oauth-token', 'access', ${hashToken(oauthToken)},
+      'pause-wiring-client', ${USER}, ${ORG}, 'mcp:read mcp:write mcp:admin',
+      now() + interval '1 hour'
+    )
+  `;
+
+  const sessionToken = 'pause-wiring-session-token';
+  await sql`
+    INSERT INTO "session" (id, token, "userId", "expiresAt", "createdAt", "updatedAt")
+    VALUES ('pause-wiring-session', ${sessionToken}, ${USER}, now() + interval '1 hour', now(), now())
+  `;
+  const requestIsHttps = new URL(requestOrigin()).protocol === 'https:';
+  sessionCookie = (
+    await serializeSigned(
+      sessionCookieName(requestIsHttps),
+      sessionToken,
+      testEnv.BETTER_AUTH_SECRET as string,
+      {
+        httpOnly: true,
+        path: '/',
+        sameSite: 'Lax',
+        secure: requestIsHttps,
+      }
+    )
+  ).split(';', 1)[0] as string;
 });
 
-async function pauseOrg(): Promise<void> {
+async function pauseOrg(organizationId = ORG): Promise<void> {
   const { getDb } = await import('../../db/client.js');
   const sql = getDb();
   await sql`
     INSERT INTO deployment_pause (organization_id, apply_id, rollback_of, paused_by)
-    VALUES (${ORG}, ${APPLY_ID}, ${ROLLED_BACK}, ${USER})
+    VALUES (${organizationId}, ${APPLY_ID}, ${ROLLED_BACK}, ${USER})
     ON CONFLICT (organization_id) DO UPDATE SET rollback_of = EXCLUDED.rollback_of
   `;
 }
@@ -82,23 +152,47 @@ async function request(opts: {
   method: string;
   applyId?: string;
   rollbackOf?: string;
+  orgSlug?: string;
+  auth?: 'pat' | 'oauth' | 'session' | 'settings-cookie' | 'invalid-pat-with-session';
 }): Promise<{ status: number; body: Record<string, unknown>; reached: boolean }> {
   const { MultiTenantProvider } = await import('../multi-tenant.js');
   const provider = new MultiTenantProvider();
 
   let reached = false;
-  const app = new Hono();
+  const app = new Hono<{ Bindings: Env }>();
   app.use('/api/:orgSlug/*', (c, next) => provider.resolveAuth(c, next));
   app.all('/api/:orgSlug/probe', (c) => {
     reached = true;
     return c.json({ ok: true });
   });
 
-  const headers: Record<string, string> = { authorization: `Bearer ${token}` };
+  const headers: Record<string, string> = {};
+  switch (opts.auth ?? 'pat') {
+    case 'pat':
+      headers.authorization = `Bearer ${token}`;
+      break;
+    case 'oauth':
+      headers.authorization = `Bearer ${oauthToken}`;
+      break;
+    case 'session':
+      headers.cookie = sessionCookie;
+      break;
+    case 'settings-cookie':
+      headers.cookie = 'lobu_settings_session=opaque-gateway-session';
+      break;
+    case 'invalid-pat-with-session':
+      headers.authorization = 'Bearer owl_pat_invalid';
+      headers.cookie = sessionCookie;
+      break;
+  }
   if (opts.applyId) headers['x-lobu-apply-id'] = opts.applyId;
   if (opts.rollbackOf) headers['x-lobu-rollback-of'] = opts.rollbackOf;
 
-  const res = await app.request(`/api/${ORG}/probe`, { method: opts.method, headers });
+  const orgSlug = opts.orgSlug ?? ORG;
+  const res = await app.fetch(
+    new Request(`${requestOrigin()}/api/${orgSlug}/probe`, { method: opts.method, headers }),
+    testEnv
+  );
   const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
   return { status: res.status, body, reached };
 }
@@ -144,13 +238,76 @@ describe('promotions pause is enforced in the auth funnel', () => {
     const sql = getDb();
     await sql`
       INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
-      VALUES (${ORG}, ${`deployment_${ROLLED_BACK}`}, 'change', '{}'::jsonb,
-              ${JSON.stringify({ category: 'deployment' })}::jsonb)
+      VALUES (${ORG}, ${`deployment_${ROLLED_BACK}`}, 'change',
+              ${sql.json({ manifest: { state: {} } })},
+              ${sql.json({
+                category: 'deployment',
+                apply_id: ROLLED_BACK,
+                status: 'succeeded',
+              })})
     `;
 
     const res = await request({ method: 'PATCH', applyId: APPLY_ID, rollbackOf: ROLLED_BACK });
 
     expect(res.status).toBe(200);
     expect(res.reached).toBe(true);
+  });
+
+  test('OAuth resolves the requested member org before consulting its pause', async () => {
+    await pauseOrg(OTHER_ORG);
+    const res = await request({
+      method: 'PATCH',
+      applyId: APPLY_ID,
+      orgSlug: OTHER_ORG,
+      auth: 'oauth',
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.reached).toBe(false);
+  });
+
+  test('a PAT cannot cross into another org even when its owner is a member', async () => {
+    await pauseOrg(OTHER_ORG);
+    const res = await request({
+      method: 'PATCH',
+      applyId: APPLY_ID,
+      orgSlug: OTHER_ORG,
+      auth: 'pat',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.reached).toBe(false);
+  });
+
+  test('a Better Auth session resolves the URL org and is gated', async () => {
+    await pauseOrg();
+    const res = await request({ method: 'PATCH', applyId: APPLY_ID, auth: 'session' });
+
+    expect(res.status).toBe(409);
+    expect(res.reached).toBe(false);
+  });
+
+  test('an invalid PAT cannot fall back to a valid session cookie', async () => {
+    await pauseOrg();
+    const res = await request({
+      method: 'PATCH',
+      applyId: APPLY_ID,
+      auth: 'invalid-pat-with-session',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.reached).toBe(false);
+  });
+
+  test('the gateway settings cookie is not an org-authentication credential', async () => {
+    await pauseOrg();
+    const res = await request({
+      method: 'PATCH',
+      applyId: APPLY_ID,
+      auth: 'settings-cookie',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.reached).toBe(false);
   });
 });

--- a/packages/server/src/workspace/__tests__/multi-tenant-pause-gate.test.ts
+++ b/packages/server/src/workspace/__tests__/multi-tenant-pause-gate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Execution coverage for the wiring that makes the promotions pause real:
+ * `resolveAuth` → `setContextAndContinue` → `checkApplyPause`.
+ *
+ * The sibling suite (src/utils/__tests__/deployment-pause.test.ts) proves the
+ * pause DECISION in isolation. That is not enough on its own: the decision is
+ * only worth anything if the funnel actually consults it, and the four lines
+ * that do so are otherwise covered by nothing but typecheck.
+ *
+ * This drives the REAL `MultiTenantProvider` with a REAL PAT rather than the
+ * src/lobu route harness, which replaces `mcpAuth` with a stub that only sets
+ * context vars — a test written there passes with the guard deleted, which is
+ * exactly the reassurance we must not buy.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup.js';
+
+const ORG = 'org-pause-wiring';
+const USER = 'u-pause-wiring';
+const APPLY_ID = 'apl_dddddddd-1111-2222-3333-444444444444';
+const ROLLED_BACK = 'apl_eeeeeeee-1111-2222-3333-444444444444';
+
+let token = '';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+
+  await sql`
+    INSERT INTO organization (id, name, slug) VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${USER}, 'Pause', 'pause-wiring@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES ('m-pause-wiring', ${ORG}, ${USER}, 'owner', now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  // Both caches are module-level and survive resetTestDatabase, so a prior
+  // test's slug→id and org:user→role entries would outlive the rows.
+  const { invalidateMembershipRoleCache, invalidateOrgSlugCache } = await import(
+    '../multi-tenant.js'
+  );
+  invalidateOrgSlugCache(ORG);
+  invalidateMembershipRoleCache(ORG, USER);
+
+  const { PersonalAccessTokenService } = await import('../../auth/tokens.js');
+  token = (await new PersonalAccessTokenService(sql).create(USER, ORG, 'pause-wiring')).token;
+});
+
+async function pauseOrg(): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO deployment_pause (organization_id, apply_id, rollback_of, paused_by)
+    VALUES (${ORG}, ${APPLY_ID}, ${ROLLED_BACK}, ${USER})
+    ON CONFLICT (organization_id) DO UPDATE SET rollback_of = EXCLUDED.rollback_of
+  `;
+}
+
+/**
+ * Mount the real provider exactly as the server does and issue one request.
+ * `reached` reports whether the downstream handler ran, so a 409 that came
+ * from the guard is distinguishable from a handler that merely errored.
+ */
+async function request(opts: {
+  method: string;
+  applyId?: string;
+  rollbackOf?: string;
+}): Promise<{ status: number; body: Record<string, unknown>; reached: boolean }> {
+  const { MultiTenantProvider } = await import('../multi-tenant.js');
+  const provider = new MultiTenantProvider();
+
+  let reached = false;
+  const app = new Hono();
+  app.use('/api/:orgSlug/*', (c, next) => provider.resolveAuth(c, next));
+  app.all('/api/:orgSlug/probe', (c) => {
+    reached = true;
+    return c.json({ ok: true });
+  });
+
+  const headers: Record<string, string> = { authorization: `Bearer ${token}` };
+  if (opts.applyId) headers['x-lobu-apply-id'] = opts.applyId;
+  if (opts.rollbackOf) headers['x-lobu-rollback-of'] = opts.rollbackOf;
+
+  const res = await app.request(`/api/${ORG}/probe`, { method: opts.method, headers });
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  return { status: res.status, body, reached };
+}
+
+describe('promotions pause is enforced in the auth funnel', () => {
+  test('a paused org refuses an apply-run mutation before the handler runs', async () => {
+    await pauseOrg();
+    const res = await request({ method: 'PATCH', applyId: APPLY_ID });
+
+    expect(res.status).toBe(409);
+    expect(res.body.paused).toBe(true);
+    // The whole point of gating here: the mutation never executes.
+    expect(res.reached).toBe(false);
+  });
+
+  test('the same request succeeds when the org is not paused', async () => {
+    const res = await request({ method: 'PATCH', applyId: APPLY_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.reached).toBe(true);
+  });
+
+  test('a paused org still serves reads, so the diff and --dry-run keep working', async () => {
+    await pauseOrg();
+    const res = await request({ method: 'GET', applyId: APPLY_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.reached).toBe(true);
+  });
+
+  test('traffic outside an apply run is never gated', async () => {
+    await pauseOrg();
+    // A UI or one-off API edit carries no apply id and must stay editable.
+    const res = await request({ method: 'PATCH' });
+
+    expect(res.status).toBe(200);
+    expect(res.reached).toBe(true);
+  });
+
+  test('a genuine rollback passes through the pause it is exiting', async () => {
+    await pauseOrg();
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    await sql`
+      INSERT INTO events (organization_id, origin_id, semantic_type, payload_data, metadata)
+      VALUES (${ORG}, ${`deployment_${ROLLED_BACK}`}, 'change', '{}'::jsonb,
+              ${JSON.stringify({ category: 'deployment' })}::jsonb)
+    `;
+
+    const res = await request({ method: 'PATCH', applyId: APPLY_ID, rollbackOf: ROLLED_BACK });
+
+    expect(res.status).toBe(200);
+    expect(res.reached).toBe(true);
+  });
+});

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -1,4 +1,5 @@
 import { looksLikeWorkerToken, verifyWorkerToken } from '@lobu/core';
+import { checkApplyPause } from '../utils/deployment-pause';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
@@ -266,6 +267,24 @@ export class MultiTenantProvider implements WorkspaceProvider {
       if (overrides.user !== undefined) c.set('user', overrides.user as any);
       if (overrides.session !== undefined) c.set('session', overrides.session as any);
       if (overrides.authSource !== undefined) c.set('authSource', overrides.authSource);
+      // Promotions pause, enforced at the ONE point every authenticated request
+      // passes through. `lobu apply` mutates config across ~25 endpoints spread
+      // over the tool proxy and several routers; gating them individually
+      // guarantees the next one added misses it, and gating the deployment
+      // SUMMARY route enforces nothing (it is written after the mutations, and
+      // the CLI swallows its failure). Sitting here means a route added later is
+      // covered by construction — and a route that somehow bypasses this is
+      // unauthenticated, a far louder bug.
+      //
+      // Ordered cheapest-first: the header read costs a map lookup and is absent
+      // on every request that is not part of an apply run, so nothing outside
+      // `lobu apply` ever reaches the query.
+      const pauseApplyId = c.req.header('x-lobu-apply-id');
+      if (pauseApplyId) {
+        const blocked = await checkApplyPause(c, pauseApplyId, requestedToolName);
+        if (blocked) return blocked;
+      }
+
       // The cb (workers/* gating mw) may return a Response to short-circuit;
       // Hono's plain `Next` returns void. `next()` resolves to one of those —
       // pass it back to the caller so a short-circuit Response actually

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -1,5 +1,4 @@
 import { looksLikeWorkerToken, verifyWorkerToken } from '@lobu/core';
-import { checkApplyPause } from '../utils/deployment-pause';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
@@ -15,6 +14,7 @@ import { getDb } from '../db/client';
 import { getRevokedTokenStore } from '../gateway/auth/revoked-token-store';
 import { resolveRestToolGetRoute } from '../http/rest-tool-routes';
 import type { Env } from '../index';
+import { checkApplyPause } from '../utils/deployment-pause';
 import logger from '../utils/logger';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import type {
@@ -268,13 +268,14 @@ export class MultiTenantProvider implements WorkspaceProvider {
       if (overrides.session !== undefined) c.set('session', overrides.session as any);
       if (overrides.authSource !== undefined) c.set('authSource', overrides.authSource);
       // Promotions pause, enforced at the ONE point every authenticated request
-      // passes through. `lobu apply` mutates config across ~25 endpoints spread
-      // over the tool proxy and several routers; gating them individually
-      // guarantees the next one added misses it, and gating the deployment
-      // SUMMARY route enforces nothing (it is written after the mutations, and
-      // the CLI swallows its failure). Sitting here means a route added later is
-      // covered by construction — and a route that somehow bypasses this is
-      // unauthenticated, a far louder bug.
+      // passes through. `lobu apply` mutates config across a dozen-plus
+      // endpoints spread over the tool proxy and several routers; gating them
+      // individually guarantees the next one added misses it, and gating the
+      // deployment SUMMARY route enforces nothing (it is written after the
+      // mutations, and the CLI swallows its failure). Sitting here means a
+      // route added later is covered by construction — a route that skips this
+      // funnel resolves no org at all, and `getBlockingPause` treats that as
+      // ungated.
       //
       // Ordered cheapest-first: the header read costs a map lookup and is absent
       // on every request that is not part of an apply run, so nothing outside

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -55,6 +55,10 @@ export default defineConfig({
       "src/utils/__tests__/device-pin-tombstones.test.ts",
       "src/utils/__tests__/catalog-connectors-compile.test.ts",
       "src/utils/__tests__/compiler-core.test.ts",
+      // Unlike the three above, this one needs Postgres (it executes the pause
+      // decision against real rows), so it runs in the bun:test/Postgres job
+      // alongside src/lobu/__tests__ rather than in the pure-unit job.
+      "src/utils/__tests__/deployment-pause.test.ts",
       "**/node_modules/**",
       "**/dist/**",
     ],

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -147,7 +147,7 @@ gate_server_integration_bun() {
     for f in $files; do echo ">> bun test $f"; bun test "$f" || rc=1; done
   done
   [ "$rc" -eq 0 ] || return 1
-  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__ packages/server/src/tools/admin/__tests__ packages/server/src/auth/oauth/__tests__ --timeout 30000 || return 1
+  bun test packages/server/src/lobu/__tests__ packages/server/src/scheduled packages/server/src/workspace/__tests__ packages/server/src/tools/admin/__tests__ packages/server/src/auth/oauth/__tests__ packages/server/src/utils/__tests__/deployment-pause.test.ts --timeout 30000 || return 1
   bun test packages/connector-worker/integration-tests || return 1
   GATE_RAN_BUN=1
 }


### PR DESCRIPTION
## What

The promotions pause is now enforced server-side for cooperating `lobu apply`
runs. A CI job or older CLI that carries `x-lobu-apply-id` can no longer mutate
a paused organization by posting directly to authenticated API or tool paths.

The header is a workflow marker, not an authentication credential. The server
still resolves the caller and organization from PAT, OAuth, or Better Auth
session state. An otherwise-authorized caller may omit the header and make an
ordinary one-off edit; this change prevents accidental re-promotion by the
apply workflow rather than revoking an operator's existing authority.

## Enforcement boundary

The request guard runs after authoritative authentication and organization
resolution in `MultiTenantProvider`, before the downstream handler. Tool calls
reuse the exact access tier returned by `checkToolAccess`, so read/write
classification cannot drift between authorization and pause enforcement.

Three exact exemptions keep recovery and diagnosis usable:

- tool-proxy requests defer to the args-aware tool guard, preserving reads and
  `--dry-run` even though the HTTP method is POST
- `POST /api/:org/deployments` remains available to record the refused run's
  audit summary after mutations have stopped
- `DELETE /api/:org/deployments/pause` remains available for `--resume`

Rollback now sets the pause before its first mutation and fails closed if that
write fails. `x-lobu-rollback-of` is accepted only when the authenticated
organization owns a succeeded or partially-failed deployment event whose
identity, metadata, and manifest snapshot all match the claimed apply ID.
Malformed, nonexistent, cross-org, colliding, failed, blocked, and snapshotless
targets remain blocked.

## Database safety

The rollback probe is backed by a non-partial
`events(organization_id, origin_id)` index. The migration builds it
concurrently, is marked non-transactional/no-quiesce, and heals an invalid
same-name index before creation. The production query and the pair lookup were
checked with `EXPLAIN`; the migration was also applied and mutation-tested on a
real Postgres 18 instance.

## Verification

- current-head pause/auth/tool/deployment server suites: 115 pass
- neighboring CLI apply suites: 350 pass
- CI-style combined server lane: 180 pass
- invalid-index migration heal: 7 pass
- Better Auth funnel under both HTTP default and HTTPS
  `PUBLIC_GATEWAY_URL`: 10 pass in each mode
- canonical live CLI smoke: real rollback restored its snapshot, the following
  real apply was refused by the server pause, and explicit `--resume` cleared
  it; the full local smoke was 98 pass / 2 unrelated failures / 4 skipped, with
  both failures caused by this Mac lacking the optional `isolated-vm` binary
  for entity write-rule execution
- `make pre-pr`: clean after rebasing onto current `origin/main` (workspace
  builds, strict typecheck, knip, Biome, naming, LLM-client, entity-write gates)
- pre-review mutation checks proved the auth funnel guard and invalid-index
  heal are load-bearing

## Residual risk

The pause check is request-bound, so a mutation already past the guard when a
rollback creates the pause may finish. Concurrent operators may also race an
explicit `--resume`; eliminating those windows requires a lease/CAS protocol,
not another route check. The new concurrent index avoids table-write blocking,
but its build time on a production-sized `events` table is not measured here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment pause protection to prevent blocked mutations while an organization is paused.
  * Allowed read operations, pause-resume actions, and verified rollback operations to continue during a pause.
  * Added rollback identification so valid rollback runs can proceed safely.

* **Bug Fixes**
  * Ensured pause enforcement applies consistently across authenticated workspace and tool requests.

* **Tests**
  * Expanded integration coverage for paused deployments, rollback validation, read/write access, and multi-tenant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
