### PR TITLE
ci: cache the bubblewrap .deb so a stalled mirror cannot fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,16 @@ jobs:
         with:
           node-version: "22"
 
+      # Cache the .deb so the steady-state install touches no apt mirror at all.
+      # The mirror stall this avoids is a HANG, not an error, so no retry policy
+      # can bound it — only not needing the network can. Keyed on the runner
+      # image, which is what determines the package version.
+      - name: Cache bubblewrap package
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lobu-bwrap
+          key: bwrap-deb-${{ runner.os }}-${{ runner.arch }}-v1
+
       - name: Install bubblewrap (for embedded exec-sandbox tests)
         # The ONLY job that requires bwrap: the worker exec-sandbox escape
         # matrix here (LOBU_REQUIRE_EXEC_SANDBOX=1) hard-fails without it, and
@@ -1232,6 +1242,7 @@ jobs:
           bash scripts/lib/__tests__/review-upstream-guard.test.sh
           bash scripts/lib/__tests__/review-skip.test.sh
           bash scripts/lib/__tests__/review-cache.test.sh
+          bash scripts/lib/__tests__/install-bubblewrap.test.sh
 
       - name: Preview workflow guards
         # The preview deploy's mid-flight teardown decides whether to delete a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,19 @@ jobs:
 
       # Cache the .deb so the steady-state install touches no apt mirror at all.
       # The mirror stall this avoids is a HANG, not an error, so no retry policy
-      # can bound it — only not needing the network can. Keyed on the runner
-      # image, which is what determines the package version.
+      # can bound it — only not needing the network can.
+      #
+      # ImageOS is in the key because runner.os/runner.arch are Linux/X64 on
+      # EVERY Ubuntu image: without it a .deb cached on 24.04 would be restored
+      # onto whatever image comes next. A stale .deb degrades safely (dpkg
+      # fails, the script falls through to apt) but it would spend the runtime
+      # this cache exists to save, on exactly the runs where the image just
+      # changed.
       - name: Cache bubblewrap package
         uses: actions/cache@v4
         with:
           path: ~/.cache/lobu-bwrap
-          key: bwrap-deb-${{ runner.os }}-${{ runner.arch }}-v1
+          key: bwrap-deb-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
 
       - name: Install bubblewrap (for embedded exec-sandbox tests)
         # The ONLY job that requires bwrap: the worker exec-sandbox escape

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -22,6 +22,9 @@ CACHE_DIR="${BWRAP_DEB_CACHE:-$HOME/.cache/lobu-bwrap}"
 # Overridable so the stash path is reachable from the test suite; apt itself
 # always writes here.
 APT_ARCHIVES="${APT_ARCHIVES_DIR:-/var/cache/apt/archives}"
+# Overridable for the same reason: the sysctl branch only exists on Linux, so
+# without a seam it is unreachable from a macOS dev run and first executes in CI.
+APPARMOR_FLAG="${APPARMOR_USERNS_FLAG:-/proc/sys/kernel/apparmor_restrict_unprivileged_userns}"
 mkdir -p "$CACHE_DIR"
 
 have_bwrap() { command -v bwrap >/dev/null 2>&1; }
@@ -86,7 +89,7 @@ fi
 # to close.
 
 # Only flip the AppArmor userns restriction when the runner kernel exposes it.
-if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+if [ -e "$APPARMOR_FLAG" ]; then
   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 fi
 

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -75,7 +75,7 @@ if ! have_bwrap; then
     if sudo cp "$deb" "$CACHE_DIR/" 2>/dev/null; then
       sudo chown "$(id -u):$(id -g)" "$CACHE_DIR/$(basename "$deb")" 2>/dev/null || true
       echo "cached $(basename "$deb") for future runs"
-    fi || true
+    fi
   done
 fi
 

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -2,42 +2,88 @@
 # Install bubblewrap for the worker exec-sandbox and prove it delivers real
 # isolation on this runner.
 #
-# Why this is a script and not duplicated inline `run:` blocks: the `unit` and
-# `sdk-cli-e2e` jobs both need bwrap, and the unit job now runs the
+# Why this is a script and not an inline `run:` block: the unit job runs the
 # escape matrix under LOBU_REQUIRE_EXEC_SANDBOX=1 (a missing bwrap is a test
