### PR TITLE
feat(helm): add durable artifact PVC topology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,11 @@ MEMORY_URL=https://lobu.com/mcp
 # System skills registry URL (points to config/system-skills.json)
 # LOBU_SYSTEM_SKILLS_URL=file:///app/config/system-skills.json
 
+# Binary artifact storage. When omitted, Lobu uses a temporary directory.
+# Production deployments should point this at durable storage every app replica
+# can mount. The Helm chart always sets it, using its artifact PVC when enabled.
+# LOBU_ARTIFACTS_DIR=/var/lib/lobu/artifacts
+
 # ===========================================
 # TRANSACTIONAL EMAIL (Resend)
 # ===========================================

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -67,8 +67,14 @@ jobs:
             charts/lobu/templates charts/lobu/values.yaml; then
             exit 0
           fi
-          if git diff --quiet "$BASE_SHA" HEAD -- charts/lobu/Chart.yaml; then
-            echo "ChartVersion reconciliation requires charts/lobu/Chart.yaml to change with runtime chart templates or values." >&2
+          base_version="$(git show "${BASE_SHA}:charts/lobu/Chart.yaml" | awk '$1 == "version:" { print $2; exit }')"
+          head_version="$(awk '$1 == "version:" { print $2; exit }' charts/lobu/Chart.yaml)"
+          if [ -z "$base_version" ] || [ -z "$head_version" ]; then
+            echo "Could not read the chart version from charts/lobu/Chart.yaml." >&2
+            exit 1
+          fi
+          if [ "$base_version" = "$head_version" ]; then
+            echo "ChartVersion reconciliation requires charts/lobu/Chart.yaml#version to change with runtime chart templates or values." >&2
             exit 1
           fi
 

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -45,6 +45,33 @@ jobs:
             exit 1
           fi
 
+      - name: Render durable artifact storage
+        run: |
+          helm template lobu charts/lobu --namespace lobu \
+            --set app.artifacts.enabled=true \
+            --set app.artifacts.storageClass=lobu-local-retain \
+            >/tmp/lobu-artifacts.yaml
+          grep -q '^kind: PersistentVolumeClaim$' /tmp/lobu-artifacts.yaml
+          grep -q 'storageClassName: lobu-local-retain' /tmp/lobu-artifacts.yaml
+          grep -q 'name: LOBU_ARTIFACTS_DIR' /tmp/lobu-artifacts.yaml
+          grep -q 'mountPath: /var/lib/lobu/artifacts' /tmp/lobu-artifacts.yaml
+          grep -q 'claimName: lobu-app-artifacts' /tmp/lobu-artifacts.yaml
+
+      - name: Require a chart version bump for runtime chart changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          if git diff --quiet "$BASE_SHA" HEAD -- \
+            charts/lobu/templates charts/lobu/values.yaml; then
+            exit 0
+          fi
+          if git diff --quiet "$BASE_SHA" HEAD -- charts/lobu/Chart.yaml; then
+            echo "ChartVersion reconciliation requires charts/lobu/Chart.yaml to change with runtime chart templates or values." >&2
+            exit 1
+          fi
+
       - name: Render migration upgrade with mandatory quiescence
         run: |
           helm template lobu charts/lobu --namespace lobu --is-upgrade \
@@ -92,6 +119,11 @@ jobs:
 
       - name: Exercise migration failure recovery
         run: sh charts/lobu/tests/migrate-upgrade-recovery.sh
+
+      # Artifact storage is the only durable-media path: a topology that
+      # renders but cannot share bytes across replicas loses media silently.
+      - name: Artifact storage topology fails closed
+        run: bash charts/lobu/tests/artifacts-topology.sh
 
   publish:
     needs: lint

--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 15.5.0
+version: 15.5.1
 appVersion: 15.5.0
 keywords:
   - lobu

--- a/charts/lobu/templates/_helpers.tpl
+++ b/charts/lobu/templates/_helpers.tpl
@@ -95,3 +95,16 @@ Create the embeddings service image name
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s/%s-embeddings:%s" .Values.image.registry .Values.image.repository $tag }}
 {{- end }}
