### PR TITLE
fix(daemon): stop CLI after terminal heartbeat conflict

### DIFF
--- a/packages/connector-worker/AGENTS.md
+++ b/packages/connector-worker/AGENTS.md
@@ -37,6 +37,9 @@ pipeline also used by `@lobu/cli` and `@lobu/server`.
   it spawns the user's local agent CLI per its `AgentSpec` (from
   `@lobu/core/contracts/worker/device-automation`) with the user's own
   environment minus `WORKER_API_TOKEN` — not the connector-child env allowlist.
+  `automation-process.ts` owns that CLI's OS process tree: it spawns the agent
+  under a process-group anchor so descendants can be terminated through an
+  identity the kernel cannot recycle underneath the daemon.
 - `self-check/` — connector-runtime parity assertions (packaging only; no
   network or DB).
 - `embeddings*.ts` — local/remote embedding generation for emitted content and

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -207,12 +207,12 @@ beforeAll(async () => {
   );
   writeFileSync(
     parentLossIgnoringGrandchildBinary,
-    `#!/usr/bin/env node\nconst fs = require('node:fs');\nif (process.env.FAKE_CLI_GRANDCHILD_PID) fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nif (process.env.FAKE_CLI_PID_LOG) fs.appendFileSync(process.env.FAKE_CLI_PID_LOG, process.pid + '\\n');\nif (process.env.FAKE_CLI_CLEANUP_FILE) {\n  setInterval(() => {\n    if (fs.existsSync(process.env.FAKE_CLI_CLEANUP_FILE)) process.exit(0);\n  }, 25);\n  setTimeout(() => process.exit(0), 30_000);\n}\nif (process.env.FAKE_CLI_GRANDCHILD_PID) fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
   );
   chmodSync(parentLossIgnoringGrandchildBinary, 0o755);
   writeFileSync(
     parentLossIgnoringTargetBinary,
-    `#!/usr/bin/env node\nconst fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nspawn(process.env.FAKE_CLI_GRANDCHILD_BINARY, [], { env: process.env, stdio: 'ignore' });\nif (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nif (process.env.FAKE_CLI_PID_LOG) fs.appendFileSync(process.env.FAKE_CLI_PID_LOG, process.pid + '\\n');\nif (process.env.FAKE_CLI_CLEANUP_FILE) {\n  setInterval(() => {\n    if (fs.existsSync(process.env.FAKE_CLI_CLEANUP_FILE)) process.exit(0);\n  }, 25);\n  setTimeout(() => process.exit(0), 30_000);\n}\nspawn(process.env.FAKE_CLI_GRANDCHILD_BINARY, [], { env: process.env, stdio: 'ignore' });\nif (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
   );
   chmodSync(parentLossIgnoringTargetBinary, 0o755);
   process.env.FAKE_CLI_LOG = argsLog;
@@ -381,6 +381,40 @@ describe('automation arm e2e', () => {
       await cleanupFailedParentLossTest(supervisorPid, ownedPids);
     }
   }, 15_000);
