### PR TITLE
refactor(promotion): report a policy-denied create where every other refusal is reported

### DIFF
--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -620,19 +620,18 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     `;
     expect(Number(cards[0].c)).toBeGreaterThan(0);
 
-    // ...and the change set records no denial, because nothing was refused.
+    // ...and nothing was refused. complete-window writes a change_set only when
+    // the window produced at least one change (`entityChanges.length > 0`), and a
+    // held create produces none — so the absence of the event IS the assertion.
+    // Guarding this behind `if (changeSet)` would make it never run: reporting the
+    // deferral as a refusal writes a change_set, which is exactly what must fail.
     const [changeSet] = await sql`
       SELECT metadata FROM current_event_records
       WHERE run_id = ${runId}
         AND organization_id = ${workspace.org.id}
         AND semantic_type = 'change_set'
     `;
-    if (changeSet) {
-      const meta = changeSet.metadata as Record<string, unknown>;
-      expect(Number(meta.denied_count ?? 0)).toBe(0);
-      const changes = (meta.changes ?? []) as Array<{ kind: string }>;
-      expect(changes.filter((c) => c.kind === 'denied')).toHaveLength(0);
-    }
+    expect(changeSet).toBeUndefined();
   });
 
   it('is idempotent across a same-window replay — no duplicate entities', async () => {

--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -566,6 +566,75 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(changes.every((c) => (c.denied?.reason ?? '').length > 0)).toBe(true);
   });
 
+  it("a create=approval policy on the OWNING AGENT cards the create instead of refusing it", async () => {
+    // The sibling of the deny case above, and the branch that separates the two.
+    // 'approval' and 'deny' both stop the inline insert, but only one is a refusal:
+    // a held create must be QUEUED, and must not be written into the change set as
+    // denied — recording it as a refusal makes the caller skip the carding branch,
+    // so the row reads as rejected and the approval it was owed is never queued.
+    // Drives the real `write_approval_policies` resolver through complete_window,
+    // not a test interceptor.
+    const ctx = await setupKeyedAutomation();
+    const { sql, workspace, automationId, parentEntityId, agent } = ctx;
+
+    const policyRows = await sql<{ id: number }>`
+      INSERT INTO write_approval_policies
+        (organization_id, resource_class, principal_kind, principal_id)
+      VALUES (${workspace.org.id}, 'entity', 'agent', ${agent.agentId})
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO write_policy_action_effects (policy_id, action, effect)
+      VALUES (${Number(policyRows[0].id)}, 'create', 'approval')
+    `;
+
+    await createTestEvent({
+      entity_id: parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+    await completeWithToken(ctx, token, runId);
+
+    // Held, not written: no promotion claimed an identity.
+    const promoted = await sql<{ c: number }>`
+      SELECT COUNT(*)::int AS c
+      FROM entity_identities
+      WHERE organization_id = ${workspace.org.id}
+        AND namespace = 'automation_key'
+        AND identifier LIKE ${`${automationId}::%`}
+    `;
+    expect(Number(promoted[0].c)).toBe(0);
+
+    // Held, not refused: an approval card exists for the create...
+    const cards = await sql<{ c: number }>`
+      SELECT COUNT(*)::int AS c
+      FROM current_event_records
+      WHERE organization_id = ${workspace.org.id}
+        AND semantic_type = 'operation'
+        AND interaction_type = 'approval'
+        AND interaction_status = 'pending'
+    `;
+    expect(Number(cards[0].c)).toBeGreaterThan(0);
+
+    // ...and the change set records no denial, because nothing was refused.
+    const [changeSet] = await sql`
+      SELECT metadata FROM current_event_records
+      WHERE run_id = ${runId}
+        AND organization_id = ${workspace.org.id}
+        AND semantic_type = 'change_set'
+    `;
+    if (changeSet) {
+      const meta = changeSet.metadata as Record<string, unknown>;
+      expect(Number(meta.denied_count ?? 0)).toBe(0);
+      const changes = (meta.changes ?? []) as Array<{ kind: string }>;
+      expect(changes.filter((c) => c.kind === 'denied')).toHaveLength(0);
+    }
+  });
+
   it('is idempotent across a same-window replay — no duplicate entities', async () => {
     const ctx = await setupKeyedAutomation();
     const { sql, workspace, automationId, parentEntityId } = ctx;

--- a/packages/server/src/__tests__/integration/automations/promotion-gate-fail-closed.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promotion-gate-fail-closed.test.ts
@@ -8,9 +8,11 @@
  * complete_window does) with a test interceptor registered into the gate.
  */
 
+import { ApprovalAttribution } from "@lobu/core/contracts/interaction-envelope";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
 	__resetMutationGateForTests,
+	deferEntityCreate,
 	registerMutationInterceptor,
 } from "../../../authz/entity-mutation-gate";
 import type { DbClient } from "../../../db/client";
@@ -134,6 +136,74 @@ describe("mutation gate fail-closed in automation promotion", () => {
 		expect(await promotedIdentities(ctx)).toHaveLength(0);
 	});
 
+	/**
+	 * The HANDLE on a row that was never written. `promote-keyed-entities.test.ts`
+	 * already proves a policy-denied create reaches the persisted change set with
+	 * `source: 'policy'` and a reason; what it does not pin is the identity of that
+	 * record — `entityId: 0` and the proposed name. Both are load-bearing:
+	 * complete-window links the change set with `filter((id) => id > 0)`, so a
+	 * refused create that reported any other id would link the timeline to an
+	 * unrelated entity, and the name is the only thing left to read it back by.
+	 *
+	 * Also pins the record across a move: this refusal used to be re-derived at the
+	 * caller from the type-wide gate decision, and is now returned by
+	 * `upsertKeyedEntity` like every other refusal.
+	 */
+	it("a denied create records the policy refusal in the run's change set", async () => {
+		const ctx = await setup();
+		registerMutationInterceptor({
+			name: "test-deny-create-record",
+			evaluate: async (req) =>
+				req.action === "create"
+					? { outcome: "deny", reason: "quota exceeded" }
+					: null,
+		});
+
+		const result = await promote(ctx, "low");
+
+		expect(result.changes).toHaveLength(1);
+		// A refused create has no row, so it carries no id and is recorded under
+		// the name the automation proposed.
+		expect(result.changes[0].entityId).toBe(0);
+		expect(result.changes[0]).toMatchObject({
+			kind: "denied",
+			name: "Stability · App Crashes",
+			denied: { source: "policy", reason: "quota exceeded" },
+		});
+	});
+
+	/**
+	 * The negative that keeps the create branch honest. `defer` and `deny` are both
+	 * "not allow", and both block the inline insert — but only one is a refusal.
+	 * Reporting a deferral as `denied` SWALLOWS the card: the caller records the
+	 * refusal and `continue`s before it reaches the carding branch, so the row is
+	 * marked rejected and the approval it was owed is never queued.
+	 */
+	it("a DEFERRED create is carded, not recorded as a refusal", async () => {
+		const ctx = await setup();
+		registerMutationInterceptor({
+			name: "test-defer-create-record",
+			evaluate: async (req) =>
+				req.action === "create"
+					? {
+							outcome: "defer",
+							deferred: deferEntityCreate({
+								entityData: { entity_type: "topic", name: "App Crashes" },
+								proposal: {},
+								attribution: ApprovalAttribution.Automation,
+							}),
+						}
+					: null,
+		});
+
+		const result = await promote(ctx, "low");
+
+		expect(result.created).toBe(0);
+		expect(result.deferred).toHaveLength(1);
+		expect(result.changes.filter((c) => c.kind === "denied")).toHaveLength(0);
+		expect(await promotedIdentities(ctx)).toHaveLength(0);
+	});
+
 	it("a denied update applies no fields (row skipped, window not poisoned)", async () => {
 		const ctx = await setup();
 
@@ -160,5 +230,10 @@ describe("mutation gate fail-closed in automation promotion", () => {
 
 		const [after] = await promotedIdentities(ctx);
 		expect((after.metadata as Record<string, unknown>).severity).toBe("low");
+		expect(second.changes).toHaveLength(1);
+		expect(second.changes[0]).toMatchObject({
+			kind: "denied",
+			denied: { source: "policy", reason: "rate limited" },
+		});
 	});
 });

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -36,6 +36,7 @@
 import { slugify } from '@lobu/core';
 import { ApprovalAttribution } from '@lobu/core/contracts/interaction-envelope';
 import {
+  type CreateOrDeleteDecision,
   deferEntityCreate,
   deferEntityFieldChange,
   type DeferredMutation,
@@ -300,8 +301,12 @@ async function upsertKeyedEntity(params: {
    * fails closed (deny) rather than promote under no agent envelope.
    */
   automationOwnerResolved: boolean;
-  /** Org policy: creates of this type queue an approval instead of inserting. */
-  createNeedsApproval: boolean;
+  /**
+   * The type-wide org-policy decision for creates of this type, resolved once per
+   * promotion. Passed whole rather than as a derived boolean so the refusal is
+   * reported from the same place as every other refusal — see `denied` below.
+   */
+  createGate: CreateOrDeleteDecision;
 }): Promise<{
   entityId: number;
   created: boolean;
@@ -310,12 +315,11 @@ async function upsertKeyedEntity(params: {
   applied: Record<string, AppliedChange>;
   blockedCreate: boolean;
   /**
-   * Set when the write was REFUSED here: every rule deny, plus a policy deny on
-   * an UPDATE. A policy deny on a CREATE is decided by the type-wide gate before
-   * this runs, so it returns as a plain `blockedCreate` and the caller derives
-   * that one. Carries the reason so the run's change set can record WHY, not
-   * just that a row was skipped: containment means the window survives, so
-   * nothing else marks it.
+   * Set when the write was REFUSED here — every refusal, whichever decider made
+   * it: a rule deny on either op, and a policy deny on an update or a create.
+   * Carries the reason so the run's change set can record WHY, not just that a
+   * row was skipped: containment means the window survives, so nothing else
+   * marks it.
    */
   denied?: { source: 'policy' | 'rule'; reason: string };
   /**
@@ -479,11 +483,22 @@ async function upsertKeyedEntity(params: {
     }
   }
 
-  // Org policy holds creates of this type for approval — no insert, no identity
-  // claim. The caller queues a durable create proposal post-commit; when it is
-  // approved and re-promoted, the identity claim above dedupes as usual.
-  if (params.createNeedsApproval) {
-    return { entityId: 0, created: false, blocked: {}, applied: {}, blockedCreate: true };
+  // Org policy is not an unqualified allow for creates of this type — no insert,
+  // no identity claim. A `defer` means the caller queues a durable create proposal
+  // post-commit; when it is approved and re-promoted, the identity claim above
+  // dedupes as usual. A `deny` is reported as a refusal right here, so no caller
+  // has to re-derive from the type-wide decision which of the two it was.
+  if (params.createGate.outcome !== 'allow') {
+    return {
+      entityId: 0,
+      created: false,
+      blocked: {},
+      applied: {},
+      blockedCreate: true,
+      ...(params.createGate.outcome === 'deny'
+        ? { denied: { source: 'policy' as const, reason: params.createGate.reason } }
+        : {}),
+    };
   }
 
   // 2. Create the entity (sequence-allocated id — multi-replica safe),
@@ -670,7 +685,6 @@ export async function promoteAutomationEntityOutput(
     entityData: { entity_type: entityTypeSlug, name: '' },
     proposal: {},
   });
-  const createNeedsApproval = createGate.outcome !== 'allow';
   if (createGate.outcome === 'deny') {
     logger.warn(
       { automationId, organizationId, entityTypeSlug, reason: createGate.reason },
@@ -765,21 +779,12 @@ export async function promoteAutomationEntityOutput(
           automationId,
           automationAgentId: automationOwner.ownerAgentId,
           automationOwnerResolved: automationOwner.resolved,
-          createNeedsApproval,
+          createGate,
         })
       );
-      // A refusal, on either op and from either decider. Every rule deny — and a
-      // policy deny on an UPDATE — arrives as `denied`. A policy deny on a CREATE
-      // carries no such marker: it returns early as a plain blocked create, so
-      // read it off the type-wide gate decision instead. The two can never
-      // disagree, because that early return happens before the insert the rule
-      // runs inside.
-      const refusal =
-        denied ??
-        (blockedCreate && createGate.outcome === 'deny'
-          ? ({ source: 'policy', reason: createGate.reason } as const)
-          : null);
-      if (refusal) {
+      // A refusal, on either op and from either decider — rule or policy. Every
+      // one of them arrives as `denied`; there is nothing left to re-derive here.
+      if (denied) {
         logger.warn(
           {
             automationId,
@@ -788,8 +793,8 @@ export async function promoteAutomationEntityOutput(
             stableKey,
             entityId,
             op: blockedCreate ? 'create' : 'update',
-            deniedBy: refusal.source,
-            reason: refusal.reason,
+            deniedBy: denied.source,
+            reason: denied.reason,
           },
           '[promote-keyed-entities] write denied — row skipped'
         );
@@ -797,7 +802,7 @@ export async function promoteAutomationEntityOutput(
         // set so it is queryable next to the writes that DID land. A refused
         // CREATE has no id, so it is recorded under the name the automation
         // proposed — the only handle a reader has on a row never written.
-        result.changes.push({ entityId, name, kind: 'denied', applied: {}, denied: refusal });
+        result.changes.push({ entityId, name, kind: 'denied', applied: {}, denied });
         continue;
       }
       if (blockedCreate) {


### PR DESCRIPTION
## Summary
- `upsertKeyedEntity` took `createNeedsApproval: boolean` — a value derived from the type-wide create gate decision at the caller, which then re-derived the refusal from that same decision to record it. Every other refusal (rule deny on either op, policy deny on an update) already came back as `denied` from inside.
- Pass the decision (`CreateOrDeleteDecision`) instead, and return `denied` for the policy CREATE deny too. The caller's refusal branch collapses to `if (denied)`.
- **Pure refactor.** The observable change-set record is byte-identical; there is no red state to reproduce. Proven by checking out `origin/main`'s copy of `promote-keyed-entities.ts` and running the new tests against it — all pass there too.

Closes the create-gate item tracked in the entity-write-seam follow-ups (Fable's suggestion on #2927).

## Test plan
- [x] Intended files staged explicitly (3), then `make pre-pr` clean — all 7 gates
- [x] Tests run: targeted vitest, exit code preserved (not read off a pipe)

```
$ bunx vitest run src/__tests__/integration/automations/promotion-gate-fail-closed.test.ts \
                 src/__tests__/integration/automations/promote-keyed-entities.test.ts
 Test Files  2 passed (2)
      Tests  29 passed (29)
