### PR TITLE
feat(automations): let platform-written events activate Automations as roots

### DIFF
--- a/packages/server/src/__tests__/integration/automations/workspace-event-roots.test.ts
+++ b/packages/server/src/__tests__/integration/automations/workspace-event-roots.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Root workspace events: rows the platform wrote itself, with no Automation
+ * upstream of them.
+ *
+ * Before this, `loadWorkspaceEvent` threw on any event whose `automation_id`
+ * was null, so only Automation outputs could ever reach a subscriber — a
+ * device coming online or a connection being deleted was unsubscribable by
+ * construction. These tests drive the real writer (`insertConnectionlessAuditEvent`)
+ * rather than hand-building rows, so a regression in how the type is stamped
+ * fails here too.
+ *
+ * Nothing enqueues roots yet; `activateWorkspaceEventTask` is called directly.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { activateWorkspaceEventTask } from '../../../automations/workspace-event';
+import type { WorkspaceEventActivationTaskPayload } from '../../../automations/workspace-event-contract';
+import {
+  insertConnectionlessAuditEvent,
+  insertEvent,
+} from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { ensureMemberEntityType } from '../../../utils/member-entity-type';
+import { createTestAgent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+async function subscriberOrg(eventTypes: string[][]) {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({ name: 'Workspace Event Root Org' });
+  const ownerUserId = workspace.users.owner.id;
+  // A workspace trigger may only name an event type some entity type declares
+  // (`assertAutomationTriggerConnections`). For an entity-type-less trigger the
+  // catalog is the union across the org, so declaring on `$member` is what
+  // makes a type subscribable org-wide. Platform-emitted types have no
+  // declaring entity type yet — closing that catalog gap is separate work; here
+  // the types are declared explicitly so the activation path itself is what is
+  // under test.
+  await ensureMemberEntityType(workspace.org.id);
+  await sql`
+    UPDATE entity_types
+    SET event_kinds = ${sql.json(
+      Object.fromEntries(
+        eventTypes.flat().map((type) => [type, { description: type }])
+      )
+    )}
+    WHERE organization_id = ${workspace.org.id} AND slug = '$member'
+  `;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'workspace-event-root-agent',
+  });
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+  const automationIds: number[] = [];
+  for (const [index, types] of eventTypes.entries()) {
+    const created = (await api.automations.create({
+      slug: `root-consumer-${index}`,
+      prompt: 'Handle the platform event.',
+      triggers: [
+        {
+          kind: 'event',
+          source: 'workspace',
+          event_types: types,
+          execution: 'window',
+          active_run: 'queue',
+        },
+      ],
+      agent_id: agent.agentId,
+    })) as { automation_id: string };
+    automationIds.push(Number(created.automation_id));
+  }
+  return { workspace, automationIds };
+}
+
+/** The payload the platform will hand a root: itself as the only ancestor-free root. */
+function rootPayload(
+  organizationId: string,
+  eventId: number
+): WorkspaceEventActivationTaskPayload {
+  return {
+    organizationId,
+    eventId,
+    rootEventIds: [eventId],
+    causalAutomationIds: [],
+    depth: 1,
+  };
+}
+
+describe('workspace events with no producing Automation', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('activates a subscriber named by the stamped <subject>.<op> type', async () => {
+    const sql = getTestDb();
+    // The second Automation subscribes to a sibling op. It exists to prove the
+    // GIN needle narrows rather than matching every dotted subscriber.
+    const { workspace, automationIds } = await subscriberOrg([
+      ['device.online'],
+      ['device.offline'],
+    ]);
+    const [onlineConsumer] = automationIds;
+
+    const event = await insertConnectionlessAuditEvent(
+      {
+        organizationId: workspace.org.id,
+        entityIds: [],
+        originId: 'device:root-worker:online',
+        semanticType: 'change',
+        title: 'Device came online',
+        content: 'A device worker started reporting.',
+        metadata: { category: 'device', worker_id: 'root-worker' },
+      },
+      { subject: 'device', op: 'online' }
+    );
+
+    // The writer stamped it and left `automation_id` null: this row is a root.
+    const stored = await sql<{
+      automation_id: number | null;
+      event_type: string | null;
+    }>`
+      SELECT automation_id, metadata->>'_lobu_event_type' AS event_type
+      FROM events WHERE id = ${event.id}
+    `;
+    expect(stored[0]).toEqual({
+      automation_id: null,
+      event_type: 'device.online',
+    });
+
+    await expect(
+      activateWorkspaceEventTask(rootPayload(workspace.org.id, event.id), sql)
+    ).resolves.toMatchObject({
+      matched: 1,
+      queued: 1,
+      invalidCausalPath: false,
+    });
+
+    const runs = await sql<{
+      automation_id: number;
+      approved_input: Record<string, unknown>;
+    }>`
+      SELECT automation_id, approved_input
+      FROM runs
+      WHERE run_type = 'automation'
+        AND organization_id = ${workspace.org.id}
+    `;
+    expect(runs.map((row) => Number(row.automation_id))).toEqual([
+      onlineConsumer,
+    ]);
+    expect(runs[0]?.approved_input).toMatchObject({
+      delivery_ids: [`workspace-event:${event.id}`],
+      trigger_signal: {
+        kind: 'event',
+        source: 'workspace',
+        event_id: event.id,
+        // The specific name, not the `change` semantic type every audit row
+        // shares — otherwise the consumer cannot tell what happened.
+        event_type: 'device.online',
+        causal_automation_ids: [],
+        depth: 1,
+      },
+    });
+  });
+
+  it('also activates a subscriber named by the raw semantic type', async () => {
+    const sql = getTestDb();
+    const { workspace, automationIds } = await subscriberOrg([['change']]);
+
+    const event = await insertConnectionlessAuditEvent(
+      {
+        organizationId: workspace.org.id,
+        entityIds: [],
+        originId: 'connection:root-conn:deleted',
+        semanticType: 'change',
+        title: 'Connection deleted',
+        content: 'A connection was removed.',
+        metadata: { category: 'connection' },
+      },
+      { subject: 'connection', op: 'deleted' }
+    );
+
+    // Both arms of the needle have to fire: stamping a specific type must not
+    // silently unsubscribe an Automation already listening to `change`.
+    await expect(
+      activateWorkspaceEventTask(rootPayload(workspace.org.id, event.id), sql)
+    ).resolves.toMatchObject({ matched: 1, queued: 1 });
+    const runs = await sql<{ automation_id: number }>`
+      SELECT automation_id FROM runs
+      WHERE run_type = 'automation' AND organization_id = ${workspace.org.id}
+    `;
+    expect(runs.map((row) => Number(row.automation_id))).toEqual(automationIds);
+  });
+
+  it('terminates a root that arrives claiming ancestry', async () => {
+    const sql = getTestDb();
+    const { workspace, automationIds } = await subscriberOrg([['device.online']]);
+
+    const event = await insertConnectionlessAuditEvent(
+      {
+        organizationId: workspace.org.id,
+        entityIds: [],
+        originId: 'device:forged-worker:online',
+        semanticType: 'change',
+        title: 'Device came online',
+        content: 'A device worker started reporting.',
+        metadata: {},
+      },
+      { subject: 'device', op: 'online' }
+    );
+
+    // Nothing ran before a root, so a non-empty causal path is incoherent.
+    // Honoring it would let the payload name the subscriber as its own
+    // ancestor, which the matcher reads as "already ran" and skips.
+    await expect(
+      activateWorkspaceEventTask(
+        {
+          ...rootPayload(workspace.org.id, event.id),
+          causalAutomationIds: automationIds,
+        },
+        sql
+      )
+    ).resolves.toMatchObject({
+      matched: 0,
+      queued: 0,
+      invalidCausalPath: true,
+    });
+    expect(
+      await sql`
+        SELECT id FROM runs
+        WHERE run_type = 'automation' AND organization_id = ${workspace.org.id}
+      `
+    ).toHaveLength(0);
+  });
+
+  it('loads a producerless event that carries no stamp', async () => {
+    const sql = getTestDb();
+    const { workspace } = await subscriberOrg([['observation']]);
+
+    // Not every producerless row is an audit row. This one predates the stamp
+    // in shape, and must still load and match on its semantic type rather than
+    // throwing the way `loadWorkspaceEvent` used to.
+    const event = await insertEvent({
+      organizationId: workspace.org.id,
+      entityIds: [],
+      originId: 'unstamped-producerless-observation',
+      semanticType: 'observation',
+      content: 'An observation with no producing Automation.',
+    });
+
+    await expect(
+      activateWorkspaceEventTask(rootPayload(workspace.org.id, event.id), sql)
+    ).resolves.toMatchObject({ matched: 1, queued: 1 });
+  });
+
+  it('still requires a produced event to name its producer', async () => {
+    const sql = getTestDb();
+    const { workspace, automationIds } = await subscriberOrg([['observation']]);
+    const [consumerId] = automationIds;
+
+    const event = await insertEvent({
+      organizationId: workspace.org.id,
+      entityIds: [],
+      originId: 'produced-observation',
+      semanticType: 'observation',
+      content: 'An observation a different Automation produced.',
+      automationId: consumerId,
+    });
+
+    // Relaxing the root gate must not relax this one: an event that DOES have
+    // a producer still has to carry that producer in its causal path, or the
+    // loop bound is unenforceable.
+    await expect(
+      activateWorkspaceEventTask(rootPayload(workspace.org.id, event.id), sql)
+    ).resolves.toMatchObject({
+      matched: 0,
+      queued: 0,
+      invalidCausalPath: true,
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/events/audit-event-type-stamp.test.ts
+++ b/packages/server/src/__tests__/integration/events/audit-event-type-stamp.test.ts
@@ -18,10 +18,8 @@
 
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
-import {
-  formatAuditEventType,
-  insertConnectionlessAuditEvent,
-} from '../../../utils/insert-event';
+import { formatAuditEventType } from '../../../utils/audit-event-type';
+import { insertConnectionlessAuditEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import { createTestOrganization } from '../../setup/test-fixtures';
 

--- a/packages/server/src/__tests__/unit/automation-event-trigger.test.ts
+++ b/packages/server/src/__tests__/unit/automation-event-trigger.test.ts
@@ -312,6 +312,7 @@ describe('automation event trigger matching', () => {
     };
     const event = {
       semanticType: 'risk_detected',
+      auditEventType: null,
       entityTypeSlugs: ['account'],
       metadata: { severity: 'high', reviewed: false, score: 92 },
     };
@@ -326,6 +327,78 @@ describe('automation event trigger matching', () => {
       matchesWorkspaceEventTrigger(trigger, {
         ...event,
         metadata: { ...event.metadata, severity: 'low' },
+      })
+    ).toBe(false);
+  });
+
+  test('matches platform audit rows by stamped type or by semantic type', () => {
+    // Every audit row shares the `change` semantic type, so the stamp is the
+    // only way to name one kind of change. Both names must work: dropping the
+    // semantic arm would silently unsubscribe anyone already listening to
+    // `change`, and dropping the stamped arm is the whole point of the stamp.
+    const auditRow = {
+      semanticType: 'change',
+      auditEventType: 'device.online',
+      entityTypeSlugs: [] as string[],
+      metadata: {},
+    };
+    const bySubject = {
+      kind: 'event',
+      source: 'workspace',
+      event_types: ['device.online'],
+    } satisfies AutomationWorkspaceEventTrigger;
+    const bySemanticType = {
+      kind: 'event',
+      source: 'workspace',
+      event_types: ['change'],
+    } satisfies AutomationWorkspaceEventTrigger;
+    expect(matchesWorkspaceEventTrigger(bySubject, auditRow)).toBe(true);
+    expect(matchesWorkspaceEventTrigger(bySemanticType, auditRow)).toBe(true);
+    expect(
+      matchesWorkspaceEventTrigger(
+        {
+          kind: 'event',
+          source: 'workspace',
+          event_types: ['device.offline'],
+        },
+        auditRow
+      )
+    ).toBe(false);
+    // A plain Automation output carries no stamp, so a `<subject>.<op>`
+    // subscription must not pick it up on the semantic arm alone.
+    expect(
+      matchesWorkspaceEventTrigger(bySubject, {
+        ...auditRow,
+        auditEventType: null,
+      })
+    ).toBe(false);
+  });
+
+  test('an audit row still honors entity-type and metadata narrowing', () => {
+    const trigger: AutomationWorkspaceEventTrigger = {
+      kind: 'event',
+      source: 'workspace',
+      entity_type: 'account',
+      event_types: ['entity.updated'],
+      match: { field: 'owner' },
+    };
+    const event = {
+      semanticType: 'change',
+      auditEventType: 'entity.updated',
+      entityTypeSlugs: ['account'],
+      metadata: { field: 'owner' },
+    };
+    expect(matchesWorkspaceEventTrigger(trigger, event)).toBe(true);
+    expect(
+      matchesWorkspaceEventTrigger(trigger, {
+        ...event,
+        entityTypeSlugs: ['contact'],
+      })
+    ).toBe(false);
+    expect(
+      matchesWorkspaceEventTrigger(trigger, {
+        ...event,
+        metadata: { field: 'stage' },
       })
     ).toBe(false);
   });

--- a/packages/server/src/automations/workspace-event.ts
+++ b/packages/server/src/automations/workspace-event.ts
@@ -10,6 +10,7 @@ import { createAutomationEventRun } from '../runs/queue-service';
 import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../scheduled/task-definitions';
 import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
 import { resolveAutomationExecutor } from '../tools/admin/manage_automations/executors';
+import { readAuditEventType } from '../utils/audit-event-type';
 import logger from '../utils/logger';
 import { dispatchAutomationRunsBestEffort } from './activation';
 import {
@@ -25,11 +26,24 @@ import {
 interface WorkspaceEventRecord {
   id: number;
   semanticType: string;
+  /**
+   * The stamped `<subject>.<op>` type for a platform-written audit row, or
+   * null for an Automation output. Carried alongside `semanticType` rather
+   * than collapsed into it because a subscription may legitimately name
+   * either: audit rows all share the `change` semantic type, so the stamp is
+   * the only way to subscribe to one kind of change without the rest.
+   */
+  auditEventType: string | null;
   metadata: Record<string, unknown>;
   entityIds: number[];
   entityTypeSlugs: string[];
   occurredAt: string;
-  producerAutomationId: number;
+  /**
+   * The Automation that produced this event, or null for a root — an event the
+   * platform itself wrote (a device coming online, a connection deleted) with
+   * no Automation upstream of it.
+   */
+  producerAutomationId: number | null;
 }
 
 interface MatchingWorkspaceEventActivation {
@@ -108,14 +122,33 @@ export async function enqueueWorkspaceEventActivations(
   );
 }
 
+/**
+ * The type names a subscription may use for this event, most specific first.
+ *
+ * An Automation output is nameable only by its semantic type. A platform-written
+ * audit row is additionally nameable by its stamped `<subject>.<op>` type, which
+ * is what makes `device.online` subscribable without also matching every other
+ * row whose semantic type is `change`.
+ */
+function subscribableEventTypes(
+  event: Pick<WorkspaceEventRecord, 'semanticType' | 'auditEventType'>
+): string[] {
+  return event.auditEventType == null
+    ? [event.semanticType]
+    : [event.auditEventType, event.semanticType];
+}
+
 export function matchesWorkspaceEventTrigger(
   trigger: AutomationWorkspaceEventTrigger,
   event: Pick<
     WorkspaceEventRecord,
-    'semanticType' | 'metadata' | 'entityTypeSlugs'
+    'semanticType' | 'auditEventType' | 'metadata' | 'entityTypeSlugs'
   >
 ): boolean {
-  if (!trigger.event_types.includes(event.semanticType)) return false;
+  const namesThisEvent = subscribableEventTypes(event).some((eventType) =>
+    trigger.event_types.includes(eventType)
+  );
+  if (!namesThisEvent) return false;
   if (
     trigger.entity_type !== undefined &&
     !event.entityTypeSlugs.includes(trigger.entity_type)
@@ -160,11 +193,6 @@ async function loadWorkspaceEvent(
     if (lineage[0]?.superseded_by != null) return null;
     throw new Error(`Workspace event ${eventId} was not found`);
   }
-  if (row.automation_id == null) {
-    throw new Error(
-      `Workspace event ${eventId} is not a declared Automation output`
-    );
-  }
   const entityIds = parsePgNumberArray(row.entity_ids);
   const entityTypes =
     entityIds.length > 0
@@ -179,15 +207,18 @@ async function loadWorkspaceEvent(
         ORDER BY et.slug
       `
       : [];
+  const metadata =
+    row.metadata && typeof row.metadata === 'object' ? row.metadata : {};
   return {
     id: Number(row.id),
     semanticType: String(row.semantic_type),
-    metadata:
-      row.metadata && typeof row.metadata === 'object' ? row.metadata : {},
+    auditEventType: readAuditEventType(metadata),
+    metadata,
     entityIds,
     entityTypeSlugs: entityTypes.map((item) => String(item.slug)),
     occurredAt: new Date(row.occurred_at).toISOString(),
-    producerAutomationId: Number(row.automation_id),
+    producerAutomationId:
+      row.automation_id == null ? null : Number(row.automation_id),
   };
 }
 
@@ -200,13 +231,27 @@ async function findMatchingWorkspaceEventActivations(
   matches: MatchingWorkspaceEventActivation[];
   fanoutLimited: boolean;
 }> {
-  const needle = [
+  // Coarse GIN needle, narrowed precisely by `matchesWorkspaceEventTrigger`
+  // below. An audit row is subscribable under two names, and containment
+  // cannot express a disjunction, so each name gets its own arm — the same
+  // shape `findMatchingAutomationActivations` uses for connector triggers.
+  // One arm alone would be wrong in both directions: the audit arm misses
+  // Automations subscribed to the raw semantic type, and the semantic arm
+  // misses every `<subject>.<op>` subscriber.
+  const needle = (eventType: string) => [
     {
       kind: 'event',
       source: 'workspace',
-      event_types: [signal.event_type],
+      event_types: [eventType],
     },
   ];
+  const triggerFilter =
+    event.auditEventType == null
+      ? db`w.triggers @> ${db.json(needle(event.semanticType))}::jsonb`
+      : db`(
+          w.triggers @> ${db.json(needle(event.auditEventType))}::jsonb
+          OR w.triggers @> ${db.json(needle(event.semanticType))}::jsonb
+        )`;
   const rows = await db`
     SELECT w.id, w.organization_id, w.agent_id, w.entity_ids,
            w.device_worker_id::text AS device_worker_id,
@@ -216,7 +261,7 @@ async function findMatchingWorkspaceEventActivations(
       AND w.status = 'active'
       AND w.current_version_id IS NOT NULL
       AND (w.agent_id IS NOT NULL OR w.device_worker_id IS NOT NULL)
-      AND w.triggers @> ${db.json(needle)}::jsonb
+      AND ${triggerFilter}
     ORDER BY w.id ASC
   `;
 
@@ -308,7 +353,16 @@ export async function activateWorkspaceEventTask(
     );
     return EMPTY_WORKSPACE_EVENT_ACTIVATION_RESULT;
   }
-  if (!causalAutomationIds.includes(event.producerAutomationId)) {
+  // A root carries no ancestry by construction: nothing ran before it. Demand
+  // that literally rather than skipping the check, because ancestry is what
+  // suppresses re-entry — a payload that pairs a producerless event with a
+  // non-empty path is either corrupt or an attempt to silence an Automation by
+  // naming it as its own ancestor, and neither should activate anything.
+  const producerMatchesCausalPath =
+    event.producerAutomationId == null
+      ? causalAutomationIds.length === 0
+      : causalAutomationIds.includes(event.producerAutomationId);
+  if (!producerMatchesCausalPath) {
     logger.error(
       {
         eventId: payload.eventId,
@@ -347,7 +401,7 @@ export async function activateWorkspaceEventTask(
     kind: 'event',
     source: 'workspace',
     event_id: event.id,
-    event_type: event.semanticType,
+    event_type: event.auditEventType ?? event.semanticType,
     delivery_id: `workspace-event:${event.id}`,
     occurred_at: event.occurredAt,
     root_event_ids: payload.rootEventIds,

--- a/packages/server/src/utils/audit-event-type.ts
+++ b/packages/server/src/utils/audit-event-type.ts
@@ -1,0 +1,53 @@
+/**
+ * The audit/lifecycle event vocabulary, in one dependency-free module.
+ *
+ * Both ends of the seam need it: `insert-event.ts` stamps the type at write
+ * time and `automations/workspace-event.ts` reads it back at match time.
+ * Keeping the key and its codec here rather than in the writer lets the reader
+ * import them without an import cycle once the writer starts enqueueing
+ * activations.
+ *
+ * Dotted and past-tense to match the event-type vocabulary already in use
+ * (`feed.auto_paused`, `message.created`), NOT the underscored `origin_type`
+ * audit tag, which stays an internal provenance field.
+ */
+
+export interface AuditEventType {
+  /**
+   * The domain object: `device`, `connection`, `entity`, `relationship`, …
+   *
+   * Free-form so a new subject costs no code here. State-change writers pass
+   * their existing `AuditResourceKind` slugs, which are hyphenated and
+   * sometimes compound (`agent-settings`, `auth-profile`) — kept as-is rather
+   * than renamed, since those slugs are already the dashboard's pivot.
+   */
+  subject: string;
+  /** Past-tense transition: `created`, `updated`, `deleted`, `linked`, … */
+  op: string;
+}
+
+/**
+ * Reserved metadata key carrying the formatted type.
+ *
+ * In the server-owned `_lobu_*` namespace, which `save_content` strips from
+ * caller-supplied metadata, so an agent cannot forge a subscription target.
+ */
+export const AUDIT_EVENT_TYPE_METADATA_KEY = '_lobu_event_type';
+
+/** `{subject:'device', op:'created'}` -> `'device.created'`. */
+export function formatAuditEventType(type: AuditEventType): string {
+  return `${type.subject}.${type.op}`;
+}
+
+/**
+ * The stamped type on a persisted row, or null when the row is not an audit
+ * event. Non-string and empty values read as absent rather than throwing: the
+ * events table is append-only, so rows predating the stamp are permanent and
+ * must stay loadable.
+ */
+export function readAuditEventType(
+  metadata: Record<string, unknown> | null | undefined
+): string | null {
+  const value = metadata?.[AUDIT_EVENT_TYPE_METADATA_KEY];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -8,6 +8,11 @@
 import { retryWithBackoff } from '@lobu/core';
 import { type DbClient, getDb } from '../db/client';
 import {
+  AUDIT_EVENT_TYPE_METADATA_KEY,
+  type AuditEventType,
+  formatAuditEventType,
+} from './audit-event-type';
+import {
   type AuditResourceKind,
   type ConfigResourceKind,
   redactConfigState,
@@ -690,39 +695,6 @@ interface ChangeEventParams {
   clientId?: string | null;
 }
 
-/**
- * What happened, as one `<subject>.<op>` pair — the single vocabulary every
- * audit writer speaks.
- *
- * Required by the funnel rather than optional so a new writer cannot introduce
- * an untyped audit row by omission: leaving it out is a compile error, not a
- * silently unclassifiable event. The four `record*` helpers below each supply
- * it from data they already hold, so adding a new event type costs no code
- * here — pass a new `subject`.
- *
- * Dotted and past-tense to match the event-type vocabulary already in use
- * (`feed.auto_paused`, `message.created`), NOT the underscored `origin_type`
- * audit tag, which stays an internal provenance field.
- */
-export interface AuditEventType {
-  /**
-   * The domain object: `device`, `connection`, `entity`, `relationship`, …
-   *
-   * Free-form so a new subject costs no code here. State-change writers pass
-   * their existing `AuditResourceKind` slugs, which are hyphenated and
-   * sometimes compound (`agent-settings`, `auth-profile`) — kept as-is rather
-   * than renamed, since those slugs are already the dashboard's pivot.
-   */
-  subject: string;
-  /** Past-tense transition: `created`, `updated`, `deleted`, `linked`, … */
-  op: string;
-}
-
-/** `{subject:'device', op:'created'}` -> `'device.created'`. */
-export function formatAuditEventType(type: AuditEventType): string {
-  return `${type.subject}.${type.op}`;
-}
-
 const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
 
 /**
@@ -734,6 +706,12 @@ const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
  * `_lobu_idempotency_key` (unique per org via `idx_events_org_idempotency_key`)
  * so a concurrent or retry insert after an ambiguous success resolves to the
  * winner instead of appending a duplicate.
+ *
+ * `eventType` is required rather than optional so a new writer cannot introduce
+ * an untyped audit row by omission: leaving it out is a compile error, not a
+ * silently unclassifiable event. The `record*` helpers below each supply it
+ * from data they already hold, so adding a new event type costs no code here —
+ * pass a new `subject`.
  */
 export async function insertConnectionlessAuditEvent(
   params: InsertEventParams,
@@ -743,7 +721,7 @@ export async function insertConnectionlessAuditEvent(
   const metadata: Record<string, unknown> = {
     ...(params.metadata ?? {}),
     _lobu_idempotency_key: idempotencyKey,
-    _lobu_event_type: formatAuditEventType(eventType),
+    [AUDIT_EVENT_TYPE_METADATA_KEY]: formatAuditEventType(eventType),
   };
 
   try {


### PR DESCRIPTION
## Summary

- A workspace event could only reach a subscriber if an Automation produced it — `loadWorkspaceEvent` threw on any row whose `automation_id` was null. Everything the platform writes itself (device online, connection deleted, entity updated) was unsubscribable by construction, though the rows have existed all along.
- Roots now load, with an empty-ancestry invariant in place of the throw: nothing ran before a root, so a non-empty causal path is incoherent, and honoring a forged one would let a payload name a subscriber as its own ancestor to silence it. An event that *does* have a producer still has to name it.
- The matcher and GIN needle learn `_lobu_event_type` (stamped in #2931). Every audit row shares the `change` semantic type, so the stamp is the only way to subscribe to one kind of change without the rest. Both names resolve via two OR'd containment arms — the shape `findMatchingAutomationActivations` already uses for connector triggers.

**Inert in production.** Nothing enqueues roots yet, so no new activation can fire.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates: build, strict typecheck, knip, biome, naming, gateway-LLM, entity-write funnel)
- [x] Tests run: targeted `bunx vitest run` + `bun test`
- [ ] Bug fix: red→fix→green outputs pasted below — n/a, this is a capability change, not a bug fix
- [ ] If bot runtime changed: n/a

```
# new + changed suites
✓ workspace-event-roots.test.ts (5 tests)
✓ audit-event-type-stamp.test.ts (4 tests)
  Tests  9 passed (9)

# full regression over the affected areas
bunx vitest run src/__tests__/integration/automations/ src/__tests__/integration/events/
  Test Files  81 passed (81)
       Tests  547 passed (547)

# matcher unit tests
bun test src/__tests__/unit/automation-event-trigger.test.ts
  18 pass  0 fail
```

### Mutation testing

Each production change was reverted individually to confirm the tests fail for the reason claimed, not incidentally:

| mutation | result |
|---|---|
| matcher ignores the stamped type | 1 failed — stamped-arm test |
| root invariant removed (producerless skips the check) | 1 failed — forged-ancestry test |
| signal carries the semantic type, not the stamped one | 1 failed — `event_type` assertion |
| needle keeps only the stamped arm | 1 failed — semantic-arm test |
| restore the producer-required throw | 4 failed — the expected blast radius |

Also confirmed the two unit assertions fail under the first mutation (18 pass → 16 pass, 2 fail).

## Notes

Tests drive the real writer (`insertConnectionlessAuditEvent`) against Postgres rather than hand-building rows, so a regression in how the type is stamped fails here too.

The `<subject>.<op>` vocabulary moves out of `insert-event.ts` into `utils/audit-event-type.ts`: writer and reader both need it, and the reader would otherwise close an import cycle once the writer enqueues.

**Known follow-up, deliberately out of scope.** Subscribing to a platform event type is still gated by `assertAutomationTriggerConnections`, which requires the type to appear in the union of `entity_types.event_kinds`. Platform events have no declaring entity type, so `device.online` is unsubscribable *at the subscription surface* even though the activation path now handles it end to end — the tests declare the types explicitly to isolate what is under test. Owletto's trigger picker (`automation-trigger-editor.tsx:83`) reads that same catalog, so whatever closes the gap fixes validation and discovery together. That is an API-surface decision and needs sign-off before it is built.
