### PR TITLE
fix(server): show approval decision provenance

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -1062,6 +1062,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const creationSessionId = await initSession(`/mcp/${org.slug}`, {
       agentId: actingAgent.agentId,
     });
+    const hostConversationId = 'chatgpt-approval-conversation';
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -1074,6 +1075,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
             agent_id: 'mcp-app-approval-agent',
             name: 'MCP App Approval Agent',
           },
+          _meta: { 'openai/session': hostConversationId },
         },
       },
       headers: { 'mcp-session-id': creationSessionId },
@@ -1100,6 +1102,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     `;
     const runId = Number(approval?.run_id);
     expect(runId).toBeGreaterThan(0);
+    await getDb()`
+      UPDATE mcp_client_conversations
+      SET title = 'Release approval E2E'
+      WHERE organization_id = ${org.id}
+        AND client_id = ${client.client_id}
+        AND conversation_id = ${hostConversationId}
+    `;
 
     // Possessing a valid app capability does not replace the canonical human
     // authority check. A plain member can read the shared approval card but
@@ -1161,7 +1170,6 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       sessionToken: writeToken,
       agentId: actingAgent.agentId,
     });
-    const hostConversationId = 'chatgpt-approval-conversation';
     const renderResponse = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -1289,6 +1297,18 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect.objectContaining({
         title: expect.stringMatching(/rejected/i),
         actions: [],
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'text',
+            label: 'Conversation',
+            value: expect.stringContaining('Release approval E2E'),
+          }),
+          expect.objectContaining({
+            type: 'text',
+            label: 'Decision',
+            value: expect.stringMatching(/^Rejected by .+ · \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/),
+          }),
+        ]),
       })
     );
 
@@ -1366,14 +1386,25 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
   });
 
   it('renders a completed approval once and preserves its submitted form values', async () => {
+    const [automation] = await getDb()<{ id: number }>`
+      INSERT INTO automations (
+        organization_id, agent_id, created_by, automation_group_id, name
+      ) VALUES (
+        ${org.id}, ${actingAgent.agentId}, ${owner.id}, 0, 'Hourly approval sweep'
+      )
+      RETURNING id
+    `;
     const [run] = await getDb()<{ id: number }>`
