### PR TITLE
fix(mcp): echo the saved payload to every card, not only negotiated clients

### DIFF
--- a/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-indexing-status.test.ts
@@ -44,7 +44,7 @@ describe('saveContent > honest indexing status', () => {
     await addUserToOrganization(user.id, org.id, 'owner');
   });
 
-  function ctx(mcpAppsSupported = false): ToolContext {
+  function ctx(headlessResult = false): ToolContext {
     return {
       organizationId: org.id,
       userId: user.id,
@@ -55,7 +55,7 @@ describe('saveContent > honest indexing status', () => {
       allowCrossOrg: true,
       scopes: ['mcp:write'],
       sourceContext: null,
-      mcpAppsSupported,
+      headlessResult,
     } as ToolContext;
   }
 
@@ -68,7 +68,7 @@ describe('saveContent > honest indexing status', () => {
         metadata: {},
       } as never,
       {} as never,
-      ctx(true)
+      ctx()
     );
 
     // Durable storage is synchronous — always reported, always exact-readable.
@@ -76,9 +76,9 @@ describe('saveContent > honest indexing status', () => {
     expect(result.durable_at).toBe(result.created_at);
     expect(result.exact_read.content_ids).toEqual([result.id]);
 
-    // For an MCP App caller the result echoes the persisted row, so the ordinary
-    // text save — not just the json_template one — carries its own body back with
-    // no second read. The non-App shape is pinned by the next test.
+    // A direct tool call echoes the persisted row, so the ordinary text save —
+    // not just the json_template one — carries its own body back with no second
+    // read. The headless shape is pinned by the next test.
     expect(result.payload_type).toBe('text');
     expect(result.payload_text).toBe(
       'A memory whose embedding the async backfill has not produced yet.'
@@ -103,11 +103,11 @@ describe('saveContent > honest indexing status', () => {
         metadata: {},
       } as never,
       {} as never,
-      ctx()
+      ctx(true)
     );
     expect(result.indexing_status).toBe('pending');
-    // No MCP App to render an inline card, so the payload echo is withheld and
-    // the caller keeps the compact receipt plus the exact-read id.
+    // A headless nested SDK save mounts no card, so the payload echo is
+    // withheld and the caller keeps the compact receipt plus the exact-read id.
     expect(result.payload_type).toBeUndefined();
 
     // Simulate the backfill/worker writing the chunk-0 embedding under the

--- a/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
@@ -52,9 +52,8 @@ describe('saveContent > json_template save-side schema', () => {
       scopedToOrg: false,
       allowCrossOrg: true,
       scopes: ['mcp:write'],
-      // The render-payload echo below is gated on an MCP App caller; without
-      // this the save still succeeds but returns the compact receipt only.
-      mcpAppsSupported: true,
+      // A direct (non-headless) call echoes the render payload below; only a
+      // nested SDK save with `headlessResult` keeps the compact receipt.
     };
   });
 

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -634,7 +634,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text.length).toBeLessThan(10_000);
   });
 
-  it('omits the saved payload when the client does not advertise MCP Apps', async () => {
+  it('still echoes the saved payload to a client that did not advertise MCP Apps', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
       advertiseMcpApps: false,
     });
@@ -661,24 +661,17 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.result?.isError).not.toBe(true);
-    // The write still succeeds and stays exactly readable by id — only the
-    // inline render payload, which this client cannot render, is withheld.
+    // The payload follows the binding. claude.ai renders the card while
+    // declaring no Apps capability, so withholding the body here mounted a
+    // widget with nothing in it (measured on prod 2026-08-20).
     expect(body.result?.structuredContent).toEqual(
       expect.objectContaining({
         title: 'Plain note',
         exact_read: expect.objectContaining({ method: 'client.knowledge.read' }),
+        payload_type: 'text',
+        payload_text: 'body-visible-only-to-app-hosts',
       })
     );
-    for (const key of [
-      'payload_type',
-      'payload_text',
-      'payload_data',
-      'payload_template',
-      'attachments',
-      'source_url',
-    ]) {
-      expect(body.result?.structuredContent).not.toHaveProperty(key);
-    }
     expect(body.result?.content?.[0]?.text).not.toContain(
       'body-visible-only-to-app-hosts'
     );

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -189,7 +189,11 @@ export function buildClientSDK(
 	// client.knowledge.save inside run_sdk has no card of its own, so it must
 	// keep the compact SDK receipt instead of echoing the saved payload into a
 	// headless result.
-	const headlessCtx: ToolContext = { ...ctx, mcpAppsSupported: false };
+	const headlessCtx: ToolContext = {
+		...ctx,
+		mcpAppsSupported: false,
+		headlessResult: true,
+	};
 	ctx = opts?.abortSignal
 		? { ...headlessCtx, abortSignal: opts.abortSignal }
 		: headlessCtx;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -120,6 +120,17 @@ export interface ToolContext {
   mcpSessionId?: string | null;
   /** True only for an MCP session that negotiated the standard Apps UI extension. */
   mcpAppsSupported?: boolean | null;
+  /**
+   * True when this call is a nested SDK method rather than the directly
+   * advertised tool call, so its result mounts no card of its own.
+   *
+   * Deliberately NOT `mcpAppsSupported`: a host can render a card without
+   * negotiating the Apps extension (claude.ai does), so negotiation cannot
+   * stand in for "this result is displayed". What decides whether to echo the
+   * saved payload is whether anything will render it, and a nested
+   * `client.knowledge.save` inside `run_sdk` never does.
+   */
+  headlessResult?: boolean | null;
   /** Host-only encrypted token supplied by the Lobu MCP App for one approval click. */
   mcpAppApprovalCapability?: string | null;
   /**
@@ -263,7 +274,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; MCP App calls also echo bounded payloads for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
+      'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; the result also echoes the bounded saved payload for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -696,16 +696,27 @@ async function saveContentImpl(
   }
 
   // Read real semantic-index readiness for this specific event rather than
-  // asserting a fixed 'pending'. For MCP App callers, also read the persisted
-  // payload for the inline card; other surfaces keep their compact receipt. The
-  // per-column CASE keeps that a single round trip — a caller that cannot render
-  // the payload never pays to ship it.
+  // asserting a fixed 'pending', and read back the persisted payload the inline
+  // card renders.
+  //
+  // This used to be gated on the caller having negotiated MCP Apps, on the
+  // theory that a client which cannot render the payload should not pay to ship
+  // it. That theory died on prod: claude.ai renders the card while declaring no
+  // Apps capability at all, so the gate handed it a card with no body. The
+  // declaration is not a usable proxy for "can render" — the tool binding
+  // stopped being gated on it for the same reason (see mcp-handler.ts) — and
+  // the payload has to follow the binding, or the host mounts an empty widget.
+  //
+  // The cost is small and bounded: this is the content the caller just sent us,
+  // echoed back to the surface that displays it. What still opts out is a
+  // nested SDK save inside `run_sdk`, which mounts no card of its own — see
+  // `headlessResult`. The per-column CASE keeps that a single round trip.
   // `needsEmbeddingSql` is the same predicate the embed backfill and worker use,
   // so callers can never disagree with the pipeline on what "indexed" means.
   // Embeddings are usually produced by the async backfill (so this is 'pending'),
   // but when one is supplied inline the row is already searchable.
   const savedId = Number(row.id);
-  const shouldReadInlinePayload = ctx.mcpAppsSupported === true;
+  const shouldReadInlinePayload = ctx.headlessResult !== true;
   const [savedEvent] = await sql`
     SELECT
       CASE WHEN ${shouldReadInlinePayload} THEN e.payload_type END AS payload_type,
@@ -754,9 +765,9 @@ async function saveContentImpl(
     semantic_type: semanticType,
     // When present, this is the exact durable payload, not the caller's
     // arguments: it keeps idempotent retries honest and gives MCP App hosts the
-    // same event the Lobu Activity UI reads from Postgres. Absent for non-App
-    // callers and for oversized events, which keep the compact receipt and the
-    // exact-read id rather than exceeding the App snapshot limit.
+    // same event the Lobu Activity UI reads from Postgres. Absent for headless
+    // nested SDK saves and for oversized events, which keep the compact receipt
+    // and the exact-read id rather than exceeding the App snapshot limit.
     ...(boundedInlinePayload ?? {}),
     created_at: String(row.created_at),
     // Row is committed by now; exact reads by id are available from this instant.


### PR DESCRIPTION
## What

The inline render payload on `save_memory` results is now gated on `headlessResult` instead of `mcpAppsSupported`.

## Why

#2960 sent the App binding to every client, because claude.ai renders cards while declaring no Apps capability. The payload stayed gated on that same declaration, so Claude got the card and none of its contents — the interaction shell reads `payload_type` / `payload_text` / `payload_template` / `payload_data` (`result-view.tsx:225-237`) and had nothing to render.

Confirmed against prod. A `save_memory` result for a non-declaring client:

```json
{"id":5292567,"title":"Payload gate probe","semantic_type":"note",
 "indexing_status":"pending","exact_read":{...},"view_url":"..."}
```

No `payload_type`, no `payload_text`, no `payload_data`. A bare receipt.

## What is preserved

The old flag was doing two jobs. The one worth keeping: a nested `client.knowledge.save` inside `run_sdk` mounts no card of its own and must stay a compact receipt, or every nested save bloats the SDK result. That is now `headlessResult`, set where it actually belongs — in `buildClientSDK`.

The job it should never have had was standing in for "can render". claude.ai proves the declaration doesn't carry that meaning.

## Red / green

Removing `headlessResult` from the headless context:

```
× keeps ClientSDK saves headless when their source session supports Apps
  → expected { id: 1, entity_ids: [], …(16) } to not have property "payload_type"
```

With it, 33/33 across the three affected suites. `make pre-pr` clean.

## Test plan

- [x] `mcp-app-resources.test.ts` 27/27, `save-content-indexing-status` 2/2, `save-content-json-template` 4/4
- [x] Mutation-tested the headless opt-out
- [x] Two suites that pinned the old gate updated, both branches covered
- [ ] After deploy, re-run the Claude card and confirm it renders with a body

## Deliberately not changed

`mcp_app.ts:393` still requires `mcpAppsSupported` before issuing an in-card approval capability. The same reasoning applies, but that grants the power to act rather than the data to display, so it wants its own decision rather than riding along here.