VITEST_EXIT=0
```

- [x] No red→green to paste: this is a refactor, not a bug fix. Baseline evidence instead —

```
# origin/main's source + the new tests
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Mutation testing (the tests are load-bearing)

The branch this refactor introduces is `defer` vs `deny`: both are "not allow" and both block the inline insert, but only one is a refusal. Reporting a deferral as `denied` makes the caller record the refusal and `continue` **before** the carding branch — the row reads as rejected and the approval it was owed is never queued.

| Mutation | Test that reddens |
|---|---|
| drop the `denied` report from the create branch | `a denied create records the policy refusal in the run's change set` |
| report `denied` on every non-allow (defer included) | `a DEFERRED create is carded, not recorded as a refusal` |
| ″ (same mutation, real-path test) | `a create=approval policy on the OWNING AGENT cards the create instead of refusing it` → `expected 0 to be greater than 0` (the card count — swallowed, exactly as described) |

The third test drives the real `write_approval_policies` resolver through `complete_window`, so the defer branch is not covered only by a synthetic interceptor.

## Notes
- `acl-sync-lock.test.ts > skips a second sync of the SAME connection while one is in flight` fails under a 3-directory parallel batch on **`origin/main` too** (659/660 both with and without this change; passes 2/2 in isolation). Pre-existing flake, untouched by this diff — `acl-sync-lock.test.ts` imports nothing from the changed file. Leaving it to CI to adjudicate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation policy handling for entity creation and updates.
  * Creation requests requiring approval are now queued correctly instead of being treated as denied.
  * Denied creations no longer create entities or approval requests.
  * Deferred creations remain available for approval without being recorded as refusals.
  * Denied updates preserve existing entity information while accurately recording the policy refusal.
  * Added validation coverage for approval, denial, and fail-closed automation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->