### PR TITLE
fix(mcp): issue and redeem the approval capability without the Apps declaration

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -948,7 +948,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?._meta?.['mcp/www_authenticate']).toBeUndefined();
   });
 
-  it('still binds the app for a client that did not advertise MCP Apps, while keeping app-only tools hidden', async () => {
+  it('binds the app and completes an approval for a client that did not advertise MCP Apps, while keeping app-only tools hidden', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
       advertiseMcpApps: false,
     });
@@ -1021,19 +1021,41 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     const renderBody = await renderResponse.json();
     expect(renderBody.result?.isError).not.toBe(true);
-    // The binding ships even without negotiation, but the app-only approval
-    // capability does not: the binding names a surface, the capability grants
-    // the power to act through it.
     expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
       LOBU_INTERACTION_RESOURCE_URI
     );
-    expect(renderBody.result?._meta?.['lobu/approval-capability']).toBeUndefined();
-    // The registered approval reader still carries the viewer role, while the
-    // app-only approval capability is withheld from this non-App client.
+    const capability = renderBody.result?._meta?.['lobu/approval-capability'];
+    expect(typeof capability).toBe('string');
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');
     expect(renderBody.result?.structuredContent?.actions).toEqual([
+      expect.objectContaining({ id: 'approve', tool: 'resolve_approval' }),
+      expect.objectContaining({ id: 'reject', tool: 'resolve_approval' }),
       expect.objectContaining({ id: 'review', href: expect.stringMatching(/^https?:\/\//) }),
     ]);
+    const rejectResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'non-declaring-reject',
+        method: 'tools/call',
+        params: {
+          name: 'resolve_approval',
+          arguments: {
+            run_id: runId,
+            decision: 'reject',
+            _meta: { 'lobu/approval-capability': capability },
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect((await rejectResponse.json()).result?.isError).not.toBe(true);
+
+    const [settled] = await getDb()<{ approval_status: string }>`
+      SELECT approval_status FROM runs
+      WHERE id = ${runId} AND organization_id = ${org.id}
+    `;
+    expect(settled).toMatchObject({ approval_status: 'rejected' });
   });
 
   it('keeps an approval mutation text-only and resolves it only with the hidden app capability', async () => {

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -388,9 +388,19 @@ function canIssueApprovalCapability(
   clientId: string;
   mcpSessionId: string;
 } {
+  // Deliberately NOT gated on `ctx.mcpAppsSupported`. That flag answers "did
+  // the client announce the Apps extension", which is a different question
+  // from "can this client render a card and call back through it" — claude.ai
+  // renders while announcing nothing, so gating here left its card showing
+  // Approve/Reject it could never obtain the right to press.
+  //
+  // This widens who receives the capability without widening what it reaches:
+  // the token stays bound to org/user/client/session with a TTL, and
+  // `resolve_approval` stays absent from `tools/list` for a non-declaring
+  // client, so the model cannot invoke it — only the rendered card can, via
+  // `tools/call`. The conditions kept below are the ones carrying real weight.
   return (
     status === 'pending' &&
-    ctx.mcpAppsSupported === true &&
     ctx.tokenType === 'oauth' &&
     Boolean(ctx.userId && ctx.clientId && ctx.mcpSessionId) &&
     !belongsToApprovalWindow(row)
@@ -546,9 +556,13 @@ const resolveApprovalImpl = async (
   ctx: ToolContext
 ): Promise<LobuView> => {
   const capability = readApprovalCapability(ctx.mcpAppApprovalCapability);
+  // Drops `ctx.mcpAppsSupported` for the same reason issuance does — and it
+  // has to drop it in the SAME change, or a card holding a freshly-issued
+  // capability gets a 403 on every press. What remains authenticates the round
+  // trip: the capability must name this run, org, user and client, still be
+  // bound to the calling host, and not have expired.
   if (
     capability.runId !== args.run_id ||
-    ctx.mcpAppsSupported !== true ||
     capability.organizationId !== ctx.organizationId ||
     capability.userId !== ctx.userId ||
     capability.clientId !== ctx.clientId ||


### PR DESCRIPTION
## What

`canIssueApprovalCapability` and `resolveApprovalImpl` both required `ctx.mcpAppsSupported` — that the client announced the `io.modelcontextprotocol/ui` extension. Both conditions are removed.

That flag answers *"did the client announce apps"*, which is not the same question as *"can the client render one and call back through it"*. claude.ai renders cards while announcing nothing, so its approval card showed an "Open in Lobu" link and no inline Approve/Reject.

This is the same class as #2960 (the tool binding) and #2968 (the render payload): the extension declaration was being used as a proxy for "can render", which it is not.

## Why both halves in one change

Ungating issuance alone would hand the card a capability and then 403 on every press — `resolveApprovalImpl` had the matching gate. The new test fails against either half reverted.

## Why this is not a widening of authority

It widens *who receives* the capability, not *what it reaches*:

- the token stays bound to org / user / client / session with a TTL
- `resolve_approval` stays absent from `tools/list` for a non-declaring client, so the model cannot invoke it — only the rendered card can, via `tools/call` (this was already the documented design: hidden, not disabled)
- the canonical approval handler still runs its own membership and run-owner/admin checks
- the `review` href action remains in the list either way, so a host whose widget bridge cannot complete a tool call keeps the working escape hatch it has today

## Test plan

- [x] Red: `expected 'undefined' to be 'string'` — capability withheld from a non-declaring client
- [x] Green: full round trip for a non-declaring session — render → capability → `resolve_approval` → run settles, asserted against the `runs` row
- [x] Mutation: restoring **either** gate independently fails the test (`expected 'undefined' to be 'string'` for issuance, `expected true not to be true` for redemption)
- [x] Capability asserted absent from `structuredContent` and from `content[0].text`, so it never reaches the model
- [x] `bunx vitest run src/__tests__/integration/mcp/` — 154 passed, 2 skipped, 13 files
- [x] `make pre-pr` clean

## Verification still owed

I could not verify from outside that Claude's widget bridge actually completes a `tools/call` — the card is a cross-origin iframe on `claudemcpcontent.com`, and neither the accessibility tree nor page JS reaches inside it. If that bridge does not work, the card gains two buttons that fail and keeps the working review link; it does not lose anything it has today. Worth a manual click-through in Claude after rollout.