### PR TITLE
fix(devices): expire child tokens and stop the mint chain at depth 1

### DIFF
--- a/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Child-token lifecycle for /api/me/devices/mint-child-token (#2884 follow-up).
+ *
+ * A minted child PAT used to carry the bare `device_worker:run` scope — the
+ * exact scope the mint gate checks — and no expiry, so a child could mint
+ * children forever and every link lived until manually revoked. Now:
+ *
+ *   - children are stamped `device_worker:child` and get a hard expiry
+ *   - a child may re-mint its own bound worker_id on the SAME platform (the old
+ *     PAT is revoked in the same transaction) — the refresh path a device has
+ *     before its token expires, without re-pairing
+ *   - a child may NOT obtain credentials for any other worker_id: the chain
+ *     stops at depth 1, so revoking a device's PAT cannot leave grandchildren
+ *
+ * First-party device grants (Mac bridge OAuth, `lobu login` device-code) carry
+ * no child marker and keep pairing new siblings.
+ */
+
+import { Hono } from 'hono';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { parseScopes } from '../../auth/oauth/utils';
+import { mintDeviceChildToken } from '../../worker-api/device-management';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+  RATE_LIMIT_ENABLED: 'false',
+} as unknown as Env;
+
+async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    UPDATE "organization"
+    SET metadata = ${JSON.stringify({ personal_org_for_user_id: userId })}
+    WHERE id = ${orgId}
+  `;
+}
+
+type AuthShape = { scopes: string[]; workerId?: string } | null;
+
+type MintApp = Hono<{
+  Bindings: Env;
+  Variables: { user: { id: string }; mcpAuthInfo: AuthShape };
+}>;
+
+function mintApp(userId: string, auth: AuthShape): MintApp {
+  const app: MintApp = new Hono();
+  app.post(
+    '/api/me/devices/mint-child-token',
+    async (c, next) => {
+      c.set('user', { id: userId });
+      c.set('mcpAuthInfo', auth);
+      await next();
+    },
+    (c) => mintDeviceChildToken(c)
+  );
+  return app;
+}
+
+async function seedUser(email: string): Promise<string> {
+  const personalOrg = await createTestOrganization({ name: `Personal ${email}` });
+  const user = await createTestUser({ email });
+  await markPersonalOrg(personalOrg.id, user.id);
+  await addUserToOrganization(user.id, personalOrg.id, 'owner');
+  return user.id;
+}
+
+async function mint(
+  userId: string,
+  auth: AuthShape,
+  body: Record<string, unknown>
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await mintApp(userId, auth).request(
+    '/api/me/devices/mint-child-token',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    TEST_ENV
+  );
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+const PARENT_AUTH: AuthShape = { scopes: ['device_worker:run'] };
+
+describe('device child-token lifecycle', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mints children with the child marker and a hard expiry', async () => {
+    const sql = getTestDb();
+    const userId = await seedUser('child-lifecycle-mint@test.example.com');
+
+    const { status, json } = await mint(userId, PARENT_AUTH, {
+      platform: 'headless',
+      label: 'herdr-life',
+    });
+    expect(status).toBe(200);
+
+    const rows = (await sql`
+      SELECT scope, expires_at FROM personal_access_tokens
+      WHERE user_id = ${userId} AND worker_id = ${json.worker_id as string}
+        AND revoked_at IS NULL
+    `) as unknown as Array<{ scope: string; expires_at: Date | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scope).toBe('device_worker:run device_worker:child');
+    // parseScopes must keep BOTH — an unlisted marker would be silently
+    // dropped at verify time, making the depth-1 gate vacuous.
+    expect(parseScopes(rows[0].scope)).toEqual([
+      'device_worker:run',
+      'device_worker:child',
+    ]);
+    expect(rows[0].expires_at).not.toBeNull();
+    const days =
+      (new Date(rows[0].expires_at as unknown as string).getTime() -
+        Date.now()) /
+      86_400_000;
+    expect(days).toBeGreaterThan(85);
+    expect(days).toBeLessThan(95);
+    // The response tells the caller when the credential it just stored dies.
+    expect(typeof json.expires_at).toBe('string');
+  });
+
+  it('a child cannot mint a NEW device credential — the chain stops at depth 1', async () => {
+    const userId = await seedUser('child-lifecycle-chain@test.example.com');
+    const first = await mint(userId, PARENT_AUTH, {
+      platform: 'headless',
+      label: 'herdr-parent',
+    });
+    expect(first.status).toBe(200);
+    const childAuth: AuthShape = {
+      scopes: ['device_worker:run', 'device_worker:child'],
+      workerId: first.json.worker_id as string,
+    };
+
+    // No worker_id (fresh identity) and a different worker_id both refuse.
+    const fresh = await mint(userId, childAuth, { platform: 'headless' });
+    expect(fresh.status).toBe(403);
+    expect(String(fresh.json.error_description)).toMatch(/own worker_id/);
+
+    const sibling = await mint(userId, childAuth, {
+      platform: 'chrome-extension',
+      worker_id: 'some-other-worker',
+    });
+    expect(sibling.status).toBe(403);
+
+    // Its OWN worker_id under a different platform is the same escalation with
+    // extra steps: reuse requires a platform match, so without the second arm
+    // of the gate this falls through to a fresh uuid — a brand-new device
+    // credential minted by a child.
+    const swapped = await mint(userId, childAuth, {
+      platform: 'chrome-extension',
+      worker_id: first.json.worker_id as string,
+    });
+    expect(swapped.status).toBe(403);
+    expect(swapped.json.access_token).toBeUndefined();
+  });
+
+  it('a child CAN rotate its own worker_id, revoking the previous PAT', async () => {
+    const sql = getTestDb();
+    const userId = await seedUser('child-lifecycle-rotate@test.example.com');
+    const first = await mint(userId, PARENT_AUTH, {
+      platform: 'headless',
+      label: 'herdr-rotate',
+    });
+    expect(first.status).toBe(200);
+    const workerId = first.json.worker_id as string;
+
+    const rotated = await mint(
+      userId,
+      { scopes: ['device_worker:run', 'device_worker:child'], workerId },
+      { platform: 'headless', worker_id: workerId }
+    );
+    expect(rotated.status).toBe(200);
+    expect(rotated.json.worker_id).toBe(workerId);
+    expect(rotated.json.access_token).not.toBe(first.json.access_token);
+
+    const live = (await sql`
+      SELECT token_prefix FROM personal_access_tokens
+      WHERE user_id = ${userId} AND worker_id = ${workerId} AND revoked_at IS NULL
+    `) as unknown as Array<{ token_prefix: string }>;
+    expect(live).toHaveLength(1);
+    expect(String(rotated.json.access_token)).toContain(live[0].token_prefix);
+  });
+});

--- a/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
@@ -5,21 +5,23 @@
  * exact scope the mint gate checks — and no expiry, so a child could mint
  * children forever and every link lived until manually revoked. Now:
  *
- *   - children are stamped `device_worker:child` and get a hard expiry
+ *   - newly minted children get a hard expiry (forward-only: legacy children
+ *     keep their null expiry until they rotate — a retroactive backfill is an
+ *     owner decision this change deliberately does not take)
  *   - a child may re-mint its own bound worker_id on the SAME platform (the old
  *     PAT is revoked in the same transaction) — the refresh path a device has
  *     before its token expires, without re-pairing
  *   - a child may NOT obtain credentials for any other worker_id: the chain
- *     stops at depth 1, so revoking a device's PAT cannot leave grandchildren
+ *     stops at depth 1, so no new grandchild can outlive a revoked parent PAT
  *
- * First-party device grants (Mac bridge OAuth, `lobu login` device-code) carry
- * no child marker and keep pairing new siblings.
+ * Unbound first-party device grants (Mac bridge OAuth, `lobu login`
+ * device-code) keep pairing new siblings.
  */
 
 import { Hono } from 'hono';
 import { beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../../index';
-import { parseScopes } from '../../auth/oauth/utils';
+import { PersonalAccessTokenService } from '../../auth/tokens';
 import { mintDeviceChildToken } from '../../worker-api/device-management';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import {
@@ -91,6 +93,15 @@ async function mint(
   return { status: res.status, json: (await res.json()) as Record<string, unknown> };
 }
 
+async function verifyPat(token: unknown): Promise<Exclude<AuthShape, null>> {
+  const auth = await new PersonalAccessTokenService(getTestDb()).verify(String(token));
+  expect(auth).not.toBeNull();
+  return {
+    scopes: auth!.scopes,
+    ...(auth!.workerId ? { workerId: auth!.workerId } : {}),
+  };
+}
+
 const PARENT_AUTH: AuthShape = { scopes: ['device_worker:run'] };
 
 describe('device child-token lifecycle', () => {
@@ -98,7 +109,7 @@ describe('device child-token lifecycle', () => {
     await cleanupTestDatabase();
   });
 
-  it('mints children with the child marker and a hard expiry', async () => {
+  it('mints worker-bound children with a hard expiry', async () => {
     const sql = getTestDb();
     const userId = await seedUser('child-lifecycle-mint@test.example.com');
 
@@ -114,13 +125,7 @@ describe('device child-token lifecycle', () => {
         AND revoked_at IS NULL
     `) as unknown as Array<{ scope: string; expires_at: Date | null }>;
     expect(rows).toHaveLength(1);
