### PR TITLE
feat(authz): govern force_delete_tree with the same $deleted rule the soft path uses

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -144,6 +144,18 @@ async function readDeletedAt(id: number): Promise<Date | null> {
 	return rows[0].deleted_at;
 }
 
+/**
+ * A force delete removes the ROW, so `deleted_at` cannot report on it — the
+ * absence of the row is the observation.
+ */
+async function rowExists(id: number): Promise<boolean> {
+	const sql = getTestDb();
+	const rows = await sql<{ id: number }[]>`
+    SELECT id FROM entities WHERE id = ${id}
+  `;
+	return rows.length > 0;
+}
+
 async function seedOrg(name: string) {
 	const org = await createTestOrganization({ name });
 	const user = await createTestUser();
@@ -548,6 +560,189 @@ describe("entity row validation at the physical writer", () => {
 			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
 
 			expect(await readDeletedAt(invoice.id)).toBeNull();
+		}, 60_000);
+	});
+
+	/**
+	 * `force_delete_tree` is the OTHER way a caller reaches destruction, and it
+	 * does not go past the soft-delete seam at all: it walks the tree and hands
+	 * the ids to `hardDeleteEntityRows`. Left ungoverned, "a posted invoice cannot
+	 * be deleted" would have meant "cannot be deleted without passing
+	 * force_delete_tree=true" — a control with a published bypass.
+	 *
+	 * It answers to `$deleted`, the same name the soft path uses, because a hard
+	 * delete is not a lesser destruction than a tombstone. (Contrast merge, which
+	 * earned its own `$merged_into`: merging a duplicate into its canonical record
+	 * is a correction, so freezing deletion must not freeze dedupe.)
+	 */
+	describe("force delete", () => {
+		it("denies force-deleting a frozen row, and the row survives", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			await expect(
+				deleteEntity(invoice.id, true, TEST_ENV, ctxFor(org.id, { userId: user.id })),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			// The row itself, not its tombstone column: a hard delete would have
+			// removed it outright.
+			expect(await rowExists(invoice.id)).toBe(true);
+		}, 60_000);
+
+		/**
+		 * The tree case, and the reason judging only the root would be a hole: the
+		 * caller names the PARENT, and the frozen row is a descendant it never
+		 * mentioned. Deleting a folder must not be a way to destroy the posted
+		 * invoice inside it.
+		 */
+		it("denies the whole tree when a DESCENDANT is frozen", async () => {
+			const { org, user } = await seedOrg("Frozen child");
+			await seedType(org.id, "folder", null);
+			await seedType(org.id, "invoice", invoiceCompiled);
+			const ctx = ctxFor(org.id, { userId: user.id });
+
+			const folder = await createEntity({
+				entity_type: "folder",
+				name: "2026 filings",
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: {},
+			} as Parameters<typeof createEntity>[0]);
+			const invoice = await createEntity({
+				entity_type: "invoice",
+				name: "INV-CHILD",
+				organization_id: org.id,
+				parent_id: folder.id,
+				created_by: user.id,
+				metadata: { status: "draft", einvoice_uuid: null, amount: 100 },
+			} as Parameters<typeof createEntity>[0]);
+			await updateEntity(invoice.id, { metadata: { status: "issued" } }, TEST_ENV, ctx);
+			await updateEntity(
+				invoice.id,
+				{ metadata: { status: "posted", einvoice_uuid: "uuid-child" } },
+				TEST_ENV,
+				ctx,
+			);
+
+			await expect(deleteEntity(folder.id, true, TEST_ENV, ctx)).rejects.toThrow(
+				/posted is frozen: \$deleted is not writable/,
+			);
+
+			// Atomic: the folder the rule said nothing about is still there too.
+			expect(await rowExists(folder.id)).toBe(true);
+			expect(await rowExists(invoice.id)).toBe(true);
+		}, 60_000);
+
+		/** The complement — the seam must not stop force delete generally. */
+		it("force-deletes a tree the rule does not freeze", async () => {
+			const { org, user } = await seedOrg("Free tree");
+			await seedType(org.id, "folder", null);
+			await seedType(org.id, "invoice", invoiceCompiled);
+			const ctx = ctxFor(org.id, { userId: user.id });
+
+			const folder = await createEntity({
+				entity_type: "folder",
+				name: "drafts",
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: {},
+			} as Parameters<typeof createEntity>[0]);
+			const invoice = await createEntity({
+				entity_type: "invoice",
+				name: "INV-DRAFT",
+				organization_id: org.id,
+				parent_id: folder.id,
+				created_by: user.id,
+				metadata: { status: "draft", einvoice_uuid: null, amount: 100 },
+			} as Parameters<typeof createEntity>[0]);
+
+			const result = await deleteEntity(folder.id, true, TEST_ENV, ctx);
+
+			expect(result.deleted).toBe(2);
+			expect(await rowExists(folder.id)).toBe(false);
+			expect(await rowExists(invoice.id)).toBe(false);
+		}, 60_000);
+
+		/**
+		 * The approval replay passes `force_delete_tree` straight through with the
+		 * `$deleted` grant, so a force delete a human approved has to apply — else
+		 * the card is minted, approved, and then throws on the replay.
+		 */
+		it("honours an approved force delete the rule escalated", async () => {
+			const { org, user, doc } = await seedEscalatingDoc();
+
+			await expect(
+				deleteEntity(doc.id, true, TEST_ENV, ctxFor(org.id, { userId: user.id })),
+			).rejects.toThrow(/second pair of eyes \(approval required for \$deleted\)/);
+
+			await deleteEntity(doc.id, true, TEST_ENV, ctxFor(org.id, { userId: user.id }), {
+				approvedFields: ["$deleted"],
+			});
+
+			expect(await rowExists(doc.id)).toBe(false);
+		}, 60_000);
+
+		/** A grant waives an ESCALATE. It may never launder a DENY. */
+		it("does not let a force-delete grant launder a deny", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			await expect(
+				deleteEntity(invoice.id, true, TEST_ENV, ctxFor(org.id, { userId: user.id }), {
+					approvedFields: ["$deleted"],
+				}),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			expect(await rowExists(invoice.id)).toBe(true);
+		}, 60_000);
+
+		/**
+		 * The force dry run is the report a caller reads before committing to an
+		 * irreversible delete. Reporting "would remove 1 entities" for a tree a rule
+		 * refuses is optimistic in the one direction that matters.
+		 */
+		it("reports the rule verdict in a force dry run", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			const preview = await deleteEntity(
+				invoice.id,
+				true,
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+				{ dryRun: true },
+			);
+
+			expect(preview.message).toMatch(/would NOT run/);
+			expect(preview.message).toMatch(/posted is frozen: \$deleted is not writable/);
+			expect(preview.refused).toBe(true);
+			expect(preview.deleted).toBe(0);
+			// The dependency report still rides along: a caller told "no" still wants
+			// to know what it was going to touch.
+			expect(preview.tree?.entities).toBe(1);
+			expect(await rowExists(invoice.id)).toBe(true);
+		}, 60_000);
+
+		it("still reports the removal in a force dry run the rule permits", async () => {
+			const { org, user, invoice } = await seedInvoice("draft");
+
+			const preview = await deleteEntity(
+				invoice.id,
+				true,
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+				{ dryRun: true },
+			);
+
+			expect(preview.message).toMatch(/would remove 1 entities/);
+			expect(preview.refused).toBeUndefined();
+			expect(await rowExists(invoice.id)).toBe(true);
+		}, 60_000);
+
+		/** A type with no rule at all must not pay for the seam existing. */
+		it("force-deletes a row whose type declares no rule", async () => {
+			const { org, user, invoice } = await seedInvoice("posted", null);
+
+			await deleteEntity(invoice.id, true, TEST_ENV, ctxFor(org.id, { userId: user.id }));
+
+			expect(await rowExists(invoice.id)).toBe(false);
 		}, 60_000);
 	});
 });

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -71,7 +71,8 @@ export interface EntityRowValidationVerdict {
  * `manage_entity`'s delete and merge paths have no `EntityRowValidationError`
  * catch (only its CREATE path does), so an escalate with no policy card behind
  * it fails closed like link auto-create. A `deny` stops the write either way,
- * and a hard delete never reaches this seam at all.
+ * and the hard (force) delete reaches this seam under the same `$deleted` name,
+ * so freezing a row freezes both delete paths.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;
@@ -92,8 +93,9 @@ export class EntityRowValidationError extends Error {
  * The complement (`metadata`, `name`, `slug`, `parentId`, `content`,
  * `softDelete`) IS governed: freezing a document has to stop a rename, not
  * merely a metadata edit, and it has to stop the row being tombstoned out from
- * under the rule that froze it. (A hard delete removes the row without a patch,
- * so it never passes through here — see `deleteEntity`.)
+ * under the rule that froze it. `deleteEntity` proposes `softDelete` for a hard
+ * (force) delete too, so a row about to be destroyed outright is judged by the
+ * same `$deleted` name instead of slipping past the seam.
  */
 const UNGOVERNED_COLUMNS: ReadonlySet<string> = new Set([
 	"currentViewTemplateVersionId",

--- a/packages/server/src/authz/entity-rule-executor.ts
+++ b/packages/server/src/authz/entity-rule-executor.ts
@@ -67,12 +67,12 @@ export interface EntityRuleBatch {
 	compiled: string;
 	rows: EntityRuleRow[];
 	/**
-	 * `delete` is deliberately absent: a soft delete reaches this seam as an
+	 * `delete` is deliberately absent: both delete paths reach this seam as an
 	 * ordinary patch whose one governed column is `$deleted` flipping to true, so
-	 * a rule judges it as an `update` and `changed("$deleted")` is what tells it
-	 * apart. A hard delete (`force_delete_tree`) removes the row outright and
-	 * never reaches this seam at all, so a `delete` op would be a contract only
-	 * half the deletes could honour.
+	 * a rule judges them as an `update` and `changed("$deleted")` is what tells
+	 * it apart. A hard delete (`force_delete_tree`) removes the row outright, but
+	 * it proposes that same `$deleted` patch first, so a `delete` op would name an
+	 * operation neither path actually presents.
 	 */
 	op: "create" | "update";
 	timeoutMs?: number;

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1636,6 +1636,27 @@ export async function deleteEntity(
     };
 
     if (opts?.dryRun) {
+      // Preview the RULE too, or the preview lies — the same reasoning the soft
+      // path below spells out. A pool read is right here because a dry run
+      // enforces nothing: the verdict is advisory by construction, and the real
+      // delete re-asks it under lock.
+      try {
+        await validateEntityRowPatchGrantingApprovedFields({
+          tx: sql,
+          ids: entityTreeIds,
+          patch: { softDelete: true },
+          approvedFields: opts?.approvedFields ?? [],
+        });
+      } catch (err) {
+        if (!(err instanceof EntityRowValidationError)) throw err;
+        return {
+          message: `Dry run: force delete would NOT run — ${err.verdict.reason}`,
+          deleted: 0,
+          dry_run: true,
+          refused: true,
+          tree: report,
+        };
+      }
       return {
         message: `Dry run: force delete would remove ${report.entities} entities and detach ${report.events_detached} event rows`,
         deleted: 0,
@@ -1655,6 +1676,33 @@ export async function deleteEntity(
       // org generation, the reverse of organization deletion's parent-then-
       // cascade order unless the org is claimed up front.
       await lockOrgForAclInvalidation(tx, ctx.organizationId);
+      // A force delete answers to the same `$deleted` name a soft delete does.
+      // Hard deletion is not a lesser destruction than a tombstone, so giving
+      // `force` its own reserved name would turn every "this row cannot be
+      // deleted" rule into "cannot be deleted without passing
+      // force_delete_tree=true" — a control with a documented bypass. This is
+      // the opposite call from merge, which got its own `$merged_into` precisely
+      // because merging a duplicate into its canonical record is a correction
+      // and not a destruction at all.
+      //
+      // Every id in the tree is judged, not just the root: a descendant carries
+      // its own type's rules, and deleting a parent must not be a way to destroy
+      // a frozen child.
+      //
+      // Locked first for the reason the soft path locks — the verdict has to
+      // describe the rows this transaction actually removes.
+      await tx`
+        SELECT id FROM entities
+        WHERE id = ANY(${entityTreeIdsLiteral}::bigint[])
+        ORDER BY id
+        FOR UPDATE
+      `;
+      await validateEntityRowPatchGrantingApprovedFields({
+        tx,
+        ids: entityTreeIds,
+        patch: { softDelete: true },
+        approvedFields: opts?.approvedFields ?? [],
+      });
       // Force-delete removes ACL edges along with everything else. That is
       // correct — the entity is gone, so its membership projection must go too —
       // but the `entity_relationships` trigger refuses authorization-bearing
@@ -1857,9 +1905,14 @@ export async function deleteEntity(
   // it until the tombstone commits, so no concurrent write can change the state
   // the verdict was based on.
   //
-  // Scope is the soft-delete path only. `force` above hard-deletes the tree
-  // through `hardDeleteEntityRows`, which no rule sees: freezing a row does not
-  // survive a force delete.
+  // `force` above asks the same question of every row in the tree before it
+  // hard-deletes any of them, so freezing a row survives both delete paths. The
+  // physical helper `hardDeleteEntityRows` itself stays unguarded and is
+  // deliberately exempt: its other callers are rollback paths that destroy a row
+  // the platform created moments earlier in the same request
+  // (`entity-link-upsert`, `promote-keyed-entities`, `canvas-events`,
+  // `eval-cases`). Judging those would let a tenant rule wedge a half-built
+  // record in place, which is the failure the rollback exists to prevent.
   //
   // A deny throws rather than returning: approval cannot launder an illegal
   // state into a legal one. An escalate throws too UNLESS this call is the


### PR DESCRIPTION
## Summary
- `deleteEntity(force=true)` walked the entity tree and handed the ids straight to `hardDeleteEntityRows`, so no write rule ever saw it. A rule that froze deletion meant "cannot be deleted **without passing `force_delete_tree=true`**" — a control with a published bypass. The force path now proposes the same `$deleted` patch the soft path does, under lock, before it destroys anything.
- Every id in the tree is judged, not just the root: a descendant carries its own type's rules, and deleting a parent must not be a way to destroy a frozen child.
- The force dry run previews the verdict and returns `refused: true`; a preflight that says "would remove 1 entities" for a tree a rule refuses is optimistic in the one direction that matters before an irreversible delete.
- No new surface. `entity-field-approval` already replays a delete card with `force_delete_tree` and grants exactly `["$deleted"]`, so an escalating rule on a force delete is honoured by the card a human approved — and a `deny` still cannot be laundered.
- `hardDeleteEntityRows` itself stays unguarded, now documented as a deliberate exemption: its other callers (`entity-link-upsert`, `promote-keyed-entities`, `canvas-events`, `eval-cases`) are same-request rollback paths that destroy a row the platform created moments earlier. Judging those would let a tenant rule wedge a half-built record in place.

Hard deletion answers to `$deleted` rather than earning its own reserved name, because it is not a lesser destruction than a tombstone. That is the opposite call from merge in #2950, which got `$merged_into` precisely because merging a duplicate into its canonical record is a correction — freezing deletion must not freeze dedupe.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bunx vitest run src/__tests__/integration/authz/entity-row-validation.test.ts` (28/28) and the whole `authz/` integration directory (231/231, 26 files)
- [x] Bug fix: red→fix→green outputs pasted below

### RED — new `force delete` suite against unmodified `entity-management.ts`

```
$ bunx vitest run src/__tests__/integration/authz/entity-row-validation.test.ts -t "force delete"

 FAIL  ... > force delete > reports the rule verdict in a force dry run
 AssertionError: expected 'Dry run: force delete would remove 1 …' to match /would NOT run/

 Test Files  1 failed (1)
      Tests  5 failed | 3 passed | 20 skipped (28)
```

The 3 that pass are the negative controls — the permitted-tree, permitted-dry-run and no-rule cases must pass both before and after, or the suite would only be proving that force delete broke.

### GREEN — same file with the seam in place

```
$ bunx vitest run src/__tests__/integration/authz/entity-row-validation.test.ts

 ✓ src/__tests__/integration/authz/entity-row-validation.test.ts (28 tests) 4302ms

 Test Files  1 passed (1)
      Tests  28 passed (28)
```

```
$ bunx vitest run src/__tests__/integration/authz/

 Test Files  26 passed (26)
      Tests  231 passed (231)
```

## Notes
Follow-ups this does not do, deliberately:
- A rule **escalate** on either delete path still fails closed rather than minting a card — `manage_entity`'s delete branch has no `EntityRowValidationError` catch (only its create branch does). The grant plumbing is already correct for when it gets one; this PR does not add it.
- The merge kernel's winner-metadata patch and redirect repoint remain ungoverned, as does unmerge.
