### PR TITLE
feat(cli): first-run device wizard + consistent daemon worker id

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -14,6 +14,7 @@ import { apiUrlToGatewayOrigin } from "../internal/context";
 import * as context from "../internal/context";
 import * as credentials from "../internal/credentials";
 import * as deviceState from "../internal/device-state";
+import * as deviceWizardModule from "../commands/_lib/device-wizard";
 
 /**
  * Context URLs carry the SDK path (`https://app.lobu.ai/api/v1`) but the worker
@@ -143,8 +144,6 @@ describe("lobu daemon", () => {
     spyOn(context, "getCurrentContextName").mockResolvedValue("local");
     spyOn(deviceState, "loadDeviceState").mockResolvedValue({
       workerId: "macos:confirmed-box",
-      workerTokenPrefix: "owl_pat_x",
-      registeredAt: new Date().toISOString(),
     });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
@@ -152,6 +151,36 @@ describe("lobu daemon", () => {
 
     await daemonCommand({});
 
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
+  });
+
+  test("interactive boot with a cached device id does not re-prompt via the wizard", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8795",
+      source: "config",
+    });
+    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:confirmed-box",
+    });
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:should-not-run",
+      source: "created",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+    const originalIsTTY = process.stdin.isTTY;
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    try {
+      await daemonCommand({});
+    } finally {
+      (process.stdin as { isTTY?: boolean }).isTTY = originalIsTTY;
+    }
+
+    // The cached id wins and the wizard never runs once a device is configured.
+    expect(wizard).not.toHaveBeenCalled();
     expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
   });
 

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -12,7 +12,6 @@ import * as daemonModule from "@lobu/connector-worker/daemon";
 import { daemonCommand } from "../commands/daemon";
 import { apiUrlToGatewayOrigin } from "../internal/context";
 import * as context from "../internal/context";
-import * as credentials from "../internal/credentials";
 import * as deviceState from "../internal/device-state";
 import * as deviceWizardModule from "../commands/_lib/device-wizard";
 
@@ -45,16 +44,46 @@ describe("apiUrlToGatewayOrigin", () => {
   });
 });
 
+/**
+ * Every env key `detectInteractiveSession` triggers on. The suite itself often
+ * runs inside one of these agents, so leaving any of them set would silently
+ * route `daemonCommand` down the per-session lane and make the host-device
+ * assertions below pass or fail depending on where the tests are run.
+ */
+const SESSION_ENV_KEYS = [
+  "WORKER_API_TOKEN",
+  "CI",
+  "CLAUDE_PID",
+  "CLAUDE_CODE_SESSION_ID",
+  "CODEX_THREAD_ID",
+  "CODEX_SESSION_ID",
+  "OPENCODE_PID",
+  "OPENCODE_SESSION_ID",
+] as const;
+
 describe("lobu daemon", () => {
+  const originalEnv = new Map<string, string | undefined>();
+  let originalStdinIsTTY: boolean | undefined;
+  let originalStdoutIsTTY: boolean | undefined;
+
   beforeEach(() => {
-    // Deterministic auth precondition so the setup guard never fires and each
-    // test drives `startDaemonCommand` regardless of the host's real config.
-    spyOn(credentials, "getToken").mockResolvedValue("session-token");
     spyOn(context, "getCurrentContextName").mockResolvedValue("local");
-    delete process.env.WORKER_API_TOKEN;
+    for (const key of SESSION_ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    originalStdinIsTTY = process.stdin.isTTY;
+    originalStdoutIsTTY = process.stdout.isTTY;
+    process.env.WORKER_API_TOKEN = "owl_pat_durable-device-token";
+    (process.stdin as { isTTY?: boolean }).isTTY = false;
+    (process.stdout as { isTTY?: boolean }).isTTY = false;
   });
 
   afterEach(() => {
+    for (const [key, value] of originalEnv) restoreEnv(key, value);
+    originalEnv.clear();
+    (process.stdin as { isTTY?: boolean }).isTTY = originalStdinIsTTY;
+    (process.stdout as { isTTY?: boolean }).isTTY = originalStdoutIsTTY;
     mock.restore();
   });
 
@@ -83,7 +112,14 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("http://127.0.0.1:9564");
   });
 
-  test("--inside-claude is forwarded for centralized interactive detection", async () => {
+  test("--inside-claude bypasses cache and wizard so the daemon derives a per-session id", async () => {
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:cached-host",
+    });
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:wizard-host",
+      source: "created",
+    });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
@@ -95,13 +131,16 @@ describe("lobu daemon", () => {
 
     expect(start.mock.calls[0]?.[0]).toMatchObject({
       apiUrl: "http://127.0.0.1:9564",
-      platform: undefined,
+      platform: "headless",
       defaultPlatform: process.platform === "darwin" ? "macos" : "headless",
+      workerId: undefined,
       insideClaude: true,
     });
+    expect(load).not.toHaveBeenCalled();
+    expect(wizard).not.toHaveBeenCalled();
   });
 
-  test("an explicit --worker-id is passed through and never overridden", async () => {
+  test("an explicit --worker-id wins while --inside-claude still forces its lane", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "prod",
       url: "https://app.lobu.ai/api/v1",
@@ -111,9 +150,37 @@ describe("lobu daemon", () => {
       undefined as never
     );
 
-    await daemonCommand({ workerId: "macos:mybox" });
+    await daemonCommand({
+      workerId: "headless:attached-explicit",
+      insideClaude: true,
+    });
 
-    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:mybox");
+    expect(start.mock.calls[0]?.[0]).toMatchObject({
+      workerId: "headless:attached-explicit",
+      insideClaude: true,
+    });
+  });
+
+  test("auto-detected Codex bypasses the host cache and remains in the centralized session lane", async () => {
+    process.env.CODEX_THREAD_ID = "thread-exact";
+    process.env.CODEX_SESSION_ID = "thread-exact";
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:cached-host",
+    });
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:wizard-host",
+      source: "created",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+
+    expect(start.mock.calls[0]?.[0]?.workerId).toBeUndefined();
+    expect(start.mock.calls[0]?.[0]?.platform).toBe("headless");
+    expect(load).not.toHaveBeenCalled();
+    expect(wizard).not.toHaveBeenCalled();
   });
 
   test("non-interactive first run falls back to the computed default id", async () => {
@@ -171,38 +238,66 @@ describe("lobu daemon", () => {
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
-    const originalIsTTY = process.stdin.isTTY;
     (process.stdin as { isTTY?: boolean }).isTTY = true;
-    try {
-      await daemonCommand({});
-    } finally {
-      (process.stdin as { isTTY?: boolean }).isTTY = originalIsTTY;
-    }
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    await daemonCommand({});
 
     // The cached id wins and the wizard never runs once a device is configured.
     expect(wizard).not.toHaveBeenCalled();
     expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
   });
 
-  test("fresh install with no session and no durable token gets setup guidance", async () => {
-    // No stored credential and a placeholder default context → the daemon has
-    // nothing to authorize against and should say so up front, not hit the
-    // fail-closed PAT guard with no context.
+  test("a stored OAuth login never substitutes for a durable worker PAT", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
       url: "http://127.0.0.1:8787",
       source: "config",
     });
-    credentials.getToken.mockResolvedValueOnce(null as never);
     delete process.env.WORKER_API_TOKEN;
-
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
     await expect(daemonCommand({})).rejects.toThrow(
-      "Could not determine a gateway to poll"
+      /durable.*WORKER_API_TOKEN.*device_worker:run/s
     );
     expect(start).not.toHaveBeenCalled();
+  });
+
+  test("a fresh TTY runs the wizard once and forwards its chosen identity", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:chosen-by-wizard",
+      source: "created",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+
+    expect(wizard).toHaveBeenCalledTimes(1);
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:chosen-by-wizard");
+  });
+
+  test("CI never prompts even when attached to a pseudo-TTY", async () => {
+    process.env.CI = "true";
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:should-not-run",
+      source: "created",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+
+    expect(wizard).not.toHaveBeenCalled();
+    expect(start.mock.calls[0]?.[0]?.workerId).toContain(":");
   });
 
   test("--no-interactive-session is forwarded as an explicit opt-out", async () => {
@@ -218,3 +313,8 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.interactiveSession).toBe(false);
   });
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -1,8 +1,19 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { hostname } from "node:os";
 import * as daemonModule from "@lobu/connector-worker/daemon";
 import { daemonCommand } from "../commands/daemon";
 import { apiUrlToGatewayOrigin } from "../internal/context";
 import * as context from "../internal/context";
