### PR TITLE
fix(mcp): resolve superseded interaction resource URIs to the current shell

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -266,19 +266,22 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);
   });
 
-  it('refuses every retired interaction URI instead of aliasing it', async () => {
-    // Retired ids used to be enumerated and re-served, each pinned to the
-    // template it was issued with (a packed self-contained one or the external
-    // one); that table was deleted along with the packed template. A host only
-    // asks for one when it re-reads a chat transcript old enough that its own
-    // cache has been evicted, and that card fails alone. Nothing current
-    // resolves through here, so a bump no longer has a list to forget.
+  it('serves the current template for a superseded interaction URI, and still refuses an unknown one', async () => {
+    // A host reads the resource id once, from `resources/list` and the
+    // tool-level `openai/outputTemplate` it captured at connect time, and
+    // caches it for the life of that connection. So every already-connected
+    // host asks for the PREVIOUS id the moment a bump lands. When that 404'd,
+    // the card died for everyone until each user hit Refresh on the connector
+    // (confirmed on prod: ChatGPT rendered `Failed to fetch template` with the
+    // sandbox iframe at height 0; refreshing the plugin fixed it with no code
+    // change). Every version resolves to the one shell we serve today.
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const currentVersion = Number(
       LOBU_INTERACTION_RESOURCE_URI.match(/\/v(\d+)\.html$/)?.[1]
     );
     expect(currentVersion).toBeGreaterThan(30);
-    const retired = [
+    const superseded = [
+      // The earliest ids predate the `.html` suffix.
       'ui://lobu/interaction/v1',
       'ui://lobu/interaction/v2',
       'ui://lobu/interaction/v7.html',
@@ -287,7 +290,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       `ui://lobu/interaction/v${currentVersion - 1}.html`,
     ];
 
-    for (const uri of retired) {
+    for (const uri of superseded) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
@@ -299,8 +302,40 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         token,
       });
       const body = await response.json();
-      // The card fails; the session does not. A retired id must not read as a
-      // successful empty render, which a host would cache and never retry.
+      const content = body.result?.contents?.[0];
+      // Echo back the id that was ASKED for, not the canonical one: that is
+      // the key the host files the result under.
+      expect(content?.uri).toBe(uri);
+      expect(content?.mimeType).toBe('text/html;profile=mcp-app');
+      // The same external shell the current id serves — not an empty render,
+      // which a host would cache and never retry.
+      expect(content?.text).toContain('mcp-app-external-stub');
+      expect(content?.text).toContain(
+        'src="http://localhost/mcp-apps/interaction/assets/app.js?v=js123"'
+      );
+      expect(content?._meta?.ui?.csp).toBeTruthy();
+    }
+
+    // Resolution is scoped to the interaction shell. Anything else is still an
+    // error, so a typo or a foreign `ui://` id cannot silently render Lobu's.
+    for (const uri of [
+      'ui://lobu/interaction/vNext.html',
+      'ui://lobu/interaction/v42.htm',
+      'ui://lobu/interaction',
+      'ui://lobu/dashboard/v1.html',
+      'ui://other/interaction/v1.html',
+    ]) {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: uri,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      const body = await response.json();
       expect(body.result).toBeUndefined();
       expect(JSON.stringify(body.error)).toContain(uri);
     }

--- a/packages/server/src/mcp-app-resource-uris.ts
+++ b/packages/server/src/mcp-app-resource-uris.ts
@@ -1,5 +1,6 @@
 /**
- * The canonical MCP App resource URI.
+ * The canonical MCP App resource URI, and the matcher that keeps older ones
+ * resolvable.
  *
  * The URI is the host's cache key for the template, and hosts cache both
  * successful and failed `resources/read` results under it. That is the only
@@ -13,12 +14,36 @@
  * an old shell still renders today's app; only its caching degrades. Bump for a
  * change to the shell's own structure, or to evict a poisoned host cache.
  *
- * Retired URIs are not resolvable. The old alias table re-served 37 retired
- * ids, each pinned to the template it was issued with — 21 to a packed
- * self-contained one, 16 to the external one. The packed template is gone with
- * this change, and nothing current resolves through a retired id, so the table
- * was deleted rather than re-pointed. A host that still asks for one is reading
- * a chat transcript old enough that its own cache has since been evicted; that
- * card fails alone, and nothing current is affected.
+ * **Every version resolves to the same template, and that is load-bearing.** A
+ * host does not read the id out of the tool result it just received; it reads
+ * the one it captured at connect time, from `resources/list` and the tool-level
+ * `openai/outputTemplate`. That handshake is cached for the life of the
+ * connection. So the moment a bump lands, every already-connected host asks for
+ * the *previous* id — and if that id 404s, the card dies for everyone until
+ * each user manually refreshes the connector, which nobody knows to do.
+ *
+ * Verified on prod 2026-08-20, same host and bundle, only the handshake
+ * differing: a stale ChatGPT connection rendered `Error loading app / Failed to
+ * fetch template` with the sandbox iframe collapsed to height 0, and Claude
+ * failed the same way without saying so. Clicking Refresh on the plugin — which
+ * re-fetches the handshake — made the identical prompt render at 400px.
+ *
+ * This is not a compatibility shim for old code paths. There is exactly one
+ * template; the packed self-contained variant is gone, and the 37-entry alias
+ * table that used to pin each retired id to the template it shipped with went
+ * with it. Resolving any version to the single template we serve today is the
+ * correct answer to "give me the Lobu interaction shell", and it makes a bump
+ * mean what the comment above claims it means: a cache eviction, not an outage.
  */
 export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v42.html';
+
+/**
+ * Any interaction-shell id, current or superseded. The `.html` suffix is
+ * optional because the earliest ids predate it, and a host that cached one is
+ * exactly the host this exists to keep working.
+ */
+const LOBU_INTERACTION_URI_PATTERN = /^ui:\/\/lobu\/interaction\/v\d+(?:\.html)?$/;
+
+export function isLobuInteractionResourceUri(uri: string): boolean {
+  return LOBU_INTERACTION_URI_PATTERN.test(uri);
+}

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -40,7 +40,10 @@ import {
   isValidAgentId,
   touchAgentLastUsed,
 } from './lobu/stores/postgres-stores';
-import { LOBU_INTERACTION_RESOURCE_URI } from './mcp-app-resource-uris';
+import {
+  isLobuInteractionResourceUri,
+  LOBU_INTERACTION_RESOURCE_URI,
+} from './mcp-app-resource-uris';
 import {
   clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
   mcpSessionMap,
@@ -377,7 +380,16 @@ function createServerForContext(
         contents: [{ uri, mimeType: 'text/markdown', text: skill.text }],
       };
     }
-    const app = MCP_APP_RESOURCES[uri];
+    // A host reads the id it captured from `resources/list` at connect time,
+    // not the one in the tool result it just received, so a superseded version
+    // still arrives here for the life of that connection. Resolve any of them
+    // to the one interaction shell we serve, and echo back the id that was
+    // asked for — that is what the host keys its cache on.
+    const app =
+      MCP_APP_RESOURCES[uri] ??
+      (isLobuInteractionResourceUri(uri)
+        ? MCP_APP_RESOURCES[LOBU_INTERACTION_RESOURCE_URI]
+        : undefined);
     if (!app) throw new Error(`Unknown resource: ${uri}`);
     const html = await renderMcpAppTemplate(
       app.appDir,


### PR DESCRIPTION
## What

`resources/read` now resolves any `ui://lobu/interaction/v<N>` id (the `.html` suffix optional, since the earliest ids predate it) to the single interaction shell we serve, echoing back the id that was asked for. Anything outside that shape still errors.

## Why

A host reads the MCP App resource id once, from `resources/list` and the tool-level `openai/outputTemplate` it captures at connect time, and caches it for the life of the connection. It does not re-read the id from the tool result in front of it. So the moment the canonical id is bumped, every already-connected host asks for the *previous* id.

Removing the alias table made that a hard 404, so a bump took the card down for every connected user until each of them manually hit Refresh on the connector, which nobody knows to do.

Confirmed on prod — same host, same bundle, only the handshake differing:

```
before plugin refresh   iframe h=0     "Error loading app | Failed to fetch template"
after plugin refresh    iframe h=400   "Saved in Lobu as memory #528866"
```

Claude failed the same way without saying so.

## Not the alias table coming back

That table pinned each retired id to the template it shipped with, including the packed self-contained variant, which is gone. There is exactly one template now, and the shell pins assets by content digest with the asset route already serving current bytes for a stale digest — an old shell renders today's app, it just caches worse. A bump now means what its comment always claimed: evict the host's cache, not break the card.

## Red / green

Reverting the resolver alone, keeping the test:

```
× serves the current template for a superseded interaction URI, and still refuses an unknown one
  → expected undefined to be 'ui://lobu/interaction/v1'
  Tests  1 failed | 26 passed (27)
```

With the resolver:

```
✓ src/__tests__/integration/mcp/mcp-app-resources.test.ts (27 tests) 8140ms
  Tests  27 passed (27)
```

`make pre-pr` clean. `make review-fix` (fable) made zero edits.

## Test plan

- [x] `bunx vitest run src/__tests__/integration/mcp/mcp-app-resources.test.ts` — 27/27
- [x] Mutation-tested: the new assertions fail for the right reason without the resolver
- [x] Negative cases covered — `vNext.html`, `v42.htm`, suffix-less path, foreign app id, foreign host id all still error
- [ ] Re-verify a stale ChatGPT and Claude connection renders after rollout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Superseded interaction resource links now continue to resolve to the current interaction interface.
  * Resource responses preserve the originally requested link for compatibility.
  * Invalid, unrelated, and unknown resource links continue to return appropriate errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->