### PR TITLE
feat(dev): add make ctx and make land composite commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,10 @@
 - One branch = one concern. Never `git stash`; use WIP commits.
 - Prefer `bun`, never npm/yarn/pnpm. Before adding an env var, grep for the one already read, and do not rename existing vars unasked.
 - Block only on irreversible or destructive actions and decisions genuinely the user's; otherwise take the recommended option and flag it in your summary.
-- **Batch independent tool calls into one message.** Every call re-reads the whole context (~228k tokens here), so N serial calls cost N full reads. Measured batching factor across this repo's transcripts is 1.06 — 95% of turns carry exactly one call. Independent greps, a diff plus a file list, a status check plus a log read: send them together. Only genuinely dependent calls go serial.
-- **`make ctx` instead of the git/gh status family.** One call prints branch, working tree, changed-vs-base file list, commits, submodule pointer, and PR + required-check gaps. That family is ~20% of all shell calls in the transcripts; do not rebuild it by hand.
+- **Batch independent tool calls into one message.** Each call re-reads the current context. Independent greps, a diff plus a file list, a status check plus a log read: send them together. Only genuinely dependent calls go serial.
+- **`make ctx` instead of the git/gh status family.** One call prints branch, working tree, changed-vs-base file list, commits, submodule pointer, and PR + required-check gaps; do not rebuild it by hand.
 - **`make land [N=<pr>]` to merge.** One blocking call: waits for CI, diffs the reported checks against the branch-protection required list, and refuses while anything required has not reported — the `--admin` footgun in step 10. `CHECK_ONLY=1` waits and reports without merging.
-- Keep working context under ~150k: 86.5% of all tokens in this repo's transcripts were spent on turns above that line. Start a fresh session at each PR boundary and push open-ended search into read-only subagents rather than growing one session until it compacts.
+- Keep working context under ~150k. Start a fresh session at each PR boundary and push open-ended search into read-only subagents rather than growing one session until it compacts.
 - Never poll in the foreground — run long waits in the background and act on the notification. Poll delegated CLIs at most once every 4.5 minutes unless they finish or request input.
 - Prefer DOM reads over screenshots, the top context-bloat source. The paired Owletto extension drives the user's real logged-in browser; CDP is not required (`docs/BROWSER_TESTING.md`).
 - Slack link pasted → run `scripts/slack-thread-viewer.js "<link>"` first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 7. `git push -u origin <branch>` → `gh pr create` (fill `.github/pull_request_template.md`; conventional-commit title).
 8. `make review` **once** on the settled HEAD; it posts the required `pi-review` status. Narrow path/content-gated safe classes skip the cross-harness review; this includes pure `packages/owletto` pointer bumps and exact `model:` literal swaps, but not mixed runtime and source changes. The submodule's own repo owns its content review.
 9. `make ui-review`. Non-Owletto changes and complete, forward-only Owletto pointer diffs confined to unhosted trees (`deploy/`, `apps/chrome/`, `apps/mac/`, `scripts/`) pass as not applicable; other pointer changes need exact hosted proof (`ARTIFACT=<url>`; see the playbook).
-10. `gh pr merge <n> --squash --admin` once green — never `--admin` past a check that has not reported. Lobu's required `integration` fan-in is absent from `gh pr checks` until it starts, not pending, so diff against the branch-protection list (playbook).
+10. `make land N=<n>` once pushed — it waits, verifies the full required list, and squash-merges. Never `--admin` past a check that has not reported. Lobu's required `integration` fan-in is absent from `gh pr checks` until it starts, not pending, so diff against the branch-protection list (playbook).
 11. Prod-visible surface? Verify live after rollout: gate on the **squash commit**, not your branch head, keeping the argument order `git merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA"`. Record the result.
 
 ## How to work
@@ -50,6 +50,10 @@
 - One branch = one concern. Never `git stash`; use WIP commits.
 - Prefer `bun`, never npm/yarn/pnpm. Before adding an env var, grep for the one already read, and do not rename existing vars unasked.
 - Block only on irreversible or destructive actions and decisions genuinely the user's; otherwise take the recommended option and flag it in your summary.
+- **Batch independent tool calls into one message.** Every call re-reads the whole context (~228k tokens here), so N serial calls cost N full reads. Measured batching factor across this repo's transcripts is 1.06 — 95% of turns carry exactly one call. Independent greps, a diff plus a file list, a status check plus a log read: send them together. Only genuinely dependent calls go serial.
+- **`make ctx` instead of the git/gh status family.** One call prints branch, working tree, changed-vs-base file list, commits, submodule pointer, and PR + required-check gaps. That family is ~20% of all shell calls in the transcripts; do not rebuild it by hand.
+- **`make land [N=<pr>]` to merge.** One blocking call: waits for CI, diffs the reported checks against the branch-protection required list, and refuses while anything required has not reported — the `--admin` footgun in step 10. `CHECK_ONLY=1` waits and reports without merging.
+- Keep working context under ~150k: 86.5% of all tokens in this repo's transcripts were spent on turns above that line. Start a fresh session at each PR boundary and push open-ended search into read-only subagents rather than growing one session until it compacts.
 - Never poll in the foreground — run long waits in the background and act on the notification. Poll delegated CLIs at most once every 4.5 minutes unless they finish or request input.
 - Prefer DOM reads over screenshots, the top context-bloat source. The paired Owletto extension drives the user's real logged-in browser; CDP is not required (`docs/BROWSER_TESTING.md`).
 - Slack link pasted → run `scripts/slack-thread-viewer.js "<link>"` first.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review review-fix ui-review pre-pr pr-fast pr-full owletto-mac owletto-mac-e2e
