### PR TITLE
docs(authz): settle the merge kernel's ungoverned writes as declared exemptions

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-merge-rule-seam.test.ts
@@ -12,9 +12,9 @@
  * tenant must be able to freeze deletion without freezing dedupe. The
  * discriminating test below is the one that proves the two are separable.
  *
- * Scope: the LOSER's tombstone only. The winner's metadata patch and the
- * redirect repoint are deliberately not governed here — see the kernel comment
- * in `entity-merge.ts`.
+ * Scope: the LOSER's tombstone only. The winner's metadata patch, the redirect
+ * repoint, and unmerge are declared exemptions with their reasons spelled out on
+ * `transitionEntityMergeRows` in `entity-management.ts`.
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -566,14 +566,26 @@ export async function patchEntityRows(params: {
  * the tombstone is an implementation detail of the redirect, and a tenant must
  * be able to freeze deletion without freezing dedupe.
  *
- * REMAINING GAP: the winner's metadata patch and the redirect repoint are still
- * ungoverned, and unmerge (`liveness: "live"`) is deliberately left free so a
- * freeze cannot strand a row tombstoned. The winner is the hard one:
- * `mergeEntityState` appends the loser's name to `metadata.aliases` on every
- * merge, so governing it would present a metadata change to the rule engine on
- * every single merge — a rule freezing a canonical row would make it unable to
- * absorb any duplicate. That needs a decision about what approving a merge
- * grants, not a call added here.
+ * The merge's other three writes are DECLARED EXEMPTIONS, not oversights:
+ *
+ *  - The WINNER's metadata patch. `mergeEntityState` is winner-preserving: it
+ *    fills only fields the winner left undefined/null/empty, unions arrays, and
+ *    appends the loser's name to `metadata.aliases`. It cannot overwrite a value
+ *    the winner already holds, so freezing a field already means a merge cannot
+ *    change it. Governing the patch anyway would present a metadata change on
+ *    EVERY merge — the alias append guarantees one — so a rule freezing the
+ *    canonical record would make it unable to absorb any duplicate, which is
+ *    exactly backwards: the canonical row is the one you merge INTO. The
+ *    residual hole is narrow and named: filling a BLANK field on a frozen winner
+ *    is a write no rule sees. Closing it means judging the patch minus the alias
+ *    ledger, which makes `aliases` platform vocabulary a tenant can no longer
+ *    govern — a rule-contract change, not a call added here.
+ *  - The redirect repoint. Step 4 of `applyMergeInTransaction` flattens rows
+ *    that ALREADY point at the loser so they point at the winner instead. Those
+ *    rows are tombstones of merges that were judged when they happened; asking
+ *    again would re-litigate a settled decision on a row nobody is editing.
+ *  - Unmerge (`liveness: "live"`). Left free on purpose, so a freeze added after
+ *    a merge cannot strand a row tombstoned with no way back.
  */
 export async function transitionEntityMergeRows(params: {
 	tx: DbClient;


### PR DESCRIPTION
## Summary
- `transitionEntityMergeRows` called the winner's metadata patch, the redirect repoint, and unmerge a "REMAINING GAP" that "needs a decision". The decision is made. This records it — a comment that says a hole is open is what makes the next reader propose closing it, and it already caused one wrong claim in a design discussion.
- **The winner's patch stays ungoverned.** `mergeEntityState` is winner-preserving: it fills only fields the winner left `undefined`/`null`/`""`, unions arrays, and appends the loser's name to `metadata.aliases`. It cannot overwrite a value the winner already holds, so freezing a field already means a merge cannot change it. Governing the patch anyway would present a metadata change on **every** merge — the alias append guarantees one — and a rule freezing the canonical record would then be unable to absorb any duplicate. That is backwards: the canonical row is the one you merge *into*.
- **The residual hole is named, not papered over:** filling a *blank* field on a frozen winner is a write no rule sees. Closing it means judging the patch minus the alias ledger, which turns `aliases` into platform vocabulary a tenant can no longer govern — a change to the rule contract, not a call added at this seam.
- **The redirect repoint** flattens rows that already point at the loser; each was judged when its own merge happened, so asking again re-litigates a settled decision on a row nobody is editing.
- **Unmerge stays free** so a freeze added after a merge cannot strand a row tombstoned with no way back.
- Also fixes the merge-seam test's cross-reference, which pointed at `entity-merge.ts` for a comment that lives in `entity-management.ts`.

Comment-only; no runtime change.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `make pre-pr`'s gate suite (19/19). No behaviour changed, so no red→green pair exists to paste — the diff is two doc comments.

## Notes
Companion to #2950 (merge under `$merged_into`) and #2963 (`force_delete_tree` under `$deleted`). With those three, the entity-destruction map is: soft delete governed, force delete governed, loser tombstone governed, winner patch / redirect / unmerge exempt with reasons stated in the code.
