### PR TITLE
fix(tools): make save_memory metadata optional

### DIFF
--- a/packages/server/src/__tests__/integration/events/save-content-optional-metadata.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-optional-metadata.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration test: `save_memory` accepts calls without `metadata`.
+ * Omitted metadata passes the shared tool validator and is normalized to `{}`
+ * by the save path; ordinary caller metadata remains accepted.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { saveContent } from '../../../tools/save_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > optional metadata', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Optional Metadata Org' });
+    user = await createTestUser({ email: 'optional-metadata@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+    };
+  });
+
+  it('saves a plain note with no metadata key at all', async () => {
+    const saved = await saveContent(
+      {
+        content: 'a note saved without any metadata',
+        semantic_type: 'content',
+      },
+      {} as never,
+      ctx
+    );
+
+    expect(saved.id).toBeGreaterThan(0);
+    expect(saved.created).toBe(true);
+    expect(saved.metadata).toEqual({});
+  });
+
+  it('still preserves ordinary metadata when supplied', async () => {
+    const saved = await saveContent(
+      {
+        content: 'a note saved with metadata',
+        semantic_type: 'content',
+        metadata: { namespace: 'optional-metadata-test', importance: 'low' },
+      },
+      {} as never,
+      ctx
+    );
+
+    expect(saved.metadata).toMatchObject({
+      namespace: 'optional-metadata-test',
+      importance: 'low',
+    });
+  });
+});

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -185,10 +185,12 @@ export const SaveContentSchema = Type.Object({
       description: 'When the event actually happened (ISO 8601). Defaults to now if omitted.',
     })
   ),
-  metadata: Type.Record(Type.String(), Type.Any(), {
-    description:
-      'Structured metadata — validated against the entity type schema or semantic_type schema',
-  }),
+  metadata: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        'Structured metadata, validated against the metadata schema for the selected event kind when non-empty. Omit when no structured metadata is needed; an absent value is treated as {}.',
+    })
+  ),
   supersedes_event_id: Type.Optional(
     Type.Number({
       description:


### PR DESCRIPTION
## What

`metadata` was the only field in `SaveContentSchema` not wrapped in `Type.Optional`. Every other input is optional, including `content`, so the simplest possible call — save this text as a note — failed with:

```
Invalid arguments for save_memory: /metadata: Expected required property
```

## Why it looks like an oversight rather than a contract

Nothing downstream ever wanted it:

- `validateSaveContentSemanticType` already types the parameter as `Record<string, unknown> | undefined | null`
- the impl already spreads `{ ...(args.metadata ?? {}) }`
- callers were working around it by passing a literal `{}` (including our own `all-tools-e2e` fixture)

I hit this driving the prod MCP endpoint by hand during the #2968 verification, which is what surfaced it.

## Class check

The other bare `metadata: Type.Record(...)` declarations are all *result* schemas — `SaveContentResultSchema`, `EntitySchema` in `search.ts`, `MergedRecordSchema` in `resolve_path.ts`. The server always populates those, so they correctly stay required. This input schema was the only instance.

## Test plan

- [x] Red: `ToolUserError: Invalid arguments for save_memory: /metadata: Expected required property`
- [x] Green: new `save-content-optional-metadata.test.ts` — omitting `metadata` saves and persists `{}`; supplying it still persists verbatim
- [x] `bunx vitest run src/__tests__/integration/events/ src/__tests__/integration/tools/` — 411 passed, 68 files
- [x] `make pre-pr` clean

## Note

This relaxes an input constraint, so it is additive for existing callers — anything passing `{}` today keeps working unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata is now optional when saving content.
  * Omitted metadata is automatically treated as an empty object.
  * Supplied metadata continues to be validated against the selected event type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->