+import * as credentials from "../internal/credentials";
+import * as deviceState from "../internal/device-state";
 
 /**
  * Context URLs carry the SDK path (`https://app.lobu.ai/api/v1`) but the worker
@@ -34,6 +45,14 @@ describe("apiUrlToGatewayOrigin", () => {
 });
 
 describe("lobu daemon", () => {
+  beforeEach(() => {
+    // Deterministic auth precondition so the setup guard never fires and each
+    // test drives `startDaemonCommand` regardless of the host's real config.
+    spyOn(credentials, "getToken").mockResolvedValue("session-token");
+    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
+    delete process.env.WORKER_API_TOKEN;
+  });
+
   afterEach(() => {
     mock.restore();
   });
@@ -81,14 +100,80 @@ describe("lobu daemon", () => {
     });
   });
 
-  test("the default daemon does not enable parent delivery", async () => {
+  test("an explicit --worker-id is passed through and never overridden", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
 
-    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+    await daemonCommand({ workerId: "macos:mybox" });
 
-    expect(start.mock.calls[0]?.[0]?.insideClaude).toBeUndefined();
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:mybox");
+  });
+
+  test("non-interactive first run falls back to the computed default id", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8795",
+      source: "config",
+    });
+    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe(
+      `${process.platform === "darwin" ? "macos" : "headless"}:${hostname().split(".")[0]}`
+    );
+  });
+
+  test("non-interactive boot reuses a cached device id when present", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8795",
+      source: "config",
+    });
+    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:confirmed-box",
+      workerTokenPrefix: "owl_pat_x",
+      registeredAt: new Date().toISOString(),
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
+  });
+
+  test("fresh install with no session and no durable token gets setup guidance", async () => {
+    // No stored credential and a placeholder default context → the daemon has
+    // nothing to authorize against and should say so up front, not hit the
+    // fail-closed PAT guard with no context.
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    credentials.getToken.mockResolvedValueOnce(null as never);
+    delete process.env.WORKER_API_TOKEN;
+
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+    await expect(daemonCommand({})).rejects.toThrow(
+      "Could not determine a gateway to poll"
+    );
+    expect(start).not.toHaveBeenCalled();
   });
 
   test("--no-interactive-session is forwarded as an explicit opt-out", async () => {

--- a/packages/cli/src/__tests__/device-state.test.ts
+++ b/packages/cli/src/__tests__/device-state.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as os from "node:os";
@@ -16,6 +23,22 @@ describe("workerTokenPrefix", () => {
 
   test("returns null when no token is present", () => {
     expect(workerTokenPrefix(undefined)).toBeNull();
+  });
+
+  test("never echoes a token it cannot truncate", () => {
+    // The wizard prints this value followed by an ellipsis, so returning a
+    // short token verbatim would leak the live secret under a label claiming
+    // it was truncated. Anything too short to shorten is withheld entirely.
+    for (const short of ["owl_pat_ab", "owl_pat_abcd", "x"]) {
+      expect(workerTokenPrefix(short)).toBeNull();
+    }
+  });
+
+  test("a real-length PAT keeps only a non-reconstructable stem", () => {
+    const token = `owl_pat_${"a".repeat(24)}`;
+    const prefix = workerTokenPrefix(token) as string;
+    expect(token.startsWith(prefix)).toBe(true);
+    expect(prefix.length).toBeLessThan(token.length);
   });
 });
 
@@ -36,6 +59,10 @@ describe("device-state cache", () => {
 
     const loaded = await loadDeviceState("local");
     expect(loaded?.workerId).toBe("macos:myhost");
+    expect(statSync(join(dir, ".lobu", "devices")).mode & 0o777).toBe(0o700);
+    expect(
+      statSync(join(dir, ".lobu", "devices", "local.json")).mode & 0o777
+    ).toBe(0o600);
   });
 
   test("returns null when no state exists", async () => {
@@ -53,13 +80,51 @@ describe("device-state cache", () => {
       workerId: "macos:x",
     });
     // Corrupt the file to simulate an invalid payload.
-    const { writeFileSync } = await import("node:fs");
     writeFileSync(
       join(dir, ".lobu", "devices", "local.json"),
       JSON.stringify({ workerTokenPrefix: "x" })
     );
 
     expect(await loadDeviceState("local")).toBeNull();
+  });
+
+  test("repairs a corrupt cache atomically while preserving the bad payload", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+    const devicesDir = join(dir, ".lobu", "devices");
+    mkdirSync(devicesDir, { recursive: true });
+    writeFileSync(join(devicesDir, "local.json"), "not-json\n");
+
+    const saved = await saveDeviceState("local", {
+      workerId: "headless:repaired",
+    });
+
+    expect(saved.workerId).toBe("headless:repaired");
+    expect((await loadDeviceState("local"))?.workerId).toBe(
+      "headless:repaired"
+    );
+    expect(
+      readdirSync(devicesDir).some((name) => name.includes(".corrupt-"))
+    ).toBe(true);
+  });
+
+  test("concurrent first writes converge on one durable worker identity", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+
+    const results = await Promise.all([
+      saveDeviceState("local", { workerId: "headless:first" }),
+      saveDeviceState("local", { workerId: "headless:second" }),
+    ]);
+    const loaded = await loadDeviceState("local");
+
+    expect(results[0]?.workerId).toBe(results[1]?.workerId);
+    expect(loaded?.workerId).toBe(results[0]?.workerId);
+    expect(
+      readdirSync(join(dir, ".lobu", "devices")).filter((name) =>
+        name.endsWith(".tmp")
+      )
+    ).toHaveLength(0);
   });
 
   test("sanitizes the context name for the file path", async () => {
@@ -71,7 +136,6 @@ describe("device-state cache", () => {
     });
 
     // The context name with slashes/spaces becomes a single safe filename.
-    const { readdirSync } = await import("node:fs");
     const files = readdirSync(join(dir, ".lobu", "devices"));
     expect(files).toHaveLength(1);
     expect(files[0]).not.toMatch(/[/\s]/);

--- a/packages/cli/src/__tests__/device-state.test.ts
+++ b/packages/cli/src/__tests__/device-state.test.ts
@@ -32,13 +32,10 @@ describe("device-state cache", () => {
 
     await saveDeviceState("local", {
       workerId: "macos:myhost",
-      workerTokenPrefix: "owl_pat_x",
     });
 
     const loaded = await loadDeviceState("local");
     expect(loaded?.workerId).toBe("macos:myhost");
-    expect(loaded?.workerTokenPrefix).toBe("owl_pat_x");
-    expect(loaded?.registeredAt).toBeTruthy();
   });
 
   test("returns null when no state exists", async () => {
@@ -54,7 +51,6 @@ describe("device-state cache", () => {
 
     await saveDeviceState("local", {
       workerId: "macos:x",
-      workerTokenPrefix: null,
     });
     // Corrupt the file to simulate an invalid payload.
     const { writeFileSync } = await import("node:fs");
@@ -72,7 +68,6 @@ describe("device-state cache", () => {
 
     await saveDeviceState("prod/api v1", {
       workerId: "macos:host",
-      workerTokenPrefix: null,
     });
 
     // The context name with slashes/spaces becomes a single safe filename.

--- a/packages/cli/src/__tests__/device-state.test.ts
+++ b/packages/cli/src/__tests__/device-state.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as os from "node:os";
+import {
+  loadDeviceState,
+  saveDeviceState,
+  workerTokenPrefix,
+} from "../internal/device-state";
+
+describe("workerTokenPrefix", () => {
+  test("truncates a long token to a privacy-safe prefix", () => {
+    expect(workerTokenPrefix("owl_pat_abcdefghijklmnop")).toBe("owl_pat_abcd");
+  });
+
+  test("returns null when no token is present", () => {
+    expect(workerTokenPrefix(undefined)).toBeNull();
+  });
+});
+
+describe("device-state cache", () => {
+  let dir: string;
+  afterEach(() => {
+    mock.restore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("round-trips a saved state and loads it back", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+
+    await saveDeviceState("local", {
+      workerId: "macos:myhost",
+      workerTokenPrefix: "owl_pat_x",
+    });
+
+    const loaded = await loadDeviceState("local");
+    expect(loaded?.workerId).toBe("macos:myhost");
+    expect(loaded?.workerTokenPrefix).toBe("owl_pat_x");
+    expect(loaded?.registeredAt).toBeTruthy();
+  });
+
+  test("returns null when no state exists", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+
+    expect(await loadDeviceState("local")).toBeNull();
+  });
+
+  test("returns null for an empty or invalid workerId", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+
+    await saveDeviceState("local", {
+      workerId: "macos:x",
+      workerTokenPrefix: null,
+    });
+    // Corrupt the file to simulate an invalid payload.
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      join(dir, ".lobu", "devices", "local.json"),
+      JSON.stringify({ workerTokenPrefix: "x" })
+    );
+
+    expect(await loadDeviceState("local")).toBeNull();
+  });
+
+  test("sanitizes the context name for the file path", async () => {
+    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(dir);
+
+    await saveDeviceState("prod/api v1", {
+      workerId: "macos:host",
+      workerTokenPrefix: null,
+    });
+
+    // The context name with slashes/spaces becomes a single safe filename.
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(join(dir, ".lobu", "devices"));
+    expect(files).toHaveLength(1);
+    expect(files[0]).not.toMatch(/[/\s]/);
+  });
+});

--- a/packages/cli/src/commands/__tests__/device-wizard.test.ts
+++ b/packages/cli/src/commands/__tests__/device-wizard.test.ts
@@ -47,8 +47,6 @@ function stubFetch(body: { devices?: unknown[] } | { error: string }): void {
 function stubSave(): void {
   spyOn(deviceState, "saveDeviceState").mockResolvedValue({
     workerId: "macos:Mac",
-    workerTokenPrefix: null,
-    registeredAt: new Date().toISOString(),
   });
 }
 
@@ -82,8 +80,6 @@ describe("deviceWizard", () => {
     stubFetch({ error: "Unauthorized" });
     const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
       workerId: "macos:custom",
-      workerTokenPrefix: null,
-      registeredAt: new Date().toISOString(),
     });
 
     const result = await deviceWizard({
@@ -117,8 +113,6 @@ describe("deviceWizard", () => {
     });
     const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
       workerId: "macos:existing-box",
-      workerTokenPrefix: null,
-      registeredAt: new Date().toISOString(),
     });
 
     const result = await deviceWizard({
@@ -161,5 +155,38 @@ describe("deviceWizard", () => {
 
     expect(result.source).toBe("created");
     expect(result.workerId).toBe("macos:Mac");
+  });
+
+  test("only ever sends the stored token to the resolved context origin", async () => {
+    mockContext();
+    spyOn(apiClient, "listOrganizations").mockResolvedValue([
+      { slug: "personal", personal: true },
+    ]);
+    // The wizard takes no caller-supplied apiUrl at all — the token-bearing
+    // GET /api/me/devices is always built from the resolved context's origin,
+    // so a `lobu daemon --api-url attacker.invalid` can never capture the bearer
+    // (mirrors resolveApiTarget's refusal to send context creds elsewhere).
+    stubFetch({
+      devices: [{ id: "d", worker_id: "macos:x", platform: "macos" }],
+    });
+    stubSave();
+
+    await deviceWizard({
+      suggestedWorkerId: "macos:Mac",
+      prompts: fakePrompts({ select: async () => "personal" }),
+    });
+
+    const calls = (globalThis.fetch as unknown as ReturnType<typeof spyOn>).mock
+      .calls as Array<[string | Request, RequestInit?]>;
+    const urls = calls.map((c) => String(c[0]));
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url.startsWith("http://127.0.0.1:8795/")).toBe(true);
+    }
+    for (const [, init] of calls) {
+      const auth = (init?.headers as Record<string, string> | undefined)
+        ?.Authorization;
+      expect(auth).toBe("Bearer local-token");
+    }
   });
 });

--- a/packages/cli/src/commands/__tests__/device-wizard.test.ts
+++ b/packages/cli/src/commands/__tests__/device-wizard.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as credentials from "../../internal/credentials";
+import * as deviceState from "../../internal/device-state";
+import * as apiClient from "../../internal/api-client";
+import * as context from "../../internal/context";
+import { deviceWizard, type DeviceWizardPrompts } from "../_lib/device-wizard";
+
+/**
+ * The wizard is interactive (TTY-only), so its branch logic is unit-tested here
+ * by injecting fake prompts plus stubbed remote calls. This pins the decisions
+ * that matter for identity consistency: existing-device reuse vs a freshly
+ * confirmed id, and the org the summary targets.
+ */
+
+function mockContext(): void {
+  spyOn(context, "resolveContext").mockResolvedValue({
+    name: "local",
+    url: "http://127.0.0.1:8795",
+    source: "config",
+  });
+  spyOn(credentials, "getToken").mockResolvedValue("local-token");
+}
+
+function fakePrompts(
+  overrides: Partial<DeviceWizardPrompts> = {}
+): DeviceWizardPrompts {
+  return {
+    select: async () => "personal",
+    confirm: async () => true,
+    input: async () => "macos:custom",
+    ...overrides,
+  };
+}
+
+function stubFetch(body: { devices?: unknown[] } | { error: string }): void {
+  const hasError = Object.hasOwn(body as object, "error");
+  const raw = JSON.stringify(body);
+  spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: !hasError,
+    status: hasError ? 401 : 200,
+    statusText: hasError ? "Unauthorized" : "OK",
+    json: async () => body,
+    text: async () => raw,
+  } as never);
+}
+
+function stubSave(): void {
+  spyOn(deviceState, "saveDeviceState").mockResolvedValue({
+    workerId: "macos:Mac",
+    workerTokenPrefix: null,
+    registeredAt: new Date().toISOString(),
+  });
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("deviceWizard", () => {
+  test("confirms the suggested id and persists it when there are no remote devices", async () => {
+    mockContext();
+    spyOn(apiClient, "listOrganizations").mockResolvedValue([
+      { slug: "personal", personal: true },
+    ]);
+    stubFetch({ error: "Unauthorized" });
+    stubSave();
+
+    const result = await deviceWizard({
+      suggestedWorkerId: "macos:Mac",
+      prompts: fakePrompts(),
+    });
+
+    expect(result.source).toBe("created");
+    expect(result.workerId).toBe("macos:Mac");
+  });
+
+  test("uses a custom id when the user declines the suggested one", async () => {
+    mockContext();
+    spyOn(apiClient, "listOrganizations").mockResolvedValue([
+      { slug: "personal", personal: true },
+    ]);
+    stubFetch({ error: "Unauthorized" });
+    const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
+      workerId: "macos:custom",
+      workerTokenPrefix: null,
+      registeredAt: new Date().toISOString(),
+    });
+
+    const result = await deviceWizard({
+      suggestedWorkerId: "macos:Mac",
+      prompts: fakePrompts({
+        confirm: async () => false,
+        input: async () => "macos:custom",
+      }),
+    });
+
+    expect(result.workerId).toBe("macos:custom");
+    expect(saveSpy.mock.calls[0]?.[1]?.workerId).toBe("macos:custom");
+  });
+
+  test("reuses an existing registered device id when the user picks one", async () => {
+    mockContext();
+    spyOn(apiClient, "listOrganizations").mockResolvedValue([
+      { slug: "personal", personal: true },
+    ]);
+    stubFetch({
+      devices: [
+        {
+          id: "dev-1",
+          worker_id: "macos:existing-box",
+          platform: "macos",
+          label: "My Mac",
+          organization_slug: "personal",
+          organization_name: "Personal",
+        },
+      ],
+    });
+    const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
+      workerId: "macos:existing-box",
+      workerTokenPrefix: null,
+      registeredAt: new Date().toISOString(),
+    });
+
+    const result = await deviceWizard({
+      suggestedWorkerId: "macos:Mac",
+      prompts: fakePrompts({
+        select: async () => "macos:existing-box" as unknown as string,
+      }),
+    });
+
+    expect(result.source).toBe("reused");
+    expect(result.workerId).toBe("macos:existing-box");
+    expect(saveSpy.mock.calls[0]?.[1]?.workerId).toBe("macos:existing-box");
+  });
+
+  test("falls back to the fresh-id branch when the user picks start-new", async () => {
+    mockContext();
+    spyOn(apiClient, "listOrganizations").mockResolvedValue([
+      { slug: "personal", personal: true },
+    ]);
+    stubFetch({
+      devices: [
+        {
+          id: "dev-1",
+          worker_id: "macos:other",
+          platform: "macos",
+          label: "Old",
+          organization_slug: null,
+          organization_name: null,
+        },
+      ],
+    });
+    stubSave();
+
+    const result = await deviceWizard({
+      suggestedWorkerId: "macos:Mac",
+      prompts: fakePrompts({
+        select: async () => "__new__" as unknown as string,
+      }),
+    });
+
+    expect(result.source).toBe("created");
+    expect(result.workerId).toBe("macos:Mac");
+  });
+});

