### PR TITLE
fix(migrations): flush deferred Automation trigger

### DIFF
--- a/db/migrations/20260820120000_remove_canvas_runtime.sql
+++ b/db/migrations/20260820120000_remove_canvas_runtime.sql
@@ -247,6 +247,10 @@ FROM canvas_run_map mapping
 JOIN canvas_members head ON head.event_id = mapping.head_event_id
 WHERE run.id = mapping.run_id;
 
+-- Synthesized completed runs stamp automations.last_run_completed_at. Flush the
+-- table's deferred version FK before the structural cutover alters automations.
+SET CONSTRAINTS ALL IMMEDIATE;
+
 -- canvas-result-cutover:end
 
 -- Child work used the Canvas root as its parent key. Prefer the producer that

--- a/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/db/automation-schema-vocabulary.test.ts
@@ -100,6 +100,12 @@ describe('Automation schema vocabulary', () => {
       await sql.begin(async (tx: typeof sql) => {
         const windowStart = '2026-08-18T00:00:00.000Z';
         const windowEnd = '2026-08-19T00:00:00.000Z';
+        await tx`
+          ALTER TABLE automations
+            ALTER CONSTRAINT automations_current_version_id_fkey DEFERRABLE INITIALLY DEFERRED,
+            ADD COLUMN notification_channel text,
+            ADD COLUMN notification_priority text
+        `;
         const createLegacyCanvas = async (params: {
           slug: string;
           payload: Record<string, unknown>;
@@ -159,6 +165,20 @@ describe('Automation schema vocabulary', () => {
           metadataIdKey: 'watcher_id',
           contentAnalyzed: 5,
         });
+        const [legacyVersion] = await tx<{ id: number }[]>`
+          INSERT INTO automation_versions (
+            automation_id, version, name, created_by, prompt, version_sources
+          ) VALUES (
+            ${legacyResult.automationId}, 1, 'Legacy result cutover', ${user.id},
+            'Preserve the legacy result', '[]'::jsonb
+          )
+          RETURNING id
+        `;
+        await tx`
+          UPDATE automations
+          SET current_version_id = ${legacyVersion.id}
+          WHERE id = ${legacyResult.automationId}
+        `;
 
         // The marked section runs before the full migration drops this legacy
         // relation key; the test database has already applied that final drop.
@@ -187,6 +207,12 @@ describe('Automation schema vocabulary', () => {
           RETURNING id
         `;
         await tx.unsafe(loadCanvasResultCutover());
+        // Production rejected the later structural cutover while this FK check was pending.
+        await tx`
+          ALTER TABLE automations
+            DROP COLUMN notification_channel,
+            DROP COLUMN notification_priority
+        `;
         await tx.unsafe(loadOrphanReactionCutover());
 
         const [run] = await tx`


### PR DESCRIPTION
## Summary
- flush the deferred Automation version FK after synthesizing legacy completed runs
- cover the exact production failure with a rollback-only structural-change probe

## Production evidence
The unapplied Canvas removal migration rolled back safely with PostgreSQL 55006: `cannot ALTER TABLE "automations" because it has pending trigger events`. The existing completed-run trigger updates `automations.last_run_completed_at`; its version FK is initially deferred.

## Validation
- focused production-shaped integration test: 7/7
- SQL lint: clean
- `make pre-pr`: clean

Migration has never applied in production; this corrects it in place.