### PR TITLE
fix(automations): make a stalled device Automation diagnosable

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -375,7 +375,7 @@ export type SaveMemoryResponse = SaveMemoryResponses[keyof SaveMemoryResponses];
 export type SearchSdkData = {
   body: {
     /**
-     * SDK method or runtime-helper discovery query. Use a namespace (e.g. 'automations'), one or more dotted paths separated by whitespace (e.g. 'automations.create ctx.sleep'), an optional client. prefix, or free text. Pass mode='read' for query_sdk-safe methods only; omit mode for your full run_sdk tier. Namespaces: agents, authProfiles, automations, catalog, classifiers, connections, conversations, ctx, entities, entitySchema, feeds, knowledge, metrics, notifications, operations, organizations, schedules, viewTemplates.
+     * SDK method or runtime-helper discovery query. Use a namespace (e.g. 'automations'), one or more dotted paths separated by whitespace (e.g. 'automations.create ctx.sleep'), an optional client. prefix, or free text. Pass mode='read' for query_sdk-safe methods only; omit mode for your full run_sdk tier. Namespaces: agents, authProfiles, automations, catalog, classifiers, connections, conversations, ctx, devices, entities, entitySchema, feeds, knowledge, metrics, notifications, operations, organizations, schedules, viewTemplates.
      */
     query: string;
     /**
@@ -1455,6 +1455,10 @@ export type ManageEntitySchemaData = {
       [key: string]: unknown;
     };
     /**
+     * [entity_type: create/update] TypeScript write rules for this type, as source. The default export receives one row per write — `{ committed, patch, next, op, changed(field), deny(reason), escalate(fields, reason) }` — and may only NARROW what is allowed: there is no `allow`. Compiled server-side on save and executed at the entity write seam, so an illegal state is rejected no matter which caller proposed it. Note `patch` is the fully MERGED value set, not a delta, so compare against `committed` rather than testing for a key's presence. `null` clears the rules; omit to leave unchanged.
+     */
+    rules_source?: null | string;
+    /**
      * [relationship_type: create] Whether the relationship is symmetric (A↔B = B↔A). Default false. Create-only: affects relationship canonicalization/dedup for existing rows, so an update carrying is_symmetric is rejected (not silently dropped). To change it, create a new type and migrate.
      */
     is_symmetric?: boolean;
@@ -1537,6 +1541,7 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          rules_source?: string | null;
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1583,6 +1588,7 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          rules_source?: string | null;
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1627,6 +1633,7 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          rules_source?: string | null;
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1671,6 +1678,7 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          rules_source?: string | null;
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -4472,7 +4480,7 @@ export type ManageAutomationsData = {
        */
       max_budget_usd?: number;
       /**
-       * Model alias/id passed to the CLI (--model).
+       * Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.
        */
       model?: string;
       /**

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4480,7 +4480,7 @@ export type ManageAutomationsData = {
        */
       max_budget_usd?: number;
       /**
-       * Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.
+       * Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's model providers -- the built-in providers plus any you have registered under Providers (e.g. 'openai/gpt-4.1', 'deepseek/deepseek-v4-flash') -- or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.
        */
       model?: string;
       /**

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -263,3 +263,40 @@ describe('automation arm failure diagnosis', () => {
     expect(completions[0].body.error).toContain('Credit balance is too low');
   });
 });
+
+/**
+ * A timed-out CLI is the one exit path with no diagnosis attached: the run row
+ * gets `output_tail` from stdout only, and the timeout branch built its error
+ * from a fixed string, so whatever the CLI wrote to stderr before it stalled
+ * was dropped. That is how a device Automation can fail 39 times in a row and
+ * leave nothing behind to explain why (prod #71, Aug 18-19).
+ */
+describe('automation arm timeout diagnosis', () => {
+  const stderrStallBinary = path.join(tmp, 'pi-stderr-stall');
+
+  beforeAll(() => {
+    // Writes its diagnosis to stderr, then stalls until the deadline kills it.
+    writeFileSync(
+      stderrStallBinary,
+      `#!/bin/sh\necho "MCP server handshake failed: connection refused" >&2\nsleep 4\n`
+    );
+    chmodSync(stderrStallBinary, 0o755);
+  });
+
+  test('keeps the stderr the CLI wrote before it stalled', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const stalling = cfg();
+    stalling.timeoutMs = 500;
+    stalling.binaryOverrides = { pi: stderrStallBinary };
+
+    await executeAutomationRun(client(), automationJob(), stalling);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('timeout');
+    // The deadline itself still has to be reported — it is the primary fact.
+    expect(completions[0].body.error).toContain('timeout');
+    // ...but so does the only evidence of WHY the CLI stalled.
+    expect(completions[0].body.error).toContain('MCP server handshake failed');
+  }, 30_000);
+});

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -89,6 +89,8 @@ export interface ExecutorResult {
 const STDOUT_CAP = 4 * 1024 * 1024;
 const STDERR_CAP = 1 * 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 600_000;
+/** Cap on the CLI-output tail folded into `runs.error_message`. */
+const DETAIL_TAIL_CHARS = 500;
 const LOCAL_MAX_ROUNDS = 8;
 const EXIT_REPORT_DELIVERY_ATTEMPTS = 3;
 const EXIT_REPORT_RETRY_DELAY_MS = 2000;
@@ -346,9 +348,23 @@ async function runCli(
 
     let exitReason: WorkerExitReason;
     let errorMessage: string | null;
+    // The last thing the CLI said before it stopped. Prefer stderr, but fall
+    // back to stdout. `claude` prints its fatal on stdout ("Credit balance is
+    // too low") and leaves stderr empty, so reading stderr alone reported the
+    // most likely real failure as a bare "exited with non-zero status 1" with
+    // the cause only in output_tail; `opencode` logs to stderr instead. Bounded
+    // because this lands in `runs.error_message`, and stderr is capped at 1 MiB.
+    const detail = (
+      stderrData.toString('utf8').trim() || stdoutData.toString('utf8').trim()
+    ).slice(-DETAIL_TAIL_CHARS);
     if (timedOut) {
       exitReason = 'timeout';
-      errorMessage = `${label} exited via ${killedSignal ?? 'SIGTERM'} after ${Math.trunc(timeoutMs / 1000)}s timeout`;
+      const deadline = `${label} exited via ${killedSignal ?? 'SIGTERM'} after ${Math.trunc(timeoutMs / 1000)}s timeout`;
+      // The deadline alone says nothing about WHY the CLI stalled, and a
+      // stalled CLI usually wrote nothing to stdout — so `output_tail` is NULL
+      // and this message is the only surviving evidence. Prod #71 failed this
+      // way 39 consecutive times and left no diagnosis behind.
+      errorMessage = detail === '' ? deadline : `${deadline}: ${detail}`;
     } else if (exitCode === 0) {
       exitReason = 'ok';
       errorMessage = null;
@@ -357,13 +373,6 @@ async function runCli(
       errorMessage = `${label} exited via signal (status=${proc.signalCode})`;
     } else {
       exitReason = 'error_message';
-      // Prefer stderr, but fall back to the tail of stdout. `claude` prints its
-      // fatal there ("Credit balance is too low") and leaves stderr empty, so
-      // reading stderr alone reported the most likely real failure as a bare
-      // "exited with non-zero status 1" with the cause only in output_tail.
-      const detail =
-        stderrData.toString('utf8').trim() ||
-        stdoutData.toString('utf8').trim().slice(-500);
       errorMessage =
         detail === ''
           ? `${label} exited with non-zero status ${exitCode}`

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -320,7 +320,7 @@ export const AutomationExecutionConfigSchema = Type.Object(
     model: Type.Optional(
       Type.String({
         description:
-          "Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (agent_kind + device_worker_id) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.",
+          "Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.",
       })
     ),
     permission_mode: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -320,7 +320,7 @@ export const AutomationExecutionConfigSchema = Type.Object(
     model: Type.Optional(
       Type.String({
         description:
-          "Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.",
+          "Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (device_worker_id set) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's model providers -- the built-in providers plus any you have registered under Providers (e.g. 'openai/gpt-4.1', 'deepseek/deepseek-v4-flash') -- or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.",
       })
     ),
     permission_mode: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -319,7 +319,8 @@ export const AutomationExecutionConfigSchema = Type.Object(
     ),
     model: Type.Optional(
       Type.String({
-        description: "Model alias/id passed to the CLI (--model).",
+        description:
+          "Model override for this Automation. ONE field, two namespaces, resolved by where the Automation runs: a device-pinned Automation (agent_kind + device_worker_id) passes this verbatim to the local CLI as --model, so it must name a provider that CLI has registered (e.g. 'opencode-go/deepseek-v4-flash'); a server-dispatched Automation resolves it against the org's inference providers (e.g. 'deepseek/deepseek-v4-flash'), or 'auto'. The two are NOT interchangeable — a CLI ref on the server lane fails at the provider, and a server ref on a device lane fails at the CLI.",
       })
     ),
     permission_mode: Type.Optional(

--- a/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
@@ -2,7 +2,7 @@
  * `execution_config.model` is ONE stored field with TWO resolution namespaces
  * (see the comment on `getAutomationModelOverride`): a device-pinned Automation
  * hands the ref verbatim to a local CLI as `--model`, while a server-dispatched
- * one resolves it against the org's `inference_providers`. Nothing checked which
+ * one resolves it against the org's model providers. Nothing checked which
  * lane a ref belonged to, so both directions failed silently at run time. In
  * prod on 2026-08-19 both happened within eight minutes:
  *
@@ -10,11 +10,24 @@
  *   15:09  #5  (server)  OpenRouter 400: opencode-go/deepseek-v4-flash is not a valid model ID
  *
  * The server can only police the lane whose registry it holds. A provider-
- * qualified ref on the SERVER lane must name a live `inference_providers.slug`;
- * the device lane is left alone because the CLI's provider registry lives on
- * the user's machine and the server cannot see it.
+ * qualified ref on the SERVER lane must name a slug in
+ * `listOrgModelProviderSlugs` — registry modules with a system key UNION the
+ * org's `inference_providers` rows; the device lane is left alone because the
+ * CLI's provider registry lives on the user's machine and the server cannot
+ * see it.
+ *
+ * NOTE: this harness never boots the gateway, so `getModelProviderModules()`
+ * is `[]` by default and the union would collapse to the rows inserted below.
+ * That is exactly how an `inference_providers`-only guard passed every test in
+ * this file while falsely rejecting `openai/gpt-4.1` in production. The
+ * registry half is therefore covered by registering a real module into
+ * `moduleRegistry` (its own doc comment sanctions this for tests) rather than
+ * by mocking: `mock.module` in bun is process-GLOBAL, so stubbing
+ * `provider-secrets` to fake the union broke every sibling suite that imports
+ * `readSandboxSecret` from it.
  */
 
+import { moduleRegistry } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   addUserToOrganization,
@@ -151,5 +164,38 @@ describe('execution_config.model namespace guard', () => {
         execution_config: { model: 'opencode-go/deepseek-v4-flash' },
       })
     ).rejects.toThrow(/opencode-go/);
+  });
+  it('accepts a system-key registry provider that has no inference_providers row', async () => {
+    // The other half of `listOrgModelProviderSlugs`. Registered here because
+    // this harness never boots the gateway, so the real 17 providers from
+    // config/providers.json (openai, claude, deepseek, …) are absent. Without
+    // this arm the guard could regress to inference_providers-only and every
+    // test above would still pass, while a valid `openai/gpt-4.1` server-lane
+    // Automation got rejected at the write.
+    moduleRegistry.register({
+      name: 'test-system-provider-module',
+      isEnabled: () => true,
+      init: async () => {},
+      registerEndpoints: () => {},
+      providerId: 'test-system-provider',
+      getSecretEnvVarNames: () => [],
+    } as never);
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT 1 AS present FROM inference_providers
+      WHERE organization_id = ${orgId} AND slug = 'test-system-provider'
+    `) as Array<{ present: number }>;
+    expect(row).toBeUndefined();
+
+    const created = (await owner.automations.create({
+      slug: 'server-lane-system-provider',
+      name: 'Server Lane System Provider',
+      prompt: 'Do a thing.',
+      triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+      agent_id: agentId,
+      execution_config: { model: 'test-system-provider/some-model' },
+    })) as { automation_id: string };
+    expect(created.automation_id).toBeDefined();
   });
 });

--- a/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `execution_config.model` is ONE stored field with TWO resolution namespaces
+ * (see the comment on `getAutomationModelOverride`): a device-pinned Automation
+ * hands the ref verbatim to a local CLI as `--model`, while a server-dispatched
+ * one resolves it against the org's `inference_providers`. Nothing checked which
+ * lane a ref belonged to, so both directions failed silently at run time. In
+ * prod on 2026-08-19 both happened within eight minutes:
+ *
+ *   15:01  #71 (device)  opencode: ProviderModelNotFoundError deepseek/deepseek-v4-flash
+ *   15:09  #5  (server)  OpenRouter 400: opencode-go/deepseek-v4-flash is not a valid model ID
+ *
+ * The server can only police the lane whose registry it holds. A provider-
+ * qualified ref on the SERVER lane must name a live `inference_providers.slug`;
+ * the device lane is left alone because the CLI's provider registry lives on
+ * the user's machine and the server cannot see it.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+
+describe('execution_config.model namespace guard', () => {
+  let owner: TestApiClient;
+  let orgId: string;
+  let agentId: string;
+  let deviceWorkerId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Model Namespace Org' });
+    const user = await createTestUser({ email: 'model-namespace@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    orgId = org.id;
+    owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+    const agent = await createTestAgent({
+      organizationId: org.id,
+      ownerUserId: user.id,
+    });
+    agentId = agent.agentId;
+
+    const sql = getTestDb();
+    // One live provider, exactly as an org that has registered `deepseek` would.
+    await sql`
+      INSERT INTO inference_providers (organization_id, slug, kind, display_name,
+        api_key_ref, capabilities, status)
+      VALUES (${orgId}, 'deepseek', 'openai-compatible', 'DeepSeek',
+        'secret://test', ${sql.json({ text: { model: 'deepseek-v4-flash' } })}, 'active')
+    `;
+    const [device] = (await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, app_version,
+        capabilities, label, organization_id, connector_manifests)
+      VALUES (${user.id}, 'mac-model-namespace', 'macos', '15.0.0',
+        ${sql.json({})}, 'Test Mac', ${orgId}, ${sql.json({})})
+      RETURNING id::text AS id
+    `) as unknown as Array<{ id: string }>;
+    deviceWorkerId = device.id;
+  });
+
+  it('rejects a CLI-namespace model on a server-dispatched Automation', async () => {
+    await expect(
+      owner.automations.create({
+        slug: 'server-lane-bad-model',
+        name: 'Server Lane Bad Model',
+        prompt: 'Do a thing.',
+        triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+        agent_id: agentId,
+        execution_config: { model: 'opencode-go/deepseek-v4-flash' },
+      })
+    ).rejects.toThrow(/opencode-go/);
+  });
+
+  it('accepts a model naming a registered provider', async () => {
+    const created = (await owner.automations.create({
+      slug: 'server-lane-good-model',
+      name: 'Server Lane Good Model',
+      prompt: 'Do a thing.',
+      triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+      agent_id: agentId,
+      execution_config: { model: 'deepseek/deepseek-v4-flash' },
+    })) as { automation_id: string };
+    expect(created.automation_id).toBeDefined();
+  });
+
+  it('leaves a device-pinned Automation alone — its CLI registry is off-server', async () => {
+    const created = (await owner.automations.create({
+      slug: 'device-lane-cli-model',
+      name: 'Device Lane CLI Model',
+      prompt: 'Do a thing.',
+      triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+      agent_id: agentId,
+      agent_kind: 'opencode',
+      device_worker_id: deviceWorkerId,
+      execution_config: { model: 'opencode-go/deepseek-v4-flash' },
+    })) as { automation_id: string };
+    expect(created.automation_id).toBeDefined();
+  });
+
+  it("does not second-guess 'auto' or a bare model id", async () => {
+    for (const [index, model] of ['auto', 'deepseek-v4-flash'].entries()) {
+      const created = (await owner.automations.create({
+        slug: `server-lane-unqualified-${index}`,
+        name: `Server Lane Unqualified ${index}`,
+        prompt: 'Do a thing.',
+        triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+        agent_id: agentId,
+        execution_config: { model },
+      })) as { automation_id: string };
+      expect(created.automation_id).toBeDefined();
+    }
+  });
+
+  it('rejects the same bad ref arriving through update', async () => {
+    const created = (await owner.automations.create({
+      slug: 'server-lane-update-target',
+      name: 'Server Lane Update Target',
+      prompt: 'Do a thing.',
+      triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+      agent_id: agentId,
+    })) as { automation_id: string };
+
+    await expect(
+      owner.automations.update({
+        automation_id: created.automation_id,
+        execution_config: { model: 'opencode-go/deepseek-v4-flash' },
+      })
+    ).rejects.toThrow(/opencode-go/);
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
@@ -79,6 +79,23 @@ describe('execution_config.model namespace guard', () => {
     ).rejects.toThrow(/opencode-go/);
   });
 
+  it('still rejects on the server lane when agent_kind is set without a device pin', async () => {
+    // agent_kind alone selects a local CLI runtime on the DEVICE lane and is
+    // otherwise inert; it must not be read as a device pin that exempts the
+    // server lane from the model guard.
+    await expect(
+      owner.automations.create({
+        slug: 'server-lane-agent-kind-only',
+        name: 'Server Lane Agent Kind Only',
+        prompt: 'Do a thing.',
+        triggers: [{ kind: 'schedule', cron: '0 * * * *' }],
+        agent_id: agentId,
+        agent_kind: 'opencode',
+        execution_config: { model: 'opencode-go/deepseek-v4-flash' },
+      })
+    ).rejects.toThrow(/opencode-go/);
+  });
+
   it('accepts a model naming a registered provider', async () => {
     const created = (await owner.automations.create({
       slug: 'server-lane-good-model',

--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -234,4 +234,32 @@ describe("manage_operations get_run — internal runs", () => {
 		expect(card?.automation_id).toBe(automationId);
 		expect(retiredVocabularyKeys(card)).toEqual([]);
 	});
+	/**
+	 * A device-executed Automation reports how its local CLI exited
+	 * (`exit_reason`/`exit_code`/`exit_signal`) plus the tail of what the CLI
+	 * printed (`output_tail`). The worker writes all four, but no read surface
+	 * selected them and `runs` is not in the query_sql allowlist — so the only
+	 * forensic record of a timed-out device Automation was reachable only by
+	 * querying the database directly. Prod #71 stalled 39 times undiagnosed.
+	 */
+	it("surfaces the device-CLI exit diagnostics through get_run", async () => {
+		const db = getTestDb();
+		const [row] = (await db`
+      INSERT INTO runs (organization_id, run_type, action_key, status,
+        error_message, exit_reason, exit_code, exit_signal, output_tail,
+        created_at, run_at)
+      VALUES (${orgId}, 'automation', null, 'failed',
+        'opencode exited via SIGTERM after 600s timeout', 'timeout', 15, 'SIGTERM',
+        'MCP server handshake failed: connection refused',
+        now(), now())
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		const id = Number(row.id);
+
+		const got = (await getRun(id)).run as Record<string, unknown>;
+		expect(got.exit_reason).toBe("timeout");
+		expect(Number(got.exit_code)).toBe(15);
+		expect(got.exit_signal).toBe("SIGTERM");
+		expect(got.output_tail).toContain("MCP server handshake failed");
+	});
 });

--- a/packages/server/src/__tests__/unit/automation-execution-config.test.ts
+++ b/packages/server/src/__tests__/unit/automation-execution-config.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'bun:test';
 import { ManageAutomationsSchema } from '../../tools/admin/manage_automations';
 import {
+  assertServerLaneModelResolves,
   assertValidExecutionConfig,
   type ExecutionConfigCaller,
 } from '../../tools/admin/automation-execution-config';
@@ -111,4 +112,61 @@ describe('assertValidExecutionConfig — elevated permission_mode gate', () => {
       expect(() => assertValidExecutionConfig({ permission_mode: mode }, member)).not.toThrow();
     }
   });
+});
+
+/**
+ * `lobu apply` writes Automations at phase 6 and org-owned inference providers
+ * at phase 10b, so a config declaring BOTH a provider and an Automation pinned
+ * to that provider's model reaches the model guard four phases before the
+ * provider row exists. The guard must stand down for an apply run rather than
+ * reject a config that is internally consistent — and do it before touching the
+ * database, since there is nothing to look up yet.
+ */
+describe('assertServerLaneModelResolves — lobu apply exemption', () => {
+  const applyRun = {
+    executionConfig: { model: 'not-registered-yet/some-model' },
+    organizationId: 'org_apply',
+    isDevicePinned: false,
+  };
+
+  it('stands down for an apply run (no provider lookup, no throw)', async () => {
+    await expect(
+      assertServerLaneModelResolves({ ...applyRun, applyId: 'apply_abc123' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('reaches the provider lookup off an apply run', async () => {
+    // Asserts the DB-less failure BY NAME, not a bare `toThrow()`: the point is
+    // that this call gets as far as the provider lookup, which is exactly what
+    // the apply arm above short-circuits past. The real rejection (a
+    // ToolUserError naming the unregistered slug) is covered against a live
+    // database in integration/automations/automation-model-namespace.test.ts.
+    await expect(
+      assertServerLaneModelResolves({ ...applyRun, applyId: null })
+    ).rejects.toThrow(/DATABASE_URL/);
+  });
+
+  it('skips a device-pinned Automation without a lookup', async () => {
+    await expect(
+      assertServerLaneModelResolves({
+        ...applyRun,
+        isDevicePinned: true,
+        applyId: null,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(['auto', 'bare-model-id', ''])(
+    "does not second-guess %o",
+    async (model) => {
+      await expect(
+        assertServerLaneModelResolves({
+          executionConfig: { model },
+          organizationId: 'org_apply',
+          isDevicePinned: false,
+          applyId: null,
+        })
+      ).resolves.toBeUndefined();
+    }
+  );
 });

--- a/packages/server/src/lobu/model-config.ts
+++ b/packages/server/src/lobu/model-config.ts
@@ -46,6 +46,30 @@ export type ModelValidationError =
     };
 
 /**
+ * Every provider slug a `<slug>/<model>` ref may name at the ORG level:
+ * registry provider modules (system keys — `openai`, `claude`, `deepseek`, …
+ * from `config/providers.json`) UNION the org's own `inference_providers` rows.
+ *
+ * Exported because this union IS the definition of "a provider this org can
+ * route to", and more than one write path has to answer that question — the
+ * agent `models` allow-list here, and `execution_config.model` on a
+ * server-dispatched Automation. Resolving against `inference_providers` alone
+ * silently rejects every system-key provider, which is a valid config for an
+ * org that never registered a row of its own.
+ */
+export async function listOrgModelProviderSlugs(
+  organizationId: string,
+): Promise<Set<string>> {
+  const slugs = new Set<string>(
+    getModelProviderModules().map((m) => m.providerId),
+  );
+  for (const row of await listInferenceProviders(organizationId)) {
+    slugs.add(row.slug);
+  }
+  return slugs;
+}
+
+/**
  * Validate an agent `models` allow-list against the org's providers. Pure of any
  * HTTP context: every entry must be an explicit `<slug>/<model>` ref (no bare
  * ids, no `auto`) whose slug resolves at the ORG level (a registry provider
@@ -82,13 +106,7 @@ export async function validateModelRefsAgainstOrg(
     }
   }
 
-  // Org-level slug resolution: registry modules ∪ the org's provider rows.
-  const orgSlugs = new Set<string>(
-    getModelProviderModules().map((m) => m.providerId),
-  );
-  for (const row of await listInferenceProviders(organizationId)) {
-    orgSlugs.add(row.slug);
-  }
+  const orgSlugs = await listOrgModelProviderSlugs(organizationId);
   for (const ref of entries) {
     if (isUnresolvedModelRef(ref)) continue;
     const providerId = ref.slice(0, ref.indexOf("/"));

--- a/packages/server/src/tools/admin/automation-execution-config.ts
+++ b/packages/server/src/tools/admin/automation-execution-config.ts
@@ -1,3 +1,4 @@
+import { getInferenceProviderBySlug } from '../../lobu/stores/provider-secrets';
 import { ToolUserError } from '../../utils/errors';
 import { isAdminOrOwnerRole } from '../access-control';
 
@@ -58,4 +59,61 @@ export function assertValidExecutionConfig(value: unknown, caller: ExecutionConf
       `execution_config.permission_mode '${mode}' requires an owner or admin role; members may use: default, plan, auto, acceptEdits.`
     );
   }
+}
+
+/**
+ * Reject a model ref that names a provider this org has not registered.
+ *
+ * `execution_config.model` is ONE stored field with TWO resolution namespaces
+ * (see `getAutomationModelOverride` in automations/automation.ts). A
+ * device-pinned Automation passes the ref verbatim to a local CLI as `--model`,
+ * so it must name a provider THAT CLI has registered; a server-dispatched one
+ * resolves it against the org's `inference_providers`, where a server-lane ref
+ * is `<provider slug>/<model>` (`modelRefFromDefaultRow` builds it that way).
+ *
+ * Only the server lane is policed, because only its registry lives here — the
+ * CLI's provider list is on the user's machine and the server cannot see it.
+ * Left unchecked, a CLI-namespace ref on the server lane is accepted at the
+ * write and then fails on every scheduled run: prod Automation #5 took an
+ * `opencode-go/…` ref and answered `OpenRouter 400: not a valid model ID`.
+ *
+ * Deliberately narrow, so the check can only fire on a ref it fully understands:
+ * an absent/blank model, `auto`, and an unqualified id (no `/`) all pass. The
+ * org's registered providers are a human declaration, not a heuristic — the
+ * only thing being asserted is that the named one exists.
+ *
+ * `lobu apply` is exempt, and that is a soundness limit rather than a courtesy:
+ * apply writes Automations at phase 6 and org-owned inference providers at
+ * phase 10b, so a config declaring BOTH a provider and an Automation on that
+ * provider's model reaches this check four phases before the provider row
+ * exists. Rejecting there would fail a config that is internally consistent —
+ * and against a CLI already published to npm. Closing that hole means moving
+ * apply's provider phase ahead of its Automation phase first.
+ */
+export async function assertServerLaneModelResolves(params: {
+  executionConfig: unknown;
+  organizationId: string;
+  /** Effective pin AFTER the patch — either field set means the device lane. */
+  isDevicePinned: boolean;
+  /** `ctx.applyId` — non-null only for a `lobu apply` run. */
+  applyId?: string | null;
+}): Promise<void> {
+  const { executionConfig, organizationId, isDevicePinned, applyId } = params;
+  if (executionConfig === undefined || executionConfig === null) return;
+  if (applyId != null) return;
+  if (isDevicePinned) return;
+  const raw = (executionConfig as { model?: unknown }).model;
+  if (typeof raw !== 'string') return;
+  const model = raw.trim();
+  if (model === '' || model === 'auto') return;
+  const slash = model.indexOf('/');
+  if (slash <= 0) return;
+  const slug = model.slice(0, slash);
+  if (await getInferenceProviderBySlug(organizationId, slug)) return;
+  throw new ToolUserError(
+    `execution_config.model '${model}' names inference provider '${slug}', which this organization has not registered. ` +
+      `Register it first, use a model from a provider you have, or pass 'auto'. ` +
+      `Note: a device-pinned Automation (agent_kind + device_worker_id) instead resolves this ref against the local CLI's own providers, which are not interchangeable with these.`,
+    400
+  );
 }

--- a/packages/server/src/tools/admin/automation-execution-config.ts
+++ b/packages/server/src/tools/admin/automation-execution-config.ts
@@ -93,7 +93,7 @@ export function assertValidExecutionConfig(value: unknown, caller: ExecutionConf
 export async function assertServerLaneModelResolves(params: {
   executionConfig: unknown;
   organizationId: string;
-  /** Effective pin AFTER the patch — either field set means the device lane. */
+  /** Effective pin AFTER the patch — a set device_worker_id means the device lane. */
   isDevicePinned: boolean;
   /** `ctx.applyId` — non-null only for a `lobu apply` run. */
   applyId?: string | null;
@@ -113,7 +113,7 @@ export async function assertServerLaneModelResolves(params: {
   throw new ToolUserError(
     `execution_config.model '${model}' names inference provider '${slug}', which this organization has not registered. ` +
       `Register it first, use a model from a provider you have, or pass 'auto'. ` +
-      `Note: a device-pinned Automation (agent_kind + device_worker_id) instead resolves this ref against the local CLI's own providers, which are not interchangeable with these.`,
+      `Note: a device-pinned Automation (device_worker_id set) instead resolves this ref against the local CLI's own providers, which are not interchangeable with these.`,
     400
   );
 }

--- a/packages/server/src/tools/admin/automation-execution-config.ts
+++ b/packages/server/src/tools/admin/automation-execution-config.ts
@@ -1,4 +1,4 @@
-import { getInferenceProviderBySlug } from '../../lobu/stores/provider-secrets';
+import { listOrgModelProviderSlugs } from '../../lobu/model-config';
 import { ToolUserError } from '../../utils/errors';
 import { isAdminOrOwnerRole } from '../access-control';
 
@@ -68,8 +68,11 @@ export function assertValidExecutionConfig(value: unknown, caller: ExecutionConf
  * (see `getAutomationModelOverride` in automations/automation.ts). A
  * device-pinned Automation passes the ref verbatim to a local CLI as `--model`,
  * so it must name a provider THAT CLI has registered; a server-dispatched one
- * resolves it against the org's `inference_providers`, where a server-lane ref
- * is `<provider slug>/<model>` (`modelRefFromDefaultRow` builds it that way).
+ * resolves it against the org's model providers — registry modules with a
+ * system key UNION its own `inference_providers` rows, which is exactly the set
+ * `listOrgModelProviderSlugs` returns and the same one the agent `models`
+ * allow-list is validated against. A server-lane ref is `<provider slug>/<model>`
+ * (`modelRefFromDefaultRow` builds it that way).
  *
  * Only the server lane is policed, because only its registry lives here — the
  * CLI's provider list is on the user's machine and the server cannot see it.
@@ -109,10 +112,10 @@ export async function assertServerLaneModelResolves(params: {
   const slash = model.indexOf('/');
   if (slash <= 0) return;
   const slug = model.slice(0, slash);
-  if (await getInferenceProviderBySlug(organizationId, slug)) return;
+  if ((await listOrgModelProviderSlugs(organizationId)).has(slug)) return;
   throw new ToolUserError(
-    `execution_config.model '${model}' names inference provider '${slug}', which this organization has not registered. ` +
-      `Register it first, use a model from a provider you have, or pass 'auto'. ` +
+    `execution_config.model '${model}' names model provider '${slug}', which this organization cannot route to. ` +
+      `Register it under Providers, use a model from a provider you have, or pass 'auto'. ` +
       `Note: a device-pinned Automation (device_worker_id set) instead resolves this ref against the local CLI's own providers, which are not interchangeable with these.`,
     400
   );

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -124,7 +124,7 @@ export async function handleCreate(
   await assertServerLaneModelResolves({
     executionConfig: args.execution_config,
     organizationId: ctx.organizationId,
-    isDevicePinned: args.device_worker_id != null || args.agent_kind != null,
+    isDevicePinned: args.device_worker_id != null,
     applyId: ctx.applyId,
   });
 
@@ -536,16 +536,19 @@ export async function handleUpdate(
   // Judge the model against the lane the Automation will be on AFTER this
   // patch, not the one it is on now: clearing a device pin in the same call
   // moves the ref onto the server lane, where it has to resolve.
+  //
+  // Only an incoming `execution_config` is judged. Clearing the pin WITHOUT
+  // re-sending one leaves an already-stored CLI-namespace ref on the now-server
+  // lane, and it fails at dispatch rather than here. That is deliberate:
+  // re-validating the stored model would make unrelated updates start failing
+  // on legacy rows nobody is touching.
   await assertServerLaneModelResolves({
     executionConfig: args.execution_config,
     organizationId: currentRow.organization_id,
     isDevicePinned:
-      (args.device_worker_id !== undefined
+      args.device_worker_id !== undefined
         ? args.device_worker_id != null
-        : currentRow.device_worker_id != null) ||
-      (args.agent_kind !== undefined
-        ? args.agent_kind != null
-        : currentRow.agent_kind != null),
+        : currentRow.device_worker_id != null,
     applyId: ctx.applyId,
   });
   const triggerWrite = resolveAutomationTriggerWrite({

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -17,7 +17,10 @@ import {
   enableClassifiersOnEntity,
 } from '../../../automations/classifier-extraction';
 import { assertDeviceWorkerAccess } from '../automation-device-access';
-import { assertValidExecutionConfig } from '../automation-execution-config';
+import {
+  assertServerLaneModelResolves,
+  assertValidExecutionConfig,
+} from '../automation-execution-config';
 import { assertEntityIdsInOrg, getNextNumericId, requireExists } from '../helpers/db-helpers';
 import type { ToolContext } from '../../registry';
 import type { ManageAutomationsArgs } from '../manage_automations';
@@ -118,6 +121,12 @@ export async function handleCreate(
     throw new ToolUserError('slug is required for create action');
   }
   assertValidExecutionConfig(args.execution_config, ctx);
+  await assertServerLaneModelResolves({
+    executionConfig: args.execution_config,
+    organizationId: ctx.organizationId,
+    isDevicePinned: args.device_worker_id != null || args.agent_kind != null,
+    applyId: ctx.applyId,
+  });
 
   // entity_id is optional: omit it for an org-scoped/global automation.
   const entityId = args.entity_id;
@@ -524,6 +533,21 @@ export async function handleUpdate(
     current_skills: Array<{ name: string; content: string }> | null;
     current_outputs: Record<string, unknown> | null;
   };
+  // Judge the model against the lane the Automation will be on AFTER this
+  // patch, not the one it is on now: clearing a device pin in the same call
+  // moves the ref onto the server lane, where it has to resolve.
+  await assertServerLaneModelResolves({
+    executionConfig: args.execution_config,
+    organizationId: currentRow.organization_id,
+    isDevicePinned:
+      (args.device_worker_id !== undefined
+        ? args.device_worker_id != null
+        : currentRow.device_worker_id != null) ||
+      (args.agent_kind !== undefined
+        ? args.agent_kind != null
+        : currentRow.agent_kind != null),
+    applyId: ctx.applyId,
+  });
   const triggerWrite = resolveAutomationTriggerWrite({
     triggers: args.triggers,
     currentTriggers: currentRow.triggers ?? [],

--- a/packages/server/src/tools/admin/manage_operations/handlers/runs.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/runs.ts
@@ -213,7 +213,13 @@ export async function handleGetRun(
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
            r.created_at, r.completed_at,
-           r.initiator_kind, r.initiator_ref, r.created_by_user_id
+           r.initiator_kind, r.initiator_ref, r.created_by_user_id,
+           -- How a device-executed Automation's local CLI ended, and the tail of
+           -- what it printed. The worker has always written these four; nothing
+           -- read them back, so a timed-out device Automation could only be
+           -- diagnosed by querying the database directly. Single-row fetch only:
+           -- output_tail is up to 2000 chars, too heavy for a list page.
+           r.exit_reason, r.exit_code, r.exit_signal, r.output_tail
     FROM runs r
     WHERE r.id = ${args.run_id}
       AND r.organization_id = ${ctx.organizationId}


### PR DESCRIPTION
## Summary

Three gaps found while investigating prod Automation **#71**, which failed **39 consecutive times** (Aug 18–19) leaving nothing behind to explain why.

1. **The timeout exit path discarded stderr.** `output_tail` is fed from stdout only, and a stalled agent CLI usually prints nothing there — so the run row carried no evidence at all. In prod, **42 of 54** device-automation timeout rows have a NULL tail. The deadline is still reported first (it is the primary fact) with the CLI's last output appended. The stdout fallback that only the non-zero arm had is now shared by both, bounded at 500 chars because it lands in `runs.error_message` and stderr is capped at 1 MiB.

2. **`runs.exit_reason` / `exit_code` / `exit_signal` / `output_tail` were write-only.** The worker has always written them; neither `get_run` nor `list_runs` selected them, and `runs` is not in the `query_sql` allowlist — so the only forensic record of a timed-out device Automation was reachable *solely* by querying the database directly. `get_run` now returns all four (redacted through the existing `deepRedactSecrets` path). `list_runs` is deliberately left alone: `output_tail` is up to 2000 chars and a 20-row page would carry 40 KB of it.

3. **`execution_config.model` is ONE stored field with TWO resolution namespaces.** A device-pinned Automation passes the ref verbatim to a local CLI as `--model`; a server-dispatched one resolves it against the org's `inference_providers`. Nothing checked which lane a ref belonged to, so both directions failed silently at run time — in prod, both within eight minutes:

   ```
   15:01  #71 (device)  opencode: ProviderModelNotFoundError deepseek/deepseek-v4-flash
   15:09  #5  (server)  OpenRouter 400: opencode-go/deepseek-v4-flash is not a valid model ID
   ```

   A provider-qualified ref on the **server** lane must now name a live provider slug.

### Scope limits on the guard (deliberate)

- It polices only the lane whose registry the server holds. The device CLI's provider list lives on the user's machine; there is nothing here to check it against.
- Narrow by construction: absent/blank, `auto`, and unqualified ids (no `/`) all pass. The org's registered providers are a human declaration, not a heuristic — the only thing asserted is that the named one exists.
- **It stands down for a `lobu apply` run**, keyed on `ctx.applyId`. This is a soundness limit, not a courtesy: apply writes Automations at phase 6 (`apply-cmd.ts:924`) and org-owned inference providers at phase 10b (`:1218`), so a config declaring **both** a provider and an Automation on that provider's model reaches the guard four phases before the provider row exists. Rejecting there would fail an internally consistent config — against a CLI already published to npm at 15.0.0. Closing that hole means reordering apply's phases first (follow-up).

### Checked against real prod data before shipping

None of the org's live Automations are rejected, and the guard *would* have caught the #5 breakage:

```
 id | device_lane | model                      | provider registered?
  5 | f           | deepseek/deepseek-v4-flash | yes   -> passes
 20 | f           | qwen/qwen3.8-max-preview   | yes   -> passes
 70 | t           | opencode-go/...            | device lane -> exempt
 71 | t           | opencode-go/...            | device lane -> exempt
```

`opencode-go` is not a registered provider in that org, so #5 carrying `opencode-go/...` on the server lane is exactly what now gets rejected at the write.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun test` + `bunx vitest run` (below)
- [x] Bug fix: red→fix→green outputs pasted below

### 1. Timeout drops stderr — red

New e2e case: a fake CLI writes its diagnosis to stderr, then stalls past the deadline.

```
299 |     // ...but so does the only evidence of WHY the CLI stalled.
300 |     expect(completions[0].body.error).toContain('MCP server handshake failed');
                                            ^
error: expect(received).toContain(expected)

Expected to contain: "MCP server handshake failed"
Received: "pi exited via SIGTERM after 0s timeout"

(fail) automation arm timeout diagnosis > keeps the stderr the CLI wrote before it stalled
 6 pass
 1 fail
```

Green:

```
 7 pass
 0 fail
Ran 7 tests across 1 file.
```

### 2. Write-only diagnostics — red

```
FAIL  operations-getrun-internal.test.ts > surfaces the device-CLI exit diagnostics through get_run
AssertionError: expected undefined to be 'timeout'
- Expected: "timeout"
+ Received: undefined
 Tests  1 failed | 7 passed (8)
```

Green: `Tests  8 passed (8)`

### 3. Model namespace guard — red

Both rejection cases pass straight through today; the three acceptance cases already held:

```
 ❯ automation-model-namespace.test.ts:136
     ).rejects.toThrow(/opencode-go/);
 Tests  2 failed | 3 passed (5)
```

Green: `Tests  5 passed (5)`

### Suites

```
server integration (automations/ + operations-getrun):  37 files, 338 tests passed
server unit (automation-execution-config):              22 passed
server unit (sandbox):                                 149 passed
connector-worker automation-arm-e2e:                     7 passed
make pre-pr:                                           clean (build, typecheck, knip, biome,
                                                       naming, gateway-LLM, entity-write)
```

`packages/connector-worker`'s full suite has 15 pre-existing failures in this worktree — all `Cannot find module` for unbuilt workspace dists, in files this branch does not touch. Baseline-confirmed by re-running them without the change.

## Notes

Submodule pointer bumps `packages/owletto` to `51a6f18e` — lobu-ai/owletto#901, which mirrors fix (1) in the Mac app's `AutomationDispatcher` (the runtime that actually executes #71) and fixes a matching stdout-fallback drift on its non-zero arm. That PR's classification is mutation-tested. **Merge the owletto PR last.**

Follow-ups, not in this PR:
- Reorder `lobu apply` so the provider phase precedes the Automation phase, then drop the apply exemption from the guard (needs a CLI publish first).
- #71's stall is still unexplained. This PR is what should make the next occurrence name itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automation run details now show device execution diagnostics, including exit reason, code, signal, output tail, and failure status.
  - Server-dispatched Automations now validate model provider references during creation and updates.
  - Device-pinned Automations continue supporting locally resolved model references.

- **Bug Fixes**
  - Timeout errors now preserve relevant CLI diagnostic output, with bounded stderr/stdout details.
  - Nonzero CLI failures consistently include available diagnostic output.

- **Documentation**
  - Clarified model configuration behavior for device-worker and server-side provider namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->