### PR TITLE
fix(authz): verify a declared automation_source at every write surface

### DIFF
--- a/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
@@ -13,7 +13,10 @@
  * anchoring a canvas; this is the same rule on the attribution path.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
-import { verifiedAutomationSource } from '../../../tools/execute';
+import {
+  resolveAutomationAttribution,
+  verifiedAutomationSource,
+} from '../../../automations/automation-source';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import { createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
@@ -87,5 +90,99 @@ describe('declared automation_source verification', () => {
     await expect(
       verifiedAutomationSource(null, org.organizationId)
     ).resolves.toBeNull();
+  });
+});
+
+describe('resolveAutomationAttribution precedence', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('lets the trusted session identity win, WINDOW INCLUDED', async () => {
+    const org = await orgWithAutomation('Session Org', 'session');
+    const other = await orgWithAutomation('Other Org', 'other');
+    // Every call site's comment claimed the session automation wins, but each
+    // one still took the declared WINDOW when the session's was null-ish — the
+    // exact retag this precedence exists to stop. The session pair is atomic.
+    await expect(
+      resolveAutomationAttribution(
+        {
+          organizationId: org.organizationId,
+          actingAutomationId: org.automationId,
+          actingWindowId: 42,
+        },
+        { automation_id: other.automationId, window_id: 99 }
+      )
+    ).resolves.toEqual({ automationId: org.automationId, windowId: 42 });
+  });
+
+  it('gives a windowless session NO window, rather than the declared one', async () => {
+    const org = await orgWithAutomation('Windowless Session', 'w-session');
+    const other = await orgWithAutomation('Window Donor', 'w-donor');
+    // The case the previous assertion missed: with a session window present,
+    // `actingWindowId ?? declared.window_id` yields the session's either way. A
+    // session carrying an automation but NO window is the only shape that tells
+    // the two apart — and it is reachable, since the agent and device lanes set
+    // `actingAutomationId` from the auth context with `actingWindowId` null.
+    await expect(
+      resolveAutomationAttribution(
+        {
+          organizationId: org.organizationId,
+          actingAutomationId: org.automationId,
+          actingWindowId: null,
+        },
+        { automation_id: other.automationId, window_id: 99 }
+      )
+    ).resolves.toEqual({ automationId: org.automationId, windowId: null });
+  });
+
+  it('honors a declared source the organization owns when off-session', async () => {
+    const org = await orgWithAutomation('Declared Org', 'declared');
+    await expect(
+      resolveAutomationAttribution(
+        { organizationId: org.organizationId },
+        { automation_id: org.automationId, window_id: 5 }
+      )
+    ).resolves.toEqual({ automationId: org.automationId, windowId: 5 });
+  });
+
+  it('yields NO attribution for a foreign declared source', async () => {
+    const victim = await orgWithAutomation('Foreign Victim', 'f-victim');
+    const attacker = await orgWithAutomation('Foreign Attacker', 'f-attacker');
+    await expect(
+      resolveAutomationAttribution(
+        { organizationId: attacker.organizationId },
+        { automation_id: victim.automationId, window_id: 5 }
+      )
+    ).resolves.toEqual({ automationId: null, windowId: null });
+  });
+
+  it('drops the WINDOW too when the Automation fails verification', async () => {
+    const org = await orgWithAutomation('Half Org', 'half');
+    // A window without its Automation names an approval batch nothing owns, so
+    // a half-applied attribution is worse than none.
+    await expect(
+      resolveAutomationAttribution(
+        { organizationId: org.organizationId },
+        { automation_id: 2147483000, window_id: 5 }
+      )
+    ).resolves.toEqual({ automationId: null, windowId: null });
+  });
+
+  it('attributes a windowless declaration to the Automation alone', async () => {
+    const org = await orgWithAutomation('Windowless Org', 'windowless');
+    await expect(
+      resolveAutomationAttribution(
+        { organizationId: org.organizationId },
+        { automation_id: org.automationId }
+      )
+    ).resolves.toEqual({ automationId: org.automationId, windowId: null });
+  });
+
+  it('returns nothing when the caller declared nothing and holds no session', async () => {
+    const org = await orgWithAutomation('Bare Org', 'bare');
+    await expect(
+      resolveAutomationAttribution({ organizationId: org.organizationId }, undefined)
+    ).resolves.toEqual({ automationId: null, windowId: null });
   });
 });

