### PR TITLE
fix(migrations): repair orphaned Automation reaction [migration-never-applied]

### DIFF
--- a/db/migrations/20260820120000_remove_canvas_runtime.sql
+++ b/db/migrations/20260820120000_remove_canvas_runtime.sql
@@ -341,6 +341,42 @@ SET window_id = source.run_id
 FROM source_for_reaction source
 WHERE reaction.id = source.id;
 
+-- reaction-orphan-cutover:start
+-- One production notification reaction from the retired best-effort path has
+-- automation_id copied into window_id and no run_id. Preserve that bookkeeping
+-- row only when its source is unambiguous: exactly one completed run for the
+-- same organization and Automation in the preceding five minutes. Any other
+-- orphan remains untouched so the assertion below still fails closed.
+WITH orphaned_notification_reaction AS MATERIALIZED (
+  SELECT reaction.id, reaction.organization_id, reaction.automation_id,
+         reaction.created_at
+  FROM public.automation_reactions reaction
+  WHERE reaction.window_id = reaction.automation_id
+    AND reaction.reaction_type = 'notification_sent'
+    AND reaction.tool_name = 'notify'
+    AND reaction.run_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.runs existing WHERE existing.id = reaction.window_id
+    )
+), unique_source_run AS (
+  SELECT reaction.id, MIN(candidate.id) AS run_id
+  FROM orphaned_notification_reaction reaction
+  JOIN public.runs candidate
+    ON candidate.organization_id = reaction.organization_id
+   AND candidate.automation_id = reaction.automation_id
+   AND candidate.run_type = 'automation'
+   AND candidate.status = 'completed'
+   AND candidate.completed_at BETWEEN reaction.created_at - interval '5 minutes'
+                                  AND reaction.created_at
+  GROUP BY reaction.id
+  HAVING COUNT(*) = 1
+)
+UPDATE public.automation_reactions reaction
+SET window_id = source.run_id
+FROM unique_source_run source
+WHERE reaction.id = source.id;
+-- reaction-orphan-cutover:end
+
 WITH source_for_merge AS (
   SELECT operation.id, COALESCE((
     SELECT member.run_id

--- a/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
@@ -9,6 +9,8 @@ const CUTOVER_MIGRATION = '20260816000010_automation_vocabulary.sql';
 const CANVAS_REMOVAL_MIGRATION = '20260820120000_remove_canvas_runtime.sql';
 const CANVAS_RESULT_CUTOVER_START = '-- canvas-result-cutover:start';
 const CANVAS_RESULT_CUTOVER_END = '-- canvas-result-cutover:end';
+const REACTION_ORPHAN_CUTOVER_START = '-- reaction-orphan-cutover:start';
+const REACTION_ORPHAN_CUTOVER_END = '-- reaction-orphan-cutover:end';
 const TRAIT_REWRITE_START = '-- connector-trait-merge-strategy:start';
 const TRAIT_REWRITE_END = '-- connector-trait-merge-strategy:end';
 const ENTITY_REWRITE_START = '-- entity-metadata-cutover:start';
@@ -48,6 +50,14 @@ function loadCanvasResultCutover(): string {
   const end = up.indexOf(CANVAS_RESULT_CUTOVER_END);
   if (start < 0 || end < start) throw new Error('Could not locate Canvas result cutover');
   return up.slice(start + CANVAS_RESULT_CUTOVER_START.length, end);
+}
+
+function loadReactionOrphanCutover(): string {
+  const up = loadMigrationUpSection(resolveMigrationsDir(), CANVAS_REMOVAL_MIGRATION);
+  const start = up.indexOf(REACTION_ORPHAN_CUTOVER_START);
+  const end = up.indexOf(REACTION_ORPHAN_CUTOVER_END);
+  if (start < 0 || end < start) throw new Error('Could not locate reaction orphan cutover');
+  return up.slice(start + REACTION_ORPHAN_CUTOVER_START.length, end);
 }
 
 describe('Automation schema vocabulary', () => {
@@ -228,6 +238,88 @@ describe('Automation schema vocabulary', () => {
           },
           run_metadata: { content_analyzed: 5 },
         });
+
+        throw new Rollback();
+      });
+    } catch (error) {
+      if (!(error instanceof Rollback)) throw error;
+    }
+  });
+
+  it('repairs only an unambiguous legacy notification reaction source', async () => {
+    const sql = getTestDb();
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const agent = await createTestAgent({
+      organizationId: org.id,
+      ownerUserId: user.id,
+      agentId: 'reaction-orphan-cutover-agent',
+    });
+
+    try {
+      await sql.begin(async (tx: typeof sql) => {
+        const automationId = -710_001;
+        await tx`
+          INSERT INTO automations (
+            id, organization_id, created_by, agent_id, automation_group_id,
+            name, slug
+          ) VALUES (
+            ${automationId}, ${org.id}, ${user.id}, ${agent.agentId}, ${automationId},
+            'Reaction orphan cutover', 'reaction-orphan-cutover'
+          )
+        `;
+        const [uniqueRun] = await tx<{ id: number }[]>`
+          INSERT INTO runs (
+            organization_id, run_type, automation_id, status, approval_status,
+            created_at, completed_at
+          ) VALUES (
+            ${org.id}, 'automation', ${automationId}, 'completed', 'auto',
+            '2026-08-02T01:26:04.000Z', '2026-08-02T01:26:04.000Z'
+          )
+          RETURNING id
+        `;
+        await tx`
+          INSERT INTO runs (
+            organization_id, run_type, automation_id, status, approval_status,
+            created_at, completed_at
+          ) VALUES
+            (${org.id}, 'automation', ${automationId}, 'completed', 'auto',
+             '2026-08-02T02:25:00.000Z', '2026-08-02T02:25:00.000Z'),
+            (${org.id}, 'automation', ${automationId}, 'completed', 'auto',
+             '2026-08-02T02:25:00.000Z', '2026-08-02T02:25:00.000Z')
+        `;
+
+        // The marked section runs before the full migration renames this column
+        // and re-points its foreign key; the test database has already applied
+        // both, so restore the legacy shape and run the shipped SQL verbatim.
+        await tx`
+          ALTER TABLE automation_reactions
+          DROP CONSTRAINT automation_reactions_source_run_id_fkey
+        `;
+        await tx`ALTER TABLE automation_reactions RENAME COLUMN source_run_id TO window_id`;
+        const reactions = await tx<{ id: number }[]>`
+          INSERT INTO automation_reactions (
+            organization_id, automation_id, window_id, reaction_type,
+            tool_name, tool_args, created_at
+          ) VALUES
+            (${org.id}, ${automationId}, ${automationId}, 'notification_sent', 'notify',
+             '{}'::jsonb, '2026-08-02T01:26:15.000Z'),
+            (${org.id}, ${automationId}, ${automationId}, 'notification_sent', 'notify',
+             '{}'::jsonb, '2026-08-02T02:26:00.000Z')
+          RETURNING id
+        `;
+
+        await tx.unsafe(loadReactionOrphanCutover());
+        const repaired = await tx<{ window_id: number }[]>`
+          SELECT window_id
+          FROM automation_reactions
+          WHERE id IN ${tx(reactions.map((reaction) => reaction.id))}
+          ORDER BY id
+        `;
+        expect(repaired.map((reaction) => Number(reaction.window_id))).toEqual([
+          Number(uniqueRun.id),
+          automationId,
+        ]);
 
         throw new Rollback();
       });


### PR DESCRIPTION
## Summary

- repair the one legacy `notification_sent` reaction whose retired best-effort writer copied `automation_id` into `window_id`
- re-attribute only when exactly one completed run from the same organization and Automation exists in the preceding five minutes
- leave every ambiguous or differently shaped orphan untouched so the existing migration assertion still fails closed

## Why this edits the existing migration

`20260820120000_remove_canvas_runtime.sql` is merged but has never completed in production, so dbmate has not recorded it. The current production migrate job rolls back cleanly at its first Canvas assertion. PR #3001 clears that assertion; without this follow-up the same migration would then fail later at the Automation-reaction assertion.

## Production evidence (read-only, 2026-08-21)

- 1,450 `automation_reactions.window_id` values do not currently reference a run
- 1,449 are Canvas-root references handled by the existing `source_for_reaction` cutover
- exactly 1 row matches this repair's deliberately narrow predicate
- exactly 1 same-org/same-Automation completed run falls in its five-minute window: run `828963`, completed 10.4 seconds before the reaction
- the production-shaped selection plan completed in about 15 ms

No production rows were changed during diagnosis.

## Validation

- `make review-fix`
- `make pre-pr`
- `bun run test -- run src/__tests__/integration/db/automation-schema-vocabulary.test.ts` (8 passed)
- `bun run db:lint db/migrations/20260820120000_remove_canvas_runtime.sql`
- read-only production predicate/count and query-plan checks

The regression executes the shipped SQL text verbatim against the legacy column shape, proves the unique candidate is repaired, and proves two candidates remain unresolved.

## Release note

Do not merge/release PR #3003 until this lands and release-please refreshes. The next migrate job is the first full production-shaped execution, so deployment verification must watch it through completion before considering the release healthy.
