### PR TITLE
fix(ci): give the prod rollout gate headroom over observed deploy latency

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -55,7 +55,10 @@ jobs:
     # still covers plain health.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    # Must exceed ROLLOUT_WAIT (1200s) plus the full-history checkout the
+    # is-ancestor test needs and the remaining checks, or the job is killed
+    # mid-wait and reports nothing rather than a verdict.
+    timeout-minutes: 30
     steps:
       # Full history: the rollout gate runs `git merge-base --is-ancestor`
       # against the SHA prod reports, which a shallow clone cannot resolve.
@@ -75,15 +78,31 @@ jobs:
                 || (github.event_name == 'workflow_run'
                     && github.event.workflow_run.head_sha)
                 || '' }}
-          # Flux polls the registry then rolls the deployment; ~10min covers a
-          # normal rollout without turning a genuinely stuck deploy into a
-          # 25-minute job. Any run that expects a SHA gets that wait, including a
-          # manual spot-check dispatched right after a merge; a manual run with
-          # no expect_sha has nothing to wait for.
+          # Flux polls the registry then rolls the deployment. Every Flux
+          # interval on the path is 1m (ImageRepository, ImagePolicy,
+          # ImageUpdateAutomation, GitRepository, Kustomization), so a healthy
+          # rollout lands 2-3min after build-app pushes — measured on 6120c04b,
+          # which went live ~2.5min after its push.
+          #
+          # 600s had no headroom over that, and on 2026-08-21 it expired twice
+          # inside one hour (795935f5 at 01:00:11, 2cbb2492 at 01:03:37) while
+          # prod still reported 97808ba7. Both SHAs did deploy shortly after,
+          # so the gate alarmed on a rollout that was merely slower than
+          # typical, on the Slack channel that a genuinely stuck deploy also
+          # pages. 1200s keeps the alarm meaningful while still bounding a
+          # wedged deploy, and stays under timeout-minutes.
+          #
+          # NOTE: why a 1m-interval path took >10min twice is NOT explained by
+          # this change; it only stops the detector firing inside the normal
+          # spread. See the issue linked in the PR.
+          #
+          # Any run that expects a SHA gets that wait, including a manual
+          # spot-check dispatched right after a merge; a manual run with no
+          # expect_sha has nothing to wait for.
           ROLLOUT_WAIT: >-
             ${{ inputs.rollout_wait
                 || ((github.event_name == 'workflow_run' || inputs.expect_sha)
-                    && '600')
+                    && '1200')
                 || '0' }}
         run: |
           chmod +x scripts/prod-smoke.sh

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -40,7 +40,7 @@ on:
         description: Require this commit to be live (ancestor test)
         required: false
       rollout_wait:
-        description: Seconds to wait for expect_sha to appear (default 600 when expect_sha is set)
+        description: Seconds to wait for expect_sha to appear (default 1200 when expect_sha is set)
         required: false
 
 permissions:


### PR DESCRIPTION
## Problem

`prod-smoke`'s rollout gate waited 600s for the expected SHA to appear in prod's reported revision. It expired twice inside one hour on 2026-08-21:

```
FAIL — 795935f5f86e is NOT in the deployed revision 97808ba7aba7 after 600s
FAIL — 2cbb2492ece5 is NOT in the deployed revision 97808ba7aba7 after 600s
```

7 of 8 checks passed in both runs; the rollout wait was the only failure. Both SHAs did deploy shortly afterwards, so the gate alarmed on a rollout that was slower than typical rather than broken.

That matters because the failure step posts to the same Slack devops channel as `build-images`' `notify-failure` and the Flux notification-controller. A detector that cries wolf on the normal spread makes a real stuck deploy harder to see, and `prod-smoke` is explicitly documented as a detector, not a release gate.

## Measured baseline

A healthy rollout lands 2-3 min after `build-app` pushes — `6120c04b`'s build completed 01:20:12 and its pods restarted ~01:20:33. Every Flux interval on the path is `1m` (ImageRepository, ImagePolicy, ImageUpdateAutomation, GitRepository, Kustomization). So 600s was ~4x the norm with no headroom, and 1200s restores margin without letting a wedged deploy sit unreported.

`timeout-minutes` goes 25 → 30 because a 1200s wait plus the `fetch-depth: 0` checkout the `git merge-base --is-ancestor` test requires would otherwise risk the job being killed mid-wait, which reports nothing at all instead of a verdict.

## What this does NOT fix

Why a path with 1m intervals took >10 min twice is **not explained** by this change, and I did not want a threshold bump to bury it — filed as #3018. The leading candidate is tag ordering in the `ImagePolicy` selector: tags are `YYYYMMDD-HHMMSS-NNNNNN` stamped by `generate-tag` at job *start*, not at push, and for the `7e893d59` build those were 11 min apart (`generate-tag` 00:51:53, `build-app` done 01:02:32). If overlapping builds finish out of stamp order, a just-pushed image may not be selected as latest until a later build supersedes it — in which case some commits never become the deployed revision and no budget fixes the gate.

## Test plan

Workflow-only change; there is no test suite covering `prod-smoke.yml`.

- `actionlint .github/workflows/prod-smoke.yml` → clean
- YAML round-trips through a parser; `jobs.smoke.timeout-minutes` resolves to `30`
- `ROLLOUT_WAIT` expression re-read after edit, `inputs.rollout_wait` override precedence unchanged, and the no-`expect_sha` path still resolves `'0'` so the scheduled canary keeps skipping the gate

The real verification is the next post-merge `workflow_run`, which I'll check rather than assume.