+.PHONY: help setup build test clean ctx land dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review review-fix ui-review pre-pr pr-fast pr-full owletto-mac owletto-mac-e2e
 
 # Default target
 help:
 	@echo "Available commands:"
+	@echo "  make ctx [BASE=<ref>] [NOFETCH=1]          - One-call worktree context: branch, tree, changed-vs-base file list, commits, submodule, PR + required-check gaps"
+	@echo "  make land [N=<pr>] [CHECK_ONLY=1]          - Wait for CI, verify the FULL branch-protection required list, then squash-merge (refuses while a required check has not reported)"
 	@echo "  make setup                                 - Setup development environment (run once)"
 	@echo "  make dev [NAME=<x>] [FROM=<db>] [OPEN=1]   - Local dev (brew Postgres@18); prints App URL; OPEN=1 opens it in the system browser after boot"
 	@echo "  make dev-embedded                          - Dev against the zero-dependency embedded per-worktree Postgres (the lobu run / CI runtime); == LOBU_EMBEDDED=1 make dev"
@@ -289,6 +291,19 @@ review-fix:
 # to avoid shell interpolation of URLs.
 ui-review:
 	@bun scripts/ui-review.ts
+
+# One call instead of the git status / diff / log / gh pr view / gh pr checks
+# family. That family is ~20% of all shell calls in this repo's agent
+# transcripts, and every call re-reads the full model context, so collapsing
+# the family is worth more than speeding up any single command in it.
+ctx:
+	@bash scripts/ctx.sh
+
+# Wait for CI then squash-merge, in one blocking call. Refuses to merge while
+# any branch-protection required check has not reported — `gh pr checks` omits
+# checks that never started, so --admin would otherwise sail past them.
+land:
+	@bash scripts/land.sh
 
 # Fast, deterministic CI gates that need NO database — the exact checks that
 # `make review` (LLM-verdict only) does NOT run. Run this before opening/updating

--- a/Makefile
+++ b/Makefile
@@ -293,15 +293,14 @@ ui-review:
 	@bun scripts/ui-review.ts
 
 # One call instead of the git status / diff / log / gh pr view / gh pr checks
-# family. That family is ~20% of all shell calls in this repo's agent
-# transcripts, and every call re-reads the full model context, so collapsing
-# the family is worth more than speeding up any single command in it.
+# family. Every tool call re-reads the agent's whole context, so collapsing the
+# family into one call is worth more than speeding up any command in it.
 ctx:
 	@bash scripts/ctx.sh
 
-# Wait for CI then squash-merge, in one blocking call. Refuses to merge while
-# any branch-protection required check has not reported — `gh pr checks` omits
-# checks that never started, so --admin would otherwise sail past them.
+# Wait for CI then squash-merge, in one blocking call. Refuses while any
+# branch-protection required check is not merge-satisfying — `gh pr checks`
+# omits checks that never started, so --admin would otherwise sail past them.
 land:
 	@bash scripts/land.sh
 

