### PR TITLE
fix(ci): stop merges cancelling main's validation, build the graph in task-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,8 @@ on:
 permissions:
   contents: read
 
-# Auto-cancel superseded runs. PR revisions are obsolete after a force-push or
-# rebase, and a newer main SHA contains every older main SHA. Keeping stale main
-# runs alive consumed the same 20-slot hosted-runner pool while newer required
-# PR checks waited. Deployment is driven by Build and Push Images, not this
-# workflow, so only the newest CI result per ref is useful.
+# Auto-cancel superseded PR runs. PR revisions are obsolete after a force-push
+# or rebase, so keeping them alive only makes newer required checks wait.
 #
 # CI_LINUX_RUNNER is an optional repository variable used for runner A/B tests.
 # Leaving it unset preserves GitHub-hosted execution; setting it changes only
@@ -27,20 +24,37 @@ permissions:
 # author (TRUSTED_AUTHORS, whitespace-separated). Pushes, workflow_dispatch,
 # and the `make pr-full` Depot gate are never routed to it.
 #
-# The `github.run_id` fallback exists for `depot ci run`, which `make
-# pr-full` uses to execute this same file against a local staged tree.
-# That path supplies no ref, so `github.ref` expanded empty and every local
-# dispatch in the org collapsed into one group literally named `ci-`. Combined
-# with cancel-in-progress, the newest gate anywhere killed whatever was running
-# — a different branch, a different worktree, a different person — and the
-# victim saw only "Cancelled due to the workflow concurrency policy", which
-# names this block rather than any Depot-side limit. Two dispatchers that each
-# retry on cancellation then deadlock, neither ever attesting. Falling back to
-# the run id gives each local dispatch its own group. GitHub keeps the per-ref
-# semantics unchanged: `github.ref` is always set for push and pull_request.
+# Pull requests share a per-ref group and cancel obsolete revisions. EVERY OTHER
+# execution gets its own run-id group, so it neither cancels nor is cancelled.
+#
+# Main pushes used to share the group too, because `github.ref` is
+# `refs/heads/main` for every merge — so each merge killed the previous merge's
+# full-graph run. Measured over 40 consecutive main runs: 15 cancelled, 23
+# green, 2 failed. About a third of merged commits never completed a
+# validation, the release commit for 15.3.1 among them, and the PR check that
+# preceded each one only ever validated the PR head rather than what landed.
+#
+# Setting `cancel-in-progress: false` would NOT have been enough: a concurrency
+# group holds only one PENDING run, so a third merge still evicts the second
+# before it starts. Only a distinct group per run removes the contention.
+#
+# The tradeoff, which was the original reason for cancelling: main runs no
+# longer yield, so they hold slots in the same 20-slot hosted pool that
+# required PR checks draw from. That is accepted deliberately — a merged commit
+# nobody validated is worse than a PR check that waits — but if the pool starts
+# starving, revisit here rather than reinstating blanket cancellation.
+#
+# The run-id group is also load-bearing for `depot ci run`, which `make pr-full`
+# uses to execute this file against a local staged tree. That path supplies no
+# ref, so `github.ref` expanded empty and every local dispatch in the org
+# collapsed into one group literally named `ci-`; the newest gate anywhere
+# killed whatever was running — a different branch, worktree, or person — and
+# the victim saw only "Cancelled due to the workflow concurrency policy", which
+# names THIS block rather than any Depot-side limit. Two dispatchers that each
+# retry on cancellation then deadlock, neither ever attesting.
 concurrency:
-  group: ci-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Resolve the Linux runner backend from the PR author. Trusted authors

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -19,7 +19,8 @@
 #   1. Creates a lobu worktree at .claude/worktrees/<name> on branch feat/<name>.
 #   2. Initializes packages/owletto submodule on a real named branch feat/<name>
 #      (never detached HEAD — fixes the "we keep losing changes" bug).
-#   3. Runs `bun install` after submodule init (avoids the bun.lock prune bug).
+#   3. Runs `bun install` after submodule init (avoids the bun.lock prune bug),
+#      then builds the package graph so the server unit suite can actually run.
 #   4. Copies .env from the main repo (gitignored secrets don't auto-carry into
 #      a fresh worktree, so `make dev` / `lobu run` would otherwise fail at boot).
 #   5. Writes .env.local with PORT / WORKER_PROXY_PORT picked to avoid collisions
