### PR TITLE
fix(approvals): apply builder-run proposals without re-entering the fresh-call scope gate

### DIFF
--- a/packages/server/src/__tests__/integration/tools/manage-automations-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-automations-approval-e2e.test.ts
@@ -339,6 +339,50 @@ describe("manage_automations — builder gate e2e", () => {
 		expect(eventRows[0]?.interaction_status).toBe("completed");
 	});
 
+	it("approve from a write-scoped human session (no mcp:admin) still applies the held mutation", async () => {
+		const created = (await executeTool(
+			"manage_automations",
+			{
+				action: "create",
+				slug: "write-scope-approved",
+				name: "Write Scope Approved",
+				prompt: "Track write-scope approvals.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			agentCtx
+		)) as PendingApproval;
+		expect(created.status).toBe("pending_approval");
+
+		// resolve_approval intentionally requires only mcp:write. After validating
+		// its app capability, it calls manage_operations with a human context that
+		// preserves those scopes. The owner's role authorizes the decision; applying
+		// it must not re-enter the fresh-call mcp:admin gate.
+		const writeScopedOwnerCtx = baseCtx(orgId, ownerId, "owner", [
+			"mcp:read",
+			"mcp:write",
+		]);
+		const approveRes = (await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: created.run_id },
+			TEST_ENV,
+			writeScopedOwnerCtx
+		)) as { approved?: true; error?: string };
+		expect(approveRes.error).toBeUndefined();
+		expect(approveRes.approved).toBe(true);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT approval_status, status, error_message FROM runs
+			WHERE id = ${created.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows[0]?.approval_status).toBe("approved");
+		expect(runRows[0]?.error_message).toBeNull();
+		expect(runRows[0]?.status).toBe("completed");
+
+		expect(await automationExists(orgId, "write-scope-approved")).toBe(true);
+	});
+
 	it("reject cancels the held create: no automation, run cancelled, event superseded 'rejected'", async () => {
 		const created = (await executeTool(
 			"manage_automations",

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -932,7 +932,30 @@ export async function applyManageAutomationsProposal(
         }
       }
     }
-    return runManageAutomations(args, env, applyCtx);
+    // The approval path already established the human's authority. Dispatch
+    // directly so this server-side continuation does not re-enter routeAction's
+    // fresh-call mcp:admin gate; resolve_approval intentionally requires only
+    // mcp:write.
+    switch (args.action) {
+      case 'create':
+        return handleCreate(args, env, applyCtx);
+      case 'update':
+        return handleUpdate(args, env, applyCtx);
+      case 'create_version':
+        return handleCreateVersion(args, env, applyCtx);
+      case 'create_from_version':
+        return handleCreateFromVersion(args, env, applyCtx);
+      case 'set_reaction_script':
+        return handleSetReactionScript(args, env, applyCtx);
+      case 'delete':
+        return handleDelete(args, applyCtx);
+      default:
+        // Only write actions queue (automationWriteAction gates the queue path);
+        // a held proposal with any other action is corrupt — fail the apply.
+        throw new ToolUserError(
+          `Queued manage_automations proposal holds a non-write action: ${args.action}`
+        );
+    }
   });
 }
 

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -188,6 +188,11 @@ interface BuilderApprovalHandler {
 	/**
 	 * Apply the held proposal on approval (the family's write handler).
 	 *
+	 * Dispatch directly rather than through the routed tool surface: the approval
+	 * path already verifies a human with authority, while resolve_approval itself
+	 * intentionally requires only mcp:write. Re-entering routeAction would add a
+	 * fresh-call mcp:admin gate after the run has been claimed.
+	 *
 	 * `input` is what the HUMAN supplied with their decision (`approve({ input })`),
 	 * distinct from the agent-authored `proposal`. It was previously accepted by
 	 * the tool contract and then dropped on the floor here, so a form-shaped


### PR DESCRIPTION
## Summary
- Approving a queued `manage_automations` write from a write-scoped human session — the `resolve_approval` MCP App card path; claude.ai tokens never carry `mcp:admin` — claimed the run **approved**, then failed the apply on `routeAction`'s transport-scope gate: the run landed `approved`+`failed` with `"Action manage_automations.create_version requires an MCP session with admin access."` and the held mutation was never applied (prod run 1067579, found by the first real Approve click through the #2973 card).
- The approver's authority is already established by `requireHumanApprovalContext` + `requireApprovalAuthority` (admin-or-owner role); the apply is a server-side continuation of that decision, not a fresh call. Dispatch directly to the write handlers — the exact pattern `applyManageAgentsProposal` and `applyEntityChangeProposal` already use; `manage_automations` was the only builder family re-entering the routed surface.
- Encodes the rule on `BuilderApprovalHandler.apply` so a future family doesn't reintroduce it.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (build + typecheck + knip + biome + naming + funnel gates)
- [x] Tests run: `bunx vitest run src/__tests__/integration/tools/manage-automations-approval-e2e.test.ts` (12/12, includes 11 pre-existing gate tests through the new dispatch) + `operations-approval-*` / `operations-member-execute-authz` suites (39/39)
- [x] Bug fix: red→fix→green below
- [ ] If bot runtime changed: n/a

**Red** (new test, before fix):
```
AssertionError: expected 'Action manage_automations.create requ…' to be null
+ Received:
"Action manage_automations.create requires an MCP session with admin access."
```

**Green** (after fix):
```
 ✓ src/__tests__/integration/tools/manage-automations-approval-e2e.test.ts (12 tests) 545ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Notes
- Prod repro: run 1067579 (`approval_status='approved'`, `status='failed'`) — approved via the claude.ai card at 12:44 UTC today, apply died on the scope gate. This class of run could park → get approved → die, every time, for any OAuth/PAT approver without `mcp:admin`; web-session approvers were unaffected (scope sentinel).