-# failure, not a silent skip). Keeping one copy means the retry policy and the
-# AppArmor workaround can't drift apart between jobs.
+# failure, not a silent skip), so the retry policy and the AppArmor workaround
+# have to live in one place.
+#
+# Install strategy is layered, cheapest first, because apt is the ONLY step
+# here that can fail and it fails by HANGING. #2894 made the stalled azure
+# mirror fail fast, and it worked — but apt then fell through to
+# archive.ubuntu.com, which stalled MID-TRANSFER on 126 kB InRelease files.
+# `Acquire::http::Timeout` is a connect/response timeout; it does not abort a
+# connection that is still trickling. So each attempt burned its full timeout
+# and the retry loop simply did that three times: a 12m37s red build that never
+# reached a test. Retrying harder cannot fix a hang — the fix is to stop
+# needing the network at all.
 set -euo pipefail
 
-# apt mirrors flake. Because a failed install is now a RED build rather than a
-# silent skip, retry to keep that rare — then fail loudly instead of falling
-# through to the test steps with no sandbox. The retry loop only helps when
-# apt FAILS fast: a stalled mirror (or dpkg lock) hangs the command until the
-# job timeout, so every apt call is wrapped in `timeout` — a stall becomes a
-# fast failure that the next attempt rides over.
-#
-# The GitHub runner's default azure.archive.ubuntu.com mirror stalls (~5min:
-# the update burns the whole 240s timeout on attempt 1, then a retry succeeds).
-# Per-request Acquire::http::Timeout makes a hanging mirror fail in seconds
-# instead, so apt falls through to the responsive mirror (archive.ubuntu.com)
-# on the SAME attempt — the retry loop stays for the genuinely-down case.
-installed=""
-APT_FLAGS="-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 -o Acquire::ftp::Timeout=15"
-for attempt in 1 2 3; do
-  if sudo timeout 240 apt-get update $APT_FLAGS \
-      && sudo timeout 300 apt-get install $APT_FLAGS -y --no-install-recommends bubblewrap coreutils; then
-    installed=1
-    break
+CACHE_DIR="${BWRAP_DEB_CACHE:-$HOME/.cache/lobu-bwrap}"
+# Overridable so the stash path is reachable from the test suite; apt itself
+# always writes here.
+APT_ARCHIVES="${APT_ARCHIVES_DIR:-/var/cache/apt/archives}"
+mkdir -p "$CACHE_DIR"
+
+have_bwrap() { command -v bwrap >/dev/null 2>&1; }
+
+# --- Layer 1: already installed -------------------------------------------
+# Runner images change; if a future one ships bubblewrap we should pay nothing.
+if have_bwrap; then
+  echo "bwrap already present at $(command -v bwrap) — no install needed"
+fi
+
+# --- Layer 2: cached .deb (the steady state: NO network at all) ------------
+if ! have_bwrap; then
+  cached=$(find "$CACHE_DIR" -maxdepth 1 -name 'bubblewrap_*.deb' 2>/dev/null | head -1)
+  if [ -n "$cached" ]; then
+    echo "installing bwrap from cached $(basename "$cached") (no network)"
+    sudo dpkg -i "$cached" || echo "cached .deb rejected; falling through to apt"
   fi
-  if [ "$attempt" -lt 3 ]; then
-    echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
-    sleep $((attempt * 5))
-  fi
-done
-if [ -z "$installed" ]; then
-  echo "::error::bubblewrap install failed after 3 attempts"
+fi
+
+# --- Layer 3: apt, and stash the .deb so layer 2 wins next time ------------
+# Timeouts are per-attempt and deliberately tighter than the old 240s/300s: a
+# stalled mirror should cost seconds of the budget, not minutes. Three attempts
+# at 90s+90s caps the worst case near 9 minutes of the old 12m37s, and the
+# cache means the common run never gets here.
+if ! have_bwrap; then
+  APT_FLAGS="-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 -o Acquire::ftp::Timeout=15"
+  for attempt in 1 2 3; do
+    if sudo timeout 90 apt-get update $APT_FLAGS \
+        && sudo timeout 90 apt-get install $APT_FLAGS -y --no-install-recommends bubblewrap; then
+      break
+    fi
+    if [ "$attempt" -lt 3 ]; then
+      echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
+      sleep $((attempt * 5))
+    fi
+  done
+
+  # Best-effort: keep the .deb for the next run. apt may have auto-cleaned it,
+  # which is why this never gates the install.
+  # The stash is an optimisation and must never turn a SUCCESSFUL install into a
+  # red build. Note `set -e` alone does NOT give you that: POSIX exempts every
+  # command in an `&&` list except the last, so a failing `cp && chown` does not
+  # abort — but a bare `sudo cp` on its own line WOULD. Guarding explicitly means
+  # the property survives someone later unfolding this into simple commands, and
+  # keeps a permission error out of the log where it reads as a real failure.
+  for deb in "$APT_ARCHIVES"/bubblewrap_*.deb; do
+    [ -e "$deb" ] || continue
+    if sudo cp "$deb" "$CACHE_DIR/" 2>/dev/null; then
+      sudo chown "$(id -u):$(id -g)" "$CACHE_DIR/$(basename "$deb")" 2>/dev/null || true
+      echo "cached $(basename "$deb") for future runs"
+    fi || true
+  done
+fi
+
+if ! have_bwrap; then
+  echo "::error::bubblewrap unavailable after cache and 3 apt attempts"
   exit 1
 fi
