### PR TITLE
test(gateway): wait for the run row, not the in-handler flag, in the deferral test

### DIFF
--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -178,17 +178,24 @@ describe("RunsQueue — deferral retries (isDeferralError contract)", () => {
       done = true;
     });
 
+    // Poll the ROW, not the in-handler `done` flag. `done` is set inside the
+    // handler, which returns before the queue writes `status='completed'` — so
+    // waiting on it and then reading the row is a read-too-early race that
+    // reports `claimed` on a loaded runner. The companion test below already
+    // polls the row for exactly this reason.
+    const sql = getDb();
+    let rows: { status: string; attempts: number | string }[] = [];
     const start = Date.now();
-    while (!done && Date.now() - start < 5000) {
+    while (rows[0]?.status !== "completed" && Date.now() - start < 5000) {
       await new Promise((r) => setTimeout(r, 50));
+      rows = [
+        ...(await sql<{ status: string; attempts: number | string }>`
+          SELECT status, attempts FROM runs WHERE queue_name = 'test-deferral'
+        `),
+      ];
     }
     expect(done).toBe(true);
     expect(calls).toBe(3);
-
-    const sql = getDb();
-    const rows = await sql<{ status: string; attempts: number | string }>`
-      SELECT status, attempts FROM runs WHERE queue_name = 'test-deferral'
-    `;
     expect(rows[0]?.status).toBe("completed");
     expect(Number(rows[0]?.attempts ?? -1)).toBe(0);
   });


### PR DESCRIPTION
## Summary
- `a deferral-flagged throw reschedules without consuming an attempt` polled a `done` flag set *inside* the job handler, then immediately read `runs.status` and asserted `completed`. The handler returns before the queue writes that status, so the read could land in the gap.
- On a loaded CI runner it did: PR #2958, run `32327396686`, `runs-queue-integration.test.ts:192` — `Expected: "completed" / Received: "claimed"`.
- The companion test 14 lines below (`a plain throw at the same budget fails the job`) already polls the row for exactly this reason. This makes the two match.
- **Not a timeout change.** The loop budget stays 5s. The failing run took 1215.99ms, so it never came near the budget — raising it would have fixed nothing. (I said "5s budget" in an earlier note before reading the assertion; that was wrong.)
- `done` and `calls` are still asserted, so what the test proves is unchanged — only the moment it looks.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test src/gateway/__tests__/runs-queue-integration.test.ts` → 9/9 pass

### On red→green: the failure is real but not locally reproducible

The reproduction is the CI log above, with the exact line and observed value. It does **not** reproduce on an unloaded Mac. I probed for it rather than assuming — replaced the assertion with a print of the status observed at the old read point and ran the suite 6 times:

```
PROBE: status observed at the old read point = completed
PROBE: status observed at the old read point = completed
PROBE: status observed at the old read point = completed
PROBE: status observed at the old read point = completed
PROBE: status observed at the old read point = completed
```

So: 5/5 locally benign, and the race only opens when the queue's completion write is slow enough. Recording that plainly rather than claiming a local red I did not get. The fix is structural — the new loop cannot exit in a non-`completed` state except by timing out, so the assertion that failed is no longer reachable.

```
$ bun test src/gateway/__tests__/runs-queue-integration.test.ts
 9 pass
 0 fail
 25 expect() calls
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of deferred task completion checks.
  * Prevented intermittent test failures caused by timing differences between task processing and status updates.
  * Ensured completion and retry counts are verified only after the latest status is persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->