+
+{{/* Fail before rendering an app topology that cannot share durable artifacts. */}}
+{{- define "lobu.validateArtifactTopology" -}}
+{{- if .Values.app.artifacts.enabled }}
+{{- $appEnv := default dict .Values.app.env }}
+{{- if and (gt (int .Values.app.replicaCount) 1) (ne .Values.app.artifacts.accessMode "ReadWriteMany") }}
+{{- fail "app.replicaCount > 1 with app.artifacts.enabled=true requires app.artifacts.accessMode=ReadWriteMany so every replica can read the same durable bytes" }}
+{{- end }}
+{{- if and (hasKey $appEnv "LOBU_ARTIFACTS_DIR") (ne (get $appEnv "LOBU_ARTIFACTS_DIR") .Values.app.artifacts.mountPath) }}
+{{- fail "app.env.LOBU_ARTIFACTS_DIR must equal app.artifacts.mountPath when artifact storage is enabled" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/lobu/templates/app-artifacts-pvc.yaml
+++ b/charts/lobu/templates/app-artifacts-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.app.artifacts.enabled }}
+{{- include "lobu.validateArtifactTopology" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lobu.fullname" . }}-app-artifacts
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  accessModes:
+    - {{ .Values.app.artifacts.accessMode }}
+  {{- if .Values.app.artifacts.storageClass }}
+  storageClassName: {{ .Values.app.artifacts.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.app.artifacts.size }}
+{{- end }}

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "lobu.validateArtifactTopology" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -76,6 +77,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if not (hasKey (default dict .Values.app.env) "LOBU_ARTIFACTS_DIR") }}
+            - name: LOBU_ARTIFACTS_DIR
+              value: {{ ternary .Values.app.artifacts.mountPath "/tmp/lobu-artifacts" .Values.app.artifacts.enabled | quote }}
+            {{- end }}
             {{- if .Values.ingress.hosts }}
             - name: BASE_URL
               value: {{ printf "https://%s" (first .Values.ingress.hosts) | quote }}
@@ -147,16 +152,29 @@ spec:
             periodSeconds: {{ .Values.healthCheck.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.livenessProbe.failureThreshold }}
-          {{- if .Values.app.workspaces.enabled }}
+          {{- if or .Values.app.workspaces.enabled .Values.app.artifacts.enabled }}
           volumeMounts:
+            {{- if .Values.app.workspaces.enabled }}
             - name: workspaces
               mountPath: /app/workspaces
