### PR TITLE
fix(ci): exempt the vendored Barman Cloud manifests from the naming gate

### DIFF
--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -483,6 +483,8 @@ const CANONICAL_SCAN_EXCLUSIONS = new Set([
   // Vendored/generated Kubernetes API descriptions use generic standards prose.
   "packages/owletto/deploy/k8s/infrastructure/cert-manager/cert-manager.yaml",
   "packages/owletto/deploy/k8s/clusters/buremba-prod/cert-manager.yaml",
+  "packages/owletto/deploy/k8s/infrastructure/barman-plugin/manifest.yaml",
+  "packages/owletto/deploy/k8s/clusters/lobu-prod/barman-plugin.yaml",
 ]);
 
 function isCanonicalScanException(file: string): boolean {


### PR DESCRIPTION
## Problem

owletto#898/#899 vendored the CloudNativePG **Barman Cloud plugin** CRD manifests. Their generated API documentation uses "behavior" in the ordinary English sense:

```
manifest.yaml:40: Specification of the desired behavior of the ObjectStore.
manifest.yaml:132: a specific timeout or defining custom behavior, users can use this field
```

The exposed-surface naming gate reads that as retired product vocabulary — 10 occurrences across two files, none of them ours to rename.

This blocks **every** Owletto pointer bump past `9b75dfc3`, not just one PR. Hit first on #2925:

```
check-exposed-surface-naming: retired watcher/Behavior vocabulary is banned
from the live repository. Found 10 occurrence(s):
  packages/owletto/deploy/k8s/clusters/lobu-prod/barman-plugin.yaml:14
  packages/owletto/deploy/k8s/infrastructure/barman-plugin/manifest.yaml:40
  ...
```

`migrations` also reported red there, but only as a gate on this job (`FORMAT_LINT_RESULT: failure`) — one cause, two red checks.

## Change

Two exact paths added to `CANONICAL_SCAN_EXCLUSIONS`, directly below the cert-manager entries that exist for the identical reason:

```ts
// Vendored/generated Kubernetes API descriptions use generic standards prose.
"packages/owletto/deploy/k8s/infrastructure/cert-manager/cert-manager.yaml",
"packages/owletto/deploy/k8s/clusters/buremba-prod/cert-manager.yaml",
"packages/owletto/deploy/k8s/infrastructure/barman-plugin/manifest.yaml",
"packages/owletto/deploy/k8s/clusters/lobu-prod/barman-plugin.yaml",
```

Exact paths, not a `deploy/` prefix: the gate should keep failing closed for anything we actually author there. The gate's own scope statement already says generated third-party material is exempt — this is that, and only that.

## Verification

With the Owletto pin at `7988913d` (which contains the vendored manifests):

```
$ bun scripts/check-exposed-surface-naming.ts
check-exposed-surface-naming: clean — Automation is canonical across live tracked files.
exit=0
```

Mutation-tested — dropping the manifest exemption fails again, so the entry is doing the work:

```
check-exposed-surface-naming: retired watcher/Behavior vocabulary is banned from the live repository. Found 9 occurrence(s):
  packages/owletto/deploy/k8s/infrastructure/barman-plugin/manifest.yaml:40: Specification of the desired behavior of the ObjectStore.
```