+
+# `coreutils` used to be installed alongside; it is present on every Ubuntu
+# runner image, so asking apt for it only widened the window this script exists
+# to close.
 
 # Only flip the AppArmor userns restriction when the runner kernel exposes it.
 if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then

--- a/scripts/lib/__tests__/install-bubblewrap.test.sh
+++ b/scripts/lib/__tests__/install-bubblewrap.test.sh
@@ -112,11 +112,16 @@ case "$out" in *"::error::"*) ;; *) fail "exhausted: no ::error:: annotation: $o
 echo "ok: an unavailable bwrap fails the build closed"
 
 # --- 4. apt succeeds but the cache is unwritable: install must still pass ----
-# The stash is an optimisation. `set -e` on a bare `cp && chown` would let a
-# read-only cache dir turn a perfectly good install red.
+# The stash is an optimisation and must not turn a good install red.
+#
+# Precisely what this case discriminates: a bare `sudo cp` on its own line. It
+# does NOT discriminate `cp && chown` — errexit exempts every command in an
+# `&&` list except the last, so that form was already safe and survives the
+# mutation. The guard is written explicitly anyway, so the property holds if
+# someone later unfolds it into simple commands, which is what this pins.
 setup_case
-# Without a .deb here the stash loop never runs and this case asserts nothing —
-# it passed against a deliberately reverted `cp && chown` until this line existed.
+# Without a .deb here the stash loop never runs at all and this case asserts
+# nothing — it passed against every mutation until this line existed.
 echo "stub" > "$work/archives/bubblewrap_1.2.3_amd64.deb"
 chmod 500 "$work/cache"
 cat > "$work/bin/apt-get" <<EOF

