### PR TITLE
test: make deployment pause index proof deterministic

### DIFF
--- a/packages/server/src/utils/__tests__/deployment-pause.test.ts
+++ b/packages/server/src/utils/__tests__/deployment-pause.test.ts
@@ -351,17 +351,20 @@ describe('promotions pause — the funnel decision', () => {
     const { getDb } = await import('../../db/client.js');
     const sql = getDb();
     const [catalog] = await sql`
-      SELECT i.indpred IS NULL AS non_partial
+      SELECT
+        i.indpred IS NULL AS non_partial,
+        pg_get_indexdef(i.indexrelid) AS definition
       FROM pg_index i
       JOIN pg_class c ON c.oid = i.indexrelid
       JOIN pg_namespace n ON n.oid = c.relnamespace
       WHERE n.nspname = 'public' AND c.relname = 'idx_events_org_origin'
     `;
     expect(catalog?.non_partial).toBe(true);
+    expect(catalog?.definition).toContain('(organization_id, origin_id)');
 
-    const plans = await sql.begin(async (tx) => {
+    const production = await sql.begin(async (tx) => {
       await tx`SET LOCAL enable_seqscan = off`;
-      const production = await tx`
+      return tx`
         EXPLAIN (FORMAT JSON)
         SELECT 1
         FROM events
@@ -375,18 +378,8 @@ describe('promotions pause — the funnel decision', () => {
           AND jsonb_typeof(payload_data->'manifest'->'state') = 'object'
         LIMIT 1
       `;
-      const orgOrigin = await tx`
-        EXPLAIN (FORMAT JSON)
-        SELECT 1
-        FROM events
-        WHERE organization_id = ${ORG}
-          AND origin_id = ${`deployment_${ROLLED_BACK}`}
-        LIMIT 1
-      `;
-      return { production, orgOrigin };
     });
-    expect(JSON.stringify(plans.production)).toContain('Index Scan');
-    expect(JSON.stringify(plans.production)).not.toContain('Seq Scan');
-    expect(JSON.stringify(plans.orgOrigin)).toContain('idx_events_org_origin');
+    expect(JSON.stringify(production)).toContain('Index Scan');
+    expect(JSON.stringify(production)).not.toContain('Seq Scan');
   });
 });


### PR DESCRIPTION
## Summary\n- make the deployment-pause index proof independent of PostgreSQL choosing one specific valid index on a tiny test table\n- deterministically verify idx_events_org_origin is non-partial and covers organization_id plus origin_id\n- retain the real production-query EXPLAIN assertions that require an index scan and reject a sequential scan\n\n## Why\nThe prior assertion failed in separate CI runs when PostgreSQL chose idx_events_organization_id and applied origin_id as a filter. That plan was still index-backed, so the exact index-name assertion was planner-sensitive.\n\n## Validation\n- make review-fix BASE=origin/main\n- make pre-pr\n- deployment-pause.test.ts passed three consecutive DB-backed runs: 19/19 each\n- server tsc --noEmit