### PR TITLE
fix(mcp): mark audited retrieval tools read-only

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -395,7 +395,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(tool).toEqual(
       expect.objectContaining({
         annotations: expect.objectContaining({
-          readOnlyHint: false,
+          readOnlyHint: true,
           destructiveHint: false,
           openWorldHint: false,
           idempotentHint: false,

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -56,16 +56,15 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(byName.has('execute')).toBe(false);
 
     const expectedSafetyHints = {
-      // These operations do not change workspace content or external systems,
-      // but OAuth and PAT invocations append private audit/activity records.
-      // OpenAI's read-only and idempotent hints therefore both remain false.
-      search_memory: [false, false, false],
-      search_sdk: [false, false, false],
-      query_sdk: [false, false, false],
-      query_sql: [false, false, false],
+      // Invocation audits are server bookkeeping, not mutations performed by
+      // these retrieval tools against workspace or external state.
+      search_memory: [true, false, false],
+      search_sdk: [true, false, false],
+      query_sdk: [true, false, false],
+      query_sql: [true, false, false],
       save_memory: [false, false, false],
       run_sdk: [false, true, true],
-      get_approval: [false, false, false],
+      get_approval: [true, false, false],
     } as const;
 
     for (const [toolName, [readOnlyHint, openWorldHint, destructiveHint]] of Object.entries(

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -209,8 +209,12 @@ const READ_ONLY = {
 // OpenAI Apps submission semantics reserve `openWorldHint` for tools that can
 // CHANGE public internet or third-party state. Live reads from a user's private
 // connectors remain closed-world even though they contact an external service.
+//
+// These tools only retrieve data. Their invocation audit is server bookkeeping,
+// not an operation on workspace or third-party state, so it does not make the
+// tool a write. Authorization stays separately pinned by `authorizationReadOnly`.
 const AUDITED_READ = {
-  readOnlyHint: false,
+  readOnlyHint: true,
   destructiveHint: false,
   openWorldHint: false,
   idempotentHint: false,


### PR DESCRIPTION
## What

`search_memory`, `search_sdk`, `query_sdk`, `query_sql` and `get_approval` advertised `readOnlyHint: false` via `AUDITED_READ`, because each OAuth/PAT invocation appends an audit/activity record.

That record is the server logging its own call, not an operation on workspace or third-party state — which is what both host definitions of the hint describe. Anthropic: *"retrieves data but never modifies it."* OpenAI: *"does not create, update, delete, or send data outside the conversation."*

## Why now

Two concrete costs:

- **Claude prompts on every read.** Read-only tools run without per-call confirmation; everything else interrupts the user. Every "what do we know about X?" threw a permission dialog.
- **The Connectors Directory submission portal flagged all seven tools as writing data**, which is what surfaced this.

It also misstates the action for OpenAI Apps review, where an incorrect action label is a documented common rejection cause.

## What is NOT changed

- **Authorization.** `isAuthorizationReadOnly` (`registry.ts`) prefers the explicit `authorizationReadOnly` field over the annotation, and these five tools already set it. Scope tiers are untouched.
- **Auditing.** The append-only events ledger still receives a row per invocation; the existing `records query_sql audit rows in the append-only events ledger` test passes unchanged.
- **`save_memory` and `run_sdk`**, which genuinely write, keep their annotations.
- **`idempotentHint`**, `destructiveHint`, `openWorldHint` on `AUDITED_READ`.

## Testing

Red→green proof — reverting `AUDITED_READ.readOnlyHint` to `false` fails for the right reason:

```
× exposes explicit SDK and memory tools with the expected annotations
  → search_memory.readOnlyHint: expected false to be true
```

Green after the fix:

```
Test Files  2 passed (2)
     Tests  36 passed (36)
```

(`query-tool.test.ts`, `mcp-app-resources.test.ts`.) `make pre-pr` clean.