### PR TITLE
fix(server): make worker dispatch claim-aware

### DIFF
--- a/packages/server/src/__tests__/integration/device-action-wait.test.ts
+++ b/packages/server/src/__tests__/integration/device-action-wait.test.ts
@@ -35,7 +35,7 @@ import {
   waitForDeviceActionRunWithOptions,
 } from '../../tools/admin/device-action-wait';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
-import { createTestOrganization } from '../setup/test-fixtures';
+import { createTestOrganization, seedOwnerContext } from '../setup/test-fixtures';
 
 async function insertChromeConnector(organizationId: string): Promise<void> {
   const sql = getTestDb();
@@ -357,6 +357,79 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
     const expiresInMs = (expiresAt as Date).getTime() - createdBefore;
     expect(expiresInMs).toBeGreaterThan(DEVICE_ACTION_QUEUE_BUDGET_MS - 5_000);
     expect(expiresInMs).toBeLessThan(DEVICE_ACTION_QUEUE_BUDGET_MS + 5_000);
+  });
+
+  it('a device-pinned action queued behind a busy serial worker times out once without redispatch', async () => {
+    const sql = getTestDb();
+    const { org, user } = await seedOwnerContext({
+      orgName: 'Busy Device Action Org',
+    });
+    await insertChromeConnector(org.id);
+    const workerId = 'busy-device-action-worker';
+    const [device] = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label,
+        organization_id, last_seen_at
+      ) VALUES (
+        ${user.id}, ${workerId}, 'chrome-extension',
+        ${sql.json(['browser.debugger'])}, 'Busy Chrome', ${org.id}, current_timestamp
+      )
+      RETURNING id
+    `) as Array<{ id: string }>;
+    const connId = await insertChromeConnection(org.id, device.id);
+
+    // Device workers execute serially. Model the exact worker already holding
+    // one action while another direct action is queued for the same pin. The
+    // due-feed pull path cannot defer this row because actions are created by
+    // their caller, not by the scheduled-feed materializer.
+    await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key,
+        connector_version, action_key, action_input, approval_status, status,
+        claimed_at, last_heartbeat_at, claimed_by, created_at
+      ) VALUES (
+        ${org.id}, 'action', ${connId}, 'chrome', '0.2.0', 'busy_action',
+        ${sql.json({})}, 'auto', 'running', current_timestamp,
+        current_timestamp, ${workerId}, current_timestamp
+      )
+    `;
+    const createdBefore = Date.now();
+    const queued = await createConnectorOperationRun({
+      organizationId: org.id,
+      connectionId: connId,
+      connectorKey: 'chrome',
+      operationKey: 'queued_behind_busy',
+      operationInput: { url: 'about:blank' },
+      approvalMode: 'device',
+      requireCompiledCode: false,
+    });
+    expect(queued.status).toBe('pending');
+    const expiresAt = await expiresAtOf(queued.runId);
+    expect(expiresAt).not.toBeNull();
+    const expiresInMs = (expiresAt as Date).getTime() - createdBefore;
+    expect(expiresInMs).toBeGreaterThan(DEVICE_ACTION_QUEUE_BUDGET_MS - 5_000);
+    expect(expiresInMs).toBeLessThan(DEVICE_ACTION_QUEUE_BUDGET_MS + 5_000);
+
+    const out = await waitForDeviceActionRunWithOptions(
+      queued.runId,
+      org.id,
+      FAST_BUDGETS
+    );
+    expect(out.status).toBe('timeout');
+    expect(out.error_message).toContain('was never claimed');
+    expect(out.error_message).toContain('Busy Chrome');
+
+    const queuedRows = await sql`
+      SELECT status, error_message
+      FROM runs
+      WHERE organization_id = ${org.id}
+        AND run_type = 'action'
+        AND action_key = 'queued_behind_busy'
+    `;
+    expect(queuedRows).toHaveLength(1);
+    expect(queuedRows[0].status).toBe('timeout');
+    expect(String(queuedRows[0].error_message)).toContain('no device claimed the run');
+    expect(String(queuedRows[0].error_message)).toContain('Busy Chrome');
   });
 
   it('queued (durable human-decision) runs get NO expires_at', async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -3,8 +3,6 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
-import type { Env } from '../../index';
-import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestConnection, createTestConnectorDefinition } from '../setup/test-fixtures';
 import { post } from '../setup/test-helpers';
@@ -119,25 +117,10 @@ async function poll(
   });
 }
 