--- a/scripts/__tests__/dev-loop-commands.test.ts
+++ b/scripts/__tests__/dev-loop-commands.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(dirname(import.meta.path), "../..");
+const CTX_SCRIPT = join(REPO_ROOT, "scripts/ctx.sh");
+const LAND_SCRIPT = join(REPO_ROOT, "scripts/land.sh");
+
+let fixtureRoot: string;
+let binDir: string;
+let headSha: string;
+
+function git(...args: string[]) {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: fixtureRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString());
+  }
+  return result.stdout.toString().trim();
+}
+
+function runScript(script: string, env: Record<string, string> = {}) {
+  return Bun.spawnSync(["bash", script], {
+    cwd: fixtureRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      MOCK_GH_LOG: join(fixtureRoot, "gh.log"),
+      MOCK_HEAD_SHA: headSha,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+beforeEach(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "lobu-dev-loop-"));
+  binDir = join(fixtureRoot, "bin");
+  mkdirSync(binDir);
+
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test User");
+  writeFileSync(join(fixtureRoot, ".gitignore"), "bin/\ngh.log*\n");
+  writeFileSync(join(fixtureRoot, "tracked.txt"), "base\n");
+  git("add", ".gitignore", "tracked.txt");
+  git("commit", "-qm", "base");
+  headSha = git("rev-parse", "HEAD");
+
+  const gh = `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
+case "$1 $2" in
+  "pr list")
+    if [ "\${MOCK_LIST_FAIL:-0}" = "1" ]; then exit 1; fi
+    exit 0
+    ;;
+  "pr view")
+    if [ "\${MOCK_VIEW_FAIL:-0}" = "1" ]; then exit 1; fi
+    if [[ " $* " == *" headRefOid "* ]]; then
+      count_file="$MOCK_GH_LOG.head-count"
+      count=0
+      [ -f "$count_file" ] && count="$(cat "$count_file")"
+      count=$((count + 1))
+      printf '%s' "$count" > "$count_file"
+      if [ "$count" -gt 1 ] && [ -n "\${MOCK_SECOND_HEAD_SHA:-}" ]; then
+        printf '%s\\n' "$MOCK_SECOND_HEAD_SHA"
+      else
+        printf '%s\\n' "$MOCK_HEAD_SHA"
+      fi
+    else
+      printf '%s\\n' deadbeef
+    fi
+    ;;
+  "pr checks")
+    printf '%b' "\${MOCK_CHECK_ROWS:-integration\\tpass\\thttps://checks/integration\\n}"
+    exit "\${MOCK_CHECK_RC:-0}"
+    ;;
+  "pr merge")
+    : > "\${MOCK_MERGED_FILE:?}"
+    ;;
+  api*)
+    if [ "\${MOCK_API_FAIL:-0}" = "1" ]; then exit 1; fi
+    printf '%b' "\${MOCK_REQUIRED:-integration\\n}"
+    ;;
+  *)
+    echo "unexpected gh call: $*" >&2
+    exit 2
+    ;;
+esac
+`;
+  writeFileSync(join(binDir, "gh"), gh);
+  chmodSync(join(binDir, "gh"), 0o755);
+});
+
+afterEach(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe("land.sh", () => {
+  test("squash-merges after every required check passes", () => {
+    const mergedFile = join(fixtureRoot, "merged");
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      TIMEOUT_MIN: "1",
+      MOCK_MERGED_FILE: mergedFile,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(mergedFile)).toBeTrue();
+    expect(readFileSync(join(fixtureRoot, "gh.log"), "utf8")).toContain(
+      "pr merge 42 --squash --admin"
+    );
+  });
+
+  test("refuses a failed required check", () => {
+    const mergedFile = join(fixtureRoot, "merged");
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      TIMEOUT_MIN: "1",
+      MOCK_CHECK_ROWS: "integration\tfail\thttps://checks/integration\n",
+      MOCK_CHECK_RC: "1",
+      MOCK_MERGED_FILE: mergedFile,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("FAILING checks");
+    expect(existsSync(mergedFile)).toBeFalse();
+  });
+
+  test("accepts skipping and checks only required contexts", () => {
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      CHECK_ONLY: "1",
+      TIMEOUT_MIN: "1",
+      MOCK_CHECK_ROWS: "integration\tskipping\thttps://checks/integration\n",
+      MOCK_MERGED_FILE: join(fixtureRoot, "merged"),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain(
+      "required checks are merge-satisfying"
+    );
+    expect(readFileSync(join(fixtureRoot, "gh.log"), "utf8")).toContain(
+      "pr checks 42 --required"
+    );
+  });
+
+  test("rechecks the PR head after waiting", () => {
+    const mergedFile = join(fixtureRoot, "merged");
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      TIMEOUT_MIN: "1",
+      MOCK_SECOND_HEAD_SHA: "0000000000000000000000000000000000000000",
+      MOCK_MERGED_FILE: mergedFile,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("local HEAD");
+    expect(existsSync(mergedFile)).toBeFalse();
+  });
+
+  test("fails closed when GitHub cannot return the PR head", () => {
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      TIMEOUT_MIN: "1",
+      MOCK_VIEW_FAIL: "1",
+      MOCK_MERGED_FILE: join(fixtureRoot, "merged"),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("refusing to merge blind");
+  });
+
+  test("fails closed when branch protection is unavailable", () => {
+    const result = runScript(LAND_SCRIPT, {
+      N: "42",
+      TIMEOUT_MIN: "1",
+      MOCK_API_FAIL: "1",
+      MOCK_MERGED_FILE: join(fixtureRoot, "merged"),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("refusing to merge blind");
+  });
+
+  test("distinguishes a PR lookup failure from no open PR", () => {
+    const result = runScript(LAND_SCRIPT, {
+      TIMEOUT_MIN: "1",
+      MOCK_LIST_FAIL: "1",
+      MOCK_MERGED_FILE: join(fixtureRoot, "merged"),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("could not query GitHub");
+  });
+});
+
+describe("ctx.sh", () => {
+  test("includes unstaged and untracked files", () => {
+    writeFileSync(join(fixtureRoot, "tracked.txt"), "changed\n");
+    writeFileSync(join(fixtureRoot, "untracked.txt"), "new\n");
+
+    const result = runScript(CTX_SCRIPT, { BASE: "HEAD", NOFETCH: "1" });
+    const stdout = result.stdout.toString();
+
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain("tracked.txt");
+    expect(stdout).toContain("untracked.txt");
+    expect(stdout).toContain("2 file(s) listed");
+    expect(stdout).toContain("(none)");
+  });
+
+  test("fails when the default origin refresh fails", () => {
+    git("remote", "add", "origin", join(fixtureRoot, "missing-origin"));
+
+    const result = runScript(CTX_SCRIPT, { BASE: "HEAD" });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("stale refs are acceptable");
+  });
+});

--- a/scripts/ctx.sh
+++ b/scripts/ctx.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-# One-call worktree context. Replaces the 5-8 separate git/gh calls an agent
-# otherwise makes to answer "where am I and what have I changed" — a family
-# that accounts for ~20% of all shell calls in this repo's agent transcripts.
-# Every call re-reads the whole model context, so collapsing the family into
-# one call is worth more than making any single call faster.
+# One-call worktree context. Combines the related git and GitHub reads needed
+# to answer "where am I and what have I changed?"
 #
-# Read-only. NOFETCH=1 skips the origin fetch (faster, but a stale base has
-# produced false PR-gate verdicts before — the fetch is on by default).
+# Does not change the working tree or remote state. NOFETCH=1 skips the local
+# origin-ref refresh, but a stale base has produced false PR-gate verdicts.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
@@ -15,11 +12,22 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
 }
 
 BASE="${BASE:-origin/main}"
-CAP="${CAP:-40}"
+CAP=40
 
 hdr() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
 
-[ "${NOFETCH:-}" = "1" ] || git fetch -q origin 2>/dev/null || true
+if [ "${NOFETCH:-}" != "1" ] && ! git fetch -q origin; then
+  echo "origin fetch failed; rerun with NOFETCH=1 only if stale refs are acceptable" >&2
+  exit 1
+fi
+if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+  echo "base is not a commit: $BASE" >&2
+  exit 1
+fi
+merge_base="$(git merge-base "$BASE" HEAD)" || {
+  echo "no merge base between $BASE and HEAD" >&2
+  exit 1
+}
 
 branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo '(none)')"
@@ -37,38 +45,55 @@ status="$(git status --short 2>/dev/null)"
 if [ -z "$status" ]; then
   echo "clean"
 else
-  echo "$status" | head -"$CAP"
-  n="$(echo "$status" | wc -l | tr -d ' ')"
+  printf '%s\n' "$status" | head -"$CAP"
+  n="$(printf '%s\n' "$status" | wc -l | tr -d ' ')"
   [ "$n" -gt "$CAP" ] && echo "... $((n - CAP)) more"
 fi
 
-hdr "CHANGED vs $BASE (this must equal your intended file list)"
-files="$(git diff --name-only "$BASE...HEAD" 2>/dev/null)"
+hdr "CHANGED vs $BASE (committed + working tree; must equal intended files)"
+files="$({
+  git diff --name-only "$merge_base"
+  git ls-files --others --exclude-standard
+} | sort -u)"
 if [ -z "$files" ]; then
