### PR TITLE
refactor(notifications): drop the approval card path nothing calls any more

### DIFF
--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -7,16 +7,15 @@ import {
 } from "../../notifications/triggers";
 
 /**
- * Golden-pins approval card/body rendering for all four structured shapes
- * (field change, entity create, entity delete, entity merge) plus the generic
- * fallback. The in-app and Slack expectations differ where their markup
- * syntaxes require different escaping.
+ * Golden-pins the approval TITLE and Markdown BODY for all four structured
+ * shapes (field change, entity create, entity delete, entity merge) plus the
+ * generic fallback.
+ *
+ * Chat rendering is deliberately absent here: entity approvals reach Slack
+ * through the `entity_change_approval` event kind now, so their card is pinned
+ * by `template-card.test.ts` against the same template the web and MCP
+ * surfaces walk. `buildActionApprovalCard` survives only for asks.
  */
-
-function cardText(card: ReturnType<typeof buildActionApprovalCard>): string {
-	const first = (card as { children: Array<{ content?: string }> }).children[0];
-	return first.content ?? "";
-}
 
 describe("approval notification rendering", () => {
 	test("field change: body + card with escaping, diff lines, why, review link", () => {
@@ -44,13 +43,6 @@ describe("approval notification rendering", () => {
 				"\nField is protected: severity (currently set by you).\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/42)",
 		);
-		expect(cardText(buildActionApprovalCard({ runId: 42, approvalUrl, details }))).toBe(
-			"*Requested by:* Automation &lt;One&gt;\n" +
-				"*Entity:* <https://app.lobu.ai/acme/topic/app-crashes|App &amp; Crashes>\n" +
-				"\n*Severity*\n~high~\n→ critical\n" +
-				"\n*Name*\n~Old Name~\n→ New &lt;Name&gt;\n" +
-				"\n*Why approval is needed:* Field is protected: severity (currently set by you).",
-		);
 	});
 
 	test("field change without name/url/reason: id fallback link, why fallback, leading blank in card", () => {
@@ -65,10 +57,6 @@ describe("approval notification rendering", () => {
 			"**An automation** wants to update Topic (#9):\n" +
 				'- Status: ~Not set~\n→ { "nested": true }\n' +
 				"\nThis change needs a human approval before it is applied.",
-		);
-		expect(cardText(buildActionApprovalCard({ details }))).toBe(
-			'\n*Status*\n~Not set~\n→ { "nested": true }\n' +
-				"\n*Why approval is needed:* This change needs a human approval before it is applied.",
 		);
 	});
 
@@ -91,13 +79,6 @@ describe("approval notification rendering", () => {
 				"- Entity type: topic\n- Name: Slow & Loading\n- Parent id: 3\n" +
 				'\nAn automation proposes creating topic "Slow & Loading".\n' +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/44)",
-		);
-		expect(cardText(buildActionApprovalCard({ runId: 44, approvalUrl, details }))).toBe(
-			"*Requested by:* An automation\n" +
-				"*Entity:* Slow &amp; Loading\n" +
-				"\n*Proposed action:* Create this entity\n" +
-				"*Entity type:* topic\n*Name:* Slow &amp; Loading\n*Parent id:* 3\n" +
-				'\n*Why approval is needed:* An automation proposes creating topic "Slow &amp; Loading".',
 		);
 	});
 
@@ -132,12 +113,6 @@ describe("approval notification rendering", () => {
 				"- Entity id: 11\n- Entity type: topic\n" + String.raw`- Name: Old \<Topic\>` + "\n- Force delete tree: false\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/45)",
 		);
-		expect(cardText(buildActionApprovalCard({ runId: 45, details }))).toBe(
-			"*Requested by:* An agent\n" +
-				"*Entity:* <https://app.lobu.ai/acme/topic/old-topic|Old Topic>\n" +
-				"\n*Proposed action:* Delete this entity\n" +
-				"*Entity id:* 11\n*Entity type:* topic\n*Name:* Old &lt;Topic&gt;\n*Force delete tree:* false",
-		);
 	});
 
 	test("entity merge: names both entities and renders a merge action", () => {
@@ -163,15 +138,12 @@ describe("approval notification rendering", () => {
 		expect(formatActionApprovalBody({ details })).toContain(
 			"**An automation** wants to merge Duplicate Person (#12).",
 		);
-		expect(cardText(buildActionApprovalCard({ details }))).toContain(
-			"*Proposed action:* Merge these entities",
-		);
 	});
 
-	test("escaping is per-surface: Markdown neutralises link/emphasis, Slack neutralises mrkdwn", () => {
-		// One hostile name, two surfaces. The Markdown body must not let it forge a
-		// link or bold run; the Slack card must not let it ping the channel or
-		// spoof `<url|label>`. Neither surface may leak the OTHER's escaping.
+	test("Markdown escaping neutralises link and emphasis delimiters", () => {
+		// One hostile name. The Markdown body must not let it forge a link or a
+		// bold run, and Slack's entity escaping must not leak into it — the chat
+		// side of this pair is pinned in `template-card.test.ts`.
 		const details: ActionApprovalDetails = {
 			kind: "entity_change",
 			operation: "delete",
@@ -195,18 +167,6 @@ describe("approval notification rendering", () => {
 		expect(body).toContain(
 			"\n\n" + String.raw`\# \[Review \[nested\]\](https://evil)`,
 		);
-
-		const card = cardText(buildActionApprovalCard({ details }));
-		// Slack: angle brackets/ampersand entity-escaped so `<!channel>` is inert.
-		expect(card).toContain(
-			"*Requested by:* [Review [nested]](https://evil)",
-		);
-		expect(card).toContain(
-			"*Entity:* *Urgent* &lt;!channel&gt; &amp; [click](https://evil)",
-		);
-		// The Markdown backslashes must not bleed into the Slack surface.
-		expect(card).not.toContain("\\*");
-		expect(card).not.toContain("\\[");
 	});
 
 	test("markdown escaping covers strikethrough, autolinks, and unmatched brackets", () => {
@@ -310,6 +270,33 @@ describe("approval notification rendering", () => {
 			},
 		});
 		expect(body).toContain("- Severity: ~high~\n→ critical");
+	});
+
+	test("an ask that takes no input still gets decision buttons", () => {
+		// The one surviving caller. `inputSchema: null` is the caller ASSERTING
+		// the decision carries no answer — omitting it must not get buttons that
+		// would discard one.
+		const card = buildActionApprovalCard({
+			runId: 47,
+			approvalUrl: "https://app.lobu.ai/acme/runs/47",
+			summary: "Ship it?",
+			inputSchema: null,
+		});
+		const actions = (
+			card as unknown as {
+				children: Array<{
+					type: string;
+					children?: Array<{ id?: string; url?: string }>;
+				}>;
+			}
+		).children
+			.filter((c) => c.type === "actions")
+			.flatMap((c) => c.children ?? []);
+		expect(actions.map((a) => a.id ?? a.url)).toEqual([
+			"run-approval:47:approve",
+			"run-approval:47:reject",
+			"https://app.lobu.ai/acme/runs/47",
+		]);
 	});
 
 	test("generic action: no card, connection fallback body", () => {

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -9,7 +9,6 @@ import {
 	ENTITY_CHANGE_APPROVAL_KIND,
 	INVITATION_RECEIVED_KIND,
 } from "../utils/platform-event-kinds";
-import { escapeSlackText } from "../utils/slack-text";
 import { buildResourcePermalink } from "../utils/url-builder";
 import { resolveAskAffordance } from "./ask-schema";
 import { createNotificationForUsers, getOrgSlug } from "./service";
@@ -117,10 +116,6 @@ export function formatFieldChangeAction(
 
 function formatReviewLink(url: string): string {
 	return `[Review in Lobu](${url})`;
-}
-
-function formatCardLink(label: string, url: string): string {
-	return `<${url}|${escapeSlackText(label.replace(/[<>|]/g, ""))}>`;
 }
 
 /**
@@ -294,38 +289,6 @@ function renderApprovalBody(
 	return lines.join("\n");
 }
 
-/** Slack mrkdwn card text (bold labels, `<url|label>` links). */
-function renderApprovalCardText(model: ApprovalRenderModel): string {
-	const lines: string[] = [];
-	if (model.requestedBy)
-		lines.push(`*Requested by:* ${escapeSlackText(model.requestedBy)}`);
-	if (model.entityName) {
-		lines.push(
-			`*Entity:* ${
-				model.entityUrl
-					? formatCardLink(model.entityName, model.entityUrl)
-					: escapeSlackText(model.entityName)
-			}`,
-		);
-	}
-	if (model.diffs) {
-		for (const d of model.diffs)
-			lines.push(
-				"",
-				`*${d.label}*`,
-				`~${escapeSlackText(d.current)}~\n→ ${escapeSlackText(d.proposed)}`,
-			);
-	}
-	if (model.action) {
-		lines.push("", `*Proposed action:* ${model.action}`);
-		for (const p of model.proposal)
-			lines.push(`*${p.label}:* ${escapeSlackText(p.value)}`);
-	}
-	if (model.why)
-		lines.push("", `*Why approval is needed:* ${escapeSlackText(model.why)}`);
-	return lines.join("\n");
-}
-
 export function formatActionApprovalBody(params: {
 	connectionName?: string;
 	approvalUrl?: string;
@@ -369,8 +332,7 @@ export function formatActionApprovalBody(params: {
 export function buildActionApprovalCard(params: {
 	runId?: number;
 	approvalUrl?: string;
-	details?: ActionApprovalDetails;
-	/** Fallback body when there is no entity diff to render (e.g. an ask). */
+	/** The card body — for an ask, the question being put to the approver. */
 	summary?: string | null;
 	/**
 	 * The interaction's answer schema. `null` asserts "this decision takes no
@@ -380,30 +342,18 @@ export function buildActionApprovalCard(params: {
 	 */
 	inputSchema?: Record<string, unknown> | null;
 }) {
-	const isEntityDetail =
-		params.details != null &&
-		["entity_field_change", "entity_change"].includes(params.details.kind);
-	const cardText = isEntityDetail
-		? renderApprovalCardText(
-				buildApprovalRenderModel(params.details as ActionApprovalDetails),
-			)
-		: (params.summary?.trim() ?? "");
-
-	// Entity approvals provably carry no input schema (they hold their proposal
-	// in `runs.action_input`, not an answer schema), so they stay decidable from
-	// chat. Everything else must SAY it takes no input to get buttons.
-	const decisionOnly = isEntityDetail
-		? true
-		: params.inputSchema !== undefined &&
-			resolveAskAffordance(params.inputSchema).kind === "binary";
-
-	// With neither an entity diff nor decision buttons, the card would carry a
-	// review link and nothing else — which the markdown body already says. Fall
-	// back to the body rather than emitting a card that only repeats it.
-	if (!isEntityDetail && !decisionOnly) return undefined;
+	// Only a no-input decision is decidable from chat. Without buttons the card
+	// would carry a review link and nothing else, which the markdown body
+	// already says — so fall back to the body rather than repeat it.
+	if (
+		params.inputSchema === undefined ||
+		resolveAskAffordance(params.inputSchema).kind !== "binary"
+	) {
+		return undefined;
+	}
 
 	const actions = [];
-	if (params.runId && decisionOnly) {
+	if (params.runId) {
 		actions.push(
 			Button({
 				id: `run-approval:${params.runId}:approve`,
@@ -423,13 +373,11 @@ export function buildActionApprovalCard(params: {
 	}
 	if (params.approvalUrl) {
 		actions.push(
-			LinkButton({
-				url: params.approvalUrl,
-				label: decisionOnly ? "Review in Lobu" : "Answer in Lobu",
-			}),
+			LinkButton({ url: params.approvalUrl, label: "Review in Lobu" }),
 		);
 	}
 
+	const cardText = params.summary?.trim() ?? "";
 	return Card({
 		children: [
 			...(cardText ? [CardText(cardText)] : []),

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -316,18 +316,16 @@ export function formatActionApprovalBody(params: {
 }
 
 /**
- * The chat card for an approval, on the SAME affordance rule the web row uses.
+ * The chat card for an ask, on the SAME affordance rule the web row uses.
  *
  * Sharing `resolveAskAffordance` is the point: the decision "can this be
  * settled in one click, or does it need real input?" is derived once from the
- * schema and answered identically on every surface. It previously returned
- * undefined for anything that was not an entity change, so Automation and agent
- * write approvals reached Slack with NO card and no way to act.
+ * schema and answered identically on every surface. Decision-only asks get
+ * Approve/Reject; anything needing input gets the review link ONLY — a button
+ * that cannot carry the human's input would report success while discarding it.
  *
- * Decision-only approvals get Approve/Reject. Anything needing input gets the
- * review link ONLY — never buttons. A button that cannot carry the human's
- * input would report success while discarding it, which is exactly the defect
- * this whole change set exists to remove.
+ * Entity and operation approvals never come through here: they render through
+ * their platform event kinds in `notifyActionApprovalNeeded`.
  */
 export function buildActionApprovalCard(params: {
 	runId?: number;


### PR DESCRIPTION
## What

#2935 moved entity approvals onto the `entity_change_approval` event kind. No caller passes `details` to `buildActionApprovalCard` any more, which left a dead branch and two symbols only that branch reached.

Removed:
- the `details` param and the `isEntityDetail` branch of `buildActionApprovalCard`
- `renderApprovalCardText` — reachable only through it
- `formatCardLink`, plus the `escapeSlackText` import it was the sole user of

Dropping `isEntityDetail` also exposes that `decisionOnly` is always true past the early return, so the `"Answer in Lobu"` label was already unreachable.

The one surviving caller is `tools/admin/notify.ts` (an ask), which passes `inputSchema`.

## Evidence

Callers on the merged main, not the working tree:

```
$ git grep -n buildActionApprovalCard origin/main -- '*.ts' | grep -v __tests__
origin/main:packages/server/src/tools/admin/notify.ts:21:  import { buildActionApprovalCard } ...
origin/main:packages/server/src/tools/admin/notify.ts:387:  ? (buildActionApprovalCard({
origin/main:packages/server/src/notifications/triggers.ts:369: export function buildActionApprovalCard(
```

`notify.ts:387` passes `runId`/`approvalUrl`/`summary`/`inputSchema` — never `details`.

Tests:
```
bun test src/__tests__/unit/approval-notification-render.test.ts   13 pass 0 fail
bun test src/__tests__/unit/                                     1240 pass 0 fail 18 skip
make pre-pr                                                       all 7 gates clean
```

Mutation-tested the new ask assertion: flipping the affordance guard to `=== "binary"` fails exactly that test (12 pass / 1 fail), then restored.

## Test plan

`approval-notification-render.test.ts` keeps every title and Markdown-body golden pin and loses only its Slack card assertions — entity approvals now render through the kind, pinned by `template-card.test.ts` against the same template the web and MCP surfaces walk. Adds the positive ask case, which had no coverage: `inputSchema: null` gets Approve/Reject plus the review link.

## Risk

Low. Pure removal of an unreachable path; no behavior change for asks, which are the only live caller.