--- a/packages/cli/src/commands/__tests__/device-wizard.test.ts
+++ b/packages/cli/src/commands/__tests__/device-wizard.test.ts
@@ -1,25 +1,9 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import * as credentials from "../../internal/credentials";
 import * as deviceState from "../../internal/device-state";
-import * as apiClient from "../../internal/api-client";
-import * as context from "../../internal/context";
 import { deviceWizard, type DeviceWizardPrompts } from "../_lib/device-wizard";
 
-/**
- * The wizard is interactive (TTY-only), so its branch logic is unit-tested here
- * by injecting fake prompts plus stubbed remote calls. This pins the decisions
- * that matter for identity consistency: existing-device reuse vs a freshly
- * confirmed id, and the org the summary targets.
- */
-
-function mockContext(): void {
-  spyOn(context, "resolveContext").mockResolvedValue({
-    name: "local",
-    url: "http://127.0.0.1:8795",
-    source: "config",
-  });
-  spyOn(credentials, "getToken").mockResolvedValue("local-token");
-}
+const API_URL = "http://127.0.0.1:8795";
+const WORKER_TOKEN = "owl_pat_durable-device-token";
 
 function fakePrompts(
   overrides: Partial<DeviceWizardPrompts> = {}
@@ -32,22 +16,58 @@ function fakePrompts(
   };
 }
 
