### PR TITLE
perf(db): project stored event content length

### DIFF
--- a/db/migrations/20260820150000_current_event_records_stored_content_length.sql
+++ b/db/migrations/20260820150000_current_event_records_stored_content_length.sql
@@ -1,0 +1,96 @@
+-- `events.content_length` is already a stored generated column with the exact
+-- PostgreSQL character-count value exposed by this view. Project that stored
+-- value instead of recomputing length(payload_text) for every view read. The
+-- output name, type, column order, and row set stay unchanged.
+
+-- migrate:up
+
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    e.content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    e.linked_org_ids,
+    e.identity_ns,
+    e.identity_key,
+    e.automation_id,
+    e.automation_version_id
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+-- migrate:down
+
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    e.linked_org_ids,
+    e.identity_ns,
+    e.identity_key,
+    e.automation_id,
+    e.automation_version_id
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -21,6 +21,7 @@ import {
   addUserToOrganization,
   createTestConnectorDefinition,
 	createTestConnection,
+  createTestEvent,
   createTestOrganization,
   createTestUser,
 } from '../../setup/test-fixtures';
@@ -103,6 +104,68 @@ describe('migration invariants', () => {
           AND column_name IN ('embedding', 'embedding_model')
       `;
       expect(rows).toHaveLength(0);
+    });
+
+    it('current_event_records projects the stored events.content_length column (#2983)', async () => {
+      const sql = getTestDb();
+      const [row] = await sql<{ definition: string }[]>`
+        SELECT pg_get_viewdef('public.current_event_records'::regclass, true) AS definition
+      `;
+      expect(row?.definition).toMatch(/\n\s+content_length,\n/);
+      expect(row?.definition).not.toMatch(/length\s*\(\s*(?:e\.)?payload_text\s*\)/i);
+    });
+
+    it('current_event_records content_length preserves PostgreSQL character and NULL semantics', async () => {
+      const sql = getTestDb();
+      // 5 codepoints as PostgreSQL length() counts them: A, 😀 U+1F600 (one
+      // codepoint, two UTF-16 units in JS), e, U+0301 combining accent (é), 終.
+      // Explicit escapes so Unicode normalization can't silently recompose the
+      // accent and change the expected count.
+      const content = 'A\u{1F600}e\u0301\u7D42';
+      const org = await createTestOrganization({ name: 'Content Length Invariant Org' });
+      const event = await createTestEvent({ content, organization_id: org.id });
+      const [row] = await sql<{
+        stored_length: number;
+        projected_length: number;
+        measured_length: number;
+      }[]>`
+        SELECT
+          e.content_length AS stored_length,
+          current.content_length AS projected_length,
+          length(e.payload_text) AS measured_length
+        FROM public.events e
+        JOIN public.current_event_records current ON current.id = e.id
+        WHERE e.id = ${event.id}
+      `;
+      expect(row).toEqual({
+        stored_length: 5,
+        projected_length: 5,
+        measured_length: 5,
+      });
+
+      const [nullEvent] = await sql<{ id: string }[]>`
+        INSERT INTO public.events (organization_id, origin_id, payload_text)
+        VALUES (${org.id}, ${`content-length-null-${org.id}`}, NULL)
+        RETURNING id
+      `;
+      const [nullRow] = await sql<{
+        payload_text: string | null;
+        stored_length: number;
+        projected_length: number;
+      }[]>`
+        SELECT
+          e.payload_text,
+          e.content_length AS stored_length,
+          current.content_length AS projected_length
+        FROM public.events e
+        JOIN public.current_event_records current ON current.id = e.id
+        WHERE e.id = ${nullEvent.id}
+      `;
+      expect(nullRow).toEqual({
+        payload_text: null,
+        stored_length: 0,
+        projected_length: 0,
+      });
     });
 
     it('stale orphan tables entity_read_grant + mcp_proxy_sessions are dropped (2026-06-16 audit)', async () => {


### PR DESCRIPTION
## Summary

- project the stored events.content_length value through current_event_records instead of recomputing length(payload_text) on every read
- preserve the existing view columns, order, predicate, ownership, grants, and rollback definition
- pin PostgreSQL character and NULL semantics with normalization-safe Unicode coverage and an explicit NULL-payload regression

## Test plan

- [x] Intended files staged explicitly
- [x] Red baseline: the focused invariant failed because the view definition recomputed content_length
- [x] Green: migration-invariants.test.ts passed 16/16 against embedded PostgreSQL, including Unicode length 5 and NULL stored/projected length 0
- [x] bun run db:lint reported 0 issues
- [x] CLAUDE_REVIEW_MODEL=fable make review-fix completed and its Unicode test hardening was retained
- [x] make pre-pr completed all 7 stages
- [x] git diff --check clean

## Notes

Part of #2983. This is the behavior-neutral migration prerequisite only; the bounded agent projections and additive ContentItem contract remain in later slices.