@@ -153,6 +154,18 @@ if [[ $refresh_only -eq 0 ]]; then
 
   echo "→ bun install"
   (cd "$worktree_dir" && bun install)
+
+  # Server unit modules import `@lobu/connector-worker/compile`, whose workspace
+  # export points at generated `dist/compile/index.js`. A fresh worktree has no
+  # dist, so `bun install` alone leaves the suite unrunnable — and it fails as
+  # "Cannot find module '@lobu/connector-worker/compile'", which reads like a
+  # missing DEPENDENCY rather than a missing BUILD. That misdirection is the
+  # whole cost: CI runs this same command before its own `bun test` ("Build
+  # package graph for unit-test runtime resolution"), so CI stayed green while
+  # every new worktree did not. ~10s, so it rides along rather than hiding
+  # behind a flag.
+  echo "→ building package graph (needed by the server unit suite)"
+  (cd "$worktree_dir" && node scripts/build-packages.mjs --skip-applications)
 fi
 
 if [[ -f "$repo/.env" ]]; then


### PR DESCRIPTION
## Summary

Two pipeline defects found while measuring why the PR loop feels slow. Across the last 40 merged PRs, **correlation between changed lines and time-to-merge is 0.14** — the cost is the pipeline, not the diff. (A 2-line pointer bump took 130 min; a 7,604-line refactor took 156 min.)

### 1. Every merge cancelled the previous merge's validation

`ci.yml` runs on both `pull_request` and `push: branches: [main]`, and the concurrency group was keyed on `github.ref` — which is `refs/heads/main` for *every* merge. So back-to-back merges killed each other's full-graph run.

Measured over 40 consecutive main runs: **15 cancelled, 23 success, 2 failure.** About a third of merged commits never completed a validation, including the release commit for `15.3.1` (`eedcfbd23`). The PR check that preceded each one only validated the PR head, not what landed.

`cancel-in-progress: false` alone would **not** have fixed it — a concurrency group holds only one *pending* run, so a third merge still evicts the second before it starts. Only a distinct group per non-PR run removes the contention:

```yaml
group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR iteration still cancels superseded pushes, which is pure waste. The `run_id` fallback that `depot ci run` / `make pr-full` depends on is preserved and now covers main pushes too.

**Accepted tradeoff, called out in the comment:** main runs no longer yield, so they hold slots in the same 20-slot hosted pool that required PR checks draw from. That was the original reason for blanket cancellation. A merged commit nobody validated is worse than a PR check that waits — but if the pool starts starving, the comment says to revisit there rather than reinstate blanket cancellation.

### 2. `task-setup` left every new worktree unable to run the server unit suite

It runs `bun install` but never builds the package graph. Server unit modules import `@lobu/connector-worker/compile`, whose workspace export points at generated `dist/compile/index.js`, which a fresh worktree does not have. It fails as:

```
error: Cannot find module '@lobu/connector-worker/compile'
from .../packages/server/src/utils/connector-catalog.ts
```

That reads like a missing **dependency**, not a missing **build** — which is the whole cost, since it sends whoever hits it down the wrong path. CI runs this exact command before its own `bun test` ("Build package graph for unit-test runtime resolution"), which is why CI was green while every fresh worktree was not.

Measured at ~10s, so it runs unconditionally rather than behind a flag.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 7 gates)
- [x] `actionlint .github/workflows/ci.yml` — pass; `shellcheck -S error scripts/task-setup.sh` — pass

**End-to-end for (2)** — provisioned a throwaway worktree with the patched script and ran a server unit suite in it with **no manual build**:
```
=== server unit test in a BRAND NEW task-setup worktree, no manual build ===
 62 pass
 0 fail
```
The same suite in an unpatched fresh worktree:
```
error: Cannot find module '@lobu/connector-worker/compile'
 0 pass
 1 fail
```
The throwaway worktree was removed afterwards.

**(1) is a workflow-config change** and is not exercised until this merges — the observable proof is that the next merge to main should leave a *completed* CI run rather than a cancelled one. Worth spot-checking after the following merge.

## Notes
Expression semantics: `A && B || C` yields `B` when `A` is true and `C` otherwise, so PRs group by ref and everything else by run id. Verified with actionlint; GitHub evaluates `cancel-in-progress` expressions to a boolean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Pull request checks now automatically cancel superseded revisions.
  * Main branch and local build runs no longer interfere with one another.

* **Developer Experience**
  * Project setup now builds the package graph automatically after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->