### PR TITLE
feat(automations): make platform events subscribable from a computed catalog

### DIFF
--- a/packages/server/src/__tests__/integration/automations/platform-event-subscription.test.ts
+++ b/packages/server/src/__tests__/integration/automations/platform-event-subscription.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Subscribing to platform events, at the surface where it was blocked.
+ *
+ * The activation path could already deliver a platform audit row to a
+ * subscriber, but `assertAutomationTriggerConnections` rejected the
+ * subscription itself: it required the type to appear in some entity type's
+ * `event_kinds`, and platform events have no declaring entity type. These
+ * tests cover the seam from the caller's side — creating the Automation — plus
+ * the collision guard that keeps the two catalogs from merging.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { createTestAgent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+async function orgWithAgent(name: string) {
+  const workspace = await TestWorkspace.create({ name });
+  const ownerUserId = workspace.users.owner.id;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'platform-subscription-agent',
+  });
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+  return { workspace, agent, api };
+}
+
+function workspaceTrigger(eventTypes: string[], entityType?: string) {
+  return [
+    {
+      kind: 'event',
+      source: 'workspace',
+      event_types: eventTypes,
+      execution: 'window',
+      active_run: 'queue',
+      ...(entityType ? { entity_type: entityType } : {}),
+    },
+  ];
+}
+
+describe('platform event subscriptions', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('accepts a platform type that no entity type declares', async () => {
+    const { agent, api } = await orgWithAgent('Platform Subscribe Org');
+    // Nothing is declared anywhere in this organization. Before the computed
+    // catalog this threw "Workspace does not declare workspace event".
+    const created = (await api.automations.create({
+      slug: 'connection-consumer',
+      prompt: 'Handle the platform event.',
+      triggers: workspaceTrigger(['connection.deleted']),
+      agent_id: agent.agentId,
+    })) as { automation_id: string };
+    expect(Number(created.automation_id)).toBeGreaterThan(0);
+  });
+
+  it('rejects a typo instead of accepting a subscription that can never fire', async () => {
+    const { agent, api } = await orgWithAgent('Platform Typo Org');
+    await expect(
+      api.automations.create({
+        slug: 'typo-consumer',
+        prompt: 'Handle the platform event.',
+        triggers: workspaceTrigger(['connection.delted']),
+        agent_id: agent.agentId,
+      })
+    ).rejects.toThrow(/does not declare workspace event/i);
+  });
+
+  it('rejects `change`, which names a storage class rather than an event', async () => {
+    const { agent, api } = await orgWithAgent('Change Firehose Org');
+    // Undeclared, so this fails at validation. The matcher refuses it too —
+    // see workspace-event-roots — because an org MAY declare `change` as a
+    // content kind, and that must not turn into an audit firehose.
+    await expect(
+      api.automations.create({
+        slug: 'firehose-consumer',
+        prompt: 'Handle every write.',
+        triggers: workspaceTrigger(['change']),
+        agent_id: agent.agentId,
+      })
+    ).rejects.toThrow(/does not declare workspace event/i);
+  });
+
+  it('narrows an entity subscription by entity type', async () => {
+    const { agent, api } = await orgWithAgent('Entity Narrow Org');
+    await api.entity_schema.createType({
+      slug: 'invoice',
+      name: 'Invoice',
+      metadata_schema: { type: 'object', properties: {} },
+    });
+    // "When an invoice changes" is the platform `entity.updated` event plus the
+    // trigger's existing entity_type filter — no per-entity-type event needed.
+    const created = (await api.automations.create({
+      slug: 'invoice-consumer',
+      prompt: 'Handle the invoice change.',
+      triggers: workspaceTrigger(['entity.updated'], 'invoice'),
+      agent_id: agent.agentId,
+    })) as { automation_id: string };
+    expect(Number(created.automation_id)).toBeGreaterThan(0);
+  });
+
+  it('refuses to let an entity type redeclare a platform event type', async () => {
+    const { api } = await orgWithAgent('Collision Org');
+    // `event_kinds` is what `save_content` validates against, so declaring
+    // `connection.deleted` here would make it postable as ordinary content and
+    // let a forged row activate real subscribers.
+    await expect(
+      api.entity_schema.createType({
+        slug: 'forged',
+        name: 'Forged',
+        metadata_schema: { type: 'object', properties: {} },
+        event_kinds: { 'connection.deleted': { description: 'forged' } },
+      })
+    ).rejects.toThrow(/may not redeclare platform event types/i);
+
+    await api.entity_schema.createType({
+      slug: 'legit',
+      name: 'Legit',
+      metadata_schema: { type: 'object', properties: {} },
+      event_kinds: { risk_detected: { description: 'fine' } },
+    });
+    // The same guard runs on update, not only create — otherwise a clean type
+    // could be amended into the collision afterwards.
+    await expect(
+      api.entity_schema.updateType({
+        slug: 'legit',
+        event_kinds: { 'device.deleted': { description: 'forged' } },
+      })
+    ).rejects.toThrow(/may not redeclare platform event types/i);
+  });
+
+  it('leaves the declared content catalog working alongside the platform one', async () => {
+    const sql = getTestDb();
+    const { workspace, agent, api } = await orgWithAgent('Union Org');
+    await api.entity_schema.createType({
+      slug: 'account',
+      name: 'Account',
+      metadata_schema: { type: 'object', properties: {} },
+      event_kinds: { risk_detected: { description: 'A risk was detected' } },
+    });
+    const created = (await api.automations.create({
+      slug: 'union-consumer',
+      prompt: 'Handle either.',
+      triggers: workspaceTrigger(['risk_detected']),
+      agent_id: agent.agentId,
+    })) as { automation_id: string };
+    expect(Number(created.automation_id)).toBeGreaterThan(0);
+    expect(
+      await sql`
+        SELECT id FROM automations WHERE organization_id = ${workspace.org.id}
+      `
+    ).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/workspace-event-roots.test.ts
+++ b/packages/server/src/__tests__/integration/automations/workspace-event-roots.test.ts
@@ -20,6 +20,7 @@ import {
   insertEvent,
 } from '../../../utils/insert-event';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { isPlatformEventType } from '../../../automations/platform-event-catalog';
 import { ensureMemberEntityType } from '../../../utils/member-entity-type';
 import { createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
@@ -28,23 +29,22 @@ async function subscriberOrg(eventTypes: string[][]) {
   const sql = getTestDb();
   const workspace = await TestWorkspace.create({ name: 'Workspace Event Root Org' });
   const ownerUserId = workspace.users.owner.id;
-  // A workspace trigger may only name an event type some entity type declares
-  // (`assertAutomationTriggerConnections`). For an entity-type-less trigger the
-  // catalog is the union across the org, so declaring on `$member` is what
-  // makes a type subscribable org-wide. Platform-emitted types have no
-  // declaring entity type yet — closing that catalog gap is separate work; here
-  // the types are declared explicitly so the activation path itself is what is
-  // under test.
+  // A workspace trigger may only name an event type some catalog declares
+  // (`assertAutomationTriggerConnections`). Platform `<subject>.<op>` types come
+  // from the computed platform catalog and need no declaration — that is the
+  // point, and the tests below rely on it. Only non-platform types are declared
+  // here, on `$member`, whose `event_kinds` is the org-wide content registry.
+  const declared = eventTypes.flat().filter((type) => !isPlatformEventType(type));
   await ensureMemberEntityType(workspace.org.id);
-  await sql`
-    UPDATE entity_types
-    SET event_kinds = ${sql.json(
-      Object.fromEntries(
-        eventTypes.flat().map((type) => [type, { description: type }])
-      )
-    )}
-    WHERE organization_id = ${workspace.org.id} AND slug = '$member'
-  `;
+  if (declared.length > 0) {
+    await sql`
+      UPDATE entity_types
+      SET event_kinds = ${sql.json(
+        Object.fromEntries(declared.map((type) => [type, { description: type }]))
+      )}
+      WHERE organization_id = ${workspace.org.id} AND slug = '$member'
+    `;
+  }
   const agent = await createTestAgent({
     organizationId: workspace.org.id,
     ownerUserId,
@@ -100,22 +100,22 @@ describe('workspace events with no producing Automation', () => {
     // The second Automation subscribes to a sibling op. It exists to prove the
     // GIN needle narrows rather than matching every dotted subscriber.
     const { workspace, automationIds } = await subscriberOrg([
-      ['device.online'],
-      ['device.offline'],
+      ['device.deleted'],
+      ['connection.deleted'],
     ]);
-    const [onlineConsumer] = automationIds;
+    const [deviceConsumer] = automationIds;
 
     const event = await insertConnectionlessAuditEvent(
       {
         organizationId: workspace.org.id,
         entityIds: [],
-        originId: 'device:root-worker:online',
+        originId: 'device:root-worker:deleted',
         semanticType: 'change',
         title: 'Device came online',
         content: 'A device worker started reporting.',
         metadata: { category: 'device', worker_id: 'root-worker' },
       },
-      { subject: 'device', op: 'online' }
+      { subject: 'device', op: 'deleted' }
     );
 
     // The writer stamped it and left `automation_id` null: this row is a root.
@@ -128,7 +128,7 @@ describe('workspace events with no producing Automation', () => {
     `;
     expect(stored[0]).toEqual({
       automation_id: null,
-      event_type: 'device.online',
+      event_type: 'device.deleted',
     });
 
     await expect(
@@ -149,7 +149,7 @@ describe('workspace events with no producing Automation', () => {
         AND organization_id = ${workspace.org.id}
     `;
     expect(runs.map((row) => Number(row.automation_id))).toEqual([
-      onlineConsumer,
+      deviceConsumer,
     ]);
     expect(runs[0]?.approved_input).toMatchObject({
       delivery_ids: [`workspace-event:${event.id}`],
@@ -159,16 +159,16 @@ describe('workspace events with no producing Automation', () => {
         event_id: event.id,
         // The specific name, not the `change` semantic type every audit row
         // shares — otherwise the consumer cannot tell what happened.
-        event_type: 'device.online',
+        event_type: 'device.deleted',
         causal_automation_ids: [],
         depth: 1,
       },
     });
   });
 
-  it('also activates a subscriber named by the raw semantic type', async () => {
+  it('does not let a `change` subscription become an audit firehose', async () => {
     const sql = getTestDb();
-    const { workspace, automationIds } = await subscriberOrg([['change']]);
+    const { workspace } = await subscriberOrg([['change']]);
 
     const event = await insertConnectionlessAuditEvent(
       {
@@ -183,33 +183,35 @@ describe('workspace events with no producing Automation', () => {
       { subject: 'connection', op: 'deleted' }
     );
 
-    // Both arms of the needle have to fire: stamping a specific type must not
-    // silently unsubscribe an Automation already listening to `change`.
+    // Every audit row carries `change`, so matching it would wake this
+    // Automation on essentially every write in the organization. An audit row
+    // is named by its stamped type and nothing else.
     await expect(
       activateWorkspaceEventTask(rootPayload(workspace.org.id, event.id), sql)
-    ).resolves.toMatchObject({ matched: 1, queued: 1 });
-    const runs = await sql<{ automation_id: number }>`
-      SELECT automation_id FROM runs
-      WHERE run_type = 'automation' AND organization_id = ${workspace.org.id}
-    `;
-    expect(runs.map((row) => Number(row.automation_id))).toEqual(automationIds);
+    ).resolves.toMatchObject({ matched: 0, queued: 0 });
+    expect(
+      await sql`
+        SELECT id FROM runs
+        WHERE run_type = 'automation' AND organization_id = ${workspace.org.id}
+      `
+    ).toHaveLength(0);
   });
 
   it('terminates a root that arrives claiming ancestry', async () => {
     const sql = getTestDb();
-    const { workspace, automationIds } = await subscriberOrg([['device.online']]);
+    const { workspace, automationIds } = await subscriberOrg([['device.deleted']]);
 
     const event = await insertConnectionlessAuditEvent(
       {
         organizationId: workspace.org.id,
         entityIds: [],
-        originId: 'device:forged-worker:online',
+        originId: 'device:forged-worker:deleted',
         semanticType: 'change',
         title: 'Device came online',
         content: 'A device worker started reporting.',
         metadata: {},
       },
-      { subject: 'device', op: 'online' }
+      { subject: 'device', op: 'deleted' }
     );
 
     // Nothing ran before a root, so a non-empty causal path is incoherent.

--- a/packages/server/src/__tests__/unit/automation-event-trigger.test.ts
+++ b/packages/server/src/__tests__/unit/automation-event-trigger.test.ts
@@ -331,41 +331,40 @@ describe('automation event trigger matching', () => {
     ).toBe(false);
   });
 
-  test('matches platform audit rows by stamped type or by semantic type', () => {
-    // Every audit row shares the `change` semantic type, so the stamp is the
-    // only way to name one kind of change. Both names must work: dropping the
-    // semantic arm would silently unsubscribe anyone already listening to
-    // `change`, and dropping the stamped arm is the whole point of the stamp.
+  test('names an audit row by its stamped type only, never by `change`', () => {
     const auditRow = {
       semanticType: 'change',
-      auditEventType: 'device.online',
+      auditEventType: 'connection.deleted',
       entityTypeSlugs: [] as string[],
       metadata: {},
     };
     const bySubject = {
       kind: 'event',
       source: 'workspace',
-      event_types: ['device.online'],
-    } satisfies AutomationWorkspaceEventTrigger;
-    const bySemanticType = {
-      kind: 'event',
-      source: 'workspace',
-      event_types: ['change'],
+      event_types: ['connection.deleted'],
     } satisfies AutomationWorkspaceEventTrigger;
     expect(matchesWorkspaceEventTrigger(bySubject, auditRow)).toBe(true);
-    expect(matchesWorkspaceEventTrigger(bySemanticType, auditRow)).toBe(true);
+    // Every audit row shares `change`, so matching on it would wake an
+    // Automation on essentially every write in the organization. The depth and
+    // fan-out limits bound the resulting cascade, not that ingress.
+    expect(
+      matchesWorkspaceEventTrigger(
+        { kind: 'event', source: 'workspace', event_types: ['change'] },
+        auditRow
+      )
+    ).toBe(false);
     expect(
       matchesWorkspaceEventTrigger(
         {
           kind: 'event',
           source: 'workspace',
-          event_types: ['device.offline'],
+          event_types: ['connection.created'],
         },
         auditRow
       )
     ).toBe(false);
     // A plain Automation output carries no stamp, so a `<subject>.<op>`
-    // subscription must not pick it up on the semantic arm alone.
+    // subscription must not pick it up by semantic type.
     expect(
       matchesWorkspaceEventTrigger(bySubject, {
         ...auditRow,

--- a/packages/server/src/__tests__/unit/platform-event-catalog.test.ts
+++ b/packages/server/src/__tests__/unit/platform-event-catalog.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The platform event catalog is COMPUTED from the audit writers' own
+ * vocabularies, so these assertions are about the derivation rules rather than
+ * a hand-kept list: which subjects contribute, which ops each one reports, and
+ * what must never appear.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  AUDIT_LIFECYCLE_SUBJECTS,
+  isPlatformEventType,
+  platformEventKinds,
+} from '../../automations/platform-event-catalog';
+
+describe('platform event catalog', () => {
+  test('derives config, workspace-identity, and lifecycle subjects', () => {
+    // Keys are dotted, so `toHaveProperty` would read them as nested paths.
+    const keys = Object.keys(platformEventKinds());
+    // From CONFIG_RESOURCE_KINDS, which exists for redaction — no second list.
+    expect(keys).toContain('connection.deleted');
+    expect(keys).toContain('feed.created');
+    expect(keys).toContain('provider-key.updated');
+    // From WORKSPACE_AUDIT_RESOURCE_KINDS.
+    expect(keys).toContain('invitation.created');
+    // From AUDIT_LIFECYCLE_SUBJECTS.
+    expect(keys).toContain('device.deleted');
+    expect(keys).toContain('client.created');
+    for (const subject of AUDIT_LIFECYCLE_SUBJECTS) {
+      expect(isPlatformEventType(`${subject}.created`)).toBe(true);
+    }
+  });
+
+  test('lists only ops a writer actually emits', () => {
+    // Edges report past-tense link verbs and are never "created".
+    expect(isPlatformEventType('relationship.linked')).toBe(true);
+    expect(isPlatformEventType('relationship.unlinked')).toBe(true);
+    expect(isPlatformEventType('relationship.created')).toBe(false);
+    // Entity rows report one op: the writer stamps only updates, and entity
+    // creates and deletes carry no `<subject>.<op>` audit event at all.
+    expect(isPlatformEventType('entity.updated')).toBe(true);
+    expect(isPlatformEventType('entity.created')).toBe(false);
+  });
+
+  test('never offers `change`, the storage classification', () => {
+    // Subscribing to `change` would mean "a row was written" — every audit row
+    // carries it, so it is not something that happened.
+    expect(isPlatformEventType('change')).toBe(false);
+    expect(Object.keys(platformEventKinds())).not.toContain('change');
+  });
+
+  test('rejects malformed and unknown names', () => {
+    expect(isPlatformEventType('device.onlien')).toBe(false);
+    expect(isPlatformEventType('device')).toBe(false);
+    expect(isPlatformEventType('')).toBe(false);
+    expect(isPlatformEventType('observation')).toBe(false);
+  });
+
+  test('every entry carries a description for the trigger picker', () => {
+    const kinds = platformEventKinds();
+    const entries = Object.entries(kinds);
+    expect(entries.length).toBeGreaterThan(20);
+    expect(
+      entries.every(([, definition]) => definition.description.length > 0)
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/automations/platform-event-catalog.ts
+++ b/packages/server/src/automations/platform-event-catalog.ts
@@ -1,8 +1,26 @@
 /**
- * Platform-owned Automation event keys that every connector may declare.
+ * Platform-owned Automation event keys — the events Lobu itself emits, for
+ * both trigger sources.
+ *
+ * `source: "<connector>"` — `withPlatformAutomationEvents` injects platform
+ * keys into every connector's declared `automation_events`.
+ * `source: "workspace"` — `platformEventKinds` supplies the audit funnel's
+ * `<subject>.<op>` types, which no entity type declares and which were
+ * therefore unsubscribable no matter what the activation path supported.
+ *
+ * Both halves live here because they are the same idea on two surfaces, and
+ * the `<subject>.<op>` spelling is shared (`feed.auto_paused` alongside
+ * `feed.deleted`). The two never collide: a trigger names one `source`, so the
+ * catalogs are consulted independently.
+ *
  * Kept free of activation / DB imports so catalog validation and unit tests
  * stay dependency-light.
  */
+
+import {
+	CONFIG_RESOURCE_KINDS,
+	WORKSPACE_AUDIT_RESOURCE_KINDS,
+} from "../utils/config-redaction";
 
 /** Hard auto-pause after consecutive feed failures (feed-backoff). */
 export const PLATFORM_EVENT_FEED_AUTO_PAUSED = "feed.auto_paused";
@@ -35,4 +53,100 @@ export function withPlatformAutomationEvents<T extends { key: string }>(
 		if (!seen.has(platform.key)) merged.push(platform);
 	}
 	return merged;
+}
+
+// ============================================
+// Workspace source: the audit funnel's vocabulary
+// ============================================
+
+/** Transitions every config- and lifecycle-shaped subject reports. */
+const CRUD_OPS = ["created", "updated", "deleted"] as const;
+
+/**
+ * Subjects `recordLifecycleEvent` reports on. Platform objects, NOT user-defined
+ * entity types: a row in `entities` reports through the `entity` subject below,
+ * narrowed by the trigger's `entity_type` field.
+ *
+ * The writer is typed against this union, so a subject that is emitted but not
+ * listed here is a compile error rather than an event nothing can subscribe to.
+ */
+export const AUDIT_LIFECYCLE_SUBJECTS = [
+	"agent",
+	"automation",
+	"client",
+	"connection",
+	"device",
+	// Also a workspace audit subject, emitted by a different writer. Listing it
+	// twice is harmless — the catalog dedupes by `<subject>.<op>` key — and the
+	// type must carry it or `auth/index.tsx` cannot compile.
+	"member",
+] as const;
+
+export type AuditLifecycleSubject = (typeof AUDIT_LIFECYCLE_SUBJECTS)[number];
+
+/** Transitions `recordEdgeChangeEvent` reports, past-tense. */
+export const EDGE_OPS = ["linked", "unlinked", "updated"] as const;
+
+export type EdgeOp = (typeof EDGE_OPS)[number];
+
+/**
+ * Every `<subject>.<op>` the audit funnel can produce.
+ *
+ * Ops are listed per subject rather than crossed with every subject, so the
+ * catalog names only pairs a writer actually emits: `relationship.linked` is
+ * real, `relationship.created` is not, and offering the latter would be a
+ * subscription that can never fire.
+ */
+function buildWorkspacePlatformEventTypes(): Map<string, string> {
+	const types = new Map<string, string>();
+	const add = (subject: string, ops: readonly string[], what: string) => {
+		for (const op of ops) types.set(`${subject}.${op}`, `${what} ${op}`);
+	};
+	for (const subject of CONFIG_RESOURCE_KINDS) {
+		add(subject, CRUD_OPS, `Workspace configuration — ${subject}`);
+	}
+	for (const subject of WORKSPACE_AUDIT_RESOURCE_KINDS) {
+		add(subject, CRUD_OPS, `Workspace identity — ${subject}`);
+	}
+	for (const subject of AUDIT_LIFECYCLE_SUBJECTS) {
+		add(subject, CRUD_OPS, `Platform object — ${subject}`);
+	}
+	// Entity rows report under one subject; `entity_type` on the trigger is what
+	// narrows a subscription to invoices or tickets. Only `updated` is emitted —
+	// the entity-row writer stamps updates alone; entity creates and deletes
+	// carry no `<subject>.<op>` audit event at all.
+	add("entity", ["updated"], "Entity record");
+	add("relationship", EDGE_OPS, "Entity relationship");
+	return types;
+}
+
+const WORKSPACE_PLATFORM_EVENT_TYPES = buildWorkspacePlatformEventTypes();
+
+export interface WorkspacePlatformEventDef {
+	description: string;
+}
+
+/**
+ * The catalog in `entity_types.event_kinds` shape, so trigger validation and
+ * the picker can union it with the declared catalogs instead of special-casing
+ * platform events.
+ *
+ * Deliberately NOT merged into `$member.event_kinds`, which is the org-wide
+ * registry for *savable content* kinds. That registry gates `save_content`, so
+ * a platform type listed there would let a caller post
+ * `semantic_type: "device.deleted"` as ordinary content and have it match real
+ * subscriptions. Subscription validation unions the two; content validation
+ * must not.
+ */
+export function platformEventKinds(): Record<string, WorkspacePlatformEventDef> {
+	const kinds: Record<string, WorkspacePlatformEventDef> = {};
+	for (const [eventType, description] of WORKSPACE_PLATFORM_EVENT_TYPES) {
+		kinds[eventType] = { description };
+	}
+	return kinds;
+}
+
+/** True when the audit funnel can emit this `<subject>.<op>` type. */
+export function isPlatformEventType(eventType: string): boolean {
+	return WORKSPACE_PLATFORM_EVENT_TYPES.has(eventType);
 }

--- a/packages/server/src/automations/triggers.ts
+++ b/packages/server/src/automations/triggers.ts
@@ -11,7 +11,10 @@ import type { DbClient } from "../db/client";
 import { listCatalogEntries } from "../catalog/load";
 import { validateSchedule, validateTimezone } from "../utils/cron";
 import { ToolUserError } from "../utils/errors";
-import { withPlatformAutomationEvents } from "./platform-event-catalog";
+import {
+	platformEventKinds,
+	withPlatformAutomationEvents,
+} from "./platform-event-catalog";
 import { resolveAutomationEventCatalog } from "./connector-derived";
 
 export interface AutomationTriggerProjection {
@@ -414,8 +417,13 @@ export async function assertAutomationTriggerConnections(
 					`Workspace event trigger entity type '${entityTypeSlug}' was not found in this organization.`
 				);
 			}
+			// Platform events union in on both branches. Without an entity type the
+			// catalog is the whole workspace; WITH one, `entity.updated` narrowed by
+			// `entity_type` is exactly how an Automation subscribes to "an invoice
+			// changed", so dropping the union there would break the common case.
 			const eventKinds = Object.assign(
 				{},
+				platformEventKinds(),
 				...rows.map((row) =>
 					row.event_kinds && typeof row.event_kinds === "object"
 						? row.event_kinds

--- a/packages/server/src/automations/workspace-event.ts
+++ b/packages/server/src/automations/workspace-event.ts
@@ -28,10 +28,10 @@ interface WorkspaceEventRecord {
   semanticType: string;
   /**
    * The stamped `<subject>.<op>` type for a platform-written audit row, or
-   * null for an Automation output. Carried alongside `semanticType` rather
-   * than collapsed into it because a subscription may legitimately name
-   * either: audit rows all share the `change` semantic type, so the stamp is
-   * the only way to subscribe to one kind of change without the rest.
+   * null for an Automation output. Kept separate from `semanticType` so the
+   * matcher can name an audit row by its stamp only: every audit row shares
+   * the `change` semantic type, and naming by that would wake a subscriber on
+   * essentially every write in the organization.
    */
   auditEventType: string | null;
   metadata: Record<string, unknown>;
@@ -123,19 +123,20 @@ export async function enqueueWorkspaceEventActivations(
 }
 
 /**
- * The type names a subscription may use for this event, most specific first.
+ * The single name a subscription uses for this event.
  *
- * An Automation output is nameable only by its semantic type. A platform-written
- * audit row is additionally nameable by its stamped `<subject>.<op>` type, which
- * is what makes `device.online` subscribable without also matching every other
- * row whose semantic type is `change`.
+ * A platform audit row is named by its stamped `<subject>.<op>` type; anything
+ * else by its semantic type. Audit rows are deliberately NOT also matchable by
+ * their raw `change` semantic type: every audit row shares it, so a `change`
+ * subscription would wake an Automation on essentially every write in the
+ * organization, and the depth and fan-out limits bound the resulting cascade,
+ * not that ingress. `change` is a storage classification, not something that
+ * happened, so the platform catalog never offers it.
  */
-function subscribableEventTypes(
+function subscribableEventType(
   event: Pick<WorkspaceEventRecord, 'semanticType' | 'auditEventType'>
-): string[] {
-  return event.auditEventType == null
-    ? [event.semanticType]
-    : [event.auditEventType, event.semanticType];
+): string {
+  return event.auditEventType ?? event.semanticType;
 }
 
 export function matchesWorkspaceEventTrigger(
@@ -145,10 +146,7 @@ export function matchesWorkspaceEventTrigger(
     'semanticType' | 'auditEventType' | 'metadata' | 'entityTypeSlugs'
   >
 ): boolean {
-  const namesThisEvent = subscribableEventTypes(event).some((eventType) =>
-    trigger.event_types.includes(eventType)
-  );
-  if (!namesThisEvent) return false;
+  if (!trigger.event_types.includes(subscribableEventType(event))) return false;
   if (
     trigger.entity_type !== undefined &&
     !event.entityTypeSlugs.includes(trigger.entity_type)
@@ -231,27 +229,15 @@ async function findMatchingWorkspaceEventActivations(
   matches: MatchingWorkspaceEventActivation[];
   fanoutLimited: boolean;
 }> {
-  // Coarse GIN needle, narrowed precisely by `matchesWorkspaceEventTrigger`
-  // below. An audit row is subscribable under two names, and containment
-  // cannot express a disjunction, so each name gets its own arm — the same
-  // shape `findMatchingAutomationActivations` uses for connector triggers.
-  // One arm alone would be wrong in both directions: the audit arm misses
-  // Automations subscribed to the raw semantic type, and the semantic arm
-  // misses every `<subject>.<op>` subscriber.
-  const needle = (eventType: string) => [
+  // Coarse GIN needle on the event's one subscribable name, narrowed precisely
+  // by `matchesWorkspaceEventTrigger` below.
+  const needle = [
     {
       kind: 'event',
       source: 'workspace',
-      event_types: [eventType],
+      event_types: [subscribableEventType(event)],
     },
   ];
-  const triggerFilter =
-    event.auditEventType == null
-      ? db`w.triggers @> ${db.json(needle(event.semanticType))}::jsonb`
-      : db`(
-          w.triggers @> ${db.json(needle(event.auditEventType))}::jsonb
-          OR w.triggers @> ${db.json(needle(event.semanticType))}::jsonb
-        )`;
   const rows = await db`
     SELECT w.id, w.organization_id, w.agent_id, w.entity_ids,
            w.device_worker_id::text AS device_worker_id,
@@ -261,7 +247,7 @@ async function findMatchingWorkspaceEventActivations(
       AND w.status = 'active'
       AND w.current_version_id IS NOT NULL
       AND (w.agent_id IS NOT NULL OR w.device_worker_id IS NOT NULL)
-      AND ${triggerFilter}
+      AND w.triggers @> ${db.json(needle)}::jsonb
     ORDER BY w.id ASC
   `;
 
@@ -401,7 +387,7 @@ export async function activateWorkspaceEventTask(
     kind: 'event',
     source: 'workspace',
     event_id: event.id,
-    event_type: event.auditEventType ?? event.semanticType,
+    event_type: subscribableEventType(event),
     delivery_id: `workspace-event:${event.id}`,
     occurred_at: event.occurredAt,
     root_event_ids: payload.rootEventIds,

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -20,6 +20,7 @@ import {
   type ViewTemplateTab,
 } from '@lobu/core/contracts/tools/manage-entity-schema';
 import { validateEntityMetrics } from '@lobu/connector-sdk';
+import { isPlatformEventType } from '../../automations/platform-event-catalog';
 import { compileEntityRule } from '../../authz/entity-rule-executor';
 import { type DbClient, getDb } from '../../db/client';
 import { validateMetricReadModes } from '../../metrics/read-mode';
@@ -186,6 +187,29 @@ function assertValidMetricsConfig(metricsConfig: unknown): void {
   ];
   if (errors.length > 0) {
     throw invalidSchema(`invalid metrics_config: ${errors.join('; ')}`);
+  }
+}
+
+/**
+ * Reject event kinds that collide with the platform's own `<subject>.<op>`
+ * vocabulary.
+ *
+ * `event_kinds` is the registry `save_content` validates against, so a type
+ * declared here becomes postable as ordinary content. Declaring
+ * `connection.deleted` would therefore let any caller with content-write
+ * access post a row that Automations subscribed to real connection deletions
+ * would activate on. Blocking the collision at declaration is the chokepoint —
+ * checking on every save would leave already-declared collisions live.
+ */
+function assertEventKindsAvoidPlatformVocabulary(
+  eventKinds: Record<string, unknown> | null | undefined
+): void {
+  if (!eventKinds || typeof eventKinds !== 'object') return;
+  const reserved = Object.keys(eventKinds).filter(isPlatformEventType);
+  if (reserved.length > 0) {
+    throw invalidSchema(
+      `event_kinds may not redeclare platform event types: ${reserved.join(', ')}`
+    );
   }
 }
 
@@ -515,6 +539,7 @@ async function etHandleCreate(
   // metadata_schema is stored as the author sent it — measure/dimension roles for
   // a derived type are classified ON READ (see etHandleGet), never persisted.
   assertValidMetricsConfig(args.metrics_config);
+  assertEventKindsAvoidPlatformVocabulary(args.event_kinds);
   const metadataSchema = args.metadata_schema ? sql.json(args.metadata_schema) : null;
   const eventKinds = args.event_kinds ? sql.json(args.event_kinds) : null;
   const metricsConfig = args.metrics_config ? sql.json(args.metrics_config) : null;
@@ -620,6 +645,7 @@ async function etHandleUpdate(
   }
   assertValidMetricsConfig(args.metrics_config);
   assertValidBacking(args.backing);
+  assertEventKindsAvoidPlatformVocabulary(args.event_kinds);
   // Converting a populated stored type to a derived (view-backed) type would
   // orphan its existing rows (the view ignores them). Reject it.
   if (args.backing?.sql) {

--- a/packages/server/src/utils/config-redaction.ts
+++ b/packages/server/src/utils/config-redaction.ts
@@ -19,7 +19,7 @@ export { REDACTED_SENTINEL };
  * `kind` union so per-kind counts and per-resource rows line up in the
  * deployments UI without a mapping table.
  */
-const CONFIG_RESOURCE_KINDS = [
+export const CONFIG_RESOURCE_KINDS = [
   'agent',
   'agent-settings',
   'platform',
@@ -44,11 +44,21 @@ export function isConfigResourceKind(
   return typeof kind === 'string' && CONFIG_RESOURCE_KIND_SET.has(kind);
 }
 
-/** Server-emitted workspace identity resources; never part of `lobu apply`. */
+/**
+ * Server-emitted workspace identity resources; never part of `lobu apply`.
+ *
+ * A runtime const rather than a bare type union because the platform event
+ * catalog enumerates these to decide what an Automation may subscribe to — a
+ * type alone cannot be iterated, and a second hand-kept list would drift.
+ */
+export const WORKSPACE_AUDIT_RESOURCE_KINDS = [
+  'organization',
+  'member',
+  'invitation',
+] as const;
+
 export type WorkspaceAuditResourceKind =
-  | 'organization'
-  | 'member'
-  | 'invitation';
+  (typeof WORKSPACE_AUDIT_RESOURCE_KINDS)[number];
 
 export type AuditResourceKind = ConfigResourceKind | WorkspaceAuditResourceKind;
 

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -12,6 +12,10 @@ import {
   type AuditEventType,
   formatAuditEventType,
 } from './audit-event-type';
+import type {
+  AuditLifecycleSubject,
+  EdgeOp,
+} from '../automations/platform-event-catalog';
 import {
   type AuditResourceKind,
   type ConfigResourceKind,
@@ -850,7 +854,7 @@ export function recordEdgeChangeEvent(params: EdgeChangeEventParams): void {
   // Keep this stable across the retry below, while allowing a relationship
   // revived by unmerge to record the same operation again later.
   const originId = `edge:${params.relationshipId}:${params.op}:${crypto.randomUUID()}`;
-  const verb =
+  const verb: EdgeOp =
     params.op === 'link' ? 'linked' : params.op === 'unlink' ? 'unlinked' : 'updated';
 
   retryWithBackoff(
@@ -904,12 +908,16 @@ type LifecycleOp = 'created' | 'updated' | 'deleted';
 interface LifecycleEventParams {
   organizationId: string;
   /**
-   * Entity-type slug used by dashboard SQL to pivot lifecycle rows
-   * (`metadata->>'entity_type'`). Kept as a free-form string so new entity
-   * types can emit without touching this file — keep slugs short, lowercase,
-   * singular: `agent`, `connection`, `automation`, `device`, `member`, `client`.
+   * Platform object this row is about, used by dashboard SQL to pivot lifecycle
+   * rows (`metadata->>'entity_type'`).
+   *
+   * Narrowed to `AUDIT_LIFECYCLE_SUBJECTS` rather than free-form: the same
+   * value becomes the `<subject>` half of a subscribable event type, so a
+   * subject the catalog does not know about would emit an event nothing can
+   * ever subscribe to. Adding one is a one-line change in the catalog, which
+   * then makes it subscribable and discoverable in the same edit.
    */
-  entityType: string;
+  entityType: AuditLifecycleSubject;
   op: LifecycleOp;
   entityId: string | number;
   /** Human-readable summary (e.g. "Agent 'Marketing' created"). */


### PR DESCRIPTION
## Summary

- Platform audit rows (`connection.deleted`, `device.deleted`, `entity.updated`) had no declaring entity type, so `assertAutomationTriggerConnections` rejected any subscription to them — unsubscribable at the surface no matter what the activation path supported. They now resolve from a **computed** catalog.
- Computed, not hand-listed: config subjects come from `CONFIG_RESOURCE_KINDS` (exists for redaction), workspace subjects from `WORKSPACE_AUDIT_RESOURCE_KINDS` (promoted from a type union to a runtime const so it can be enumerated), and the writers are now **typed against** the closed unions — emitting a subject the catalog doesn't know is a compile error. That narrowing immediately caught `member`, which `auth/index.tsx` emits and a hand-kept list had missed.
- **`change` is deliberately absent**, which makes #2938 *smaller*: the two-arm matcher collapses back to one name per event (−14 lines in `workspace-event.ts`).
- Lives beside the connector half in `platform-event-catalog.ts` — same idea on two surfaces, both spelling types `<subject>.<op>`.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates), plus `check-security-patterns.sh`
- [x] Tests run: targeted `bunx vitest run` + `bun test`
- [ ] Bug fix: n/a — capability change
- [ ] Bot runtime: n/a

```
# new + changed suites
✓ platform-event-subscription.test.ts   (6 tests)
✓ workspace-event-roots.test.ts         (5 tests)
✓ platform-event-catalog.test.ts        (5 tests)
✓ automation-event-trigger.test.ts     (18 tests)

# regression over affected areas
bunx vitest run src/__tests__/integration/automations/ src/__tests__/integration/events/
  Test Files  81 passed (81)
       Tests  553 passed (553)
```

### Mutation testing

| mutation | result |
|---|---|
| validation drops the platform catalog | 4 failed |
| collision guard removed | 1 failed |
| catalog offers `change` | 1 failed |
| matcher matches audit rows by semantic type | 1 failed *(unit)* |
| needle widened back to two arms | 1 failed *(integration)* |

The last two are listed separately on purpose: the matcher and the needle each guard one half, and the integration test alone does **not** catch a matcher regression because the needle filters the row out first. Unit covers the matcher, integration covers the needle.

## Notes

**Why the two catalogs must never merge.** `event_kinds` is what `save_content` validates against, so an entity type declaring `connection.deleted` would make it postable as ordinary content and let a forged row activate subscribers of real connection deletions. `manage_entity_schema` now rejects that collision on create **and** update — at declaration, since checking on save would leave already-declared collisions live.

**Entity-level subscriptions need no new subjects.** `entity.updated` narrowed by the trigger's existing `entity_type` field is exactly "when an invoice changed".

**Blast radius.** Prod has **0 workspace-event subscriptions across 120 Automations**, so no existing subscription changes behavior.

**Follow-up, deliberately not here.** The trigger picker still can't show these: it reads `event_kinds` via the shared `useEntityTypes` query, which has 7 consumers. Injecting a synthetic `$platform` type would feed the picker for free but would also inject ~60 platform types into the events-tab content-kind dropdown (`event-kind-options.ts:110`) — reintroducing the exact catalog merge this PR prevents, and with no Owletto diff, `ui-review` would not gate it. The picker needs a dedicated field plus a small Owletto change instead.