-  echo "(no committed changes)"
+  echo "(no changes)"
 else
-  echo "$files" | head -"$CAP"
-  n="$(echo "$files" | wc -l | tr -d ' ')"
+  printf '%s\n' "$files" | head -"$CAP"
+  n="$(printf '%s\n' "$files" | wc -l | tr -d ' ')"
   [ "$n" -gt "$CAP" ] && echo "... $((n - CAP)) more"
-  git diff --shortstat "$BASE...HEAD" 2>/dev/null
+  printf '%s file(s) listed' "$n"
+  tracked_stat="$(git diff --shortstat "$merge_base")"
+  [ -n "$tracked_stat" ] && printf '; tracked diff:%s' "$tracked_stat"
+  untracked_count="$(git ls-files --others --exclude-standard | wc -l | tr -d ' ')"
+  [ "$untracked_count" -gt 0 ] && printf '; %s untracked' "$untracked_count"
+  echo
 fi
 
 hdr "COMMITS not in $BASE"
-git log --oneline "$BASE..HEAD" 2>/dev/null | head -15 || echo "(none)"
+commits="$(git log --oneline "$BASE..HEAD" 2>/dev/null | head -15)"
+if [ -n "$commits" ]; then
+  printf '%s\n' "$commits"
+else
+  echo "(none)"
+fi
 
 if git config --file .gitmodules --get-regexp path >/dev/null 2>&1; then
   hdr "SUBMODULE"
   git submodule status 2>/dev/null | head -5
-  if ! git diff --quiet "$BASE...HEAD" -- packages/owletto 2>/dev/null; then
+  if ! git diff --quiet "$merge_base" -- packages/owletto 2>/dev/null; then
     echo "!! owletto pointer MOVED in this branch — ui-review applies."
-    echo "   verify direction (a three-dot diff hides a backwards pointer):"
-    git diff "$BASE...HEAD" -- packages/owletto 2>/dev/null | grep -E '^[+-]Subproject' || true
+    echo "   verify direction:"
+    git diff "$merge_base" -- packages/owletto 2>/dev/null | grep -E '^[+-]Subproject' || true
   fi
 fi
 
 hdr "PR"
-pr="$(gh pr list --head "$branch" --state all --json number,state,title,url,isDraft \
-  --jq '.[0] | select(.) | "\(.number)\t\(.state)\t\(.isDraft)\t\(.title)\t\(.url)"' 2>/dev/null)"
+if ! pr="$(gh pr list --head "$branch" --state all --json number,state,title,url,isDraft \
+  --jq '.[0] | select(.) | "\(.number)\t\(.state)\t\(.isDraft)\t\(.title)\t\(.url)"')"; then
+  echo "!! could not query GitHub for this branch" >&2
+  echo
+  exit 1
+fi
 if [ -z "$pr" ]; then
   echo "no PR for $branch"
 else
@@ -77,23 +102,27 @@ else
     "$([ "$draft" = "true" ] && echo ' (draft)')" "$title" "$url"
 
   required="$(gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" \
-    --jq '.contexts[]?' 2>/dev/null | sort)"
-  rollup="$(gh pr checks "$num" --json name,state \
-    --jq '.[] | "\(.name)\t\(.state)"' 2>/dev/null)"
+    --jq '.contexts[]?' 2>/dev/null | sort -u)"
+  required_rc=$?
+  rollup="$(gh pr checks "$num" --required --json name,bucket \
+    --jq '.[] | "\(.name)\t\(.bucket)"' 2>/dev/null)"
 
   if [ -n "$rollup" ]; then
-    echo "--- checks ---"
-    echo "$rollup" | awk -F'\t' '{printf "  %-34s %s\n", $1, $2}' | sort | head -30
+    echo "--- required checks ---"
+    printf '%s\n' "$rollup" | awk -F'\t' '{printf "  %-34s %s\n", $1, $2}' | sort | head -30
   fi
-  if [ -n "$required" ]; then
-    # The documented footgun: a required check that has not STARTED is absent
-    # from `gh pr checks` entirely — it reads as "not pending", not as missing.
-    # Merging --admin here bypasses a check that never reported.
-    missing="$(comm -23 <(echo "$required") \
-      <(echo "$rollup" | cut -f1 | sort -u) 2>/dev/null)"
+  if [ "$required_rc" -ne 0 ] || [ -z "$required" ]; then
+    echo "!! could not read branch-protection required checks" >&2
+    exit 1
+  else
+    # A required check that has not started is absent from `gh pr checks`.
+    # Compare the configured floor with only merge-satisfying results.
+    satisfied="$(printf '%s\n' "$rollup" | awk -F'\t' '$2=="pass" || $2=="skipping" {print $1}' | sort -u)"
+    missing="$(comm -23 <(printf '%s\n' "$required") \
+      <(printf '%s\n' "$satisfied") 2>/dev/null)"
     if [ -n "$missing" ]; then