-      INSERT INTO runs (organization_id, run_type, status, approval_status, action_output)
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, action_output, automation_id
+      )
       VALUES (
         ${org.id},
         'internal',
         'completed',
         'approved',
-        ${getDb().json({ answer: { reviewer_note: 'Looks good', release_window: 'Tomorrow' } })}
+        ${getDb().json({ answer: { reviewer_note: 'Looks good', release_window: 'Tomorrow' } })},
+        ${automation.id}
       )
       RETURNING id
     `;
@@ -1402,6 +1433,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       interactionOutput: {
         answer: { reviewer_note: 'Looks good', release_window: 'Tomorrow' },
       },
+      metadata: { reviewed_by_name: 'Legacy Reviewer' },
     });
 
     const sessionId = await initSession(`/mcp/${org.slug}`);
@@ -1426,8 +1458,20 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         actions: [],
         blocks: expect.arrayContaining([
           expect.objectContaining({
+            type: 'text',
+            label: 'Automation',
+            value: 'Hourly approval sweep',
+          }),
+          expect.objectContaining({
             type: 'form',
             initialValues: { reviewer_note: 'Looks good', release_window: 'Tomorrow' },
+          }),
+          expect.objectContaining({
+            type: 'text',
+            label: 'Decision',
+            value: expect.stringMatching(
+              /^Completed by Legacy Reviewer · \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/
+            ),
           }),
         ]),
       })
@@ -1513,6 +1557,11 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(serialized).not.toContain('plaintext-schema-api-key');
     expect(serialized).not.toContain('plaintext-form-api-key');
     expect(serialized).toContain('[redacted]');
+    expect(view.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Source', value: 'Direct request' }),
+      ])
+    );
     expect(view.title.length).toBeLessThanOrEqual(200);
     expect(view.blocks.length).toBeLessThanOrEqual(100);
     expect(view.actions.length).toBeLessThanOrEqual(10);

--- a/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/approval-chat-origin.test.ts
@@ -306,5 +306,14 @@ describe("resolveApprovalChatOrigin", () => {
 			kind: "automation",
 			label: "Hourly incident triage",
 		});
+		expect(
+			await resolveInteractionActionOrigin({
+				organizationId: org.id,
+				automationId: Number(automation.id),
+			}),
+		).toEqual({
+			kind: "automation",
+			label: "Hourly incident triage",
+		});
 	});
 });

--- a/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
@@ -175,6 +175,7 @@ describe("approval-event atomicity (item 16)", () => {
 		expect(eventRows[0].organization_id).toBe(orgId);
 		expect(eventRows[0].metadata).toMatchObject({
 			mcp_session_id: "session-approval-atomicity",
+			initiator: { kind: "user", user_id: userId },
 		});
 
 		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;

--- a/packages/server/src/__tests__/unit/run-initiator.test.ts
+++ b/packages/server/src/__tests__/unit/run-initiator.test.ts
@@ -20,6 +20,7 @@ describe("resolveRunInitiator", () => {
 				user_id: "user_1",
 				client_id: "claude-ai",
 				conversation_id: "conv-1",
+				platform: "mcp",
 			},
 			createdByUserId: "user_1",
 		});

--- a/packages/server/src/notifications/action-card-state.ts
+++ b/packages/server/src/notifications/action-card-state.ts
@@ -31,17 +31,19 @@ function bounded(value: string, max = 240): string {
 		: normalized;
 }
 
+export function actionOriginLabel(kind: ActionOrigin["kind"]): string {
+	return kind === "automation"
+		? "Automation"
+		: kind === "conversation"
+			? "Conversation"
+			: "Source";
+}
+
 export function actionOriginSubtitle(
 	origin: ActionOrigin | null | undefined,
 ): string | undefined {
 	if (!origin?.label.trim()) return undefined;
-	const prefix =
-		origin.kind === "automation"
-			? "Automation"
-			: origin.kind === "conversation"
-				? "Conversation"
-				: "Source";
-	return `${prefix}: ${escapeSlackText(bounded(origin.label))}`;
+	return `${actionOriginLabel(origin.kind)}: ${escapeSlackText(bounded(origin.label))}`;
 }
 
 export function addActionOrigin(
@@ -56,7 +58,7 @@ export function addActionOrigin(
 	};
 }
 
-function formatUtc(value: string | Date | null | undefined): string | null {
+export function formatUtc(value: string | Date | null | undefined): string | null {
 	if (!value) return null;
 	const date = value instanceof Date ? value : new Date(value);
 	if (Number.isNaN(date.getTime())) return null;

--- a/packages/server/src/notifications/action-origin.ts
+++ b/packages/server/src/notifications/action-origin.ts
@@ -1,9 +1,6 @@
 import { getDb } from "../db/client";
 import { parseAutomationRunConversationId } from "../gateway/permissions/automation-run-intent";
-import {
-	currentMcpActivityAttribution,
-	type McpActivityAttribution,
-} from "../lobu/stores/mcp-client-conversations";
+import { currentMcpActivityAttribution } from "../lobu/stores/mcp-client-conversations";
 import type { ToolContext } from "../tools/registry";
 import type { ActionOrigin } from "./action-card-state";
 
@@ -46,7 +43,7 @@ async function automationOrigin(
 
 async function mcpConversationOrigin(
 	organizationId: string,
-	activity: McpActivityAttribution,
+	activity: { clientIdentity: string; activityId: string },
 ): Promise<ActionOrigin> {
 	const rows = await getDb()<{
 		title: string | null;
@@ -77,10 +74,17 @@ async function resolveConversationActionOrigin(params: {
 	platform?: string | null;
 	conversationId?: string | null;
 	agentId?: string | null;
+	clientIdentity?: string | null;
 }): Promise<ActionOrigin> {
 	let title: string | null = null;
 	const sourcePlatform = params.platform?.trim().toLowerCase() || null;
 	const storedPlatform = sourcePlatform === "api" ? "web" : sourcePlatform;
+	if (storedPlatform === "mcp" && params.conversationId && params.clientIdentity) {
+		return mcpConversationOrigin(params.organizationId, {
+			clientIdentity: params.clientIdentity,
+			activityId: params.conversationId,
+		});
+	}
 	if (storedPlatform && params.conversationId) {
 		const rows = await getDb()<{
 			title: string | null;
@@ -110,8 +114,18 @@ export async function resolveInteractionActionOrigin(params: {
 	platform?: string | null;
 	conversationId?: string | null;
 	agentId?: string | null;
+	clientIdentity?: string | null;
+	automationId?: number | null;
 	source?: string | null;
 }): Promise<ActionOrigin> {
+	if (params.organizationId && params.automationId != null) {
+		return automationOrigin(params.organizationId, params.automationId).catch(
+			() => ({
+				kind: "automation",
+				label: `Automation #${params.automationId}`,
+			}),
+		);
+	}
 	if (params.organizationId && params.source === "automation-run") {
 		const run = parseAutomationRunConversationId(params.conversationId ?? "");
 		if (run) {
@@ -131,6 +145,7 @@ export async function resolveInteractionActionOrigin(params: {
 		platform: params.platform,
 		conversationId: params.conversationId,
 		agentId: params.agentId,
+		clientIdentity: params.clientIdentity,
 	}).catch(() => ({ kind: "conversation", label: fallback }));
 }
 

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -34,6 +34,7 @@ import logger from "../../../../utils/logger";
 import { buildResourcePermalink } from "../../../../utils/url-builder";
 import { trackAutomationReaction } from "../../../../utils/automation-reactions";
 import { dispatchChromeActionToExtension } from "../../../../worker-api/dispatch-chrome-action";
+import { resolveRunInitiator } from "../../../initiator";
 import type { ToolContext } from "../../../registry";
 import { getOrgUrlContext } from "../../../view-urls";
 import { waitForDeviceActionRun } from "../../device-action-wait";
@@ -687,6 +688,7 @@ export async function handleExecute(
 				return { claim: createdRun, eventId: null };
 			}
 			const createdRunId = createdRun.runId;
+			const initiator = resolveRunInitiator(ctx);
 			const event = await insertEvent(
 				{
 				entityIds,
@@ -716,6 +718,10 @@ export async function handleExecute(
 					connection_name:
 						connection.display_name ?? connection.connector_key,
 					run_id: createdRunId,
+					initiator: {
+						kind: initiator.initiatorKind,
+						...initiator.initiatorRef,
+					},
 					...currentMcpActivityEventMetadata(ctx),
 				},
 				authorName: ctx.clientId ?? "agent",

--- a/packages/server/src/tools/initiator.ts
+++ b/packages/server/src/tools/initiator.ts
@@ -45,6 +45,7 @@ export function resolveRunInitiator(ctx: InitiatorSource): RunInitiatorColumns {
 				user_id: ctx.userId ?? null,
 				client_id: ctx.clientId ?? null,
 				conversation_id: ctx.sourceContext?.conversationId ?? null,
+				platform: ctx.sourceContext?.platform ?? null,
 			},
 			createdByUserId: ctx.userId ?? null,
 		};

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -6,7 +6,14 @@ import {
   REDACTED_SENTINEL,
 } from '@lobu/core';
 import { type Static, Type } from '@sinclair/typebox';
+import { getDb } from '../db/client';
 import type { Env } from '../index';
+import {
+  type ActionOrigin,
+  actionOriginLabel,
+  formatUtc,
+} from '../notifications/action-card-state';
+import { resolveInteractionActionOrigin } from '../notifications/action-origin';
 import { ToolUserError } from '../utils/errors';
 import { buildResourcePermalink } from '../utils/url-builder';
 import { getContent } from './get_content';
@@ -332,6 +339,10 @@ function approvalBlocks(row: {
 type ApprovalContentItem = {
   id: number;
   run_id: number;
+  created_at: string;
+  client_id: string | null;
+  agent_id: string | null;
+  automation_id: number | null;
   title: string | null;
   payload_text: string;
   interaction_type: 'approval';
@@ -341,6 +352,98 @@ type ApprovalContentItem = {
   interaction_output: Record<string, unknown> | null;
   metadata: Record<string, unknown> | null;
 };
+
+function stringOrNull(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function approvalDecisionBlock(
+  row: ApprovalContentItem,
+  status: string
+): LobuViewBlock | null {
+  if (status === 'pending') return null;
+  const reviewer =
+    typeof row.metadata?.reviewed_by_name === 'string'
+      ? row.metadata.reviewed_by_name.trim()
+      : '';
+  // A decision appends a NEW event version (supersedeActionEvent), so this
+  // row's created_at is the decision time for cards written before
+  // `reviewed_at` was stamped.
+  const timestamp =
+    formatUtc(
+      typeof row.metadata?.reviewed_at === 'string' ? row.metadata.reviewed_at : row.created_at
+    ) ?? '';
+  const decisionStatus =
+    row.metadata?.reviewed_at && (status === 'completed' || status === 'failed')
+      ? 'approved'
+      : status;
+  const decision = `${decisionStatus.charAt(0).toUpperCase()}${decisionStatus.slice(1)}`;
+  return {
+    type: 'text',
+    label: 'Decision',
+    value: `${decision}${reviewer ? ` by ${reviewer}` : ''}${timestamp ? ` · ${timestamp}` : ''}`,
+    muted: true,
+  };
+}
+
+async function approvalOrigin(row: ApprovalContentItem, ctx: ToolContext): Promise<ActionOrigin> {
+  const runs = await getDb()<{
+    automation_id: number | null;
+    initiator_ref: Record<string, unknown> | null;
+    original_client_id: string | null;
+  }>`
+    SELECT r.automation_id, r.initiator_ref, original.client_id AS original_client_id
+    FROM runs r
+    LEFT JOIN LATERAL (
+      SELECT e.client_id
+      FROM events e
+      WHERE e.run_id = r.id
+        AND e.organization_id = r.organization_id
+        AND e.interaction_type = 'approval'
+      ORDER BY e.id ASC
+      LIMIT 1
+    ) original ON true
+    WHERE r.id = ${row.run_id} AND r.organization_id = ${ctx.organizationId}
+    LIMIT 1
+  `;
+  const metadata = row.metadata ?? {};
+  const initiator = isRecord(metadata.initiator)
+    ? metadata.initiator
+    : (runs[0]?.initiator_ref ?? {});
+  const automationId =
+    Number(runs[0]?.automation_id ?? row.automation_id ?? initiator.automation_id ?? 0) || null;
+  // The MCP activity row is keyed by the host conversation id when the host
+  // exposes one and by the transport session id when it does not — the same
+  // choice `currentMcpActivityAttribution` made when the row was written.
+  const mcpActivityId =
+    stringOrNull(metadata.mcp_conversation_id) ?? stringOrNull(metadata.mcp_session_id);
+  const conversationId = mcpActivityId ?? stringOrNull(initiator.conversation_id);
+  if (!automationId && !conversationId) return { kind: 'direct', label: 'Direct request' };
+  return resolveInteractionActionOrigin({
+    organizationId: ctx.organizationId,
+    automationId,
+    conversationId,
+    // get_content's `platform` column carries the event's connector_key, never a
+    // chat platform, so it is deliberately not a fallback here.
+    platform: mcpActivityId ? 'mcp' : stringOrNull(initiator.platform),
+    clientIdentity:
+      ctx.memberRole != null
+        ? (stringOrNull(initiator.client_id) ?? row.client_id ?? runs[0]?.original_client_id ?? null)
+        : null,
+    agentId: row.agent_id ?? stringOrNull(initiator.agent_id),
+  });
+}
+
+function approvalOriginBlock(origin: ActionOrigin): LobuViewBlock {
+  return {
+    type: 'text',
+    label: actionOriginLabel(origin.kind),
+    value: displayValue(origin.label, TEXT_VALUE_MAX_LENGTH),
+    muted: true,
+  };
+}
 
 function isApprovalContentItem(value: unknown, runId: number): value is ApprovalContentItem {
   if (!isRecord(value)) return false;
@@ -463,8 +566,13 @@ async function findApprovalRow(
 
 async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Promise<LobuView> {
   const row = await findApprovalRow(runId, env, ctx);
+  const origin = await approvalOrigin(row, ctx).catch(() => ({
+    kind: 'direct' as const,
+    label: 'Direct request',
+  }));
 
   const status = row.interaction_status ?? 'pending';
+  const decisionBlock = approvalDecisionBlock(row, status);
   const baseTitle = displayValue(row.title ?? `Approval run ${runId}`, TITLE_MAX_LENGTH).replace(
     /\s+—\s+(?:pending approval|approved|rejected|completed|failed|cancelled)$/i,
     ''
@@ -519,13 +627,17 @@ async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Pro
       TITLE_MAX_LENGTH
     ),
     tone: status === 'pending' ? 'warning' : 'default',
-    blocks: approvalBlocks({
-      content: row.payload_text,
-      interaction_input_schema: row.interaction_input_schema,
-      interaction_input: row.interaction_input,
-      interaction_output: row.interaction_output,
-      metadata: row.metadata,
-    }),
+    blocks: [
+      ...approvalBlocks({
+        content: row.payload_text,
+        interaction_input_schema: row.interaction_input_schema,
+        interaction_input: row.interaction_input,
+        interaction_output: row.interaction_output,
+        metadata: row.metadata,
+      }),
+      approvalOriginBlock(origin),
+      ...(decisionBlock ? [decisionBlock] : []),
+    ],
     actions,
   };
   if (canIssueApprovalCapability(row, status, ctx)) {


### PR DESCRIPTION
## Summary
- show the triggering Automation or conversation on native approval cards
- show terminal decision actor and UTC time while removing mutating actions
- persist connector-operation initiator provenance at the existing approval event boundary
- reuse the same source labels and UTC formatting as chat action receipts

## Verification
- `make pre-pr`
- server typecheck
- 17/17 focused unit tests
- 36/36 focused database-backed integration tests, including full MCP App resources coverage
- `make build-packages`

## Notes
- no schema, migration, or public API change
- older terminal MCP approvals recover their original client identity from the approval event chain when available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval details now show where an approval originated, such as a conversation, automation, or external source.
  - Resolved approvals include a clear decision summary and reviewer information.
  - Conversation-based approvals retain their conversation context throughout the approval process.

- **Bug Fixes**
  - Approval processing now prevents incomplete records when an approval event fails, improving consistency and reliability.
  - Automation and agent-session approval origins are identified more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->