### PR TITLE
feat(automations): execute headless device Automations on a per-run agent session

### DIFF
--- a/packages/cli/src/commands/memory/_lib/memory-auth.test.ts
+++ b/packages/cli/src/commands/memory/_lib/memory-auth.test.ts
@@ -3,7 +3,12 @@ import { MCP_PROTOCOL_VERSION } from "@lobu/core";
 import * as internal from "../../../internal/index.js";
 import { memoryRunCommand } from "../run.js";
 import { mcpRpc } from "./mcp.js";
-import { getSessionForOrg, getUsableToken } from "./memory-auth.js";
+import {
+  getSessionForOrg,
+  getUsableToken,
+  normalizeMcpUrl,
+  resolveOrg,
+} from "./memory-auth.js";
 
 const CLOUD_MCP_URL = "https://lobu.ai/mcp";
 
@@ -29,6 +34,22 @@ describe("memory auth URL resolution", () => {
   afterEach(() => {
     mock.restore();
     delete process.env.LOBU_API_TOKEN;
+    delete process.env.LOBU_MEMORY_URL;
+    delete process.env.LOBU_MEMORY_ORG;
+  });
+
+  test("preserves a mounted named MCP endpoint", () => {
+    expect(normalizeMcpUrl("https://gateway.test/lobu/mcp/lobu-memory")).toBe(
+      "https://gateway.test/lobu/mcp/lobu-memory"
+    );
+  });
+
+  test("explicit runtime MCP URL and bearer ignore the saved active org", async () => {
+    spyOn(internal, "getActiveOrg").mockResolvedValue("wrong-org");
+    process.env.LOBU_API_TOKEN = "runtime-bearer";
+    process.env.LOBU_MEMORY_URL = "https://gateway.test/lobu/mcp/lobu-memory";
+    expect(await resolveOrg()).toBeUndefined();
+    expect(internal.getActiveOrg).not.toHaveBeenCalled();
   });
 
   test("getSessionForOrg honors an explicit --url", async () => {

--- a/packages/cli/src/commands/memory/_lib/memory-auth.ts
+++ b/packages/cli/src/commands/memory/_lib/memory-auth.ts
@@ -21,7 +21,10 @@ export function normalizeMcpUrl(input: string): string {
   url.search = "";
   if (!url.pathname || url.pathname === "/") {
     url.pathname = "/mcp";
-  } else if (!url.pathname.startsWith("/mcp")) {
+  } else if (
+    !url.pathname.startsWith("/mcp") &&
+    !url.pathname.includes("/mcp/")
+  ) {
     url.pathname = `${url.pathname.replace(/\/+$/, "")}/mcp`;
   }
   return url.toString().replace(/\/+$/, "");
@@ -121,6 +124,9 @@ export async function resolveOrg(
 ): Promise<string | undefined> {
   if (orgFlag) return orgFlag;
   if (process.env.LOBU_MEMORY_ORG) return process.env.LOBU_MEMORY_ORG;
+  // Explicit runtime bearer + MCP URL is self-contained; do not rewrite a mounted endpoint with ambient org state.
+  if (process.env.LOBU_API_TOKEN?.trim() && process.env.LOBU_MEMORY_URL?.trim())
+    return undefined;
   if (session?.org) return session.org;
   return getActiveOrg(context);
 }

--- a/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
+++ b/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
@@ -100,6 +100,40 @@ describe("device worker poll body", () => {
     expect(calls[0].body).toMatchObject({ label: "Buraks-MacBook-Pro" });
   });
 
+  test("a headless device advertises automations.execute without being told to", async () => {
+    // The gateway's Automation claim lane matches this exact string, so the
+    // build — not the operator's --capabilities flag — is what opts a headless
+    // daemon in. Without it, every headless device silently stops claiming
+    // Automation runs.
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-6",
+      capabilities: { "os.shell": true, "os.files": true },
+      platform: "headless",
+    }).poll();
+
+    expect(calls[0].body.capabilities).toEqual({
+      "os.shell": true,
+      "os.files": true,
+      "automations.execute": true,
+    });
+  });
+
+  test("macOS is not given automations.execute — its allowlist would drop it", async () => {
+    // The poll lane exempts macOS outright; advertising a string the macos
+    // allowlist rejects would only log a dropped-capability warning per poll.
+    const { calls } = capturePoll();
+    await new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-7",
+      capabilities: { "os.files": true },
+      platform: "macos",
+    }).poll();
+
+    expect(calls[0].body.capabilities).not.toHaveProperty("automations.execute");
+  });
+
   test("capability names survive verbatim — the server matches them as strings", async () => {
     // `required_capability` is compared with `= ANY(...)` against these exact
     // strings, so any normalization here (case-folding, dot handling) would

--- a/packages/connector-worker/src/__tests__/executor-automation.test.ts
+++ b/packages/connector-worker/src/__tests__/executor-automation.test.ts
@@ -18,8 +18,11 @@ import {
   type AutomationRunIo,
   type ExecutorResult,
 } from '../daemon/automation.js';
-import type { AutomationPollPayload } from '@lobu/core/contracts/worker/protocol';
-import type { CompleteAutomationRequest } from '@lobu/core/contracts/worker/protocol';
+import { executeRun } from '../daemon/executor.js';
+import type {
+  AutomationPollPayload,
+  CompleteAutomationRequest,
+} from '@lobu/core/contracts/worker/protocol';
 
 function makeResult(overrides: Partial<ExecutorResult> = {}): ExecutorResult {
   return {
@@ -245,7 +248,6 @@ function makeSafetyNetClient() {
 
 describe('executeRun try/catch safety net', () => {
   test('catches unhandled errors and terminates the run via complete', async () => {
-    const { executeRun } = await import('../daemon/executor.js');
     const { client, completes } = makeSafetyNetClient();
 
     const result = await executeRun(
@@ -261,7 +263,6 @@ describe('executeRun try/catch safety net', () => {
   });
 
   test('automation-lane unhandled error terminates via complete-automation, never the sync endpoint', async () => {
-    const { executeRun } = await import('../daemon/executor.js');
     const { client, completes, automationCompletes } = makeSafetyNetClient();
 
     // payload present but malformed (automation key missing) → throws inside

--- a/packages/connector-worker/src/__tests__/executor-automation.test.ts
+++ b/packages/connector-worker/src/__tests__/executor-automation.test.ts
@@ -14,9 +14,11 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   dispatchAutomationResumeLoop,
+  resolveAutomationRunAccess,
   type AutomationRunIo,
   type ExecutorResult,
 } from '../daemon/automation.js';
+import type { AutomationPollPayload } from '@lobu/core/contracts/worker/protocol';
 import type { CompleteAutomationRequest } from '@lobu/core/contracts/worker/protocol';
 
 function makeResult(overrides: Partial<ExecutorResult> = {}): ExecutorResult {
@@ -217,25 +219,34 @@ describe('dispatchAutomationResumeLoop', () => {
   });
 });
 
+function makeSafetyNetClient() {
+  const completes: Array<Record<string, unknown>> = [];
+  const automationCompletes: Array<{ runId: number; req: Record<string, unknown> }> = [];
+  const client = {
+    id: 'test-worker',
+    version: 'test',
+    async heartbeat() {},
+    async stream() {},
+    async complete(req: Record<string, unknown>) { completes.push(req); },
+    async completeAction() {},
+    async completeEmbeddings() {},
+    async completeAuth() {},
+    async emitAuthArtifact() {},
+    async pollAuthSignal() { return { signal: null }; },
+    async fetchEventsForEmbedding() { return []; },
+    async dispatchChromeAction() { return {}; },
+    async completeAutomation(runId: number, req: Record<string, unknown>) {
+      automationCompletes.push({ runId, req });
+      return { ok: true, status: 'completed' };
+    },
+  };
+  return { client, completes, automationCompletes };
+}
+
 describe('executeRun try/catch safety net', () => {
   test('catches unhandled errors and terminates the run via complete', async () => {
     const { executeRun } = await import('../daemon/executor.js');
-    const completes: Array<Record<string, unknown>> = [];
-    const client = {
-      id: 'test-worker',
-      version: 'test',
-      async heartbeat() {},
-      async stream() {},
-      async complete(req: Record<string, unknown>) { completes.push(req); },
-      async completeAction() {},
-      async completeEmbeddings() {},
-      async completeAuth() {},
-      async emitAuthArtifact() {},
-      async pollAuthSignal() { return { signal: null }; },
-      async fetchEventsForEmbedding() { return []; },
-      async dispatchChromeAction() { return {}; },
-      async completeAutomation() { return { ok: true, status: 'completed' }; },
-    };
+    const { client, completes } = makeSafetyNetClient();
 
     const result = await executeRun(
       client as any,
@@ -247,5 +258,66 @@ describe('executeRun try/catch safety net', () => {
     expect(completes).toHaveLength(1);
     expect(completes[0]!.status).toBe('failed');
     expect(completes[0]!.run_id).toBe(9);
+  });
+
+  test('automation-lane unhandled error terminates via complete-automation, never the sync endpoint', async () => {
+    const { executeRun } = await import('../daemon/executor.js');
+    const { client, completes, automationCompletes } = makeSafetyNetClient();
+
+    // payload present but malformed (automation key missing) → throws inside
+    // executeAutomationRun before its own reporting kicks in, exercising the
+    // outer net. The sync /complete endpoint must NOT be used: it would
+    // finalize the run row but skip the automation-side bookkeeping.
+    const result = await executeRun(
+      client as any,
+      { run_id: 12, run_type: 'automation', payload: {} } as any,
+      {}
+    );
+
+    expect(result.error).toBeTruthy();
+    expect(completes).toHaveLength(0);
+    expect(automationCompletes).toHaveLength(1);
+    expect(automationCompletes[0]!.runId).toBe(12);
+    expect(automationCompletes[0]!.req.exit_reason).toBe('crash');
+    expect(String(automationCompletes[0]!.req.error)).toBeTruthy();
+  });
+});
+
+describe('resolveAutomationRunAccess', () => {
+  const daemonWiring = { url: 'http://daemon.local/api/mcp', bearer: 'daemon-pat' };
+  const basePayload = (
+    session?: NonNullable<AutomationPollPayload['context']['agent_session']>
+  ): AutomationPollPayload => ({
+    automation: { id: '7' },
+    event: { fired_at: '2026-08-20T00:00:00.000Z' },
+    context: {
+      device: {},
+      user: {},
+      ...(session ? { agent_session: session } : {}),
+    },
+  });
+
+  test('prefers the per-run agent session for both MCP wiring and CLI env', () => {
+    const session = {
+      conversation_id: 'agent_automation_7_run_9',
+      mcp_url: 'https://gateway.test/lobu/mcp/lobu-memory',
+      token: 'run-scoped-token',
+      expires_at: Date.now() + 60_000,
+    };
+    const access = resolveAutomationRunAccess(basePayload(session), daemonWiring);
+    expect(access.wiring).toEqual({
+      url: 'https://gateway.test/lobu/mcp/lobu-memory',
+      bearer: 'run-scoped-token',
+    });
+    expect(access.env).toEqual({
+      LOBU_API_TOKEN: 'run-scoped-token',
+      LOBU_MEMORY_URL: 'https://gateway.test/lobu/mcp/lobu-memory',
+    });
+  });
+
+  test('falls back to the daemon wiring (and no env override) without a session', () => {
+    const access = resolveAutomationRunAccess(basePayload(), daemonWiring);
+    expect(access.wiring).toBe(daemonWiring);
+    expect(access.env).toEqual({});
   });
 });

--- a/packages/connector-worker/src/__tests__/executor-automation.test.ts
+++ b/packages/connector-worker/src/__tests__/executor-automation.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Headless Automation execution lane — tests through the AutomationRunIo seam.
+ *
+ * The daemon claims `run_type='automation'` runs only when it advertises
+ * `automations.execute` (server-side gate in worker-api/poll.ts); once
+ * claimed, the executor must reach a TERMINAL state via complete-automation
+ * for every outcome: clean exit, CLI failure, timeout, or an unexpected throw.
+ *
+ * These tests exercise the dispatchAutomationResumeLoop via its injected IO
+ * seam — no real subprocesses are spawned, keeping tests fast and hermetic.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  dispatchAutomationResumeLoop,
+  type AutomationRunIo,
+  type ExecutorResult,
+} from '../daemon/automation.js';
+import type { CompleteAutomationRequest } from '@lobu/core/contracts/worker/protocol';
+
+function makeResult(overrides: Partial<ExecutorResult> = {}): ExecutorResult {
+  return {
+    output: 'fake output',
+    error: null,
+    exitCode: 0,
+    exitSignal: null,
+    exitReason: 'ok',
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+describe('dispatchAutomationResumeLoop', () => {
+  test('clean exit reports success and returns', async () => {
+    const reports: CompleteAutomationRequest[] = [];
+    const io: AutomationRunIo = {
+      async run() { return makeResult(); },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          exit_code: result.exitCode,
+          exit_reason: result.exitReason,
+          finalize_attempt: finalizeAttempt,
+        });
+        return { ok: true, status: 'completed' };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toBeUndefined();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]!.exit_code).toBe(0);
+    expect(reports[0]!.exit_reason).toBe('ok');
+  });
+
+  test('non-zero exit delivers error via report', async () => {
+    const reports: CompleteAutomationRequest[] = [];
+    const io: AutomationRunIo = {
+      async run() { return makeResult({ exitCode: 3, error: 'boom', exitReason: 'crash' }); },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          error: result.error ?? undefined,
+          exit_code: result.exitCode,
+          exit_reason: result.exitReason,
+          finalize_attempt: finalizeAttempt,
+        });
+        return { ok: true, status: 'completed' };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toBeUndefined();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]!.exit_code).toBe(3);
+    expect(reports[0]!.exit_reason).toBe('crash');
+    expect(reports[0]!.error).toBe('boom');
+  });
+
+  test('signal exit is reported', async () => {
+    const reports: CompleteAutomationRequest[] = [];
+    const io: AutomationRunIo = {
+      async run() { return makeResult({ exitCode: null, exitSignal: 'SIGTERM', exitReason: 'timeout' }); },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          exit_signal: result.exitSignal,
+          exit_reason: result.exitReason,
+          finalize_attempt: finalizeAttempt,
+        });
+        return { ok: true, status: 'completed' };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toBeUndefined();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]!.exit_signal).toBe('SIGTERM');
+  });
+
+  test('resume response re-spawns with nudge', async () => {
+    let round = 0;
+    const reports: CompleteAutomationRequest[] = [];
+    const runs: (string | undefined)[] = [];
+    const io: AutomationRunIo = {
+      async run(nudge) {
+        round++;
+        runs.push(nudge);
+        if (round === 1) return makeResult({ output: 'partial work' });
+        return makeResult({ output: 'done' });
+      },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          finalize_attempt: finalizeAttempt,
+        });
+        if (round === 1) {
+          return { ok: true, status: 'resume', attempt: 1, max_attempts: 3, nudge: 'Please finalize the window.' };
+        }
+        return { ok: true, status: 'completed' };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toBeUndefined();
+    expect(reports).toHaveLength(2);
+    expect(runs[0]).toBeUndefined();
+    expect(runs[1]).toContain('Please finalize the window.');
+  });
+
+  test('loop exhausted by repeated resumes returns error', async () => {
+    const reports: CompleteAutomationRequest[] = [];
+    const io: AutomationRunIo = {
+      async run() { return makeResult(); },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          finalize_attempt: finalizeAttempt,
+        });
+        return { ok: true, status: 'resume', attempt: 1, max_attempts: 99, nudge: 'again' };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(reports).toHaveLength(8);
+    expect(result.error).toContain('safety cap');
+  });
+
+  test('run exception reports error and returns', async () => {
+    const errors: string[] = [];
+    const io: AutomationRunIo = {
+      async run() { throw new Error('binary not found'); },
+      async deliver() { return { ok: true, status: 'completed' }; },
+      async reportError(error) { errors.push(error); },
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toContain('binary not found');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('binary not found');
+  });
+
+  test('idempotent response still continues the loop (server-level idempotency)', async () => {
+    let round = 0;
+    const reports: CompleteAutomationRequest[] = [];
+    const io: AutomationRunIo = {
+      async run() {
+        round++;
+        return makeResult({ output: `round ${round}` });
+      },
+      async deliver(result, finalizeAttempt) {
+        reports.push({
+          worker_id: 'test-worker',
+          output: result.output,
+          finalize_attempt: finalizeAttempt,
+        });
+        if (round === 1) return { ok: true, status: 'resume', attempt: 1, max_attempts: 3, nudge: 'nudge' };
+        return { ok: true, status: 'resume', idempotent: true };
+      },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(reports).toHaveLength(8);
+    expect(result.error).toContain('safety cap');
+  });
+
+  test('null deliver response returns without error', async () => {
+    const io: AutomationRunIo = {
+      async run() { return makeResult(); },
+      async deliver() { return null; },
+      async reportError() {},
+    };
+
+    const result = await dispatchAutomationResumeLoop(io);
+
+    expect(result.error).toBeUndefined();
+    expect(result.itemsCollected).toBe(0);
+  });
+});
+
+describe('executeRun try/catch safety net', () => {
+  test('catches unhandled errors and terminates the run via complete', async () => {
+    const { executeRun } = await import('../daemon/executor.js');
+    const completes: Array<Record<string, unknown>> = [];
+    const client = {
+      id: 'test-worker',
+      version: 'test',
+      async heartbeat() {},
+      async stream() {},
+      async complete(req: Record<string, unknown>) { completes.push(req); },
+      async completeAction() {},
+      async completeEmbeddings() {},
+      async completeAuth() {},
+      async emitAuthArtifact() {},
+      async pollAuthSignal() { return { signal: null }; },
+      async fetchEventsForEmbedding() { return []; },
+      async dispatchChromeAction() { return {}; },
+      async completeAutomation() { return { ok: true, status: 'completed' }; },
+    };
+
+    const result = await executeRun(
+      client as any,
+      { run_id: 9, run_type: 'sync' } as any,
+      {}
+    );
+
+    expect(result.error).toContain('Invalid run: missing run_id or connector_key');
+    expect(completes).toHaveLength(1);
+    expect(completes[0]!.status).toBe('failed');
+    expect(completes[0]!.run_id).toBe(9);
+  });
+});

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -16,11 +16,13 @@
  * drift.
  *
  * Unlike connector children (which inherit a small system-env allowlist), the
- * spawned agent CLI must run as the user: it inherits the daemon's environment
- * (PATH, HOME, the user's CLI credentials) minus the `WORKER_API_TOKEN` env
- * var, so the child cannot act as the worker/poll loop — it authenticates
- * through its own `~/.config/lobu` credentials or the MCP bearer wired
- * per-spec (deliberately the daemon's own bearer, as in the Mac dispatcher).
+ * spawned agent CLI runs in the user's environment (PATH, HOME) minus the
+ * `WORKER_API_TOKEN` env var, so the child cannot act as the worker/poll loop.
+ * Its Lobu credential is the poll envelope's per-run `agent_session` when the
+ * server minted one (see `resolveAutomationRunAccess`): the run authenticates
+ * as the Automation's assigned agent, not as the daemon or the user's ambient
+ * CLI session. The daemon's own bearer remains only the fallback for servers
+ * that predate session minting.
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -270,31 +272,65 @@ function buildMcp(
   return { mcpArgs, mcpEnv, cleanup };
 }
 
+/** The credential set one automation run's spawned CLI executes with. */
+export interface AutomationRunAccess {
+  /** Lobu MCP wiring for the CLI's mcp config (buildMcp). */
+  wiring: { url: string; bearer?: string } | undefined;
+  /** Extra env for the child process (LOBU_API_TOKEN / LOBU_MEMORY_URL). */
+  env: Record<string, string>;
+}
+
+/**
+ * Resolve what credential the spawned CLI runs with. When the poll envelope
+ * carries a per-run `agent_session`, the CLI authenticates as the automation's
+ * assigned agent for exactly this run: the session token goes into the MCP
+ * wiring AND into LOBU_API_TOKEN/LOBU_MEMORY_URL, which `lobu memory` prefers
+ * over the device's ambient CLI session — so an unattended run never acts as
+ * the human user or the daemon. Without a session (older server, or a run with
+ * no usable assigned agent) fall back to the daemon's own wiring, the
+ * pre-session dispatch path.
+ */
+export function resolveAutomationRunAccess(
+  payload: AutomationPollPayload,
+  daemonWiring: { url: string; bearer?: string } | undefined
+): AutomationRunAccess {
+  const session = payload.context.agent_session;
+  if (!session) return { wiring: daemonWiring, env: {} };
+  return {
+    wiring: { url: session.mcp_url, bearer: session.token },
+    env: {
+      LOBU_API_TOKEN: session.token,
+      LOBU_MEMORY_URL: session.mcp_url,
+    },
+  };
+}
+
 /** Spawn one CLI run and classify how it ended. */
 async function runCli(
   spec: AgentSpec,
   prompt: string,
   config: AutomationPollPayload['automation']['execution_config'],
-  mcpWiring: { url: string; bearer?: string } | undefined,
+  access: AutomationRunAccess,
   timeoutMs: number,
   binaryPath?: string
 ): Promise<ExecutorResult> {
   const binary = binaryPath ?? locateBinary(spec.binaryName);
   if (!binary || !existsSync(binary)) throw new ExecutableNotFoundError(spec.binaryName);
 
-  const { mcpArgs, mcpEnv, cleanup } = buildMcp(spec, mcpWiring);
+  const { mcpArgs, mcpEnv, cleanup } = buildMcp(spec, access.wiring);
   try {
     const args = buildArguments(spec, prompt, config, mcpArgs, timeoutMs / 1000);
     const started = Date.now();
 
     // Inherit the user's environment (PATH, HOME, CLI credentials) but drop
     // WORKER_API_TOKEN so the child cannot act as the worker/poll loop itself.
-    // The same bearer is still wired into the child's MCP config on purpose
+    // The run's bearer is wired into the child's MCP config on purpose
     // (buildMcp above) — that is how the spawned CLI reaches Lobu tools, same
     // as the Mac `AutomationDispatcher`; what we withhold is the daemon role.
     const env: NodeJS.ProcessEnv = { ...process.env };
     delete env.WORKER_API_TOKEN;
     for (const [key, value] of Object.entries(mcpEnv)) env[key] = value;
+    for (const [key, value] of Object.entries(access.env)) env[key] = value;
     // GUI/app-launched daemons can have a stripped PATH; re-add common installs.
     const extraPath = searchDirs().join(':');
     const currentPath = env.PATH ?? '/usr/bin:/bin';
@@ -481,7 +517,7 @@ export async function executeAutomationRun(
         spec,
         prompt,
         payload.automation.execution_config,
-        client.mcpWiring,
+        resolveAutomationRunAccess(payload, client.mcpWiring),
         timeoutMs,
         cfg.binaryOverrides?.[spec.kind]
       );

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -21,8 +21,8 @@
  * Its Lobu credential is the poll envelope's per-run `agent_session` when the
  * server minted one (see `resolveAutomationRunAccess`): the run authenticates
  * as the Automation's assigned agent, not as the daemon or the user's ambient
- * CLI session. The daemon's own bearer remains only the fallback for servers
- * that predate session minting.
+ * CLI session. The daemon's own bearer remains only the fallback for a run the
+ * server sent no session for — an older server, or one that could not mint.
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -192,6 +192,19 @@ export class WorkerClient implements ExecutorClient {
     return kinds;
   }
 
+  /**
+   * Capabilities this poll advertises. On the headless platform the daemon adds
+   * `automations.execute` itself: the gateway hands `run_type='automation'` runs
+   * only to devices advertising it, so the string is the build signal that keeps
+   * an older daemon — one whose executor mishandles the automation lane — from
+   * claiming and wedging a run. Whether this host can actually launch the
+   * Automation's CLI is a separate gate: the `agent_kinds` discovered below.
+   */
+  private advertisedCapabilities(): WorkerCapabilities {
+    if (this.platform !== 'headless') return this.capabilities;
+    return { ...this.capabilities, 'automations.execute': true };
+  }
+
   private authHeaders(): Record<string, string> {
     return this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {};
   }
@@ -227,7 +240,7 @@ export class WorkerClient implements ExecutorClient {
   async poll(): Promise<PollResponse> {
     return this.requestJson<PollResponse>('/api/workers/poll', {
       worker_id: this.workerId,
-      capabilities: this.capabilities,
+      capabilities: this.advertisedCapabilities(),
       version: this.version,
       // app_version belongs to the device registration fields, so omit both for
       // fleet workers rather than sending empty values. A device worker also

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -174,6 +174,18 @@ export async function executeRun(
             status: 'failed',
             error_message: message,
           });
+        } else if (job.run_type === 'automation') {
+          // Automation runs terminate ONLY via /complete-automation — the sync
+          // /complete endpoint would finalize the run row but skip the
+          // automation-side bookkeeping (schedule advance, failure accounting),
+          // wedging the schedule the way a stuck run would.
+          await client.completeAutomation(job.run_id, {
+            worker_id: client.id,
+            output: '',
+            error: message,
+            duration_ms: 0,
+            exit_reason: 'crash',
+          });
         } else {
           await client.complete({
             run_id: job.run_id,

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -116,9 +116,12 @@ export function resolveEffectiveEnv(env: Env, job: PollResponse): Env {
 }
 
 /**
- * Execute a run (sync, action, or automation).
+ * Execute a run (sync, action, automation, embed_backfill, or auth).
  *
- * Dispatches to sync, action, or automation execution based on run_type.
+ * Dispatches by `run_type` and NEVER throws: every lane reports its own
+ * terminal state via the lane-appropriate `client.complete*` endpoint, and an
+ * unexpected error here is likewise terminated before it can leave a claimed
+ * run stuck `running` (the daemon's fire-and-forget `.catch` only logs).
  */
 export async function executeRun(
   client: ExecutorClient,
@@ -130,23 +133,61 @@ export async function executeRun(
   // Fold the gateway's authoritative egress config in once so every downstream
   // mode handler gets the same non-downgradable policy and operator exemptions.
   const env = resolveEffectiveEnv(workerEnv, job);
-  switch (job.run_type) {
-    case 'action':
-      return executeActionRun(client, job, env, cfg);
-    case 'automation':
-      // Device workers (user-scoped auth) may be handed an automation run when
-      // the automation is pinned to their device. Spawn the local agent CLI and
-      // report the process exit via /complete-automation. Trusted fleet workers
-      // never reach this arm — the poll endpoint's automation claim branch is
-      // unreachable for them — but if a run does slip through (deploy skew), the
-      // dispatcher reports the failure rather than stomping the run.
-      return executeAutomationRun(client, job, cfg);
-    case 'embed_backfill':
-      return executeEmbedBackfillRun(client, job, env, cfg);
-    case 'auth':
-      return executeAuthRun(client, job, env, cfg);
-    default:
-      return executeSyncRun(client, job, env, cfg);
+  try {
+    switch (job.run_type) {
+      case 'action':
+        return await executeActionRun(client, job, env, cfg);
+      case 'automation':
+        // Device workers (user-scoped auth) may be handed an automation run when
+        // the automation is pinned to their device. Spawn the local agent CLI and
+        // report the process exit via /complete-automation. Trusted fleet workers
+        // never reach this arm — the poll endpoint's automation claim branch is
+        // unreachable for them — but if a run does slip through (deploy skew), the
+        // dispatcher reports the failure rather than stomping the run.
+        return await executeAutomationRun(client, job, cfg);
+      case 'embed_backfill':
+        return await executeEmbedBackfillRun(client, job, env, cfg);
+      case 'auth':
+        return await executeAuthRun(client, job, env, cfg);
+      default:
+        return await executeSyncRun(client, job, env, cfg);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.info(
+      `[executor] Unhandled ${job.run_type ?? 'unknown'} run ${job.run_id} failure:`,
+      message
+    );
+    if (job.run_id) {
+      try {
+        if (job.run_type === 'action') {
+          await client.completeAction({
+            run_id: job.run_id,
+            worker_id: client.id,
+            status: 'failed',
+            error_message: message,
+          });
+        } else if (job.run_type === 'auth') {
+          await client.completeAuth({
+            run_id: job.run_id,
+            worker_id: client.id,
+            status: 'failed',
+            error_message: message,
+          });
+        } else {
+          await client.complete({
+            run_id: job.run_id,
+            worker_id: client.id,
+            status: 'failed',
+            error_message: message,
+            items_collected: 0,
+          });
+        }
+      } catch (completeErr) {
+        log.info('[executor] Terminal completion after unhandled failure errored:', completeErr);
+      }
+    }
+    return { itemsCollected: 0, error: message };
   }
 }
 

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -133,7 +133,7 @@ const SYSTEM_ENV_KEYS = [
   'NODE_PATH',
   'PLAYWRIGHT_BROWSERS_PATH',
 ];
-export function pickSystemEnv(): Record<string, string | undefined> {
+function pickSystemEnv(): Record<string, string | undefined> {
   const env: Record<string, string | undefined> = {};
   for (const key of SYSTEM_ENV_KEYS) {
     if (process.env[key]) env[key] = process.env[key];

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -133,7 +133,7 @@ const SYSTEM_ENV_KEYS = [
   'NODE_PATH',
   'PLAYWRIGHT_BROWSERS_PATH',
 ];
-function pickSystemEnv(): Record<string, string | undefined> {
+export function pickSystemEnv(): Record<string, string | undefined> {
   const env: Record<string, string | undefined> = {};
   for (const key of SYSTEM_ENV_KEYS) {
     if (process.env[key]) env[key] = process.env[key];

--- a/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
+++ b/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
@@ -48,18 +48,25 @@ describe("platform allowlist lookups ignore inherited keys", () => {
     );
   });
 
-  test("headless devices authorize shell+files but nothing browser-ish", () => {
-    // A server/VM device (herdr) advertises the shell/files it actually has;
-    // browser and UI capabilities must be dropped, never silently granted.
+  test("headless devices authorize shell+files+automation execution but nothing browser-ish", () => {
+    // A server/VM device (herdr) advertises the shell/files it actually has
+    // plus `automations.execute` (the daemon runs local agent CLIs to complete
+    // Automations); browser and UI capabilities must be dropped, never silently
+    // granted.
     expect(isKnownPlatform("headless")).toBe(true);
     const authorized = authorizeCapabilities("headless", [
       "os.shell",
       "os.files",
+      "automations.execute",
       "os.notifications",
       "browser.tabs",
       "computer_use",
     ]);
-    expect(authorized.authorized.sort()).toEqual(["os.files", "os.shell"]);
+    expect(authorized.authorized.sort()).toEqual([
+      "automations.execute",
+      "os.files",
+      "os.shell",
+    ]);
     expect(authorized.dropped.sort()).toEqual([
       "browser.tabs",
       "computer_use",

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -60,10 +60,11 @@ export const MAC_DEVICE_CAPABILITIES = [
 //
 // `automations.execute` is the rolling-deploy-safe claim gate for headless
 // Automation execution: the server only hands `run_type='automation'` runs to
-// device workers that advertise it, so an old deployed connector-worker (which
-// refuses automation runs) can never claim and wedge one. The daemon auto-
-// advertises it on the headless platform; a device that cannot run the local
-// agent CLIs simply does not opt in.
+// device workers that advertise it, so a daemon build that predates the
+// automation lane can never claim one and wedge it. The daemon adds the string
+// itself on the headless platform (WorkerClient.advertisedCapabilities), which
+// is what makes it a build signal rather than an operator flag; whether a given
+// host can launch the Automation's CLI is the separate `agent_kinds` gate.
 export const HEADLESS_CAPABILITIES = [
   "os.shell",
   "os.files",

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -57,7 +57,18 @@ export const MAC_DEVICE_CAPABILITIES = [
 // The device daemon can run agent work and touch a shell/files, but has no
 // browser to drive and no screen to notify. Keep this set small and honest -
 // add strings here only as headless connectors actually land.
-export const HEADLESS_CAPABILITIES = ["os.shell", "os.files"] as const;
+//
+// `automations.execute` is the rolling-deploy-safe claim gate for headless
+// Automation execution: the server only hands `run_type='automation'` runs to
+// device workers that advertise it, so an old deployed connector-worker (which
+// refuses automation runs) can never claim and wedge one. The daemon auto-
+// advertises it on the headless platform; a device that cannot run the local
+// agent CLIs simply does not opt in.
+export const HEADLESS_CAPABILITIES = [
+  "os.shell",
+  "os.files",
+  "automations.execute",
+] as const;
 
 const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {
   macos: [

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -172,6 +172,26 @@ export const AutomationPollContextSchema = Type.Object({
   user: Type.Object({
     user_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   }),
+  // Non-macOS device execution only: the per-run lobu-memory MCP session.
+  // `token` is a WorkerToken minted for the automation's ASSIGNED AGENT via
+  // buildAutomationRunWorkerAccess — never the polling device's PAT (a child
+  // PAT is bound to the user's personal org and can't authenticate to a
+  // team-org Automation). `mcp_url` is the gateway MCP proxy endpoint
+  // (`{PUBLIC_GATEWAY_URL}/mcp/lobu-memory`), which validates the worker
+  // token and promotes it into a direct-auth MCP session for the token's org.
+  // The daemon hands both to the spawned CLI as its MCP wiring and as
+  // LOBU_API_TOKEN / LOBU_MEMORY_URL so `lobu memory` runs as the automation's
+  // agent for this run. Absent when the run has no usable assigned agent —
+  // the daemon then falls back to its own wiring. macOS is exempt: Owletto's
+  // bridge dispatches with its own credential machinery.
+  agent_session: Type.Optional(
+    Type.Object({
+      conversation_id: Type.String(),
+      mcp_url: Type.String(),
+      token: Type.String(),
+      expires_at: Type.Number(),
+    })
+  ),
 });
 
 /**
@@ -184,67 +204,6 @@ export const AutomationPollPayloadSchema = Type.Object({
   automation: AutomationPollMetaSchema,
   event: AutomationPollEventSchema,
   context: AutomationPollContextSchema,
-});
-
-/**
- * The payload envelope a claimed `run_type='automation'` run carries. The
- * device-side executor (Owletto's AutomationDispatcher on macOS, the
- * connector-worker daemon on headless herdr) reads `automation.agent_kind` to
- * pick a local CLI and `automation.execution_config` for its timeout/budget,
- * and embeds the output contract from `extraction_schema` in the prompt.
- * Mirror of the server's `worker-api/poll.ts` automation response — do not
- * add server-only keys here (the server already strips them via
- * `stripServerOnlyExecutionConfig`); a strict device-side decode drops unknown
- * fields.
- */
-export const AutomationPayloadSchema = Type.Object({
-  automation: Type.Object({
-    id: Type.String(),
-    name: Type.Union([Type.String(), Type.Null()]),
-    slug: Type.Union([Type.String(), Type.Null()]),
-    agent_kind: Type.Union([Type.String(), Type.Null()]),
-    notification_channel: Type.String(),
-    notification_priority: Type.String(),
-    execution_config: Type.Union([
-      Type.Record(Type.String(), Type.Unknown()),
-      Type.Null(),
-    ]),
-    prompt: Type.Union([Type.String(), Type.Null()]),
-    extraction_schema: Type.Union([
-      Type.Record(Type.String(), Type.Unknown()),
-      Type.Null(),
-    ]),
-  }),
-  event: Type.Object({
-    trigger_event_id: Type.Union([Type.String(), Type.Null()]),
-    fired_at: Type.String(),
-    payload: Type.Record(Type.String(), Type.Unknown()),
-  }),
-  context: Type.Object({
-    device: Type.Object({
-      worker_id: Type.Union([Type.String(), Type.Null()]),
-    }),
-    user: Type.Object({
-      user_id: Type.Union([Type.String(), Type.Null()]),
-    }),
-    // Non-macOS device execution only: the per-run lobu-memory MCP session.
-    // `token` is a WorkerToken minted for the automation's ASSIGNED AGENT via
-    // buildAutomationRunWorkerAccess — never the polling device's PAT (a child
-    // PAT is bound to the user's personal org and can't authenticate to a
-    // team-org Automation). The executor sends it as `Authorization: Bearer`
-    // plus the `x-lobu-memory-direct-auth: 1` header against the org-scoped
-    // `/mcp/{orgSlug}` URL, which promotes it into a direct-auth MCP session
-    // (see workspace/multi-tenant.ts). macOS is exempt: Owletto's bridge
-    // dispatches with its own credential machinery.
-    agent_session: Type.Optional(
-      Type.Object({
-        conversation_id: Type.String(),
-        mcp_url: Type.String(),
-        token: Type.String(),
-        expires_at: Type.Number(),
-      })
-    ),
-  }),
 });
 
 /** `POST /api/workers/poll` response body (a claimed run, or a poll-again). */
@@ -537,7 +496,6 @@ export type RunType = Static<typeof RunTypeSchema>;
 export type WorkerExitReason = Static<typeof WorkerExitReasonSchema>;
 export type WorkerExitDiagnostics = Static<typeof WorkerExitDiagnosticsSchema>;
 export type OAuthCredentials = Static<typeof OAuthCredentialsSchema>;
-export type AutomationPayload = Static<typeof AutomationPayloadSchema>;
 export type PollRequest = Static<typeof PollRequestSchema>;
 export type PollResponse = Static<typeof PollResponseSchema>;
 export type AutomationExecutionConfig = Static<

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -186,6 +186,67 @@ export const AutomationPollPayloadSchema = Type.Object({
   context: AutomationPollContextSchema,
 });
 
+/**
+ * The payload envelope a claimed `run_type='automation'` run carries. The
+ * device-side executor (Owletto's AutomationDispatcher on macOS, the
+ * connector-worker daemon on headless herdr) reads `automation.agent_kind` to
+ * pick a local CLI and `automation.execution_config` for its timeout/budget,
+ * and embeds the output contract from `extraction_schema` in the prompt.
+ * Mirror of the server's `worker-api/poll.ts` automation response — do not
+ * add server-only keys here (the server already strips them via
+ * `stripServerOnlyExecutionConfig`); a strict device-side decode drops unknown
+ * fields.
+ */
+export const AutomationPayloadSchema = Type.Object({
+  automation: Type.Object({
+    id: Type.String(),
+    name: Type.Union([Type.String(), Type.Null()]),
+    slug: Type.Union([Type.String(), Type.Null()]),
+    agent_kind: Type.Union([Type.String(), Type.Null()]),
+    notification_channel: Type.String(),
+    notification_priority: Type.String(),
+    execution_config: Type.Union([
+      Type.Record(Type.String(), Type.Unknown()),
+      Type.Null(),
+    ]),
+    prompt: Type.Union([Type.String(), Type.Null()]),
+    extraction_schema: Type.Union([
+      Type.Record(Type.String(), Type.Unknown()),
+      Type.Null(),
+    ]),
+  }),
+  event: Type.Object({
+    trigger_event_id: Type.Union([Type.String(), Type.Null()]),
+    fired_at: Type.String(),
+    payload: Type.Record(Type.String(), Type.Unknown()),
+  }),
+  context: Type.Object({
+    device: Type.Object({
+      worker_id: Type.Union([Type.String(), Type.Null()]),
+    }),
+    user: Type.Object({
+      user_id: Type.Union([Type.String(), Type.Null()]),
+    }),
+    // Non-macOS device execution only: the per-run lobu-memory MCP session.
+    // `token` is a WorkerToken minted for the automation's ASSIGNED AGENT via
+    // buildAutomationRunWorkerAccess — never the polling device's PAT (a child
+    // PAT is bound to the user's personal org and can't authenticate to a
+    // team-org Automation). The executor sends it as `Authorization: Bearer`
+    // plus the `x-lobu-memory-direct-auth: 1` header against the org-scoped
+    // `/mcp/{orgSlug}` URL, which promotes it into a direct-auth MCP session
+    // (see workspace/multi-tenant.ts). macOS is exempt: Owletto's bridge
+    // dispatches with its own credential machinery.
+    agent_session: Type.Optional(
+      Type.Object({
+        conversation_id: Type.String(),
+        mcp_url: Type.String(),
+        token: Type.String(),
+        expires_at: Type.Number(),
+      })
+    ),
+  }),
+});
+
 /** `POST /api/workers/poll` response body (a claimed run, or a poll-again). */
 export const PollResponseSchema = Type.Object({
   next_poll_seconds: Type.Optional(Type.Number()),
@@ -476,6 +537,7 @@ export type RunType = Static<typeof RunTypeSchema>;
 export type WorkerExitReason = Static<typeof WorkerExitReasonSchema>;
 export type WorkerExitDiagnostics = Static<typeof WorkerExitDiagnosticsSchema>;
 export type OAuthCredentials = Static<typeof OAuthCredentialsSchema>;
+export type AutomationPayload = Static<typeof AutomationPayloadSchema>;
 export type PollRequest = Static<typeof PollRequestSchema>;
 export type PollResponse = Static<typeof PollResponseSchema>;
 export type AutomationExecutionConfig = Static<

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -181,9 +181,9 @@ export const AutomationPollContextSchema = Type.Object({
   // token and promotes it into a direct-auth MCP session for the token's org.
   // The daemon hands both to the spawned CLI as its MCP wiring and as
   // LOBU_API_TOKEN / LOBU_MEMORY_URL so `lobu memory` runs as the automation's
-  // agent for this run. Absent when the run has no usable assigned agent —
-  // the daemon then falls back to its own wiring. macOS is exempt: Owletto's
-  // bridge dispatches with its own credential machinery.
+  // agent for this run. Absent when the run has no usable assigned agent, or
+  // when minting failed — the daemon then falls back to its own wiring. macOS
+  // is exempt: Owletto's bridge dispatches with its own credential machinery.
   agent_session: Type.Optional(
     Type.Object({
       conversation_id: Type.String(),

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Rolling-deploy-safe claim gate for the Automation lane in /api/workers/poll.
+ *
+ * A headless connector-worker daemon refuses `run_type='automation'` runs, so
+ * before this gate it could claim one from poll and leave it stuck `running`
+ * forever (the executor returns a refusal the daemon's fire-and-forget loop
+ * ignores). The fix: the poll automation lane only matches devices that
+ * advertise `automations.execute` (the daemon opts in by auto-advertising it
+ * on the headless platform) — with the macOS exemption preserving the
+ * pre-capability behavior for Owletto's bridge, which advertises a fixed
+ * capability set with no such string.
+ *
+ * These tests drive the real poll endpoint with a device-pinned automation:
+ *   - headless device WITHOUT automations.execute → no claim (run stays pending)
+ *   - headless device WITH automations.execute → claims + payload envelope
+ *   - macOS device with capabilities:{} → still claims (exemption)
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { verifyWorkerToken } from '@lobu/core';
+import type { DbClient } from '../../../db/client';
+import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+async function createWorkerBoundPat(
+  userId: string,
+  organizationId: string,
+  workerId: string,
+  scope = 'device_worker:run'
+): Promise<{ token: string }> {
+  const sql = getTestDb();
+  const token = `owl_pat_${generateSecureToken(24)}`;
+  const tokenHash = hashToken(token);
+  const tokenPrefix = token.substring(0, 12);
+  await sql`
+    INSERT INTO personal_access_tokens (
+      token_hash, token_prefix, user_id, organization_id, name, scope, worker_id,
+      created_at, updated_at
+    ) VALUES (
+      ${tokenHash}, ${tokenPrefix}, ${userId}, ${organizationId},
+      ${`Test worker PAT (${workerId})`}, ${scope}, ${workerId},
+      NOW(), NOW()
+    )
+  `;
+  return { token };
+}
+
+async function setupDevicePinnedAutomation(opts: {
+  workerId: string;
+  platform: string;
+  capabilities: Record<string, boolean>;
+}): Promise<{
+  sql: ReturnType<typeof getTestDb>;
+  dbClient: DbClient;
+  workspace: Awaited<ReturnType<typeof TestWorkspace.create>>;
+  automationId: number;
+}> {
+  const sql = getTestDb();
+  const dbClient = sql as unknown as DbClient;
+  const workspace = await TestWorkspace.create({ name: 'Headless Claim Gate Org' });
+  const ownerUserId = workspace.users.owner.id;
+
+  const inserted = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+    VALUES (${ownerUserId}, ${opts.workerId}, ${opts.platform}, ${sql.json(opts.capabilities)}, 'Device', ${workspace.org.id})
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  const deviceWorkerId = String(inserted[0].id);
+
+  const entity = await createTestEntity({
+    name: 'Claim Gate Entity',
+    organization_id: workspace.org.id,
+    created_by: ownerUserId,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'claim-gate-agent',
+    name: 'Claim Gate Agent',
+  });
+  const automation = (await workspace.owner.automations.create({
+    entity_id: entity.id,
+    slug: 'claim-gate-automation',
+    name: 'Claim Gate Automation',
+    prompt: 'Summarize {{entities}}.',
+    triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+    agent_id: agent.agentId,
+  })) as { automation_id: string };
+  const automationId = Number(automation.automation_id);
+
+  await sql`
+    UPDATE automations
+    SET device_worker_id = ${deviceWorkerId}::uuid,
+        agent_kind = 'opencode'
+    WHERE id = ${automationId}
+  `;
+
+  return { sql, dbClient, workspace, automationId };
+}
+
+describe('headless Automation claim gate (automations.execute)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  // First test in the file pays the on-demand connector-catalog compile on the
+  // trigger path; give it room so the claim gate itself (not cold-start time)
+  // decides the outcome.
+  it('headless device WITHOUT automations.execute does not claim — run stays pending', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'headless-legacy',
+      platform: 'headless',
+      capabilities: { 'os.shell': true },
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'headless-legacy'
+    );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+    const { run_id } = (await trig.json()) as { run_id: number };
+
+    // An old daemon (no automations.execute) must NOT be handed the automation
+    // run — it would refuse to execute and wedge it.
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: { worker_id: 'headless-legacy', capabilities: { 'os.shell': true } },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as { run_id?: number; run_type?: string };
+    expect(job.run_id).toBeUndefined();
+
+    const [run] = await ctx.sql`
+      SELECT status FROM runs WHERE id = ${run_id}
+    `;
+    expect(String(run.status)).toBe('pending');
+  }, 60_000);
+
+  it('headless device WITH automations.execute claims the run and gets the payload envelope', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'headless-herdr',
+      platform: 'headless',
+      capabilities: { 'os.shell': true, 'automations.execute': true },
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'headless-herdr'
+    );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'headless-herdr',
+        capabilities: { 'os.shell': true, 'automations.execute': true },
+      },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as {
+      run_id?: number;
+      run_type?: string;
+      organization_id?: string;
+      payload?: {
+        automation?: { agent_kind?: string; execution_config?: Record<string, unknown>; prompt?: string };
+        context?: { agent_session?: { conversation_id: string; mcp_url: string; token: string; expires_at: number } };
+      };
+    };
+    expect(job.run_type).toBe('automation');
+    expect(job.run_id).toBeGreaterThan(0);
+    expect(job.organization_id).toBe(ctx.workspace.org.id);
+    expect(job.payload?.automation?.agent_kind).toBe('opencode');
+    expect(job.payload?.automation?.prompt).toContain('client.automations.completeWindow');
+    const agentSession = job.payload?.context?.agent_session;
+    expect(agentSession?.conversation_id).toBe(
+      `claim-gate-agent_automation_${ctx.automationId}_run_${job.run_id}`
+    );
+    // Canonical headless lobu-memory MCP URL: PUBLIC_GATEWAY_URL (mounted under
+    // /lobu) followed by /mcp/lobu-memory.
+    expect(agentSession?.mcp_url).toContain('/lobu/mcp/lobu-memory');
+    expect(typeof agentSession?.expires_at).toBe('number');
+    expect(agentSession!.expires_at).toBeGreaterThan(Date.now());
+    const claims = verifyWorkerToken(agentSession!.token);
+    expect(claims.agentId).toBe('claim-gate-agent');
+    expect(claims.organizationId).toBe(ctx.workspace.org.id);
+    expect(claims.conversationId).toBe(agentSession!.conversation_id);
+
+    const [run] = await ctx.sql`
+      SELECT status FROM runs WHERE id = ${job.run_id}
+    `;
+    expect(String(run.status)).toBe('running');
+  });
+
+  it('worker poll cannot overwrite a user-set device label', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'headless-label',
+      platform: 'headless',
+      capabilities: { 'os.shell': true },
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'headless-label'
+    );
+
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'headless-label',
+        platform: 'headless',
+        app_version: 'test',
+        label: 'daemon reported label',
+        capabilities: { 'os.shell': true },
+      },
+    });
+    expect(pollRes.status).toBe(200);
+
+    const [device] = await ctx.sql`
+      SELECT label FROM device_workers WHERE worker_id = 'headless-label'
+    `;
+    expect(String(device.label)).toBe('Device');
+  });
+
+  it('macOS device with capabilities:{} still claims (pre-capability exemption)', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'mac-exempt',
+      platform: 'macos',
+      capabilities: {},
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'mac-exempt'
+    );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+
+    // Owletto's bridge advertises a fixed capability set with no
+    // automations.execute — it must keep working unchanged.
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: { worker_id: 'mac-exempt', capabilities: {} },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as {
+      run_type?: string;
+      run_id?: number;
+      payload?: { context?: { agent_session?: unknown } };
+    };
+    expect(job.run_type).toBe('automation');
+    expect(job.run_id).toBeGreaterThan(0);
+    // macOS keeps the Owletto dispatch path — no run-scoped agent session.
+    expect(job.payload?.context?.agent_session).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -1,22 +1,25 @@
 /**
  * Rolling-deploy-safe claim gate for the Automation lane in /api/workers/poll.
  *
- * A headless connector-worker daemon refuses `run_type='automation'` runs, so
- * before this gate it could claim one from poll and leave it stuck `running`
- * forever (the executor returns a refusal the daemon's fire-and-forget loop
- * ignores). The fix: the poll automation lane only matches devices that
- * advertise `automations.execute` (the daemon opts in by auto-advertising it
- * on the headless platform) — with the macOS exemption preserving the
- * pre-capability exemption for Owletto's bridge, which advertises a fixed
- * capability set with no such string.
+ * A daemon build that predates the automation lane mishandles a
+ * `run_type='automation'` run — it falls through to the sync path, which
+ * finalizes the run row without the Automation-side bookkeeping and wedges the
+ * schedule. Nothing stopped such a device from claiming one. The fix: the poll
+ * automation lane only matches devices advertising `automations.execute`, which
+ * the daemon adds itself on the headless platform (so it is a build signal, not
+ * an operator flag) — with the macOS arm preserving the pre-capability
+ * exemption for Owletto's bridge, which advertises a fixed capability set with
+ * no such string.
  *
  * These tests drive the real poll endpoint with a device-pinned automation:
  *   - headless device WITHOUT automations.execute → no claim (run stays pending)
  *   - headless device WITH automations.execute → claims + payload envelope
+ *   - headless automation with no assigned agent → claims, no run-scoped session
  *   - macOS device with capabilities:{} → still claims (exemption)
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { randomBytes } from 'node:crypto';
 import { verifyWorkerToken } from '@lobu/core';
 import type { DbClient } from '../../../db/client';
 import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
@@ -102,6 +105,20 @@ async function setupDevicePinnedAutomation(opts: {
 }
 
 describe('headless Automation claim gate (automations.execute)', () => {
+  // The dispatch path MINTS a worker token, which encrypts. Own the key here
+  // rather than inheriting it: a fork that starts without one would otherwise
+  // exercise the mint-failure fallback and silently stop asserting the session.
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = randomBytes(32).toString('base64');
+  });
+
+  afterAll(() => {
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+  });
+
   beforeEach(async () => {
     await cleanupTestDatabase();
   });
@@ -188,6 +205,8 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(typeof agentSession?.expires_at).toBe('number');
     expect(agentSession!.expires_at).toBeGreaterThan(Date.now());
     const claims = verifyWorkerToken(agentSession!.token);
+    expect(claims).not.toBeNull();
+    if (!claims) throw new Error('minted automation worker token did not verify');
     expect(claims.agentId).toBe('claim-gate-agent');
     expect(claims.organizationId).toBe(ctx.workspace.org.id);
     expect(claims.conversationId).toBe(agentSession!.conversation_id);

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -198,34 +198,56 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(String(run.status)).toBe('running');
   });
 
-  it('worker poll cannot overwrite a user-set device label', async () => {
+  it('automation without an assigned agent still dispatches instructions-only (no run-scoped session)', async () => {
     const ctx = await setupDevicePinnedAutomation({
-      workerId: 'headless-label',
+      workerId: 'headless-agentless',
       platform: 'headless',
-      capabilities: { 'os.shell': true },
+      capabilities: { 'os.shell': true, 'automations.execute': true },
     });
+    // Legacy shape: automations existed (and executed) before agent assignment
+    // was wired into device dispatch. They must keep dispatching with the
+    // instructions prompt + exit-report completion, not fail at claim time.
+    await ctx.sql`
+      UPDATE automations SET agent_id = NULL WHERE id = ${ctx.automationId}
+    `;
     const { token } = await createWorkerBoundPat(
       ctx.workspace.users.owner.id,
       ctx.workspace.org.id,
-      'headless-label'
+      'headless-agentless'
     );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
 
     const pollRes = await post('/api/workers/poll', {
       token,
       body: {
-        worker_id: 'headless-label',
-        platform: 'headless',
-        app_version: 'test',
-        label: 'daemon reported label',
-        capabilities: { 'os.shell': true },
+        worker_id: 'headless-agentless',
+        capabilities: { 'os.shell': true, 'automations.execute': true },
       },
     });
     expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as {
+      run_id?: number;
+      run_type?: string;
+      error?: string;
+      payload?: {
+        automation?: { prompt?: string };
+        context?: { agent_session?: unknown };
+      };
+    };
+    expect(job.run_type).toBe('automation');
+    expect(job.run_id).toBeGreaterThan(0);
+    expect(job.payload?.automation?.prompt).toContain('Summarize');
+    expect(job.payload?.automation?.prompt).not.toContain(
+      'client.automations.completeWindow'
+    );
+    expect(job.payload?.context?.agent_session).toBeUndefined();
 
-    const [device] = await ctx.sql`
-      SELECT label FROM device_workers WHERE worker_id = 'headless-label'
+    const [run] = await ctx.sql`
+      SELECT status FROM runs WHERE id = ${job.run_id}
     `;
-    expect(String(device.label)).toBe('Device');
+    expect(String(run.status)).toBe('running');
   });
 
   it('macOS device with capabilities:{} still claims (pre-capability exemption)', async () => {

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -7,7 +7,7 @@
  * ignores). The fix: the poll automation lane only matches devices that
  * advertise `automations.execute` (the daemon opts in by auto-advertising it
  * on the headless platform) — with the macOS exemption preserving the
- * pre-capability behavior for Owletto's bridge, which advertises a fixed
+ * pre-capability exemption for Owletto's bridge, which advertises a fixed
  * capability set with no such string.
  *
  * These tests drive the real poll endpoint with a device-pinned automation:

--- a/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
+++ b/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
@@ -108,4 +108,24 @@ describe("automation dispatch message", () => {
 			"If there is no content, do not fabricate results.",
 		);
 	});
+
+	it("builds the same completion contract for a device executor without an agent id", () => {
+		const message = buildDispatchMessage({
+			automationId: 71,
+			runId: 9001,
+			executor: "device",
+			payload: {
+				automation_id: 71,
+				window_start: "2026-08-18T00:00:00.000Z",
+				window_end: "2026-08-19T00:00:00.000Z",
+				dispatch_source: "manual",
+			},
+		});
+
+		expect(message).toContain("client.knowledge.read({ automation_id: 71");
+		expect(message).toContain("client.automations.completeWindow");
+		expect(message).toContain('"executor": "device"');
+		expect(message).not.toContain("Assigned agent ID: undefined");
+		expect(message).not.toContain("Session agent ID: undefined");
+	});
 });

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -1016,8 +1016,9 @@ export async function runAutomationTick(
 export function buildDispatchMessage(params: {
 	automationId: number;
 	runId: number;
-	agentId: string;
-	sessionAgentId: string;
+	agentId?: string;
+	sessionAgentId?: string;
+	executor?: string;
 	payload: AutomationRunPayload;
 	automationInstructions?: string;
 }): string {
@@ -1039,7 +1040,7 @@ export function buildDispatchMessage(params: {
 				"",
 				`Automation ID: ${params.automationId}`,
 				`Automation run ID: ${params.runId}`,
-				`Assigned agent ID: ${params.agentId}`,
+				...(params.agentId ? [`Assigned agent ID: ${params.agentId}`] : []),
 				"Result delivery: silent",
 				"",
 				"Automation instructions:",
@@ -1058,7 +1059,7 @@ export function buildDispatchMessage(params: {
 			"",
 			`Automation ID: ${params.automationId}`,
 			`Automation run ID: ${params.runId}`,
-			`Assigned agent ID: ${params.agentId}`,
+			...(params.agentId ? [`Assigned agent ID: ${params.agentId}`] : []),
 			`Result delivery: ${params.payload.trigger_output ?? "silent"}`,
 			"",
 			"Automation instructions:",
@@ -1086,8 +1087,8 @@ export function buildDispatchMessage(params: {
 		"",
 		`Automation ID: ${params.automationId}`,
 		`Automation run ID: ${params.runId}`,
-		`Assigned agent ID: ${params.agentId}`,
-		`Session agent ID: ${params.sessionAgentId}`,
+		...(params.agentId ? [`Assigned agent ID: ${params.agentId}`] : []),
+		...(params.sessionAgentId ? [`Session agent ID: ${params.sessionAgentId}`] : []),
 		`Queued window start: ${params.payload.window_start}`,
 		`Queued window end: ${params.payload.window_end}`,
 		`Dispatch source: ${params.payload.dispatch_source}`,
@@ -1106,11 +1107,11 @@ export function buildDispatchMessage(params: {
 		"4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:",
 		JSON.stringify(
 			{
-				executor: "lobu-agent",
-				agent_id: params.agentId,
+				executor: params.executor ?? "lobu-agent",
+				...(params.agentId ? { agent_id: params.agentId } : {}),
 				automation_run_id: params.runId,
 				dispatch_source: params.payload.dispatch_source,
-				session_agent_id: params.sessionAgentId,
+				...(params.sessionAgentId ? { session_agent_id: params.sessionAgentId } : {}),
 			},
 			null,
 			2
@@ -1246,7 +1247,7 @@ async function getAutomationModelOverride(
 	return typeof model === "string" && model.trim() ? model.trim() : undefined;
 }
 
-async function ensureAutomationAgentExists(
+export async function ensureAutomationAgentExists(
 	sql: DbClient,
 	organizationId: string,
 	agentId: string

--- a/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
+++ b/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { verifyWorkerToken } from "@lobu/core";
 import { buildAutomationRunWorkerAccess } from "../services/automation-run-worker-token.js";
+
+// Minting encrypts with ENCRYPTION_KEY. The gateway lane runs many files in one
+// bun process and its peers set/restore the key per file, so this suite cannot
+// inherit one — set our own, as `agent-session-create.test.ts` does.
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+let savedKey: string | undefined;
+
+beforeAll(() => {
+  savedKey = process.env.ENCRYPTION_KEY;
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+});
+
+afterAll(() => {
+  if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = savedKey;
+});
 
 describe("Automation run WorkerToken parity", () => {
   test("packs the canonical Automation conversation and tenant claims", () => {
@@ -12,6 +29,10 @@ describe("Automation run WorkerToken parity", () => {
     });
     expect(access.conversationId).toBe("developer_automation_120_run_456");
     const claims = verifyWorkerToken(access.token);
+    // `verifyWorkerToken` returns null for a token it cannot decrypt/verify;
+    // assert it here so a broken mint fails as a claim mismatch, not a TypeError.
+    expect(claims).not.toBeNull();
+    if (!claims) throw new Error("worker token did not verify");
     expect(claims.agentId).toBe("developer");
     expect(claims.organizationId).toBe("org-team");
     expect(claims.conversationId).toBe(access.conversationId);

--- a/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
+++ b/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { verifyWorkerToken } from "@lobu/core";
+import { buildAutomationRunWorkerAccess } from "../services/automation-run-worker-token.js";
+
+describe("Automation run WorkerToken parity", () => {
+  test("packs the canonical Automation conversation and tenant claims", () => {
+    const access = buildAutomationRunWorkerAccess({
+      agentId: "developer",
+      automationId: 120,
+      runId: 456,
+      organizationId: "org-team",
+    });
+    expect(access.conversationId).toBe("developer_automation_120_run_456");
+    const claims = verifyWorkerToken(access.token);
+    expect(claims.agentId).toBe("developer");
+    expect(claims.organizationId).toBe("org-team");
+    expect(claims.conversationId).toBe(access.conversationId);
+    expect(claims.channelId).toBe("api_automation_120");
+    expect(claims.platform).toBe("api");
+  });
+
+  test("rejects a non-canonical conversation id", () => {
+    expect(() =>
+      buildAutomationRunWorkerAccess({
+        agentId: "developer",
+        automationId: 120,
+        runId: 456,
+        organizationId: "org-team",
+        conversationId: "developer_other",
+      })
+    ).toThrow(/Automation conversation mismatch/);
+  });
+});

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -904,7 +904,8 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         return c.json({ success: false, error: "Forbidden" }, 403);
       }
       if (existing) {
-        // Reuse existing session — touch lastActivity and return existing token
+        // Reuse the existing session — touch lastActivity and hand back a
+        // freshly minted token for it (tokens are stateless, never stored).
         await sessMgr.touchSession(conversationId);
 
         const { token, expiresAt } = mintSessionToken();

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -45,6 +45,7 @@ import {
   verifyAutomationRunIntent,
 } from "../../permissions/automation-run-intent.js";
 import { buildApiConversationId } from "../../services/api-conversation-id.js";
+import { buildAutomationRunWorkerAccess } from "../../services/automation-run-worker-token.js";
 import { resolveAgentOptions } from "../../services/platform-helpers.js";
 import type { SseManager } from "../../services/sse-manager.js";
 import type { ISessionManager, ThreadSession } from "../../session.js";
@@ -874,20 +875,28 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         // Reuse existing session — touch lastActivity and return existing token
         await sessMgr.touchSession(conversationId);
 
-        const token = generateWorkerToken(
-          agentId,
-          conversationId,
-          deploymentName,
-          {
+        const automationAccess =
+          automationIntent && tokenOrganizationId
+            ? buildAutomationRunWorkerAccess({
+                agentId,
+                automationId: automationIntent.automationId,
+                runId: automationIntent.runId,
+                organizationId: tokenOrganizationId,
+                conversationId,
+              })
+            : null;
+        const token =
+          automationAccess?.token ??
+          generateWorkerToken(agentId, conversationId, deploymentName, {
             channelId,
             agentId,
             organizationId: tokenOrganizationId,
             platform: "api",
             sessionKey: userId,
-          }
-        );
+          });
 
-        const expiresAt = Date.now() + TOKEN_EXPIRATION_MS;
+        const expiresAt =
+          automationAccess?.expiresAt ?? Date.now() + TOKEN_EXPIRATION_MS;
         const baseUrl = pubUrl || "http://localhost:8080";
 
         logger.info(
@@ -908,15 +917,28 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       }
     }
 
-    const token = generateWorkerToken(agentId, conversationId, deploymentName, {
-      channelId,
-      agentId,
-      organizationId: tokenOrganizationId,
-      platform: "api",
-      sessionKey: userId,
-    });
+    const automationAccess =
+      automationIntent && tokenOrganizationId
+        ? buildAutomationRunWorkerAccess({
+            agentId,
+            automationId: automationIntent.automationId,
+            runId: automationIntent.runId,
+            organizationId: tokenOrganizationId,
+            conversationId,
+          })
+        : null;
+    const token =
+      automationAccess?.token ??
+      generateWorkerToken(agentId, conversationId, deploymentName, {
+        channelId,
+        agentId,
+        organizationId: tokenOrganizationId,
+        platform: "api",
+        sessionKey: userId,
+      });
 
-    const expiresAt = Date.now() + TOKEN_EXPIRATION_MS;
+    const expiresAt =
+      automationAccess?.expiresAt ?? Date.now() + TOKEN_EXPIRATION_MS;
 
     const session: ThreadSession = {
       conversationId,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -853,6 +853,38 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     const channelId = `api_${userId}`;
     const deploymentName = `api-${agentId.slice(0, 8)}`;
 
+    // Automation sessions mint through buildAutomationRunWorkerAccess so the
+    // token identity matches the canonical `..._automation_<id>_run_<id>`
+    // correlation AND the advertised expiry matches the worker token's real
+    // verification TTL (WORKER_TOKEN_TTL_MS, default 2h) — the generic
+    // TOKEN_EXPIRATION_MS (24h) overstated it. Non-automation sessions keep the
+    // generic mint unchanged.
+    const mintSessionToken = (): { token: string; expiresAt: number } => {
+      const automationAccess =
+        automationIntent && tokenOrganizationId
+          ? buildAutomationRunWorkerAccess({
+              agentId,
+              automationId: automationIntent.automationId,
+              runId: automationIntent.runId,
+              organizationId: tokenOrganizationId,
+              conversationId,
+            })
+          : null;
+      return {
+        token:
+          automationAccess?.token ??
+          generateWorkerToken(agentId, conversationId, deploymentName, {
+            channelId,
+            agentId,
+            organizationId: tokenOrganizationId,
+            platform: "api",
+            sessionKey: userId,
+          }),
+        expiresAt:
+          automationAccess?.expiresAt ?? Date.now() + TOKEN_EXPIRATION_MS,
+      };
+    };
+
     // Try to resume existing session (unless forceNew is requested).
     // Refuse cross-tenant resume defensively: even though the userId fallback
     // above is per-org-unique for the default-agent path, a future caller that
@@ -875,28 +907,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         // Reuse existing session — touch lastActivity and return existing token
         await sessMgr.touchSession(conversationId);
 
-        const automationAccess =
-          automationIntent && tokenOrganizationId
-            ? buildAutomationRunWorkerAccess({
-                agentId,
-                automationId: automationIntent.automationId,
-                runId: automationIntent.runId,
-                organizationId: tokenOrganizationId,
-                conversationId,
-              })
-            : null;
-        const token =
-          automationAccess?.token ??
-          generateWorkerToken(agentId, conversationId, deploymentName, {
-            channelId,
-            agentId,
-            organizationId: tokenOrganizationId,
-            platform: "api",
-            sessionKey: userId,
-          });
-
-        const expiresAt =
-          automationAccess?.expiresAt ?? Date.now() + TOKEN_EXPIRATION_MS;
+        const { token, expiresAt } = mintSessionToken();
         const baseUrl = pubUrl || "http://localhost:8080";
 
         logger.info(
@@ -917,28 +928,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       }
     }
 
-    const automationAccess =
-      automationIntent && tokenOrganizationId
-        ? buildAutomationRunWorkerAccess({
-            agentId,
-            automationId: automationIntent.automationId,
-            runId: automationIntent.runId,
-            organizationId: tokenOrganizationId,
-            conversationId,
-          })
-        : null;
-    const token =
-      automationAccess?.token ??
-      generateWorkerToken(agentId, conversationId, deploymentName, {
-        channelId,
-        agentId,
-        organizationId: tokenOrganizationId,
-        platform: "api",
-        sessionKey: userId,
-      });
-
-    const expiresAt =
-      automationAccess?.expiresAt ?? Date.now() + TOKEN_EXPIRATION_MS;
+    const { token, expiresAt } = mintSessionToken();
 
     const session: ThreadSession = {
       conversationId,

--- a/packages/server/src/gateway/services/automation-run-worker-token.ts
+++ b/packages/server/src/gateway/services/automation-run-worker-token.ts
@@ -1,0 +1,50 @@
+import { generateWorkerToken } from "@lobu/core";
+
+export interface AutomationRunWorkerAccess {
+  conversationId: string;
+  token: string;
+  expiresAt: number;
+}
+
+function workerTokenTtlMs(): number {
+  const raw = Number.parseInt(process.env.WORKER_TOKEN_TTL_MS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 2 * 60 * 60 * 1000;
+}
+
+/**
+ * Mint the exact WorkerToken identity used by a verified Automation Agent API
+ * session. Device-pinned Automations use this same identity for lobu-memory MCP
+ * access; the device PAT remains poll/lifecycle-only and never crosses orgs.
+ */
+export function buildAutomationRunWorkerAccess(args: {
+  agentId: string;
+  automationId: number;
+  runId: number;
+  organizationId: string;
+  conversationId?: string;
+}): AutomationRunWorkerAccess {
+  const expectedConversationId = `${args.agentId}_automation_${args.automationId}_run_${args.runId}`;
+  const conversationId = args.conversationId ?? expectedConversationId;
+  if (conversationId !== expectedConversationId) {
+    throw new Error(
+      `Automation conversation mismatch: expected ${expectedConversationId}, got ${conversationId}`
+    );
+  }
+
+  const userId = `automation_${args.automationId}`;
+  const channelId = `api_${userId}`;
+  const deploymentName = `api-${args.agentId.slice(0, 8)}`;
+
+  const issuedAt = Date.now();
+  return {
+    conversationId,
+    expiresAt: issuedAt + workerTokenTtlMs(),
+    token: generateWorkerToken(args.agentId, conversationId, deploymentName, {
+      channelId,
+      agentId: args.agentId,
+      organizationId: args.organizationId,
+      platform: "api",
+      sessionKey: userId,
+    }),
+  };
+}

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -12,6 +12,13 @@ import {
   automationTriggerSignals,
   isWorkspaceEventTriggerSignal,
 } from '../automations/workspace-event-contract';
+import {
+  buildDispatchMessage,
+  ensureAutomationAgentExists,
+  parseAutomationRunPayload,
+} from '../automations/automation';
+import { buildAutomationRunWorkerAccess } from '../gateway/services/automation-run-worker-token';
+import { resolvePublicGatewayUrl } from '../utils/public-origin';
 import { getDb, parsePgTextArray, pgTextArray } from '../db/client';
 import type { Outputs } from '../types/automations';
 import { deriveAutomationExtractionSchema } from '../utils/automation-extraction-schema';
@@ -368,7 +375,6 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           platform = COALESCE(device_workers.platform, EXCLUDED.platform),
           app_version = EXCLUDED.app_version,
           capabilities = EXCLUDED.capabilities,
-          label = COALESCE(EXCLUDED.label, device_workers.label),
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
           connector_manifests = CASE
             WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests
@@ -653,6 +659,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
               AND ${deviceWorkerId}::uuid IS NOT NULL
               AND r.approved_input ? 'device_worker_id'
               AND r.approved_input->>'device_worker_id' = ${deviceWorkerId}::text
+              AND (
+                'automations.execute' = ANY(${pgTextArray(authorizedCapabilities)}::text[])
+                OR ${effectivePlatform} = 'macos'
+              )
               AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
               AND (
                 ${agentKindsParam}::text[] IS NULL
@@ -749,6 +759,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         cd.required_capability AS connector_required_capability,
         ap.auth_data AS auth_profile_auth_data,
         w.name AS automation_name,
+        w.agent_id AS automation_agent_id,
         w.slug AS automation_slug,
         w.agent_kind AS automation_agent_kind,
         w.notification_channel AS automation_notification_channel,
@@ -840,6 +851,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     window_id: number | null;
     organization_id: string;
     automation_name: string | null;
+    automation_agent_id: string | null;
     automation_slug: string | null;
     automation_agent_kind: string | null;
     automation_notification_channel: string | null;
@@ -913,6 +925,53 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         ...pollMetadata,
       });
     }
+    let devicePrompt = automationInstructions;
+    let agentSession: { conversation_id: string; mcp_url: string; token: string; expires_at: number } | undefined;
+    if (effectivePlatform !== 'macos') {
+      const runPayload = parseAutomationRunPayload(approved);
+      const agentId =
+        typeof approved['agent_id'] === 'string' && approved['agent_id'].trim()
+          ? approved['agent_id'].trim()
+          : row.automation_agent_id?.trim() || null;
+      if (!runPayload || row.automation_id == null || !agentId) {
+        const message = !agentId
+          ? `Automation run ${row.run_id} has no assigned agent — cannot mint run-scoped MCP access.`
+          : `Automation run ${row.run_id} is missing its pinned agent identity`;
+        await failClaimedWorkerRun({ runId: row.run_id, workerId: worker_id, errorMessage: message });
+        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message, ...pollMetadata });
+      }
+      if (!(await ensureAutomationAgentExists(sql, row.organization_id, agentId))) {
+        const message = `Assigned agent "${agentId}" does not exist in this organization.`;
+        await failClaimedWorkerRun({ runId: row.run_id, workerId: worker_id, errorMessage: message });
+        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message, ...pollMetadata });
+      }
+      devicePrompt = buildDispatchMessage({
+        automationId: row.automation_id,
+        runId: row.run_id,
+        agentId,
+        payload: runPayload,
+        automationInstructions: automationInstructions ?? undefined,
+        executor: 'device',
+      });
+      // Per-run Automation agent session (same WorkerToken identity as the
+      // server-side dispatcher's agent session) — never the device's PAT, which
+      // is bound to the user's personal org and can't authenticate to a
+      // team-org Automation. The executor sends the token as the MCP bearer
+      // against the canonical headless lobu-memory endpoint.
+      const access = buildAutomationRunWorkerAccess({
+        agentId,
+        automationId: row.automation_id,
+        runId: row.run_id,
+        organizationId: row.organization_id,
+      });
+      agentSession = {
+        conversation_id: access.conversationId,
+        mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
+        token: access.token,
+        expires_at: access.expiresAt,
+      };
+    }
+
     return c.json({
       ...pollMetadata,
       run_id: row.run_id,
@@ -943,7 +1002,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           // id/name/slug), so a scheduled automation's local CLI got a bare
           // "process this" and improvised; shipping it lets the device run the
           // real prompt. Null only if the automation has no version row.
-          prompt: automationInstructions,
+          prompt: devicePrompt,
           // The derived extraction contract (entity-typed → derived from that
           // entity type's metadata_schema; untyped → null). The dispatcher embeds
           // it in the prompt as the output contract: the CLI must finish with a
@@ -968,6 +1027,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           user: {
             user_id: effectiveWorkerUserId ?? null,
           },
+          ...(agentSession ? { agent_session: agentSession } : {}),
         },
       },
     });

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -375,6 +375,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           platform = COALESCE(device_workers.platform, EXCLUDED.platform),
           app_version = EXCLUDED.app_version,
           capabilities = EXCLUDED.capabilities,
+          label = COALESCE(EXCLUDED.label, device_workers.label),
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
           connector_manifests = CASE
             WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests
@@ -927,49 +928,52 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     }
     let devicePrompt = automationInstructions;
     let agentSession: { conversation_id: string; mcp_url: string; token: string; expires_at: number } | undefined;
-    if (effectivePlatform !== 'macos') {
+    if (effectivePlatform !== 'macos' && row.automation_id != null) {
       const runPayload = parseAutomationRunPayload(approved);
       const agentId =
         typeof approved['agent_id'] === 'string' && approved['agent_id'].trim()
           ? approved['agent_id'].trim()
           : row.automation_agent_id?.trim() || null;
-      if (!runPayload || row.automation_id == null || !agentId) {
-        const message = !agentId
-          ? `Automation run ${row.run_id} has no assigned agent — cannot mint run-scoped MCP access.`
-          : `Automation run ${row.run_id} is missing its pinned agent identity`;
-        await failClaimedWorkerRun({ runId: row.run_id, workerId: worker_id, errorMessage: message });
-        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message, ...pollMetadata });
+      if (
+        runPayload &&
+        agentId &&
+        (await ensureAutomationAgentExists(sql, row.organization_id, agentId))
+      ) {
+        devicePrompt = buildDispatchMessage({
+          automationId: row.automation_id,
+          runId: row.run_id,
+          agentId,
+          payload: runPayload,
+          automationInstructions: automationInstructions ?? undefined,
+          executor: 'device',
+        });
+        // Per-run Automation agent session (same WorkerToken identity as the
+        // server-side dispatcher's agent session) — never the device's PAT,
+        // which is bound to the user's personal org and can't authenticate to
+        // a team-org Automation. The daemon injects the token into the spawned
+        // CLI (env + MCP wiring) against the gateway MCP proxy endpoint.
+        const access = buildAutomationRunWorkerAccess({
+          agentId,
+          automationId: row.automation_id,
+          runId: row.run_id,
+          organizationId: row.organization_id,
+        });
+        agentSession = {
+          conversation_id: access.conversationId,
+          mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
+          token: access.token,
+          expires_at: access.expiresAt,
+        };
+      } else {
+        // No assigned agent (or no parseable run payload): dispatch the
+        // pre-session shape — instructions prompt + exit-report completion on
+        // the daemon's own wiring — rather than failing a run that used to
+        // execute. Only runs with a real agent identity get a minted session.
+        logger.warn(
+          { run_id: row.run_id, automation_id: row.automation_id, agent_id: agentId },
+          '[poll] headless automation has no usable assigned agent; dispatching instructions-only (no run-scoped MCP session)'
+        );
       }
-      if (!(await ensureAutomationAgentExists(sql, row.organization_id, agentId))) {
-        const message = `Assigned agent "${agentId}" does not exist in this organization.`;
-        await failClaimedWorkerRun({ runId: row.run_id, workerId: worker_id, errorMessage: message });
-        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message, ...pollMetadata });
-      }
-      devicePrompt = buildDispatchMessage({
-        automationId: row.automation_id,
-        runId: row.run_id,
-        agentId,
-        payload: runPayload,
-        automationInstructions: automationInstructions ?? undefined,
-        executor: 'device',
-      });
-      // Per-run Automation agent session (same WorkerToken identity as the
-      // server-side dispatcher's agent session) — never the device's PAT, which
-      // is bound to the user's personal org and can't authenticate to a
-      // team-org Automation. The executor sends the token as the MCP bearer
-      // against the canonical headless lobu-memory endpoint.
-      const access = buildAutomationRunWorkerAccess({
-        agentId,
-        automationId: row.automation_id,
-        runId: row.run_id,
-        organizationId: row.organization_id,
-      });
-      agentSession = {
-        conversation_id: access.conversationId,
-        mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
-        token: access.token,
-        expires_at: access.expiresAt,
-      };
     }
 
     return c.json({

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -662,7 +662,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
               AND r.approved_input->>'device_worker_id' = ${deviceWorkerId}::text
               AND (
                 'automations.execute' = ANY(${pgTextArray(authorizedCapabilities)}::text[])
-                OR ${effectivePlatform} = 'macos'
+                OR ${effectivePlatform}::text = 'macos'
               )
               AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
               AND (
@@ -952,18 +952,31 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         // which is bound to the user's personal org and can't authenticate to
         // a team-org Automation. The daemon injects the token into the spawned
         // CLI (env + MCP wiring) against the gateway MCP proxy endpoint.
-        const access = buildAutomationRunWorkerAccess({
-          agentId,
-          automationId: row.automation_id,
-          runId: row.run_id,
-          organizationId: row.organization_id,
-        });
-        agentSession = {
-          conversation_id: access.conversationId,
-          mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
-          token: access.token,
-          expires_at: access.expiresAt,
-        };
+        //
+        // Minting encrypts, so it can throw (missing/short ENCRYPTION_KEY). The
+        // run is ALREADY claimed by this point, so letting that escape would 500
+        // the poll and strand it `running` — the exact wedge the claim gate
+        // exists to prevent. Degrade to the pre-session dispatch instead.
+        try {
+          const access = buildAutomationRunWorkerAccess({
+            agentId,
+            automationId: row.automation_id,
+            runId: row.run_id,
+            organizationId: row.organization_id,
+          });
+          agentSession = {
+            conversation_id: access.conversationId,
+            mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
+            token: access.token,
+            expires_at: access.expiresAt,
+          };
+        } catch (err) {
+          devicePrompt = automationInstructions;
+          logger.error(
+            { run_id: row.run_id, automation_id: row.automation_id, agent_id: agentId, err },
+            '[poll] failed to mint the Automation run session; dispatching instructions-only'
+          );
+        }
       } else {
         // No assigned agent (or no parseable run payload): dispatch the
         // pre-session shape — instructions prompt + exit-report completion on


### PR DESCRIPTION
## Summary

Makes headless (non-macOS) device Automation execution work end to end, with the spawned CLI running as the Automation's assigned agent instead of the daemon's durable PAT:

- **Claim gate**: `/api/workers/poll` hands `run_type='automation'` runs only to device workers advertising `automations.execute`; macOS keeps the pre-capability exemption. A daemon build that predates the automation lane can no longer claim and wedge a run — and `WorkerClient` now actually advertises the string itself on the headless platform (the gate previously matched a capability nothing sent, which would have silently stopped every headless device from claiming automation runs).
- **Per-run agent session (server)**: at claim time the poll response carries `context.agent_session` — a WorkerToken minted via `buildAutomationRunWorkerAccess` for the Automation's assigned agent, bound to the canonical `<agent>_automation_<id>_run_<id>` conversation, expiring on the real verification TTL (`WORKER_TOKEN_TTL_MS`, default 2h). `mcp_url` targets the gateway MCP proxy (`{PUBLIC_GATEWAY_URL}/mcp/lobu-memory`), which already validates worker tokens and promotes them into a direct-auth MCP session.
- **Per-run agent session (daemon)**: `resolveAutomationRunAccess` prefers the session over the daemon's own wiring — the token goes into the spawned CLI's MCP config AND into `LOBU_API_TOKEN`/`LOBU_MEMORY_URL`, which `lobu memory` prefers over the device's ambient CLI session. The unattended run acts as the Automation's agent, never as the human user or the daemon. Older servers (no session) fall back to the previous daemon wiring.
- **Agentless fallback, not a brick**: a run whose Automation has no usable assigned agent dispatches the pre-session shape (instructions prompt + exit-report completion) instead of failing at claim time.
- **Safety net**: `executeRun` never throws; an unhandled error terminates the claimed run via the lane-appropriate endpoint — the automation lane reports through `/complete-automation` (sync `/complete` would finalize the run row but skip automation-side bookkeeping). Poll-side, a session-mint failure degrades to instructions-only dispatch instead of 500ing a run that is already claimed.
- **Agent-session mint parity**: the Agent API's Automation sessions mint through the same `buildAutomationRunWorkerAccess`, and the advertised `expiresAt` now matches the token's real 2h verification TTL (was overstated as 24h).
- `lobu memory` CLI: an explicit runtime bearer + MCP URL (`LOBU_API_TOKEN` + `LOBU_MEMORY_URL`) is self-contained — ambient active-org state no longer rewrites a mounted endpoint.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (build + typecheck + knip + biome + naming)
- [x] Tests run: `bun test packages/connector-worker/src/__tests__/executor-automation.test.ts` (12 pass), `bunx vitest run src/__tests__/integration/automations/headless-automation-claim-gate.test.ts` (4 pass), `bun test` for capabilities/memory-auth/dispatch-message/worker-token suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval — n/a

### red → green

**Safety-net routing** (`executeRun` catch sent automation failures to the sync `/complete` endpoint). New test `automation-lane unhandled error terminates via complete-automation, never the sync endpoint` against the previous executor:

```
error: expect(received).toHaveLength(expected)
Expected length: 0
Received length: 1   # sync complete() received the automation failure
(fail) executeRun try/catch safety net > automation-lane unhandled error terminates via complete-automation, never the sync endpoint
11 pass, 1 fail
```

After routing the automation lane to `client.completeAutomation`:

```
12 pass, 0 fail — Ran 12 tests across 1 file.
```

**Agentless claim brick** (previous poll.ts permanently failed any headless automation run without an assigned agent). New test `automation without an assigned agent still dispatches instructions-only (no run-scoped session)` against the previous poll.ts:

```
AssertionError: expected undefined to be 'automation'   # run was failed at claim, not dispatched
Tests  1 failed | 3 passed (4)
```

After the fallback:

```
Tests  4 passed (4)
```

## Notes
- The dead `AutomationPayloadSchema` mirror is deleted; `agent_session` lives on the real decode schema (`AutomationPollContextSchema`) the daemon consumes.
- The `device_workers.label` upsert fix that was bundled here moves to its own PR.
- Rollout order: server deploys first (mints sessions), daemons pick them up as they update; the daemon-wiring fallback covers the skew window and can be removed once prod has rolled.