-/**
- * Poll and claim the just-installed connector's due feed run. When the poll
- * handler's materialize cooldown is hot (see the primer comment below), the
- * first poll installs the connector but claims nothing; running the
- * materializer directly and re-polling is the deterministic equivalent of
- * waiting out the 5s cooldown.
- */
 async function pollClaimingDueFeed(workerId: string, connectorManifests: unknown[]) {
-  const first = await poll(workerId, connectorManifests);
-  expect(first.status).toBe(200);
-  const firstBody = await first.json();
-  if (firstBody.connector_key) {
-    return firstBody;
-  }
-
-  await materializeDueFeeds({} as Env, getTestDb());
-  const second = await poll(workerId, connectorManifests);
-  expect(second.status).toBe(200);
-  return second.json();
+  const response = await poll(workerId, connectorManifests);
+  expect(response.status).toBe(200);
+  return response.json();
 }
 
 const OWLETTO_MANIFEST_DIRS = (() => {
@@ -188,15 +171,6 @@ describe('device connector manifests', () => {
 
   it('installs a metadata-only device connector from poll and claims its feed run without compiled_code', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
-
-    // Prime the poll handler's module-level due-feed-materialize cooldown
-    // (worker-api/poll.ts). The integration suite runs singleFork +
-    // isolate:false, so any poll in the previous ~5s — from this file or any
-    // other — leaves the cooldown hot and the next poll skips materialization.
-    // Making that state explicit turns a timing-dependent flake into a
-    // deterministic scenario.
-    const primer = await poll(workerId, []);
-    expect(primer.status).toBe(200);
 
     const body = await pollClaimingDueFeed(workerId, [manifest()]);
 

--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -1,8 +1,9 @@
 /**
  * Scheduled feed materialization must respect the liveness of a connection's
  * pinned device. An offline device cannot claim the run, so queueing one only
- * creates a worker_claim_timeout failure episode. The feed stays overdue while
- * the device is offline and is materialized as soon as that device polls again.
+ * produces a run that ages into a worker_claim_timeout dispatch failure. The
+ * feed stays overdue while the device is offline and is materialized as soon
+ * as that device polls again.
  *
  * Only EXECUTION pins defer. A chrome-extension pin on a non-chrome connector
  * is browser affinity — worker-api/poll.ts keeps that parent sync on the fleet
@@ -10,11 +11,17 @@
  * syncing while the browser is closed.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../../index';
-import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
+import {
+  type DueFeedClaimContext,
+  materializeDueFeeds,
+} from '../../scheduled/check-due-feeds';
 import { getSchedulerHealth } from '../../scheduled/scheduler-health';
 import { DEVICE_ONLINE_WINDOW_SECONDS } from '../../utils/device-liveness';
+import logger from '../../utils/logger';
+import { pollWorkerJob } from '../../worker-api/poll';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import {
   createTestConnection,
@@ -174,5 +181,324 @@ describe('scheduled feed device liveness', () => {
       [affinityFeedId]: 1,
       [unpinnedFeedId]: 1,
     });
+  });
+
+  it('materializes one due feed only when the current idle poller can claim it', async () => {
+    const sql = getTestDb();
+    const { org, user } = await seedOwnerContext({
+      orgName: 'Poll Scoped Feed Scheduler Org',
+    });
+
+    async function createDevice(
+      workerId: string,
+      platform: 'macos' | 'chrome-extension',
+      capabilities: string[]
+    ): Promise<string> {
+      const [device] = (await sql`
+        INSERT INTO device_workers (
+          user_id, worker_id, platform, capabilities, label,
+          organization_id, last_seen_at
+        ) VALUES (
+          ${user.id}, ${workerId}, ${platform}, ${sql.json(capabilities)},
+          ${workerId}, ${org.id}, current_timestamp
+        )
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      return device.id;
+    }
+
+    async function createDueFeed(options: {
+      connectorKey: string;
+      deviceId?: string;
+      requiredCapability?: string;
+    }): Promise<number> {
+      await createTestConnectorDefinition({
+        key: options.connectorKey,
+        name: options.connectorKey,
+        feeds_schema: { items: { description: 'Items' } },
+        organization_id: org.id,
+      });
+      if (options.requiredCapability) {
+        await sql`
+          UPDATE connector_definitions
+          SET required_capability = ${options.requiredCapability}
+          WHERE key = ${options.connectorKey}
+            AND organization_id = ${org.id}
+        `;
+      }
+      const connection = await createTestConnection({
+        organization_id: org.id,
+        connector_key: options.connectorKey,
+        created_by: user.id,
+        createDefaultFeed: false,
+      });
+      if (options.deviceId) {
+        await sql`
+          UPDATE connections
+          SET device_worker_id = ${options.deviceId}::uuid
+          WHERE id = ${connection.id}
+        `;
+      }
+      const [feed] = (await sql`
+        INSERT INTO feeds (
+          organization_id, connection_id, feed_key, status, kind, virtual,
+          schedule, next_run_at, created_at, updated_at
+        ) VALUES (
+          ${org.id}, ${connection.id}, 'items', 'active', 'collected', false,
+          '* * * * *', current_timestamp - INTERVAL '5 minutes',
+          current_timestamp, current_timestamp
+        )
+        RETURNING id
+      `) as unknown as Array<{ id: number }>;
+      return Number(feed.id);
+    }
+
+    const macDeviceId = await createDevice('poll-scoped-mac', 'macos', ['os.shell']);
+    const chromeDeviceId = await createDevice('poll-scoped-chrome', 'chrome-extension', [
+      'browser.history',
+    ]);
+    const macPinnedFeedId = await createDueFeed({
+      connectorKey: 'test.poll-scoped.mac',
+      deviceId: macDeviceId,
+    });
+    const chromePinnedFeedId = await createDueFeed({
+      connectorKey: 'chrome.history',
+      deviceId: chromeDeviceId,
+    });
+    const browserAffinityFeedId = await createDueFeed({
+      connectorKey: 'test.poll-scoped.affinity',
+      deviceId: chromeDeviceId,
+    });
+    const fleetFeedId = await createDueFeed({
+      connectorKey: 'test.poll-scoped.fleet',
+    });
+    const brokenFleetFeedId = await createDueFeed({
+      connectorKey: 'test.poll-scoped.broken-fleet',
+    });
+    await sql`
+      DELETE FROM connector_versions
+      WHERE connector_key = 'test.poll-scoped.broken-fleet'
+    `;
+    await sql`
+      UPDATE feeds
+      SET next_run_at = current_timestamp - INTERVAL '10 minutes'
+      WHERE id = ${brokenFleetFeedId}
+    `;
+    const capabilityFeedId = await createDueFeed({
+      connectorKey: 'test.poll-scoped.capability',
+      requiredCapability: 'os.shell',
+    });
+    const healthBeforePoll = await getSchedulerHealth({} as Env);
+    expect(healthBeforePoll.metrics.activeFeeds).toBe(6);
+    expect(healthBeforePoll.metrics.overdueFeeds).toBe(5);
+    const fleetContext: DueFeedClaimContext = {
+      isUserScopedWorker: false,
+      deviceWorkerId: null,
+      authorizedCapabilities: [],
+      capabilityMatchSet: [''],
+      orgScopeIds: [''],
+      baseOrgScopeIds: [''],
+      workerHardensDbEgress: true,
+    };
+    const macContext: DueFeedClaimContext = {
+      isUserScopedWorker: true,
+      deviceWorkerId: macDeviceId,
+      authorizedCapabilities: ['os.shell'],
+      capabilityMatchSet: ['os.shell'],
+      orgScopeIds: [org.id],
+      baseOrgScopeIds: [org.id],
+      workerHardensDbEgress: false,
+    };
+    const chromeContext: DueFeedClaimContext = {
+      isUserScopedWorker: true,
+      deviceWorkerId: chromeDeviceId,
+      authorizedCapabilities: ['browser.history'],
+      capabilityMatchSet: ['browser.history'],
+      orgScopeIds: [org.id],
+      baseOrgScopeIds: [org.id],
+      workerHardensDbEgress: false,
+    };
+
+    // Production incident shape: the Mac is recently seen but busy, so it is not
+    // the worker polling here. A fleet poll must not enqueue its
+    // execution-pinned work — it only gets the fleet feed and the
+    // browser-affinity one, which is deliberately fleet work. The deliberately
+    // unrunnable oldest fleet feed throws, so it counts as neither created nor
+    // skipped — the loop logs it and moves on rather than letting it
+    // monopolize the poller's single successful creation slot.
+    expect(
+      await materializeDueFeeds({} as Env, sql, {
+        claimContext: fleetContext,
+        maxRunsCreated: 1,
+      })
+    ).toEqual({ dueFeeds: 3, runsCreated: 1, skipped: 0 });
+    expect(
+      await materializeDueFeeds({} as Env, sql, {
+        claimContext: fleetContext,
+        maxRunsCreated: 1,
+      })
+    ).toEqual({ dueFeeds: 2, runsCreated: 1, skipped: 0 });
+
+    // The device registry upsert is best-effort. If it transiently fails but
+    // the fallback resolves the existing device row, this current poll is
+    // stronger readiness evidence than its stale stored timestamp.
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = current_timestamp - INTERVAL '10 minutes'
+      WHERE id = ${macDeviceId}::uuid
+    `;
+
+    // The Mac poll owns both its explicit pin and the unpinned capability lane,
+    // but each idle poll materializes only one claim slot.
+    expect(
+      await materializeDueFeeds({} as Env, sql, {
+        claimContext: macContext,
+        maxRunsCreated: 1,
+      })
+    ).toEqual({ dueFeeds: 2, runsCreated: 1, skipped: 0 });
+    expect(
+      await materializeDueFeeds({} as Env, sql, {
+        claimContext: macContext,
+        maxRunsCreated: 1,
+      })
+    ).toEqual({ dueFeeds: 1, runsCreated: 1, skipped: 0 });
+
+    expect(
+      await materializeDueFeeds({} as Env, sql, {
+        claimContext: chromeContext,
+        maxRunsCreated: 1,
+      })
+    ).toEqual({ dueFeeds: 1, runsCreated: 1, skipped: 0 });
+
+    const runs = (await sql`
+      SELECT feed_id, COUNT(*)::int AS count
+      FROM runs
+      WHERE run_type = 'sync'
+      GROUP BY feed_id
+      ORDER BY feed_id
+    `) as unknown as Array<{ feed_id: number; count: number }>;
+    expect(
+      Object.fromEntries(runs.map((run) => [Number(run.feed_id), Number(run.count)]))
+    ).toEqual({
+      [macPinnedFeedId]: 1,
+      [chromePinnedFeedId]: 1,
+      [browserAffinityFeedId]: 1,
+      [fleetFeedId]: 1,
+      [capabilityFeedId]: 1,
+    });
+    expect(runs.some((run) => Number(run.feed_id) === brokenFleetFeedId)).toBe(false);
+  });
+
+  it('delivers an overdue execution-pinned feed when its device resumes polling', async () => {
+    const sql = getTestDb();
+    const { org, user } = await seedOwnerContext({
+      orgName: 'Resumed Device Scheduler Org',
+    });
+    const workerId = 'resumed-device-worker';
+    const [device] = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label,
+        organization_id, last_seen_at
+      ) VALUES (
+        ${user.id}, ${workerId}, 'macos', ${sql.json([])}, 'Resumed Mac',
+        ${org.id}, current_timestamp - INTERVAL '10 minutes'
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: string }>;
+    await createTestConnectorDefinition({
+      key: 'test.scheduler-resumed-device',
+      name: 'Resumed Device Connector',
+      feeds_schema: { items: { description: 'Items' } },
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'test.scheduler-resumed-device',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
+    await sql`
+      UPDATE connections
+      SET device_worker_id = ${device.id}::uuid
+      WHERE id = ${connection.id}
+    `;
+    const [feed] = (await sql`
+      INSERT INTO feeds (
+        organization_id, connection_id, feed_key, status, kind, virtual,
+        schedule, next_run_at, created_at, updated_at
+      ) VALUES (
+        ${org.id}, ${connection.id}, 'items', 'active', 'collected', false,
+        '* * * * *', current_timestamp - INTERVAL '5 minutes',
+        current_timestamp, current_timestamp
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const app = new Hono();
+    app.post(
+      '/api/workers/poll',
+      async (c, next) => {
+        c.set('workerAuthMode' as never, 'user' as never);
+        c.set('workerUserId' as never, user.id as never);
+        c.set('workerOrgIds' as never, [org.id] as never);
+        c.set('organizationId' as never, org.id as never);
+        c.set('mcpAuthInfo' as never, { scopes: ['device_worker:run'] } as never);
+        await next();
+      },
+      (c) => pollWorkerJob(c as never)
+    );
+    const poll = (pollingWorkerId: string) =>
+      app.fetch(
+        new Request('http://localhost/api/workers/poll', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            worker_id: pollingWorkerId,
+            platform: 'macos',
+            app_version: '1.0.0',
+            capabilities: {},
+          }),
+        }),
+        {} as never
+      );
+
+    const info = vi.spyOn(logger, 'info');
+    try {
+      // A different idle worker polls first and materializes nothing — the feed
+      // is pinned to this device, so it is outside that worker's claim lanes.
+      // The exact device can materialize it on its next poll.
+      expect((await poll('bystander-device-worker')).status).toBe(200);
+
+      const response = await poll(workerId);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(Number(body.feed_id)).toBe(Number(feed.id));
+      expect(body.run_type).toBe('sync');
+
+      const runs = await sql`
+        SELECT id, status, claimed_by
+        FROM runs
+        WHERE feed_id = ${feed.id}
+          AND run_type = 'sync'
+      `;
+      expect(runs).toHaveLength(1);
+      expect(String(runs[0].status)).toBe('running');
+      expect(String(runs[0].claimed_by)).toBe(workerId);
+
+      const dispatchEvents = info.mock.calls.filter(
+        (call) => call[1] === '[pollWorkerJob] Materialized due sync for current poller'
+      );
+      expect(dispatchEvents).toHaveLength(1);
+      expect(dispatchEvents[0]?.[0]).toMatchObject({
+        dispatch_event: 'worker_scoped_sync_materialized',
+        run_id: Number(runs[0].id),
+        feed_id: Number(feed.id),
+        worker_id: workerId,
+        device_worker_id: device.id,
+        eligibility_lane: 'device_pin',
+      });
+    } finally {
+      info.mockRestore();
+    }
   });
 });

--- a/packages/server/src/__tests__/integration/device-manifest-virtual-feed.test.ts
+++ b/packages/server/src/__tests__/integration/device-manifest-virtual-feed.test.ts
@@ -207,11 +207,14 @@ describe('device manifest auto-wire — virtual feeds', () => {
       await pollWithManifest(workerId, [shippingManifest()]);
 
       // Simulate a row created before the manifest declared this key virtual:
-      // it has collected history and a due time. Reconcile must not convert it
+      // it has collected history and a scheduled time. Keep that time in the
+      // future so this test isolates manifest reconciliation from the poller's
+      // separate responsibility to materialize genuinely due collected feeds.
+      // Reconcile must not convert it
       // (that would strand its events behind a live-read path) and must not
-      // clear its due time while leaving it collected (that would freeze it).
+      // clear its schedule while leaving it collected (that would freeze it).
       const sql = getTestDb();
-      const dueAt = new Date('2026-08-19T00:00:00Z');
+      const dueAt = new Date('2099-08-19T00:00:00Z');
       await sql`
         UPDATE feeds SET kind = 'collected', virtual = false, next_run_at = ${dueAt}
         WHERE feed_key = ${VIRTUAL_FEED}

--- a/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
+++ b/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
@@ -144,10 +144,12 @@ describe('scheduler and worker ingestion contracts', () => {
     });
     const [feed] = await sql`
       INSERT INTO feeds (
-        organization_id, connection_id, feed_key, status, schedule, next_run_at, created_at, updated_at
+        organization_id, connection_id, feed_key, status, schedule, next_run_at,
+        last_sync_status, last_error, consecutive_failures, created_at, updated_at
       ) VALUES (
         ${org.id}, ${connection.id}, 'mentions', 'active', '* * * * *',
-        current_timestamp - INTERVAL '1 minute', current_timestamp, current_timestamp
+        current_timestamp - INTERVAL '1 minute', 'failed', 'previous_source_error', 2,
+        current_timestamp, current_timestamp
       )
       RETURNING id
     `;
@@ -156,11 +158,13 @@ describe('scheduler and worker ingestion contracts', () => {
     expect(materialized.runsCreated).toBe(1);
 
     const [queuedFeed] = await sql`
-      SELECT last_sync_status, next_run_at
+      SELECT last_sync_status, last_error, consecutive_failures, next_run_at
       FROM feeds
       WHERE id = ${feed.id}
     `;
-    expect(String(queuedFeed.last_sync_status)).toBe('pending');
+    expect(String(queuedFeed.last_sync_status)).toBe('failed');
+    expect(String(queuedFeed.last_error)).toBe('previous_source_error');
+    expect(Number(queuedFeed.consecutive_failures)).toBe(2);
     expect(new Date(String(queuedFeed.next_run_at)).getTime()).toBeGreaterThan(Date.now());
 
     const [responseA, responseB] = await Promise.all([
@@ -185,9 +189,18 @@ describe('scheduler and worker ingestion contracts', () => {
     expect(runs).toHaveLength(1);
     expect(String(runs[0].status)).toBe('running');
     expect(['worker-a', 'worker-b']).toContain(String(runs[0].claimed_by));
+
+    const [claimedFeed] = await sql`
+      SELECT last_sync_status, last_error, consecutive_failures
+      FROM feeds
+      WHERE id = ${feed.id}
+    `;
+    expect(String(claimedFeed.last_sync_status)).toBe('pending');
+    expect(claimedFeed.last_error).toBeNull();
+    expect(Number(claimedFeed.consecutive_failures)).toBe(2);
   });
 
-  it('projects a manually triggered sync as pending immediately', async () => {
+  it('preserves source health while a manually triggered sync awaits dispatch', async () => {
     const sql = getTestDb();
     const org = await createTestOrganization({ name: 'Manual Sync State Org' });
 
@@ -206,10 +219,11 @@ describe('scheduler and worker ingestion contracts', () => {
     const [feed] = await sql`
       INSERT INTO feeds (
         organization_id, connection_id, feed_key, status, schedule, next_run_at,
-        created_at, updated_at
+        last_sync_status, last_error, consecutive_failures, created_at, updated_at
       ) VALUES (
         ${org.id}, ${connection.id}, 'mentions', 'active', '0 * * * *',
-        current_timestamp - INTERVAL '1 minute', current_timestamp, current_timestamp
+        current_timestamp - INTERVAL '1 minute', 'failed', 'previous_source_error', 2,
+        current_timestamp, current_timestamp
       )
       RETURNING id
     `;
@@ -219,11 +233,13 @@ describe('scheduler and worker ingestion contracts', () => {
     expect(runId).not.toBeNull();
 
     const [queuedFeed] = await sql`
-      SELECT last_sync_status, next_run_at
+      SELECT last_sync_status, last_error, consecutive_failures, next_run_at
       FROM feeds
       WHERE id = ${feed.id}
     `;
-    expect(String(queuedFeed.last_sync_status)).toBe('pending');
+    expect(String(queuedFeed.last_sync_status)).toBe('failed');
+    expect(String(queuedFeed.last_error)).toBe('previous_source_error');
+    expect(Number(queuedFeed.consecutive_failures)).toBe(2);
     expect(new Date(String(queuedFeed.next_run_at)).getTime()).toBeGreaterThan(Date.now());
   });
 });

--- a/packages/server/src/connectors/feed-backoff.ts
+++ b/packages/server/src/connectors/feed-backoff.ts
@@ -1,15 +1,17 @@
 /**
  * Failure backoff + hard auto-pause policy for scheduled connector feeds.
  *
- * A feed that keeps failing (device offline, revoked auth, connector bug) used
- * to re-enqueue every plain cron cadence: the reschedule path and the
- * claim-timeout reaper both stamped `next_run_at = nextRunAtFromCron(...)`
- * regardless of `consecutive_failures`. On a 5-minute feed that is a failing
- * run every 5 minutes, forever — hammering the connector, the worker lane, and
- * (for GitHub etc.) the upstream API rate limit.
+ * A feed whose connector keeps failing (revoked auth, source outage, connector
+ * bug) used to re-enqueue every plain cron cadence regardless of
+ * `consecutive_failures`. On a 5-minute feed that is a failing run every 5
+ * minutes, forever — hammering the connector and its upstream API rate limit.
  *
- * This module centralises two policies so the reschedule path (run-lifecycle.ts)
- * and the claim-timeout reaper (check-stalled-executions.ts) apply the SAME math:
+ * The policy lives here so the completion path (run-lifecycle.ts) and the
+ * `feed.auto_paused` signal (automations/platform-events.ts) read the same
+ * numbers. It applies ONLY once connector code has actually executed and
+ * reported an outcome. A never-claimed run is a dispatch failure — the
+ * connector never ran — so check-stalled-executions.ts deliberately does not
+ * consume this source-health budget.
  *
  *  1. Exponential backoff on `next_run_at` after a failure, so a failing feed
  *     retries progressively less often instead of every cadence.

--- a/packages/server/src/gateway/metrics/__tests__/registered-counters.test.ts
+++ b/packages/server/src/gateway/metrics/__tests__/registered-counters.test.ts
@@ -4,9 +4,9 @@
  * dead on arrival. Nothing at build time catches the mismatch — a counter can
  * be incremented on a hot path for months while reading as "no events".
  *
- * This walks every `incrementCounter("literal")` call in the server source and
- * asserts the name was registered, so adding a counter without registering it
- * fails here instead of in production silence.
+ * This walks every `incrementCounter("literal")` call in the server source
+ * (either quote style) and asserts the name was registered, so adding a
+ * counter without registering it fails here instead of in production silence.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -16,7 +16,10 @@ import { describe, expect, test } from "bun:test";
 import { getMetricsText } from "../prometheus";
 
 const SRC_ROOT = join(import.meta.dir, "../../..");
-const CALL_RE = /incrementCounter\(\s*"([a-z_0-9]+)"/g;
+// Both quote styles: server sources are biome-excluded and mix ' and ", so a
+// double-quote-only pattern silently skipped whole files (poll.ts,
+// with-retry.ts, task-scheduler.ts, check-stalled-executions.ts).
+const CALL_RE = /incrementCounter\(\s*["']([a-z_0-9]+)["']/g;
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir)) {

--- a/packages/server/src/gateway/metrics/prometheus.ts
+++ b/packages/server/src/gateway/metrics/prometheus.ts
@@ -93,6 +93,21 @@ function initializeMetrics() {
     "counter"
   );
   registerMetric(
+    "lobu_worker_dispatch_failures_total",
+    "Connector runs that timed out before any worker claimed them, by run type and bounded reason",
+    "counter"
+  );
+  registerMetric(
+    "lobu_worker_claim_query_errors_total",
+    "Worker poll claim queries that failed after DB retries, by worker kind and platform",
+    "counter"
+  );
+  registerMetric(
+    "lobu_worker_polls_total",
+    "Authorized worker polls received, by worker kind and platform",
+    "counter"
+  );
+  registerMetric(
     "lobu_process_start_time_seconds",
     "Start time of the process since unix epoch in seconds",
     "gauge"

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -427,12 +427,13 @@ async function createSyncRunWithClient(
   const nextRunAt = feed.schedule
     ? nextRunAtFromCron(feed.schedule, new Date(), feed.timezone)
     : null;
-  // A dry run inserts the run row and stops there. The sibling `UPDATE feeds`
-  // below is a real side effect — it stamps `last_sync_status = 'pending'`,
-  // clears `last_error`, and rolls `next_run_at` forward to the next cron slot.
-  // Letting a dry run do that would move the feed's schedule and overwrite the
-  // recorded outcome of the last REAL sync, which is exactly the state a dry
-  // run exists to leave untouched.
+  // A dry run inserts the run row and stops there. A real enqueue advances only
+  // the schedule. Source health (`last_sync_status`, `last_error`, and the
+  // failure budget) remains the outcome of the last EXECUTED connector run
+  // until a worker actually claims this one. Treating a merely queued run as
+  // connector activity made never-claimed dispatch failures overwrite source
+  // health. poll.ts marks the feed pending atomically with a successful claim.
+  // A dry run must not move the schedule either.
   const inserted = dryRun
     ? await sql`
     INSERT INTO runs (
@@ -458,9 +459,7 @@ async function createSyncRunWithClient(
       RETURNING id, feed_id
     )
     UPDATE feeds f
-    SET last_sync_status = 'pending',
-        last_error = NULL,
-        next_run_at = ${nextRunAt},
+    SET next_run_at = ${nextRunAt},
         updated_at = current_timestamp
     FROM inserted i
     WHERE f.id = i.feed_id

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -186,15 +186,23 @@ async function currentApprovalCardStatus(runId: number): Promise<string> {
 }
 
 describe("reapStaleRuns — connector lanes", () => {
-	test("a stale never-claimed sync is finalized without an immediate retry", async () => {
+	test("a stale never-claimed sync is a dispatch failure and preserves source health", async () => {
 		const feedId = 3131;
 		await seedFeed(feedId);
 		const sql = getDb();
 		await sql`
       UPDATE feeds
-      SET last_sync_status = 'pending',
+      SET last_sync_status = 'success',
+          last_error = NULL,
+          consecutive_failures = 19,
+          first_failure_at = current_timestamp - INTERVAL '1 day',
           next_run_at = current_timestamp + INTERVAL '1 hour'
       WHERE id = ${feedId}
+    `;
+		const [feedBefore] = await sql`
+      SELECT last_sync_status, last_error, consecutive_failures,
+             first_failure_at, next_run_at, status
+      FROM feeds WHERE id = ${feedId}
     `;
 		const pendingId = await seedRun({
 			status: "pending",
@@ -208,6 +216,10 @@ describe("reapStaleRuns — connector lanes", () => {
 
 		expect(result.reaped).toBe(1);
 		expect(result.retriesCreated).toBe(0);
+		expect(result.dispatchFailures).toHaveLength(1);
+		expect(result.dispatchFailures[0]?.reason).toBe(
+			"fleet_or_unpinned_no_claim",
+		);
 		expect(await statusOf(pendingId)).toBe("timeout");
 
 		const pending = await sql`
@@ -216,15 +228,93 @@ describe("reapStaleRuns — connector lanes", () => {
     `;
 		expect(pending).toHaveLength(0);
 		const [feed] = await sql`
-      SELECT last_sync_status, last_error, consecutive_failures, next_run_at
+      SELECT last_sync_status, last_error, consecutive_failures,
+             first_failure_at, next_run_at, status
       FROM feeds WHERE id = ${feedId}
     `;
-		expect(String(feed.last_sync_status)).toBe("failed");
-		expect(String(feed.last_error)).toBe("worker_claim_timeout");
-		expect(Number(feed.consecutive_failures)).toBe(1);
-		expect(new Date(String(feed.next_run_at)).getTime()).toBeGreaterThan(
-			Date.now(),
+		expect(feed).toEqual(feedBefore);
+	});
+
+	test("classifies no device poll separately from a poll that was capability-ineligible", async () => {
+		const sql = getDb();
+		await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (
+        'reaper-device-user', 'Reaper Device User', 'reaper-device@test.local',
+        true, current_timestamp, current_timestamp
+      )
+    `;
+		await sql`
+      INSERT INTO connector_definitions (
+        key, name, version, organization_id, status, required_capability,
+        created_at, updated_at
+      ) VALUES (
+        'fake', 'Fake Device Connector', '1.0.0', ${ORG_ID}, 'active',
+        'os.shell', current_timestamp, current_timestamp
+      )
+    `;
+		const devices = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label,
+        organization_id, last_seen_at
+      ) VALUES
+        (
+          'reaper-device-user', 'reaper-offline', 'macos', ${sql.json(["os.shell"])},
+          'Offline device', ${ORG_ID}, current_timestamp - INTERVAL '10 minutes'
+        ),
+        (
+          'reaper-device-user', 'reaper-ineligible', 'macos', ${sql.json([])},
+          'Ineligible device', ${ORG_ID}, current_timestamp
+        )
+      RETURNING id, worker_id
+    `) as unknown as Array<{ id: string; worker_id: string }>;
+		const offlineDevice = devices.find((device) => device.worker_id === "reaper-offline");
+		const ineligibleDevice = devices.find(
+			(device) => device.worker_id === "reaper-ineligible",
 		);
+		expect(offlineDevice).toBeDefined();
+		expect(ineligibleDevice).toBeDefined();
+
+		const offlineFeedId = 4101;
+		const ineligibleFeedId = 4102;
+		await seedFeed(offlineFeedId);
+		await seedFeed(ineligibleFeedId);
+		await sql`
+      UPDATE connections
+      SET device_worker_id = CASE id
+        WHEN ${offlineFeedId} THEN ${offlineDevice?.id}::uuid
+        WHEN ${ineligibleFeedId} THEN ${ineligibleDevice?.id}::uuid
+      END
+      WHERE id IN (${offlineFeedId}, ${ineligibleFeedId})
+    `;
+		const offlineRunId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			feedId: offlineFeedId,
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		const ineligibleRunId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			feedId: ineligibleFeedId,
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		await sql`
+      UPDATE runs
+      SET connection_id = feed_id, connector_key = 'fake'
+      WHERE id IN (${offlineRunId}, ${ineligibleRunId})
+    `;
+
+		const result = await reapStaleRuns();
+		const reasons = Object.fromEntries(
+			result.dispatchFailures.map((failure) => [failure.runId, failure.reason]),
+		);
+		expect(reasons).toEqual({
+			[offlineRunId]: "no_device_poll_during_pending_window",
+			[ineligibleRunId]: "device_ineligible_required_capability",
+		});
 	});
 
 	test("a fresh never-claimed sync remains pending", async () => {
@@ -275,7 +365,19 @@ describe("reapStaleRuns — connector lanes", () => {
 		const result = await reapStaleRuns();
 
 		expect(result.reaped).toBe(1);
+		expect(result.retriesCreated).toBe(0);
+		expect(result.dispatchFailures).toEqual([
+			expect.objectContaining({
+				runId: autoId,
+				runType: "action",
+				reason: "fleet_or_unpinned_no_claim",
+			}),
+		]);
 		expect(await statusOf(autoId)).toBe("timeout");
+		const [row] = await getDb()`
+			SELECT error_message FROM runs WHERE id = ${autoId}
+		`;
+		expect(row.error_message).toBe("worker_claim_timeout");
 	});
 
 	test("a page-activated action waits until its explicit expiry", async () => {
@@ -955,15 +1057,14 @@ describe("reapStaleRuns — atomic timeout + retry (lobu#862)", () => {
  * would come back as a REAL sync and persist everything the operator asked to
  * only preview — silently, on a timer, with no one watching.
  *
- * The never-claimed path is the same class of bug in the other direction: it
- * stamps the FEED failed, increments consecutive_failures, backs off
- * next_run_at and can auto-pause. Those record the outcome of real syncs; a
- * dry run must not degrade the real schedule.
+ * The never-claimed path is a dispatch failure for both real and dry syncs, so
+ * neither may stamp connector/source failure state. The dry-run control keeps
+ * that invariant explicit while its stronger no-resurrection rule is tested.
  *
- * The non-dry controls for both live above ("a stale never-claimed sync is
- * finalized without an immediate retry" and "a stale sync run gets timed out
- * AND a retry queued in one statement") — without them these tests would pass
- * against a reaper that had stopped working entirely.
+ * The non-dry controls for both live above ("a stale never-claimed sync is a
+ * dispatch failure and preserves source health" and "a stale sync run gets
+ * timed out AND a retry queued in one statement") — without them these tests
+ * would pass against a reaper that had stopped working entirely.
  */
 describe("reapStaleRuns — dry runs are reaped but never resurrected", () => {
 	test("a stale claimed dry sync is timed out and NOT retried as a real sync", async () => {

--- a/packages/server/src/scheduled/check-due-feeds.ts
+++ b/packages/server/src/scheduled/check-due-feeds.ts
@@ -1,8 +1,9 @@
 /**
- * Scheduled Job: Check Due Feeds
+ * Due-feed materialization
  *
- * Runs every minute to find active feeds where next_run_at <= NOW()
- * and creates pending sync runs for them.
+ * The production caller is worker-api/poll.ts: once an idle worker proves it
+ * is actively polling, the gateway finds due feeds that exact worker can claim,
+ * creates at most one pending sync, then claims it in the same request.
  *
  * Primary feed scheduler for the V1 integration platform.
  */
@@ -14,6 +15,10 @@ import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import { createSyncRun } from '../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
+import {
+  type ConnectorClaimContext,
+  connectorClaimLaneSql,
+} from '../worker-api/connector-claim-lanes';
 import { materializeDueItems } from './due-materializer';
 
 interface CheckDueFeedsResult {
@@ -28,17 +33,81 @@ interface DueFeedRow {
   connection_id: number;
   feed_key: string;
   connector_key: string;
+  eligibility_lane: DueFeedEligibilityLane;
 }
 
-export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<CheckDueFeedsResult> {
+export type DueFeedEligibilityLane =
+  | 'unscoped'
+  | 'fleet'
+  | 'fleet_browser_affinity'
+  | 'device_capability'
+  | 'device_pin';
+
+export interface MaterializedDueFeedRun {
+  runId: number;
+  feedId: number;
+  eligibilityLane: DueFeedEligibilityLane;
+}
+
+/** Claim facts already authorized by worker-api/poll.ts for this exact poller. */
+export type DueFeedClaimContext = ConnectorClaimContext;
+
+interface MaterializeDueFeedsOptions {
+  /** When present, only materialize work this exact idle poller can claim. */
+  claimContext?: DueFeedClaimContext;
+  /** Poll-triggered materialization fills one successful queue slot per poll. */
+  maxRunsCreated?: number;
+  /** Reports creation details to the poll caller, which defers its structured
+   * log until the surrounding transaction commits successfully. */
+  onRunCreated?: (run: MaterializedDueFeedRun) => void;
+}
+
+export async function materializeDueFeeds(
+  env: Env,
+  db?: DbClient,
+  options?: MaterializeDueFeedsOptions
+): Promise<CheckDueFeedsResult> {
   const sql = db ?? getDb();
+  const claimContext = options?.claimContext;
+  const isUserScopedWorker = claimContext?.isUserScopedWorker ?? false;
+  const deviceWorkerId = claimContext?.deviceWorkerId ?? null;
+  const claimEligibility = claimContext
+    ? connectorClaimLaneSql(sql, claimContext, {
+        runType: sql`'sync'`,
+        connectorKey: sql`c.connector_key`,
+        organizationId: sql`f.organization_id`,
+        activationKind: sql`NULL::text`,
+        activatedAt: sql`NULL::timestamptz`,
+        connectionDeviceWorkerId: sql`c.device_worker_id`,
+        pinPlatform: sql`pin_dw.platform`,
+        requiredCapability: sql`cd.required_capability`,
+      })
+    : sql`true`;
 
   const counts = await materializeDueItems<DueFeedRow>({
     label: 'CheckDueFeeds',
     fetchDue: () => sql<DueFeedRow>`
-      SELECT f.id, f.organization_id, f.connection_id, f.feed_key, c.connector_key
+      SELECT f.id, f.organization_id, f.connection_id, f.feed_key, c.connector_key,
+        CASE
+          WHEN ${claimContext == null} THEN 'unscoped'
+          WHEN ${!isUserScopedWorker} AND c.device_worker_id IS NOT NULL
+            THEN 'fleet_browser_affinity'
+          WHEN ${!isUserScopedWorker} THEN 'fleet'
+          WHEN c.device_worker_id IS NOT NULL THEN 'device_pin'
+          ELSE 'device_capability'
+        END AS eligibility_lane
       FROM feeds f
       JOIN connections c ON c.id = f.connection_id
+      LEFT JOIN device_workers pin_dw ON pin_dw.id = c.device_worker_id
+      LEFT JOIN LATERAL (
+        SELECT cd.required_capability
+        FROM connector_definitions cd
+        WHERE cd.key = c.connector_key
+          AND cd.organization_id = f.organization_id
+          AND cd.status = 'active'
+        ORDER BY cd.updated_at DESC, cd.id DESC
+        LIMIT 1
+      ) cd ON true
       WHERE f.status = 'active'
         AND c.status = 'active'
         AND c.deleted_at IS NULL
@@ -57,8 +126,8 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
         -- activation_kind NULL, so a scheduled sync is never one; the device
         -- lanes take it only when the pin matches the polling device. A run
         -- queued now would therefore just age into a worker_claim_timeout.
-        -- Leave the feed past next_run_at instead, so the first tick after that
-        -- device polls picks it up.
+        -- Leave the feed past next_run_at instead, so that device's next poll
+        -- picks it up.
         --
         -- A chrome-extension pin on a non-chrome connector is NOT an execution
         -- pin — it means "scrape with this browser", and poll.ts keeps the
@@ -74,6 +143,16 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
               AND (
                 dw.last_seen_at > current_timestamp
                   - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+                -- The device polling RIGHT NOW is online by construction:
+                -- this materialization runs inside its own poll. That poll
+                -- normally already stamped last_seen_at = now() on the
+                -- device_workers upsert, so this arm is what keeps the feed
+                -- eligible on the fallback path where that upsert failed
+                -- (non-fatal) and poll.ts resolved deviceWorkerId by lookup.
+                OR (
+                  ${isUserScopedWorker}
+                  AND dw.id = ${deviceWorkerId}::uuid
+                )
                 OR (
                   dw.platform = 'chrome-extension'
                   AND c.connector_key NOT LIKE 'chrome%'
@@ -81,6 +160,10 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
               )
           )
         )
+        -- Use the same connector claim predicate as worker-api/poll.ts before
+        -- creating the run. A scheduler-admitted sync is therefore eligible
+        -- for the exact poller that materialized it.
+        AND ${claimEligibility}
         AND f.next_run_at <= current_timestamp
         AND NOT EXISTS (
           SELECT 1 FROM runs r
@@ -105,6 +188,11 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
         return 'skipped';
       }
       const runId = created.runId;
+      options?.onRunCreated?.({
+        runId,
+        feedId: feed.id,
+        eligibilityLane: feed.eligibility_lane,
+      });
       logger.debug(
         `[CheckDueFeeds] Created run ${runId} for feed ${feed.id} (${feed.connector_key}/${feed.feed_key})`
       );
@@ -118,8 +206,8 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
         logger.info(`[CheckDueFeeds] Created ${runsCreated} runs (${skipped} skipped)`);
       }
     },
+    maxRunsCreated: options?.maxRunsCreated,
   });
 
   return { dueFeeds: counts.due, runsCreated: counts.runsCreated, skipped: counts.skipped };
 }
-

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -39,10 +39,9 @@
  */
 
 import type { ReservedSql } from 'postgres';
-import { maybeEmitFeedAutoPausedAfterFailure } from '../automations/platform-events';
 import { intervals } from '../config/intervals';
-import { feedBackoff } from '../connectors/feed-backoff';
 import { type DbClient, getDb } from '../db/client';
+import { incrementCounter } from '../gateway/metrics/prometheus';
 import type { Env } from '../index';
 import { classifyRunOutcome } from '../runs/run-outcome';
 import {
@@ -162,6 +161,27 @@ export async function sweepAbandonedVirtualFeedReadRuns(
   return Number(result.count ?? 0);
 }
 
+type DispatchFailureReason =
+  | 'fleet_or_unpinned_no_claim'
+  | 'fleet_or_browser_affinity_no_claim'
+  | 'pinned_device_missing'
+  | 'no_device_poll_during_pending_window'
+  | 'device_ineligible_required_capability'
+  | 'device_activity_seen_but_unclaimed';
+
+interface DispatchFailureDiagnostic {
+  runId: number;
+  runType: string;
+  connectorKey: string | null;
+  connectionId: number | null;
+  deviceWorkerId: string | null;
+  platform: string | null;
+  pendingAgeSeconds: number;
+  lastDeviceActivityAt: string | null;
+  requiredCapability: string | null;
+  reason: DispatchFailureReason;
+}
+
 interface ReapStaleRunsResult {
   /** Whether the advisory lock was acquired. False means another pod is
    *  already running the sweep; the caller should treat this as a no-op. */
@@ -170,6 +190,8 @@ interface ReapStaleRunsResult {
   reaped: number;
   /** Retry rows inserted for stalled claimed/running sync runs (never pending). */
   retriesCreated: number;
+  /** Never-claimed rows, classified independently from connector/source health. */
+  dispatchFailures: DispatchFailureDiagnostic[];
 }
 
 /**
@@ -207,7 +229,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
     `) as unknown as Array<{ acquired: boolean }>;
     const acquired = !!lockRows[0]?.acquired;
     if (!acquired) {
-      return { acquired: false, reaped: 0, retriesCreated: 0 };
+      return { acquired: false, reaped: 0, retriesCreated: 0, dispatchFailures: [] };
     }
 
     try {
@@ -232,11 +254,6 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
 
       const heartbeatErrorMessage = 'worker_heartbeat_lost';
       const claimErrorMessage = 'worker_claim_timeout';
-      // Failure-backoff / auto-pause policy shared with the completion path
-      // (run-lifecycle.ts) so both apply identical math (item 5, #2033).
-      const backoffBaseMs = feedBackoff.baseMs;
-      const backoffMaxMs = feedBackoff.maxMs;
-      const pauseThreshold = feedBackoff.pauseThreshold;
 
       // Approval-gated action runs have a durable card, so their timeout must
       // supersede that card in the SAME transaction as the runs write. Process
@@ -342,9 +359,10 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       }
 
       // Reap + recover in a single statement using CTEs. Claimed/running sync
-      // rows get one fresh retry; never-claimed rows are finalized on the feed
-      // without a retry because another pending row would only repeat the same
-      // unavailable-worker failure. Doing this in one statement makes
+      // rows get one fresh retry. Never-claimed rows are audit-only dispatch
+      // failures: connector code never ran, so they must not mutate source
+      // health, consume its failure budget, or auto-pause its feed. Doing the
+      // timeout + claimed-run retry in one statement makes
       // the timeout + retry atomic — if the process crashes after the
       // statement returns, both writes are durable; if it crashes
       // before, neither is. The previous shape (bulk UPDATE RETURNING +
@@ -386,7 +404,8 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           FROM stale_candidates c
           WHERE r.id = c.id
           RETURNING r.id, r.run_type, r.feed_id, r.connection_id, r.connector_key,
-                    r.connector_version, r.organization_id, r.dry_run, c.stale_status
+                    r.connector_version, r.organization_id, r.dry_run, r.created_at,
+                    c.stale_status
         ),
         retries AS (
           INSERT INTO public.runs (
@@ -421,44 +440,45 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
             )
           RETURNING id, feed_id
         ),
-        finalized_pending_feeds AS (
-          -- Never-claimed sync runs (device/worker offline). Without a
-          -- next_run_at backoff these feeds re-enqueue every plain cadence
-          -- (check-due-feeds picks next_run_at <= now()), so an offline device
-          -- gets hammered every 5 min forever. Apply the SAME exponential
-          -- backoff as the completion path (feed-backoff.ts), computed from the
-          -- post-increment failure count, and hard-pause past the threshold
-          -- (the feeds trigger nulls next_run_at on status='paused').
-          UPDATE public.feeds f
-          SET last_sync_at = current_timestamp,
-              last_sync_status = 'failed',
-              last_error = ${claimErrorMessage},
-              consecutive_failures = f.consecutive_failures + 1,
-              first_failure_at = COALESCE(f.first_failure_at, current_timestamp),
-              status = CASE
-                WHEN f.consecutive_failures + 1 >= ${pauseThreshold} THEN 'paused'
-                ELSE f.status
-              END,
-              next_run_at = CASE
-                WHEN f.consecutive_failures + 1 >= ${pauseThreshold} THEN NULL
-                ELSE GREATEST(
-                  COALESCE(f.next_run_at, current_timestamp),
-                  current_timestamp + (LEAST(
-                    ${backoffBaseMs}::bigint * (2 ^ LEAST(f.consecutive_failures, 30))::bigint,
-                    ${backoffMaxMs}::bigint
-                  ) || ' milliseconds')::interval
-                )
-              END,
-              updated_at = current_timestamp
+        dispatch_failures AS (
+          SELECT
+            t.id,
+            t.run_type,
+            t.connector_key,
+            t.connection_id,
+            c.device_worker_id,
+            dw.platform,
+            EXTRACT(EPOCH FROM (current_timestamp - t.created_at)) AS pending_age_seconds,
+            dw.last_seen_at,
+            cd.required_capability,
+            CASE
+              WHEN c.device_worker_id IS NULL
+                THEN 'fleet_or_unpinned_no_claim'
+              WHEN dw.id IS NULL
+                THEN 'pinned_device_missing'
+              WHEN dw.platform = 'chrome-extension'
+                AND t.connector_key NOT LIKE 'chrome%'
+                THEN 'fleet_or_browser_affinity_no_claim'
+              WHEN dw.last_seen_at < t.created_at
+                THEN 'no_device_poll_during_pending_window'
+              WHEN cd.required_capability IS NOT NULL
+                AND NOT COALESCE(dw.capabilities ? cd.required_capability, false)
+                THEN 'device_ineligible_required_capability'
+              ELSE 'device_activity_seen_but_unclaimed'
+            END AS reason
           FROM timed_out t
-          WHERE t.run_type = 'sync'
-            AND t.stale_status = 'pending'
-            -- A never-claimed dry run must not stamp the feed failed, back off
-            -- next_run_at, or auto-pause — those record the outcome of REAL
-            -- syncs, which a dry run leaves untouched (see runs.dry_run).
-            AND NOT t.dry_run
-            AND t.feed_id = f.id
-          RETURNING f.id, f.consecutive_failures, f.status
+          LEFT JOIN public.connections c ON c.id = t.connection_id
+          LEFT JOIN public.device_workers dw ON dw.id = c.device_worker_id
+          LEFT JOIN LATERAL (
+            SELECT definitions.required_capability
+            FROM public.connector_definitions definitions
+            WHERE definitions.key = t.connector_key
+              AND definitions.organization_id = t.organization_id
+              AND definitions.status = 'active'
+            ORDER BY definitions.updated_at DESC, definitions.id DESC
+            LIMIT 1
+          ) cd ON true
+          WHERE t.stale_status = 'pending'
         )
         SELECT
           (SELECT count(*)::int FROM timed_out) AS reaped,
@@ -474,20 +494,26 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
               AND NOT dry_run) AS sync_eligible,
           (SELECT coalesce(
              json_agg(json_build_object(
-               'id', id,
-               'consecutive_failures', consecutive_failures
+               'runId', id,
+               'runType', run_type,
+               'connectorKey', connector_key,
+               'connectionId', connection_id,
+               'deviceWorkerId', device_worker_id,
+               'platform', platform,
+               'pendingAgeSeconds', pending_age_seconds,
+               'lastDeviceActivityAt', last_seen_at,
+               'requiredCapability', required_capability,
+               'reason', reason
              )),
              '[]'::json
            )
-           FROM finalized_pending_feeds
-           WHERE status = 'paused'
-             AND consecutive_failures = ${pauseThreshold}
-          ) AS auto_paused_feeds
+           FROM dispatch_failures
+          ) AS dispatch_failures
       `) as unknown as Array<{
         reaped: number;
         retries_created: number;
         sync_eligible: number;
-        auto_paused_feeds: unknown;
+        dispatch_failures: unknown;
       }>;
 
       const reapedRow = reaped[0];
@@ -497,31 +523,55 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       const syncEligible = reapedRow?.sync_eligible ?? 0;
 
       if (reapedCount === 0) {
-        return { acquired: true, reaped: 0, retriesCreated: 0 };
+        return { acquired: true, reaped: 0, retriesCreated: 0, dispatchFailures: [] };
       }
 
-      // Threshold-crossing hard pauses from the never-claimed path → Automation signal.
-      const autoPausedRaw = reapedRow?.auto_paused_feeds;
-      const autoPausedList: Array<{ id: number; consecutive_failures: number }> =
-        Array.isArray(autoPausedRaw)
-          ? (autoPausedRaw as Array<{ id: number; consecutive_failures: number }>)
-          : typeof autoPausedRaw === 'string'
-            ? (JSON.parse(autoPausedRaw) as Array<{
-                id: number;
-                consecutive_failures: number;
-              }>)
-            : [];
-      for (const paused of autoPausedList) {
-        void maybeEmitFeedAutoPausedAfterFailure({
-          feedId: Number(paused.id),
-          consecutiveFailures: Number(paused.consecutive_failures),
-          pauseThreshold,
-        }).catch((err) => {
-          logger.error(
-            { feed_id: paused.id, error: String(err) },
-            '[reaper] maybeEmitFeedAutoPausedAfterFailure threw',
-          );
+      const dispatchFailuresRaw = reapedRow?.dispatch_failures;
+      const parsedDispatchFailures = Array.isArray(dispatchFailuresRaw)
+        ? dispatchFailuresRaw
+        : typeof dispatchFailuresRaw === 'string'
+          ? JSON.parse(dispatchFailuresRaw)
+          : [];
+      const dispatchFailures = (parsedDispatchFailures as Array<Record<string, unknown>>).map(
+        (failure): DispatchFailureDiagnostic => ({
+          runId: Number(failure.runId),
+          runType: String(failure.runType),
+          connectorKey: failure.connectorKey == null ? null : String(failure.connectorKey),
+          connectionId: failure.connectionId == null ? null : Number(failure.connectionId),
+          deviceWorkerId:
+            failure.deviceWorkerId == null ? null : String(failure.deviceWorkerId),
+          platform: failure.platform == null ? null : String(failure.platform),
+          pendingAgeSeconds: Number(failure.pendingAgeSeconds),
+          lastDeviceActivityAt:
+            failure.lastDeviceActivityAt == null
+              ? null
+              : String(failure.lastDeviceActivityAt),
+          requiredCapability:
+            failure.requiredCapability == null ? null : String(failure.requiredCapability),
+          reason: String(failure.reason) as DispatchFailureReason,
+        })
+      );
+      for (const failure of dispatchFailures) {
+        incrementCounter('lobu_worker_dispatch_failures_total', {
+          run_type: failure.runType,
+          reason: failure.reason,
         });
+        logger.warn(
+          {
+            classification: 'dispatch_unavailable',
+            run_id: failure.runId,
+            run_type: failure.runType,
+            connector_key: failure.connectorKey,
+            connection_id: failure.connectionId,
+            device_worker_id: failure.deviceWorkerId,
+            platform: failure.platform,
+            pending_age_seconds: failure.pendingAgeSeconds,
+            device_last_activity_at: failure.lastDeviceActivityAt,
+            required_capability: failure.requiredCapability,
+            claim_eligibility_reject_reason: failure.reason,
+          },
+          '[reaper] Worker never claimed connector run'
+        );
       }
 
       logger.warn(
@@ -547,7 +597,12 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
         );
       }
 
-      return { acquired: true, reaped: reapedCount, retriesCreated };
+      return {
+        acquired: true,
+        reaped: reapedCount,
+        retriesCreated,
+        dispatchFailures,
+      };
     } finally {
       await reserved`SELECT pg_advisory_unlock(${REAPER_ADVISORY_LOCK_KEY})`;
     }

--- a/packages/server/src/scheduled/due-materializer.ts
+++ b/packages/server/src/scheduled/due-materializer.ts
@@ -47,6 +47,9 @@ interface MaterializeDueItemsOptions<T> {
   onFound?: (items: readonly T[]) => void;
   /** Called once after the loop with the final counts (only when due > 0). */
   onDone?: (counts: DueMaterializeCounts) => void;
+  /** Stop after this many successful run creations, while still scanning past
+   * skipped or broken head rows. Omit to process the full fetched batch. */
+  maxRunsCreated?: number;
 }
 
 export async function materializeDueItems<T>(
@@ -64,6 +67,9 @@ export async function materializeDueItems<T>(
   let skipped = 0;
 
   for (const item of items) {
+    if (options.maxRunsCreated !== undefined && runsCreated >= options.maxRunsCreated) {
+      break;
+    }
     try {
       const outcome = await options.createRun(item);
       if (outcome === 'created') runsCreated++;

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -59,10 +59,10 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
   try {
     // Get feed counts.
     //
-    // A feed whose connection is pinned to an offline device for EXECUTION is
-    // held back on purpose (check-due-feeds.ts): only that device can claim the
-    // run, so the feed stays past next_run_at until the device polls again.
-    // Counting those as overdue would put this endpoint in a permanent 503 for
+    // Device-owned feeds are held back on purpose (check-due-feeds.ts) until a
+    // claim-capable device actually polls. That includes an offline execution
+    // pin and an unpinned connector with a required device capability. Counting
+    // either as scheduler lag would put this endpoint in a permanent 503 for
     // the ordinary case of a closed laptop — the same "train operators to
     // ignore it" failure the approval-TTL grace below avoids.
     //
@@ -71,20 +71,18 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
     // connectors/connector-health.ts). "Is the scheduler firing" and "is that
     // laptop on" are different questions, answered on different surfaces.
     //
-    // The device predicate must stay the exact complement of the scheduler's,
-    // browser-affinity carve-out included: a chrome-extension pin on a
-    // non-chrome connector still runs on the fleet, so such a feed is genuinely
-    // overdue.
+    // Browser affinity stays a fleet lane: a chrome-extension pin on a
+    // non-chrome connector is genuinely overdue. A fresh execution pin also
+    // remains overdue here until its 2-minute liveness proxy ages out, making a
+    // sustained stopped poll loop visible without charging source health.
     const feedStats = await sql`
       WITH scheduling AS (
         SELECT
           f.status,
           f.next_run_at,
-          EXISTS (
-            SELECT 1
-            FROM connections c
-            JOIN device_workers dw ON dw.id = c.device_worker_id
-            WHERE c.id = f.connection_id
+          (
+            (
+              c.device_worker_id IS NOT NULL
               AND dw.last_seen_at <= current_timestamp
                 - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
               AND NOT COALESCE(
@@ -92,8 +90,24 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
                   AND c.connector_key NOT LIKE 'chrome%',
                 false
               )
+            )
+            OR (
+              c.device_worker_id IS NULL
+              AND cd.required_capability IS NOT NULL
+            )
           ) AS device_deferred
         FROM feeds f
+        LEFT JOIN connections c ON c.id = f.connection_id
+        LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
+        LEFT JOIN LATERAL (
+          SELECT definitions.required_capability
+          FROM connector_definitions definitions
+          WHERE definitions.key = c.connector_key
+            AND definitions.organization_id = f.organization_id
+            AND definitions.status = 'active'
+          ORDER BY definitions.updated_at DESC, definitions.id DESC
+          LIMIT 1
+        ) cd ON true
         WHERE f.deleted_at IS NULL
       )
       SELECT

--- a/packages/server/src/utils/device-liveness.ts
+++ b/packages/server/src/utils/device-liveness.ts
@@ -2,9 +2,12 @@
  * How fresh a device worker's `last_seen_at` must be for the device to count
  * as online, and how to describe that freshness to a human.
  *
- * `device_workers.last_seen_at` is written on every `/api/workers/poll` and on
- * device registration — nowhere else — so it is a true liveness signal rather
- * than a config timestamp.
+ * `device_workers.last_seen_at` is written on every `/api/workers/poll`, on
+ * device registration, and when a device refreshes its child credential. A
+ * stale value proves no poll occurred after it; a fresh value is only a
+ * liveness proxy, not proof that the claim query ran. Scheduled execution pins
+ * therefore use the current poll itself as their stronger readiness signal
+ * (check-due-feeds.ts), while this window remains useful for UI/offline hints.
  *
  * ## Why 2 minutes
  *

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -1,0 +1,105 @@
+import type { DbClient } from '../db/client';
+import { pgTextArray } from '../db/client';
+import { isCloudMode } from '../utils/cloud-mode';
+import { DB_EGRESS_HARDENED_CONNECTOR_KEYS } from '../utils/connector-cloud-gate';
+
+type SqlFragment = ReturnType<DbClient>;
+
+export interface ConnectorClaimContext {
+  isUserScopedWorker: boolean;
+  deviceWorkerId: string | null;
+  authorizedCapabilities: string[];
+  capabilityMatchSet: string[];
+  orgScopeIds: string[];
+  baseOrgScopeIds: string[];
+  workerHardensDbEgress: boolean;
+}
+
+interface ConnectorClaimLaneRefs {
+  runType: SqlFragment;
+  connectorKey: SqlFragment;
+  organizationId: SqlFragment;
+  activationKind: SqlFragment;
+  activatedAt: SqlFragment;
+  connectionDeviceWorkerId: SqlFragment;
+  pinPlatform: SqlFragment;
+  requiredCapability: SqlFragment;
+}
+
+/**
+ * Shared connector-run claim predicate. worker-api/poll.ts uses it to claim
+ * queued connector work; check-due-feeds.ts applies the same predicate to a
+ * prospective scheduled sync before creating its run. Keep every fleet,
+ * capability, device-pin, browser-affinity, and DB-egress decision here so a
+ * scheduler-admitted sync is claimable by the poller that materialized it.
+ */
+export function connectorClaimLaneSql(
+  sql: DbClient,
+  context: ConnectorClaimContext,
+  refs: ConnectorClaimLaneRefs
+): SqlFragment {
+  const dbEgressHardenedKeys = pgTextArray([...DB_EGRESS_HARDENED_CONNECTOR_KEYS]);
+  const pageActivated = sql`
+    ${refs.activationKind} = 'page_visit'
+    AND ${refs.activatedAt} IS NOT NULL
+  `;
+
+  return sql`
+    (
+      -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
+      -- their exact device; browser-affinity parent runs stay on fleet.
+      (
+        ${!context.isUserScopedWorker}
+        AND COALESCE(${refs.requiredCapability}, '') = ANY(
+          ${pgTextArray(context.capabilityMatchSet)}::text[]
+        )
+        AND (
+          ${!isCloudMode()}
+          OR ${context.workerHardensDbEgress}
+          OR NOT (${refs.connectorKey} = ANY(${dbEgressHardenedKeys}::text[]))
+        )
+        AND (
+          (${pageActivated})
+          OR ${refs.connectionDeviceWorkerId} IS NULL
+          OR (
+            ${refs.pinPlatform} = 'chrome-extension'
+            AND ${refs.runType} IN ('sync', 'auth', 'embed_backfill')
+            AND ${refs.connectorKey} NOT LIKE 'chrome%'
+          )
+        )
+      )
+      -- User-scoped worker claiming an unpinned capability connector in its
+      -- base org scope. Page-activated work is handled by the fleet parent.
+      OR (
+        ${context.isUserScopedWorker}
+        AND ${refs.requiredCapability} IS NOT NULL
+        AND ${refs.requiredCapability} = ANY(
+          ${pgTextArray(context.authorizedCapabilities)}::text[]
+        )
+        AND ${refs.connectionDeviceWorkerId} IS NULL
+        AND NOT COALESCE(${pageActivated}, false)
+        AND ${refs.organizationId} = ANY(${pgTextArray(context.baseOrgScopeIds)}::text[])
+      )
+      -- Exact execution pin. A chrome-extension pin on a non-chrome parent is
+      -- browser affinity, so sync/auth/embed_backfill stay on fleet instead.
+      OR (
+        ${context.isUserScopedWorker}
+        AND ${context.deviceWorkerId}::uuid IS NOT NULL
+        AND ${refs.connectionDeviceWorkerId} = ${context.deviceWorkerId}::uuid
+        AND NOT COALESCE(${pageActivated}, false)
+        AND (
+          ${refs.requiredCapability} IS NULL
+          OR ${refs.requiredCapability} = ANY(
+            ${pgTextArray(context.authorizedCapabilities)}::text[]
+          )
+        )
+        AND ${refs.organizationId} = ANY(${pgTextArray(context.orgScopeIds)}::text[])
+        AND NOT (
+          ${refs.pinPlatform} = 'chrome-extension'
+          AND ${refs.runType} IN ('sync', 'auth', 'embed_backfill')
+          AND ${refs.connectorKey} NOT LIKE 'chrome%'
+        )
+      )
+    )
+  `;
+}

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -5,7 +5,7 @@
  * platform binding, capability authorization, and multi-lane run claiming.
  */
 
-import { authorizeCapabilities } from '@lobu/core';
+import { authorizeCapabilities, isKnownPlatform } from '@lobu/core';
 import type { PollRequest } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
 import {
@@ -23,16 +23,17 @@ import { getDb, parsePgTextArray, pgTextArray } from '../db/client';
 import type { Outputs } from '../types/automations';
 import { deriveAutomationExtractionSchema } from '../utils/automation-extraction-schema';
 import { withDbRetry } from '../db/with-retry';
+import { incrementCounter } from '../gateway/metrics/prometheus';
 import type { Env } from '../index';
 import { claimPendingAutomationRun } from '../runs/queue-service';
 import { parseAutomationSkillSnapshots } from '../automations/skill-snapshots';
-import { materializeDueFeeds } from '../scheduled/check-due-feeds';
+import {
+  type MaterializedDueFeedRun,
+  materializeDueFeeds,
+} from '../scheduled/check-due-feeds';
 import { reconcileDeviceCapabilities } from './device-reconcile';
 import { findBundledConnectorFile } from '../utils/connector-catalog';
-import {
-  DB_EGRESS_HARDENED_CONNECTOR_KEYS,
-  assertConnectorAllowedInCloud,
-} from '../utils/connector-cloud-gate';
+import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { resolveDeviceClaimableOrgs } from '../utils/device-claimable-orgs';
 import { errorMessage } from '../utils/errors';
@@ -46,6 +47,10 @@ import { isCloudMode } from '../utils/cloud-mode';
 import { normalizeAdvertisedCapabilities, normalizeAgentKinds } from './shared';
 import { storedManifestMap, validateDeviceConnectorManifests } from './device-manifests';
 import type { RunOutcome } from '../runs/run-outcome';
+import {
+  type ConnectorClaimContext,
+  connectorClaimLaneSql,
+} from './connector-claim-lanes';
 
 // A failure at the DISPATCH stage means the agent never ran: the run is not
 // evidence about the agent regardless of the message, so no message
@@ -53,8 +58,6 @@ import type { RunOutcome } from '../runs/run-outcome';
 const DISPATCH_FAILURE_OUTCOME: RunOutcome = 'infra_error';
 
 const DUE_FEEDS_LOCK_KEY = 71001;
-const DUE_FEED_MATERIALIZE_COOLDOWN_MS = 5000;
-let lastDueFeedMaterializeAttemptAt = 0;
 
 /**
  * Fail a run that this worker already claimed. Approval-gated actions also
@@ -312,9 +315,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // predates the hardening (it would default to allow-private and reopen
   // private-IP/plaintext egress). Read the RAW advertised map — this is a fleet
   // worker, not a device-authorized one, so the platform-authorized set does not
-  // apply. Gated in the (1A) fleet claim branch below; only active in cloud mode.
+  // apply. Gated in the shared fleet claim lane; only active in cloud mode.
   const workerHardensDbEgress = capabilities.db_egress_hardening === true;
-  const dbEgressHardenedKeys = pgTextArray([...DB_EGRESS_HARDENED_CONNECTOR_KEYS]);
 
   // Device-worker registry: upsert device_workers row for user-scoped workers
   // so /api/me/devices can enumerate them. Also ensure advertised capability
@@ -472,13 +474,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // re-anchored local device, whose org is claimableOrgIds. A signed-in
   // worker with no org in scope can claim nothing; a re-anchored device with no
   // org falls through to the empty-array gate (claims only by capability).
-  if (c.var.workerAuthMode === 'user' && (!claimableOrgIds || claimableOrgIds.length === 0)) {
-    // No org in scope — nothing this worker can ever claim.
-    return c.json({
-      next_poll_seconds: 30,
-      ...(effectivePlatform === 'chrome-extension' ? { page_activations: [] } : {}),
-    });
-  }
+  const hasEmptyUserOrgScope =
+    c.var.workerAuthMode === 'user' && (!claimableOrgIds || claimableOrgIds.length === 0);
   const orgScopeActive = isUserScopedWorker;
   // Always pass a non-empty array to ANY() to keep the SQL valid; the gate
   // below only activates when orgScopeActive is true.
@@ -493,6 +490,40 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     orgScopeActive && effectiveWorkerOrgIds && effectiveWorkerOrgIds.length > 0
       ? effectiveWorkerOrgIds
       : [''];
+  const connectorClaimContext: ConnectorClaimContext = {
+    isUserScopedWorker,
+    deviceWorkerId,
+    authorizedCapabilities,
+    capabilityMatchSet,
+    orgScopeIds,
+    baseOrgScopeIds,
+    workerHardensDbEgress,
+  };
+  const workerKind = isUserScopedWorker ? 'device' : 'fleet';
+  // `platform` is self-reported in the poll body and is only pinned to the
+  // stored value once a device_workers row exists, so it must be collapsed to
+  // the known set before it becomes a metric label — an unbounded label value
+  // both blows up series cardinality and is emitted unescaped by
+  // getMetricsText().
+  const platformLabel = effectivePlatform
+    ? isKnownPlatform(effectivePlatform)
+      ? effectivePlatform
+      : 'unknown'
+    : 'none';
+  incrementCounter('lobu_worker_polls_total', {
+    worker_kind: workerKind,
+    platform: platformLabel,
+  });
+  if (hasEmptyUserOrgScope) {
+    // No org in scope — nothing this worker can ever claim. The rejection is
+    // deferred to here (rather than returning at the check above) so the poll
+    // is still counted: "this worker is alive but claims nothing" and "this
+    // worker stopped polling" must not look identical on the metric.
+    return c.json({
+      next_poll_seconds: 30,
+      ...(effectivePlatform === 'chrome-extension' ? { page_activations: [] } : {}),
+    });
+  }
 
   const pageActivations =
     isUserScopedWorker && effectivePlatform === 'chrome-extension'
@@ -551,90 +582,16 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             -- (1) Connector-worker lanes: sync / action / embed_backfill / auth.
             (
               r.run_type IN ('sync', 'action', 'embed_backfill', 'auth')
-              AND (
-                -- (1A) trusted/anonymous fleet worker: no-capability cloud
-                --      connectors, any org — never a connection pinned for
-                --      *execution*. Browser-affinity pins (chrome-extension on
-                --      non-chrome parent syncs) still allow fleet claim.
-                (
-                  ${!isUserScopedWorker}
-                  AND COALESCE(cd.required_capability, '') = ANY(${pgTextArray(capabilityMatchSet)}::text[])
-                  -- Capability negotiation: in cloud mode, a fleet worker may
-                  -- only claim a DB-egress-hardened connector run (postgres,
-                  -- future warehouses) if it advertises db_egress_hardening.
-                  -- Old workers that predate the hardening advertise nothing and
-                  -- leave the run pending for a new worker. Empty set / non-cloud
-                  -- / hardened worker => no-op. Device (user-scoped) branches
-                  -- below are untouched: postgres is a fleet no-capability
-                  -- connector, never a device-pinned one, so they never see it.
-                  AND (
-                    ${!isCloudMode()}
-                    OR ${workerHardensDbEgress}
-                    OR NOT (r.connector_key = ANY(${dbEgressHardenedKeys}::text[]))
-                  )
-                  AND (
-                    -- Page activation chooses the browser that owns subsequent
-                    -- sub-actions; it does not choose the worker that executes
-                    -- the connector parent. The parent always stays on fleet.
-                    (
-                      r.activation_kind = 'page_visit'
-                      AND r.activated_at IS NOT NULL
-                    )
-                    OR con.device_worker_id IS NULL
-                    OR (
-                      -- Browser affinity (not job host). Exclude run_type=action:
-                      -- scrape actions are always connector_key='chrome' and use
-                      -- the org chrome connection pin, not the parent
-                      -- connection's browser-affinity pin.
-                      pin_dw.platform = 'chrome-extension'
-                      AND r.run_type IN ('sync', 'auth', 'embed_backfill')
-                      AND r.connector_key NOT LIKE 'chrome%'
-                    )
-                  )
-                )
-                -- (1B) user-scoped device worker: an unpinned capability-matched
-                --      device connector in an org this worker can see. Capability
-                --      match goes through the authorized set — a chrome-extension
-                --      claiming os.shell is dropped server-side (see
-                --      @lobu/core/capabilities), and that dropped string MUST NOT
-                --      match a connectors required_capability here either.
-                OR (
-                  ${isUserScopedWorker}
-                  AND cd.required_capability IS NOT NULL
-                  AND cd.required_capability = ANY(${pgTextArray(authorizedCapabilities)}::text[])
-                  AND con.device_worker_id IS NULL
-                  AND NOT COALESCE(
-                    r.activation_kind = 'page_visit'
-                    AND r.activated_at IS NOT NULL,
-                    false
-                  )
-                  AND r.organization_id = ANY(${pgTextArray(baseOrgScopeIds)}::text[])
-                )
-                -- ... or any connection explicitly pinned to THIS device for
-                --     *execution* (e.g. WhatsApp on Mac). Browser-affinity pins
-                --     (chrome-extension + non-chrome parent sync) must NOT be
-                --     claimed by the extension — those runs stay on the fleet.
-                OR (
-                  ${isUserScopedWorker}
-                  AND ${deviceWorkerId}::uuid IS NOT NULL
-                  AND con.device_worker_id = ${deviceWorkerId}::uuid
-                  AND NOT COALESCE(
-                    r.activation_kind = 'page_visit'
-                    AND r.activated_at IS NOT NULL,
-                    false
-                  )
-                  AND (
-                    cd.required_capability IS NULL
-                    OR cd.required_capability = ANY(${pgTextArray(authorizedCapabilities)}::text[])
-                  )
-                  AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
-                  AND NOT (
-                    pin_dw.platform = 'chrome-extension'
-                    AND r.run_type IN ('sync', 'auth', 'embed_backfill')
-                    AND r.connector_key NOT LIKE 'chrome%'
-                  )
-                )
-              )
+              AND ${connectorClaimLaneSql(tx, connectorClaimContext, {
+                runType: tx`r.run_type`,
+                connectorKey: tx`r.connector_key`,
+                organizationId: tx`r.organization_id`,
+                activationKind: tx`r.activation_kind`,
+                activatedAt: tx`r.activated_at`,
+                connectionDeviceWorkerId: tx`con.device_worker_id`,
+                pinPlatform: tx`pin_dw.platform`,
+                requiredCapability: tx`cd.required_capability`,
+              })}
             )
             -- (2) Automation lane: an automation run with approved_input.device_worker_id
             --     matching this device. Automations don't carry a connection_id and
@@ -715,19 +672,37 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         if (!claimed) return null;
       } else {
         const claimed = await tx`
-          UPDATE runs
-          SET status = 'running',
-              claimed_at = current_timestamp,
-              last_heartbeat_at = current_timestamp,
-              claimed_by = ${worker_id}
-          WHERE id = ${runId}
-            AND status = 'pending'
-            AND (
-              run_type <> 'action'
-              OR expires_at IS NULL
-              OR expires_at > now()
-            )
-          RETURNING id
+          WITH claimed_run AS (
+            UPDATE runs
+            SET status = 'running',
+                claimed_at = current_timestamp,
+                last_heartbeat_at = current_timestamp,
+                claimed_by = ${worker_id}
+            WHERE id = ${runId}
+              AND status = 'pending'
+              AND (
+                run_type <> 'action'
+                OR expires_at IS NULL
+                OR expires_at > now()
+              )
+            RETURNING id, run_type, feed_id, dry_run
+          ), marked_feed AS (
+            -- Feed health describes connector/source execution, not queue
+            -- admission. Only a successful worker claim starts a real sync.
+            -- Nothing SELECTs from this CTE: a data-modifying WITH sub-statement
+            -- runs exactly once and to completion whether or not the primary
+            -- query reads it, so the stamp lands atomically with the claim.
+            UPDATE feeds f
+            SET last_sync_status = 'pending',
+                last_error = NULL,
+                updated_at = current_timestamp
+            FROM claimed_run claimed
+            WHERE claimed.run_type = 'sync'
+              AND NOT claimed.dry_run
+              AND claimed.feed_id = f.id
+            RETURNING f.id
+          )
+          SELECT id FROM claimed_run
         `;
         if (claimed.length === 0) return null;
       }
@@ -798,27 +773,78 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       return rows[0] ?? null;
     });
 
-  let pending = await withDbRetry('worker_poll_claim', claimNextPendingRun);
+  const claimWithDiagnostics = async () => {
+    try {
+      return await withDbRetry('worker_poll_claim', claimNextPendingRun);
+    } catch (err) {
+      incrementCounter('lobu_worker_claim_query_errors_total', {
+        worker_kind: workerKind,
+        platform: platformLabel,
+      });
+      logger.error(
+        {
+          classification: 'dispatch_unavailable',
+          stage: 'worker_claim_query',
+          worker_id,
+          device_worker_id: deviceWorkerId,
+          worker_kind: workerKind,
+          platform: effectivePlatform,
+          error: errorMessage(err),
+        },
+        '[pollWorkerJob] Worker claim query failed after retries'
+      );
+      throw err;
+    }
+  };
+
+  let pending = await claimWithDiagnostics();
 
   if (!pending) {
-    const now = Date.now();
-    if (now - lastDueFeedMaterializeAttemptAt >= DUE_FEED_MATERIALIZE_COOLDOWN_MS) {
-      lastDueFeedMaterializeAttemptAt = now;
-
-      await sql.begin(async (tx) => {
+    // Keep the explicit return type: TypeScript cannot infer the assignment
+    // made inside onRunCreated when it narrows the transaction result.
+    const materializedRun = await sql.begin(
+      async (tx): Promise<MaterializedDueFeedRun | null> => {
         const lockRows = await tx<{ acquired: boolean }>`
           SELECT pg_try_advisory_xact_lock(${DUE_FEEDS_LOCK_KEY}) AS acquired
         `;
 
         if (!lockRows[0]?.acquired) {
-          return;
+          return null;
         }
 
-        await materializeDueFeeds(c.env, tx);
-      });
+        let createdRun: MaterializedDueFeedRun | null = null;
+        await materializeDueFeeds(c.env, tx, {
+          claimContext: connectorClaimContext,
+          // The caller has exactly one free claim slot. Scan past broken or
+          // raced head rows, but stop after filling that one slot.
+          maxRunsCreated: 1,
+          onRunCreated: (run) => {
+            createdRun = run;
+          },
+        });
+        return createdRun;
+      }
+    );
 
-      pending = await withDbRetry('worker_poll_claim', claimNextPendingRun);
+    // Production Pino defaults to info. Emit one correlatable event only
+    // when this exact poller actually materialized a scoped sync, after the
+    // transaction committed. Ordinary empty polls stay metric-only, avoiding
+    // per-worker log volume and high-cardinality metric labels.
+    if (materializedRun) {
+      logger.info(
+        {
+          dispatch_event: 'worker_scoped_sync_materialized',
+          run_id: materializedRun.runId,
+          feed_id: materializedRun.feedId,
+          worker_id,
+          device_worker_id: deviceWorkerId,
+          eligibility_lane: materializedRun.eligibilityLane,
+        },
+        '[pollWorkerJob] Materialized due sync for current poller'
+      );
     }
+
+    pending = await claimWithDiagnostics();
   }
 
   if (!pending) {


### PR DESCRIPTION
## Summary

- Materialize overdue feeds from the polling worker claim context, so fleet, device, capability, and browser-affinity eligibility match the claim lanes instead of globally enqueueing work for another worker.
- Treat a never-claimed timeout as `dispatch_unavailable`: retain the terminal audit run while preserving feed/source failure state and preventing dispatch failures from consuming the auto-pause budget.
- Add bounded dispatch behavior and production observability: at most one successful materialization per idle poll, database advisory-lock serialization across replicas, low-cardinality poll/claim/dispatch counters, per-timeout reject diagnostics, and an info-level `worker_scoped_sync_materialized` event carrying run/feed/worker/device IDs plus the eligibility lane.

No connection visibility or ACL policy changes are included.

## Production evidence

Read-only correlation separated three failure modes:

- All sampled `worker_claim_timeout` rows were never claimed, not claimed workers that hung.
- WhatsApp run `1072406` was pending while its exact serial Mac worker was occupied by automation run `1072392`; an unrelated fleet poll materialized the device-owned sync, which then could not be claimed before the reaper deadline.
- Older Chrome timeouts had no matching Chrome poll traffic and predated the offline-device scheduler fix in #2989.
- The recent 502 incident was a separate rollout failure: the 15.2.0 migration hook failed and the quiesced server/worker rollout rolled back. There is no evidence that incident is the weeks-long timeout root cause.

## Device-pinned direct actions

This change pull-materializes scheduled syncs only. Direct device actions remain caller-created queue rows because callers synchronously await their result. A busy serial device can therefore leave a direct action pending, but the existing contract is bounded: `approvalMode=device` sets a 60-second claim horizon, the waiter records one terminal timeout with the pinned device last-poll context, and neither the waiter nor reaper redispatches it as a sync. A pinned/busy integration test now locks that behavior down.

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted server integration/scheduler/metrics suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Red before the fix:

```text
stale-run-reaper: expected feed failures/status/error to remain 19/active/source_error;
received 20/paused/worker_claim_timeout

scheduling-contract: expected enqueue to preserve failed/source error;
received pending/cleared error

production-log audit: resumed exact device claimed the sync, but zero info-level
materialization correlation events were emitted
```

Green after the fix:

```text
claim-lane integration graph: 8 files, 64 pass, 0 fail
stale reaper + counter registry: 34 pass, 0 fail
review-fix regression sweep: 14 adjacent suites green
make pre-pr on final rebased HEAD: all 7 gates clean
```

Coverage includes a manifest reconciliation fixture isolated from legitimate due-feed scheduling, offline-before-materialization, exact-device resumption, stale heartbeat with a current exact poll, capability rejection diagnostics, browser affinity, cloud/fleet behavior, head-of-line failure, dry-run safety, claimed-worker retry preservation, multi-replica reaper races, committed info-level poll/run correlation, and busy device-pinned direct actions.

## Notes

The scheduler and claim query now call one shared connector-lane predicate. The ineffective process-local poll throttle was removed; the transaction-scoped advisory lock and active-run uniqueness constraint remain the cross-replica correctness boundary.