### PR TITLE
refactor(cli): simplify device wizard state

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -7,7 +7,6 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { hostname } from "node:os";
 import * as daemonModule from "@lobu/connector-worker/daemon";
 import { daemonCommand } from "../commands/daemon";
 import { apiUrlToGatewayOrigin } from "../internal/context";
@@ -67,7 +66,6 @@ describe("lobu daemon", () => {
   let originalStdoutIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
     for (const key of SESSION_ENV_KEYS) {
       originalEnv.set(key, process.env[key]);
       delete process.env[key];
@@ -93,6 +91,7 @@ describe("lobu daemon", () => {
       url: "https://app.lobu.ai/api/v1",
       source: "config",
     });
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
@@ -102,7 +101,16 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("https://app.lobu.ai");
   });
 
-  test("an explicit --api-url is passed through untouched", async () => {
+  test("an explicit --api-url passes through without context-backed setup", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:cached-context-device",
+    });
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:wizard-device",
+      source: "created",
+    });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
@@ -110,6 +118,36 @@ describe("lobu daemon", () => {
     await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
 
     expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("http://127.0.0.1:9564");
+    expect(load).not.toHaveBeenCalled();
+    expect(wizard).not.toHaveBeenCalled();
+  });
+
+  test("LOBU_API_URL is an override too and never borrows the context's device", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:9564",
+      source: "env",
+    });
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:cached-context-device",
+    });
+    const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "macos:wizard-device",
+      source: "created",
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(load).not.toHaveBeenCalled();
+    expect(wizard).not.toHaveBeenCalled();
+    expect(start.mock.calls[0]?.[0]?.workerId).not.toBe(
+      "macos:cached-context-device"
+    );
   });
 
   test("--inside-claude bypasses cache and wizard so the daemon derives a per-session id", async () => {
@@ -140,17 +178,16 @@ describe("lobu daemon", () => {
     expect(wizard).not.toHaveBeenCalled();
   });
 
-  test("an explicit --worker-id wins while --inside-claude still forces its lane", async () => {
-    spyOn(context, "resolveContext").mockResolvedValue({
-      name: "prod",
-      url: "https://app.lobu.ai/api/v1",
-      source: "config",
+  test("an explicit --worker-id wins over both the cache and the session lane", async () => {
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "macos:cached-host",
     });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
 
     await daemonCommand({
+      apiUrl: "http://127.0.0.1:9564",
       workerId: "headless:attached-explicit",
       insideClaude: true,
     });
@@ -159,6 +196,7 @@ describe("lobu daemon", () => {
       workerId: "headless:attached-explicit",
       insideClaude: true,
     });
+    expect(load).not.toHaveBeenCalled();
   });
 
   test("auto-detected Codex bypasses the host cache and remains in the centralized session lane", async () => {
@@ -183,51 +221,12 @@ describe("lobu daemon", () => {
     expect(wizard).not.toHaveBeenCalled();
   });
 
-  test("non-interactive first run falls back to the computed default id", async () => {
-    spyOn(context, "resolveContext").mockResolvedValue({
-      name: "local",
-      url: "http://127.0.0.1:8795",
-      source: "config",
-    });
-    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
-    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
-    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
-      undefined as never
-    );
-
-    await daemonCommand({});
-
-    expect(start.mock.calls[0]?.[0]?.workerId).toBe(
-      `${process.platform === "darwin" ? "macos" : "headless"}:${hostname().split(".")[0]}`
-    );
-  });
-
-  test("non-interactive boot reuses a cached device id when present", async () => {
-    spyOn(context, "resolveContext").mockResolvedValue({
-      name: "local",
-      url: "http://127.0.0.1:8795",
-      source: "config",
-    });
-    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
-    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
-      workerId: "macos:confirmed-box",
-    });
-    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
-      undefined as never
-    );
-
-    await daemonCommand({});
-
-    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
-  });
-
   test("interactive boot with a cached device id does not re-prompt via the wizard", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
       url: "http://127.0.0.1:8795",
       source: "config",
     });
-    spyOn(context, "getCurrentContextName").mockResolvedValue("local");
     spyOn(deviceState, "loadDeviceState").mockResolvedValue({
       workerId: "macos:confirmed-box",
     });
@@ -258,7 +257,7 @@ describe("lobu daemon", () => {
       undefined as never
     );
     await expect(daemonCommand({})).rejects.toThrow(
-      /durable.*WORKER_API_TOKEN.*device_worker:run/s
+      /durable.*WORKER_API_TOKEN.*lobu token create --raw/s
     );
     expect(start).not.toHaveBeenCalled();
   });
