### PR TITLE
fix(server): settle terminal chat action cards

### DIFF
--- a/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
@@ -10,9 +10,14 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { upsertConversation } from "../../../gateway/services/conversations-store";
+import {
+	resolveActionOrigin,
+	resolveInteractionActionOrigin,
+} from "../../../notifications/action-origin";
 import { resolveApprovalChatOrigin } from "../../../tools/admin/approval-delivery";
 import type { ToolContext } from "../../../tools/registry";
-import { cleanupTestDatabase } from "../../setup/test-db";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import { createTestAutomationSubscription } from "../../setup/automation-subscriptions";
 import {
 	addUserToOrganization,
@@ -223,5 +228,83 @@ describe("resolveApprovalChatOrigin", () => {
 		);
 
 		expect(target.channelId).toBeNull();
+	});
+
+	it("names the materialized conversation that triggered an action", async () => {
+		const org = await createTestOrganization();
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "release-agent",
+			ownerUserId: user.id,
+		});
+		await upsertConversation({
+			organizationId: org.id,
+			agentId: agent.agentId,
+			platform: "slack",
+			conversationId: "slack:C_RELEASE",
+			threadId: null,
+			kind: "platform",
+			title: "Release prep",
+			locationLabel: "#release-prep",
+			lastActivityAt: new Date(),
+		});
+
+		const origin = await resolveActionOrigin(
+			ctxFor({
+				organizationId: org.id,
+				agentId: agent.agentId,
+				connectionId: "conn-release",
+				channelId: "slack:C_RELEASE",
+			}),
+		);
+
+		expect(origin).toEqual({
+			kind: "conversation",
+			label: "Slack — Release prep",
+		});
+	});
+
+	it("prefers the verified Automation over conversation context", async () => {
+		const sql = getTestDb();
+		const org = await createTestOrganization();
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "triage-agent",
+			ownerUserId: user.id,
+		});
+		const [automation] = await sql<{ id: number }[]>`
+			INSERT INTO automations (
+				organization_id, agent_id, created_by, automation_group_id, name
+			) VALUES (${org.id}, ${agent.agentId}, ${user.id}, 0, 'Hourly incident triage')
+			RETURNING id
+		`;
+		const ctx = {
+			...ctxFor({
+				organizationId: org.id,
+				agentId: agent.agentId,
+				connectionId: "conn-release",
+				channelId: "slack:C_RELEASE",
+			}),
+			actingAutomationId: Number(automation.id),
+		} as ToolContext;
+
+		expect(await resolveActionOrigin(ctx)).toEqual({
+			kind: "automation",
+			label: "Hourly incident triage",
+		});
+		expect(
+			await resolveInteractionActionOrigin({
+				organizationId: org.id,
+				conversationId: `agent_automation_${automation.id}_run_77`,
+				source: "automation-run",
+			}),
+		).toEqual({
+			kind: "automation",
+			label: "Hourly incident triage",
+		});
 	});
 });

--- a/packages/server/src/__tests__/integration/notifications/approval-live-state.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/approval-live-state.test.ts
@@ -1,6 +1,14 @@
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { listNotifications } from "../../../notifications/service";
+import { Actions, Button, Card, CardText, LinkButton } from "chat";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../../../index";
+import { __setChatInstanceManagerForTests } from "../../../lobu/gateway";
+import {
+	listNotifications,
+	refreshApprovalNotificationCards,
+} from "../../../notifications/service";
+import { manageOperations } from "../../../tools/admin/manage_operations";
 import { listOrgActivity } from "../../../tools/admin/manage_operations/activity-feed";
+import type { ToolContext } from "../../../tools/registry";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	addUserToOrganization,
@@ -69,6 +77,10 @@ describe("approval notification live state", () => {
 
 	afterAll(async () => {
 		await cleanupTestDatabase();
+	});
+
+	afterEach(() => {
+		__setChatInstanceManagerForTests(null);
 	});
 
 	it("resolves the proposal run and exposes inline policy with current state", async () => {
@@ -180,5 +192,119 @@ describe("approval notification live state", () => {
 				interaction_status: "expired",
 			}),
 		);
+	});
+
+	it("settles every persisted chat copy with reviewer, time, and origin", async () => {
+		const sql = getTestDb();
+		const org = await createTestOrganization({ slug: "acme" });
+		const user = await createTestUser({ name: "Ada Reviewer" });
+		await addUserToOrganization(user.id, org.id, "owner");
+		const [run] = await sql`
+			INSERT INTO runs (
+				organization_id, run_type, action_key, approval_status, status, created_at
+			) VALUES (${org.id}, 'action', 'search_jira', 'pending', 'pending', now())
+			RETURNING id
+		`;
+		const runId = Number(run.id);
+		const proposal = await createTestEvent({
+			organization_id: org.id,
+			title: "Search Jira proposal",
+			content: "Pending approval",
+			semantic_type: "operation",
+		});
+		await sql`
+			UPDATE events
+			SET run_id = ${runId},
+			    interaction_type = 'approval',
+			    interaction_status = 'pending'
+			WHERE id = ${proposal.id}
+		`;
+		const initialCard = Card({
+			title: "Search Jira issues",
+			subtitle: "Conversation: Slack — #release-prep",
+			children: [
+				CardText("JQL: project = LOBU"),
+				Actions([
+					Button({
+						id: `run-approval:${runId}:approve`,
+						label: "Approve",
+						style: "primary",
+					}),
+					Button({
+						id: `run-approval:${runId}:reject`,
+						label: "Reject",
+						style: "danger",
+					}),
+					LinkButton({
+						url: "https://app.lobu.ai/acme/memory?run_ids=1",
+						label: "Review in Lobu",
+					}),
+				]),
+			],
+		});
+		await createTestEvent({
+			organization_id: org.id,
+			title: "Search Jira issues",
+			content: "Review this operation",
+			semantic_type: "notification",
+			metadata: {
+				notification_type: "action_approval_needed",
+				resource_type: "event",
+				resource_id: String(proposal.id),
+				resource_url: `/acme/memory?run_ids=${runId}`,
+				card: initialCard,
+				delivery: [
+					{
+						connectionId: "conn-slack",
+						channelKey: "slack:C123",
+						messageId: "1700000000.000500",
+						threadId: "C123",
+					},
+				],
+			},
+		});
+		const editMessageContent = vi.fn(async () => undefined);
+		__setChatInstanceManagerForTests({ editMessageContent });
+		const result = await manageOperations(
+			{ action: "reject", run_id: runId },
+			{} as Env,
+			{
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+				isAuthenticated: true,
+				tokenType: "session",
+				scopes: ["mcp:read", "mcp:write"],
+				scopedToOrg: true,
+				allowCrossOrg: false,
+			} as ToolContext,
+		);
+		expect(result).toEqual(expect.objectContaining({ rejected: true, run_id: runId }));
+		await vi.waitFor(() =>
+			expect(editMessageContent).toHaveBeenCalledTimes(1),
+		);
+
+		const settledJson = JSON.stringify(editMessageContent.mock.calls[0]);
+		expect(settledJson).toContain("Conversation: Slack — #release-prep");
+		expect(settledJson).toContain("*Rejected* by Ada Reviewer");
+		expect(settledJson).toContain("UTC");
+		expect(settledJson).toContain('"label":"View in Lobu"');
+		expect(settledJson).not.toContain('"type":"button"');
+
+		await sql`UPDATE runs SET approval_status = 'expired' WHERE id = ${runId}`;
+		await sql`
+			UPDATE events
+			SET metadata = metadata || ${sql.json({ reason: "Approval window elapsed." })}::jsonb
+			WHERE organization_id = ${org.id}
+			  AND run_id = ${runId}
+			  AND interaction_type = 'approval'
+			  AND superseded_by IS NULL
+		`;
+		editMessageContent.mockClear();
+		await refreshApprovalNotificationCards(org.id, [runId]);
+		const expiredCard = JSON.stringify(editMessageContent.mock.calls[0]);
+		expect(expiredCard).toContain("*Expired*");
+		expect(expiredCard).toContain("Approval window elapsed.");
+		expect(expiredCard).not.toContain('"label":"Approve"');
 	});
 });

