### PR TITLE
fix(server): audit entity policy denials

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-write-denial-audit.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-write-denial-audit.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Durable audit coverage for policy refusals at manage_entity's two
+ * pre-transaction seams. A clean 403 is only truthful when the append-only
+ * denial row committed first; the attempted entity mutation must never run.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { manageEntity } from "../../../tools/admin/manage_entity";
+import type { ToolContext } from "../../../tools/registry";
+import { persistEntityWritePolicyDenial } from "../../../utils/entity-write-denial-audit";
+import { ToolUserError } from "../../../utils/errors";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+	seedSystemEntityTypes,
+} from "../../setup/test-fixtures";
+
+const env = {} as Env;
+
+function agentContext(
+	organizationId: string,
+	userId: string,
+	agentId: string,
+): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as ToolContext;
+}
+
+async function policyEffect(
+	organizationId: string,
+	principalId: string,
+	action: "create" | "delete",
+	effect: "approval" | "deny",
+): Promise<void> {
+	const sql = getTestDb();
+	const [policy] = await sql<{ id: number }[]>`
+		INSERT INTO write_approval_policies (
+			organization_id, resource_class, principal_kind, principal_id
+		) VALUES (
+			${organizationId}, 'entity', 'agent', ${principalId}
+		)
+		RETURNING id
+	`;
+	await sql`
+		INSERT INTO write_policy_action_effects (policy_id, action, effect)
+		VALUES (${policy.id}, ${action}, ${effect})
+	`;
+}
+
+async function denialEvents(organizationId: string) {
+	return getTestDb()`
+		SELECT id, to_jsonb(entity_ids) AS entity_ids, origin_id, origin_type,
+		       title, payload_type, payload_text, payload_data, metadata,
+		       organization_id, to_jsonb(linked_org_ids) AS linked_org_ids,
+		       automation_id, run_id, created_by, client_id
+		FROM events
+		WHERE organization_id = ${organizationId}
+		  AND semantic_type = 'change'
+		  AND metadata->>'category' = 'entity_write_denial'
+		ORDER BY id
+	`;
+}
+
+describe("manage_entity policy-denial audit", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		await seedSystemEntityTypes();
+	});
+
+	it("persists a privacy-safe create denial while creating no entity", async () => {
+		const org = await createTestOrganization({ name: "Denied Create Audit Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await policyEffect(org.id, agent.agentId, "create", "deny");
+
+		const secretName = "attempted-name-must-not-persist";
+		const secretContent = "attempted-content-must-not-persist";
+		const secretValue = "attempted-metadata-value-must-not-persist";
+		await expect(
+			manageEntity(
+				{
+					action: "create",
+					entity_type: "brand",
+					name: secretName,
+					content: secretContent,
+					metadata: { private_attempt: secretValue },
+				},
+				env,
+				agentContext(org.id, user.id, agent.agentId),
+			),
+		).rejects.toMatchObject({ httpStatus: 403 });
+
+		const entities = await getTestDb()`
+			SELECT id FROM entities
+			WHERE organization_id = ${org.id} AND name = ${secretName}
+		`;
+		expect(entities).toHaveLength(0);
+
+		const events = await denialEvents(org.id);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			entity_ids: null,
+			origin_type: "entity_write_denial",
+			title: "Entity create denied by policy",
+			payload_type: "empty",
+			payload_text: null,
+			payload_data: {},
+			organization_id: org.id,
+			linked_org_ids: [],
+		});
+		expect(events[0].metadata).toMatchObject({
+			category: "entity_write_denial",
+			denial_source: "policy",
+			operation: "create",
+			denied_fields: [],
+			entity_id: null,
+			entity_type: "brand",
+			principal_kind: "agent",
+			principal_id: agent.agentId,
+			automation_id: null,
+			run_id: null,
+			tool_call_id_or_equivalent: expect.stringMatching(
+				/^[0-9a-f]{8}-[0-9a-f-]{27}$/,
+			),
+			_lobu_event_type: "entity.denied",
+		});
+		expect(events[0].origin_id).toBe(
+			`entity_write_denial:v1:${events[0].metadata.tool_call_id_or_equivalent}:create`,
+		);
+		const stored = JSON.stringify(events[0]);
+		expect(stored).not.toContain(secretName);
+		expect(stored).not.toContain(secretContent);
+		expect(stored).not.toContain(secretValue);
+	});
+
+	it("persists an anchored delete denial while leaving the entity live", async () => {
+		const org = await createTestOrganization({ name: "Denied Delete Audit Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const entity = await createTestEntity({
+			organization_id: org.id,
+			entity_type: "brand",
+			name: "Entity that must remain live",
+			created_by: user.id,
+		});
+		await policyEffect(org.id, agent.agentId, "delete", "deny");
+
+		await expect(
+			manageEntity(
+				{ action: "delete", entity_id: entity.id },
+				env,
+				agentContext(org.id, user.id, agent.agentId),
+			),
+		).rejects.toMatchObject({ httpStatus: 403 });
+
+		const [storedEntity] = await getTestDb()`
+			SELECT deleted_at FROM entities WHERE id = ${entity.id}
+		`;
+		expect(storedEntity.deleted_at).toBeNull();
+
+		const events = await denialEvents(org.id);
+		expect(events).toHaveLength(1);
+		expect(events[0].entity_ids).toEqual([entity.id]);
+		expect(events[0].linked_org_ids).toEqual([]);
+		expect(events[0].metadata).toMatchObject({
+			category: "entity_write_denial",
+			denial_source: "policy",
+			operation: "delete",
+			denied_fields: [],
+			entity_id: entity.id,
+			entity_type: "brand",
+			principal_kind: "agent",
+			principal_id: agent.agentId,
+		});
+	});
+
+	it("does not attach a caller-org audit to a public entity owned by another org", async () => {
+		const callerOrg = await createTestOrganization({ name: "Audit Caller Org" });
+		const publicOrg = await createTestOrganization({
+			name: "Public Catalog Org",
+			visibility: "public",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, callerOrg.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: callerOrg.id,
+			ownerUserId: user.id,
+		});
+		const publicEntity = await createTestEntity({
+			organization_id: publicOrg.id,
+			entity_type: "brand",
+			name: "Readable public entity",
+			created_by: user.id,
+		});
+		await policyEffect(callerOrg.id, agent.agentId, "delete", "deny");
+
+		await expect(
+			manageEntity(
+				{ action: "delete", entity_id: publicEntity.id },
+				env,
+				agentContext(callerOrg.id, user.id, agent.agentId),
+			),
+		).rejects.toMatchObject({ httpStatus: 403 });
+
+		const events = await denialEvents(callerOrg.id);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ entity_ids: null, linked_org_ids: [] });
+		expect(events[0].metadata).toMatchObject({
+			operation: "delete",
+			entity_id: publicEntity.id,
+		});
+		const [storedEntity] = await getTestDb()`
+			SELECT deleted_at FROM entities WHERE id = ${publicEntity.id}
+		`;
+		expect(storedEntity.deleted_at).toBeNull();
+	});
+
+	it("reuses one stable attempt id after failure and on duplicate delivery", async () => {
+		const org = await createTestOrganization({ name: "Idempotent Audit Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const attemptId = "4dd3f5d0-4f2c-4fda-a086-bf1e103d0d73";
+		const validCtx = agentContext(org.id, user.id, agent.agentId);
+		const invalidCtx = {
+			...validCtx,
+			userId: "user_missing_for_audit_fk",
+		};
+		const audit = {
+			attemptId,
+			operation: "create" as const,
+			reason: "Policy denied creating brand",
+			entityId: null,
+			entityType: "brand",
+			entityOrganizationId: null,
+			actor: {
+				kind: "agent" as const,
+				id: agent.agentId,
+				ownerAgentId: null,
+				ownerResolved: true,
+			},
+			automationId: null,
+		};
+
+		await expect(
+			persistEntityWritePolicyDenial({ ...audit, ctx: invalidCtx }),
+		).rejects.toThrow(
+			"Entity write was blocked, but its denial audit could not be persisted",
+		);
+		await persistEntityWritePolicyDenial({ ...audit, ctx: validCtx });
+		await persistEntityWritePolicyDenial({ ...audit, ctx: validCtx });
+
+		const events = await denialEvents(org.id);
+		expect(events).toHaveLength(1);
+		expect(events[0].metadata.tool_call_id_or_equivalent).toBe(attemptId);
+		expect(events[0].metadata._lobu_idempotency_key).toBe(
+			`audit:entity_write_denial:v1:${attemptId}:create`,
+		);
+	});
+
+	it("returns operational errors and leaves create/delete mutations absent when audits cannot commit", async () => {
+		const org = await createTestOrganization({ name: "Failed Audit Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await policyEffect(org.id, agent.agentId, "create", "deny");
+		const ctx = agentContext(org.id, user.id, agent.agentId);
+		ctx.userId = "user_missing_for_load_bearing_audit";
+
+		let failure: unknown;
+		try {
+			await manageEntity(
+				{ action: "create", entity_type: "brand", name: "Must not exist" },
+				env,
+				ctx,
+			);
+		} catch (err) {
+			failure = err;
+		}
+		expect(failure).toBeInstanceOf(Error);
+		expect(failure).not.toBeInstanceOf(ToolUserError);
+		expect(failure).toMatchObject({
+			message: "Entity write was blocked, but its denial audit could not be persisted",
+		});
+		const entities = await getTestDb()`
+			SELECT id FROM entities
+			WHERE organization_id = ${org.id} AND name = 'Must not exist'
+		`;
+		expect(entities).toHaveLength(0);
+		expect(await denialEvents(org.id)).toHaveLength(0);
+
+		const entity = await createTestEntity({
+			organization_id: org.id,
+			entity_type: "brand",
+			name: "Must remain live",
+			created_by: user.id,
+		});
+		await getTestDb()`
+			INSERT INTO write_policy_action_effects (policy_id, action, effect)
+			SELECT id, 'delete', 'deny'
+			FROM write_approval_policies
+			WHERE organization_id = ${org.id}
+			  AND principal_kind = 'agent'
+			  AND principal_id = ${agent.agentId}
+		`;
+		await expect(
+			manageEntity({ action: "delete", entity_id: entity.id }, env, ctx),
+		).rejects.toMatchObject({
+			message: "Entity write was blocked, but its denial audit could not be persisted",
+		});
+		const [storedEntity] = await getTestDb()`
+			SELECT deleted_at FROM entities WHERE id = ${entity.id}
+		`;
+		expect(storedEntity.deleted_at).toBeNull();
+		expect(await denialEvents(org.id)).toHaveLength(0);
+	});
+
+	it("does not audit schema validation failures", async () => {
+		const org = await createTestOrganization({ name: "Validation Failure Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await policyEffect(org.id, agent.agentId, "create", "deny");
+
+		await expect(
+			manageEntity(
+				{ action: "create", entity_type: "brand", name: "" },
+				env,
+				agentContext(org.id, user.id, agent.agentId),
+			),
+		).rejects.toMatchObject({ httpStatus: 400 });
+		expect(await denialEvents(org.id)).toHaveLength(0);
+	});
+
+	it("does not classify an approval deferral as a denial", async () => {
+		const org = await createTestOrganization({ name: "Deferred Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await policyEffect(org.id, agent.agentId, "create", "approval");
+
+		const result = await manageEntity(
+			{ action: "create", entity_type: "brand", name: "Deferred entity" },
+			env,
+			agentContext(org.id, user.id, agent.agentId),
+		);
+		expect(result).toMatchObject({
+			action: "create",
+			approval_queued: true,
+		});
+		expect(await denialEvents(org.id)).toHaveLength(0);
+		const entities = await getTestDb()`
+			SELECT id FROM entities
+			WHERE organization_id = ${org.id} AND name = 'Deferred entity'
+		`;
+		expect(entities).toHaveLength(0);
+	});
+});

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -19,6 +19,8 @@
  * - unmerge: Reverse a ledger-backed merge when its after-state is unchanged
  */
 
+import { randomUUID } from "node:crypto";
+
 import {
 	ApprovalAttribution,
 	type ApprovalAttribution as ApprovalAttributionType,
@@ -75,6 +77,7 @@ import {
 	previewMerge,
 } from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
+import { persistEntityWritePolicyDenial } from "../../utils/entity-write-denial-audit";
 import {
 	recordChangeEvent,
 	recordEdgeChangeEvent,
@@ -382,6 +385,17 @@ async function handleCreate(
 		proposal,
 	});
 	if (createDecision.outcome === "deny") {
+		await persistEntityWritePolicyDenial({
+			ctx,
+			attemptId: randomUUID(),
+			operation: "create",
+			reason: createDecision.reason,
+			entityId: null,
+			entityType: args.entity_type,
+			entityOrganizationId: null,
+			actor,
+			automationId: createAttribution.automationId,
+		});
 		throw new ToolUserError(createDecision.reason, 403);
 	}
 	if (createDecision.outcome === "defer") {
@@ -1547,6 +1561,17 @@ async function handleDelete(
 		current,
 	});
 	if (deleteDecision.outcome === "deny") {
+		await persistEntityWritePolicyDenial({
+			ctx,
+			attemptId: randomUUID(),
+			operation: "delete",
+			reason: deleteDecision.reason,
+			entityId: entity.id,
+			entityType: entity.entity_type,
+			entityOrganizationId: entity.organization_id ?? null,
+			actor: deleteActor,
+			automationId: deleteAttribution.automationId,
+		});
 		throw new ToolUserError(deleteDecision.reason, 403);
 	}
 	// Preflight: report what the delete would remove/detach without mutating.

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -329,6 +329,8 @@ export interface EntityData {
 
 export interface CreatedEntity {
   id: number;
+  /** Internal ownership projection used to avoid cross-org audit anchors. */
+  organization_id?: string;
   entity_type: string;
   name: string;
   slug: string;
@@ -1489,7 +1491,7 @@ export async function getEntity(
   //   2. public-catalog entity (anyone reads, except `$member`)
   const result = await sql<CreatedEntity>`
     SELECT
-      e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at,
+      e.id, e.organization_id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at,
       e.current_view_template_version_id,
       pe.name as parent_name, pe.slug as parent_slug, pet.slug as parent_entity_type,
       (

--- a/packages/server/src/utils/entity-write-denial-audit.ts
+++ b/packages/server/src/utils/entity-write-denial-audit.ts
@@ -1,0 +1,112 @@
+import { retryWithBackoff } from "@lobu/core";
+import type { ActingPrincipal } from "../authz/entity-policy";
+import { currentMcpActivityEventMetadata } from "../lobu/stores/mcp-client-conversations";
+import type { ToolContext } from "../tools/registry";
+import { insertConnectionlessAuditEvent } from "./insert-event";
+import logger from "./logger";
+
+export type EntityWriteDenialOperation = "create" | "delete";
+
+export interface EntityWritePolicyDenialAudit {
+	ctx: ToolContext;
+	attemptId: string;
+	operation: EntityWriteDenialOperation;
+	reason: string;
+	entityId: number | null;
+	entityType: string;
+	entityOrganizationId: string | null;
+	actor: ActingPrincipal;
+	automationId: number | null;
+}
+
+const LOAD_BEARING_AUDIT_RETRY = {
+	maxRetries: 1,
+	baseDelay: 500,
+} as const;
+
+/**
+ * Persist the append-only policy-denial row before manage_entity returns its
+ * 403. This write is deliberately load-bearing: if the audit cannot commit,
+ * the caller receives an operational failure and the guarded mutation remains
+ * unreachable.
+ */
+export async function persistEntityWritePolicyDenial(
+	params: EntityWritePolicyDenialAudit,
+): Promise<void> {
+	const {
+		ctx,
+		attemptId,
+		operation,
+		reason,
+		entityId,
+		entityType,
+		entityOrganizationId,
+		actor,
+		automationId,
+	} = params;
+	const sameOrgEntityIds =
+		entityId !== null && entityOrganizationId === ctx.organizationId
+			? [entityId]
+			: [];
+	const originId = `entity_write_denial:v1:${attemptId}:${operation}`;
+
+	try {
+		await retryWithBackoff(
+			() =>
+				insertConnectionlessAuditEvent(
+					{
+						entityIds: sameOrgEntityIds,
+						organizationId: ctx.organizationId,
+						originId,
+						title: `Entity ${operation} denied by policy`,
+						payloadType: "empty",
+						semanticType: "change",
+						originType: "entity_write_denial",
+						metadata: {
+							category: "entity_write_denial",
+							denial_source: "policy",
+							operation,
+							reason,
+							denied_fields: [],
+							entity_id: entityId,
+							entity_type: entityType,
+							principal_kind: actor.kind,
+							principal_id: actor.id,
+							automation_id: automationId,
+							run_id: ctx.actingRunId ?? null,
+							tool_call_id_or_equivalent: attemptId,
+							...currentMcpActivityEventMetadata(ctx),
+						},
+						createdBy: ctx.userId,
+						clientId: ctx.clientId ?? null,
+						automationId,
+						runId: ctx.actingRunId ?? null,
+					},
+					{ subject: "entity", op: "denied" },
+				),
+			LOAD_BEARING_AUDIT_RETRY,
+		);
+	} catch (err) {
+		logger.error(
+			{
+				err,
+				organizationId: ctx.organizationId,
+				attemptId,
+				operation,
+				denialSource: "policy",
+				reason,
+				entityId,
+				entityType,
+				principalKind: actor.kind,
+				principalId: actor.id,
+				automationId,
+				runId: ctx.actingRunId ?? null,
+			},
+			"[entity-write-denial] load-bearing denial audit failed; entity mutation remains blocked",
+		);
+		throw new Error(
+			"Entity write was blocked, but its denial audit could not be persisted",
+			{ cause: err },
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Persist an awaited, load-bearing append-only audit event before manage_entity returns a create or delete policy denial.
- Keep the envelope structural and privacy-safe, anchor only same-organization entities, and reuse one per-attempt UUID across the bounded internal retry.
- Fail with an operational error when audit persistence fails while proving the guarded entity mutation remains absent.

## Test plan

- `CLAUDE_REVIEW_MODEL=fable make review-fix`
- `cd packages/server && bun run test -- run src/__tests__/integration/entities/entity-write-denial-audit.test.ts src/__tests__/integration/authz/write-policy-action-effect-parity.test.ts src/__tests__/integration/authz/write-policy-floor-and-mode.test.ts src/__tests__/integration/authz/entity-row-validation.test.ts`
- `bun test packages/server/src/__tests__/unit/entity-mutation-gate.test.ts packages/server/src/__tests__/unit/entity-policy.test.ts`
- `make pre-pr`

## Notes

- Part of #2866
- This slice intentionally excludes update denials, row-rule denials, promote-keyed-entities, notifications, catalog, API, schema, and UI changes.
- A genuinely new tool delivery receives a new attempt UUID; the stable origin id deduplicates retries of the same audit attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable, privacy-safe audit records for denied entity creation and deletion attempts.
  * Audit records include relevant operation, entity, actor, automation, and attempt details.
  * Duplicate audit delivery is handled safely, with stable attempt tracking.

* **Bug Fixes**
  * Denied mutations remain blocked if audit persistence encounters an operational failure.
  * Schema validation failures and approval deferrals are not incorrectly recorded as policy denials.

* **Tests**
  * Added comprehensive coverage for denial auditing, cross-organization entities, retries, and mutation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->