@@ -266,6 +265,11 @@ describe("lobu daemon", () => {
   test("a fresh TTY runs the wizard once and forwards its chosen identity", async () => {
     (process.stdin as { isTTY?: boolean }).isTTY = true;
     (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:9564",
+      source: "config",
+    });
     spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
     const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
       workerId: "macos:chosen-by-wizard",
@@ -275,9 +279,14 @@ describe("lobu daemon", () => {
       undefined as never
     );
 
-    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+    await daemonCommand({});
 
     expect(wizard).toHaveBeenCalledTimes(1);
+    expect(wizard.mock.calls[0]?.[0]).toMatchObject({
+      context: "local",
+      gatewayOrigin: "http://127.0.0.1:9564",
+      platform: process.platform === "darwin" ? "macos" : "headless",
+    });
     expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:chosen-by-wizard");
   });
 
@@ -285,6 +294,11 @@ describe("lobu daemon", () => {
     process.env.CI = "true";
     (process.stdin as { isTTY?: boolean }).isTTY = true;
     (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:9564",
+      source: "config",
+    });
     spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
     const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
       workerId: "macos:should-not-run",
@@ -294,7 +308,7 @@ describe("lobu daemon", () => {
       undefined as never
     );
 
-    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+    await daemonCommand({});
 
     expect(wizard).not.toHaveBeenCalled();
     expect(start.mock.calls[0]?.[0]?.workerId).toContain(":");

--- a/packages/cli/src/__tests__/device-state.test.ts
+++ b/packages/cli/src/__tests__/device-state.test.ts
@@ -8,136 +8,73 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
 import * as os from "node:os";
-import {
-  loadDeviceState,
-  saveDeviceState,
-  workerTokenPrefix,
-} from "../internal/device-state";
-
-describe("workerTokenPrefix", () => {
-  test("truncates a long token to a privacy-safe prefix", () => {
-    expect(workerTokenPrefix("owl_pat_abcdefghijklmnop")).toBe("owl_pat_abcd");
-  });
-
-  test("returns null when no token is present", () => {
-    expect(workerTokenPrefix(undefined)).toBeNull();
-  });
-
-  test("never echoes a token it cannot truncate", () => {
-    // The wizard prints this value followed by an ellipsis, so returning a
-    // short token verbatim would leak the live secret under a label claiming
-    // it was truncated. Anything too short to shorten is withheld entirely.
-    for (const short of ["owl_pat_ab", "owl_pat_abcd", "x"]) {
-      expect(workerTokenPrefix(short)).toBeNull();
-    }
-  });
-
-  test("a real-length PAT keeps only a non-reconstructable stem", () => {
-    const token = `owl_pat_${"a".repeat(24)}`;
-    const prefix = workerTokenPrefix(token) as string;
-    expect(token.startsWith(prefix)).toBe(true);
-    expect(prefix.length).toBeLessThan(token.length);
-  });
-});
+import { join } from "node:path";
+import { loadDeviceState, saveDeviceState } from "../internal/device-state";
 
 describe("device-state cache", () => {
-  let dir: string;
+  let home: string | undefined;
+
   afterEach(() => {
     mock.restore();
-    rmSync(dir, { recursive: true, force: true });
+    if (home) rmSync(home, { recursive: true, force: true });
+    home = undefined;
   });
 
-  test("round-trips a saved state and loads it back", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
+  function useTemporaryHome(): string {
+    home = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
+    spyOn(os, "homedir").mockReturnValue(home);
+    return home;
+  }
 
-    await saveDeviceState("local", {
+  test("round-trips owner-only state scoped to context and platform", async () => {
+    const dir = useTemporaryHome();
+
+    await saveDeviceState("local", "macos", {
       workerId: "macos:myhost",
     });
 
-    const loaded = await loadDeviceState("local");
-    expect(loaded?.workerId).toBe("macos:myhost");
-    expect(statSync(join(dir, ".lobu", "devices")).mode & 0o777).toBe(0o700);
-    expect(
-      statSync(join(dir, ".lobu", "devices", "local.json")).mode & 0o777
-    ).toBe(0o600);
-  });
-
-  test("returns null when no state exists", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
-
-    expect(await loadDeviceState("local")).toBeNull();
-  });
-
-  test("returns null for an empty or invalid workerId", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
-
-    await saveDeviceState("local", {
-      workerId: "macos:x",
+    expect(await loadDeviceState("local", "macos")).toEqual({
+      workerId: "macos:myhost",
     });
-    // Corrupt the file to simulate an invalid payload.
-    writeFileSync(
-      join(dir, ".lobu", "devices", "local.json"),
-      JSON.stringify({ workerTokenPrefix: "x" })
-    );
+    expect(await loadDeviceState("local", "headless")).toBeNull();
+    expect(await loadDeviceState("prod", "macos")).toBeNull();
 
-    expect(await loadDeviceState("local")).toBeNull();
+    const devicesDir = join(dir, ".config", "lobu", "devices");
+    const [file] = readdirSync(devicesDir);
+    expect(file).not.toMatch(/[/\s]/);
+    expect(statSync(devicesDir).mode & 0o777).toBe(0o700);
+    expect(statSync(join(devicesDir, file as string)).mode & 0o777).toBe(0o600);
   });
 
-  test("repairs a corrupt cache atomically while preserving the bad payload", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
-    const devicesDir = join(dir, ".lobu", "devices");
+  test("returns null for absent or malformed state", async () => {
+    const dir = useTemporaryHome();
+    const devicesDir = join(dir, ".config", "lobu", "devices");
     mkdirSync(devicesDir, { recursive: true });
-    writeFileSync(join(devicesDir, "local.json"), "not-json\n");
+    writeFileSync(join(devicesDir, "local--macos.json"), "not-json\n");
 
-    const saved = await saveDeviceState("local", {
-      workerId: "headless:repaired",
-    });
-
-    expect(saved.workerId).toBe("headless:repaired");
-    expect((await loadDeviceState("local"))?.workerId).toBe(
-      "headless:repaired"
-    );
-    expect(
-      readdirSync(devicesDir).some((name) => name.includes(".corrupt-"))
-    ).toBe(true);
+    expect(await loadDeviceState("missing", "macos")).toBeNull();
+    expect(await loadDeviceState("local", "macos")).toBeNull();
+    await expect(
+      saveDeviceState("local", "macos", { workerId: "macos:myhost" })
+    ).rejects.toThrow(/already exists or is unreadable/);
   });
 
-  test("concurrent first writes converge on one durable worker identity", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
+  test("rejects a concurrent first setup instead of starting two daemons", async () => {
+    useTemporaryHome();
 
-    const results = await Promise.all([
-      saveDeviceState("local", { workerId: "headless:first" }),
-      saveDeviceState("local", { workerId: "headless:second" }),
+    const results = await Promise.allSettled([
+      saveDeviceState("local", "macos", { workerId: "macos:first" }),
+      saveDeviceState("local", "macos", { workerId: "macos:second" }),
     ]);
-    const loaded = await loadDeviceState("local");
 
-    expect(results[0]?.workerId).toBe(results[1]?.workerId);
-    expect(loaded?.workerId).toBe(results[0]?.workerId);
     expect(
-      readdirSync(join(dir, ".lobu", "devices")).filter((name) =>
-        name.endsWith(".tmp")
-      )
-    ).toHaveLength(0);
-  });
-
-  test("sanitizes the context name for the file path", async () => {
-    dir = mkdtempSync(join(tmpdir(), "lobu-device-state-"));
-    spyOn(os, "homedir").mockReturnValue(dir);
-
-    await saveDeviceState("prod/api v1", {
-      workerId: "macos:host",
-    });
-
-    // The context name with slashes/spaces becomes a single safe filename.
-    const files = readdirSync(join(dir, ".lobu", "devices"));
-    expect(files).toHaveLength(1);
-    expect(files[0]).not.toMatch(/[/\s]/);
+      results.filter((result) => result.status === "fulfilled")
+    ).toHaveLength(1);
+    const rejection = results.find((result) => result.status === "rejected");
+    expect(String(rejection?.reason)).toContain("already exists");
+    expect((await loadDeviceState("local", "macos"))?.workerId).toMatch(
+      /^macos:(first|second)$/
+    );
   });
 });

--- a/packages/cli/src/commands/__tests__/device-wizard.test.ts
+++ b/packages/cli/src/commands/__tests__/device-wizard.test.ts
@@ -2,14 +2,14 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as deviceState from "../../internal/device-state";
 import { deviceWizard, type DeviceWizardPrompts } from "../_lib/device-wizard";
 
-const API_URL = "http://127.0.0.1:8795";
+const GATEWAY_ORIGIN = "http://127.0.0.1:8795";
 const WORKER_TOKEN = "owl_pat_durable-device-token";
 
 function fakePrompts(
   overrides: Partial<DeviceWizardPrompts> = {}
 ): DeviceWizardPrompts {
   return {
-    select: async () => "personal",
+    select: async () => "__lobu_new_device__",
     confirm: async () => true,
     input: async () => "macos:custom",
     ...overrides,
@@ -21,7 +21,8 @@ function wizardOptions(
 ): Parameters<typeof deviceWizard>[0] {
   return {
     context: "local",
-    apiUrl: API_URL,
+    gatewayOrigin: GATEWAY_ORIGIN,
+    platform: "macos",
     suggestedWorkerId: "macos:Mac",
     workerApiToken: WORKER_TOKEN,
     prompts: fakePrompts(),
@@ -39,35 +40,17 @@ function response(body: unknown, status = 200): Response {
   } as never;
 }
 
-function stubFetch(options: {
-  devices?: unknown[];
-  devicesStatus?: number;
-  tokenOrg?: string;
-}): ReturnType<typeof spyOn> {
-  return spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-    const url = String(input);
-    if (url.endsWith("/oauth/userinfo")) {
-      return response({
-        organization_slug: options.tokenOrg ?? "personal",
-        personal_org_slug: "personal",
-        organizations: [
-          { slug: "personal", name: "Personal", personal: true },
-          { slug: "org-a", name: "Org A", personal: false },
-          { slug: "org-b", name: "Org B", personal: false },
-        ],
-      });
-    }
-    return response(
-      options.devicesStatus === 200 || options.devicesStatus === undefined
-        ? { devices: options.devices ?? [] }
-        : { error: "Unauthorized" },
-      options.devicesStatus ?? 200
-    );
-  });
+function stubDevices(
+  devices: unknown[],
+  status = 200
+): ReturnType<typeof spyOn> {
+  return spyOn(globalThis, "fetch").mockResolvedValue(
+    response(status === 200 ? { devices } : { error: "Unauthorized" }, status)
+  );
 }
 
-function stubSave(workerId = "macos:Mac"): ReturnType<typeof spyOn> {
-  return spyOn(deviceState, "saveDeviceState").mockResolvedValue({ workerId });
+function stubSave(): ReturnType<typeof spyOn> {
+  return spyOn(deviceState, "saveDeviceState").mockResolvedValue();
 }
 
 afterEach(() => {
@@ -75,19 +58,33 @@ afterEach(() => {
 });
 
 describe("deviceWizard", () => {
-  test("confirms and persists a fresh identity when the server has no devices", async () => {
-    stubFetch({ devices: [] });
+  test("confirms and persists a fresh identity without a no-op workspace prompt", async () => {
+    stubDevices([]);
     const save = stubSave();
+    const select = mock(async () => "__lobu_new_device__");
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.map(String).join(" "));
+    });
 
-    const result = await deviceWizard(wizardOptions());
+    const result = await deviceWizard(
+      wizardOptions({ prompts: fakePrompts({ select }) })
+    );
 
     expect(result).toEqual({ source: "created", workerId: "macos:Mac" });
-    expect(save.mock.calls[0]?.[1]).toEqual({ workerId: "macos:Mac" });
+    expect(select).not.toHaveBeenCalled();
+    expect(save.mock.calls[0]).toEqual([
+      "local",
+      "macos",
+      { workerId: "macos:Mac" },
+    ]);
+    expect(logs.join("\n")).not.toContain("Token:");
+    expect(logs.join("\n")).not.toContain("selected workspace");
   });
 
   test("uses a custom id when the user declines the suggestion", async () => {
-    stubFetch({ devices: [] });
-    const save = stubSave("macos:custom");
+    stubDevices([]);
+    const save = stubSave();
 
     const result = await deviceWizard(
       wizardOptions({
@@ -98,92 +95,139 @@ describe("deviceWizard", () => {
       })
     );
 
-    expect(result.workerId).toBe("macos:custom");
-    expect(save.mock.calls[0]?.[1]).toEqual({ workerId: "macos:custom" });
+    expect(result).toEqual({ source: "created", workerId: "macos:custom" });
+    expect(save.mock.calls[0]?.[2]).toEqual({ workerId: "macos:custom" });
   });
 
-  test("maps a selected server device id back to its exact worker identity", async () => {
-    stubFetch({
-      devices: [
-        {
-          id: "dev-1",
-          worker_id: "__new__",
-          platform: "macos",
-          label: "Literal sentinel worker",
-          organization_slug: "personal",
-        },
-      ],
-    });
-    stubSave("__new__");
-    const selections = ["personal", "dev-1"];
+  test("offers only offline devices from the daemon platform", async () => {
+    stubDevices([
+      {
+        id: "matching-offline",
+        worker_id: "macos:offline",
+        platform: "macos",
+        online: false,
+        label: "Offline Mac",
+      },
+      {
+        id: "wrong-platform",
+        worker_id: "headless:box",
+        platform: "headless",
+        online: false,
+      },
+      {
+        id: "matching-online",
+        worker_id: "macos:online",
+        platform: "macos",
+        online: true,
+      },
+    ]);
+    stubSave();
+    const offered: string[] = [];
 
     const result = await deviceWizard(
       wizardOptions({
-        prompts: fakePrompts({ select: async () => selections.shift() ?? "" }),
+        prompts: fakePrompts({
+          select: async (config) => {
+            offered.push(
+              ...config.choices.flatMap((choice) =>
+                "value" in choice ? [String(choice.value)] : []
+              )
+            );
+            return "matching-offline";
+          },
+        }),
       })
     );
 
-    expect(result).toEqual({ source: "reused", workerId: "__new__" });
+    expect(result).toEqual({ source: "reused", workerId: "macos:offline" });
+    expect(offered).toContain("matching-offline");
+    expect(offered).not.toContain("wrong-platform");
+    expect(offered).not.toContain("matching-online");
   });
 
-  test("cross-org reuse reports the server org and never claims the selected workspace is the pin", async () => {
-    stubFetch({
-      tokenOrg: "org-a",
-      devices: [
-        {
-          id: "dev-b",
-          worker_id: "macos:org-b-device",
-          platform: "macos",
-          label: "Org B Mac",
-          organization_slug: "org-b",
-          organization_name: "Org B",
-        },
-      ],
-    });
-    stubSave("macos:org-b-device");
-    const selections = ["org-a", "dev-b"];
-    const logs: string[] = [];
-    spyOn(console, "log").mockImplementation((...args) => {
-      logs.push(args.map(String).join(" "));
-    });
-
-    const result = await deviceWizard(
-      wizardOptions({
-        prompts: fakePrompts({ select: async () => selections.shift() ?? "" }),
-      })
-    );
-
-    const output = logs.join("\n");
-    expect(result).toEqual({
-      source: "reused",
-      workerId: "macos:org-b-device",
-    });
-    expect(output).toContain('server reports workspace "org-b"');
-    expect(output).toContain('selected workspace "org-a" was guidance only');
-    expect(output).not.toContain('Device workspace: "org-a"');
-    expect(output).not.toContain("org-scoped to org-a");
-  });
-
-  test("a new device says only that the worker PAT determines attachment", async () => {
-    stubFetch({ devices: [], tokenOrg: "org-a" });
+  test("reports the reused device's server workspace", async () => {
+    stubDevices([
+      {
+        id: "dev-b",
+        worker_id: "macos:org-b-device",
+        platform: "macos",
+        online: false,
+        organization_slug: "org-b",
+      },
+    ]);
     stubSave();
     const logs: string[] = [];
     spyOn(console, "log").mockImplementation((...args) => {
       logs.push(args.map(String).join(" "));
     });
 
-    await deviceWizard(wizardOptions());
-
-    const output = logs.join("\n");
-    expect(output).toContain(
-      "WORKER_API_TOKEN determines its workspace attachment on first poll"
+    await deviceWizard(
+      wizardOptions({
+        prompts: fakePrompts({ select: async () => "dev-b" }),
+      })
     );
-    expect(output).not.toContain("Device workspace:");
-    expect(output).not.toContain("org-scoped to");
+
+    expect(logs.join("\n")).toContain('server workspace: "org-b"');
   });
 
-  test("device-list failures stop setup instead of silently creating a duplicate", async () => {
-    stubFetch({ devicesStatus: 401 });
+  test("a new id matching an offline device reuses it instead of duplicating", async () => {
+    stubDevices([
+      {
+        id: "same-box",
+        worker_id: "macos:Mac",
+        platform: "macos",
+        online: false,
+        organization_slug: "org-a",
+      },
+    ]);
+    const save = stubSave();
+
+    const result = await deviceWizard(
+      wizardOptions({
+        prompts: fakePrompts({ select: async () => "__lobu_new_device__" }),
+      })
+    );
+
+    expect(result).toEqual({ source: "reused", workerId: "macos:Mac" });
+    expect(save.mock.calls[0]?.[2]).toEqual({ workerId: "macos:Mac" });
+  });
+
+  test("rejects a new id already bound to another platform", async () => {
+    stubDevices([
+      {
+        id: "other-platform",
+        worker_id: "macos:Mac",
+        platform: "headless",
+        online: false,
+      },
+    ]);
+    const save = stubSave();
+
+    await expect(deviceWizard(wizardOptions())).rejects.toThrow(
+      /registered as headless/
+    );
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  test("rejects a new id that is already online", async () => {
+    stubDevices([
+      {
+        id: "already-running",
+        worker_id: "macos:Mac",
+        platform: "macos",
+        online: true,
+      },
+    ]);
+    const save = stubSave();
+
+    await expect(deviceWizard(wizardOptions())).rejects.toThrow(
+      /already online/
+    );
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  test("device-list failures stop setup instead of creating a duplicate", async () => {
+    stubDevices([], 401);
     const save = stubSave();
 
     await expect(deviceWizard(wizardOptions())).rejects.toThrow(
@@ -192,31 +236,17 @@ describe("deviceWizard", () => {
     expect(save).not.toHaveBeenCalled();
   });
 
-  test("uses only the durable worker PAT against the daemon origin", async () => {
-    const fetchSpy = stubFetch({ devices: [] });
+  test("uses the durable worker PAT only against the resolved gateway", async () => {
+    const fetchSpy = stubDevices([]);
     stubSave();
 
-    await deviceWizard(
-      wizardOptions({ apiUrl: "https://gateway.example.test/api/v1" })
+    await deviceWizard(wizardOptions());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [input, init] = fetchSpy.mock.calls[0] as [unknown, RequestInit];
+    expect(String(input)).toBe(`${GATEWAY_ORIGIN}/api/me/devices`);
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${WORKER_TOKEN}`
     );
-
-    expect(fetchSpy).toHaveBeenCalled();
-    for (const [input, init] of fetchSpy.mock.calls) {
-      expect(String(input).startsWith("https://gateway.example.test/")).toBe(
-        true
-      );
-      expect((init?.headers as Record<string, string>).Authorization).toBe(
-        `Bearer ${WORKER_TOKEN}`
-      );
-    }
-  });
-
-  test("returns the first-writer cache identity from an overlapping first boot", async () => {
-    stubFetch({ devices: [] });
-    stubSave("macos:other-process-won");
-
-    const result = await deviceWizard(wizardOptions());
-
-    expect(result.workerId).toBe("macos:other-process-won");
   });
 });

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -1,10 +1,8 @@
 import { confirm, input, select } from "@inquirer/prompts";
 import chalk from "chalk";
-import { apiUrlToGatewayOrigin } from "../../internal/context.js";
 import {
   saveDeviceState,
   WORKER_ID_PATTERN,
-  workerTokenPrefix,
 } from "../../internal/device-state.js";
 import {
   extractApiError,
@@ -13,57 +11,155 @@ import {
 } from "../../internal/http.js";
 
 const NEW_DEVICE_CHOICE = "__lobu_new_device__";
-/** Stands in for the personal org when `/oauth/userinfo` did not name it. */
-const PERSONAL_FALLBACK_CHOICE = "__lobu_personal__";
 
-/**
- * First-run interactive onboarding for `lobu daemon`.
- *
- * The server remains authoritative for both identity and workspace attachment:
- * an existing device reports its stored workspace, while a new device attaches
- * according to the durable worker PAT on its first poll. The local cache only
- * keeps subsequent boots on the same `worker_id`.
- */
 export interface DeviceWizardOptions {
-  context?: string;
-  /** Actual daemon gateway URL; the worker PAT is sent only here. */
-  apiUrl: string;
-  /** Pre-computed default `<platform>:<hostname>` id. */
+  context: string;
+  gatewayOrigin: string;
+  platform: string;
   suggestedWorkerId: string;
-  /** Durable worker PAT used by the daemon. */
   workerApiToken: string;
-  /** Overridable prompts (defaults to real inquirer); injectable for tests. */
   prompts?: DeviceWizardPrompts;
 }
 
-/** A registered device as returned by `GET /api/me/devices`. */
 interface RemoteDevice {
   id: string;
   worker_id: string;
   platform: string | null;
-  label: string | null;
-  organization_slug: string | null;
-  organization_name: string | null;
-}
-
-interface OrganizationInfo {
-  slug: string;
-  name?: string;
-  personal?: boolean;
+  online: boolean;
+  label?: string | null;
+  organization_slug?: string | null;
 }
 
 export interface DeviceWizardResult {
   workerId: string;
-  /** How the id was chosen, including a concurrent first boot winning first. */
-  source: "reused" | "created" | "cached";
+  source: "reused" | "created";
+}
+
+export interface DeviceWizardPrompts {
+  select: (config: Parameters<typeof select>[0]) => Promise<string>;
+  confirm: (config: Parameters<typeof confirm>[0]) => Promise<boolean>;
+  input: (config: Parameters<typeof input>[0]) => Promise<string>;
+}
+
+export async function deviceWizard(
+  options: DeviceWizardOptions
+): Promise<DeviceWizardResult> {
+  const prompts = options.prompts ?? { select, confirm, input };
+  const devices = await fetchRemoteDevices(
+    options.gatewayOrigin,
+    options.workerApiToken
+  );
+  const reusable = devices.filter(
+    (device) => device.platform === options.platform && !device.online
+  );
+
+  console.log();
+  console.log(chalk.bold("  Set up this device as a Lobu worker"));
+  console.log(
+    chalk.dim(
+      "  It polls the gateway for connector syncs, actions, and device Automations.\n"
+    )
+  );
+
+  let workerId = options.suggestedWorkerId;
+  let source: DeviceWizardResult["source"] = "created";
+  let selectedDevice: RemoteDevice | undefined;
+
+  if (reusable.length > 0) {
+    const choice = await prompts.select({
+      message: "Pick an offline device identity (or start a new one)",
+      choices: [
+        {
+          value: NEW_DEVICE_CHOICE,
+          name: chalk.dim("Start a new device"),
+        },
+        ...reusable.map((device) => ({
+          value: device.id,
+          name: `${device.label ?? device.worker_id}${
+            device.organization_slug
+              ? chalk.dim(` — ${device.organization_slug}`)
+              : ""
+          }`,
+        })),
+      ],
+    });
+    if (choice !== NEW_DEVICE_CHOICE) {
+      selectedDevice = reusable.find((device) => device.id === choice);
+      if (!selectedDevice) {
+        throw new Error("Selected device is no longer available");
+      }
+      workerId = selectedDevice.worker_id;
+      source = "reused";
+    }
+  }
+
+  if (source === "created") {
+    const confirmed = await prompts.confirm({
+      message: `Register this machine as device "${chalk.bold(options.suggestedWorkerId)}"?`,
+      default: true,
+    });
+    if (!confirmed) {
+      workerId = (
+        await prompts.input({
+          message:
+            "Enter a device id (letters, digits, dot, underscore, colon, hyphen):",
+          validate: (value) =>
+            WORKER_ID_PATTERN.test(value.trim())
+              ? true
+              : "Use 1-128 characters of letters, digits, dot, underscore, colon or hyphen",
+        })
+      ).trim();
+    }
+
+    const collision = devices.find((device) => device.worker_id === workerId);
+    if (collision) {
+      if (collision.platform !== options.platform) {
+        throw new Error(
+          `Device "${workerId}" is registered as ${collision.platform ?? "an unknown platform"}; choose a different id.`
+        );
+      }
+      if (collision.online) {
+        throw new Error(
+          `Device "${workerId}" is already online; stop its daemon or choose a different id.`
+        );
+      }
+      selectedDevice = collision;
+      source = "reused";
+    }
+  }
+
+  await saveDeviceState(options.context, options.platform, { workerId });
+
+  console.log(chalk.green(`\n  Device identity "${workerId}" saved locally.`));
+  if (source === "reused") {
+    const workspace = selectedDevice?.organization_slug;
+    console.log(
+      chalk.dim(
+        `  Reusing the existing device; server workspace: ${workspace ? `"${workspace}"` : "unattached"}.`
+      )
+    );
+  } else {
+    console.log(
+      chalk.dim(
+        "  WORKER_API_TOKEN determines its workspace attachment on first poll."
+      )
+    );
+  }
+  console.log(
+    chalk.dim(
+      `  Saved for context "${options.context}" on ${options.platform}; later runs reuse it.`
+    )
+  );
+  console.log();
+
+  return { workerId, source };
 }
 
 async function fetchRemoteDevices(
-  apiUrl: string,
+  gatewayOrigin: string,
   token: string
 ): Promise<RemoteDevice[]> {
-  const origin = apiUrlToGatewayOrigin(apiUrl);
-  const url = `${origin}/api/me/devices`;
+  const url = `${gatewayOrigin}/api/me/devices`;
   const res = await fetchWithRetry(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -82,41 +178,6 @@ async function fetchRemoteDevices(
   return parsed.devices.filter(isRemoteDevice);
 }
 
-async function fetchOrganizations(
-  apiUrl: string,
-  token: string
-): Promise<OrganizationInfo[]> {
-  const origin = apiUrlToGatewayOrigin(apiUrl);
-  const res = await fetchWithRetry(`${origin}/oauth/userinfo`, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!res.ok) return [];
-  const body = (await res.json().catch(() => null)) as {
-    personal_org_slug?: unknown;
-    organizations?: unknown;
-  } | null;
-  if (!body || !Array.isArray(body.organizations)) return [];
-  const personal =
-    typeof body.personal_org_slug === "string" ? body.personal_org_slug : null;
-  const organizations: OrganizationInfo[] = [];
-  for (const entry of body.organizations) {
-    if (!entry || typeof entry !== "object") continue;
-    const value = entry as Record<string, unknown>;
-    if (typeof value.slug !== "string" || !value.slug) continue;
-    organizations.push({
-      slug: value.slug,
-      ...(typeof value.name === "string" ? { name: value.name } : {}),
-      ...(value.personal === true || value.slug === personal
-        ? { personal: true }
-        : {}),
-    });
-  }
-  return organizations;
-}
-
 function isRemoteDevice(value: unknown): value is RemoteDevice {
   if (!value || typeof value !== "object") return false;
   const device = value as Record<string, unknown>;
@@ -124,176 +185,8 @@ function isRemoteDevice(value: unknown): value is RemoteDevice {
     typeof device.id === "string" &&
     device.id.length > 0 &&
     typeof device.worker_id === "string" &&
-    device.worker_id.length > 0
+    device.worker_id.length > 0 &&
+    (device.platform === null || typeof device.platform === "string") &&
+    typeof device.online === "boolean"
   );
-}
-
-/** The prompt primitives the wizard drives; injectable for deterministic tests. */
-export interface DeviceWizardPrompts {
-  select: (config: Parameters<typeof select>[0]) => Promise<string>;
-  confirm: (config: Parameters<typeof confirm>[0]) => Promise<boolean>;
-  input: (config: Parameters<typeof input>[0]) => Promise<string>;
-}
-
-export async function deviceWizard(
-  options: DeviceWizardOptions
-): Promise<DeviceWizardResult> {
-  const prompts = options.prompts ?? { select, confirm, input };
-  // The daemon URL and PAT are explicit inputs; a stale/missing context file
-  // must not block setup or redirect either credential. The context name is
-  // only a local cache namespace.
-  const contextName = options.context?.trim() || "gateway";
-  const [orgs, devices] = await Promise.all([
-    // Organization discovery is optional guidance. Device discovery is not:
-    // hiding its failure could create a duplicate identity.
-    fetchOrganizations(options.apiUrl, options.workerApiToken).catch(() => []),
-    fetchRemoteDevices(options.apiUrl, options.workerApiToken),
-  ]);
-  const tokenPrefix = workerTokenPrefix(options.workerApiToken);
-
-  const personal = orgs.find((org) => org.personal === true)?.slug;
-  const orgOptions = orgs
-    .filter((org) => org.slug !== personal)
-    .map((org) => ({
-      value: org.slug,
-      name:
-        org.name && org.name !== org.slug
-          ? `${org.slug} (${org.name})`
-          : org.slug,
-    }));
-  const personalLabel = personal
-    ? chalk.bold(personal) + chalk.dim(" (your private workspace)")
-    : "personal";
-
-  console.log();
-  console.log(chalk.bold("  Set up this device as a Lobu worker"));
-  console.log(
-    chalk.dim(
-      "  It polls the gateway for connector syncs, actions, and device Automations.\n"
-    )
-  );
-
-  // A `device_worker:run`-only PAT cannot read `/oauth/userinfo`, so org
-  // discovery legitimately comes back empty or single-valued. Prompting for a
-  // choice that has exactly one option asks the user to confirm a foregone
-  // conclusion, so only ask when there is something to pick between.
-  const personalChoice = {
-    value: personal ?? PERSONAL_FALLBACK_CHOICE,
-    name: personalLabel,
-  };
-  const orgTarget =
-    orgOptions.length > 0
-      ? await prompts.select({
-          message:
-            "Which workspace do you intend this device to run for? (guidance only; the worker PAT decides)",
-          choices: [personalChoice, ...orgOptions],
-        })
-      : personalChoice.value;
-  const selectedOrg =
-    orgTarget === PERSONAL_FALLBACK_CHOICE
-      ? (personal ?? "personal")
-      : orgTarget;
-
-  let workerId = options.suggestedWorkerId;
-  let source: DeviceWizardResult["source"] = "created";
-  let selectedDevice: RemoteDevice | undefined;
-
-  if (devices.length > 0) {
-    const choice = await prompts.select({
-      message: "Pick a device identity (or start a new one)",
-      choices: [
-        {
-          value: NEW_DEVICE_CHOICE,
-          name: chalk.dim("Start a new device with a fresh id"),
-        },
-        ...devices.map((device) => ({
-          value: device.id,
-          name: `${device.label ?? device.worker_id}${device.organization_slug ? chalk.dim(` — ${device.organization_slug}`) : ""}`,
-        })),
-      ],
-    });
-    if (choice !== NEW_DEVICE_CHOICE) {
-      selectedDevice = devices.find((device) => device.id === choice);
-      if (!selectedDevice) {
-        throw new Error("Selected device is no longer available");
-      }
-      workerId = selectedDevice.worker_id;
-      source = "reused";
-    }
-  }
-
-  if (source === "created") {
-    const confirmed = await prompts.confirm({
-      message: `Register this machine as device "${chalk.bold(options.suggestedWorkerId)}"?`,
-      default: true,
-    });
-    if (!confirmed) {
-      const custom = await prompts.input({
-        message:
-          "Enter a device id (letters, digits, dot, underscore, colon, hyphen):",
-        validate: (value) =>
-          WORKER_ID_PATTERN.test(value.trim())
-            ? true
-            : "Use 1-128 characters of letters, digits, dot, underscore, colon or hyphen",
-      });
-      workerId = custom.trim();
-    }
-  }
-
-  const saved = await saveDeviceState(contextName, { workerId });
-  if (saved.workerId !== workerId) {
-    workerId = saved.workerId;
-    source = "cached";
-    selectedDevice = undefined;
-  }
-
-  console.log(chalk.green(`\n  Device identity "${workerId}" saved locally.`));
-  if (source === "reused") {
-    const actualOrg = selectedDevice?.organization_slug;
-    console.log(
-      chalk.dim(
-        `  Reusing the existing device row; the server reports workspace ${actualOrg ? `"${actualOrg}"` : "unattached"}.`
-      )
-    );
-    console.log(
-      chalk.dim(
-        `  The selected workspace "${selectedOrg}" was guidance only and did not move the existing device.`
-      )
-    );
-  } else if (source === "cached") {
-    console.log(
-      chalk.dim(
-        "  Another concurrent first boot saved this identity first; both daemons will use the same cached id."
-      )
-    );
-  } else {
-    console.log(
-      chalk.dim(
-        "  New device; WORKER_API_TOKEN determines its workspace attachment on first poll."
-      )
-    );
-    console.log(
-      chalk.dim(
-        `  The selected workspace "${selectedOrg}" is token-selection guidance only.`
-      )
-    );
-  }
-  console.log(
-    chalk.dim(
-      `  Token: ${tokenPrefix ?? "unknown"}… (the server verifies its scope and attachment on poll).`
-    )
-  );
-  console.log(
-    chalk.dim(
-      `  Saved under ~/.lobu/devices/ for context "${contextName}" (local only; the server owns the attachment).`
-    )
-  );
-  console.log(
-    chalk.dim(
-      "  Later `lobu daemon` runs reuse this without asking, unless you pass --worker-id or delete the file."
-    )
-  );
-  console.log();
-
-  return { workerId, source };
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -5,7 +5,6 @@ import {
 import { hostname } from "node:os";
 import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
 import { loadDeviceState } from "../internal/device-state.js";
-import { getCurrentContextName } from "../internal/index.js";
 import { deviceWizard } from "./_lib/device-wizard.js";
 
 export interface DaemonOptions {
@@ -25,11 +24,14 @@ const SETUP_MESSAGE =
   "  - run `lobu login` to configure a context, or\n" +
   "  - pass --api-url <origin>.";
 
+// `device_worker:run` is NOT mintable as a PAT scope (see `AVAILABLE_PAT_SCOPES`
+// server-side); the `/api/workers/*` gate accepts the mintable `mcp:write`
+// scope, so the remediation requests that least-privilege alternative.
 const TOKEN_SETUP_MESSAGE =
   "A device daemon requires a durable owl_pat_ token in WORKER_API_TOKEN; " +
   "a stored OAuth login expires and is never used as daemon authentication.\n" +
-  "Mint a device PAT with the required worker scope, then start the daemon:\n" +
-  '  WORKER_API_TOKEN=$(lobu token create --raw --org <slug> --scope "device_worker:run profile:read") lobu daemon';
+  "Mint a device PAT, then start the daemon:\n" +
+  "  WORKER_API_TOKEN=$(lobu token create --raw --org <slug> --scope mcp:write) lobu daemon";
 
 /**
  * `lobu daemon` — run a device worker that polls the gateway for jobs
@@ -48,19 +50,22 @@ const TOKEN_SETUP_MESSAGE =
  * to that token's org (an org-scoped PAT → that org, personal/session → the
  * personal org).
  *
- * On FIRST interactive boot, a short wizard lets you confirm the device id and
- * see the server's current attachment, then caches the choice at
- * `~/.lobu/devices/<context>.json` so later runs bootstrap silently. Pass
- * `--worker-id`, run non-interactively/under CI, inherit a supported agent
- * session, or delete the cache to bypass the wizard.
+ * On a named context's first interactive boot, a short wizard confirms the
+ * device identity. Explicit URL overrides stay stateless and use the same
+ * deterministic default as other non-interactive starts.
  */
 export async function daemonCommand(options: DaemonOptions): Promise<void> {
   let apiUrl = options.apiUrl?.trim();
+  let contextName: string | undefined;
   if (!apiUrl) {
     try {
       // The worker API is mounted at the ORIGIN, not under the context's
       // `/api/v1` SDK path — see `apiUrlToGatewayOrigin`.
-      apiUrl = apiUrlToGatewayOrigin((await resolveContext()).url);
+      const context = await resolveContext();
+      apiUrl = apiUrlToGatewayOrigin(context.url);
+      // LOBU_API_URL is an override just like --api-url: it must not inherit
+      // device state from the otherwise-current named context.
+      if (context.source !== "env") contextName = context.name;
     } catch {
       // No context configured — surface the explicit requirement below.
     }
@@ -88,12 +93,10 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     ...(options.insideClaude === true ? { insideClaude: true } : {}),
   });
   const explicitWorkerId = options.workerId?.trim() || undefined;
-  // An inherited agent session (or the legacy --inside-claude flag) registers a
-  // per-session headless device, and the shared daemon bootstrap derives that
-  // id itself. Handing it a cached or wizard-chosen id here would override that
-  // routing, so this lane contributes neither an id nor a host platform. The
-  // legacy flag holds the lane even when its startup metadata is momentarily
-  // absent, since detection re-runs on the next boot.
+  // Centralized session detection must own the per-session id. Passing a cache
+  // or wizard id here would override Claude/Codex/OpenCode routing in the shared
+  // daemon bootstrap. The legacy flag stays headless even when its startup
+  // metadata is temporarily absent and detection retries per run.
   const sessionLane =
     launchContext.interactiveSession !== undefined ||
     options.insideClaude === true;
@@ -103,6 +106,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
       ? undefined
       : await resolveWorkerId(
           launchContext.platform ?? defaultPlatform,
+          contextName,
           apiUrl,
           workerApiToken
         ));
@@ -129,28 +133,34 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
 
 /**
  * Resolve an ordinary host device's `worker_id` after explicit and inherited
- * session identities have already been handled by the caller: cached identity,
- * then the TTY-only first-run wizard, then `<platform>:<hostname>`.
+ * session identities have already been handled by the caller: a URL override
+ * takes `<platform>:<hostname>` outright, and a named context takes its cached
+ * identity, then the TTY-only first-run wizard, then `<platform>:<hostname>`.
  *
  * The wizard only runs on a TTY, only when the id is absent, and only when there
  * is no cached device yet — so a fully-configured daemon never prompts.
  */
 async function resolveWorkerId(
   platform: string,
+  contextName: string | undefined,
   apiUrl: string,
   workerApiToken: string
 ): Promise<string> {
   const shortHost = hostname().split(".")[0] || hostname();
   const suggested = `${platform}:${shortHost}`;
 
-  const contextName = (await getCurrentContextName()).trim() || undefined;
-  const cached = contextName ? await loadDeviceState(contextName) : null;
+  // URL overrides are intentionally stateless: they are commonly temporary
+  // local/self-hosted targets and must never borrow another context's identity.
+  if (!contextName) return suggested;
+
+  const cached = await loadDeviceState(contextName, platform);
   if (cached?.workerId) return cached.workerId;
 
   if (canPrompt()) {
     const result = await deviceWizard({
       context: contextName,
-      apiUrl,
+      gatewayOrigin: apiUrl,
+      platform,
       suggestedWorkerId: suggested,
       workerApiToken,
     });

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -1,52 +1,31 @@
-import { randomUUID } from "node:crypto";
-import {
-  chmod,
-  mkdir,
-  open,
-  readFile,
-  rename,
-  stat,
-  unlink,
-} from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-/**
- * Device identity charset accepted for `worker_id`. Mirrors the daemon's own
- * boot-time guard in `@lobu/connector-worker` so the CLI rejects an id the
- * daemon would reject anyway, before it reaches the cache or the gateway.
- */
 export const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
-const LOCK_RETRY_MS = 25;
-const LOCK_TIMEOUT_MS = 5_000;
-const STALE_LOCK_MS = 30_000;
 
-/**
- * Per-context device state cache, persisted under `~/.lobu/devices/`.
- *
- * This is a LOCAL cache, never the source of truth: the server owns the device
- * row (`device_workers.organization_id`) and its identity (`(user_id,
- * worker_id)`). Its only job is to make a repeated `lobu daemon` on the same
- * machine reuse the same confirmed worker id, so a restart does not silently
- * churn into a second device. Only `workerId` is stored.
- */
 export interface DeviceState {
-  /** The confirmed `worker_id` passed to the daemon on every run. */
   workerId: string;
 }
 
+// Resolve lazily so home-directory overrides use the matching config root.
 function devicesDir(): string {
-  return join(homedir(), ".lobu", "devices");
+  return join(homedir(), ".config", "lobu", "devices");
 }
 
-function statePath(context: string): string {
-  const safe = context.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join(devicesDir(), `${safe}.json`);
+function statePath(context: string, platform: string): string {
+  const key = `${encodeURIComponent(context)}--${encodeURIComponent(platform)}`;
+  return join(devicesDir(), `${key}.json`);
 }
 
-function parseDeviceState(raw: string): DeviceState | null {
+export async function loadDeviceState(
+  context: string,
+  platform: string
+): Promise<DeviceState | null> {
   try {
-    const parsed = JSON.parse(raw) as Partial<DeviceState>;
+    const parsed = JSON.parse(
+      await readFile(statePath(context, platform), "utf-8")
+    ) as Partial<DeviceState>;
     if (
       typeof parsed.workerId !== "string" ||
       !WORKER_ID_PATTERN.test(parsed.workerId)
@@ -59,30 +38,12 @@ function parseDeviceState(raw: string): DeviceState | null {
   }
 }
 
-export async function loadDeviceState(
-  context: string
-): Promise<DeviceState | null> {
-  try {
-    return parseDeviceState(await readFile(statePath(context), "utf-8"));
-  } catch {
-    // Absent, unreadable, or unparseable all mean the same thing to the caller:
-    // there is no confirmed identity yet, so fall through to setup.
-    return null;
-  }
-}
-
-/**
- * Atomically persist the first valid identity for a context.
- *
- * Concurrent first boots serialize through an owner-only lock and all return
- * the same winner. A corrupt prior payload is moved aside for diagnosis before
- * the replacement is renamed into place; no reader can observe a partial JSON
- * write.
- */
+/** Persist one completed setup without allowing two first boots to race. */
 export async function saveDeviceState(
   context: string,
+  platform: string,
   state: DeviceState
-): Promise<DeviceState> {
+): Promise<void> {
   if (!WORKER_ID_PATTERN.test(state.workerId)) {
     throw new Error(`invalid device worker id '${state.workerId}'`);
   }
@@ -91,64 +52,22 @@ export async function saveDeviceState(
   await mkdir(dir, { recursive: true, mode: 0o700 });
   await chmod(dir, 0o700);
 
-  const path = statePath(context);
-  const existing = await loadDeviceState(context);
-  if (existing) return existing;
-
-  const lockPath = `${path}.lock`;
-  const lock = await acquireLock(lockPath);
-  let tempPath: string | undefined;
   try {
-    const winner = await loadDeviceState(context);
-    if (winner) return winner;
-
-    try {
-      await stat(path);
-      await rename(path, `${path}.corrupt-${randomUUID()}`);
-    } catch (error) {
-      if (!isErrno(error, "ENOENT")) throw error;
+    await writeFile(
+      statePath(context, platform),
+      `${JSON.stringify(state, null, 2)}\n`,
+      { flag: "wx", mode: 0o600 }
+    );
+  } catch (error) {
+    if (isErrno(error, "EEXIST")) {
+      // Either a concurrent first boot won the race, or the caller read an
+      // unreadable/invalid file as "no identity yet" — `loadDeviceState`
+      // reports both as null, so name both causes rather than guess.
+      throw new Error(
+        `Device state at ${statePath(context, platform)} already exists or is unreadable; stop any other daemon on this context, or delete that file to redo setup.`
+      );
     }
-
-    tempPath = `${path}.${randomUUID()}.tmp`;
-    const temp = await open(tempPath, "wx", 0o600);
-    try {
-      await temp.writeFile(`${JSON.stringify(state, null, 2)}\n`, "utf-8");
-      await temp.sync();
-    } finally {
-      await temp.close();
-    }
-    await rename(tempPath, path);
-    tempPath = undefined;
-    await chmod(path, 0o600);
-    return state;
-  } finally {
-    if (tempPath) await unlink(tempPath).catch(() => undefined);
-    await lock.close().catch(() => undefined);
-    await unlink(lockPath).catch(() => undefined);
-  }
-}
-
-async function acquireLock(
-  lockPath: string
-): Promise<Awaited<ReturnType<typeof open>>> {
-  const started = Date.now();
-  while (true) {
-    try {
-      return await open(lockPath, "wx", 0o600);
-    } catch (error) {
-      if (!isErrno(error, "EEXIST")) throw error;
-      const lockStat = await stat(lockPath).catch(() => null);
-      if (lockStat && Date.now() - lockStat.mtimeMs > STALE_LOCK_MS) {
-        await unlink(lockPath).catch(() => undefined);
-        continue;
-      }
-      if (Date.now() - started >= LOCK_TIMEOUT_MS) {
-        throw new Error(
-          `Timed out waiting for concurrent device setup (${lockPath})`
-        );
-      }
-      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
-    }
+    throw error;
   }
 }
 
@@ -159,21 +78,4 @@ function isErrno(error: unknown, code: string): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === code
   );
-}
-
-/** Longest stem shown for a worker PAT: `owl_pat_` plus four secret chars. */
-const TOKEN_PREFIX_LENGTH = 12;
-
-/**
- * A short stem of a worker PAT, so the user can confirm *which* token a device
- * booted with without the terminal echoing the secret.
- *
- * Never returns the token whole. A real PAT is `owl_pat_` + 24 random chars, so
- * the stem always drops most of it; a value too short to truncate is malformed
- * rather than a usable credential, and is reported as such instead of printed.
- */
-export function workerTokenPrefix(token: string | undefined): string | null {
-  if (!token) return null;
-  if (token.length <= TOKEN_PREFIX_LENGTH) return null;
-  return token.slice(0, TOKEN_PREFIX_LENGTH);
 }


### PR DESCRIPTION
## Summary
- Keep explicit API URL and LOBU_API_URL overrides stateless; only named contexts participate in cached device setup.
- Remove the no-op workspace/token-prefix wizard UI and replace the lock/quarantine state machinery with one owner-only create-once state file.
- Offer only same-platform offline devices for reuse, reject live or cross-platform collisions, and retain automatic interactive-session lanes.

Net result: 214 fewer lines across the six CLI implementation/test files added by #3014.

## Test plan
- [ ] Intended files staged explicitly, then make pr-full clean (not run; make pre-pr used as the documented local gate)
- [x] Tests run: full CLI suite, focused daemon/wizard/state suite, connector-worker interactive-session suite
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran ./scripts/test-bot.sh or relevant eval (not applicable)

Red before the simplification:
- focused device tests: 2 failed, 23 passed
- explicit API URL entered context-backed state setup
- the wizard offered wrong-platform and online devices

Green:
- focused daemon/wizard/state tests: 26 passed, 0 failed
- full packages/cli suite: 677 passed, 1 skipped, 0 failed
- connector-worker interactive-session tests: 24 passed, 0 failed
- make pre-pr: clean
- built CLI smoke: missing durable token and malformed worker ID both fail closed with exit 1

## Notes
No API/SDK surface was added. The existing API URL override remains supported, but it no longer participates in persisted wizard identity. No Owletto or hosted UI changes are in this follow-up.
