### PR TITLE
fix(auth): stamp Automation worker token source

### DIFF
--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   generateWorkerToken,
   generateWorkerTokenPair,
+  looksLikeWorkerToken,
   verifyEgressProxyToken,
   verifyWorkerToken,
   type WorkerTokenData,
@@ -102,6 +103,25 @@ describe("worker auth token", () => {
     // hex chars only
     for (const p of parts) {
       expect(p).toMatch(/^[0-9a-f]+$/);
+    }
+  });
+
+  test("recognizes only worker-token ciphertext envelopes", () => {
+    const token = generateWorkerToken("user-1", "conv-1", "deploy-A", {
+      channelId: "C1",
+    });
+    expect(looksLikeWorkerToken(token)).toBe(true);
+    expect(looksLikeWorkerToken("0a:0B:ff")).toBe(true);
+
+    for (const value of [
+      "",
+      "aa:bb",
+      "aa:bb:cc:dd",
+      "aa::cc",
+      "aa:gg:cc",
+      "owl_pat_not-a-worker-token",
+    ]) {
+      expect(looksLikeWorkerToken(value)).toBe(false);
     }
   });
 

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -5,6 +5,16 @@ import { decrypt, encrypt } from "../utils/encryption";
 const logger = createLogger("worker-auth");
 
 /**
+ * Fast envelope check for the AES-GCM worker-token wire format.
+ *
+ * This does not authenticate or decrypt the token. Call {@link verifyWorkerToken}
+ * before trusting any claim.
+ */
+export function looksLikeWorkerToken(token: string): boolean {
+  return /^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/i.test(token);
+}
+
+/**
  * Worker authentication using encrypted conversation ID.
  * Token format: encrypted(JSON payload of thread metadata).
  */

--- a/packages/server/src/__tests__/unit/automations/automation-preflight-token.test.ts
+++ b/packages/server/src/__tests__/unit/automations/automation-preflight-token.test.ts
@@ -1,0 +1,52 @@
+import {
+	__resetEncryptionKeyCacheForTests,
+	verifyWorkerToken,
+	type WorkerTokenData,
+} from "@lobu/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { preflightAutomationMemoryTools } from "../../../automations/automation";
+import { AUTOMATION_RUN_SOURCE } from "../../../gateway/automation-run-session";
+
+const TEST_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("Automation memory preflight token", () => {
+	const originalFetch = globalThis.fetch;
+	let savedKey: string | undefined;
+
+	beforeEach(() => {
+		savedKey = process.env.ENCRYPTION_KEY;
+		process.env.ENCRYPTION_KEY = TEST_KEY;
+		__resetEncryptionKeyCacheForTests();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+		else process.env.ENCRYPTION_KEY = savedKey;
+		__resetEncryptionKeyCacheForTests();
+		vi.restoreAllMocks();
+	});
+
+	it("stamps the Automation run source on the worker bearer", async () => {
+		let claims: WorkerTokenData | null = null;
+		globalThis.fetch = vi.fn(async (_input, init) => {
+			const authorization = new Headers(init?.headers).get("Authorization");
+			expect(authorization).toMatch(/^Bearer /);
+			claims = verifyWorkerToken(authorization!.slice("Bearer ".length));
+			return Response.json({
+				tools: [{ name: "query_sdk" }, { name: "run_sdk" }],
+			});
+		});
+
+		await expect(
+			preflightAutomationMemoryTools({
+				organizationId: "org-team",
+				agentId: "developer",
+				runId: 456,
+			}),
+		).resolves.toEqual({ ok: true });
+
+		expect(claims?.source).toBe(AUTOMATION_RUN_SOURCE);
+	});
+});

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -15,6 +15,7 @@ import { intervals } from "../config/intervals";
 import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
 import { getInternalGatewayUrl } from "../gateway/config/index";
+import { AUTOMATION_RUN_SOURCE } from "../gateway/automation-run-session";
 import { incrementCounter, setGauge } from "../gateway/metrics/prometheus";
 import type { Env } from "../index";
 import { isLobuGatewayRunning } from "../lobu/gateway";
@@ -1188,7 +1189,7 @@ const LOBU_MEMORY_MCP_ID = "lobu-memory";
 // now that flat admin tools are omitted from MCP tools/list.
 const AUTOMATION_REQUIRED_TOOLS = ["query_sdk", "run_sdk"];
 
