### PR TITLE
feat(automations): expose the platform event catalog to trigger pickers

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1564,6 +1564,13 @@ export type ManageEntitySchemaResponses = {
             } | null;
           }>;
         }>;
+        platform_event_kinds: {
+          [key: string]:
+            | unknown
+            | {
+                description: string;
+              };
+        };
         list_scope: "accessible" | "organization";
         organization_id: string;
       }

--- a/packages/core/src/contracts/tools/manage-entity-schema.ts
+++ b/packages/core/src/contracts/tools/manage-entity-schema.ts
@@ -340,6 +340,19 @@ export const ManageEntitySchemaResultSchema = Type.Union([
     schema_type: Type.Literal("entity_type"),
     action: Type.Literal("list"),
     entity_types: Type.Array(EntityTypeRowSchema),
+    /**
+     * Event types the PLATFORM emits, which no entity type declares.
+     *
+     * A dedicated field rather than a synthetic `$platform` entity type: the
+     * events tab builds its content-kind dropdown from the same entity-type
+     * list, and a pseudo type would offer platform events as savable content
+     * kinds. Trigger pickers union this with the declared `event_kinds`;
+     * content surfaces ignore it.
+     */
+    platform_event_kinds: Type.Record(
+      Type.String(),
+      Type.Object({ description: Type.String() })
+    ),
     list_scope: Type.Union([
       Type.Literal("accessible"),
       Type.Literal("organization"),

--- a/packages/server/src/__tests__/integration/entity-schema/platform-event-kinds-field.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/platform-event-kinds-field.test.ts
@@ -17,6 +17,7 @@ import { manageEntitySchema } from '../../../tools/admin/manage_entity_schema';
 import { platformEventKinds } from '../../../automations/platform-event-catalog';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestOrganization } from '../../setup/test-fixtures';
+import { ensureMemberEntityType } from '../../../utils/member-entity-type';
 import type { ToolContext } from '../../../tools/registry';
 
 describe('manage_entity_schema list exposes the platform event catalog', () => {
@@ -25,6 +26,9 @@ describe('manage_entity_schema list exposes the platform event catalog', () => {
   beforeEach(async () => {
     await cleanupTestDatabase();
     const org = await createTestOrganization({ name: 'Platform Kinds Org' });
+    // Seed $member's built-in event_kinds so the leak guard below inspects a
+    // real declared registry instead of an empty table.
+    await ensureMemberEntityType(org.id);
     ctx = {
       organizationId: org.id,
       userId: null,
@@ -66,6 +70,9 @@ describe('manage_entity_schema list exposes the platform event catalog', () => {
       slug: string;
       event_kinds: Record<string, unknown> | null;
     }>;
+    // Vacuity guard: the seeded $member registry must be here, or the loop
+    // below inspects nothing and proves nothing.
+    expect(rows.length).toBeGreaterThan(0);
     const platformKeys = Object.keys(platformEventKinds());
     for (const row of rows) {
       for (const key of Object.keys(row.event_kinds ?? {})) {

--- a/packages/server/src/__tests__/integration/entity-schema/platform-event-kinds-field.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/platform-event-kinds-field.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The trigger picker's route to platform events.
+ *
+ * `connection.deleted` and friends are declared by no entity type, so a picker
+ * built from the union of `entity_types.event_kinds` — which is exactly how
+ * Owletto builds it — can never list them. `manage_entity_schema` list
+ * therefore carries them in a dedicated field.
+ *
+ * Dedicated rather than a synthetic `$platform` entity type on purpose: the
+ * events tab builds its content-kind dropdown from the same list, and a pseudo
+ * type would offer platform events as savable content kinds. Trigger surfaces
+ * union this field in; content surfaces ignore it.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { manageEntitySchema } from '../../../tools/admin/manage_entity_schema';
+import { platformEventKinds } from '../../../automations/platform-event-catalog';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+import type { ToolContext } from '../../../tools/registry';
+
+describe('manage_entity_schema list exposes the platform event catalog', () => {
+  let ctx: ToolContext;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Platform Kinds Org' });
+    ctx = {
+      organizationId: org.id,
+      userId: null,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      tokenType: 'oauth',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+    } as unknown as ToolContext;
+  });
+
+  async function listResult() {
+    return (await manageEntitySchema(
+      { schema_type: 'entity_type', action: 'list' } as never,
+      {} as never,
+      ctx
+    )) as {
+      platform_event_kinds?: Record<string, { description: string }>;
+      entity_types: Array<{ slug: string }>;
+    };
+  }
+
+  it('returns the computed catalog, not a stored list', async () => {
+    const result = await listResult();
+    expect(result.platform_event_kinds).toEqual(platformEventKinds());
+    // A representative platform type no entity type declares.
+    expect(result.platform_event_kinds).toHaveProperty('connection.deleted');
+  });
+
+  it('does not leak the catalog into any entity type', async () => {
+    const result = await listResult();
+    // The guard that keeps the events tab honest: no returned entity type may
+    // carry a platform key, or it becomes offerable as a savable content kind.
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT slug, event_kinds FROM entity_types WHERE event_kinds IS NOT NULL
+    `) as unknown as Array<{
+      slug: string;
+      event_kinds: Record<string, unknown> | null;
+    }>;
+    const platformKeys = Object.keys(platformEventKinds());
+    for (const row of rows) {
+      for (const key of Object.keys(row.event_kinds ?? {})) {
+        expect(platformKeys).not.toContain(key);
+      }
+    }
+    // And no synthetic pseudo type was injected into the list.
+    expect(result.entity_types.map((t) => t.slug)).not.toContain('$platform');
+  });
+});

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -20,7 +20,10 @@ import {
   type ViewTemplateTab,
 } from '@lobu/core/contracts/tools/manage-entity-schema';
 import { validateEntityMetrics } from '@lobu/connector-sdk';
-import { isPlatformEventType } from '../../automations/platform-event-catalog';
+import {
+  isPlatformEventType,
+  platformEventKinds,
+} from '../../automations/platform-event-catalog';
 import { compileEntityRule } from '../../authz/entity-rule-executor';
 import { type DbClient, getDb } from '../../db/client';
 import { validateMetricReadModes } from '../../metrics/read-mode';
@@ -355,6 +358,9 @@ async function etHandleList(
 		schema_type: 'entity_type',
 		action: 'list',
 		entity_types: entityTypes,
+		// Computed, never stored — same catalog trigger validation consults, so
+		// the picker cannot drift from what a subscription will accept.
+		platform_event_kinds: platformEventKinds(),
 		list_scope: args.list_scope ?? 'accessible',
 		organization_id: ctx.organizationId,
 	};


### PR DESCRIPTION
## Summary

- Platform events became subscribable in #2944, but **no UI could show them**. Every trigger picker builds its workspace catalog from the union of `entity_types.event_kinds`, and platform events are declared by no entity type — so `connection.deleted` was reachable through the API and invisible in the product, which in practice means nobody finds it.
- `manage_entity_schema` list now carries them in a dedicated `platform_event_kinds` field, computed from the same catalog trigger validation consults, so the picker cannot drift from what a subscription will accept.

## Why a dedicated field, not a `$platform` entity type

The `$platform` route was investigated first and rejected. The events tab builds its **content-kind** dropdown from this same entity-type list, so a pseudo type would offer platform events as savable content kinds — and `$member.event_kinds` gates `save_content`, which is exactly the merge `platform-event-catalog.ts` already refuses to make in its own doc comment. Trigger surfaces union this field in; content surfaces ignore it.

## Scope

API-surface addition, so it was surfaced and confirmed before building.

Server-side only — the Owletto consumer is **lobu-ai/owletto#907**, and the pointer bump is deliberately **not** in this PR so `ui-review` stays not-applicable here. Order is safe either way: the frontend reads `r.platform_event_kinds ?? {}`, so it degrades to today's behaviour against a server without the field.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] Full server suite **4239 passed / 2 skipped across 467 files**
- [x] 2 new tests, both mutation-checked

| Mutation | Result |
|---|---|
| omit the field entirely | 1 failed / 1 passed |
| return an empty catalog | 1 failed / 1 passed |

One test asserts the catalog is computed rather than stored; the other guards the separation that motivated the design — no entity type carries a platform key, and no `$platform` type appears in the list.