+            {{- end }}
+            {{- if .Values.app.artifacts.enabled }}
+            - name: artifacts
+              mountPath: {{ .Values.app.artifacts.mountPath }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
-      {{- if .Values.app.workspaces.enabled }}
+      {{- if or .Values.app.workspaces.enabled .Values.app.artifacts.enabled }}
       volumes:
+        {{- if .Values.app.workspaces.enabled }}
         - name: workspaces
           persistentVolumeClaim:
             claimName: {{ include "lobu.fullname" . }}-app-workspaces
+        {{- end }}
+        {{- if .Values.app.artifacts.enabled }}
+        - name: artifacts
+          persistentVolumeClaim:
+            claimName: {{ include "lobu.fullname" . }}-app-artifacts
+        {{- end }}
       {{- end }}

--- a/charts/lobu/tests/artifacts-topology.sh
+++ b/charts/lobu/tests/artifacts-topology.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/lobu}"
+render() {
+  helm template topology-test "$chart_dir" "$@"
+}
+
+default_render="$(render)"
+grep -q 'value: "/tmp/lobu-artifacts"' <<<"$default_render"
+
+null_env_values="$(mktemp)"
+trap 'rm -f "$null_env_values"' EXIT
+printf 'app:\n  env:\n' >"$null_env_values"
+render -f "$null_env_values" >/dev/null
+
+rwo_render="$(render --set app.artifacts.enabled=true --set app.replicaCount=1 --set app.artifacts.accessMode=ReadWriteOnce)"
+grep -q 'accessModes:' <<<"$rwo_render"
+grep -q -- '- ReadWriteOnce' <<<"$rwo_render"
+grep -q 'mountPath: /var/lib/lobu/artifacts' <<<"$rwo_render"
+grep -q 'value: "/var/lib/lobu/artifacts"' <<<"$rwo_render"
+
+rwx_render="$(render --set app.artifacts.enabled=true --set app.replicaCount=2 --set app.artifacts.accessMode=ReadWriteMany)"
+grep -q -- '- ReadWriteMany' <<<"$rwx_render"
+grep -q 'replicas: 2' <<<"$rwx_render"
+
+# Assert on the guard's own message, not just a non-zero exit: any unrelated
+# chart error would otherwise satisfy a bare "helm template failed" check and
+# leave the topology guard untested.
+expect_render_failure() {
+  local expected="$1"
+  shift
+  local output
+  if output="$(render "$@" 2>&1)"; then
+    echo "expected rendering to fail: $expected" >&2
+    exit 1
+  fi
+  if ! grep -qF "$expected" <<<"$output"; then
+    echo "rendering failed for the wrong reason; wanted: $expected" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+expect_render_failure \
+  "requires app.artifacts.accessMode=ReadWriteMany" \
+  --show-only templates/deployment.yaml \
+  --set app.artifacts.enabled=true \
+  --set app.replicaCount=2 \
+  --set app.artifacts.accessMode=ReadWriteOnce
+
+expect_render_failure \
+  "app.env.LOBU_ARTIFACTS_DIR must equal app.artifacts.mountPath" \
+  --set app.artifacts.enabled=true \
+  --set app.env.LOBU_ARTIFACTS_DIR=/tmp/wrong

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -149,6 +149,23 @@ app:
     size: 20Gi
     storageClass: ""
 
+  # Durable binary artifacts (images, audio, files) shared by every app
+  # replica. When disabled the chart explicitly uses pod-local /tmp, so media
+  # does not survive restarts or reliably cross replicas. The default stays off
+  # for local/self-hosted installs; production should enable this with storage
+  # that every scheduled app pod can mount.
+  # When enabled, ReadWriteOnce is supported only with replicaCount: 1; more
+  # than one app replica requires an RWX-capable class and accessMode:
+  # ReadWriteMany, and rendering fails closed otherwise. Leaving this disabled
+  # on a multi-replica install still renders — media then lands on pod-local
+  # /tmp and neither survives a restart nor crosses replicas.
+  artifacts:
+    enabled: false
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    mountPath: /var/lib/lobu/artifacts
+
   # Keep replicas off a single node. Without this the scheduler is free to put
   # every replica on one node, where one node loss removes all capacity and the
   # PodDisruptionBudget cannot help (it does not apply to node failure).


### PR DESCRIPTION
## Summary
- add an optional durable artifact PVC and mount it at `LOBU_ARTIFACTS_DIR`
- fail Helm rendering when an RWO volume is paired with more than one steady app replica
- retain rolling availability for the supported single-replica RWO deployment (the merged Owletto rollout policy from lobu-ai/owletto#917)
- require chart version bumps for runtime chart changes and exercise the topology in chart CI

## Deployment contract
- default/self-hosted installs remain unchanged and use `/tmp/lobu-artifacts`
- production enables `app.artifacts.enabled=true`, `storageClass=lobu-local-retain`, `accessMode=ReadWriteOnce`, and `app.replicaCount=1`
- multi-replica installs must supply RWX storage
- the PVC carries `helm.sh/resource-policy: keep`

## Verification
- `helm lint charts/lobu`
- `bash charts/lobu/tests/artifacts-topology.sh`
- repository pre-commit Biome and TypeScript checks

Stack foundation for #3013; it intentionally contains no artifact-store or approval runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional durable storage for binary artifacts in Helm deployments.
  * Supports configurable storage size, class, access mode, and mount path.
  * Automatically provisions retained persistent storage when enabled.

* **Bug Fixes**
  * Added validation to prevent incompatible storage configurations, replica counts, and mount paths.
  * Artifact directory settings now receive safe defaults.

* **Documentation**
  * Documented optional artifact storage, temporary defaults, and durable-storage deployment guidance.

* **Chores**
  * Updated the Helm chart release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->