-async function preflightAutomationMemoryTools(params: {
+export async function preflightAutomationMemoryTools(params: {
 	organizationId: string;
 	agentId: string;
 	runId: number;
@@ -1203,6 +1204,7 @@ async function preflightAutomationMemoryTools(params: {
 			agentId: params.agentId,
 			organizationId: params.organizationId,
 			platform: "api",
+			source: AUTOMATION_RUN_SOURCE,
 			sessionKey: `automation_${params.runId}`,
 		}
 	);

--- a/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
+++ b/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { verifyWorkerToken } from "@lobu/core";
+import { AUTOMATION_RUN_SOURCE } from "../automation-run-session.js";
 import { buildAutomationRunWorkerAccess } from "../services/automation-run-worker-token.js";
 
 // Minting encrypts with ENCRYPTION_KEY. The gateway lane runs many files in one
@@ -38,6 +39,7 @@ describe("Automation run WorkerToken parity", () => {
     expect(claims.conversationId).toBe(access.conversationId);
     expect(claims.channelId).toBe("api_automation_120");
     expect(claims.platform).toBe("api");
+    expect(claims.source).toBe(AUTOMATION_RUN_SOURCE);
   });
 
   test("rejects a non-canonical conversation id", () => {

--- a/packages/server/src/gateway/services/automation-run-worker-token.ts
+++ b/packages/server/src/gateway/services/automation-run-worker-token.ts
@@ -1,4 +1,5 @@
 import { generateWorkerToken } from "@lobu/core";
+import { AUTOMATION_RUN_SOURCE } from "../automation-run-session.js";
 
 export interface AutomationRunWorkerAccess {
   conversationId: string;
@@ -44,6 +45,7 @@ export function buildAutomationRunWorkerAccess(args: {
       agentId: args.agentId,
       organizationId: args.organizationId,
       platform: "api",
+      source: AUTOMATION_RUN_SOURCE,
       sessionKey: userId,
     }),
   };

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -1,4 +1,4 @@
-import { verifyWorkerToken } from '@lobu/core';
+import { looksLikeWorkerToken, verifyWorkerToken } from '@lobu/core';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
@@ -284,7 +284,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
         ? authHeader.slice(7)
         : null;
     const directAuthTokenData =
-      directAuthBearer && /^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/i.test(directAuthBearer)
+      directAuthBearer && looksLikeWorkerToken(directAuthBearer)
         ? verifyWorkerToken(directAuthBearer)
         : null;
     if (directAuthBearer && (directAuthHeader || directAuthTokenData)) {


### PR DESCRIPTION
## Summary

- Stamp `source: "automation-run"` on both Automation worker-token compatibility mints: the Agent API/device session and the Automations memory preflight.
- Move worker-token envelope detection into the core auth module and cover it at its wire-format source.
- Keep direct-auth behavior unchanged in this first deployment.

## Test plan

- [x] `make pre-pr`
- [x] `bun test packages/core/src/__tests__/worker-auth.test.ts`
- [x] `bun test packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts`
- [x] `cd packages/server && bun test src/__tests__/unit/automations/automation-preflight-token.test.ts`
- [x] Red to green: before the source stamps, focused assertions observed no Automation source on these two tokens; after the change, both decrypt to `source: "automation-run"` and the shared envelope helper tests pass.

## Notes

Part of #2979.

This is the compatibility-only first deployment. It does not enforce or narrow direct MCP authentication and intentionally leaves #2979 open.

Deploy this PR first, then wait at least the effective worker-token lifetime before a separate enforcement deployment. With source defaults, that boundary is `WORKER_TOKEN_TTL_MS + WORKER_TOKEN_CLOCK_SKEW_MS` (2h + 30s by default); production values and complete rollout time must be verified before enforcement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for worker-token formats before authentication.
  * Automation preflight requests now include standardized run-source metadata.
  * Automation-generated worker access tokens include the canonical run source.

* **Bug Fixes**
  * Improved handling of malformed or unrelated worker bearer tokens, reducing unnecessary authentication attempts.

* **Tests**
  * Added coverage for valid, malformed, and unrelated token formats.
  * Added verification of automation preflight authentication and token metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->