### PR TITLE
feat(connectors): read device-backed virtual feeds live, retaining nothing

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/device-virtual-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/device-virtual-feed-read.test.ts
@@ -1,0 +1,1214 @@
+/**
+ * Device-backed virtual-feed live read — end to end.
+ *
+ * `whatsapp.local` is a metadata-only device manifest: there is no compiled
+ * connector on the server, so the `query()`/`search()` pushdown that serves
+ * every other virtual feed cannot serve this one. The read is dispatched to the
+ * paired Mac over the existing device action queue and awaited there.
+ *
+ * What each case pins:
+ *
+ *   (a) ROUTING — a `runtime`-bearing connector takes the device path, and the
+ *       reserved `__lobu_virtual_feed_read` run is claimed by the pinned device
+ *       through the ordinary `/api/workers/poll`, carrying the caller's terms
+ *       and window. Rows come back through `/api/workers/complete-action`.
+ *   (b) NO RETENTION — a live read writes no events and no checkpoint, and the
+ *       run row that carried the rows is scrubbed of BOTH the device's output
+ *       and the caller's recall terms. The rows transit Postgres (that is the
+ *       cross-replica transport); they must not stay there.
+ *   (c) The scrub survives every exit: device failure, a malformed device
+ *       reply, and an exception thrown by the waiter itself.
+ *   (d) OFFLINE — a read against a device that has stopped polling fails fast
+ *       with a diagnosis, without parking a run for the 60s queue budget.
+ */
+
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { AuthzScope } from '../../../authz/scope';
+
+// The waiter is swapped through a server-internal slot so two cases can make it
+// throw. NOT `vi.mock`: vitest runs this package with `isolate: false` (one
+// shared module graph for the whole Postgres-backed run), and under that
+// setting a module mock only lands if this file is the first to import
+// `connector-pushdown` — these cases passed alone and timed out in a full run.
+const { readVirtualFeed } = await import('../../../lib/connector-pushdown');
+const { readDeviceVirtualFeed, __setDeviceActionWaiterForTest } = await import(
+  '../../../lib/device-virtual-feed'
+);
+const { DEVICE_VIRTUAL_FEED_ACTION_KEY } = await import(
+  '../../../lib/device-virtual-feed-protocol'
+);
+const { pollWorkerJob } = await import('../../../worker-api/poll');
+const { cleanupTestDatabase, getTestDb } = await import('../../setup/test-db');
+const { addUserToOrganization, createTestOrganization, createTestUser } = await import(
+  '../../setup/test-fixtures'
+);
+const { post } = await import('../../setup/test-helpers');
+
+const CONNECTOR_KEY = 'whatsapp.local';
+const CONNECTOR_VERSION = '0.3.0';
+const FEED_KEY = 'messages_live';
+const WORKER_ID = 'wk-wa-virtual';
+
+const DEVICE_ROWS = [
+  {
+    id: 'wa-1',
+    occurred_at: '2026-08-18T09:00:00.000Z',
+    text: 'invoice 4471 is overdue',
+    chat_jid: '15551230000@s.whatsapp.net',
+    chat_name: 'Dana Ruiz',
+    is_group: false,
+    from_me: false,
+    sender_phone: '15551230000',
+  },
+];
+const DEVICE_COLUMNS = [
+  { name: 'id', type: 'text' },
+  { name: 'occurred_at', type: 'timestamptz' },
+  { name: 'text', type: 'text' },
+];
+
+let orgId: string;
+let userId: string;
+let deviceWorkerId: string;
+let connectionId: number;
+let feedId: number;
+
+const scope = (): AuthzScope => ({ organizationId: orgId, principal: userId });
+
+async function setDeviceLastSeen(interval: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    UPDATE device_workers SET last_seen_at = now() - ${interval}::interval
+    WHERE id = ${deviceWorkerId}::uuid
+  `;
+}
+
+async function setDeviceCapabilities(capabilities: string[]): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    UPDATE device_workers SET capabilities = ${sql.json(capabilities)}
+    WHERE id = ${deviceWorkerId}::uuid
+  `;
+}
+
+/** Rows the org has ever persisted from this connection, by any path. */
+async function countPersistence(): Promise<{ events: number; checkpointed: number }> {
+  const sql = getTestDb();
+  const [events] = (await sql`
+    SELECT count(*)::int AS n FROM events WHERE organization_id = ${orgId}
+  `) as Array<{ n: number }>;
+  const [checkpointed] = (await sql`
+    SELECT count(*)::int AS n FROM feeds
+    WHERE id = ${feedId} AND (checkpoint IS NOT NULL OR next_run_at IS NOT NULL)
+  `) as Array<{ n: number }>;
+  return { events: events.n, checkpointed: checkpointed.n };
+}
+
+async function readRunRows(): Promise<
+  Array<{ id: number; status: string; action_key: string; action_input: unknown; action_output: unknown }>
+> {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, status, action_key, action_input, action_output
+    FROM runs
+    WHERE organization_id = ${orgId} AND run_type = 'action'
+    ORDER BY id
+  `) as Array<{
+    id: number;
+    status: string;
+    action_key: string;
+    action_input: unknown;
+    action_output: unknown;
+  }>;
+}
+
+/**
+ * Stand in for the Mac app: poll until the reserved live-read run is handed
+ * over, then answer it. Uses the real worker endpoints, so this also proves
+ * poll.ts routes a `run_type='action'` row on a device-pinned connection to the
+ * device that owns the pin.
+ */
+async function respondAsDevice(
+  reply: { status: 'success'; action_output: Record<string, unknown> } | { status: 'failed'; error_message: string }
+): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const response = await post('/api/workers/poll', {
+      body: {
+        worker_id: WORKER_ID,
+        platform: 'macos',
+        app_version: '9.9.0',
+        label: 'Test Mac',
+        capabilities: { whatsapp_local: true },
+      },
+    });
+    expect(response.status).toBe(200);
+    const job = await response.json();
+    if (job?.run_id && job?.operation_key === DEVICE_VIRTUAL_FEED_ACTION_KEY) {
+      const completion = await post('/api/workers/complete-action', {
+        body: { run_id: job.run_id, worker_id: WORKER_ID, ...reply },
+      });
+      expect(completion.status).toBe(200);
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('device never received the virtual-feed read job');
+}
+
+describe('device-backed virtual feed read', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'WA Live' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'wa-live@test.com' });
+    userId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const sql = getTestDb();
+    // Anonymous local device polls adopt the personal-org owner; mark this org
+    // as that user's personal org so the poll resolves to them.
+    await sql`
+      UPDATE "organization"
+      SET metadata = ${sql.json({ personal_org_for_user_id: userId })}
+      WHERE id = ${orgId}
+    `;
+    const device = (await sql`
+      INSERT INTO device_workers
+        (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+      VALUES (${userId}, ${WORKER_ID}, 'macos', '9.9.0',
+              ${sql.json(['whatsapp_local'])}, 'Test Mac', ${orgId})
+      RETURNING id
+    `) as Array<{ id: string }>;
+    deviceWorkerId = device[0].id;
+
+    // A device-manifest connector: `runtime` set, NO compiled code. That is the
+    // whole reason the compiled pushdown cannot serve it.
+    await sql`
+      INSERT INTO connector_definitions
+        (key, name, version, organization_id, status, runtime, required_capability,
+         feeds_schema, auth_schema, created_at, updated_at)
+      VALUES (${CONNECTOR_KEY}, 'WhatsApp (this Mac)', ${CONNECTOR_VERSION}, ${orgId}, 'active',
+              ${sql.json({ platforms: ['macos'] })}, 'whatsapp_local',
+              ${sql.json({ [FEED_KEY]: { key: FEED_KEY, virtual: true } })},
+              ${sql.json({ methods: [{ type: 'none' }] })}, NOW(), NOW())
+    `;
+    await sql`
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+    `;
+    const connection = (await sql`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, visibility,
+         device_worker_id, created_by, created_at, updated_at)
+      VALUES (${orgId}, ${CONNECTOR_KEY}, 'whatsapp-local', 'WhatsApp (this Mac)', 'active', 'private',
+              ${deviceWorkerId}::uuid, ${userId}, NOW(), NOW())
+      RETURNING id
+    `) as Array<{ id: number }>;
+    connectionId = connection[0].id;
+    const feed = (await sql`
+      INSERT INTO feeds
+        (organization_id, connection_id, feed_key, display_name, status, config,
+         kind, virtual, next_run_at)
+      VALUES (${orgId}, ${connectionId}, ${FEED_KEY}, 'Messages (live)', 'active',
+              ${sql.json({ recall: true, chat_filter: 'all' })}, 'virtual', true, NULL)
+      RETURNING id
+    `) as Array<{ id: number }>;
+    feedId = feed[0].id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    __setDeviceActionWaiterForTest(null);
+    await setDeviceLastSeen('5 seconds');
+    await setDeviceCapabilities(['whatsapp_local']);
+    await getTestDb()`DELETE FROM runs WHERE organization_id = ${orgId}`;
+  });
+
+  it('dispatches to the paired device, returns live rows, and retains nothing', async () => {
+    const reading = readVirtualFeed({
+      scope: scope(),
+      feedId,
+      terms: ['invoice'],
+      limit: 25,
+      offset: 5,
+    });
+    const job = await respondAsDevice({
+      status: 'success',
+      action_output: { rows: DEVICE_ROWS, columns: DEVICE_COLUMNS },
+    });
+
+    // (a) The device was handed the caller's intent, not a bare "read the feed".
+    expect(job.connector_key).toBe(CONNECTOR_KEY);
+    expect(job.action_input).toMatchObject({
+      feed_key: FEED_KEY,
+      terms: ['invoice'],
+      limit: 25,
+      offset: 5,
+    });
+    // Feed config rides along so the device can apply the declared filters.
+    expect((job.action_input as { config: Record<string, unknown> }).config).toMatchObject({
+      chat_filter: 'all',
+    });
+
+    const live = await reading;
+    expect(live.rows).toEqual(DEVICE_ROWS);
+    expect(live.columns).toEqual(DEVICE_COLUMNS);
+
+    // (b) Nothing persisted: no events, no checkpoint, no due time — and the
+    // transport row no longer holds the messages or the search terms.
+    expect(await countPersistence()).toEqual({ events: 0, checkpointed: 0 });
+    const runs = await readRunRows();
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('completed');
+    expect(runs[0].action_key).toBe(DEVICE_VIRTUAL_FEED_ACTION_KEY);
+    expect(runs[0].action_output).toBeNull();
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(runs[0])).not.toContain('invoice 4471');
+    expect(JSON.stringify(runs[0])).not.toContain('Dana Ruiz');
+  }, 30_000);
+
+  it('surfaces a device-side failure and still scrubs the run', async () => {
+    const reading = readVirtualFeed({ scope: scope(), feedId, terms: ['payslip'] });
+    await respondAsDevice({ status: 'failed', error_message: 'Full Disk Access denied' });
+
+    await expect(reading).rejects.toThrow(/failed on the paired device: Full Disk Access denied/);
+    const runs = await readRunRows();
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(runs[0])).not.toContain('payslip');
+  }, 30_000);
+
+  it('rejects a malformed device reply rather than reporting an empty result', async () => {
+    const reading = readVirtualFeed({ scope: scope(), feedId });
+    await respondAsDevice({ status: 'success', action_output: { unexpected: true } });
+
+    await expect(reading).rejects.toThrow(/malformed/);
+    const runs = await readRunRows();
+    expect(runs[0].action_output).toBeNull();
+  }, 30_000);
+
+  // The scrub lives in a `finally` that wraps the WAIT, not just its result:
+  // a DB error inside the poll loop throws, and without this the run row would
+  // keep the caller's terms (and any rows a device had already posted).
+  it('scrubs the run even when the waiter itself throws', async () => {
+    __setDeviceActionWaiterForTest(async () => {
+      throw new Error('connection terminated unexpectedly');
+    });
+    await expect(
+      readVirtualFeed({ scope: scope(), feedId, terms: ['mortgage'] })
+    ).rejects.toThrow(/connection terminated unexpectedly/);
+
+    const runs = await readRunRows();
+    expect(runs).toHaveLength(1);
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(runs[0])).not.toContain('mortgage');
+  });
+
+  // Blanking the payload is not enough on the throw path: the run is still
+  // `pending`, its claim horizon has not expired, and a device that polls a
+  // moment later would claim it and POST a fresh page of messages straight back
+  // into the row we just cleared. Closing the run in the same statement is what
+  // makes the scrub final.
+  it('closes an abandoned run so a late device answer cannot repopulate it', async () => {
+    __setDeviceActionWaiterForTest(async () => {
+      throw new Error('connection terminated unexpectedly');
+    });
+    await expect(
+      readVirtualFeed({ scope: scope(), feedId, terms: ['tenancy deposit'] })
+    ).rejects.toThrow(/connection terminated unexpectedly/);
+
+    const [abandoned] = await readRunRows();
+    expect(abandoned.status).toBe('timeout');
+
+    // The device comes back and tries to answer the run it was about to claim.
+    const claim = await post('/api/workers/poll', {
+      body: {
+        worker_id: WORKER_ID,
+        platform: 'macos',
+        app_version: '9.9.0',
+        label: 'Test Mac',
+        capabilities: { whatsapp_local: true },
+      },
+    });
+    expect(claim.status).toBe(200);
+    // A terminal run is not claimable, so the poll hands back no job at all.
+    expect((await claim.json())?.run_id).toBeUndefined();
+
+    // And a completion posted anyway is refused rather than re-filling the row.
+    const late = await post('/api/workers/complete-action', {
+      body: {
+        run_id: abandoned.id,
+        worker_id: WORKER_ID,
+        status: 'success',
+        action_output: { rows: DEVICE_ROWS, columns: DEVICE_COLUMNS },
+      },
+    });
+    expect(await late.json()).toMatchObject({ success: false, reason: 'already_finalized' });
+
+    const [after] = await readRunRows();
+    expect(after.status).toBe('timeout');
+    expect(after.action_output).toBeNull();
+    expect(after.action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(after)).not.toContain('tenancy deposit');
+    expect(JSON.stringify(after)).not.toContain('Dana Ruiz');
+  });
+
+  // The pin is read off a row this caller does not necessarily own end to end,
+  // and the offline diagnosis quotes the device's label and last-poll time. It
+  // must be reached THROUGH the org's own connection, or a corrupt pin reports
+  // another tenant's machine back in an error string.
+  it('never describes a device the org\'s connection does not actually pin', async () => {
+    const sql = getTestDb();
+    const foreign = (await sql`
+      INSERT INTO device_workers
+        (user_id, worker_id, platform, app_version, capabilities, label, organization_id, last_seen_at)
+      VALUES (${userId}, ${'wk-other-tenant'}, 'macos', '9.9.0',
+              ${sql.json(['whatsapp_local'])}, 'Acme Corp Mac', ${'org-someone-else'}, now())
+      RETURNING id
+    `) as Array<{ id: string }>;
+
+    // A pin naming a device this org's connection does not hold: the preflight
+    // reaches the device through the connection, so it finds nothing.
+    const error = await readDeviceVirtualFeed({
+      organizationId: orgId,
+      feedId,
+      feedKey: FEED_KEY,
+      feedConfig: {},
+      connectionId,
+      connectorKey: CONNECTOR_KEY,
+      deviceWorkerId: foreign[0].id,
+      requiredCapability: 'whatsapp_local',
+    }).then(
+      () => new Error('expected the read to be refused'),
+      (err: unknown) => err as Error
+    );
+    expect(error.message).toMatch(/cannot reach/);
+    // And nothing about the other tenant's machine reaches this caller.
+    expect(error.message).not.toContain('Acme Corp Mac');
+    expect(error.message).not.toContain('last polled');
+    expect(await readRunRows()).toHaveLength(0);
+
+    await sql`DELETE FROM device_workers WHERE id = ${foreign[0].id}::uuid`;
+  });
+
+  it('fails fast with a diagnosis when the paired device is offline', async () => {
+    await setDeviceLastSeen('30 minutes');
+    await expect(readVirtualFeed({ scope: scope(), feedId })).rejects.toThrow(
+      /is unavailable: device "Test Mac" is offline \(last polled 30m ago\)/
+    );
+    // No run parked for the 60s queue budget — the server already knew.
+    expect(await readRunRows()).toHaveLength(0);
+  });
+
+  it('fails fast when the device no longer grants the connector capability', async () => {
+    await setDeviceCapabilities([]);
+    await expect(readVirtualFeed({ scope: scope(), feedId })).rejects.toThrow(
+      /no longer grants 'whatsapp_local'/
+    );
+    expect(await readRunRows()).toHaveLength(0);
+  });
+});
+
+/**
+ * Which org an UNPINNED device-backed virtual feed may be served in.
+ *
+ * poll.ts branch 1B gates the unpinned claim on `baseOrgScopeIds` — the worker
+ * token's bound org plus the owner's personal org. At preflight time no token
+ * has been presented, so the bound org is unknowable and only the personal-org
+ * half is derivable. The preflight therefore serves exactly that lane and tells
+ * a shared workspace to pin instead. Widening it to "any org the owner is a
+ * member of" would report servable for runs branch 1B never claims, turning an
+ * instant error into a 60-second queue timeout.
+ *
+ *   (1) PERSONAL org, unpinned, owner's device online — served end to end, even
+ *       though `device_workers.organization_id` still points at a different,
+ *       stale home org. The token here is genuinely user-scoped and bound to
+ *       the personal org, so the real branch-1B SQL is what claims the run.
+ *   (2) TEAM org, unpinned, owned by a mere member — refused with the fix ("pin
+ *       this connection"), and zero runs enqueued.
+ *   (3) That same TEAM connection, once PINNED, is served — the pinned branch
+ *       already reaches through the connection and allows a foreign home org.
+ */
+const PERSONAL_WORKER_ID = 'wk-wa-personal';
+const CAPABILITY = 'whatsapp_local';
+
+const PERSONAL_ROWS = [{ id: 'wa-90', occurred_at: '2026-08-18T09:00:00.000Z', text: 'live row' }];
+const PERSONAL_COLUMNS = [
+  { name: 'id', type: 'text' },
+  { name: 'occurred_at', type: 'timestamptz' },
+  { name: 'text', type: 'text' },
+];
+
+let personalUserId: string;
+let personalOrgId: string;
+let staleHomeOrgId: string;
+let teamOrgId: string;
+let personalDeviceWorkerId: string;
+let personalFeedId: number;
+let teamFeedId: number;
+let teamConnectionId: number;
+
+const scopeIn = (organizationId: string): AuthzScope => ({ organizationId, principal: personalUserId });
+
+/**
+ * The real poll handler behind a stub for the auth middleware ONLY — the shape
+ * device-management-mint.test.ts uses. Everything that decides whether this
+ * device may claim (branch 1B, `baseOrgScopeIds`, the capability allowlist, the
+ * device_workers upsert) is production code.
+ *
+ * `boundOrgId` is what the worker token is bound to, so `workerOrgIds` here is
+ * the genuine [bound org, personal org] pair poll.ts computes from a real
+ * device_worker:run token.
+ */
+function personalDeviceApp(boundOrgId: string): Hono {
+  const app = new Hono();
+  app.post(
+    '/api/workers/poll',
+    async (c, next) => {
+      c.set('workerAuthMode' as never, 'user' as never);
+      c.set('workerUserId' as never, personalUserId as never);
+      c.set(
+        'workerOrgIds' as never,
+        Array.from(new Set([boundOrgId, personalOrgId])) as never
+      );
+      c.set('organizationId' as never, boundOrgId as never);
+      c.set('mcpAuthInfo' as never, { scopes: ['device_worker:run'] } as never);
+      await next();
+    },
+    (c) => pollWorkerJob(c as never)
+  );
+  return app;
+}
+
+async function pollPersonalDevice(boundOrgId: string): Promise<Record<string, unknown> | null> {
+  const response = await personalDeviceApp(boundOrgId).fetch(
+    new Request('http://localhost/api/workers/poll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        worker_id: PERSONAL_WORKER_ID,
+        platform: 'macos',
+        app_version: '9.9.0',
+        label: 'Personal Mac',
+        capabilities: { [CAPABILITY]: true },
+      }),
+    }),
+    {} as never
+  );
+  expect(response.status).toBe(200);
+  return (await response.json()) as Record<string, unknown> | null;
+}
+
+/** Stand in for the Mac: claim the reserved live-read run and answer it. */
+async function respondAsPersonalDevice(boundOrgId: string): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const job = await pollPersonalDevice(boundOrgId);
+    if (job?.run_id && job?.operation_key === DEVICE_VIRTUAL_FEED_ACTION_KEY) {
+      const completion = await post('/api/workers/complete-action', {
+        body: {
+          run_id: job.run_id,
+          worker_id: PERSONAL_WORKER_ID,
+          status: 'success',
+          action_output: { rows: PERSONAL_ROWS, columns: PERSONAL_COLUMNS },
+        },
+      });
+      expect(completion.status).toBe(200);
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('device never received the virtual-feed read job');
+}
+
+async function countRuns(organizationId: string): Promise<number> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT count(*)::int AS n FROM runs WHERE organization_id = ${organizationId}
+  `) as Array<{ n: number }>;
+  return row.n;
+}
+
+async function readFails(organizationId: string, feedId: number): Promise<Error> {
+  const error = await readVirtualFeed({
+    scope: scopeIn(organizationId),
+    feedId,
+    terms: ['live'],
+    limit: 10,
+  }).then(
+    () => null,
+    (err: Error) => err
+  );
+  if (!error) throw new Error('expected the read to be refused');
+  return error;
+}
+
+/** A device-manifest connector + an unpinned virtual feed in `organizationId`. */
+async function seedPersonalLaneConnection(
+  organizationId: string,
+  slug: string
+): Promise<{ connectionId: number; feedId: number }> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO connector_definitions
+      (key, name, version, organization_id, status, runtime, required_capability,
+       feeds_schema, auth_schema, created_at, updated_at)
+    VALUES (${CONNECTOR_KEY}, 'WhatsApp (this Mac)', ${CONNECTOR_VERSION}, ${organizationId}, 'active',
+            ${sql.json({ platforms: ['macos'] })}, ${CAPABILITY},
+            ${sql.json({ [FEED_KEY]: { key: FEED_KEY, virtual: true } })},
+            ${sql.json({ methods: [{ type: 'none' }] })}, NOW(), NOW())
+  `;
+  const connection = (await sql`
+    INSERT INTO connections
+      (organization_id, connector_key, slug, display_name, status, visibility,
+       device_worker_id, created_by, created_at, updated_at)
+    VALUES (${organizationId}, ${CONNECTOR_KEY}, ${slug}, 'WhatsApp (this Mac)',
+            'active', 'organization', NULL, ${personalUserId}, NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  const feed = (await sql`
+    INSERT INTO feeds
+      (organization_id, connection_id, feed_key, display_name, status, config,
+       kind, virtual, next_run_at)
+    VALUES (${organizationId}, ${connection[0].id}, ${FEED_KEY}, 'Messages (live)', 'active',
+            ${sql.json({ recall: true })}, 'virtual', true, NULL)
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return { connectionId: connection[0].id, feedId: feed[0].id };
+}
+
+describe('unpinned device virtual-feed reads are a personal-org lane', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const user = await createTestUser({ email: 'wa-personal@test.com' });
+    personalUserId = user.id;
+
+    const personal = await createTestOrganization({ name: 'Personal' });
+    personalOrgId = personal.id;
+    await addUserToOrganization(personalUserId, personalOrgId, 'owner');
+    const staleHome = await createTestOrganization({ name: 'Old Home' });
+    staleHomeOrgId = staleHome.id;
+    await addUserToOrganization(personalUserId, staleHomeOrgId, 'owner');
+    const team = await createTestOrganization({ name: 'Acme Workspace' });
+    teamOrgId = team.id;
+    await addUserToOrganization(personalUserId, teamOrgId, 'member');
+
+    const sql = getTestDb();
+    await sql`
+      UPDATE "organization" SET metadata = ${sql.json({ personal_org_for_user_id: personalUserId })}
+      WHERE id = ${personalOrgId}
+    `;
+
+    // `organization_id` is the device's HOME org, written once at pairing. It
+    // points at neither org under test, which is the point: the lane is decided
+    // by which org IS this user's personal one, not by this stale column.
+    const device = (await sql`
+      INSERT INTO device_workers
+        (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+      VALUES (${personalUserId}, ${PERSONAL_WORKER_ID}, 'macos', '9.9.0',
+              ${sql.json([CAPABILITY])}, 'Personal Mac', ${staleHomeOrgId})
+      RETURNING id
+    `) as Array<{ id: string }>;
+    personalDeviceWorkerId = device[0].id;
+
+    await sql`
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+    `;
+    personalFeedId = (await seedPersonalLaneConnection(personalOrgId, 'whatsapp-personal')).feedId;
+    const teamSeed = await seedPersonalLaneConnection(teamOrgId, 'whatsapp-team');
+    teamConnectionId = teamSeed.connectionId;
+    teamFeedId = teamSeed.feedId;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    const sql = getTestDb();
+    await sql`DELETE FROM runs WHERE organization_id IN (${personalOrgId}, ${teamOrgId})`;
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])}
+      WHERE id = ${personalDeviceWorkerId}::uuid
+    `;
+    await sql`
+      UPDATE connections SET device_worker_id = NULL WHERE id = ${teamConnectionId}
+    `;
+  });
+
+  it('serves an unpinned read in the personal org despite a stale device home org', async () => {
+    const sql = getTestDb();
+    const [home] = (await sql`
+      SELECT organization_id FROM device_workers WHERE id = ${personalDeviceWorkerId}::uuid
+    `) as Array<{ organization_id: string }>;
+    // The premise: were these equal the case would prove nothing.
+    expect(home.organization_id).toBe(staleHomeOrgId);
+    expect(home.organization_id).not.toBe(personalOrgId);
+
+    const reading = readVirtualFeed({
+      scope: scopeIn(personalOrgId),
+      feedId: personalFeedId,
+      terms: ['live'],
+      limit: 10,
+    });
+    const job = await respondAsPersonalDevice(personalOrgId);
+
+    expect(job.connector_key).toBe(CONNECTOR_KEY);
+    expect(job.operation_key).toBe(DEVICE_VIRTUAL_FEED_ACTION_KEY);
+    const live = await reading;
+    expect(live.rows).toEqual(PERSONAL_ROWS);
+
+    // The home org is set-once, so serving the personal org did not re-anchor
+    // the device — the next read is the same shape.
+    const [after] = (await sql`
+      SELECT organization_id FROM device_workers WHERE id = ${personalDeviceWorkerId}::uuid
+    `) as Array<{ organization_id: string }>;
+    expect(after.organization_id).toBe(staleHomeOrgId);
+  });
+
+  it('refuses an unpinned read in a team org and says to pin it', async () => {
+    const error = await readFails(teamOrgId, teamFeedId);
+    expect(error.message).toMatch(/not pinned to a device/);
+    // The fix, not just the diagnosis.
+    expect(error.message).toMatch(/pin it to the device that should serve it/);
+    // Membership in the team org is NOT what makes a device servable: branch 1B
+    // gates on the token's bound org, which this preflight cannot see.
+    expect(error.message).not.toMatch(/no online device/);
+    expect(await countRuns(teamOrgId)).toBe(0);
+  });
+
+  it('serves the same team connection once it is pinned to the device', async () => {
+    const sql = getTestDb();
+    await sql`
+      UPDATE connections SET device_worker_id = ${personalDeviceWorkerId}::uuid
+      WHERE id = ${teamConnectionId}
+    `;
+
+    const reading = readVirtualFeed({
+      scope: scopeIn(teamOrgId),
+      feedId: teamFeedId,
+      terms: ['live'],
+      limit: 10,
+    });
+    const job = await respondAsPersonalDevice(teamOrgId);
+    expect(job.operation_key).toBe(DEVICE_VIRTUAL_FEED_ACTION_KEY);
+    const live = await reading;
+    expect(live.rows).toEqual(PERSONAL_ROWS);
+  });
+});
+
+/**
+ * Lifecycle of the transport run: DEADLINES and ORPHAN sweeping.
+ *
+ * The read seam's `finally` scrubs on every path the gateway process survives.
+ * Two holes remain, and this block is about both:
+ *
+ *   (1) AMBIENT recall must not inherit the deliberate-read budget. A live feed
+ *       opted into `search_memory` is a side dish — it runs on every call — so
+ *       one sleeping laptop must not stall a chat turn for the device queue's
+ *       60s pre-claim plus 95s post-claim. The deadline ABORTS rather than only
+ *       racing: the waiter stops polling and terminalizes its run, and the
+ *       cleanup scrubs it, so nothing is left holding a page of messages.
+ *   (2) A gateway that DIES mid-read runs no `finally` at all. The retention
+ *       promise cannot rest on a process staying alive, so the reaper
+ *       re-asserts it set-wise from whichever replica is up.
+ */
+const LIFECYCLE_WORKER_ID = 'wk-wa-lifecycle';
+
+const { gatherRecall, RECALL_SOURCES } = await import('../../../tools/search');
+const { sweepAbandonedVirtualFeedReadRuns } = await import(
+  '../../../scheduled/check-stalled-executions'
+);
+const { manageOperations } = await import('../../../tools/admin/manage_operations');
+const { ownerToolContext } = await import('../../setup/test-fixtures');
+// manage_operations builds org-scoped view URLs, so the workspace provider has
+// to be up. Initialized HERE rather than inherited from whichever suite booted
+// the app first — that would make this case pass only in a particular file
+// order.
+const { initWorkspaceProvider } = await import('../../../workspace');
+
+let lifecycleOrgId: string;
+let lifecycleUserId: string;
+let lifecycleDeviceId: string;
+let lifecycleConnectionId: number;
+let lifecycleFeedId: number;
+
+const virtualRecallSource = () => {
+  const source = RECALL_SOURCES.find((s) => s.kind === 'virtual');
+  if (!source) throw new Error('the virtual recall source is no longer registered');
+  return source;
+};
+
+/**
+ * A second recall source that always succeeds fast. Its facet is how we tell
+ * "the virtual feed was skipped" from "recall itself fell over" — the point of
+ * a per-source deadline is that the other readers still answer.
+ */
+const fastStubSource = {
+  kind: 'conversation' as const,
+  source: 'chat-channel' as never,
+  lens: 'recall' as const,
+  canRead: () => true,
+  read: async () => ({
+    conversation_messages: [
+      {
+        id: 1,
+        channel: 'stub',
+        text: 'other recall sources still answered',
+        author: null,
+        occurred_at: null,
+      },
+    ],
+  }),
+} as unknown as (typeof RECALL_SOURCES)[number];
+
+function lifecycleRecallContext(): Parameters<typeof gatherRecall>[1] {
+  return {
+    query: 'invoice',
+    contentAgentId: undefined,
+    contentLimit: 5,
+    env: {} as never,
+  };
+}
+
+async function lifecycleRuns(): Promise<
+  Array<{
+    id: number;
+    status: string;
+    action_key: string;
+    action_input: unknown;
+    action_output: unknown;
+    error_message: string | null;
+  }>
+> {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, status, action_key, action_input, action_output, error_message
+    FROM runs
+    WHERE organization_id = ${lifecycleOrgId} AND run_type = 'action'
+    ORDER BY id
+  `) as Array<{
+    id: number;
+    status: string;
+    action_key: string;
+    action_input: unknown;
+    action_output: unknown;
+    error_message: string | null;
+  }>;
+}
+
+/** Insert a live-read run in an arbitrary state, bypassing the read seam. */
+async function seedReservedRun(opts: {
+  status: string;
+  actionKey?: string;
+  completedAtSecondsAgo?: number | null;
+  expiresAtSecondsFromNow?: number | null;
+  claimedSecondsAgo?: number | null;
+  heartbeatSecondsAgo?: number | null;
+}): Promise<number> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, connection_id, connector_key, connector_version,
+      action_key, action_input, action_output, approval_status, status,
+      completed_at, expires_at, claimed_at, last_heartbeat_at, created_at
+    ) VALUES (
+      ${lifecycleOrgId}, 'action', ${lifecycleConnectionId}, ${CONNECTOR_KEY},
+      ${CONNECTOR_VERSION},
+      ${opts.actionKey ?? DEVICE_VIRTUAL_FEED_ACTION_KEY},
+      ${sql.json({ feed_key: FEED_KEY, terms: ['tenancy deposit'], chat_jids: ['15551230000@s.whatsapp.net'] })},
+      ${sql.json({ rows: DEVICE_ROWS })},
+      'auto', ${opts.status},
+      ${opts.completedAtSecondsAgo == null
+        ? null
+        : sql`current_timestamp - (${opts.completedAtSecondsAgo}::int * interval '1 second')`},
+      ${opts.expiresAtSecondsFromNow == null
+        ? null
+        : sql`current_timestamp + (${opts.expiresAtSecondsFromNow}::int * interval '1 second')`},
+      ${opts.claimedSecondsAgo == null
+        ? null
+        : sql`current_timestamp - (${opts.claimedSecondsAgo}::int * interval '1 second')`},
+      ${opts.heartbeatSecondsAgo == null
+        ? null
+        : sql`current_timestamp - (${opts.heartbeatSecondsAgo}::int * interval '1 second')`},
+      current_timestamp
+    )
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return row.id;
+}
+
+/**
+ * Wait for the transport run to reach its terminal, scrubbed state.
+ *
+ * The recall deadline returns control to the CALLER first and lets the aborted
+ * read finish tearing itself down behind it — that ordering is the point (the
+ * caller is not made to wait on cleanup), so the assertion has to follow the
+ * cleanup rather than assume it already ran. Bounded: if it never converges the
+ * test fails on the assertions after this returns.
+ */
+async function awaitScrubbedRun(timeoutMs = 5_000): Promise<
+  Array<{ id: number; status: string; action_input: unknown; action_output: unknown }>
+> {
+  const deadline = Date.now() + timeoutMs;
+  let runs = await lifecycleRuns();
+  while (Date.now() < deadline) {
+    if (runs.length > 0 && runs.every((r) => r.status === 'timeout' && r.action_output === null)) {
+      return runs;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    runs = await lifecycleRuns();
+  }
+  return runs;
+}
+
+async function readRunById(runId: number): Promise<{
+  status: string;
+  action_input: unknown;
+  action_output: unknown;
+  error_message: string | null;
+}> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT status, action_input, action_output, error_message FROM runs WHERE id = ${runId}
+  `) as Array<{
+    status: string;
+    action_input: unknown;
+    action_output: unknown;
+    error_message: string | null;
+  }>;
+  return row;
+}
+
+describe('device virtual-feed read lifecycle — deadlines and orphan sweeping', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await initWorkspaceProvider();
+    const org = await createTestOrganization({ name: 'WA Lifecycle' });
+    lifecycleOrgId = org.id;
+    const user = await createTestUser({ email: 'wa-lifecycle@test.com' });
+    lifecycleUserId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const sql = getTestDb();
+    await sql`
+      UPDATE "organization" SET metadata = ${sql.json({ personal_org_for_user_id: lifecycleUserId })}
+      WHERE id = ${lifecycleOrgId}
+    `;
+    const device = (await sql`
+      INSERT INTO device_workers
+        (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+      VALUES (${lifecycleUserId}, ${LIFECYCLE_WORKER_ID}, 'macos', '9.9.0',
+              ${sql.json([CAPABILITY])}, 'Lifecycle Mac', ${lifecycleOrgId})
+      RETURNING id
+    `) as Array<{ id: string }>;
+    lifecycleDeviceId = device[0].id;
+
+    // No `actions_schema`: the reserved read key is protocol, never a declared
+    // operation. The manage_operations case below is what pins that.
+    await sql`
+      INSERT INTO connector_definitions
+        (key, name, version, organization_id, status, runtime, required_capability,
+         feeds_schema, auth_schema, created_at, updated_at)
+      VALUES (${CONNECTOR_KEY}, 'WhatsApp (this Mac)', ${CONNECTOR_VERSION}, ${lifecycleOrgId},
+              'active', ${sql.json({ platforms: ['macos'] })}, ${CAPABILITY},
+              ${sql.json({ [FEED_KEY]: { key: FEED_KEY, virtual: true } })},
+              ${sql.json({ methods: [{ type: 'none' }] })}, NOW(), NOW())
+    `;
+    await sql`
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+    `;
+    const connection = (await sql`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, visibility,
+         device_worker_id, created_by, created_at, updated_at)
+      VALUES (${lifecycleOrgId}, ${CONNECTOR_KEY}, 'whatsapp-lifecycle', 'WhatsApp (this Mac)',
+              'active', 'organization', ${lifecycleDeviceId}::uuid, ${lifecycleUserId}, NOW(), NOW())
+      RETURNING id
+    `) as Array<{ id: number }>;
+    lifecycleConnectionId = connection[0].id;
+    const feed = (await sql`
+      INSERT INTO feeds
+        (organization_id, connection_id, feed_key, display_name, status, config,
+         kind, virtual, next_run_at)
+      VALUES (${lifecycleOrgId}, ${lifecycleConnectionId}, ${FEED_KEY}, 'Messages (live)', 'active',
+              ${sql.json({ recall: true })}, 'virtual', true, NULL)
+      RETURNING id
+    `) as Array<{ id: number }>;
+    lifecycleFeedId = feed[0].id;
+  });
+
+  afterAll(async () => {
+    __setDeviceActionWaiterForTest(null);
+    await cleanupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    __setDeviceActionWaiterForTest(null);
+    const sql = getTestDb();
+    await sql`DELETE FROM runs WHERE organization_id = ${lifecycleOrgId}`;
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])}
+      WHERE id = ${lifecycleDeviceId}::uuid
+    `;
+  });
+
+  // The abort has to reach the WAITER, not just the caller. A `Promise.race`
+  // alone would return control while the run stayed pending for the full 60s
+  // queue budget, holding the caller's terms and claimable by a device that
+  // would then post a page of messages into it.
+  it('an aborted read stops waiting, terminalizes the run, and scrubs it', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 400);
+
+    const startedAt = Date.now();
+    const error = await readDeviceVirtualFeed({
+      organizationId: lifecycleOrgId,
+      feedId: lifecycleFeedId,
+      feedKey: FEED_KEY,
+      feedConfig: {},
+      connectionId: lifecycleConnectionId,
+      connectorKey: CONNECTOR_KEY,
+      deviceWorkerId: lifecycleDeviceId,
+      requiredCapability: CAPABILITY,
+      terms: ['tenancy deposit'],
+      signal: controller.signal,
+    }).then(
+      () => null,
+      (err: Error) => err
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    if (!error) throw new Error('expected the aborted read to fail');
+    // Reported as a caller deadline, NOT as a device timeout: nothing here says
+    // the device is unhealthy — it was never given the 60s the other message
+    // would quote.
+    expect(error.message).toMatch(/cut short by the caller's read deadline/);
+    // Nowhere near the 60s pre-claim budget it would otherwise have waited.
+    expect(elapsedMs).toBeLessThan(10_000);
+
+    const runs = await lifecycleRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('timeout');
+    expect(runs[0].action_output).toBeNull();
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(runs[0])).not.toContain('tenancy deposit');
+  }, 30_000);
+
+  // The preflight is two DB round-trips. An ambient read on a few seconds'
+  // budget can spend it in there, and enqueueing afterwards would create a
+  // transport run whose only future is cancellation — a row briefly holding the
+  // caller's terms for a read nobody is waiting on.
+  it('creates no transport run when the deadline expires during the preflight', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const error = await readDeviceVirtualFeed({
+      organizationId: lifecycleOrgId,
+      feedId: lifecycleFeedId,
+      feedKey: FEED_KEY,
+      feedConfig: {},
+      connectionId: lifecycleConnectionId,
+      connectorKey: CONNECTOR_KEY,
+      deviceWorkerId: lifecycleDeviceId,
+      requiredCapability: CAPABILITY,
+      terms: ['tenancy deposit'],
+      signal: controller.signal,
+    }).then(
+      () => null,
+      (err: Error) => err
+    );
+
+    if (!error) throw new Error('expected the aborted read to fail');
+    expect(error.message).toMatch(/before the request reached the paired device/);
+    // Nothing enqueued at all — not enqueued-then-scrubbed.
+    expect(await lifecycleRuns()).toHaveLength(0);
+  });
+
+  it('bounds ambient recall to the per-feed budget while other sources still answer', async () => {
+    const startedAt = Date.now();
+    const recalled = await gatherRecall(
+      { organizationId: lifecycleOrgId, principal: lifecycleUserId },
+      lifecycleRecallContext(),
+      [virtualRecallSource(), fastStubSource]
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    // The budget bounded it. Without the deadline this is the device queue's
+    // 60s pre-claim wait, on every single search_memory call.
+    expect(elapsedMs).toBeLessThan(20_000);
+    // The live feed contributed nothing — correctly, no device answered.
+    expect(recalled.virtual_feeds).toBeUndefined();
+    // …and the other reader was untouched by it.
+    expect(recalled.conversation_messages).toHaveLength(1);
+
+    // The abandoned transport run was closed and emptied, not left in flight.
+    const runs = await awaitScrubbedRun();
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('timeout');
+    expect(runs[0].action_output).toBeNull();
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+  }, 40_000);
+
+  it('still returns live rows when the device answers inside the budget', async () => {
+    // A device that answers immediately: the deadline exists to bound the slow
+    // case, and must not cost the fast one.
+    __setDeviceActionWaiterForTest(async () => ({
+      status: 'completed' as const,
+      output: { rows: DEVICE_ROWS, columns: DEVICE_COLUMNS },
+    }));
+
+    const recalled = await gatherRecall(
+      { organizationId: lifecycleOrgId, principal: lifecycleUserId },
+      lifecycleRecallContext(),
+      [virtualRecallSource(), fastStubSource]
+    );
+
+    expect(recalled.virtual_feeds).toHaveLength(1);
+    expect(recalled.virtual_feeds?.[0]).toMatchObject({
+      feed_id: lifecycleFeedId,
+      feed_key: FEED_KEY,
+      rows: DEVICE_ROWS,
+    });
+    expect(recalled.conversation_messages).toHaveLength(1);
+  }, 30_000);
+
+  // Everything below is the CRASH path: rows the in-process `finally` never got
+  // to, because the process that owned it is gone.
+  it('scrubs a completed live-read run the crashed gateway never cleaned up', async () => {
+    const runId = await seedReservedRun({ status: 'completed', completedAtSecondsAgo: 120 });
+
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(1);
+
+    const after = await readRunById(runId);
+    // The verdict is not the sweep's to rewrite — only the payload is.
+    expect(after.status).toBe('completed');
+    expect(after.action_output).toBeNull();
+    expect(after.action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(JSON.stringify(after)).not.toContain('tenancy deposit');
+    expect(JSON.stringify(after)).not.toContain('15551230000@s.whatsapp.net');
+    expect(JSON.stringify(after)).not.toContain('invoice 4471');
+
+    // Idempotent: a second tick has nothing left to do.
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(0);
+  });
+
+  it('times out AND scrubs an in-flight live-read run whose claim horizon lapsed', async () => {
+    const runId = await seedReservedRun({ status: 'pending', expiresAtSecondsFromNow: -30 });
+
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(1);
+
+    const after = await readRunById(runId);
+    // Terminal, so a device that wakes up late cannot claim it and post a fresh
+    // page of messages into the row we just cleared.
+    expect(after.status).toBe('timeout');
+    expect(after.action_output).toBeNull();
+    expect(after.action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(after.error_message).toMatch(/swept by the run reaper/);
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(0);
+  });
+
+  // `expires_at` on a device action is the UNCLAIMED claim horizon, not an
+  // execution deadline — queue-service stamps it so an unclaimed run cannot sit
+  // pending forever, and poll.ts enforces it only against `status = 'pending'`.
+  // A device that claimed a WhatsApp query one second before expiry is doing
+  // exactly what it was asked to; timing it out here would kill live work on a
+  // clock that was never about execution.
+  it('leaves a CLAIMED run with a lapsed horizon alone while it is still beating', async () => {
+    for (const status of ['claimed', 'running']) {
+      const runId = await seedReservedRun({
+        status,
+        expiresAtSecondsFromNow: -30,
+        claimedSecondsAgo: 40,
+        heartbeatSecondsAgo: 1,
+      });
+
+      expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(0);
+
+      const after = await readRunById(runId);
+      expect(after.status).toBe(status);
+      expect(after.action_output).not.toBeNull();
+      // The heartbeat/coarse reaper owns this row's failure; once IT
+      // terminalizes, the terminal-grace lane clears the payload on a later
+      // tick, so nothing is left holding messages either way.
+      expect(JSON.stringify(after.action_input)).toContain('tenancy deposit');
+      await getTestDb()`DELETE FROM runs WHERE id = ${runId}`;
+    }
+  });
+
+  // The grace is the whole reason the sweep can run on a 30s tick without
+  // breaking healthy reads: a run marked `completed` a moment ago is about to
+  // be picked up by a waiter polling every 500ms.
+  it('leaves a freshly completed run alone until the grace elapses', async () => {
+    const runId = await seedReservedRun({ status: 'completed', completedAtSecondsAgo: 1 });
+
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(0);
+
+    const after = await readRunById(runId);
+    expect(after.action_output).not.toBeNull();
+    expect(JSON.stringify(after.action_input)).toContain('tenancy deposit');
+  });
+
+  it('never touches an unrelated action run', async () => {
+    const reservedId = await seedReservedRun({ status: 'completed', completedAtSecondsAgo: 120 });
+    const unrelatedId = await seedReservedRun({
+      status: 'completed',
+      actionKey: 'send_message',
+      completedAtSecondsAgo: 120,
+    });
+
+    expect(await sweepAbandonedVirtualFeedReadRuns(getTestDb())).toBe(1);
+
+    expect((await readRunById(reservedId)).action_output).toBeNull();
+    const unrelated = await readRunById(unrelatedId);
+    expect(unrelated.action_output).not.toBeNull();
+    expect(JSON.stringify(unrelated.action_input)).toContain('tenancy deposit');
+  });
+
+  // The reserved key is dispatched by the gateway, never declared. Declaring it
+  // would flip `supportsExecute` and publish a read seam as a user-invokable
+  // operation — so it must not be listable or executable through the operations
+  // surface at all.
+  it('does not expose the reserved read key as a manage_operations operation', async () => {
+    const ctx = ownerToolContext(lifecycleOrgId, lifecycleUserId);
+    const listed = (await manageOperations(
+      { action: 'list_available', connector_key: CONNECTOR_KEY },
+      {} as never,
+      ctx
+    )) as { operations?: Array<{ operation_key: string }> };
+    expect(
+      (listed.operations ?? []).some((o) => o.operation_key === DEVICE_VIRTUAL_FEED_ACTION_KEY)
+    ).toBe(false);
+
+    const executed = (await manageOperations(
+      {
+        action: 'execute',
+        connection_id: lifecycleConnectionId,
+        operation_key: DEVICE_VIRTUAL_FEED_ACTION_KEY,
+        input: { feed_key: FEED_KEY, terms: ['invoice'], limit: 5, offset: 0, sort: null },
+      },
+      {} as never,
+      ctx
+    ).catch((err: Error) => ({ success: false, error: err.message }))) as {
+      success?: boolean;
+      error?: string;
+    };
+    expect(executed.success).not.toBe(true);
+    // Refused because the key is not in `actions_schema` — the same gate any
+    // undeclared operation hits, which is exactly the property being pinned.
+    expect(String(executed.error ?? '')).toBe(
+      `Invalid operation_key '${DEVICE_VIRTUAL_FEED_ACTION_KEY}' for this connection.`
+    );
+    // And no run was enqueued behind the refusal.
+    expect(await lifecycleRuns()).toHaveLength(0);
+  }, 30_000);
+});

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
@@ -24,6 +24,8 @@ import type { Env } from '../../../index';
 import { readVirtualFeed } from '../../../lib/connector-pushdown';
 import { materializeDueFeeds } from '../../../scheduled/check-due-feeds';
 import { createAuthProfile } from '../../../utils/auth-profiles';
+import { COMPILE_CONFIG_HASH } from '@lobu/connector-worker/compile';
+import { compileConnectorSource } from '../../../utils/connector-compiler';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { addUserToOrganization, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
 
@@ -178,6 +180,37 @@ describe('virtual feed flag (Slice 2)', () => {
     expect(ok.rows.length).toBe(3);
   }, 60_000);
 
+  // Routing regression: `connector_definitions.runtime` is DESCRIPTIVE metadata
+  // (platforms, nix inputs), not a durable "device-only" claim. A connector that
+  // declares one and still has code — as this bundled one does, with
+  // `connector_versions.compiled_code IS NULL` and its source on disk — must keep
+  // the compiled pushdown. Routing it to a device would demote a real `query()`
+  // to a round-trip and fail outright wherever no device is paired.
+  it('keeps a runtime-declaring COMPILED connector on the pushdown, not the device seam', async () => {
+    const db = getTestDb();
+    await db`
+      UPDATE connector_definitions
+      SET runtime = ${db.json({ platforms: ['macos', 'linux'], nix: { packages: ['postgresql'] } })}
+      WHERE key = 'postgres' AND organization_id = ${orgId}
+    `;
+    try {
+      const res = await readVirtualFeed({ scope: ownerScope(), feedId: orgFeedId, limit: 10 });
+      // Real rows from the connector's own query(), so the compiled path ran.
+      expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot', 'banana']);
+      // And no device action run was enqueued behind it.
+      const actions = await db`
+        SELECT count(*)::int AS n FROM runs
+        WHERE organization_id = ${orgId} AND run_type = 'action'
+      `;
+      expect(Number((actions[0] as { n: number }).n)).toBe(0);
+    } finally {
+      await db`
+        UPDATE connector_definitions SET runtime = NULL
+        WHERE key = 'postgres' AND organization_id = ${orgId}
+      `;
+    }
+  }, 60_000);
+
   it('refuses to read a NON-virtual feed live', async () => {
     await expect(
       readVirtualFeed({ scope: ownerScope(), feedId: nonVirtualFeedId })
@@ -198,5 +231,165 @@ describe('virtual feed flag (Slice 2)', () => {
     await expect(
       readVirtualFeed({ scope: ownerScope(), feedId: pausedId })
     ).rejects.toThrow(/not found or not accessible/i);
+  }, 60_000);
+});
+
+/**
+ * Which virtual feeds take the DEVICE seam, and which stay on the compiled
+ * pushdown.
+ *
+ * `connector_definitions.runtime` is descriptive metadata (platforms, nix
+ * inputs). On its own it is not a durable "no server code" signal, so routing
+ * asks the same question the EXECUTION resolver asks: does
+ * `resolveConnectorCodeForKey` → `resolveConnectorCode` have something to run?
+ * That is `connector_versions.compiled_code`, or a bundled source file on disk —
+ * and nothing else.
+ *
+ * `source_path` is deliberately excluded, and this file pins that. It appears in
+ * queue-service's `resolveActiveConnectorVersion`, but that is a laxer READINESS
+ * gate; `resolveConnectorCode` never loads it. Device manifests set it to
+ * `device-manifest://…` precisely as a non-executable marker, so adopting the
+ * laxer union would classify every device connector as having code and break
+ * this routing outright.
+ */
+
+const RUNTIME_META = { platforms: ['macos', 'linux'], nix: { packages: ['ffmpeg'] } };
+
+const COMPILED_KEY = 'demo.routing.compiled';
+const SOURCE_PATH_ONLY_KEY = 'demo.routing.source_path_only';
+
+const COMPILED_SOURCE = `
+export class MyConnector {
+  definition = {
+    key: '${COMPILED_KEY}',
+    name: 'Compiled With Runtime',
+    version: '1.0.0',
+    feeds: { rows: { name: 'Rows' } },
+  };
+  async sync() { return { items: [] }; }
+  async execute() { return { success: true, output: {} }; }
+  async query() {
+    return {
+      rows: [{ id: 1, name: 'from compiled query()' }],
+      columns: [{ name: 'id', type: 'integer' }, { name: 'name', type: 'text' }],
+      total: 1,
+    };
+  }
+}
+`;
+
+describe('virtual feed routing — device seam vs compiled pushdown', () => {
+  let routingOrgId: string;
+  let routingUserId: string;
+  let compiledFeedId: number;
+  let sourcePathFeedId: number;
+
+  const routingScope = (): AuthzScope => ({
+    organizationId: routingOrgId,
+    principal: routingUserId,
+  });
+
+  /** A definition + connection + virtual feed for one connector key. */
+  async function seedRoutingConnector(opts: {
+    key: string;
+    compiledCode: string | null;
+    sourcePath: string | null;
+  }): Promise<number> {
+    const db = getTestDb();
+    await db`
+      INSERT INTO connector_definitions
+        (key, name, version, runtime, feeds_schema, auth_schema, organization_id, status,
+         created_at, updated_at)
+      VALUES (${opts.key}, ${opts.key}, '1.0.0', ${db.json(RUNTIME_META)},
+              ${db.json({ rows: { key: 'rows', virtual: true } })}, ${db.json({})},
+              ${routingOrgId}, 'active', NOW(), NOW())
+    `;
+    await db`
+      INSERT INTO connector_versions
+        (connector_key, version, compiled_code, source_path, compile_config_hash, created_at)
+      VALUES (${opts.key}, '1.0.0', ${opts.compiledCode}, ${opts.sourcePath},
+              ${opts.compiledCode ? COMPILE_CONFIG_HASH : null}, NOW())
+    `;
+    const [conn] = await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, visibility,
+         created_by, created_at, updated_at)
+      VALUES (${routingOrgId}, ${opts.key}, ${`c-${opts.key}`}, ${opts.key}, 'active',
+              'org', ${routingUserId}, NOW(), NOW())
+      RETURNING id
+    `;
+    const [feed] = await db`
+      INSERT INTO feeds
+        (organization_id, connection_id, feed_key, status, virtual, kind, config,
+         created_at, updated_at)
+      VALUES (${routingOrgId}, ${Number((conn as { id: number }).id)}, 'rows', 'active', true,
+              'virtual', ${db.json({})}, NOW(), NOW())
+      RETURNING id
+    `;
+    return Number((feed as { id: number }).id);
+  }
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'VFeedRouting' });
+    routingOrgId = org.id;
+    const user = await createTestUser({ email: 'vfeed-routing@test.com' });
+    routingUserId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    // Representation 1: a stored compiled artifact.
+    const compiled = await compileConnectorSource(COMPILED_SOURCE);
+    compiledFeedId = await seedRoutingConnector({
+      key: COMPILED_KEY,
+      compiledCode: compiled.compiledCode,
+      sourcePath: null,
+    });
+
+    // The device-manifest shape: NO compiled code, NO bundled file on disk, and
+    // a `source_path` that is a marker rather than loadable source.
+    sourcePathFeedId = await seedRoutingConnector({
+      key: SOURCE_PATH_ONLY_KEY,
+      compiledCode: null,
+      sourcePath: `device-manifest://macos/${SOURCE_PATH_ONLY_KEY}@1.0.0`,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  // Representation 1 of "has runnable code": a STORED compiled artifact.
+  it('keeps a runtime-declaring connector with STORED compiled code on the pushdown', async () => {
+    const res = await readVirtualFeed({ scope: routingScope(), feedId: compiledFeedId });
+    // Rows produced by the connector's own query(), so the compiled path ran.
+    expect(res.rows).toEqual([{ id: 1, name: 'from compiled query()' }]);
+    const actions = await getTestDb()`
+      SELECT count(*)::int AS n FROM runs
+      WHERE organization_id = ${routingOrgId} AND run_type = 'action'
+    `;
+    expect(Number((actions[0] as { n: number }).n)).toBe(0);
+  }, 60_000);
+
+  // Representation 2 — a BUNDLED on-disk source with compiled_code NULL — is
+  // covered by the postgres fixture in the suite above ('keeps a
+  // runtime-declaring COMPILED connector on the pushdown, not the device seam').
+
+  // The negative, and the reason routing must not borrow queue-service's laxer
+  // runnable union: `source_path` alone is NOT executable code. If it counted,
+  // every device-manifest connector would be misrouted to the compiled path and
+  // die in resolveConnectorCodeForKey instead of reaching its paired Mac.
+  it('routes a runtime connector whose only artifact is a source_path to the device seam', async () => {
+    const error = await readVirtualFeed({
+      scope: routingScope(),
+      feedId: sourcePathFeedId,
+    }).then(
+      () => null,
+      (err: Error) => err
+    );
+    if (!error) throw new Error('expected the read to be refused');
+    // The DEVICE seam's preflight spoke, not the compiled resolver. That is the
+    // routing assertion: a compiled-path failure would say "No compiled code".
+    expect(error.message).toMatch(/Live read of feed 'rows' is unavailable/);
+    expect(error.message).not.toMatch(/No compiled code/);
   }, 60_000);
 });

