### PR TITLE
fix(devices): stop poll and re-mint heartbeats from clobbering a user-set device label

### DIFF
--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -103,6 +103,11 @@ export const PollRequestSchema = Type.Object({
   capabilities: Type.Optional(Type.Record(Type.String(), Type.Boolean())),
   platform: Type.Optional(Type.String()),
   app_version: Type.Optional(Type.String()),
+  /**
+   * Display name for the device, applied only when this poll is the device's
+   * first registration. Later polls ignore it — the name belongs to the user
+   * once they set one on the Devices page (`PATCH /api/me/devices/:id`).
+   */
   label: Type.Optional(Type.String()),
   connector_manifests: Type.Optional(Type.Unknown()),
   /**

--- a/packages/server/src/__tests__/integration/device-label-poll.test.ts
+++ b/packages/server/src/__tests__/integration/device-label-poll.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `device_workers.label` lifecycle: the label is set at first registration (or
+ * child-token mint) and after that belongs to the user via
+ * `PATCH /api/me/devices/:id`. A poll heartbeat must never overwrite it — the
+ * headless daemon reports its hostname as `label` on every poll, which used to
+ * clobber a rename made on the Devices page seconds earlier.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken, hashToken } from '../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+import { TestWorkspace } from '../setup/test-mcp-client';
+
+async function createWorkerBoundPat(
+  userId: string,
+  organizationId: string,
+  workerId: string
+): Promise<{ token: string }> {
+  const sql = getTestDb();
+  const token = `owl_pat_${generateSecureToken(24)}`;
+  await sql`
+    INSERT INTO personal_access_tokens (
+      token_hash, token_prefix, user_id, organization_id, name, scope, worker_id,
+      created_at, updated_at
+    ) VALUES (
+      ${hashToken(token)}, ${token.substring(0, 12)}, ${userId}, ${organizationId},
+      ${`Test worker PAT (${workerId})`}, 'device_worker:run', ${workerId},
+      NOW(), NOW()
+    )
+  `;
+  return { token };
+}
+
+describe('device_workers.label vs poll registration', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('a poll heartbeat cannot overwrite a stored device label', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Label Poll Org' });
+    const ownerUserId = workspace.users.owner.id;
+
+    // A label the user set (Devices page PATCH lands exactly this state).
+    await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+      VALUES (${ownerUserId}, 'label-keeper', 'headless', ${sql.json({ 'os.shell': true })}, 'My build box', ${workspace.org.id})
+    `;
+    const { token } = await createWorkerBoundPat(
+      ownerUserId,
+      workspace.org.id,
+      'label-keeper'
+    );
+
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'label-keeper',
+        platform: 'headless',
+        app_version: 'test',
+        label: 'daemon-reported-hostname',
+        capabilities: { 'os.shell': true },
+      },
+    });
+    expect(pollRes.status).toBe(200);
+
+    const rows = (await sql`
+      SELECT label FROM device_workers WHERE worker_id = 'label-keeper'
+    `) as unknown as Array<{ label: string | null }>;
+    expect(rows[0].label).toBe('My build box');
+  });
+
+  it('first poll registration still records the reported label', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Label Insert Org' });
+    const ownerUserId = workspace.users.owner.id;
+    const { token } = await createWorkerBoundPat(
+      ownerUserId,
+      workspace.org.id,
+      'label-fresh'
+    );
+
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'label-fresh',
+        platform: 'headless',
+        app_version: 'test',
+        label: 'herdr-box-1',
+        capabilities: { 'os.shell': true },
+      },
+    });
+    expect(pollRes.status).toBe(200);
+
+    const rows = (await sql`
+      SELECT label FROM device_workers WHERE worker_id = 'label-fresh'
+    `) as unknown as Array<{ label: string | null }>;
+    expect(rows[0].label).toBe('herdr-box-1');
+  });
+});

--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -146,6 +146,56 @@ describe('headless device mint (mint-child-token)', () => {
     expect(pats[1].revoked_at).toBeNull();
   });
 
+  it('a re-mint cannot overwrite a stored device label', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Label' });
+    const user = await createTestUser({ email: 'headless-mint-label@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    const app = mintApp(user.id);
+
+    const first = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'headless', label: 'herdr-box' }),
+      },
+      TEST_ENV
+    );
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { worker_id: string };
+
+    // The user renames it on the Devices page (PATCH /api/me/devices/:id
+    // lands exactly this state).
+    await sql`
+      UPDATE device_workers SET label = 'Build box'
+      WHERE user_id = ${user.id} AND worker_id = ${firstBody.worker_id}
+    `;
+
+    // Daemon restarts and re-registers, still self-reporting its hostname.
+    const second = await app.request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'headless',
+          worker_id: firstBody.worker_id,
+          label: 'herdr-box',
+        }),
+      },
+      TEST_ENV
+    );
+    expect(second.status).toBe(200);
+
+    const rows = (await sql`
+      SELECT label FROM device_workers
+      WHERE user_id = ${user.id} AND worker_id = ${firstBody.worker_id}
+    `) as unknown as Array<{ label: string | null }>;
+    expect(rows[0].label).toBe('Build box');
+  });
+
   it('does not reuse a chrome-extension worker_id when re-minting as headless', async () => {
     const sql = getTestDb();
     const personalOrg = await createTestOrganization({ name: 'Personal Cross' });

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -300,12 +300,16 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     // (poll's ON CONFLICT preserves it via COALESCE + a SELECT-then-reject
     // check, and the gateway's capability authorization uses the stored
     // platform rather than whatever the bearer self-reports).
+    // The label is recorded on insert only: a re-mint carries whatever the
+    // client self-reports (a headless daemon sends its hostname), which must
+    // not clobber a name the user set on the Devices page — same reason poll's
+    // ON CONFLICT leaves it alone. `PATCH /api/me/devices/:id` owns it after
+    // first registration.
     const upsertDeviceWorker = (db: typeof sql) => db`
       INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
       VALUES (${userId}, ${workerId}, ${platform}, ${db.json([])}, ${label}, ${organizationId})
       ON CONFLICT (user_id, worker_id) DO UPDATE
-        SET last_seen_at = NOW(),
-            label = COALESCE(EXCLUDED.label, device_workers.label)
+        SET last_seen_at = NOW()
     `;
 
     let created: { id: number; token: string };
@@ -409,8 +413,10 @@ const DEVICE_LABEL_MAX_LEN = 80;
  *
  *  - `label` — human display name (Devices page). Empty/null clears it so the
  *    UI falls back to the platform label ("Chrome", "Mac", …). Poll heartbeats
- *    only overwrite when the device itself sends a non-null label, so a
- *    user-set name sticks across Chrome extension / Mac app check-ins.
+ *    never overwrite a stored label — it is recorded at first registration (or
+ *    child-token mint) and after that changes only through this endpoint, so a
+ *    user-set name sticks even against a headless daemon that reports its
+ *    hostname as `label` on every poll.
  *  - `organization_id` — re-attach to a different workspace the caller belongs
  *    to. Moving un-pins and pauses the connections (and their feeds) it backed
  *    in the previous workspace.

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -375,7 +375,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           platform = COALESCE(device_workers.platform, EXCLUDED.platform),
           app_version = EXCLUDED.app_version,
           capabilities = EXCLUDED.capabilities,
-          label = COALESCE(EXCLUDED.label, device_workers.label),
+          -- label is deliberately absent: it is recorded on insert and owned by
+          -- the user afterwards (PATCH /api/me/devices/:id). A heartbeat that
+          -- wrote it back would clobber a Devices-page rename on the next poll,
+          -- since a headless daemon self-reports its hostname every time.
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
           connector_manifests = CASE
             WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests


### PR DESCRIPTION
## Summary
- `/api/workers/poll`'s device upsert wrote `label = COALESCE(EXCLUDED.label, device_workers.label)` on every conflict, so a headless daemon reporting its hostname each poll reverted a Devices-page rename seconds after the user made it. The re-mint branch of `mint-child-token` had the same clobber.
- The label is now recorded at first registration (or first mint) only; after that it belongs to the user via `PATCH /api/me/devices/:id`. Doc comments on the PATCH handler and the poll contract state the lifecycle.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Tests run: `bunx vitest run src/__tests__/integration/device-label-poll.test.ts src/__tests__/integration/device-management-mint.test.ts` — 7 passed
- [x] Bug fix: red→fix→green below

### red → green
New test `a poll heartbeat cannot overwrite a stored device label` against unmodified poll.ts:
```
AssertionError: expected 'daemon-reported-hostname' to be 'My build box'
Tests  1 failed | 1 passed (2)
```
After removing the label assignment from both ON CONFLICT arms:
```
Tests  7 passed (7)   # label + mint suites
```

## Notes
Split out of #2943 (it was an unexplained drive-by there); this PR carries the whole class — both upsert writers.