--- a/scripts/lib/__tests__/install-bubblewrap.test.sh
+++ b/scripts/lib/__tests__/install-bubblewrap.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/install-bubblewrap.sh.
+#
+# The script guards a security control: `unit` runs the exec-sandbox escape
+# matrix under LOBU_REQUIRE_EXEC_SANDBOX=1, so a bwrap that quietly fails to
+# install must turn the build RED. The layered install added for the apt-mirror
+# hang gave that property three new ways to regress silently — a cache path
+# that swallows a failure, or a best-effort stash that sinks a good install —
+# so each layer is pinned here.
+#
+# Everything runs against stubs on PATH. Nothing here touches apt or the
+# network, which is the same property the script is trying to buy in CI.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="$repo_root/scripts/install-bubblewrap.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# A sandbox with stub bin/ and cache/ per case, so cases cannot leak into
+# each other through an installed binary or a left-over .deb.
+setup_case() {
+  work="$(mktemp -d)"
+  mkdir -p "$work/bin" "$work/cache" "$work/real" "$work/archives"
+  cat > "$work/real/bwrap" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "--version" ] && { echo "bubblewrap 0.0.0 (stub)"; exit 0; }
+exit 0
+EOF
+  chmod +x "$work/real/bwrap"
+  cat > "$work/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+  cat > "$work/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift; exec "$@"
+EOF
+  chmod +x "$work/bin/sudo" "$work/bin/timeout"
+}
+
+run_script() {
+  set +e
+  out="$(PATH="$work/bin:/usr/bin:/bin" BWRAP_DEB_CACHE="$work/cache" \
+    APT_ARCHIVES_DIR="$work/archives" bash "$script" probe 2>&1)"
+  rc=$?
+  set -e
+}
+
+# --- 1. bwrap already on PATH: install must be skipped entirely -------------
+setup_case
+cp "$work/real/bwrap" "$work/bin/bwrap"
+cat > "$work/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+echo "REACHED_APT"; exit 0
+EOF
+chmod +x "$work/bin/apt-get"
+run_script
+[ "$rc" -eq 0 ] || fail "preinstalled: expected pass, got $rc: $out"
+case "$out" in *"already present"*) ;; *) fail "preinstalled: no skip message: $out";; esac
+case "$out" in *REACHED_APT*) fail "preinstalled: apt was invoked anyway: $out";; esac
+echo "ok: a preinstalled bwrap skips the install"
+
+# --- 2. cached .deb: dpkg installs it and apt is never reached --------------
+# This is the steady state the cache exists to produce. If apt is reached here,
+# the mirror hang is back in the critical path and the fix is worthless.
+setup_case
+echo "stub" > "$work/cache/bubblewrap_1.2.3_amd64.deb"
+cat > "$work/bin/dpkg" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "-i" ] && { cp "$work/real/bwrap" "$work/bin/bwrap"; exit 0; }
+exit 1
+EOF
+cat > "$work/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+echo "REACHED_APT"; exit 0
+EOF
+chmod +x "$work/bin/dpkg" "$work/bin/apt-get"
+run_script
+[ "$rc" -eq 0 ] || fail "cached: expected pass, got $rc: $out"
+case "$out" in *"no network"*) ;; *) fail "cached: did not use the cache: $out";; esac
+case "$out" in *REACHED_APT*) fail "cached: apt reached despite a cache hit: $out";; esac
+echo "ok: a cached .deb installs without touching apt"
+
+# --- 3. nothing works: must FAIL CLOSED -------------------------------------
+# The whole point. A green job with no bwrap means the escape matrix
+# describe.skip()s itself and containment stops being verified, unnoticed.
+setup_case
+cat > "$work/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+echo "simulated mirror failure" >&2; exit 1
+EOF
+chmod +x "$work/bin/apt-get"
+run_script
+[ "$rc" -ne 0 ] || fail "exhausted: expected FAILURE, got pass — bwrap would silently vanish: $out"
+case "$out" in *"::error::"*) ;; *) fail "exhausted: no ::error:: annotation: $out";; esac
+echo "ok: an unavailable bwrap fails the build closed"
+
+# --- 4. apt succeeds but the cache is unwritable: install must still pass ----
+# The stash is an optimisation. `set -e` on a bare `cp && chown` would let a
+# read-only cache dir turn a perfectly good install red.
+setup_case
+# Without a .deb here the stash loop never runs and this case asserts nothing —
+# it passed against a deliberately reverted `cp && chown` until this line existed.
+echo "stub" > "$work/archives/bubblewrap_1.2.3_amd64.deb"
+chmod 500 "$work/cache"
+cat > "$work/bin/apt-get" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "update" ] && exit 0
+cp "$work/real/bwrap" "$work/bin/bwrap"
+exit 0
+EOF
+chmod +x "$work/bin/apt-get"
+run_script
+chmod 700 "$work/cache"
+[ "$rc" -eq 0 ] || fail "unwritable cache: a best-effort stash failed the install: $out"
+echo "ok: a failed cache stash does not fail a good install"
+
+echo "install-bubblewrap.test.sh: all cases passed"

--- a/scripts/lib/__tests__/install-bubblewrap.test.sh
+++ b/scripts/lib/__tests__/install-bubblewrap.test.sh
@@ -38,13 +38,23 @@ EOF
 #!/usr/bin/env bash
 shift; exec "$@"
 EOF
-  chmod +x "$work/bin/sudo" "$work/bin/timeout"
+  # A test must never flip a real kernel sysctl. On Linux the apparmor flag
+  # EXISTS, so the script takes that branch and `sudo sysctl` would run for
+  # real — stub it, and point the script at a fake flag file so the branch is
+  # exercised identically on macOS and Linux.
+  cat > "$work/bin/sysctl" <<'EOF'
+#!/usr/bin/env bash
+echo "sysctl(stub) $*"
+EOF
+  chmod +x "$work/bin/sudo" "$work/bin/timeout" "$work/bin/sysctl"
+  : > "$work/apparmor_flag"
 }
 
 run_script() {
   set +e
   out="$(PATH="$work/bin:/usr/bin:/bin" BWRAP_DEB_CACHE="$work/cache" \
-    APT_ARCHIVES_DIR="$work/archives" bash "$script" probe 2>&1)"
+    APT_ARCHIVES_DIR="$work/archives" APPARMOR_USERNS_FLAG="$work/apparmor_flag" \
+    bash "$script" probe 2>&1)"
   rc=$?
   set -e
 }