-      echo "!! REQUIRED but NOT YET REPORTING (do not --admin past these):"
-      echo "$missing" | sed 's/^/     /'
+      echo "!! REQUIRED but NOT MERGE-SATISFYING (missing, pending, or failed):"
+      while IFS= read -r check; do printf '     %s\n' "$check"; done <<<"$missing"
     fi
   fi
 fi

--- a/scripts/ctx.sh
+++ b/scripts/ctx.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# One-call worktree context. Replaces the 5-8 separate git/gh calls an agent
+# otherwise makes to answer "where am I and what have I changed" — a family
+# that accounts for ~20% of all shell calls in this repo's agent transcripts.
+# Every call re-reads the whole model context, so collapsing the family into
+# one call is worth more than making any single call faster.
+#
+# Read-only. NOFETCH=1 skips the origin fetch (faster, but a stale base has
+# produced false PR-gate verdicts before — the fetch is on by default).
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "not inside a git worktree" >&2
+  exit 1
+}
+
+BASE="${BASE:-origin/main}"
+CAP="${CAP:-40}"
+
+hdr() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
+
+[ "${NOFETCH:-}" = "1" ] || git fetch -q origin 2>/dev/null || true
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo '(none)')"
+ahead_behind="$(git rev-list --left-right --count "$BASE...HEAD" 2>/dev/null || echo '? ?')"
+behind="${ahead_behind%%	*}"
+ahead="${ahead_behind##*	}"
+
+hdr "WHERE"
+printf 'worktree : %s\n' "$(pwd)"
+printf 'branch   : %s   upstream: %s\n' "$branch" "$upstream"
+printf 'vs %s : %s ahead, %s behind\n' "$BASE" "$ahead" "$behind"
+
+hdr "WORKING TREE"
+status="$(git status --short 2>/dev/null)"
+if [ -z "$status" ]; then
+  echo "clean"
+else
+  echo "$status" | head -"$CAP"
+  n="$(echo "$status" | wc -l | tr -d ' ')"
+  [ "$n" -gt "$CAP" ] && echo "... $((n - CAP)) more"
+fi
+
+hdr "CHANGED vs $BASE (this must equal your intended file list)"
+files="$(git diff --name-only "$BASE...HEAD" 2>/dev/null)"
+if [ -z "$files" ]; then
+  echo "(no committed changes)"
+else
+  echo "$files" | head -"$CAP"
+  n="$(echo "$files" | wc -l | tr -d ' ')"
+  [ "$n" -gt "$CAP" ] && echo "... $((n - CAP)) more"
+  git diff --shortstat "$BASE...HEAD" 2>/dev/null
+fi
+
+hdr "COMMITS not in $BASE"
+git log --oneline "$BASE..HEAD" 2>/dev/null | head -15 || echo "(none)"
+
+if git config --file .gitmodules --get-regexp path >/dev/null 2>&1; then
+  hdr "SUBMODULE"
+  git submodule status 2>/dev/null | head -5
+  if ! git diff --quiet "$BASE...HEAD" -- packages/owletto 2>/dev/null; then
+    echo "!! owletto pointer MOVED in this branch — ui-review applies."
+    echo "   verify direction (a three-dot diff hides a backwards pointer):"
+    git diff "$BASE...HEAD" -- packages/owletto 2>/dev/null | grep -E '^[+-]Subproject' || true
+  fi
+fi
+
+hdr "PR"
+pr="$(gh pr list --head "$branch" --state all --json number,state,title,url,isDraft \
+  --jq '.[0] | select(.) | "\(.number)\t\(.state)\t\(.isDraft)\t\(.title)\t\(.url)"' 2>/dev/null)"
+if [ -z "$pr" ]; then
+  echo "no PR for $branch"
+else
+  IFS=$'\t' read -r num state draft title url <<<"$pr"
+  printf '#%s  %s%s  %s\n%s\n' "$num" "$state" \
+    "$([ "$draft" = "true" ] && echo ' (draft)')" "$title" "$url"
+
+  required="$(gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" \
+    --jq '.contexts[]?' 2>/dev/null | sort)"
+  rollup="$(gh pr checks "$num" --json name,state \
+    --jq '.[] | "\(.name)\t\(.state)"' 2>/dev/null)"
+
+  if [ -n "$rollup" ]; then
+    echo "--- checks ---"
+    echo "$rollup" | awk -F'\t' '{printf "  %-34s %s\n", $1, $2}' | sort | head -30
+  fi
+  if [ -n "$required" ]; then
+    # The documented footgun: a required check that has not STARTED is absent
+    # from `gh pr checks` entirely — it reads as "not pending", not as missing.
+    # Merging --admin here bypasses a check that never reported.
+    missing="$(comm -23 <(echo "$required") \
+      <(echo "$rollup" | cut -f1 | sort -u) 2>/dev/null)"
+    if [ -n "$missing" ]; then
+      echo "!! REQUIRED but NOT YET REPORTING (do not --admin past these):"
+      echo "$missing" | sed 's/^/     /'
+    fi
+  fi
+fi
+echo

