### PR TITLE
fix(notifications): give every chat table a real header row

### DIFF
--- a/packages/core/src/json-template.ts
+++ b/packages/core/src/json-template.ts
@@ -65,7 +65,7 @@ export function isHttpUrl(value: string): boolean {
 }
 
 /** `pull_request_opened` → `Pull Request Opened`. */
-function titleCaseWords(value: string): string {
+export function titleCaseWords(value: string): string {
   return value
     .replace(/[-_]/g, " ")
     .replace(/\s+/g, " ")

--- a/packages/server/src/__tests__/unit/absolute-permalink.test.ts
+++ b/packages/server/src/__tests__/unit/absolute-permalink.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { toAbsolutePermalink } from "../../utils/url-builder";
+
+/**
+ * In-app permalinks are relative on purpose — the inbox resolves them against
+ * whatever origin the user is on. Slack cannot: it answers a relative button
+ * `url` with `invalid_blocks` and drops the WHOLE message, so this conversion
+ * is what stands between an approval card and no notification at all.
+ */
+describe("toAbsolutePermalink", () => {
+	it("absolutises a relative permalink against the configured origin", () => {
+		expect(
+			toAbsolutePermalink("/acme/memory?run_ids=991", "https://app.lobu.ai"),
+		).toBe("https://app.lobu.ai/acme/memory?run_ids=991");
+	});
+
+	it("leaves an already-absolute url alone", () => {
+		expect(
+			toAbsolutePermalink("https://app.lobu.ai/x", "https://other.example"),
+		).toBe("https://app.lobu.ai/x");
+	});
+
+	it("joins a path that does not start with a slash", () => {
+		expect(toAbsolutePermalink("acme/runs/1", "https://app.lobu.ai")).toBe(
+			"https://app.lobu.ai/acme/runs/1",
+		);
+	});
+
+	it("returns undefined for nothing to link", () => {
+		expect(toAbsolutePermalink(null, "https://app.lobu.ai")).toBeUndefined();
+		expect(toAbsolutePermalink(undefined, "https://app.lobu.ai")).toBeUndefined();
+	});
+});

--- a/packages/server/src/__tests__/unit/absolute-permalink.test.ts
+++ b/packages/server/src/__tests__/unit/absolute-permalink.test.ts
@@ -40,6 +40,30 @@ describe("toAbsolutePermalink", () => {
 		expect(toAbsolutePermalink(undefined, "https://app.lobu.ai")).toBeUndefined();
 	});
 
+	it("refuses a url whose scheme we did not choose", () => {
+		// The origin join is what makes these dangerous: with no `http` prefix
+		// they would come back out as `https://app.lobu.ai/javascript:alert(1)`
+		// — a link wearing our domain, on a card the reader trusts. `notify`
+		// takes `resource_url` as an agent-supplied tool argument, so this is
+		// reachable without any template involved.
+		expect(
+			toAbsolutePermalink("javascript:alert(1)", "https://app.lobu.ai"),
+		).toBeUndefined();
+		expect(
+			toAbsolutePermalink("//evil.example/x", "https://app.lobu.ai"),
+		).toBeUndefined();
+		expect(toAbsolutePermalink("   ", "https://app.lobu.ai")).toBeUndefined();
+	});
+
+	it("still takes an absolute https url and a plain relative path", () => {
+		expect(toAbsolutePermalink("https://evil.example/x", "https://app.lobu.ai")).toBe(
+			"https://evil.example/x",
+		);
+		expect(toAbsolutePermalink("/acme/x", "https://app.lobu.ai")).toBe(
+			"https://app.lobu.ai/acme/x",
+		);
+	});
+
 	it("returns undefined when no public origin is configured", () => {
 		// A backend-only deployment falls back to the hosted UI, so pinning a
 		// local frontend is what makes "no origin at all" reachable. The caller

--- a/packages/server/src/__tests__/unit/absolute-permalink.test.ts
+++ b/packages/server/src/__tests__/unit/absolute-permalink.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	__resetPublicOriginCachesForTests,
+	__setLocalFrontendForTests,
+} from "../../utils/public-origin";
 import { toAbsolutePermalink } from "../../utils/url-builder";
 
 /**
@@ -8,6 +12,11 @@ import { toAbsolutePermalink } from "../../utils/url-builder";
  * is what stands between an approval card and no notification at all.
  */
 describe("toAbsolutePermalink", () => {
+	afterEach(() => {
+		__resetPublicOriginCachesForTests();
+		__setLocalFrontendForTests(undefined);
+	});
+
 	it("absolutises a relative permalink against the configured origin", () => {
 		expect(
 			toAbsolutePermalink("/acme/memory?run_ids=991", "https://app.lobu.ai"),
@@ -29,5 +38,17 @@ describe("toAbsolutePermalink", () => {
 	it("returns undefined for nothing to link", () => {
 		expect(toAbsolutePermalink(null, "https://app.lobu.ai")).toBeUndefined();
 		expect(toAbsolutePermalink(undefined, "https://app.lobu.ai")).toBeUndefined();
+	});
+
+	it("returns undefined when no public origin is configured", () => {
+		// A backend-only deployment falls back to the hosted UI, so pinning a
+		// local frontend is what makes "no origin at all" reachable. The caller
+		// then omits the button — a card with no button still delivers, which a
+		// message Slack rejected does not.
+		delete process.env.PUBLIC_GATEWAY_URL;
+		// Reset FIRST — it clears the local-frontend pin too.
+		__resetPublicOriginCachesForTests();
+		__setLocalFrontendForTests(true);
+		expect(toAbsolutePermalink("/acme/memory?run_ids=991")).toBeUndefined();
 	});
 });

--- a/packages/server/src/__tests__/unit/platform-event-kinds.test.ts
+++ b/packages/server/src/__tests__/unit/platform-event-kinds.test.ts
@@ -13,7 +13,10 @@
 
 import { STRUCTURAL_NODE_TYPES } from "@lobu/core/json-template";
 import { describe, expect, it } from "bun:test";
-import { PLATFORM_EVENT_KINDS } from "../../utils/platform-event-kinds";
+import {
+	ENTITY_CHANGE_APPROVAL_KIND,
+	PLATFORM_EVENT_KINDS,
+} from "../../utils/platform-event-kinds";
 import { validateJsonTemplate } from "../../utils/validate-json-template";
 
 type Node = Record<string, unknown>;
@@ -116,5 +119,64 @@ describe("the validator and the renderers agree on the DSL", () => {
 		expect(() =>
 			validateJsonTemplate({ type: "entity-board", props: { boardId: "q3" } }),
 		).not.toThrow();
+	});
+});
+
+/**
+ * The web renderer lays a `context` strip out with a flex `gap`, which applies
+ * between DIRECT children only. A separator is NOT a direct child — it is
+ * grouped with the value it introduces inside a `span`, so that `gap` never
+ * reaches between them and the page reads "· requested byCRM sync". Chat
+ * normalises whitespace and so never shows the defect, which is exactly why
+ * nothing but this pins it.
+ *
+ * A standalone label (`Operation`) IS a direct child and needs no trailing
+ * space, so the rule is scoped to the literals that carry a separator.
+ */
+describe("context separators keep their trailing space", () => {
+	const SEPARATOR = "·";
+
+	function contextLiterals(node: unknown, inContext: boolean, out: string[]): void {
+		if (!node || typeof node !== "object") return;
+		if (Array.isArray(node)) {
+			for (const child of node) contextLiterals(child, inContext, out);
+			return;
+		}
+		const n = node as Record<string, unknown>;
+		const here = inContext || n.type === "context";
+		if (here && n.type === "text" && typeof n.content === "string") {
+			out.push(n.content);
+		}
+		for (const [key, value] of Object.entries(n)) {
+			if (key === "type" || key === "content") continue;
+			contextLiterals(value, here, out);
+		}
+	}
+
+	for (const [slug, kind] of Object.entries(PLATFORM_EVENT_KINDS)) {
+		if (!kind.jsonTemplate) continue;
+		it(`${slug}: every separator literal ends with a space`, () => {
+			const literals: string[] = [];
+			contextLiterals(kind.jsonTemplate, false, literals);
+			const separators = literals.filter((text) => text.includes(SEPARATOR));
+			// A kind whose strip has no separator has nothing to pin; one that has
+			// them must have found them here.
+			expect(separators.every((text) => text.endsWith(" "))).toBe(true);
+		});
+	}
+
+	it("finds the separators it claims to be checking", () => {
+		// Without this the suite above passes vacuously the moment the walk stops
+		// reaching into `if`/`span`, which is exactly where separators live.
+		const literals: string[] = [];
+		contextLiterals(
+			PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND].jsonTemplate,
+			false,
+			literals,
+		);
+		expect(literals.filter((text) => text.includes(SEPARATOR))).toEqual([
+			"· ",
+			"· requested by ",
+		]);
 	});
 });

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -899,6 +899,54 @@ describe("entity change approvals render through their kind", () => {
 		);
 	});
 
+	it("clamps the body without cutting an escaped entity in half", () => {
+		// `renderApprovalBody` emits one line per proposed field and has no cap of
+		// its own, so a wide entity-create routinely runs past MAX_TEXT_CHARS.
+		// Escaping happens BEFORE the clamp, so a naive slice lands inside `&amp;`
+		// and Slack renders the `&am` fragment literally — on the card the reader
+		// is approving.
+		// A RUN of ampersands guarantees the cut lands inside an entity
+		// whatever the exact budget works out to, rather than depending on the
+		// padding happening to line up with it.
+		const long = `${"a".repeat(1880)}${"&".repeat(30)}`;
+		const card = buildKindCard({
+			metadataSchema: APPROVAL_KIND.metadataSchema,
+			jsonTemplate: APPROVAL_KIND.jsonTemplate,
+			data: { operation: "create_issue", connection: "GitHub", input: {} },
+			body: long,
+		});
+		const text = body(card) ?? "";
+		// Non-vacuity: the clamp must actually have fired.
+		expect(text.endsWith("…")).toBe(true);
+		expect(text.length).toBeLessThanOrEqual(1900);
+		// Every `&` that survives introduces a COMPLETE entity.
+		expect(/&(?!amp;|lt;|gt;)/.test(text)).toBe(false);
+	});
+
+	it("clamps a field value without cutting an escaped entity in half", () => {
+		// Same defect one block down. A cell is clamped RAW at MAX_CELL_CHARS
+		// (400) on the way in, so the only value that still overflows the field
+		// budget afterwards is one that escaping expands — 400 ampersands become
+		// 2000 characters, and the cut lands inside the last `&amp;`.
+		const KIND = PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
+		const card = buildKindCard({
+			metadataSchema: KIND.metadataSchema,
+			jsonTemplate: KIND.jsonTemplate,
+			data: {
+				entityTypeLabel: "Person",
+				entityName: "Ada",
+				action: "Create this entity",
+				proposal: [
+					{ label: "Bio", value: "&".repeat(400) },
+				],
+				diffs: null,
+			},
+		});
+		const value = pairs(card).find(([label]) => label === "Bio")?.[1] ?? "";
+		expect(value.endsWith("…")).toBe(true);
+		expect(/&(?!amp;|lt;|gt;)/.test(value)).toBe(false);
+	});
+
 	it("still carries the decision buttons the bridge already routes", () => {
 		const card = build({
 			entityTypeLabel: "Person",

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -334,6 +334,31 @@ describe("table headers", () => {
 		expect(rows(card)).toEqual([["Email", "a@x", "b@x"]]);
 	});
 
+	it("takes every header row out of the body, not just the promoted one", () => {
+		// A `thead` may declare more than one `tr` (a grouped header). Only the
+		// first can become Slack's header row; the rest must not fall through and
+		// render as data indistinguishable from the record.
+		const th = (t: string) => ({ type: "th", children: [{ type: "text", content: t }] });
+		const td = (t: string) => ({ type: "td", children: [{ type: "text", content: t }] });
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "table", children: [
+						{ type: "thead", children: [
+							{ type: "tr", children: [th("Change"), th("Change")] },
+							{ type: "tr", children: [th("Current"), th("Proposed")] },
+						] },
+						{ type: "tbody", children: [{ type: "tr", children: [td("Eng"), td("Staff Eng")] }] },
+					] },
+				],
+			},
+			data: {},
+		});
+		expect(headers(card)).toEqual(["Change", "Change"]);
+		expect(rows(card)).toEqual([["Eng", "Staff Eng"]]);
+	});
+
 	it("treats a row of th + td as data, not a header", () => {
 		// The default template's `th` is a per-row LABEL, not a column name. Only a
 		// row of nothing but `th` is a header — HTML's own rule.
@@ -457,6 +482,35 @@ describe("platform limits", () => {
 		const cell = pairs(card)[0][1];
 		expect(cell.length).toBeLessThanOrEqual(400);
 		expect(cell.endsWith("…")).toBe(true);
+	});
+
+	it("chunks a long field run instead of losing its tail", () => {
+		// Slack caps fields per SECTION at 10 — a cap on the block, not on what
+		// the card may show. Slicing to 10 made a 15-row entity-create proposal
+		// silently lose rows 11+, and the reader approves a record with no sign
+		// anything is missing.
+		const rows = Array.from({ length: 15 }, (_, i) => ({
+			type: "tr",
+			children: [
+				{ type: "th", children: [{ type: "text", content: `Field ${i + 1}` }] },
+				{ type: "td", children: [{ type: "text", content: `value ${i + 1}` }] },
+			],
+		}));
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [{ type: "table", children: [{ type: "tbody", children: rows }] }],
+			},
+			data: {},
+		});
+		expect(pairs(card)).toHaveLength(15);
+		expect(pairs(card)[14]).toEqual(["Field 15", "value 15"]);
+		// Split across sections, none of which breaches Slack's cap.
+		const blocks = kids(card).filter((c) => c.type === "fields");
+		expect(blocks).toHaveLength(2);
+		for (const block of blocks) {
+			expect((block.children as unknown[]).length).toBeLessThanOrEqual(10);
+		}
 	});
 
 	it("uses fields, not a headless table, for a label/value schema", () => {

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -267,6 +267,33 @@ describe("Slack escaping is per destination", () => {
 	});
 });
 
+describe("the subtitle's duplicate review link", () => {
+	it("drops the body line that links to the page the button already opens", () => {
+		// The body is written for the TEXT fallback, where there is no button.
+		const card = buildKindCard({
+			metadataSchema: APPROVAL_KIND.metadataSchema,
+			data: { operation: "run", connection: "Mac Shell", input: {} },
+			subtitle:
+				"A queued action on **Mac Shell** is waiting.\n\nReview: [Review in Lobu](https://app.lobu.ai/acme/memory?run_ids=42)",
+			url: "https://app.lobu.ai/acme/memory?run_ids=42",
+		});
+		expect(card?.subtitle).toBe("A queued action on Mac Shell is waiting.");
+		expect(buttons(card).map((b) => b.url)).toContain(
+			"https://app.lobu.ai/acme/memory?run_ids=42",
+		);
+	});
+
+	it("keeps a link that points somewhere the card does NOT already offer", () => {
+		const card = buildKindCard({
+			metadataSchema: APPROVAL_KIND.metadataSchema,
+			data: { operation: "run", connection: "Mac Shell", input: {} },
+			subtitle: "See [the runbook](https://wiki.example/runbook) first.",
+			url: "https://app.lobu.ai/acme/memory?run_ids=42",
+		});
+		expect(card?.subtitle).toBe("See the runbook first.");
+	});
+});
+
 describe("table headers", () => {
 	it("lifts a declared thead out of the body into the header row", () => {
 		// Slack ALWAYS draws a table's first row as its header. Left in the body a

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -918,6 +918,47 @@ describe("the context strip", () => {
 		expect(strip(card)).toBe("Ada");
 	});
 
+	it("refuses a protocol-relative url — the origin join would fake our domain", () => {
+		// `//evil.example/x` carries no scheme, so a scheme test alone waves it
+		// through and the origin join renders `https://app.lobu.ai//evil.example/x`
+		// — a link that looks like ours and goes nowhere.
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+		const card = ctx(
+			[
+				{
+					type: "link",
+					props: { href: "{{url}}" },
+					children: [{ type: "text", content: "Ada" }],
+				},
+			],
+			{ url: "//evil.example/x" },
+		);
+		expect(strip(card)).toBe("Ada");
+	});
+
+	it("drops whole segments at the budget rather than cutting one", () => {
+		// The parts are finished mrkdwn. A cut lands mid-`<url|label>` and Slack
+		// renders the wreckage literally, so the tail goes instead.
+		const long = "x".repeat(600);
+		const card = ctx(
+			[
+				{ type: "data", path: "a" },
+				{ type: "data", path: "b" },
+				{
+					type: "link",
+					props: { href: "https://app.lobu.ai/acme/person/ada" },
+					children: [{ type: "text", content: "Ada" }],
+				},
+			],
+			{ a: long, b: long },
+		);
+		const text = strip(card) ?? "";
+		expect(text).toBe(long);
+		// The dropped link is absent OUTRIGHT — no half-rendered `<...|` left over.
+		expect(text).not.toContain("<");
+	});
+
 	it("refuses to vouch for a non-http scheme", () => {
 		// With an origin configured, an unabsolutisable url is the ONLY thing
 		// standing between `javascript:` and a rendered link — without the scheme

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -35,6 +35,24 @@ function rows(card: Card | null): string[][] {
 	const table = kids(card).find((c) => c.type === "table");
 	return (table?.rows as string[][]) ?? [];
 }
+/**
+ * Label/value pairs of the card's `fields` blocks. A two-column table has no
+ * column names to show and Slack would draw its header row as an empty band, so
+ * the builder emits native fields for that shape instead of a headless table.
+ */
+function pairs(card: Card | null): string[][] {
+	return kids(card)
+		.filter((c) => c.type === "fields")
+		.flatMap((c) =>
+			(c.children as Array<{ label: string; value: string }>).map((f) => [
+				f.label,
+				f.value,
+			]),
+		);
+}
+/** Column headers of the first table, which Slack renders as its first row. */
+const headers = (card: Card | null) =>
+	(kids(card).find((c) => c.type === "table")?.headers as string[]) ?? [];
 const texts = (card: Card | null) =>
 	kids(card)
 		.filter((c) => c.type === "text")
@@ -50,7 +68,7 @@ const schema = (properties: Record<string, unknown>) => ({
 });
 
 describe("default template (no authored json_template)", () => {
-	it("renders one row per schema field, label then value", () => {
+	it("renders one field per schema property, label then value", () => {
 		const card = buildKindCard({
 			metadataSchema: APPROVAL_KIND.metadataSchema,
 			data: {
@@ -59,11 +77,14 @@ describe("default template (no authored json_template)", () => {
 				input: { title: "Fix it" },
 			},
 		});
-		expect(rows(card)).toEqual([
+		expect(pairs(card)).toEqual([
 			["Operation", "create_issue"],
 			["Connection", "GitHub"],
 			["Input", "Title: Fix it"],
 		]);
+		// Not a table: two columns have no names, and Slack would draw the header
+		// row as an empty band above them.
+		expect(kids(card).some((c) => c.type === "table")).toBe(false);
 	});
 
 	it("honours x-table-column order, x-table-label, title and x-hidden", () => {
@@ -76,7 +97,7 @@ describe("default template (no authored json_template)", () => {
 			}),
 			data: { first: "a", later: "b", secret: "nope", renamed: "c" },
 		});
-		expect(rows(card)).toEqual([
+		expect(pairs(card)).toEqual([
 			["First", "a"],
 			["Later", "b"],
 			["Renamed", "c"],
@@ -88,7 +109,7 @@ describe("default template (no authored json_template)", () => {
 			metadataSchema: APPROVAL_KIND.metadataSchema,
 			data: { operation: "x", connection: null, input: undefined },
 		});
-		expect(rows(card)).toEqual([
+		expect(pairs(card)).toEqual([
 			["Operation", "x"],
 			["Connection", "—"],
 			["Input", "—"],
@@ -131,7 +152,7 @@ describe("authored json_template", () => {
 			data: { operation: "deploy" },
 		});
 		expect(texts(card)).toEqual(["Deploy approval"]);
-		expect(rows(card)).toEqual([["Service", "deploy"]]);
+		expect(pairs(card)).toEqual([["Service", "deploy"]]);
 	});
 
 	it("takes the if branch matching the data, like the web renderer", () => {
@@ -180,7 +201,7 @@ describe("authored json_template", () => {
 			},
 			data: { lines: [{ name: "Widgets", qty: 12 }, { name: "Gadgets", qty: 3 }] },
 		});
-		expect(rows(card)).toEqual([
+		expect(pairs(card)).toEqual([
 			["Widgets", "12"],
 			["Gadgets", "3"],
 		]);
@@ -222,13 +243,17 @@ describe("authored json_template", () => {
 describe("Slack escaping is per destination", () => {
 	const hostile = "<!channel> & <https://evil.example|Review in Lobu>";
 
-	it("leaves table cells unescaped — the adapter emits them as raw_text", () => {
+	it("escapes a value that rides in fields — those are mrkdwn, not raw_text", () => {
 		const card = buildKindCard({
 			metadataSchema: schema({ v: { type: "string", title: "V" } }),
 			data: { v: hostile },
 		});
-		// Escaping here would show the reader a literal `&lt;`.
-		expect(rows(card)).toEqual([["V", hostile]]);
+		// A label/value pair renders as fields, and the adapter emits those through
+		// `mrkdwn()`. Unescaped, this value would ping the channel. Table CELLS are
+		// the opposite case and stay raw — pinned by the diffs table below.
+		expect(pairs(card)).toEqual([
+			["V", "&lt;!channel&gt; &amp; &lt;https://evil.example|Review in Lobu&gt;"],
+		]);
 	});
 
 	it("escapes free text, which the adapter emits as mrkdwn", () => {
@@ -239,6 +264,75 @@ describe("Slack escaping is per destination", () => {
 		expect(texts(card)[0]).toBe(
 			"&lt;!channel&gt; &amp; &lt;https://evil.example|Review in Lobu&gt;",
 		);
+	});
+});
+
+describe("table headers", () => {
+	it("lifts a declared thead out of the body into the header row", () => {
+		// Slack ALWAYS draws a table's first row as its header. Left in the body a
+		// declared header row was drawn twice: once as an empty band, once as data.
+		const th = (t: string) => ({ type: "th", children: [{ type: "text", content: t }] });
+		const td = (t: string) => ({ type: "td", children: [{ type: "text", content: t }] });
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{
+						type: "table",
+						children: [
+							{ type: "thead", children: [{ type: "tr", children: [th("Field"), th("Current"), th("Proposed")] }] },
+							{ type: "tbody", children: [{ type: "tr", children: [td("Email"), td("a@x"), td("b@x")] }] },
+						],
+					},
+				],
+			},
+			data: {},
+		});
+		expect(headers(card)).toEqual(["Field", "Current", "Proposed"]);
+		expect(rows(card)).toEqual([["Email", "a@x", "b@x"]]);
+	});
+
+	it("treats a row of th + td as data, not a header", () => {
+		// The default template's `th` is a per-row LABEL, not a column name. Only a
+		// row of nothing but `th` is a header — HTML's own rule.
+		const card = buildKindCard({
+			metadataSchema: schema({
+				a: { type: "string", title: "A" },
+				b: { type: "string", title: "B" },
+				c: { type: "string", title: "C" },
+			}),
+			data: { a: "1", b: "2", c: "3" },
+		});
+		expect(pairs(card)).toEqual([
+			["A", "1"],
+			["B", "2"],
+			["C", "3"],
+		]);
+	});
+
+	it("renders the data-driven form the web renderer supports", () => {
+		// `{type:"table", data, columns}` has no `tr` children, so it used to fall
+		// through to "no rows" — dropping the only content and, with it, the whole
+		// card. `columns` names the headers, so this shape never has to guess.
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "table", props: { caption: "Risks" }, data: "{{risks}}", columns: ["risk_name", "severity"] },
+				],
+			},
+			data: {
+				risks: [
+					{ risk_name: "Leak", severity: "high" },
+					{ risk_name: "Cost", severity: "low" },
+				],
+			},
+		});
+		expect(headers(card)).toEqual(["Risk Name", "Severity"]);
+		expect(rows(card)).toEqual([
+			["Leak", "high"],
+			["Cost", "low"],
+		]);
 	});
 });
 
@@ -286,12 +380,12 @@ describe("platform limits", () => {
 			metadataSchema: schema({ v: { type: "string", title: "V" } }),
 			data: { v: "x".repeat(6000) },
 		});
-		const cell = rows(card)[0][1];
+		const cell = pairs(card)[0][1];
 		expect(cell.length).toBeLessThanOrEqual(400);
 		expect(cell.endsWith("…")).toBe(true);
 	});
 
-	it("keeps every row rectangular so Slack accepts the table", () => {
+	it("uses fields, not a headless table, for a label/value schema", () => {
 		const card = buildKindCard({
 			metadataSchema: schema({
 				a: { type: "string", title: "A" },
@@ -299,13 +393,13 @@ describe("platform limits", () => {
 			}),
 			data: { a: "1", b: "2" },
 		});
-		const table = kids(card).find((c) => c.type === "table") as {
-			headers: string[];
-			rows: string[][];
-		};
-		const width = table.headers.length;
-		expect(width).toBe(2);
-		for (const row of table.rows) expect(row).toHaveLength(width);
+		// Two columns become fields, so there is no header row to leave blank.
+		// Rectangularity for real tables is pinned by the ragged-row test above.
+		expect(kids(card).some((c) => c.type === "table")).toBe(false);
+		expect(pairs(card)).toEqual([
+			["A", "1"],
+			["B", "2"],
+		]);
 	});
 });
 
@@ -477,7 +571,7 @@ describe("structural edge cases", () => {
 			},
 			data: { groups: [{ name: "G1", rows: ["x", "y"] }, { name: "G2", rows: ["z"] }] },
 		});
-		expect(rows(card)).toEqual([["G1", "x"], ["G1", "y"], ["G2", "z"]]);
+		expect(pairs(card)).toEqual([["G1", "x"], ["G1", "y"], ["G2", "z"]]);
 	});
 });
 
@@ -512,7 +606,7 @@ describe("entity change approvals render through their kind", () => {
 		]);
 	});
 
-	it("shows a create as one row per proposed field", () => {
+	it("shows a create as one field per proposed value", () => {
 		const card = build({
 			entityTypeLabel: "Company",
 			entityName: "Acme Robotics",
@@ -525,7 +619,14 @@ describe("entity change approvals render through their kind", () => {
 				{ label: "Domain", value: "acme.example" },
 			],
 		});
-		expect(rows(card)).toEqual([
+		// The proposal is a label/value pair, so it lands in fields — under its own
+		// caption, so "Entity: Acme Robotics" (context) cannot be mistaken for
+		// "Name: Acme Robotics" (the value being approved).
+		expect(texts(card)).toContain("*Proposed change*");
+		expect(pairs(card)).toEqual([
+			["Action", "Create this entity"],
+			["Type", "Company"],
+			["Entity", "Acme Robotics"],
 			["Name", "Acme Robotics"],
 			["Domain", "acme.example"],
 		]);

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -376,6 +376,38 @@ describe("table headers", () => {
 			["Cost", "low"],
 		]);
 	});
+
+	it("names the data-driven table by the prop the web renderer reads", () => {
+		// That form is titled with `title`, not `caption`, so reading only
+		// `caption` would label the same table differently on the two surfaces.
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "table", props: { title: "Risks" }, data: "{{risks}}", columns: ["risk_name"] },
+				],
+			},
+			data: { risks: [{ risk_name: "Leak" }] },
+		});
+		expect(kids(card).find((c) => c.type === "table")?.caption).toBe("Risks");
+	});
+
+	it("drops a table whose declared columns are empty", () => {
+		// `columns: []` resolves every row to no cells at all — a table with no
+		// columns, which is not a shape to hand the adapter.
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "text", content: "Risks" },
+					{ type: "table", data: "{{risks}}", columns: [] },
+				],
+			},
+			data: { risks: [{ risk_name: "Leak" }] },
+		});
+		expect(kids(card).some((c) => c.type === "table")).toBe(false);
+		expect(texts(card)).toEqual(["Risks"]);
+	});
 });
 
 describe("decision actions", () => {
@@ -436,7 +468,8 @@ describe("platform limits", () => {
 			data: { a: "1", b: "2" },
 		});
 		// Two columns become fields, so there is no header row to leave blank.
-		// Rectangularity for real tables is pinned by the ragged-row test above.
+		// Rectangularity for real tables is pinned by the ragged-row test in
+		// "structural edge cases".
 		expect(kids(card).some((c) => c.type === "table")).toBe(false);
 		expect(pairs(card)).toEqual([
 			["A", "1"],
@@ -447,6 +480,13 @@ describe("platform limits", () => {
 
 describe("template-declared controls", () => {
 	const bound = (props: Record<string, unknown>) => ({ type: "button", props });
+
+	// A failed assertion must not leave the configured origin behind for the
+	// sibling suites, which assert on its absence.
+	afterEach(() => {
+		delete process.env.PUBLIC_GATEWAY_URL;
+		__resetPublicOriginCachesForTests();
+	});
 
 	it("renders a button whose action the bridge can actually route", () => {
 		const card = buildKindCard({
@@ -505,6 +545,42 @@ describe("template-declared controls", () => {
 			data: {},
 		});
 		expect(buttons(card).map((b) => b.url)).toEqual(["https://lobu.ai/runbook"]);
+	});
+
+	it("absolutises a link button's url — Slack takes it verbatim", () => {
+		// A relative button url is answered with `invalid_blocks`, which drops the
+		// whole message. Same rule as the strip, applied at the button.
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [{ type: "link-button", props: { label: "Open", url: "/acme/memory?run_ids=1" } }],
+			},
+			data: {},
+		});
+		expect(buttons(card).map((b) => b.url)).toEqual([
+			"https://app.lobu.ai/acme/memory?run_ids=1",
+		]);
+	});
+
+	it("degrades a link button we cannot vouch for to its label", () => {
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "text", content: "Runbook" },
+					{ type: "link-button", props: { label: "Open", url: "javascript:alert(1)" } },
+				],
+			},
+			data: {},
+		});
+		expect(buttons(card)).toEqual([]);
+		// The label is not lost with the control — a dead button costs the whole
+		// message, a plain label costs nothing.
+		expect(texts(card)).toEqual(["Runbook\nOpen"]);
 	});
 
 	it("resolves {{path}} interpolation in a control label", () => {
@@ -824,8 +900,11 @@ describe("the context strip", () => {
 	it("keeps the label as plain text when the url cannot be absolutised", () => {
 		// No configured origin and no local frontend would normally fall back to
 		// the hosted UI; pinning both is what makes "unresolvable" reachable.
-		__setLocalFrontendForTests(true);
+		// Reset FIRST: the reset clears the local-frontend pin as well, so pinning
+		// before it leaves the answer up to whether this checkout happens to have
+		// a built bundle — green here, red in CI.
 		__resetPublicOriginCachesForTests();
+		__setLocalFrontendForTests(true);
 		const card = ctx(
 			[
 				{
@@ -853,7 +932,6 @@ describe("the context strip", () => {
 					children: [{ type: "text", content: "Ada" }],
 				},
 			],
-			// eslint-disable-next-line no-script-url -- the point of the test
 			{ url: "javascript:alert(1)" },
 		);
 		expect(strip(card)).toBe("Ada");
@@ -896,7 +974,9 @@ describe("the context strip", () => {
 		];
 		expect(strip(ctx(children, { type: "Person", name: "Ada" }))).toBe("*Person* · Ada");
 		expect(strip(ctx(children, { type: "Person" }))).toBe("*Person*");
-		expect(strip(ctx(children, { name: "Ada" }))).toBe("· Ada");
+		// The first value absent is the case the authored-separator rule cannot
+		// cover on its own: the strip drops the `·` left with nothing before it.
+		expect(strip(ctx(children, { name: "Ada" }))).toBe("Ada");
 	});
 
 	it("does not turn a body into a card the template could not draw", () => {

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -12,8 +12,12 @@
  * something an assertion could drift away from.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { buildKindCard } from "../../notifications/template-card";
+import {
+	__resetPublicOriginCachesForTests,
+	__setLocalFrontendForTests,
+} from "../../utils/public-origin";
 import {
 	CONNECTOR_OPERATION_APPROVAL_KIND,
 	ENTITY_CHANGE_APPROVAL_KIND,
@@ -53,6 +57,16 @@ function pairs(card: Card | null): string[][] {
 /** Column headers of the first table, which Slack renders as its first row. */
 const headers = (card: Card | null) =>
 	(kids(card).find((c) => c.type === "table")?.headers as string[]) ?? [];
+/**
+ * The card's opening prose — the notification body, which is a leading `text`
+ * child now that the subtitle slot belongs to the context strip.
+ */
+const body = (card: Card | null) => {
+	const first = kids(card)[0];
+	return first?.type === "text" ? (first.content as string) : undefined;
+};
+/** The context strip: one Slack `context` block, carried as the subtitle. */
+const strip = (card: Card | null) => card?.subtitle;
 const texts = (card: Card | null) =>
 	kids(card)
 		.filter((c) => c.type === "text")
@@ -267,17 +281,17 @@ describe("Slack escaping is per destination", () => {
 	});
 });
 
-describe("the subtitle's duplicate review link", () => {
+describe("the body's duplicate review link", () => {
 	it("drops the body line that links to the page the button already opens", () => {
 		// The body is written for the TEXT fallback, where there is no button.
 		const card = buildKindCard({
 			metadataSchema: APPROVAL_KIND.metadataSchema,
+			jsonTemplate: APPROVAL_KIND.jsonTemplate,
 			data: { operation: "run", connection: "Mac Shell", input: {} },
-			subtitle:
-				"A queued action on **Mac Shell** is waiting.\n\nReview: [Review in Lobu](https://app.lobu.ai/acme/memory?run_ids=42)",
+			body: "A queued action on **Mac Shell** is waiting.\n\nReview: [Review in Lobu](https://app.lobu.ai/acme/memory?run_ids=42)",
 			url: "https://app.lobu.ai/acme/memory?run_ids=42",
 		});
-		expect(card?.subtitle).toBe("A queued action on Mac Shell is waiting.");
+		expect(body(card)).toBe("A queued action on Mac Shell is waiting.");
 		expect(buttons(card).map((b) => b.url)).toContain(
 			"https://app.lobu.ai/acme/memory?run_ids=42",
 		);
@@ -286,11 +300,12 @@ describe("the subtitle's duplicate review link", () => {
 	it("keeps a link that points somewhere the card does NOT already offer", () => {
 		const card = buildKindCard({
 			metadataSchema: APPROVAL_KIND.metadataSchema,
+			jsonTemplate: APPROVAL_KIND.jsonTemplate,
 			data: { operation: "run", connection: "Mac Shell", input: {} },
-			subtitle: "See [the runbook](https://wiki.example/runbook) first.",
+			body: "See [the runbook](https://wiki.example/runbook) first.",
 			url: "https://app.lobu.ai/acme/memory?run_ids=42",
 		});
-		expect(card?.subtitle).toBe("See the runbook first.");
+		expect(body(card)).toBe("See the runbook first.");
 	});
 });
 
@@ -646,14 +661,14 @@ describe("entity change approvals render through their kind", () => {
 				{ label: "Domain", value: "acme.example" },
 			],
 		});
-		// The proposal is a label/value pair, so it lands in fields — under its own
-		// caption, so "Entity: Acme Robotics" (context) cannot be mistaken for
+		// Type and Entity identify the card, so they are in the strip, not the
+		// body. The proposal is a label/value pair, so it lands in fields — under
+		// its own caption, so the strip's "Acme Robotics" cannot be mistaken for
 		// "Name: Acme Robotics" (the value being approved).
+		expect(strip(card)).toBe("*Company* · Acme Robotics");
 		expect(texts(card)).toContain("*Proposed change*");
 		expect(pairs(card)).toEqual([
 			["Action", "Create this entity"],
-			["Type", "Company"],
-			["Entity", "Acme Robotics"],
 			["Name", "Acme Robotics"],
 			["Domain", "acme.example"],
 		]);
@@ -669,10 +684,10 @@ describe("entity change approvals render through their kind", () => {
 			proposal: [],
 			diffs: [{ label: "Amount", current: "$1,200", proposed: "$18,400" }],
 		});
-		const fieldLabels = kids(card)
-			.filter((c) => c.type === "fields")
-			.flatMap((c) => (c.children as Array<{ label: string }>).map((f) => f.label));
-		expect(fieldLabels).toEqual(["Type"]);
+		// Nothing optional resolved, so the fields block never opens — and the
+		// strip is the type alone rather than a `·` with nothing after it.
+		expect(pairs(card)).toEqual([]);
+		expect(strip(card)).toBe("*Deal*");
 	});
 
 	it("escapes the mrkdwn header fields but not the raw_text table cells", () => {
@@ -686,43 +701,43 @@ describe("entity change approvals render through their kind", () => {
 			proposal: [],
 			diffs: [{ label: "Bio", current: null, proposed: hostile }],
 		});
-		const entityField = kids(card)
-			.filter((c) => c.type === "fields")
-			.flatMap((c) => c.children as Array<{ label: string; value: string }>)
-			.find((f) => f.label === "Entity");
-		expect(entityField?.value).toBe(
-			"&lt;!channel&gt; &amp; &lt;https://evil.example|Review in Lobu&gt;",
+		// The strip goes out as mrkdwn, so a raw `<!channel>` in an entity name
+		// would ping the room from a trusted card and a raw `<url|text>` would
+		// render a link spoofing the genuine one.
+		expect(strip(card)).toBe(
+			"*Person* · &lt;!channel&gt; &amp; &lt;https://evil.example|Review in Lobu&gt;",
 		);
 		// Cells go out as raw_text, which Slack never parses — escaping here would
 		// show the reader a literal `&lt;`.
 		expect(rows(card)[0][2]).toBe(hostile);
 	});
 
-	it("flattens the Markdown body into the subtitle — mrkdwn is not Markdown", () => {
+	it("flattens the Markdown body — mrkdwn is not Markdown", () => {
 		// This is the real approval body: `escapeMarkdownText` backslashes and a
 		// `[Review in Lobu](url)` link that the card already carries as a button.
 		// Rendered raw through `mrkdwn()`, every one of those shows literally.
 		const card = buildKindCard({
 			metadataSchema: APPROVAL_KIND.metadataSchema,
+			jsonTemplate: APPROVAL_KIND.jsonTemplate,
 			data: { operation: "create_issue", connection: "GitHub", input: {} },
-			subtitle:
-				"A queued action on **Mac Shell** is waiting.\n\nReview: [Review in Lobu](https://app.lobu.ai/runs/42)",
+			body: "A queued action on **Mac Shell** is waiting.\n\nReview: [Review in Lobu](https://app.lobu.ai/runs/42)",
 		});
-		expect(card.subtitle).toBe(
+		expect(body(card)).toBe(
 			"A queued action on Mac Shell is waiting.\n\nReview: Review in Lobu",
 		);
 	});
 
-	it("escapes the subtitle — the adapter renders it as mrkdwn", () => {
-		// The subtitle is the notification body, and an approval body carries the
+	it("escapes the body — the adapter renders it as mrkdwn", () => {
+		// The body is the notification body, and an approval body carries the
 		// connection name, which we do not author. `blocks.js` puts it through
 		// `mrkdwn()`, so a raw `<!channel>` would ping the room from a trusted card.
 		const card = buildKindCard({
 			metadataSchema: APPROVAL_KIND.metadataSchema,
+			jsonTemplate: APPROVAL_KIND.jsonTemplate,
 			data: { operation: "create_issue", connection: "GitHub", input: {} },
-			subtitle: "<!channel> approve <https://evil.example|Review in Lobu>",
+			body: "<!channel> approve <https://evil.example|Review in Lobu>",
 		});
-		expect(card.subtitle).toBe(
+		expect(body(card)).toBe(
 			"&lt;!channel&gt; approve &lt;https://evil.example|Review in Lobu&gt;",
 		);
 	});
@@ -742,5 +757,209 @@ describe("entity change approvals render through their kind", () => {
 			"run-approval:991:reject",
 			"https://app.lobu.ai/runs/991",
 		]);
+	});
+});
+
+/**
+ * The context strip — the card's identity line, which the Slack adapter emits
+ * as a `context` block above the body.
+ *
+ * Everything here is about it staying TRUE rather than looking right: a link
+ * that cannot be opened from chat is worse than a name with no link, a control
+ * has no inline form at all, and a value the template did not resolve must take
+ * its separator with it instead of leaving the strip opening on a `·`.
+ */
+describe("the context strip", () => {
+	const ctx = (children: unknown[], data: Record<string, unknown> = {}) =>
+		buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "context", children },
+					{ type: "text", content: "body" },
+				],
+			},
+			data,
+		});
+
+	afterEach(() => {
+		delete process.env.PUBLIC_GATEWAY_URL;
+		__resetPublicOriginCachesForTests();
+		__setLocalFrontendForTests(undefined);
+	});
+
+	it("renders a link as Slack's `<url|label>`, not as a button", () => {
+		const card = ctx(
+			[
+				{
+					type: "link",
+					props: { href: "{{url}}" },
+					children: [{ type: "data", path: "name" }],
+				},
+			],
+			{ url: "https://app.lobu.ai/acme/person/ada", name: "Ada Lovelace" },
+		);
+		expect(strip(card)).toBe("<https://app.lobu.ai/acme/person/ada|Ada Lovelace>");
+		// A context block holds no controls, so the link must NOT also have been
+		// promoted into the actions row.
+		expect(buttons(card)).toEqual([]);
+	});
+
+	it("absolutises a relative permalink — chat has no origin to resolve against", () => {
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+		const card = ctx(
+			[
+				{
+					type: "link",
+					props: { href: "{{url}}" },
+					children: [{ type: "text", content: "Ada" }],
+				},
+			],
+			{ url: "/acme/person/ada" },
+		);
+		expect(strip(card)).toBe("<https://app.lobu.ai/acme/person/ada|Ada>");
+	});
+
+	it("keeps the label as plain text when the url cannot be absolutised", () => {
+		// No configured origin and no local frontend would normally fall back to
+		// the hosted UI; pinning both is what makes "unresolvable" reachable.
+		__setLocalFrontendForTests(true);
+		__resetPublicOriginCachesForTests();
+		const card = ctx(
+			[
+				{
+					type: "link",
+					props: { href: "{{url}}" },
+					children: [{ type: "text", content: "Ada" }],
+				},
+			],
+			{ url: "/acme/person/ada" },
+		);
+		expect(strip(card)).toBe("Ada");
+	});
+
+	it("refuses to vouch for a non-http scheme", () => {
+		// With an origin configured, an unabsolutisable url is the ONLY thing
+		// standing between `javascript:` and a rendered link — without the scheme
+		// guard the origin join turns it into one.
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+		const card = ctx(
+			[
+				{
+					type: "link",
+					props: { href: "{{url}}" },
+					children: [{ type: "text", content: "Ada" }],
+				},
+			],
+			// eslint-disable-next-line no-script-url -- the point of the test
+			{ url: "javascript:alert(1)" },
+		);
+		expect(strip(card)).toBe("Ada");
+	});
+
+	it("drops a control rather than drawing a label that cannot be pressed", () => {
+		// `@name` is the DSL's action binding, so this button IS routable — it
+		// reaches the strip as a real control and is dropped there because a
+		// context block holds none, not because it failed to resolve.
+		const card = ctx([
+			{ type: "text", content: "Person" },
+			{
+				type: "button",
+				props: { label: "Approve", onClick: "@run-approval:1:approve" },
+			},
+		]);
+		expect(strip(card)).toBe("Person");
+		// It is dropped from the strip, not relocated into the actions row.
+		expect(buttons(card)).toEqual([]);
+	});
+
+	it("takes an absent value's separator with it", () => {
+		const children = [
+			{
+				type: "if",
+				condition: "type",
+				then: { type: "strong", children: [{ type: "data", path: "type" }] },
+			},
+			{
+				type: "if",
+				condition: "name",
+				then: {
+					type: "span",
+					children: [
+						{ type: "text", content: "·" },
+						{ type: "data", path: "name" },
+					],
+				},
+			},
+		];
+		expect(strip(ctx(children, { type: "Person", name: "Ada" }))).toBe("*Person* · Ada");
+		expect(strip(ctx(children, { type: "Person" }))).toBe("*Person*");
+		expect(strip(ctx(children, { name: "Ada" }))).toBe("· Ada");
+	});
+
+	it("does not turn a body into a card the template could not draw", () => {
+		// The body is the same prose the markdown fallback already carries. A
+		// template that resolved to nothing must still fall back rather than
+		// produce a card that says nothing the fallback did not.
+		expect(
+			buildKindCard({
+				jsonTemplate: {
+					type: "card",
+					children: [
+						{ type: "if", condition: "never", then: { type: "text", content: "x" } },
+					],
+				},
+				data: {},
+				body: "A queued action is waiting.",
+			}),
+		).toBeNull();
+	});
+
+	it("is absent, not empty, when nothing in it resolved", () => {
+		expect(strip(ctx([{ type: "data", path: "missing" }]))).toBeUndefined();
+	});
+
+	it("escapes strip content — it goes out as mrkdwn", () => {
+		const card = ctx([{ type: "data", path: "name" }], {
+			name: "<!channel> & <https://evil.example|Review in Lobu>",
+		});
+		expect(strip(card)).toBe(
+			"&lt;!channel&gt; &amp; &lt;https://evil.example|Review in Lobu&gt;",
+		);
+	});
+
+	it("puts the connector operation's identity in the strip, its input in the body", () => {
+		const kind = PLATFORM_EVENT_KINDS[CONNECTOR_OPERATION_APPROVAL_KIND];
+		const card = buildKindCard({
+			metadataSchema: kind.metadataSchema,
+			jsonTemplate: kind.jsonTemplate,
+			data: {
+				operation: "Deploy to production",
+				connection: "Acme Shell",
+				input: { cmd: "helm upgrade lobu ./chart" },
+			},
+		});
+		expect(strip(card)).toBe("*Operation* Deploy to production · via Acme Shell");
+		expect(pairs(card).map((p) => p[0])).toEqual(["Input"]);
+	});
+
+	it("links the entity under review from the approval strip", () => {
+		const kind = PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
+		const card = buildKindCard({
+			metadataSchema: kind.metadataSchema,
+			jsonTemplate: kind.jsonTemplate,
+			data: {
+				entityTypeLabel: "Person",
+				entityName: "Ada Lovelace",
+				entityUrl: "https://app.lobu.ai/acme/person/ada-lovelace",
+				requestedBy: "nightly-triage",
+				diffs: [{ label: "Email", current: "a@old", proposed: "a@new" }],
+			},
+		});
+		expect(strip(card)).toBe(
+			"*Person* · <https://app.lobu.ai/acme/person/ada-lovelace|Ada Lovelace> · requested by nightly-triage",
+		);
 	});
 });

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -662,6 +662,33 @@ describe("structural edge cases", () => {
 		expect(kids(card).some((c) => c.type === "table")).toBe(false);
 	});
 
+	it("drops a table left with only its header row", () => {
+		// A declared `thead` over an `each` that resolved to nothing. The header
+		// is lifted out, no data row survives, and the table goes with it.
+		//
+		// The alternative — keep the row as DATA once it is the only one — is the
+		// bug this file exists to fix: Slack draws a table's first row as its
+		// header, so that renders "Field | Current" as a data row beneath an
+		// empty band. Column names with nothing under them say nothing; the
+		// prose around them still does.
+		const th = (t: string) => ({ type: "th", children: [{ type: "text", content: t }] });
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{ type: "text", content: "Nothing changed." },
+					{ type: "table", children: [
+						{ type: "thead", children: [{ type: "tr", children: [th("Field"), th("Current")] }] },
+						{ type: "tbody", children: [{ type: "each", items: "rows", as: "r", render: { type: "tr", children: [{ type: "td", children: [{ type: "data", path: "r" }] }] } }] },
+					] },
+				],
+			},
+			data: { rows: [] },
+		});
+		expect(kids(card).some((c) => c.type === "table")).toBe(false);
+		expect(texts(card)).toEqual(["Nothing changed."]);
+	});
+
 	it("pads ragged rows so Slack accepts the table", () => {
 		const card = buildKindCard({
 			jsonTemplate: {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -8,6 +8,7 @@ import type { McpActivityAttribution } from "../lobu/stores/mcp-client-conversat
 import { resolveSlackUserIdForUser } from "../lobu/stores/chat-identity.js";
 import { resolveEventKindDefinition } from "../utils/event-kind-validation";
 import { insertEvent } from "../utils/insert-event";
+import { toAbsolutePermalink } from "../utils/url-builder";
 import logger from "../utils/logger";
 import { isUniqueViolation } from "../utils/pg-errors";
 import { buildKindCard } from "./template-card";
@@ -484,7 +485,11 @@ async function resolveNotificationKindCard(
 			data: params.payloadData ?? {},
 			title: params.title,
 			subtitle: params.body ?? undefined,
-			url: params.resourceUrl,
+			// Chat has no origin to resolve against, and Slack answers a relative
+			// button url with `invalid_blocks` — dropping the entire message, not
+			// just the button. The stored `resource_url` stays relative for the
+			// inbox; only the card gets the absolute form.
+			url: toAbsolutePermalink(params.resourceUrl),
 			decisionRunId: params.decisionRunId,
 		});
 	} catch (err) {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -484,7 +484,7 @@ async function resolveNotificationKindCard(
 			jsonTemplate: kind.jsonTemplate,
 			data: params.payloadData ?? {},
 			title: params.title,
-			subtitle: params.body ?? undefined,
+			body: params.body ?? undefined,
 			// Chat has no origin to resolve against, and Slack answers a relative
 			// button url with `invalid_blocks` — dropping the entire message, not
 			// just the button. The stored `resource_url` stays relative for the

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -430,6 +430,36 @@ function fragsToChildren(frags: Frag[]): {
 	return { children, actions };
 }
 
+/**
+ * The card's subtitle, from the notification's Markdown body.
+ *
+ * Two things have to happen. The adapter renders the subtitle through
+ * `mrkdwn()`, which is NOT Markdown, so `**bold**`, the backslashes
+ * `escapeMarkdownText` left behind, and `[Review in Lobu](url)` would all show
+ * literally — flatten with the SDK's own converter, then escape, because the
+ * body is not ours (an approval body carries the connection name) and a raw
+ * `<!channel>` in it pings the room from a trusted card.
+ *
+ * And the body is written for the TEXT fallback, where there is no button, so
+ * it ends with a link to the very page this card already offers as one. Drop
+ * the line carrying that link — matched on the URL, not on its wording — or the
+ * card reads "Review: Review in Lobu" directly above a Review in Lobu button.
+ */
+function subtitleFor(
+	subtitle: string | null | undefined,
+	url: string | null | undefined,
+): string | undefined {
+	if (!subtitle) return undefined;
+	const body = url
+		? subtitle
+				.split("\n")
+				.filter((line) => !line.includes(`](${url})`))
+				.join("\n")
+		: subtitle;
+	const flattened = markdownToPlainText(body).trim();
+	return flattened ? escapeSlackText(flattened) : undefined;
+}
+
 export function buildKindCard(params: {
 	metadataSchema?: Record<string, unknown> | null;
 	jsonTemplate?: Record<string, unknown> | null;
@@ -507,15 +537,7 @@ export function buildKindCard(params: {
 
 	return Card({
 		title: params.title,
-		// The subtitle is the notification's Markdown body, and the adapter renders
-		// it through `mrkdwn()` — which is NOT Markdown, so `**bold**`, the
-		// backslashes `escapeMarkdownText` left behind, and `[Review in Lobu](url)`
-		// would all show literally. Flatten with the SDK's own converter, then
-		// escape: the body is not ours (an approval body carries the connection
-		// name), and raw, a `<!channel>` in it pings the room from a trusted card.
-		subtitle: params.subtitle
-			? escapeSlackText(markdownToPlainText(params.subtitle))
-			: undefined,
+		subtitle: subtitleFor(params.subtitle, params.url),
 		children,
 	});
 }

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -66,6 +66,8 @@ const MAX_CELL_CHARS = 400;
 /** Slack paginates a native table; show the whole record rather than page 1. */
 const TABLE_PAGE_SIZE = 100;
 const MAX_TEXT_CHARS = 1900;
+/** Slack's per-`section` field cap. A longer run is chunked, never truncated. */
+const MAX_FIELDS_PER_SECTION = 10;
 /**
  * The strip is one Slack text object (3000). Kept well under it because a
  * context block is small grey type: past a line or two it stops being chrome
@@ -376,9 +378,12 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 				// Slack's native table ALWAYS renders its first row as the header, so
 				// a declared header row has to be lifted out of the body — left in
 				// place it would be drawn twice: once as an empty band, once as data.
-				const headerRow = walked.find((r) => r.header);
-				headers = headerRow ? headerRow.cells : [];
-				rows = walked.filter((r) => r !== headerRow).map((r) => r.cells);
+				// EVERY header row leaves the body, not just the one promoted: a
+				// `thead` may declare more than one `tr`, and the leftovers would
+				// render as data indistinguishable from the record.
+				const headerRows = walked.filter((r) => r.header);
+				headers = headerRows[0]?.cells ?? [];
+				rows = walked.filter((r) => !r.header).map((r) => r.cells);
 			}
 			rows = rows.slice(0, MAX_ROWS);
 			if (rows.length === 0) return [];
@@ -509,21 +514,29 @@ function fragsToChildren(frags: Frag[]): {
 		const batch = pendingFields;
 		pendingFields = [];
 		if (batch.length === 0) return;
-		children.push(
-			Fields(
-				// Slack rejects the message past 10 fields per section, and applies
-				// its 2000-char cap to the RENDERED `*label*\nvalue`, so the two
-				// share one budget.
-				batch.slice(0, 10).map((f) => {
-					const label = escapeSlackText(f.label);
-					return Field({
-						label,
-						value:
-							clamp(escapeSlackText(f.value), MAX_TEXT_CHARS - label.length) || "—",
-					});
-				}),
-			),
-		);
+		// Slack rejects the message past 10 fields per SECTION — a cap on the
+		// block, not on what we may show — so a longer run is chunked across
+		// several. It used to be sliced to 10, which was survivable while only a
+		// schema's own header fields came through here and became a silent
+		// truncation the moment a label/value TABLE was routed to fields: a
+		// 15-row entity-create `proposal` lost rows 11+, and the reader approved
+		// a record with no sign that anything was missing.
+		for (let start = 0; start < batch.length; start += MAX_FIELDS_PER_SECTION) {
+			children.push(
+				Fields(
+					batch.slice(start, start + MAX_FIELDS_PER_SECTION).map((f) => {
+						const label = escapeSlackText(f.label);
+						// Slack applies its 2000-char cap to the RENDERED
+						// `*label*\nvalue`, so the two share one budget.
+						return Field({
+							label,
+							value:
+								clamp(escapeSlackText(f.value), MAX_TEXT_CHARS - label.length) || "—",
+						});
+					}),
+				),
+			);
+		}
 	};
 	const flush = () => {
 		flushText();

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -17,8 +17,10 @@
  * card links out to the full record instead of quietly showing a subset.
  */
 import {
+	formatValue,
 	type TemplateNode,
 	type TemplateVisitor,
+	titleCaseWords,
 	walkTemplate,
 } from "@lobu/core/json-template";
 import {
@@ -75,8 +77,8 @@ function clamp(value: string, max: number): string {
  */
 type Frag =
 	| { kind: "text"; text: string }
-	| { kind: "cell"; text: string }
-	| { kind: "row"; cells: string[] }
+	| { kind: "cell"; text: string; th: boolean }
+	| { kind: "row"; cells: string[]; header: boolean }
 	| { kind: "field"; label: string; value: string }
 	| { kind: "action"; element: ActionElement }
 	| { kind: "block"; child: CardChild };
@@ -222,35 +224,103 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 		if (type === "th" || type === "td") {
 			// Clamped again at table level once the shape is known; this is only a
 			// sanity bound on a single pathological cell.
-			return [{ kind: "cell", text: clamp(textOf(children), MAX_CELL_CHARS) }];
+			return [
+				{
+					kind: "cell",
+					text: clamp(textOf(children), MAX_CELL_CHARS),
+					th: type === "th",
+				},
+			];
 		}
 		if (type === "tr") {
-			const cells = children
-				.filter((c): c is Extract<Frag, { kind: "cell" }> => c.kind === "cell")
-				.map((c) => c.text);
-			return cells.length > 0 ? [{ kind: "row", cells }] : [];
+			const cells = children.filter(
+				(c): c is Extract<Frag, { kind: "cell" }> => c.kind === "cell",
+			);
+			if (cells.length === 0) return [];
+			// HTML's own rule: a row of nothing but `th` IS the header row. That
+			// covers `thead > tr > th` and a loose header `tr` identically, and
+			// leaves the default template's per-row `th` label (th + td) a data row.
+			return [
+				{
+					kind: "row",
+					cells: cells.map((c) => c.text),
+					header: cells.every((c) => c.th),
+				},
+			];
 		}
 		if (type === "table") {
-			const rows = children
-				.filter((c): c is Extract<Frag, { kind: "row" }> => c.kind === "row")
-				.map((c) => c.cells)
-				.slice(0, MAX_ROWS);
+			// The data-driven form the web renderer supports: a `table` carrying a
+			// resolved array plus `columns`. It has no `tr` children at all, so
+			// without this it fell through to "no rows" and the table vanished from
+			// the card silently. `columns` also names the headers, which is the one
+			// shape that never has to guess them.
+			const declaredColumns = Array.isArray(props.columns)
+				? (props.columns as unknown[]).map((c) =>
+						typeof c === "string" ? c : str((c as { name?: unknown })?.name),
+					)
+				: null;
+			const dataRows = Array.isArray(props.data)
+				? (props.data as unknown[]).filter(
+						(r): r is Record<string, unknown> => typeof r === "object" && r !== null,
+					)
+				: null;
+			let headers: string[] = [];
+			let rows: string[][] = [];
+			if (declaredColumns && dataRows) {
+				headers = declaredColumns.map(titleCaseWords);
+				rows = dataRows.map((row) =>
+					declaredColumns.map((col) => formatValue(row[col])),
+				);
+			} else {
+				const walked = children.filter(
+					(c): c is Extract<Frag, { kind: "row" }> => c.kind === "row",
+				);
+				// Slack's native table ALWAYS renders its first row as the header, so
+				// a declared header row has to be lifted out of the body — left in
+				// place it would be drawn twice: once as an empty band, once as data.
+				const headerRow = walked.find((r) => r.header);
+				headers = headerRow ? headerRow.cells : [];
+				rows = walked.filter((r) => r !== headerRow).map((r) => r.cells);
+			}
+			rows = rows.slice(0, MAX_ROWS);
 			if (rows.length === 0) return [];
 			const width = Math.min(
-				rows.reduce((w, r) => Math.max(w, r.length), 0),
+				Math.max(
+					rows.reduce((w, r) => Math.max(w, r.length), 0),
+					headers.length,
+				),
 				MAX_COLS,
 			);
+			// A label/value table has no column names to show, and Slack would draw
+			// the header row as an empty band above it. `Fields` is the native shape
+			// for exactly this pair, so use it rather than a table missing its head.
+			if (headers.length === 0 && width === 2) {
+				const asFields = rows.map((r) => ({
+					kind: "field" as const,
+					label: clamp(r[0] ?? "", MAX_CELL_CHARS),
+					value: clamp(r[1] ?? "", MAX_CELL_CHARS),
+				}));
+				// A caption is the only thing separating these from whatever fields
+				// precede them. Without it the card runs "Entity: Grace" (context)
+				// straight into "Name: Grace" (the value being approved), and the
+				// assembler merges both into one indistinguishable block.
+				const caption = str(props.caption);
+				return caption
+					? [{ kind: "text" as const, text: `*${caption}*` }, ...asFields]
+					: asFields;
+			}
 			// Share the whole-table budget across the cells that actually exist, so
 			// a wide or long table keeps its native rendering instead of silently
 			// collapsing to ASCII.
 			const cellBudget = Math.max(
 				MIN_CELL_CHARS,
-				Math.min(MAX_CELL_CHARS, Math.floor(MAX_TABLE_CHARS / (rows.length * width || 1))),
+				Math.min(
+					MAX_CELL_CHARS,
+					Math.floor(MAX_TABLE_CHARS / ((rows.length + 1) * width || 1)),
+				),
 			);
-			// Slack's native table always renders its first row as the header, and
-			// the default entity template has no `thead` — its `th` is a per-row
-			// label in column 0. Blank headers keep the shape rectangular without
-			// inventing column names the template never declared.
+			const pad = (r: string[]) =>
+				Array.from({ length: width }, (_, i) => clamp(r[i] ?? "", cellBudget));
 			return [
 				{
 					kind: "block",
@@ -259,10 +329,10 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 						// to the literal "Table"; name the thing being shown instead.
 						caption: str(props.caption, "Details"),
 						pageSize: TABLE_PAGE_SIZE,
-						headers: Array.from({ length: width }, () => ""),
-						rows: rows.map((r) =>
-							Array.from({ length: width }, (_, i) => clamp(r[i] ?? "", cellBudget)),
-						),
+						// Blank only when the template declared no header row and the
+						// shape is not a label/value pair — we will not invent names.
+						headers: pad(headers),
+						rows: rows.map(pad),
 					}),
 				},
 			];

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -144,23 +144,39 @@ const PASSTHROUGH = new Set([
 ]);
 
 /**
- * Slack renders a link as `<url|label>`, and ONLY for an absolute http(s) one:
- * a relative href there is drawn as literal `<...>` junk, and a `javascript:`
- * one is a link we would be vouching for. Anything else keeps the label as
- * plain text — a name without a link still reads, a broken link does not.
+ * The absolute http(s) form of a template-authored url, or undefined when there
+ * is none worth handing to chat.
+ *
+ * Both link surfaces need exactly this: Slack draws `<url|label>` only for an
+ * absolute http(s) url (a relative one shows as literal `<...>` junk), and it
+ * takes a button `url` verbatim — answering a relative one with
+ * `invalid_blocks`, which drops the WHOLE message rather than the button.
+ *
+ * A scheme we did not choose is never absolutised into one we did: without that
+ * check `javascript:alert(1)` has no `http` prefix, so it would fall through to
+ * the origin join and come back out as a link — to a dead path on our own
+ * domain, from a card the reader trusts.
  */
-const contextLink = (rawUrl: string, label: string): string => {
-	const text = escapeSlackText(label);
+function safeAbsoluteUrl(rawUrl: string): string | undefined {
 	const trimmed = rawUrl.trim();
-	// A scheme we did not choose is never absolutised into one we did: without
-	// this, `javascript:alert(1)` has no `http` prefix, so it falls through to
-	// the origin join below and comes back out as a link — to a dead path on our
-	// own domain, from a card the reader trusts.
-	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) return text;
+	if (!trimmed) return undefined;
+	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) {
+		return undefined;
+	}
 	// An in-app permalink is stored relative so the inbox resolves it against
 	// whatever origin the reader is on; chat has no origin to resolve against.
 	const url = toAbsolutePermalink(trimmed);
-	if (!url || !/^https?:\/\//i.test(url)) return text;
+	return url && /^https?:\/\//i.test(url) ? url : undefined;
+}
+
+/**
+ * A link inside the strip. No usable url keeps the label as plain text — a name
+ * without a link still reads, a broken link does not.
+ */
+const contextLink = (rawUrl: string, label: string): string => {
+	const text = escapeSlackText(label);
+	const url = safeAbsoluteUrl(rawUrl);
+	if (!url) return text;
 	// `>` would close the link early and `|` would re-split it, so neither can
 	// survive inside the URL half.
 	return /[<>|]/.test(url) ? text : `<${url}|${text}>`;
@@ -225,16 +241,19 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 			];
 		}
 		if (type === "link-button" || type === "link" || type === "a") {
-			const url = str(props.url || props.href);
-			if (!url) return [];
+			const raw = str(props.url || props.href);
+			if (!raw) return [];
+			const label = clamp(str(props.label) || textOf(children) || raw, 75);
+			// Slack takes a button url verbatim and answers a relative or non-http
+			// one with `invalid_blocks` — dropping the WHOLE message, not just the
+			// button. With no url to vouch for, the label degrades to text: a name
+			// without a link still reads, and the strip renders it the same way.
+			const url = safeAbsoluteUrl(raw);
+			if (!url) return [{ kind: "text", text: label }];
 			return [
 				{
 					kind: "action",
-					element: LinkButton({
-						url,
-						label: clamp(str(props.label) || textOf(children) || url, 75),
-						style: buttonStyle(props.style),
-					}),
+					element: LinkButton({ url, label, style: buttonStyle(props.style) }),
 				},
 			];
 		}
@@ -353,6 +372,9 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 				),
 				MAX_COLS,
 			);
+			// `columns: []` resolves to a table with no cells at all — nothing to
+			// show, so drop it rather than hand the adapter an empty shape.
+			if (width === 0) return [];
 			// A label/value table has no column names to show, and Slack would draw
 			// the header row as an empty band above it. `Fields` is the native shape
 			// for exactly this pair, so use it rather than a table missing its head.
@@ -389,7 +411,9 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 					child: Table({
 						// The caption is announced by Slack above the table and defaults
 						// to the literal "Table"; name the thing being shown instead.
-						caption: str(props.caption, "Details"),
+						// The data-driven form names itself with `title` (that is the
+						// prop the web renderer reads), so accept either.
+						caption: str(props.caption ?? props.title, "Details"),
 						pageSize: TABLE_PAGE_SIZE,
 						// Blank only when the template declared no header row and the
 						// shape is not a label/value pair — we will not invent names.
@@ -400,16 +424,18 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 			];
 		}
 		if (type === "context") {
-			// Segments are authored, not inferred: the template writes its own
-			// separators inside the same `if` as the value they follow, so an
-			// absent value takes its separator with it and the strip never opens
-			// or closes on a dangling `·`.
+			// Segments are authored, not inferred: the template writes each
+			// separator inside the same `if` as the value it introduces, so an
+			// absent value takes its separator with it. That rule cannot cover the
+			// FIRST value being absent — the next segment's `·` then has nothing
+			// before it — so the strip drops a leading separator itself.
 			const text = children
 				.map(contextInline)
 				.filter((part) => part.length > 0)
 				.join(" ")
 				.replace(/\s+/g, " ")
-				.trim();
+				.trim()
+				.replace(/^·\s*/, "");
 			return text ? [{ kind: "context", text: clamp(text, MAX_CONTEXT_CHARS) }] : [];
 		}
 		if (type === "divider" || type === "hr") {
@@ -534,9 +560,11 @@ function fragsToChildren(frags: Frag[]): {
  * `<!channel>` in it pings the room from a trusted card.
  *
  * And the body is written for the TEXT fallback, where there is no button, so
- * it ends with a link to the very page this card already offers as one. Drop
- * the line carrying that link — matched on the URL, not on its wording — or the
- * card reads "Review: Review in Lobu" directly above a Review in Lobu button.
+ * it ends with a review link — usually to the very page this card already
+ * offers as one. Drop the line carrying THAT url, matched on the url rather
+ * than its wording, or the card reads "Review: Review in Lobu" directly above a
+ * Review in Lobu button. A body link to anywhere else is a second destination,
+ * so it stays.
  */
 function bodyTextFor(
 	body: string | null | undefined,

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -80,6 +80,35 @@ function clamp(value: string, max: number): string {
 }
 
 /**
+ * Clamp text that has ALREADY been through `escapeSlackText`.
+ *
+ * Escaping expands (`&` becomes `&amp;`), so the cap has to be applied to the
+ * escaped form — that is the budget Slack actually counts, and clamping the raw
+ * text first can still hand Slack a string well over the limit. But a plain
+ * slice of escaped text lands inside an entity often enough to matter: the cut
+ * leaves `&am`, and Slack renders the fragment literally in a card the reader is
+ * about to approve. An approval body is built one line per proposed field with
+ * no bound of its own (`renderApprovalBody`), so this is the ordinary case for a
+ * wide entity, not a pathological one. Cut, then walk back off a trailing
+ * partial entity.
+ */
+function clampEscaped(value: string, max: number): string {
+	if (value.length <= max) return value;
+	let cut = value.slice(0, max - 1);
+	const lastAmp = cut.lastIndexOf("&");
+	// The longest entity we emit is `&amp;` (5). A `&` within that distance of
+	// the end with no `;` after it is a partial one.
+	if (
+		lastAmp !== -1 &&
+		cut.length - lastAmp <= 5 &&
+		!cut.slice(lastAmp).includes(";")
+	) {
+		cut = cut.slice(0, lastAmp);
+	}
+	return `${cut}…`;
+}
+
+/**
  * What the walk emits. Cells and rows are intermediate: a `td` cannot know
  * whether it is inside a table until its `tr`, and a `tr` cannot become a card
  * child on its own.
@@ -508,7 +537,7 @@ function fragsToChildren(frags: Frag[]): {
 	const flushText = () => {
 		const text = pendingText.join("\n").trim();
 		pendingText = [];
-		if (text) children.push(CardText(clamp(escapeSlackText(text), MAX_TEXT_CHARS)));
+		if (text) children.push(CardText(clampEscaped(escapeSlackText(text), MAX_TEXT_CHARS)));
 	};
 	const flushFields = () => {
 		const batch = pendingFields;
@@ -531,7 +560,8 @@ function fragsToChildren(frags: Frag[]): {
 						return Field({
 							label,
 							value:
-								clamp(escapeSlackText(f.value), MAX_TEXT_CHARS - label.length) || "—",
+								clampEscaped(escapeSlackText(f.value), MAX_TEXT_CHARS - label.length) ||
+											"—",
 						});
 					}),
 				),
@@ -670,7 +700,7 @@ export function buildKindCard(params: {
 	// Ahead of everything the template drew: the body says what is being asked,
 	// and the record below it is the evidence for that ask.
 	const body = bodyTextFor(params.body, params.url);
-	if (body) children.unshift(CardText(clamp(body, MAX_TEXT_CHARS)));
+	if (body) children.unshift(CardText(clampEscaped(body, MAX_TEXT_CHARS)));
 
 	const actions: ActionElement[] = [...templateActions];
 	if (params.decisionRunId) {

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -160,6 +160,12 @@ const PASSTHROUGH = new Set([
 function safeAbsoluteUrl(rawUrl: string): string | undefined {
 	const trimmed = rawUrl.trim();
 	if (!trimmed) return undefined;
+	// `//evil.example/x` carries no scheme, so the scheme test below waves it
+	// through and the origin join turns it into `https://origin//evil.example/x`
+	// — a dead path on our own domain, which is the exact thing this refuses to
+	// vouch for. It is not a host we would reach either way, but the reader sees
+	// a link that looks like ours.
+	if (trimmed.startsWith("//")) return undefined;
 	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) {
 		return undefined;
 	}
@@ -181,6 +187,26 @@ const contextLink = (rawUrl: string, label: string): string => {
 	// survive inside the URL half.
 	return /[<>|]/.test(url) ? text : `<${url}|${text}>`;
 };
+
+/**
+ * Join strip segments within the budget by DROPPING whole segments, never by
+ * cutting one.
+ *
+ * The parts are finished mrkdwn: a cut lands mid-`<url|label>` or mid-`&amp;`
+ * and Slack renders the wreckage literally. A strip is chrome, so losing its
+ * tail costs nothing the record below does not already say.
+ */
+function joinWithinBudget(parts: string[], separator: string): string {
+	const kept: string[] = [];
+	let used = 0;
+	for (const part of parts) {
+		const cost = kept.length === 0 ? part.length : part.length + separator.length;
+		if (used + cost > MAX_CONTEXT_CHARS) break;
+		kept.push(part);
+		used += cost;
+	}
+	return kept.join(separator);
+}
 
 /**
  * One frag as inline strip content. A control has no inline form — a button
@@ -429,14 +455,14 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 			// absent value takes its separator with it. That rule cannot cover the
 			// FIRST value being absent — the next segment's `·` then has nothing
 			// before it — so the strip drops a leading separator itself.
-			const text = children
-				.map(contextInline)
-				.filter((part) => part.length > 0)
-				.join(" ")
+			const text = joinWithinBudget(
+				children.map(contextInline).filter((part) => part.length > 0),
+				" ",
+			)
 				.replace(/\s+/g, " ")
 				.trim()
 				.replace(/^·\s*/, "");
-			return text ? [{ kind: "context", text: clamp(text, MAX_CONTEXT_CHARS) }] : [];
+			return text ? [{ kind: "context", text }] : [];
 		}
 		if (type === "divider" || type === "hr") {
 			return [{ kind: "block", child: Divider() }];
@@ -673,7 +699,7 @@ export function buildKindCard(params: {
 		title: params.title,
 		// Several `context` nodes read as one strip; the separator is ours here
 		// because no template authored the space between two of its own blocks.
-		subtitle: context.length > 0 ? clamp(context.join(" · "), MAX_CONTEXT_CHARS) : undefined,
+		subtitle: context.length > 0 ? joinWithinBudget(context, " · ") || undefined : undefined,
 		children,
 	});
 }

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -45,6 +45,7 @@ import {
 } from "chat";
 import { resolveEntityRender } from "../utils/default-entity-template";
 import { escapeSlackText } from "../utils/slack-text";
+import { toAbsolutePermalink } from "../utils/url-builder";
 
 /** Slack degrades a table past these to an ASCII code fence; keep it native. */
 const MAX_ROWS = 100;
@@ -65,6 +66,12 @@ const MAX_CELL_CHARS = 400;
 /** Slack paginates a native table; show the whole record rather than page 1. */
 const TABLE_PAGE_SIZE = 100;
 const MAX_TEXT_CHARS = 1900;
+/**
+ * The strip is one Slack text object (3000). Kept well under it because a
+ * context block is small grey type: past a line or two it stops being chrome
+ * and starts competing with the record it introduces.
+ */
+const MAX_CONTEXT_CHARS = 900;
 
 function clamp(value: string, max: number): string {
 	return value.length > max ? `${value.slice(0, max - 1)}…` : value;
@@ -76,7 +83,13 @@ function clamp(value: string, max: number): string {
  * child on its own.
  */
 type Frag =
-	| { kind: "text"; text: string }
+	| { kind: "text"; text: string; strong?: boolean }
+	/**
+	 * One rendered context strip — already mrkdwn, already escaped. It leaves the
+	 * body entirely: `buildKindCard` lifts it into the card's SUBTITLE, which the
+	 * Slack adapter emits as a `context` block.
+	 */
+	| { kind: "context"; text: string }
 	| { kind: "cell"; text: string; th: boolean }
 	| { kind: "row"; cells: string[]; header: boolean }
 	| { kind: "field"; label: string; value: string }
@@ -129,6 +142,55 @@ const PASSTHROUGH = new Set([
 	"thead",
 	"fragment",
 ]);
+
+/**
+ * Slack renders a link as `<url|label>`, and ONLY for an absolute http(s) one:
+ * a relative href there is drawn as literal `<...>` junk, and a `javascript:`
+ * one is a link we would be vouching for. Anything else keeps the label as
+ * plain text — a name without a link still reads, a broken link does not.
+ */
+const contextLink = (rawUrl: string, label: string): string => {
+	const text = escapeSlackText(label);
+	const trimmed = rawUrl.trim();
+	// A scheme we did not choose is never absolutised into one we did: without
+	// this, `javascript:alert(1)` has no `http` prefix, so it falls through to
+	// the origin join below and comes back out as a link — to a dead path on our
+	// own domain, from a card the reader trusts.
+	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) return text;
+	// An in-app permalink is stored relative so the inbox resolves it against
+	// whatever origin the reader is on; chat has no origin to resolve against.
+	const url = toAbsolutePermalink(trimmed);
+	if (!url || !/^https?:\/\//i.test(url)) return text;
+	// `>` would close the link early and `|` would re-split it, so neither can
+	// survive inside the URL half.
+	return /[<>|]/.test(url) ? text : `<${url}|${text}>`;
+};
+
+/**
+ * One frag as inline strip content. A control has no inline form — a button
+ * cannot be pressed inside a context block — so it contributes nothing rather
+ * than a dead label.
+ */
+function contextInline(frag: Frag): string {
+	switch (frag.kind) {
+		case "text":
+			return frag.strong
+				? `*${escapeSlackText(frag.text)}*`
+				: escapeSlackText(frag.text);
+		case "cell":
+			return escapeSlackText(frag.text);
+		case "field":
+			return `${escapeSlackText(frag.label)}: ${escapeSlackText(frag.value)}`;
+		case "action":
+			return frag.element.type === "link-button"
+				? contextLink(frag.element.url, frag.element.label)
+				: "";
+		case "context":
+			return frag.text;
+		default:
+			return "";
+	}
+}
 
 const textOf = (frags: Frag[]): string =>
 	frags
@@ -337,6 +399,19 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 				},
 			];
 		}
+		if (type === "context") {
+			// Segments are authored, not inferred: the template writes its own
+			// separators inside the same `if` as the value they follow, so an
+			// absent value takes its separator with it and the strip never opens
+			// or closes on a dangling `·`.
+			const text = children
+				.map(contextInline)
+				.filter((part) => part.length > 0)
+				.join(" ")
+				.replace(/\s+/g, " ")
+				.trim();
+			return text ? [{ kind: "context", text: clamp(text, MAX_CONTEXT_CHARS) }] : [];
+		}
 		if (type === "divider" || type === "hr") {
 			return [{ kind: "block", child: Divider() }];
 		}
@@ -345,6 +420,12 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 			const body = textOf(children) || str(props.value);
 			return body ? [{ kind: "text", text: `\`\`\`\n${body}\n\`\`\`` }] : [];
 		}
+		// Emphasis is only carried where the surface has a form for it (the strip);
+		// everywhere else it stays prose, as it always has.
+		if (type === "strong" || type === "b") {
+			const body = textOf(children) || str(props.children) || str(props.value);
+			return body ? [{ kind: "text", text: body, strong: true }] : [];
+		}
 		if (
 			type === "markdown" ||
 			type === "badge" ||
@@ -352,7 +433,6 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 			type === "h1" ||
 			type === "h2" ||
 			type === "h3" ||
-			type === "strong" ||
 			type === "em" ||
 			type === "label"
 		) {
@@ -369,9 +449,11 @@ const makeCardVisitor = (unroutable: Set<string>): TemplateVisitor<Frag> => ({
 function fragsToChildren(frags: Frag[]): {
 	children: CardChild[];
 	actions: ActionElement[];
+	context: string[];
 } {
 	const children: CardChild[] = [];
 	const actions: ActionElement[] = [];
+	const context: string[] = [];
 	let pendingText: string[] = [];
 	let pendingFields: Array<{ label: string; value: string }> = [];
 
@@ -410,6 +492,12 @@ function fragsToChildren(frags: Frag[]): {
 			actions.push(frag.element);
 			continue;
 		}
+		// Strip content is chrome for the whole card, not a child of wherever the
+		// template happened to declare it, so it leaves the body stream entirely.
+		if (frag.kind === "context") {
+			context.push(frag.text);
+			continue;
+		}
 		if (frag.kind === "field") {
 			flushText();
 			pendingFields.push(frag);
@@ -427,13 +515,18 @@ function fragsToChildren(frags: Frag[]): {
 		else pendingText.push(frag.text);
 	}
 	flush();
-	return { children, actions };
+	return { children, actions, context };
 }
 
 /**
- * The card's subtitle, from the notification's Markdown body.
+ * The card's opening prose, from the notification's Markdown body.
  *
- * Two things have to happen. The adapter renders the subtitle through
+ * It is a SECTION, not the subtitle: the subtitle slot is the Slack `context`
+ * block, which the template's own strip claims (see the `context` component).
+ * A context block is small grey type — right for "Person · Ada Lovelace ·
+ * run #991", wrong for the sentence saying what is being asked.
+ *
+ * Two things have to happen to the body first. The adapter renders it through
  * `mrkdwn()`, which is NOT Markdown, so `**bold**`, the backslashes
  * `escapeMarkdownText` left behind, and `[Review in Lobu](url)` would all show
  * literally — flatten with the SDK's own converter, then escape, because the
@@ -445,18 +538,18 @@ function fragsToChildren(frags: Frag[]): {
  * the line carrying that link — matched on the URL, not on its wording — or the
  * card reads "Review: Review in Lobu" directly above a Review in Lobu button.
  */
-function subtitleFor(
-	subtitle: string | null | undefined,
+function bodyTextFor(
+	body: string | null | undefined,
 	url: string | null | undefined,
 ): string | undefined {
-	if (!subtitle) return undefined;
-	const body = url
-		? subtitle
+	if (!body) return undefined;
+	const withoutDuplicateLink = url
+		? body
 				.split("\n")
 				.filter((line) => !line.includes(`](${url})`))
 				.join("\n")
-		: subtitle;
-	const flattened = markdownToPlainText(body).trim();
+		: body;
+	const flattened = markdownToPlainText(withoutDuplicateLink).trim();
 	return flattened ? escapeSlackText(flattened) : undefined;
 }
 
@@ -465,7 +558,8 @@ export function buildKindCard(params: {
 	jsonTemplate?: Record<string, unknown> | null;
 	data: Record<string, unknown>;
 	title?: string;
-	subtitle?: string;
+	/** The notification's Markdown body, rendered as the card's opening prose. */
+	body?: string;
 	/** Permalink to the event, so the full rendering is always one click away. */
 	url?: string | null;
 	/**
@@ -484,9 +578,14 @@ export function buildKindCard(params: {
 
 	const unsupported = new Set<string>();
 	const unroutable = new Set<string>();
-	const { children, actions: templateActions } = fragsToChildren(
+	const {
+		children,
+		actions: templateActions,
+		context,
+	} = fragsToChildren(
 		walkTemplate(template, params.data, makeCardVisitor(unroutable), unsupported),
 	);
+
 	if (unroutable.size > 0) {
 		const names = [...unroutable].sort();
 		children.push(
@@ -504,9 +603,16 @@ export function buildKindCard(params: {
 		);
 	}
 
-	// Checked only after the notes above: a card whose every control was dropped
-	// still has something true to say, and saying it beats silence.
+	// Checked only after the notes above, and BEFORE the body is prepended: the
+	// body is the same prose the markdown fallback already carries, so counting
+	// it here would turn "the template rendered nothing" into a card that says
+	// nothing the fallback did not.
 	if (children.length === 0 && templateActions.length === 0) return null;
+
+	// Ahead of everything the template drew: the body says what is being asked,
+	// and the record below it is the evidence for that ask.
+	const body = bodyTextFor(params.body, params.url);
+	if (body) children.unshift(CardText(clamp(body, MAX_TEXT_CHARS)));
 
 	const actions: ActionElement[] = [...templateActions];
 	if (params.decisionRunId) {
@@ -537,7 +643,9 @@ export function buildKindCard(params: {
 
 	return Card({
 		title: params.title,
-		subtitle: subtitleFor(params.subtitle, params.url),
+		// Several `context` nodes read as one strip; the separator is ours here
+		// because no template authored the space between two of its own blocks.
+		subtitle: context.length > 0 ? clamp(context.join(" · "), MAX_CONTEXT_CHARS) : undefined,
 		children,
 	});
 }

--- a/packages/server/src/notifications/template-card.ts
+++ b/packages/server/src/notifications/template-card.ts
@@ -158,20 +158,11 @@ const PASSTHROUGH = new Set([
  * domain, from a card the reader trusts.
  */
 function safeAbsoluteUrl(rawUrl: string): string | undefined {
-	const trimmed = rawUrl.trim();
-	if (!trimmed) return undefined;
-	// `//evil.example/x` carries no scheme, so the scheme test below waves it
-	// through and the origin join turns it into `https://origin//evil.example/x`
-	// — a dead path on our own domain, which is the exact thing this refuses to
-	// vouch for. It is not a host we would reach either way, but the reader sees
-	// a link that looks like ours.
-	if (trimmed.startsWith("//")) return undefined;
-	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) {
-		return undefined;
-	}
 	// An in-app permalink is stored relative so the inbox resolves it against
 	// whatever origin the reader is on; chat has no origin to resolve against.
-	const url = toAbsolutePermalink(trimmed);
+	// `toAbsolutePermalink` owns the refusals (protocol-relative, foreign
+	// scheme) so every caller gets them, not just this one.
+	const url = toAbsolutePermalink(rawUrl);
 	return url && /^https?:\/\//i.test(url) ? url : undefined;
 }
 

--- a/packages/server/src/utils/platform-event-kinds.ts
+++ b/packages/server/src/utils/platform-event-kinds.ts
@@ -57,7 +57,7 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 							then: {
 								type: "span",
 								children: [
-									{ type: "text", content: "· via" },
+									{ type: "text", content: "· via " },
 									{ type: "data", path: "connection" },
 								],
 							},
@@ -140,6 +140,12 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 				 * carries its own leading separator inside the same `if`, so an
 				 * absent one takes its `·` with it.
 				 *
+				 * The trailing space in each separator is load-bearing. Chat joins
+				 * strip segments with one and normalises the run; the web renderer
+				 * lays the strip out with a flex `gap`, which applies BETWEEN direct
+				 * children and not inside the `span` grouping a separator with its
+				 * value — so without it the page reads "· requested byCRM sync".
+				 *
 				 * The name links to the entity when we have a URL for it, which is
 				 * the one thing a reader deciding from chat could not otherwise
 				 * reach: the record as it stands TODAY, next to the change proposed
@@ -162,7 +168,7 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 							then: {
 								type: "span",
 								children: [
-									{ type: "text", content: "·" },
+									{ type: "text", content: "· " },
 									{
 										type: "if",
 										condition: "entityUrl",
@@ -182,7 +188,7 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 							then: {
 								type: "span",
 								children: [
-									{ type: "text", content: "· requested by" },
+									{ type: "text", content: "· requested by " },
 									{ type: "data", path: "requestedBy" },
 								],
 							},

--- a/packages/server/src/utils/platform-event-kinds.ts
+++ b/packages/server/src/utils/platform-event-kinds.ts
@@ -136,43 +136,78 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 						},
 					],
 				},
+				// Two shapes, so two tables. An update is three columns whose middle
+				// and right only mean anything once they are NAMED — "Eng" next to
+				// "Staff Eng" is undecidable without `Current`/`Proposed` above it.
+				// A create/delete/merge is a label/value pair, which needs no header
+				// and renders as native fields in chat.
 				{
-					type: "table",
-					props: { caption: "Proposed change" },
-					children: [
-						{
-							type: "tbody",
-							children: [
-								// An update: one row per changed field, current then proposed.
-								{
-									type: "each",
-									items: "diffs",
-									as: "d",
-									render: {
+					type: "if",
+					condition: "diffs",
+					then: {
+						type: "table",
+						props: { caption: "Proposed change" },
+						children: [
+							{
+								type: "thead",
+								children: [
+									{
 										type: "tr",
 										children: [
-											{ type: "th", children: [{ type: "data", path: "d.label" }] },
-											{ type: "td", children: [{ type: "data", path: "d.current", fallback: "—" }] },
-											{ type: "td", children: [{ type: "data", path: "d.proposed", fallback: "—" }] },
+											{ type: "th", children: [{ type: "text", content: "Field" }] },
+											{ type: "th", children: [{ type: "text", content: "Current" }] },
+											{ type: "th", children: [{ type: "text", content: "Proposed" }] },
 										],
 									},
-								},
-								// A create / delete / merge: one row per proposed field.
-								{
-									type: "each",
-									items: "proposal",
-									as: "p",
-									render: {
-										type: "tr",
-										children: [
-											{ type: "th", children: [{ type: "data", path: "p.label" }] },
-											{ type: "td", children: [{ type: "data", path: "p.value", fallback: "—" }] },
-										],
+								],
+							},
+							{
+								type: "tbody",
+								children: [
+									{
+										type: "each",
+										items: "diffs",
+										as: "d",
+										render: {
+											type: "tr",
+											children: [
+												{ type: "th", children: [{ type: "data", path: "d.label" }] },
+												{ type: "td", children: [{ type: "data", path: "d.current", fallback: "—" }] },
+												{ type: "td", children: [{ type: "data", path: "d.proposed", fallback: "—" }] },
+											],
+										},
 									},
-								},
-							],
-						},
-					],
+								],
+							},
+						],
+					},
+				},
+				{
+					type: "if",
+					condition: "proposal",
+					then: {
+						type: "table",
+						props: { caption: "Proposed change" },
+						children: [
+							{
+								type: "tbody",
+								children: [
+									{
+										type: "each",
+										items: "proposal",
+										as: "p",
+										render: {
+											type: "tr",
+											children: [
+												{ type: "th", children: [{ type: "data", path: "p.label" }] },
+												{ type: "td", children: [{ type: "data", path: "p.value", fallback: "—" }] },
+											],
+										},
+									},
+								],
+							},
+						],
+					},
 				},
 			],
 		},

--- a/packages/server/src/utils/platform-event-kinds.ts
+++ b/packages/server/src/utils/platform-event-kinds.ts
@@ -36,6 +36,46 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 	 */
 	[CONNECTOR_OPERATION_APPROVAL_KIND]: {
 		description: "A connector operation waiting for a human decision.",
+		/**
+		 * Which operation, on which connection, is the card's IDENTITY, not two
+		 * more rows of its record — so it goes in the `context` strip and the body
+		 * is left to the one thing the decision actually turns on, the input. Read
+		 * as a field table it was three rows of two words each, which is how a
+		 * two-column layout wastes a whole card.
+		 */
+		jsonTemplate: {
+			type: "card",
+			children: [
+				{
+					type: "context",
+					children: [
+						{ type: "strong", children: [{ type: "text", content: "Operation" }] },
+						{ type: "data", path: "operation" },
+						{
+							type: "if",
+							condition: "connection",
+							then: {
+								type: "span",
+								children: [
+									{ type: "text", content: "· via" },
+									{ type: "data", path: "connection" },
+								],
+							},
+						},
+					],
+				},
+				{
+					type: "fields",
+					children: [
+						{
+							type: "field",
+							props: { label: "Input" },
+							children: [{ type: "data", path: "input", fallback: "—" }],
+						},
+					],
+				},
+			],
+		},
 		metadataSchema: {
 			type: "object",
 			properties: {
@@ -74,6 +114,9 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 				action: { type: "string", title: "Action" },
 				entityTypeLabel: { type: "string", title: "Type" },
 				entityName: { type: "string", title: "Entity" },
+				// The entity's own page. A link TARGET, never a row of its own — the
+				// name in the strip is what carries it.
+				entityUrl: { type: "string", title: "Entity URL", "x-hidden": true },
 				requestedBy: { type: "string", title: "Requested by" },
 				why: { type: "string", title: "Why approval is needed" },
 				diffs: { type: "array", title: "Changes", "x-hidden": true },
@@ -90,6 +133,62 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 		jsonTemplate: {
 			type: "card",
 			children: [
+				/**
+				 * WHAT is under review — its type, its name, who asked — introduces
+				 * the card rather than filling it: those three never change the
+				 * decision, they identify what the decision is about. Each value
+				 * carries its own leading separator inside the same `if`, so an
+				 * absent one takes its `·` with it.
+				 *
+				 * The name links to the entity when we have a URL for it, which is
+				 * the one thing a reader deciding from chat could not otherwise
+				 * reach: the record as it stands TODAY, next to the change proposed
+				 * to it.
+				 */
+				{
+					type: "context",
+					children: [
+						{
+							type: "if",
+							condition: "entityTypeLabel",
+							then: {
+								type: "strong",
+								children: [{ type: "data", path: "entityTypeLabel" }],
+							},
+						},
+						{
+							type: "if",
+							condition: "entityName",
+							then: {
+								type: "span",
+								children: [
+									{ type: "text", content: "·" },
+									{
+										type: "if",
+										condition: "entityUrl",
+										then: {
+											type: "link",
+											props: { href: "{{entityUrl}}" },
+											children: [{ type: "data", path: "entityName" }],
+										},
+										else: { type: "data", path: "entityName" },
+									},
+								],
+							},
+						},
+						{
+							type: "if",
+							condition: "requestedBy",
+							then: {
+								type: "span",
+								children: [
+									{ type: "text", content: "· requested by" },
+									{ type: "data", path: "requestedBy" },
+								],
+							},
+						},
+					],
+				},
 				{
 					type: "fields",
 					children: [
@@ -100,29 +199,6 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 								type: "field",
 								props: { label: "Action" },
 								children: [{ type: "data", path: "action" }],
-							},
-						},
-						{
-							type: "field",
-							props: { label: "Type" },
-							children: [{ type: "data", path: "entityTypeLabel", fallback: "—" }],
-						},
-						{
-							type: "if",
-							condition: "entityName",
-							then: {
-								type: "field",
-								props: { label: "Entity" },
-								children: [{ type: "data", path: "entityName" }],
-							},
-						},
-						{
-							type: "if",
-							condition: "requestedBy",
-							then: {
-								type: "field",
-								props: { label: "Requested by" },
-								children: [{ type: "data", path: "requestedBy" }],
 							},
 						},
 						{

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -27,6 +27,28 @@ function withBaseUrl(baseUrl: string | undefined, path: string): string {
   return `${baseUrl}${path}`;
 }
 
+/**
+ * Absolutise a permalink for a destination that cannot resolve a relative one.
+ *
+ * In-app links are built relative on purpose so the inbox resolves them against
+ * whatever origin the user is on. Chat has no origin: Slack rejects a relative
+ * `url` on a button with `invalid_blocks` and drops the WHOLE message, so a
+ * relative link there costs the notification its delivery.
+ *
+ * Returns undefined when no public origin is configured — a card with no button
+ * still delivers, which a rejected message does not.
+ */
+export function toAbsolutePermalink(
+  url: string | null | undefined,
+  baseUrl?: string
+): string | undefined {
+  if (!url) return undefined;
+  if (/^https?:\/\//i.test(url)) return url;
+  const origin = getPublicWebUrl(undefined, baseUrl);
+  if (!origin) return undefined;
+  return `${origin}${url.startsWith('/') ? '' : '/'}${url}`;
+}
+
 export function getPublicWebUrl(requestUrl?: string, baseUrl?: string): string | undefined {
   const base = baseUrl || getConfiguredPublicOrigin();
   if (base) return normalizeBaseUrl(base);

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -43,10 +43,21 @@ export function toAbsolutePermalink(
   baseUrl?: string
 ): string | undefined {
   if (!url) return undefined;
-  if (/^https?:\/\//i.test(url)) return url;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  // Refused BEFORE the origin join, because the join is what makes them
+  // dangerous. `//evil.example/x` and `javascript:alert(1)` both carry no
+  // `http` prefix, so without this they come back out as
+  // `https://app.lobu.ai//evil.example/x` — a link wearing our domain and
+  // going nowhere — from a card the reader trusts. Every caller needs this,
+  // not just the ones that remembered: `notify`'s `resource_url` is an
+  // agent-supplied tool argument.
+  if (trimmed.startsWith('//')) return undefined;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return undefined;
   const origin = getPublicWebUrl(undefined, baseUrl);
   if (!origin) return undefined;
-  return `${origin}${url.startsWith('/') ? '' : '/'}${url}`;
+  return `${origin}${trimmed.startsWith('/') ? '' : '/'}${trimmed}`;
 }
 
 export function getPublicWebUrl(requestUrl?: string, baseUrl?: string): string | undefined {


### PR DESCRIPTION
## The bug

Reported from a live Slack card — an empty band above the only row:

```
Details
┌──────────────────────────────┐
│                              │  ← headers: ["", ""]
├──────────────┬───────────────┤
│ Operation    │ run           │
└──────────────┴───────────────┘
```

`@chat-adapter/slack`'s `tableToBlocks` prepends `element.headers` as row 0 unconditionally — there is no headerless path — and `template-card.ts` passed `Array.from({ length: width }, () => "")` for every table.

Auditing every table found four shapes, wrong in four different ways.

| Shape | Before | After |
|---|---|---|
| label/value (default schema table) | `headers: ["",""]` — blank band | native `Fields` |
| entity diffs | `headers: ["","",""]` — 3 unnamed columns | `Field / Current / Proposed` |
| template declares a `thead` | blank band **and** header demoted to a data row | header lifted into `headers` |
| `{type:"table", data, columns}` | `buildKindCard` returns `null` — card dropped | rendered, `columns` name the headers |

The entity-diff one is not cosmetic. On an approval card, `Eng` beside `Staff Eng` is undecidable without `Current`/`Proposed` above it.

The data-driven one is worse than it looks: that node has no `tr` children, so it fell through to "no rows" and returned `[]` — which the visitor contract reads as *handled, nothing to emit*. The table vanished silently and, when it was the only content, took the whole card down to plain text with it.

## Approach

A `tr` of nothing but `th` is the header row — HTML's own rule, so it works inside `thead` and for a loose header row alike, and it correctly leaves the default template's per-row `th` **label** (th + td) a data row.

Two columns have no column names to show, so that shape becomes `Fields` rather than a table missing its head. It keeps its caption as a separator — without it the card runs `Entity: Acme` (context) straight into `Name: Acme` (the value being approved) in one indistinguishable block.

Because an update (3 columns) and a create (2 columns) are genuinely different shapes, the entity kind now declares two `if`-guarded tables instead of one with ragged rows. The `thead` also improves the web and MCP render, which walk the same template.

## Escaping consequence

Field values go out as mrkdwn, not the `raw_text` that table cells use, so values in the label/value shape are escaped now — `flushFields` already did this. Table cells stay raw; the diffs test pins that.

## Evidence

Before / after on the same four inputs:

```
BEFORE
1. connector op   table headers ["",""]      rows [[Operation,run],[Connection,—],[Input,]]
2. entity update  table headers ["","",""]   rows [[Email,a@x,b@x],[Role,Eng,Staff Eng]]
3. declared thead table headers ["","",""]   rows [[Field,Current,Proposed],[Email,a@x,b@x]]
4. data-driven    NULL CARD

AFTER
1. connector op   fields [[Operation,run],[Connection,Mac Shell],[Input,Cmd: ls]]
2. entity update  table headers [Field,Current,Proposed] rows [[Email,a@x,b@x],[Role,Eng,Staff Eng]]
3. declared thead table headers [Field,Current,Proposed] rows [[Email,a@x,b@x]]
4. data-driven    table headers [Risk Name,Severity]     rows [[Leak,high],[Cost,low]]
```

```
bun test src/__tests__/unit/template-card.test.ts   38 pass 0 fail   (was 35)
bun test src/__tests__/unit/                      1242 pass 0 fail
make pre-pr                                       all 7 gates clean
```

10 existing tests changed: each pinned the old blank-header behaviour, and each now asserts the fixed shape. Three tests added for the two cases that had no coverage at all — a declared `thead`, and the data-driven form.

## Risk

Medium — this changes what every notification card looks like in chat. No delivery-path change: the same `Card` goes to the same adapter, and the field/table limits and clamps are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification card links now open reliably using complete absolute URLs.
  * Removed duplicate links from notification subtitles and improved text formatting.
  * Improved escaping of notification content for clearer, safer rendering.

* **Improvements**
  * Tables in notification cards now render as structured fields with clearer headers and spacing.
  * Entity approval notifications now separate proposed changes from existing values, with layouts tailored to each change type.
  * Improved support for external links, nested content, and data-driven tables in rendered notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->