+
+  test('TERM-ignoring parent-loss fixtures obey the synthetic cleanup backstop', async () => {
+    if (process.platform === 'win32') return;
+    let targetPid: number | undefined;
+    let ownedPids: number[] = [];
+    try {
+      const target = spawn(parentLossIgnoringTargetBinary, [], {
+        detached: true,
+        env: {
+          ...process.env,
+          FAKE_CLI_PID: parentLossTargetPid,
+          FAKE_CLI_GRANDCHILD_BINARY: parentLossIgnoringGrandchildBinary,
+          FAKE_CLI_GRANDCHILD_PID: parentLossGrandchildPid,
+        },
+        stdio: 'ignore',
+      });
+      targetPid = target.pid;
+      await waitForFiles([parentLossTargetPid, parentLossGrandchildPid], 1000);
+      ownedPids = [
+        Number(readFileSync(parentLossTargetPid, 'utf8')),
+        Number(readFileSync(parentLossGrandchildPid, 'utf8')),
+      ];
+
+      writeFileSync(syntheticCleanupSignal, 'exit');
+      expect(await waitForProcessesToExit(ownedPids, 1000)).toBe(true);
+      const loggedPids = readFileSync(syntheticPidLog, 'utf8')
+        .trim()
+        .split('\n')
+        .map(Number);
+      for (const pid of ownedPids) expect(loggedPids).toContain(pid);
+    } finally {
+      await cleanupFailedParentLossTest(targetPid, ownedPids);
+    }
+  }, 10_000);
 
   test('spawns the CLI, drains output, and posts the exit report', async () => {
     completions = [];

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -7,13 +7,14 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import type { CompleteAutomationResponse, PollResponse } from '@lobu/core/contracts/worker/protocol';
+import { executeAutomationRun } from '../daemon/automation.js';
+import { CLI_SUPERVISOR_SOURCE } from '../daemon/automation-process.js';
 import { WorkerClient } from '../daemon/client.js';
-import { CLI_SUPERVISOR_SOURCE, executeAutomationRun } from '../daemon/automation.js';
 import type { ExecutorConfig } from '../daemon/executor.js';
 
 /**

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -448,7 +448,7 @@ describe('automation arm e2e', () => {
     expect(completions[0].body.exit_reason).toBe('error_message');
   });
 
-  test('a terminal heartbeat conflict stops the CLI without posting a stale completion', async () => {
+  test('a terminal heartbeat conflict stops the CLI and reports its device exit', async () => {
     completions = [];
     script = [{ status: 'completed' }];
     heartbeatStatus = 409;
@@ -467,8 +467,11 @@ describe('automation arm e2e', () => {
     const elapsedMs = Date.now() - startedAt;
 
     expect(result).toEqual({ itemsCollected: 0 });
-    // The run the server already finalized must not be reported on again.
-    expect(completions).toHaveLength(0);
+    // The server's terminal-safe completion path retains device provenance and
+    // duration without replacing the outcome that made heartbeat return 409.
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('ok');
+    expect(completions[0].body.exit_signal).toBe('SIGTERM');
     expect(readFileSync(heartbeatConflictTerminated, 'utf8')).toBe('SIGTERM');
     const childPid = Number(readFileSync(heartbeatConflictPid, 'utf8'));
     expect(() => process.kill(childPid, 0)).toThrow();

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -1,11 +1,19 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import type { CompleteAutomationResponse, PollResponse } from '@lobu/core/contracts/worker/protocol';
 import { WorkerClient } from '../daemon/client.js';
-import { executeAutomationRun } from '../daemon/automation.js';
+import { CLI_SUPERVISOR_SOURCE, executeAutomationRun } from '../daemon/automation.js';
 import type { ExecutorConfig } from '../daemon/executor.js';
 
 /**
@@ -17,7 +25,29 @@ import type { ExecutorConfig } from '../daemon/executor.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'lobu-automation-e2e-'));
 const fakeBinary = path.join(tmp, 'pi');
+const heartbeatConflictBinary = path.join(tmp, 'pi-heartbeat-conflict');
+const heartbeatConflictGrandchildBinary = path.join(tmp, 'pi-heartbeat-grandchild');
+const transientHeartbeatBinary = path.join(tmp, 'pi-transient-heartbeat');
 const argsLog = path.join(tmp, 'args.log');
+const heartbeatConflictPid = path.join(tmp, 'heartbeat-conflict.pid');
+const heartbeatConflictTerminated = path.join(tmp, 'heartbeat-conflict-terminated.log');
+const heartbeatConflictGrandchildPid = path.join(tmp, 'heartbeat-conflict-grandchild.pid');
+const heartbeatConflictGrandchildTerminated = path.join(
+  tmp,
+  'heartbeat-conflict-grandchild-terminated.log'
+);
+const heartbeatConflictGrandchildAnchor = path.join(tmp, 'heartbeat-conflict-anchor.log');
+const syntheticCleanupSignal = path.join(tmp, 'synthetic-cleanup.signal');
+const syntheticPidLog = path.join(tmp, 'synthetic-pids.log');
+const parentLossHarness = path.join(tmp, 'parent-loss-harness.js');
+const parentLossSupervisorPid = path.join(tmp, 'parent-loss-supervisor.pid');
+const parentLossTargetPid = path.join(tmp, 'parent-loss-target.pid');
+const parentLossTargetTerminated = path.join(tmp, 'parent-loss-target-terminated.log');
+const parentLossGrandchildPid = path.join(tmp, 'parent-loss-grandchild.pid');
+const parentLossGrandchildTerminated = path.join(tmp, 'parent-loss-grandchild-terminated.log');
+const parentLossGrandchildAnchor = path.join(tmp, 'parent-loss-grandchild-anchor.log');
+const parentLossIgnoringTargetBinary = path.join(tmp, 'parent-loss-ignoring-target');
+const parentLossIgnoringGrandchildBinary = path.join(tmp, 'parent-loss-ignoring-grandchild');
 
 function automationJob(): PollResponse {
   return {
@@ -42,6 +72,11 @@ let server: http.Server;
 let baseUrl: string;
 let completions: Array<{ path: string; body: Record<string, unknown> }>;
 let script: CompleteAutomationResponse[];
+let heartbeatStatus = 200;
+let heartbeatRequests = 0;
+let heartbeatReadyFiles: string[] = [];
+let heartbeatStatusAfterFirstCompletion: number | null = null;
+let firstCompletionResponseDelayMs = 0;
 
 function cfg(): ExecutorConfig {
   return {
@@ -63,13 +98,128 @@ function client(): WorkerClient {
   });
 }
 
+async function waitForFiles(files: string[], timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!files.every((file) => existsSync(file)) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  if (!files.every((file) => existsSync(file))) {
+    throw new Error(`timed out waiting for ${files.length} process proof files`);
+  }
+}
+
+async function waitForChildExit(proc: ChildProcess, timeoutMs: number): Promise<number | null> {
+  if (proc.exitCode !== null) return proc.exitCode;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child exit timed out')), timeoutMs);
+    proc.once('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+async function waitForProcessesToExit(pids: number[], timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (pids.some(processIsAlive) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return pids.every((pid) => !processIsAlive(pid));
+}
+
+async function launchParentLossHarness(
+  targetBinary: string,
+  grandchildBinary: string
+): Promise<{ supervisorPid: number; ownedPids: number[] }> {
+  const harness = spawn(process.execPath, [parentLossHarness], {
+    env: {
+      ...process.env,
+      FAKE_CLI_BINARY: targetBinary,
+      FAKE_CLI_SUPERVISOR_PID_FILE: parentLossSupervisorPid,
+      FAKE_CLI_PID: parentLossTargetPid,
+      FAKE_CLI_TERMINATED: parentLossTargetTerminated,
+      FAKE_CLI_GRANDCHILD_BINARY: grandchildBinary,
+      FAKE_CLI_GRANDCHILD_PID: parentLossGrandchildPid,
+      FAKE_CLI_GRANDCHILD_TERMINATED: parentLossGrandchildTerminated,
+      FAKE_CLI_GRANDCHILD_ANCHOR: parentLossGrandchildAnchor,
+    },
+    stdio: 'ignore',
+  });
+  if ((await waitForChildExit(harness, 5000)) !== 0) {
+    throw new Error('parent-loss harness failed before exiting');
+  }
+  await waitForFiles(
+    [parentLossSupervisorPid, parentLossTargetPid, parentLossGrandchildPid],
+    1000
+  );
+  const supervisorPid = Number(readFileSync(parentLossSupervisorPid, 'utf8'));
+  return {
+    supervisorPid,
+    ownedPids: [
+      supervisorPid,
+      Number(readFileSync(parentLossTargetPid, 'utf8')),
+      Number(readFileSync(parentLossGrandchildPid, 'utf8')),
+    ],
+  };
+}
+
+async function cleanupFailedParentLossTest(
+  supervisorPid: number | undefined,
+  ownedPids: number[]
+): Promise<void> {
+  // The passing path never signals a numeric pid. On a regression, first let
+  // cooperative fixtures exit, then remove only the still-live group leader
+  // this test just created so a red test cannot leak an immortal supervisor.
+  writeFileSync(syntheticCleanupSignal, 'exit');
+  if (ownedPids.length > 1) await waitForProcessesToExit(ownedPids.slice(1), 500);
+  if (supervisorPid != null && processIsAlive(supervisorPid)) {
+    try {
+      process.kill(-supervisorPid, 'SIGKILL');
+    } catch {}
+    await waitForProcessesToExit([supervisorPid], 1000);
+  }
+}
+
 beforeAll(async () => {
   writeFileSync(
     fakeBinary,
     `#!/bin/sh\necho "FAKE_OUTPUT"\necho "---INVOCATION---" >> "$FAKE_CLI_LOG"\nprintf '%s\\n' "$@" >> "$FAKE_CLI_LOG"\nexit 0\n`
   );
   chmodSync(fakeBinary, 0o755);
+  writeFileSync(
+    heartbeatConflictBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nif (process.env.FAKE_CLI_PID_LOG) fs.appendFileSync(process.env.FAKE_CLI_PID_LOG, process.pid + '\\n');\nif (process.env.FAKE_CLI_CLEANUP_FILE) {\n  setInterval(() => {\n    if (fs.existsSync(process.env.FAKE_CLI_CLEANUP_FILE)) process.exit(0);\n  }, 25);\n  setTimeout(() => process.exit(0), 30_000);\n}\nif (process.env.FAKE_CLI_GRANDCHILD_BINARY) {\n  spawn(process.env.FAKE_CLI_GRANDCHILD_BINARY, [], {\n    env: { ...process.env, FAKE_CLI_SUPERVISOR_PID: String(process.ppid) },\n    stdio: 'ignore',\n  });\n}\nprocess.on('SIGTERM', () => {\n  if (process.env.FAKE_CLI_TERMINATED) fs.writeFileSync(process.env.FAKE_CLI_TERMINATED, 'SIGTERM');\n  process.exit(0);\n});\nif (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\nconst exitAfterMs = Number(process.env.FAKE_CLI_EXIT_AFTER_MS);\nif (Number.isFinite(exitAfterMs) && exitAfterMs > 0) {\n  setTimeout(() => {\n    process.stdout.write('GRACEFUL_HEARTBEAT_OUTPUT');\n    process.exit(0);\n  }, exitAfterMs);\n} else {\n  setInterval(() => {}, 1000);\n}\n`
+  );
+  chmodSync(heartbeatConflictBinary, 0o755);
+  writeFileSync(
+    heartbeatConflictGrandchildBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nif (process.env.FAKE_CLI_PID_LOG) fs.appendFileSync(process.env.FAKE_CLI_PID_LOG, process.pid + '\\n');\nif (process.env.FAKE_CLI_CLEANUP_FILE) {\n  setInterval(() => {\n    if (fs.existsSync(process.env.FAKE_CLI_CLEANUP_FILE)) process.exit(0);\n  }, 25);\n  setTimeout(() => process.exit(0), 30_000);\n}\nprocess.on('SIGTERM', () => {\n  if (process.env.FAKE_CLI_GRANDCHILD_TERMINATED) {\n    fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_TERMINATED, 'SIGTERM');\n  }\n  if (process.env.FAKE_CLI_GRANDCHILD_ANCHOR) {\n    let anchorAlive = false;\n    try {\n      process.kill(Number(process.env.FAKE_CLI_SUPERVISOR_PID), 0);\n      anchorAlive = true;\n    } catch {}\n    fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_ANCHOR, String(anchorAlive));\n  }\n  process.exit(0);\n});\nif (process.env.FAKE_CLI_GRANDCHILD_PID) {\n  fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_PID, String(process.pid));\n}\nsetInterval(() => {}, 1000);\n`
+  );
+  chmodSync(heartbeatConflictGrandchildBinary, 0o755);
+  writeFileSync(
+    transientHeartbeatBinary,
+    `#!/usr/bin/env node\nsetTimeout(() => {\n  process.stdout.write('TRANSIENT_HEARTBEAT_OUTPUT');\n  process.exit(0);\n}, 150);\n`
+  );
+  chmodSync(transientHeartbeatBinary, 0o755);
+  writeFileSync(
+    parentLossHarness,
+    `const fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nconst supervisor = spawn(process.execPath, ['-e', ${JSON.stringify(CLI_SUPERVISOR_SOURCE)}, '--', process.env.FAKE_CLI_BINARY], { detached: true, env: process.env, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });\nfs.writeFileSync(process.env.FAKE_CLI_SUPERVISOR_PID_FILE, String(supervisor.pid));\nconst deadline = Date.now() + 3000;\nconst ready = setInterval(() => {\n  if (fs.existsSync(process.env.FAKE_CLI_PID) && fs.existsSync(process.env.FAKE_CLI_GRANDCHILD_PID)) {\n    clearInterval(ready);\n    process.exit(0);\n  }\n  if (Date.now() >= deadline) process.exit(2);\n}, 25);\n`
+  );
+  writeFileSync(
+    parentLossIgnoringGrandchildBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nif (process.env.FAKE_CLI_GRANDCHILD_PID) fs.writeFileSync(process.env.FAKE_CLI_GRANDCHILD_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
+  );
+  chmodSync(parentLossIgnoringGrandchildBinary, 0o755);
+  writeFileSync(
+    parentLossIgnoringTargetBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nspawn(process.env.FAKE_CLI_GRANDCHILD_BINARY, [], { env: process.env, stdio: 'ignore' });\nif (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\nprocess.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);\n`
+  );
+  chmodSync(parentLossIgnoringTargetBinary, 0o755);
   process.env.FAKE_CLI_LOG = argsLog;
+  process.env.FAKE_CLI_PID = heartbeatConflictPid;
+  process.env.FAKE_CLI_TERMINATED = heartbeatConflictTerminated;
+  process.env.FAKE_CLI_CLEANUP_FILE = syntheticCleanupSignal;
+  process.env.FAKE_CLI_PID_LOG = syntheticPidLog;
 
   server = http.createServer((req, res) => {
     const chunks: Buffer[] = [];
@@ -79,13 +229,34 @@ beforeAll(async () => {
       if (req.method === 'POST' && req.url?.includes('/complete-automation')) {
         completions.push({ path: req.url ?? '', body: body ? JSON.parse(body) : {} });
         const reply = script.shift() ?? { status: 'completed' };
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(JSON.stringify(reply));
+        if (completions.length === 1 && heartbeatStatusAfterFirstCompletion != null) {
+          heartbeatStatus = heartbeatStatusAfterFirstCompletion;
+        }
+        const sendReply = () => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify(reply));
+        };
+        if (completions.length === 1 && firstCompletionResponseDelayMs > 0) {
+          setTimeout(sendReply, firstCompletionResponseDelayMs);
+        } else {
+          sendReply();
+        }
         return;
       }
       if (req.method === 'POST' && req.url?.includes('/heartbeat')) {
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end('{}');
+        heartbeatRequests += 1;
+        // Hold the 409 back until the fake CLI has recorded its pid: cancelling
+        // before the child exists would leave nothing to prove was killed.
+        const status =
+          heartbeatStatus === 409 && !heartbeatReadyFiles.every((file) => existsSync(file))
+            ? 200
+            : heartbeatStatus;
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(
+          status === 200
+            ? '{}'
+            : JSON.stringify({ error: 'Run is not in progress' })
+        );
         return;
       }
       res.writeHead(404);
@@ -99,12 +270,73 @@ beforeAll(async () => {
 
 afterAll(async () => {
   delete process.env.FAKE_CLI_LOG;
+  delete process.env.FAKE_CLI_PID;
+  delete process.env.FAKE_CLI_TERMINATED;
+  delete process.env.FAKE_CLI_EXIT_AFTER_MS;
+  delete process.env.FAKE_CLI_GRANDCHILD_BINARY;
+  delete process.env.FAKE_CLI_GRANDCHILD_PID;
+  delete process.env.FAKE_CLI_GRANDCHILD_TERMINATED;
+  delete process.env.FAKE_CLI_GRANDCHILD_ANCHOR;
+  delete process.env.FAKE_CLI_CLEANUP_FILE;
+  delete process.env.FAKE_CLI_PID_LOG;
   await new Promise<void>((resolve) => server.close(() => resolve()));
   rmSync(tmp, { recursive: true, force: true });
 });
 
 beforeEach(() => {
   rmSync(argsLog, { force: true });
+  rmSync(heartbeatConflictPid, { force: true });
+  rmSync(heartbeatConflictTerminated, { force: true });
+  rmSync(heartbeatConflictGrandchildPid, { force: true });
+  rmSync(heartbeatConflictGrandchildTerminated, { force: true });
+  rmSync(heartbeatConflictGrandchildAnchor, { force: true });
+  rmSync(syntheticCleanupSignal, { force: true });
+  rmSync(syntheticPidLog, { force: true });
+  rmSync(parentLossSupervisorPid, { force: true });
+  rmSync(parentLossTargetPid, { force: true });
+  rmSync(parentLossTargetTerminated, { force: true });
+  rmSync(parentLossGrandchildPid, { force: true });
+  rmSync(parentLossGrandchildTerminated, { force: true });
+  rmSync(parentLossGrandchildAnchor, { force: true });
+  delete process.env.FAKE_CLI_EXIT_AFTER_MS;
+  delete process.env.FAKE_CLI_GRANDCHILD_BINARY;
+  delete process.env.FAKE_CLI_GRANDCHILD_PID;
+  delete process.env.FAKE_CLI_GRANDCHILD_TERMINATED;
+  delete process.env.FAKE_CLI_GRANDCHILD_ANCHOR;
+  heartbeatStatus = 200;
+  heartbeatRequests = 0;
+  heartbeatReadyFiles = [];
+  heartbeatStatusAfterFirstCompletion = null;
+  firstCompletionResponseDelayMs = 0;
+});
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  // Signal only the synthetic scripts we own. Polling liveness is harmless if
+  // a pid was recycled; unlike raw process.kill(pid, SIGKILL), it can never
+  // terminate an unrelated process after a successful test.
+  writeFileSync(syntheticCleanupSignal, 'exit');
+  const pids = existsSync(syntheticPidLog)
+    ? readFileSync(syntheticPidLog, 'utf8')
+        .trim()
+        .split('\n')
+        .map(Number)
+        .filter((pid) => Number.isInteger(pid) && pid > 0)
+    : [];
+  const deadline = Date.now() + 2000;
+  while (pids.some(processIsAlive) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  const leaked = pids.filter(processIsAlive);
+  if (leaked.length > 0) throw new Error(`synthetic process cleanup timed out (${leaked.length})`);
 });
 
 function readArgsLog(): string {
@@ -116,6 +348,40 @@ function readArgsLog(): string {
 }
 
 describe('automation arm e2e', () => {
+  test('a parent process exit terminates its detached supervisor and owned CLI tree', async () => {
+    if (process.platform === 'win32') return;
+    let supervisorPid: number | undefined;
+    let ownedPids: number[] = [];
+    try {
+      ({ supervisorPid, ownedPids } = await launchParentLossHarness(
+        heartbeatConflictBinary,
+        heartbeatConflictGrandchildBinary
+      ));
+
+      expect(await waitForProcessesToExit(ownedPids, 5000)).toBe(true);
+      expect(readFileSync(parentLossTargetTerminated, 'utf8')).toBe('SIGTERM');
+      expect(readFileSync(parentLossGrandchildTerminated, 'utf8')).toBe('SIGTERM');
+      expect(readFileSync(parentLossGrandchildAnchor, 'utf8')).toBe('true');
+    } finally {
+      await cleanupFailedParentLossTest(supervisorPid, ownedPids);
+    }
+  }, 15_000);
+
+  test('parent loss force-kills the owned tree when every target ignores SIGTERM', async () => {
+    if (process.platform === 'win32') return;
+    let supervisorPid: number | undefined;
+    let ownedPids: number[] = [];
+    try {
+      ({ supervisorPid, ownedPids } = await launchParentLossHarness(
+        parentLossIgnoringTargetBinary,
+        parentLossIgnoringGrandchildBinary
+      ));
+      expect(await waitForProcessesToExit(ownedPids, 5000)).toBe(true);
+    } finally {
+      await cleanupFailedParentLossTest(supervisorPid, ownedPids);
+    }
+  }, 15_000);
+
   test('spawns the CLI, drains output, and posts the exit report', async () => {
     completions = [];
     script = [{ status: 'completed' }];
@@ -148,6 +414,27 @@ describe('automation arm e2e', () => {
     expect(log).toContain('FINALIZE NUDGE');
   });
 
+  test('a terminal heartbeat latched before a resume response prevents the next spawn', async () => {
+    completions = [];
+    script = [
+      { status: 'resume', attempt: 1, max_attempts: 2, nudge: 'finalize it' },
+      { status: 'completed' },
+    ];
+    heartbeatStatusAfterFirstCompletion = 409;
+    // Model a resume response already committed while an independent terminal
+    // transition makes heartbeats return 409 before that response reaches us.
+    firstCompletionResponseDelayMs = 100;
+    const raced = cfg();
+    raced.heartbeatIntervalMs = 10;
+
+    const result = await executeAutomationRun(client(), automationJob(), raced);
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    expect(heartbeatRequests).toBeGreaterThan(0);
+    expect(completions).toHaveLength(1);
+    expect(readArgsLog().split('---INVOCATION---').length - 1).toBe(1);
+  });
+
   test('a missing binary reports a terminal failure instead of hanging', async () => {
     completions = [];
     script = [{ status: 'completed' }];
@@ -159,6 +446,105 @@ describe('automation arm e2e', () => {
     expect(completions).toHaveLength(1);
     expect(completions[0].body.error).toContain('binary not found');
     expect(completions[0].body.exit_reason).toBe('error_message');
+  });
+
+  test('a terminal heartbeat conflict stops the CLI without posting a stale completion', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    heartbeatStatus = 409;
+    const conflict = cfg();
+    conflict.heartbeatIntervalMs = 10;
+    conflict.timeoutMs = 8000;
+    conflict.terminalHeartbeatGraceMs = 100;
+    conflict.binaryOverrides = { pi: heartbeatConflictBinary };
+    process.env.FAKE_CLI_GRANDCHILD_BINARY = heartbeatConflictGrandchildBinary;
+    process.env.FAKE_CLI_GRANDCHILD_PID = heartbeatConflictGrandchildPid;
+    process.env.FAKE_CLI_GRANDCHILD_TERMINATED = heartbeatConflictGrandchildTerminated;
+    heartbeatReadyFiles = [heartbeatConflictPid, heartbeatConflictGrandchildPid];
+
+    const startedAt = Date.now();
+    const result = await executeAutomationRun(client(), automationJob(), conflict);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    // The run the server already finalized must not be reported on again.
+    expect(completions).toHaveLength(0);
+    expect(readFileSync(heartbeatConflictTerminated, 'utf8')).toBe('SIGTERM');
+    const childPid = Number(readFileSync(heartbeatConflictPid, 'utf8'));
+    expect(() => process.kill(childPid, 0)).toThrow();
+    expect(readFileSync(heartbeatConflictGrandchildTerminated, 'utf8')).toBe('SIGTERM');
+    const grandchildPid = Number(readFileSync(heartbeatConflictGrandchildPid, 'utf8'));
+    expect(() => process.kill(grandchildPid, 0)).toThrow();
+    // Cancelled on the heartbeat, not left to the clock: an uncancelled run
+    // burns the 8s timeout plus the SIGTERM/SIGKILL grace windows (~16s).
+    expect(elapsedMs).toBeLessThan(4000);
+  }, 30_000);
+
+  test('a post-complete heartbeat conflict lets the CLI exit and report normally', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    heartbeatStatus = 409;
+    process.env.FAKE_CLI_EXIT_AFTER_MS = '250';
+    const graceful = cfg();
+    graceful.heartbeatIntervalMs = 10;
+    graceful.terminalHeartbeatGraceMs = 1000;
+    graceful.binaryOverrides = { pi: heartbeatConflictBinary };
+    heartbeatReadyFiles = [heartbeatConflictPid];
+
+    const result = await executeAutomationRun(client(), automationJob(), graceful);
+
+    expect(result.error).toBeUndefined();
+    expect(heartbeatRequests).toBeGreaterThan(0);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.output).toContain('GRACEFUL_HEARTBEAT_OUTPUT');
+    expect(existsSync(heartbeatConflictTerminated)).toBe(false);
+  });
+
+  test('a leader exiting inside the heartbeat grace cannot orphan its grandchild', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    heartbeatStatus = 409;
+    process.env.FAKE_CLI_EXIT_AFTER_MS = '250';
+    process.env.FAKE_CLI_GRANDCHILD_BINARY = heartbeatConflictGrandchildBinary;
+    process.env.FAKE_CLI_GRANDCHILD_PID = heartbeatConflictGrandchildPid;
+    process.env.FAKE_CLI_GRANDCHILD_TERMINATED = heartbeatConflictGrandchildTerminated;
+    process.env.FAKE_CLI_GRANDCHILD_ANCHOR = heartbeatConflictGrandchildAnchor;
+    heartbeatReadyFiles = [heartbeatConflictPid, heartbeatConflictGrandchildPid];
+    const gracefulTree = cfg();
+    gracefulTree.heartbeatIntervalMs = 10;
+    gracefulTree.terminalHeartbeatGraceMs = 1000;
+    gracefulTree.binaryOverrides = { pi: heartbeatConflictBinary };
+
+    const result = await executeAutomationRun(client(), automationJob(), gracefulTree);
+
+    expect(result.error).toBeUndefined();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.output).toContain('GRACEFUL_HEARTBEAT_OUTPUT');
+    // The real CLI exited on its own, but the supervisor retained the group id
+    // long enough to terminate and reap its still-running grandchild safely.
+    expect(existsSync(heartbeatConflictTerminated)).toBe(false);
+    expect(readFileSync(heartbeatConflictGrandchildTerminated, 'utf8')).toBe('SIGTERM');
+    expect(readFileSync(heartbeatConflictGrandchildAnchor, 'utf8')).toBe('true');
+    const childPid = Number(readFileSync(heartbeatConflictPid, 'utf8'));
+    const grandchildPid = Number(readFileSync(heartbeatConflictGrandchildPid, 'utf8'));
+    expect(() => process.kill(childPid, 0)).toThrow();
+    expect(() => process.kill(grandchildPid, 0)).toThrow();
+  });
+
+  test('a transient heartbeat failure does not cancel a healthy CLI', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    heartbeatStatus = 503;
+    const transient = cfg();
+    transient.heartbeatIntervalMs = 10;
+    transient.binaryOverrides = { pi: transientHeartbeatBinary };
+
+    const result = await executeAutomationRun(client(), automationJob(), transient);
+
+    expect(result.error).toBeUndefined();
+    expect(heartbeatRequests).toBeGreaterThan(0);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.output).toContain('TRANSIENT_HEARTBEAT_OUTPUT');
   });
 });
 
@@ -177,15 +563,17 @@ describe('automation arm drain deadline', () => {
       bothPipesBinary,
       // Same as above, but the grandchild inherits stderr too — the only shape
       // that can tell a shared deadline apart from two sequential ones.
-      `#!/bin/sh\ntrap '' TERM\nsleep 20 &\necho "PARTIAL_OUTPUT"\nsleep 20\n`
+      `#!/usr/bin/env node\nconst { spawn } = require('node:child_process');\nspawn(${JSON.stringify(heartbeatConflictGrandchildBinary)}, [], { detached: true, env: process.env, stdio: ['ignore', 'inherit', 'inherit'] });\nprocess.on('SIGTERM', () => {});\nconsole.log('PARTIAL_OUTPUT');\nsetTimeout(() => {}, 20_000);\n`
     );
     chmodSync(bothPipesBinary, 0o755);
 
     writeFileSync(
       hangBinary,
-      // Ignore SIGTERM so the run reaches the SIGKILL arm, and leave a
-      // grandchild holding stdout well past the 2s post-SIGKILL flush window.
-      `#!/bin/sh\ntrap '' TERM\nsleep 15 &\necho "PARTIAL_OUTPUT"\nsleep 15\n`
+      // Ignore SIGTERM so the run reaches the SIGKILL arm, and daemonize the
+      // grandchild into its own process group (`detached: true`) so the tree
+      // kill cannot reach it and it keeps holding the inherited stdout write
+      // end well past the 2s post-SIGKILL flush window.
+      `#!/usr/bin/env node\nconst { spawn } = require('node:child_process');\nspawn(${JSON.stringify(heartbeatConflictGrandchildBinary)}, [], { detached: true, env: process.env, stdio: ['ignore', 'inherit', 'ignore'] });\nprocess.on('SIGTERM', () => {});\nconsole.log('PARTIAL_OUTPUT');\nsetTimeout(() => {}, 15_000);\n`
     );
     chmodSync(hangBinary, 0o755);
   });
@@ -273,6 +661,7 @@ describe('automation arm failure diagnosis', () => {
  */
 describe('automation arm timeout diagnosis', () => {
   const stderrStallBinary = path.join(tmp, 'pi-stderr-stall');
+  const stderrSigtermProofBinary = path.join(tmp, 'pi-stderr-sigterm-proof');
 
   beforeAll(() => {
     // Writes its diagnosis to stderr, then stalls until the deadline kills it.
@@ -281,6 +670,14 @@ describe('automation arm timeout diagnosis', () => {
       `#!/bin/sh\necho "MCP server handshake failed: connection refused" >&2\nsleep 4\n`
     );
     chmodSync(stderrStallBinary, 0o755);
+
+    // Same, but ignores SIGTERM so the tree kill escalates to SIGKILL — the
+    // path where the supervisor dies before reporting the CLI outcome.
+    writeFileSync(
+      stderrSigtermProofBinary,
+      `#!/usr/bin/env node\nprocess.on('SIGTERM', () => {});\nconsole.error('MCP server handshake failed: connection refused');\nsetTimeout(() => {}, 15_000);\n`
+    );
+    chmodSync(stderrSigtermProofBinary, 0o755);
   });
 
   test('keeps the stderr the CLI wrote before it stalled', async () => {
@@ -298,5 +695,23 @@ describe('automation arm timeout diagnosis', () => {
     expect(completions[0].body.error).toContain('timeout');
     // ...but so does the only evidence of WHY the CLI stalled.
     expect(completions[0].body.error).toContain('MCP server handshake failed');
+  }, 30_000);
+
+  test('SIGKILL escalation does not mask the stderr diagnosis with a supervisor error', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const stalling = cfg();
+    stalling.timeoutMs = 500;
+    stalling.binaryOverrides = { pi: stderrSigtermProofBinary };
+
+    await executeAutomationRun(client(), automationJob(), stalling);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('timeout');
+    // SIGKILL takes the supervisor with the CLI before it can relay the exit;
+    // its synthetic placeholder must lose to what the CLI actually wrote.
+    expect(completions[0].body.error).toContain('SIGKILL');
+    expect(completions[0].body.error).toContain('MCP server handshake failed');
+    expect(completions[0].body.error).not.toContain('supervisor exited before reporting');
   }, 30_000);
 });

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -499,6 +499,7 @@ describe('automation arm e2e', () => {
     expect(result.error).toBeUndefined();
     expect(heartbeatRequests).toBeGreaterThan(0);
     expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_signal).toBeNull();
     expect(completions[0].body.output).toContain('GRACEFUL_HEARTBEAT_OUTPUT');
     expect(existsSync(heartbeatConflictTerminated)).toBe(false);
   });

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -5,21 +5,23 @@ import type {
   CompleteAutomationResponse,
 } from '@lobu/core/contracts/worker/protocol';
 import {
+  type AutomationRunIo,
   buildArguments,
   deliverExitReport,
   dispatchAutomationResumeLoop,
+  type ExecutorResult,
+} from '../daemon/automation.js';
+import {
   signalOwnedPosixProcessGroup,
   terminateWindowsProcessTree,
   waitForOwnedPosixTreeToQuiesce,
   waitForTargetExitAfterTermination,
-  type AutomationRunIo,
-  type ExecutorResult,
-} from '../daemon/automation.js';
+} from '../daemon/automation-process.js';
 import {
+  type ExecutorClient,
   interpretCompleteAutomationResponse,
   WorkerDecodeError,
   WorkerHttpError,
-  type ExecutorClient,
 } from '../daemon/client.js';
 
 function okResult(): ExecutorResult {
@@ -104,7 +106,7 @@ describe('Windows process-tree termination', () => {
         directSignals.push(signal);
         return true;
       },
-    } as unknown as import('node:child_process').ChildProcess;
+    } as unknown as ChildProcess;
 
     const result = await terminateWindowsProcessTree(
       proc,

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
 import { DEVICE_AGENT_SPECS_BY_KIND } from '@lobu/core/contracts/worker/device-automation';
 import type {
   CompleteAutomationResponse,
@@ -9,6 +10,8 @@ import {
   dispatchAutomationResumeLoop,
   signalOwnedPosixProcessGroup,
   terminateWindowsProcessTree,
+  waitForOwnedPosixTreeToQuiesce,
+  waitForTargetExitAfterTermination,
   type AutomationRunIo,
   type ExecutorResult,
 } from '../daemon/automation.js';
@@ -48,6 +51,44 @@ describe('POSIX process-group ownership', () => {
     const liveOwner = { pid: 4242, exitCode: null, signalCode: null };
     expect(signalOwnedPosixProcessGroup(liveOwner, 'SIGTERM', sendSignal)).toBe(true);
     expect(signals).toEqual([{ pid: -4242, signal: 'SIGTERM' }]);
+  });
+
+  test('an unavailable membership probe preserves the remaining SIGTERM grace', async () => {
+    const waits: number[] = [];
+    const owner = {
+      pid: 4242,
+      exitCode: null,
+      signalCode: null,
+    } as unknown as ChildProcess;
+
+    expect(
+      await waitForOwnedPosixTreeToQuiesce(
+        owner,
+        3000,
+        async () => null,
+        async (ms) => {
+          waits.push(ms);
+        }
+      )
+    ).toBe(false);
+    expect(waits).toHaveLength(1);
+    expect(waits[0]).toBeGreaterThan(2900);
+  });
+});
+
+describe('terminated target metadata', () => {
+  test('an absent supervisor report is bounded by the reap deadline', async () => {
+    const lateTarget = new Promise<{
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      error: string | null;
+    }>((resolve) => {
+      setTimeout(() => resolve({ exitCode: 0, signalCode: null, error: null }), 50);
+    });
+
+    const result = await waitForTargetExitAfterTermination(lateTarget, 5);
+
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -7,6 +7,8 @@ import {
   buildArguments,
   deliverExitReport,
   dispatchAutomationResumeLoop,
+  signalOwnedPosixProcessGroup,
+  terminateWindowsProcessTree,
   type AutomationRunIo,
   type ExecutorResult,
 } from '../daemon/automation.js';
@@ -27,6 +29,56 @@ function okResult(): ExecutorResult {
     durationMs: 1,
   };
 }
+
+describe('POSIX process-group ownership', () => {
+  test('an exited supervisor never signals a numerically reused process group', () => {
+    if (process.platform === 'win32') return;
+    const signals: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    const sendSignal = ((pid: number, signal: NodeJS.Signals | number) => {
+      signals.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    // Model the exact reuse hazard: the old ChildProcess still carries 4242,
+    // but exitCode proves its ownership ended and a new group may now own 4242.
+    const staleOwner = { pid: 4242, exitCode: 0, signalCode: null };
+    expect(signalOwnedPosixProcessGroup(staleOwner, 'SIGKILL', sendSignal)).toBe(false);
+    expect(signals).toEqual([]);
+
+    const liveOwner = { pid: 4242, exitCode: null, signalCode: null };
+    expect(signalOwnedPosixProcessGroup(liveOwner, 'SIGTERM', sendSignal)).toBe(true);
+    expect(signals).toEqual([{ pid: -4242, signal: 'SIGTERM' }]);
+  });
+});
+
+describe('Windows process-tree termination', () => {
+  test('a failed graceful tree kill escalates the tree before touching the supervisor', async () => {
+    const treeKillCalls: boolean[] = [];
+    const directSignals: NodeJS.Signals[] = [];
+    const proc = {
+      pid: 4242,
+      exitCode: null,
+      signalCode: null,
+      kill: (signal: NodeJS.Signals) => {
+        directSignals.push(signal);
+        return true;
+      },
+    } as unknown as import('node:child_process').ChildProcess;
+
+    const result = await terminateWindowsProcessTree(
+      proc,
+      async (_owner, force) => {
+        treeKillCalls.push(force);
+        return force;
+      },
+      async () => true
+    );
+
+    expect(result).toBe('SIGKILL');
+    expect(treeKillCalls).toEqual([false, true]);
+    expect(directSignals).toEqual([]);
+  });
+});
 
 /** Scripted resume-loop IO. `deliver` is a single-shot script (the retry logic
  * lives in `deliverExitReport`, tested separately). */

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -14,7 +14,6 @@ import {
 import {
   signalOwnedPosixProcessGroup,
   terminateWindowsProcessTree,
-  waitForOwnedPosixTreeToQuiesce,
   waitForTargetExitAfterTermination,
 } from '../daemon/automation-process.js';
 import {
@@ -53,28 +52,6 @@ describe('POSIX process-group ownership', () => {
     const liveOwner = { pid: 4242, exitCode: null, signalCode: null };
     expect(signalOwnedPosixProcessGroup(liveOwner, 'SIGTERM', sendSignal)).toBe(true);
     expect(signals).toEqual([{ pid: -4242, signal: 'SIGTERM' }]);
-  });
-
-  test('an unavailable membership probe preserves the remaining SIGTERM grace', async () => {
-    const waits: number[] = [];
-    const owner = {
-      pid: 4242,
-      exitCode: null,
-      signalCode: null,
-    } as unknown as ChildProcess;
-
-    expect(
-      await waitForOwnedPosixTreeToQuiesce(
-        owner,
-        3000,
-        async () => null,
-        async (ms) => {
-          waits.push(ms);
-        }
-      )
-    ).toBe(false);
-    expect(waits).toHaveLength(1);
-    expect(waits[0]).toBeGreaterThan(2900);
   });
 });
 

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -10,7 +10,7 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 const SUPPORTS_PROCESS_GROUPS = process.platform !== 'win32';
-const POSIX_TREE_TERM_GRACE_MS = 3000;
+const TREE_TERM_GRACE_MS = 3000;
 const PROCESS_REAP_GRACE_MS = 5000;
 /** Bounds one `ps` snapshot without trusting a partial process table. */
 const PS_OUTPUT_CAP_BYTES = 4 * 1024 * 1024;
@@ -22,94 +22,105 @@ const PS_OUTPUT_CAP_BYTES = 4 * 1024 * 1024;
  * descendants still receive the group signal, while the supervisor remains the
  * ownership anchor until the daemon releases or SIGKILLs it.
  *
- * POSIX caller contract: spawn this source with `detached: true`, making the
- * supervisor the session/process-group leader whose pgid equals its pid. Its
- * parent-loss path uses that invariant for safe negative-pid group signals.
+ * POSIX caller contract: serialize and spawn this closure-free function with
+ * `detached: true`, making the supervisor the session/process-group leader
+ * whose pgid equals its pid. Its parent-loss path uses that invariant for safe
+ * negative-pid group signals.
  */
-export const CLI_SUPERVISOR_SOURCE = String.raw`
-const { spawn } = require('node:child_process');
-const [binary, ...args] = process.argv.slice(1);
-let targetFinished = false;
-let parentLost = false;
-let target;
-const keepAlive = setInterval(() => {}, 2147483647);
-const send = (message) => {
-  try { process.send?.(message); } catch {}
-};
-const finish = (code, signal, error) => {
-  if (targetFinished) return;
-  targetFinished = true;
-  if (!parentLost) send({ type: 'target-exit', code, signal, error });
-};
-const stopAfterParentLoss = () => {
-  if (parentLost) return;
-  parentLost = true;
-  clearInterval(keepAlive);
+function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
+  const [binary, ...args] = process.argv.slice(1);
+  let targetFinished = false;
+  let parentLost = false;
+  let target: ChildProcess | undefined;
+  const keepAlive = setInterval(() => {}, 2147483647);
+  const send = (message: Record<string, unknown>) => {
+    try { process.send?.(message); } catch {}
+  };
+  const finish = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    error: string | null
+  ) => {
+    if (targetFinished) return;
+    targetFinished = true;
+    if (!parentLost) send({ type: 'target-exit', code, signal, error });
+  };
+  const stopAfterParentLoss = () => {
+    if (parentLost) return;
+    parentLost = true;
+    clearInterval(keepAlive);
 
-  if (process.platform === 'win32') {
-    // Keep this process alive as the tree root until taskkill gets its chance.
-    // The timer is deliberately ref'ed: parent loss must not let the supervisor
-    // exit before the owned CLI tree has been addressed.
+    if (process.platform === 'win32') {
+      // Keep this process alive as the tree root until taskkill gets its chance.
+      // The timer is deliberately ref'ed: parent loss must not let the supervisor
+      // exit before the owned CLI tree has been addressed.
+      try {
+        const killer = spawnChild('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        });
+        killer.once('error', () => {});
+      } catch {}
+      setTimeout(() => {
+        try { target?.kill('SIGKILL'); } catch {}
+        process.exit(1);
+      }, treeTermGraceMs);
+      return;
+    }
+
+    // This detached supervisor is still the live session/group leader, so its
+    // own negative pid cannot have been recycled. Ignore SIGTERM here while the
+    // target and descendants get a graceful window, then kill the complete group
+    // including this anchor so parent loss cannot leave an immortal orphan.
     try {
-      const killer = spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
-        stdio: 'ignore',
+      process.kill(-process.pid, 'SIGTERM');
+    } catch {
+      try { target?.kill('SIGTERM'); } catch {}
+    }
+    setTimeout(() => {
+      try {
+        process.kill(-process.pid, 'SIGKILL');
+      } catch {
+        try { target?.kill('SIGKILL'); } catch {}
+        process.exit(1);
+      }
+    }, treeTermGraceMs);
+  };
+  process.on('SIGTERM', () => {});
+  process.once('disconnect', stopAfterParentLoss);
+  process.on('message', (message: unknown) => {
+    if (
+      typeof message !== 'object' ||
+      message == null ||
+      (message as Record<string, unknown>).type !== 'release' ||
+      !targetFinished
+    ) return;
+    clearInterval(keepAlive);
+    process.exit(0);
+  });
+  if (!binary) {
+    finish(127, null, 'automation supervisor missing target binary');
+  } else {
+    try {
+      target = spawnChild(binary, args, {
+        env: process.env,
+        stdio: ['ignore', 'inherit', 'inherit'],
         windowsHide: true,
       });
-      killer.once('error', () => {});
-    } catch {}
-    setTimeout(() => {
-      try { target?.kill('SIGKILL'); } catch {}
-      process.exit(1);
-    }, 3000);
-    return;
-  }
-
-  // This detached supervisor is still the live session/group leader, so its
-  // own negative pid cannot have been recycled. Ignore SIGTERM here while the
-  // target and descendants get a graceful window, then kill the complete group
-  // including this anchor so parent loss cannot leave an immortal orphan.
-  try {
-    process.kill(-process.pid, 'SIGTERM');
-  } catch {
-    try { target?.kill('SIGTERM'); } catch {}
-  }
-  setTimeout(() => {
-    try {
-      process.kill(-process.pid, 'SIGKILL');
-    } catch {
-      try { target?.kill('SIGKILL'); } catch {}
-      process.exit(1);
+    } catch (error) {
+      finish(127, null, error instanceof Error ? error.message : String(error));
     }
-  }, 3000);
-};
-process.on('SIGTERM', () => {});
-process.once('disconnect', stopAfterParentLoss);
-process.on('message', (message) => {
-  if (message?.type !== 'release' || !targetFinished) return;
-  clearInterval(keepAlive);
-  process.exit(0);
-});
-if (!binary) {
-  finish(127, null, 'automation supervisor missing target binary');
-} else {
-  try {
-    target = spawn(binary, args, {
-      env: process.env,
-      stdio: ['ignore', 'inherit', 'inherit'],
-      windowsHide: true,
+    target?.once('error', (error) => {
+      finish(127, null, error instanceof Error ? error.message : String(error));
     });
-  } catch (error) {
-    finish(127, null, error instanceof Error ? error.message : String(error));
+    target?.once('exit', (code, signal) => finish(code, signal, null));
   }
-  target?.once('error', (error) => {
-    finish(127, null, error instanceof Error ? error.message : String(error));
+  setImmediate(() => {
+    if (!process.connected) stopAfterParentLoss();
   });
-  target?.once('exit', (code, signal) => finish(code, signal, null));
 }
-setImmediate(() => {
-  if (!process.connected) stopAfterParentLoss();
-});
-`;
+
+export const CLI_SUPERVISOR_SOURCE = `(${runCliSupervisor.toString()})(require('node:child_process').spawn, ${TREE_TERM_GRACE_MS});`;
 
 interface TargetExit {
   exitCode: number | null;
@@ -372,7 +383,7 @@ export async function terminateWindowsProcessTree(
   waitForExit: typeof waitForSignalledExit = waitForSignalledExit
 ): Promise<'SIGTERM' | 'SIGKILL'> {
   const gracefulTreeKillSent = await terminateTree(proc, false);
-  if (gracefulTreeKillSent && (await waitForExit(proc, 3000))) return 'SIGTERM';
+  if (gracefulTreeKillSent && (await waitForExit(proc, TREE_TERM_GRACE_MS))) return 'SIGTERM';
 
   // If taskkill itself is unavailable, direct ChildProcess.kill remains the
   // best-effort fallback. It cannot guarantee cleanup of an already-orphaned
@@ -394,7 +405,7 @@ export async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'S
       await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
       return 'SIGTERM';
     }
-    if (await waitForOwnedPosixTreeToQuiesce(proc, POSIX_TREE_TERM_GRACE_MS)) {
+    if (await waitForOwnedPosixTreeToQuiesce(proc, TREE_TERM_GRACE_MS)) {
       return 'SIGTERM';
     }
     if (!signalOwnedPosixProcessGroup(proc, 'SIGKILL')) proc.kill('SIGKILL');

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -7,13 +7,10 @@
  */
 
 import { type ChildProcess, spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
 
 const SUPPORTS_PROCESS_GROUPS = process.platform !== 'win32';
 const TREE_TERM_GRACE_MS = 3000;
 const PROCESS_REAP_GRACE_MS = 5000;
-/** Bounds one `ps` snapshot without trusting a partial process table. */
-const PS_OUTPUT_CAP_BYTES = 4 * 1024 * 1024;
 
 /**
  * Keep a process-group leader alive after the actual CLI exits. The daemon can
@@ -225,67 +222,6 @@ export function signalOwnedPosixProcessGroup(
   }
 }
 
-/** Read a snapshot of one POSIX group without signalling its numeric id. */
-function listPosixProcessGroupMembers(pgid: number): Promise<number[] | null> {
-  const psBinary = existsSync('/bin/ps')
-    ? '/bin/ps'
-    : existsSync('/usr/bin/ps')
-      ? '/usr/bin/ps'
-      : 'ps';
-  return new Promise((resolve) => {
-    let proc: ChildProcess;
-    try {
-      proc = spawn(psBinary, ['-axo', 'pid=,pgid='], {
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      });
-    } catch {
-      resolve(null);
-      return;
-    }
-    let settled = false;
-    let output = '';
-    const settle = (members: number[] | null) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(members);
-    };
-    const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      settle(null);
-    }, 1000);
-    timer.unref?.();
-    // A dropped chunk would silently shrink the member list, and an
-    // undercount is exactly what makes releasing the anchor unsafe. Cap the
-    // buffer, but treat hitting the cap as "no proof" rather than a short read.
-    let truncated = false;
-    proc.stdout?.setEncoding('utf8');
-    proc.stdout?.on('data', (chunk: string) => {
-      if (output.length + chunk.length > PS_OUTPUT_CAP_BYTES) {
-        truncated = true;
-        return;
-      }
-      output += chunk;
-    });
-    proc.once('error', () => settle(null));
-    proc.once('close', (code) => {
-      if (code !== 0 || truncated) {
-        settle(null);
-        return;
-      }
-      const members: number[] = [];
-      for (const line of output.split('\n')) {
-        const [pidText, pgidText] = line.trim().split(/\s+/);
-        const pid = Number(pidText);
-        const rowPgid = Number(pgidText);
-        if (Number.isInteger(pid) && rowPgid === pgid) members.push(pid);
-      }
-      settle(members);
-    });
-  });
-}
-
 /** Ask the supervisor to release its non-reusable group identity and reap it. */
 export async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): Promise<boolean> {
   if (proc.exitCode !== null || proc.signalCode !== null) return true;
@@ -301,47 +237,6 @@ export async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): P
   // failed release into a negative-pgid signal after the anchor might be gone.
   proc.kill('SIGKILL');
   await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
-  return false;
-}
-
-/**
- * Wait until SIGTERM leaves only the supervisor in its group. Before releasing
- * the anchor, freeze the group and take a second snapshot so no live member can
- * fork across the observation. A process outside this new session cannot join
- * the group, so releasing the sole remaining supervisor is then race-free.
- */
-export async function waitForOwnedPosixTreeToQuiesce(
-  proc: ChildProcess,
-  timeoutMs: number,
-  listMembers: (pgid: number) => Promise<number[] | null> = listPosixProcessGroupMembers,
-  wait: (ms: number) => Promise<void> = sleep
-): Promise<boolean> {
-  const pgid = proc.pid;
-  if (pgid == null) return false;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const members = await listMembers(pgid);
-    if (members == null) {
-      // An unavailable or overloaded `ps` removes our proof that only the
-      // ownership anchor remains; it must not also remove the target's TERM
-      // grace. Consume the remaining window, then escalate while the anchor is
-      // still live and the negative pgid is still safe.
-      const remainingMs = deadline - Date.now();
-      if (remainingMs > 0) await wait(remainingMs);
-      return false;
-    }
-    if (members.length === 1 && members[0] === pgid) {
-      if (!signalOwnedPosixProcessGroup(proc, 'SIGSTOP')) return false;
-      const frozenMembers = await listMembers(pgid);
-      if (frozenMembers?.length === 1 && frozenMembers[0] === pgid) {
-        if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
-        return releaseSupervisor(proc);
-      }
-      // The anchor is still live and stopped, so this cannot target a reused id.
-      if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
-    }
-    await wait(Math.min(100, Math.max(1, deadline - Date.now())));
-  }
   return false;
 }
 
@@ -405,9 +300,11 @@ export async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'S
       await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
       return 'SIGTERM';
     }
-    if (await waitForOwnedPosixTreeToQuiesce(proc, TREE_TERM_GRACE_MS)) {
-      return 'SIGTERM';
-    }
+    // The supervisor deliberately survives SIGTERM, keeping the pgid owned for
+    // the complete grace window. Escalating that still-owned group avoids both
+    // PID reuse and the process-table scan/freeze/recount machinery that an
+    // early release would require.
+    await sleep(TREE_TERM_GRACE_MS);
     if (!signalOwnedPosixProcessGroup(proc, 'SIGKILL')) proc.kill('SIGKILL');
     await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
     return 'SIGKILL';

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -340,7 +340,7 @@ export async function waitForOwnedPosixTreeToQuiesce(
       // The anchor is still live and stopped, so this cannot target a reused id.
       if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
     }
-    await wait(Math.min(25, Math.max(1, deadline - Date.now())));
+    await wait(Math.min(100, Math.max(1, deadline - Date.now())));
   }
   return false;
 }

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -1,0 +1,453 @@
+/**
+ * OS process supervision for the device Automation arm.
+ *
+ * Kept separate from automation.ts so spawn/heartbeat/resume policy does not
+ * share a control-flow surface with POSIX group ownership and Windows tree
+ * termination.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const SUPPORTS_PROCESS_GROUPS = process.platform !== 'win32';
+const POSIX_TREE_TERM_GRACE_MS = 3000;
+const PROCESS_REAP_GRACE_MS = 5000;
+/** Bounds one `ps` snapshot without trusting a partial process table. */
+const PS_OUTPUT_CAP_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Keep a process-group leader alive after the actual CLI exits. The daemon can
+ * then clean up descendants through an identity that the kernel cannot recycle
+ * underneath it. The supervisor deliberately ignores SIGTERM; the CLI and its
+ * descendants still receive the group signal, while the supervisor remains the
+ * ownership anchor until the daemon releases or SIGKILLs it.
+ *
+ * POSIX caller contract: spawn this source with `detached: true`, making the
+ * supervisor the session/process-group leader whose pgid equals its pid. Its
+ * parent-loss path uses that invariant for safe negative-pid group signals.
+ */
+export const CLI_SUPERVISOR_SOURCE = String.raw`
+const { spawn } = require('node:child_process');
+const [binary, ...args] = process.argv.slice(1);
+let targetFinished = false;
+let parentLost = false;
+let target;
+const keepAlive = setInterval(() => {}, 2147483647);
+const send = (message) => {
+  try { process.send?.(message); } catch {}
+};
+const finish = (code, signal, error) => {
+  if (targetFinished) return;
+  targetFinished = true;
+  if (!parentLost) send({ type: 'target-exit', code, signal, error });
+};
+const stopAfterParentLoss = () => {
+  if (parentLost) return;
+  parentLost = true;
+  clearInterval(keepAlive);
+
+  if (process.platform === 'win32') {
+    // Keep this process alive as the tree root until taskkill gets its chance.
+    // The timer is deliberately ref'ed: parent loss must not let the supervisor
+    // exit before the owned CLI tree has been addressed.
+    try {
+      const killer = spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', () => {});
+    } catch {}
+    setTimeout(() => {
+      try { target?.kill('SIGKILL'); } catch {}
+      process.exit(1);
+    }, 3000);
+    return;
+  }
+
+  // This detached supervisor is still the live session/group leader, so its
+  // own negative pid cannot have been recycled. Ignore SIGTERM here while the
+  // target and descendants get a graceful window, then kill the complete group
+  // including this anchor so parent loss cannot leave an immortal orphan.
+  try {
+    process.kill(-process.pid, 'SIGTERM');
+  } catch {
+    try { target?.kill('SIGTERM'); } catch {}
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-process.pid, 'SIGKILL');
+    } catch {
+      try { target?.kill('SIGKILL'); } catch {}
+      process.exit(1);
+    }
+  }, 3000);
+};
+process.on('SIGTERM', () => {});
+process.once('disconnect', stopAfterParentLoss);
+process.on('message', (message) => {
+  if (message?.type !== 'release' || !targetFinished) return;
+  clearInterval(keepAlive);
+  process.exit(0);
+});
+if (!binary) {
+  finish(127, null, 'automation supervisor missing target binary');
+} else {
+  try {
+    target = spawn(binary, args, {
+      env: process.env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+      windowsHide: true,
+    });
+  } catch (error) {
+    finish(127, null, error instanceof Error ? error.message : String(error));
+  }
+  target?.once('error', (error) => {
+    finish(127, null, error instanceof Error ? error.message : String(error));
+  });
+  target?.once('exit', (code, signal) => finish(code, signal, null));
+}
+setImmediate(() => {
+  if (!process.connected) stopAfterParentLoss();
+});
+`;
+
+interface TargetExit {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  error: string | null;
+}
+
+interface SupervisedCli {
+  supervisor: ChildProcess;
+  targetExit: Promise<TargetExit>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Wait for the supervised CLI to exit, the timeout to lapse, or cancellation. */
+export function waitForTargetExit(
+  targetExit: Promise<TargetExit>,
+  timeoutMs: number,
+  abortSignal?: AbortSignal
+): Promise<{ timedOut: boolean; aborted: boolean; target?: TargetExit }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (outcome: {
+      timedOut: boolean;
+      aborted: boolean;
+      target?: TargetExit;
+    }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve(outcome);
+    };
+    const onAbort = () => settle({ timedOut: false, aborted: true });
+    const timer = setTimeout(() => {
+      settle({ timedOut: true, aborted: false });
+    }, timeoutMs);
+    timer.unref?.();
+    targetExit.then((target) => settle({ timedOut: false, aborted: false, target }));
+    if (abortSignal?.aborted) onAbort();
+    else abortSignal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Await the target metadata after process-tree termination. */
+export async function waitForTargetExitAfterTermination(
+  targetExit: Promise<TargetExit>,
+  timeoutMs = PROCESS_REAP_GRACE_MS
+): Promise<TargetExit | null> {
+  const { target } = await waitForTargetExit(targetExit, timeoutMs);
+  return target ?? null;
+}
+
+/** Wait a bounded interval for a signal sent to the child to take effect. */
+function waitForSignalledExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      proc.removeListener('exit', onExit);
+      resolve(exited);
+    };
+    const onExit = () => settle(true);
+    const timer = setTimeout(() => settle(false), timeoutMs);
+    timer.unref?.();
+    proc.once('exit', onExit);
+  });
+}
+
+type ProcessGroupOwner = Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode'>;
+
+/**
+ * Signal a POSIX group only while its supervisor is a live ownership anchor.
+ * Once the anchor has exited, its numeric pid/pgid may refer to an unrelated
+ * future process group and must never be used as a negative-pid signal target.
+ * Exported only so the PID-reuse safety invariant has a direct regression test.
+ */
+export function signalOwnedPosixProcessGroup(
+  owner: ProcessGroupOwner,
+  signal: NodeJS.Signals,
+  sendSignal: typeof process.kill = process.kill
+): boolean {
+  if (
+    !SUPPORTS_PROCESS_GROUPS ||
+    owner.pid == null ||
+    owner.exitCode !== null ||
+    owner.signalCode !== null
+  ) {
+    return false;
+  }
+  try {
+    sendSignal(-owner.pid, signal);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw err;
+  }
+}
+
+/** Read a snapshot of one POSIX group without signalling its numeric id. */
+function listPosixProcessGroupMembers(pgid: number): Promise<number[] | null> {
+  const psBinary = existsSync('/bin/ps')
+    ? '/bin/ps'
+    : existsSync('/usr/bin/ps')
+      ? '/usr/bin/ps'
+      : 'ps';
+  return new Promise((resolve) => {
+    let proc: ChildProcess;
+    try {
+      proc = spawn(psBinary, ['-axo', 'pid=,pgid='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    let settled = false;
+    let output = '';
+    const settle = (members: number[] | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(members);
+    };
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      settle(null);
+    }, 1000);
+    timer.unref?.();
+    // A dropped chunk would silently shrink the member list, and an
+    // undercount is exactly what makes releasing the anchor unsafe. Cap the
+    // buffer, but treat hitting the cap as "no proof" rather than a short read.
+    let truncated = false;
+    proc.stdout?.setEncoding('utf8');
+    proc.stdout?.on('data', (chunk: string) => {
+      if (output.length + chunk.length > PS_OUTPUT_CAP_BYTES) {
+        truncated = true;
+        return;
+      }
+      output += chunk;
+    });
+    proc.once('error', () => settle(null));
+    proc.once('close', (code) => {
+      if (code !== 0 || truncated) {
+        settle(null);
+        return;
+      }
+      const members: number[] = [];
+      for (const line of output.split('\n')) {
+        const [pidText, pgidText] = line.trim().split(/\s+/);
+        const pid = Number(pidText);
+        const rowPgid = Number(pgidText);
+        if (Number.isInteger(pid) && rowPgid === pgid) members.push(pid);
+      }
+      settle(members);
+    });
+  });
+}
+
+/** Ask the supervisor to release its non-reusable group identity and reap it. */
+export async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return true;
+  let sent = false;
+  try {
+    if (proc.connected) {
+      proc.send?.({ type: 'release' });
+      sent = true;
+    }
+  } catch {}
+  if (sent && (await waitForSignalledExit(proc, timeoutMs))) return true;
+  // Direct ChildProcess.kill uses the still-owned process handle; never turn a
+  // failed release into a negative-pgid signal after the anchor might be gone.
+  proc.kill('SIGKILL');
+  await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+  return false;
+}
+
+/**
+ * Wait until SIGTERM leaves only the supervisor in its group. Before releasing
+ * the anchor, freeze the group and take a second snapshot so no live member can
+ * fork across the observation. A process outside this new session cannot join
+ * the group, so releasing the sole remaining supervisor is then race-free.
+ */
+export async function waitForOwnedPosixTreeToQuiesce(
+  proc: ChildProcess,
+  timeoutMs: number,
+  listMembers: (pgid: number) => Promise<number[] | null> = listPosixProcessGroupMembers,
+  wait: (ms: number) => Promise<void> = sleep
+): Promise<boolean> {
+  const pgid = proc.pid;
+  if (pgid == null) return false;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const members = await listMembers(pgid);
+    if (members == null) {
+      // An unavailable or overloaded `ps` removes our proof that only the
+      // ownership anchor remains; it must not also remove the target's TERM
+      // grace. Consume the remaining window, then escalate while the anchor is
+      // still live and the negative pgid is still safe.
+      const remainingMs = deadline - Date.now();
+      if (remainingMs > 0) await wait(remainingMs);
+      return false;
+    }
+    if (members.length === 1 && members[0] === pgid) {
+      if (!signalOwnedPosixProcessGroup(proc, 'SIGSTOP')) return false;
+      const frozenMembers = await listMembers(pgid);
+      if (frozenMembers?.length === 1 && frozenMembers[0] === pgid) {
+        if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
+        return releaseSupervisor(proc);
+      }
+      // The anchor is still live and stopped, so this cannot target a reused id.
+      if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
+    }
+    await wait(Math.min(25, Math.max(1, deadline - Date.now())));
+  }
+  return false;
+}
+
+/** Windows has no negative-pid process groups; taskkill supplies bounded tree cleanup. */
+function taskkillWindowsTree(proc: ChildProcess, force: boolean): Promise<boolean> {
+  if (proc.pid == null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const killer = spawn(
+      'taskkill',
+      ['/PID', String(proc.pid), '/T', ...(force ? ['/F'] : [])],
+      { stdio: 'ignore', windowsHide: true }
+    );
+    let settled = false;
+    const settle = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(ok);
+    };
+    const timer = setTimeout(() => {
+      killer.kill();
+      settle(false);
+    }, 3000);
+    timer.unref?.();
+    killer.once('error', () => settle(false));
+    killer.once('exit', (code) => settle(code === 0));
+  });
+}
+
+/**
+ * Keep the supervisor alive until Windows has had its forced tree-kill chance.
+ * Killing only the supervisor after a failed graceful `taskkill /T` would
+ * orphan the real CLI and make its numeric tree root unusable. Exported, with
+ * its collaborators injectable, only so that ordering is testable off Windows.
+ */
+export async function terminateWindowsProcessTree(
+  proc: ChildProcess,
+  terminateTree: typeof taskkillWindowsTree = taskkillWindowsTree,
+  waitForExit: typeof waitForSignalledExit = waitForSignalledExit
+): Promise<'SIGTERM' | 'SIGKILL'> {
+  const gracefulTreeKillSent = await terminateTree(proc, false);
+  if (gracefulTreeKillSent && (await waitForExit(proc, 3000))) return 'SIGTERM';
+
+  // If taskkill itself is unavailable, direct ChildProcess.kill remains the
+  // best-effort fallback. It cannot guarantee cleanup of an already-orphaned
+  // descendant, so use it only after the forced tree attempt has failed.
+  if (!(await terminateTree(proc, true))) proc.kill('SIGKILL');
+  await waitForExit(proc, PROCESS_REAP_GRACE_MS);
+  return 'SIGKILL';
+}
+
+/**
+ * Stop the complete CLI process tree, escalating to SIGKILL if any POSIX group
+ * member ignores SIGTERM. Returns the signal that actually ended it, which the
+ * timeout branch reports as `exit_signal`.
+ */
+export async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'SIGKILL'> {
+  if (SUPPORTS_PROCESS_GROUPS) {
+    if (!signalOwnedPosixProcessGroup(proc, 'SIGTERM')) {
+      proc.kill('SIGTERM');
+      await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+      return 'SIGTERM';
+    }
+    if (await waitForOwnedPosixTreeToQuiesce(proc, POSIX_TREE_TERM_GRACE_MS)) {
+      return 'SIGTERM';
+    }
+    if (!signalOwnedPosixProcessGroup(proc, 'SIGKILL')) proc.kill('SIGKILL');
+    await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+    return 'SIGKILL';
+  }
+
+  return terminateWindowsProcessTree(proc);
+}
+
+/** Spawn the real CLI beneath a persistent process-group ownership anchor. */
+export function spawnSupervisedCli(
+  binary: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): SupervisedCli {
+  const supervisor = spawn(
+    process.execPath,
+    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
+    {
+      detached: SUPPORTS_PROCESS_GROUPS,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      windowsHide: true,
+    }
+  );
+  const targetExit = new Promise<TargetExit>((resolve) => {
+    let settled = false;
+    const settle = (target: TargetExit) => {
+      if (settled) return;
+      settled = true;
+      resolve(target);
+    };
+    supervisor.on('message', (message: unknown) => {
+      if (typeof message !== 'object' || message == null) return;
+      const value = message as Record<string, unknown>;
+      if (value.type !== 'target-exit') return;
+      settle({
+        exitCode: typeof value.code === 'number' ? value.code : null,
+        signalCode: typeof value.signal === 'string' ? (value.signal as NodeJS.Signals) : null,
+        error: typeof value.error === 'string' ? value.error : null,
+      });
+    });
+    supervisor.once('error', (error) => {
+      settle({ exitCode: null, signalCode: null, error: error.message });
+    });
+    supervisor.once('exit', (code, signal) => {
+      settle({
+        exitCode: code,
+        signalCode: signal,
+        error: 'automation process supervisor exited before reporting the CLI outcome',
+      });
+    });
+  });
+  return { supervisor, targetExit };
+}

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -25,16 +25,16 @@
  * server sent no session for — an older server, or one that could not mint.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Readable } from 'node:stream';
 import {
-  buildDeviceAutomationPrompt,
-  DEVICE_AGENT_SPECS_BY_KIND,
   type AgentKind,
   type AgentSpec,
+  buildDeviceAutomationPrompt,
+  DEVICE_AGENT_SPECS_BY_KIND,
 } from '@lobu/core/contracts/worker/device-automation';
 import type {
   AutomationPollPayload,
@@ -43,6 +43,13 @@ import type {
   WorkerExitReason,
 } from '@lobu/core/contracts/worker/protocol';
 import { locateBinary, searchDirs } from './agent-binaries.js';
+import {
+  releaseSupervisor,
+  spawnSupervisedCli,
+  terminateChild,
+  waitForTargetExit,
+  waitForTargetExitAfterTermination,
+} from './automation-process.js';
 import type { ExecutorClient } from './client.js';
 import { WorkerDecodeError, WorkerHttpError } from './client.js';
 import { log } from './log.js';
@@ -68,7 +75,7 @@ export interface AutomationExecutorConfig {
   insideClaude?: boolean;
   /** Stops a pending parent handoff during daemon shutdown. */
   shutdownSignal?: AbortSignal;
-  /** Grace for a CLI that completed the run over MCP and is winding down. */
+  /** Test-only override; production deliberately uses the 15-second default. */
   terminalHeartbeatGraceMs?: number;
   /**
    * Agent to use when the Automation names no `agent_kind`.
@@ -108,116 +115,6 @@ const LOCAL_MAX_ROUNDS = 8;
 const EXIT_REPORT_DELIVERY_ATTEMPTS = 3;
 const EXIT_REPORT_RETRY_DELAY_MS = 2000;
 const TERMINAL_HEARTBEAT_GRACE_MS = 15_000;
-const SUPPORTS_PROCESS_GROUPS = process.platform !== 'win32';
-const POSIX_TREE_TERM_GRACE_MS = 3000;
-const PROCESS_REAP_GRACE_MS = 5000;
-
-/**
- * Keep a process-group leader alive after the actual CLI exits. The daemon can
- * then clean up descendants through an identity that the kernel cannot recycle
- * underneath it. The supervisor deliberately ignores SIGTERM; the CLI and its
- * descendants still receive the group signal, while the supervisor remains the
- * ownership anchor until the daemon releases or SIGKILLs it.
- *
- * POSIX caller contract: spawn this source with `detached: true`, making the
- * supervisor the session/process-group leader whose pgid equals its pid. Its
- * parent-loss path uses that invariant for safe negative-pid group signals.
- */
-export const CLI_SUPERVISOR_SOURCE = String.raw`
-const { spawn } = require('node:child_process');
-const [binary, ...args] = process.argv.slice(1);
-let targetFinished = false;
-let parentLost = false;
-let target;
-const keepAlive = setInterval(() => {}, 2147483647);
-const send = (message) => {
-  try { process.send?.(message); } catch {}
-};
-const finish = (code, signal, error) => {
-  if (targetFinished) return;
-  targetFinished = true;
-  if (!parentLost) send({ type: 'target-exit', code, signal, error });
-};
-const stopAfterParentLoss = () => {
-  if (parentLost) return;
-  parentLost = true;
-  clearInterval(keepAlive);
-
-  if (process.platform === 'win32') {
-    // Keep this process alive as the tree root until taskkill gets its chance.
-    // The timer is deliberately ref'ed: parent loss must not let the supervisor
-    // exit before the owned CLI tree has been addressed.
-    try {
-      const killer = spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
-        stdio: 'ignore',
-        windowsHide: true,
-      });
-      killer.once('error', () => {});
-    } catch {}
-    setTimeout(() => {
-      try { target?.kill('SIGKILL'); } catch {}
-      process.exit(1);
-    }, 3000);
-    return;
-  }
-
-  // This detached supervisor is still the live session/group leader, so its
-  // own negative pid cannot have been recycled. Ignore SIGTERM here while the
-  // target and descendants get a graceful window, then kill the complete group
-  // including this anchor so parent loss cannot leave an immortal orphan.
-  try {
-    process.kill(-process.pid, 'SIGTERM');
-  } catch {
-    try { target?.kill('SIGTERM'); } catch {}
-  }
-  setTimeout(() => {
-    try {
-      process.kill(-process.pid, 'SIGKILL');
-    } catch {
-      try { target?.kill('SIGKILL'); } catch {}
-      process.exit(1);
-    }
-  }, 3000);
-};
-process.on('SIGTERM', () => {});
-process.once('disconnect', stopAfterParentLoss);
-process.on('message', (message) => {
-  if (message?.type !== 'release' || !targetFinished) return;
-  clearInterval(keepAlive);
-  process.exit(0);
-});
-if (!binary) {
-  finish(127, null, 'automation supervisor missing target binary');
-} else {
-  try {
-    target = spawn(binary, args, {
-      env: process.env,
-      stdio: ['ignore', 'inherit', 'inherit'],
-      windowsHide: true,
-    });
-  } catch (error) {
-    finish(127, null, error instanceof Error ? error.message : String(error));
-  }
-  target?.once('error', (error) => {
-    finish(127, null, error instanceof Error ? error.message : String(error));
-  });
-  target?.once('exit', (code, signal) => finish(code, signal, null));
-}
-setImmediate(() => {
-  if (!process.connected) stopAfterParentLoss();
-});
-`;
-
-interface TargetExit {
-  exitCode: number | null;
-  signalCode: NodeJS.Signals | null;
-  error: string | null;
-}
-
-interface SupervisedCli {
-  supervisor: ChildProcess;
-  targetExit: Promise<TargetExit>;
-}
 
 /** Sentinel for "binary not on PATH" so it maps to a distinct exit reason. */
 class ExecutableNotFoundError extends Error {
@@ -289,324 +186,6 @@ async function awaitDrain(
   if (outcome !== expired) return outcome;
   stream.destroy();
   return pending;
-}
-
-/** Wait for the supervised CLI to exit, the timeout to lapse, or cancellation. */
-function waitForTargetExit(
-  targetExit: Promise<TargetExit>,
-  timeoutMs: number,
-  abortSignal?: AbortSignal
-): Promise<{ timedOut: boolean; aborted: boolean; target?: TargetExit }> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const settle = (outcome: {
-      timedOut: boolean;
-      aborted: boolean;
-      target?: TargetExit;
-    }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      abortSignal?.removeEventListener('abort', onAbort);
-      resolve(outcome);
-    };
-    const onAbort = () => settle({ timedOut: false, aborted: true });
-    const timer = setTimeout(() => {
-      settle({ timedOut: true, aborted: false });
-    }, timeoutMs);
-    timer.unref?.();
-    targetExit.then((target) => settle({ timedOut: false, aborted: false, target }));
-    if (abortSignal?.aborted) onAbort();
-    else abortSignal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-/** Await the target metadata after process-tree termination. */
-export async function waitForTargetExitAfterTermination(
-  targetExit: Promise<TargetExit>,
-  timeoutMs = PROCESS_REAP_GRACE_MS
-): Promise<TargetExit | null> {
-  const { target } = await waitForTargetExit(targetExit, timeoutMs);
-  return target ?? null;
-}
-
-/** Wait a bounded interval for a signal sent to the child to take effect. */
-function waitForSignalledExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
-  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
-  return new Promise((resolve) => {
-    let settled = false;
-    const settle = (exited: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      proc.removeListener('exit', onExit);
-      resolve(exited);
-    };
-    const onExit = () => settle(true);
-    const timer = setTimeout(() => settle(false), timeoutMs);
-    timer.unref?.();
-    proc.once('exit', onExit);
-  });
-}
-
-type ProcessGroupOwner = Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode'>;
-
-/**
- * Signal a POSIX group only while its supervisor is a live ownership anchor.
- * Once the anchor has exited, its numeric pid/pgid may refer to an unrelated
- * future process group and must never be used as a negative-pid signal target.
- * Exported only so the PID-reuse safety invariant has a direct regression test.
- */
-export function signalOwnedPosixProcessGroup(
-  owner: ProcessGroupOwner,
-  signal: NodeJS.Signals,
-  sendSignal: typeof process.kill = process.kill
-): boolean {
-  if (
-    !SUPPORTS_PROCESS_GROUPS ||
-    owner.pid == null ||
-    owner.exitCode !== null ||
-    owner.signalCode !== null
-  ) {
-    return false;
-  }
-  try {
-    sendSignal(-owner.pid, signal);
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
-    throw err;
-  }
-}
-
-/** Read a snapshot of one POSIX group without signalling its numeric id. */
-function listPosixProcessGroupMembers(pgid: number): Promise<number[] | null> {
-  const psBinary = existsSync('/bin/ps')
-    ? '/bin/ps'
-    : existsSync('/usr/bin/ps')
-      ? '/usr/bin/ps'
-      : 'ps';
-  return new Promise((resolve) => {
-    let proc: ChildProcess;
-    try {
-      proc = spawn(psBinary, ['-axo', 'pid=,pgid='], {
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      });
-    } catch {
-      resolve(null);
-      return;
-    }
-    let settled = false;
-    let output = '';
-    const settle = (members: number[] | null) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(members);
-    };
-    const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      settle(null);
-    }, 1000);
-    timer.unref?.();
-    proc.stdout?.setEncoding('utf8');
-    proc.stdout?.on('data', (chunk: string) => {
-      if (output.length < 4 * 1024 * 1024) output += chunk;
-    });
-    proc.once('error', () => settle(null));
-    proc.once('close', (code) => {
-      if (code !== 0) {
-        settle(null);
-        return;
-      }
-      const members: number[] = [];
-      for (const line of output.split('\n')) {
-        const [pidText, pgidText] = line.trim().split(/\s+/);
-        const pid = Number(pidText);
-        const rowPgid = Number(pgidText);
-        if (Number.isInteger(pid) && rowPgid === pgid) members.push(pid);
-      }
-      settle(members);
-    });
-  });
-}
-
-/** Ask the supervisor to release its non-reusable group identity and reap it. */
-async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): Promise<boolean> {
-  if (proc.exitCode !== null || proc.signalCode !== null) return true;
-  let sent = false;
-  try {
-    if (proc.connected) {
-      proc.send?.({ type: 'release' });
-      sent = true;
-    }
-  } catch {}
-  if (sent && (await waitForSignalledExit(proc, timeoutMs))) return true;
-  // Direct ChildProcess.kill uses the still-owned process handle; never turn a
-  // failed release into a negative-pgid signal after the anchor might be gone.
-  proc.kill('SIGKILL');
-  await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
-  return false;
-}
-
-/**
- * Wait until SIGTERM leaves only the supervisor in its group. Before releasing
- * the anchor, freeze the group and take a second snapshot so no live member can
- * fork across the observation. A process outside this new session cannot join
- * the group, so releasing the sole remaining supervisor is then race-free.
- */
-export async function waitForOwnedPosixTreeToQuiesce(
-  proc: ChildProcess,
-  timeoutMs: number,
-  listMembers: (pgid: number) => Promise<number[] | null> = listPosixProcessGroupMembers,
-  wait: (ms: number) => Promise<void> = sleep
-): Promise<boolean> {
-  const pgid = proc.pid;
-  if (pgid == null) return false;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const members = await listMembers(pgid);
-    if (members == null) {
-      // An unavailable or overloaded `ps` removes our proof that only the
-      // ownership anchor remains; it must not also remove the target's TERM
-      // grace. Consume the remaining window, then escalate while the anchor is
-      // still live and the negative pgid is still safe.
-      const remainingMs = deadline - Date.now();
-      if (remainingMs > 0) await wait(remainingMs);
-      return false;
-    }
-    if (members.length === 1 && members[0] === pgid) {
-      if (!signalOwnedPosixProcessGroup(proc, 'SIGSTOP')) return false;
-      const frozenMembers = await listMembers(pgid);
-      if (frozenMembers?.length === 1 && frozenMembers[0] === pgid) {
-        if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
-        return releaseSupervisor(proc);
-      }
-      // The anchor is still live and stopped, so this cannot target a reused id.
-      if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
-    }
-    await wait(Math.min(25, Math.max(1, deadline - Date.now())));
-  }
-  return false;
-}
-
-/** Windows has no negative-pid process groups; taskkill supplies bounded tree cleanup. */
-function taskkillWindowsTree(proc: ChildProcess, force: boolean): Promise<boolean> {
-  if (proc.pid == null) return Promise.resolve(true);
-  return new Promise((resolve) => {
-    const killer = spawn(
-      'taskkill',
-      ['/PID', String(proc.pid), '/T', ...(force ? ['/F'] : [])],
-      { stdio: 'ignore', windowsHide: true }
-    );
-    let settled = false;
-    const settle = (ok: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(ok);
-    };
-    const timer = setTimeout(() => {
-      killer.kill();
-      settle(false);
-    }, 3000);
-    timer.unref?.();
-    killer.once('error', () => settle(false));
-    killer.once('exit', (code) => settle(code === 0));
-  });
-}
-
-/**
- * Keep the supervisor alive until Windows has had its forced tree-kill chance.
- * Killing only the supervisor after a failed graceful `taskkill /T` would
- * orphan the real CLI and make its numeric tree root unusable. Exported, with
- * its collaborators injectable, only so that ordering is testable off Windows.
- */
-export async function terminateWindowsProcessTree(
-  proc: ChildProcess,
-  terminateTree: typeof taskkillWindowsTree = taskkillWindowsTree,
-  waitForExit: typeof waitForSignalledExit = waitForSignalledExit
-): Promise<'SIGTERM' | 'SIGKILL'> {
-  const gracefulTreeKillSent = await terminateTree(proc, false);
-  if (gracefulTreeKillSent && (await waitForExit(proc, 3000))) return 'SIGTERM';
-
-  // If taskkill itself is unavailable, direct ChildProcess.kill remains the
-  // best-effort fallback. It cannot guarantee cleanup of an already-orphaned
-  // descendant, so use it only after the forced tree attempt has failed.
-  if (!(await terminateTree(proc, true))) proc.kill('SIGKILL');
-  await waitForExit(proc, PROCESS_REAP_GRACE_MS);
-  return 'SIGKILL';
-}
-
-/**
- * Stop the complete CLI process tree, escalating to SIGKILL if any POSIX group
- * member ignores SIGTERM. Returns the signal that actually ended it, which the
- * timeout branch reports as `exit_signal`.
- */
-async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'SIGKILL'> {
-  if (SUPPORTS_PROCESS_GROUPS) {
-    if (!signalOwnedPosixProcessGroup(proc, 'SIGTERM')) {
-      proc.kill('SIGTERM');
-      await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
-      return 'SIGTERM';
-    }
-    if (await waitForOwnedPosixTreeToQuiesce(proc, POSIX_TREE_TERM_GRACE_MS)) {
-      return 'SIGTERM';
-    }
-    if (!signalOwnedPosixProcessGroup(proc, 'SIGKILL')) proc.kill('SIGKILL');
-    await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
-    return 'SIGKILL';
-  }
-
-  return terminateWindowsProcessTree(proc);
-}
-
-/** Spawn the real CLI beneath a persistent process-group ownership anchor. */
-function spawnSupervisedCli(
-  binary: string,
-  args: string[],
-  env: NodeJS.ProcessEnv
-): SupervisedCli {
-  const supervisor = spawn(
-    process.execPath,
-    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
-    {
-      detached: SUPPORTS_PROCESS_GROUPS,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      windowsHide: true,
-    }
-  );
-  const targetExit = new Promise<TargetExit>((resolve) => {
-    let settled = false;
-    const settle = (target: TargetExit) => {
-      if (settled) return;
-      settled = true;
-      resolve(target);
-    };
-    supervisor.on('message', (message: unknown) => {
-      if (typeof message !== 'object' || message == null) return;
-      const value = message as Record<string, unknown>;
-      if (value.type !== 'target-exit') return;
-      settle({
-        exitCode: typeof value.code === 'number' ? value.code : null,
-        signalCode: typeof value.signal === 'string' ? (value.signal as NodeJS.Signals) : null,
-        error: typeof value.error === 'string' ? value.error : null,
-      });
-    });
-    supervisor.once('error', (error) => {
-      settle({ exitCode: null, signalCode: null, error: error.message });
-    });
-    supervisor.once('exit', (code, signal) => {
-      settle({
-        exitCode: code,
-        signalCode: signal,
-        error: 'automation process supervisor exited before reporting the CLI outcome',
-      });
-    });
-  });
-  return { supervisor, targetExit };
 }
 
 /** Assemble argv from the spec + execution config, mirroring `SpecExecutor`. */

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -813,8 +813,12 @@ async function runCli(
     const label = spec.binaryName;
     const exitCode = target?.exitCode ?? null;
     const targetSignal = target?.signalCode ?? null;
+    // Once the target exits, cleanupSignal belongs only to its supervisor or
+    // descendants and must not overwrite the target's own exit metadata.
     const exitSignal =
-      killedSignal ?? cleanupSignal ?? (targetSignal != null ? `signal:${targetSignal}` : null);
+      killedSignal ??
+      (cancelled ? cleanupSignal : null) ??
+      (targetSignal != null ? `signal:${targetSignal}` : null);
 
     let exitReason: WorkerExitReason;
     let errorMessage: string | null;

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -497,7 +497,8 @@ function taskkillWindowsTree(proc: ChildProcess, force: boolean): Promise<boolea
 /**
  * Keep the supervisor alive until Windows has had its forced tree-kill chance.
  * Killing only the supervisor after a failed graceful `taskkill /T` would
- * orphan the real CLI and make its numeric tree root unusable.
+ * orphan the real CLI and make its numeric tree root unusable. Exported, with
+ * its collaborators injectable, only so that ordering is testable off Windows.
  */
 export async function terminateWindowsProcessTree(
   proc: ChildProcess,
@@ -780,15 +781,11 @@ async function runCli(
         terminalHeartbeatGraceMs
       );
       target = gracefulExit.target;
-      if (!target) {
-        cancelled = true;
-        // The exit report is discarded below, so the signal it took is moot.
-        await terminateChild(proc);
-        supervisorSettled = true;
-      } else {
-        cleanupSignal = await terminateChild(proc);
-        supervisorSettled = true;
-      }
+      // Either way the tree must go: a CLI that exited still leaves the
+      // supervisor and any descendants it spawned holding the group.
+      cancelled = !target;
+      cleanupSignal = await terminateChild(proc);
+      supervisorSettled = true;
     } else if (timedOut) {
       killedSignal = await terminateChild(proc);
       supervisorSettled = true;
@@ -813,13 +810,11 @@ async function runCli(
       awaitDrain(stderrPromise, proc.stderr!, drainDeadlineMs),
     ]);
 
-    if (cancelled) throw new AutomationRunNoLongerActiveError();
-
     const label = spec.binaryName;
     const exitCode = target?.exitCode ?? null;
     const targetSignal = target?.signalCode ?? null;
     const exitSignal =
-      killedSignal ?? (targetSignal != null ? `signal:${targetSignal}` : null);
+      killedSignal ?? cleanupSignal ?? (targetSignal != null ? `signal:${targetSignal}` : null);
 
     let exitReason: WorkerExitReason;
     let errorMessage: string | null;
@@ -838,7 +833,13 @@ async function runCli(
       target?.error ||
       ''
     ).slice(-DETAIL_TAIL_CHARS);
-    if (timedOut) {
+    if (cancelled) {
+      // The server owns the terminal outcome, but complete-automation remains
+      // terminal-safe so it can retain device provenance and duration. Report
+      // this intentional local stop as clean instead of inventing a failure.
+      exitReason = 'ok';
+      errorMessage = null;
+    } else if (timedOut) {
       exitReason = 'timeout';
       const deadline = `${label} exited via ${killedSignal ?? 'SIGTERM'} after ${Math.trunc(timeoutMs / 1000)}s timeout`;
       // The deadline alone says nothing about WHY the CLI stalled, and a
@@ -979,6 +980,9 @@ export async function executeAutomationRun(
             `[executor] Automation run ${runId} is no longer active; waiting for the local CLI to exit`
           );
           runAbort.abort();
+          // The outcome is already settled server-side; stop beating at a run
+          // that will 409 for the rest of the terminal grace.
+          clearInterval(heartbeat);
         }
         return;
       }
@@ -1082,8 +1086,8 @@ export async function dispatchAutomationResumeLoop(
       result = await io.run(finalizeNudge);
     } catch (err) {
       if (err instanceof AutomationRunNoLongerActiveError) {
-        // The server already owns this run's outcome; the CLI has been stopped.
-        // Reporting an exit now would stomp whatever it settled on.
+        // The terminal heartbeat landed before this round spawned, so there is
+        // no local process exit or device metadata to report.
         return { itemsCollected: 0 };
       }
       // Unambiguous: nothing has been reported yet. Missing binary is a

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -363,9 +363,13 @@ async function runCli(
     const supervised = spawnSupervisedCli(binary, args, env);
     const proc = supervised.supervisor;
     supervisor = proc;
+    const { stdout, stderr } = proc;
+    if (!stdout || !stderr) {
+      throw new Error('automation supervisor spawned without stdio pipes');
+    }
 
-    const stdoutPromise = drain(proc.stdout!, STDOUT_CAP);
-    const stderrPromise = drain(proc.stderr!, STDERR_CAP);
+    const stdoutPromise = drain(stdout, STDOUT_CAP);
+    const stderrPromise = drain(stderr, STDERR_CAP);
 
     const initialExit = await waitForTargetExit(supervised.targetExit, timeoutMs, abortSignal);
     const { timedOut, aborted } = initialExit;
@@ -409,8 +413,8 @@ async function runCli(
       { data: stdoutData, truncated: stdoutTruncated },
       { data: stderrData },
     ] = await Promise.all([
-      awaitDrain(stdoutPromise, proc.stdout!, drainDeadlineMs),
-      awaitDrain(stderrPromise, proc.stderr!, drainDeadlineMs),
+      awaitDrain(stdoutPromise, stdout, drainDeadlineMs),
+      awaitDrain(stderrPromise, stderr, drainDeadlineMs),
     ]);
 
     const label = spec.binaryName;

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -390,13 +390,17 @@ async function runCli(
       // Either way the tree must go: a CLI that exited still leaves the
       // supervisor and any descendants it spawned holding the group.
       cancelled = !target;
-      cleanupSignal = await terminateChild(proc);
+      const treeSignal = await terminateChild(proc);
       supervisorSettled = true;
+      target ??=
+        (await waitForTargetExitAfterTermination(supervised.targetExit)) ?? undefined;
+      cleanupSignal = target && target.signalCode !== 'SIGKILL' ? 'SIGTERM' : treeSignal;
     } else if (timedOut) {
-      killedSignal = await terminateChild(proc);
+      const treeSignal = await terminateChild(proc);
       supervisorSettled = true;
       target =
         (await waitForTargetExitAfterTermination(supervised.targetExit)) ?? undefined;
+      killedSignal = target && target.signalCode !== 'SIGKILL' ? 'SIGTERM' : treeSignal;
     } else {
       await releaseSupervisor(proc);
       supervisorSettled = true;

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -68,6 +68,8 @@ export interface AutomationExecutorConfig {
   insideClaude?: boolean;
   /** Stops a pending parent handoff during daemon shutdown. */
   shutdownSignal?: AbortSignal;
+  /** Grace for a CLI that completed the run over MCP and is winding down. */
+  terminalHeartbeatGraceMs?: number;
   /**
    * Agent to use when the Automation names no `agent_kind`.
    *
@@ -105,12 +107,127 @@ const DETAIL_TAIL_CHARS = 500;
 const LOCAL_MAX_ROUNDS = 8;
 const EXIT_REPORT_DELIVERY_ATTEMPTS = 3;
 const EXIT_REPORT_RETRY_DELAY_MS = 2000;
+const TERMINAL_HEARTBEAT_GRACE_MS = 15_000;
+const SUPPORTS_PROCESS_GROUPS = process.platform !== 'win32';
+const POSIX_TREE_TERM_GRACE_MS = 3000;
+const PROCESS_REAP_GRACE_MS = 5000;
+
+/**
+ * Keep a process-group leader alive after the actual CLI exits. The daemon can
+ * then clean up descendants through an identity that the kernel cannot recycle
+ * underneath it. The supervisor deliberately ignores SIGTERM; the CLI and its
+ * descendants still receive the group signal, while the supervisor remains the
+ * ownership anchor until the daemon releases or SIGKILLs it.
+ */
+export const CLI_SUPERVISOR_SOURCE = String.raw`
+const { spawn } = require('node:child_process');
+const [binary, ...args] = process.argv.slice(1);
+let targetFinished = false;
+let parentLost = false;
+let target;
+const keepAlive = setInterval(() => {}, 2147483647);
+const send = (message) => {
+  try { process.send?.(message); } catch {}
+};
+const finish = (code, signal, error) => {
+  if (targetFinished) return;
+  targetFinished = true;
+  if (!parentLost) send({ type: 'target-exit', code, signal, error });
+};
+const stopAfterParentLoss = () => {
+  if (parentLost) return;
+  parentLost = true;
+  clearInterval(keepAlive);
+
+  if (process.platform === 'win32') {
+    // Keep this process alive as the tree root until taskkill gets its chance.
+    // The timer is deliberately ref'ed: parent loss must not let the supervisor
+    // exit before the owned CLI tree has been addressed.
+    try {
+      const killer = spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', () => {});
+    } catch {}
+    setTimeout(() => {
+      try { target?.kill('SIGKILL'); } catch {}
+      process.exit(1);
+    }, 3000);
+    return;
+  }
+
+  // This detached supervisor is still the live session/group leader, so its
+  // own negative pid cannot have been recycled. Ignore SIGTERM here while the
+  // target and descendants get a graceful window, then kill the complete group
+  // including this anchor so parent loss cannot leave an immortal orphan.
+  try {
+    process.kill(-process.pid, 'SIGTERM');
+  } catch {
+    try { target?.kill('SIGTERM'); } catch {}
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-process.pid, 'SIGKILL');
+    } catch {
+      try { target?.kill('SIGKILL'); } catch {}
+      process.exit(1);
+    }
+  }, 3000);
+};
+process.on('SIGTERM', () => {});
+process.once('disconnect', stopAfterParentLoss);
+process.on('message', (message) => {
+  if (message?.type !== 'release' || !targetFinished) return;
+  clearInterval(keepAlive);
+  process.exit(0);
+});
+if (!binary) {
+  finish(127, null, 'automation supervisor missing target binary');
+} else {
+  try {
+    target = spawn(binary, args, {
+      env: process.env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+      windowsHide: true,
+    });
+  } catch (error) {
+    finish(127, null, error instanceof Error ? error.message : String(error));
+  }
+  target?.once('error', (error) => {
+    finish(127, null, error instanceof Error ? error.message : String(error));
+  });
+  target?.once('exit', (code, signal) => finish(code, signal, null));
+}
+setImmediate(() => {
+  if (!process.connected) stopAfterParentLoss();
+});
+`;
+
+interface TargetExit {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  error: string | null;
+}
+
+interface SupervisedCli {
+  supervisor: ChildProcess;
+  targetExit: Promise<TargetExit>;
+}
 
 /** Sentinel for "binary not on PATH" so it maps to a distinct exit reason. */
 class ExecutableNotFoundError extends Error {
   constructor(name: string) {
     super(`${name} binary not found on PATH`);
     this.name = 'ExecutableNotFoundError';
+  }
+}
+
+/** The server has already finalized or released this claimed run. */
+class AutomationRunNoLongerActiveError extends Error {
+  constructor() {
+    super('automation run is no longer active');
+    this.name = 'AutomationRunNoLongerActiveError';
   }
 }
 
@@ -170,30 +287,302 @@ async function awaitDrain(
   return pending;
 }
 
-/** Wait for the child to exit, or report the timeout lapsed. */
-function waitForExit(
-  proc: ChildProcess,
-  timeoutMs: number
-): Promise<{ timedOut: boolean }> {
+/** Wait for the supervised CLI to exit, the timeout to lapse, or cancellation. */
+function waitForTargetExit(
+  targetExit: Promise<TargetExit>,
+  timeoutMs: number,
+  abortSignal?: AbortSignal
+): Promise<{ timedOut: boolean; aborted: boolean; target?: TargetExit }> {
   return new Promise((resolve) => {
     let settled = false;
-    const onExit = () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        resolve({ timedOut: false });
-      }
+    const settle = (outcome: {
+      timedOut: boolean;
+      aborted: boolean;
+      target?: TargetExit;
+    }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve(outcome);
     };
+    const onAbort = () => settle({ timedOut: false, aborted: true });
     const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        proc.removeListener('exit', onExit);
-        resolve({ timedOut: true });
-      }
+      settle({ timedOut: true, aborted: false });
     }, timeoutMs);
+    timer.unref?.();
+    targetExit.then((target) => settle({ timedOut: false, aborted: false, target }));
+    if (abortSignal?.aborted) onAbort();
+    else abortSignal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Wait a bounded interval for a signal sent to the child to take effect. */
+function waitForSignalledExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      proc.removeListener('exit', onExit);
+      resolve(exited);
+    };
+    const onExit = () => settle(true);
+    const timer = setTimeout(() => settle(false), timeoutMs);
     timer.unref?.();
     proc.once('exit', onExit);
   });
+}
+
+type ProcessGroupOwner = Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode'>;
+
+/**
+ * Signal a POSIX group only while its supervisor is a live ownership anchor.
+ * Once the anchor has exited, its numeric pid/pgid may refer to an unrelated
+ * future process group and must never be used as a negative-pid signal target.
+ * Exported only so the PID-reuse safety invariant has a direct regression test.
+ */
+export function signalOwnedPosixProcessGroup(
+  owner: ProcessGroupOwner,
+  signal: NodeJS.Signals,
+  sendSignal: typeof process.kill = process.kill
+): boolean {
+  if (
+    !SUPPORTS_PROCESS_GROUPS ||
+    owner.pid == null ||
+    owner.exitCode !== null ||
+    owner.signalCode !== null
+  ) {
+    return false;
+  }
+  try {
+    sendSignal(-owner.pid, signal);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw err;
+  }
+}
+
+/** Read a snapshot of one POSIX group without signalling its numeric id. */
+function listPosixProcessGroupMembers(pgid: number): Promise<number[] | null> {
+  const psBinary = existsSync('/bin/ps')
+    ? '/bin/ps'
+    : existsSync('/usr/bin/ps')
+      ? '/usr/bin/ps'
+      : 'ps';
+  return new Promise((resolve) => {
+    let proc: ChildProcess;
+    try {
+      proc = spawn(psBinary, ['-axo', 'pid=,pgid='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    let settled = false;
+    let output = '';
+    const settle = (members: number[] | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(members);
+    };
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      settle(null);
+    }, 1000);
+    timer.unref?.();
+    proc.stdout?.setEncoding('utf8');
+    proc.stdout?.on('data', (chunk: string) => {
+      if (output.length < 4 * 1024 * 1024) output += chunk;
+    });
+    proc.once('error', () => settle(null));
+    proc.once('close', (code) => {
+      if (code !== 0) {
+        settle(null);
+        return;
+      }
+      const members: number[] = [];
+      for (const line of output.split('\n')) {
+        const [pidText, pgidText] = line.trim().split(/\s+/);
+        const pid = Number(pidText);
+        const rowPgid = Number(pgidText);
+        if (Number.isInteger(pid) && rowPgid === pgid) members.push(pid);
+      }
+      settle(members);
+    });
+  });
+}
+
+/** Ask the supervisor to release its non-reusable group identity and reap it. */
+async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return true;
+  let sent = false;
+  try {
+    if (proc.connected) {
+      proc.send?.({ type: 'release' });
+      sent = true;
+    }
+  } catch {}
+  if (sent && (await waitForSignalledExit(proc, timeoutMs))) return true;
+  // Direct ChildProcess.kill uses the still-owned process handle; never turn a
+  // failed release into a negative-pgid signal after the anchor might be gone.
+  proc.kill('SIGKILL');
+  await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+  return false;
+}
+
+/**
+ * Wait until SIGTERM leaves only the supervisor in its group. Before releasing
+ * the anchor, freeze the group and take a second snapshot so no live member can
+ * fork across the observation. A process outside this new session cannot join
+ * the group, so releasing the sole remaining supervisor is then race-free.
+ */
+async function waitForOwnedPosixTreeToQuiesce(
+  proc: ChildProcess,
+  timeoutMs: number
+): Promise<boolean> {
+  const pgid = proc.pid;
+  if (pgid == null) return false;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const members = await listPosixProcessGroupMembers(pgid);
+    if (members == null) return false;
+    if (members.length === 1 && members[0] === pgid) {
+      if (!signalOwnedPosixProcessGroup(proc, 'SIGSTOP')) return false;
+      const frozenMembers = await listPosixProcessGroupMembers(pgid);
+      if (frozenMembers?.length === 1 && frozenMembers[0] === pgid) {
+        if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
+        return releaseSupervisor(proc);
+      }
+      // The anchor is still live and stopped, so this cannot target a reused id.
+      if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
+    }
+    await sleep(Math.min(25, Math.max(1, deadline - Date.now())));
+  }
+  return false;
+}
+
+/** Windows has no negative-pid process groups; taskkill supplies bounded tree cleanup. */
+function taskkillWindowsTree(proc: ChildProcess, force: boolean): Promise<boolean> {
+  if (proc.pid == null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const killer = spawn(
+      'taskkill',
+      ['/PID', String(proc.pid), '/T', ...(force ? ['/F'] : [])],
+      { stdio: 'ignore', windowsHide: true }
+    );
+    let settled = false;
+    const settle = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(ok);
+    };
+    const timer = setTimeout(() => {
+      killer.kill();
+      settle(false);
+    }, 3000);
+    timer.unref?.();
+    killer.once('error', () => settle(false));
+    killer.once('exit', (code) => settle(code === 0));
+  });
+}
+
+/**
+ * Keep the supervisor alive until Windows has had its forced tree-kill chance.
+ * Killing only the supervisor after a failed graceful `taskkill /T` would
+ * orphan the real CLI and make its numeric tree root unusable.
+ */
+export async function terminateWindowsProcessTree(
+  proc: ChildProcess,
+  terminateTree: typeof taskkillWindowsTree = taskkillWindowsTree,
+  waitForExit: typeof waitForSignalledExit = waitForSignalledExit
+): Promise<'SIGTERM' | 'SIGKILL'> {
+  const gracefulTreeKillSent = await terminateTree(proc, false);
+  if (gracefulTreeKillSent && (await waitForExit(proc, 3000))) return 'SIGTERM';
+
+  // If taskkill itself is unavailable, direct ChildProcess.kill remains the
+  // best-effort fallback. It cannot guarantee cleanup of an already-orphaned
+  // descendant, so use it only after the forced tree attempt has failed.
+  if (!(await terminateTree(proc, true))) proc.kill('SIGKILL');
+  await waitForExit(proc, PROCESS_REAP_GRACE_MS);
+  return 'SIGKILL';
+}
+
+/**
+ * Stop the complete CLI process tree, escalating to SIGKILL if any POSIX group
+ * member ignores SIGTERM. Returns the signal that actually ended it, which the
+ * timeout branch reports as `exit_signal`.
+ */
+async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'SIGKILL'> {
+  if (SUPPORTS_PROCESS_GROUPS) {
+    if (!signalOwnedPosixProcessGroup(proc, 'SIGTERM')) {
+      proc.kill('SIGTERM');
+      await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+      return 'SIGTERM';
+    }
+    if (await waitForOwnedPosixTreeToQuiesce(proc, POSIX_TREE_TERM_GRACE_MS)) {
+      return 'SIGTERM';
+    }
+    if (!signalOwnedPosixProcessGroup(proc, 'SIGKILL')) proc.kill('SIGKILL');
+    await waitForSignalledExit(proc, PROCESS_REAP_GRACE_MS);
+    return 'SIGKILL';
+  }
+
+  return terminateWindowsProcessTree(proc);
+}
+
+/** Spawn the real CLI beneath a persistent process-group ownership anchor. */
+function spawnSupervisedCli(
+  binary: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): SupervisedCli {
+  const supervisor = spawn(
+    process.execPath,
+    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
+    {
+      detached: SUPPORTS_PROCESS_GROUPS,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      windowsHide: true,
+    }
+  );
+  const targetExit = new Promise<TargetExit>((resolve) => {
+    let settled = false;
+    const settle = (target: TargetExit) => {
+      if (settled) return;
+      settled = true;
+      resolve(target);
+    };
+    supervisor.on('message', (message: unknown) => {
+      if (typeof message !== 'object' || message == null) return;
+      const value = message as Record<string, unknown>;
+      if (value.type !== 'target-exit') return;
+      settle({
+        exitCode: typeof value.code === 'number' ? value.code : null,
+        signalCode: typeof value.signal === 'string' ? (value.signal as NodeJS.Signals) : null,
+        error: typeof value.error === 'string' ? value.error : null,
+      });
+    });
+    supervisor.once('error', (error) => {
+      settle({ exitCode: null, signalCode: null, error: error.message });
+    });
+    supervisor.once('exit', (code, signal) => {
+      settle({
+        exitCode: code,
+        signalCode: signal,
+        error: 'automation process supervisor exited before reporting the CLI outcome',
+      });
+    });
+  });
+  return { supervisor, targetExit };
 }
 
 /** Assemble argv from the spec + execution config, mirroring `SpecExecutor`. */
