### PR TITLE
feat(entities): preview a merge's rule verdict with dry_run

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -935,7 +935,7 @@ export type ManageEntityData = {
      */
     force_delete_tree?: boolean;
     /**
-     * [delete] Preflight only: report what the delete would remove/detach without mutating anything
+     * [delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.
      */
     dry_run?: boolean;
     /**
@@ -1300,6 +1300,7 @@ export type ManageEntityResponses = {
         loser_entity_ids?: Array<number>;
         moved_identities: number;
         repointed_edges: number;
+        dry_run?: boolean;
         resolution?: {
           decision: "auto_merge" | "human";
           reason: string;

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -233,7 +233,7 @@ export const ManageEntitySchema = Type.Object({
   dry_run: Type.Optional(
     Type.Boolean({
       description:
-        "[delete] Preflight only: report what the delete would remove/detach without mutating anything",
+        "[delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.",
     })
   ),
 
@@ -543,6 +543,9 @@ export const ManageEntityResultSchema = Type.Union([
       loser_entity_ids: Type.Optional(Type.Array(Type.Integer())),
       moved_identities: Type.Integer(),
       repointed_edges: Type.Integer(),
+      // Preflight only. A dry run reports the rule verdict and writes nothing,
+      // so moved_identities/repointed_edges are 0 and mean "not attempted".
+      dry_run: Type.Optional(Type.Boolean()),
       resolution: Type.Optional(
         Type.Object({
           decision: Type.Union([

--- a/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
@@ -25,6 +25,7 @@ import {
 	applyEntityChangeProposal,
 	proposeEntityMerge,
 } from "../../../tools/admin/entity-field-approval";
+import { manageEntity } from "../../../tools/admin/manage_entity";
 import { createEntity } from "../../../utils/entity-management";
 import { applyMerge, applyMergeGroup } from "../../../utils/entity-merge";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
@@ -286,6 +287,52 @@ describe("write rules at the merge kernel", () => {
 
 		const after = await readRow(loser.id);
 		expect(after.merged_into).toBe(winner.id);
+	}, 60_000);
+
+	it("previews a rule refusal on a dry run, mutating nothing", async () => {
+		// Without this, the first anyone learns a merge is blocked is a failed 409.
+		const { org, user, invoices } = await seedInvoices(denyMergeCompiled);
+		const [loser, winner] = invoices;
+
+		const res = (await manageEntity(
+			{
+				action: "merge",
+				entity_id: loser.id,
+				winner_entity_id: winner.id,
+				dry_run: true,
+			} as Parameters<typeof manageEntity>[0],
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res.dry_run).toBe(true);
+		expect(res.message).toMatch(/would NOT be applied/);
+		expect(res.message).toMatch(/cannot be merged away/);
+
+		// A preview enforces nothing AND mutates nothing.
+		const after = await readRow(loser.id);
+		expect(after.deleted_at).toBeNull();
+		expect(after.merged_into).toBeNull();
+	}, 60_000);
+
+	it("says a legal merge would be applied, and still does not apply it", async () => {
+		const { org, user, invoices } = await seedInvoices(denyDeleteOnlyCompiled);
+		const [loser, winner] = invoices;
+
+		const res = (await manageEntity(
+			{
+				action: "merge",
+				entity_id: loser.id,
+				winner_entity_id: winner.id,
+				dry_run: true,
+			} as Parameters<typeof manageEntity>[0],
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res.message).toMatch(/would be applied/);
+		expect(res.message).not.toMatch(/would NOT be applied/);
+		expect((await readRow(loser.id)).merged_into).toBeNull();
 	}, 60_000);
 
 	it("leaves an unruled type exactly as cheap as before", async () => {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -828,11 +828,7 @@ async function handleMerge(
 	// and before the review branch below — a dry run must never create an
 	// approval, exactly as on the delete path.
 	if (args?.dry_run) {
-		const preview = await previewMerge({
-			orgId: ctx.organizationId,
-			loserIds,
-			winnerId,
-		});
+		const preview = await previewMerge({ loserIds, winnerId });
 		return {
 			action: "merge",
 			success: true,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -65,7 +65,11 @@ import {
 	type RelationshipColumnSpec,
 	updateEntity,
 } from "../../utils/entity-management";
-import { applyMergeGroup, applyUnmerge } from "../../utils/entity-merge";
+import {
+	applyMergeGroup,
+	applyUnmerge,
+	previewMerge,
+} from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
 import {
 	recordChangeEvent,
@@ -817,6 +821,31 @@ async function handleMerge(
 				identities: identities.get(loserId) ?? [],
 			})),
 		});
+	}
+
+	// Preflight: report the rule verdict without mutating and without queuing.
+	// Placed after the role gate (a principal who may not merge gets no preview)
+	// and before the review branch below — a dry run must never create an
+	// approval, exactly as on the delete path.
+	if (args?.dry_run) {
+		const preview = await previewMerge({
+			orgId: ctx.organizationId,
+			loserIds,
+			winnerId,
+		});
+		return {
+			action: "merge",
+			success: true,
+			message: preview.refused
+				? `Dry run: the merge would NOT be applied — ${preview.reason}`
+				: "Dry run: the merge would be applied",
+			winner_entity_id: winnerId,
+			loser_entity_id: loserIds[0],
+			loser_entity_ids: loserIds,
+			moved_identities: 0,
+			repointed_edges: 0,
+			dry_run: true,
+		};
 	}
 
 	if (actor.kind !== "user" && resolution?.decision === "review") {

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -113,7 +113,7 @@ export interface ApplyMergeGroupParams {
  * behind it.
  */
 export async function previewMerge(
-	params: { orgId: string; loserIds: number[]; winnerId: number },
+	params: { loserIds: number[]; winnerId: number },
 	db: DbClient = getDb(),
 ): Promise<{ refused: boolean; reason: string | null }> {
 	const loserIds = [...new Set(params.loserIds)].sort((a, b) => a - b);

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -36,7 +36,10 @@ import {
 	type ResolutionEvidence,
 } from "../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../entity-resolution/staleness";
-import { validateEntityRowMergeGrantingApprovedFields } from "../authz/entity-row-validation";
+import {
+	EntityRowValidationError,
+	validateEntityRowMergeGrantingApprovedFields,
+} from "../authz/entity-row-validation";
 import { transitionEntityMergeRows } from "./entity-management";
 import logger from "./logger";
 import {
@@ -91,6 +94,42 @@ export interface ApplyMergeGroupParams {
 	expectedResolutionFingerprint?: string;
 	/** See {@link ApplyMergeParams.approvedFields}. */
 	approvedFields?: readonly string[];
+}
+
+/**
+ * Preflight a merge against the type's write rules WITHOUT mutating anything.
+ *
+ * The mirror of `deleteEntity`'s dry run, and it exists for the same reason: a
+ * rule refusal should be visible before someone commits to the merge, not
+ * discovered as a failed 409 afterwards.
+ *
+ * Reads on the POOL deliberately. A preview enforces nothing, so there is no
+ * check for a concurrent write to overtake — the verdict is advisory by
+ * construction, and `applyMergeInTransaction` re-asks it under lock. This is
+ * the same exemption `deleteEntity`'s dry run takes.
+ *
+ * Waives nothing: `approvedFields` is empty, so an escalate reports as
+ * "approval required" exactly as it would refuse a real merge with no card
+ * behind it.
+ */
+export async function previewMerge(
+	params: { orgId: string; loserIds: number[]; winnerId: number },
+	db: DbClient = getDb(),
+): Promise<{ refused: boolean; reason: string | null }> {
+	const loserIds = [...new Set(params.loserIds)].sort((a, b) => a - b);
+	if (loserIds.length === 0) return { refused: false, reason: null };
+	try {
+		await validateEntityRowMergeGrantingApprovedFields({
+			tx: db,
+			loserIds,
+			mergedInto: params.winnerId,
+			approvedFields: [],
+		});
+	} catch (err) {
+		if (!(err instanceof EntityRowValidationError)) throw err;
+		return { refused: true, reason: err.verdict.reason };
+	}
+	return { refused: false, reason: null };
 }
 
 /**


### PR DESCRIPTION
## Summary
- #2950 made a merge refusable by a type's write rules, but left no way to ask before committing — a refusal surfaced only as a failed 409 *after* the attempt. Delete has had a preflight since #2932; merge now has the same one.
- `previewMerge` mirrors `deleteEntity`'s dry run, including its deliberate pool read: a preview enforces nothing, so there is no check for a concurrent write to overtake, and `applyMergeInTransaction` re-asks the verdict under lock.
- It waives nothing (`approvedFields: []`), so an escalate previews as refused exactly as it would fail a real merge with no card behind it.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bunx vitest run` (8 in the merge-seam suite; 27 files across the authz dir + merge-tool suite as regression)
- [x] Mutation-tested (below)

```
Tests  8 passed (8)
Regression: Test Files  27 passed (27)
```

### Mutation testing

| Mutation | Result |
|---|---|
| report success regardless of the rule verdict | 1 test fails |
| let the dry run fall through and actually merge | 2 tests fail |

## Notes

**Placement is load-bearing.** The branch sits *after* the admin/owner gate — a principal who may not merge gets no preview — and *before* the review branch, so a dry run can never queue an approval. That is the same ordering the delete path documents.

**Why `previewMerge` lives in `entity-merge.ts` and not the handler:** `manage_entity.ts` is not on the granting-validator allowlist in `scripts/check-security-patterns.sh`. A preview is not a good enough reason to widen that module boundary, so the capability is exposed from the module that already owns merge — exactly as the delete preview lives in `entity-management.ts`.

**Contract change** (the API surface part of this): `dry_run` was documented `[delete]` and is now `[delete, merge]`, and the merge result variant carries `dry_run`. On a preview, `moved_identities` and `repointed_edges` are `0` and mean "not attempted", not "nothing to do".

Follow-up from the #2950 thread; the remaining items there are the winner-metadata grant (blocked on the `aliases` footgun) and hard-delete governance.