### PR TITLE
fix(test): reap embedded-Postgres clusters orphaned by a killed run

### DIFF
--- a/packages/server/src/__tests__/setup/reap-stale-clusters.ts
+++ b/packages/server/src/__tests__/setup/reap-stale-clusters.ts
@@ -1,36 +1,40 @@
 /**
- * Pure, side-effect-free reaper for orphaned embedded-Postgres test clusters.
+ * Dependency-light reaper for orphaned embedded-Postgres test clusters.
  *
  * Killed test runs (SIGKILL / timeout / OOM / ENOSPC / `pkill`) skip teardown
  * and leak their `lobu-test-pg-*` data dir (~150-400 MB) to tmp; a session of
  * them once filled 65 GB. `startEmbeddedBackend()` calls this before creating
- * its own cluster, so a kill can never accumulate.
+ * its first cluster in each test process, so old leaks are reclaimed by a later
+ * run.
  *
- * Deliberately imports ONLY node:fs/path — no `embedded-postgres` — so the
- * no-database unit suite can import and test it without pulling the native
- * embedded-Postgres package (the reason this lives in its own module).
+ * Deliberately imports ONLY node:fs/path/child_process — no `embedded-postgres`
+ * — so the no-database unit suite can import and test it without pulling the
+ * native embedded-Postgres package (the reason this lives in its own module).
  */
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** 1h — far longer than any integration run, so an *idle* hit is orphaned. */
+/**
+ * Grace period before an unowned cluster is eligible for removal. 1h is far
+ * longer than any integration run, so a cluster idle for that long is orphaned.
+ */
 export const STALE_CLUSTER_MS = 60 * 60 * 1000;
 