-    expect(rows[0].scope).toBe('device_worker:run device_worker:child');
-    // parseScopes must keep BOTH — an unlisted marker would be silently
-    // dropped at verify time, making the depth-1 gate vacuous.
-    expect(parseScopes(rows[0].scope)).toEqual([
-      'device_worker:run',
-      'device_worker:child',
-    ]);
+    expect(rows[0].scope).toBe('device_worker:run');
     expect(rows[0].expires_at).not.toBeNull();
     const days =
       (new Date(rows[0].expires_at as unknown as string).getTime() -
@@ -128,6 +133,10 @@ describe('device child-token lifecycle', () => {
       86_400_000;
     expect(days).toBeGreaterThan(85);
     expect(days).toBeLessThan(95);
+    expect(await verifyPat(json.access_token)).toEqual({
+      scopes: ['device_worker:run'],
+      workerId: json.worker_id,
+    });
     // The response tells the caller when the credential it just stored dies.
     expect(typeof json.expires_at).toBe('string');
   });
@@ -139,10 +148,8 @@ describe('device child-token lifecycle', () => {
       label: 'herdr-parent',
     });
     expect(first.status).toBe(200);
-    const childAuth: AuthShape = {
-      scopes: ['device_worker:run', 'device_worker:child'],
-      workerId: first.json.worker_id as string,
-    };
+    const childAuth = await verifyPat(first.json.access_token);
+    expect(childAuth.workerId).toBe(first.json.worker_id);
 
     // No worker_id (fresh identity) and a different worker_id both refuse.
     const fresh = await mint(userId, childAuth, { platform: 'headless' });
@@ -177,11 +184,10 @@ describe('device child-token lifecycle', () => {
     expect(first.status).toBe(200);
     const workerId = first.json.worker_id as string;
 
-    const rotated = await mint(
-      userId,
-      { scopes: ['device_worker:run', 'device_worker:child'], workerId },
-      { platform: 'headless', worker_id: workerId }
-    );
+    const rotated = await mint(userId, await verifyPat(first.json.access_token), {
+      platform: 'headless',
+      worker_id: workerId,
+    });
     expect(rotated.status).toBe(200);
     expect(rotated.json.worker_id).toBe(workerId);
     expect(rotated.json.access_token).not.toBe(first.json.access_token);
@@ -192,5 +198,64 @@ describe('device child-token lifecycle', () => {
     `) as unknown as Array<{ token_prefix: string }>;
     expect(live).toHaveLength(1);
     expect(String(rotated.json.access_token)).toContain(live[0].token_prefix);
+  });
+
+  it('a LEGACY child (bare scope, worker-bound) is still held to the depth-1 gate', async () => {
+    // Children minted before this change carry a null expires_at and the bare
+    // `device_worker:run` scope. Their worker binding must still classify
+    // them as children, or every already-issued child keeps unlimited mint
+    // power until it happens to rotate.
+    const sql = getTestDb();
+    const userId = await seedUser('child-lifecycle-legacy@test.example.com');
+    const first = await mint(userId, PARENT_AUTH, {
+      platform: 'headless',
+      label: 'herdr-legacy',
+    });
+    expect(first.status).toBe(200);
+    const workerId = first.json.worker_id as string;
+    await sql`
+      UPDATE personal_access_tokens
+      SET expires_at = NULL
+      WHERE user_id = ${userId} AND worker_id = ${workerId} AND revoked_at IS NULL
+    `;
+    const legacyInfo = await new PersonalAccessTokenService(sql).verify(
+      String(first.json.access_token)
+    );
+    expect(legacyInfo).not.toBeNull();
+    const legacyChildAuth: Exclude<AuthShape, null> = {
+      scopes: legacyInfo!.scopes,
+      ...(legacyInfo!.workerId ? { workerId: legacyInfo!.workerId } : {}),
+    };
+    expect(legacyChildAuth).toEqual({ scopes: ['device_worker:run'], workerId });
+
+    const fresh = await mint(userId, legacyChildAuth, { platform: 'headless' });
+    expect(fresh.status).toBe(403);
+    expect(String(fresh.json.error_description)).toMatch(/own worker_id/);
+
+    const sibling = await mint(userId, legacyChildAuth, {
+      platform: 'chrome-extension',
+      worker_id: 'some-other-worker',
+    });
+    expect(sibling.status).toBe(403);
+
+    // Rotation of its own identity keeps working and upgrades the row to an
+    // expiring token through the normal re-register.
+    const rotated = await mint(userId, legacyChildAuth, {
+      platform: 'headless',
+      worker_id: workerId,
+    });
+    expect(rotated.status).toBe(200);
+    expect(rotated.json.worker_id).toBe(workerId);
+    const upgraded = await verifyPat(rotated.json.access_token);
+    expect(upgraded).toEqual({
+      scopes: ['device_worker:run'],
+      workerId,
+    });
+    const expiry = (await sql`
+      SELECT expires_at FROM personal_access_tokens
+      WHERE user_id = ${userId} AND worker_id = ${workerId} AND revoked_at IS NULL
+    `) as unknown as Array<{ expires_at: Date | null }>;
+    expect(expiry).toHaveLength(1);
+    expect(expiry[0].expires_at).not.toBeNull();
   });
 });

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -18,15 +18,6 @@ export const AVAILABLE_SCOPES = [
   // instance's LOBU_CLOUD_PAT must be minted explicitly with this scope
   // (`lobu token create --scope connections:token`).
   'connections:token',
-  // Marker stamped ONLY by /api/me/devices/mint-child-token on the PATs it
-  // mints. It grants nothing; its presence tells the mint endpoint the caller
-  // is itself a minted child, which may re-mint its own worker_id but not mint
-  // credentials for any other device (the chain stops at depth 1). Listed here
-  // because parseScopes drops unknown scopes — an unlisted marker would be
-  // silently stripped at verify time and the depth-1 gate would never fire.
-  // Not advertised in discovery and not in AVAILABLE_PAT_SCOPES, so no client
-  // can ask for it; carrying it only ever narrows what a token may do.
-  'device_worker:child',
 ] as const;
 
 /**
@@ -41,14 +32,8 @@ export const AVAILABLE_SCOPES = [
  * - `device_worker:run` — personal device workers only (device-code grant).
  * - `connections:token` — first-party `lobu login` device-code grant or an
  *   explicitly minted PAT; never third-party auth-code tokens.
- * - `device_worker:child` — stamped only on PATs minted by
- *   /api/me/devices/mint-child-token; nothing else may request or mint it.
  */
-export const NON_PUBLIC_OAUTH_SCOPES = [
-  'device_worker:run',
-  'connections:token',
-  'device_worker:child',
-] as const;
+export const NON_PUBLIC_OAUTH_SCOPES = ['device_worker:run', 'connections:token'] as const;
 
 /**
  * Scopes advertised via OAuth discovery (RFC 8414 / RFC 9728).

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -18,6 +18,15 @@ export const AVAILABLE_SCOPES = [
   // instance's LOBU_CLOUD_PAT must be minted explicitly with this scope
   // (`lobu token create --scope connections:token`).
   'connections:token',
+  // Marker stamped ONLY by /api/me/devices/mint-child-token on the PATs it
+  // mints. It grants nothing; its presence tells the mint endpoint the caller
+  // is itself a minted child, which may re-mint its own worker_id but not mint
+  // credentials for any other device (the chain stops at depth 1). Listed here
+  // because parseScopes drops unknown scopes — an unlisted marker would be
+  // silently stripped at verify time and the depth-1 gate would never fire.
+  // Not advertised in discovery and not in AVAILABLE_PAT_SCOPES, so no client
+  // can ask for it; carrying it only ever narrows what a token may do.
+  'device_worker:child',
 ] as const;
 
 /**
@@ -32,8 +41,14 @@ export const AVAILABLE_SCOPES = [
  * - `device_worker:run` — personal device workers only (device-code grant).
  * - `connections:token` — first-party `lobu login` device-code grant or an
  *   explicitly minted PAT; never third-party auth-code tokens.
+ * - `device_worker:child` — stamped only on PATs minted by
+ *   /api/me/devices/mint-child-token; nothing else may request or mint it.
  */
-export const NON_PUBLIC_OAUTH_SCOPES = ['device_worker:run', 'connections:token'] as const;
+export const NON_PUBLIC_OAUTH_SCOPES = [
+  'device_worker:run',
+  'connections:token',
+  'device_worker:child',
+] as const;
 
 /**
  * Scopes advertised via OAuth discovery (RFC 8414 / RFC 9728).

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -165,6 +165,28 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
 }
 
 /**
+ * Scope of every child PAT this endpoint mints: `device_worker:run` drives the
+ * poll/run lanes; `device_worker:child` marks the token as a minted child so
+ * the depth-1 gate in `mintDeviceChildToken` refuses to let it mint any device
+ * credential but its own.
+ */
+const CHILD_PAT_SCOPE = 'device_worker:run device_worker:child';
+/**
+ * Child PATs expire, so an orphaned or leaked one stops working on its own
+ * instead of living until someone revokes it by hand. A device refreshes by
+ * re-minting through this endpoint with its stored worker_id (the reuse branch
+ * keeps the device identity and revokes the old token) — which for a headless
+ * daemon means a re-register, since nothing rotates the PAT in place today.
+ */
+const CHILD_PAT_EXPIRES_IN_DAYS = 90;
+/** Refusal body for both arms of the depth-1 gate (see `mintDeviceChildToken`). */
+const CHILD_SELF_MINT_ONLY = {
+  error: 'insufficient_scope',
+  error_description:
+    'a device child token can only re-mint its own worker_id, not mint new device credentials',
+} as const;
+
+/**
  * POST /api/me/devices/mint-child-token  { platform, label? }
  *
  * Hand-off path for the Mac bridge to pair a sibling device (today: the
@@ -173,8 +195,9 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
  * personal org, generate a new worker_id, and return both for the sibling
  * to use as if it had completed device-authorization on its own.
  *
- * Scope of the child token is the same `device_worker:run` scope the
- * regular Mac OAuth flow ends up with — capability authorization at
+ * The child token carries `CHILD_PAT_SCOPE`: the `device_worker:run` scope the
+ * regular Mac OAuth flow ends up with, plus the `device_worker:child` marker
+ * that stops the chain at depth 1. Capability authorization at
  * /api/workers/poll still constrains what the child can advertise per its
  * declared `platform` (see @lobu/core/capabilities).
  */
@@ -241,6 +264,18 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
   // below, so a stale/garbage value just falls through to a fresh mint.
   const requestedWorkerId = (body.worker_id ?? '').trim();
 
+  // The chain stops at depth 1: a PAT this endpoint minted (marked
+  // `device_worker:child`) may ROTATE itself — re-mint its own bound
+  // worker_id, which revokes the old PAT in the same transaction — but may
+  // not mint credentials for any other device. Only a first-party device
+  // grant (Mac bridge OAuth, `lobu login` device-code) pairs new siblings,
+  // so revoking a device's PAT cannot leave grandchildren behind.
+  const callerIsMintedChild = callerScopes.includes('device_worker:child');
+  const callerBoundWorkerId = c.var.mcpAuthInfo?.workerId ?? null;
+  if (callerIsMintedChild && (!requestedWorkerId || requestedWorkerId !== callerBoundWorkerId)) {
+    return c.json(CHILD_SELF_MINT_ONLY, 403);
+  }
+
   try {
     const sql = getDb();
     // Device clients (Owletto Chrome extension via the Mac bridge) ALWAYS bind
@@ -287,6 +322,14 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       workerId = crypto.randomUUID();
     }
     const reused = workerId === requestedWorkerId;
+    // Matching the caller's own worker_id is not enough: the reuse lookup also
+    // requires the SAME platform, so a child re-declaring its worker_id under a
+    // different platform falls through to a fresh uuid — i.e. a brand-new
+    // device credential, exactly what the depth-1 gate refuses. A child's mint
+    // must land on the reuse branch or not at all.
+    if (callerIsMintedChild && !reused) {
+      return c.json(CHILD_SELF_MINT_ONLY, 403);
+    }
 
     const patService = new PersonalAccessTokenService(sql);
     // Upsert the device_workers row (exists on reuse, created on first mint).
@@ -312,7 +355,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
         SET last_seen_at = NOW()
     `;
 
-    let created: { id: number; token: string };
+    let created: { id: number; token: string; expires_at: Date | null };
     if (reused) {
       created = await sql.begin(async (tx) => {
         await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:mint-child'), hashtext(${workerId}))`;
@@ -329,9 +372,10 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
           organizationId,
           `device:${platform}:${workerId.slice(0, 8)}`,
           {
-            scope: 'device_worker:run',
+            scope: CHILD_PAT_SCOPE,
             description: label ?? undefined,
             workerId,
+            expiresInDays: CHILD_PAT_EXPIRES_IN_DAYS,
           }
         );
         await tx`
@@ -350,9 +394,10 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
         organizationId,
         `device:${platform}:${workerId.slice(0, 8)}`,
         {
-          scope: 'device_worker:run',
+          scope: CHILD_PAT_SCOPE,
           description: label ?? undefined,
           workerId,
+          expiresInDays: CHILD_PAT_EXPIRES_IN_DAYS,
         }
       );
       // Fresh row — no staleness to race against, so the upsert runs outside a
@@ -391,6 +436,9 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     return c.json({
       worker_id: workerId,
       access_token: created.token,
+      // The child PAT's hard expiry, so a caller that stores the token can tell
+      // when it must re-mint rather than discovering it as a 401 on poll.
+      expires_at: created.expires_at?.toISOString() ?? null,
       session_token: sessionToken,
       gateway_url: gatewayUrl,
       label,

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -165,18 +165,16 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
 }
 
 /**
- * Scope of every child PAT this endpoint mints: `device_worker:run` drives the
- * poll/run lanes; `device_worker:child` marks the token as a minted child so
- * the depth-1 gate in `mintDeviceChildToken` refuses to let it mint any device
- * credential but its own.
- */
-const CHILD_PAT_SCOPE = 'device_worker:run device_worker:child';
-/**
  * Child PATs expire, so an orphaned or leaked one stops working on its own
  * instead of living until someone revokes it by hand. A device refreshes by
  * re-minting through this endpoint with its stored worker_id (the reuse branch
  * keeps the device identity and revokes the old token) — which for a headless
  * daemon means a re-register, since nothing rotates the PAT in place today.
+ *
+ * Forward-only: legacy children (minted before this shipped) keep their null
+ * expiry until they rotate. A retroactive backfill would hard-kill working
+ * devices at day 90 with no rotation client shipped — an owner decision, not
+ * one this change takes.
  */
 const CHILD_PAT_EXPIRES_IN_DAYS = 90;
 /** Refusal body for both arms of the depth-1 gate (see `mintDeviceChildToken`). */
@@ -195,9 +193,9 @@ const CHILD_SELF_MINT_ONLY = {
  * personal org, generate a new worker_id, and return both for the sibling
  * to use as if it had completed device-authorization on its own.
  *
- * The child token carries `CHILD_PAT_SCOPE`: the `device_worker:run` scope the
- * regular Mac OAuth flow ends up with, plus the `device_worker:child` marker
- * that stops the chain at depth 1. Capability authorization at
+ * The child token carries the same `device_worker:run` scope the regular Mac
+ * OAuth flow ends up with. Its stored worker_id binding stops the mint chain at
+ * depth 1, while capability authorization at
  * /api/workers/poll still constrains what the child can advertise per its
  * declared `platform` (see @lobu/core/capabilities).
  */
@@ -264,14 +262,20 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
   // below, so a stale/garbage value just falls through to a fresh mint.
   const requestedWorkerId = (body.worker_id ?? '').trim();
 
-  // The chain stops at depth 1: a PAT this endpoint minted (marked
-  // `device_worker:child`) may ROTATE itself — re-mint its own bound
-  // worker_id, which revokes the old PAT in the same transaction — but may
-  // not mint credentials for any other device. Only a first-party device
-  // grant (Mac bridge OAuth, `lobu login` device-code) pairs new siblings,
-  // so revoking a device's PAT cannot leave grandchildren behind.
-  const callerIsMintedChild = callerScopes.includes('device_worker:child');
+  // The chain stops at depth 1: a PAT this endpoint minted may ROTATE itself —
+  // re-mint its own bound worker_id, which revokes the old PAT in the same
+  // transaction — but may not mint credentials for any other device. Only a
+  // first-party device grant (Mac bridge OAuth, `lobu login` device-code)
+  // pairs new siblings, preventing any new grandchild credential from
+  // surviving revocation of its parent device's PAT.
+  //
+  // This endpoint is the only writer of worker-bound PATs (local-init and the
+  // org-token route mint unbound; first-party device grants are OAuth tokens,
+  // which carry no workerId), so a bearer bound to a worker_id is an
+  // endpoint-minted child. Binding also recognizes every already-issued child;
+  // no new scope or token-shape compatibility path is needed.
   const callerBoundWorkerId = c.var.mcpAuthInfo?.workerId ?? null;
+  const callerIsMintedChild = callerBoundWorkerId !== null;
   if (callerIsMintedChild && (!requestedWorkerId || requestedWorkerId !== callerBoundWorkerId)) {
     return c.json(CHILD_SELF_MINT_ONLY, 403);
   }
@@ -372,7 +376,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
           organizationId,
           `device:${platform}:${workerId.slice(0, 8)}`,
           {
-            scope: CHILD_PAT_SCOPE,
+            scope: 'device_worker:run',
             description: label ?? undefined,
             workerId,
             expiresInDays: CHILD_PAT_EXPIRES_IN_DAYS,
@@ -394,7 +398,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
         organizationId,
         `device:${platform}:${workerId.slice(0, 8)}`,
         {
-          scope: CHILD_PAT_SCOPE,
+          scope: 'device_worker:run',
           description: label ?? undefined,
           workerId,
           expiresInDays: CHILD_PAT_EXPIRES_IN_DAYS,


### PR DESCRIPTION
## Summary
- A child device PAT minted by `/api/me/devices/mint-child-token` carried the bare `device_worker:run` scope — the exact scope the mint gate checks — and no expiry. A stolen child token could therefore mint fresh device credentials forever (unbounded chain), and every link lived until manually revoked.
- Now children get a 90-day expiry, and a child may only re-mint **its own bound worker_id** (self-rotation before expiry, revoking the old PAT in the same transaction). Minting a NEW device identity or another worker's credential from a child returns 403 — the chain stops at depth 1, so revoking a device's PAT cannot leave live grandchildren.
- **A child is recognized by its worker binding, not a scope marker.** `mint-child-token` is the ONLY writer of worker-bound PATs (`/api/local-init` and the org-token route mint unbound; first-party device grants — Mac bridge OAuth, `lobu login` device-code — are OAuth tokens carrying no `workerId`), so `mcpAuthInfo.workerId != null` ⇒ endpoint-minted child. That classification also covers every **legacy** child already issued (review round 1 blocker: the earlier marker-scope draft let legacy bare-scope children bypass the gate). An earlier draft added a `device_worker:child` marker scope; it was dropped before merge — binding is the single mechanism and no scope-surface change ships.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (build + typecheck + knip + biome + naming)
- [x] Tests run: `cd packages/server && bunx vitest run src/__tests__/integration/device-child-token-lifecycle.test.ts src/__tests__/integration/device-management-mint.test.ts` — 8 tests (4 lifecycle incl. new legacy-child regression + 4 pre-existing mint/reuse tests green under the gate)
- [x] Bug fix: red→fix→green outputs pasted below

### Red (gate reverted to marker-only classification — mutation run)
```
× a LEGACY child (bare scope, worker-bound) is still held to the depth-1 gate
Tests  1 failed | 3 passed (4)
```

### Green (with fix)
```
✓ device-child-token-lifecycle.test.ts (4 tests)
✓ device-management-mint.test.ts (4 tests)
Tests  8 passed (8)
```

## Notes
- **API-surface addition, flagged for review:** the mint response now includes `expires_at` so daemons know when their credential dies. No scope changes ship.
- Rotation authority comes from the PAT's stored `worker_id`, surfaced by `PersonalAccessTokenService.verify()` into `mcpAuthInfo.workerId` — not from the request body.
- **Forward-only, deliberately:** legacy children keep their null expiry until they rotate (their next re-mint lands the 90-day expiry). `make review-fix` proposed an idempotent backfill migration stamping `expires_at = NOW() + 90 days` on existing worker-bound PATs plus a verifier-side `created_at + 90d` fallback; both were **rejected here** — with no rotation client shipped, retroactive expiry hard-kills working devices at day 90, and a prod data migration on live credentials is an owner decision. The depth-1 escalation (the actual security hole) is closed for legacy tokens by the binding classification alone. If the owner wants the expiry backfill later, it is a one-statement idempotent migration.
- The depth-1 gate has two arms: (1) a child must request its own bound worker_id; (2) the request must land on the reuse branch — its own worker_id under a DIFFERENT platform falls through to a fresh uuid, i.e. a brand-new credential, so it is refused too (`make review-fix` round 1 found this arm; deleting only it reproduces `expected 200 to be 403`).
- Lifecycle tests derive child auth from the REAL persisted token via `PersonalAccessTokenService.verify()` (not hand-built shapes), so the test context cannot drift from what production hands the gate.
- **Accepted knowingly — rotation client is a follow-up:** no shipped caller re-mints today (the Mac bridge mints with the Mac app's OAuth bearer; the headless daemon snapshots its token at boot), so at day 90 a newly-minted headless daemon starts getting 401s until re-paired or its runner re-mints. The gate explicitly permits self-rotation so the daemon-side proactive re-mint can ship without server changes.
- Out of scope, for the record: `POST /api/local-init` still mints an unbound, non-expiring `device_worker:run` PAT that can mint children freely — consistent with "only worker-bound tokens are children," but worth a separate look.
- Inferred behavior change (not exercised e2e): a device row deleted from the Devices page now gets 403 when its child token re-mints (fresh-uuid fallthrough is refused) instead of silently resurrecting under a new uuid; its existing PAT keeps working and poll re-creates the row.
