### PR TITLE
fix(workers): mint an org-scoped MCP URL a spawned CLI can actually open

### DIFF
--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -181,9 +181,8 @@ export const AutomationPollContextSchema = Type.Object({
   // `token` is a WorkerToken minted for the automation's ASSIGNED AGENT via
   // buildAutomationRunWorkerAccess — never the polling device's PAT (a child
   // PAT is bound to the user's personal org and can't authenticate to a
-  // team-org Automation). `mcp_url` is the gateway MCP proxy endpoint
-  // (`{PUBLIC_GATEWAY_URL}/mcp/lobu-memory`), which validates the worker
-  // token and promotes it into a direct-auth MCP session for the token's org.
+  // team-org Automation). `mcp_url` is the org-scoped direct MCP endpoint
+  // (`<public origin>/mcp/<orgSlug>`), where the bearer opens its own session.
   // The daemon hands both to the spawned CLI as its MCP wiring and as
   // LOBU_API_TOKEN / LOBU_MEMORY_URL so `lobu memory` runs as the automation's
   // agent for this run. Absent when the run has no usable assigned agent, or

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -23,6 +23,7 @@ import { randomBytes } from 'node:crypto';
 import { verifyWorkerToken } from '@lobu/core';
 import type { DbClient } from '../../../db/client';
 import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
+import { resolvePublicOrigin } from '../../../utils/public-origin';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
@@ -199,9 +200,9 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(agentSession?.conversation_id).toBe(
       `claim-gate-agent_automation_${ctx.automationId}_run_${job.run_id}`
     );
-    // Canonical headless lobu-memory MCP URL: PUBLIC_GATEWAY_URL (mounted under
-    // /lobu) followed by /mcp/lobu-memory.
-    expect(agentSession?.mcp_url).toContain('/lobu/mcp/lobu-memory');
+    expect(agentSession?.mcp_url).toBe(
+      `${resolvePublicOrigin('http://localhost/api/workers/poll')}/mcp/${encodeURIComponent(ctx.workspace.org.slug)}`
+    );
     expect(typeof agentSession?.expires_at).toBe('number');
     expect(agentSession!.expires_at).toBeGreaterThan(Date.now());
     const claims = verifyWorkerToken(agentSession!.token);

--- a/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Headerless WorkerToken auth on the org-scoped direct MCP endpoint.
+ *
+ * A device Automation run hands its spawned agent CLI (claude, opencode, the
+ * lobu CLI via LOBU_MEMORY_URL) the per-run WorkerToken and an MCP URL. Those
+ * clients speak raw streamable-HTTP MCP and cannot attach the gateway-internal
+ * `x-lobu-memory-direct-auth` header. The verified token must retain its
+ * organization and revocation boundaries when it enters the same auth lane.
+ */
+
+import { generateWorkerToken, verifyWorkerToken } from '@lobu/core';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getRevokedTokenStore } from '../../../gateway/auth/revoked-token-store';
+import { buildAutomationRunWorkerAccess } from '../../../gateway/services/automation-run-worker-token';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+const AGENT_ID = 'headerless-agent';
+
+const INITIALIZE_BODY = {
+  jsonrpc: '2.0',
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-03-26',
+    capabilities: {},
+    clientInfo: { name: 'spawned-cli', version: '1.0.0' },
+  },
+  id: 0,
+};
+
+describe('worker-token MCP auth without the direct-auth header', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let otherOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let workerToken: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    org = await createTestOrganization({ name: 'Headerless Org' });
+    otherOrg = await createTestOrganization({ name: 'Headerless Other Org' });
+    const user = await createTestUser({});
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await addUserToOrganization(user.id, otherOrg.id, 'owner');
+    await createTestAgent({
+      organizationId: org.id,
+      agentId: AGENT_ID,
+      ownerUserId: user.id,
+    });
+    // Agent ids are org-scoped, so reproducing the same id in the other org
+    // proves the signed organization claim — not id uniqueness — is the fence.
+    await createTestAgent({
+      organizationId: otherOrg.id,
+      agentId: AGENT_ID,
+      ownerUserId: user.id,
+    });
+    workerToken = buildAutomationRunWorkerAccess({
+      agentId: AGENT_ID,
+      automationId: 1,
+      runId: 1,
+      organizationId: org.id,
+    }).token;
+  });
+
+  it('a bare WorkerToken bearer opens a fresh MCP session on /mcp/<orgSlug>', async () => {
+    const initResponse = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: workerToken,
+    });
+    expect(initResponse.status).toBe(200);
+    const sessionId = initResponse.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    // The session is usable, not merely opened: tools/list answers on it.
+    await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      token: workerToken,
+      headers: { 'mcp-session-id': sessionId as string },
+    });
+    const toolsResponse = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+      token: workerToken,
+      headers: { 'mcp-session-id': sessionId as string },
+    });
+    expect(toolsResponse.status).toBe(200);
+    const tools = (await toolsResponse.json()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    const names = (tools.result?.tools ?? []).map((t) => t.name);
+    expect(names).toContain('query_sdk');
+    expect(names).toContain('run_sdk');
+  });
+
+  it('refuses the token on another org even when that org has the same agent id', async () => {
+    const response = await post(`/mcp/${otherOrg.slug}`, {
+      body: INITIALIZE_BODY,
+      token: workerToken,
+    });
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe('insufficient_scope');
+  });
+
+  it('refuses a worker token with no signed organization context', async () => {
+    const orglessToken = generateWorkerToken(AGENT_ID, 'orgless-conversation', 'api-orgless', {
+      channelId: 'api-orgless',
+      agentId: AGENT_ID,
+      platform: 'api',
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: orglessToken,
+    });
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe('invalid_token');
+  });
+
+  it('a bearer that is not a worker token still falls through to OAuth auth', async () => {
+    const response = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: 'not-a-worker-token-and-not-a-pat',
+    });
+    // The headerless promotion must not swallow ordinary bearers: this one
+    // does not match the worker-token envelope, so OAuth handles and rejects it.
+    expect(response.status).toBe(401);
+  });
+
+  it('an explicit direct-auth header with a non-verifying bearer stays a hard 401', async () => {
+    const response = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: 'not-a-worker-token-and-not-a-pat',
+      headers: { 'X-Lobu-Memory-Direct-Auth': '1' },
+    });
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error_description?: string };
+    expect(String(body.error_description)).toMatch(/worker token/i);
+  });
+
+  it('refuses a revoked worker token', async () => {
+    const access = buildAutomationRunWorkerAccess({
+      agentId: AGENT_ID,
+      automationId: 1,
+      runId: 2,
+      organizationId: org.id,
+    });
+    const claims = verifyWorkerToken(access.token);
+    if (!claims?.jti) throw new Error('minted Automation worker token has no jti');
+    await getRevokedTokenStore().revoke(claims.jti, access.expiresAt);
+
+    const response = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: access.token,
+    });
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe('invalid_token');
+  });
+});

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -18,7 +18,7 @@ import {
   parseAutomationRunPayload,
 } from '../automations/automation';
 import { buildAutomationRunWorkerAccess } from '../gateway/services/automation-run-worker-token';