@@ -61,6 +71,9 @@ run_script
 [ "$rc" -eq 0 ] || fail "preinstalled: expected pass, got $rc: $out"
 case "$out" in *"already present"*) ;; *) fail "preinstalled: no skip message: $out";; esac
 case "$out" in *REACHED_APT*) fail "preinstalled: apt was invoked anyway: $out";; esac
+# The apparmor branch is Linux-only in production; assert it ran here so the
+# seam cannot rot into an untested path again.
+case "$out" in *"sysctl(stub)"*) ;; *) fail "preinstalled: apparmor branch never ran: $out";; esac
 echo "ok: a preinstalled bwrap skips the install"
 
 # --- 2. cached .deb: dpkg installs it and apt is never reached --------------


### PR DESCRIPTION
## Summary

- `unit` burned **12m37s and went red without running a single test** — three apt attempts, each timing out at 240s installing bubblewrap.
- **#2894's mitigation worked.** The log shows the stalled azure mirror `Ign`'d in four seconds and apt falling through to `archive.ubuntu.com` exactly as designed. The failure is one step further on: the *fallback* mirror stalled **mid-transfer** on 126 kB `InRelease` files. `Acquire::http::Timeout` is a connect/response timeout — it does not abort a connection that is still trickling.
- That is why this has now survived two fixes. **A hang cannot be bounded by a retry policy.** It can only be avoided by not needing the network.

```
21:44:39  Ign: azure.archive.ubuntu.com …    ← 15s timeout worked, skipped fast
21:44:43  Hit: archive.ubuntu.com noble      ← fell through as designed
21:44:44  Get:3 noble-updates InRelease [126 kB]
21:48:20  apt-get failed (attempt 2/3)       ← 3m36s later. Full budget burned.
21:48:30 … 21:52:30  attempt 3, exactly 240s, dead
```

## The fix

Layered, cheapest first:

| layer | cost | when |
|---|---|---|
| 1. `bwrap` already on PATH | nothing | if a runner image ever ships it |
| 2. cached `.deb` → `dpkg -i` | **zero network** | the steady state |
| 3. apt | bounded 90s+90s ×3 | cache miss only — then stashes the `.deb` so layer 2 wins next time |

Also drops `coreutils` from the install list: it ships on every Ubuntu runner, so asking apt for it only widened the window this script exists to close.

## Why not just remove bubblewrap

Removing it would not turn the sandbox tests red. `exec-sandbox.test.ts` would `describe.skip` itself and `unit` would stay **green**, so the only Linux proof that a spawned binary is actually contained would stop running with nothing to notice it. The existing CI comment says exactly this.

**Daytona does not cover this.** It appears only in `Makefile` and `scripts/run-remote-ci.sh` / `scripts/lib/gate-*.sh` — it sandboxes *our CI* (`make pr-full`). bwrap is production runtime containment *inside the worker*, per spawned command:

> just-bash's interpreter and `ReadWriteFs` already root file ops in the thread workspace, but spawned binaries (gh, git, lobu, anything from /nix/store) bypass that — once execFile fires, the child has the host's full FS view.

Different boundary, different threat, different layer.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: new `scripts/lib/__tests__/install-bubblewrap.test.sh`, wired into the existing "Review tooling shell tests" step
- [x] Bug fix: root cause identified from the failing log, pasted above
- [ ] Bot runtime unchanged

### Mutation testing

Each mutation kills exactly one case:

| Mutation | Result |
|---|---|
| remove the fail-closed `exit 1` | ✗ case 3 — a missing bwrap would go green |
| skip the cache layer | ✗ case 2 — `REACHED_APT`, mirror back in the hot path |
| unfold the stash into a bare `sudo cp` | ✗ case 4 — `Permission denied` fails a good install |

### One correction worth recording

`set -e` alone does **not** protect the best-effort stash. POSIX exempts every command in an `&&` list except the last, so the original `cp && chown` never aborted on a failed `cp` — but a bare `sudo cp` on its own line would. My first attempt at this guard was justified by that wrong belief; the comment now states the real rule and case 4 proves the property against the mutation that actually triggers it.

An earlier version of case 4 was also **vacuous**: `/var/cache/apt/archives` does not exist on macOS, so the stash loop never ran and the case asserted nothing. `APT_ARCHIVES_DIR` now makes that path reachable, mirroring the existing `BWRAP_DEB_CACHE` seam.

## Notes

Steady state after this lands: `unit` contacts no package mirror at all. The cache key is `bwrap-deb-${{ runner.os }}-${{ runner.arch }}-v1` — bump the suffix to force a refresh.
