### PR TITLE
feat(authz): govern merge with entity write rules, under its own name

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Write rules at the MERGE kernel.
+ *
+ * `deleteEntity` has been rule-governed since #2932, but `deleteEntity` is not
+ * the only writer of `entities.deleted_at`: `transitionEntityMergeRows`
+ * tombstones the losing row of a merge and asked nobody. A rule that freezes a
+ * row therefore stopped the delete and not the merge, which is the difference
+ * between a control and a suggestion.
+ *
+ * Merge gets its OWN reserved name rather than borrowing `$deleted`. Merging a
+ * duplicate into its canonical record is a correction, not a destruction, and a
+ * tenant must be able to freeze deletion without freezing dedupe. The
+ * discriminating test below is the one that proves the two are separable.
+ *
+ * Scope: the LOSER's tombstone only. The winner's metadata patch and the
+ * redirect repoint are deliberately not governed here — see the kernel comment
+ * in `entity-merge.ts`.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { compileEntityRule } from "../../../authz/entity-rule-executor";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import {
+	applyEntityChangeProposal,
+	proposeEntityMerge,
+} from "../../../tools/admin/entity-field-approval";
+import { createEntity } from "../../../utils/entity-management";
+import { applyMerge, applyMergeGroup } from "../../../utils/entity-merge";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+/** Blocks the merge itself, naming the merge — not the tombstone it implies. */
+const DENY_MERGE_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.deny("a posted invoice cannot be merged away");
+  }
+};
+`;
+
+/**
+ * The SEPARATION probe: freezes deletion and says nothing about merging. If
+ * merge reuses `$deleted`, this rule blocks a legitimate dedupe of a
+ * double-entered invoice — the exact false positive the reserved name avoids.
+ */
+const DENY_DELETE_ONLY_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$deleted") && row.next.$deleted) {
+    row.deny("a posted invoice cannot be deleted");
+  }
+};
+`;
+
+/** Asks for review of the merge, so the grant on the approval replay is exercised. */
+const ESCALATE_MERGE_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.escalate(["$merged_into"], "a merge needs a second pair of eyes");
+  }
+};
+`;
+
+const TEST_ENV = {} as Env;
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as unknown as ToolContext;
+}
+
+let denyMergeCompiled: string;
+let denyDeleteOnlyCompiled: string;
+let escalateMergeCompiled: string;
+
+async function seedType(
+	organizationId: string,
+	slug: string,
+	rulesCompiled: string | null,
+) {
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO entity_types (organization_id, slug, name, metadata_schema,
+                              rules_compiled, created_at, updated_at)
+    VALUES (${organizationId}, ${slug}, ${slug}, ${sql.json({ type: "object" })},
+            ${rulesCompiled}, current_timestamp, current_timestamp)
+  `;
+}
+
+async function readRow(id: number) {
+	const sql = getTestDb();
+	const rows = await sql<
+		{ deleted_at: Date | null; merged_into: string | number | null }[]
+	>`
+    SELECT deleted_at, merged_into FROM entities WHERE id = ${id}
+  `;
+	const row = rows[0];
+	// bigint comes back as text on one driver path and a number on the other.
+	return {
+		deleted_at: row.deleted_at,
+		merged_into: row.merged_into == null ? null : Number(row.merged_into),
+	};
+}
+
+/**
+ * An org with a ruled `invoice` type and `count` invoices in it. Creates run
+ * through the real entry point, so a fixture cannot be born in a state its own
+ * rule forbids.
+ */
+async function seedInvoices(rule: string | null, count = 2) {
+	const org = await createTestOrganization({ name: "Merge seam" });
+	const user = await createTestUser();
+	await addUserToOrganization(user.id, org.id, "owner");
+	await seedType(org.id, "invoice", rule);
+
+	const invoices = [];
+	for (let i = 0; i < count; i++) {
+		invoices.push(
+			await createEntity({
+				entity_type: "invoice",
+				name: `INV-${i + 1}`,
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: { status: "posted", amount: 100 },
+			} as Parameters<typeof createEntity>[0]),
+		);
+	}
+	return { org, user, invoices };
+}
+
+describe("write rules at the merge kernel", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+		[denyMergeCompiled, denyDeleteOnlyCompiled, escalateMergeCompiled] =
+			await Promise.all([
+				compileEntityRule(DENY_MERGE_RULE),
+				compileEntityRule(DENY_DELETE_ONLY_RULE),
+				compileEntityRule(ESCALATE_MERGE_RULE),
+			]);
+	}, 60_000);
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("blocks a merge when a rule denies $merged_into", async () => {
+		const { org, user, invoices } = await seedInvoices(denyMergeCompiled);
+		const [loser, winner] = invoices;
+
+		await expect(
+			applyMerge({
+				orgId: org.id,
+				loserId: loser.id,
+				winnerId: winner.id,
+				mergedBy: user.id,
+			}),
+		).rejects.toThrow(/cannot be merged away/);
+
+		// The whole transaction rolled back: no tombstone, no redirect.
+		const after = await readRow(loser.id);
+		expect(after.deleted_at).toBeNull();
+		expect(after.merged_into).toBeNull();
+	}, 60_000);
+
+	it("allows a merge when the rule only freezes $deleted", async () => {
+		// THE SEPARATION PROOF. Deleting this invoice is forbidden; merging a
+		// duplicate into its canonical record is a correction and must still work.
+		const { org, user, invoices } = await seedInvoices(denyDeleteOnlyCompiled);
+		const [loser, winner] = invoices;
+
+		await applyMerge({
+			orgId: org.id,
+			loserId: loser.id,
+			winnerId: winner.id,
+			mergedBy: user.id,
+		});
+
+		const after = await readRow(loser.id);
+		expect(after.deleted_at).not.toBeNull();
+		expect(after.merged_into).toBe(winner.id);
+	}, 60_000);
+
+	it("fails a whole group and names the offending loser", async () => {
+		const { org, user, invoices } = await seedInvoices(denyMergeCompiled, 3);
+		const [loserA, loserB, winner] = invoices;
+
+		const err = await applyMergeGroup({
+			orgId: org.id,
+			loserIds: [loserA.id, loserB.id],
+			winnerId: winner.id,
+			mergedBy: user.id,
+		}).catch((e: unknown) => e as Error);
+
+		expect(err).toBeInstanceOf(Error);
+		// Naming the row is what makes a wedged resolution batch diagnosable.
+		expect(err.message).toMatch(new RegExp(`\\b${loserA.id}\\b`));
+
+		// Atomic: the second loser is untouched even though its own merge was legal.
+		for (const id of [loserA.id, loserB.id]) {
+			const after = await readRow(id);
+			expect(after.deleted_at).toBeNull();
+			expect(after.merged_into).toBeNull();
+		}
+	}, 60_000);
+
+	it("applies a merge a human approved, waiving the escalate it asked for", async () => {
+		const { org, user, invoices } = await seedInvoices(escalateMergeCompiled);
+		const [loser, winner] = invoices;
+
+		// Unapproved: the rule asks for review and the merge fails closed.
+		await expect(
+			applyMerge({
+				orgId: org.id,
+				loserId: loser.id,
+				winnerId: winner.id,
+				mergedBy: user.id,
+			}),
+		).rejects.toThrow(/second pair of eyes/);
+
+		// Approved: the grant covers exactly the field the card was minted for.
+		await applyMergeGroup({
+			orgId: org.id,
+			loserIds: [loser.id],
+			winnerId: winner.id,
+			mergedBy: user.id,
+			approvedFields: ["$merged_into"],
+		});
+
+		const after = await readRow(loser.id);
+		expect(after.merged_into).toBe(winner.id);
+	}, 60_000);
+
+	it("applies an approved merge CARD through the real propose->persist->apply path", async () => {
+		// The direct-call test above proves the kernel honours a grant. This one
+		// proves the approval path actually SENDS the right one: swap the literal
+		// in `entity-field-approval.ts` and only this test notices.
+		const sql = getTestDb();
+		const { org, user, invoices } = await seedInvoices(escalateMergeCompiled);
+		const [loser, winner] = invoices;
+		const ctx = ctxFor(org.id, user.id);
+
+		await proposeEntityMerge(
+			ctx,
+			{
+				entity_ids: [loser.id],
+				winner_entity_id: winner.id,
+			} as Parameters<typeof proposeEntityMerge>[1],
+			[
+				{ id: loser.id, keys: { name: ["inv-1"] } },
+				{ id: winner.id, keys: { name: ["inv-2"] } },
+			],
+		);
+
+		// Read back what the card actually stored — a hand-built proposal would
+		// pass with the propose->persist->apply plumbing severed.
+		const [queued] = await sql<{ action_input: unknown }[]>`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${org.id}
+      ORDER BY id DESC LIMIT 1
+    `;
+		const proposal = (
+			typeof queued.action_input === "string"
+				? JSON.parse(queued.action_input)
+				: queued.action_input
+		) as Record<string, unknown>;
+		expect(proposal.operation).toBe("merge");
+
+		// Applied inside a transaction, because that is what production does.
+		await sql.begin(async (tx) => {
+			await applyEntityChangeProposal(proposal as never, ctx, TEST_ENV, tx);
+		});
+
+		const after = await readRow(loser.id);
+		expect(after.merged_into).toBe(winner.id);
+	}, 60_000);
+
+	it("leaves an unruled type exactly as cheap as before", async () => {
+		const { org, user, invoices } = await seedInvoices(null);
+		const [loser, winner] = invoices;
+
+		await applyMerge({
+			orgId: org.id,
+			loserId: loser.id,
+			winnerId: winner.id,
+			mergedBy: user.id,
+		});
+
+		expect((await readRow(loser.id)).merged_into).toBe(winner.id);
+	}, 60_000);
+});

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -57,20 +57,21 @@ export interface EntityRowValidationVerdict {
  * Throwing rather than returning a verdict is deliberate: it makes failing
  * closed the DEFAULT for every caller. Only a caller with approval machinery to
  * route an escalation into opts in by catching this and reading {@link verdict}
- * — `updateEntity`, and automation promotion (`promote-keyed-entities`). Merge,
- * link auto-create and eval scaffolding have nowhere to queue a card, so for
- * them a rule that asked for review must stop the write — which is exactly what
- * an uncaught throw does.
+ * — `updateEntity`, and automation promotion (`promote-keyed-entities`). Link
+ * auto-create and eval scaffolding have nowhere to queue a card, so for them a
+ * rule that asked for review must stop the write — which is exactly what an
+ * uncaught throw does.
  *
- * Soft-delete (`deleteEntity`) is the in-between case, and the distinction is
- * WHO asked for the review. The POLICY gate can queue a delete card, and
- * applying that card grants `$deleted` — the one field a delete card can be said
- * to have approved — so a rule escalating on `$deleted` no longer dead-ends an
- * approval a human already gave. But a rule escalate does not itself mint a
- * card: `manage_entity`'s delete path has no `EntityRowValidationError` catch
- * (only its CREATE path does), so an escalate with no policy card behind it
- * fails closed like merge and link auto-create. A `deny` stops the delete either
- * way, and a hard delete never reaches this seam at all.
+ * Soft-delete (`deleteEntity`) and merge (`applyMergeInTransaction`) are the
+ * in-between cases, and the distinction is WHO asked for the review. The POLICY
+ * gate can queue a delete or merge card, and applying that card grants
+ * `$deleted` or `$merged_into` — the one field each card can be said to have
+ * approved — so a rule escalating on it no longer dead-ends an approval a human
+ * already gave. But a rule escalate does not itself mint a card:
+ * `manage_entity`'s delete and merge paths have no `EntityRowValidationError`
+ * catch (only its CREATE path does), so an escalate with no policy card behind
+ * it fails closed like link auto-create. A `deny` stops the write either way,
+ * and a hard delete never reaches this seam at all.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;
@@ -102,13 +103,23 @@ const UNGOVERNED_COLUMNS: ReadonlySet<string> = new Set([
 	"contentHash",
 ]);
 
-/** Reserved `$`-names a rule sees for non-metadata columns. */
+/**
+ * Reserved `$`-names a rule sees for non-metadata columns.
+ *
+ * This is the rule VOCABULARY, not the shape of `EntityRowPatch`. `mergedInto`
+ * has no key on that patch — the merge ledger is written by
+ * `transitionEntityMergeRows`, never `patchEntityRows` — so `flatten` never
+ * finds it and only the merge seam proposes it. Keeping it here is what makes
+ * `$merged_into` one namespace with the rest, so a rule reads
+ * `row.next.$merged_into` exactly as it reads `row.next.$deleted`.
+ */
 const RESERVED_COLUMN_NAMES: Readonly<Record<string, string>> = {
 	name: "$name",
 	slug: "$slug",
 	parentId: "$parent_id",
 	content: "$content",
 	softDelete: "$deleted",
+	mergedInto: "$merged_into",
 };
 
 function touchesGovernedColumn(patch: EntityRowPatch): boolean {
@@ -147,6 +158,7 @@ interface CommittedRow {
 	parent_id: string | number | null;
 	content: string | null;
 	deleted_at: Date | null;
+	merged_into: string | number | null;
 }
 
 function committedState(row: CommittedRow): Record<string, unknown> {
@@ -162,6 +174,7 @@ function committedState(row: CommittedRow): Record<string, unknown> {
 		$parent_id: row.parent_id == null ? null : Number(row.parent_id),
 		$content: row.content ?? null,
 		$deleted: row.deleted_at != null,
+		$merged_into: row.merged_into == null ? null : Number(row.merged_into),
 	};
 }
 
@@ -260,6 +273,32 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 	// Fast path: nothing a rule could govern, so no read and no evaluation.
 	if (!touchesGovernedColumn(patch)) return branded;
 
+	await enforceCompiledRules({
+		tx,
+		ids,
+		flatPatch: flatten(patch, patch.metadata),
+		approvedFields,
+	});
+	return branded;
+}
+
+/**
+ * Read every target row, group by compiled rule, evaluate, and enforce the
+ * verdicts. Shared by the patch seam and the merge seam so the two cannot drift
+ * on how a deny is logged or how a grant waives an escalate.
+ *
+ * Takes an ALREADY-FLAT patch, because the two seams flatten differently: an
+ * ordinary patch maps its columns through `RESERVED_COLUMN_NAMES`, while a
+ * merge proposes exactly one reserved name and has no metadata of its own.
+ */
+async function enforceCompiledRules(params: {
+	tx: DbClient;
+	ids: number[];
+	flatPatch: Record<string, unknown>;
+	approvedFields: readonly string[];
+}): Promise<void> {
+	const { tx, ids, flatPatch, approvedFields } = params;
+
 	// The pool runs with `fetch_types: false`, so a raw JS array binds as
 	// "malformed array literal". Bind the formatted `{n,n}` text and cast, exactly
 	// as `patchEntityRows` itself does.
@@ -268,7 +307,7 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 	// costs no extra round trip.
 	const rows = await tx<CommittedRow>`
     SELECT e.id, e.metadata, e.name, e.slug, e.parent_id, e.content,
-           e.deleted_at, et.rules_compiled
+           e.deleted_at, e.merged_into, et.rules_compiled
     FROM entities e
     JOIN entity_types et ON et.id = e.entity_type_id
     WHERE e.id = ANY(${pgBigintArray(ids)}::bigint[])
@@ -278,7 +317,6 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 	// isolate at all, which keeps an unruled org's writes exactly as cheap as
 	// they are today.
 	const groups = new Map<string, { ids: number[]; rows: EntityRuleRow[] }>();
-	const flatPatch = flatten(patch, patch.metadata);
 	for (const row of rows) {
 		if (!row.rules_compiled) continue;
 		const group = groups.get(row.rules_compiled) ?? { ids: [], rows: [] };
@@ -286,7 +324,7 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 		group.rows.push({ committed: committedState(row), patch: flatPatch });
 		groups.set(row.rules_compiled, group);
 	}
-	if (groups.size === 0) return branded;
+	if (groups.size === 0) return;
 
 	for (const [compiled, group] of groups) {
 		const verdicts = await runEntityRules({
@@ -339,7 +377,51 @@ export async function validateEntityRowPatchGrantingApprovedFields(params: {
 			}
 		}
 	}
-	return branded;
+}
+
+/**
+ * Validate the MERGE of a losing row into a winner.
+ *
+ * Merge does NOT borrow `$deleted`. A merge tombstones the loser as an
+ * implementation detail of the redirect, but the act is a consolidation, not a
+ * destruction: the row's data survives, reachable through `merged_into`, and
+ * `applyUnmerge` can put it back. A tenant must be able to freeze deletion of a
+ * posted invoice without also freezing the dedupe of a double-entered one, so
+ * the merge gets its own reserved name and a rule says which it means.
+ *
+ * Scope is the LOSER's transition only. The winner's metadata patch is NOT
+ * validated here: `mergeEntityState` appends the loser's name to
+ * `metadata.aliases` on every merge, so validating the winner would present a
+ * metadata change to the rule engine every single time — a rule freezing a
+ * canonical row would make it unable to absorb any duplicate at all. That needs
+ * a decision about what approving a merge grants, not a call added here. The
+ * redirect repoint (`expectedMergedInto` non-null) is likewise out of scope: it
+ * only ever touches rows that are already tombstoned.
+ *
+ * Same handle contract as the patch seam — the caller's transaction, never
+ * `getDb()`, because `applyMergeInTransaction` already holds the row locks this
+ * verdict is judged under.
+ *
+ * @throws EntityRowValidationError when a rule denies or escalates the merge.
+ */
+export async function validateEntityRowMergeGrantingApprovedFields(params: {
+	tx: DbClient;
+	/** The rows being merged AWAY. The winner is not judged here. */
+	loserIds: number[];
+	/** The canonical row they are being pointed at. */
+	mergedInto: number;
+	/** REQUIRED, as on the patch seam. `["$merged_into"]` when this call is the
+	 * application of a merge a human approved. */
+	approvedFields: readonly string[];
+}): Promise<void> {
+	const { tx, loserIds, mergedInto, approvedFields } = params;
+	if (loserIds.length === 0) return;
+	await enforceCompiledRules({
+		tx,
+		ids: loserIds,
+		flatPatch: { [RESERVED_COLUMN_NAMES.mergedInto]: mergedInto },
+		approvedFields,
+	});
 }
 
 /**

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -1375,7 +1375,14 @@ export async function applyEntityChangeProposal(
 				evidence: resolved.evidence,
 			},
 		};
-		return applyMergeGroupInTransaction(params, db);
+		// This IS the approval, scoped exactly as the delete path is: a merge card
+		// approves the merge and nothing else, so the grant is the one reserved
+		// name the merge seam proposes. A `deny` still throws — approval cannot
+		// make an illegal merge legal.
+		return applyMergeGroupInTransaction(
+			{ ...params, approvedFields: ["$merged_into"] },
+			db,
+		);
 	}
 	const deleteProposal = asDeleteProposal(proposal);
 	// The grant comes from the write this card REPLAYS. A delete card's entire

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -559,11 +559,21 @@ export async function patchEntityRows(params: {
  * Merge and unmerge are one compound transaction — never run `runMutationGate`
  * from here.
  *
- * KNOWN GAP: a type's write rules do not cover this path either, so a rule that
- * freezes a row does not stop that row being merged away or restored. Merge is a
- * topology change rather than a field edit — `committed`/`patch` do not describe
- * it, so a rule written against fields could not judge it as-is. Closing this
- * needs a merge-shaped verdict, not a call to `validateEntityRowPatch` here.
+ * Write rules are enforced by the CALLER, not here. `applyMergeInTransaction`
+ * runs `validateEntityRowMergeGrantingApprovedFields` over the losing row —
+ * under the locks it already holds and before any write — proposing the
+ * reserved name `$merged_into`. Merge deliberately does NOT reuse `$deleted`:
+ * the tombstone is an implementation detail of the redirect, and a tenant must
+ * be able to freeze deletion without freezing dedupe.
+ *
+ * REMAINING GAP: the winner's metadata patch and the redirect repoint are still
+ * ungoverned, and unmerge (`liveness: "live"`) is deliberately left free so a
+ * freeze cannot strand a row tombstoned. The winner is the hard one:
+ * `mergeEntityState` appends the loser's name to `metadata.aliases` on every
+ * merge, so governing it would present a metadata change to the rule engine on
+ * every single merge — a rule freezing a canonical row would make it unable to
+ * absorb any duplicate. That needs a decision about what approving a merge
+ * grants, not a call added here.
  */
 export async function transitionEntityMergeRows(params: {
 	tx: DbClient;

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -36,6 +36,7 @@ import {
 	type ResolutionEvidence,
 } from "../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../entity-resolution/staleness";
+import { validateEntityRowMergeGrantingApprovedFields } from "../authz/entity-row-validation";
 import { transitionEntityMergeRows } from "./entity-management";
 import logger from "./logger";
 import {
@@ -61,6 +62,13 @@ export interface ApplyMergeParams {
   /** Who triggered the merge (agent id / user id) — for the tombstone audit. */
   mergedBy: string;
 	resolution?: MergeResolutionProvenance;
+	/**
+	 * Set ONLY when this call is the application of a merge a human already
+	 * approved, so a rule that escalates on the merge does not escalate the very
+	 * merge its escalation asked for. `["$merged_into"]` is the whole vocabulary
+	 * a merge card can be said to have approved.
+	 */
+	approvedFields?: readonly string[];
 }
 
 export interface ApplyMergeResult {
@@ -81,6 +89,8 @@ export interface ApplyMergeGroupParams {
   mergedBy: string;
 	resolution?: MergeResolutionProvenance;
 	expectedResolutionFingerprint?: string;
+	/** See {@link ApplyMergeParams.approvedFields}. */
+	approvedFields?: readonly string[];
 }
 
 /**
@@ -146,6 +156,7 @@ export async function applyMergeGroupInTransaction(
         winnerId: params.winnerId,
         mergedBy: params.mergedBy,
 				resolution: params.resolution,
+				approvedFields: params.approvedFields,
       },
       tx,
     );
@@ -240,6 +251,19 @@ async function applyMergeInTransaction(
 			"applyMerge: cannot merge entities of different entity types",
 		);
   }
+
+	// The type's write rules judge the merge, under the locks taken above and
+	// BEFORE any row is written — a denied merge should cost no work, and the
+	// verdict must be read from the same snapshot the writes commit into.
+	//
+	// The loser only. See `validateEntityRowMergeGrantingApprovedFields` for why
+	// the winner's metadata and the redirect repoint are deliberately excluded.
+	await validateEntityRowMergeGrantingApprovedFields({
+		tx,
+		loserIds: [loserId],
+		mergedInto: winnerId,
+		approvedFields: params.approvedFields ?? [],
+	});
 
 	const identitiesBefore = await tx<{
 		id: number;

--- a/scripts/check-security-patterns.sh
+++ b/scripts/check-security-patterns.sh
@@ -16,10 +16,10 @@
 #     packages/server/src/gateway/orchestration/. WS3 hardening replaced this
 #     with a strict attribute-ref validator; the loose form must stay out.
 #   - Imports of the GRANTING entity-row validators
-#     (`validateEntityRow{Patch,Insert}GrantingApprovedFields`) outside the
-#     approval apply path (entity-field-approval.ts) and the write kernel
-#     (entity-management.ts) — the only importers allowed to waive a rule
-#     escalation.
+#     (`validateEntityRow{Patch,Insert,Merge}GrantingApprovedFields`) outside
+#     the approval apply path (entity-field-approval.ts) and the write kernels
+#     (entity-management.ts, entity-merge.ts) — the only importers allowed to
+#     waive a rule escalation.
 #
 # Out of scope: the postgres.js `.unsafe(query, params)` form is the SAFE
 # parameterized API — flagging it would be noise. We rely on the
@@ -122,12 +122,13 @@ fi
 # staged/committed (the CI case) but not while untracked in a dirty worktree.
 echo "  -> granting validator imports outside the approval apply path"
 HITS=$(
-  git grep -nE 'validateEntityRow(Patch|Insert)GrantingApprovedFields' -- \
+  git grep -nE 'validateEntityRow(Patch|Insert|Merge)GrantingApprovedFields' -- \
     'packages/' \
     2>/dev/null \
     | grep -E '\.tsx?:' \
     | grep -v '^packages/server/src/tools/admin/entity-field-approval.ts:' \
     | grep -v '^packages/server/src/utils/entity-management.ts:' \
+    | grep -v '^packages/server/src/utils/entity-merge.ts:' \
     | grep -v '^packages/server/src/authz/entity-row-validation.ts:' \
     | grep -v '/__tests__/' \
     | filter_allowlist


### PR DESCRIPTION
## Summary
- `deleteEntity` has been rule-governed since #2932, but it is not the only writer of `entities.deleted_at`. `transitionEntityMergeRows` tombstones the losing row of a merge and asked nobody, so a rule that froze a row stopped the delete and not the merge.
- Merge gets its **own** reserved name, `$merged_into`, rather than borrowing `$deleted`. The tombstone is an implementation detail of the redirect — the loser's data survives via `merged_into` and `applyUnmerge` puts it back — so merging a double-entered posted invoice into its canonical record is a correction, not a destruction. A tenant must be able to freeze deletion without freezing dedupe.
- Validation runs in `applyMergeInTransaction` after the row locks are taken and before any write; the approval replay passes `["$merged_into"]` exactly as the delete path passes `["$deleted"]`.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bunx vitest run` (new suite + all merge/resolution suites + whole authz integration dir)
- [x] Bug fix: red→fix→green outputs pasted below

### Red → green

```
BEFORE:  Tests  3 failed | 2 passed (5)   ← rule not enforced at the merge kernel
AFTER:   Tests  6 passed (6)
```

### Mutation testing

The tests are load-bearing, not decorative:

| Mutation | Result |
|---|---|
| drop the `validateEntityRowMergeGrantingApprovedFields` call from the kernel | 3 tests fail |
| swap the replay grant `["$merged_into"]` → `["$deleted"]` | 1 test fails |
| drop the replay grant entirely | 1 test fails |

The middle two only fail because of a test added after the first mutation pass **survived**: the original suite called `applyMergeGroup` directly, proving the kernel honours *a* grant but never that the approval path *sends the right one*. The added test drives the real propose → persist → apply round trip and reads the card back out of `runs.action_input`.

### Regression sweep

```
authz integration dir:            26 files, 223 tests passed
merge + resolution suites:         5 files,  59 tests passed
```

## Notes

**The discriminating test is the point of the design**: a rule denying `$deleted` must **not** block a merge, while one denying `$merged_into` must. That is what justifies the new reserved name existing.

**Deliberately out of scope**, documented at the kernel rather than left implicit:
- The **winner's metadata patch**. `mergeEntityState` appends the loser's name to `metadata.aliases` on *every* merge, so governing the winner would present a metadata change to the rule engine every single time — a rule freezing a canonical row would make it unable to absorb any duplicate at all. That needs a decision about what approving a merge grants, not a call added here.
- The **redirect repoint** (`entity-merge.ts:418`), which only ever touches already-tombstoned rows.
- **Unmerge**, left free so a freeze cannot strand a row tombstoned with no way back.

**Blast radius is zero today.** No entity type in production declares rules (`rules_source`/`rules_compiled` are null on all 261), so no live behavior changes; the unruled path early-outs before any rule read. This is the cheapest possible moment to close the bypass — the window shuts the moment a tenant declares a rule, after which changing what `$deleted` means on a merge would be a breaking semantic change to their control.

`enforceCompiledRules` is extracted so the patch seam and merge seam cannot drift on how a deny is logged or how a grant waives an escalate. `scripts/check-security-patterns.sh` was widened to `(Patch|Insert|Merge)` so the new granting export is inside the same module boundary.

Follow-up: `manage_entity`'s merge path has no `dry_run`, so unlike delete there is no preview of a rule refusal.