-import { resolvePublicGatewayUrl } from '../utils/public-origin';
+import { resolvePublicOrigin } from '../utils/public-origin';
 import { getDb, parsePgTextArray, pgTextArray } from '../db/client';
 import type { Outputs } from '../types/automations';
 import { deriveAutomationExtractionSchema } from '../utils/automation-extraction-schema';
@@ -746,6 +746,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         r.automation_id,
         r.window_id,
         r.organization_id,
+        org.slug AS organization_slug,
         r.created_at AS run_created_at,
         r.auth_profile_id AS run_auth_profile_id,
         f.feed_key,
@@ -773,6 +774,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         wv.skills AS automation_skills,
         wv.outputs AS automation_outputs
       FROM runs r
+      LEFT JOIN organization org ON org.id = r.organization_id
       LEFT JOIN feeds f ON f.id = r.feed_id
       LEFT JOIN connections conn ON conn.id = r.connection_id
       LEFT JOIN LATERAL (
@@ -854,6 +856,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     automation_id: number | null;
     window_id: number | null;
     organization_id: string;
+    organization_slug: string | null;
     automation_name: string | null;
     automation_agent_id: string | null;
     automation_slug: string | null;
@@ -954,13 +957,21 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         // server-side dispatcher's agent session) — never the device's PAT,
         // which is bound to the user's personal org and can't authenticate to
         // a team-org Automation. The daemon injects the token into the spawned
-        // CLI (env + MCP wiring) against the gateway MCP proxy endpoint.
+        // CLI (env + MCP wiring).
+        //
+        // Use the org-scoped direct endpoint: the gateway MCP proxy owns its
+        // upstream session lifecycle and cannot serve a raw client's initialize.
         //
         // Minting encrypts, so it can throw (missing/short ENCRYPTION_KEY). The
         // run is ALREADY claimed by this point, so letting that escape would 500
         // the poll and strand it `running` — the exact wedge the claim gate
         // exists to prevent. Degrade to the pre-session dispatch instead.
         try {
+          if (!row.organization_slug) {
+            throw new Error(
+              `organization ${row.organization_id} has no slug to scope the MCP session URL`
+            );
+          }
           const access = buildAutomationRunWorkerAccess({
             agentId,
             automationId: row.automation_id,
@@ -969,7 +980,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           });
           agentSession = {
             conversation_id: access.conversationId,
-            mcp_url: `${resolvePublicGatewayUrl()}/mcp/lobu-memory`,
+            mcp_url: `${resolvePublicOrigin(c.req.url)}/mcp/${encodeURIComponent(row.organization_slug)}`,
             token: access.token,
             expires_at: access.expiresAt,
           };

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -11,6 +11,7 @@ import type { AuthInfo } from '../auth/oauth/types';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { isPublicReadable } from '../auth/tool-access';
 import { getDb } from '../db/client';
+import { getRevokedTokenStore } from '../gateway/auth/revoked-token-store';
 import { resolveRestToolGetRoute } from '../http/rest-tool-routes';
 import type { Env } from '../index';
 import logger from '../utils/logger';
@@ -272,14 +273,32 @@ export class MultiTenantProvider implements WorkspaceProvider {
       return (await next()) ?? undefined;
     }
 
-    // 1) Embedded worker direct-auth for the in-process lobu-memory MCP.
-    // The gateway MCP proxy sets this header after validating/issuing the worker
-    // token. Treat it as an internal admin-scoped MCP session for the URL org so
-    // unattended automation runs can use memory tools without a second OAuth loop.
-    if (authHeader?.startsWith('Bearer ') && c.req.header('x-lobu-memory-direct-auth') === '1') {
-      const workerToken = authHeader.slice(7);
-      const tokenData = verifyWorkerToken(workerToken);
+    // 1) Worker-token direct-auth for the in-process lobu-memory MCP. The
+    // gateway proxy marks this lane explicitly; spawned Automation CLIs cannot
+    // attach that internal header, so a verified worker bearer on an MCP route
+    // enters the same lane. Non-worker bearers still fall through to PAT,
+    // OAuth, or session auth.
+    const directAuthHeader = c.req.header('x-lobu-memory-direct-auth') === '1';
+    const directAuthBearer =
+      authHeader?.startsWith('Bearer ') && (directAuthHeader || isMcpRoute)
+        ? authHeader.slice(7)
+        : null;
+    const directAuthTokenData =
+      directAuthBearer && /^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/i.test(directAuthBearer)
+        ? verifyWorkerToken(directAuthBearer)
+        : null;
+    if (directAuthBearer && (directAuthHeader || directAuthTokenData)) {
+      const tokenData = directAuthTokenData;
       if (!tokenData) {
+        return c.json(
+          { error: 'invalid_token', error_description: 'Invalid or expired worker token' },
+          401,
+          {
+            'WWW-Authenticate': bearerChallenge('invalid_token'),
+          }
+        );
+      }
+      if (tokenData.jti && (await getRevokedTokenStore().isRevoked(tokenData.jti))) {
         return c.json(
           { error: 'invalid_token', error_description: 'Invalid or expired worker token' },
           401,
@@ -292,6 +311,24 @@ export class MultiTenantProvider implements WorkspaceProvider {
         return c.json(
           { error: 'invalid_request', error_description: 'Organization slug required in URL' },
           400
+        );
+      }
+      if (!tokenData.organizationId) {
+        return c.json(
+          { error: 'invalid_token', error_description: 'Worker token missing organization context' },
+          401,
+          {
+            'WWW-Authenticate': bearerChallenge('invalid_token'),
+          }
+        );
+      }
+      if (tokenData.organizationId !== requestedOrgId) {
+        return c.json(
+          {
+            error: 'insufficient_scope',
+            error_description: 'Worker token is not valid for this organization',
+          },
+          403
         );
       }
       if (!tokenData.agentId) {


### PR DESCRIPTION
## Summary
- **Root cause (proven live):** the `agent_session.mcp_url` minted by #2943's poll automation lane pointed at the gateway MCP proxy (`{PUBLIC_GATEWAY_URL}/mcp/lobu-memory`). That proxy pre-initializes its own upstream session keyed on (agent, mcp, scope) and forwards the downstream client's `initialize` WITH that session id, so the upstream mcp-handler answers 400 "Server already initialized" — for EVERY raw streamable-HTTP client (claude prints "Execution error" and hangs to the run timeout; opencode and the lobu CLI fail the same handshake). The proxy's REST sub-routes work; its raw MCP endpoint was never client-openable.
- **Fix (owner-selected option B):** mint the org-scoped direct endpoint `<public origin>/mcp/<orgSlug>` instead, and accept a **verified WorkerToken bearer** there without the gateway-internal `x-lobu-memory-direct-auth` header. Env-injected clients cannot attach headers (`LOBU_MEMORY_URL` carries none), and verification is cryptographic — only this server can mint a WorkerToken (AES-256-GCM over a server-side key; the bearer must match the `iv:tag:ciphertext` wire shape before a decrypt is even attempted).
- The headerless lane is gated to MCP routes only and enters the SAME direct-auth lane the header used: jti revocation check (parity with every other worker-token acceptance point), token-org == URL-org, agent must exist in the URL org, owner must be org admin. Non-worker bearers fall through to PAT/OAuth/session auth unchanged; the explicit header with a non-verifying bearer stays a hard 401.
- Poll now resolves the org slug via a JOIN in the claim query and derives the origin from the request (configured public origin wins), so dev daemons get a reachable URL and prod gets the canonical one.

## Test plan
- [x] Red (against the pre-fix tree): the new suite failed 3/4 — bare WorkerToken 401'd on `/mcp/<orgSlug>`, wrong-org case couldn't reach its 403, fall-through case masked; claim-gate asserted the proxy URL.
- [x] Green: `worker-token-headerless-auth.test.ts` (4) + `headless-automation-claim-gate.test.ts` (4+2 new lane assertions) — 10 passed; full `src/__tests__/integration/mcp/` — **15 files, 163 passed**.
- [x] **Full autonomous e2e** (real dev gateway, real `lobu daemon --platform headless`, real claude CLI, zero manual steps): run claimed → claude opened the minted org-scoped URL with the per-run WorkerToken → `query_sdk` → `completeWindow` → **run 23 `completed`, exit ok, window_id 6, 37.9s**. Same rig against the proxy URL reproduced the 400 on every client.
- [x] Prod de-risk: `api.lobu.ai/mcp` and `app.lobu.ai/mcp` both respond 401 (routed and auth-gated), so the org-scoped mint is reachable at the public origin.
- [x] `make pre-pr` clean; `make review-fix` ran (codex) — its jti-revocation, org-equality, and wire-format-regex hardening are included; each verified against the actual code (revocation parity sites: proxy-shared, config-service, worker-gateway, internal middleware, public agent).

## Notes
- **Auth-surface change, owner-approved:** accepting verified WorkerToken bearers on `/mcp/:orgSlug` without the internal header was explicitly chosen (option B) over teaching every client to send the header (option A) — the lobu CLI's `LOBU_MEMORY_URL` lane cannot send headers at all.
- `owl_pat_`/other bearers never enter the worker lane (wire-format check), so PAT auth on MCP routes is byte-for-byte unchanged.
- The daemon-PAT fallback (`<origin>/mcp` + PAT) still works for servers that don't mint sessions yet.
