### PR TITLE
fix(feeds): defer offline device syncs

### DIFF
--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Scheduled feed materialization must respect the liveness of a connection's
+ * pinned device. An offline device cannot claim the run, so queueing one only
+ * creates a worker_claim_timeout failure episode. The feed stays overdue while
+ * the device is offline and is materialized as soon as that device polls again.
+ *
+ * Only EXECUTION pins defer. A chrome-extension pin on a non-chrome connector
+ * is browser affinity — worker-api/poll.ts keeps that parent sync on the fleet
+ * and refuses it on the extension's own claim lane — so those feeds keep
+ * syncing while the browser is closed.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
+import { getSchedulerHealth } from '../../scheduled/scheduler-health';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../../utils/device-liveness';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  seedOwnerContext,
+} from '../setup/test-fixtures';
+
+describe('scheduled feed device liveness', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('defers only an offline execution pin, and only until that device polls again', async () => {
+    const sql = getTestDb();
+    const { org, user } = await seedOwnerContext({
+      orgName: 'Device Feed Scheduler Org',
+    });
+
+    async function createDevice(
+      label: string,
+      staleSeconds: number,
+      platform: 'macos' | 'chrome-extension' | null = 'macos'
+    ): Promise<string> {
+      const [device] = (await sql`
+        INSERT INTO device_workers (
+          user_id, worker_id, platform, capabilities, label,
+          organization_id, last_seen_at
+        ) VALUES (
+          ${user.id}, ${`worker-${label}`}, ${platform}, ${sql.json([])},
+          ${label}, ${org.id},
+          current_timestamp - make_interval(secs => ${staleSeconds})
+        )
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      return device.id;
+    }
+
+    async function createDueFeed(connectorKey: string, deviceId?: string): Promise<number> {
+      await createTestConnectorDefinition({
+        key: connectorKey,
+        name: connectorKey,
+        feeds_schema: { items: { description: 'Items' } },
+        organization_id: org.id,
+      });
+      const connection = await createTestConnection({
+        organization_id: org.id,
+        connector_key: connectorKey,
+        created_by: user.id,
+        createDefaultFeed: false,
+      });
+      if (deviceId) {
+        await sql`
+          UPDATE connections
+          SET device_worker_id = ${deviceId}::uuid
+          WHERE id = ${connection.id}
+        `;
+      }
+      const [feed] = (await sql`
+        INSERT INTO feeds (
+          organization_id, connection_id, feed_key, status, kind, virtual,
+          schedule, next_run_at, created_at, updated_at
+        ) VALUES (
+          ${org.id}, ${connection.id}, 'items', 'active', 'collected', false,
+          '* * * * *', current_timestamp - INTERVAL '5 minutes',
+          current_timestamp, current_timestamp
+        )
+        RETURNING id
+      `) as unknown as Array<{ id: number }>;
+      return Number(feed.id);
+    }
+
+    const staleDeviceId = await createDevice('Stale Mac', DEVICE_ONLINE_WINDOW_SECONDS + 60);
+    const onlineDeviceId = await createDevice('Online Mac', 5);
+    const staleBrowserId = await createDevice(
+      'Closed Chrome',
+      DEVICE_ONLINE_WINDOW_SECONDS + 60,
+      'chrome-extension'
+    );
+    const staleLegacyDeviceId = await createDevice(
+      'Legacy Device',
+      DEVICE_ONLINE_WINDOW_SECONDS + 60,
+      null
+    );
+    const staleFeedId = await createDueFeed('test.scheduler-stale-device', staleDeviceId);
+    const onlineFeedId = await createDueFeed('test.scheduler-online-device', onlineDeviceId);
+    const affinityFeedId = await createDueFeed('test.scheduler-affinity', staleBrowserId);
+    await createDueFeed('test.scheduler-legacy-device', staleLegacyDeviceId);
+    const unpinnedFeedId = await createDueFeed('test.scheduler-unpinned');
+    const [staleBefore] = await sql`
+      SELECT next_run_at FROM feeds WHERE id = ${staleFeedId}
+    `;
+
+    const firstPass = await materializeDueFeeds({} as Env, sql);
+    expect(firstPass).toEqual({ dueFeeds: 3, runsCreated: 3, skipped: 0 });
+
+    const firstRuns = (await sql`
+      SELECT feed_id FROM runs
+      WHERE run_type = 'sync'
+      ORDER BY feed_id
+    `) as unknown as Array<{ feed_id: number }>;
+    expect(firstRuns.map((run) => Number(run.feed_id))).toEqual(
+      [onlineFeedId, affinityFeedId, unpinnedFeedId].sort((a, b) => a - b)
+    );
+
+    const [staleDeferred] = await sql`
+      SELECT next_run_at, last_sync_status
+      FROM feeds
+      WHERE id = ${staleFeedId}
+    `;
+    expect(new Date(String(staleDeferred.next_run_at)).getTime()).toBe(
+      new Date(String(staleBefore.next_run_at)).getTime()
+    );
+    expect(staleDeferred.last_sync_status).toBeNull();
+
+    // A deferred feed sits past next_run_at for as long as its device is away,
+    // so /health/scheduler must not read that as a stalled scheduler. Keep an
+    // online-pinned feed equally overdue to prove the filter does not hide
+    // genuine scheduler lag along with intentional device deferrals.
+    await sql`
+      UPDATE feeds
+      SET next_run_at = current_timestamp - INTERVAL '2 hours'
+      WHERE id IN (${staleFeedId}, ${onlineFeedId})
+    `;
+    const health = await getSchedulerHealth({} as Env);
+    expect(health.metrics.overdueFeeds).toBe(1);
+    expect(health.metrics.overdueByHours).toBeGreaterThan(1);
+    expect(health.issues.filter((issue) => issue.includes('overdue'))).toHaveLength(1);
+
+    // Restore the online feed's materialized schedule before checking that the
+    // newly-live stale device alone becomes eligible on the next pass.
+    await sql`
+      UPDATE feeds
+      SET next_run_at = current_timestamp + INTERVAL '1 hour'
+      WHERE id = ${onlineFeedId}
+    `;
+
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = current_timestamp
+      WHERE id = ${staleDeviceId}::uuid
+    `;
+    const refreshedPass = await materializeDueFeeds({} as Env, sql);
+    expect(refreshedPass).toEqual({ dueFeeds: 1, runsCreated: 1, skipped: 0 });
+
+    const finalRuns = (await sql`
+      SELECT feed_id, COUNT(*)::int AS count
+      FROM runs
+      WHERE run_type = 'sync'
+      GROUP BY feed_id
+      ORDER BY feed_id
+    `) as unknown as Array<{ feed_id: number; count: number }>;
+    expect(
+      Object.fromEntries(finalRuns.map((run) => [Number(run.feed_id), Number(run.count)]))
+    ).toEqual({
+      [staleFeedId]: 1,
+      [onlineFeedId]: 1,
+      [affinityFeedId]: 1,
+      [unpinnedFeedId]: 1,
+    });
+  });
+});

--- a/packages/server/src/scheduled/check-due-feeds.ts
+++ b/packages/server/src/scheduled/check-due-feeds.ts
@@ -10,6 +10,7 @@
 import type { DbClient } from '../db/client';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import { createSyncRun } from '../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
@@ -50,6 +51,36 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
         -- next_run_at NULL, so it could never match anyway (belt and suspenders).
         AND f.kind = 'collected'
         AND f.virtual IS NOT TRUE
+        -- A connection pinned for EXECUTION can only run while that device is
+        -- polling. In worker-api/poll.ts the fleet lane (1A) takes a pinned
+        -- connection only for a page-activated run, and createSyncRun leaves
+        -- activation_kind NULL, so a scheduled sync is never one; the device
+        -- lanes take it only when the pin matches the polling device. A run
+        -- queued now would therefore just age into a worker_claim_timeout.
+        -- Leave the feed past next_run_at instead, so the first tick after that
+        -- device polls picks it up.
+        --
+        -- A chrome-extension pin on a non-chrome connector is NOT an execution
+        -- pin — it means "scrape with this browser", and poll.ts keeps the
+        -- parent sync on the fleet (lane 1A claims it; the extension's own lane
+        -- explicitly refuses it). Those feeds must keep syncing while the
+        -- browser is closed, so they are never deferred here.
+        AND (
+          c.device_worker_id IS NULL
+          OR EXISTS (
+            SELECT 1
+            FROM device_workers dw
+            WHERE dw.id = c.device_worker_id
+              AND (
+                dw.last_seen_at > current_timestamp
+                  - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+                OR (
+                  dw.platform = 'chrome-extension'
+                  AND c.connector_key NOT LIKE 'chrome%'
+                )
+              )
+          )
+        )
         AND f.next_run_at <= current_timestamp
         AND NOT EXISTS (
           SELECT 1 FROM runs r

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -8,6 +8,7 @@
 import { intervals } from '../config/intervals';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import { EXECUTING_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 
@@ -56,18 +57,57 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
   const issues: string[] = [];
 
   try {
-    // Get feed counts
+    // Get feed counts.
+    //
+    // A feed whose connection is pinned to an offline device for EXECUTION is
+    // held back on purpose (check-due-feeds.ts): only that device can claim the
+    // run, so the feed stays past next_run_at until the device polls again.
+    // Counting those as overdue would put this endpoint in a permanent 503 for
+    // the ordinary case of a closed laptop — the same "train operators to
+    // ignore it" failure the approval-TTL grace below avoids.
+    //
+    // This drops no signal: a pinned device that has gone silent is already an
+    // operator-facing alert on its own hours-scale threshold (`device_stale` in
+    // connectors/connector-health.ts). "Is the scheduler firing" and "is that
+    // laptop on" are different questions, answered on different surfaces.
+    //
+    // The device predicate must stay the exact complement of the scheduler's,
+    // browser-affinity carve-out included: a chrome-extension pin on a
+    // non-chrome connector still runs on the fleet, so such a feed is genuinely
+    // overdue.
     const feedStats = await sql`
+      WITH scheduling AS (
+        SELECT
+          f.status,
+          f.next_run_at,
+          EXISTS (
+            SELECT 1
+            FROM connections c
+            JOIN device_workers dw ON dw.id = c.device_worker_id
+            WHERE c.id = f.connection_id
+              AND dw.last_seen_at <= current_timestamp
+                - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+              AND NOT COALESCE(
+                dw.platform = 'chrome-extension'
+                  AND c.connector_key NOT LIKE 'chrome%',
+                false
+              )
+          ) AS device_deferred
+        FROM feeds f
+        WHERE f.deleted_at IS NULL
+      )
       SELECT
         CAST(SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS INTEGER) as active_feeds,
-        CAST(SUM(CASE WHEN status = 'active' AND next_run_at < current_timestamp THEN 1 ELSE 0 END) AS INTEGER) as overdue_feeds,
+        CAST(SUM(CASE
+          WHEN status = 'active' AND next_run_at < current_timestamp AND NOT device_deferred
+            THEN 1 ELSE 0
+        END) AS INTEGER) as overdue_feeds,
         MAX(CASE
-          WHEN status = 'active' AND next_run_at < current_timestamp
+          WHEN status = 'active' AND next_run_at < current_timestamp AND NOT device_deferred
             THEN EXTRACT(EPOCH FROM (current_timestamp - next_run_at)) / 3600.0
           ELSE NULL
         END) as max_overdue_hours
-      FROM feeds
-      WHERE deleted_at IS NULL
+      FROM scheduling
     `;
 
     const activeFeeds = Number(feedStats[0]?.active_feeds || 0);


### PR DESCRIPTION
## Summary

- Defer scheduled collected-feed syncs while their execution-pinned device is outside the canonical 120-second online window, leaving the feed overdue for immediate pickup after the next poll.
- Preserve fleet scheduling for Chrome-extension browser-affinity pins on non-Chrome connectors, matching the existing worker claim lanes.
- Exclude intentionally device-deferred feeds from the existing scheduler-overdue alarm without adding a new API field, including legacy devices whose platform is null.

## Test plan

- [x] `make pre-pr`
- [x] Focused scheduler, scheduling-contract, and health suites (3 files, 14 tests)
- [x] Red-to-green regression proof
- [x] `git diff --check`

Red on the original scheduler:

```text
expected { dueFeeds: 3, runsCreated: 3, skipped: 0 }
to deeply equal { dueFeeds: 2, runsCreated: 2, skipped: 0 }
```

Green after the fix:

```text
Test Files  3 passed (3)
Tests       14 passed (14)
```

## Notes

Manual sync creation is unchanged and remains covered by the existing scheduling contract test. The health regression also covers legacy device rows with a null platform so SQL null semantics cannot make a deliberately deferred feed look overdue.

Closes #2954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled feed handling for connections tied to offline devices.
  * Deferred feeds now wait for the device to come back online instead of advancing prematurely.
  * Scheduler health metrics no longer flag intentional device-related deferrals as overdue.
  * Feeds materialize correctly after the associated device resumes polling.
* **Tests**
  * Added coverage for online, offline, legacy, and browser-affinity feed scheduling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->