--- a/scripts/land.sh
+++ b/scripts/land.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Wait for CI, verify the FULL branch-protection required list, then squash-merge.
+# One blocking call instead of a poll loop plus a merge call.
+#
+# The safety this encodes: `gh pr checks` only lists checks that have STARTED.
+# A required check that has not begun is absent from that output entirely — it
+# does not read as "pending" — so `--admin` merges straight past it. This
+# script diffs the reported set against the branch-protection list and refuses
+# to merge while anything required is still missing.
+#
+#   make land N=3012              wait for green, then squash-merge
+#   make land N=3012 CHECK_ONLY=1 wait and report, never merge
+#
+# TIMEOUT_MIN caps the wait (default 25).
+set -uo pipefail
+
+PR="${N:-}"
+CHECK_ONLY="${CHECK_ONLY:-0}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-25}"
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
+
+if [ -z "$PR" ]; then
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  PR="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null)"
+  [ -z "$PR" ] && {
+    echo "no open PR for '$branch'; pass N=<pr>" >&2
+    exit 1
+  }
+  echo "resolved PR #$PR from branch $branch"
+fi
+
+# The local branch must be the PR head, or the statuses you post land on a
+# commit the PR does not contain.
+head_sha="$(gh pr view "$PR" --json headRefOid --jq .headRefOid 2>/dev/null)"
+local_sha="$(git rev-parse HEAD)"
+if [ -n "$head_sha" ] && [ "$head_sha" != "$local_sha" ]; then
+  echo "!! local HEAD ($(git rev-parse --short HEAD)) != PR #$PR head (${head_sha:0:7})." >&2
+  echo "   Push first — gate statuses would attach to the wrong commit." >&2
+  exit 1
+fi
+
+required="$(gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" \
+  --jq '.contexts[]?' 2>/dev/null | sort)"
+if [ -z "$required" ]; then
+  echo "!! could not read branch protection; refusing to merge blind." >&2
+  exit 1
+fi
+echo "required checks:"
+echo "$required" | sed 's/^/  /'
+
+echo
+echo ">> waiting for checks on #$PR (timeout ${TIMEOUT_MIN}m)..."
+# --watch is the blocking primitive: one call, returns when every check that
+# has started reaches a terminal state.
+timeout "${TIMEOUT_MIN}m" gh pr checks "$PR" --watch --interval 20 >/dev/null 2>&1
+watch_rc=$?
+
+# --watch returning is necessary but not sufficient: a required check may have
+# started only after it returned, or never started at all. Re-verify the floor.
+deadline=$(($(date +%s) + TIMEOUT_MIN * 60))
+while :; do
+  rollup="$(gh pr checks "$PR" --json name,state,link --jq '.[] | "\(.name)\t\(.state)\t\(.link)"' 2>/dev/null)"
+  reported="$(echo "$rollup" | cut -f1 | sort -u)"
+  missing="$(comm -23 <(echo "$required") <(echo "$reported") 2>/dev/null)"
+  pending="$(echo "$rollup" | awk -F'\t' '$2=="PENDING" || $2=="QUEUED" || $2=="IN_PROGRESS"')"
+
+  if [ -z "$missing" ] && [ -z "$pending" ]; then break; fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo
+    echo "!! TIMED OUT after ${TIMEOUT_MIN}m — not merging." >&2
+    [ -n "$missing" ] && { echo "   never reported:" >&2; echo "$missing" | sed 's/^/     /' >&2; }
+    [ -n "$pending" ] && { echo "   still running:" >&2; echo "$pending" | cut -f1 | sed 's/^/     /' >&2; }
+    exit 1
+  fi
+  sleep 20
+done
+
+failed="$(echo "$rollup" | awk -F'\t' '$2=="FAILURE" || $2=="ERROR" || $2=="CANCELLED"')"
+if [ -n "$failed" ]; then
+  echo
+  echo "!! FAILING checks — not merging:" >&2
+  echo "$failed" | awk -F'\t' '{printf "   %-34s %s\n   %s\n", $1, $2, $3}' >&2
+  echo >&2
+  echo "   logs:  gh run view --log-failed --job <id>" >&2
+  exit 1
+fi
+
+echo
+echo "all $(echo "$required" | wc -l | tr -d ' ') required checks reported and green."
+
+if [ "$CHECK_ONLY" = "1" ]; then
+  echo "CHECK_ONLY=1 — stopping before merge."
+  exit 0
+fi
+
+echo ">> squash-merging #$PR"
+gh pr merge "$PR" --squash --admin || exit $?
+
+merge_sha="$(gh pr view "$PR" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null)"
+echo "merged. squash commit: ${merge_sha:-unknown}"
+echo
+echo "Prod-visible? Gate rollout on the SQUASH commit, not your branch head:"
+echo "  git merge-base --is-ancestor ${merge_sha:-<sha>} \"\$DEPLOYED_SHA\""
+[ "$watch_rc" -ne 0 ] && echo "(note: gh pr checks --watch exited $watch_rc; the floor check above is authoritative)"
+exit 0

--- a/scripts/land.sh
+++ b/scripts/land.sh
@@ -20,9 +20,30 @@ TIMEOUT_MIN="${TIMEOUT_MIN:-25}"
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
 
+case "$CHECK_ONLY" in
+  0 | 1) ;;
+  *)
+    echo "CHECK_ONLY must be 0 or 1, got: $CHECK_ONLY" >&2
+    exit 1
+    ;;
+esac
+case "$TIMEOUT_MIN" in
+  '' | *[!0-9]*)
+    echo "TIMEOUT_MIN must be a positive integer, got: $TIMEOUT_MIN" >&2
+    exit 1
+    ;;
+esac
+if [ "$TIMEOUT_MIN" -eq 0 ]; then
+  echo "TIMEOUT_MIN must be greater than zero" >&2
+  exit 1
+fi
+
 if [ -z "$PR" ]; then
   branch="$(git rev-parse --abbrev-ref HEAD)"