--- a/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-attribution.test.ts
@@ -1,15 +1,17 @@
 /**
  * A caller-declared `automation_source` must not be trusted for provenance.
  *
- * `automation_source` is tool input, so an org member can name any id. Audit
- * rows stamp `events.automation_id` from it, so an unverified id does two
+ * `automation_source` is tool input, so an org member can name any pair of ids.
+ * Audit rows stamp `events.automation_id` from it, so an unverified id does two
  * kinds of damage: it misattributes the row — and lets it inherit that
  * Automation's causal chain, which is what bounds a cascade — and, because the
  * column carries a foreign key while audit writes are fire-and-forget, a
  * nonexistent id fails the INSERT and DROPS the audit row with no caller-
- * visible error.
+ * visible error. The window is the third: paired with someone else's
+ * `window_id`, an otherwise-legitimate proposal lands in that Automation's
+ * approval card.
  *
- * `notify.ts` already validates this field against the caller's org before
+ * `notify.ts` already validates the pair against the caller's org before
  * anchoring a canvas; this is the same rule on the attribution path.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -18,7 +20,7 @@ import {
   verifiedAutomationSource,
 } from '../../../automations/automation-source';
 import { cleanupTestDatabase } from '../../setup/test-db';
-import { createTestAgent } from '../../setup/test-fixtures';
+import { createCanvasWindow, createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
 
 async function orgWithAutomation(name: string, slug: string) {
@@ -39,9 +41,20 @@ async function orgWithAutomation(name: string, slug: string) {
     prompt: 'Anything.',
     agent_id: agent.agentId,
   })) as { automation_id: string };
-  return {
+  const automationId = Number(created.automation_id);
+  const windowId = await createCanvasWindow({
+    automationId,
     organizationId: workspace.org.id,
-    automationId: Number(created.automation_id),
+    windowStart: '2026-01-01T00:00:00.000Z',
+    windowEnd: '2026-01-08T00:00:00.000Z',
+    createdBy: ownerUserId,
+  });
+  return {
+    api,
+    agentId: agent.agentId,
+    organizationId: workspace.org.id,
+    automationId,
+    windowId,
   };
 }
 
@@ -54,20 +67,18 @@ describe('declared automation_source verification', () => {
     const org = await orgWithAutomation('Owner Org', 'owned');
     await expect(
       verifiedAutomationSource(
-        { automationId: org.automationId, windowId: 7 },
+        { automationId: org.automationId, windowId: org.windowId },
         org.organizationId
       )
-    ).resolves.toEqual({ automationId: org.automationId, windowId: 7 });
+    ).resolves.toEqual({ automationId: org.automationId, windowId: org.windowId });
   });
 
   it('rejects an Automation belonging to another organization', async () => {
     const victim = await orgWithAutomation('Victim Org', 'victim');
     const attacker = await orgWithAutomation('Attacker Org', 'attacker');
-    // The id exists, so the foreign key would happily accept it — only the org
-    // check stops the attacker attributing its writes to another org's chain.
     await expect(
       verifiedAutomationSource(
-        { automationId: victim.automationId, windowId: 1 },
+        { automationId: victim.automationId, windowId: victim.windowId },
         attacker.organizationId
       )
     ).resolves.toBeNull();
@@ -75,11 +86,9 @@ describe('declared automation_source verification', () => {
 
   it('rejects an id that does not exist at all', async () => {
     const org = await orgWithAutomation('Ghost Org', 'ghost');
-    // Unverified, this is the id that would fail the FK and silently drop the
-    // audit row.
     await expect(
       verifiedAutomationSource(
-        { automationId: 2147483000, windowId: 1 },
+        { automationId: 2147483000, windowId: org.windowId },
         org.organizationId
       )
     ).resolves.toBeNull();
@@ -91,6 +100,28 @@ describe('declared automation_source verification', () => {
       verifiedAutomationSource(null, org.organizationId)
     ).resolves.toBeNull();
   });
+
+  it('rejects a window belonging to another Automation in the same organization', async () => {
+    const org = await orgWithAutomation('Pair Org', 'pair');
+    const created = (await org.api.automations.create({
+      slug: 'pair-other',
+      prompt: 'Anything.',
+      agent_id: org.agentId,
+    })) as { automation_id: string };
+    const otherWindowId = await createCanvasWindow({
+      automationId: Number(created.automation_id),
+      organizationId: org.organizationId,
+      windowStart: '2026-01-08T00:00:00.000Z',
+      windowEnd: '2026-01-15T00:00:00.000Z',
+    });
+
+    await expect(
+      verifiedAutomationSource(
+        { automationId: org.automationId, windowId: otherWindowId },
+        org.organizationId
+      )
+    ).resolves.toBeNull();
+  });
 });
 
 describe('resolveAutomationAttribution precedence', () => {
@@ -98,32 +129,24 @@ describe('resolveAutomationAttribution precedence', () => {
     await cleanupTestDatabase();
   });
 
-  it('lets the trusted session identity win, WINDOW INCLUDED', async () => {
+  it('lets the trusted session identity win, including its window', async () => {
     const org = await orgWithAutomation('Session Org', 'session');
     const other = await orgWithAutomation('Other Org', 'other');
-    // Every call site's comment claimed the session automation wins, but each
-    // one still took the declared WINDOW when the session's was null-ish — the
-    // exact retag this precedence exists to stop. The session pair is atomic.
     await expect(
       resolveAutomationAttribution(
         {
           organizationId: org.organizationId,
           actingAutomationId: org.automationId,
-          actingWindowId: 42,
+          actingWindowId: org.windowId,
         },
-        { automation_id: other.automationId, window_id: 99 }
+        { automation_id: other.automationId, window_id: other.windowId }
       )
-    ).resolves.toEqual({ automationId: org.automationId, windowId: 42 });
+    ).resolves.toEqual({ automationId: org.automationId, windowId: org.windowId });
   });
 
-  it('gives a windowless session NO window, rather than the declared one', async () => {
+  it('gives a windowless session no window rather than the declared one', async () => {
     const org = await orgWithAutomation('Windowless Session', 'w-session');
     const other = await orgWithAutomation('Window Donor', 'w-donor');
-    // The case the previous assertion missed: with a session window present,
-    // `actingWindowId ?? declared.window_id` yields the session's either way. A
-    // session carrying an automation but NO window is the only shape that tells
-    // the two apart — and it is reachable, since the agent and device lanes set
-    // `actingAutomationId` from the auth context with `actingWindowId` null.
     await expect(
       resolveAutomationAttribution(
         {
@@ -131,7 +154,7 @@ describe('resolveAutomationAttribution precedence', () => {
           actingAutomationId: org.automationId,
           actingWindowId: null,
         },
-        { automation_id: other.automationId, window_id: 99 }
+        { automation_id: other.automationId, window_id: other.windowId }
       )
     ).resolves.toEqual({ automationId: org.automationId, windowId: null });
   });
@@ -141,42 +164,30 @@ describe('resolveAutomationAttribution precedence', () => {
     await expect(
       resolveAutomationAttribution(
         { organizationId: org.organizationId },
-        { automation_id: org.automationId, window_id: 5 }
+        { automation_id: org.automationId, window_id: org.windowId }
       )
-    ).resolves.toEqual({ automationId: org.automationId, windowId: 5 });
+    ).resolves.toEqual({ automationId: org.automationId, windowId: org.windowId });
   });
 
-  it('yields NO attribution for a foreign declared source', async () => {
+  it('yields no attribution for a foreign declared source', async () => {
     const victim = await orgWithAutomation('Foreign Victim', 'f-victim');
     const attacker = await orgWithAutomation('Foreign Attacker', 'f-attacker');
     await expect(
       resolveAutomationAttribution(
         { organizationId: attacker.organizationId },
-        { automation_id: victim.automationId, window_id: 5 }
+        { automation_id: victim.automationId, window_id: victim.windowId }
       )
     ).resolves.toEqual({ automationId: null, windowId: null });
   });
 
-  it('drops the WINDOW too when the Automation fails verification', async () => {
+  it('drops the window too when the Automation fails verification', async () => {
     const org = await orgWithAutomation('Half Org', 'half');
-    // A window without its Automation names an approval batch nothing owns, so
-    // a half-applied attribution is worse than none.
     await expect(
       resolveAutomationAttribution(
         { organizationId: org.organizationId },
-        { automation_id: 2147483000, window_id: 5 }
+        { automation_id: 2147483000, window_id: org.windowId }
       )
     ).resolves.toEqual({ automationId: null, windowId: null });
-  });
-
-  it('attributes a windowless declaration to the Automation alone', async () => {
-    const org = await orgWithAutomation('Windowless Org', 'windowless');
-    await expect(
-      resolveAutomationAttribution(
-        { organizationId: org.organizationId },
-        { automation_id: org.automationId }
-      )
-    ).resolves.toEqual({ automationId: org.automationId, windowId: null });
   });
 
   it('returns nothing when the caller declared nothing and holds no session', async () => {

--- a/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
@@ -8,7 +8,9 @@
  * the part a future refactor can silently undo.
  *
  * `automation_reactions` is the observable end of that path: a row appears with
- * the Automation credited for the write, or no row appears at all.
+ * the Automation credited for the write, or no row appears at all. Each case
+ * pairs the forged declaration with an owned one, so a change that disabled
+ * reaction tracking outright cannot make these pass by writing nothing.
  *
  * Only the cross-org case is asserted here. A NONEXISTENT id is invisible at
  * this surface: the composite foreign key already rejected the insert and the
@@ -18,7 +20,7 @@
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
-import { createTestAgent } from '../../setup/test-fixtures';
+import { createCanvasWindow, createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
 
 async function orgWithAutomationAndWindow(name: string, slug: string) {
@@ -39,19 +41,36 @@ async function orgWithAutomationAndWindow(name: string, slug: string) {
     prompt: 'Anything.',
     agent_id: agent.agentId,
   })) as { automation_id: string };
+  const automationId = Number(created.automation_id);
+  const windowId = await createCanvasWindow({
+    automationId,
+    organizationId: workspace.org.id,
+    windowStart: '2026-01-01T00:00:00.000Z',
+    windowEnd: '2026-01-08T00:00:00.000Z',
+    createdBy: ownerUserId,
+  });
   return {
     api,
     organizationId: workspace.org.id,
-    automationId: Number(created.automation_id),
+    automationId,
+    windowId,
   };
 }
 
 async function reactionRows(organizationId: string) {
-  return getTestDb()<{ automation_id: number; window_id: number }>`
+  const rows = await getTestDb()<{
+    automation_id: number | string;
+    window_id: number | string;
+  }>`
     SELECT automation_id, window_id
     FROM automation_reactions
     WHERE organization_id = ${organizationId}
+    ORDER BY id
   `;
+  return rows.map((row) => ({
+    automation_id: Number(row.automation_id),
+    window_id: Number(row.window_id),
+  }));
 }
 
 describe('write surfaces refuse an unowned automation_source', () => {
@@ -59,25 +78,81 @@ describe('write surfaces refuse an unowned automation_source', () => {
     await cleanupTestDatabase();
   });
 
-  it('credits nobody when save_memory declares another org’s Automation', async () => {
+  it('keeps only owned credit when save_memory also declares another org’s Automation', async () => {
     const victim = await orgWithAutomationAndWindow('Surface Victim', 's-victim');
     const attacker = await orgWithAutomationAndWindow('Surface Attacker', 's-attacker');
 
-    // Deliberately the SDK namespace, not `executeTool`: `client.knowledge.save`
-    // calls the handler directly, so the dispatch-level verification added in
-    // #2952 never runs on this path. The surface has to hold on its own.
+    await attacker.api.knowledge.save({
+      semantic_type: 'note',
+      metadata: {},
+      title: 'Owned credit',
+      content: 'Attributed to this organization’s Automation.',
+      automation_source: {
+        automation_id: attacker.automationId,
+        window_id: attacker.windowId,
+      },
+    });
+
     await attacker.api.knowledge.save({
       semantic_type: 'note',
       metadata: {},
       title: 'Borrowed credit',
       content: 'Attributed to an Automation this org does not own.',
-      automation_source: { automation_id: victim.automationId, window_id: 1 },
+      automation_source: {
+        automation_id: victim.automationId,
+        window_id: victim.windowId,
+      },
     });
 
-    // The write itself is fine — attribution is a hint, not a permission — but
-    // it must land on nobody rather than on the victim's feedback record.
-    await expect(reactionRows(attacker.organizationId)).resolves.toEqual([]);
+    await expect(reactionRows(attacker.organizationId)).resolves.toEqual([
+      { automation_id: attacker.automationId, window_id: attacker.windowId },
+    ]);
     await expect(reactionRows(victim.organizationId)).resolves.toEqual([]);
   });
 
+  it('keeps only owned credit when manage_entity also declares another org’s Automation', async () => {
+    const victim = await orgWithAutomationAndWindow('Entity Victim', 'e-victim');
+    const attacker = await orgWithAutomationAndWindow('Entity Attacker', 'e-attacker');
+    await attacker.api.entity_schema.createType({ slug: 'company', name: 'Company' });
+    await attacker.api.entity_schema.createRelType({ slug: 'related', name: 'Related' });
+    const from = (await attacker.api.entities.create({
+      type: 'company',
+      name: 'From',
+    })) as { entity: { id: number } };
+    const to = (await attacker.api.entities.create({
+      type: 'company',
+      name: 'To',
+    })) as { entity: { id: number } };
+    const borrowedTo = (await attacker.api.entities.create({
+      type: 'company',
+      name: 'Borrowed To',
+    })) as { entity: { id: number } };
+
+    await attacker.api.entities.manage({
+      action: 'link',
+      from_entity_id: from.entity.id,
+      to_entity_id: to.entity.id,
+      relationship_type_slug: 'related',
+      automation_source: {
+        automation_id: attacker.automationId,
+        window_id: attacker.windowId,
+      },
+    });
+
+    await attacker.api.entities.manage({
+      action: 'link',
+      from_entity_id: from.entity.id,
+      to_entity_id: borrowedTo.entity.id,
+      relationship_type_slug: 'related',
+      automation_source: {
+        automation_id: victim.automationId,
+        window_id: victim.windowId,
+      },
+    });
+
+    await expect(reactionRows(attacker.organizationId)).resolves.toEqual([
+      { automation_id: attacker.automationId, window_id: attacker.windowId },
+    ]);
+    await expect(reactionRows(victim.organizationId)).resolves.toEqual([]);
+  });
 });

--- a/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The verification has to hold at the WRITE SURFACES, not just in the helper.
+ *
+ * `manage_entity` merged the trusted session identity with the caller-declared
+ * `automation_source` inline at seven places, and `save_content` took the
+ * declared pair verbatim with no precedence at all. A unit test on the resolver
+ * proves the rule; these prove the surfaces actually go through it, which is
+ * the part a future refactor can silently undo.
+ *
+ * `automation_reactions` is the observable end of that path: a row appears with
+ * the Automation credited for the write, or no row appears at all.
+ *
+ * Only the cross-org case is asserted here. A NONEXISTENT id is invisible at
+ * this surface: the composite foreign key already rejected the insert and the
+ * call site swallows the error, so the row count was zero before this change
+ * too. Asserting it here would pass either way — `automation-source-attribution`
+ * covers that case where the difference is actually observable.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+async function orgWithAutomationAndWindow(name: string, slug: string) {
+  const workspace = await TestWorkspace.create({ name });
+  const ownerUserId = workspace.users.owner.id;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: `${slug}-agent`,
+  });
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+  const created = (await api.automations.create({
+    slug,
+    prompt: 'Anything.',
+    agent_id: agent.agentId,
+  })) as { automation_id: string };
+  return {
+    api,
+    organizationId: workspace.org.id,
+    automationId: Number(created.automation_id),
+  };
+}
+
+async function reactionRows(organizationId: string) {
+  return getTestDb()<{ automation_id: number; window_id: number }>`
+    SELECT automation_id, window_id
+    FROM automation_reactions
+    WHERE organization_id = ${organizationId}
+  `;
+}
+
+describe('write surfaces refuse an unowned automation_source', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('credits nobody when save_memory declares another org’s Automation', async () => {
+    const victim = await orgWithAutomationAndWindow('Surface Victim', 's-victim');
+    const attacker = await orgWithAutomationAndWindow('Surface Attacker', 's-attacker');
+
+    // Deliberately the SDK namespace, not `executeTool`: `client.knowledge.save`
+    // calls the handler directly, so the dispatch-level verification added in
+    // #2952 never runs on this path. The surface has to hold on its own.
+    await attacker.api.knowledge.save({
+      semantic_type: 'note',
+      metadata: {},
+      title: 'Borrowed credit',
+      content: 'Attributed to an Automation this org does not own.',
+      automation_source: { automation_id: victim.automationId, window_id: 1 },
+    });
+
+    // The write itself is fine — attribution is a hint, not a permission — but
+    // it must land on nobody rather than on the victim's feedback record.
+    await expect(reactionRows(attacker.organizationId)).resolves.toEqual([]);
+    await expect(reactionRows(victim.organizationId)).resolves.toEqual([]);
+  });
+
+});

--- a/packages/server/src/automations/automation-source.ts
+++ b/packages/server/src/automations/automation-source.ts
@@ -1,0 +1,103 @@
+/**
+ * Who to attribute a durable write to, resolved once for every write surface.
+ *
+ * An acting Automation reaches a handler on two channels: `ctx.actingAutomationId`,
+ * stamped by the reaction executor and therefore trustworthy, and a caller-declared
+ * `automation_source` argument, which is ordinary user input. Every surface used to
+ * merge them inline with `ctx.actingAutomationId ?? args.automation_source?.automation_id`,
+ * which trusts the declared half without ever checking it names an Automation in
+ * this organization. That has three consequences, all silent:
+ *
+ *   - a foreign id misattributes the write to another Automation, and where the
+ *     value reaches `events.automation_id` it also inherits that Automation's
+ *     causal chain (`workspace-event-enqueue.ts`)
+ *   - a NONEXISTENT id fails the `events_automation_id_fkey` constraint, and
+ *     because audit writes are fire-and-forget the row is dropped entirely
+ *   - a declared window belonging to a different Automation batches this
+ *     proposal into that Automation's approval card
+ *
+ * `notify.ts` has validated this field for exactly these reasons since it was
+ * added; `execute.ts` started doing so in #2952. This module is that same rule
+ * in one place, so a new write surface inherits it instead of re-deriving it.
+ *
+ * Kept free of tool and gateway imports so any write surface can reach it.
+ */
+
+import type { DbClient } from '../db/client';
+import { getDb } from '../db/client';
+
+/** The Automation a durable write is attributed to, after verification. */
+export interface AutomationAttribution {
+  automationId: number | null;
+  windowId: number | null;
+}
+
+/** The `automation_source` shape every tool contract declares. */
+export interface DeclaredAutomationSource {
+  automation_id: number;
+  window_id?: number | null;
+}
+
+/** The parts of a ToolContext this resolution reads. */
+export interface ActingAutomationSession {
+  organizationId: string;
+  actingAutomationId?: number | null;
+  actingWindowId?: number | null;
+}
+
+/**
+ * Drop a declared source that does not name an Automation in this organization.
+ *
+ * Returns null rather than throwing: attribution is a provenance hint, and a bad
+ * hint should cost the caller its attribution, not fail their tool call. The
+ * window is not paired to the Automation here — `loadRunEventCausality` scopes
+ * its run lookup to the producing Automation, so a foreign window inherits
+ * nothing.
+ */
+export async function verifiedAutomationSource(
+  declared: { automationId: number; windowId: number | null } | null,
+  organizationId: string,
+  db: DbClient = getDb()
+): Promise<{ automationId: number; windowId: number | null } | null> {
+  if (!declared) return null;
+  const rows = await db<{ id: number }>`
+    SELECT id
+    FROM automations
+    WHERE id = ${declared.automationId}
+      AND organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  return rows[0] ? declared : null;
+}
+
+/**
+ * The Automation and window a write surface should record.
+ *
+ * The trusted session identity wins outright — including its window. Letting a
+ * declared window through on a reaction session is what would let a script retag
+ * its deferral into another Automation's approval batch, which is the precedence
+ * every call site's comment already claimed without the code enforcing it.
+ *
+ * Off-session, the declared source is honored only once verified. An unverified
+ * declaration yields no attribution at all rather than a half-applied one: a
+ * window without its Automation names a batch nothing owns.
+ */
+export async function resolveAutomationAttribution(
+  ctx: ActingAutomationSession,
+  declared: DeclaredAutomationSource | null | undefined,
+  db: DbClient = getDb()
+): Promise<AutomationAttribution> {
+  if (ctx.actingAutomationId != null) {
+    return {
+      automationId: ctx.actingAutomationId,
+      windowId: ctx.actingWindowId ?? null,
+    };
+  }
+  if (!declared) return { automationId: null, windowId: null };
+  const verified = await verifiedAutomationSource(
+    { automationId: declared.automation_id, windowId: declared.window_id ?? null },
+    ctx.organizationId,
+    db
+  );
+  return verified ?? { automationId: null, windowId: null };
+}

--- a/packages/server/src/automations/automation-source.ts
+++ b/packages/server/src/automations/automation-source.ts
@@ -13,7 +13,7 @@
  *     causal chain (`workspace-event-enqueue.ts`)
  *   - a NONEXISTENT id fails the `events_automation_id_fkey` constraint, and
  *     because audit writes are fire-and-forget the row is dropped entirely
- *   - a declared window belonging to a different Automation batches this
+ *   - a declared window belonging to a DIFFERENT Automation batches this
  *     proposal into that Automation's approval card
  *
  * `notify.ts` has validated this field for exactly these reasons since it was
@@ -23,53 +23,63 @@
  * Kept free of tool and gateway imports so any write surface can reach it.
  */
 
-import type { DbClient } from '../db/client';
 import { getDb } from '../db/client';
 
 /** The Automation a durable write is attributed to, after verification. */
-export interface AutomationAttribution {
+interface AutomationAttribution {
   automationId: number | null;
   windowId: number | null;
 }
 
-/** The `automation_source` shape every tool contract declares. */
-export interface DeclaredAutomationSource {
+/**
+ * The `automation_source` shape every tool contract declares.
+ *
+ * Both halves are required: `manage_entity`, `save_content`, and `notify` all
+ * type `window_id` as `Type.Number()`, so a declaration missing one is malformed
+ * input, not a partial one to honor.
+ */
+interface DeclaredAutomationSource {
   automation_id: number;
-  window_id?: number | null;
+  window_id: number;
 }
 
 /** The parts of a ToolContext this resolution reads. */
-export interface ActingAutomationSession {
+interface ActingAutomationSession {
   organizationId: string;
   actingAutomationId?: number | null;
   actingWindowId?: number | null;
 }
 
 /**
- * Drop a declared source that does not name an Automation in this organization.
+ * Drop a declared source unless the Automation belongs to this organization AND
+ * the window belongs to that Automation.
+ *
+ * The pairing is the half that is easy to miss: an org member can name their own
+ * Automation next to someone else's `window_id` and land the proposal in that
+ * window's approval card. `notify.ts` has paired the two the same way since it
+ * was added.
  *
  * Returns null rather than throwing: attribution is a provenance hint, and a bad
- * hint should cost the caller its attribution, not fail their tool call. The
- * window is not paired to the Automation here — `loadRunEventCausality` scopes
- * its run lookup to the producing Automation, so a foreign window inherits
- * nothing.
+ * hint should cost the caller its attribution, not fail their tool call.
  */
 export async function verifiedAutomationSource(
-  declared: { automationId: number; windowId: number | null } | null,
-  organizationId: string,
-  // Resolved AFTER the guard, never as a default parameter: a default is
-  // evaluated at call time, so `getDb()` would run on every call — including
-  // the overwhelmingly common one with nothing declared, and including unit
-  // suites that boot no database at all.
-  db?: DbClient
-): Promise<{ automationId: number; windowId: number | null } | null> {
+  declared: { automationId: number; windowId: number } | null,
+  organizationId: string
+): Promise<{ automationId: number; windowId: number } | null> {
   if (!declared) return null;
-  const client = db ?? getDb();
-  const rows = await client<{ id: number }>`
-    SELECT id
-    FROM automations
-    WHERE id = ${declared.automationId}
-      AND organization_id = ${organizationId}
+  // `getDb()` is reached only AFTER the guard, and never as a default parameter:
+  // a default is evaluated at call time, so it would run on every call — the
+  // overwhelmingly common one with nothing declared included, and unit suites
+  // that boot no database at all.
+  const rows = await getDb()<{ id: number }>`
+    SELECT a.id
+    FROM automations a
+    JOIN canvas_windows w
+      ON w.id = ${declared.windowId}
+     AND w.automation_id = a.id
+     AND w.organization_id = a.organization_id
+    WHERE a.id = ${declared.automationId}
+      AND a.organization_id = ${organizationId}
     LIMIT 1
   `;
   return rows[0] ? declared : null;
@@ -89,8 +99,7 @@ export async function verifiedAutomationSource(
  */
 export async function resolveAutomationAttribution(
   ctx: ActingAutomationSession,
-  declared: DeclaredAutomationSource | null | undefined,
-  db?: DbClient
+  declared: DeclaredAutomationSource | null | undefined
 ): Promise<AutomationAttribution> {
   if (ctx.actingAutomationId != null) {
     return {
@@ -100,9 +109,8 @@ export async function resolveAutomationAttribution(
   }
   if (!declared) return { automationId: null, windowId: null };
   const verified = await verifiedAutomationSource(
-    { automationId: declared.automation_id, windowId: declared.window_id ?? null },
-    ctx.organizationId,
-    db
+    { automationId: declared.automation_id, windowId: declared.window_id },
+    ctx.organizationId
   );
   return verified ?? { automationId: null, windowId: null };
 }

--- a/packages/server/src/automations/automation-source.ts
+++ b/packages/server/src/automations/automation-source.ts
@@ -57,10 +57,15 @@ export interface ActingAutomationSession {
 export async function verifiedAutomationSource(
   declared: { automationId: number; windowId: number | null } | null,
   organizationId: string,
-  db: DbClient = getDb()
+  // Resolved AFTER the guard, never as a default parameter: a default is
+  // evaluated at call time, so `getDb()` would run on every call — including
+  // the overwhelmingly common one with nothing declared, and including unit
+  // suites that boot no database at all.
+  db?: DbClient
 ): Promise<{ automationId: number; windowId: number | null } | null> {
   if (!declared) return null;
-  const rows = await db<{ id: number }>`
+  const client = db ?? getDb();
+  const rows = await client<{ id: number }>`
     SELECT id
     FROM automations
     WHERE id = ${declared.automationId}
@@ -85,7 +90,7 @@ export async function verifiedAutomationSource(
 export async function resolveAutomationAttribution(
   ctx: ActingAutomationSession,
   declared: DeclaredAutomationSource | null | undefined,
-  db: DbClient = getDb()
+  db?: DbClient
 ): Promise<AutomationAttribution> {
   if (ctx.actingAutomationId != null) {
     return {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -41,6 +41,13 @@ import {
 	evaluateEntityMutation,
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
+import { resolveAutomationAttribution } from "../../automations/automation-source";
+import {
+	type DbClient,
+	getDb,
+	pgBigintArray,
+	pgTextArray,
+} from "../../db/client";
 import { discoverWorkspaceResolutionGroups } from "../../entity-resolution/discovery";
 import { loadLiveEntityIdentities } from "../../entity-resolution/identities";
 import {
@@ -48,12 +55,6 @@ import {
 	RESOLUTION_FINGERPRINT_VERSION,
 } from "../../entity-resolution/policy";
 import { wasResolutionRejected } from "../../entity-resolution/rejection";
-import {
-	type DbClient,
-	getDb,
-	pgBigintArray,
-	pgTextArray,
-} from "../../db/client";
 import type { Env } from "../../index";
 import {
 	batchLoadRelationships,
@@ -98,7 +99,6 @@ import { buildEntityUrl } from "../../utils/url-builder";
 import { trackAutomationReaction } from "../../utils/automation-reactions";
 import { isAdminOrOwnerRole } from "../access-control";
 import { MEMBER_ENTITY_TYPE_SLUG } from "../constants";
-import { resolveAutomationAttribution } from "../../automations/automation-source";
 import type { ToolContext } from "../registry";
 import { withValidatedArgs } from "../validate-args";
 import {
@@ -236,9 +236,9 @@ async function manageEntityImpl(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-  const result = await runManageEntity(args, env, ctx);
+	const result = await runManageEntity(args, env, ctx);
 
-  // Track automation reaction for mutating actions
+	// Track automation reaction for mutating actions.
 	// Reaction tracking took the declared source verbatim — no session
 	// precedence, no ownership check — so an unowned id credited another
 	// Automation's feedback record. Still gated on the caller HAVING declared a
@@ -255,38 +255,38 @@ async function manageEntityImpl(
 		reactionAttribution.windowId != null &&
 		"action" in result
 	) {
-    const reactionType =
+		const reactionType =
 			result.action === "create"
 				? "entity_created"
 				: result.action === "update"
 					? "entity_updated"
 					: result.action === "link"
 						? "entity_linked"
-            : null;
-    if (reactionType) {
-      const entityId =
+						: null;
+		if (reactionType) {
+			const entityId =
 				result.action === "create" && "entity" in result
-          ? (result as any).entity.id
-          : args.entity_id;
-      await trackAutomationReaction({
-        organizationId: ctx.organizationId,
-        automationId: reactionAttribution.automationId,
-        windowId: reactionAttribution.windowId,
-        reactionType,
+					? result.entity?.id
+					: args.entity_id;
+			await trackAutomationReaction({
+				organizationId: ctx.organizationId,
+				automationId: reactionAttribution.automationId,
+				windowId: reactionAttribution.windowId,
+				reactionType,
 				toolName: "manage_entity",
-        toolArgs: {
-          action: args.action,
-          entity_type: args.entity_type,
-          name: args.name,
-          entity_id: args.entity_id,
-        },
-        toolResult: result as Record<string, unknown>,
-        entityId,
-      });
-    }
-  }
+				toolArgs: {
+					action: args.action,
+					entity_type: args.entity_type,
+					name: args.name,
+					entity_id: args.entity_id,
+				},
+				toolResult: result as Record<string, unknown>,
+				entityId,
+			});
+		}
+	}
 
-  return result;
+	return result;
 }
 
 // ============================================

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -98,6 +98,7 @@ import { buildEntityUrl } from "../../utils/url-builder";
 import { trackAutomationReaction } from "../../utils/automation-reactions";
 import { isAdminOrOwnerRole } from "../access-control";
 import { MEMBER_ENTITY_TYPE_SLUG } from "../constants";
+import { resolveAutomationAttribution } from "../../automations/automation-source";
 import type { ToolContext } from "../registry";
 import { withValidatedArgs } from "../validate-args";
 import {
@@ -238,7 +239,22 @@ async function manageEntityImpl(
   const result = await runManageEntity(args, env, ctx);
 
   // Track automation reaction for mutating actions
-	if (args.automation_source && "action" in result) {
+	// Reaction tracking took the declared source verbatim — no session
+	// precedence, no ownership check — so an unowned id credited another
+	// Automation's feedback record. Still gated on the caller HAVING declared a
+	// source: resolving one for every reaction session would start tracking
+	// mutations that were never tracked before, which is a product change, not
+	// this fix.
+	const reactionAttribution = args.automation_source
+		? await resolveAutomationAttribution(ctx, args.automation_source)
+		: null;
+	// A reaction record is keyed by BOTH ids, so a source that resolves without a
+	// window has nothing to record against.
+	if (
+		reactionAttribution?.automationId != null &&
+		reactionAttribution.windowId != null &&
+		"action" in result
+	) {
     const reactionType =
 			result.action === "create"
 				? "entity_created"
@@ -254,8 +270,8 @@ async function manageEntityImpl(
           : args.entity_id;
       await trackAutomationReaction({
         organizationId: ctx.organizationId,
-        automationId: args.automation_source.automation_id,
-        windowId: args.automation_source.window_id,
+        automationId: reactionAttribution.automationId,
+        windowId: reactionAttribution.windowId,
         reactionType,
 				toolName: "manage_entity",
         toolArgs: {
@@ -340,6 +356,13 @@ async function handleCreate(
 		metadata: entityData.metadata ?? {},
 	};
 	const actor = await actingPrincipalFor(args, ctx);
+	// Resolved once for the create path: the gate, the deferral, and the audit
+	// row it produces must all name the SAME Automation, or an approval card and
+	// its provenance disagree about who proposed the row.
+	const createAttribution = await resolveAutomationAttribution(
+		ctx,
+		args.automation_source
+	);
 	const attribution = attributionFor(actor);
 	const createDecision = await runMutationGate({
 		action: "create",
@@ -347,12 +370,8 @@ async function handleCreate(
 		principalKind: actor.kind,
 		sql: getDb(),
 		attribution,
-		// The TRUSTED reaction-session automation/window WINS (same precedence as
-		// resolveActingPrincipal): a reaction can't retag its deferral into another
-		// automation's approval batch by passing a foreign automation_source. The
-		// caller-supplied source is only honored OUTSIDE a reaction session.
-		automationId: ctx.actingAutomationId ?? args.automation_source?.automation_id ?? null,
-		windowId: ctx.actingWindowId ?? args.automation_source?.window_id ?? null,
+		automationId: createAttribution.automationId,
+		windowId: createAttribution.windowId,
 		principalId: actor.id,
 		ownerAgentId: actor.ownerAgentId,
 		ownerResolved: actor.ownerResolved,
@@ -411,9 +430,8 @@ async function handleCreate(
 			// Exactly what the approver consents to; a later, different escalation
 			// still needs its own card.
 			escalatedFields: err.verdict.fields,
-			automationId:
-				ctx.actingAutomationId ?? args.automation_source?.automation_id ?? null,
-			windowId: ctx.actingWindowId ?? args.automation_source?.window_id ?? null,
+			automationId: createAttribution.automationId,
+			windowId: createAttribution.windowId,
 		}).queue(ctx, env);
 		return {
 			action: "create",
@@ -566,12 +584,18 @@ async function handleUpdate(
 		updateData.affirm_fields = args.affirm_fields;
 
 	const updateActor = await actingPrincipalFor(args, ctx);
+	// Update records only the window (the batch key); the Automation itself comes
+	// from the acting principal. It still resolves through the shared rule so a
+	// declared window cannot outlive the Automation that failed verification.
+	const updateAttribution = await resolveAutomationAttribution(
+		ctx,
+		args.automation_source
+	);
 	const updatedEntity = await updateEntity(entityId, updateData, env, ctx, {
 		policyPrincipalKind: updateActor.kind,
 		attribution: attributionFor(updateActor),
 		principalId: updateActor.id,
-		// Trusted reaction-session window WINS — see the create path.
-		windowId: ctx.actingWindowId ?? args.automation_source?.window_id ?? null,
+		windowId: updateAttribution.windowId,
 		ownerAgentId: updateActor.ownerAgentId,
 		ownerResolved: updateActor.ownerResolved,
 	});
@@ -733,6 +757,12 @@ async function handleMerge(
 	if (actor.kind === "user" && !isAdminOrOwnerRole(ctx.memberRole)) {
 		throw new ToolUserError("Only an admin or owner may merge entities", 403);
 	}
+	// Both merge outcomes — the queued proposal and the auto-merge decision —
+	// record the same Automation, so resolve it once for the handler.
+	const mergeAttribution = await resolveAutomationAttribution(
+		ctx,
+		args.automation_source
+	);
 	const loserIds = [
 		...new Set(
 			args.duplicate_entity_ids ?? (args.entity_id ? [args.entity_id] : []),
@@ -870,10 +900,8 @@ async function handleMerge(
 				entity_ids: loserIds,
 				winner_entity_id: winnerId,
 				evidence: resolution.evidence,
-				automation_id:
-					ctx.actingAutomationId ?? args.automation_source?.automation_id ?? null,
-				window_id:
-					ctx.actingWindowId ?? args.automation_source?.window_id ?? null,
+				automation_id: mergeAttribution.automationId,
+				window_id: mergeAttribution.windowId,
 				source_run_id: ctx.actingRunId ?? null,
 				policy_hash: resolution.policyHash,
 				resolution_fingerprint: resolution.fingerprint,
@@ -927,14 +955,8 @@ async function handleMerge(
 					: {
 							decision: "auto_merge",
 							sourceRunId: ctx.actingRunId ?? null,
-							automationId:
-								ctx.actingAutomationId ??
-								args.automation_source?.automation_id ??
-								null,
-							windowId:
-								ctx.actingWindowId ??
-								args.automation_source?.window_id ??
-								null,
+							automationId: mergeAttribution.automationId,
+							windowId: mergeAttribution.windowId,
 							policyHash: resolution?.policyHash ?? null,
 							evidence: resolution?.evidence ?? [],
 						},
@@ -1450,6 +1472,10 @@ async function handleDelete(
 	}
 
 	const deleteActor = await actingPrincipalFor(args, ctx);
+	const deleteAttribution = await resolveAutomationAttribution(
+		ctx,
+		args?.automation_source
+	);
 	const attribution = attributionFor(deleteActor);
 	const current = {
 		id: entity.id,
@@ -1465,9 +1491,8 @@ async function handleDelete(
 		principalKind: deleteActor.kind,
 		sql: getDb(),
 		attribution,
-		// Trusted reaction-session automation/window WINS — see the create path.
-		automationId: ctx.actingAutomationId ?? args?.automation_source?.automation_id ?? null,
-		windowId: ctx.actingWindowId ?? args?.automation_source?.window_id ?? null,
+		automationId: deleteAttribution.automationId,
+		windowId: deleteAttribution.windowId,
 		principalId: deleteActor.id,
 		ownerAgentId: deleteActor.ownerAgentId,
 		ownerResolved: deleteActor.ownerResolved,

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -419,7 +419,7 @@ const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
  */
 function declaredAutomationSource(
   args: Record<string, unknown>
-): { automationId: number; windowId: number | null } | null {
+): { automationId: number; windowId: number } | null {
   const source = args.automation_source;
   if (!source || typeof source !== 'object') return null;
   const positiveInteger = (value: unknown): number | null =>
@@ -430,9 +430,11 @@ function declaredAutomationSource(
     (source as { automation_id?: unknown }).automation_id
   );
   if (automationId == null) return null;
+  const windowId = positiveInteger((source as { window_id?: unknown }).window_id);
+  if (windowId == null) return null;
   return {
     automationId,
-    windowId: positiveInteger((source as { window_id?: unknown }).window_id),
+    windowId,
   };
 }
 

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -5,8 +5,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { verifiedAutomationSource } from '../automations/automation-source';
 import { runWithActingAutomation } from '../utils/acting-automation-context';
-import { getDb } from '../db/client';
 import type { Context } from 'hono';
 import { isToolError, retryWithBackoff, ToolError } from '@lobu/core';
 import {
@@ -406,30 +406,6 @@ export async function executeTool(
  * anyway — its `retryable` flag is advisory for the agent.
  */
 const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
-
-/**
- * Drop a declared source that does not name an Automation in this organization.
- *
- * Returns null rather than throwing: attribution is a provenance hint, and a
- * bad hint should cost the caller its attribution, not fail their tool call.
- * The window is not paired to the Automation here — `loadRunEventCausality`
- * scopes its run lookup to the producing Automation, so a foreign window
- * inherits nothing.
- */
-export async function verifiedAutomationSource(
-  declared: { automationId: number; windowId: number | null } | null,
-  organizationId: string
-): Promise<{ automationId: number; windowId: number | null } | null> {
-  if (!declared) return null;
-  const rows = await getDb()<{ id: number }>`
-    SELECT id
-    FROM automations
-    WHERE id = ${declared.automationId}
-      AND organization_id = ${organizationId}
-    LIMIT 1
-  `;
-  return rows[0] ? declared : null;
-}
 
 /**
  * The `automation_source` an agent declared on this call.

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -10,6 +10,7 @@
 import { Buffer } from 'node:buffer';
 import { normalizeAuthUserId, normalizeEmail } from '@lobu/connector-sdk/identity-normalize';
 import { type Static, Type } from '@sinclair/typebox';
+import { resolveAutomationAttribution } from '../automations/automation-source';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
 import { type DbClient, getDb, parsePgNumberArray } from '../db/client';
@@ -29,7 +30,6 @@ import { ensureMemberEntityType } from '../utils/member-entity-type';
 import { requireWriteAccess } from '../utils/organization-access';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { validateTemplateHandlers } from '../utils/validate-json-template';
-import { resolveAutomationAttribution } from '../automations/automation-source';
 import { trackAutomationReaction } from '../utils/automation-reactions';
 import { isSystemContext } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -29,6 +29,7 @@ import { ensureMemberEntityType } from '../utils/member-entity-type';
 import { requireWriteAccess } from '../utils/organization-access';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { validateTemplateHandlers } from '../utils/validate-json-template';
+import { resolveAutomationAttribution } from '../automations/automation-source';
 import { trackAutomationReaction } from '../utils/automation-reactions';
 import { isSystemContext } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
@@ -680,12 +681,19 @@ async function saveContentImpl(
     inserted ? 'Content saved via save_memory' : 'Content save replay returned existing event'
   );
 
-  // Track automation reaction if attribution source is provided
-  if (inserted && args.automation_source) {
+  // Track automation reaction if attribution source is provided.
+  // The declared source is caller input: resolve it through the shared rule so a
+  // reaction session's own identity wins and an id belonging to another
+  // organization credits nobody.
+  const reactionAttribution =
+    inserted && args.automation_source
+      ? await resolveAutomationAttribution(ctx, args.automation_source)
+      : null;
+  if (reactionAttribution?.automationId != null && reactionAttribution.windowId != null) {
     await trackAutomationReaction({
       organizationId: ctx.organizationId,
-      automationId: args.automation_source.automation_id,
-      windowId: args.automation_source.window_id,
+      automationId: reactionAttribution.automationId,
+      windowId: reactionAttribution.windowId,
       reactionType: 'content_saved',
       toolName: 'save_memory',
       toolArgs: { entity_ids: finalEntityIds, semantic_type: semanticType, title: args.title },


### PR DESCRIPTION
## Summary
- `automation_source` is ordinary tool input, but every write surface merged it with the trusted session identity inline (`ctx.actingAutomationId ?? args.automation_source?.automation_id`) and never checked the declared half named an Automation in the caller's organization. `manage_entity` did this at seven places; `save_content` took the declared pair verbatim with no precedence at all.
- One resolver now owns the rule (`automations/automation-source.ts`), and both write surfaces go through it. It verifies the Automation **and** pairs the declared `window_id` to it — the shape `notify.ts` has used since it was added — so a member cannot pair their own Automation with someone else's window and land the proposal in that window's approval card.
- The trusted session pair wins atomically, window included: letting a declared window through on a reaction session is the retag the precedence exists to stop, and every call site's comment already claimed this without the code enforcing it.

Three silent consequences this closes:
- a foreign id misattributes the write, and where the value reaches `events.automation_id` it inherits that Automation's causal chain (`workspace-event-enqueue.ts`)
- a nonexistent id fails `events_automation_id_fkey`, and because audit writes are fire-and-forget the row is dropped with no caller-visible error
- a declared window belonging to another Automation batches the proposal into that Automation's approval card

`window_id` is `Type.Number()` on every contract that declares the field, so a declaration missing it is malformed input, not a partial one to honor — `declaredAutomationSource` rejects the pair rather than passing a null window.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-llm, entity-write)
- [x] Tests run: `bunx vitest run src/__tests__/integration/tools/automation-source-attribution.test.ts src/__tests__/integration/tools/automation-source-surface.test.ts` → **13 pass / 0 fail**, plus `bun test src/__tests__/unit` → 1246 pass / 0 fail

### Red → green
The window-pairing predicate is mutation-proven. Dropping `AND w.automation_id = a.id` from the JOIN:

```
× declared automation_source verification > rejects a window belonging to another Automation in the same organization
  → expected { automationId: 1, windowId: 19 } to be null
Tests  1 failed | 10 passed (11)
```

Restored, the same file is 11/11 green. Exactly one test moves, and it fails for the reason claimed.

An earlier revision typed the db handle as a default parameter (`db: DbClient = getDb()`); defaults evaluate at call time, so `getDb()` ran on every call including unit suites that boot no database. CI caught it; the handle is now resolved inside the function, after the guard, with a comment saying why.

## Notes
The surface tests pair each forged declaration with an owned one, so a change that disabled reaction tracking outright cannot make them pass by writing nothing. The SDK namespaces call handlers directly rather than through `executeTool`, which is why the verification lives in the handlers and not only at dispatch.
