### PR TITLE
fix(cli): surface local sign-in diagnostics

### DIFF
--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -10,13 +10,17 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Credentials } from "../internal/credentials";
 import {
+  announceLocalSignIn,
   autoApplyLocalProject,
   findEnclosingMonorepoRoot,
+  getLocalSignInWarning,
   isSharedDatabaseUrl,
   resolveBackendBundle,
   shouldAutoApplyLocalProject,
   shouldRefuseSharedDatabaseUrl,
+  waitForServerReachable,
 } from "../commands/dev";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -313,6 +317,350 @@ describe("shouldAutoApplyLocalProject", () => {
         hasLobuConfig: false,
       })
     ).toBe(false);
+  });
+});
+
+describe("lobu run local sign-in diagnostics", () => {
+  const successfulResponse = () =>
+    new Response(
+      JSON.stringify({
+        session_token: "session-secret",
+        device_token: "device-secret",
+        user: { id: "user-1", email: "dev@example.com" },
+        organization: { slug: "local-install" },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+  const dependencies = () => ({
+    waitForReachable: async () => true,
+    fetchImpl: async () => successfulResponse(),
+    addContextImpl: async () => undefined,
+    saveCredentialsImpl: async () => undefined,
+    setActiveOrgImpl: async () => undefined,
+    getCurrentContextNameImpl: async () => "local",
+    setCurrentContextImpl: async () => undefined,
+  });
+
+  test("keeps the current /health liveness contract", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      requested.push(String(input));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      expect(await waitForServerReachable("http://127.0.0.1:8787", 100)).toBe(
+        true
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requested).toEqual(["http://127.0.0.1:8787/health"]);
+  });
+
+  test("reports the stage when the server never becomes reachable", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      waitForReachable: async () => false,
+    });
+
+    expect(result).toMatchObject({
+      ready: false,
+      stage: "server_unreachable",
+    });
+  });
+
+  test("treats an external backend as an intentional skip", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", false, {
+      ...dependencies(),
+      fetchImpl: async () => {
+        throw new Error("must not call local-init");
+      },
+    });
+
+    expect(result).toEqual({ ready: false, skipped: "external_backend" });
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: false,
+        hasLobuConfig: true,
+      })
+    ).toBeNull();
+  });
+
+  test("reports a local-init HTTP failure without reading its body", async () => {
+    let bodyRead = false;
+    const response = new Response(
+      JSON.stringify({ credential: "do-not-print" }),
+      { status: 503 }
+    );
+    const originalJson = response.json.bind(response);
+    response.json = async () => {
+      bodyRead = true;
+      return originalJson();
+    };
+
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () => response,
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_http",
+      detail: "HTTP 503",
+    });
+    expect(bodyRead).toBe(false);
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBe(
+      "Local sign-in failed during the local-init request (HTTP 503); project auto-apply was skipped."
+    );
+  });
+
+  test("reports a rejected local-init request without echoing its error", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () => {
+        throw new Error("credential=do-not-print");
+      },
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_http",
+      detail: "request failed after the server became reachable",
+    });
+    expect(JSON.stringify(result)).not.toContain("do-not-print");
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBe(
+      "Local sign-in failed during the local-init request (request failed after the server became reachable); project auto-apply was skipped."
+    );
+  });
+
+  test("reports an invalid local-init payload without echoing it", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ credential: "do-not-print" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response did not contain a session or device token",
+    });
+    expect(JSON.stringify(result)).not.toContain("do-not-print");
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBe(
+      "Local sign-in failed during the local-init response (response did not contain a session or device token); project auto-apply was skipped."
+    );
+  });
+
+  test("reports invalid JSON without persisting or echoing its body", async () => {
+    let persisted = false;
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () =>
+        new Response("credential=do-not-print", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      saveCredentialsImpl: async () => {
+        persisted = true;
+      },
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response was not valid JSON",
+    });
+    expect(persisted).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("do-not-print");
+  });
+
+  test("reports a non-object local-init payload instead of throwing", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () => Response.json(null),
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response did not contain a JSON object",
+    });
+  });
+
+  test("rejects wrong-type tokens before persisting credentials", async () => {
+    let persisted = false;
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () =>
+        Response.json({
+          session_token: { credential: "malformed-secret-shape" },
+          organization: { slug: "local-install" },
+        }),
+      saveCredentialsImpl: async () => {
+        persisted = true;
+      },
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response contained invalid field types",
+    });
+    expect(persisted).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("malformed-secret-shape");
+  });
+
+  test("classifies a wrong-type organization slug as a payload failure", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () =>
+        Response.json({
+          session_token: "session-secret",
+          organization: { slug: { invalid: true } },
+        }),
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response contained invalid field types",
+    });
+  });
+
+  test("falls back to a valid device token when the session token is empty", async () => {
+    let saved: Credentials | undefined;
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      fetchImpl: async () =>
+        Response.json({
+          session_token: "   ",
+          device_token: "device-secret",
+          organization: { slug: "local-install" },
+        }),
+      saveCredentialsImpl: async (credentials) => {
+        saved = credentials;
+      },
+    });
+
+    expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
+    expect(saved).toMatchObject({
+      accessToken: "device-secret",
+      localWorkerToken: "device-secret",
+    });
+  });
+
+  test("reports local context setup failures without echoing the error", async () => {
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      addContextImpl: async () => {
+        throw new Error("credential=do-not-print");
+      },
+    });
+
+    expect(result).toEqual({
+      ready: false,
+      stage: "context_setup",
+      detail: 'could not register or persist the "local" context',
+    });
+    expect(JSON.stringify(result)).not.toContain("do-not-print");
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBe(
+      'Local sign-in failed during local CLI context setup (could not register or persist the "local" context); project auto-apply was skipped.'
+    );
+  });
+
+  test("returns ready after registering the local context", async () => {
+    const calls: string[] = [];
+    const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+      ...dependencies(),
+      addContextImpl: async (name, url) => {
+        calls.push(`context:${name}:${url}`);
+      },
+      saveCredentialsImpl: async (_credentials, name) => {
+        calls.push(`credentials:${name}`);
+      },
+      setActiveOrgImpl: async (slug, name) => {
+        calls.push(`org:${slug}:${name}`);
+      },
+    });
+
+    expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
+    expect(calls).toEqual([
+      "context:local:http://127.0.0.1:8787",
+      "credentials:local",
+      "org:local-install:local",
+    ]);
+    expect(
+      getLocalSignInWarning(result, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBeNull();
+  });
+
+  test("warns only when an embedded project will skip auto-apply", () => {
+    const failure = {
+      ready: false as const,
+      stage: "local_init_http" as const,
+      detail: "HTTP 503",
+    };
+
+    expect(
+      getLocalSignInWarning(failure, {
+        embedded: true,
+        hasLobuConfig: true,
+      })
+    ).toBe(
+      "Local sign-in failed during the local-init request (HTTP 503); project auto-apply was skipped."
+    );
+    expect(
+      getLocalSignInWarning(failure, {
+        embedded: true,
+        hasLobuConfig: false,
+      })
+    ).toBeNull();
+  });
+
+  test("does not claim the server is running after any sign-in failure", () => {
+    const warning = getLocalSignInWarning(
+      {
+        ready: false,
+        stage: "server_unreachable",
+        detail: "the server did not answer /health within the startup window",
+      },
+      { embedded: true, hasLobuConfig: true }
+    );
+
+    expect(warning).toBe(
+      "Local sign-in failed during server startup (the server did not answer /health within the startup window); project auto-apply was skipped."
+    );
+    expect(warning).not.toContain("still running");
   });
 });
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -38,6 +38,34 @@ interface DevOptions {
   unsafeSharedDb?: boolean;
 }
 
