### PR TITLE
fix(feeds): exclude paused feeds from health filters

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3028,11 +3028,11 @@ export type ManageFeedsData = {
          */
         entity_id?: number;
         /**
-         * Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses — a feed that keeps failing stays 'active' (or auto-pauses). Use `health` to find failing feeds.
+         * Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses — a feed that keeps failing stays 'active' (or auto-pauses). Use `health` to find failing feeds that are still active on non-paused connections.
          */
         status?: "active" | "paused";
         /**
-         * Filter by runtime health, independent of lifecycle status. 'failing' = last sync failed or the feed has one or more consecutive failures; 'healthy' = otherwise. Surfaces active-but-failing feeds the `status` filter cannot.
+         * Filter by runtime health for active feeds on non-paused connections; paused feeds and feeds on paused connections are excluded. 'failing' = last sync failed or the feed has one or more consecutive failures; 'healthy' = otherwise. Surfaces active-but-failing feeds the `status` filter cannot.
          */
         health?: "healthy" | "failing";
         /**
@@ -3134,7 +3134,7 @@ export type ManageFeedsData = {
          */
         feed_id: number;
         /**
-         * Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list_feeds` action's `health: failing` filter to find failing feeds.
+         * Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list_feeds` action's `health: failing` filter to find failing active feeds.
          */
         status?: "active" | "paused";
         display_name?: string;

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -31,13 +31,13 @@ export const ListFeedsAction = Type.Object({
   status: Type.Optional(
     Type.Union([Type.Literal("active"), Type.Literal("paused")], {
       description:
-        "Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses — a feed that keeps failing stays 'active' (or auto-pauses). Use `health` to find failing feeds.",
+        "Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses — a feed that keeps failing stays 'active' (or auto-pauses). Use `health` to find failing feeds that are still active on non-paused connections.",
     })
   ),
   health: Type.Optional(
     Type.Union([Type.Literal("healthy"), Type.Literal("failing")], {
       description:
-        "Filter by runtime health, independent of lifecycle status. 'failing' = last sync failed or the feed has one or more consecutive failures; 'healthy' = otherwise. Surfaces active-but-failing feeds the `status` filter cannot.",
+        "Filter by runtime health for active feeds on non-paused connections; paused feeds and feeds on paused connections are excluded. 'failing' = last sync failed or the feed has one or more consecutive failures; 'healthy' = otherwise. Surfaces active-but-failing feeds the `status` filter cannot.",
     })
   ),
   ...PaginationFields,
@@ -150,7 +150,7 @@ export const UpdateFeedAction = Type.Object({
   status: Type.Optional(
     Type.Union([Type.Literal("active"), Type.Literal("paused")], {
       description:
-        "Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list_feeds` action's `health: failing` filter to find failing feeds.",
+        "Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list_feeds` action's `health: failing` filter to find failing active feeds.",
     })
   ),
   display_name: Type.Optional(Type.String()),

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -7,10 +7,11 @@
  *    total:3 even when more matched — and `total === limit` was
  *    indistinguishable from an exact count. It is now COUNT(*) OVER() across
  *    the whole filtered set, plus a `has_more` flag.
- *  - A feed keeps `status = 'active'` while its syncs fail (until it crosses
- *    the auto-pause threshold), so the `status` filter can never surface a
- *    failing-but-active feed. The new `health` filter matches on
- *    last_sync_status/consecutive_failures.
+ *  - A feed keeps `status = 'active'` while its syncs fail (until auto-pause
+ *    takes over), so the `status` filter can never surface a failing-but-active
+ *    feed. The `health` filter matches active feeds on
+ *    last_sync_status/consecutive_failures; paused feeds and feeds on paused
+ *    connections are lifecycle history, not current health.
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -25,6 +26,7 @@ describe("list_feeds health filter and true total", () => {
 	let orgId: string;
 	let ctx: ToolContext;
 	let connectionId: number;
+	let pausedConnectionId: number;
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -41,10 +43,20 @@ describe("list_feeds health filter and true total", () => {
 			createDefaultFeed: false,
 		});
 		connectionId = conn.id;
+		const pausedConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "hackernews",
+			status: "paused",
+			createDefaultFeed: false,
+		});
+		pausedConnectionId = pausedConn.id;
 
 		const sql = getTestDb();
-		// 5 feeds: 3 healthy active, 1 active-but-failing (last sync failed),
-		// 1 active with consecutive failures but last sync not yet marked failed.
+		// On the active connection: 3 healthy active, 2 failing active, and 3
+		// paused. The paused set covers a feed paused one failure in, one at the
+		// default `feedBackoff.pauseThreshold` (20) where auto-pause fires, and one
+		// paused while healthy — so both health branches have a paused row they
+		// would otherwise have matched.
 		const feeds: Array<{
 			key: string;
 			status: string;
@@ -56,6 +68,9 @@ describe("list_feeds health filter and true total", () => {
 			{ key: "h3", status: "active", last: null, fails: 0 },
 			{ key: "bad1", status: "active", last: "failed", fails: 14 },
 			{ key: "bad2", status: "active", last: "success", fails: 3 },
+			{ key: "paused-manual-failed", status: "paused", last: "failed", fails: 1 },
+			{ key: "paused-auto-failed", status: "paused", last: "failed", fails: 20 },
+			{ key: "paused-healthy", status: "paused", last: "success", fails: 0 },
 		];
 		for (const f of feeds) {
 			await sql`
@@ -68,15 +83,31 @@ describe("list_feeds health filter and true total", () => {
 				)
 			`;
 		}
+		// The paused parent carries active feeds that would match each health
+		// predicate on sync history alone, but derive attention='paused'.
+		for (const f of [
+			{ key: "paused-connection-failing", last: "failed", fails: 1 },
+			{ key: "paused-connection-healthy", last: "success", fails: 0 },
+		]) {
+			await sql`
+				INSERT INTO feeds (
+					organization_id, connection_id, feed_key, status,
+					last_sync_status, consecutive_failures, entity_ids, created_at, updated_at
+				) VALUES (
+					${orgId}, ${pausedConnectionId}, ${f.key}, 'active',
+					${f.last}, ${f.fails}, ARRAY[]::bigint[], NOW(), NOW()
+				)
+			`;
+		}
 	});
 
-	async function list(args: Record<string, unknown>): Promise<{
+	async function runList(args: Record<string, unknown>): Promise<{
 		feeds: Array<Record<string, unknown>>;
 		total: number;
 		has_more: boolean;
 	}> {
 		return (await manageFeeds(
-			{ action: "list_feeds", connection_id: connectionId, ...args },
+			{ action: "list_feeds", ...args },
 			{} as Env,
 			ctx,
 		)) as {
@@ -86,15 +117,19 @@ describe("list_feeds health filter and true total", () => {
 		};
 	}
 
+	async function list(args: Record<string, unknown>) {
+		return runList({ connection_id: connectionId, ...args });
+	}
+
 	it("reports the true total across pages, not the page length, with has_more", async () => {
 		const page1 = await list({ limit: 2, offset: 0 });
 		expect(page1.feeds).toHaveLength(2);
-		expect(page1.total).toBe(5);
+		expect(page1.total).toBe(8);
 		expect(page1.has_more).toBe(true);
 
-		const lastPage = await list({ limit: 2, offset: 4 });
-		expect(lastPage.feeds).toHaveLength(1);
-		expect(lastPage.total).toBe(5);
+		const lastPage = await list({ limit: 2, offset: 6 });
+		expect(lastPage.feeds).toHaveLength(2);
+		expect(lastPage.total).toBe(8);
 		expect(lastPage.has_more).toBe(false);
 	});
 
@@ -105,19 +140,20 @@ describe("list_feeds health filter and true total", () => {
 		}
 	});
 
-	it("health=failing surfaces active-but-failing feeds status cannot", async () => {
-		// status filter sees them all as active
+	it("health=failing includes only active failing feeds", async () => {
+		// The status filter cannot separate them: bad1/bad2 read as 'active'
+		// alongside h1-h3.
 		const active = await list({ status: "active" });
 		expect(active.total).toBe(5);
 
-		const failing = await list({ health: "failing" });
+		const failing = await runList({ health: "failing" });
 		const keys = failing.feeds.map((f) => f.feed_key).sort();
 		expect(keys).toEqual(["bad1", "bad2"]);
 		expect(failing.total).toBe(2);
 	});
 
-	it("health=healthy excludes failing feeds", async () => {
-		const healthy = await list({ health: "healthy" });
+	it("health=healthy includes only active healthy feeds", async () => {
+		const healthy = await runList({ health: "healthy" });
 		const keys = healthy.feeds.map((f) => f.feed_key).sort();
 		expect(keys).toEqual(["h1", "h2", "h3"]);
 		expect(healthy.total).toBe(3);
@@ -131,12 +167,12 @@ describe("list_feeds health filter and true total", () => {
 	});
 
 	it("reports the true total (not 0) for an offset past the last page", async () => {
-		// 5 feeds match; an offset beyond them yields an empty page. total must
+		// 8 feeds match; an offset beyond them yields an empty page. total must
 		// still be the whole-filter count via the overshoot fallback, not 0 read
 		// off the empty page's window function.
 		const overshoot = await list({ limit: 2, offset: 10 });
 		expect(overshoot.feeds).toHaveLength(0);
-		expect(overshoot.total).toBe(5);
+		expect(overshoot.total).toBe(8);
 		expect(overshoot.has_more).toBe(false);
 	});
 
@@ -172,6 +208,21 @@ describe("list_feeds health filter and true total", () => {
 		// h1/h2 succeeded → healthy.
 		expect(byKey.get("h1")?.attention).toBe("healthy");
 		expect(byKey.get("h2")?.attention).toBe("healthy");
+		// Paused feeds stay lifecycle history regardless of their last outcome.
+		expect(byKey.get("paused-manual-failed")?.attention).toBe("paused");
+		expect(byKey.get("paused-auto-failed")?.attention).toBe("paused");
+		expect(byKey.get("paused-healthy")?.attention).toBe("paused");
+		const pausedParent = await runList({
+			connection_id: pausedConnectionId,
+			limit: 10,
+		});
+		// Assert the count first: an empty page would make the loop below pass
+		// vacuously.
+		expect(pausedParent.feeds).toHaveLength(2);
+		for (const feed of pausedParent.feeds) {
+			expect(feed.status).toBe("active");
+			expect(feed.attention).toBe("paused");
+		}
 		for (const f of res.feeds) {
 			expect(f).not.toHaveProperty("incident_eligible");
 		}

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -858,7 +858,7 @@ export default async (_ctx, client) => {
 	},
 	"feeds.list": {
 		summary:
-			"List data-sync feeds. `status` filters by lifecycle (active|paused); `health` filters by runtime health independent of status ('failing' = last sync failed or consecutive failures, 'healthy' = otherwise) — use it to find active-but-failing feeds the status filter cannot surface. Result carries `total` and `has_more`.",
+			"List data-sync feeds. `status` filters by lifecycle (active|paused); `health` filters active feeds on non-paused connections by runtime health ('failing' = last sync failed or consecutive failures, 'healthy' = otherwise) — use it to find active-but-failing feeds the status filter cannot surface. Paused feeds and feeds on paused connections are excluded. Result carries `total` and `has_more`.",
 		access: "read",
 		signature:
 			"feeds.list(input?: { connection_id?: number; status?: 'active' | 'paused'; health?: 'healthy' | 'failing'; feed_ids?: number[]; entity_id?: number; limit?: number; offset?: number }): Promise<unknown>",

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -179,14 +179,24 @@ async function handleListFeeds(
   if (args.status) {
     where = sql`${where} AND f.status = ${args.status}`;
   }
-  // Runtime health, independent of lifecycle status: a feed keeps `status =
-  // 'active'` while its syncs fail (until it crosses the auto-pause threshold),
-  // so `status` alone can never surface active-but-failing feeds. 'failing' =
-  // the last sync failed OR at least one consecutive failure is recorded.
-  if (args.health === 'failing') {
-    where = sql`${where} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
-  } else if (args.health === 'healthy') {
-    where = sql`${where} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
+  // Runtime health applies only to feeds in the active lifecycle. A feed keeps
+  // `status = 'active'` while its syncs fail — until `shouldHardPauseFeed`
+  // auto-pauses it — so `status` alone cannot surface active-but-failing feeds.
+  // Once the feed or its parent connection is paused, its last outcome is
+  // lifecycle history rather than current health, so the guard scopes BOTH
+  // branches and such a row comes back as neither failing nor healthy. This
+  // mirrors `isPaused` in connectors/feed-health-semantics.ts, so the filter
+  // and the `attention` each row carries cannot disagree — a row the filter
+  // called 'healthy' never renders as attention 'paused'. `health` combined
+  // with `status: 'paused'` is therefore an empty intersection by
+  // construction.
+  if (args.health) {
+    where = sql`${where} AND f.status = 'active' AND c.status <> 'paused'`;
+    if (args.health === 'failing') {
+      where = sql`${where} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
+    } else {
+      where = sql`${where} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
+    }
   }
   if (args.feed_ids?.length) {
     where = sql`${where} AND f.id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;


### PR DESCRIPTION
## Summary

- Treat `health=healthy|failing` as active-feed health, excluding manually/auto-paused feeds and active feeds whose parent connection is paused.
- Keep the TypeBox contract, generated client docs, and agent-facing SDK summary aligned with those semantics without changing request shapes or types.
- Add DB integration coverage for active healthy/failing controls, paused feed histories, and active healthy/failing feeds under a paused connection.

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted integration/E2E and feed-semantics/sandbox unit tests
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Red before the paused-parent query guard:

```text
Test Files  1 failed (1)
Tests       2 failed | 6 passed (8)
health=failing unexpectedly included paused-connection-failing
health=healthy unexpectedly included paused-connection-healthy
Both rows carried attention=paused.
```

Green after the fix, repeated after rebasing onto current main:

```text
bun run test -- run src/__tests__/integration/feeds-list-health-and-count.test.ts src/__tests__/integration/tools/all-tools-e2e.test.ts
Test Files  2 passed (2)
Tests       37 passed (37)

bun test src/__tests__/unit/sandbox/method-metadata.test.ts src/__tests__/unit/sandbox/read-only.test.ts src/__tests__/unit/feed-health-semantics.test.ts
56 pass, 0 fail

make pre-pr
✅ pre-pr gates clean
```

## Notes

- The generated client diff was produced with `bun run generate` against the local OpenAPI endpoint and is comment-only.
- No database, API shape, or SDK type change.

Closes #2955
