### PR TITLE
fix(automations): bound audit-mediated cascades and verify declared sources

### DIFF
--- a/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
+++ b/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
@@ -469,4 +469,113 @@ describe('audit rows inherit the producing run causal chain', () => {
     expect(queued[0]!.depth).toBe(1);
     expect(queued[0]!.causalAutomationIds).toEqual([automationId]);
   });
+
+  it('starts a fresh chain when the run was woken by a connector event', async () => {
+    const { organizationId, automationId } = await subscriber('Connector Org', [
+      'connection.deleted',
+    ]);
+    const sql = getTestDb();
+    // A connector-triggered run: `approved_input` HAS trigger signals, but none
+    // of them workspace ones. Deriving ancestry from these would produce an
+    // EMPTY root set, which `activateWorkspaceEventTask` rejects — the row must
+    // instead start its own chain.
+    const rows = (await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, action_key, status, automation_id,
+        approved_input
+      ) VALUES (
+        ${organizationId}, 'automation', 'run_automation', 'running',
+        ${automationId},
+        ${sql.json({
+          trigger_signals: [
+            {
+              connector_key: 'gmail',
+              event_type: 'message.received',
+              delivery_id: 'gmail:msg-1',
+              label: 'New message',
+              input_text: 'New message received',
+            },
+          ],
+        })}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    await runWithActingAutomation(
+      { automationId, runId: Number(rows[0]!.id) },
+      async () => {
+        recordLifecycleEvent({
+          organizationId,
+          entityType: 'connection',
+          op: 'deleted',
+          entityId: 99,
+          summary: 'Connection deleted by a connector-triggered run',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+    );
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.rootEventIds).toHaveLength(1);
+    expect(queued[0]!.depth).toBe(1);
+    expect(queued[0]!.causalAutomationIds).toEqual([automationId]);
+  });
+
+  it('does not inherit through a window belonging to another Automation', async () => {
+    const { organizationId, automationId, api, agentId } = await subscriber(
+      'Foreign Window Org',
+      ['connection.deleted']
+    );
+    const upstreamAutomationId = await secondAutomation(api, agentId, 'upstream');
+    const windowId = 4711;
+    const sql = getTestDb();
+    // The run behind the declared window belongs to the OTHER Automation.
+    // `automation_source.window_id` is caller input, so inheriting through it
+    // would plant that Automation into this row's causal path — suppressing it
+    // downstream. The run lookup is scoped to the producer and finds nothing.
+    await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, action_key, status, automation_id,
+        window_id, approved_input
+      ) VALUES (
+        ${organizationId}, 'automation', 'run_automation', 'running',
+        ${upstreamAutomationId}, ${windowId},
+        ${sql.json({
+          trigger_signals: [
+            {
+              kind: 'event',
+              source: 'workspace',
+              event_id: 7575,
+              event_type: 'connection.deleted',
+              delivery_id: 'workspace-event:7575',
+              occurred_at: new Date().toISOString(),
+              root_event_ids: [7575],
+              causal_automation_ids: [upstreamAutomationId],
+              depth: 5,
+            },
+          ],
+        })}
+      )
+    `;
+
+    await runWithActingAutomation(
+      { automationId, runId: null, windowId },
+      async () => {
+        recordLifecycleEvent({
+          organizationId,
+          entityType: 'connection',
+          op: 'deleted',
+          entityId: 111,
+          summary: 'Connection deleted with a foreign declared window',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+    );
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued[0]!.depth).toBe(1);
+    expect(queued[0]!.rootEventIds).toHaveLength(1);
+    expect(queued[0]!.causalAutomationIds).toEqual([automationId]);
+  });
 });

--- a/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
+++ b/packages/server/src/__tests__/integration/automations/platform-event-enqueue.test.ts
@@ -12,7 +12,10 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
 import { createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
-import { recordLifecycleEvent } from '../../../utils/insert-event';
+import {
+  insertConnectionlessAuditEvent,
+  recordLifecycleEvent,
+} from '../../../utils/insert-event';
 import { runWithActingAutomation } from '../../../utils/acting-automation-context';
 import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../../../scheduled/task-definitions';
 
@@ -54,7 +57,23 @@ async function subscriber(name: string, eventTypes: string[]) {
   return {
     organizationId: workspace.org.id,
     automationId: Number(created.automation_id),
+    api,
+    agentId: agent.agentId,
   };
+}
+
+/** A second real Automation in the same org — `events.automation_id` has a FK. */
+async function secondAutomation(
+  api: Awaited<ReturnType<typeof subscriber>>['api'],
+  agentId: string,
+  slug: string
+): Promise<number> {
+  const created = (await api.automations.create({
+    slug,
+    prompt: 'Upstream automation.',
+    agent_id: agentId,
+  })) as { automation_id: string };
+  return Number(created.automation_id);
 }
 
 /** Activation tasks queued for an org, newest last. */
@@ -147,7 +166,7 @@ describe('platform event activation enqueue', () => {
     // The same audit write, but driven by the subscribing Automation — the
     // shape that would otherwise loop forever, since every self-write mints a
     // fresh root at depth 1 and the depth cap never bites.
-    await runWithActingAutomation(automationId, async () => {
+    await runWithActingAutomation({ automationId }, async () => {
       recordLifecycleEvent({
         organizationId,
         entityType: 'connection',
@@ -170,7 +189,7 @@ describe('platform event activation enqueue', () => {
       'connection.deleted',
     ]);
 
-    await runWithActingAutomation(automationId, async () => {
+    await runWithActingAutomation({ automationId }, async () => {
       recordLifecycleEvent({
         organizationId,
         entityType: 'connection',
@@ -221,5 +240,233 @@ describe('platform event activation enqueue', () => {
       LIMIT 1
     `;
     expect(rows[0]!.automation_id).toBeNull();
+  });
+});
+
+/**
+ * Inheriting the producing run's chain.
+ *
+ * Naming only the immediate producer closes the SELF loop but leaves a mutual
+ * one open: A writes (causal `[A]`) wakes B, B writes (causal `[B]`) wakes A,
+ * forever, because every audit row starts a fresh root at depth 1 and the
+ * depth cap therefore never accrues. These cover the inheritance that makes
+ * each hop a real step in one chain.
+ */
+describe('audit rows inherit the producing run causal chain', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  /** A run for `automationId` that was itself woken by a workspace event. */
+  async function runWokenByWorkspaceEvent(args: {
+    organizationId: string;
+    automationId: number;
+    upstreamAutomationId: number;
+    rootEventId: number;
+    depth: number;
+  }): Promise<{ runId: number }> {
+    const sql = getTestDb();
+    const rows = (await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, action_key, status, automation_id,
+        approved_input
+      ) VALUES (
+        ${args.organizationId}, 'automation', 'run_automation', 'running',
+        ${args.automationId},
+        ${sql.json({
+          trigger_signals: [
+            {
+              kind: 'event',
+              source: 'workspace',
+              event_id: args.rootEventId,
+              event_type: 'connection.deleted',
+              delivery_id: `workspace-event:${args.rootEventId}`,
+              occurred_at: new Date().toISOString(),
+              root_event_ids: [args.rootEventId],
+              causal_automation_ids: [args.upstreamAutomationId],
+              depth: args.depth,
+            },
+          ],
+        })}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    return { runId: Number(rows[0]!.id) };
+  }
+
+  it('accrues depth and ancestry instead of minting a fresh root', async () => {
+    const { organizationId, automationId, api, agentId } = await subscriber(
+      'Chain Org',
+      ['connection.deleted']
+    );
+    const upstreamAutomationId = await secondAutomation(api, agentId, 'upstream');
+    const rootEventId = 4242;
+    const { runId } = await runWokenByWorkspaceEvent({
+      organizationId,
+      automationId,
+      upstreamAutomationId,
+      rootEventId,
+      depth: 1,
+    });
+
+    await runWithActingAutomation({ automationId, runId }, async () => {
+      recordLifecycleEvent({
+        organizationId,
+        entityType: 'connection',
+        op: 'deleted',
+        entityId: 77,
+        summary: 'Connection deleted inside a woken run',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued).toHaveLength(1);
+    const activation = queued[0]!;
+    // Depth ACCRUES — this is the property that makes MAX_WORKSPACE_EVENT_DEPTH
+    // reachable across audit-mediated hops. A fresh root would report 1.
+    expect(activation.depth).toBe(2);
+    // The chain keeps its original root rather than restarting at this row.
+    expect(activation.rootEventIds).toEqual([rootEventId]);
+    // Both the upstream Automation and this producer are excluded downstream,
+    // which is what stops the mutual A -> B -> A cascade.
+    expect(activation.causalAutomationIds).toEqual([
+      upstreamAutomationId,
+      automationId,
+    ]);
+  });
+
+  it('resolves the run through the declared window when the lane has no run id', async () => {
+    const { organizationId, automationId, api, agentId } = await subscriber(
+      'Window Org',
+      ['connection.deleted']
+    );
+    const upstreamAutomationId = await secondAutomation(api, agentId, 'upstream');
+    const rootEventId = 5353;
+    const windowId = 909;
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, action_key, status, automation_id,
+        window_id, approved_input
+      ) VALUES (
+        ${organizationId}, 'automation', 'run_automation', 'running',
+        ${automationId}, ${windowId},
+        ${sql.json({
+          trigger_signals: [
+            {
+              kind: 'event',
+              source: 'workspace',
+              event_id: rootEventId,
+              event_type: 'connection.deleted',
+              delivery_id: `workspace-event:${rootEventId}`,
+              occurred_at: new Date().toISOString(),
+              root_event_ids: [rootEventId],
+              causal_automation_ids: [upstreamAutomationId],
+              depth: 3,
+            },
+          ],
+        })}
+      )
+    `;
+
+    // The agent and device lanes carry `actingRunId = null`; only the declared
+    // `automation_source.window_id` reaches the run.
+    await runWithActingAutomation(
+      { automationId, runId: null, windowId },
+      async () => {
+        recordLifecycleEvent({
+          organizationId,
+          entityType: 'connection',
+          op: 'deleted',
+          entityId: 88,
+          summary: 'Connection deleted by an agent-lane run',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+    );
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued[0]!.depth).toBe(4);
+    expect(queued[0]!.rootEventIds).toEqual([rootEventId]);
+  });
+
+  it('does not inherit when an explicit producer disagrees with the ambient scope', async () => {
+    const { organizationId, automationId, api, agentId } = await subscriber(
+      'Mismatch Org',
+      ['connection.deleted']
+    );
+    // A REAL second Automation: `events.automation_id` carries a foreign key,
+    // so a fabricated id would fail the insert rather than test attribution.
+    const otherAutomationId = await secondAutomation(api, agentId, 'other');
+    const { runId } = await runWokenByWorkspaceEvent({
+      organizationId,
+      automationId,
+      upstreamAutomationId: automationId,
+      rootEventId: 6464,
+      depth: 2,
+    });
+
+    // Inside the scope of `automationId`'s run, but the row is explicitly
+    // attributed to a DIFFERENT Automation. Inheriting the surrounding run's
+    // chain would put another Automation's ancestry on this row.
+    await runWithActingAutomation({ automationId, runId }, async () => {
+      await insertConnectionlessAuditEvent(
+        {
+          entityIds: [],
+          organizationId,
+          originId: `explicit_producer_${Date.now()}`,
+          title: 'Connection deleted, explicitly attributed',
+          semanticType: 'change',
+          automationId: otherAutomationId,
+          metadata: {
+            category: 'lifecycle',
+            entity_type: 'connection',
+            op: 'deleted',
+            entity_id: '55',
+          },
+        },
+        { subject: 'connection', op: 'deleted' }
+      );
+    });
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued[0]!.causalAutomationIds).toEqual([otherAutomationId]);
+    expect(queued[0]!.depth).toBe(1);
+  });
+
+  it('starts a fresh chain when the producing run had no workspace trigger', async () => {
+    const { organizationId, automationId } = await subscriber('Fresh Org', [
+      'connection.deleted',
+    ]);
+    const sql = getTestDb();
+    // A schedule- or connector-triggered run: real producer, no upstream chain.
+    const rows = (await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, action_key, status, automation_id
+      ) VALUES (
+        ${organizationId}, 'automation', 'run_automation', 'running',
+        ${automationId}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    await runWithActingAutomation(
+      { automationId, runId: Number(rows[0]!.id) },
+      async () => {
+        recordLifecycleEvent({
+          organizationId,
+          entityType: 'connection',
+          op: 'deleted',
+          entityId: 66,
+          summary: 'Connection deleted by a scheduled run',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+    );
+
+    const queued = await waitForActivations(organizationId, 1);
+    expect(queued[0]!.depth).toBe(1);
+    expect(queued[0]!.causalAutomationIds).toEqual([automationId]);
   });
 });

--- a/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
@@ -1,0 +1,91 @@
+/**
+ * A caller-declared `automation_source` must not be trusted for provenance.
+ *
+ * `automation_source` is tool input, so an org member can name any id. Audit
+ * rows stamp `events.automation_id` from it, so an unverified id does two
+ * kinds of damage: it misattributes the row — and lets it inherit that
+ * Automation's causal chain, which is what bounds a cascade — and, because the
+ * column carries a foreign key while audit writes are fire-and-forget, a
+ * nonexistent id fails the INSERT and DROPS the audit row with no caller-
+ * visible error.
+ *
+ * `notify.ts` already validates this field against the caller's org before
+ * anchoring a canvas; this is the same rule on the attribution path.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { verifiedAutomationSource } from '../../../tools/execute';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestAgent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+async function orgWithAutomation(name: string, slug: string) {
+  const workspace = await TestWorkspace.create({ name });
+  const ownerUserId = workspace.users.owner.id;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: `${slug}-agent`,
+  });
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+  const created = (await api.automations.create({
+    slug,
+    prompt: 'Anything.',
+    agent_id: agent.agentId,
+  })) as { automation_id: string };
+  return {
+    organizationId: workspace.org.id,
+    automationId: Number(created.automation_id),
+  };
+}
+
+describe('declared automation_source verification', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('accepts an Automation the caller organization owns', async () => {
+    const org = await orgWithAutomation('Owner Org', 'owned');
+    await expect(
+      verifiedAutomationSource(
+        { automationId: org.automationId, windowId: 7 },
+        org.organizationId
+      )
+    ).resolves.toEqual({ automationId: org.automationId, windowId: 7 });
+  });
+
+  it('rejects an Automation belonging to another organization', async () => {
+    const victim = await orgWithAutomation('Victim Org', 'victim');
+    const attacker = await orgWithAutomation('Attacker Org', 'attacker');
+    // The id exists, so the foreign key would happily accept it — only the org
+    // check stops the attacker attributing its writes to another org's chain.
+    await expect(
+      verifiedAutomationSource(
+        { automationId: victim.automationId, windowId: 1 },
+        attacker.organizationId
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('rejects an id that does not exist at all', async () => {
+    const org = await orgWithAutomation('Ghost Org', 'ghost');
+    // Unverified, this is the id that would fail the FK and silently drop the
+    // audit row.
+    await expect(
+      verifiedAutomationSource(
+        { automationId: 2147483000, windowId: 1 },
+        org.organizationId
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('passes through an absent declaration untouched', async () => {
+    const org = await orgWithAutomation('Empty Org', 'empty');
+    await expect(
+      verifiedAutomationSource(null, org.organizationId)
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/server/src/automations/workspace-event-enqueue.ts
+++ b/packages/server/src/automations/workspace-event-enqueue.ts
@@ -17,6 +17,7 @@ import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
 import {
   automationTriggerSignals,
   deriveWorkspaceEventCausality,
+  isWorkspaceEventTriggerSignal,
   type WorkspaceEventActivationTaskPayload,
 } from './workspace-event-contract';
 
@@ -87,11 +88,18 @@ export async function enqueueWorkspaceEventActivations(
  * step in the same chain, which is what the depth and breadth caps measure.
  *
  * Returns null when there is no run to inherit from — an agent that declared no
- * window, or a run that was never activated by a workspace event. The caller
- * then falls back to a root, which is correct: nothing upstream to accrue.
+ * window, or a run that was never activated by a workspace event (a scheduled
+ * or connector-triggered run carries signals, but none of them workspace ones).
+ * The caller then falls back to a root, which is correct: nothing upstream to
+ * accrue.
  *
  * Looked up by run id when the lane exposes one, else by the declared window,
- * which resolves to the same run through `runs.window_id`.
+ * which resolves to the same run through `runs.window_id`. Both lookups are
+ * scoped to the producing Automation as well as the org: the window id can be
+ * caller-declared (`automation_source`), and inheriting a run of a DIFFERENT
+ * Automation would plant that Automation into this row's causal path —
+ * suppressing it downstream, i.e. silencing it. `notify.ts` validates the same
+ * pair before anchoring a canvas.
  */
 export async function loadRunEventCausality(
   organizationId: string,
@@ -111,6 +119,7 @@ export async function loadRunEventCausality(
           FROM public.runs
           WHERE id = ${ref.runId}
             AND organization_id = ${organizationId}
+            AND automation_id = ${producerAutomationId}
           LIMIT 1
         `
       : await db<{ approved_input: unknown }>`
@@ -118,14 +127,19 @@ export async function loadRunEventCausality(
           FROM public.runs
           WHERE window_id = ${ref.windowId}
             AND organization_id = ${organizationId}
+            AND automation_id = ${producerAutomationId}
           ORDER BY id DESC
           LIMIT 1
         `;
   const approvedInput = rows[0]?.approved_input;
   if (!approvedInput || typeof approvedInput !== 'object') return null;
+  // Only workspace signals carry ancestry. A connector- or schedule-woken run
+  // has signals too, and passing those through would derive an EMPTY root set
+  // — which `activateWorkspaceEventTask` rejects, dropping a legitimate
+  // activation. Such a run starts a chain, exactly like no run at all.
   const signals = automationTriggerSignals(
     approvedInput as { trigger_signal?: unknown; trigger_signals?: unknown }
-  );
+  ).filter(isWorkspaceEventTriggerSignal);
   if (signals.length === 0) return null;
   // Throws past the breadth / root caps. That is the cascade limit doing its
   // job, so let it propagate: the caller treats a failed derivation as "do not

--- a/packages/server/src/automations/workspace-event-enqueue.ts
+++ b/packages/server/src/automations/workspace-event-enqueue.ts
@@ -14,7 +14,11 @@ import type { DbClient } from '../db/client';
 import { getDb, pgTextArray } from '../db/client';
 import { WORKSPACE_EVENT_ACTIVATION_TASK } from '../scheduled/task-definitions';
 import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
-import type { WorkspaceEventActivationTaskPayload } from './workspace-event-contract';
+import {
+  automationTriggerSignals,
+  deriveWorkspaceEventCausality,
+  type WorkspaceEventActivationTaskPayload,
+} from './workspace-event-contract';
 
 /**
  * Which of `eventTypes` at least one active Automation subscribes to.
@@ -71,4 +75,60 @@ export async function enqueueWorkspaceEventActivations(
       },
     }))
   );
+}
+
+/**
+ * The causal ancestry an audit row should inherit from the run that produced it.
+ *
+ * Without this an audit-mediated chain never accrues depth: every audit row
+ * would start a fresh root at depth 1, so `MAX_WORKSPACE_EVENT_DEPTH` could
+ * never bite and a mutual A -> B -> A cascade would be bounded only by fan-out
+ * and run cooldown. Inheriting the driving run's signals makes each hop a real
+ * step in the same chain, which is what the depth and breadth caps measure.
+ *
+ * Returns null when there is no run to inherit from — an agent that declared no
+ * window, or a run that was never activated by a workspace event. The caller
+ * then falls back to a root, which is correct: nothing upstream to accrue.
+ *
+ * Looked up by run id when the lane exposes one, else by the declared window,
+ * which resolves to the same run through `runs.window_id`.
+ */
+export async function loadRunEventCausality(
+  organizationId: string,
+  ref: { runId: number | null; windowId: number | null },
+  producerAutomationId: number,
+  db: DbClient = getDb()
+): Promise<{
+  rootEventIds: number[];
+  causalAutomationIds: number[];
+  depth: number;
+} | null> {
+  if (ref.runId == null && ref.windowId == null) return null;
+  const rows =
+    ref.runId != null
+      ? await db<{ approved_input: unknown }>`
+          SELECT approved_input
+          FROM public.runs
+          WHERE id = ${ref.runId}
+            AND organization_id = ${organizationId}
+          LIMIT 1
+        `
+      : await db<{ approved_input: unknown }>`
+          SELECT approved_input
+          FROM public.runs
+          WHERE window_id = ${ref.windowId}
+            AND organization_id = ${organizationId}
+          ORDER BY id DESC
+          LIMIT 1
+        `;
+  const approvedInput = rows[0]?.approved_input;
+  if (!approvedInput || typeof approvedInput !== 'object') return null;
+  const signals = automationTriggerSignals(
+    approvedInput as { trigger_signal?: unknown; trigger_signals?: unknown }
+  );
+  if (signals.length === 0) return null;
+  // Throws past the breadth / root caps. That is the cascade limit doing its
+  // job, so let it propagate: the caller treats a failed derivation as "do not
+  // queue", which terminates the chain rather than restarting it as a root.
+  return deriveWorkspaceEventCausality(signals, producerAutomationId);
 }

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -6,6 +6,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { runWithActingAutomation } from '../utils/acting-automation-context';
+import { getDb } from '../db/client';
 import type { Context } from 'hono';
 import { isToolError, retryWithBackoff, ToolError } from '@lobu/core';
 import {
@@ -312,9 +313,31 @@ export async function executeTool(
   // caller-declared `automation_source` for an agent or device running a
   // window. Setting it once here rather than at each audit writer is what keeps
   // provenance from drifting as writers are added.
+  // A declared source is caller input. Verify it against this org before it can
+  // reach `events.automation_id` — an unowned id would misattribute the audit
+  // row (and inherit that Automation's causal chain), and a nonexistent one
+  // would fail the FK and DROP the audit row entirely, since audit writes are
+  // fire-and-forget. Same rule `notify.ts` already applies to this field.
+  // Skipped whenever a trusted reaction identity is present, and skipped
+  // entirely when nothing was declared, so ordinary tool calls pay nothing.
+  const declaredSource =
+    toolContext.actingAutomationId != null
+      ? null
+      : await verifiedAutomationSource(
+          declaredAutomationSource(args),
+          toolContext.organizationId
+        );
   const runHandler = () =>
     runWithActingAutomation(
-      toolContext.actingAutomationId ?? declaredAutomationSourceId(args),
+      {
+        automationId:
+          toolContext.actingAutomationId ?? declaredSource?.automationId,
+        // The run is what carries causal ancestry. Reaction sessions have it
+        // directly; agent and device lanes carry `actingRunId = null`, so the
+        // declared window is the second route to the same run.
+        runId: toolContext.actingRunId ?? null,
+        windowId: toolContext.actingWindowId ?? declaredSource?.windowId ?? null,
+      },
       () =>
         trackMCPToolCall(toolName, args, () =>
           tool.handler(args, env, toolContext)
@@ -385,21 +408,53 @@ export async function executeTool(
 const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
 
 /**
- * The `automation_source.automation_id` an agent declared on this call.
+ * The `automation_source` an agent declared on this call.
  *
  * Self-declared and therefore advisory — an agent that omits it is attributed
  * to nothing, exactly as today. The reaction identity checked first is
  * server-set and cannot be forged, so the non-forgeable source always wins.
+ *
+ * The window travels with the automation id because it is the agent lane's
+ * only route to the driving run, and the run is what carries causal ancestry.
  */
-function declaredAutomationSourceId(
+/**
+ * Drop a declared source that does not name an Automation in this organization.
+ *
+ * Returns null rather than throwing: attribution is a provenance hint, and a
+ * bad hint should cost the caller its attribution, not fail their tool call.
+ */
+export async function verifiedAutomationSource(
+  declared: { automationId: number; windowId: number | null } | null,
+  organizationId: string
+): Promise<{ automationId: number; windowId: number | null } | null> {
+  if (!declared) return null;
+  const rows = await getDb()<{ id: number }>`
+    SELECT id
+    FROM automations
+    WHERE id = ${declared.automationId}
+      AND organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  return rows[0] ? declared : null;
+}
+
+function declaredAutomationSource(
   args: Record<string, unknown>
-): number | null {
+): { automationId: number; windowId: number | null } | null {
   const source = args.automation_source;
   if (!source || typeof source !== 'object') return null;
-  const id = (source as { automation_id?: unknown }).automation_id;
-  return typeof id === 'number' && Number.isSafeInteger(id) && id > 0
-    ? id
-    : null;
+  const positiveInteger = (value: unknown): number | null =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+      ? value
+      : null;
+  const automationId = positiveInteger(
+    (source as { automation_id?: unknown }).automation_id
+  );
+  if (automationId == null) return null;
+  return {
+    automationId,
+    windowId: positiveInteger((source as { window_id?: unknown }).window_id),
+  };
 }
 
 /** True when a thrown value is a retryable typed error. */

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -408,20 +408,13 @@ export async function executeTool(
 const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
 
 /**
- * The `automation_source` an agent declared on this call.
- *
- * Self-declared and therefore advisory — an agent that omits it is attributed
- * to nothing, exactly as today. The reaction identity checked first is
- * server-set and cannot be forged, so the non-forgeable source always wins.
- *
- * The window travels with the automation id because it is the agent lane's
- * only route to the driving run, and the run is what carries causal ancestry.
- */
-/**
  * Drop a declared source that does not name an Automation in this organization.
  *
  * Returns null rather than throwing: attribution is a provenance hint, and a
  * bad hint should cost the caller its attribution, not fail their tool call.
+ * The window is not paired to the Automation here — `loadRunEventCausality`
+ * scopes its run lookup to the producing Automation, so a foreign window
+ * inherits nothing.
  */
 export async function verifiedAutomationSource(
   declared: { automationId: number; windowId: number | null } | null,
@@ -438,6 +431,16 @@ export async function verifiedAutomationSource(
   return rows[0] ? declared : null;
 }
 
+/**
+ * The `automation_source` an agent declared on this call.
+ *
+ * Self-declared and therefore advisory — an agent that omits it is attributed
+ * to nothing, exactly as today. The reaction identity checked first is
+ * server-set and cannot be forged, so the non-forgeable source always wins.
+ *
+ * The window travels with the automation id because it is the agent lane's
+ * only route to the driving run, and the run is what carries causal ancestry.
+ */
 function declaredAutomationSource(
   args: Record<string, unknown>
 ): { automationId: number; windowId: number | null } | null {

--- a/packages/server/src/utils/acting-automation-context.ts
+++ b/packages/server/src/utils/acting-automation-context.ts
@@ -12,6 +12,11 @@
  * Owletto, a cron tick, and a connector sync genuinely ARE root causes, and
  * that is exactly what a null producer means to the activation path.
  *
+ * The scope carries the driving RUN as well as the Automation, because the
+ * audit-write path needs the run's causal ancestry to bound a mutual
+ * A -> B -> A cascade — an audit row that starts a fresh root every time makes
+ * the depth cap unreachable.
+ *
  * Kept dependency-free so `insert-event.ts` can read it without pulling any
  * automation runtime into the write path.
  */
@@ -20,6 +25,19 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 interface ActingAutomationScope {
   automationId: number;
+  /**
+   * The automation run driving this call, when the lane exposes one. Reaction
+   * sessions carry it; agent tool calls do not (see `notify.ts`), which is why
+   * {@link ActingAutomationScope.windowId} exists as the second route to the
+   * same run.
+   */
+  runId: number | null;
+  /**
+   * The automation-run window driving this call. Resolves to the same run via
+   * `runs.window_id`, covering the agent and device lanes where only a
+   * caller-declared `automation_source` is available.
+   */
+  windowId: number | null;
 }
 
 const actingAutomationContext =
@@ -33,16 +51,42 @@ const actingAutomationContext =
  * caller's provenance.
  */
 export function runWithActingAutomation<T>(
-  automationId: number | null | undefined,
+  acting: {
+    automationId: number | null | undefined;
+    runId?: number | null;
+    windowId?: number | null;
+  },
   fn: () => T
 ): T {
-  if (automationId == null) {
+  if (acting.automationId == null) {
     return actingAutomationContext.exit(fn);
   }
-  return actingAutomationContext.run({ automationId }, fn);
+  return actingAutomationContext.run(
+    {
+      automationId: acting.automationId,
+      runId: acting.runId ?? null,
+      windowId: acting.windowId ?? null,
+    },
+    fn
+  );
 }
 
 /** The Automation driving this call, or null outside any automation scope. */
 export function getActingAutomationId(): number | null {
   return actingAutomationContext.getStore()?.automationId ?? null;
+}
+
+/**
+ * The full acting scope, for callers that need the run behind the Automation.
+ *
+ * Audit-row activation uses it to INHERIT the driving run's causal path
+ * instead of minting a fresh root — which is what bounds an A -> B -> A
+ * cascade, since depth only accrues when ancestry is carried forward.
+ */
+export function getActingAutomationScope(): {
+  automationId: number;
+  runId: number | null;
+  windowId: number | null;
+} | null {
+  return actingAutomationContext.getStore() ?? null;
 }

--- a/packages/server/src/utils/acting-automation-context.ts
+++ b/packages/server/src/utils/acting-automation-context.ts
@@ -71,17 +71,13 @@ export function runWithActingAutomation<T>(
   );
 }
 
-/** The Automation driving this call, or null outside any automation scope. */
-export function getActingAutomationId(): number | null {
-  return actingAutomationContext.getStore()?.automationId ?? null;
-}
-
 /**
- * The full acting scope, for callers that need the run behind the Automation.
+ * The Automation driving this call and the run behind it, or null outside any
+ * automation scope.
  *
- * Audit-row activation uses it to INHERIT the driving run's causal path
- * instead of minting a fresh root — which is what bounds an A -> B -> A
- * cascade, since depth only accrues when ancestry is carried forward.
+ * Audit-row activation uses the run to INHERIT its causal path instead of
+ * minting a fresh root — which is what bounds an A -> B -> A cascade, since
+ * depth only accrues when ancestry is carried forward.
  */
 export function getActingAutomationScope(): {
   automationId: number;

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -7,10 +7,11 @@
 
 import { retryWithBackoff } from '@lobu/core';
 import { type DbClient, getDb } from '../db/client';
-import { getActingAutomationId } from './acting-automation-context';
+import { getActingAutomationScope } from './acting-automation-context';
 import {
   enqueueWorkspaceEventActivations,
   findSubscribedWorkspaceEventTypes,
+  loadRunEventCausality,
 } from '../automations/workspace-event-enqueue';
 import {
   AUDIT_EVENT_TYPE_METADATA_KEY,
@@ -714,19 +715,24 @@ interface ChangeEventParams {
  * id, and `createAutomationEventRun` dedupes per Automation on the
  * `workspace-event:<id>` delivery id even if a second task is ever queued.
  *
- * Causality is read off the row itself rather than passed in: a row with no
- * producer is a root (empty ancestry, depth 1), and a row produced by an
- * Automation names that Automation as its own causal path. That is what stops
- * an Automation waking itself on the audit exhaust of its own write — the
- * matcher skips any Automation already in `causal_automation_ids`, and
- * `activateWorkspaceEventTask` rejects a payload whose ancestry disagrees with
- * the row's producer.
+ * Causality comes from the producer and the run that produced it. A row with
+ * no producer is a root (empty ancestry, depth 1). A row produced by an
+ * Automation names that Automation as its own causal path, which stops it
+ * waking itself — the matcher skips any Automation already in
+ * `causal_automation_ids`, and `activateWorkspaceEventTask` rejects a payload
+ * whose ancestry disagrees with the row's producer.
+ *
+ * When the producing run itself came from a workspace event, the row INHERITS
+ * that run's ancestry instead of starting over. Without inheriting, an
+ * A -> B -> A cascade would run forever: each audit row would be a fresh root
+ * at depth 1, so the depth cap could never accrue across hops.
  */
 async function queueWorkspaceEventActivation(args: {
   organizationId: string;
   eventId: number;
   eventType: string;
   producerAutomationId: number | null;
+  actingRun: { runId: number | null; windowId: number | null } | null;
 }): Promise<void> {
   try {
     const subscribed = await findSubscribedWorkspaceEventTypes(
@@ -734,18 +740,30 @@ async function queueWorkspaceEventActivation(args: {
       [args.eventType]
     );
     if (!subscribed.has(args.eventType)) return;
+    // Inherit the producing run's chain when there is one; otherwise this row
+    // genuinely starts a chain. Resolved only after the subscription check, so
+    // an unsubscribed org never pays for the lookup.
+    const inherited =
+      args.producerAutomationId == null || args.actingRun == null
+        ? null
+        : await loadRunEventCausality(
+            args.organizationId,
+            args.actingRun,
+            args.producerAutomationId
+          );
     const sql = getDb();
     await sql.begin(async (tx) => {
       await enqueueWorkspaceEventActivations(tx, [
         {
           organizationId: args.organizationId,
           eventId: args.eventId,
-          rootEventIds: [args.eventId],
+          rootEventIds: inherited?.rootEventIds ?? [args.eventId],
           causalAutomationIds:
-            args.producerAutomationId == null
+            inherited?.causalAutomationIds ??
+            (args.producerAutomationId == null
               ? []
-              : [args.producerAutomationId],
-          depth: 1,
+              : [args.producerAutomationId]),
+          depth: inherited?.depth ?? 1,
         },
       ]);
     });
@@ -794,8 +812,9 @@ export async function insertConnectionlessAuditEvent(
   // Who caused this change. An explicit id wins over ambient scope so a writer
   // that already resolved its producer keeps saying so; absent both, the row is
   // a genuine root (a person, a cron tick, a connector sync).
+  const actingScope = getActingAutomationScope();
   const producerAutomationId =
-    params.automationId ?? getActingAutomationId();
+    params.automationId ?? actingScope?.automationId ?? null;
 
   try {
     const inserted = await insertEvent({
@@ -809,6 +828,13 @@ export async function insertConnectionlessAuditEvent(
       eventId: inserted.id,
       eventType: formattedEventType,
       producerAutomationId,
+      // Only the ambient scope knows the run; an explicitly-passed producer
+      // carries no run reference, so such a row starts its own chain.
+      actingRun:
+        actingScope != null &&
+        actingScope.automationId === producerAutomationId
+          ? { runId: actingScope.runId, windowId: actingScope.windowId }
+          : null,
     });
     return inserted;
   } catch (error) {


### PR DESCRIPTION
Follow-up to #2947, which closed the **self**-trigger loop but left a **mutual** one open.

## The cascade #2947 did not bound

Audit-path activations always minted a depth-1 root carrying only the immediate producer, so depth never accrued across audit-mediated hops: A writes (causal `[A]`) wakes B, B writes (causal `[B]`) wakes A, forever. `MAX_WORKSPACE_EVENT_DEPTH` could never bite, and the cascade was bounded only by fan-out and run cooldown.

Now an audit row **inherits the producing run's chain**. The acting-automation scope carries the driving run, and `loadRunEventCausality` reads that run's trigger signals into `deriveWorkspaceEventCausality` — the same accrual `complete_window` already performs. Each hop becomes a real step in one chain, so the depth and breadth caps measure what they were designed to measure. A run with no workspace trigger still starts a fresh chain, which is correct: nothing upstream to accrue.

Two lanes reach the same run. Reaction sessions carry `actingRunId`; agent and device tool calls carry `actingRunId = null` (per the note in `notify.ts`), so the declared `automation_source.window_id` resolves the run through `runs.window_id`.

## Three ways caller input could do damage

`automation_source` is tool input, and #2947 let it reach `events.automation_id` unchecked. That turned out to matter more than attribution:

1. **An id from another organization** would misattribute the row *and* let it inherit that Automation's causal chain.
2. **A nonexistent id** would fail the foreign key — and because audit writes are fire-and-forget, the audit row would be **dropped with no caller-visible error**. Found by a test, not by reading: fabricating an upstream id made the insert fail, which is also why the new tests create real Automations through the API rather than inventing ids.
3. **A window belonging to a different Automation in the same org** would inherit that Automation's ancestry and plant it into this row's causal path — and since the matcher skips any Automation already in `causal_automation_ids`, that **silences it downstream**. `producerMatchesCausalPath` cannot catch this either, because it tests `includes()` rather than equality.

The fix is the pair validation `notify.ts` already applies to this field: verify the automation against the caller's org, and scope the run lookup by `automation_id` as well as org. Skipped entirely when a trusted reaction identity is present or nothing was declared, so ordinary tool calls pay nothing.

A fourth bug in the same area: `loadRunEventCausality` bailed only on zero signals, but a schedule- or connector-woken run carries signals that simply are not workspace ones — `deriveWorkspaceEventCausality` then returned an **empty `rootEventIds`**, which `activateWorkspaceEventTask` rejects as malformed, silently dropping a legitimate activation after its five retries.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates, knip included)
- [x] Full server suite **4247 passed / 2 skipped across 467 files**
- [x] 11 enqueue tests + 4 source-verification tests, each mutation-checked

| Mutation | Result |
|---|---|
| never inherit (always a fresh root) | 2 failed / 6 passed |
| ignore the window fallback | 1 failed / 7 passed |
| inherit even with no signals | 2 failed / 6 passed |
| ignore the scope-mismatch guard | 1 failed / 8 passed |
| drop the org scope from the check | 1 failed / 3 passed |
| accept every declaration | 2 failed / 2 passed |
| drop the workspace-signal filter | 1 failed / 10 passed |
| drop the `automation_id` scoping | 1 failed / 10 passed |

## Notes

- Three of these were found by `make review-fix` (Fable) after my own mutation pass came back clean. I verified each against the code before accepting — the empty-`rootEventIds` payload really is rejected downstream, since `isWorkspaceEventTriggerSignal` requires a non-empty root set.
- **Same class, left alone deliberately:** `manage_entity.ts:350,411` flow a declared `automation_source` into `runMutationGate` / `deferEntityCreate` without org verification. Pre-existing and on the approval-batch path rather than the `events.automation_id` FK path, so it is out of scope here — but it should get a follow-up reusing `verifiedAutomationSource`.
- `verifiedAutomationSource` is exported only for its test; knip is clean on it, but that is why it is exported.