--- a/packages/server/src/__tests__/integration/device-manifest-virtual-feed.test.ts
+++ b/packages/server/src/__tests__/integration/device-manifest-virtual-feed.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Auto-wire of a manifest feed declared `virtual: true`.
+ *
+ * `feeds.kind` is IMMUTABLE — nothing converts a collected feed to virtual in
+ * place — so a connector that wants both a durable history and a live read must
+ * declare TWO feed keys, and reconcile has to create each with the right kind at
+ * INSERT time. Before this, every declared feed was inserted `collected` with a
+ * due time, so a virtual feed would have been scheduled for syncs no device can
+ * serve while its live-read path stayed unreachable.
+ *
+ * The second thing pinned here is the `recall` seed. A JSON Schema `default` is
+ * documentation: validation never writes it back, so `feeds.config` stays NULL —
+ * and `search_memory`'s virtual fan-out selects on `config->>'recall' = 'true'`
+ * off the COLUMN. Without materializing the default at create, ambient recall
+ * would silently never reach the Mac, however the manifest advertises itself.
+ *
+ * Driven through the real `/api/workers/poll` with the SHIPPING manifest, so a
+ * manifest edit that drops `virtual` or the `recall` default fails here.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../auth/oauth/utils';
+import type { Env } from '../../index';
+import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+
+const CONNECTOR_KEY = 'whatsapp.local';
+const COLLECTED_FEED = 'messages';
+const VIRTUAL_FEED = 'messages_live';
+
+const MANIFEST_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../owletto/apps/mac/Owletto/ConnectorManifests/whatsapp_local.json'
+);
+
+/**
+ * The owletto submodule is a private repo, so contributor sandboxes without
+ * access cannot init it. Skip there — but in CI (which checks it out) a missing
+ * manifest must FAIL, not skip, or a broken checkout silently drops coverage.
+ */
+const itWithManifest = existsSync(MANIFEST_PATH) ? it : process.env.CI ? it : it.skip;
+
+function shippingManifest(): Record<string, unknown> {
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as Record<string, unknown>;
+}
+
+async function seedDeviceOwner() {
+  const sql = getTestDb();
+  const userId = `user_${generateSecureToken(4)}`;
+  const orgId = `org-wa-virtual-${generateSecureToken(4)}`;
+  const workerId = `wk-${generateSecureToken(6)}`;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'WA Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+  `;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+    VALUES (${orgId}, 'WA Org', ${orgId}, 'private',
+            ${sql.json({ personal_org_for_user_id: userId })}, NOW())
+  `;
+  await sql`
+    INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`mem_${generateSecureToken(4)}`}, ${orgId}, ${userId}, 'owner', NOW())
+  `;
+  await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+    VALUES (${userId}, ${workerId}, 'macos', '9.9.0', ${sql.json([])}, 'Test Mac', ${orgId})
+  `;
+  return { userId, orgId, workerId };
+}
+
+async function pollWithManifest(workerId: string, manifests: unknown[]) {
+  const response = await post('/api/workers/poll', {
+    body: {
+      worker_id: workerId,
+      platform: 'macos',
+      app_version: '9.9.0',
+      label: 'Test Mac',
+      capabilities: { whatsapp_local: true },
+      connector_manifests: manifests,
+    },
+  });
+  expect(response.status).toBe(200);
+  return response;
+}
+
+interface FeedRow {
+  display_name: string | null;
+  feed_key: string;
+  kind: string;
+  virtual: boolean;
+  schedule: string | null;
+  next_run_at: Date | string | null;
+  config: Record<string, unknown> | null;
+}
+
+async function readFeeds(orgId: string): Promise<Record<string, FeedRow>> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT f.feed_key, f.display_name, f.kind, f.virtual, f.schedule, f.next_run_at, f.config
+    FROM feeds f
+    JOIN connections c ON c.id = f.connection_id
+    WHERE c.organization_id = ${orgId} AND c.connector_key = ${CONNECTOR_KEY}
+      AND f.deleted_at IS NULL
+    ORDER BY f.feed_key
+  `) as unknown as FeedRow[];
+  return Object.fromEntries(rows.map((row) => [row.feed_key, row]));
+}
+
+/** Feed keys the sync scheduler has minted a run for in this org. */
+async function syncedFeedKeys(orgId: string): Promise<string[]> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT DISTINCT f.feed_key
+    FROM runs r
+    JOIN feeds f ON f.id = r.feed_id
+    WHERE r.organization_id = ${orgId} AND r.run_type = 'sync'
+    ORDER BY f.feed_key
+  `) as unknown as Array<{ feed_key: string }>;
+  return rows.map((row) => row.feed_key);
+}
+
+describe('device manifest auto-wire — virtual feeds', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+  afterEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  itWithManifest(
+    'wires the shipping manifest into a collected feed AND a virtual feed opted into recall',
+    async () => {
+      const { orgId, workerId } = await seedDeviceOwner();
+      await pollWithManifest(workerId, [shippingManifest()]);
+
+      const feeds = await readFeeds(orgId);
+      expect(Object.keys(feeds).sort()).toEqual([COLLECTED_FEED, VIRTUAL_FEED]);
+
+      // The existing collected feed is untouched by any of this: it keeps its
+      // durable events + person attribution, and it stays schedulable.
+      const collected = feeds[COLLECTED_FEED];
+      expect(collected.kind).toBe('collected');
+      expect(collected.virtual).toBe(false);
+      // `recall` is seeded for the LIVE feed only — turning ambient recall on
+      // for a collected feed would mean nothing (it is already indexed) and the
+      // seed must not leak across feed keys.
+      expect(collected.config ?? {}).not.toHaveProperty('recall');
+
+      // Two feeds on one connector need two LEGIBLE names. Falling back to the
+      // connector's own name (`WhatsApp (this Mac)`) for both would leave the
+      // user two identical rows and no way to tell which one is live — and the
+      // manifest already declares the distinguishing names.
+      expect(collected.display_name).toBe('Messages');
+
+      const live = feeds[VIRTUAL_FEED];
+      expect(live.display_name).toBe('Messages (live)');
+      expect(live.kind).toBe('virtual');
+      expect(live.virtual).toBe(true);
+      expect(live.schedule).toBeNull();
+      expect(live.next_run_at).toBeNull();
+      // The gate search_memory actually reads, materialized onto the column.
+      expect(live.config?.recall).toBe(true);
+
+      // The property the NULL due time exists for: the scheduler picks up the
+      // collected feed and never the virtual one. A virtual feed with a due
+      // time would mint sync runs no device can serve, failing the feed on
+      // every tick.
+      await materializeDueFeeds({} as Env, getTestDb());
+      expect(await syncedFeedKeys(orgId)).toEqual([COLLECTED_FEED]);
+    }
+  );
+
+  itWithManifest('is idempotent — a second poll does not give the virtual feed a due time', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    await pollWithManifest(workerId, [shippingManifest()]);
+    await pollWithManifest(workerId, [shippingManifest()]);
+
+    const feeds = await readFeeds(orgId);
+    expect(feeds[VIRTUAL_FEED].next_run_at).toBeNull();
+    expect(feeds[VIRTUAL_FEED].kind).toBe('virtual');
+    expect(feeds[VIRTUAL_FEED].config?.recall).toBe(true);
+    // The seed is CREATE-only: a user who turns recall off keeps it off.
+    const sql = getTestDb();
+    await sql`
+      UPDATE feeds SET config = ${sql.json({ recall: false })}
+      WHERE feed_key = ${VIRTUAL_FEED}
+        AND connection_id IN (
+          SELECT id FROM connections
+          WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        )
+    `;
+    await pollWithManifest(workerId, [shippingManifest()]);
+    expect((await readFeeds(orgId))[VIRTUAL_FEED].config?.recall).toBe(false);
+  });
+
+  itWithManifest(
+    'leaves an existing feed alone when its kind disagrees with the manifest',
+    async () => {
+      const { orgId, workerId } = await seedDeviceOwner();
+      await pollWithManifest(workerId, [shippingManifest()]);
+
+      // Simulate a row created before the manifest declared this key virtual:
+      // it has collected history and a due time. Reconcile must not convert it
+      // (that would strand its events behind a live-read path) and must not
+      // clear its due time while leaving it collected (that would freeze it).
+      const sql = getTestDb();
+      const dueAt = new Date('2026-08-19T00:00:00Z');
+      await sql`
+        UPDATE feeds SET kind = 'collected', virtual = false, next_run_at = ${dueAt}
+        WHERE feed_key = ${VIRTUAL_FEED}
+          AND connection_id IN (
+            SELECT id FROM connections
+            WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+          )
+      `;
+
+      await pollWithManifest(workerId, [shippingManifest()]);
+
+      const feeds = await readFeeds(orgId);
+      expect(feeds[VIRTUAL_FEED].kind).toBe('collected');
+      expect(feeds[VIRTUAL_FEED].virtual).toBe(false);
+      expect(new Date(feeds[VIRTUAL_FEED].next_run_at as string).toISOString()).toBe(
+        dueAt.toISOString()
+      );
+    }
+  );
+});