+export type LocalSignInFailureStage =
+  | "server_unreachable"
+  | "local_init_http"
+  | "local_init_payload"
+  | "context_setup";
+
+export type LocalSignInResult =
+  | { ready: true; localOrgSlug?: string }
+  | { ready: false; skipped: "external_backend" }
+  | {
+      ready: false;
+      stage: LocalSignInFailureStage;
+      detail?: string;
+    };
+
+export interface LocalSignInDependencies {
+  waitForReachable: (url: string) => Promise<boolean>;
+  fetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
+  addContextImpl: (name: string, url: string) => Promise<unknown>;
+  saveCredentialsImpl: (
+    credentials: Credentials,
+    contextName: string
+  ) => Promise<unknown>;
+  setActiveOrgImpl: (slug: string, contextName: string) => Promise<unknown>;
+  getCurrentContextNameImpl: () => Promise<string>;
+  setCurrentContextImpl: (contextName: string) => Promise<unknown>;
+}
+
 function connectorRefKey(ref: ConnectorRef): string {
   return typeof ref === "string" ? ref : new ref().definition.key;
 }
@@ -403,7 +431,19 @@ export async function devCommand(
   // persists the session as the `local` CLI context so `lobu chat -c local`
   // works without a separate `lobu login`.
   void announceLocalSignIn(gatewayUrl, mode === "embedded").then(
-    async ({ ready: localContextReady, localOrgSlug }) => {
+    async (localSignIn) => {
+      const localContextReady = localSignIn.ready;
+      const localOrgSlug = localSignIn.ready
+        ? localSignIn.localOrgSlug
+        : undefined;
+      const hasLobuConfig = existsSync(join(cwd, "lobu.config.ts"));
+      const signInWarning = getLocalSignInWarning(localSignIn, {
+        embedded: mode === "embedded",
+        hasLobuConfig,
+      });
+      if (signInWarning) {
+        console.warn(chalk.yellow(`  ${signInWarning}`));
+      }
       // Once the `local` context is confirmed registered + active, push the
       // project's lobu.config.ts into the embedded DB so the scaffolded agent is
       // usable via `lobu chat -c local …` with no separate `lobu apply`.
@@ -414,7 +454,7 @@ export async function devCommand(
         shouldAutoApplyLocalProject({
           mode,
           localContextReady,
-          hasLobuConfig: existsSync(join(cwd, "lobu.config.ts")),
+          hasLobuConfig,
         })
       ) {
         await autoApplyLocalProject(cwd, gatewayUrl, localOrgSlug);
@@ -596,63 +636,167 @@ export function resolveBackendBundle(
  * gateway, persist the session as that context's bearer credential, and
  * print a deep-link URL the user can click to land logged into the SPA.
  *
- * Best-effort: a failure here (server not ready, /local-init refused
- * because real users exist, etc.) just skips the banner. The endpoint is
- * loopback-only and idempotent so it's safe to fire unconditionally.
+ * Best-effort: a failure here (server not ready, /local-init refused because
+ * real users exist, etc.) returns a credential-safe diagnostic stage. The
+ * caller warns only when a local project would otherwise have auto-applied.
+ * The endpoint is loopback-only and idempotent so it's safe to fire
+ * unconditionally.
  */
-async function announceLocalSignIn(
+const defaultLocalSignInDependencies: LocalSignInDependencies = {
+  waitForReachable: waitForServerReachable,
+  fetchImpl: (url, init) => fetch(url, init),
+  addContextImpl: addContext,
+  saveCredentialsImpl: saveCredentials,
+  setActiveOrgImpl: setActiveOrg,
+  getCurrentContextNameImpl: getCurrentContextName,
+  setCurrentContextImpl: setCurrentContext,
+};
+
+export async function announceLocalSignIn(
   gatewayUrl: string,
-  embedded: boolean
-): Promise<{ ready: boolean; localOrgSlug?: string }> {
+  embedded: boolean,
+  dependencies: LocalSignInDependencies = defaultLocalSignInDependencies
+): Promise<LocalSignInResult> {
   // Poll briefly so the announce lands AFTER the server's own startup
   // banner without racing it.
-  const reachable = await waitForServerReachable(gatewayUrl);
-  if (!reachable) return { ready: false };
+  const reachable = await dependencies.waitForReachable(gatewayUrl);
+  if (!reachable) {
+    return {
+      ready: false,
+      stage: "server_unreachable",
+      detail: "the server did not answer /health within the startup window",
+    };
+  }
 
   // Only the embedded path seeds the bootstrap user → /local-init will refuse
   // on an external-Postgres deployment with real signups. Skip the network
   // call entirely in that case to keep the banner quiet.
-  if (!embedded) return { ready: false };
+  if (!embedded) return { ready: false, skipped: "external_backend" };
 
+  let res: Response;
   try {
-    const res = await fetch(`${gatewayUrl}/api/local-init`, {
+    res = await dependencies.fetchImpl(`${gatewayUrl}/api/local-init`, {
       method: "POST",
       headers: { "X-Lobu-Client": "lobu-run" },
     });
-    if (!res.ok) return { ready: false };
-    const body = (await res.json()) as {
-      device_token?: string;
-      session_token?: string;
-      user?: { id?: string; email?: string; name?: string };
-      organization?: { id?: string; slug?: string; name?: string };
+  } catch {
+    return {
+      ready: false,
+      stage: "local_init_http",
+      detail: "request failed after the server became reachable",
     };
-    // CLI's default token is the Better Auth session token; session auth
-    // carries the user's org membership and works for admin REST + MCP calls.
-    // Persist the companion worker PAT too for the gateway agent API, which
-    // still authenticates that surface via worker/OAuth bearer tokens. The
-    // same session token is passed to the browser deep-link URL so the SPA
-    // hook reaches /api/exchange-token → Better Auth session cookie.
-    const cliToken = body.session_token ?? body.device_token;
-    if (!cliToken) return { ready: false };
+  }
+  if (!res.ok) {
+    return {
+      ready: false,
+      stage: "local_init_http",
+      detail: `HTTP ${res.status}`,
+    };
+  }
 
+  let parsedBody: unknown;
+  try {
+    parsedBody = await res.json();
+  } catch {
+    return {
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response was not valid JSON",
+    };
+  }
+  if (
+    !parsedBody ||
+    typeof parsedBody !== "object" ||
+    Array.isArray(parsedBody)
+  ) {
+    return {
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response did not contain a JSON object",
+    };
+  }
+  const body = parsedBody as Record<string, unknown>;
+  const optionalRecord = (
+    value: unknown
+  ): Record<string, unknown> | null | undefined => {
+    if (value == null) return undefined;
+    return typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  };
+  const user = optionalRecord(body.user);
+  const organization = optionalRecord(body.organization);
+  const hasInvalidStringField = (
+    record: Record<string, unknown>,
+    field: string
+  ) => record[field] !== undefined && typeof record[field] !== "string";
+  if (
+    user === null ||
+    organization === null ||
+    hasInvalidStringField(body, "session_token") ||
+    hasInvalidStringField(body, "device_token") ||
+    (user &&
+      ["id", "email", "name"].some((field) =>
+        hasInvalidStringField(user, field)
+      )) ||
+    (organization &&
+      ["id", "slug", "name"].some((field) =>
+        hasInvalidStringField(organization, field)
+      ))
+  ) {
+    return {
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response contained invalid field types",
+    };
+  }
+  const nonEmptyString = (value: unknown): string | undefined => {
+    if (typeof value !== "string") return undefined;
+    const trimmed = value.trim();
+    return trimmed === "" ? undefined : trimmed;
+  };
+  const sessionToken = nonEmptyString(body.session_token);
+  const deviceToken = nonEmptyString(body.device_token);
+  const userId = nonEmptyString(user?.id);
+  const userEmail = nonEmptyString(user?.email);
+  const userName = nonEmptyString(user?.name);
+  const orgSlug = nonEmptyString(organization?.slug);
+
+  // CLI's default token is the Better Auth session token; session auth
+  // carries the user's org membership and works for admin REST + MCP calls.
+  // Persist the companion worker PAT too for the gateway agent API, which
+  // still authenticates that surface via worker/OAuth bearer tokens. The
+  // same session token is passed to the browser deep-link URL so the SPA
+  // hook reaches /api/exchange-token → Better Auth session cookie.
+  const cliToken = sessionToken ?? deviceToken;
+  if (!cliToken) {
+    return {
+      ready: false,
+      stage: "local_init_payload",
+      detail: "response did not contain a session or device token",
+    };
+  }
+
+  try {
     const contextName = "local";
-    await addContext(contextName, gatewayUrl);
+    await dependencies.addContextImpl(contextName, gatewayUrl);
     const creds: Credentials = {
       accessToken: cliToken,
-      ...(body.device_token ? { localWorkerToken: body.device_token } : {}),
-      ...(body.user?.email ? { email: body.user.email } : {}),
-      ...(body.user?.name ? { name: body.user.name } : {}),
-      ...(body.user?.id ? { userId: body.user.id } : {}),
+      ...(deviceToken ? { localWorkerToken: deviceToken } : {}),
+      ...(userEmail ? { email: userEmail } : {}),
+      ...(userName ? { name: userName } : {}),
+      ...(userId ? { userId } : {}),
     };
-    await saveCredentials(creds, contextName);
+    await dependencies.saveCredentialsImpl(creds, contextName);
     // Bind the bootstrap org slug returned by /api/local-init to the
     // context. Without this, `lobu apply -c local` errors with
     // "No organization selected" until the user manually runs
     // `lobu org set <slug>`. The server is the source of truth — it
     // auto-provisioned this org for the install operator.
-    const orgSlug = body.organization?.slug?.trim();
     if (orgSlug) {
-      await setActiveOrg(orgSlug, contextName).catch(() => undefined);
+      await dependencies
+        .setActiveOrgImpl(orgSlug, contextName)
+        .catch(() => undefined);
     }
     // Auto-switch the active context so plain `lobu apply` / `lobu chat`
     // from any shell hit this loopback server instead of whatever cloud
@@ -661,9 +805,9 @@ async function announceLocalSignIn(
     // `local`; `lobu run` from a shell previously on `lobu` cloud prints
     // the switch.
     try {
-      const current = await getCurrentContextName();
+      const current = await dependencies.getCurrentContextNameImpl();
       if (current !== contextName) {
-        await setCurrentContext(contextName);
+        await dependencies.setCurrentContextImpl(contextName);
         process.stderr.write(
           `Switched active context to "${contextName}" (lobu run)\n`
         );
@@ -673,10 +817,10 @@ async function announceLocalSignIn(
     }
 
     const url = new URL(gatewayUrl);
-    url.searchParams.set("lobu_token", body.session_token ?? cliToken);
+    url.searchParams.set("lobu_token", cliToken);
     console.log();
     console.log(
-      chalk.green(`  Signed in as ${body.user?.email ?? "Local Developer"}.`)
+      chalk.green(`  Signed in as ${userEmail ?? "Local Developer"}.`)
     );
     console.log(chalk.dim(`    Web UI:   `) + chalk.cyan(url.toString()));
     console.log(
@@ -690,12 +834,39 @@ async function announceLocalSignIn(
     // cloud org must not redirect the local apply — that 404s silently).
     return { ready: true, localOrgSlug: orgSlug };
   } catch {
-    // Swallow — the banner is best-effort.
-    return { ready: false };
+    return {
+      ready: false,
+      stage: "context_setup",
+      detail: 'could not register or persist the "local" context',
+    };
   }
 }
 
-async function waitForServerReachable(
+const localSignInStageLabels: Record<LocalSignInFailureStage, string> = {
+  server_unreachable: "server startup",
+  local_init_http: "the local-init request",
+  local_init_payload: "the local-init response",
+  context_setup: "local CLI context setup",
+};
+
+export function getLocalSignInWarning(
+  result: LocalSignInResult,
+  options: { embedded: boolean; hasLobuConfig: boolean }
+): string | null {
+  if (
+    !options.embedded ||
+    !options.hasLobuConfig ||
+    result.ready ||
+    !("stage" in result)
+  ) {
+    return null;
+  }
+
+  const detail = result.detail ? ` (${result.detail})` : "";
+  return `Local sign-in failed during ${localSignInStageLabels[result.stage]}${detail}; project auto-apply was skipped.`;
+}
+
+export async function waitForServerReachable(
   url: string,
   timeoutMs = 30_000
 ): Promise<boolean> {


### PR DESCRIPTION
## Summary

- return explicit credential-safe stages when local sign-in cannot establish the local context
- warn only when an embedded project with lobu.config.ts would otherwise have auto-applied
- preserve the existing /health probe, bounded polling, external-mode skip, local-only context pinning, and auto-apply safety gate

## Test plan

- [x] Fresh reproduction on current main was negative: /health 200, POST /api/local-init 200, sign-in and auto-apply completed
- [x] Red diagnostics contract captured silent server, HTTP, payload, and context failures
- [x] Reviewer regression was red at 31 pass / 5 warning-expectation failures, then focused dev.test.ts passed 36/36 after removing the unprovable liveness claim
- [x] Fetch rejection and invalid-JSON branches are pinned without echoing or persisting credential-shaped data; payload/context warning labels and success suppression are exact assertions
- [x] Non-TTY CLI top-level src suite passed 113/113; full `packages/cli/src` suite passed 649 with 1 intentional skip
- [x] Built CLI and real node bin/lobu.js run --help completed
- [x] Full post-change scripts/cli-smoke.sh passed 100, failed 0, skipped 4 before the final warning-only edit
- [x] CLAUDE_REVIEW_MODEL=fable make review-fix completed
- [x] make pre-pr completed all 7 stages
- [x] git diff --check clean

## Notes

Part of #2869. Current main serves /health and the reported missing POST did not reproduce, so this PR does not change the health path or claim to fix that historical symptom. It implements the independently valid diagnostics and privacy contract only.
