### PR TITLE
fix(mcp): send the App binding to every client, not only negotiated ones

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -515,6 +515,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         visibility: ['model', 'app'],
       })
     );
+    // The binding above ships regardless of negotiation; what proves the
+    // negotiated flag survived recovery is the app-only tool staying listed.
+    expect(
+      body.result?.tools?.some(
+        (entry: { name?: string }) => entry.name === 'resolve_approval'
+      )
+    ).toBe(true);
   });
 
   it('returns the exact saved event payload for the save_memory App card', async () => {
@@ -948,7 +955,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?._meta?.['mcp/www_authenticate']).toBeUndefined();
   });
 
-  it('keeps the text fallback when the client does not advertise MCP Apps support', async () => {
+  it('still binds the app for a client that did not advertise MCP Apps, while keeping app-only tools hidden', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
       advertiseMcpApps: false,
     });
@@ -967,8 +974,19 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const tool = body.result?.tools?.find(
       (entry: { name?: string }) => entry.name === 'get_approval'
     );
-    expect(tool?._meta?.ui).toBeUndefined();
+    // The binding ships to every client: `resources/list` already advertises
+    // the app unconditionally, and a host that renders apps without declaring
+    // the extension (claude.ai) could otherwise see the app but never bind it.
+    expect(tool?._meta?.ui).toEqual(
+      expect.objectContaining({ resourceUri: LOBU_INTERACTION_RESOURCE_URI })
+    );
+    expect(tool?._meta?.['openai/outputTemplate']).toBe(LOBU_INTERACTION_RESOURCE_URI);
+    // A client that ignores `_meta` is unaffected: the human-readable surface
+    // is unchanged.
     expect(typeof tool?.description).toBe('string');
+    // What stays gated is the tool filter: an app-only tool is still withheld
+    // from a client that never negotiated (hidden, not disabled — `tools/call`
+    // still dispatches it, so a rendered card can drive its own resolver).
     expect(
       body.result?.tools?.some(
         (entry: { name?: string }) => entry.name === 'resolve_approval'
@@ -1010,8 +1028,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     const renderBody = await renderResponse.json();
     expect(renderBody.result?.isError).not.toBe(true);
+    // The binding ships even without negotiation, but the app-only approval
+    // capability does not: the binding names a surface, the capability grants
+    // the power to act through it.
+    expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
+      LOBU_INTERACTION_RESOURCE_URI
+    );
     expect(renderBody.result?._meta?.['lobu/approval-capability']).toBeUndefined();
-    expect(renderBody.result?._meta?.['openai/outputTemplate']).toBeUndefined();
     // The registered approval reader still carries the viewer role, while the
     // app-only approval capability is withheld from this non-App client.
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -325,7 +325,16 @@ function createServerForContext(
             ? [{ type: 'noauth' as const }, ...t.securitySchemes]
             : t.securitySchemes
           : undefined;
-        const appMeta = mcpAppsSupported ? t._meta : undefined;
+        // The app binding ships to every client, negotiated or not:
+        // `resources/list` already advertises the app unconditionally, and some
+        // hosts (claude.ai) render apps without declaring the extension, so
+        // gating the binding on the declared capability left them an app they
+        // could see but never bind — no iframe mounted at all. `_meta` is inert
+        // to a client that does not understand it, so text-only callers are
+        // unaffected. What stays gated is the visibility filter above: app-only
+        // tools remain hidden from clients that did not negotiate (hidden, not
+        // disabled — `tools/call` still dispatches them, so a rendered card can
+        // drive its own resolver).
         return {
           name: t.name,
           description: t.description,
@@ -333,10 +342,10 @@ function createServerForContext(
           ...(t.annotations && { annotations: t.annotations }),
           ...(t.outputSchema && { outputSchema: t.outputSchema }),
           ...(securitySchemes && { securitySchemes }),
-          ...(appMeta || securitySchemes
+          ...(t._meta || securitySchemes
             ? {
                 _meta: {
-                  ...(appMeta ?? {}),
+                  ...(t._meta ?? {}),
                   // MCP Apps 2025-11-25 retains `_meta.securitySchemes` as the
                   // compatibility mirror for hosts that predate the top-level field.
                   ...(securitySchemes && { securitySchemes }),
@@ -491,14 +500,17 @@ function createServerForContext(
         Array.isArray(attachedMeta?.['mcp/www_authenticate']) &&
         attachedMeta['mcp/www_authenticate'].length > 0;
       const softError = isSoftErrorResult(publicResult) || attachedAuthChallenge;
-      const uiResourceUri = mcpAppsSupported
-        ? (tool?.mcpMeta?.ui as { resourceUri?: unknown } | undefined)?.resourceUri
-        : undefined;
+      const uiResourceUri = (
+        tool?.mcpMeta?.ui as { resourceUri?: unknown } | undefined
+      )?.resourceUri;
       // The standard MCP Apps linkage lives on the tool descriptor. ChatGPT's
       // compatibility path also reads openai/outputTemplate from the concrete
       // successful tool result before it fetches and mounts the resource. Keep
-      // the URI server-authored and omit it for clients that did not negotiate
-      // Apps support so headless callers retain their text-only result path.
+      // the URI server-authored and send it to every client, for the same
+      // reason the descriptor carries it unconditionally: a host that ignores
+      // `_meta` keeps its text-only result path, while a host that renders
+      // apps without declaring the extension can still bind the result to the
+      // resource we advertised.
       const appResultMeta =
         typeof uiResourceUri === 'string'
           ? { 'openai/outputTemplate': uiResourceUri }


### PR DESCRIPTION
## What

`tools/list` and `tools/call` now send `_meta.ui` and `openai/outputTemplate` to every client, instead of stripping them unless the client declared the `io.modelcontextprotocol/ui` extension at `initialize`.

## Why

`resources/list` already advertises the MCP App unconditionally. Gating only the tool side left any host that reads the resource list with an app it could see and never bind to.

claude.ai is that host. Measured on prod 2026-08-20, same org, same bundle, driven through the real browser:

```
ChatGPT   iframe 768x172   "Lobu ready"                                  no errors
Claude    no iframe anywhere (shadow roots walked)
          "There was a problem displaying content from Lobu"
```

The tool call succeeded in both — memory 5289915 was written from the Claude session. Only the card failed.

Stored `last_capabilities`, written verbatim from `initialize` (`clients.ts:65`), explain the split:

```
ChatGPT        extensions: {'io.modelcontextprotocol/ui': {'mimeTypes': ['text/html;profile=mcp-app']}}
MCP Inspector  extensions: {'io.modelcontextprotocol/ui': {...}, '…/tasks': {}}
Claude         {roots, elicitation}          ← no extensions key at all
```

## What is deliberately still gated

`_meta` is inert to a client that doesn't understand it, so a text-only caller is unaffected by receiving the binding — which is exactly why `resources/list` could always send it. The tool **filter** stays gated: app-only tools remain hidden from clients that never negotiated. Hidden is not disabled, since `tools/call` still dispatches them, so a card that does render can drive its own resolver.

The app-only approval capability (`lobu/approval-capability`) and the inline render payload (`save_content.ts:708`) also stay gated. Naming a surface and granting the power to act through it are different questions, and I'd rather widen those on evidence than on symmetry.

## Test plan

- [x] `bunx vitest run src/__tests__/integration/mcp/mcp-app-resources.test.ts` — 27/27
- [x] `make pre-pr` clean
- [x] Mutation-tested the recovery assertion (see below)
- [ ] After deploy, re-run the same prompt in claude.ai and confirm an iframe mounts

## One test was made vacuous, and is now not

`preserves negotiated Apps metadata after cross-replica session recovery` asserted on `_meta.ui`, which this change makes unconditional — so it would have passed even if recovery lost the flag entirely. It now asserts `resolve_approval` stays listed, the signal in `tools/list` that still depends on the negotiated flag. Forcing the flag false fails it:

```
× preserves negotiated Apps metadata after cross-replica session recovery
  → expected false to be true
```

## Honest limit

I never saw claude.ai's own `initialize` on the wire, so the cause is inferred, not observed: no Claude row on prod has ever sent `extensions`, ChatGPT's does and renders, and claude.ai fails exactly the way the gate predicts. Prod is the only place this can be confirmed, same as the fix it follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UI metadata and resource bindings are now advertised consistently for compatible tools.
  - Rendered tool results can be associated with their UI resources when supported.

- **Bug Fixes**
  - Clients without MCP Apps support continue to receive text-only results.
  - App-only tools remain hidden from unsupported clients, including after session recovery.
  - Approval responses now correctly include resource bindings without unsupported approval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->