### PR TITLE
refactor(notifications): name the platform NOTIFICATION kinds for what they are

### DIFF
--- a/docs/plans/chat-notification-cards.md
+++ b/docs/plans/chat-notification-cards.md
@@ -37,7 +37,7 @@ silently showing a subset. The same rule covers template-declared controls: a
 button whose action nothing in the interaction bridge routes is dropped with a
 note rather than drawn dead.
 
-## Platform event kinds
+## Platform notification kinds
 
 `utils/platform-notification-kinds.ts` declares the kinds the platform emits, consulted
 as the **last** resort in `resolveEventKindDefinition` so an org that declares

--- a/docs/plans/chat-notification-cards.md
+++ b/docs/plans/chat-notification-cards.md
@@ -39,7 +39,7 @@ note rather than drawn dead.
 
 ## Platform event kinds
 
-`utils/platform-event-kinds.ts` declares the kinds the platform emits, consulted
+`utils/platform-notification-kinds.ts` declares the kinds the platform emits, consulted
 as the **last** resort in `resolveEventKindDefinition` so an org that declares
 the same slug still wins. Each kind declares a `metadataSchema` (and, where the
 interesting content is a list, a hand-authored `jsonTemplate`):

--- a/packages/server/src/__tests__/integration/connector-health-reauth-notify.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-reauth-notify.test.ts
@@ -11,7 +11,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { runConnectorHealthCheck } from '../../connectors/connector-health';
-import { BROWSER_SESSION_EXPIRED_KIND } from '../../utils/platform-event-kinds';
+import { BROWSER_SESSION_EXPIRED_KIND } from '../../utils/platform-notification-kinds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { addUserToOrganization, createTestOrganization, createTestUser } from '../setup/test-fixtures';
 

--- a/packages/server/src/__tests__/unit/platform-notification-kinds.test.ts
+++ b/packages/server/src/__tests__/unit/platform-notification-kinds.test.ts
@@ -15,8 +15,8 @@ import { STRUCTURAL_NODE_TYPES } from "@lobu/core/json-template";
 import { describe, expect, it } from "bun:test";
 import {
 	ENTITY_CHANGE_APPROVAL_KIND,
-	PLATFORM_EVENT_KINDS,
-} from "../../utils/platform-event-kinds";
+	PLATFORM_NOTIFICATION_KINDS,
+} from "../../utils/platform-notification-kinds";
 import { validateJsonTemplate } from "../../utils/validate-json-template";
 
 type Node = Record<string, unknown>;
@@ -61,7 +61,7 @@ function boundRoots(node: unknown, scoped: Set<string>, out: Set<string>): void 
 	boundRoots(n.children, scoped, out);
 }
 