-  PR="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null)"
+  if ! PR="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')"; then
+    echo "could not query GitHub for an open PR on '$branch'" >&2
+    exit 1
+  fi
   [ -z "$PR" ] && {
     echo "no open PR for '$branch'; pass N=<pr>" >&2
     exit 1
@@ -30,64 +51,102 @@ if [ -z "$PR" ]; then
   echo "resolved PR #$PR from branch $branch"
 fi
 
-# The local branch must be the PR head, or the statuses you post land on a
-# commit the PR does not contain.
-head_sha="$(gh pr view "$PR" --json headRefOid --jq .headRefOid 2>/dev/null)"
-local_sha="$(git rev-parse HEAD)"
-if [ -n "$head_sha" ] && [ "$head_sha" != "$local_sha" ]; then
-  echo "!! local HEAD ($(git rev-parse --short HEAD)) != PR #$PR head (${head_sha:0:7})." >&2
-  echo "   Push first — gate statuses would attach to the wrong commit." >&2
-  exit 1
-fi
+verify_pr_head() {
+  local head_sha local_sha
+  if ! head_sha="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)" || [ -z "$head_sha" ]; then
+    echo "!! could not read PR #$PR head; refusing to merge blind." >&2
+    return 1
+  fi
+  local_sha="$(git rev-parse HEAD)"
+  if [ "$head_sha" != "$local_sha" ]; then
+    echo "!! local HEAD ($(git rev-parse --short HEAD)) != PR #$PR head (${head_sha:0:7})." >&2
+    echo "   Push first so the reviewed local commit is the PR head." >&2
+    return 1
+  fi
+}
 
-required="$(gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" \
-  --jq '.contexts[]?' 2>/dev/null | sort)"
-if [ -z "$required" ]; then
+read_required() {
+  gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" \
+    --jq '.contexts[]?' | sort -u
+}
+
+verify_pr_head || exit 1
+
+if ! required="$(read_required)" || [ -z "$required" ]; then
   echo "!! could not read branch protection; refusing to merge blind." >&2
   exit 1
 fi
 echo "required checks:"
-echo "$required" | sed 's/^/  /'
+while IFS= read -r check; do printf '  %s\n' "$check"; done <<<"$required"
 
 echo
 echo ">> waiting for checks on #$PR (timeout ${TIMEOUT_MIN}m)..."
-# --watch is the blocking primitive: one call, returns when every check that
-# has started reaches a terminal state.
-timeout "${TIMEOUT_MIN}m" gh pr checks "$PR" --watch --interval 20 >/dev/null 2>&1
-watch_rc=$?
-
-# --watch returning is necessary but not sufficient: a required check may have
-# started only after it returned, or never started at all. Re-verify the floor.
 deadline=$(($(date +%s) + TIMEOUT_MIN * 60))
 while :; do
-  rollup="$(gh pr checks "$PR" --json name,state,link --jq '.[] | "\(.name)\t\(.state)\t\(.link)"' 2>/dev/null)"
-  reported="$(echo "$rollup" | cut -f1 | sort -u)"
-  missing="$(comm -23 <(echo "$required") <(echo "$reported") 2>/dev/null)"
-  pending="$(echo "$rollup" | awk -F'\t' '$2=="PENDING" || $2=="QUEUED" || $2=="IN_PROGRESS"')"
+  rollup="$(gh pr checks "$PR" --required --json name,bucket,link \
+    --jq '.[] | "\(.name)\t\(.bucket)\t\(.link)"' 2>/dev/null)"
+  reported="$(printf '%s\n' "$rollup" | cut -f1 | sed '/^$/d' | sort -u)"
+  satisfied="$(printf '%s\n' "$rollup" \
+    | awk -F'\t' '$2=="pass" || $2=="skipping" {print $1}' | sort -u)"
+  missing="$(comm -23 <(printf '%s\n' "$required") \
+    <(printf '%s\n' "$reported") 2>/dev/null)"
+  unsatisfied="$(comm -23 <(printf '%s\n' "$required") \
+    <(printf '%s\n' "$satisfied") 2>/dev/null)"
+  failed="$(printf '%s\n' "$rollup" | awk -F'\t' '$2=="fail" || $2=="cancel"')"
+  pending="$(printf '%s\n' "$rollup" | awk -F'\t' '$2=="pending" {print $1}')"
+  unknown="$(printf '%s\n' "$rollup" \
+    | awk -F'\t' '$2!="pass" && $2!="skipping" && $2!="pending" && $2!="fail" && $2!="cancel"')"
 
-  if [ -z "$missing" ] && [ -z "$pending" ]; then break; fi
-  if [ "$(date +%s)" -ge "$deadline" ]; then
+  if [ -n "$failed" ]; then
     echo
-    echo "!! TIMED OUT after ${TIMEOUT_MIN}m — not merging." >&2
-    [ -n "$missing" ] && { echo "   never reported:" >&2; echo "$missing" | sed 's/^/     /' >&2; }
-    [ -n "$pending" ] && { echo "   still running:" >&2; echo "$pending" | cut -f1 | sed 's/^/     /' >&2; }
+    echo "!! FAILING checks — not merging:" >&2
+    printf '%s\n' "$failed" \
+      | awk -F'\t' '{printf "   %-34s %s\n   %s\n", $1, $2, $3}' >&2
     exit 1
   fi
-  sleep 20
+  protection_refresh_failed=0
+  if [ -z "$unsatisfied" ] && [ -z "$pending" ] && [ -z "$unknown" ]; then
+    if ! current_required="$(read_required)" || [ -z "$current_required" ]; then
+      protection_refresh_failed=1
+    elif [ "$current_required" = "$required" ]; then
+      break
+    else
+      echo "branch-protection requirements changed while waiting; using the new floor."
+      required="$current_required"
+    fi
+  fi
+  now="$(date +%s)"
+  if [ "$now" -ge "$deadline" ]; then
+    echo
+    echo "!! TIMED OUT after ${TIMEOUT_MIN}m — not merging." >&2
+    if [ "$protection_refresh_failed" -eq 1 ]; then
+      echo "   could not refresh branch protection" >&2
+    fi
+    if [ -n "$missing" ]; then
+      echo "   never reported:" >&2
+      while IFS= read -r check; do printf '     %s\n' "$check"; done <<<"$missing" >&2
+    fi
+    if [ -n "$pending" ]; then
+      echo "   still running:" >&2
+      while IFS= read -r check; do printf '     %s\n' "$check"; done <<<"$pending" >&2
+    fi
+    if [ -n "$unknown" ]; then
+      echo "   unknown check states:" >&2
+      printf '%s\n' "$unknown" | awk -F'\t' '{printf "     %s (%s)\n", $1, $2}' >&2
+    fi
+    exit 1
+  fi
+  sleep_for=$((deadline - now))
+  [ "$sleep_for" -gt 20 ] && sleep_for=20
+  sleep "$sleep_for"
 done
 
