### PR TITLE
fix(migrations): preserve legacy Canvas results

### DIFF
--- a/db/migrations/20260820120000_remove_canvas_runtime.sql
+++ b/db/migrations/20260820120000_remove_canvas_runtime.sql
@@ -88,31 +88,45 @@ SET action_output = COALESCE(result_event.payload_data, run.action_output),
 FROM result_event
 WHERE run.id = result_event.run_id;
 
--- The retired skip-if-unchanged path stored an empty Canvas cursor without a
--- run. Preserve that cursor as the same completed skipped run used today.
-CREATE TEMP TABLE skipped_canvas_run_map (
+-- Canvas rows imported from watcher_windows can predate the run ledger. Reuse
+-- a historical run already keyed to the Canvas root; otherwise synthesize the
+-- completed Automation run that the persisted result proves occurred.
+CREATE TEMP TABLE runless_canvas_run_map (
   legacy_id bigint PRIMARY KEY,
   run_id bigint NOT NULL,
   head_event_id bigint NOT NULL,
-  head_payload_data jsonb NOT NULL
+  head_payload_data jsonb,
+  synthesized boolean NOT NULL
 ) ON COMMIT DROP;
 
-INSERT INTO skipped_canvas_run_map (
-  legacy_id, run_id, head_event_id, head_payload_data
+INSERT INTO runless_canvas_run_map (
+  legacy_id, run_id, head_event_id, head_payload_data, synthesized
 )
 SELECT
   head.legacy_id,
-  nextval(pg_get_serial_sequence('public.runs', 'id')),
+  COALESCE(owner.run_id, nextval(pg_get_serial_sequence('public.runs', 'id'))),
   head.event_id,
-  head.payload_data
+  head.payload_data,
+  owner.run_id IS NULL
 FROM canvas_members head
 JOIN public.automations automation
   ON automation.id = head.automation_id
  AND automation.organization_id = head.organization_id
+LEFT JOIN LATERAL (
+  SELECT run.id AS run_id
+  FROM public.runs run
+  WHERE run.window_id = head.legacy_id
+    AND run.run_type = 'automation'
+    AND run.automation_id = head.automation_id
+    AND run.organization_id = head.organization_id
+  ORDER BY run.id DESC
+  LIMIT 1
+) owner ON true
 WHERE head.superseded_by IS NULL
-  AND head.payload_data = '{}'::jsonb
-  AND head.metadata->'content_analyzed' = '0'::jsonb
-  AND head.metadata->>'automation_id' = head.automation_id::text
+  AND (
+    head.metadata->>'automation_id' = head.automation_id::text
+    OR head.metadata->>'watcher_id' = head.automation_id::text
+  )
   AND head.metadata->>'window_start' IS NOT NULL
   AND head.metadata->>'window_end' IS NOT NULL
   AND head.metadata->>'granularity' IS NOT NULL
@@ -132,14 +146,14 @@ INSERT INTO public.runs (
   created_at, completed_at
 )
 SELECT
-  skipped.run_id,
+  runless.run_id,
   head.organization_id,
   'automation',
   head.automation_id,
   'auto',
   'completed',
   'scoreable',
-  '{}'::jsonb,
+  head.payload_data,
   jsonb_strip_nulls(jsonb_build_object(
     'automation_id', head.automation_id,
     'window_start', head.metadata->>'window_start',
@@ -148,15 +162,25 @@ SELECT
     'version_id', head.metadata->'version_id',
     'granularity', head.metadata->>'granularity'
   )),
-  '{"content_analyzed":0,"skipped_unchanged":true}'::jsonb,
+  (CASE
+    WHEN head.metadata ? 'content_analyzed'
+      THEN jsonb_build_object('content_analyzed', head.metadata->'content_analyzed')
+    ELSE '{}'::jsonb
+  END) || (CASE
+    WHEN head.payload_data = '{}'::jsonb
+      AND head.metadata->'content_analyzed' = '0'::jsonb
+      THEN '{"skipped_unchanged":true}'::jsonb
+    ELSE '{}'::jsonb
+  END),
   concat(
     'automation:', head.automation_id, ':scheduled:',
     head.metadata->>'window_start', ':', head.metadata->>'window_end'
   ),
   head.created_at,
   head.created_at
-FROM skipped_canvas_run_map skipped
-JOIN canvas_members head ON head.event_id = skipped.head_event_id;
+FROM runless_canvas_run_map runless
+JOIN canvas_members head ON head.event_id = runless.head_event_id
+WHERE runless.synthesized;
 
 -- A current head may instead be a human correction with no run_id. Attribute
 -- that corrected payload to the latest producing run in the chain.
@@ -188,7 +212,7 @@ ORDER BY head.legacy_id, head.created_at DESC, head.event_id DESC;
 
 INSERT INTO canvas_run_map (legacy_id, run_id, head_event_id, head_payload_data)
 SELECT legacy_id, run_id, head_event_id, head_payload_data
-FROM skipped_canvas_run_map;
+FROM runless_canvas_run_map;
 
 DO $assert_canvas_heads$
 BEGIN
@@ -205,8 +229,22 @@ END
 $assert_canvas_heads$;
 
 UPDATE public.runs run
-SET action_output = COALESCE(mapping.head_payload_data, run.action_output)
+SET action_output = COALESCE(mapping.head_payload_data, run.action_output),
+    approved_input = COALESCE(run.approved_input, '{}'::jsonb)
+      || jsonb_strip_nulls(jsonb_build_object(
+        'window_start', head.metadata->>'window_start',
+        'window_end', head.metadata->>'window_end',
+        'granularity', head.metadata->>'granularity',
+        'version_id', head.metadata->'version_id'
+      )),
+    run_metadata = (COALESCE(run.run_metadata, '{}'::jsonb) - 'automation_run_id' - 'run_id')
+      || CASE
+        WHEN head.metadata ? 'content_analyzed'
+          THEN jsonb_build_object('content_analyzed', head.metadata->'content_analyzed')
+        ELSE '{}'::jsonb
+      END
 FROM canvas_run_map mapping
+JOIN canvas_members head ON head.event_id = mapping.head_event_id
 WHERE run.id = mapping.run_id;
 
 -- canvas-result-cutover:end

--- a/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
@@ -69,7 +69,7 @@ describe('Automation schema vocabulary', () => {
     expect(up).not.toMatch(/SET\s+\w+\s*=\s*replace\s*\(\s*replace\s*\([^;]*::text/is);
   });
 
-  it('preserves a legacy runless skip-if-unchanged cursor as a completed run', async () => {
+  it('preserves legacy runless Canvas results as completed runs', async () => {
     const sql = getTestDb();
     const org = await createTestOrganization();
     const user = await createTestUser();
@@ -81,54 +81,96 @@ describe('Automation schema vocabulary', () => {
 
     try {
       await sql.begin(async (tx: typeof sql) => {
-        const [automation] = await tx<{ id: number }[]>`
-          WITH next_id AS (
-            SELECT nextval('automations_id_seq')::int AS id
-          )
-          INSERT INTO automations (
-            id, organization_id, created_by, agent_id, automation_group_id,
-            name, slug
-          )
-          SELECT
-            id, ${org.id}, ${user.id}, ${agent.agentId}, id,
-            'Runless Canvas cutover', 'runless-canvas-cutover'
-          FROM next_id
-          RETURNING id
-        `;
         const windowStart = '2026-08-18T00:00:00.000Z';
         const windowEnd = '2026-08-19T00:00:00.000Z';
-        const [legacy] = await tx<{ id: number }[]>`
-          INSERT INTO events (
-            organization_id, entity_ids, origin_id, payload_type, payload_data,
-            metadata, semantic_type, automation_id, occurred_at, created_at
+        const createLegacyCanvas = async (params: {
+          slug: string;
+          payload: Record<string, unknown>;
+          metadataIdKey: 'automation_id' | 'watcher_id';
+          contentAnalyzed: number;
+        }): Promise<{ automationId: number; legacyId: number }> => {
+          const [automation] = await tx<{ id: number }[]>`
+            WITH next_id AS (
+              SELECT nextval('automations_id_seq')::int AS id
+            )
+            INSERT INTO automations (
+              id, organization_id, created_by, agent_id, automation_group_id,
+              name, slug
+            )
+            SELECT id, ${org.id}, ${user.id}, ${agent.agentId}, id, ${params.slug}, ${params.slug}
+            FROM next_id
+            RETURNING id
+          `;
+          const [legacy] = await tx<{ id: number }[]>`
+            INSERT INTO events (
+              organization_id, entity_ids, origin_id, payload_type, payload_data,
+              metadata, semantic_type, automation_id, occurred_at, created_at
+            ) VALUES (
+              ${org.id}, '{}'::bigint[], ${params.slug}, 'json_template', ${tx.json(params.payload)},
+              ${tx.json({
+                [params.metadataIdKey]: automation.id,
+                granularity: 'daily',
+                window_start: windowStart,
+                window_end: windowEnd,
+                content_analyzed: params.contentAnalyzed,
+                version_id: null,
+              })},
+              'canvas_state', ${automation.id}, ${windowEnd}, ${windowEnd}
+            )
+            RETURNING id
+          `;
+          return { automationId: automation.id, legacyId: legacy.id };
+        };
+
+        const skipped = await createLegacyCanvas({
+          slug: 'runless-canvas-cutover',
+          payload: {},
+          metadataIdKey: 'automation_id',
+          contentAnalyzed: 0,
+        });
+        const legacyPayload = { tasks: [{ title: 'Preserved result' }] };
+        const legacyResult = await createLegacyCanvas({
+          slug: 'legacy-result-cutover',
+          payload: legacyPayload,
+          metadataIdKey: 'watcher_id',
+          contentAnalyzed: 3,
+        });
+        const linkedPayload = { summary: 'Preserved linked result' };
+        const linked = await createLegacyCanvas({
+          slug: 'linked-run-cutover',
+          payload: linkedPayload,
+          metadataIdKey: 'watcher_id',
+          contentAnalyzed: 5,
+        });
+
+        // The marked section runs before the full migration drops this legacy
+        // relation key; the test database has already applied that final drop.
+        await tx`ALTER TABLE runs ADD COLUMN IF NOT EXISTS window_id bigint`;
+        const [linkedRun] = await tx<{ id: number }[]>`
+          INSERT INTO runs (
+            organization_id, run_type, automation_id, approval_status, status,
+            action_output, approved_input, run_metadata, window_id, created_at,
+            completed_at
           ) VALUES (
-            ${org.id}, '{}'::bigint[], 'runless-canvas-cutover', 'json_template', '{}'::jsonb,
-            ${tx.json({
-              automation_id: automation.id,
-              granularity: 'daily',
-              window_start: windowStart,
-              window_end: windowEnd,
-              content_analyzed: 0,
-              version_id: null,
-            })},
-            'canvas_state', ${automation.id}, ${windowEnd}, ${windowEnd}
+            ${org.id}, 'automation', ${linked.automationId}, 'auto', 'completed',
+            '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, ${linked.legacyId},
+            ${windowEnd}, ${windowEnd}
           )
           RETURNING id
         `;
-
         await tx.unsafe(loadCanvasResultCutover());
 
         const [run] = await tx`
           SELECT id, status, outcome, action_output, approved_input, run_metadata
           FROM runs
-          WHERE automation_id = ${automation.id} AND run_type = 'automation'
+          WHERE automation_id = ${skipped.automationId} AND run_type = 'automation'
         `;
         expect(run).toMatchObject({
           status: 'completed',
           outcome: 'scoreable',
           action_output: {},
           approved_input: {
-            automation_id: automation.id,
+            automation_id: skipped.automationId,
             dispatch_source: 'scheduled',
             granularity: 'daily',
             window_start: windowStart,
@@ -139,10 +181,53 @@ describe('Automation schema vocabulary', () => {
         const [mapping] = await tx`
           SELECT run_id, head_event_id
           FROM canvas_run_map
-          WHERE legacy_id = ${legacy.id}
+          WHERE legacy_id = ${skipped.legacyId}
         `;
         expect(Number(mapping.run_id)).toBe(Number(run.id));
-        expect(Number(mapping.head_event_id)).toBe(Number(legacy.id));
+        expect(Number(mapping.head_event_id)).toBe(Number(skipped.legacyId));
+
+        const [resultRun] = await tx`
+          SELECT id, status, outcome, action_output, approved_input, run_metadata
+          FROM runs
+          WHERE automation_id = ${legacyResult.automationId} AND run_type = 'automation'
+        `;
+        expect(resultRun).toMatchObject({
+          status: 'completed',
+          outcome: 'scoreable',
+          action_output: legacyPayload,
+          approved_input: {
+            automation_id: legacyResult.automationId,
+            dispatch_source: 'scheduled',
+            granularity: 'daily',
+            window_start: windowStart,
+            window_end: windowEnd,
+          },
+          run_metadata: { content_analyzed: 3 },
+        });
+        const [resultMapping] = await tx`
+          SELECT run_id, head_event_id
+          FROM canvas_run_map
+          WHERE legacy_id = ${legacyResult.legacyId}
+        `;
+        expect(Number(resultMapping.run_id)).toBe(Number(resultRun.id));
+        expect(Number(resultMapping.head_event_id)).toBe(Number(legacyResult.legacyId));
+
+        const linkedRuns = await tx`
+          SELECT id, action_output, approved_input, run_metadata
+          FROM runs
+          WHERE automation_id = ${linked.automationId} AND run_type = 'automation'
+        `;
+        expect(linkedRuns).toHaveLength(1);
+        expect(Number(linkedRuns[0].id)).toBe(Number(linkedRun.id));
+        expect(linkedRuns[0]).toMatchObject({
+          action_output: linkedPayload,
+          approved_input: {
+            granularity: 'daily',
+            window_start: windowStart,
+            window_end: windowEnd,
+          },
+          run_metadata: { content_analyzed: 5 },
+        });
 
         throw new Rollback();
       });


### PR DESCRIPTION
## Summary
- reuse historical Automation runs already keyed to legacy Canvas roots
- synthesize completed runs for valid pre-ledger results instead of dropping output
- cover empty cursors, non-empty legacy results, and linked-run reuse

## Production evidence
- failed migration version is absent from the production schema ledger
- read-only classification: 101 runless heads = 7 reused + 94 synthesized + 0 remaining

## Validation
- focused DB regression: 7/7 passed
- full pre-PR build/type/dead-code/lint/policy gates passed
- Squawk: 0 issues

The migration was merged but has never applied successfully; the commit carries the required migration-never-applied sentinel.