### PR TITLE
chore(mcp): bump the interaction resource id to v43

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -180,14 +180,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(await initSession(`/mcp/${org.slug}`)).toBeTruthy();
   });
 
-  it('serves the external v42 interaction bundle over resources/read', async () => {
+  it('serves the external v43 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v42.html' },
+        params: { uri: 'ui://lobu/interaction/v43.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -196,7 +196,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v42.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v43.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-external-stub');
     // Absolute, not `./assets/…` behind a `<base>`: Claude serves the app
@@ -320,7 +320,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // error, so a typo or a foreign `ui://` id cannot silently render Lobu's.
     for (const uri of [
       'ui://lobu/interaction/vNext.html',
-      'ui://lobu/interaction/v42.htm',
+      'ui://lobu/interaction/v43.htm',
       'ui://lobu/interaction',
       'ui://lobu/dashboard/v1.html',
       'ui://other/interaction/v1.html',
@@ -356,7 +356,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v42.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v43.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -404,10 +404,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v42.html',
+            resourceUri: 'ui://lobu/interaction/v43.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v42.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v43.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -422,10 +422,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v42.html',
+            resourceUri: 'ui://lobu/interaction/v43.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v42.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v43.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -511,7 +511,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v42.html',
+        resourceUri: 'ui://lobu/interaction/v43.html',
         visibility: ['model', 'app'],
       })
     );
@@ -574,7 +574,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain('payload_data');
     expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
     expect(body.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v42.html'
+      'ui://lobu/interaction/v43.html'
     );
   });
 
@@ -1169,7 +1169,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(capability.length).toBeGreaterThan(40);
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');
     expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v42.html'
+      'ui://lobu/interaction/v43.html'
     );
     expect(JSON.stringify(view)).not.toContain(capability);
     expect(renderBody.result?.content?.[0]?.text).not.toContain(capability);

--- a/packages/server/src/mcp-app-resource-uris.ts
+++ b/packages/server/src/mcp-app-resource-uris.ts
@@ -35,7 +35,7 @@
  * correct answer to "give me the Lobu interaction shell", and it makes a bump
  * mean what the comment above claims it means: a cache eviction, not an outage.
  */
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v42.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v43.html';
 
 /**
  * Any interaction-shell id, current or superseded. The `.html` suffix is


### PR DESCRIPTION
## What

`LOBU_INTERACTION_RESOURCE_URI` v42 → v43, plus the test literals that pin it.

## Why

This is the live rehearsal for #2949. Every host connected right now cached `v42` from its handshake and will ask `resources/read` for `v42` after this deploys — the exact path that used to return `Unknown resource` and take the card down until the user manually refreshed the connector.

Before #2949 this bump would have broken every connected card. It should now be invisible.

## Baselines captured before merging

Driven through the real logged-in browser, current prod (`v42` canonical, fresh handshakes):

```
ChatGPT   iframe h=172 w=768  asdk_app_…web-sandbox.oaiusercontent.com  "Lobu ready"   no errors
Claude    no iframe anywhere (incl. shadow roots)  "There was a problem displaying content from Lobu"
```

So ChatGPT is the venue that can validate this; Claude is already broken for an unrelated reason (see below) and can't.

## Test plan

- [x] `make pre-pr` clean
- [x] ChatGPT baseline green at v42 before merge
- [ ] After deploy, without refreshing the connector, run a Lobu tool in the same ChatGPT session and confirm the card still renders — that is the stale-id path
- [ ] Confirm `resources/list` advertises v43 while `resources/read` still serves v42

## Unrelated finding, not fixed here

Claude cannot render Lobu cards at all, and it is not the URI path. `supportsMcpApps()` requires the client to declare the `io.modelcontextprotocol/ui` extension at `initialize`, and stored `last_capabilities` on prod show:

```
ChatGPT   extensions: {'io.modelcontextprotocol/ui': {'mimeTypes': ['text/html;profile=mcp-app']}}
Claude    {roots, elicitation}  — no extensions key at all
```

With the extension absent, `appMeta` is dropped and every tool goes out without `_meta.ui.resourceUri`, so Claude has no resource to render. Filed separately rather than mixed in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the MCP interaction resource to version `v43`.
  * Interaction resources now consistently use the new version across resource views, tool information, recovered sessions, saved-memory results, and approval displays.
  * Invalid-resource handling has also been aligned with the updated resource version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->