### PR TITLE
feat(automations): queue activation for platform-written events

### DIFF
--- a/packages/server/src/__tests__/integration/automations/automation-event-outputs.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-event-outputs.test.ts
@@ -1,9 +1,7 @@
 import { inferAutomationGranularityFromSchedule } from '@lobu/connector-sdk';
 import { beforeEach, describe, expect, it } from 'vitest';
-import {
-  activateWorkspaceEventTask,
-  enqueueWorkspaceEventActivations,
-} from '../../../automations/workspace-event';
+import { activateWorkspaceEventTask } from '../../../automations/workspace-event';
+import { enqueueWorkspaceEventActivations } from '../../../automations/workspace-event-enqueue';
 import {
   MAX_WORKSPACE_EVENT_FANOUT,
   type WorkspaceEventActivationTaskPayload,

--- a/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
+++ b/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Stage C: a platform-written audit row actually reaches its subscriber.
+ *
+ * #2938 taught the activation path to handle a root, and #2944 made the type
+ * subscribable — but nothing enqueued, so a subscription could exist and never
+ * fire. These tests cover the write path: an audit row with a subscribed
+ * `<subject>.<op>` type queues an activation, and one produced by an Automation
+ * names that Automation as its own causal path so it cannot wake itself.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { createTestAgent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+import { recordLifecycleEvent } from '../../../utils/insert-event';
+import { runWithActingAutomation } from '../../../utils/acting-automation-context';
+import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../../../scheduled/task-definitions';
+
+interface QueuedActivation {
+  organizationId: string;
+  eventId: number;
+  rootEventIds: number[];
+  causalAutomationIds: number[];
+  depth: number;
+}
+
+async function subscriber(name: string, eventTypes: string[]) {
+  const workspace = await TestWorkspace.create({ name });
+  const ownerUserId = workspace.users.owner.id;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'platform-enqueue-agent',
+  });
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+  const created = (await api.automations.create({
+    slug: 'platform-consumer',
+    prompt: 'Handle the platform event.',
+    triggers: [
+      {
+        kind: 'event',
+        source: 'workspace',
+        event_types: eventTypes,
+        execution: 'window',
+        active_run: 'queue',
+      },
+    ],
+    agent_id: agent.agentId,
+  })) as { automation_id: string };
+  return {
+    organizationId: workspace.org.id,
+    automationId: Number(created.automation_id),
+  };
+}
+
+/** Activation tasks queued for an org, newest last. */
+async function queuedActivations(
+  organizationId: string
+): Promise<QueuedActivation[]> {
+  const sql = getTestDb();
+  const rows = await sql<{ action_input: { payload: QueuedActivation } }>`
+    SELECT action_input
+    FROM public.runs
+    WHERE run_type = 'task'
+      AND action_key = ${WORKSPACE_EVENT_ACTIVATION_TASK}
+      AND organization_id = ${organizationId}
+    ORDER BY id ASC
+  `;
+  return rows.map((row) => row.action_input.payload);
+}
+
+/**
+ * `recordLifecycleEvent` is fire-and-forget, so the write and its enqueue both
+ * settle after the call returns. Poll rather than sleep a fixed interval.
+ */
+async function waitForActivations(
+  organizationId: string,
+  count: number
+): Promise<QueuedActivation[]> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const queued = await queuedActivations(organizationId);
+    if (queued.length >= count) return queued;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return queuedActivations(organizationId);
+}
+
+describe('platform event activation enqueue', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('queues a root activation for a subscribed platform event', async () => {
+    const { organizationId } = await subscriber('Enqueue Org', [
+      'connection.deleted',
+    ]);
+
+    recordLifecycleEvent({
+      organizationId,
+      entityType: 'connection',
+      op: 'deleted',
+      entityId: 42,
+      summary: 'Connection deleted',
+    });
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued).toHaveLength(1);
+    const activation = queued[0]!;
+    expect(activation.organizationId).toBe(organizationId);
+    expect(activation.eventId).toBeGreaterThan(0);
+    // A root: it is its own root, nothing ran before it, depth starts at 1.
+    expect(activation.rootEventIds).toEqual([activation.eventId]);
+    expect(activation.causalAutomationIds).toEqual([]);
+    expect(activation.depth).toBe(1);
+  });
+
+  it('queues nothing when no Automation subscribes to the type', async () => {
+    // Subscribes to a DIFFERENT platform type, so the org has a workspace
+    // subscription but not one for the row being written.
+    const { organizationId } = await subscriber('Unsubscribed Org', [
+      'connection.deleted',
+    ]);
+
+    recordLifecycleEvent({
+      organizationId,
+      entityType: 'device',
+      op: 'created',
+      entityId: 7,
+      summary: 'Device created',
+    });
+
+    // Give the fire-and-forget write time to settle before asserting absence.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(await queuedActivations(organizationId)).toEqual([]);
+  });
+
+  it('names the producing Automation as its own causal path', async () => {
+    const { organizationId, automationId } = await subscriber(
+      'Self Trigger Org',
+      ['connection.deleted']
+    );
+
+    // The same audit write, but driven by the subscribing Automation — the
+    // shape that would otherwise loop forever, since every self-write mints a
+    // fresh root at depth 1 and the depth cap never bites.
+    await runWithActingAutomation(automationId, async () => {
+      recordLifecycleEvent({
+        organizationId,
+        entityType: 'connection',
+        op: 'deleted',
+        entityId: 99,
+        summary: 'Connection deleted by automation',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued).toHaveLength(1);
+    // Ancestry names the producer, so the matcher skips it and the Automation
+    // cannot be woken by the audit exhaust of its own write.
+    expect(queued[0]!.causalAutomationIds).toEqual([automationId]);
+  });
+
+  it('stamps the producing Automation on the audit row itself', async () => {
+    const { organizationId, automationId } = await subscriber('Stamp Org', [
+      'connection.deleted',
+    ]);
+
+    await runWithActingAutomation(automationId, async () => {
+      recordLifecycleEvent({
+        organizationId,
+        entityType: 'connection',
+        op: 'deleted',
+        entityId: 123,
+        summary: 'Connection deleted by automation',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    const sql = getTestDb();
+    const rows = await sql<{ automation_id: number | null }>`
+      SELECT automation_id
+      FROM public.events
+      WHERE organization_id = ${organizationId}
+        AND metadata->>'_lobu_event_type' = 'connection.deleted'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0]!.automation_id)).toBe(automationId);
+  });
+
+  it('leaves an unattributed write as a genuine root', async () => {
+    const { organizationId } = await subscriber('Root Org', [
+      'connection.deleted',
+    ]);
+
+    // No acting scope: a person in the UI, a cron tick, a connector sync.
+    recordLifecycleEvent({
+      organizationId,
+      entityType: 'connection',
+      op: 'deleted',
+      entityId: 5,
+      summary: 'Connection deleted by a person',
+    });
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued[0]!.causalAutomationIds).toEqual([]);
+
+    const sql = getTestDb();
+    const rows = await sql<{ automation_id: number | null }>`
+      SELECT automation_id
+      FROM public.events
+      WHERE organization_id = ${organizationId}
+        AND metadata->>'_lobu_event_type' = 'connection.deleted'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    expect(rows[0]!.automation_id).toBeNull();
+  });
+});

--- a/packages/server/src/automations/workspace-event-enqueue.ts
+++ b/packages/server/src/automations/workspace-event-enqueue.ts
@@ -1,0 +1,74 @@
+/**
+ * Subscription lookup and activation queueing for workspace events.
+ *
+ * Split out of `workspace-event.ts` — which owns the activation RUNTIME — so
+ * the audit write path can queue an activation without importing it. That
+ * runtime reaches `runs/queue-service`, which imports `utils/insert-event` for
+ * `stableJson`, so a writer importing the runtime directly would close an
+ * import cycle. Same reason `workspace-event-contract.ts` is kept
+ * dependency-light: the queueing end of a seam must not drag in the consuming
+ * end.
+ */
+
+import type { DbClient } from '../db/client';
+import { getDb, pgTextArray } from '../db/client';
+import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../scheduled/task-definitions';
+import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
+import type { WorkspaceEventActivationTaskPayload } from './workspace-event-contract';
+
+/**
+ * Which of `eventTypes` at least one active Automation subscribes to.
+ *
+ * Callers pass the single name a subscription would use for the event — the
+ * stamped `<subject>.<op>` type for a platform audit row, the semantic type
+ * otherwise. Passing the raw semantic type of an audit row matches nothing,
+ * which is deliberate: every audit row shares `change`.
+ */
+export async function findSubscribedWorkspaceEventTypes(
+  organizationId: string,
+  eventTypes: readonly string[],
+  db: DbClient = getDb()
+): Promise<Set<string>> {
+  const candidates = [...new Set(eventTypes)];
+  if (candidates.length === 0) return new Set();
+  const rows = await db<{ event_type: string }>`
+    SELECT DISTINCT event_type.value AS event_type
+    FROM automations w
+    CROSS JOIN LATERAL jsonb_array_elements(
+      COALESCE(w.triggers, '[]'::jsonb)
+    ) AS trigger(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(
+      CASE
+        WHEN jsonb_typeof(trigger.value->'event_types') = 'array'
+          THEN trigger.value->'event_types'
+        ELSE '[]'::jsonb
+      END
+    ) AS event_type(value)
+    WHERE w.organization_id = ${organizationId}
+      AND w.status = 'active'
+      AND w.current_version_id IS NOT NULL
+      AND (w.agent_id IS NOT NULL OR w.device_worker_id IS NOT NULL)
+      AND trigger.value->>'kind' = 'event'
+      AND trigger.value->>'source' = 'workspace'
+      AND event_type.value = ANY(${pgTextArray(candidates)}::text[])
+  `;
+  return new Set(rows.map((row) => String(row.event_type)));
+}
+
+export async function enqueueWorkspaceEventActivations(
+  tx: DbClient,
+  payloads: WorkspaceEventActivationTaskPayload[]
+): Promise<void> {
+  await enqueueTasksInTransaction(
+    tx,
+    payloads.map((payload) => ({
+      name: WORKSPACE_EVENT_ACTIVATION_TASK,
+      payload,
+      opts: {
+        idempotencyKey: `workspace-event-activation:${payload.eventId}`,
+        maxAttempts: 5,
+        organizationId: payload.organizationId,
+      },
+    }))
+  );
+}

--- a/packages/server/src/automations/workspace-event.ts
+++ b/packages/server/src/automations/workspace-event.ts
@@ -1,14 +1,7 @@
 import type { AutomationWorkspaceEventTrigger } from '@lobu/core/contracts/tools/manage-automations';
 import type { DbClient } from '../db/client';
-import {
-  getDb,
-  parsePgNumberArray,
-  pgBigintArray,
-  pgTextArray,
-} from '../db/client';
+import { getDb, parsePgNumberArray, pgBigintArray } from '../db/client';
 import { createAutomationEventRun } from '../runs/queue-service';
-import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../scheduled/task-definitions';
-import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
 import { resolveAutomationExecutor } from '../tools/admin/manage_automations/executors';
 import { readAuditEventType } from '../utils/audit-event-type';
 import logger from '../utils/logger';
@@ -72,55 +65,6 @@ const EMPTY_WORKSPACE_EVENT_ACTIVATION_RESULT = {
   fanoutLimited: false,
   invalidCausalPath: false,
 } as const satisfies WorkspaceEventActivationResult;
-
-export async function findSubscribedWorkspaceEventTypes(
-  organizationId: string,
-  eventTypes: readonly string[],
-  db: DbClient = getDb()
-): Promise<Set<string>> {
-  const candidates = [...new Set(eventTypes)];
-  if (candidates.length === 0) return new Set();
-  const rows = await db<{ event_type: string }>`
-    SELECT DISTINCT event_type.value AS event_type
-    FROM automations w
-    CROSS JOIN LATERAL jsonb_array_elements(
-      COALESCE(w.triggers, '[]'::jsonb)
-    ) AS trigger(value)
-    CROSS JOIN LATERAL jsonb_array_elements_text(
-      CASE
-        WHEN jsonb_typeof(trigger.value->'event_types') = 'array'
-          THEN trigger.value->'event_types'
-        ELSE '[]'::jsonb
-      END
-    ) AS event_type(value)
-    WHERE w.organization_id = ${organizationId}
-      AND w.status = 'active'
-      AND w.current_version_id IS NOT NULL
-      AND (w.agent_id IS NOT NULL OR w.device_worker_id IS NOT NULL)
-      AND trigger.value->>'kind' = 'event'
-      AND trigger.value->>'source' = 'workspace'
-      AND event_type.value = ANY(${pgTextArray(candidates)}::text[])
-  `;
-  return new Set(rows.map((row) => String(row.event_type)));
-}
-
-export async function enqueueWorkspaceEventActivations(
-  tx: DbClient,
-  payloads: WorkspaceEventActivationTaskPayload[]
-): Promise<void> {
-  await enqueueTasksInTransaction(
-    tx,
-    payloads.map((payload) => ({
-      name: WORKSPACE_EVENT_ACTIVATION_TASK,
-      payload,
-      opts: {
-        idempotencyKey: `workspace-event-activation:${payload.eventId}`,
-        maxAttempts: 5,
-        organizationId: payload.organizationId,
-      },
-    }))
-  );
-}
 
 /**
  * The single name a subscription uses for this event.

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -10,7 +10,7 @@ import addFormats from 'ajv-formats';
 import {
   enqueueWorkspaceEventActivations,
   findSubscribedWorkspaceEventTypes,
-} from '../../../automations/workspace-event';
+} from '../../../automations/workspace-event-enqueue';
 import {
   automationTriggerSignals,
   deriveWorkspaceEventCausality,

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -5,6 +5,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { runWithActingAutomation } from '../utils/acting-automation-context';
 import type { Context } from 'hono';
 import { isToolError, retryWithBackoff, ToolError } from '@lobu/core';
 import {
@@ -305,8 +306,20 @@ export async function executeTool(
   // single tool call so a failure can be traced across logs/audit/response.
   const callId = randomUUID();
 
+  // Attribute every audit row this handler writes to the Automation driving the
+  // call. Resolution mirrors the one gated writes already use
+  // (`manage_entity.ts`): the server-set reaction identity first, then the
+  // caller-declared `automation_source` for an agent or device running a
+  // window. Setting it once here rather than at each audit writer is what keeps
+  // provenance from drifting as writers are added.
   const runHandler = () =>
-    trackMCPToolCall(toolName, args, () => tool.handler(args, env, toolContext));
+    runWithActingAutomation(
+      toolContext.actingAutomationId ?? declaredAutomationSourceId(args),
+      () =>
+        trackMCPToolCall(toolName, args, () =>
+          tool.handler(args, env, toolContext)
+        )
+    );
 
   try {
     // Auto-retry (lobu#2051 Item 2): only transient thrown ToolErrors, and only
@@ -370,6 +383,24 @@ export async function executeTool(
  * anyway — its `retryable` flag is advisory for the agent.
  */
 const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
+
+/**
+ * The `automation_source.automation_id` an agent declared on this call.
+ *
+ * Self-declared and therefore advisory — an agent that omits it is attributed
+ * to nothing, exactly as today. The reaction identity checked first is
+ * server-set and cannot be forged, so the non-forgeable source always wins.
+ */
+function declaredAutomationSourceId(
+  args: Record<string, unknown>
+): number | null {
+  const source = args.automation_source;
+  if (!source || typeof source !== 'object') return null;
+  const id = (source as { automation_id?: unknown }).automation_id;
+  return typeof id === 'number' && Number.isSafeInteger(id) && id > 0
+    ? id
+    : null;
+}
 
 /** True when a thrown value is a retryable typed error. */
 function isRetryableToolError(err: Error): boolean {

--- a/packages/server/src/utils/acting-automation-context.ts
+++ b/packages/server/src/utils/acting-automation-context.ts
@@ -1,0 +1,48 @@
+/**
+ * The Automation driving the current call, as ambient request scope.
+ *
+ * Audit rows are written from 28 call sites across 15 files, and every one of
+ * them should record WHO caused the change. Threading a producer id through all
+ * of them would make provenance depend on each writer remembering to pass it —
+ * and a forgotten site does not fail loudly, it silently records an audit row
+ * claiming nobody did this. So the driving Automation is carried in request
+ * scope instead, the same way `orgContext` carries the tenant.
+ *
+ * Reading absent as "no Automation" is correct rather than lossy: a human in
+ * Owletto, a cron tick, and a connector sync genuinely ARE root causes, and
+ * that is exactly what a null producer means to the activation path.
+ *
+ * Kept dependency-free so `insert-event.ts` can read it without pulling any
+ * automation runtime into the write path.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface ActingAutomationScope {
+  automationId: number;
+}
+
+const actingAutomationContext =
+  new AsyncLocalStorage<ActingAutomationScope>();
+
+/**
+ * Run `fn` attributing every audit row it writes to `automationId`.
+ *
+ * A null/undefined id runs `fn` unattributed rather than inheriting an
+ * enclosing scope, so a nested unattributed call cannot silently borrow the
+ * caller's provenance.
+ */
+export function runWithActingAutomation<T>(
+  automationId: number | null | undefined,
+  fn: () => T
+): T {
+  if (automationId == null) {
+    return actingAutomationContext.exit(fn);
+  }
+  return actingAutomationContext.run({ automationId }, fn);
+}
+
+/** The Automation driving this call, or null outside any automation scope. */
+export function getActingAutomationId(): number | null {
+  return actingAutomationContext.getStore()?.automationId ?? null;
+}

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -7,6 +7,11 @@
 
 import { retryWithBackoff } from '@lobu/core';
 import { type DbClient, getDb } from '../db/client';
+import { getActingAutomationId } from './acting-automation-context';
+import {
+  enqueueWorkspaceEventActivations,
+  findSubscribedWorkspaceEventTypes,
+} from '../automations/workspace-event-enqueue';
 import {
   AUDIT_EVENT_TYPE_METADATA_KEY,
   type AuditEventType,
@@ -699,6 +704,64 @@ interface ChangeEventParams {
   clientId?: string | null;
 }
 
+/**
+ * Queue Automation activation for a freshly written audit row, when anything
+ * subscribes to its `<subject>.<op>` type.
+ *
+ * Fire-and-forget by design. The audit row is the durable record; a failure to
+ * queue its activation must never fail — or roll back — the change being
+ * audited. Double delivery is guarded twice over: the queue key is per event
+ * id, and `createAutomationEventRun` dedupes per Automation on the
+ * `workspace-event:<id>` delivery id even if a second task is ever queued.
+ *
+ * Causality is read off the row itself rather than passed in: a row with no
+ * producer is a root (empty ancestry, depth 1), and a row produced by an
+ * Automation names that Automation as its own causal path. That is what stops
+ * an Automation waking itself on the audit exhaust of its own write — the
+ * matcher skips any Automation already in `causal_automation_ids`, and
+ * `activateWorkspaceEventTask` rejects a payload whose ancestry disagrees with
+ * the row's producer.
+ */
+async function queueWorkspaceEventActivation(args: {
+  organizationId: string;
+  eventId: number;
+  eventType: string;
+  producerAutomationId: number | null;
+}): Promise<void> {
+  try {
+    const subscribed = await findSubscribedWorkspaceEventTypes(
+      args.organizationId,
+      [args.eventType]
+    );
+    if (!subscribed.has(args.eventType)) return;
+    const sql = getDb();
+    await sql.begin(async (tx) => {
+      await enqueueWorkspaceEventActivations(tx, [
+        {
+          organizationId: args.organizationId,
+          eventId: args.eventId,
+          rootEventIds: [args.eventId],
+          causalAutomationIds:
+            args.producerAutomationId == null
+              ? []
+              : [args.producerAutomationId],
+          depth: 1,
+        },
+      ]);
+    });
+  } catch (err) {
+    logger.error(
+      {
+        eventId: args.eventId,
+        eventType: args.eventType,
+        organizationId: args.organizationId,
+        error: String(err),
+      },
+      '[insert-event] failed to queue workspace-event activation; audit row is durable'
+    );
+  }
+}
+
 const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
 
 /**
@@ -722,18 +785,32 @@ export async function insertConnectionlessAuditEvent(
   eventType: AuditEventType
 ): Promise<InsertedEvent> {
   const idempotencyKey = `audit:${params.originId}`;
+  const formattedEventType = formatAuditEventType(eventType);
   const metadata: Record<string, unknown> = {
     ...(params.metadata ?? {}),
     _lobu_idempotency_key: idempotencyKey,
-    [AUDIT_EVENT_TYPE_METADATA_KEY]: formatAuditEventType(eventType),
+    [AUDIT_EVENT_TYPE_METADATA_KEY]: formattedEventType,
   };
+  // Who caused this change. An explicit id wins over ambient scope so a writer
+  // that already resolved its producer keeps saying so; absent both, the row is
+  // a genuine root (a person, a cron tick, a connector sync).
+  const producerAutomationId =
+    params.automationId ?? getActingAutomationId();
 
   try {
-    return await insertEvent({
+    const inserted = await insertEvent({
       ...params,
       connectionId: null,
+      automationId: producerAutomationId,
       metadata,
     });
+    await queueWorkspaceEventActivation({
+      organizationId: params.organizationId,
+      eventId: inserted.id,
+      eventType: formattedEventType,
+      producerAutomationId,
+    });
+    return inserted;
   } catch (error) {
     if (!isUniqueViolation(error, AUDIT_IDEMPOTENCY_INDEX)) throw error;
     const sql = getDb();


### PR DESCRIPTION
## Summary

- Stage C of the platform-events program. #2931 stamped the `<subject>.<op>` vocabulary, #2938 taught activation to handle a root, #2944 made the type subscribable — but **nothing ever enqueued one**, so a subscription could exist and never fire. `findSubscribedWorkspaceEventTypes` / `enqueueWorkspaceEventActivations` had exactly one caller: the Automation-output path in `complete-window.ts`.
- Queue from the audit-write chokepoint. `insertConnectionlessAuditEvent` is the single place an audit row gets its stamp — all 28 `record*` call sites funnel through it — so hooking there covers every platform event without touching a writer.
- **Close the self-trigger loop by recording provenance, not by adding a guard.** `events.automation_id` already means "the Automation that PRODUCED this row" and `loadWorkspaceEvent` already reads it back, but audit rows never carried it. So an entity update made *by* an Automation looked like a root and the matcher's causal-path exclusion had nothing to exclude — every self-write minted a fresh root at depth 1, so the depth cap never bit. Stamping the producer makes the existing `producerMatchesCausalPath` invariant do the work.

## Why request scope rather than 28 parameters

The producer is carried in `acting-automation-context.ts` (AsyncLocalStorage, the same shape as `orgContext`) instead of threaded through every audit writer, for the reason #2944 computed its catalog instead of writing one: provenance each writer must remember to pass will drift, and a forgotten site doesn't fail loudly — it records an audit row claiming nobody did this.

Resolution mirrors the one gated writes already use at `manage_entity.ts:350`: server-set reaction identity first, then the caller-declared `automation_source`. Absent both, null is the *correct* answer — a person in Owletto, a cron tick, and a connector sync genuinely are roots.

The two queueing functions move to `workspace-event-enqueue.ts` because importing the activation runtime from the write path would close a cycle (`insert-event` → `workspace-event` → `runs/queue-service` → `insert-event` for `stableJson`). Same split, same reason, as `workspace-event-contract.ts`. The moved SQL is byte-identical.

## Blast radius

Stamping `automation_id` on audit rows widens what that column matches. Checked every reader: most `automation_id IS NULL` hits are on `classifier_feedback`/`content_classifications` (a different table), and `stamp_automation_last_run_completed_at` is a trigger on `runs`, not `events`. The one events-level consumer is the opt-in self-exclusion filter at `execute-data-sources.ts:692`, which this makes *more* correct — an Automation shouldn't read its own audit exhaust.

**Inert on arrival.** Per #2944's prod check there are 0 workspace-event subscriptions across 120 Automations, so nothing enqueues until someone subscribes. No flag guards a path nothing reaches.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] Tests run: full server suite **4229 passed / 2 skipped across 465 files**; targeted `bunx vitest run src/__tests__/integration/automations/platform-event-enqueue.test.ts` → 5/5
- [x] 5 new integration tests, each **mutation-checked**

Mutation results — each mutation fails the test that claims it, so none are false-green:

| Mutation | Result |
|---|---|
| drop the `queueWorkspaceEventActivation` call | 3 failed / 2 passed |
| ignore the ambient producer (`?? getActingAutomationId()`) | 2 failed / 3 passed |
| always emit an empty `causalAutomationIds` | 1 failed / 4 passed |
| enqueue regardless of subscription | 3 failed / 2 passed |

## Notes

- `make review-fix` (Fable) made two edits, both verified against the code before accepting: dropped a dead `tx as unknown as DbClient` (`DbClient.begin`'s callback is already `DbClient`) and replaced `run(undefined as any)` with `AsyncLocalStorage.exit(fn)`. It also flagged an `unchanged` early-return as unreachable — confirmed (that path is gated on `onConflictUpdate`, which this caller never passes), so I removed it rather than ship a defensive check on impossible input.
- Per-audit-write cost is one extra subscription lookup against `automations`, a bounded config table (explicitly allowed by AGENTS.md). If it ever shows up hot, a per-org cached set is the fix.
- Still open after this: the trigger-picker follow-up (dedicated field on the entity-types response + a small Owletto PR — `$platform` injection was investigated and rejected, it breaks the events-tab content-kind dropdown), and `device.deleted` firing only when `organization_id` is set.