@@ -334,12 +723,20 @@ async function runCli(
   config: AutomationPollPayload['automation']['execution_config'],
   access: AutomationRunAccess,
   timeoutMs: number,
-  binaryPath?: string
+  binaryPath?: string,
+  abortSignal?: AbortSignal,
+  terminalHeartbeatGraceMs = TERMINAL_HEARTBEAT_GRACE_MS
 ): Promise<ExecutorResult> {
+  // One AbortController spans every finalize/resume round. If a terminal 409
+  // landed while the prior exit report was in flight, do not start stale work.
+  if (abortSignal?.aborted) throw new AutomationRunNoLongerActiveError();
+
   const binary = binaryPath ?? locateBinary(spec.binaryName);
   if (!binary || !existsSync(binary)) throw new ExecutableNotFoundError(spec.binaryName);
 
   const { mcpArgs, mcpEnv, cleanup } = buildMcp(spec, access.wiring);
+  let supervisor: ChildProcess | undefined;
+  let supervisorSettled = false;
   try {
     const args = buildArguments(spec, prompt, config, mcpArgs, timeoutMs / 1000);
     const started = Date.now();
@@ -360,33 +757,50 @@ async function runCli(
       env.PATH = `${extraPath}:${currentPath}`;
     }
 
-    const proc = spawn(binary, args, {
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const supervised = spawnSupervisedCli(binary, args, env);
+    const proc = supervised.supervisor;
+    supervisor = proc;
 
-    const stdoutPromise = drain(proc.stdout, STDOUT_CAP);
-    const stderrPromise = drain(proc.stderr, STDERR_CAP);
+    const stdoutPromise = drain(proc.stdout!, STDOUT_CAP);
+    const stderrPromise = drain(proc.stderr!, STDERR_CAP);
 
-    const { timedOut } = await waitForExit(proc, timeoutMs);
+    const initialExit = await waitForTargetExit(supervised.targetExit, timeoutMs, abortSignal);
+    const { timedOut, aborted } = initialExit;
+    let target = initialExit.target;
+    let cancelled = false;
     let killedSignal: string | null = null;
-    if (timedOut) {
-      proc.kill('SIGTERM');
-      killedSignal = 'SIGTERM';
-      await sleep(3000);
-      if (proc.exitCode === null && proc.signalCode === null) {
-        proc.kill('SIGKILL');
-        killedSignal = 'SIGKILL';
+    let cleanupSignal: string | null = null;
+    if (aborted) {
+      // A 409 is also the normal post-complete_window state. Let a CLI that is
+      // already winding down exit and report its device-side metadata. The
+      // supervisor remains the non-reusable tree owner throughout the grace,
+      // so a normally exiting leader cannot orphan its remaining descendants.
+      const gracefulExit = await waitForTargetExit(
+        supervised.targetExit,
+        terminalHeartbeatGraceMs
+      );
+      target = gracefulExit.target;
+      if (!target) {
+        cancelled = true;
+        // The exit report is discarded below, so the signal it took is moot.
+        await terminateChild(proc);
+        supervisorSettled = true;
+      } else {
+        cleanupSignal = await terminateChild(proc);
+        supervisorSettled = true;
       }
-      // Bounded wait for the process to be reaped so the pipes flush.
-      await Promise.race([
-        new Promise((resolve) => proc.once('exit', resolve)),
-        sleep(5000),
-      ]);
+    } else if (timedOut) {
+      killedSignal = await terminateChild(proc);
+      supervisorSettled = true;
+      target = await supervised.targetExit;
+    } else {
+      await releaseSupervisor(proc);
+      supervisorSettled = true;
     }
 
     // A SIGKILLed child gets a short flush window; a clean exit gets a long one.
-    const drainDeadlineMs = killedSignal === 'SIGKILL' ? 2000 : 60_000;
+    const drainDeadlineMs =
+      cancelled || killedSignal === 'SIGKILL' || cleanupSignal === 'SIGKILL' ? 2000 : 60_000;
     // Both pipes must race the SAME clock. Awaiting them in sequence gave
     // stderr a fresh deadline only after stdout's had expired, so a grandchild
     // holding both ends cost 2x the deadline (measured: 120s for a child that
@@ -395,14 +809,17 @@ async function runCli(
       { data: stdoutData, truncated: stdoutTruncated },
       { data: stderrData },
     ] = await Promise.all([
-      awaitDrain(stdoutPromise, proc.stdout, drainDeadlineMs),
-      awaitDrain(stderrPromise, proc.stderr, drainDeadlineMs),
+      awaitDrain(stdoutPromise, proc.stdout!, drainDeadlineMs),
+      awaitDrain(stderrPromise, proc.stderr!, drainDeadlineMs),
     ]);
 
+    if (cancelled) throw new AutomationRunNoLongerActiveError();
+
     const label = spec.binaryName;
-    const exitCode = proc.exitCode;
+    const exitCode = target?.exitCode ?? null;
+    const targetSignal = target?.signalCode ?? null;
     const exitSignal =
-      killedSignal ?? (proc.signalCode != null ? `signal:${proc.signalCode}` : null);
+      killedSignal ?? (targetSignal != null ? `signal:${targetSignal}` : null);
 
     let exitReason: WorkerExitReason;
     let errorMessage: string | null;
@@ -410,10 +827,16 @@ async function runCli(
     // back to stdout. `claude` prints its fatal on stdout ("Credit balance is
     // too low") and leaves stderr empty, so reading stderr alone reported the
     // most likely real failure as a bare "exited with non-zero status 1" with
-    // the cause only in output_tail; `opencode` logs to stderr instead. Bounded
-    // because this lands in `runs.error_message`, and stderr is capped at 1 MiB.
+    // the cause only in output_tail; `opencode` logs to stderr instead. The
+    // supervisor's error is the last resort: on SIGKILL escalation the whole
+    // group dies before the supervisor can report, and its synthetic message
+    // must not mask what the CLI actually wrote. Bounded because this lands in
+    // `runs.error_message`, and stderr is capped at 1 MiB.
     const detail = (
-      stderrData.toString('utf8').trim() || stdoutData.toString('utf8').trim()
+      stderrData.toString('utf8').trim() ||
+      stdoutData.toString('utf8').trim() ||
+      target?.error ||
+      ''
     ).slice(-DETAIL_TAIL_CHARS);
     if (timedOut) {
       exitReason = 'timeout';
@@ -426,9 +849,9 @@ async function runCli(
     } else if (exitCode === 0) {
       exitReason = 'ok';
       errorMessage = null;
-    } else if (proc.signalCode != null) {
+    } else if (targetSignal != null) {
       exitReason = 'crash';
-      errorMessage = `${label} exited via signal (status=${proc.signalCode})`;
+      errorMessage = `${label} exited via signal (status=${targetSignal})`;
     } else {
       exitReason = 'error_message';
       errorMessage =
@@ -450,6 +873,18 @@ async function runCli(
       durationMs,
     };
   } finally {
+    if (
+      supervisor &&
+      !supervisorSettled &&
+      supervisor.exitCode === null &&
+      supervisor.signalCode === null
+    ) {
+      await terminateChild(supervisor).catch(() => {
+        try {
+          supervisor?.kill('SIGKILL');
+        } catch {}
+      });
+    }
     cleanup();
   }
 }
@@ -535,8 +970,18 @@ export async function executeAutomationRun(
 
   // Heartbeat the run while the CLI executes so the server's stale-run sweeper
   // can distinguish a live turn from an abandoned one.
+  const runAbort = new AbortController();
   const heartbeat = setInterval(() => {
     client.heartbeat(runId).catch((err) => {
+      if (err instanceof WorkerHttpError && err.status === 409) {
+        if (!runAbort.signal.aborted) {
+          log.info(
+            `[executor] Automation run ${runId} is no longer active; waiting for the local CLI to exit`
+          );
+          runAbort.abort();
+        }
+        return;
+      }
       log.debug('[executor] Automation heartbeat failed:', err);
     });
   }, cfg.heartbeatIntervalMs ?? 30_000);
@@ -606,7 +1051,9 @@ export async function executeAutomationRun(
         payload.automation.execution_config,
         resolveAutomationRunAccess(payload, client.mcpWiring),
         timeoutMs,
-        cfg.binaryOverrides?.[spec.kind]
+        cfg.binaryOverrides?.[spec.kind],
+        runAbort.signal,
+        cfg.terminalHeartbeatGraceMs
       );
     },
     deliver: (result, finalizeAttempt) =>
@@ -634,6 +1081,11 @@ export async function dispatchAutomationResumeLoop(
     try {
       result = await io.run(finalizeNudge);
     } catch (err) {
+      if (err instanceof AutomationRunNoLongerActiveError) {
+        // The server already owns this run's outcome; the CLI has been stopped.
+        // Reporting an exit now would stomp whatever it settled on.
+        return { itemsCollected: 0 };
+      }
       // Unambiguous: nothing has been reported yet. Missing binary is a
       // configuration problem, not a crash.
       const reason: WorkerExitReason =

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -118,6 +118,10 @@ const PROCESS_REAP_GRACE_MS = 5000;
  * underneath it. The supervisor deliberately ignores SIGTERM; the CLI and its
  * descendants still receive the group signal, while the supervisor remains the
  * ownership anchor until the daemon releases or SIGKILLs it.
+ *
+ * POSIX caller contract: spawn this source with `detached: true`, making the
+ * supervisor the session/process-group leader whose pgid equals its pid. Its
+ * parent-loss path uses that invariant for safe negative-pid group signals.
  */
 export const CLI_SUPERVISOR_SOURCE = String.raw`
 const { spawn } = require('node:child_process');
@@ -317,6 +321,15 @@ function waitForTargetExit(
   });
 }
 
+/** Await the target metadata after process-tree termination. */
+export async function waitForTargetExitAfterTermination(
+  targetExit: Promise<TargetExit>,
+  timeoutMs = PROCESS_REAP_GRACE_MS
+): Promise<TargetExit | null> {
+  const { target } = await waitForTargetExit(targetExit, timeoutMs);
+  return target ?? null;
+}
+
 /** Wait a bounded interval for a signal sent to the child to take effect. */
 function waitForSignalledExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
   if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
@@ -443,19 +456,29 @@ async function releaseSupervisor(proc: ChildProcess, timeoutMs = 1000): Promise<
  * fork across the observation. A process outside this new session cannot join
  * the group, so releasing the sole remaining supervisor is then race-free.
  */
-async function waitForOwnedPosixTreeToQuiesce(
+export async function waitForOwnedPosixTreeToQuiesce(
   proc: ChildProcess,
-  timeoutMs: number
+  timeoutMs: number,
+  listMembers: (pgid: number) => Promise<number[] | null> = listPosixProcessGroupMembers,
+  wait: (ms: number) => Promise<void> = sleep
 ): Promise<boolean> {
   const pgid = proc.pid;
   if (pgid == null) return false;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const members = await listPosixProcessGroupMembers(pgid);
-    if (members == null) return false;
+    const members = await listMembers(pgid);
+    if (members == null) {
+      // An unavailable or overloaded `ps` removes our proof that only the
+      // ownership anchor remains; it must not also remove the target's TERM
+      // grace. Consume the remaining window, then escalate while the anchor is
+      // still live and the negative pgid is still safe.
+      const remainingMs = deadline - Date.now();
+      if (remainingMs > 0) await wait(remainingMs);
+      return false;
+    }
     if (members.length === 1 && members[0] === pgid) {
       if (!signalOwnedPosixProcessGroup(proc, 'SIGSTOP')) return false;
-      const frozenMembers = await listPosixProcessGroupMembers(pgid);
+      const frozenMembers = await listMembers(pgid);
       if (frozenMembers?.length === 1 && frozenMembers[0] === pgid) {
         if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
         return releaseSupervisor(proc);
@@ -463,7 +486,7 @@ async function waitForOwnedPosixTreeToQuiesce(
       // The anchor is still live and stopped, so this cannot target a reused id.
       if (!signalOwnedPosixProcessGroup(proc, 'SIGCONT')) return false;
     }
-    await sleep(Math.min(25, Math.max(1, deadline - Date.now())));
+    await wait(Math.min(25, Math.max(1, deadline - Date.now())));
   }
   return false;
 }
@@ -789,7 +812,8 @@ async function runCli(
     } else if (timedOut) {
       killedSignal = await terminateChild(proc);
       supervisorSettled = true;
-      target = await supervised.targetExit;
+      target =
+        (await waitForTargetExitAfterTermination(supervised.targetExit)) ?? undefined;
     } else {
       await releaseSupervisor(proc);
       supervisorSettled = true;

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -109,7 +109,7 @@ import { resolveRunnableAgentKinds } from "./agent-binaries.js";
 /** Capability strings the worker advertises, keyed by name (e.g. `browser.debugger`). */
 export type WorkerCapabilities = Record<string, boolean>;
 
-/** HTTP error carrying the status code, so delivery retries can classify it. */
+/** HTTP error carrying the status code for retry and terminal-conflict policy. */
 export class WorkerHttpError extends Error {
   constructor(
     public readonly status: number,
@@ -220,7 +220,8 @@ export class WorkerClient implements ExecutorClient {
     });
     if (!response.ok) {
       const responseText = await response.text();
-      throw new Error(`${path} failed: ${response.status} ${response.statusText} ${responseText}`);
+      const detail = `${response.statusText} ${responseText}`.trim();
+      throw new WorkerHttpError(response.status, path, detail);
     }
     return response;
   }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -62,6 +62,8 @@ async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
 export interface ExecutorConfig {
   batchSize: number;
   heartbeatIntervalMs: number;
+  /** Grace for a CLI that completed the run over MCP and is winding down. */
+  terminalHeartbeatGraceMs?: number;
   generateEmbeddings: boolean;
   timeoutMs: number;
   maxOldSpaceSize: number;

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -62,7 +62,7 @@ async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
 export interface ExecutorConfig {
   batchSize: number;
   heartbeatIntervalMs: number;
-  /** Grace for a CLI that completed the run over MCP and is winding down. */
+  /** Test-only override; production deliberately uses the 15-second default. */
   terminalHeartbeatGraceMs?: number;
   generateEmbeddings: boolean;
   timeoutMs: number;


### PR DESCRIPTION
## Summary
- preserve HTTP status on worker request failures so heartbeat policy can classify authoritative 409 conflicts
- keep one abort latch across resume rounds and precheck it before every CLI spawn, preventing a terminal heartbeat race from starting another round
- keep a persistent supervisor alive through the 15-second terminal-heartbeat grace so a leader that exits cannot orphan descendants or inherited pipes
- terminate the complete owned process tree, retain the CLI's real stderr/stdout diagnosis through SIGKILL escalation, and deliver one terminal-safe exit report so the server can stamp device provenance and duration
- make the supervisor terminate its owned CLI tree if the daemon parent disappears

Closes #2977

## Process ownership and safety
- On POSIX, the supervisor is the live session/process-group owner. Negative-PGID signals are refused after that owner exits, preventing a reused numeric PGID from reaching an unrelated group.
- Graceful release freezes the group and takes a second membership snapshot before releasing the sole supervisor; otherwise cleanup escalates while the ownership anchor is still live.
- The leader-exits/live-grandchild E2E proves the grandchild receives SIGTERM while the supervisor anchor is still alive, both processes are reaped, and the target's own exit metadata is preserved.
- Parent-loss E2Es prove both cooperative and SIGTERM-ignoring trees are removed after the daemon disappears; fixtures include PID accounting and bounded cooperative cleanup backstops.
- On Windows, graceful `taskkill /T` is followed by forced `taskkill /F /T` while the supervisor is still the usable tree root. Direct supervisor SIGKILL is only the best-effort fallback when `taskkill` itself is unavailable.
- Test cleanup uses cooperative synthetic cleanup plus liveness polling; it never raw-kills a PID read from a stale file.
- A started CLI still sends exactly one guarded `/complete-automation` report after a terminal heartbeat conflict. The server's terminal-safe path stamps device metadata without replacing its settled outcome; a resume round blocked before spawn sends no report.

## Test plan
- [x] Red-to-green terminal-heartbeat race, process-tree cancellation, and guarded exit-report coverage
- [x] Red-to-green leader-exits-with-live-grandchild ownership/reaping coverage
- [x] Red-to-green daemon-parent-loss cleanup coverage for cooperative and SIGTERM-ignoring trees
- [x] Red-to-green unavailable process-membership probe coverage: preserve the remaining SIGTERM grace before SIGKILL
- [x] Red-to-green bounded post-termination target-report coverage with deterministic fallback semantics
- [x] Red-to-green TERM-ignoring fixture cleanup-backstop and PID-accounting coverage
- [x] Red-to-green stale-owner/PID-PGID-reuse guard coverage
- [x] Red-to-green SIGKILL diagnostic-precedence coverage
- [x] Red-to-green normal-target-exit metadata coverage: supervisor/descendant cleanup does not overwrite the target exit signal
- [x] Red-to-green Windows graceful-tree-failure ordering coverage
- [x] Final rebase equivalence: 4/4 exact `range-diff`, matching stable patch IDs, matching aggregate binary diff hash, and unchanged touched-file base blobs
- [x] Exact-head focused lifecycle suite: `bun test packages/connector-worker/src/__tests__/automation-arm.test.ts packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts` (35 pass, 141 assertions)
- [x] Exact-head connector-worker typecheck: `cd packages/connector-worker && bun run typecheck`
- [x] Embedded-Postgres server contract: an exit report acks an MCP-completed run and stamps device provenance
- [x] Verified live Fable semantic review on the pre-rebase combined head; all four robustness follow-ups applied with mutation-sensitive tests
- [x] `make pre-pr` on the final combined head (all 7 stages clean)
- [x] `make ui-review` — not applicable; `packages/owletto` is unchanged

## Boundaries
- Cancellation remains intentionally limited to HTTP 409. Transport errors, 429, 5xx, and claim-reassignment 403 do not stop a healthy CLI in this change.
- A POSIX descendant that deliberately creates a new session/process group can escape this owned group. Pipe drains remain bounded, but guaranteed cleanup of deliberate escapees would require an OS/container ownership primitive such as a cgroup or job object.
- If Windows `taskkill` is unavailable, Node's direct process kill is best-effort and cannot guarantee cleanup of an already-detached descendant.
- The issue's second timer-leak path was already fixed on main by the existing `try/finally` around the resume loop.
- No API, schema, SDK, or UI contract change.



