### PR TITLE
docs(connector-sdk): name the scope collision on EntityIdentitySpec

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -639,6 +639,12 @@ export interface EntityIdentitySpec {
    * Distinct from the deleted `uniquePerOrg` flag, which was CARDINALITY — does
    * this value name one entity or many (`email_domain` names many). Scope is
    * orthogonal: `email_domain` is many-per-org yet globally meaningful.
+   *
+   * NOT the same field as `scope` on the auth schema (`ConnectorAuthEnvKeys`,
+   * `ConnectorAuthOAuth`, `ConnectorAuthInteractive`), which shares this name and
+   * this exact value union but scopes a CREDENTIAL, not an identity namespace.
+   * Check which one you are setting: writing `'connection'` here because you
+   * wrote it there forks one person into one entity per connection.
    */
   scope?: 'organization' | 'connection';
 }


### PR DESCRIPTION
## Summary
`EntityIdentitySpec.scope` and the auth schema's `scope` (`ConnectorAuthEnvKeys`, `ConnectorAuthOAuth`, `ConnectorAuthInteractive`) share a name **and** the exact same `'organization' | 'connection'` union, but scope different things — an identity namespace vs. a credential.

Setting `'connection'` on the identity spec because you set it on the auth schema forks one person into one entity per connection. That fails silently and surfaces later as duplicate entities, never as an error, which is what makes it worth a comment rather than leaving it to be rediscovered.

Comment only — no runtime, type, or API change.

## Provenance
Rescued during salvage triage of abandoned worktree branches. Of 41 salvage branches, this was the only content worth re-landing that wasn't already on main; the other 37 were stale snapshots and have been deleted.

## Test plan
- [x] `make pre-pr` clean (all 7 gates)
- [x] Verified the note still applies to current `main`: the documented field is unchanged, and all three auth types it names still exist in the same file