### PR TITLE
fix(entities): route a delete rule's escalate into an approval card

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -13,12 +13,15 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { compileEntityRule } from "../../../authz/entity-rule-executor";
 import type { Env } from "../../../index";
+import { applyEntityChangeProposal } from "../../../tools/admin/entity-field-approval";
+import { manageEntity } from "../../../tools/admin/manage_entity";
 import type { ToolContext } from "../../../tools/registry";
 import {
 	createEntity,
 	deleteEntity,
 	updateEntity,
 } from "../../../utils/entity-management";
+import { initWorkspaceProvider } from "../../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	addUserToOrganization,
@@ -84,6 +87,15 @@ export default (row) => {
 };
 `;
 
+/** PROBE an unusable escalation that cannot be replayed by any field grant. */
+const ESCALATE_NO_FIELDS_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$deleted") && row.next.$deleted) {
+    row.escalate([], "review without a field");
+  }
+};
+`;
+
 const TEST_ENV = {} as Env;
 
 // esbuild costs ~100ms per call, so compile each rule once for the whole file.
@@ -91,6 +103,7 @@ let invoiceCompiled: string;
 let ticketCompiled: string;
 let escalateDeleteCompiled: string;
 let escalateOtherFieldCompiled: string;
+let escalateNoFieldsCompiled: string;
 
 function ctxFor(
 	organizationId: string,
@@ -154,6 +167,29 @@ async function rowExists(id: number): Promise<boolean> {
     SELECT id FROM entities WHERE id = ${id}
   `;
 	return rows.length > 0;
+}
+
+async function readRunActionInput(
+	organizationId: string,
+	runId: number,
+): Promise<Record<string, unknown>> {
+	const sql = getTestDb();
+	const [run] = await sql<{ action_input: unknown }[]>`
+		SELECT action_input FROM runs
+		WHERE id = ${runId} AND organization_id = ${organizationId}
+	`;
+	if (!run) throw new Error(`Approval run ${runId} was not persisted`);
+	return (typeof run.action_input === "string"
+		? JSON.parse(run.action_input)
+		: run.action_input) as Record<string, unknown>;
+}
+
+async function countRuns(organizationId: string): Promise<number> {
+	const [row] = await getTestDb()<{ count: number }[]>`
+		SELECT COUNT(*)::int AS count FROM runs
+		WHERE organization_id = ${organizationId}
+	`;
+	return Number(row?.count ?? 0);
 }
 
 async function seedOrg(name: string) {
@@ -220,16 +256,19 @@ async function seedEscalatingDoc() {
 
 describe("entity row validation at the physical writer", () => {
 	beforeAll(async () => {
+		await initWorkspaceProvider();
 		[
 			invoiceCompiled,
 			ticketCompiled,
 			escalateDeleteCompiled,
 			escalateOtherFieldCompiled,
+			escalateNoFieldsCompiled,
 		] = await Promise.all([
 			compileEntityRule(INVOICE_RULE),
 			compileEntityRule(TICKET_RULE),
 			compileEntityRule(ESCALATE_DELETE_RULE),
 			compileEntityRule(ESCALATE_OTHER_FIELD_RULE),
+			compileEntityRule(ESCALATE_NO_FIELDS_RULE),
 		]);
 	}, 60_000);
 
@@ -564,16 +603,182 @@ describe("entity row validation at the physical writer", () => {
 	});
 
 	/**
-	 * `force_delete_tree` is the OTHER way a caller reaches destruction, and it
-	 * does not go past the soft-delete seam at all: it walks the tree and hands
-	 * the ids to `hardDeleteEntityRows`. Left ungoverned, "a posted invoice cannot
-	 * be deleted" would have meant "cannot be deleted without passing
-	 * force_delete_tree=true" — a control with a published bypass.
-	 *
-	 * It answers to `$deleted`, the same name the soft path uses, because a hard
-	 * delete is not a lesser destruction than a tombstone. (Contrast merge, which
-	 * earned its own `$merged_into`: merging a duplicate into its canonical record
-	 * is a correction, so freezing deletion must not freeze dedupe.)
+	 * `manage_entity` turns a row rule's `$deleted` escalation into a persisted
+	 * delete card. The approval replay itself is covered by
+	 * `entity-approval-atomic-apply.test.ts`.
+	 */
+	describe("escalate mints a delete card", () => {
+		it("queues the delete for approval instead of erroring", async () => {
+			const { org, user, doc } = await seedEscalatingDoc();
+
+			const res = (await manageEntity(
+				{ action: "delete", entity_id: doc.id },
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+			)) as {
+				success: boolean;
+				approval_queued?: boolean;
+				approval_run_id?: number;
+				message: string;
+			};
+
+			expect(res.success).toBe(false);
+			expect(res.approval_queued).toBe(true);
+			expect(res.approval_run_id).toEqual(expect.any(Number));
+			expect(res.message).toMatch(/second pair of eyes/);
+			const proposal = await readRunActionInput(
+				org.id,
+				res.approval_run_id ?? -1,
+			);
+			expect(proposal.operation).toBe("delete");
+			expect(proposal.reason).toEqual(expect.stringMatching(/second pair of eyes/));
+			expect(await readDeletedAt(doc.id)).toBeNull();
+		}, 60_000);
+
+		it("delays delete cleanup until the approval replay", async () => {
+			const sql = getTestDb();
+			const { org, user } = await seedOrg("Escalating member delete");
+			await seedType(org.id, "$member", escalateDeleteCompiled);
+			const email = "pending-member@example.com";
+			const member = await createEntity(
+				{
+					entity_type: "$member",
+					name: "Pending member",
+					organization_id: org.id,
+					created_by: user.id,
+					metadata: { email },
+				} as Parameters<typeof createEntity>[0],
+				{ skipHooks: true },
+			);
+			await sql`
+				INSERT INTO invitation (
+					id, "organizationId", email, role, status,
+					"expiresAt", "inviterId", "createdAt"
+				) VALUES (
+					gen_random_uuid()::text, ${org.id}, ${email}, 'member', 'pending',
+					NOW() + interval '48 hours', ${user.id}, NOW()
+				)
+			`;
+
+			const ctx = ctxFor(org.id, { userId: user.id });
+			const result = (await manageEntity(
+				{ action: "delete", entity_id: member.id },
+				TEST_ENV,
+				ctx,
+			)) as { approval_queued?: boolean; approval_run_id?: number };
+
+			expect(result.approval_queued).toBe(true);
+			let [invitation] = await sql<{ status: string }[]>`
+				SELECT status FROM invitation
+				WHERE "organizationId" = ${org.id} AND email = ${email}
+			`;
+			expect(invitation.status).toBe("pending");
+			expect(await readDeletedAt(member.id)).toBeNull();
+
+			const proposal = await readRunActionInput(
+				org.id,
+				result.approval_run_id ?? -1,
+			);
+			await sql.begin(async (tx) => {
+				await applyEntityChangeProposal(proposal as never, ctx, TEST_ENV, tx);
+			});
+
+			[invitation] = await sql<{ status: string }[]>`
+				SELECT status FROM invitation
+				WHERE "organizationId" = ${org.id} AND email = ${email}
+			`;
+			expect(invitation.status).toBe("canceled");
+			expect(await readDeletedAt(member.id)).not.toBeNull();
+		}, 60_000);
+
+		it("carries force_delete_tree onto the card", async () => {
+			const { org, user, doc } = await seedEscalatingDoc();
+
+			const res = (await manageEntity(
+				{ action: "delete", entity_id: doc.id, force_delete_tree: true },
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+			)) as { approval_run_id?: number };
+
+			const proposal = await readRunActionInput(
+				org.id,
+				res.approval_run_id ?? -1,
+			);
+			expect(proposal.force_delete_tree).toBe(true);
+		}, 60_000);
+
+		/**
+		 * The gate that keeps the card honest. A delete card's replay grants exactly
+		 * `$deleted`; an escalate naming anything else would mint a card that throws
+		 * the moment it is approved, wasting a reviewer's decision. Those keep
+		 * failing closed.
+		 */
+		it("does NOT mint a card for an escalate naming another field", async () => {
+			const { org, user } = await seedOrg("Escalates elsewhere, tool");
+			await seedType(org.id, "doc", escalateOtherFieldCompiled);
+			const doc = await createEntity({
+				entity_type: "doc",
+				name: "DOC-OTHER-TOOL",
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: { status: "open" },
+			} as Parameters<typeof createEntity>[0]);
+
+			await expect(
+				manageEntity(
+					{ action: "delete", entity_id: doc.id },
+					TEST_ENV,
+					ctxFor(org.id, { userId: user.id }),
+				),
+			).rejects.toThrow(/status/);
+
+			expect(await readDeletedAt(doc.id)).toBeNull();
+			expect(await countRuns(org.id)).toBe(0);
+		}, 60_000);
+
+		it("does NOT mint a card for an escalation with no fields", async () => {
+			const { org, user } = await seedOrg("Escalates no fields, tool");
+			await seedType(org.id, "doc", escalateNoFieldsCompiled);
+			const doc = await createEntity({
+				entity_type: "doc",
+				name: "DOC-NO-FIELDS-TOOL",
+				organization_id: org.id,
+				created_by: user.id,
+				metadata: {},
+			} as Parameters<typeof createEntity>[0]);
+
+			await expect(
+				manageEntity(
+					{ action: "delete", entity_id: doc.id },
+					TEST_ENV,
+					ctxFor(org.id, { userId: user.id }),
+				),
+			).rejects.toThrow(/approval required/);
+
+			expect(await readDeletedAt(doc.id)).toBeNull();
+			expect(await countRuns(org.id)).toBe(0);
+		}, 60_000);
+
+		/** A deny is not an escalate. Approval can never launder an illegal state. */
+		it("does NOT mint a card for a deny", async () => {
+			const { org, user, invoice } = await seedInvoice("posted");
+
+			await expect(
+				manageEntity(
+					{ action: "delete", entity_id: invoice.id },
+					TEST_ENV,
+					ctxFor(org.id, { userId: user.id }),
+				),
+			).rejects.toThrow(/posted is frozen: \$deleted is not writable/);
+
+			expect(await readDeletedAt(invoice.id)).toBeNull();
+			expect(await countRuns(org.id)).toBe(0);
+		}, 60_000);
+	});
+
+	/**
+	 * `force_delete_tree` walks the tree and reaches the rule seam as `$deleted`
+	 * before it removes any row, so a frozen descendant blocks the whole delete.
 	 */
 	describe("force delete", () => {
 		it("denies force-deleting a frozen row, and the row survives", async () => {

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -45,7 +45,7 @@ export type ValidatedEntityRowPatch = EntityRowPatch & {
 export interface EntityRowValidationVerdict {
 	outcome: "deny" | "escalate";
 	reason: string;
-	/** Fields the rule named when escalating. Empty for a deny. */
+	/** Fields the rule named when escalating; empty when it named none. */
 	fields: string[];
 	/** The row judged, or null for a create — there is no row yet. */
 	entityId: number | null;
@@ -57,22 +57,18 @@ export interface EntityRowValidationVerdict {
  * Throwing rather than returning a verdict is deliberate: it makes failing
  * closed the DEFAULT for every caller. Only a caller with approval machinery to
  * route an escalation into opts in by catching this and reading {@link verdict}
- * — `updateEntity`, and automation promotion (`promote-keyed-entities`). Link
- * auto-create and eval scaffolding have nowhere to queue a card, so for them a
- * rule that asked for review must stop the write — which is exactly what an
- * uncaught throw does.
+ * — `updateEntity`, automation promotion (`promote-keyed-entities`), and
+ * `manage_entity` deletion. Link auto-create and eval scaffolding have nowhere
+ * to queue a card, so for them a rule that asked for review must stop the write
+ * — which is exactly what an uncaught throw does.
  *
  * Soft-delete (`deleteEntity`) and merge (`applyMergeInTransaction`) are the
- * in-between cases, and the distinction is WHO asked for the review. The POLICY
- * gate can queue a delete or merge card, and applying that card grants
- * `$deleted` or `$merged_into` — the one field each card can be said to have
- * approved — so a rule escalating on it no longer dead-ends an approval a human
- * already gave. But a rule escalate does not itself mint a card:
- * `manage_entity`'s delete and merge paths have no `EntityRowValidationError`
- * catch (only its CREATE path does), so an escalate with no policy card behind
- * it fails closed like link auto-create. A `deny` stops the write either way,
- * and the hard (force) delete reaches this seam under the same `$deleted` name,
- * so freezing a row freezes both delete paths.
+ * in-between cases. The policy gate can queue either card, and `manage_entity`
+ * also turns a delete rule's `$deleted` escalation into a delete card. Applying
+ * those cards grants `$deleted` or `$merged_into` — the one field each card can
+ * be said to have approved. Callers without approval machinery still fail
+ * closed. A `deny` stops the write either way, and force delete reaches this seam
+ * under the same `$deleted` name, so freezing a row freezes both delete paths.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;
@@ -115,7 +111,7 @@ const UNGOVERNED_COLUMNS: ReadonlySet<string> = new Set([
  * `$merged_into` one namespace with the rest, so a rule reads
  * `row.next.$merged_into` exactly as it reads `row.next.$deleted`.
  */
-const RESERVED_COLUMN_NAMES: Readonly<Record<string, string>> = {
+export const RESERVED_COLUMN_NAMES: Readonly<Record<string, string>> = {
 	name: "$name",
 	slug: "$slug",
 	parentId: "$parent_id",

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -7,7 +7,10 @@
  * lives in manage_operations next to `supersedeActionEvent`.
  */
 
-import { validateEntityRowPatchGrantingApprovedFields } from "../../authz/entity-row-validation";
+import {
+	RESERVED_COLUMN_NAMES,
+	validateEntityRowPatchGrantingApprovedFields,
+} from "../../authz/entity-row-validation";
 import { createHash } from "node:crypto";
 import {
 	ApprovalAttribution,
@@ -1380,7 +1383,7 @@ export async function applyEntityChangeProposal(
 		// name the merge seam proposes. A `deny` still throws — approval cannot
 		// make an illegal merge legal.
 		return applyMergeGroupInTransaction(
-			{ ...params, approvedFields: ["$merged_into"] },
+			{ ...params, approvedFields: [RESERVED_COLUMN_NAMES.mergedInto] },
 			db,
 		);
 	}
@@ -1396,6 +1399,6 @@ export async function applyEntityChangeProposal(
 		deleteProposal.force_delete_tree ?? false,
 		env,
 		ctx,
-		{ approvedFields: ["$deleted"] },
+		{ approvedFields: [RESERVED_COLUMN_NAMES.softDelete] },
 	);
 }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -35,7 +35,10 @@ import {
 	deferEntityCreate,
 	runMutationGate,
 } from "../../authz/entity-mutation-gate";
-import { EntityRowValidationError } from "../../authz/entity-row-validation";
+import {
+	EntityRowValidationError,
+	RESERVED_COLUMN_NAMES,
+} from "../../authz/entity-row-validation";
 import {
 	type ActingPrincipal,
 	evaluateEntityMutation,
@@ -106,7 +109,7 @@ import {
 	toEntityInfo,
 } from "../view-urls";
 import { defineFlatActionTool, flatAction } from "./action-tool";
-import { proposeEntityMerge } from "./entity-field-approval";
+import { proposeEntityDelete, proposeEntityMerge } from "./entity-field-approval";
 
 export { ManageEntityResultSchema, ManageEntitySchema };
 
@@ -1525,7 +1528,52 @@ async function handleDelete(
 		} as ManageEntityResult;
 	}
 
-	const result = await deleteEntity(entityId, force, env, ctx);
+	let result: Awaited<ReturnType<typeof deleteEntity>>;
+	try {
+		result = await deleteEntity(entityId, force, env, ctx);
+	} catch (err) {
+		// Row rules run after the principal gate — under lock inside the delete
+		// transaction, and once on the pool beforehand when the type has a
+		// beforeDelete hook, so the hook's cleanup never precedes the verdict.
+		// Route only an escalation the delete card can replay; denies and unrelated
+		// fields still fail closed.
+		if (
+			!(err instanceof EntityRowValidationError) ||
+			err.verdict.outcome !== "escalate" ||
+			err.verdict.fields.length !== 1 ||
+			err.verdict.fields[0] !== RESERVED_COLUMN_NAMES.softDelete
+		) {
+			throw err;
+		}
+		const queued = await proposeEntityDelete(ctx, {
+			entity_id: entityId,
+			force_delete_tree: force,
+			current,
+			automation_id:
+				ctx.actingAutomationId ?? args?.automation_source?.automation_id ?? null,
+			window_id: ctx.actingWindowId ?? args?.automation_source?.window_id ?? null,
+			attribution,
+			reason: err.verdict.reason,
+		});
+		return {
+			action: "delete",
+			success: false,
+			message: `Delete needs approval: ${err.verdict.reason}`,
+			deleted_count: 0,
+			approval_queued: true,
+			approval_url: queued.approvalUrl,
+			approval_run_id: queued.runId,
+			approval_action: "delete",
+			approval_proposal: {
+				entity_id: entity.id,
+				entity_type: entity.entity_type,
+				name: entity.name,
+				force_delete_tree: force,
+			},
+			approval_current: current,
+			approval_attribution: attribution,
+		} as ManageEntityResult;
+	}
 
 	return {
 		action: "delete",

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1592,7 +1592,9 @@ export async function deleteEntity(
   // Validate write access (uses PG for auth tables)
   await requireWriteAccess(pgSql, entityId, ctx);
 
-  // Run beforeDelete hook (a dry run mutates nothing, so hooks stay silent)
+  // Resolve the hook now, but do not run its cleanup until the row rule has
+  // accepted the delete. The write transaction validates again under lock.
+  let runBeforeDeleteHook: (() => Promise<void>) | null = null;
   if (!opts?.skipHooks && !opts?.dryRun) {
     const entityRow = await sql`
       SELECT et.slug AS entity_type, e.metadata
@@ -1601,16 +1603,19 @@ export async function deleteEntity(
       WHERE e.id = ${entityId} AND e.deleted_at IS NULL
     `;
     if (entityRow.length > 0) {
-      const hooks = getEntityHooks(entityRow[0].entity_type as string);
-      if (hooks?.beforeDelete) {
-        await hooks.beforeDelete(
-          {
-            id: entityId,
-            entity_type: entityRow[0].entity_type as string,
-            metadata: entityRow[0].metadata as Record<string, unknown> | null,
-          },
-          { organizationId: ctx.organizationId, userId: ctx.userId }
-        );
+      const beforeDelete = getEntityHooks(
+        entityRow[0].entity_type as string
+      )?.beforeDelete;
+      if (beforeDelete) {
+        runBeforeDeleteHook = () =>
+          beforeDelete(
+            {
+              id: entityId,
+              entity_type: entityRow[0].entity_type as string,
+              metadata: entityRow[0].metadata as Record<string, unknown> | null,
+            },
+            { organizationId: ctx.organizationId, userId: ctx.userId }
+          );
       }
     }
   }
@@ -1699,6 +1704,16 @@ export async function deleteEntity(
         dry_run: true,
         tree: report,
       };
+    }
+
+    if (runBeforeDeleteHook) {
+      await validateEntityRowPatchGrantingApprovedFields({
+        tx: sql,
+        ids: entityTreeIds,
+        patch: { softDelete: true },
+        approvedFields: opts?.approvedFields ?? [],
+      });
+      await runBeforeDeleteHook();
     }
 
     // Deletion predicate for automations/feeds: only rows whose entity set is
@@ -1942,6 +1957,15 @@ export async function deleteEntity(
       deleted: 0,
       dry_run: true,
     };
+  }
+  if (runBeforeDeleteHook) {
+    await validateEntityRowPatchGrantingApprovedFields({
+      tx: sql,
+      ids: [entityId],
+      patch: { softDelete: true },
+      approvedFields: opts?.approvedFields ?? [],
+    });
+    await runBeforeDeleteHook();
   }
   // Soft delete: stamp deleted_at, governed by the type's write rules.
   //


### PR DESCRIPTION
## Summary
- A row rule's `escalate` on delete had no `EntityRowValidationError` catch in `manage_entity`, so the one verdict whose purpose is to **request a human** surfaced as a raw error with no way to grant it. `deny` and `escalate` were indistinguishable in effect.
- `handleDelete` now mints a delete card via `proposeEntityDelete` carrying the rule's own reason and `force_delete_tree`. Replaying it grants exactly `$deleted`, so the approved delete does not re-escalate on the verdict that asked for it.
- Defers `beforeDelete` hooks until **after** the verdict. Previously the hook ran first, so an escalating `$member` delete already cancelled the pending invitation before anyone approved anything.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates; local fallback — full graph runs here on CI)
- [x] Tests run: targeted `bunx vitest run src/__tests__/integration/authz/entity-row-validation.test.ts` → **34/34**; wider `authz/ + entities/` → **292/292 across 33 files**
- [x] Bug fix: red→green below

### red → green

RED (before the catch existed) — 3 failed / 2 passed, the 2 being negative controls that already failed closed:

```
× queues the delete for approval instead of erroring
× delays delete cleanup until the approval replay
× carries force_delete_tree onto the card
✓ does NOT mint a card for an escalate naming another field
✓ does NOT mint a card for a deny
```

GREEN:

```
 Test Files  1 passed (1)
      Tests  34 passed (34)
```

### mutation test — the hook deferral is load-bearing

Reverting the deferral so `beforeDelete` runs before the verdict again:

```
× delays delete cleanup until the approval replay
  → expected 'canceled' to be 'pending'
```

The invitation is cancelled before approval — exactly the defect, failing for the reason claimed.

## Notes

**Gated deliberately.** A card is minted only when the escalation names exactly the one field the card can grant. A verdict naming a *different* field, or naming **none** (an empty `fields` array, which a `.every()` guard would have accepted vacuously), would mint a card that throws on approval — so those still fail closed, as does every `deny`.

**Where the rule is asked.** Under lock inside the write transaction as before, plus once on the pool beforehand when the type has a `beforeDelete` hook. Both pool reads sit *outside* the transaction (`sql.begin`, `withEntityWriteTransaction`), so this is not the #2818 entity-write pool-starvation class. The residual TOCTOU — rule changes between the pool check and the locked one — is deliberate: running an external cleanup hook *inside* the write transaction would hold locks across network I/O, which is the worse trade.

**Merge half deliberately cut.** `proposeEntityMerge` needs `resolution.resolutionKeys`, computed only for non-user actors; and for those, `resolution?.decision === "review"` already mints a card before the apply, so a rule escalate never reaches it. The only uncovered case is non-user actor + `auto_merge` + rule escalates. Covering user-initiated merges would mean computing a resolution the user path deliberately skips.

Also collapses drift: `$deleted` / `$merged_into` were hardcoded literals at the two replay grant sites; both now use `RESERVED_COLUMN_NAMES`.