-const entries = Object.entries(PLATFORM_EVENT_KINDS);
+const entries = Object.entries(PLATFORM_NOTIFICATION_KINDS);
 
 describe("platform event kinds", () => {
 	it("declares at least the families the triggers emit", () => {
@@ -153,7 +153,7 @@ describe("context separators keep their trailing space", () => {
 		}
 	}
 
-	for (const [slug, kind] of Object.entries(PLATFORM_EVENT_KINDS)) {
+	for (const [slug, kind] of Object.entries(PLATFORM_NOTIFICATION_KINDS)) {
 		if (!kind.jsonTemplate) continue;
 		it(`${slug}: every separator literal ends with a space`, () => {
 			const literals: string[] = [];
@@ -170,7 +170,7 @@ describe("context separators keep their trailing space", () => {
 		// reaching into `if`/`span`, which is exactly where separators live.
 		const literals: string[] = [];
 		contextLiterals(
-			PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND].jsonTemplate,
+			PLATFORM_NOTIFICATION_KINDS[ENTITY_CHANGE_APPROVAL_KIND].jsonTemplate,
 			false,
 			literals,
 		);

--- a/packages/server/src/__tests__/unit/platform-notification-kinds.test.ts
+++ b/packages/server/src/__tests__/unit/platform-notification-kinds.test.ts
@@ -1,5 +1,5 @@
 /**
- * Conformance for the platform event kind registry.
+ * Conformance for the platform notification kind registry.
  *
  * Every kind here is a contract between a trigger that writes `payloadData` and
  * a template that reads it, and nothing at runtime tells you when the two drift
@@ -63,7 +63,7 @@ function boundRoots(node: unknown, scoped: Set<string>, out: Set<string>): void 
 
 const entries = Object.entries(PLATFORM_NOTIFICATION_KINDS);
 
-describe("platform event kinds", () => {
+describe("platform notification kinds", () => {
 	it("declares at least the families the triggers emit", () => {
 		expect(entries.length).toBeGreaterThanOrEqual(5);
 	});

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -21,10 +21,10 @@ import {
 import {
 	CONNECTOR_OPERATION_APPROVAL_KIND,
 	ENTITY_CHANGE_APPROVAL_KIND,
-	PLATFORM_EVENT_KINDS,
-} from "../../utils/platform-event-kinds";
+	PLATFORM_NOTIFICATION_KINDS,
+} from "../../utils/platform-notification-kinds";
 
-const APPROVAL_KIND = PLATFORM_EVENT_KINDS[CONNECTOR_OPERATION_APPROVAL_KIND];
+const APPROVAL_KIND = PLATFORM_NOTIFICATION_KINDS[CONNECTOR_OPERATION_APPROVAL_KIND];
 
 type Card = NonNullable<ReturnType<typeof buildKindCard>>;
 const kids = (card: Card | null) =>
@@ -775,7 +775,7 @@ describe("structural edge cases", () => {
 });
 
 describe("entity change approvals render through their kind", () => {
-	const KIND = PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
+	const KIND = PLATFORM_NOTIFICATION_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
 	const build = (data: Record<string, unknown>) =>
 		buildKindCard({
 			metadataSchema: KIND.metadataSchema,
@@ -928,7 +928,7 @@ describe("entity change approvals render through their kind", () => {
 		// (400) on the way in, so the only value that still overflows the field
 		// budget afterwards is one that escaping expands — 400 ampersands become
 		// 2000 characters, and the cut lands inside the last `&amp;`.
-		const KIND = PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
+		const KIND = PLATFORM_NOTIFICATION_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
 		const card = buildKindCard({
 			metadataSchema: KIND.metadataSchema,
 			jsonTemplate: KIND.jsonTemplate,
@@ -1181,7 +1181,7 @@ describe("the context strip", () => {
 	});
 
 	it("puts the connector operation's identity in the strip, its input in the body", () => {
-		const kind = PLATFORM_EVENT_KINDS[CONNECTOR_OPERATION_APPROVAL_KIND];
+		const kind = PLATFORM_NOTIFICATION_KINDS[CONNECTOR_OPERATION_APPROVAL_KIND];
 		const card = buildKindCard({
 			metadataSchema: kind.metadataSchema,
 			jsonTemplate: kind.jsonTemplate,
@@ -1196,7 +1196,7 @@ describe("the context strip", () => {
 	});
 
 	it("links the entity under review from the approval strip", () => {
-		const kind = PLATFORM_EVENT_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
+		const kind = PLATFORM_NOTIFICATION_KINDS[ENTITY_CHANGE_APPROVAL_KIND];
 		const card = buildKindCard({
 			metadataSchema: kind.metadataSchema,
 			jsonTemplate: kind.jsonTemplate,

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -8,7 +8,7 @@ import {
 	CONNECTOR_OPERATION_APPROVAL_KIND,
 	ENTITY_CHANGE_APPROVAL_KIND,
 	INVITATION_RECEIVED_KIND,
-} from "../utils/platform-event-kinds";
+} from "../utils/platform-notification-kinds";
 import { buildResourcePermalink } from "../utils/url-builder";
 import { resolveAskAffordance } from "./ask-schema";
 import { createNotificationForUsers, getOrgSlug } from "./service";

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -325,7 +325,7 @@ export function formatActionApprovalBody(params: {
  * that cannot carry the human's input would report success while discarding it.
  *
  * Entity and operation approvals never come through here: they render through
- * their platform event kinds in `notifyActionApprovalNeeded`.
+ * their platform notification kinds in `notifyActionApprovalNeeded`.
  */
 export function buildActionApprovalCard(params: {
 	runId?: number;
@@ -476,7 +476,7 @@ export async function notifyActionApprovalNeeded(params: {
 	details?: ActionApprovalDetails;
 	/**
 	 * Set ONLY for a connector operation (`run_type = 'action'`). Its presence
-	 * is what routes the notification through the platform event kind and puts
+	 * is what routes the notification through the platform notification kind and puts
 	 * Approve/Reject on the chat card — builder runs (`manage_automations`,
 	 * `manage_agents`) also arrive without `details`, but the chat click handler
 	 * cannot decide them, so they must not be inferred into this family.
@@ -508,7 +508,7 @@ export async function notifyActionApprovalNeeded(params: {
 			type: "action_approval_needed",
 			title: formatActionApprovalTitle(params.actionKey, params.details),
 			body: formatActionApprovalBody(params),
-			// Both approval families render through a platform event kind, so the
+			// Both approval families render through a platform notification kind, so the
 			// chat post, the Memory view and MCP apps all show the SAME table from
 			// one declaration instead of each surface formatting the payload again.
 			...(operation

--- a/packages/server/src/utils/event-kind-validation.ts
+++ b/packages/server/src/utils/event-kind-validation.ts
@@ -12,7 +12,7 @@
 import { getDb } from '../db/client';
 import { formatAjvError, getAjv } from './ajv-singleton';
 import { exceedsValidationLimits, isEmptyObject } from './metadata-limits';
-import { resolvePlatformEventKind } from './platform-event-kinds';
+import { resolvePlatformNotificationKind } from './platform-notification-kinds';
 import { TtlCache } from './ttl-cache';
 
 // ============================================
@@ -325,7 +325,7 @@ export async function resolveEventKindDefinition(
   const memberKinds = await getMemberEventKinds(orgId);
   // Platform kinds are the LAST resort, so an org that declares the same slug
   // keeps ownership of how it renders.
-  return memberKinds?.[semanticType] ?? resolvePlatformEventKind(semanticType);
+  return memberKinds?.[semanticType] ?? resolvePlatformNotificationKind(semanticType);
 }
 
 /**

--- a/packages/server/src/utils/platform-notification-kinds.ts
+++ b/packages/server/src/utils/platform-notification-kinds.ts
@@ -1,6 +1,12 @@
 /**
- * Event kinds the PLATFORM emits, as opposed to the ones an org authors in
- * `$member.event_kinds`.
+ * Notification kinds the PLATFORM emits, as opposed to the event kinds an org
+ * authors in `$member.event_kinds`.
+ *
+ * Named for what these are — renderable notifications — and NOT after the
+ * unrelated `platform_event_kinds` catalog on `manage_entity_schema`, which
+ * lists the `<subject>.<op>` audit events an Automation trigger can subscribe
+ * to (`automations/platform-event-catalog.ts`). Two different vocabularies met
+ * under one name once the catalog shipped; this is the notification one.
  *
  * Event-kind resolution is otherwise entirely org-authored, which is right for
  * content an org models itself. But a notification the platform raises — an
@@ -25,7 +31,7 @@ export const CONNECTION_AUTHORIZATION_KIND = "connection_authorization_needed";
 export const BROWSER_SESSION_EXPIRED_KIND = "browser_session_expired";
 export const INVITATION_RECEIVED_KIND = "invitation_received";
 
-export const PLATFORM_EVENT_KINDS: Readonly<
+export const PLATFORM_NOTIFICATION_KINDS: Readonly<
 	Record<string, EventKindDefinition>
 > = {
 	/**
@@ -336,8 +342,8 @@ export const PLATFORM_EVENT_KINDS: Readonly<
 	},
 };
 
-export function resolvePlatformEventKind(
+export function resolvePlatformNotificationKind(
 	semanticType: string,
 ): EventKindDefinition | null {
-	return PLATFORM_EVENT_KINDS[semanticType] ?? null;
+	return PLATFORM_NOTIFICATION_KINDS[semanticType] ?? null;
 }


### PR DESCRIPTION
## Summary
- `utils/platform-event-kinds.ts` holds the renderable notifications the platform raises (approval cards, reauth prompts, invitations). Stage B then shipped an unrelated `platform_event_kinds` field on `manage_entity_schema` listing the `<subject>.<op>` audit events an Automation trigger can subscribe to. One name, two vocabularies that share no rows.
- Renames the internal module and symbols to `platform-notification-kinds` / `PLATFORM_NOTIFICATION_KINDS` / `resolvePlatformNotificationKind`, and states the distinction in the module header so the next reader does not have to re-derive it.
- Internal only. `git grep` confirms the symbol reaches no API, SDK, or generated-client surface, so the shipped `platform_event_kinds` field keeps its name and no contract moves.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (7/7 gates: build, typecheck, knip, biome, naming, gateway-llm, entity-write)
- [x] Tests run: `bun test src/__tests__/unit/platform-notification-kinds.test.ts src/__tests__/unit/template-card.test.ts` → 82 pass / 0 fail

## Notes
Pure rename — no behavior change, so there is no red→green to paste. The rename is proven by the two suites that import the symbol and by a repo-wide grep returning zero remaining references to the old name.