-/**
- * True if `dir` holds a running Postgres: a `postmaster.pid` whose PID is a live
- * process. embedded-postgres writes this on start and removes it on clean stop,
- * so it's the authoritative "is this cluster in use" marker — never reap a dir
- * with a live owner, regardless of age (a long watch/CI run can exceed 1h).
- */
-export function clusterIsLive(dir: string): boolean {
+/** Postmaster PID recorded in `dir`, or null when there is no usable pid file. */
+function postmasterPid(dir: string): number | null {
   let pid: number;
   try {
-    pid = Number.parseInt(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n', 1)[0], 10);
+    pid = Number(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n', 1)[0]);
   } catch {
-    return false; // no pid file → cleanly stopped or never started
+    return null; // no pid file → cleanly stopped or never started
   }
-  if (!Number.isInteger(pid) || pid <= 0) return false;
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+/** True if `pid` is a live process, treating EPERM (not ours) as live. */
+function pidIsLive(pid: number): boolean {
   try {
     process.kill(pid, 0); // signal 0 = liveness probe; throws if the PID is gone
     return true;
@@ -42,10 +46,130 @@ export function clusterIsLive(dir: string): boolean {
 }
 
 /**
- * Remove `lobu-test-pg-*` dirs under `dir` that are both older than `staleMs`
- * (relative to `now`) AND have no live Postgres owner. The liveness gate means a
- * still-running cluster is never deleted even if it has outlived the staleness
- * window. Returns how many were removed.
+ * True when a live postmaster has no owner left to stop it.
+ *
+ * embedded-postgres starts the server with `spawn(postgres, ...)` — a DIRECT
+ * child, not a daemonising `pg_ctl start` — so the postmaster's parent is the
+ * test process itself. When that process dies without teardown the kernel
+ * normally reparents the postmaster to init/launchd, i.e. PPID becomes 1. Such
+ * a cluster is genuinely abandoned, but a bare liveness probe reports it as in
+ * use and used to preserve it indefinitely — eight were found running on one
+ * developer machine, the oldest for three days, each holding its data dir.
+ *
+ * Outside the PID-1 runner case below, a concurrently running test's postmaster
+ * retains that runner as its parent and stays protected.
+ *
+ * Fails CLOSED — any doubt reports "owned", because wrongly reaping a live
+ * test's database breaks that run, while missing an orphan only costs disk that
+ * the next start will reconsider:
+ *   - `process.pid === 1`: some containers run the test runner as init, which
+ *     would make every healthy child look orphaned.
+ *   - `ps` missing, failing, or printing something unparseable.
+ */
+function ownerIsGone(pid: number): boolean {
+  if (process.pid === 1) return false;
+  if (pid === process.pid || pid === process.ppid) return false; // never target ourselves
+  try {
+    const result = spawnSync('ps', ['-o', 'ppid=', '-p', String(pid)], { encoding: 'utf8' });
+    if (result.status !== 0 || typeof result.stdout !== 'string') return false;
+    const ppid = Number(result.stdout.trim());
+    return Number.isInteger(ppid) && ppid === 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True only if `pid` really is the postmaster for `dir`.
+ *
+ * `postmaster.pid` is a stale file on disk: after a crash the number in it can
+ * belong to an entirely unrelated process the OS has since assigned that PID to.
+ * The dead-owner path never cared, because it only ever deleted a directory —
+ * but the orphan path signals it, so acting on a recycled PID would kill
+ * somebody else's process. Require both the postgres executable and an exact
+ * `-D <dir>` argument; embedded-postgres starts the postmaster as
+ * `postgres -D <dir> -p <port>`.
+ *
+ * Fails CLOSED: no `ps`, non-zero exit, or no match means "do not signal".
+ */
+function pidIsPostmasterFor(pid: number, dir: string): boolean {
+  try {
+    const result = spawnSync('ps', ['-ww', '-o', 'command=', '-p', String(pid)], {
+      encoding: 'utf8',
+    });
+    if (result.status !== 0 || typeof result.stdout !== 'string') return false;
+    const command = result.stdout.trim();
+    const escapedDir = dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return (
+      /(?:^|\s)(?:\S*\/)?postgres(?:\s|$)/.test(command) &&
+      new RegExp(`(?:^|\\s)-D\\s+${escapedDir}(?:\\s|$)`).test(command)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start time recorded on line three of `postmaster.pid`, in Unix seconds. The
+ * directory mtime cannot age a running cluster: an orphan still checkpoints and
+ * cycles WAL segments, refreshing the directory indefinitely.
+ */
+function clusterStartedMs(dir: string): number | null {
+  try {
+    const seconds = Number(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n')[2]);
+    return Number.isInteger(seconds) && seconds > 0 ? seconds * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stop an abandoned postmaster, returning false unless it is safe to remove its
+ * data dir.
+ *
+ * The ONLY code here that signals a process, so it is where identity is
+ * established: a live PID is signalled only once it is confirmed both ownerless
+ * (PPID 1) and really this cluster's postmaster. Anything unconfirmed returns
+ * false and the caller leaves the directory alone.
+ */
+function stopOrphanedPostmaster(pid: number, dir: string): boolean {
+  if (!pidIsLive(pid)) return true;
+  if (!ownerIsGone(pid) || !pidIsPostmasterFor(pid, dir)) return false;
+  try {
+    process.kill(pid, 'SIGINT'); // PostgreSQL fast shutdown, matching embedded-postgres.stop()
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (!pidIsLive(pid)) return true;
+    spawnSync('sleep', ['0.1']);
+  }
+
+  // Recheck both ownership and identity before escalating: the old process may
+  // have exited and its PID may now belong to a new, owned postmaster.
+  if (!ownerIsGone(pid) || !pidIsPostmasterFor(pid, dir)) return false;
+  try {
+    process.kill(pid, 'SIGKILL');
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+}
+
+/**
+ * Remove `lobu-test-pg-*` dirs under `dir` that are older than `staleMs`
+ * (relative to `now`) and are not in use by a running test.
+ *
+ * Two ways a cluster qualifies:
+ *   - its postmaster is dead (crashed or killed), or
+ *   - its postmaster is alive but reparented to PID 1, so the run that owned it
+ *     is gone. That one is stopped first, then removed.
+ *
+ * A cluster whose postmaster is alive under a live parent is never touched, at
+ * any age, so a long watch/CI run cannot have its database pulled out from
+ * under it. Returns how many were removed.
  */
 export function reapStaleClustersIn(dir: string, now: number, staleMs: number): number {
   let entries: string[];
@@ -59,8 +183,24 @@ export function reapStaleClustersIn(dir: string, now: number, staleMs: number): 
     if (!name.startsWith('lobu-test-pg-')) continue;
     const path = join(dir, name);
     try {
-      if (now - statSync(path).mtimeMs <= staleMs) continue; // too young — maybe active
-      if (clusterIsLive(path)) continue; // running owner — never reap, any age
+      const pid = postmasterPid(path);
+
+      if (pid !== null && pidIsLive(pid)) {
+        // Something is alive behind this pid file, so default to PROTECTING it:
+        // the cost of a wrong "reap" is a running test losing its database, the
+        // cost of a wrong "keep" is disk the next start reconsiders.
+        //
+        // Age it off its own start time, and let `stopOrphanedPostmaster` be the
+        // single place that decides whether this really is an abandoned
+        // postmaster — it is the only code that signals, so the identity checks
+        // belong there rather than duplicated here.
+        const started = clusterStartedMs(path);
+        if (started === null || now - started <= staleMs) continue; // unknown/young → protect
+        if (!stopOrphanedPostmaster(pid, path)) continue; // unconfirmed or still up
+      } else if (now - statSync(path).mtimeMs <= staleMs) {
+        continue; // no live owner, but too young — maybe a run just starting
+      }
+
       rmSync(path, { recursive: true, force: true });
       removed++;
     } catch {

--- a/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
+++ b/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
@@ -3,11 +3,11 @@
  *
  * Killed test runs (SIGKILL / timeout / OOM / ENOSPC) skip teardown and leak
  * their `lobu-test-pg-*` data dir to tmp; a session of them once filled 65 GB.
- * The reaper removes clusters older than the staleness threshold at the start of
- * every embedded-PG start, so a kill can never accumulate. This pins that logic.
+ * The first embedded-PG start in each test process reaps old clusters left by
+ * previous killed runs. This pins that logic.
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -83,5 +83,197 @@ describe('reapStaleClustersIn', () => {
 
   it('is a no-op on a missing directory (never throws)', () => {
     expect(reapStaleClustersIn(join(root, 'does-not-exist'), now, STALE_CLUSTER_MS)).toBe(0);
+  });
+
+  it('treats a malformed PID line as having no live owner', () => {
+    const path = makeDir('lobu-test-pg-MALFORMED', STALE_CLUSTER_MS + 60_000);
+    writeFileSync(join(path, 'postmaster.pid'), `${process.pid}junk\n`);
+    const t = (now - STALE_CLUSTER_MS - 60_000) / 1000;
+    utimesSync(path, t, t);
+
+    expect(reapStaleClustersIn(root, now, STALE_CLUSTER_MS)).toBe(1);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  describe('orphaned postmaster (reparented to PID 1)', () => {
+    const spawned = new Set<number>();
+
+    function postmasterArgs(dataDir: string): string[] {
+      return ['-e', 'setInterval(() => {}, 1000)', '--', '-D', dataDir];
+    }
+
+    /**
+     * Start a process that outlives its own parent, so the kernel reparents it to
+     * PID 1 — the normal result for an embedded-postgres postmaster whose test
+     * runner is SIGKILLed. The short-lived Node parent exits after printing the
+     * child PID, and spawnSync waits for that exit, so reparenting has happened
+     * by the time this returns.
+     */
+    function orphanPostmaster(dataDir: string): number {
+      const parent = `
+        const { spawn } = require('node:child_process');
+        const child = spawn(
+          ${JSON.stringify(process.execPath)},
+          ${JSON.stringify(postmasterArgs(dataDir))},
+          { argv0: 'postgres', detached: true, stdio: 'ignore' },
+        );
+        child.unref();
+        process.stdout.write(String(child.pid));
+      `;
+      const r = spawnSync(process.execPath, ['-e', parent], { encoding: 'utf8' });
+      const pid = Number.parseInt((r.stdout ?? '').trim(), 10);
+      expect(Number.isInteger(pid) && pid > 0).toBe(true);
+      spawned.add(pid);
+      return pid;
+    }
+
+    /**
+     * A stale cluster dir whose `postmaster.pid` names a live orphan.
+     *
+     * The fake exposes the `postgres` executable name and exact `-D <dir>`
+     * arguments that the reaper requires. Its pid file records the requested
+     * start time on line three, matching PostgreSQL's format.
+     */
+    function makeOrphanDir(
+      name: string,
+      ageMs: number,
+      processDataDir: (dir: string) => string = (dir) => dir,
+    ) {
+      const p = join(root, name);
+      const pidFile = join(p, 'postmaster.pid');
+      mkdirSync(p, { recursive: true });
+      const pid = orphanPostmaster(processDataDir(p));
+      const t = (now - ageMs) / 1000;
+      writeFileSync(pidFile, `${pid}\n${p}\n${Math.floor(t)}\n`);
+      return { path: p, pid };
+    }
+
+    function isLive(pid: number): boolean {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err) {
+        return (err as NodeJS.ErrnoException).code === 'EPERM';
+      }
+    }
+
+    /**
+     * Still genuinely RUNNING — not merely a PID the kernel still answers for.
+     *
+     * A signalled direct child of this process becomes a zombie until it is
+     * waited on, and `kill(pid, 0)` succeeds for a zombie. Asserting protection
+     * with `isLive` alone therefore passes even when the process was killed,
+     * which silently hid whether the owned-cluster guard fired at all. `ps`
+     * reports state `Z` for a zombie, so exclude it.
+     */
+    function isRunning(pid: number): boolean {
+      const r = spawnSync('ps', ['-o', 'state=', '-p', String(pid)], { encoding: 'utf8' });
+      if (r.status !== 0 || typeof r.stdout !== 'string') return false;
+      const state = r.stdout.trim();
+      return state.length > 0 && !state.startsWith('Z');
+    }
+
+    /** Poll briefly because signal delivery and process teardown are asynchronous. */
+    function waitGone(pid: number): boolean {
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        if (!isLive(pid)) return true;
+        spawnSync('sleep', ['0.05']);
+      }
+      return false;
+    }
+
+    afterAll(() => {
+      for (const pid of spawned) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // already reaped by the code under test — that is the point
+        }
+      }
+    });
+
+    it('stops and removes an old cluster whose owner is gone', () => {
+      // A bare liveness probe sees a live postmaster and otherwise preserves an
+      // abandoned cluster at any age.
+      const { path, pid } = makeOrphanDir('lobu-test-pg-ORPHAN', STALE_CLUSTER_MS + 60_000);
+      expect(isRunning(pid)).toBe(true); // precondition: it really is running
+
+      const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+      expect(removed).toBe(1);
+      expect(existsSync(path)).toBe(false);
+      expect(waitGone(pid)).toBe(true); // stopped, not just unlinked
+      spawned.delete(pid);
+    });
+
+    it('keeps a young orphan (a run that just started and lost its parent)', () => {
+      const { path, pid } = makeOrphanDir('lobu-test-pg-YOUNGORPHAN', 5_000);
+
+      const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+      expect(removed).toBe(0);
+      expect(existsSync(path)).toBe(true);
+      expect(isRunning(pid)).toBe(true); // never signalled
+    });
+
+    it('never touches an old cluster whose postmaster still has a live parent', () => {
+      // The realistic form of the protection above: a process that passes the
+      // postmaster executable/data-dir identity check but whose owning run is
+      // still alive. A long watch or CI run can outlive the staleness window,
+      // and pulling its database out from under it breaks that run. This is the
+      // test that fails if the PPID check is dropped.
+      const p = join(root, 'lobu-test-pg-OWNED');
+      const pidFile = join(p, 'postmaster.pid');
+      mkdirSync(p, { recursive: true });
+      // A DIRECT child, so its PPID is this test process, not 1.
+      const child = spawn(process.execPath, postmasterArgs(p), {
+        argv0: 'postgres',
+        stdio: 'ignore',
+      });
+      const pid = child.pid;
+      expect(pid).toBeGreaterThan(0);
+      if (pid !== undefined) spawned.add(pid);
+      writeFileSync(
+        pidFile,
+        `${pid}\n${p}\n${Math.floor((now - STALE_CLUSTER_MS - 60_000) / 1000)}\n`,
+      );
+
+      const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+      expect(removed).toBe(0);
+      expect(existsSync(p)).toBe(true);
+      expect(isRunning(pid as number)).toBe(true);
+      child.kill('SIGKILL');
+      if (pid !== undefined) spawned.delete(pid);
+    });
+
+    it('never signals a PID whose data-dir argument merely shares the cluster prefix', () => {
+      // `postmaster.pid` is a plain file left behind by a crash: the OS can have
+      // reassigned that number to an unrelated process. Signalling it would kill
+      // somebody else's work, so a different exact `-D` argument must not match.
+      const { path, pid } = makeOrphanDir(
+        'lobu-test-pg-RECYCLED',
+        STALE_CLUSTER_MS + 60_000,
+        (dir) => `${dir}-other`,
+      );
+
+      const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+      expect(removed).toBe(0);
+      expect(existsSync(path)).toBe(true);
+      expect(isRunning(pid)).toBe(true);
+    });
+
+    it('keeps a live orphan when its recorded start time is invalid', () => {
+      const { path, pid } = makeOrphanDir('lobu-test-pg-NOSTART', STALE_CLUSTER_MS + 60_000);
+      writeFileSync(join(path, 'postmaster.pid'), `${pid}\n${path}\nnot-a-time\n`);
+
+      const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+      expect(removed).toBe(0);
+      expect(existsSync(path)).toBe(true);
+      expect(isRunning(pid)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- The reaper skipped any `lobu-test-pg-*` dir whose `postmaster.pid` named a **live** process, at any age. embedded-postgres starts the server with `spawn(postgres, ...)` — a direct child, not a daemonising `pg_ctl start` — so a SIGKILLed run (timeout, OOM, ENOSPC, `pkill`) leaves the postmaster reparented to PID 1 rather than reaped. Abandoned, but indistinguishable from in-use, so it survived every later start and held its ~150-400 MB data dir indefinitely.
- **Found in the wild: 8 orphaned postmasters on one machine, the oldest running 3 days.** Clearing them is part of how local free disk went 22Gi → 42Gi.
- A live postmaster with PPID 1 is now stopped (SIGINT — PostgreSQL fast shutdown, what embedded-postgres itself sends — escalating to SIGKILL after 3s) and its dir removed. One with a live parent is never touched, at any age.

Three things the age gate needed:
- Age an orphan off the start time PostgreSQL records on **line three of `postmaster.pid`**, not the directory mtime — a running postmaster keeps checkpointing and cycling WAL, refreshing the directory forever and hiding it from an mtime gate no matter how old it is.
- `postmaster.pid` is a stale file on disk, so after a crash its PID can belong to a process the OS recycled it to. Deleting a directory on that evidence is harmless; signalling it is not — so the PID must also present the postgres executable and an **exact `-D <dir>` argument**, read with `ps -ww` so a long argv isn't truncated into a false negative. Exact rather than substring, or `lobu-test-pg-AB` would match the postmaster of `lobu-test-pg-ABC` and signal the wrong process.
- Ownership and identity are **re-established after the shutdown wait, before escalating to SIGKILL**: the orphan can exit during those 3s and leave its PID to a new, owned process.

`stopOrphanedPostmaster` is the only code that signals, so it is the single place those checks live; the caller just honours its answer. Every check fails **closed** (`process.pid === 1` for a container running the runner as init, a missing/unparseable `ps`, our own PID or parent, an unreadable start time, an unconfirmable command line → all "keep").

Also drops `clusterIsLive`, which the new loop leaves with no callers.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] Tests run: `bun test packages/server/src/__tests__/unit` → **1303 pass, 18 skip, 0 fail**
- [x] Bug fix: red→green pasted below

### End-to-end, against a real embedded Postgres (not fakes)

Owner SIGKILLed, so the postmaster is genuinely reparented — **with the fix**:
```
real cluster: /var/folders/.../T/lobu-test-pg-2GTFec postmaster 19561
postmaster PPID while owner lives: 19401 (owner is 19401)
postmaster PPID after owner SIGKILL: 1
orphan still running before reap: true | dir exists: true
reaper removed: 1 | orphan alive after: false | dir exists: false
SCENARIO 2 PASS
```

Same script **against `origin/main`** — the leak:
```
error: FAIL: orphan postmaster survived the reaper
```

And the safety direction, a live owned cluster reaped with `staleMs = 0` (nothing is "too young"):
```
reaper removed: 0
OWN CLUSTER SURVIVED dir: true postmaster alive: true
query after reap: { ok: 1 }
SCENARIO 1 PASS
```

### Unit red → green
Red (new tests vs `origin/main`'s reaper): `Expected: 1, Received: 0` on `stops and removes an old cluster whose owner is gone`.
Green with the fix: `9 pass, 0 fail`.

### Mutation testing

| mutation | result |
|---|---|
| drop the chokepoint owner+identity check | ✗ killed |
| drop only the pre-SIGINT PPID-1 check | ✗ killed |
| drop both PPID-1 checks | ✗ killed |
| drop only the identity check | ✗ killed |
| loosen the exact `-D` match to a substring | ✗ killed (prefix-collision test) |
| drop the start-time age gate | ✗ killed (2 tests) |
| never stop the orphan | ✗ killed |
| **drop the pre-SIGKILL revalidation** | **survived — disclosed, see below** |

Two notes on honesty of coverage:
- The pre-SIGKILL revalidation guards PID recycling inside the 3s shutdown wait. I could not trigger that deterministically (it needs the OS to reissue a specific PID on demand), so it ships as an untested guard rather than one I claim coverage for.
- Getting the PPID mutations to die required fixing a **false-passing assertion** in the tests: a signalled direct child becomes a zombie, and `kill(pid, 0)` succeeds for a zombie, so the "must not be signalled" checks passed even when the process had been killed. They now assert via `ps` state that the process is genuinely running, not merely a PID the kernel still answers for.

The fakes are real processes presenting the `postgres` executable name and exact `-D <dir>` argument, spawned either reparented to PID 1 or as a direct child, so they exercise the same `ps` reads production does.

## Notes
Test-harness only — no runtime or product surface changes.