### PR TITLE
feat(merge): card a merge the write rule escalates instead of failing it closed

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -7,6 +7,7 @@
 
 import postgres from "postgres";
 import { beforeEach, describe, expect, it } from "vitest";
+import { compileEntityRule } from "../../../authz/entity-rule-executor";
 import { PROD_PG_VALUE_OPTIONS } from "../../../db/client";
 import {
 	assessEntityResolution,
@@ -1145,6 +1146,283 @@ describe("manage_entity merge action", () => {
 			window_id: 7001,
 			status: "active",
 		});
+	});
+
+	/**
+	 * A certain-identity merge by a non-user actor, on a type whose write rule
+	 * has the given verdict. Returns the ctx and ids so a caller can drive the
+	 * merge and read back what did (or did not) happen.
+	 */
+	async function autoMergeCandidateWithRule(
+		orgName: string,
+		ruleSource: string,
+		seed: number,
+	) {
+		const org = await createTestOrganization({ name: orgName });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+
+		// The identity rule is certain (exact email) — policy alone would auto-merge.
+		await sql`
+			UPDATE entity_types
+			SET rules_compiled = ${await compileEntityRule(ruleSource)},
+			    metadata_schema = ${sql.json({
+						type: "object",
+						properties: { email: { type: "string" }, status: { type: "string" } },
+						"x-lobu-resolution": {
+							rules: [
+								{
+									fields: ["email"],
+									normalizer: "email",
+									onMatch: "auto_merge",
+								},
+							],
+						},
+					})}
+			WHERE id = (SELECT entity_type_id FROM entities WHERE id = ${winner.id})
+		`;
+		await sql`
+			UPDATE entities
+			SET metadata = jsonb_build_object('email', 'Person@Example.com', 'status', 'open')
+			WHERE id = ${winner.id}
+		`;
+		await sql`
+			UPDATE entities
+			SET metadata = jsonb_build_object('email', 'person@example.com', 'status', 'open')
+			WHERE id = ${loser.id}
+		`;
+		await sql`
+			INSERT INTO automations
+			  (id, organization_id, agent_id, created_by, automation_group_id, name,
+			   status, notification_channel, notification_priority, min_cooldown_seconds,
+			   created_at, updated_at)
+			VALUES
+			  (${seed}, ${org.id}, 'personal-agent', ${user.id}, ${seed},
+			   'Escalating duplicate resolution', 'active', 'canvas', 'normal', 0,
+			   now(), now())
+		`;
+		const [automationRun] = await sql<{ id: number }[]>`
+			INSERT INTO runs
+			  (run_type, status, organization_id, automation_id, window_id,
+			   approval_status, created_at, completed_at)
+			VALUES
+			  ('automation', 'completed', ${org.id}, ${seed}, ${seed + 1000}, 'auto', now(), now())
+			RETURNING id
+		`;
+		const agentCtx = {
+			...ctx(org.id, user.id, "owner"),
+			userId: null,
+			agentId: "personal-agent",
+			actingAutomationId: seed,
+			actingWindowId: seed + 1000,
+			actingRunId: automationRun.id,
+		} as ToolContext;
+		return { org, user, sql, winner, loser, agentCtx };
+	}
+
+	const ESCALATE_MERGE_RULE = `
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.escalate(["$merged_into"], "a merge needs a second pair of eyes");
+  }
+};
+`;
+
+	async function countRuns(orgId: string): Promise<number> {
+		const sql = getTestDb();
+		const rows = await sql<{ n: number }[]>`
+			SELECT count(*)::int AS n FROM runs
+			WHERE organization_id = ${orgId} AND action_key IS NOT NULL
+		`;
+		return Number(rows[0]?.n ?? 0);
+	}
+
+	/**
+	 * The case the escalate-to-card work deliberately left uncovered: a NON-USER
+	 * actor whose deterministic identity rule says `auto_merge`, on a type whose
+	 * write rule escalates `$merged_into`.
+	 *
+	 * Resolution policy and the type's write rule answer different questions.
+	 * Policy asks "is this the same record?" — the identity rule is certain, so it
+	 * says merge without asking. The write rule asks "may this record be merged
+	 * away?" — and an escalate is the tenant saying "not without a human". The
+	 * second must win: certainty about identity is not consent to the write.
+	 *
+	 * Failing closed with a 409 is the wrong shape for that. It is the same
+	 * verdict the delete path used to produce before it minted a card, and it
+	 * leaves an automation with no path forward — the merge can never happen, and
+	 * no human is ever asked. The escalate already names exactly the field the
+	 * merge card's replay grants, so the card can carry it.
+	 */
+	it("cards an auto_merge whose write rule escalates, instead of failing it closed", async () => {
+		const { org, user, sql, winner, loser, agentCtx } =
+			await autoMergeCandidateWithRule(
+				"Escalating Merge Org",
+				ESCALATE_MERGE_RULE,
+				6011,
+			);
+
+		const result = (await manageEntity(
+			{
+				action: "merge",
+				entity_id: loser.id,
+				winner_entity_id: winner.id,
+			},
+			env,
+			agentCtx,
+		)) as unknown as {
+			success?: boolean;
+			approval_queued?: boolean;
+			approval_run_id?: number;
+			resolution?: { decision: string; reason: string };
+		};
+
+		// Carded, not applied and not thrown.
+		expect(result.success).toBeUndefined();
+		expect(result.approval_queued).toBe(true);
+		expect(result.approval_run_id).toEqual(expect.any(Number));
+		// The card says WHY it is waiting: the rule's words, not the policy's.
+		expect(result.resolution?.reason).toMatch(/second pair of eyes/);
+
+		// Nothing moved while the card waits.
+		const [after] = await sql`
+			SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+		`;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).toBeNull();
+
+		// The persisted card is a merge proposal for exactly this pair.
+		const [run] = await sql<{ action_input: Record<string, unknown> }[]>`
+			SELECT action_input FROM runs WHERE id = ${result.approval_run_id}
+		`;
+		expect(run.action_input.operation).toBe("merge");
+		expect(run.action_input.winner_entity_id).toBe(winner.id);
+		expect(run.action_input.entity_ids).toEqual([loser.id]);
+
+		// And the card is REPLAYABLE: approving it grants `$merged_into`, so the
+		// rule that escalated does not escalate the very merge it asked for. A
+		// card a human approves and that then throws would be worse than the 409.
+		const approved = await manageOperations(
+			{ action: "approve", run_id: result.approval_run_id as number },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in approved && approved.approved).toBe(true);
+		const [applied] = await sql`
+			SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+		`;
+		expect(Number(applied.merged_into)).toBe(winner.id);
+		expect(applied.deleted_at).not.toBeNull();
+	});
+
+	/**
+	 * The gates that keep the card honest, and the reason the routing is narrow.
+	 * A merge card's replay grants exactly `[$merged_into]` — a hardcoded literal
+	 * at the apply site. Minting a card for any other verdict produces one that
+	 * throws the moment a reviewer approves it, spending a human decision on a
+	 * write that was never going to land. A deny is not a request for review at
+	 * all, and approval must never launder one into a merge.
+	 */
+	it("does NOT card a merge the write rule DENIES", async () => {
+		const { org, sql, winner, loser, agentCtx } =
+			await autoMergeCandidateWithRule(
+				"Denying Merge Org",
+				`
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.deny("a posted record cannot be merged away");
+  }
+};
+`,
+				6021,
+			);
+		const before = await countRuns(org.id);
+
+		await expect(
+			manageEntity(
+				{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+				env,
+				agentCtx,
+			),
+		).rejects.toThrow(/cannot be merged away/);
+
+		const [after] = await sql`
+			SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+		`;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).toBeNull();
+		expect(await countRuns(org.id)).toBe(before);
+	});
+
+	it("does NOT card an escalate naming a field the merge card cannot grant", async () => {
+		// `$merged_into` ALONGSIDE a field the card never grants: the dangerous
+		// shape, because a guard that merely looks for `$merged_into` in the list
+		// would card it, and the replay re-escalates on `status` the moment a
+		// reviewer approves.
+		const { org, sql, winner, loser, agentCtx } =
+			await autoMergeCandidateWithRule(
+				"Escalates Elsewhere Merge Org",
+				`
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.escalate(["$merged_into", "status"], "a reviewer must confirm the status first");
+  }
+};
+`,
+				6031,
+			);
+		const before = await countRuns(org.id);
+
+		await expect(
+			manageEntity(
+				{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+				env,
+				agentCtx,
+			),
+		).rejects.toThrow(/status/);
+
+		const [after] = await sql`
+			SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+		`;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).toBeNull();
+		expect(await countRuns(org.id)).toBe(before);
+	});
+
+	it("does NOT card an escalation that names no fields at all", async () => {
+		// An empty field list grants nothing, so the replay re-escalates forever.
+		// The guard must test the list's CONTENTS, not just that every member is
+		// `$merged_into` — `[].every(...)` is vacuously true.
+		const { org, sql, winner, loser, agentCtx } =
+			await autoMergeCandidateWithRule(
+				"Escalates Nothing Merge Org",
+				`
+export default (row) => {
+  if (row.op === "update" && row.changed("$merged_into") && row.next.$merged_into) {
+    row.escalate([], "somebody should look at this");
+  }
+};
+`,
+				6041,
+			);
+		const before = await countRuns(org.id);
+
+		await expect(
+			manageEntity(
+				{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+				env,
+				agentCtx,
+			),
+		).rejects.toThrow(/approval required/);
+
+		const [after] = await sql`
+			SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+		`;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).toBeNull();
+		expect(await countRuns(org.id)).toBe(before);
 	});
 
 	it("discovers duplicate groups server-side from candidate IDs", async () => {

--- a/packages/server/src/authz/entity-row-validation.ts
+++ b/packages/server/src/authz/entity-row-validation.ts
@@ -58,17 +58,18 @@ export interface EntityRowValidationVerdict {
  * closed the DEFAULT for every caller. Only a caller with approval machinery to
  * route an escalation into opts in by catching this and reading {@link verdict}
  * — `updateEntity`, automation promotion (`promote-keyed-entities`), and
- * `manage_entity` deletion. Link auto-create and eval scaffolding have nowhere
- * to queue a card, so for them a rule that asked for review must stop the write
- * — which is exactly what an uncaught throw does.
+ * `manage_entity` deletion and merge. Link auto-create and eval scaffolding have
+ * nowhere to queue a card, so for them a rule that asked for review must stop the
+ * write — which is exactly what an uncaught throw does.
  *
  * Soft-delete (`deleteEntity`) and merge (`applyMergeInTransaction`) are the
  * in-between cases. The policy gate can queue either card, and `manage_entity`
- * also turns a delete rule's `$deleted` escalation into a delete card. Applying
- * those cards grants `$deleted` or `$merged_into` — the one field each card can
- * be said to have approved. Callers without approval machinery still fail
- * closed. A `deny` stops the write either way, and force delete reaches this seam
- * under the same `$deleted` name, so freezing a row freezes both delete paths.
+ * also turns a delete rule's `$deleted` escalation into a delete card and a
+ * merge rule's `$merged_into` escalation into a merge card. Applying those cards
+ * grants `$deleted` or `$merged_into` — the one field each card can be said to
+ * have approved. Callers without approval machinery still fail closed. A `deny`
+ * stops the write either way, and force delete reaches this seam under the same
+ * `$deleted` name, so freezing a row freezes both delete paths.
  */
 export class EntityRowValidationError extends Error {
 	readonly verdict: EntityRowValidationVerdict;

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -877,12 +877,30 @@ async function handleMerge(
 		};
 	}
 
-	if (actor.kind !== "user" && resolution?.decision === "review") {
+	/**
+	 * Send this merge to a human instead of applying it. Two deciders reach here
+	 * with the same card, the same suppression rule and the same shape, differing
+	 * only in who asked and why:
+	 *
+	 *  - the resolution POLICY, before any write is attempted — "is this the same
+	 *    record?" — which answers `review` when the identity evidence is not
+	 *    conclusive;
+	 *  - the type's write RULE, from inside the merge kernel — "may this record be
+	 *    merged away?" — which answers `escalate` however certain the identity is.
+	 *
+	 * They are different questions, so the second can override a policy that was
+	 * sure: certainty about identity is not consent to the write. `reason` is
+	 * whichever decider spoke, so the card says why it is waiting.
+	 */
+	const queueMergeForReview = async (
+		policy: NonNullable<typeof resolution>,
+		reason: string,
+	): Promise<ManageEntityResult> => {
 		const attribution = attributionFor(actor);
 		if (
 			await wasResolutionRejected(sql, {
 				organizationId: ctx.organizationId,
-				fingerprint: resolution.fingerprint,
+				fingerprint: policy.fingerprint,
 			})
 		) {
 			return {
@@ -892,8 +910,8 @@ async function handleMerge(
 					"This unchanged candidate was already rejected. It will be reconsidered when its evidence or policy changes.",
 				resolution: {
 					decision: "review",
-					reason: resolution.reason,
-					evidence: resolution.evidence,
+					reason,
+					evidence: policy.evidence,
 				},
 			};
 		}
@@ -902,22 +920,22 @@ async function handleMerge(
 			{
 				entity_ids: loserIds,
 				winner_entity_id: winnerId,
-				evidence: resolution.evidence,
+				evidence: policy.evidence,
 				automation_id: mergeAttribution.automationId,
 				window_id: mergeAttribution.windowId,
 				source_run_id: ctx.actingRunId ?? null,
-				policy_hash: resolution.policyHash,
-				resolution_fingerprint: resolution.fingerprint,
+				policy_hash: policy.policyHash,
+				resolution_fingerprint: policy.fingerprint,
 				resolution_fingerprint_version: RESOLUTION_FINGERPRINT_VERSION,
 				attribution,
-				reason: resolution.reason,
+				reason,
 				// The proposer's own words, kept strictly separate from `reason` (the
-				// machine-computed policy verdict). Displayed as a claim attributed to
+				// machine-computed verdict). Displayed as a claim attributed to
 				// whoever proposed the merge — it is never evidence and never affects
 				// the auto-merge decision, which is recomputed server-side above.
 				proposer_rationale: args.merge_rationale?.trim() || null,
 			},
-			resolution.resolutionKeys,
+			policy.resolutionKeys,
 		);
 		return {
 			action: "merge",
@@ -934,10 +952,14 @@ async function handleMerge(
 			next_steps: ["The merge is waiting for human approval."],
 			resolution: {
 				decision: "review",
-				reason: resolution.reason,
-				evidence: resolution.evidence,
+				reason,
+				evidence: policy.evidence,
 			},
 		};
+	};
+
+	if (actor.kind !== "user" && resolution?.decision === "review") {
+		return await queueMergeForReview(resolution, resolution.reason);
 	}
 
 	let result: Awaited<ReturnType<typeof applyMergeGroup>>;
@@ -965,6 +987,30 @@ async function handleMerge(
 						},
 		});
 	} catch (err) {
+		// The write rule judges the merge under lock inside the kernel, so its
+		// verdict arrives only once the policy has already decided to apply. Route
+		// the one escalation this card can replay — the merge card's grant is the
+		// hardcoded literal `[$merged_into]`, so an escalate naming anything else
+		// would mint a card that throws the moment a reviewer approves it. Those,
+		// and every deny, still fail closed.
+		//
+		// Scoped to a non-user actor because that is the only path with a
+		// resolution to card against: the card carries the policy hash, evidence
+		// and fingerprint the suppression check re-reads, and a human-initiated
+		// merge computes none of them. A human's merge is UNCHANGED by this — it
+		// keeps the explicit 409 it already returned. Whether an escalate should
+		// card a human's own merge too is a separate question, and answering it
+		// needs a decision about what such a card is keyed on, not this catch.
+		if (
+			actor.kind !== "user" &&
+			resolution &&
+			err instanceof EntityRowValidationError &&
+			err.verdict.outcome === "escalate" &&
+			err.verdict.fields.length === 1 &&
+			err.verdict.fields[0] === RESERVED_COLUMN_NAMES.mergedInto
+		) {
+			return await queueMergeForReview(resolution, err.verdict.reason);
+		}
 		throw new ToolUserError(
 			`Merge failed: ${err instanceof Error ? err.message : String(err)}`,
 			409,


### PR DESCRIPTION
## Summary
- Decides the case the escalate-to-card work deliberately left open: **non-user actor + `auto_merge` + the type's write rule escalates `$merged_into`**.
- Today that is a bare 409. Policy and the write rule answer different questions — policy asks *"is this the same record?"* (the identity rule was certain), the rule asks *"may this record be merged away?"*. Certainty about identity is not consent to the write, so the rule must win; but failing closed leaves the automation with no path forward and no human ever asked. That is the same dead end the delete path had before #2971.
- Route the one escalation the merge card can replay, with the **same three guards #2971 uses on delete**: outcome is `escalate`, the field list is exactly `[$merged_into]` (the hardcoded literal the replay grants), everything else rethrows.
- The review branch's card minting is factored into `queueMergeForReview`, so both deciders mint a byte-identical card and share the already-rejected suppression check. Only the `reason` differs — the card says which decider spoke.
- **A human-initiated merge is unchanged**: it keeps its existing explicit 409. Whether an escalate should card a human's own merge is a separate question — that path computes no policy hash, evidence, or fingerprint for the card to be keyed on.

No schema change, no new table or column, no API/SDK surface change.

## Test plan
- [x] Intended files staged explicitly (3); `make pre-pr` clean, **real exit 0** (all 7 gates)
- [x] `tsc --noEmit` **real exit 0**
- [x] Focused vitest, **real exit 0** (not read off a pipe)

### red → green

Red, on `origin/main`, failing for exactly the claimed reason:

```
× manage_entity merge action > cards an auto_merge whose write rule escalates, instead of failing it closed
  → Merge failed: entity 2: a merge needs a second pair of eyes (approval required for $merged_into)
    at handleMerge (packages/server/src/tools/admin/manage_entity.ts:968:9)
VITEST_EXIT=1
```

Green, with the fix, across the merge tool + both rule-seam suites:

```
$ bunx vitest run src/__tests__/integration/entities/entity-merge-tool.test.ts \
                 src/__tests__/integration/authz/entity-merge-rule-seam.test.ts \
                 src/__tests__/integration/authz/entity-row-validation.test.ts
 Test Files  3 passed (3)
      Tests  78 passed (78)
FOCUSED_VITEST_EXIT=0
```

`entity-row-validation.test.ts` is in there deliberately — it is #2971's delete-card suite, so it proves the sibling path is undisturbed.

### The card is replayable, not just minted

The test approves the card it minted and asserts the merge then applies (`merged_into` set, loser tombstoned). A card a human approves and that then throws would be worse than the 409 it replaced.

### Mutation testing

| Mutation | Killed by |
|---|---|
| `fields.length === 1 && fields[0] === …` → `true` | *naming a field the card cannot grant* **and** *names no fields at all* |
| → `fields.every(f => f === mergedInto)` | *names no fields at all* (`[].every()` is vacuously true) |
| → `fields.includes(mergedInto)` | *naming a field the card cannot grant* — the rule escalates `["$merged_into", "status"]`, so `includes` passes it while the grant covers only one of the two |

**Disclosed: one mutation SURVIVES.** Deleting `err.verdict.outcome === "escalate"` reddens nothing, because a `deny` verdict is always constructed with `fields: []` (`entity-row-validation.ts:350,543`), so the field check already excludes every deny. The check is kept anyway — it is the one that states the intent, it matches the delete path's guard exactly, and it is what stops a future deny that names fields from being carded.

## Notes
- `manage_entity` deletion **and merge** are now both listed as opt-in catchers on `EntityRowValidationError`; that docstring said the merge path had no catch, which this change makes false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity merges escalated by write rules can now be routed through the approval workflow.
  * Approved merge requests apply the permitted merge change while preserving review details and rationale.

* **Bug Fixes**
  * Merge requests denied by policy, involving unsupported fields, or lacking valid escalation rules continue to fail safely without creating unnecessary approval requests.

* **Documentation**
  * Clarified that approval cards support both deletion and merge escalations, and that approvals apply only to the specifically authorized field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->