--- a/packages/server/src/__tests__/unit/device-virtual-feed.test.ts
+++ b/packages/server/src/__tests__/unit/device-virtual-feed.test.ts
@@ -97,11 +97,12 @@ describe('device virtual feed — outcome mapping', () => {
   });
 
   // Only reachable in production after the full 60s queue budget, so it is
-  // pinned here rather than waited for.
-  it('reports a timeout as a timeout, with the budget that elapsed', () => {
+  // pinned here rather than waited for. The phase-specific budget travels in
+  // `error_message` (the waiter's job), not in `deliver`'s prefix.
+  it('reports a timeout as a timeout', () => {
     expect(() =>
       deliver(params, { status: 'timeout', error_message: 'no device claimed the run' })
-    ).toThrow(/timed out after 60s: no device claimed the run/);
+    ).toThrow(/timed out: no device claimed the run/);
   });
 });
 

--- a/packages/server/src/__tests__/unit/device-virtual-feed.test.ts
+++ b/packages/server/src/__tests__/unit/device-virtual-feed.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure helpers of the device-backed virtual-feed seam.
+ *
+ * These are the parts that decide what a caller GETS, with no database in the
+ * way: the row-window clamp (a live read must never become an unbounded scan on
+ * someone's laptop) and the device-reply normalizer (a device is an
+ * untrusted-SHAPE producer — `runs.action_output` is arbitrary JSON, so a
+ * malformed reply has to surface as an error rather than as "no messages").
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  DEVICE_VIRTUAL_FEED_DEFAULT_LIMIT,
+  DEVICE_VIRTUAL_FEED_MAX_LIMIT,
+  DEVICE_VIRTUAL_FEED_MAX_OFFSET,
+  clampDeviceVirtualFeedWindow,
+  deliver,
+  isMetadataOnlyDeviceConnector,
+  normalizeDeviceVirtualFeedOutput,
+} from '../../lib/device-virtual-feed';
+import { DEVICE_VIRTUAL_FEED_ACTION_KEY } from '../../lib/device-virtual-feed-protocol';
+import {
+  RESERVED_ACTION_KEY_PREFIX,
+  validateDeviceConnectorManifests,
+} from '../../worker-api/device-manifests';
+
+describe('device virtual feed — reserved action key', () => {
+  it('lives in the gateway-reserved namespace so a manifest can never claim it', () => {
+    expect(DEVICE_VIRTUAL_FEED_ACTION_KEY.startsWith(RESERVED_ACTION_KEY_PREFIX)).toBe(true);
+  });
+
+  // The collision this closes: the gateway dispatches the reserved key itself,
+  // so a connector declaring the same string would shadow a read seam with a
+  // user-invokable operation — and `manage_operations.execute` would happily
+  // run it.
+  it('rejects a manifest whose actions_schema claims the reserved prefix', () => {
+    const result = validateDeviceConnectorManifests({
+      platform: 'macos',
+      capabilities: ['whatsapp_local'],
+      manifests: [
+        {
+          key: 'whatsapp.local',
+          version: '9.9.9',
+          name: 'Impostor',
+          required_capability: 'whatsapp_local',
+          runtime: { platforms: ['macos'] },
+          actions_schema: { [DEVICE_VIRTUAL_FEED_ACTION_KEY]: { key: DEVICE_VIRTUAL_FEED_ACTION_KEY } },
+        },
+      ],
+    });
+    expect(result.manifests).toHaveLength(0);
+    expect(result.accepted).toBe(false);
+  });
+
+  it('still accepts a manifest declaring ordinary actions', () => {
+    const result = validateDeviceConnectorManifests({
+      platform: 'macos',
+      capabilities: ['whatsapp_local'],
+      manifests: [
+        {
+          key: 'whatsapp.local',
+          version: '9.9.9',
+          name: 'Fine',
+          required_capability: 'whatsapp_local',
+          runtime: { platforms: ['macos'] },
+          actions_schema: { send_message: { key: 'send_message' } },
+        },
+      ],
+    });
+    expect(result.accepted).toBe(true);
+    expect(result.manifests).toHaveLength(1);
+  });
+});
+
+describe('device virtual feed — outcome mapping', () => {
+  const params = {
+    organizationId: 'org-1',
+    feedId: 7,
+    feedKey: 'messages_live',
+    feedConfig: {},
+    connectionId: 3,
+    connectorKey: 'whatsapp.local',
+    deviceWorkerId: null,
+    requiredCapability: 'whatsapp_local',
+  };
+
+  it('returns the device rows on success', () => {
+    expect(
+      deliver(params, { status: 'completed', output: { rows: [{ id: 'wa-1' }] } }).rows
+    ).toEqual([{ id: 'wa-1' }]);
+  });
+
+  it('names the feed and the device in a failure', () => {
+    expect(() =>
+      deliver(params, { status: 'failed', error_message: 'Full Disk Access denied' })
+    ).toThrow(/feed 'messages_live' failed on the paired device: Full Disk Access denied/);
+  });
+
+  // Only reachable in production after the full 60s queue budget, so it is
+  // pinned here rather than waited for.
+  it('reports a timeout as a timeout, with the budget that elapsed', () => {
+    expect(() =>
+      deliver(params, { status: 'timeout', error_message: 'no device claimed the run' })
+    ).toThrow(/timed out after 60s: no device claimed the run/);
+  });
+});
+
+describe('device virtual feed — connector routing', () => {
+  it('routes a METADATA-ONLY native connector to the device', () => {
+    expect(isMetadataOnlyDeviceConnector({ platforms: ['macos'] }, false)).toBe(true);
+  });
+
+  it('leaves a fleet connector on the compiled pushdown path', () => {
+    expect(isMetadataOnlyDeviceConnector(null, false)).toBe(false);
+    expect(isMetadataOnlyDeviceConnector(undefined, false)).toBe(false);
+  });
+
+  // `runtime` is descriptive metadata (platforms, nix inputs), not a durable
+  // "device-only" claim. A connector that carries it AND ships a bundle has a
+  // real `query()`/`search()` on the server, which is a strictly better read
+  // path than a device round-trip — routing it to a device would demote it and
+  // fail outright wherever no device is paired.
+  it('keeps a COMPILED connector on the pushdown even when it declares a runtime', () => {
+    expect(isMetadataOnlyDeviceConnector({ platforms: ['macos'] }, true)).toBe(false);
+    expect(isMetadataOnlyDeviceConnector({ nix: { packages: ['ffmpeg'] } }, true)).toBe(false);
+  });
+});
+
+describe('device virtual feed — row window', () => {
+  it('defaults when the caller names no window', () => {
+    expect(clampDeviceVirtualFeedWindow(undefined, undefined)).toEqual({
+      limit: DEVICE_VIRTUAL_FEED_DEFAULT_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('caps limit AND offset — an unbounded offset is a full archive scan per request', () => {
+    expect(clampDeviceVirtualFeedWindow(10_000, 10_000_000)).toEqual({
+      limit: DEVICE_VIRTUAL_FEED_MAX_LIMIT,
+      offset: DEVICE_VIRTUAL_FEED_MAX_OFFSET,
+    });
+  });
+
+  it('floors a nonsensical window instead of passing it through', () => {
+    expect(clampDeviceVirtualFeedWindow(0, -5)).toEqual({ limit: 1, offset: 0 });
+    expect(clampDeviceVirtualFeedWindow(Number.NaN, Number.NaN)).toEqual({
+      limit: DEVICE_VIRTUAL_FEED_DEFAULT_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('truncates a fractional window rather than sending a float to the device', () => {
+    expect(clampDeviceVirtualFeedWindow(10.9, 3.7)).toEqual({ limit: 10, offset: 3 });
+  });
+});
+
+describe('device virtual feed — device reply normalization', () => {
+  it('passes through rows, columns and total', () => {
+    expect(
+      normalizeDeviceVirtualFeedOutput({
+        rows: [{ id: 'wa-1', text: 'hi' }],
+        columns: [{ name: 'id', type: 'text' }],
+        total: 42,
+      })
+    ).toEqual({
+      rows: [{ id: 'wa-1', text: 'hi' }],
+      columns: [{ name: 'id', type: 'text' }],
+      total: 42,
+    });
+  });
+
+  it('defaults a column with no declared type instead of dropping the column', () => {
+    expect(normalizeDeviceVirtualFeedOutput({ rows: [], columns: [{ name: 'id' }] }).columns).toEqual(
+      [{ name: 'id', type: 'text' }]
+    );
+  });
+
+  it('drops a column entry that names nothing', () => {
+    expect(
+      normalizeDeviceVirtualFeedOutput({ rows: [], columns: [{ type: 'text' }, 'nope', null] }).columns
+    ).toEqual([]);
+  });
+
+  it('omits a non-numeric total rather than coercing it', () => {
+    expect(normalizeDeviceVirtualFeedOutput({ rows: [], total: 'lots' }).total).toBeUndefined();
+  });
+
+  // The failure this prevents: a device that replies `{}` or `{rows: null}`
+  // would otherwise read as an authoritative empty result — "you have no
+  // WhatsApp messages about the invoice" — when the truth is that the read
+  // never happened.
+  it.each([
+    ['null', null],
+    ['a scalar', 'rows'],
+    ['an array', [{ id: 1 }]],
+    ['an object with no rows', {}],
+    ['an object whose rows is not an array', { rows: 'nope' }],
+    ['an object with a non-object row', { rows: [{ id: 1 }, 'nope'] }],
+  ])('throws on %s instead of reporting an empty result', (_label, output) => {
+    expect(() => normalizeDeviceVirtualFeedOutput(output)).toThrow(/malformed/);
+  });
+});

--- a/packages/server/src/__tests__/unit/virtual-feed-recall-sla.test.ts
+++ b/packages/server/src/__tests__/unit/virtual-feed-recall-sla.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The ambient-recall SLA spans two repositories, so it is asserted across both.
+ *
+ * `search_memory` gives ONE virtual feed `VIRTUAL_FEED_RECALL_BUDGET_MS`. A
+ * `whatsapp.local` live read is served by the paired Mac over the device action
+ * queue, so the budget is only met if the Mac is POLLING fast enough to claim
+ * the run inside it. That interval lives in the Owletto submodule
+ * (`LobuDeviceConnectivityPolicy.actionPollInterval`), where no server test
+ * would otherwise look.
+ *
+ * This is not a style check. At Owletto's previous 10s action cadence the
+ * worst-case claim path was ~11.4s against a 5s budget — every ambient WhatsApp
+ * recall timed out, always. Raising the poll interval again, or lowering the
+ * budget, must fail HERE rather than silently in production.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'bun:test';
+import { VIRTUAL_FEED_RECALL_BUDGET_MS } from '../../config/intervals';
+
+const POLICY_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../owletto/apps/mac/Owletto/LobuContextIdentity.swift'
+);
+
+/**
+ * Measured on a real 47MB WhatsApp Desktop archive. The budget has to cover the
+ * device's own work, not just the wait for it.
+ */
+const MEASURED_ARCHIVE_QUERY_MS = 900;
+/**
+ * `waitForDeviceActionRun` polls the runs table every 500ms, so a completion is
+ * observed up to one interval after the device posts it.
+ */
+const GATEWAY_WAITER_GRANULARITY_MS = 500;
+
+function readActionPollIntervalMs(): number | null {
+  if (!existsSync(POLICY_PATH)) return null;
+  const source = readFileSync(POLICY_PATH, 'utf8');
+  const match = source.match(
+    /static\s+let\s+actionPollInterval:\s*TimeInterval\s*=\s*([0-9]+(?:\.[0-9]+)?)/
+  );
+  return match ? Number(match[1]) * 1000 : null;
+}
+
+describe('ambient virtual-feed recall SLA', () => {
+  const actionPollMs = readActionPollIntervalMs();
+  // The submodule is not checked out in every environment. Skipping is honest;
+  // silently passing on a regex that matched nothing would not be.
+  const maybe = actionPollMs === null ? it.skip : it;
+
+  it('finds the Owletto poll policy to check against', () => {
+    if (!existsSync(POLICY_PATH)) return; // submodule absent — nothing to assert
+    expect(actionPollMs).not.toBeNull();
+  });
+
+  maybe('claim + query + waiter granularity fits inside the recall budget', () => {
+    const worstCase =
+      (actionPollMs as number) + MEASURED_ARCHIVE_QUERY_MS + GATEWAY_WAITER_GRANULARITY_MS;
+    expect(worstCase).toBeLessThan(VIRTUAL_FEED_RECALL_BUDGET_MS);
+  });
+
+  maybe('leaves usable network margin rather than only just fitting', () => {
+    const worstCase =
+      (actionPollMs as number) + MEASURED_ARCHIVE_QUERY_MS + GATEWAY_WAITER_GRANULARITY_MS;
+    // A budget met with 50ms to spare is met only on a quiet network.
+    expect(VIRTUAL_FEED_RECALL_BUDGET_MS - worstCase).toBeGreaterThanOrEqual(1_000);
+  });
+});

--- a/packages/server/src/config/intervals.ts
+++ b/packages/server/src/config/intervals.ts
@@ -35,6 +35,25 @@ function parseEnvInterval(name: string, fallback: string): string {
 /** How long an unclaimed device action remains eligible for worker pickup. */
 export const DEVICE_ACTION_QUEUE_BUDGET_MS = 60_000;
 
+/**
+ * Wall-clock a SINGLE virtual feed gets during AMBIENT recall (`search_memory`'s
+ * opt-in virtual fan-out).
+ *
+ * Ambient recall is a side dish: it runs on every search_memory call, alongside
+ * knowledge and conversation recall, to add rows if they are cheaply available.
+ * It must never inherit an execution budget sized for a DELIBERATE read — the
+ * device queue alone allows 60s pre-claim plus 95s post-claim, so one sleeping
+ * laptop would stall every chat turn for over two minutes to contribute
+ * nothing.
+ *
+ * 5s is the same order as the other recall readers' Postgres queries and above
+ * the ~1s a warm local read costs (a real 47MB WhatsApp archive answers in tens
+ * of milliseconds; the round trip is dominated by the device's 500ms poll
+ * granularity). Deliberate reads — manage_feeds, query_sql — pass no deadline
+ * and keep the full device budget.
+ */
+export const VIRTUAL_FEED_RECALL_BUDGET_MS = 5_000;
+
 export const intervals = {
   /** Stale threshold (seconds) for the connector-lane run reaper.
    *  120s leaves room for the 30s worker heartbeat to miss ~3 ticks before

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -12,6 +12,7 @@ import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import type { AuthzScope } from '../authz/scope';
 import { getDb } from '../db/client';
 import { dbEgressConfig } from '../utils/cloud-mode';
+import { findBundledConnectorFile } from '../utils/connector-catalog';
 import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCodeForKey } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
@@ -21,6 +22,10 @@ import {
   normalizeMcpProxyConfig,
   readAtlassianMcpVirtualFeed,
 } from '../operations/atlassian-mcp-feed';
+import {
+  isMetadataOnlyDeviceConnector,
+  readDeviceVirtualFeed,
+} from './device-virtual-feed';
 
 interface ConnectorQueryParams {
   /** The ACL gate — tenant + principal. Its `organizationId`/`principal` drive
@@ -152,6 +157,14 @@ export interface ReadVirtualFeedParams {
   limit?: number;
   offset?: number;
   sort?: { column: string; order: 'asc' | 'desc' };
+  /**
+   * Caller's deadline for this read. Honoured by the device seam, which stops
+   * waiting AND terminalizes + scrubs its transport run rather than leaving it
+   * in flight. The compiled path has no in-subprocess cancellation, so a caller
+   * that must bound wall clock (ambient recall) races this promise too — see
+   * `readVirtualFeedWithinRecallBudget` in tools/search.ts.
+   */
+  signal?: AbortSignal;
 }
 
 /** Result from {@link readVirtualFeed} — live rows, never persisted. */
@@ -183,17 +196,42 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
     `SELECT f.id, f.feed_key, f.config, f.virtual,
             c.id AS connection_id, c.connector_key,
             c.auth_profile_id, c.app_auth_profile_id,
+            c.device_worker_id,
             COALESCE(c.config, '{}'::jsonb) AS connection_config,
-            cd.mcp_config
+            cd.mcp_config, cd.runtime, cd.required_capability, cd.has_compiled_code
      FROM feeds f
      JOIN connections c ON c.id = f.connection_id
      LEFT JOIN LATERAL (
-       SELECT mcp_config
-       FROM connector_definitions
-       WHERE key = c.connector_key
-         AND status = 'active'
-         AND organization_id = $2
-       ORDER BY updated_at DESC
+       SELECT cd0.mcp_config, cd0.runtime, cd0.required_capability,
+              EXISTS (
+                -- Does the SELECTED version ship code THIS path can execute?
+                --
+                -- Mirrors resolveConnectorCodeForKey's own resolution: the
+                -- definition's version, org artifact preferred over the shared
+                -- one. source_path is deliberately NOT part of it, and that is
+                -- not an oversight — resolveConnectorCode() reads only
+                -- compiled_code (recompiling from source_code when the config
+                -- hash moved) and otherwise falls through to the bundled file;
+                -- it never loads source_path. queue-service's
+                -- resolveActiveConnectorVersion DOES accept source_path, but
+                -- that is a laxer readiness gate, and device manifests set it to
+                -- device-manifest://... precisely as a non-executable marker.
+                -- Adopting that union here would classify every device connector
+                -- as having code and break this routing outright.
+                SELECT 1
+                FROM connector_versions cv
+                WHERE cv.connector_key = cd0.key
+                  AND cv.version = cd0.version
+                  AND (cv.organization_id = cd0.organization_id
+                       OR cv.organization_id IS NULL)
+                  AND cv.compiled_code IS NOT NULL
+                  AND cv.compiled_code <> ''
+              ) AS has_compiled_code
+       FROM connector_definitions cd0
+       WHERE cd0.key = c.connector_key
+         AND cd0.status = 'active'
+         AND cd0.organization_id = $2
+       ORDER BY cd0.updated_at DESC
        LIMIT 1
      ) cd ON TRUE
      WHERE f.id = $1
@@ -214,8 +252,12 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
     connector_key: string;
     auth_profile_id: number | null;
     app_auth_profile_id: number | null;
+    device_worker_id: string | null;
     connection_config: Record<string, unknown>;
     mcp_config: Record<string, unknown> | null;
+    runtime: Record<string, unknown> | null;
+    required_capability: string | null;
+    has_compiled_code: boolean | null;
   }>;
 
   if (feedRows.length === 0) {
@@ -253,6 +295,47 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
       limit: p.limit,
       offset: p.offset,
       sort: p.sort,
+    });
+  }
+
+  // Native device connectors (whatsapp.local, apple.*, os.shell, …) are
+  // metadata-only on the server: there is no compiled bundle to run, so
+  // `resolveConnectorCodeForKey` below would throw. Their live reads are served
+  // natively by the paired device over the device action queue.
+  //
+  // The discriminator is runtime metadata AND the absence of compiled code, not
+  // `runtime != null` on its own: `runtime` is descriptive (platforms, nix
+  // inputs) and a compiled connector may legitimately carry it while still
+  // having a bundle. Such a connector keeps the compiled pushdown, which is a
+  // strictly better read path than a device round-trip. A pin is not part of
+  // this either — it says which machine executes, not whether server code
+  // exists.
+  //
+  // "Has code" is deliberately BROADER than the stored artifact: a BUNDLED
+  // connector ships as source in the image and legitimately has
+  // `connector_versions.compiled_code IS NULL` (resolveConnectorCode falls
+  // through to `findBundledConnectorFile`). Reading only the column would route
+  // every bundled connector that declares a runtime onto the device queue.
+  const hasConnectorCode =
+    feed.has_compiled_code === true || findBundledConnectorFile(feed.connector_key) !== null;
+  if (isMetadataOnlyDeviceConnector(feed.runtime, hasConnectorCode)) {
+    return readDeviceVirtualFeed({
+      organizationId: p.scope.organizationId,
+      feedId: Number(feed.id),
+      feedKey: feed.feed_key,
+      // Same precedence as the compiled path below: connection config first,
+      // feed config wins. No credentials — a device connector authenticates as
+      // the logged-in desktop app, and the worker never receives secrets.
+      feedConfig: mergeExecutionConfig(feed.connection_config, feedConfig),
+      connectionId: Number(feed.connection_id),
+      connectorKey: feed.connector_key,
+      deviceWorkerId: feed.device_worker_id,
+      requiredCapability: feed.required_capability,
+      terms: p.terms,
+      limit: p.limit,
+      offset: p.offset,
+      sort: p.sort,
+      signal: p.signal,
     });
   }
 

--- a/packages/server/src/lib/device-virtual-feed-protocol.ts
+++ b/packages/server/src/lib/device-virtual-feed-protocol.ts
@@ -1,0 +1,34 @@
+/**
+ * Wire constants for the device virtual-feed read protocol.
+ *
+ * Deliberately dependency-free. The reserved action key is needed by three
+ * unrelated layers — the read seam (lib/device-virtual-feed.ts), the manifest
+ * validator (worker-api/device-manifests.ts) and the stale-run reaper
+ * (scheduled/check-stalled-executions.ts) — and the reaper must not pull the
+ * read seam's transitive graph (runs/queue-service → connector resolution) into
+ * the scheduler just to learn one string.
+ */
+
+/**
+ * Reserved action key a device connector must implement to serve live reads of
+ * its `virtual: true` feeds.
+ *
+ * The `__lobu_` prefix is reserved protocol namespace, rejected in manifest
+ * `actions_schema` keys (`RESERVED_ACTION_KEY_PREFIX` in device-manifests.ts),
+ * so this can never collide with a connector's own public action. It is
+ * deliberately NOT declared in `actions_schema`: declaring it would flip
+ * `supportsExecute` and publish a read seam as a user-invokable operation.
+ */
+export const DEVICE_VIRTUAL_FEED_ACTION_KEY = '__lobu_virtual_feed_read';
+
+/**
+ * How long a TERMINAL live-read run keeps its payload before the reaper sweeps
+ * it, when the in-process cleanup never ran (gateway crash, pod eviction).
+ *
+ * The grace exists to not race a healthy waiter: `waitForDeviceActionRun` polls
+ * every 500ms, so a run that has just been marked `completed` is about to be
+ * read by a waiter that will then scrub it itself. Sweeping instantly would
+ * turn a normal read into an empty result. 30s is two orders of magnitude above
+ * the poll interval and far below the run-retention window.
+ */
+export const DEVICE_VIRTUAL_FEED_SCRUB_GRACE_SECONDS = 30;

--- a/packages/server/src/lib/device-virtual-feed.ts
+++ b/packages/server/src/lib/device-virtual-feed.ts
@@ -35,7 +35,6 @@
  * means uncopied, not un-transmitted.
  */
 
-import { DEVICE_ACTION_QUEUE_BUDGET_MS } from '../config/intervals';
 import { getDb, pgTextArray } from '../db/client';
 import { createConnectorOperationRun } from '../runs/queue-service';
 import { classifyRunOutcome } from '../runs/run-outcome';
@@ -450,8 +449,8 @@ async function scrubVirtualFeedRunPayload(
 
 /**
  * Turn a finished device action into the caller's result, or an error. Exported
- * for test: the timeout branch is otherwise only reachable after the full
- * 60s queue budget.
+ * for test: short of an aborted wait, the timeout branch is otherwise only
+ * reachable after a full queue budget has elapsed.
  */
 export function deliver(
   p: DeviceVirtualFeedParams,
@@ -460,18 +459,23 @@ export function deliver(
   if (outcome.status === 'timeout') {
     // An ABORTED wait is not a device timeout, and must not be reported as one:
     // the device may be perfectly healthy and simply slower than the deadline
-    // this particular caller could afford. Quoting the 60s queue budget here
-    // would send the reader diagnosing a device that was never given 60s.
+    // this particular caller could afford. Reporting a queue budget here would
+    // send the reader off diagnosing a device that was never given one.
     if (p.signal?.aborted) {
       throw new Error(
         `Live read of feed '${p.feedKey}' was cut short by the caller's read deadline ` +
           'before the paired device answered.'
       );
     }
+    // No duration is quoted here: `waitForDeviceActionRun` already names the
+    // phase-specific budget in `error_message` (60s pre-claim, 95s post-claim),
+    // and this caller cannot tell which phase it lost. Quoting the 60s queue
+    // budget would mislabel a run a device CLAIMED and then hung on as a 60s
+    // timeout when it actually waited 95s.
     throw new Error(
-      `Live read of feed '${p.feedKey}' timed out after ${Math.round(
-        DEVICE_ACTION_QUEUE_BUDGET_MS / 1000
-      )}s: ${outcome.error_message ?? 'the paired device did not respond'}`
+      `Live read of feed '${p.feedKey}' timed out: ${
+        outcome.error_message ?? 'the paired device did not respond'
+      }`
     );
   }
   if (outcome.status === 'failed') {

--- a/packages/server/src/lib/device-virtual-feed.ts
+++ b/packages/server/src/lib/device-virtual-feed.ts
@@ -1,0 +1,496 @@
+/**
+ * Live virtual-feed reads for DEVICE-backed connectors.
+ *
+ * `readVirtualFeed` (connector-pushdown.ts) reads a virtual feed by resolving
+ * the connector's COMPILED code and running its `query()` / `search()` in the
+ * connector subprocess. A device-manifest connector (`whatsapp.local`,
+ * `apple.*`, `os.shell`, …) has no compiled code at all — it is metadata-only
+ * on the server and implemented natively on the paired device — so that path
+ * cannot serve it.
+ *
+ * This module is the missing seam. It reuses the EXISTING device transport
+ * end to end rather than inventing a second one:
+ *
+ *   1. `createConnectorOperationRun({ approvalMode: 'device' })` enqueues an
+ *      ephemeral `run_type='action'` row (the same helper
+ *      `manage_operations.execute` and `dispatch-chrome-action` use).
+ *   2. The paired device claims it on its next `/api/workers/poll` — the pin
+ *      and capability rules in poll.ts already cover `run_type='action'` on a
+ *      device-pinned connection, so no claim-path change was needed.
+ *   3. The device POSTs `/api/workers/complete-action` with the rows.
+ *   4. `waitForDeviceActionRun` observes the terminal row and returns.
+ *
+ * The contract is connector-agnostic: any device connector that declares a
+ * feed with `virtual: true` in its manifest `feeds_schema` opts in, and
+ * implements the reserved {@link DEVICE_VIRTUAL_FEED_ACTION_KEY} action
+ * natively. The action key is reserved protocol, deliberately NOT declared in
+ * `actions_schema` — declaring it would flip `supportsExecute` and publish a
+ * read seam as a user-invokable operation.
+ *
+ * Retains NOTHING: no events, no checkpoint, no feed state, no embeddings. The
+ * rows DO transit Postgres — the `runs` row is how a result crosses from the
+ * device to whichever replica is waiting, and that is also what makes this
+ * multi-replica safe — but the caller's filters and the device's rows are
+ * scrubbed off that row the moment the read returns, on every path. "Virtual"
+ * means uncopied, not un-transmitted.
+ */
+
+import { DEVICE_ACTION_QUEUE_BUDGET_MS } from '../config/intervals';
+import { getDb, pgTextArray } from '../db/client';
+import { createConnectorOperationRun } from '../runs/queue-service';
+import { classifyRunOutcome } from '../runs/run-outcome';
+import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
+import { DEVICE_ONLINE_WINDOW_SECONDS, describeDeviceLastSeen } from '../utils/device-liveness';
+import logger from '../utils/logger';
+import { DEVICE_VIRTUAL_FEED_ACTION_KEY } from './device-virtual-feed-protocol';
+
+/**
+ * The waiter this module calls. Production always uses the imported one; the
+ * slot exists so a test can make the wait FAIL.
+ *
+ * Why a slot and not `vi.mock`: `packages/server/vitest.config.ts` sets
+ * `isolate: false` so one Postgres-backed module graph is shared by every test
+ * file. Under that setting whether a module mock takes effect depends on which
+ * file imported `connector-pushdown` first, which made the two waiter-failure
+ * cases pass alone and time out in a full run. A slot is load-order
+ * independent.
+ *
+ * @internal
+ */
+type DeviceActionWaiter = typeof waitForDeviceActionRun;
+let deviceActionWaiter: DeviceActionWaiter = waitForDeviceActionRun;
+
+/**
+ * TEST ONLY — not part of any public, SDK, or cross-package surface. Swaps the
+ * waiter used by {@link readDeviceVirtualFeed}; pass `null` to restore the
+ * production one. The only caller is
+ * `__tests__/integration/connectors/device-virtual-feed-read`, which resets it
+ * in `beforeEach`.
+ *
+ * @internal
+ */
+export function __setDeviceActionWaiterForTest(waiter: DeviceActionWaiter | null): void {
+  deviceActionWaiter = waiter ?? waitForDeviceActionRun;
+}
+
+/** Row cap a live device read will ever ask for, whatever the caller passed. */
+export const DEVICE_VIRTUAL_FEED_MAX_LIMIT = 500;
+/** Row count asked for when the caller names none. */
+export const DEVICE_VIRTUAL_FEED_DEFAULT_LIMIT = 50;
+/**
+ * Deepest page a live read will ask a device for. Paging is not the point of a
+ * live feed — an unbounded offset is a full archive scan per request, paid on
+ * the user's laptop — so it is fenced rather than left to the caller.
+ */
+export const DEVICE_VIRTUAL_FEED_MAX_OFFSET = 10_000;
+
+export interface DeviceVirtualFeedParams {
+  organizationId: string;
+  /** feeds.id — already resolved + visibility-fenced by the caller. */
+  feedId: number;
+  feedKey: string;
+  /** Feed config, merged with the connection config by the caller. */
+  feedConfig: Record<string, unknown>;
+  connectionId: number;
+  connectorKey: string;
+  /** `connections.device_worker_id` — the execution pin, or null when unpinned. */
+  deviceWorkerId: string | null;
+  /** `connector_definitions.required_capability` for the capability pre-check. */
+  requiredCapability: string | null;
+  terms?: string[];
+  limit?: number;
+  offset?: number;
+  sort?: { column: string; order: 'asc' | 'desc' };
+  /**
+   * Caller's deadline. Ambient recall (`search_memory`) gives a live feed a few
+   * seconds, not the 60s pre-claim + 95s post-claim device budget — a question
+   * asked in chat cannot wait on a sleeping laptop. Aborting is not the same as
+   * abandoning: the waiter stops polling, finalizes the run as `timeout`, and
+   * the cleanup in {@link readDeviceVirtualFeed} still scrubs it, so no work is
+   * left orphaned behind a `Promise.race` the caller walked away from.
+   */
+  signal?: AbortSignal;
+}
+
+export interface DeviceVirtualFeedResult {
+  rows: Record<string, unknown>[];
+  columns: { name: string; type: string }[];
+  total?: number;
+}
+
+/** The `action_input` a device receives for a live virtual-feed read. */
+export interface DeviceVirtualFeedRequest {
+  feed_key: string;
+  /** Feed + connection config. Structured filters only — never SQL. */
+  config: Record<string, unknown>;
+  /**
+   * Recall terms. Non-empty means "keyword recall"; empty/absent means a plain
+   * ordered read. Mirrors the `search()` vs `query()` split on the compiled path.
+   */
+  terms: string[];
+  limit: number;
+  offset: number;
+  /**
+   * Requested ordering, or null for the connector's declared default. A device
+   * that cannot honour the named column MUST fail the run rather than silently
+   * return a different order.
+   */
+  sort: { column: string; order: 'asc' | 'desc' } | null;
+}
+
+/**
+ * True when the org's selected active definition is a METADATA-ONLY native
+ * device connector — the only shape this seam can serve.
+ *
+ * `runtime != null` alone is not that signal. `connector_definitions.runtime`
+ * is descriptive metadata (platforms, nix inputs); a perfectly ordinary
+ * compiled connector may carry it and must keep using the compiled pushdown,
+ * whose `query()`/`search()` is a strictly better read path than a device
+ * round-trip. What makes a connector unservable by that path is the absence of
+ * a bundle: `resolveConnectorCodeForKey` throws, and there is nothing to run.
+ *
+ * So the discriminator is the conjunction: runtime metadata AND no compiled
+ * code for the selected version. Pinning is NOT part of it — a pin says which
+ * machine executes, not whether server-side code exists.
+ */
+export function isMetadataOnlyDeviceConnector(
+  runtime: unknown,
+  hasCompiledCode: boolean
+): boolean {
+  return runtime != null && !hasCompiledCode;
+}
+
+/** Clamp a caller-supplied row window into the device read budget. */
+export function clampDeviceVirtualFeedWindow(limit?: number, offset?: number): {
+  limit: number;
+  offset: number;
+} {
+  const rawLimit = Number.isFinite(limit) ? Number(limit) : DEVICE_VIRTUAL_FEED_DEFAULT_LIMIT;
+  const rawOffset = Number.isFinite(offset) ? Number(offset) : 0;
+  return {
+    limit: Math.max(1, Math.min(DEVICE_VIRTUAL_FEED_MAX_LIMIT, Math.floor(rawLimit))),
+    offset: Math.max(0, Math.min(DEVICE_VIRTUAL_FEED_MAX_OFFSET, Math.floor(rawOffset))),
+  };
+}
+
+/**
+ * Normalize whatever the device POSTed into the virtual-feed read shape.
+ *
+ * A device is an untrusted-shape producer here: `runs.action_output` is
+ * arbitrary JSON. Anything that isn't `{ rows: object[] }` is a protocol
+ * violation and throws, so a malformed device reply surfaces as an error
+ * instead of an empty result the caller reads as "no messages".
+ */
+export function normalizeDeviceVirtualFeedOutput(output: unknown): DeviceVirtualFeedResult {
+  if (output == null || typeof output !== 'object' || Array.isArray(output)) {
+    throw new Error('device returned a malformed virtual-feed result (expected an object)');
+  }
+  const record = output as Record<string, unknown>;
+  if (!Array.isArray(record.rows)) {
+    throw new Error('device returned a malformed virtual-feed result (missing `rows` array)');
+  }
+  const rows = record.rows.map((row, index) => {
+    if (row == null || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error(`device returned a malformed virtual-feed row at index ${index}`);
+    }
+    return row as Record<string, unknown>;
+  });
+  const columns = Array.isArray(record.columns)
+    ? record.columns.flatMap((column) => {
+        if (column == null || typeof column !== 'object' || Array.isArray(column)) return [];
+        const { name, type } = column as { name?: unknown; type?: unknown };
+        if (typeof name !== 'string' || name.length === 0) return [];
+        return [{ name, type: typeof type === 'string' && type ? type : 'text' }];
+      })
+    : [];
+  const total = typeof record.total === 'number' && Number.isFinite(record.total)
+    ? record.total
+    : undefined;
+  return { rows, columns, total };
+}
+
+/**
+ * Pre-flight the device BEFORE enqueueing. Without this a read against a
+ * sleeping Mac parks a run for the full queue budget and then reports a
+ * timeout — 60s to say something the server already knew. Returns null when a
+ * device can plausibly serve the read.
+ */
+async function describeUnservableDevice(
+  p: DeviceVirtualFeedParams
+): Promise<string | null> {
+  const sql = getDb();
+  if (p.deviceWorkerId) {
+    // Reached THROUGH the connection, not by device id alone. The id comes off
+    // a row this caller may not own end-to-end, and the diagnostic below quotes
+    // the device's label and last-poll time — a corrupt or cross-org
+    // `device_worker_id` would otherwise report another tenant's machine back
+    // to this org in an error string. Joining through the connection means we
+    // can only ever describe the device this org's own connection pins.
+    //
+    // Deliberately NOT `dw.organization_id = p.organizationId`: that column is
+    // the device's HOME org, and poll.ts supports a device pinned into a second
+    // org. Fencing on it would break a legitimate cross-org pin.
+    const rows = (await sql`
+      SELECT dw.label, dw.last_seen_at, dw.capabilities,
+             dw.last_seen_at > now() - ${`${DEVICE_ONLINE_WINDOW_SECONDS} seconds`}::interval AS online
+      FROM connections c
+      JOIN device_workers dw ON dw.id = c.device_worker_id
+      WHERE c.id = ${p.connectionId}
+        AND c.organization_id = ${p.organizationId}
+        AND dw.id = ${p.deviceWorkerId}::uuid
+      LIMIT 1
+    `) as Array<{
+      label: string | null;
+      last_seen_at: Date | string | null;
+      capabilities: unknown;
+      online: boolean;
+    }>;
+    const device = rows[0];
+    const name = device?.label ? `device "${device.label}"` : 'the paired device';
+    if (!device) return 'the connection is pinned to a device this workspace cannot reach';
+    if (!device.online) return `${name} is offline (${describeDeviceLastSeen(device.last_seen_at)})`;
+    const capabilities = Array.isArray(device.capabilities) ? (device.capabilities as string[]) : [];
+    if (p.requiredCapability && !capabilities.includes(p.requiredCapability)) {
+      return `${name} no longer grants '${p.requiredCapability}'`;
+    }
+    return null;
+  }
+
+  // Unpinned. The question is which org a device may serve WITHOUT a pin, and
+  // it is narrower than "an org the owner belongs to".
+  //
+  // poll.ts branch 1B gates the unpinned claim on `baseOrgScopeIds` — the
+  // worker TOKEN's bound org plus the owner's personal org. Only one of those
+  // two is derivable here: no token has been presented at preflight time, so
+  // the bound org is unknowable. Joining `member` instead would NOT mirror
+  // `baseOrgScopeIds`; it is strictly wider. A device owner can belong to many
+  // team orgs while their token is bound to none of them, and this preflight
+  // would then report "servable" for a run branch 1B will never claim — trading
+  // an instant, actionable error for a 60-second queue timeout.
+  //
+  // So the durable lane is the personal org: a device is automatically servable
+  // in the org its owner's account IS. Read from
+  // `organization.metadata->>'personal_org_for_user_id'` rather than
+  // `device_workers.organization_id`, which is set once at pairing and goes
+  // stale the moment the device is re-anchored.
+  //
+  // A shared org with no pin is refused with the fix, not a diagnosis: pinning
+  // the connection is what makes it servable, and the pinned branch above
+  // already supports that across home orgs.
+  const [target] = (await sql`
+    SELECT CASE
+             WHEN o.metadata IS NULL THEN NULL
+             ELSE (o.metadata::jsonb)->>'personal_org_for_user_id'
+           END AS personal_owner_user_id
+    FROM connections c
+    JOIN "organization" o ON o.id = c.organization_id
+    WHERE c.id = ${p.connectionId}
+      AND c.organization_id = ${p.organizationId}
+    LIMIT 1
+  `) as Array<{ personal_owner_user_id: string | null }>;
+  if (!target) return 'the connection is not visible to this workspace';
+  if (!target.personal_owner_user_id) {
+    return (
+      'this connection is not pinned to a device — pin it to the device that should serve it, ' +
+      'because only a personal workspace serves an unpinned device connection automatically'
+    );
+  }
+
+  const rows = (await sql`
+    SELECT 1
+    FROM device_workers dw
+    WHERE dw.user_id = ${target.personal_owner_user_id}
+      AND dw.last_seen_at > now() - ${`${DEVICE_ONLINE_WINDOW_SECONDS} seconds`}::interval
+      AND (
+        ${p.requiredCapability}::text IS NULL
+        OR dw.capabilities @> ${sql.json([p.requiredCapability ?? ''])}
+      )
+    LIMIT 1
+  `) as Array<unknown>;
+  if (rows.length === 0) {
+    return p.requiredCapability
+      ? `no online device is serving '${p.requiredCapability}'`
+      : 'no online device can serve this connection';
+  }
+  return null;
+}
+
+/**
+ * Read a device-backed virtual feed live. Throws with an actionable message on
+ * offline / timeout / device-reported error; never returns a partial result.
+ */
+export async function readDeviceVirtualFeed(
+  p: DeviceVirtualFeedParams
+): Promise<DeviceVirtualFeedResult> {
+  const unservable = await describeUnservableDevice(p);
+  if (unservable) {
+    throw new Error(
+      `Live read of feed '${p.feedKey}' is unavailable: ${unservable}. ` +
+        'Open the Lobu/Owletto app on the paired Mac and try again.'
+    );
+  }
+
+  // The preflight is two DB round-trips against a laptop-liveness window. An
+  // ambient read on a 5s budget can genuinely spend its deadline in there, and
+  // enqueueing after that creates a transport run whose only future is to be
+  // cancelled — a row holding the caller's terms, briefly claimable, for a read
+  // nobody is waiting on. Check here, where the cheapest correct answer is to
+  // not start.
+  if (p.signal?.aborted) {
+    throw new Error(
+      `Live read of feed '${p.feedKey}' was cut short by the caller's read deadline ` +
+        'before the request reached the paired device.'
+    );
+  }
+
+  const { limit, offset } = clampDeviceVirtualFeedWindow(p.limit, p.offset);
+  const request: DeviceVirtualFeedRequest = {
+    feed_key: p.feedKey,
+    config: p.feedConfig,
+    terms: (p.terms ?? []).map((term) => term.trim()).filter(Boolean),
+    limit,
+    offset,
+    sort: p.sort ?? null,
+  };
+
+  const run = await createConnectorOperationRun({
+    organizationId: p.organizationId,
+    connectionId: p.connectionId,
+    connectorKey: p.connectorKey,
+    operationKey: DEVICE_VIRTUAL_FEED_ACTION_KEY,
+    operationInput: request as unknown as Record<string, unknown>,
+    approvalMode: 'device',
+    // Metadata-only device connectors have no compiled bundle by construction.
+    requireCompiledCode: false,
+  });
+
+  // The run row is the TRANSPORT, not a record. `complete-action` persists the
+  // device's rows into `runs.action_output`, and `action_input` holds the
+  // caller's recall terms and filters — both would then sit in Postgres for the
+  // run-retention window, which is exactly the durable copy a virtual feed
+  // promises not to make.
+  //
+  // The WAIT is inside the try on purpose. Scrubbing only after it returns
+  // leaves the payload behind on the path where it never returns at all — a
+  // dropped connection or a query error inside the poll loop throws, and the
+  // run row keeps a full page of the user's WhatsApp messages. Every path from
+  // the INSERT onward has to reach the cleanup.
+  //
+  // The cleanup also TERMINALIZES a run that is still in flight. Blanking the
+  // payload alone is not enough on the throw path: the run can still be
+  // pending, a device can claim it after the blanking, and `complete-action`
+  // would write a fresh page of messages back into the row we just cleared.
+  // Marking it `timeout` in the same statement closes that window —
+  // `finalizeRun` only transitions a `running` run claimed by the poster, so a
+  // late completion becomes a no-op.
+  try {
+    return deliver(p, await deviceActionWaiter(run.runId, p.organizationId, p.signal));
+  } finally {
+    await scrubVirtualFeedRunPayload(run.runId, p.organizationId, p.feedKey);
+  }
+}
+
+/** Statuses from which a live-read run can still be claimed or completed. */
+const NON_TERMINAL_RUN_STATUSES = ['pending', 'claimed', 'running'] as const;
+
+/**
+ * Blank the caller's filters and the device's rows off a virtual-feed run, and
+ * close it if it is still in flight. The run row itself survives as the audit
+ * trail that a live read happened, with no trace of what was read.
+ *
+ * One statement, so scrubbing and terminalizing cannot interleave with a device
+ * claiming the run. An ALREADY-terminal run keeps its status, outcome, and
+ * timing untouched — the read's verdict is the caller's to report, not this
+ * cleanup's to overwrite.
+ *
+ * Fenced to the reserved action key (plus org + run id) so it can never touch a
+ * real operation's output. Never throws — failing to scrub must be logged, not
+ * turned into a failed read the caller retries, which would only create another
+ * unscrubbed run.
+ */
+async function scrubVirtualFeedRunPayload(
+  runId: number,
+  organizationId: string,
+  feedKey: string
+): Promise<void> {
+  const sql = getDb();
+  const inFlight = pgTextArray([...NON_TERMINAL_RUN_STATUSES]);
+  try {
+    await sql`
+      UPDATE runs
+      SET action_output = NULL,
+          action_input = ${sql.json({ scrubbed: true, feed_key: feedKey })},
+          status = CASE WHEN status = ANY(${inFlight}::text[]) THEN 'timeout' ELSE status END,
+          outcome = CASE
+            WHEN status = ANY(${inFlight}::text[])
+              THEN ${classifyRunOutcome({ status: 'timeout' })}
+            ELSE outcome
+          END,
+          completed_at = CASE
+            WHEN status = ANY(${inFlight}::text[]) THEN current_timestamp
+            ELSE completed_at
+          END,
+          error_message = CASE
+            WHEN status = ANY(${inFlight}::text[])
+              THEN ${`Virtual feed '${feedKey}' live read was abandoned before the device answered.`}
+            ELSE error_message
+          END
+      WHERE id = ${runId}
+        AND organization_id = ${organizationId}
+        AND run_type = 'action'
+        AND action_key = ${DEVICE_VIRTUAL_FEED_ACTION_KEY}
+    `;
+  } catch (err) {
+    logger.error(
+      { runId, organizationId, feedKey, err: err instanceof Error ? err.message : String(err) },
+      '[device-virtual-feed] failed to scrub live-read payload off the run row'
+    );
+  }
+}
+
+/**
+ * Turn a finished device action into the caller's result, or an error. Exported
+ * for test: the timeout branch is otherwise only reachable after the full
+ * 60s queue budget.
+ */
+export function deliver(
+  p: DeviceVirtualFeedParams,
+  outcome: Awaited<ReturnType<typeof waitForDeviceActionRun>>
+): DeviceVirtualFeedResult {
+  if (outcome.status === 'timeout') {
+    // An ABORTED wait is not a device timeout, and must not be reported as one:
+    // the device may be perfectly healthy and simply slower than the deadline
+    // this particular caller could afford. Quoting the 60s queue budget here
+    // would send the reader diagnosing a device that was never given 60s.
+    if (p.signal?.aborted) {
+      throw new Error(
+        `Live read of feed '${p.feedKey}' was cut short by the caller's read deadline ` +
+          'before the paired device answered.'
+      );
+    }
+    throw new Error(
+      `Live read of feed '${p.feedKey}' timed out after ${Math.round(
+        DEVICE_ACTION_QUEUE_BUDGET_MS / 1000
+      )}s: ${outcome.error_message ?? 'the paired device did not respond'}`
+    );
+  }
+  if (outcome.status === 'failed') {
+    throw new Error(
+      `Live read of feed '${p.feedKey}' failed on the paired device: ${
+        outcome.error_message ?? 'unknown device error'
+      }`
+    );
+  }
+
+  const result = normalizeDeviceVirtualFeedOutput(outcome.output);
+  logger.debug(
+    {
+      feedId: p.feedId,
+      feedKey: p.feedKey,
+      connectorKey: p.connectorKey,
+      rows: result.rows.length,
+    },
+    '[device-virtual-feed] live read served by paired device'
+  );
+  return result;
+}

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -42,7 +42,7 @@ import type { ReservedSql } from 'postgres';
 import { maybeEmitFeedAutoPausedAfterFailure } from '../automations/platform-events';
 import { intervals } from '../config/intervals';
 import { feedBackoff } from '../connectors/feed-backoff';
-import { getDb } from '../db/client';
+import { type DbClient, getDb } from '../db/client';
 import type { Env } from '../index';
 import { classifyRunOutcome } from '../runs/run-outcome';
 import {
@@ -52,12 +52,115 @@ import {
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { reconcileAutomationRuns, sweepStaleAutomationRuns } from '../automations/automation';
+import {
+  DEVICE_VIRTUAL_FEED_ACTION_KEY,
+  DEVICE_VIRTUAL_FEED_SCRUB_GRACE_SECONDS,
+} from '../lib/device-virtual-feed-protocol';
 import { buildStaleRunWhereSql } from './stale-run-sweeper';
 
 /** Advisory-lock key for cross-pod coordination of the stale-run reaper.
  *  Picked from the >2^31 range to avoid collisions with the queue-NOTIFY
  *  channel ids and the due-feeds lock; the high bits are arbitrary. */
 const REAPER_ADVISORY_LOCK_KEY = 0x726e7372; // 'rnsr' — runs-reaper
+
+/** Statuses a live-read run can still be claimed or completed from. */
+const VIRTUAL_FEED_IN_FLIGHT_STATUSES = "('pending', 'claimed', 'running')";
+
+/**
+ * The only in-flight status this sweep may terminalize on an expired horizon.
+ *
+ * `runs.expires_at` on a device action is the UNCLAIMED claim horizon, not an
+ * execution deadline — queue-service stamps it so an unclaimed run cannot sit
+ * pending forever, and poll.ts enforces it only against `status = 'pending'`
+ * (both the candidate scan and the claiming UPDATE). A CLAIMED run is a device
+ * actually working: WhatsApp queries a real archive, and one claimed a second
+ * before expiry is legitimately still running. Timing it out here would kill
+ * live work on a clock that was never about execution.
+ *
+ * Claimed/running failures stay with the heartbeat/coarse reaper below — the
+ * claim stamps `last_heartbeat_at`, so that predicate governs them properly.
+ * Once IT terminalizes them, the terminal-grace lane here clears their payload
+ * on a later tick, so nothing is left holding rows either way.
+ */
+const VIRTUAL_FEED_EXPIRABLE_STATUS = "'pending'";
+
+const VIRTUAL_FEED_ORPHAN_MESSAGE =
+  'Live virtual-feed read expired without a device answer (swept by the run reaper).';
+
+/**
+ * Scrub abandoned device virtual-feed read runs, set-wise.
+ *
+ * A live read carries the caller's recall terms in `action_input` and a page of
+ * the device's rows in `action_output` — the transport that lets a result cross
+ * from a laptop to whichever replica is waiting. `readDeviceVirtualFeed` clears
+ * both in a `finally`, which covers every path the gateway process survives. It
+ * covers none of the paths where it does not: an OOM kill, a pod eviction, a
+ * rolling deploy mid-read. The promise that a virtual feed keeps no copy cannot
+ * rest on a process staying alive, so the same guarantee is re-asserted from
+ * the reaper, which any replica runs.
+ *
+ * Two lanes, one statement:
+ *   - TERMINAL rows past the grace window are scrubbed, keeping their status,
+ *     outcome and timing — the read's verdict belongs to whoever ran it.
+ *   - UNCLAIMED (`pending`) rows whose claim horizon (`expires_at`) has lapsed
+ *     are timed out AND scrubbed, so a device that wakes up late cannot claim
+ *     one and post a fresh page of messages into a row nobody is waiting on.
+ *     Only `pending` — see {@link VIRTUAL_FEED_EXPIRABLE_STATUS}; a claimed run
+ *     is a device mid-query and is the heartbeat reaper's to judge.
+ *
+ * The grace is what keeps this from racing a HEALTHY waiter: a run marked
+ * `completed` seconds ago is about to be read by a poller on a 500ms cadence
+ * that will scrub it itself, and sweeping instantly would turn an ordinary read
+ * into an empty result.
+ *
+ * Idempotent: a scrubbed row no longer matches (no output, and its input
+ * carries the `scrubbed` marker), so repeat ticks are no-ops. Fenced to the
+ * reserved action key, so no real operation's input or output is ever touched.
+ */
+export async function sweepAbandonedVirtualFeedReadRuns(
+  sql: Pick<DbClient, 'unsafe'>
+): Promise<number> {
+  const result = await sql.unsafe(
+    `UPDATE runs
+     SET action_output = NULL,
+         -- Keep the feed key: it is protocol, not user content, and it is the
+         -- only thing that makes the surviving audit row legible.
+         action_input = jsonb_build_object(
+           'scrubbed', true,
+           'feed_key', action_input->>'feed_key'
+         ),
+         status = CASE WHEN status IN ${VIRTUAL_FEED_IN_FLIGHT_STATUSES}
+                    THEN 'timeout' ELSE status END,
+         outcome = CASE WHEN status IN ${VIRTUAL_FEED_IN_FLIGHT_STATUSES}
+                     THEN $2 ELSE outcome END,
+         completed_at = CASE WHEN status IN ${VIRTUAL_FEED_IN_FLIGHT_STATUSES}
+                          THEN current_timestamp ELSE completed_at END,
+         error_message = CASE WHEN status IN ${VIRTUAL_FEED_IN_FLIGHT_STATUSES}
+                           THEN $3 ELSE error_message END
+     WHERE run_type = 'action'
+       AND action_key = $1
+       -- Already-clean rows must not match, or every tick would rewrite them.
+       AND (
+         action_output IS NOT NULL
+         OR (action_input IS NOT NULL AND NOT jsonb_exists(action_input, 'scrubbed'))
+       )
+       AND (
+         (status NOT IN ${VIRTUAL_FEED_IN_FLIGHT_STATUSES}
+          AND COALESCE(completed_at, created_at)
+              <= current_timestamp - ($4::int * interval '1 second'))
+         OR (status = ${VIRTUAL_FEED_EXPIRABLE_STATUS}
+             AND expires_at IS NOT NULL
+             AND expires_at <= current_timestamp)
+       )`,
+    [
+      DEVICE_VIRTUAL_FEED_ACTION_KEY,
+      classifyRunOutcome({ status: 'timeout' }),
+      VIRTUAL_FEED_ORPHAN_MESSAGE,
+      DEVICE_VIRTUAL_FEED_SCRUB_GRACE_SECONDS,
+    ]
+  );
+  return Number(result.count ?? 0);
+}
 
 interface ReapStaleRunsResult {
   /** Whether the advisory lock was acquired. False means another pod is
@@ -108,6 +211,25 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
     }
 
     try {
+      // First, and independently of the staleness predicate below: a crashed
+      // gateway leaves live virtual-feed reads holding user rows. This is a
+      // retention guarantee, not a queue-health one, so it runs even when
+      // nothing else is stale.
+      try {
+        const scrubbed = await sweepAbandonedVirtualFeedReadRuns(reserved);
+        if (scrubbed > 0) {
+          logger.warn(
+            { scrubbed },
+            '[reaper] Scrubbed abandoned device virtual-feed read runs'
+          );
+        }
+      } catch (err) {
+        logger.error(
+          { error: String(err) },
+          '[reaper] Failed to scrub abandoned device virtual-feed read runs'
+        );
+      }
+
       const heartbeatErrorMessage = 'worker_heartbeat_lost';
       const claimErrorMessage = 'worker_claim_timeout';
       // Failure-backoff / auto-pause policy shared with the completion path

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -41,6 +41,35 @@ export async function describeRunDeviceLastSeen(
   }
 }
 
+/**
+ * Sleep between polls, but wake IMMEDIATELY on abort.
+ *
+ * A plain `setTimeout` would hold an aborted wait for the rest of the poll
+ * interval before the loop noticed, and the caller's run stays in flight —
+ * claimable, and still holding its payload — for that whole window. Callers
+ * with a short deadline (ambient recall) measure their budget in a handful of
+ * poll intervals, so "up to 500ms late" is a meaningful share of it.
+ *
+ * The listener is always removed: this runs once per poll for the life of the
+ * wait, and a signal that outlives the loop would otherwise accumulate them.
+ */
+async function sleepUnlessAborted(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  if (!abortSignal) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+    return;
+  }
+  if (abortSignal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      abortSignal.removeEventListener('abort', done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    abortSignal.addEventListener('abort', done, { once: true });
+  });
+}
+
 // Deadline strategy: two phases.
 //
 //   - PRE-CLAIM (status='pending'): how long the device has to even
@@ -126,7 +155,7 @@ export async function waitForDeviceActionRun(
     } else {
       if (now >= queueDeadline) break;
     }
-    await new Promise((r) => setTimeout(r, POLL_MS));
+    await sleepUnlessAborted(POLL_MS, abortSignal);
   }
 
   // Which phase timed out decides what the operator needs to hear. A run that

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -13,11 +13,12 @@ import { isInProcessSystemCall } from './access-control';
 import { evaluateEntityMutation, resolveActingPrincipal } from '../authz/entity-policy';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
+import { VIRTUAL_FEED_RECALL_BUDGET_MS } from '../config/intervals';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import type { ContentItem } from '@lobu/connector-sdk';
 import type { FeedReader, SourceKind } from '../lib/feed-reader';
-import { readVirtualFeed } from '../lib/connector-pushdown';
+import { readVirtualFeed, type ReadVirtualFeedResult } from '../lib/connector-pushdown';
 import {
   connectionLinkedEntityIdsSql,
   connectionLinkedToBusinessEntitySql,
@@ -776,6 +777,51 @@ const conversationSource: RecallSource = {
 };
 
 /**
+ * Read one virtual feed under the AMBIENT recall deadline.
+ *
+ * Two mechanisms, because one is not enough:
+ *
+ *   - the ABORT tells the reader to stop. The device seam threads it into
+ *     `waitForDeviceActionRun`, which stops polling and finalizes its transport
+ *     run as `timeout`, and `readDeviceVirtualFeed`'s cleanup then scrubs it.
+ *     Without this, walking away from the promise would leave a live run
+ *     holding a page of the user's messages until the 60s queue budget lapsed.
+ *   - the RACE bounds wall clock regardless. A compiled connector's `search()`
+ *     runs in a subprocess with no cancellation seam, so the abort alone cannot
+ *     promise the caller anything; the race can.
+ *
+ * The underlying promise keeps running after a race loss (that is what lets the
+ * abort-driven cleanup finish), so its eventual rejection is absorbed here —
+ * the race below owns the verdict this caller sees.
+ */
+async function readVirtualFeedWithinRecallBudget(
+  params: Parameters<typeof readVirtualFeed>[0]
+): Promise<ReadVirtualFeedResult> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const pending = readVirtualFeed({ ...params, signal: controller.signal });
+  pending.catch(() => {
+    // Owned by the race below; also absorbed so a post-deadline rejection is
+    // never an unhandled one.
+  });
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new Error(
+          `live recall exceeded its ${VIRTUAL_FEED_RECALL_BUDGET_MS}ms budget`
+        )
+      );
+    }, VIRTUAL_FEED_RECALL_BUDGET_MS);
+  });
+  try {
+    return await Promise.race([pending, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * `virtual` — live rows from opt-in virtual feeds. A virtual feed participates
  * in ambient recall ONLY when its `config.recall === true`; most virtual feeds
  * exist to be SQL-addressable (query_sql) and must NOT tax every search_memory
@@ -831,7 +877,7 @@ const virtualSource: RecallSource = {
     const blocks = await Promise.all(
       candidates.map(async (f): Promise<VirtualFeedRows | null> => {
         try {
-          const live = await readVirtualFeed({
+          const live = await readVirtualFeedWithinRecallBudget({
             scope: gate,
             feedId: f.id,
             terms: [ctx.query as string],

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -203,6 +203,8 @@ function normalizeManifest(raw: unknown): DeviceConnectorManifest {
   if (platforms.length === 0) throw new Error('runtime.platforms cannot be empty');
   const feedsSchema = optionalRecord(raw, 'feeds_schema') ?? {};
   rejectRemovedEntityLinks(feedsSchema);
+  const actionsSchema = optionalRecord(raw, 'actions_schema');
+  rejectReservedActionKeys(actionsSchema);
   return {
     key,
     version,
@@ -216,10 +218,29 @@ function normalizeManifest(raw: unknown): DeviceConnectorManifest {
     } as DeviceConnectorManifest['runtime'],
     auth_schema: optionalRecord(raw, 'auth_schema'),
     feeds_schema: feedsSchema,
-    actions_schema: optionalRecord(raw, 'actions_schema'),
+    actions_schema: actionsSchema,
     options_schema: optionalRecord(raw, 'options_schema'),
     manifest_hash: optionalStringField(raw, 'manifest_hash'),
   };
+}
+
+/**
+ * Namespace the gateway reserves for its own device-protocol action keys (e.g.
+ * the virtual-feed live read). A manifest may not claim one: the server
+ * dispatches these keys itself, so a connector declaring the same string would
+ * shadow a protocol seam with a public operation.
+ */
+export const RESERVED_ACTION_KEY_PREFIX = '__lobu_';
+
+function rejectReservedActionKeys(actionsSchema: Record<string, unknown> | null): void {
+  if (!actionsSchema) return;
+  for (const actionKey of Object.keys(actionsSchema)) {
+    if (actionKey.startsWith(RESERVED_ACTION_KEY_PREFIX)) {
+      throw new Error(
+        `actions_schema key '${actionKey}' uses the reserved '${RESERVED_ACTION_KEY_PREFIX}' prefix`
+      );
+    }
+  }
 }
 
 function rejectRemovedEntityLinks(feedsSchema: Record<string, unknown>): void {

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -28,6 +28,59 @@ import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { getDeviceManifestSourcesForUser, sortJson, type DeviceConnectorSource } from './device-manifests';
 
+/**
+ * The slice of a manifest `feeds_schema[key]` this module reads. Deliberately
+ * local and minimal — reconcile is not the place to grow a feed-definition
+ * contract, and a manifest is untyped JSON off the wire regardless.
+ */
+interface ManifestFeed {
+  name?: string;
+  virtual?: boolean;
+  configSchema?: { properties?: Record<string, unknown> } | null;
+}
+
+/**
+ * Feed config keys whose declared JSON Schema `default` must be MATERIALIZED
+ * onto a newly auto-wired virtual feed rather than left as documentation.
+ *
+ * A JSON Schema default is not written back by validation, so `feeds.config`
+ * stays NULL — invisible to anything that reads the COLUMN. `recall` is read
+ * from the column (`search_memory`'s virtual fan-out selects
+ * `f.config->>'recall' = 'true'`), so a virtual feed that declares
+ * `recall.default = true` and is auto-wired with a NULL config would never
+ * participate in ambient recall, however it advertises itself.
+ *
+ * Kept to an explicit allowlist rather than "materialize every default": the
+ * rest of a feed's schema defaults are read through the schema at use time and
+ * copying them would freeze today's value into every row.
+ */
+const MATERIALIZED_VIRTUAL_FEED_DEFAULTS = ['recall'] as const;
+
+/**
+ * Config to persist on a NEWLY created auto-wired feed. Seeded at CREATE only
+ * — never re-applied on the re-activate path below, so a user who turns
+ * `recall` off does not get it switched back on by the next poll.
+ */
+function virtualFeedSeedConfig(
+  definition: ManifestFeed | undefined,
+  isVirtual: boolean
+): Record<string, unknown> | null {
+  if (!isVirtual || !definition) return null;
+  const properties = definition.configSchema?.properties ?? {};
+  const seed: Record<string, unknown> = {};
+  for (const key of MATERIALIZED_VIRTUAL_FEED_DEFAULTS) {
+    const property = properties[key];
+    if (
+      property != null &&
+      typeof property === 'object' &&
+      (property as { default?: unknown }).default === true
+    ) {
+      seed[key] = true;
+    }
+  }
+  return Object.keys(seed).length > 0 ? seed : null;
+}
+
 /** A device worker counts toward "serves capability X" only if seen this recently. */
 const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
 
@@ -508,30 +561,82 @@ async function ensureDeviceConnectorWired(
       //    has daily_summaries + workouts) need all of them wired, not just the
       //    first one. Also re-activates feeds a previous "capability went away"
       //    pass had paused.
+      // `feeds.kind` is IMMUTABLE once a row exists — nothing converts a
+      // collected feed to virtual in place, and doing so would strand the
+      // events/checkpoints already collected under it. So the manifest's
+      // `virtual: true` has to be honoured at INSERT time; a connector that
+      // wants both keeps two feed keys (e.g. `messages` + `messages_live`).
+      const declaredFeeds = metadata.feeds as Record<string, ManifestFeed> | null;
+      const declaredVirtual = (feedKey: string): boolean =>
+        declaredFeeds?.[feedKey]?.virtual === true;
+
       for (const feedKey of feedKeys) {
+        const isVirtual = declaredVirtual(feedKey);
         const existingFeed = (await tx`
-          SELECT id FROM feeds
+          SELECT id, kind, virtual FROM feeds
           WHERE connection_id = ${connectionId}
             AND feed_key = ${feedKey}
             AND deleted_at IS NULL
           LIMIT 1
-        `) as unknown as Array<{ id: number }>;
+        `) as unknown as Array<{ id: number; kind: string | null; virtual: boolean | null }>;
 
         if (existingFeed[0]?.id) {
+          const existingIsVirtual =
+            existingFeed[0].virtual === true || existingFeed[0].kind === 'virtual';
+          if (existingIsVirtual !== isVirtual) {
+            // Kind is immutable. Reconcile heals status and due time; it must
+            // never convert a feed in place. Flipping a collected row to
+            // virtual would strand its events and checkpoint behind a read path
+            // that never looks at them; flipping the other way would start
+            // minting sync runs for a feed nothing can sync. Leave the row
+            // exactly as it is — including next_run_at, which belongs to the
+            // kind the row actually has — and say so. The fix is a new feed
+            // key, not a mutation.
+            logger.warn(
+              {
+                userId,
+                connectorKey,
+                organizationId,
+                feedId: existingFeed[0].id,
+                feedKey,
+                existingKind: existingFeed[0].kind,
+                declaredVirtual: isVirtual,
+              },
+              '[device-connectors] Manifest feed kind differs from the existing feed row; leaving it untouched (feeds.kind is immutable — declare a new feed key instead)'
+            );
+            continue;
+          }
+          // A virtual feed is read live and NEVER synced, so it must not carry a
+          // due time: `materializeDueFeeds` would mint sync runs no device can
+          // serve, and each would fail the feed.
           await tx`
             UPDATE feeds
             SET status = 'active',
-                next_run_at = COALESCE(next_run_at, NOW()),
+                next_run_at = ${isVirtual ? tx`NULL::timestamptz` : tx`COALESCE(next_run_at, NOW())`},
                 updated_at = current_timestamp
             WHERE id = ${existingFeed[0].id}
           `;
         } else {
+          const seedFeedConfig = virtualFeedSeedConfig(declaredFeeds?.[feedKey], isVirtual);
+          // The manifest's per-feed `name` when it declares one, and only the
+          // connector's own name as the fallback. A connector with several
+          // feeds (`Messages` + `Messages (live)`) otherwise wires them all
+          // under one indistinguishable label, which is exactly the case a
+          // virtual feed introduces.
+          const declaredName = declaredFeeds?.[feedKey]?.name;
+          const displayName =
+            typeof declaredName === 'string' && declaredName.trim().length > 0
+              ? declaredName.trim()
+              : metadata.name;
           await tx`
             INSERT INTO feeds (
-              organization_id, connection_id, feed_key, display_name, status, config, next_run_at
+              organization_id, connection_id, feed_key, display_name, status, config,
+              next_run_at, kind, virtual
             ) VALUES (
               ${organizationId}, ${connectionId}, ${feedKey},
-              ${metadata.name}, 'active', NULL, NOW()
+              ${displayName}, 'active', ${seedFeedConfig ? tx.json(seedFeedConfig) : null},
+              ${isVirtual ? null : new Date()},
+              ${isVirtual ? 'virtual' : 'collected'}, ${isVirtual}
             )
           `;
         }


### PR DESCRIPTION
## Summary

- Adds the missing read seam for **device-manifest connectors** (`whatsapp.local`, `apple.*`, `os.shell`). These are metadata-only on the server — no compiled code exists — so `readVirtualFeed`'s subprocess pushdown could never serve them. Live reads now go over the **existing** device action queue under the reserved `__lobu_virtual_feed_read` key; no second transport.
- **Retains nothing**: no events, no checkpoint, no feed state, no embeddings. Rows *do* transit Postgres (the `runs` row is how a result crosses from a laptop to whichever replica is waiting — that is what makes this multi-replica safe), but the caller's filters and the device's rows are scrubbed off it the moment the read returns, on every path including the one where the wait itself throws. "Virtual" means uncopied, not un-transmitted.
- Pairs with **lobu-ai/owletto#902** (native Swift half). The pointer here currently targets that PR's branch head, so `check-drift` is red until owletto#902 merges and I repin — deliberate, per the documented order.

Three defects an independent review surfaced, each now pinned by a test:

**Ambient recall deadline.** `search_memory`'s virtual fan-out was inheriting the device queue's 60s pre-claim + 95s post-claim budget — one sleeping laptop would stall *every chat turn* for over two minutes to contribute nothing. Now a 5s per-feed deadline threads an `AbortSignal` down to `waitForDeviceActionRun`, so a lapsed deadline **stops the wait and terminalizes + scrubs its run**, rather than a bare `Promise.race` walking away from live work. The compiled path has no cancellation seam, so it is raced too. Deliberate reads (`manage_feeds`, `query_sql`) pass no signal and keep the full budget.

**Crash orphans.** The in-process `finally` covers every path the gateway process survives and none where it doesn't (OOM kill, eviction, rolling deploy mid-read). A retention promise can't rest on a process staying alive, so the reaper re-asserts it set-wise. Terminal rows past a 30s grace are scrubbed keeping their verdict; **unclaimed** rows past their claim horizon are timed out and scrubbed. Only unclaimed — `expires_at` is the claim horizon, not an execution deadline (poll.ts enforces it against `status='pending'` only, at both `:536` and `:713`), and a device that claimed a WhatsApp query a second before expiry is doing exactly what it was asked to.

**Routing.** `connector_definitions.runtime` alone is not a durable device-only signal — it's descriptive metadata a compiled connector may legitimately carry, and such a connector has a real `query()` that beats a device round-trip. Routing now asks what the *execution* resolver asks: stored `compiled_code`, or a bundled source file on disk. `source_path` is deliberately excluded — it appears in queue-service's laxer readiness gate but `resolveConnectorCode` never loads it, and device manifests set it to `device-manifest://…` precisely as a non-executable marker, so adopting that union would classify every device connector as having code and break routing outright.

Also: auto-wire honours a manifest feed's declared `virtual` and `name` at INSERT (`feeds.kind` is immutable, so a connector wanting both history and live reads declares two feed keys), materializes the `recall` default onto the column the fan-out actually reads, and a cross-repo gate asserts Owletto's poll cadence still fits inside the recall budget.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (build + typecheck + knip + biome + naming + gateway-LLM + entity-write, 19 bun tests)
- [x] Tests run: targeted integration + unit, see below
- [x] Bug fix: red→green pasted below
- [ ] Bot runtime unchanged — no eval needed

| Suite | Result |
|---|---|
| 4 device/virtual-feed integration files | **49/49**, green under 4 different shuffle seeds |
| `bun test` units (incl. new cross-repo SLA gate) | 26/26 |
| stale-run reaper suites | 33/33 |
| server `tsc --noEmit` | exit 0 |
| Owletto: `xcodebuild` clean build | **SUCCEEDED**, signed, 0 errors |
| Owletto: Swift suites / 36-file typecheck | 20/20 · 0 errors |

Integration files were run under `--sequence.shuffle.files` with seeds 3/5/11/29 because this package sets `isolate: false` (one shared module graph). An earlier cut used `vi.mock` for the device waiter and passed alone but timed out in a full run — that mock is replaced by an explicit, test-only dependency slot in `device-virtual-feed.ts`, which is load-order independent.

### red → green

Four rules mutation-checked independently. Each reverts to the pre-fix behaviour and fails the test that pins it:

```
# expiry lane widened back to claimed/running
× leaves a CLAIMED run with a lapsed horizon alone while it is still beating
  → expected 1 to be +0

# routing discriminator reverted to `runtime != null`
× keeps a runtime-declaring COMPILED connector on the pushdown, not the device seam
  → Live read of feed 'query' is unavailable: this connection is not pinned to a device…

# Owletto actionPollInterval reverted to 10s (fails from the SERVER suite)
× claim + query + waiter granularity fits inside the recall budget
× leaves usable network margin rather than only just fitting

# Swift boolean-flag throw reverted to a silent default
FAIL: a present but unreadable include_system_events ("maybe") must throw  (×5)
```

Two bugs were caught by these tests rather than by review:

1. `has_compiled_code` was computed in the LATERAL but **never added to the outer `SELECT` list**, so it was always `undefined` and *every* runtime-declaring connector would have routed to the device. `tsc` couldn't see it — the row type is a manual cast.
2. The real `xcodebuild` (Owletto side) caught a **Swift 6 concurrency error** in the probe fence that `swiftc -typecheck` did not flag.

## Notes

- **Merge order**: get this green → merge lobu-ai/owletto#902 → repin to its squash SHA → merge this. Holding owletto#902 open scopes `check-drift` red to this PR instead of the whole queue.
- **App-code submodule bump**, so AGENTS step 11 rollout verification is owed after merge.
- Residual: the true device claim bound is `max(2s, syncNow cycle duration)` — `syncNow` spawns the `lobu` CLI each cycle and `isSyncing` drops overlapping ticks. Worth measuring; splitting a claim-only poll out of the heavy sync is a separate change.
- Residual: the Mac app builds and links but has **not been launched** — no live read has crossed the wire end to end yet.
- Media-cardinality left as a documented schema assumption (real archive: 53,853 `ZWAMEDIAITEM` refs, max 1 row per `ZMESSAGE`, zero duplicates), so no grouping join was added.