--- a/packages/server/src/__tests__/integration/notifications/approval-live-state.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/approval-live-state.test.ts
@@ -291,6 +291,28 @@ describe("approval notification live state", () => {
 		expect(settledJson).toContain('"label":"View in Lobu"');
 		expect(settledJson).not.toContain('"type":"button"');
 
+		const duplicateDecision = await createTestEvent({
+			organization_id: org.id,
+			title: "Later approval receipt",
+			content: "A duplicate current receipt",
+			semantic_type: "operation",
+			metadata: { reviewed_by_name: "Later Reviewer" },
+		});
+		await sql`
+			UPDATE events
+			SET run_id = ${runId},
+			    interaction_type = 'approval',
+			    interaction_status = 'rejected',
+			    occurred_at = now() + interval '1 minute'
+			WHERE id = ${duplicateDecision.id}
+		`;
+		editMessageContent.mockClear();
+		await refreshApprovalNotificationCards(org.id, [runId]);
+		expect(editMessageContent).toHaveBeenCalledTimes(1);
+		expect(JSON.stringify(editMessageContent.mock.calls[0])).toContain(
+			"Later Reviewer",
+		);
+
 		await sql`UPDATE runs SET approval_status = 'expired' WHERE id = ${runId}`;
 		await sql`
 			UPDATE events

--- a/packages/server/src/__tests__/unit/action-card-state.test.ts
+++ b/packages/server/src/__tests__/unit/action-card-state.test.ts
@@ -1,0 +1,88 @@
+import {
+	Actions,
+	Button,
+	Card,
+	CardText,
+	LinkButton,
+	Select,
+	SelectOption,
+} from "chat";
+import { describe, expect, it } from "vitest";
+import {
+	addActionOrigin,
+	actionOriginSubtitle,
+	actionResolutionText,
+	settleActionCard,
+} from "../../notifications/action-card-state";
+
+describe("terminal action cards", () => {
+	it("removes every mutating control, preserves navigation, and records actor/time", () => {
+		const card = Card({
+			title: "Search Jira issues",
+			subtitle: "Atlassian Rovo MCP",
+			children: [
+				CardText("JQL: project = LOBU"),
+				Actions([
+					Button({ id: "approve", label: "Approve", style: "primary" }),
+					Button({ id: "reject", label: "Reject", style: "danger" }),
+					Select({
+						id: "priority",
+						placeholder: "Priority",
+						options: [SelectOption({ label: "High", value: "high" })],
+					}),
+					LinkButton({
+						url: "https://app.lobu.ai/runs/7",
+						label: "Review in Lobu",
+					}),
+				]),
+			],
+		});
+
+		const settled = settleActionCard(card, {
+			status: "rejected",
+			actorName: "Burak <admin>",
+			resolvedAt: "2026-08-20T12:58:04.444Z",
+		});
+
+		expect(settled.children).toEqual([
+			CardText("JQL: project = LOBU"),
+			CardText("*Rejected* by Burak &lt;admin&gt; · 2026-08-20 12:58 UTC"),
+			Actions([
+				LinkButton({
+					url: "https://app.lobu.ai/runs/7",
+					label: "View in Lobu",
+				}),
+			]),
+		]);
+	});
+
+	it("formats verified provenance", () => {
+		expect(
+			actionOriginSubtitle({
+				kind: "automation",
+				label: "Hourly incident triage",
+			}),
+		).toBe("Automation: Hourly incident triage");
+		expect(
+			actionOriginSubtitle({
+				kind: "conversation",
+				label: "Claude Code — Release prep",
+			}),
+		).toBe("Conversation: Claude Code — Release prep");
+		expect(
+			addActionOrigin(Card({ subtitle: "Atlassian Rovo MCP", children: [] }), {
+				kind: "automation",
+				label: "Hourly incident triage",
+			}).subtitle,
+		).toBe("Atlassian Rovo MCP · Automation: Hourly incident triage");
+	});
+
+	it("bounds and escapes user-controlled receipt text", () => {
+		expect(
+			actionResolutionText({
+				status: "approved",
+				actorName: "<!channel> <https://evil.example>",
+			}),
+		).toBe("*Approved* by &lt;!channel&gt; &lt;https://evil.example&gt;");
+	});
+});

--- a/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
@@ -325,4 +325,72 @@ describe("chat interaction card cross-pod fan-out (faithful seam, real bridge + 
     fanoutCleanup();
     bridgeCleanup();
   });
+
+	test("a one-shot question settles the original card through the click adapter", async () => {
+		const sentEdit = mock(async () => undefined);
+		const threadPost = mock(async () => ({ edit: sentEdit }));
+		const thread = { id: CHANNEL, post: threadPost };
+		let actionHandler: ((event: any) => Promise<void>) | undefined;
+		const chat = {
+			onAction: mock((handler: (event: any) => Promise<void>) => {
+				actionHandler = handler;
+			}),
+			channel: mock((key: string) => (key === CHANNEL ? thread : null)),
+			getAdapter: mock((_platform: string) => null),
+			createThread: null,
+		};
+		const ingestClick = mock(async () => undefined);
+		const instance = {
+			connection: makeConnection(),
+			chat,
+			messageBridge: { ingestClick },
+			conversationState: {},
+		};
+		const manager = {
+			has: (id: string) => id === CONN,
+			getInstance: (id: string) => (id === CONN ? instance : undefined),
+		};
+		const service = new InteractionService();
+		const cleanup = registerInteractionBridge(
+			service,
+			manager as any,
+			makeConnection(),
+			chat as any,
+		);
+
+		service.emit("question:created", slackQuestion);
+		await waitFor(
+			() => threadPost.mock.calls.length === 1,
+			"question card is posted",
+		);
+		if (!actionHandler) throw new Error("question action handler was not registered");
+		const editMessage = mock(async () => undefined);
+		await actionHandler({
+			actionId: `question:${slackQuestion.id}:0`,
+			value: "Yes",
+			thread,
+			threadId: CHANNEL,
+			messageId: "1700000000.000700",
+			adapter: { editMessage },
+			user: {
+				userId: USER,
+				userName: "ada",
+				fullName: "Ada Reviewer",
+			},
+		});
+		await waitFor(
+			() => editMessage.mock.calls.length === 1 && ingestClick.mock.calls.length === 1,
+			"question card settles and click reaches worker",
+		);
+
+		expect(threadPost).toHaveBeenCalledTimes(1);
+		expect(sentEdit).not.toHaveBeenCalled();
+		const settledJson = JSON.stringify(editMessage.mock.calls[0]?.[2]);
+		expect(settledJson).toContain("*Answered*");
+		expect(settledJson).toContain("Ada Reviewer");
+		expect(settledJson).toContain("Conversation: Slack conversation");
+		expect(settledJson).not.toContain('\"type\":\"button\"');
+
+		cleanup();
+	});
 });

--- a/packages/server/src/gateway/__tests__/interaction-bridge-action-handlers.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-action-handlers.test.ts
@@ -88,6 +88,10 @@ async function seedPending(requestId: string): Promise<void> {
   await storePendingTool(requestId, PENDING, 24 * 60 * 60);
 }
 
+function editedCardJson(h: Harness): string {
+	return JSON.stringify(h.editCard.mock.calls[0]?.[0]);
+}
+
 describe("registerActionHandlers — tool approval", () => {
   beforeAll(async () => {
     await ensureDbForGatewayTests();
@@ -155,9 +159,11 @@ describe("registerActionHandlers — tool approval", () => {
       thread: h.thread,
     });
     expect(h.editCard).toHaveBeenCalledTimes(1);
-    const edited = h.editCard.mock.calls[0]?.[0] as string;
+		const edited = editedCardJson(h);
     expect(edited).toContain("github → create_issue");
-    expect(edited).toContain("Approved (1h)");
+		expect(edited).toContain("*Approved*");
+		expect(edited).toContain("Tool access allowed for 1h.");
+		expect(edited).not.toContain('"type":"button"');
   });
 
   test("approve with no pending but tracked card (late first click) edits card and posts an expired notice — no grant, no execute", async () => {
@@ -171,7 +177,7 @@ describe("registerActionHandlers — tool approval", () => {
     expect(h.executeToolDirect).not.toHaveBeenCalled();
     // Card should be edited to show the expired notice and the user told to retry.
     expect(h.editCard).toHaveBeenCalledTimes(1);
-    expect(h.editCard.mock.calls[0]?.[0] as string).toMatch(/expired/i);
+		expect(editedCardJson(h)).toMatch(/expired/i);
     expect(h.post).toHaveBeenCalledTimes(1);
     expect(h.post.mock.calls[0]?.[0] as string).toMatch(/expired/i);
   });
@@ -234,7 +240,7 @@ describe("registerActionHandlers — tool approval", () => {
     });
     expect(h.grantStore.grant).not.toHaveBeenCalled();
     expect(h.editCard).toHaveBeenCalledTimes(1);
-    expect(h.editCard.mock.calls[0]?.[0] as string).toMatch(/expired/i);
+		expect(editedCardJson(h)).toMatch(/expired/i);
     expect(h.post).toHaveBeenCalledTimes(1);
     expect(h.post.mock.calls[0]?.[0] as string).toMatch(/expired/i);
   });
@@ -248,7 +254,8 @@ describe("registerActionHandlers — tool approval", () => {
       thread: h.thread,
     });
     expect(h.editCard).toHaveBeenCalledTimes(1);
-    expect(h.editCard.mock.calls[0]?.[0] as string).toContain("Denied");
+		expect(editedCardJson(h)).toContain("*Denied*");
+		expect(editedCardJson(h)).not.toContain('"type":"button"');
   });
 });
 

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -1,5 +1,5 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Chat } from "chat";
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Actions, Button, Card, CardText, Chat, LinkButton } from "chat";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import {
   addUserToOrganization,
@@ -9,6 +9,7 @@ import {
   linkSlackIdentityInGraph,
 } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
+import { __setChatInstanceManagerForTests } from "../../lobu/gateway.js";
 import { proposeEntityFieldChange } from "../../tools/admin/entity-field-approval.js";
 import type { ToolContext } from "../../tools/registry.js";
 import { initWorkspaceProvider } from "../../workspace/index.js";
@@ -42,7 +43,9 @@ function createHarness(options: {
   // Stub Slack Web API calls so `thread.post` resolves synchronously without
   // hitting slack.com. We only care about the dispatch seam, not Slack I/O.
   const postMessage = mock(async () => ({ ts: "1700000000.000999" }) as any);
+  const editMessage = mock(async () => ({ ts: "1700000000.000100" }) as any);
   (adapter as any).postMessage = postMessage;
+  (adapter as any).editMessage = editMessage;
 
   const state = new InMemoryStateAdapter();
   const chat = new Chat({
@@ -74,6 +77,7 @@ function createHarness(options: {
     grantStore,
     executeToolDirect,
     postMessage,
+    editMessage,
   };
 }
 
@@ -104,6 +108,10 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
   beforeEach(async () => {
     await resetTestDatabase();
   });
+
+	afterEach(() => {
+		__setChatInstanceManagerForTests(null);
+	});
 
   test("signed tool-approval button triggers grant, executes tool, deletes pending", async () => {
     const pending: PendingToolInvocation = {
@@ -182,6 +190,7 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
         deploymentName: "lobu-builder",
       },
     ]);
+    expect(h.editMessage).toHaveBeenCalledTimes(1);
     expect(h.postMessage).toHaveBeenCalled();
   });
 
@@ -342,6 +351,65 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
     };
   }
 
+	async function seedDeliveredApprovalCard(
+		organizationId: string,
+		runId: number,
+	): Promise<void> {
+		const sql = getDb();
+		const [proposal] = await sql<{ id: number }>`
+			SELECT id FROM events
+			WHERE organization_id = ${organizationId}
+			  AND run_id = ${runId}
+			  AND interaction_type = 'approval'
+			ORDER BY id
+			LIMIT 1
+		`;
+		const card = Card({
+			title: "Update entity field",
+			subtitle: "Conversation: Slack — #approvals",
+			children: [
+				CardText("Severity: critical → high"),
+				Actions([
+					Button({
+						id: `run-approval:${runId}:approve`,
+						label: "Approve",
+						style: "primary",
+					}),
+					Button({
+						id: `run-approval:${runId}:reject`,
+						label: "Reject",
+						style: "danger",
+					}),
+					LinkButton({ url: "https://app.lobu.ai/review", label: "Review in Lobu" }),
+				]),
+			],
+		});
+		await sql`
+			INSERT INTO events (
+				organization_id, origin_id, title, payload_type, payload_text,
+				occurred_at, semantic_type, metadata
+			) VALUES (
+				${organizationId}, ${`notification_${runId}`}, 'Update entity field',
+				'text', 'Review this change', now(), 'notification',
+				${sql.json({
+					notification_type: "action_approval_needed",
+					resource_type: "event",
+					resource_id: String(proposal.id),
+					resource_url: "/review",
+					card,
+					delivery: [
+						{
+							connectionId: "conn-run-approval",
+							channelKey: "slack:C_APPROVALS",
+							messageId: "1700000000.000500",
+							threadId: "C_APPROVALS",
+						},
+					],
+				})}
+			)
+		`;
+	}
+
   function createRunApprovalHarness(opts: {
     organizationId: string;
     teamId: string;
@@ -414,16 +482,14 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
       SELECT metadata FROM entities WHERE id = ${fx.entityId}
     `;
     expect(entity.metadata.severity).toBe("high");
-    // The webhook returns 200 before the async onAction handler finishes:
-    // the run is marked completed and the field change applied inside
-    // manageOperations, and only then does the handler post the confirmation
-    // via thread.post -> postMessage. Poll for the post so we don't race the
-    // DB-state waitFor above (matches the unverified-user test below).
-    await waitFor(() => expect(h.postMessage).toHaveBeenCalled());
+		expect(h.postMessage).not.toHaveBeenCalled();
   });
 
   test("signed Reject button leaves the entity unchanged", async () => {
     const fx = await seedPendingFieldChange();
+		await seedDeliveredApprovalCard(fx.orgId, fx.runId);
+		const editMessageContent = mock(async () => undefined);
+		__setChatInstanceManagerForTests({ editMessageContent });
     const h = createRunApprovalHarness({
       organizationId: fx.orgId,
       teamId: fx.teamId,
@@ -455,6 +521,14 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
       SELECT metadata FROM entities WHERE id = ${fx.entityId}
     `;
     expect(entity.metadata.severity).toBe("critical");
+		await waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(1));
+		const settledJson = JSON.stringify(
+			editMessageContent.mock.calls[0]?.[1]?.content,
+		);
+		expect(settledJson).toContain("*Rejected*");
+		expect(settledJson).toContain("Admin Reviewer");
+		expect(settledJson).toContain("Conversation: Slack — #approvals");
+		expect(settledJson).not.toContain('\"type\":\"button\"');
   });
 
   test("unverified Slack user cannot approve — entity stays critical", async () => {

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -482,7 +482,8 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
       SELECT metadata FROM entities WHERE id = ${fx.entityId}
     `;
     expect(entity.metadata.severity).toBe("high");
-		expect(h.postMessage).not.toHaveBeenCalled();
+		expect(h.postMessage).toHaveBeenCalledTimes(1);
+		expect(String(h.postMessage.mock.calls[0]?.[1])).toContain("approved");
   });
 
   test("signed Reject button leaves the entity unchanged", async () => {

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -482,7 +482,7 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
       SELECT metadata FROM entities WHERE id = ${fx.entityId}
     `;
     expect(entity.metadata.severity).toBe("high");
-		expect(h.postMessage).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(h.postMessage).toHaveBeenCalledTimes(1));
 		expect(String(h.postMessage.mock.calls[0]?.[1])).toContain("approved");
   });
 

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1134,11 +1134,29 @@ export class ChatInstanceManager {
     connectionId: string,
 		opts: { threadId: string; messageId: string; text: string },
   ): Promise<void> {
+		return this.editMessageContent(connectionId, {
+			threadId: opts.threadId,
+			messageId: opts.messageId,
+			content: { markdown: opts.text },
+		});
+	}
+
+	/** Replace a bot message with any platform-neutral Chat SDK payload. */
+	async editMessageContent(
+		connectionId: string,
+		opts: {
+			threadId: string;
+			messageId: string;
+			content: AdapterPostableMessage;
+		},
+	): Promise<void> {
     await this.ensureConnectionRunning(connectionId);
     const instance = this.requireRunningInstance(connectionId);
-    await instance.chat?.adapter.editMessage(opts.threadId, opts.messageId, {
-      markdown: opts.text,
-    } as AdapterPostableMessage);
+		await instance.chat?.adapter.editMessage(
+			opts.threadId,
+			opts.messageId,
+			opts.content,
+		);
   }
 
   /** Delete a message the bot previously sent. */

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1066,12 +1066,20 @@ export function registerActionHandlers(
 				ctx,
 			).catch((error) => ({ error: String(error) }));
 			const resultRecord = result as Record<string, unknown>;
-			if (typeof resultRecord.error === "string") {
-				try {
-					await thread.post(resultRecord.error);
-				} catch {
-					// best effort
-				}
+			// Keep the terse thread receipt for cards delivered before card payloads
+			// were persisted. New cards also settle in place via manage_operations.
+			const message =
+				typeof resultRecord.message === "string"
+					? resultRecord.message
+					: typeof resultRecord.error === "string"
+						? resultRecord.error
+						: decision === "approve"
+							? "Approved."
+							: "Rejected.";
+			try {
+				await thread.post(message);
+			} catch {
+				// best effort
 			}
 			return;
 		}

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1,11 +1,25 @@
 import { createLogger } from "@lobu/core";
-import { Actions, Button, Card, CardText, LinkButton } from "chat";
+import {
+	Actions,
+	Button,
+	Card,
+	type CardElement,
+	CardText,
+	LinkButton,
+} from "chat";
 import { SCOPE_CHECK_NOT_APPLICABLE } from "../../auth/tool-access.js";
 import { getDb, pgTextArray } from "../../db/client.js";
 import type { Env } from "../../index.js";
 import { ENTITY_CHANGE_ACTION_KEYS } from "../../tools/admin/entity-field-approval.js";
 import { manageOperations } from "../../tools/admin/manage_operations.js";
 import type { ToolContext } from "../../tools/registry.js";
+import {
+	actionResolutionText,
+	type ActionOrigin,
+	actionOriginSubtitle,
+	settleActionCard,
+} from "../../notifications/action-card-state.js";
+import { resolveInteractionActionOrigin } from "../../notifications/action-origin.js";
 import {
 	pairAdminGrant,
   type PendingToolInvocation,
@@ -97,21 +111,6 @@ async function takePendingToolInvocation(
 	requestId: string,
 ): Promise<PendingToolInvocation | null> {
   return takePendingTool(requestId);
-}
-
-function describeDecision(decision: string): string {
-	switch (decision) {
-		case "1h":
-			return "Approved (1h)";
-		case "24h":
-			return "Approved (24h)";
-		case "always":
-			return "Approved (always)";
-		case "deny":
-			return "Denied";
-		default:
-			return `Decision: ${decision}`;
-	}
 }
 
 function actionEventTeamId(
@@ -227,31 +226,6 @@ export async function resolveEntityApprovalRun(
 	return { state, ownerUserId: rows[0].owner_user_id ?? null };
 }
 
-/**
- * Replace the approval card's buttons with a plain-text decision summary.
- * Best-effort: silently swallows edit failures (the card may be unreachable
- * after a long gap, or the platform may not support edits).
- */
-async function stripApprovalButtons(
-  sent: SentMessage | undefined,
-  pending: {
-    mcpId: string;
-    toolName: string;
-    args: Record<string, unknown>;
-  },
-	decision: string,
-): Promise<void> {
-  if (!sent) return;
-  const summary =
-    `*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n` +
-    `${formatToolArgs(pending.args)}\n\n_${describeDecision(decision)}_`;
-  try {
-    await sent.edit(summary);
-  } catch {
-    // best effort — card may be stale, edit may be unsupported
-  }
-}
-
 function formatToolArgs(args: Record<string, unknown>): string {
   return Object.entries(args)
     .map(([k, v]) => {
@@ -259,6 +233,94 @@ function formatToolArgs(args: Record<string, unknown>): string {
       return `  ${k}: ${val}`;
     })
     .join("\n");
+}
+
+function questionCard(
+	question: string,
+	options: string[],
+	id: string,
+	origin: ActionOrigin,
+) {
+	return Card({
+		subtitle: actionOriginSubtitle(origin),
+		children: [
+			CardText(question),
+			Actions(
+				options.map((option, index) =>
+					Button({
+						id: `question:${id}:${index}`,
+						label: option,
+						value: option,
+					}),
+				),
+			),
+		],
+	});
+}
+
+function toolApprovalCard(
+	pending: {
+		mcpId: string;
+		toolName: string;
+		args: Record<string, unknown>;
+	},
+	id: string,
+	origin: ActionOrigin,
+) {
+	return Card({
+		subtitle: actionOriginSubtitle(origin),
+		children: [
+			CardText(
+				`*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n${formatToolArgs(pending.args)}`,
+			),
+			Actions([
+				Button({
+					id: `tool:${id}:1h`,
+					label: "Allow 1h",
+					style: "primary",
+					value: "1h",
+				}),
+				Button({
+					id: `tool:${id}:24h`,
+					label: "Allow 24h",
+					style: "primary",
+					value: "24h",
+				}),
+				Button({
+					id: `tool:${id}:always`,
+					label: "Allow always",
+					style: "primary",
+					value: "always",
+				}),
+				Button({
+					id: `tool:${id}:deny`,
+					label: "Deny always",
+					style: "danger",
+					value: "deny",
+				}),
+			]),
+		],
+	});
+}
+
+async function editClickedCard(event: any, card: CardElement): Promise<boolean> {
+	const threadId =
+		typeof event.threadId === "string"
+			? event.threadId
+			: typeof event.thread?.id === "string"
+				? event.thread.id
+				: null;
+	const messageId = typeof event.messageId === "string" ? event.messageId : null;
+	if (!threadId || !messageId || !event.adapter?.editMessage) return false;
+	try {
+		await event.adapter.editMessage(threadId, messageId, {
+			card,
+			fallbackText: "Action updated",
+		});
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /** Context tracked per posted question so the click handler can feed the
@@ -473,16 +535,19 @@ export function registerInteractionBridge(
         return;
       }
 
-      const buttons = event.options.map((option, i) =>
-        Button({
-          id: `question:${event.id}:${i}`,
-          label: option,
-          value: option,
-				}),
-      );
-      const card = Card({
-        children: [CardText(event.question), Actions(buttons)],
-      });
+			const actionOrigin = await resolveInteractionActionOrigin({
+				organizationId,
+				platform: event.platform,
+				conversationId: event.conversationId,
+				agentId: connection.agentId,
+				source: event.source,
+			});
+			const card = questionCard(
+				event.question,
+				event.options,
+				event.id,
+				actionOrigin,
+			);
       const fallbackText = `${event.question}\n${event.options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`;
       const sent = await postWithFallback(
         thread,
@@ -521,43 +586,17 @@ export function registerInteractionBridge(
   const onToolApprovalNeeded = withResolvedThread<PostedToolApproval>(
     "tool:approval-needed",
     async (event, thread) => {
-      const argsText = formatToolArgs(event.args);
-      const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
+			const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${formatToolArgs(event.args)}`;
       const tid = event.id;
 
-      const card = Card({
-        children: [
-          CardText(
-						`*Tool Approval*\n${event.mcpId} → ${event.toolName}\n${argsText}`,
-          ),
-          Actions([
-            Button({
-              id: `tool:${tid}:1h`,
-              label: "Allow 1h",
-              style: "primary",
-              value: "1h",
-            }),
-            Button({
-              id: `tool:${tid}:24h`,
-              label: "Allow 24h",
-              style: "primary",
-              value: "24h",
-            }),
-            Button({
-              id: `tool:${tid}:always`,
-              label: "Allow always",
-              style: "primary",
-              value: "always",
-            }),
-            Button({
-              id: `tool:${tid}:deny`,
-              label: "Deny always",
-              style: "danger",
-              value: "deny",
-            }),
-          ]),
-        ],
-      });
+			const actionOrigin = await resolveInteractionActionOrigin({
+				organizationId: connection.organizationId,
+				platform: event.platform,
+				conversationId: event.conversationId,
+				agentId: event.agentId,
+				source: event.source,
+			});
+			const card = toolApprovalCard(event, tid, actionOrigin);
       const sent = await postWithFallback(
         thread,
         { card, fallbackText: text },
@@ -662,7 +701,7 @@ export function registerInteractionBridge(
     grantStore,
     executeToolDirect,
     claimApprovalCard,
-    async (questionId, value, thread, author) => {
+    async (questionId, value, thread, author, actionEvent) => {
       // Fast path — Slack's block_actions webhook requires a <3s response.
       // The claim is a single `UPDATE … RETURNING` on a PK and stays well
       // under the budget; the slow platform API calls (post receipt, edit
@@ -717,33 +756,49 @@ export function registerInteractionBridge(
         : "*You submitted a response.*";
 
       void (async () => {
-        // Visible "user submitted X" receipt so the click is acknowledged
-        // in-thread even before the worker responds.
-        try {
-          const card = Card({ children: [CardText(receiptText)] });
-          await thread
-            .post({ card, fallbackText: receiptText })
-            .catch(async () => {
-              await thread.post(receiptText);
-            });
-        } catch {
-          try {
-            await thread.post(receiptText);
-          } catch {
-            // best effort — even the plain-text fallback failed
-          }
-        }
-
-        // Strip the original card's buttons so it can't be clicked again.
-        if (entry.sent) {
-          try {
-            await entry.sent.edit(
-							`${question.question}\n\n_Answered: ${value}_`,
-            );
-          } catch {
-            // best effort — card may be stale or un-editable
-          }
-        }
+				const resolution = {
+					status: "answered" as const,
+					actorName: author?.fullName ?? author?.userName ?? null,
+					resolvedAt: new Date(),
+					detail: value ? `Response: ${value}` : "Response submitted.",
+				};
+				const actionOrigin = await resolveInteractionActionOrigin({
+					organizationId,
+					platform: question.platform,
+					conversationId: question.conversationId,
+					agentId: connection.agentId,
+					source: question.source,
+				});
+				const settledCard = settleActionCard(
+					questionCard(
+						question.question,
+						question.options,
+						questionId,
+						actionOrigin,
+					),
+					resolution,
+				);
+				const edited = await editClickedCard(actionEvent, settledCard);
+				if (!edited && entry.sent) {
+					try {
+						await entry.sent.edit({
+							card: settledCard,
+							fallbackText: actionResolutionText(resolution),
+						});
+					} catch {
+						// best effort — card may be stale or un-editable
+					}
+				}
+				if (!edited && !entry.sent) {
+					// The durable claim already won, but this host cannot address the
+					// original platform message. Leave a receipt instead of making the
+					// click appear to have done nothing.
+					try {
+						await thread.post(receiptText);
+					} catch {
+						// best effort
+					}
+				}
 
         // MUST route with question.userId (the original message's user), not
         // author.userId (who physically clicked). The worker session is keyed
@@ -877,6 +932,7 @@ type OnQuestionClickFn = (
   value: string,
   thread: any,
 	author: { userId?: string; userName?: string; fullName?: string } | undefined,
+	actionEvent: any,
 ) => Promise<void>;
 
 /**
@@ -1010,18 +1066,12 @@ export function registerActionHandlers(
 				ctx,
 			).catch((error) => ({ error: String(error) }));
 			const resultRecord = result as Record<string, unknown>;
-			const message =
-				typeof resultRecord.message === "string"
-					? resultRecord.message
-					: typeof resultRecord.error === "string"
-						? resultRecord.error
-						: decision === "approve"
-							? "Approved."
-							: "Rejected.";
-			try {
-				await thread.post(message);
-			} catch {
-				// best effort
+			if (typeof resultRecord.error === "string") {
+				try {
+					await thread.post(resultRecord.error);
+				} catch {
+					// best effort
+				}
 			}
 			return;
 		}
@@ -1051,13 +1101,20 @@ export function registerActionHandlers(
             { requestId, decision },
 						"Tool approval click with no pending invocation — likely expired",
           );
-          try {
-            await sent.edit(
-							"*Tool Approval*\n\n_This approval request expired before it could be acted on. Re-send your last message to retry._",
-            );
-          } catch {
-            // best effort
-          }
+					const expiredCard = settleActionCard(
+						Card({ children: [CardText("*Tool Approval*")] }),
+						{
+							status: "expired",
+							detail:
+								"Re-send your last message to create a new approval request.",
+						},
+					);
+					const edited = await editClickedCard(event, expiredCard);
+					try {
+						if (!edited) await sent.edit({ card: expiredCard });
+					} catch {
+						// best effort
+					}
           try {
             await thread.post(
 							"This tool approval request expired before it could be acted on. Re-send your last message to retry.",
@@ -1076,12 +1133,39 @@ export function registerActionHandlers(
 
       const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
 
-      // Edit the posted card to strip buttons so it can't be clicked again.
-      await stripApprovalButtons(
-        claimApprovalCard?.(requestId),
-        pending,
-				decision,
-      );
+			const resolution = {
+				status:
+					decision === "deny" ? ("denied" as const) : ("approved" as const),
+				actorName: event.user?.fullName ?? event.user?.userName ?? null,
+				resolvedAt: new Date(),
+				detail:
+					decision === "deny"
+						? "Tool access denied."
+						: `Tool access allowed ${decision === "always" ? "until revoked" : `for ${decision}`}.`,
+			};
+			const actionOrigin = await resolveInteractionActionOrigin({
+				organizationId: pending.organizationId ?? connection.organizationId,
+				platform: pending.platform,
+				conversationId: pending.conversationId,
+				agentId: pending.agentId,
+				source: pending.source,
+			});
+			const settledCard = settleActionCard(
+				toolApprovalCard(pending, requestId, actionOrigin),
+				resolution,
+			);
+			const sent = claimApprovalCard?.(requestId);
+			const edited = await editClickedCard(event, settledCard);
+			if (!edited && sent) {
+				try {
+					await sent.edit({
+						card: settledCard,
+						fallbackText: actionResolutionText(resolution),
+					});
+				} catch {
+					// Best effort: durable grant/deny state remains authoritative.
+				}
+			}
 
       // Resolve the post target. Prefer the original conversation captured at
       // the time the tool call was blocked (saved alongside the pending
@@ -1276,7 +1360,13 @@ export function registerActionHandlers(
         return;
       }
       try {
-        await onQuestionClick(questionId, responseText, thread, event.user);
+				await onQuestionClick(
+					questionId,
+					responseText,
+					thread,
+					event.user,
+					event,
+				);
       } catch (error) {
         logger.error(
           { connectionId: connection.id, error: String(error) },

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1109,17 +1109,23 @@ export function registerActionHandlers(
             { requestId, decision },
 						"Tool approval click with no pending invocation — likely expired",
           );
+					const expiredResolution = {
+						status: "expired" as const,
+						detail:
+							"Re-send your last message to create a new approval request.",
+					};
 					const expiredCard = settleActionCard(
 						Card({ children: [CardText("*Tool Approval*")] }),
-						{
-							status: "expired",
-							detail:
-								"Re-send your last message to create a new approval request.",
-						},
+						expiredResolution,
 					);
 					const edited = await editClickedCard(event, expiredCard);
 					try {
-						if (!edited) await sent.edit({ card: expiredCard });
+						if (!edited) {
+							await sent.edit({
+								card: expiredCard,
+								fallbackText: actionResolutionText(expiredResolution),
+							});
+						}
 					} catch {
 						// best effort
 					}

--- a/packages/server/src/notifications/action-card-state.ts
+++ b/packages/server/src/notifications/action-card-state.ts
@@ -3,6 +3,7 @@ import {
 	type CardChild,
 	type CardElement,
 	CardText,
+	type LinkButtonElement,
 } from "chat";
 import { escapeSlackText } from "../utils/slack-text";
 
@@ -98,7 +99,7 @@ export function settleActionCard(
 	resolution: ActionResolution,
 ): CardElement {
 	const children: CardChild[] = [];
-	const trailingLinks: Array<Record<string, unknown>> = [];
+	const trailingLinks: LinkButtonElement[] = [];
 	for (const child of card.children) {
 		if (!isRecord(child) || child.type !== "actions") {
 			children.push(child);
@@ -107,17 +108,22 @@ export function settleActionCard(
 		const actionChildren = Array.isArray(child.children) ? child.children : [];
 		const links = actionChildren.flatMap((action) => {
 			if (!isRecord(action) || action.type !== "link-button") return [];
+			if (typeof action.label !== "string" || typeof action.url !== "string") {
+				return [];
+			}
 			return [
 				{
-					...action,
+					type: "link-button" as const,
+					...(typeof action.id === "string" ? { id: action.id } : {}),
 					label:
 						action.label === "Review in Lobu" ? "View in Lobu" : action.label,
+					url: action.url,
 				},
 			];
 		});
 		trailingLinks.push(...links);
 	}
 	children.push(CardText(actionResolutionText(resolution)));
-	if (trailingLinks.length > 0) children.push(Actions(trailingLinks as never));
+	if (trailingLinks.length > 0) children.push(Actions(trailingLinks));
 	return { ...card, children };
 }

--- a/packages/server/src/notifications/action-card-state.ts
+++ b/packages/server/src/notifications/action-card-state.ts
@@ -1,0 +1,123 @@
+import {
+	Actions,
+	type CardChild,
+	type CardElement,
+	CardText,
+} from "chat";
+import { escapeSlackText } from "../utils/slack-text";
+
+export type ActionOrigin = {
+	kind: "automation" | "conversation" | "direct";
+	label: string;
+};
+
+export type ActionResolution = {
+	status:
+		| "approved"
+		| "rejected"
+		| "denied"
+		| "answered"
+		| "expired"
+		| "failed";
+	actorName?: string | null;
+	resolvedAt?: string | Date | null;
+	detail?: string | null;
+};
+
+function bounded(value: string, max = 240): string {
+	const normalized = value.replace(/\s+/g, " ").trim();
+	return normalized.length > max
+		? `${normalized.slice(0, max - 1)}…`
+		: normalized;
+}
+
+export function actionOriginSubtitle(
+	origin: ActionOrigin | null | undefined,
+): string | undefined {
+	if (!origin?.label.trim()) return undefined;
+	const prefix =
+		origin.kind === "automation"
+			? "Automation"
+			: origin.kind === "conversation"
+				? "Conversation"
+				: "Source";
+	return `${prefix}: ${escapeSlackText(bounded(origin.label))}`;
+}
+
+export function addActionOrigin(
+	card: CardElement,
+	origin: ActionOrigin | null | undefined,
+): CardElement {
+	const source = actionOriginSubtitle(origin);
+	if (!source) return card;
+	return {
+		...card,
+		subtitle: card.subtitle ? `${card.subtitle} · ${source}` : source,
+	};
+}
+
+function formatUtc(value: string | Date | null | undefined): string | null {
+	if (!value) return null;
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+	const iso = date.toISOString();
+	return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+export function actionResolutionText(resolution: ActionResolution): string {
+	let text = `*${resolution.status.charAt(0).toUpperCase()}${resolution.status.slice(1)}*`;
+	if (resolution.actorName?.trim()) {
+		text += ` by ${escapeSlackText(bounded(resolution.actorName))}`;
+	}
+	const timestamp = formatUtc(resolution.resolvedAt);
+	if (timestamp) text += ` · ${timestamp}`;
+	if (resolution.detail?.trim()) {
+		text += `\n${escapeSlackText(bounded(resolution.detail, 900))}`;
+	}
+	return text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isCard(value: unknown): value is CardElement {
+	return (
+		isRecord(value) && value.type === "card" && Array.isArray(value.children)
+	);
+}
+
+/**
+ * Turn an interactive card into its terminal receipt. All mutating controls
+ * disappear together; ordinary links survive so the audit record remains one
+ * click away. This is intentionally generic so approvals, tool grants, and
+ * one-shot questions cannot each invent a different stale-button policy.
+ */
+export function settleActionCard(
+	card: CardElement,
+	resolution: ActionResolution,
+): CardElement {
+	const children: CardChild[] = [];
+	const trailingLinks: Array<Record<string, unknown>> = [];
+	for (const child of card.children) {
+		if (!isRecord(child) || child.type !== "actions") {
+			children.push(child);
+			continue;
+		}
+		const actionChildren = Array.isArray(child.children) ? child.children : [];
+		const links = actionChildren.flatMap((action) => {
+			if (!isRecord(action) || action.type !== "link-button") return [];
+			return [
+				{
+					...action,
+					label:
+						action.label === "Review in Lobu" ? "View in Lobu" : action.label,
+				},
+			];
+		});
+		trailingLinks.push(...links);
+	}
+	children.push(CardText(actionResolutionText(resolution)));
+	if (trailingLinks.length > 0) children.push(Actions(trailingLinks as never));
+	return { ...card, children };
+}

--- a/packages/server/src/notifications/action-card-state.ts
+++ b/packages/server/src/notifications/action-card-state.ts
@@ -18,8 +18,7 @@ export type ActionResolution = {
 		| "rejected"
 		| "denied"
 		| "answered"
-		| "expired"
-		| "failed";
+		| "expired";
 	actorName?: string | null;
 	resolvedAt?: string | Date | null;
 	detail?: string | null;

--- a/packages/server/src/notifications/action-origin.ts
+++ b/packages/server/src/notifications/action-origin.ts
@@ -72,7 +72,7 @@ async function mcpConversationOrigin(
 	};
 }
 
-export async function resolveConversationActionOrigin(params: {
+async function resolveConversationActionOrigin(params: {
 	organizationId: string;
 	platform?: string | null;
 	conversationId?: string | null;

--- a/packages/server/src/notifications/action-origin.ts
+++ b/packages/server/src/notifications/action-origin.ts
@@ -1,0 +1,150 @@
+import { getDb } from "../db/client";
+import { parseAutomationRunConversationId } from "../gateway/permissions/automation-run-intent";
+import {
+	currentMcpActivityAttribution,
+	type McpActivityAttribution,
+} from "../lobu/stores/mcp-client-conversations";
+import type { ToolContext } from "../tools/registry";
+import type { ActionOrigin } from "./action-card-state";
+
+const PLATFORM_LABELS: Record<string, string> = {
+	slack: "Slack",
+	telegram: "Telegram",
+	whatsapp: "WhatsApp",
+	discord: "Discord",
+	teams: "Microsoft Teams",
+	gchat: "Google Chat",
+	mcp: "MCP",
+	web: "Lobu",
+};
+
+function platformName(value: string | null | undefined): string {
+	const platform = value?.trim().toLowerCase();
+	if (!platform || platform === "api" || platform === "lobu") return "Lobu";
+	return PLATFORM_LABELS[platform] ?? platform;
+}
+
+async function automationOrigin(
+	organizationId: string,
+	automationId: number,
+): Promise<ActionOrigin> {
+	const rows = await getDb()<{
+		name: string | null;
+	}>`
+		SELECT COALESCE(NULLIF(v.name, ''), NULLIF(a.name, '')) AS name
+		FROM automations a
+		LEFT JOIN automation_versions v ON v.id = a.current_version_id
+		WHERE a.id = ${automationId}
+		  AND a.organization_id = ${organizationId}
+		LIMIT 1
+	`;
+	return {
+		kind: "automation",
+		label: rows[0]?.name?.trim() || `Automation #${automationId}`,
+	};
+}
+
+async function mcpConversationOrigin(
+	organizationId: string,
+	activity: McpActivityAttribution,
+): Promise<ActionOrigin> {
+	const rows = await getDb()<{
+		title: string | null;
+		client_name: string | null;
+	}>`
+		SELECT mc.title, oc.client_name
+		FROM mcp_client_conversations mc
+		LEFT JOIN oauth_clients oc ON oc.id = mc.client_id
+		WHERE mc.organization_id = ${organizationId}
+		  AND mc.client_identity = ${activity.clientIdentity}
+		  AND mc.conversation_id = ${activity.activityId}
+		LIMIT 1
+	`;
+	const title = rows[0]?.title?.trim();
+	const client = rows[0]?.client_name?.trim();
+	return {
+		kind: "conversation",
+		label: title
+			? client
+				? `${client} — ${title}`
+				: title
+			: `${client ?? "MCP"} conversation`,
+	};
+}
+
+export async function resolveConversationActionOrigin(params: {
+	organizationId: string;
+	platform?: string | null;
+	conversationId?: string | null;
+	agentId?: string | null;
+}): Promise<ActionOrigin> {
+	let title: string | null = null;
+	const sourcePlatform = params.platform?.trim().toLowerCase() || null;
+	const storedPlatform = sourcePlatform === "api" ? "web" : sourcePlatform;
+	if (storedPlatform && params.conversationId) {
+		const rows = await getDb()<{
+			title: string | null;
+			location_label: string | null;
+		}>`
+			SELECT title, location_label
+			FROM conversations
+			WHERE organization_id = ${params.organizationId}
+			  AND platform = ${storedPlatform}
+			  AND conversation_id = ${params.conversationId}
+			  AND (${params.agentId ?? null}::text IS NULL OR agent_id = ${params.agentId ?? null})
+			ORDER BY last_activity_at DESC
+			LIMIT 1
+		`;
+		title = rows[0]?.title?.trim() || rows[0]?.location_label?.trim() || null;
+	}
+	const platform = platformName(sourcePlatform);
+	return {
+		kind: "conversation",
+		label: title ? `${platform} — ${title}` : `${platform} conversation`,
+	};
+}
+
+/** Resolve a transient question/tool card to an Automation or conversation. */
+export async function resolveInteractionActionOrigin(params: {
+	organizationId?: string | null;
+	platform?: string | null;
+	conversationId?: string | null;
+	agentId?: string | null;
+	source?: string | null;
+}): Promise<ActionOrigin> {
+	if (params.organizationId && params.source === "automation-run") {
+		const run = parseAutomationRunConversationId(params.conversationId ?? "");
+		if (run) return automationOrigin(params.organizationId, run.automationId);
+		return { kind: "automation", label: "Automation run" };
+	}
+	const fallback = `${platformName(params.platform)} conversation`;
+	if (!params.organizationId) return { kind: "conversation", label: fallback };
+	return resolveConversationActionOrigin({
+		organizationId: params.organizationId,
+		platform: params.platform,
+		conversationId: params.conversationId,
+		agentId: params.agentId,
+	}).catch(() => ({ kind: "conversation", label: fallback }));
+}
+
+/** Resolve human-readable provenance only from verified server context. */
+export async function resolveActionOrigin(
+	ctx: ToolContext,
+): Promise<ActionOrigin> {
+	if (ctx.actingAutomationId != null) {
+		return automationOrigin(ctx.organizationId, ctx.actingAutomationId);
+	}
+	const mcpActivity = currentMcpActivityAttribution(ctx);
+	if (mcpActivity) {
+		return mcpConversationOrigin(ctx.organizationId, mcpActivity);
+	}
+	if (ctx.sourceContext?.conversationId) {
+		return resolveConversationActionOrigin({
+			organizationId: ctx.organizationId,
+			platform: ctx.sourceContext.platform,
+			conversationId: ctx.sourceContext.conversationId,
+			agentId: ctx.agentId,
+		});
+	}
+	return { kind: "direct", label: "Direct request" };
+}

--- a/packages/server/src/notifications/action-origin.ts
+++ b/packages/server/src/notifications/action-origin.ts
@@ -114,7 +114,14 @@ export async function resolveInteractionActionOrigin(params: {
 }): Promise<ActionOrigin> {
 	if (params.organizationId && params.source === "automation-run") {
 		const run = parseAutomationRunConversationId(params.conversationId ?? "");
-		if (run) return automationOrigin(params.organizationId, run.automationId);
+		if (run) {
+			return automationOrigin(params.organizationId, run.automationId).catch(
+				() => ({
+					kind: "automation",
+					label: `Automation #${run.automationId}`,
+				}),
+			);
+		}
 		return { kind: "automation", label: "Automation run" };
 	}
 	const fallback = `${platformName(params.platform)} conversation`;
@@ -131,20 +138,24 @@ export async function resolveInteractionActionOrigin(params: {
 export async function resolveActionOrigin(
 	ctx: ToolContext,
 ): Promise<ActionOrigin> {
-	if (ctx.actingAutomationId != null) {
-		return automationOrigin(ctx.organizationId, ctx.actingAutomationId);
-	}
-	const mcpActivity = currentMcpActivityAttribution(ctx);
-	if (mcpActivity) {
-		return mcpConversationOrigin(ctx.organizationId, mcpActivity);
-	}
-	if (ctx.sourceContext?.conversationId) {
-		return resolveConversationActionOrigin({
-			organizationId: ctx.organizationId,
-			platform: ctx.sourceContext.platform,
-			conversationId: ctx.sourceContext.conversationId,
-			agentId: ctx.agentId,
-		});
+	try {
+		if (ctx.actingAutomationId != null) {
+			return await automationOrigin(ctx.organizationId, ctx.actingAutomationId);
+		}
+		const mcpActivity = currentMcpActivityAttribution(ctx);
+		if (mcpActivity) {
+			return await mcpConversationOrigin(ctx.organizationId, mcpActivity);
+		}
+		if (ctx.sourceContext?.conversationId) {
+			return await resolveConversationActionOrigin({
+				organizationId: ctx.organizationId,
+				platform: ctx.sourceContext.platform,
+				conversationId: ctx.sourceContext.conversationId,
+				agentId: ctx.agentId,
+			});
+		}
+	} catch {
+		// Provenance is display-only and must never fail the action itself.
 	}
 	return { kind: "direct", label: "Direct request" };
 }

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
-import type { CardElement } from "chat";
+import {
+	type AdapterPostableMessage,
+	type CardElement,
+} from "chat";
 import { loadConfiguredAutomationDeliveryTarget } from "../automations/delivery-target";
-import { getDb, pgTextArray } from "../db/client";
+import { getDb, pgBigintArray, pgTextArray } from "../db/client";
 import { resolveBoundChannelRows } from "../gateway/channels/bound-channels";
 import { getChatInstanceManager, isLobuGatewayRunning } from "../lobu/gateway";
 import type { McpActivityAttribution } from "../lobu/stores/mcp-client-conversations";
@@ -12,6 +15,14 @@ import { toAbsolutePermalink } from "../utils/url-builder";
 import logger from "../utils/logger";
 import { isUniqueViolation } from "../utils/pg-errors";
 import { buildKindCard } from "./template-card";
+import {
+	addActionOrigin,
+	actionResolutionText,
+	type ActionOrigin,
+	type ActionResolution,
+	isCard,
+	settleActionCard,
+} from "./action-card-state";
 
 interface CreateNotificationParams {
 	organizationId: string;
@@ -100,6 +111,8 @@ interface CreateNotificationParams {
 	entityIds?: number[];
 	/** Exact MCP conversation or transport session that caused this notification. */
 	mcpActivity?: McpActivityAttribution | null;
+	/** Verified source shown on interactive cards and persisted for later edits. */
+	actionOrigin?: ActionOrigin | null;
 	/**
 	 * The Automation run that emitted this notification, when one did.
 	 *
@@ -415,6 +428,7 @@ interface NotificationDeliveryRecord {
 async function recordDelivery(
 	eventId: number,
 	deliveries: NotificationDeliveryRecord[],
+	card?: CardElement,
 ): Promise<void> {
 	// A record exists to be addressed later, and `editMessage(threadId, messageId)`
 	// cannot address an empty id — an adapter that returned no message id has
@@ -424,10 +438,14 @@ async function recordDelivery(
 	if (addressable.length === 0) return;
 	try {
 		const sql = getDb();
+		const deliveryMetadata = {
+			delivery: addressable,
+			...(card ? { card } : {}),
+		};
 		await sql`
       UPDATE events
       SET metadata = coalesce(metadata, '{}'::jsonb)
-        || jsonb_build_object('delivery', ${sql.json(addressable)}::jsonb)
+        || ${sql.json(deliveryMetadata)}::jsonb
       WHERE id = ${eventId}
     `;
 	} catch (err) {
@@ -459,6 +477,156 @@ async function recordDeliveryError(
 			"[Notifications] Failed to record delivery error",
 		);
 	}
+}
+
+function jsonRecord(value: unknown): Record<string, unknown> {
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return {};
+}
+
+function deliveryRecords(
+	metadata: Record<string, unknown>,
+): Array<
+	Pick<NotificationDeliveryRecord, "connectionId" | "messageId" | "threadId">
+> {
+	return (Array.isArray(metadata.delivery) ? metadata.delivery : []).flatMap(
+		(entry) => {
+			const row = jsonRecord(entry);
+			const connectionId = row.connectionId;
+			const messageId = row.messageId;
+			const threadId = row.threadId;
+			return typeof connectionId === "string" &&
+				typeof messageId === "string" &&
+				messageId !== "" &&
+				typeof threadId === "string"
+				? [{ connectionId, messageId, threadId }]
+				: [];
+		},
+	);
+}
+
+type StoredApprovalNotification = {
+	run_id: number;
+	title: string;
+	metadata: unknown;
+	approval_status: string;
+	resolved_at: string | Date | null;
+	decision_metadata: unknown;
+};
+
+/**
+ * Edit every persisted chat copy of a resolved approval. This runs after the
+ * shared durable manage_operations transition, so a decision made in Slack,
+ * the web app, or MCP settles the same original card on every platform.
+ */
+export async function refreshApprovalNotificationCards(
+	organizationId: string,
+	runIds: number[],
+): Promise<void> {
+	const ids = [
+		...new Set(runIds.filter((id) => Number.isSafeInteger(id) && id > 0)),
+	];
+	if (ids.length === 0) return;
+	const manager = getChatInstanceManager();
+	if (!manager) return;
+	const rows = await getDb()<StoredApprovalNotification>`
+		SELECT
+			r.id AS run_id,
+			n.title,
+			n.metadata,
+			r.approval_status,
+			COALESCE(
+				decision.metadata->>'reviewed_at',
+				decision.occurred_at::text,
+				r.completed_at::text
+			) AS resolved_at,
+			decision.metadata AS decision_metadata
+		FROM runs r
+		JOIN events proposal
+		  ON proposal.organization_id = r.organization_id
+		 AND proposal.run_id = r.id
+		 AND proposal.interaction_type = 'approval'
+		JOIN events n
+		  ON n.organization_id = r.organization_id
+		 AND COALESCE(n.metadata->>'notification_type', 'generic') = 'action_approval_needed'
+		 AND n.metadata->>'resource_type' = 'event'
+		 AND n.metadata->>'resource_id' = proposal.id::text
+		LEFT JOIN current_event_records decision
+		  ON decision.organization_id = r.organization_id
+		 AND decision.run_id = r.id
+		 AND decision.interaction_type = 'approval'
+		WHERE r.organization_id = ${organizationId}
+		  AND r.id = ANY(${pgBigintArray(ids)}::bigint[])
+		  AND r.approval_status IN ('approved', 'rejected', 'expired')
+	`;
+
+	const edits: Promise<void>[] = [];
+	for (const row of rows) {
+		const metadata = jsonRecord(row.metadata);
+		if (!isCard(metadata.card)) continue;
+		const decisionMetadata = jsonRecord(row.decision_metadata);
+		const expiredDetail =
+			typeof decisionMetadata.expiry_reason === "string"
+				? decisionMetadata.expiry_reason
+				: typeof decisionMetadata.reason === "string"
+					? decisionMetadata.reason
+					: null;
+		const resolution: ActionResolution = {
+			status:
+				row.approval_status === "approved"
+					? "approved"
+					: row.approval_status === "expired"
+						? "expired"
+						: "rejected",
+			actorName:
+				typeof decisionMetadata.reviewed_by_name === "string"
+					? decisionMetadata.reviewed_by_name
+					: null,
+			resolvedAt: row.resolved_at,
+			detail: row.approval_status === "expired" ? expiredDetail : null,
+		};
+		const settled = settleActionCard(metadata.card, resolution);
+		const content: AdapterPostableMessage = {
+			card: settled,
+			fallbackText: `${row.title}\n${actionResolutionText(resolution)}`,
+		};
+		for (const delivery of deliveryRecords(metadata)) {
+			edits.push(
+				manager
+					.editMessageContent(delivery.connectionId, {
+						threadId: delivery.threadId,
+						messageId: delivery.messageId,
+						content,
+					})
+					.catch((err: unknown) => {
+						logger.warn(
+							{
+								err,
+								runId: row.run_id,
+								connectionId: delivery.connectionId,
+							},
+							"[Notifications] Failed to settle approval card",
+						);
+					}),
+			);
+		}
+	}
+	await Promise.all(edits);
+}
+
+/** Best-effort post-commit refresh used by every approval terminalizer. */
+export function queueApprovalNotificationCardRefresh(
+	organizationId: string,
+	runIds: number[],
+): void {
+	void refreshApprovalNotificationCards(organizationId, runIds).catch((err) =>
+		logger.warn(
+			{ err, organizationId, runIds },
+			"[Notifications] Failed to settle approval cards",
+		),
+	);
 }
 
 /**
@@ -517,7 +685,8 @@ async function deliverToBotConnections(
 	//      authoring its content twice (`payloadData` for web, a hand-built card
 	//      for chat) and drifting between them;
 	//   3. the markdown body.
-	const card = params.card ?? (await resolveNotificationKindCard(params));
+	const baseCard = params.card ?? (await resolveNotificationKindCard(params));
+	const card = baseCard ? addActionOrigin(baseCard, params.actionOrigin) : null;
 	const content = card ? { card } : { markdown: text };
 	const deliveryPlan = await resolveNotificationDeliveryPlan({
 		organizationId: params.organizationId,
@@ -557,14 +726,18 @@ async function deliverToBotConnections(
 					dm.slackUserId,
 					content,
 				);
-				await recordDelivery(eventId, [
-					{
-						connectionId: dm.connectionId,
-						channelKey: "dm",
-						messageId: sent.messageId,
-						threadId: sent.threadId,
-					},
-				]);
+				await recordDelivery(
+					eventId,
+					[
+						{
+							connectionId: dm.connectionId,
+							channelKey: "dm",
+							messageId: sent.messageId,
+							threadId: sent.threadId,
+						},
+					],
+					card ?? undefined,
+				);
 				return;
 			}
 			logger.warn(
@@ -622,7 +795,7 @@ async function deliverToBotConnections(
 				"[Notifications] Failed to post to bot connection channel",
 			);
 		});
-		await recordDelivery(eventId, delivered);
+		await recordDelivery(eventId, delivered, card ?? undefined);
 		if (deliveryPlan.strictAutomationTarget && delivered.length === 0) {
 			await recordDeliveryError(eventId, "automation_target_post_failed");
 		}

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -553,10 +553,15 @@ export async function refreshApprovalNotificationCards(
 		 AND COALESCE(n.metadata->>'notification_type', 'generic') = 'action_approval_needed'
 		 AND n.metadata->>'resource_type' = 'event'
 		 AND n.metadata->>'resource_id' = proposal.id::text
-		LEFT JOIN current_event_records decision
-		  ON decision.organization_id = r.organization_id
-		 AND decision.run_id = r.id
-		 AND decision.interaction_type = 'approval'
+		LEFT JOIN LATERAL (
+			SELECT d.occurred_at, d.metadata
+			FROM current_event_records d
+			WHERE d.organization_id = r.organization_id
+			  AND d.run_id = r.id
+			  AND d.interaction_type = 'approval'
+			ORDER BY d.occurred_at DESC, d.id DESC
+			LIMIT 1
+		) decision ON true
 		WHERE r.organization_id = ${organizationId}
 		  AND r.id = ANY(${pgBigintArray(ids)}::bigint[])
 		  AND r.approval_status IN ('approved', 'rejected', 'expired')

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -11,6 +11,7 @@ import {
 } from "../utils/platform-notification-kinds";
 import { buildResourcePermalink } from "../utils/url-builder";
 import { resolveAskAffordance } from "./ask-schema";
+import type { ActionOrigin } from "./action-card-state";
 import { createNotificationForUsers, getOrgSlug } from "./service";
 
 /** Notification content minus the org id (the dispatch helpers stamp it). */
@@ -473,6 +474,7 @@ export async function notifyActionApprovalNeeded(params: {
 	 */
 	requesterUserId?: string | null;
 	mcpActivity?: McpActivityAttribution | null;
+	actionOrigin?: ActionOrigin | null;
 	details?: ActionApprovalDetails;
 	/**
 	 * Set ONLY for a connector operation (`run_type = 'action'`). Its presence
@@ -541,6 +543,7 @@ export async function notifyActionApprovalNeeded(params: {
 			deliveryScope: "targeted",
 			ownerUserId: resolveApprovalDmTarget(params),
 			mcpActivity: params.mcpActivity,
+			actionOrigin: params.actionOrigin,
 		};
 	});
 }

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -41,6 +41,7 @@
 
 import { intervals } from "../config/intervals";
 import { getDb, pgTextArray } from "../db/client";
+import { queueApprovalNotificationCardRefresh } from "../notifications/service";
 import { supersedeActionEvent } from "../tools/admin/approval-events";
 import logger from "../utils/logger";
 import { APPROVAL_RUN_TYPES } from "../utils/run-statuses";
@@ -101,6 +102,7 @@ export async function expirePendingApprovals(
 	const reason = `Approval expired: nobody decided within ${ttlDays} day${ttlDays === 1 ? "" : "s"}.`;
 
 	let expiredCount = 0;
+	const expiredRunIdsByOrg = new Map<string, number[]>();
 	// Drain successive batches so a backlog bigger than one batch clears in this
 	// invocation. Bounded by EXPIRY_INVOCATION_LIMIT; also stops as soon as a
 	// batch comes back empty or makes no progress (see below).
@@ -143,7 +145,7 @@ export async function expirePendingApprovals(
 		const expiredBeforeBatch = expiredCount;
 		for (const candidate of candidates) {
 			try {
-				const didExpire = await sql.begin(async (tx) => {
+				const expiredRow = await sql.begin(async (tx) => {
 					// Re-assert the full candidate predicate while claiming the row. A
 					// human decision or another replica's committed expiry wins before
 					// this write.
@@ -160,7 +162,7 @@ export async function expirePendingApprovals(
             RETURNING id, organization_id, action_key
           `) as unknown as ExpiredApprovalRow[];
 					const row = rows[0];
-					if (!row) return false;
+					if (!row) return null;
 
 					// `events` stays append-only. interaction_status has no 'expired'
 					// member, so the card uses 'rejected' as its non-actionable UI state
@@ -184,9 +186,14 @@ export async function expirePendingApprovals(
 							`Cannot expire approval run ${Number(row.id)}: its approval card is missing`,
 						);
 					}
-					return true;
+					return row;
 				});
-				if (didExpire) expiredCount += 1;
+				if (expiredRow) {
+					expiredCount += 1;
+					const orgRunIds = expiredRunIdsByOrg.get(expiredRow.organization_id) ?? [];
+					orgRunIds.push(Number(expiredRow.id));
+					expiredRunIdsByOrg.set(expiredRow.organization_id, orgRunIds);
+				}
 			} catch (error) {
 				logger.warn(
 					{ runId: Number(candidate.id), error: String(error) },
@@ -201,6 +208,9 @@ export async function expirePendingApprovals(
 		if (expiredCount === expiredBeforeBatch) break;
 	}
 
+	for (const [organizationId, runIds] of expiredRunIdsByOrg) {
+		queueApprovalNotificationCardRefresh(organizationId, runIds);
+	}
 	return { expired: expiredCount };
 }
 

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -122,6 +122,9 @@ export async function supersedeActionEvent(
 		reviewer?.name ??
 		(priorMetadata.reviewed_by_name as string | undefined) ??
 		null;
+	const reviewedAt = reviewer
+		? new Date().toISOString()
+		: ((priorMetadata.reviewed_at as string | undefined) ?? null);
 
 	const nextEvent = await insertEvent(
 		{
@@ -165,6 +168,7 @@ export async function supersedeActionEvent(
 				status,
 				...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
 				...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
+				...(reviewedAt ? { reviewed_at: reviewedAt } : {}),
 				...(extraMetadata.output
 					? { action_output: extraMetadata.output }
 					: {}),

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -39,6 +39,7 @@ import {
 	currentMcpActivityAttribution,
 	currentMcpActivityEventMetadata,
 } from "../../lobu/stores/mcp-client-conversations";
+import { resolveActionOrigin } from "../../notifications/action-origin";
 import {
 	formatFieldChangeAction,
 	formatLabel,
@@ -1044,6 +1045,7 @@ export async function proposeEntityChange(
 		approvalPolicy.deliveryTarget.channelId
 			? approvalPolicy.deliveryTarget
 			: await resolveApprovalChatOrigin(ctx);
+	const actionOrigin = await resolveActionOrigin(ctx);
 
 	notifyActionApprovalNeeded({
 		orgId: ctx.organizationId,
@@ -1058,6 +1060,7 @@ export async function proposeEntityChange(
 		ownerUserId: updateProposal?.owner_user_id ?? null,
 		requesterUserId: ctx.userId ?? null,
 		mcpActivity: currentMcpActivityAttribution(ctx),
+		actionOrigin,
 		details:
 			operation === "update"
 				? {

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -50,6 +50,7 @@ import {
   validateModelRefsAgainstOrg,
 } from '../../lobu/model-config';
 import { isValidAgentId } from '../../lobu/stores/postgres-stores';
+import { resolveActionOrigin } from '../../notifications/action-origin';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { resolveApprovalChatOrigin } from './approval-delivery';
 import { insertEvent } from '../../utils/insert-event';
@@ -758,6 +759,7 @@ async function queueWriteForApproval(
 
   // One destination, never the org-wide fan-out — see resolveApprovalChatOrigin.
   const chatOrigin = await resolveApprovalChatOrigin(ctx);
+  const actionOrigin = await resolveActionOrigin(ctx);
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,
     runId,
@@ -770,6 +772,7 @@ async function queueWriteForApproval(
     teamId: chatOrigin.teamId,
     requesterUserId: ctx.userId ?? null,
     mcpActivity: currentMcpActivityAttribution(ctx),
+    actionOrigin,
   }).catch((error) =>
     logger.error(error, 'Failed to send manage_agents approval notification')
   );

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -38,6 +38,7 @@ import {
   currentMcpActivityAttribution,
   currentMcpActivityEventMetadata,
 } from '../../lobu/stores/mcp-client-conversations';
+import { resolveActionOrigin } from '../../notifications/action-origin';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { resolveApprovalChatOrigin } from './approval-delivery';
 import { insertEvent } from '../../utils/insert-event';
@@ -809,6 +810,7 @@ async function queueAutomationWriteForApproval(
 
   // One destination, never the org-wide fan-out — see resolveApprovalChatOrigin.
   const chatOrigin = await resolveApprovalChatOrigin(ctx);
+  const actionOrigin = await resolveActionOrigin(ctx);
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,
     runId,
@@ -821,6 +823,7 @@ async function queueAutomationWriteForApproval(
     teamId: chatOrigin.teamId,
     requesterUserId: ctx.userId ?? null,
     mcpActivity: currentMcpActivityAttribution(ctx),
+    actionOrigin,
   }).catch((error) => logger.error(error, 'Failed to send manage_automations approval notification'));
 
   return {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -31,6 +31,7 @@ import {
 	upsertByoChatConnection,
 } from "../../../../gateway/connections/chat-connection-service";
 import { isAtlassianMcpConfig } from "../../../../operations/atlassian-mcp-feed";
+import { queueApprovalNotificationCardRefresh } from "../../../../notifications/service";
 import {
   EMPTY_SUMMARY,
   getOperationsSummariesByConnection,
@@ -2172,7 +2173,7 @@ export async function handleDelete(
     'Connection deleted before approval; approval expired.';
   const expirePendingApprovalsBeforeDelete = async (
     db: DbClient
-  ): Promise<void> => {
+	): Promise<number[]> => {
     // The whole batch shares one transaction. If any append-only card cannot
     // advance, every run stays pending and the caller must leave the connection
     // visible so a reviewer can still act on those cards.
@@ -2189,6 +2190,7 @@ export async function handleDelete(
       ORDER BY id
       FOR UPDATE
     `;
+		const expiredRunIds: number[] = [];
     for (const pendingApproval of pendingApprovals) {
       const expired = await db<{ action_key: string | null }>`
           UPDATE runs
@@ -2224,8 +2226,9 @@ export async function handleDelete(
           `Cannot expire approval run ${pendingApproval.id}: its approval card is missing`
         );
       }
+			expiredRunIds.push(pendingApproval.id);
     }
-
+		return expiredRunIds;
   };
 
   // Phase 1: fallible EXTERNAL teardown runs FIRST, while the connection is
@@ -2277,7 +2280,7 @@ export async function handleDelete(
     `;
     if (tombstoned.length === 0) return null; // concurrently deleted
 
-    await expirePendingApprovalsBeforeDelete(tx);
+		const expiredApprovalRunIds = await expirePendingApprovalsBeforeDelete(tx);
 
     // Pause the connection's existing feeds in the same atomic lifecycle
     // transition. Keep each schedule as historical configuration, but clear its
@@ -2303,14 +2306,18 @@ export async function handleDelete(
       connectionId: args.connection_id,
     });
 
-    return tombstoned;
+		return { tombstoned, expiredApprovalRunIds };
   });
   if (deleted === null) {
     return { error: "Connection not found or already deleted" };
   }
 
   // Record change event in knowledge for audit trail
-  const conn = deleted[0];
+	queueApprovalNotificationCardRefresh(
+		organizationId,
+		deleted.expiredApprovalRunIds,
+	);
+	const conn = deleted.tombstoned[0];
   const affectedFeeds = await sql`
     SELECT DISTINCT unnest(entity_ids) AS entity_id
     FROM feeds

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2312,7 +2312,6 @@ export async function handleDelete(
     return { error: "Connection not found or already deleted" };
   }
 
-  // Record change event in knowledge for audit trail
 	queueApprovalNotificationCardRefresh(
 		organizationId,
 		deleted.expiredApprovalRunIds,
@@ -2330,6 +2329,7 @@ export async function handleDelete(
     .filter((value) => Number.isFinite(value));
 	const connName =
 		conn.display_name || conn.connector_key || args.connection_id;
+	// Record change event in knowledge for audit trail
   recordChangeEvent({
     entityIds: entityIds.map(Number),
     organizationId,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -32,6 +32,18 @@ import {
 	RejectBatchAction,
 } from "./manage_operations/schemas";
 import { queueApprovalNotificationCardRefresh } from "../../notifications/service";
+import type { ToolContext } from "../registry";
+
+function settleApprovalResult<T>(ctx: ToolContext, result: T): T {
+	const record = result as Record<string, unknown>;
+	const runIds = Array.isArray(record.run_ids)
+		? record.run_ids.map(Number)
+		: Number.isFinite(Number(record.run_id))
+			? [Number(record.run_id)]
+			: [];
+	queueApprovalNotificationCardRefresh(ctx.organizationId, runIds);
+	return result;
+}
 
 const manageOperationsTool = defineActionTool("manage_operations", {
 	list_available: action(ListAvailableAction, handleListAvailable),
@@ -39,13 +51,19 @@ const manageOperationsTool = defineActionTool("manage_operations", {
 	list_runs: action(ListRunsAction, handleListRuns),
 	get_run: action(GetRunAction, handleGetRun),
 	list_activity: action(ListActivityAction, handleListActivity),
-	approve: action(ApproveAction, handleApprove),
-	reject: action(RejectAction, handleReject),
-	approve_batch: action(ApproveBatchAction, handleApproveBatch),
-	reject_batch: action(RejectBatchAction, handleRejectBatch),
+	approve: action(ApproveAction, async (args, ctx, env) =>
+		settleApprovalResult(ctx, await handleApprove(args, ctx, env)),
+	),
+	reject: action(RejectAction, async (args, ctx) =>
+		settleApprovalResult(ctx, await handleReject(args, ctx)),
+	),
+	approve_batch: action(ApproveBatchAction, async (args, ctx, env) =>
+		settleApprovalResult(ctx, await handleApproveBatch(args, ctx, env)),
+	),
+	reject_batch: action(RejectBatchAction, async (args, ctx) =>
+		settleApprovalResult(ctx, await handleRejectBatch(args, ctx)),
+	),
 });
-
-const runManageOperations = manageOperationsTool.run;
 
 /**
  * Approval-card settlement belongs after the shared state transition, not in
@@ -53,28 +71,7 @@ const runManageOperations = manageOperationsTool.run;
  * batches convergent: whichever surface wins the durable run claim updates all
  * persisted chat copies from the same final state.
  */
-export const manageOperations: typeof runManageOperations = async (
-	args,
-	env,
-	ctx,
-) => {
-	const result = await runManageOperations(args, env, ctx);
-	if (
-		args.action === "approve" ||
-		args.action === "reject" ||
-		args.action === "approve_batch" ||
-		args.action === "reject_batch"
-	) {
-		const record = result as Record<string, unknown>;
-		const resultIds = Array.isArray(record.run_ids)
-			? record.run_ids.map(Number)
-			: Number.isFinite(Number(record.run_id))
-				? [Number(record.run_id)]
-				: [];
-		queueApprovalNotificationCardRefresh(ctx.organizationId, resultIds);
-	}
-	return result;
-};
+export const manageOperations = manageOperationsTool.run;
 export {
 	ManageOperationsResultSchema,
 	ManageOperationsSchema,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -31,6 +31,7 @@ import {
 	RejectAction,
 	RejectBatchAction,
 } from "./manage_operations/schemas";
+import { queueApprovalNotificationCardRefresh } from "../../notifications/service";
 
 const manageOperationsTool = defineActionTool("manage_operations", {
 	list_available: action(ListAvailableAction, handleListAvailable),
@@ -44,7 +45,36 @@ const manageOperationsTool = defineActionTool("manage_operations", {
 	reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
-export const manageOperations = manageOperationsTool.run;
+const runManageOperations = manageOperationsTool.run;
+
+/**
+ * Approval-card settlement belongs after the shared state transition, not in
+ * any one UI handler. This keeps Slack, web, MCP Apps, single decisions, and
+ * batches convergent: whichever surface wins the durable run claim updates all
+ * persisted chat copies from the same final state.
+ */
+export const manageOperations: typeof runManageOperations = async (
+	args,
+	env,
+	ctx,
+) => {
+	const result = await runManageOperations(args, env, ctx);
+	if (
+		args.action === "approve" ||
+		args.action === "reject" ||
+		args.action === "approve_batch" ||
+		args.action === "reject_batch"
+	) {
+		const record = result as Record<string, unknown>;
+		const resultIds = Array.isArray(record.run_ids)
+			? record.run_ids.map(Number)
+			: Number.isFinite(Number(record.run_id))
+				? [Number(record.run_id)]
+				: [];
+		queueApprovalNotificationCardRefresh(ctx.organizationId, resultIds);
+	}
+	return result;
+};
 export {
 	ManageOperationsResultSchema,
 	ManageOperationsSchema,

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -11,6 +11,7 @@ import { getDb } from "../../../../db/client";
 import type { Env } from "../../../../index";
 import { currentMcpActivityAttribution, currentMcpActivityEventMetadata } from "../../../../lobu/stores/mcp-client-conversations";
 import { callTool as callProxyTool } from "../../../../mcp-proxy/client";
+import { resolveActionOrigin } from "../../../../notifications/action-origin";
 import { notifyActionApprovalNeeded } from "../../../../notifications/triggers";
 import { resolveApprovalChatOrigin } from "../../approval-delivery";
 import { resolveActionMode } from "../../../../operations/action-modes";
@@ -751,6 +752,7 @@ export async function handleExecute(
 		// One destination, never the org-wide fan-out: the conversation that asked
 		// when there is one, else the requesting human's DM, else the inbox alone.
 		const chatOrigin = await resolveApprovalChatOrigin(ctx);
+		const actionOrigin = await resolveActionOrigin(ctx);
 		notifyActionApprovalNeeded({
 			orgId: ctx.organizationId,
 			runId,
@@ -766,6 +768,7 @@ export async function handleExecute(
 			teamId: chatOrigin.teamId,
 			requesterUserId: visibilityUserId ?? ctx.userId ?? null,
 			mcpActivity: currentMcpActivityAttribution(ctx),
+			actionOrigin,
 		}).catch((error) =>
 			logger.error(error, "Failed to send operation approval notification"),
 		);

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -12,6 +12,7 @@ import type { CardElement } from 'chat';
 import { getDb, pgTextArray } from '../../db/client';
 import { emit } from '../../events/emitter';
 import { currentMcpActivityAttribution } from '../../lobu/stores/mcp-client-conversations';
+import { resolveActionOrigin } from '../../notifications/action-origin';
 import { queueAgentAsk } from '../../notifications/ask';
 import {
   createNotificationForUsers,
@@ -293,6 +294,9 @@ async function handleSend(
       : null;
 
   const orgSlug = await getOrgSlug(ctx.organizationId);
+  const actionOrigin = args.input_schema
+    ? await resolveActionOrigin(ctx)
+    : null;
 
   // Feedback is learned from server-stamped execution provenance only.
   // `automation_source` remains a validated canvas-attribution hint above, but
@@ -393,6 +397,7 @@ async function handleSend(
         : null),
     entityIds: canvasEntityIds,
     mcpActivity: currentMcpActivityAttribution(ctx),
+    actionOrigin,
     automationId: actingAutomationId,
     automationVersionId: actingVersionId,
     runId: actingRunId,


### PR DESCRIPTION
## Summary

- settle one-shot approval, tool-grant, and question cards in place after a terminal decision
- show the verified Automation or conversation that triggered the action, plus reviewer and UTC decision time
- persist platform message addresses and the delivered card so Slack, web, and MCP decisions converge across replicas
- keep navigation links and repeatable suggestion controls active while removing stale mutating buttons

## Verification

- `make pre-pr`
- 32 focused Bun tests, including signed Slack Approve/Reject, tool approval, question, and cross-pod card edit paths
- 10 database-backed Vitest cases, including direct `manage_operations reject` settling the original Slack card
- server TypeScript typecheck

## Notes

The implementation is centralized around one generic terminal-card transformer, one provenance resolver, and the shared approval transition hook. Expiry and connection-deletion terminalizers feed that same refresh path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval and question cards now show their originating conversation, automation, or direct request.
  * Interactive cards update in place to show approved, rejected, answered, or expired states.
  * Settled cards retain relevant review links while removing action controls.
  * Approval notifications refresh across delivered chat messages after decisions, expirations, or related changes.

* **Bug Fixes**
  * Improved consistency of reviewer details, timestamps, resolution text, and fallback receipts across chat integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->