### PR TITLE
fix(entities): let a merged record be force-deleted instead of wedging on its ledger

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -93,6 +93,178 @@ describe("manage_entity merge action", () => {
 		expect(row.deleted_at).not.toBeNull();
 	});
 
+	/**
+	 * A merged record has to stay deletable. `entity_merge_operations` holds the
+	 * undo ledger with ON DELETE RESTRICT on BOTH participants, and
+	 * `entities_merged_into_fkey` refuses to let the winner go while the loser's
+	 * redirect points at it — so before this was handled, merging two records
+	 * made the survivor permanently undeletable and the caller saw a raw Postgres
+	 * constraint message instead of an answer.
+	 */
+	it("force-deletes a merge winner, taking its redirects and ledger with it", async () => {
+		const org = await createTestOrganization({ name: "Delete Merged Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const toolCtx = ctx(org.id, user.id, "owner");
+
+		await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			toolCtx,
+		);
+
+		const sql = getTestDb();
+		const ledgerBefore = (await sql`
+      SELECT count(*)::int AS n FROM entity_merge_operations
+      WHERE winner_entity_id = ${winner.id}
+    `) as Array<{ n: number }>;
+		// Guard: without a ledger row the test would pass for the wrong reason.
+		expect(ledgerBefore[0].n).toBe(1);
+
+		const res = (await manageEntity(
+			{ action: "delete", entity_id: winner.id, force_delete_tree: true },
+			env,
+			toolCtx,
+		)) as { success: boolean; deleted_count: number };
+
+		expect(res.success).toBe(true);
+		// BOTH rows go: the loser is a redirect to the winner, not a record of its
+		// own, so leaving it behind would strand a tombstone pointing at nothing.
+		expect(res.deleted_count).toBe(2);
+
+		const rows = (await sql`
+      SELECT id FROM entities WHERE id IN (${winner.id}, ${loser.id})
+    `) as Array<{ id: number }>;
+		expect(rows).toHaveLength(0);
+
+		const ledgerAfter = (await sql`
+      SELECT count(*)::int AS n FROM entity_merge_operations
+      WHERE winner_entity_id = ${winner.id} OR loser_entity_id = ${loser.id}
+    `) as Array<{ n: number }>;
+		expect(ledgerAfter[0].n).toBe(0);
+	});
+
+	/** The redirect walk must not drag in a row that merged somewhere ELSE. */
+	it("leaves an unrelated merge pair untouched", async () => {
+		const org = await createTestOrganization({ name: "Unrelated Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		// Distinct names: entity slugs are unique per parent, so a second
+		// Winner/Loser pair from `twoEntities` would collide on insert.
+		const mk = async (label: string) => ({
+			winner: await createTestEntity({
+				name: `Winner ${label}`,
+				entity_type: "person",
+				organization_id: org.id,
+				created_by: user.id,
+			}),
+			loser: await createTestEntity({
+				name: `Loser ${label}`,
+				entity_type: "person",
+				organization_id: org.id,
+				created_by: user.id,
+			}),
+		});
+		const doomed = await mk("A");
+		const bystander = await mk("B");
+		const toolCtx = ctx(org.id, user.id, "owner");
+
+		for (const pair of [doomed, bystander]) {
+			await manageEntity(
+				{
+					action: "merge",
+					entity_id: pair.loser.id,
+					winner_entity_id: pair.winner.id,
+				},
+				env,
+				toolCtx,
+			);
+		}
+
+		await manageEntity(
+			{ action: "delete", entity_id: doomed.winner.id, force_delete_tree: true },
+			env,
+			toolCtx,
+		);
+
+		const sql = getTestDb();
+		const survivors = (await sql`
+      SELECT id FROM entities
+      WHERE id IN (${bystander.winner.id}, ${bystander.loser.id})
+      ORDER BY id
+    `) as Array<{ id: number }>;
+		expect(survivors).toHaveLength(2);
+
+		const ledger = (await sql`
+      SELECT count(*)::int AS n FROM entity_merge_operations
+      WHERE winner_entity_id = ${bystander.winner.id}
+    `) as Array<{ n: number }>;
+		expect(ledger[0].n).toBe(1);
+	});
+
+	/**
+	 * The shape that makes `UNION` (not `UNION ALL`) load-bearing in
+	 * `loadEntityTreeIds`: fold a parent into its own child and the two edges
+	 * close a cycle — B.parent_id = A via the parent edge, A.merged_into = B via
+	 * the redirect edge. `UNION ALL` would recurse forever and hang the delete.
+	 */
+	it("force-deletes a parent that was merged into its own child", async () => {
+		const org = await createTestOrganization({ name: "Cycle Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const toolCtx = ctx(org.id, user.id, "owner");
+
+		const parent = await createTestEntity({
+			name: "Parent",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const child = await createTestEntity({
+			name: "Child",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+			parent_id: parent.id,
+		});
+
+		await manageEntity(
+			{ action: "merge", entity_id: parent.id, winner_entity_id: child.id },
+			env,
+			toolCtx,
+		);
+
+		const sql = getTestDb();
+		const [edges] = (await sql`
+      SELECT
+        (SELECT parent_id FROM entities WHERE id = ${child.id}) AS child_parent,
+        (SELECT merged_into FROM entities WHERE id = ${parent.id}) AS parent_merged
+    `) as Array<{ child_parent: number | null; parent_merged: number | null }>;
+		// Guard: if the merge path ever refuses this, the cycle is unreachable and
+		// the UNION rationale above needs revisiting — fail here rather than let
+		// the test pass vacuously.
+		expect(Number(edges.child_parent)).toBe(parent.id);
+		expect(Number(edges.parent_merged)).toBe(child.id);
+
+		// Target the CHILD: it is the surviving record, and the merged-away parent
+		// is soft-deleted so the delete action would 404 on it. Walking out from
+		// the child is also the direction that closes the cycle — child → parent
+		// (redirect) → child (parent edge).
+		const res = (await manageEntity(
+			{ action: "delete", entity_id: child.id, force_delete_tree: true },
+			env,
+			toolCtx,
+		)) as { success: boolean; deleted_count: number };
+
+		expect(res.success).toBe(true);
+		expect(res.deleted_count).toBe(2);
+		const rows = (await sql`
+      SELECT id FROM entities WHERE id IN (${parent.id}, ${child.id})
+    `) as Array<{ id: number }>;
+		expect(rows).toHaveLength(0);
+	}, 30_000);
+
 	it("rejects a non-admin member (403)", async () => {
 		const org = await createTestOrganization({ name: "Gate Org" });
 		const user = await createTestUser();

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -802,16 +802,40 @@ async function preventEntityCycles(
   }
 }
 
+/**
+ * Every row a force delete must remove with `entityId`: its `parent_id`
+ * descendants AND the merge tombstones that redirect into any of them.
+ *
+ * Following `merged_into` is not an extra: a row merged away has no identity of
+ * its own left — it is a redirect to its winner — and `entities_merged_into_fkey`
+ * refuses to let the winner go while the redirect points at it. Walking only the
+ * parent tree therefore made a merged-into record permanently undeletable, and
+ * the caller saw a raw Postgres constraint message rather than an answer.
+ *
+ * Both edges are followed in one CTE so a chain (C merged into B, B a child of
+ * A) is collected in a single pass. `merged_into` is already flattened at merge
+ * time, but the recursion costs nothing and does not depend on that.
+ *
+ * `UNION`, not `UNION ALL`: the two edges can reach a row twice — a child that
+ * was also merged into a sibling — and a merge can fold a parent into its own
+ * descendant, closing a cycle that only the deduplicating form terminates on.
+ *
+ * This covers every FK into `entities` that would otherwise block the delete.
+ * Of the 9, four are ON DELETE CASCADE and one SET NULL; the four RESTRICT/NO
+ * ACTION ones are `entities_parent_id_fkey` (children — the parent tree),
+ * `entities_merged_into_fkey` (redirects — this function), and
+ * `entity_merge_operations`' two (the ledger, deleted explicitly below).
+ */
 async function loadEntityTreeIds(sql: DbClient, entityId: number): Promise<number[]> {
   const rows = await sql<{ id: number }>`
     WITH RECURSIVE entity_tree AS (
       SELECT id
       FROM entities
       WHERE id = ${entityId}
-      UNION ALL
+      UNION
       SELECT e.id
       FROM entities e
-      JOIN entity_tree et ON e.parent_id = et.id
+      JOIN entity_tree et ON e.parent_id = et.id OR e.merged_into = et.id
     )
     SELECT id
     FROM entity_tree
@@ -1826,6 +1850,19 @@ export async function deleteEntity(
         DELETE FROM feeds
         WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
           AND entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
+      `;
+
+      // The merge ledger is undo state for rows that are about to stop existing,
+      // so it goes with them. Its FKs are ON DELETE RESTRICT, which is the right
+      // default — nothing should delete an entity out from under a live ledger —
+      // but this path is the one place that legitimately may, because it removes
+      // the winner and every redirect into it together (see `loadEntityTreeIds`).
+      // Without this the RESTRICT surfaced as a raw constraint error and the
+      // record could never be deleted at all.
+      await tx`
+        DELETE FROM entity_merge_operations
+        WHERE winner_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
+           OR loser_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
       `;
       await tx`
         UPDATE feeds


### PR DESCRIPTION
## Summary
- **Merging two records made the survivor permanently undeletable.** `loadEntityTreeIds` walked `parent_id` only, so a force delete removed the winner while the loser's `merged_into` redirect still pointed at it. `entities_merged_into_fkey` refused; `entity_merge_operations` refused too. Both are `ON DELETE RESTRICT`, so the caller got a raw Postgres constraint message and no way forward short of unmerging first. I hit this cleaning up prod fixtures after #2963.
- The tree walk now follows `merged_into` as well as `parent_id`, and the force cascade deletes the merge ledger for the rows it is about to remove. A row merged away is a *redirect to its winner*, not a record of its own — it goes when the winner goes; the ledger is undo state for rows that are ceasing to exist.
- `RESTRICT` stays the default on both FKs. Nothing else should delete an entity out from under a live ledger; this path is the one that legitimately may, because it removes the winner and every redirect into it in one transaction.
- **Closes the class, not the instance.** Of the 9 FKs into `entities`, four are `CASCADE` and one `SET NULL`; all four `RESTRICT`/`NO ACTION` ones are now accounted for — `entities_parent_id_fkey` by the parent tree, `entities_merged_into_fkey` by the redirect edge, and `entity_merge_operations`' two by the explicit delete.

### `UNION`, not `UNION ALL` — and it is load-bearing

A merge can fold a parent into its own child, closing a cycle between the two edges (`B.parent_id = A` via the parent edge, `A.merged_into = B` via the redirect edge). I verified that shape is actually reachable rather than assuming it — the test asserts both edges exist before it deletes, so it fails loudly if the merge path ever starts refusing it instead of passing vacuously.

Mutation test, `UNION` → `UNION ALL`:

```
MUTANT: UNION -> UNION ALL
 1: 0x10a8aa848 node::OOMErrorHandler(char const*, v8::OOMDetails const&)
Error: Channel closed
Serialized Error: { code: 'ERR_IPC_CHANNEL_CLOSED' }
```

Unbounded recursion OOMs the process, so the deduplicating form is a correctness requirement, not tidiness.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bunx vitest run src/__tests__/integration/entities/` and the wider `entities/ + authz/ + events/` sweep
- [x] Bug fix: red→fix→green outputs pasted below

### RED — three new tests against the unmodified `entity-management.ts`

```
× force-deletes a merge winner, taking its redirects and ledger with it
  → update or delete on table "entities" violates foreign key constraint "entities_merged_into_fkey" on table "entities"
× leaves an unrelated merge pair untouched
  → update or delete on table "entities" violates foreign key constraint "entities_merged_into_fkey" on table "entities"

 Tests  2 failed | 29 passed (31)
```

Both fail with the exact production error, at `hardDeleteEntityRows src/utils/entity-management.ts:632`.

### GREEN

```
$ bunx vitest run src/__tests__/integration/entities/entity-merge-tool.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)

$ bunx vitest run src/__tests__/integration/entities/
 Test Files  7 passed (7)
      Tests  56 passed (56)
```

Wider sweep before the cycle test was added — `entities/ + authz/ + events/`: **78 files, 505 tests, all passing.**

## Notes
The third test (`force-deletes a parent that was merged into its own child`) came out of `make review-fix`, which correctly caught that my original `UNION` rationale named a case that terminates under `UNION ALL` anyway. It also fixed two other comment errors: an FK census that said "three" while enumerating four, and "dropped in the cascade" for what is an explicit `DELETE`.