-function stubFetch(body: { devices?: unknown[] } | { error: string }): void {
-  const hasError = Object.hasOwn(body as object, "error");
-  const raw = JSON.stringify(body);
-  spyOn(globalThis, "fetch").mockResolvedValue({
-    ok: !hasError,
-    status: hasError ? 401 : 200,
-    statusText: hasError ? "Unauthorized" : "OK",
-    json: async () => body,
-    text: async () => raw,
-  } as never);
+function wizardOptions(
+  overrides: Partial<Parameters<typeof deviceWizard>[0]> = {}
+): Parameters<typeof deviceWizard>[0] {
+  return {
+    context: "local",
+    apiUrl: API_URL,
+    suggestedWorkerId: "macos:Mac",
+    workerApiToken: WORKER_TOKEN,
+    prompts: fakePrompts(),
+    ...overrides,
+  };
 }
 
-function stubSave(): void {
-  spyOn(deviceState, "saveDeviceState").mockResolvedValue({
-    workerId: "macos:Mac",
+function response(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Unauthorized",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as never;
+}
+
+function stubFetch(options: {
+  devices?: unknown[];
+  devicesStatus?: number;
+  tokenOrg?: string;
+}): ReturnType<typeof spyOn> {
+  return spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/oauth/userinfo")) {
+      return response({
+        organization_slug: options.tokenOrg ?? "personal",
+        personal_org_slug: "personal",
+        organizations: [
+          { slug: "personal", name: "Personal", personal: true },
+          { slug: "org-a", name: "Org A", personal: false },
+          { slug: "org-b", name: "Org B", personal: false },
+        ],
+      });
+    }
+    return response(
+      options.devicesStatus === 200 || options.devicesStatus === undefined
+        ? { devices: options.devices ?? [] }
+        : { error: "Unauthorized" },
+      options.devicesStatus ?? 200
+    );
   });
+}
+
+function stubSave(workerId = "macos:Mac"): ReturnType<typeof spyOn> {
+  return spyOn(deviceState, "saveDeviceState").mockResolvedValue({ workerId });
 }
 
 afterEach(() => {
@@ -55,138 +75,148 @@ afterEach(() => {
 });
 
 describe("deviceWizard", () => {
-  test("confirms the suggested id and persists it when there are no remote devices", async () => {
-    mockContext();
-    spyOn(apiClient, "listOrganizations").mockResolvedValue([
-      { slug: "personal", personal: true },
-    ]);
-    stubFetch({ error: "Unauthorized" });
-    stubSave();
+  test("confirms and persists a fresh identity when the server has no devices", async () => {
+    stubFetch({ devices: [] });
+    const save = stubSave();
 
-    const result = await deviceWizard({
-      suggestedWorkerId: "macos:Mac",
-      prompts: fakePrompts(),
-    });
+    const result = await deviceWizard(wizardOptions());
 
-    expect(result.source).toBe("created");
-    expect(result.workerId).toBe("macos:Mac");
+    expect(result).toEqual({ source: "created", workerId: "macos:Mac" });
+    expect(save.mock.calls[0]?.[1]).toEqual({ workerId: "macos:Mac" });
   });
 
-  test("uses a custom id when the user declines the suggested one", async () => {
-    mockContext();
-    spyOn(apiClient, "listOrganizations").mockResolvedValue([
-      { slug: "personal", personal: true },
-    ]);
-    stubFetch({ error: "Unauthorized" });
-    const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
-      workerId: "macos:custom",
-    });
+  test("uses a custom id when the user declines the suggestion", async () => {
+    stubFetch({ devices: [] });
+    const save = stubSave("macos:custom");
 
-    const result = await deviceWizard({
-      suggestedWorkerId: "macos:Mac",
-      prompts: fakePrompts({
-        confirm: async () => false,
-        input: async () => "macos:custom",
-      }),
-    });
+    const result = await deviceWizard(
+      wizardOptions({
+        prompts: fakePrompts({
+          confirm: async () => false,
+          input: async () => "macos:custom",
+        }),
+      })
+    );
 
     expect(result.workerId).toBe("macos:custom");
-    expect(saveSpy.mock.calls[0]?.[1]?.workerId).toBe("macos:custom");
+    expect(save.mock.calls[0]?.[1]).toEqual({ workerId: "macos:custom" });
   });
 
-  test("reuses an existing registered device id when the user picks one", async () => {
-    mockContext();
-    spyOn(apiClient, "listOrganizations").mockResolvedValue([
-      { slug: "personal", personal: true },
-    ]);
+  test("maps a selected server device id back to its exact worker identity", async () => {
     stubFetch({
       devices: [
         {
           id: "dev-1",
-          worker_id: "macos:existing-box",
+          worker_id: "__new__",
           platform: "macos",
-          label: "My Mac",
+          label: "Literal sentinel worker",
           organization_slug: "personal",
-          organization_name: "Personal",
         },
       ],
     });
-    const saveSpy = spyOn(deviceState, "saveDeviceState").mockResolvedValue({
-      workerId: "macos:existing-box",
-    });
+    stubSave("__new__");
+    const selections = ["personal", "dev-1"];
 
-    const result = await deviceWizard({
-      suggestedWorkerId: "macos:Mac",
-      prompts: fakePrompts({
-        select: async () => "macos:existing-box" as unknown as string,
-      }),
-    });
+    const result = await deviceWizard(
+      wizardOptions({
+        prompts: fakePrompts({ select: async () => selections.shift() ?? "" }),
+      })
+    );
 
-    expect(result.source).toBe("reused");
-    expect(result.workerId).toBe("macos:existing-box");
-    expect(saveSpy.mock.calls[0]?.[1]?.workerId).toBe("macos:existing-box");
+    expect(result).toEqual({ source: "reused", workerId: "__new__" });
   });
 
-  test("falls back to the fresh-id branch when the user picks start-new", async () => {
-    mockContext();
-    spyOn(apiClient, "listOrganizations").mockResolvedValue([
-      { slug: "personal", personal: true },
-    ]);
+  test("cross-org reuse reports the server org and never claims the selected workspace is the pin", async () => {
     stubFetch({
+      tokenOrg: "org-a",
       devices: [
         {
-          id: "dev-1",
-          worker_id: "macos:other",
+          id: "dev-b",
+          worker_id: "macos:org-b-device",
           platform: "macos",
-          label: "Old",
-          organization_slug: null,
-          organization_name: null,
+          label: "Org B Mac",
+          organization_slug: "org-b",
+          organization_name: "Org B",
         },
       ],
     });
-    stubSave();
-
-    const result = await deviceWizard({
-      suggestedWorkerId: "macos:Mac",
-      prompts: fakePrompts({
-        select: async () => "__new__" as unknown as string,
-      }),
+    stubSave("macos:org-b-device");
+    const selections = ["org-a", "dev-b"];
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.map(String).join(" "));
     });
 
-    expect(result.source).toBe("created");
-    expect(result.workerId).toBe("macos:Mac");
+    const result = await deviceWizard(
+      wizardOptions({
+        prompts: fakePrompts({ select: async () => selections.shift() ?? "" }),
+      })
+    );
+
+    const output = logs.join("\n");
+    expect(result).toEqual({
+      source: "reused",
+      workerId: "macos:org-b-device",
+    });
+    expect(output).toContain('server reports workspace "org-b"');
+    expect(output).toContain('selected workspace "org-a" was guidance only');
+    expect(output).not.toContain('Device workspace: "org-a"');
+    expect(output).not.toContain("org-scoped to org-a");
   });
 
-  test("only ever sends the stored token to the resolved context origin", async () => {
-    mockContext();
-    spyOn(apiClient, "listOrganizations").mockResolvedValue([
-      { slug: "personal", personal: true },
-    ]);
-    // The wizard takes no caller-supplied apiUrl at all — the token-bearing
-    // GET /api/me/devices is always built from the resolved context's origin,
-    // so a `lobu daemon --api-url attacker.invalid` can never capture the bearer
-    // (mirrors resolveApiTarget's refusal to send context creds elsewhere).
-    stubFetch({
-      devices: [{ id: "d", worker_id: "macos:x", platform: "macos" }],
+  test("a new device says only that the worker PAT determines attachment", async () => {
+    stubFetch({ devices: [], tokenOrg: "org-a" });
+    stubSave();
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.map(String).join(" "));
     });
+
+    await deviceWizard(wizardOptions());
+
+    const output = logs.join("\n");
+    expect(output).toContain(
+      "WORKER_API_TOKEN determines its workspace attachment on first poll"
+    );
+    expect(output).not.toContain("Device workspace:");
+    expect(output).not.toContain("org-scoped to");
+  });
+
+  test("device-list failures stop setup instead of silently creating a duplicate", async () => {
+    stubFetch({ devicesStatus: 401 });
+    const save = stubSave();
+
+    await expect(deviceWizard(wizardOptions())).rejects.toThrow(
+      /Could not list devices.*Unauthorized/s
+    );
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  test("uses only the durable worker PAT against the daemon origin", async () => {
+    const fetchSpy = stubFetch({ devices: [] });
     stubSave();
 
-    await deviceWizard({
-      suggestedWorkerId: "macos:Mac",
-      prompts: fakePrompts({ select: async () => "personal" }),
-    });
+    await deviceWizard(
+      wizardOptions({ apiUrl: "https://gateway.example.test/api/v1" })
+    );
 
-    const calls = (globalThis.fetch as unknown as ReturnType<typeof spyOn>).mock
-      .calls as Array<[string | Request, RequestInit?]>;
-    const urls = calls.map((c) => String(c[0]));
-    expect(urls.length).toBeGreaterThan(0);
-    for (const url of urls) {
-      expect(url.startsWith("http://127.0.0.1:8795/")).toBe(true);
+    expect(fetchSpy).toHaveBeenCalled();
+    for (const [input, init] of fetchSpy.mock.calls) {
+      expect(String(input).startsWith("https://gateway.example.test/")).toBe(
+        true
+      );
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        `Bearer ${WORKER_TOKEN}`
+      );
     }
-    for (const [, init] of calls) {
-      const auth = (init?.headers as Record<string, string> | undefined)
-        ?.Authorization;
-      expect(auth).toBe("Bearer local-token");
-    }
+  });
+
+  test("returns the first-writer cache identity from an overlapping first boot", async () => {
+    stubFetch({ devices: [] });
+    stubSave("macos:other-process-won");
+
+    const result = await deviceWizard(wizardOptions());
+
+    expect(result.workerId).toBe("macos:other-process-won");
   });
 });

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -34,7 +34,6 @@ import {
 
 export interface DeviceWizardOptions {
   context?: string;
-  apiUrl?: string;
   /** Pre-computed default `<platform>:<hostname>` id. */
   suggestedWorkerId: string;
   /** The token the daemon will boot with (WORKER_API_TOKEN), if any. */
@@ -97,7 +96,9 @@ export async function deviceWizard(
 ): Promise<DeviceWizardResult> {
   const prompts = options.prompts ?? { select, confirm, input };
   const target = await resolveContext(options.context);
-  const apiUrl = options.apiUrl?.trim() || target.url;
+  // The stored context token is ONLY ever sent to the resolved context's own
+  // origin — never to a caller-supplied --api-url, which an attacker could point
+  // at themselves to harvest the bearer (see resolveApiTarget's same guard).
   const token = await getToken(target.name);
 
   let orgs: Array<{ slug: string; name?: string; personal?: boolean }> = [];
@@ -108,7 +109,7 @@ export async function deviceWizard(
     orgs = await listOrganizations({ context: target.name }).catch(
       () => [] as Array<{ slug: string; name?: string; personal?: boolean }>
     );
-    devices = await fetchRemoteDevices(apiUrl, token).catch(
+    devices = await fetchRemoteDevices(target.url, token).catch(
       () => [] as RemoteDevice[]
     );
   }
@@ -136,7 +137,8 @@ export async function deviceWizard(
   );
 
   const orgTarget = await prompts.select({
-    message: "Which workspace should this device belong to?",
+    message:
+      "Which workspace will this device run for? (the pin is set by the token you export)",
     choices: [
       { value: personal ?? "__personal__", name: personalLabel },
       ...orgOptions.map((org) => ({ ...org, name: org.name ?? org.value })),
@@ -194,15 +196,19 @@ export async function deviceWizard(
   const contextName = target.name;
   await saveDeviceState(contextName, {
     workerId,
-    workerTokenPrefix: tokenPrefix,
   });
 
   console.log(
-    chalk.green(`\n  Device "${workerId}" pinned to ${orgSlug ?? "personal"}.`)
+    chalk.green(`\n  Device "${workerId}" registered (local setup).`)
   );
   console.log(
     chalk.dim(
       `  ${source === "reused" ? "Reusing an existing device row; the daemon will upsert on the same id." : "New device; it registers on the first poll."}`
+    )
+  );
+  console.log(
+    chalk.dim(
+      `  Device workspace: ${orgSlug ? `"${orgSlug}"` : "personal"}. This is set by the WORKER_API_TOKEN it auths with on poll — the selection above is guidance for which token to use.`
     )
   );
   if (tokenPrefix) {

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -1,0 +1,234 @@
+import { confirm, input, select } from "@inquirer/prompts";
+import chalk from "chalk";
+import {
+  getToken,
+  listOrganizations,
+  resolveContext,
+} from "../../internal/index.js";
+import { apiUrlToGatewayOrigin } from "../../internal/context.js";
+import {
+  fetchWithRetry,
+  parseJsonResponse,
+  extractApiError,
+} from "../../internal/http.js";
+import {
+  saveDeviceState,
+  workerTokenPrefix,
+} from "../../internal/device-state.js";
+
+/**
+ * First-run interactive onboarding for `lobu daemon`.
+ *
+ * Everything here is a guided convenience over the existing server contract:
+ *   - the device id is the `worker_id` the daemon passes on every poll; the
+ *     server upserts on `(user_id, worker_id)`, so reusing a confirmed id keeps
+ *     the device row stable instead of churning into a second device;
+ *   - the org a device is pinned to is driven by the `WORKER_API_TOKEN` it auths
+ *     with (org-scoped PAT → that org; personal/session → the personal org). The
+ *     wizard does not mutate the org itself — it just surfaces the choice so the
+ *     user mints the right token.
+ *
+ * Runs only when the CLI is interactive (a TTY) AND no explicit `--worker-id`
+ * was given. Headless / scripted runs skip the wizard entirely.
+ */
+
+export interface DeviceWizardOptions {
+  context?: string;
+  apiUrl?: string;
+  /** Pre-computed default `<platform>:<hostname>` id. */
+  suggestedWorkerId: string;
+  /** The token the daemon will boot with (WORKER_API_TOKEN), if any. */
+  workerApiToken?: string;
+  /** Overridable prompts (defaults to real inquirer); injectable for tests. */
+  prompts?: DeviceWizardPrompts;
+}
+
+/** A registered device as returned by `GET /api/me/devices`. */
+interface RemoteDevice {
+  id: string;
+  worker_id: string;
+  platform: string | null;
+  label: string | null;
+  organization_slug: string | null;
+  organization_name: string | null;
+}
+
+export interface DeviceWizardResult {
+  workerId: string;
+  /** How the id was chosen: an existing server row or a fresh confirmation. */
+  source: "reused" | "created";
+}
+
+async function fetchRemoteDevices(
+  apiUrl: string,
+  token: string
+): Promise<RemoteDevice[]> {
+  const origin = apiUrlToGatewayOrigin(apiUrl);
+  const url = `${origin}/api/me/devices`;
+  const res = await fetchWithRetry(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const parsed = (await parseJsonResponse(res, url, (msg: string) => {
+    throw new Error(msg);
+  })) as { devices?: RemoteDevice[] } | undefined;
+  if (!res.ok) {
+    const { message } = extractApiError(parsed, res.status, res.statusText);
+    throw new Error(`Could not list devices: ${message}`);
+  }
+  return parsed?.devices ?? [];
+}
+
+/**
+ * The four prompts the wizard drives. Defaults to the real inquirer prompts;
+ * injectable so unit tests can drive every branch without a TTY.
+ */
+export interface DeviceWizardPrompts {
+  select: (config: Parameters<typeof select>[0]) => Promise<string>;
+  confirm: (config: Parameters<typeof confirm>[0]) => Promise<boolean>;
+  input: (config: Parameters<typeof input>[0]) => Promise<string>;
+}
+
+/** Run the wizard. Resolves orgs (for token guidance) and the caller's existing
+ * devices, asks personal-vs-org + confirms the device id, and persists the
+ * choice so later non-interactive boots reuse it.
+ */
+export async function deviceWizard(
+  options: DeviceWizardOptions
+): Promise<DeviceWizardResult> {
+  const prompts = options.prompts ?? { select, confirm, input };
+  const target = await resolveContext(options.context);
+  const apiUrl = options.apiUrl?.trim() || target.url;
+  const token = await getToken(target.name);
+
+  let orgs: Array<{ slug: string; name?: string; personal?: boolean }> = [];
+  let devices: RemoteDevice[] = [];
+  const tokenPrefix = workerTokenPrefix(options.workerApiToken);
+
+  if (token) {
+    orgs = await listOrganizations({ context: target.name }).catch(
+      () => [] as Array<{ slug: string; name?: string; personal?: boolean }>
+    );
+    devices = await fetchRemoteDevices(apiUrl, token).catch(
+      () => [] as RemoteDevice[]
+    );
+  }
+
+  const personal = orgs.find((org) => org.personal === true)?.slug;
+  const orgOptions = orgs
+    .filter((org) => org.slug !== personal)
+    .map((org) => ({
+      value: org.slug,
+      name:
+        org.name && org.name !== org.slug
+          ? `${org.slug} (${org.name})`
+          : org.slug,
+    }));
+  const personalLabel = personal
+    ? chalk.bold(personal) + chalk.dim(" (your private workspace)")
+    : "personal";
+
+  console.log();
+  console.log(chalk.bold("  Set up this device as a Lobu worker"));
+  console.log(
+    chalk.dim(
+      "  It polls the gateway for connector syncs, actions, and device Automations.\n"
+    )
+  );
+
+  const orgTarget = await prompts.select({
+    message: "Which workspace should this device belong to?",
+    choices: [
+      { value: personal ?? "__personal__", name: personalLabel },
+      ...orgOptions.map((org) => ({ ...org, name: org.name ?? org.value })),
+    ],
+  });
+  const orgSlug =
+    orgTarget === "__personal__" ? (personal ?? undefined) : orgTarget;
+
+  // Pick an identity: reuse an existing registered device when available (so a
+  // re-run doesn't duplicate a row), else confirm the computed default id.
+  const existing = devices.filter(
+    (device) => device.worker_id && device.worker_id.length > 0
+  );
+  let workerId = options.suggestedWorkerId;
+  let source: "reused" | "created" = "reused";
+
+  if (existing.length > 0) {
+    const choice = await prompts.select({
+      message: "Pick a device identity (or start a new one)",
+      choices: [
+        {
+          value: "__new__",
+          name: chalk.dim("Start a new device with a fresh id"),
+        },
+        ...existing.map((device) => ({
+          value: device.worker_id,
+          name: `${device.label ?? device.worker_id}${device.organization_slug ? chalk.dim(` — ${device.organization_slug}`) : ""}`,
+        })),
+      ],
+    });
+    if (choice !== "__new__") {
+      workerId = choice;
+    } else {
+      source = "created";
+    }
+  } else {
+    source = "created";
+    const confirmed = await prompts.confirm({
+      message: `Register this machine as device "${chalk.bold(options.suggestedWorkerId)}"?`,
+      default: true,
+    });
+    if (!confirmed) {
+      const custom = await prompts.input({
+        message:
+          "Enter a device id (letters, digits, dot, underscore, colon, hyphen):",
+        validate: (value) =>
+          /^[A-Za-z0-9._:-]{1,128}$/.test(value.trim())
+            ? true
+            : "Use 1-128 characters of letters, digits, dot, underscore, colon or hyphen",
+      });
+      workerId = custom.trim();
+    }
+  }
+
+  const contextName = target.name;
+  await saveDeviceState(contextName, {
+    workerId,
+    workerTokenPrefix: tokenPrefix,
+  });
+
+  console.log(
+    chalk.green(`\n  Device "${workerId}" pinned to ${orgSlug ?? "personal"}.`)
+  );
+  console.log(
+    chalk.dim(
+      `  ${source === "reused" ? "Reusing an existing device row; the daemon will upsert on the same id." : "New device; it registers on the first poll."}`
+    )
+  );
+  if (tokenPrefix) {
+    console.log(
+      chalk.dim(
+        `  Token: ${tokenPrefix}… (${orgSlug ? `org-scoped to ${orgSlug}` : "personal/session"})`
+      )
+    );
+  } else {
+    console.log(
+      chalk.yellow(
+        "  No WORKER_API_TOKEN set — export a durable owl_pat_ token before the daemon can poll."
+      )
+    );
+  }
+  console.log(
+    chalk.dim(
+      `  Saved to ~/.lobu/devices/${contextName}.json (local only; the server owns the pin).`
+    )
+  );
+  console.log(
+    chalk.dim(
+      "  Later `lobu daemon` runs reuse this without asking, unless you pass --worker-id or delete the file."
+    )
+  );
+  console.log();
+
+  return { workerId, source };
+}

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -1,43 +1,37 @@
 import { confirm, input, select } from "@inquirer/prompts";
 import chalk from "chalk";
-import {
-  getToken,
-  listOrganizations,
-  resolveContext,
-} from "../../internal/index.js";
 import { apiUrlToGatewayOrigin } from "../../internal/context.js";
 import {
-  fetchWithRetry,
-  parseJsonResponse,
-  extractApiError,
-} from "../../internal/http.js";
-import {
   saveDeviceState,
+  WORKER_ID_PATTERN,
   workerTokenPrefix,
 } from "../../internal/device-state.js";
+import {
+  extractApiError,
+  fetchWithRetry,
+  parseJsonResponse,
+} from "../../internal/http.js";
+
+const NEW_DEVICE_CHOICE = "__lobu_new_device__";
+/** Stands in for the personal org when `/oauth/userinfo` did not name it. */
+const PERSONAL_FALLBACK_CHOICE = "__lobu_personal__";
 
 /**
  * First-run interactive onboarding for `lobu daemon`.
  *
- * Everything here is a guided convenience over the existing server contract:
- *   - the device id is the `worker_id` the daemon passes on every poll; the
- *     server upserts on `(user_id, worker_id)`, so reusing a confirmed id keeps
- *     the device row stable instead of churning into a second device;
- *   - the org a device is pinned to is driven by the `WORKER_API_TOKEN` it auths
- *     with (org-scoped PAT → that org; personal/session → the personal org). The
- *     wizard does not mutate the org itself — it just surfaces the choice so the
- *     user mints the right token.
- *
- * Runs only when the CLI is interactive (a TTY) AND no explicit `--worker-id`
- * was given. Headless / scripted runs skip the wizard entirely.
+ * The server remains authoritative for both identity and workspace attachment:
+ * an existing device reports its stored workspace, while a new device attaches
+ * according to the durable worker PAT on its first poll. The local cache only
+ * keeps subsequent boots on the same `worker_id`.
  */
-
 export interface DeviceWizardOptions {
   context?: string;
+  /** Actual daemon gateway URL; the worker PAT is sent only here. */
+  apiUrl: string;
   /** Pre-computed default `<platform>:<hostname>` id. */
   suggestedWorkerId: string;
-  /** The token the daemon will boot with (WORKER_API_TOKEN), if any. */
-  workerApiToken?: string;
+  /** Durable worker PAT used by the daemon. */
+  workerApiToken: string;
   /** Overridable prompts (defaults to real inquirer); injectable for tests. */
   prompts?: DeviceWizardPrompts;
 }
@@ -52,10 +46,16 @@ interface RemoteDevice {
   organization_name: string | null;
 }
 
+interface OrganizationInfo {
+  slug: string;
+  name?: string;
+  personal?: boolean;
+}
+
 export interface DeviceWizardResult {
   workerId: string;
-  /** How the id was chosen: an existing server row or a fresh confirmation. */
-  source: "reused" | "created";
+  /** How the id was chosen, including a concurrent first boot winning first. */
+  source: "reused" | "created" | "cached";
 }
 
 async function fetchRemoteDevices(
@@ -67,52 +67,89 @@ async function fetchRemoteDevices(
   const res = await fetchWithRetry(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  const parsed = (await parseJsonResponse(res, url, (msg: string) => {
-    throw new Error(msg);
-  })) as { devices?: RemoteDevice[] } | undefined;
+  const parsed = (await parseJsonResponse(res, url, (message: string) => {
+    throw new Error(message);
+  })) as { devices?: unknown } | undefined;
   if (!res.ok) {
     const { message } = extractApiError(parsed, res.status, res.statusText);
     throw new Error(`Could not list devices: ${message}`);
   }
-  return parsed?.devices ?? [];
+  if (!Array.isArray(parsed?.devices)) {
+    throw new Error(
+      "Could not list devices: gateway returned an invalid response"
+    );
+  }
+  return parsed.devices.filter(isRemoteDevice);
 }
 
-/**
- * The four prompts the wizard drives. Defaults to the real inquirer prompts;
- * injectable so unit tests can drive every branch without a TTY.
- */
+async function fetchOrganizations(
+  apiUrl: string,
+  token: string
+): Promise<OrganizationInfo[]> {
+  const origin = apiUrlToGatewayOrigin(apiUrl);
+  const res = await fetchWithRetry(`${origin}/oauth/userinfo`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) return [];
+  const body = (await res.json().catch(() => null)) as {
+    personal_org_slug?: unknown;
+    organizations?: unknown;
+  } | null;
+  if (!body || !Array.isArray(body.organizations)) return [];
+  const personal =
+    typeof body.personal_org_slug === "string" ? body.personal_org_slug : null;
+  const organizations: OrganizationInfo[] = [];
+  for (const entry of body.organizations) {
+    if (!entry || typeof entry !== "object") continue;
+    const value = entry as Record<string, unknown>;
+    if (typeof value.slug !== "string" || !value.slug) continue;
+    organizations.push({
+      slug: value.slug,
+      ...(typeof value.name === "string" ? { name: value.name } : {}),
+      ...(value.personal === true || value.slug === personal
+        ? { personal: true }
+        : {}),
+    });
+  }
+  return organizations;
+}
+
+function isRemoteDevice(value: unknown): value is RemoteDevice {
+  if (!value || typeof value !== "object") return false;
+  const device = value as Record<string, unknown>;
+  return (
+    typeof device.id === "string" &&
+    device.id.length > 0 &&
+    typeof device.worker_id === "string" &&
+    device.worker_id.length > 0
+  );
+}
+
+/** The prompt primitives the wizard drives; injectable for deterministic tests. */
 export interface DeviceWizardPrompts {
   select: (config: Parameters<typeof select>[0]) => Promise<string>;
   confirm: (config: Parameters<typeof confirm>[0]) => Promise<boolean>;
   input: (config: Parameters<typeof input>[0]) => Promise<string>;
 }
 
-/** Run the wizard. Resolves orgs (for token guidance) and the caller's existing
- * devices, asks personal-vs-org + confirms the device id, and persists the
- * choice so later non-interactive boots reuse it.
- */
 export async function deviceWizard(
   options: DeviceWizardOptions
 ): Promise<DeviceWizardResult> {
   const prompts = options.prompts ?? { select, confirm, input };
-  const target = await resolveContext(options.context);
-  // The stored context token is ONLY ever sent to the resolved context's own
-  // origin — never to a caller-supplied --api-url, which an attacker could point
-  // at themselves to harvest the bearer (see resolveApiTarget's same guard).
-  const token = await getToken(target.name);
-
-  let orgs: Array<{ slug: string; name?: string; personal?: boolean }> = [];
-  let devices: RemoteDevice[] = [];
+  // The daemon URL and PAT are explicit inputs; a stale/missing context file
+  // must not block setup or redirect either credential. The context name is
+  // only a local cache namespace.
+  const contextName = options.context?.trim() || "gateway";
+  const [orgs, devices] = await Promise.all([
+    // Organization discovery is optional guidance. Device discovery is not:
+    // hiding its failure could create a duplicate identity.
+    fetchOrganizations(options.apiUrl, options.workerApiToken).catch(() => []),
+    fetchRemoteDevices(options.apiUrl, options.workerApiToken),
+  ]);
   const tokenPrefix = workerTokenPrefix(options.workerApiToken);
-
-  if (token) {
-    orgs = await listOrganizations({ context: target.name }).catch(
-      () => [] as Array<{ slug: string; name?: string; personal?: boolean }>
-    );
-    devices = await fetchRemoteDevices(target.url, token).catch(
-      () => [] as RemoteDevice[]
-    );
-  }
 
   const personal = orgs.find((org) => org.personal === true)?.slug;
   const orgOptions = orgs
@@ -136,46 +173,56 @@ export async function deviceWizard(
     )
   );
 
-  const orgTarget = await prompts.select({
-    message:
-      "Which workspace will this device run for? (the pin is set by the token you export)",
-    choices: [
-      { value: personal ?? "__personal__", name: personalLabel },
-      ...orgOptions.map((org) => ({ ...org, name: org.name ?? org.value })),
-    ],
-  });
-  const orgSlug =
-    orgTarget === "__personal__" ? (personal ?? undefined) : orgTarget;
+  // A `device_worker:run`-only PAT cannot read `/oauth/userinfo`, so org
+  // discovery legitimately comes back empty or single-valued. Prompting for a
+  // choice that has exactly one option asks the user to confirm a foregone
+  // conclusion, so only ask when there is something to pick between.
+  const personalChoice = {
+    value: personal ?? PERSONAL_FALLBACK_CHOICE,
+    name: personalLabel,
+  };
+  const orgTarget =
+    orgOptions.length > 0
+      ? await prompts.select({
+          message:
+            "Which workspace do you intend this device to run for? (guidance only; the worker PAT decides)",
+          choices: [personalChoice, ...orgOptions],
+        })
+      : personalChoice.value;
+  const selectedOrg =
+    orgTarget === PERSONAL_FALLBACK_CHOICE
+      ? (personal ?? "personal")
+      : orgTarget;
 
-  // Pick an identity: reuse an existing registered device when available (so a
-  // re-run doesn't duplicate a row), else confirm the computed default id.
-  const existing = devices.filter(
-    (device) => device.worker_id && device.worker_id.length > 0
-  );
   let workerId = options.suggestedWorkerId;
-  let source: "reused" | "created" = "reused";
+  let source: DeviceWizardResult["source"] = "created";
+  let selectedDevice: RemoteDevice | undefined;
 
-  if (existing.length > 0) {
+  if (devices.length > 0) {
     const choice = await prompts.select({
       message: "Pick a device identity (or start a new one)",
       choices: [
         {
-          value: "__new__",
+          value: NEW_DEVICE_CHOICE,
           name: chalk.dim("Start a new device with a fresh id"),
         },
-        ...existing.map((device) => ({
-          value: device.worker_id,
+        ...devices.map((device) => ({
+          value: device.id,
           name: `${device.label ?? device.worker_id}${device.organization_slug ? chalk.dim(` — ${device.organization_slug}`) : ""}`,
         })),
       ],
     });
-    if (choice !== "__new__") {
-      workerId = choice;
-    } else {
-      source = "created";
+    if (choice !== NEW_DEVICE_CHOICE) {
+      selectedDevice = devices.find((device) => device.id === choice);
+      if (!selectedDevice) {
+        throw new Error("Selected device is no longer available");
+      }
+      workerId = selectedDevice.worker_id;
+      source = "reused";
     }
-  } else {
-    source = "created";
+  }
+
+  if (source === "created") {
     const confirmed = await prompts.confirm({
       message: `Register this machine as device "${chalk.bold(options.suggestedWorkerId)}"?`,
       default: true,
@@ -185,7 +232,7 @@ export async function deviceWizard(
         message:
           "Enter a device id (letters, digits, dot, underscore, colon, hyphen):",
         validate: (value) =>
-          /^[A-Za-z0-9._:-]{1,128}$/.test(value.trim())
+          WORKER_ID_PATTERN.test(value.trim())
             ? true
             : "Use 1-128 characters of letters, digits, dot, underscore, colon or hyphen",
       });
@@ -193,40 +240,52 @@ export async function deviceWizard(
     }
   }
 
-  const contextName = target.name;
-  await saveDeviceState(contextName, {
-    workerId,
-  });
+  const saved = await saveDeviceState(contextName, { workerId });
+  if (saved.workerId !== workerId) {
+    workerId = saved.workerId;
+    source = "cached";
+    selectedDevice = undefined;
+  }
 
-  console.log(
-    chalk.green(`\n  Device "${workerId}" registered (local setup).`)
-  );
-  console.log(
-    chalk.dim(
-      `  ${source === "reused" ? "Reusing an existing device row; the daemon will upsert on the same id." : "New device; it registers on the first poll."}`
-    )
-  );
-  console.log(
-    chalk.dim(
-      `  Device workspace: ${orgSlug ? `"${orgSlug}"` : "personal"}. This is set by the WORKER_API_TOKEN it auths with on poll — the selection above is guidance for which token to use.`
-    )
-  );
-  if (tokenPrefix) {
+  console.log(chalk.green(`\n  Device identity "${workerId}" saved locally.`));
+  if (source === "reused") {
+    const actualOrg = selectedDevice?.organization_slug;
     console.log(
       chalk.dim(
-        `  Token: ${tokenPrefix}… (${orgSlug ? `org-scoped to ${orgSlug}` : "personal/session"})`
+        `  Reusing the existing device row; the server reports workspace ${actualOrg ? `"${actualOrg}"` : "unattached"}.`
+      )
+    );
+    console.log(
+      chalk.dim(
+        `  The selected workspace "${selectedOrg}" was guidance only and did not move the existing device.`
+      )
+    );
+  } else if (source === "cached") {
+    console.log(
+      chalk.dim(
+        "  Another concurrent first boot saved this identity first; both daemons will use the same cached id."
       )
     );
   } else {
     console.log(
-      chalk.yellow(
-        "  No WORKER_API_TOKEN set — export a durable owl_pat_ token before the daemon can poll."
+      chalk.dim(
+        "  New device; WORKER_API_TOKEN determines its workspace attachment on first poll."
+      )
+    );
+    console.log(
+      chalk.dim(
+        `  The selected workspace "${selectedOrg}" is token-selection guidance only.`
       )
     );
   }
   console.log(
     chalk.dim(
-      `  Saved to ~/.lobu/devices/${contextName}.json (local only; the server owns the pin).`
+      `  Token: ${tokenPrefix ?? "unknown"}… (the server verifies its scope and attachment on poll).`
+    )
+  );
+  console.log(
+    chalk.dim(
+      `  Saved under ~/.lobu/devices/ for context "${contextName}" (local only; the server owns the attachment).`
     )
   );
   console.log(

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,5 +1,9 @@
 import { startDaemonCommand } from "@lobu/connector-worker/daemon";
+import { hostname } from "node:os";
 import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
+import { loadDeviceState } from "../internal/device-state.js";
+import { getCurrentContextName, getToken } from "../internal/index.js";
+import { deviceWizard } from "./_lib/device-wizard.js";
 
 export interface DaemonOptions {
   apiUrl?: string;
@@ -11,6 +15,14 @@ export interface DaemonOptions {
   insideClaude?: boolean;
   interactiveSession?: boolean;
 }
+
+/** Shown when `lobu daemon` can't find anything to authorize against. */
+const SETUP_MESSAGE =
+  "Could not determine a gateway to poll. Configure one of:\n" +
+  "  - run `lobu login` to set up a context (then `lobu daemon` auto-uses it), or\n" +
+  "  - pass --api-url <origin> and a durable device token:\n" +
+  "      WORKER_API_TOKEN=$(lobu token create --raw --org <slug>) lobu daemon --api-url <origin>\n" +
+  "  A long-running daemon needs a durable owl_pat_ token, not the 24h login session.";
 
 /**
  * `lobu daemon` — run a device worker that polls the gateway for jobs
@@ -26,7 +38,14 @@ export interface DaemonOptions {
  *
  * Org binding is the token, not a flag: pass a durable `owl_pat_…` PAT in
  * `WORKER_API_TOKEN` (`lobu token create --raw`); the server anchors the worker
- * to that token's org.
+ * to that token's org (an org-scoped PAT → that org, personal/session → the
+ * personal org).
+ *
+ * On FIRST interactive boot, a short wizard lets you confirm the device id and
+ * see which token/org the device will be pinned with, then caches the choice at
+ * `~/.lobu/devices/<context>.json` so later runs bootstrap silently. Pass
+ * `--worker-id`, run non-interactively (no TTY), or delete the cache to bypass
+ * the wizard.
  */
 export async function daemonCommand(options: DaemonOptions): Promise<void> {
   let apiUrl = options.apiUrl?.trim();
@@ -40,16 +59,32 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     }
   }
   if (!apiUrl) {
-    throw new Error(
-      "--api-url is required (or run `lobu login` to configure a context)"
-    );
+    throw new Error(SETUP_MESSAGE);
   }
+
+  // A device daemon polls for weeks, so it needs a durable credential: either a
+  // `WORKER_API_TOKEN` (owl_pat_) or a logged-in session it can fall back to.
+  // A brand-new install defaults to a placeholder `local` context with no stored
+  // credential, so `resolveContext()` succeeds and the user would otherwise hit
+  // the cryptic fail-closed token guard. Surface the setup options up front.
+  const contextName = (await getCurrentContextName()).trim() || undefined;
+  const hasDurableToken = Boolean(process.env.WORKER_API_TOKEN?.trim());
+  const hasSession = Boolean(await getToken(contextName));
+  if (!hasDurableToken && !hasSession) {
+    throw new Error(SETUP_MESSAGE);
+  }
+
+  const platform =
+    options.platform?.trim() ||
+    (process.platform === "darwin" ? "macos" : "headless");
+
+  const workerId = await resolveWorkerId(options, platform, apiUrl);
 
   await startDaemonCommand({
     apiUrl,
     platform: options.platform?.trim() || undefined,
     defaultPlatform: process.platform === "darwin" ? "macos" : "headless",
-    workerId: options.workerId?.trim() || undefined,
+    workerId,
     label: options.label?.trim() || undefined,
     capabilities: (options.capabilities ?? "os.shell,os.files")
       .split(",")
@@ -62,4 +97,44 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
       : {}),
     ...(options.insideClaude === true ? { insideClaude: true } : {}),
   });
+}
+
+/**
+ * Resolve the `worker_id` for this run, in priority order:
+ *   1. an explicit `--worker-id` flag (never overridden);
+ *   2. interactive first-run → the onboarding wizard (confirms identity, caches);
+ *   3. a previously cached device id (so a configured daemon stays consistent);
+ *   4. the computed `<platform>:<hostname>` default.
+ *
+ * The wizard only runs on a TTY and only when the explicit id is absent, so
+ * headless/scripted boots never prompt.
+ */
+async function resolveWorkerId(
+  options: DaemonOptions,
+  platform: string,
+  apiUrl: string
+): Promise<string> {
+  const explicit = options.workerId?.trim();
+  if (explicit) return explicit;
+
+  const shortHost = hostname().split(".")[0] || hostname();
+  const suggested = `${platform}:${shortHost}`;
+
+  const contextName = (await getCurrentContextName()).trim() || undefined;
+  const interactive = process.stdin.isTTY === true;
+
+  if (interactive) {
+    const result = await deviceWizard({
+      context: contextName,
+      apiUrl,
+      suggestedWorkerId: suggested,
+      workerApiToken: process.env.WORKER_API_TOKEN,
+    });
+    return result.workerId;
+  }
+
+  const cached = contextName ? await loadDeviceState(contextName) : null;
+  if (cached?.workerId) return cached.workerId;
+
+  return suggested;
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -78,7 +78,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     options.platform?.trim() ||
     (process.platform === "darwin" ? "macos" : "headless");
 
-  const workerId = await resolveWorkerId(options, platform, apiUrl);
+  const workerId = await resolveWorkerId(options, platform);
 
   await startDaemonCommand({
     apiUrl,
@@ -102,17 +102,17 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
 /**
  * Resolve the `worker_id` for this run, in priority order:
  *   1. an explicit `--worker-id` flag (never overridden);
- *   2. interactive first-run → the onboarding wizard (confirms identity, caches);
- *   3. a previously cached device id (so a configured daemon stays consistent);
+ *   2. a previously cached device id (so every later boot — interactive or not —
+ *      stays consistent and never re-prompts);
+ *   3. interactive first-run → the onboarding wizard (confirms identity, caches);
  *   4. the computed `<platform>:<hostname>` default.
  *
- * The wizard only runs on a TTY and only when the explicit id is absent, so
- * headless/scripted boots never prompt.
+ * The wizard only runs on a TTY, only when the id is absent, and only when there
+ * is no cached device yet — so a fully-configured daemon never prompts.
  */
 async function resolveWorkerId(
   options: DaemonOptions,
-  platform: string,
-  apiUrl: string
+  platform: string
 ): Promise<string> {
   const explicit = options.workerId?.trim();
   if (explicit) return explicit;
@@ -121,20 +121,17 @@ async function resolveWorkerId(
   const suggested = `${platform}:${shortHost}`;
 
   const contextName = (await getCurrentContextName()).trim() || undefined;
-  const interactive = process.stdin.isTTY === true;
+  const cached = contextName ? await loadDeviceState(contextName) : null;
+  if (cached?.workerId) return cached.workerId;
 
-  if (interactive) {
+  if (process.stdin.isTTY === true) {
     const result = await deviceWizard({
       context: contextName,
-      apiUrl,
       suggestedWorkerId: suggested,
       workerApiToken: process.env.WORKER_API_TOKEN,
     });
     return result.workerId;
   }
-
-  const cached = contextName ? await loadDeviceState(contextName) : null;
-  if (cached?.workerId) return cached.workerId;
 
   return suggested;
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,8 +1,11 @@
-import { startDaemonCommand } from "@lobu/connector-worker/daemon";
+import {
+  resolveDaemonLaunchContext,
+  startDaemonCommand,
+} from "@lobu/connector-worker/daemon";
 import { hostname } from "node:os";
 import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
 import { loadDeviceState } from "../internal/device-state.js";
-import { getCurrentContextName, getToken } from "../internal/index.js";
+import { getCurrentContextName } from "../internal/index.js";
 import { deviceWizard } from "./_lib/device-wizard.js";
 
 export interface DaemonOptions {
@@ -19,10 +22,14 @@ export interface DaemonOptions {
 /** Shown when `lobu daemon` can't find anything to authorize against. */
 const SETUP_MESSAGE =
   "Could not determine a gateway to poll. Configure one of:\n" +
-  "  - run `lobu login` to set up a context (then `lobu daemon` auto-uses it), or\n" +
-  "  - pass --api-url <origin> and a durable device token:\n" +
-  "      WORKER_API_TOKEN=$(lobu token create --raw --org <slug>) lobu daemon --api-url <origin>\n" +
-  "  A long-running daemon needs a durable owl_pat_ token, not the 24h login session.";
+  "  - run `lobu login` to configure a context, or\n" +
+  "  - pass --api-url <origin>.";
+
+const TOKEN_SETUP_MESSAGE =
+  "A device daemon requires a durable owl_pat_ token in WORKER_API_TOKEN; " +
+  "a stored OAuth login expires and is never used as daemon authentication.\n" +
+  "Mint a device PAT with the required worker scope, then start the daemon:\n" +
+  '  WORKER_API_TOKEN=$(lobu token create --raw --org <slug> --scope "device_worker:run profile:read") lobu daemon';
 
 /**
  * `lobu daemon` — run a device worker that polls the gateway for jobs
@@ -42,10 +49,10 @@ const SETUP_MESSAGE =
  * personal org).
  *
  * On FIRST interactive boot, a short wizard lets you confirm the device id and
- * see which token/org the device will be pinned with, then caches the choice at
+ * see the server's current attachment, then caches the choice at
  * `~/.lobu/devices/<context>.json` so later runs bootstrap silently. Pass
- * `--worker-id`, run non-interactively (no TTY), or delete the cache to bypass
- * the wizard.
+ * `--worker-id`, run non-interactively/under CI, inherit a supported agent
+ * session, or delete the cache to bypass the wizard.
  */
 export async function daemonCommand(options: DaemonOptions): Promise<void> {
   let apiUrl = options.apiUrl?.trim();
@@ -62,35 +69,56 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     throw new Error(SETUP_MESSAGE);
   }
 
-  // A device daemon polls for weeks, so it needs a durable credential: either a
-  // `WORKER_API_TOKEN` (owl_pat_) or a logged-in session it can fall back to.
-  // A brand-new install defaults to a placeholder `local` context with no stored
-  // credential, so `resolveContext()` succeeds and the user would otherwise hit
-  // the cryptic fail-closed token guard. Surface the setup options up front.
-  const contextName = (await getCurrentContextName()).trim() || undefined;
-  const hasDurableToken = Boolean(process.env.WORKER_API_TOKEN?.trim());
-  const hasSession = Boolean(await getToken(contextName));
-  if (!hasDurableToken && !hasSession) {
-    throw new Error(SETUP_MESSAGE);
+  // Stored login credentials are short-lived admin/session auth. A daemon polls
+  // for weeks and snapshots its bearer at boot, so only the explicitly exported
+  // worker PAT is accepted here (the shared daemon bootstrap validates again).
+  const workerApiToken = process.env.WORKER_API_TOKEN?.trim();
+  if (!workerApiToken?.startsWith("owl_pat_")) {
+    throw new Error(TOKEN_SETUP_MESSAGE);
   }
 
-  const platform =
-    options.platform?.trim() ||
-    (process.platform === "darwin" ? "macos" : "headless");
-
-  const workerId = await resolveWorkerId(options, platform);
+  const platform = options.platform?.trim() || undefined;
+  const defaultPlatform = process.platform === "darwin" ? "macos" : "headless";
+  const launchContext = resolveDaemonLaunchContext({
+    platform,
+    defaultPlatform,
+    ...(options.interactiveSession === false
+      ? { interactiveSession: false as const }
+      : {}),
+    ...(options.insideClaude === true ? { insideClaude: true } : {}),
+  });
+  const explicitWorkerId = options.workerId?.trim() || undefined;
+  // An inherited agent session (or the legacy --inside-claude flag) registers a
+  // per-session headless device, and the shared daemon bootstrap derives that
+  // id itself. Handing it a cached or wizard-chosen id here would override that
+  // routing, so this lane contributes neither an id nor a host platform. The
+  // legacy flag holds the lane even when its startup metadata is momentarily
+  // absent, since detection re-runs on the next boot.
+  const sessionLane =
+    launchContext.interactiveSession !== undefined ||
+    options.insideClaude === true;
+  const workerId =
+    explicitWorkerId ??
+    (sessionLane
+      ? undefined
+      : await resolveWorkerId(
+          launchContext.platform ?? defaultPlatform,
+          apiUrl,
+          workerApiToken
+        ));
+  const daemonPlatform = sessionLane ? "headless" : platform;
 
   await startDaemonCommand({
     apiUrl,
-    platform: options.platform?.trim() || undefined,
-    defaultPlatform: process.platform === "darwin" ? "macos" : "headless",
+    platform: daemonPlatform,
+    defaultPlatform,
     workerId,
     label: options.label?.trim() || undefined,
     capabilities: (options.capabilities ?? "os.shell,os.files")
       .split(",")
       .map((entry) => entry.trim())
       .filter(Boolean),
-    workerApiToken: process.env.WORKER_API_TOKEN,
+    workerApiToken,
     debug: options.debug === true,
     ...(options.interactiveSession === false
       ? { interactiveSession: false as const }
@@ -100,23 +128,18 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
 }
 
 /**
- * Resolve the `worker_id` for this run, in priority order:
- *   1. an explicit `--worker-id` flag (never overridden);
- *   2. a previously cached device id (so every later boot — interactive or not —
- *      stays consistent and never re-prompts);
- *   3. interactive first-run → the onboarding wizard (confirms identity, caches);
- *   4. the computed `<platform>:<hostname>` default.
+ * Resolve an ordinary host device's `worker_id` after explicit and inherited
+ * session identities have already been handled by the caller: cached identity,
+ * then the TTY-only first-run wizard, then `<platform>:<hostname>`.
  *
  * The wizard only runs on a TTY, only when the id is absent, and only when there
  * is no cached device yet — so a fully-configured daemon never prompts.
  */
 async function resolveWorkerId(
-  options: DaemonOptions,
-  platform: string
+  platform: string,
+  apiUrl: string,
+  workerApiToken: string
 ): Promise<string> {
-  const explicit = options.workerId?.trim();
-  if (explicit) return explicit;
-
   const shortHost = hostname().split(".")[0] || hostname();
   const suggested = `${platform}:${shortHost}`;
 
@@ -124,14 +147,24 @@ async function resolveWorkerId(
   const cached = contextName ? await loadDeviceState(contextName) : null;
   if (cached?.workerId) return cached.workerId;
 
-  if (process.stdin.isTTY === true) {
+  if (canPrompt()) {
     const result = await deviceWizard({
       context: contextName,
+      apiUrl,
       suggestedWorkerId: suggested,
-      workerApiToken: process.env.WORKER_API_TOKEN,
+      workerApiToken,
     });
     return result.workerId;
   }
 
   return suggested;
+}
+
+function canPrompt(): boolean {
+  const ci = process.env.CI?.trim().toLowerCase();
+  return (
+    process.stdin.isTTY === true &&
+    process.stdout.isTTY === true &&
+    (!ci || ci === "0" || ci === "false")
+  );
 }

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -1,6 +1,25 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+/**
+ * Device identity charset accepted for `worker_id`. Mirrors the daemon's own
+ * boot-time guard in `@lobu/connector-worker` so the CLI rejects an id the
+ * daemon would reject anyway, before it reaches the cache or the gateway.
+ */
+export const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+const STALE_LOCK_MS = 30_000;
 
 /**
  * Per-context device state cache, persisted under `~/.lobu/devices/`.
@@ -9,26 +28,29 @@ import { join } from "node:path";
  * row (`device_workers.organization_id`) and its identity (`(user_id,
  * worker_id)`). Its only job is to make a repeated `lobu daemon` on the same
  * machine reuse the same confirmed worker id, so a restart does not silently
- * churn into a second device. Only `workerId` is stored — nothing else is read
- * back on load.
+ * churn into a second device. Only `workerId` is stored.
  */
 export interface DeviceState {
   /** The confirmed `worker_id` passed to the daemon on every run. */
   workerId: string;
 }
 
-function statePath(context: string): string {
-  const safe = context.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join(homedir(), ".lobu", "devices", `${safe}.json`);
+function devicesDir(): string {
+  return join(homedir(), ".lobu", "devices");
 }
 
-export async function loadDeviceState(
-  context: string
-): Promise<DeviceState | null> {
+function statePath(context: string): string {
+  const safe = context.replace(/[^A-Za-z0-9._-]/g, "_");
+  return join(devicesDir(), `${safe}.json`);
+}
+
+function parseDeviceState(raw: string): DeviceState | null {
   try {
-    const raw = await readFile(statePath(context), "utf-8");
     const parsed = JSON.parse(raw) as Partial<DeviceState>;
-    if (typeof parsed.workerId !== "string" || parsed.workerId.length === 0) {
+    if (
+      typeof parsed.workerId !== "string" ||
+      !WORKER_ID_PATTERN.test(parsed.workerId)
+    ) {
       return null;
     }
     return { workerId: parsed.workerId };
@@ -37,16 +59,121 @@ export async function loadDeviceState(
   }
 }
 
+export async function loadDeviceState(
+  context: string
+): Promise<DeviceState | null> {
+  try {
+    return parseDeviceState(await readFile(statePath(context), "utf-8"));
+  } catch {
+    // Absent, unreadable, or unparseable all mean the same thing to the caller:
+    // there is no confirmed identity yet, so fall through to setup.
+    return null;
+  }
+}
+
+/**
+ * Atomically persist the first valid identity for a context.
+ *
+ * Concurrent first boots serialize through an owner-only lock and all return
+ * the same winner. A corrupt prior payload is moved aside for diagnosis before
+ * the replacement is renamed into place; no reader can observe a partial JSON
+ * write.
+ */
 export async function saveDeviceState(
   context: string,
   state: DeviceState
 ): Promise<DeviceState> {
-  await mkdir(join(homedir(), ".lobu", "devices"), { recursive: true });
-  await writeFile(statePath(context), `${JSON.stringify(state, null, 2)}\n`);
-  return state;
+  if (!WORKER_ID_PATTERN.test(state.workerId)) {
+    throw new Error(`invalid device worker id '${state.workerId}'`);
+  }
+
+  const dir = devicesDir();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await chmod(dir, 0o700);
+
+  const path = statePath(context);
+  const existing = await loadDeviceState(context);
+  if (existing) return existing;
+
+  const lockPath = `${path}.lock`;
+  const lock = await acquireLock(lockPath);
+  let tempPath: string | undefined;
+  try {
+    const winner = await loadDeviceState(context);
+    if (winner) return winner;
+
+    try {
+      await stat(path);
+      await rename(path, `${path}.corrupt-${randomUUID()}`);
+    } catch (error) {
+      if (!isErrno(error, "ENOENT")) throw error;
+    }
+
+    tempPath = `${path}.${randomUUID()}.tmp`;
+    const temp = await open(tempPath, "wx", 0o600);
+    try {
+      await temp.writeFile(`${JSON.stringify(state, null, 2)}\n`, "utf-8");
+      await temp.sync();
+    } finally {
+      await temp.close();
+    }
+    await rename(tempPath, path);
+    tempPath = undefined;
+    await chmod(path, 0o600);
+    return state;
+  } finally {
+    if (tempPath) await unlink(tempPath).catch(() => undefined);
+    await lock.close().catch(() => undefined);
+    await unlink(lockPath).catch(() => undefined);
+  }
 }
 
+async function acquireLock(
+  lockPath: string
+): Promise<Awaited<ReturnType<typeof open>>> {
+  const started = Date.now();
+  while (true) {
+    try {
+      return await open(lockPath, "wx", 0o600);
+    } catch (error) {
+      if (!isErrno(error, "EEXIST")) throw error;
+      const lockStat = await stat(lockPath).catch(() => null);
+      if (lockStat && Date.now() - lockStat.mtimeMs > STALE_LOCK_MS) {
+        await unlink(lockPath).catch(() => undefined);
+        continue;
+      }
+      if (Date.now() - started >= LOCK_TIMEOUT_MS) {
+        throw new Error(
+          `Timed out waiting for concurrent device setup (${lockPath})`
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+    }
+  }
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+/** Longest stem shown for a worker PAT: `owl_pat_` plus four secret chars. */
+const TOKEN_PREFIX_LENGTH = 12;
+
+/**
+ * A short stem of a worker PAT, so the user can confirm *which* token a device
+ * booted with without the terminal echoing the secret.
+ *
+ * Never returns the token whole. A real PAT is `owl_pat_` + 24 random chars, so
+ * the stem always drops most of it; a value too short to truncate is malformed
+ * rather than a usable credential, and is reported as such instead of printed.
+ */
 export function workerTokenPrefix(token: string | undefined): string | null {
   if (!token) return null;
-  return token.length > 12 ? token.slice(0, 12) : token;
+  if (token.length <= TOKEN_PREFIX_LENGTH) return null;
+  return token.slice(0, TOKEN_PREFIX_LENGTH);
 }

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -1,0 +1,67 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Per-context device state cache, persisted under `~/.lobu/devices/`.
+ *
+ * This is a LOCAL cache, never the source of truth: the server owns the device
+ * row (`device_workers.organization_id`) and its identity (`(user_id,
+ * worker_id)`). Its only job is to make a repeated `lobu daemon` on the same
+ * machine reuse the same confirmed worker id (and remember the token/org it was
+ * pinned with), so a restart does not silently churn into a second device.
+ */
+export interface DeviceState {
+  /** The confirmed `worker_id` passed to the daemon on every run. */
+  workerId: string;
+  /** The token prefix that the org/anchor was pinned with (privacy-safe). */
+  workerTokenPrefix: string | null;
+  /** ISO timestamp the state was written. */
+  registeredAt: string;
+}
+
+function statePath(context: string): string {
+  const safe = context.replace(/[^A-Za-z0-9._-]/g, "_");
+  return join(homedir(), ".lobu", "devices", `${safe}.json`);
+}
+
+export async function loadDeviceState(
+  context: string
+): Promise<DeviceState | null> {
+  try {
+    const raw = await readFile(statePath(context), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<DeviceState>;
+    if (typeof parsed.workerId !== "string" || parsed.workerId.length === 0) {
+      return null;
+    }
+    return {
+      workerId: parsed.workerId,
+      workerTokenPrefix:
+        typeof parsed.workerTokenPrefix === "string"
+          ? parsed.workerTokenPrefix
+          : null,
+      registeredAt:
+        typeof parsed.registeredAt === "string" ? parsed.registeredAt : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveDeviceState(
+  context: string,
+  state: Omit<DeviceState, "registeredAt">
+): Promise<DeviceState> {
+  await mkdir(join(homedir(), ".lobu", "devices"), { recursive: true });
+  const full: DeviceState = {
+    ...state,
+    registeredAt: new Date().toISOString(),
+  };
+  await writeFile(statePath(context), `${JSON.stringify(full, null, 2)}\n`);
+  return full;
+}
+
+export function workerTokenPrefix(token: string | undefined): string | null {
+  if (!token) return null;
+  return token.length > 12 ? token.slice(0, 12) : token;
+}

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -8,16 +8,13 @@ import { join } from "node:path";
  * This is a LOCAL cache, never the source of truth: the server owns the device
  * row (`device_workers.organization_id`) and its identity (`(user_id,
  * worker_id)`). Its only job is to make a repeated `lobu daemon` on the same
- * machine reuse the same confirmed worker id (and remember the token/org it was
- * pinned with), so a restart does not silently churn into a second device.
+ * machine reuse the same confirmed worker id, so a restart does not silently
+ * churn into a second device. Only `workerId` is stored — nothing else is read
+ * back on load.
  */
 export interface DeviceState {
   /** The confirmed `worker_id` passed to the daemon on every run. */
   workerId: string;
-  /** The token prefix that the org/anchor was pinned with (privacy-safe). */
-  workerTokenPrefix: string | null;
-  /** ISO timestamp the state was written. */
-  registeredAt: string;
 }
 
 function statePath(context: string): string {
@@ -34,15 +31,7 @@ export async function loadDeviceState(
     if (typeof parsed.workerId !== "string" || parsed.workerId.length === 0) {
       return null;
     }
-    return {
-      workerId: parsed.workerId,
-      workerTokenPrefix:
-        typeof parsed.workerTokenPrefix === "string"
-          ? parsed.workerTokenPrefix
-          : null,
-      registeredAt:
-        typeof parsed.registeredAt === "string" ? parsed.registeredAt : "",
-    };
+    return { workerId: parsed.workerId };
   } catch {
     return null;
   }
@@ -50,15 +39,11 @@ export async function loadDeviceState(
 
 export async function saveDeviceState(
   context: string,
-  state: Omit<DeviceState, "registeredAt">
+  state: DeviceState
 ): Promise<DeviceState> {
   await mkdir(join(homedir(), ".lobu", "devices"), { recursive: true });
-  const full: DeviceState = {
-    ...state,
-    registeredAt: new Date().toISOString(),
-  };
-  await writeFile(statePath(context), `${JSON.stringify(full, null, 2)}\n`);
-  return full;
+  await writeFile(statePath(context), `${JSON.stringify(state, null, 2)}\n`);
+  return state;
 }
 
 export function workerTokenPrefix(token: string | undefined): string | null {

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -16,5 +16,9 @@ export type { ExecutorConfig } from './executor.js';
 export { executeRun } from './executor.js';
 export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
-export { startDaemonCommand, type DaemonStartOptions } from './start.js';
+export {
+  resolveDaemonLaunchContext,
+  startDaemonCommand,
+  type DaemonStartOptions,
+} from './start.js';
 export { executeClaimedAutomationRun, UnexecutableRunError } from './execute-run.js';


### PR DESCRIPTION
## Summary
- `lobu daemon` now runs an interactive first-run wizard: pick a workspace (defaults to personal), confirm the device id (or reuse an existing registered device via `GET /api/me/devices`), then cache the choice at `~/.lobu/devices/<context>.json` so later boots are silent and consistent.
- The server stays authoritative for the org anchor (`device_workers.organization_id` is driven by the token); the local cache only stabilizes `worker_id` identity so a restart doesn't churn into a second device row.
- Fail with clear setup guidance when neither a durable `WORKER_API_TOKEN` nor a stored login exists (a fresh install previously masked this behind the placeholder default `local` context and hit the cryptic fail-closed PAT guard).
- Owletto UI: map the `headless` platform to `CLI` in the Devices UI; drop the phantom `node` platform (it was never a real device platform).

## Test plan
- [x] CLI: `bun test` in `packages/cli` — 663 pass, 0 fail
- [x] `make pre-pr` clean (build, typecheck, knip, biome, naming)
- [x] Live-tested built binary: interactive wizard (PTY), non-interactive reuse of cached id, and the not-logged-in setup message
- [x] Owletto: device + smoke tests (74) pass, `tsc -b` + biome clean
- [ ] GitHub CI full graph (pending)

## Notes
Owletto content change lives in lobu-ai/owletto#913. This PR bumps the submodule pointer to that commit.