### PR TITLE
fix(migrations): preserve orphan Automation reaction

### DIFF
--- a/db/migrations/20260820120000_remove_canvas_runtime.sql
+++ b/db/migrations/20260820120000_remove_canvas_runtime.sql
@@ -341,6 +341,38 @@ SET window_id = source.run_id
 FROM source_for_reaction source
 WHERE reaction.id = source.id;
 
+-- An early reaction writer stored automation_id in window_id instead of the
+-- Canvas root. Recover only the unambiguous same-organization result whose
+-- declared window contains the reaction timestamp; ambiguous rows still fail
+-- the assertion below instead of being silently misattributed.
+-- orphan-reaction-cutover:start
+WITH orphan_reaction_candidate AS (
+  SELECT reaction.id, current.run_id
+  FROM public.automation_reactions reaction
+  LEFT JOIN public.runs existing
+    ON existing.id = reaction.window_id
+   AND existing.organization_id = reaction.organization_id
+   AND existing.automation_id = reaction.automation_id
+  JOIN canvas_run_map current ON true
+  JOIN canvas_members head ON head.event_id = current.head_event_id
+  WHERE existing.id IS NULL
+    AND reaction.window_id = reaction.automation_id
+    AND head.organization_id = reaction.organization_id
+    AND head.automation_id = reaction.automation_id
+    AND reaction.created_at >= (head.metadata->>'window_start')::timestamptz
+    AND reaction.created_at <= (head.metadata->>'window_end')::timestamptz
+), source_for_orphan_reaction AS (
+  SELECT id, min(run_id) AS run_id
+  FROM orphan_reaction_candidate
+  GROUP BY id
+  HAVING count(*) = 1
+)
+UPDATE public.automation_reactions reaction
+SET window_id = source.run_id
+FROM source_for_orphan_reaction source
+WHERE reaction.id = source.id;
+-- orphan-reaction-cutover:end
+
 WITH source_for_merge AS (
   SELECT operation.id, COALESCE((
     SELECT member.run_id
@@ -468,7 +500,10 @@ BEGIN
   END IF;
   IF EXISTS (
     SELECT 1 FROM public.automation_reactions reaction
-    LEFT JOIN public.runs run ON run.id = reaction.window_id
+    LEFT JOIN public.runs run
+      ON run.id = reaction.window_id
+     AND run.organization_id = reaction.organization_id
+     AND run.automation_id = reaction.automation_id
     WHERE run.id IS NULL
   ) THEN
     RAISE EXCEPTION 'Cannot retire Canvas: an Automation reaction has no producing run';

--- a/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
@@ -9,6 +9,8 @@ const CUTOVER_MIGRATION = '20260816000010_automation_vocabulary.sql';
 const CANVAS_REMOVAL_MIGRATION = '20260820120000_remove_canvas_runtime.sql';
 const CANVAS_RESULT_CUTOVER_START = '-- canvas-result-cutover:start';
 const CANVAS_RESULT_CUTOVER_END = '-- canvas-result-cutover:end';
+const ORPHAN_REACTION_CUTOVER_START = '-- orphan-reaction-cutover:start';
+const ORPHAN_REACTION_CUTOVER_END = '-- orphan-reaction-cutover:end';
 const TRAIT_REWRITE_START = '-- connector-trait-merge-strategy:start';
 const TRAIT_REWRITE_END = '-- connector-trait-merge-strategy:end';
 const ENTITY_REWRITE_START = '-- entity-metadata-cutover:start';
@@ -30,8 +32,13 @@ function resolveMigrationsDir(): string {
   throw new Error('Could not locate db/migrations from the test directory');
 }
 
-function loadMarkedSection(startMarker: string, endMarker: string, label: string): string {
-  const up = loadMigrationUpSection(resolveMigrationsDir(), CUTOVER_MIGRATION);
+function loadMarkedSection(
+  startMarker: string,
+  endMarker: string,
+  label: string,
+  migration = CUTOVER_MIGRATION,
+): string {
+  const up = loadMigrationUpSection(resolveMigrationsDir(), migration);
   const start = up.indexOf(startMarker);
   const end = up.indexOf(endMarker);
   if (start < 0 || end < start) throw new Error(`Could not locate ${label}`);
@@ -43,11 +50,21 @@ function loadTraitRewrite(): string {
 }
 
 function loadCanvasResultCutover(): string {
-  const up = loadMigrationUpSection(resolveMigrationsDir(), CANVAS_REMOVAL_MIGRATION);
-  const start = up.indexOf(CANVAS_RESULT_CUTOVER_START);
-  const end = up.indexOf(CANVAS_RESULT_CUTOVER_END);
-  if (start < 0 || end < start) throw new Error('Could not locate Canvas result cutover');
-  return up.slice(start + CANVAS_RESULT_CUTOVER_START.length, end);
+  return loadMarkedSection(
+    CANVAS_RESULT_CUTOVER_START,
+    CANVAS_RESULT_CUTOVER_END,
+    'Canvas result cutover',
+    CANVAS_REMOVAL_MIGRATION,
+  );
+}
+
+function loadOrphanReactionCutover(): string {
+  return loadMarkedSection(
+    ORPHAN_REACTION_CUTOVER_START,
+    ORPHAN_REACTION_CUTOVER_END,
+    'orphan reaction cutover',
+    CANVAS_REMOVAL_MIGRATION,
+  );
 }
 
 describe('Automation schema vocabulary', () => {
@@ -146,6 +163,17 @@ describe('Automation schema vocabulary', () => {
         // The marked section runs before the full migration drops this legacy
         // relation key; the test database has already applied that final drop.
         await tx`ALTER TABLE runs ADD COLUMN IF NOT EXISTS window_id bigint`;
+        await tx`ALTER TABLE automation_reactions DROP CONSTRAINT IF EXISTS automation_reactions_source_run_id_fkey`;
+        await tx`ALTER TABLE automation_reactions RENAME COLUMN source_run_id TO window_id`;
+        const [orphanReaction] = await tx<{ id: number }[]>`
+          INSERT INTO automation_reactions (
+            organization_id, automation_id, window_id, reaction_type, tool_name, created_at
+          ) VALUES (
+            ${org.id}, ${legacyResult.automationId}, ${legacyResult.automationId},
+            'notification_sent', 'notify', '2026-08-18T12:00:00.000Z'
+          )
+          RETURNING id
+        `;
         const [linkedRun] = await tx<{ id: number }[]>`
           INSERT INTO runs (
             organization_id, run_type, automation_id, approval_status, status,
@@ -159,6 +187,7 @@ describe('Automation schema vocabulary', () => {
           RETURNING id
         `;
         await tx.unsafe(loadCanvasResultCutover());
+        await tx.unsafe(loadOrphanReactionCutover());
 
         const [run] = await tx`
           SELECT id, status, outcome, action_output, approved_input, run_metadata
@@ -211,6 +240,12 @@ describe('Automation schema vocabulary', () => {
         `;
         expect(Number(resultMapping.run_id)).toBe(Number(resultRun.id));
         expect(Number(resultMapping.head_event_id)).toBe(Number(legacyResult.legacyId));
+        const [preservedReaction] = await tx`
+          SELECT window_id
+          FROM automation_reactions
+          WHERE id = ${orphanReaction.id}
+        `;
+        expect(Number(preservedReaction.window_id)).toBe(Number(resultRun.id));
 
         const linkedRuns = await tx`
           SELECT id, action_output, approved_input, run_metadata


### PR DESCRIPTION
## Summary
- preserve the one legacy Automation reaction whose old writer stored its Automation id instead of its Canvas root
- accept only a unique same-organization, same-Automation window containing the reaction timestamp
- strengthen the migration assertion against cross-Automation run-id collisions
- add a focused preservation regression

## Validation
- focused Automation schema vocabulary test (7/7)
- SQL migration lint (0 issues)
- make pre-pr
- production ledger confirms migration 20260820120000 is still unapplied

This is a migration-never-applied follow-up to #3001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of automation reactions that were disconnected from their associated runs.
  - Reactions are now validated against the correct organization, automation, and execution run.
  - Ambiguous or unmatched reactions continue to be flagged for validation rather than assigned incorrectly.

- **Improvements**
  - Updated execution and event terminology for clearer, more consistent run-based reporting.
  - Added migration coverage to verify legacy automation reactions are correctly linked during upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->