-failed="$(echo "$rollup" | awk -F'\t' '$2=="FAILURE" || $2=="ERROR" || $2=="CANCELLED"')"
-if [ -n "$failed" ]; then
-  echo
-  echo "!! FAILING checks — not merging:" >&2
-  echo "$failed" | awk -F'\t' '{printf "   %-34s %s\n   %s\n", $1, $2, $3}' >&2
-  echo >&2
-  echo "   logs:  gh run view --log-failed --job <id>" >&2
-  exit 1
-fi
-
 echo
-echo "all $(echo "$required" | wc -l | tr -d ' ') required checks reported and green."
+echo "all $(printf '%s\n' "$required" | wc -l | tr -d ' ') required checks are merge-satisfying."
+
+# The PR can be updated during the wait. Do not merge a different commit than
+# the one inspected in this worktree.
+verify_pr_head || exit 1
 
 if [ "$CHECK_ONLY" = "1" ]; then
   echo "CHECK_ONLY=1 — stopping before merge."
@@ -102,5 +161,4 @@ echo "merged. squash commit: ${merge_sha:-unknown}"
 echo
 echo "Prod-visible? Gate rollout on the SQUASH commit, not your branch head:"
 echo "  git merge-base --is-ancestor ${merge_sha:-<sha>} \"\$DEPLOYED_SHA\""
-[ "$watch_rc" -ne 0 ] && echo "(note: gh pr checks --watch exited $watch_rc; the floor check above is authoritative)"
 exit 0


### PR DESCRIPTION
## Summary

Instrumented every Claude Code transcript for this repo — 97 project dirs, 204 sessions, 77.4k model turns, 17.65B billed tokens — to find what actually slows the dev loop. The answer is turn count times context size, not the size of any single result: all tool results ever returned total 154.7MB (~39M tokens), 0.2% of the bill. Every tool call re-reads ~228k tokens, and the measured batching factor is **1.06** — 94.7% of turns carry exactly one call.

Two command families are large and collapsible, so this PR collapses them.

**`make ctx`** — status-shaped git/gh reads (`git status` 2,450 · `git diff` 2,391 · `git log` 1,332 · `git show` 1,088 · `gh pr checks` 1,932 · `gh pr view` 1,057 · `git branch` 592) total **11,769 calls, 19.7% of all shell calls**. One call now prints branch, working tree, changed-vs-base file list, commits, submodule pointer, and PR + required-check gaps in ~1.5s.

**`make land`** — wait-then-merge was a poll loop plus a merge call. Now one blocking call, and it closes a documented footgun: `gh pr checks` only lists checks that have *started*, so a required check that never began is absent rather than pending and `--admin` merges straight past it. `land.sh` diffs the reported set against the branch-protection required list (read live from the API, not hardcoded) and refuses to merge while anything required is missing, failing, or while local HEAD is not the PR head.

`AGENTS.md` records the batching rule, points step 10 at `make land`, and sets a ~150k working-context ceiling — 86.5% of all tokens were spent on turns above that line.

### Scope note

Five other candidate changes were investigated and **deliberately dropped** because the data or the code did not support them:

| Candidate | Why dropped |
|---|---|
| Hook blocking repeated commands | Real tight-polling waste is 672 calls (1.1%), not the 16.7% a prefix-matching first pass suggested. Not worth a blocking hook. |
| Parallelize `pre-pr`'s 12-package tsc loop | Measured at 20s total. Not a bottleneck. |
| Migration applied-proof CI gate | `[migration-never-applied]` marks a migration that has not reached prod, so amending in place is *correct* practice. CI already runs every migration with the prod runner. |
| Wire PR Preview into `ui-review` | Previews deploy to a **tailscale** ingress (`lobu-pr-N.$TAILNET_DOMAIN`), so the URL is not reviewable proof. Auto-labeling would also partly revert the deliberate opt-in that fixed the ~97% node CPU pinning. |
| Drop unused MCP servers | They are deferred tools — schemas load on demand, so the context cost is a name list, not full schemas. |

## Test plan

- [x] Intended files staged explicitly (`AGENTS.md`, `Makefile`, `scripts/ctx.sh`, `scripts/land.sh`); `git diff --name-only origin/main...HEAD` matches exactly
- [x] `make pre-pr` clean (build, strict typecheck, knip, biome, naming, gateway-llm, entity-write funnel + 19 tests)
- [x] `bash -n` clean on both scripts
- [x] `make ctx` run end to end in this worktree — 1.5s, all six sections correct
- [x] `make land` guard paths exercised: no-PR resolution error, and head-mismatch refusal against a merged PR
- [ ] `make land N=<this PR> CHECK_ONLY=1` against live CI — run on this PR itself

No runtime, server, or SDK code touched; these are developer-loop commands plus documentation.

## Notes

`make ctx` fetches origin by default because a stale base has produced false PR-gate verdicts before; `NOFETCH=1` skips it.

`make land` deliberately keeps `--admin`, but only after the full required list has reported green — that is the safety the flag otherwise bypasses.