### PR TITLE
fix(server): persist and verify media artifacts

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -48,6 +48,7 @@ describe('MCP media resources', () => {
   let token: string;
   let artifactStore: ArtifactStore;
   let artifactsDir: string;
+  let restoreCoreServices: (() => void) | undefined;
   const previousArtifactsDir = process.env.LOBU_ARTIFACTS_DIR;
   const previousEncryptionKey = process.env.ENCRYPTION_KEY;
 
@@ -58,6 +59,10 @@ describe('MCP media resources', () => {
       '12345678901234567890123456789012'
     ).toString('base64');
     artifactStore = new ArtifactStore();
+    const coreServices = vi
+      .spyOn(lobuGateway, 'getLobuCoreServices')
+      .mockReturnValue({ getArtifactStore: () => artifactStore });
+    restoreCoreServices = () => coreServices.mockRestore();
 
     await cleanupTestDatabase();
     await seedSystemEntityTypes();
@@ -77,6 +82,7 @@ describe('MCP media resources', () => {
   });
 
   afterAll(() => {
+    restoreCoreServices?.();
     if (previousArtifactsDir === undefined) delete process.env.LOBU_ARTIFACTS_DIR;
     else process.env.LOBU_ARTIFACTS_DIR = previousArtifactsDir;
     if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
@@ -165,14 +171,7 @@ describe('MCP media resources', () => {
         },
       ],
     });
-    const coreServices = vi
-      .spyOn(lobuGateway, 'getLobuCoreServices')
-      .mockReturnValue({ getArtifactStore: () => artifactStore });
-    try {
-      await streamContent(ctx);
-    } finally {
-      coreServices.mockRestore();
-    }
+    await streamContent(ctx);
     expect(result()).toMatchObject({ status: 200, body: { total_items: 1 } });
 
     const [event] = await sql`
@@ -278,14 +277,7 @@ describe('MCP media resources', () => {
         },
       ],
     });
-    const failedInsertServices = vi
-      .spyOn(lobuGateway, 'getLobuCoreServices')
-      .mockReturnValue({ getArtifactStore: () => artifactStore });
-    try {
-      await streamContent(failedInsert.ctx);
-    } finally {
-      failedInsertServices.mockRestore();
-    }
+    await streamContent(failedInsert.ctx);
     expect(failedInsert.result().status).toBe(500);
     expect((await readdir(artifactsDir)).sort()).toEqual(artifactsBeforeFailedInsert);
   });
@@ -433,12 +425,7 @@ describe('MCP media resources', () => {
       `.then((rows) => rows[0]),
     ]);
     const artifactsBefore = (await readdir(artifactsDir)).sort();
-    const coreServices = vi
-      .spyOn(lobuGateway, 'getLobuCoreServices')
-      .mockReturnValue({ getArtifactStore: () => artifactStore });
-
-    try {
-      const rollback = mockWorkerCtx({
+    const rollback = mockWorkerCtx({
         run_id: Number(rollbackRun!.id),
         worker_id: 'worker-media-cleanup',
         status: 'success',
@@ -452,13 +439,13 @@ describe('MCP media resources', () => {
           ],
         },
       });
-      await completeActionRun(rollback.ctx);
-      expect(rollback.result().status).toBe(500);
-      expect((rollback.result().body as { error?: string }).error).toContain(
-        'approval card is missing'
-      );
+    await completeActionRun(rollback.ctx);
+    expect(rollback.result().status).toBe(500);
+    expect((rollback.result().body as { error?: string }).error).toContain(
+      'approval card is missing'
+    );
 
-      const zeroRows = mockWorkerCtx({
+    const zeroRows = mockWorkerCtx({
         run_id: Number(finalizedRun!.id),
         worker_id: 'worker-media-cleanup',
         status: 'success',
@@ -472,14 +459,11 @@ describe('MCP media resources', () => {
           ],
         },
       });
-      await completeActionRun(zeroRows.ctx);
-      expect(zeroRows.result()).toMatchObject({
-        status: 200,
-        body: { success: false, reason: 'already_finalized' },
-      });
-    } finally {
-      coreServices.mockRestore();
-    }
+    await completeActionRun(zeroRows.ctx);
+    expect(zeroRows.result()).toMatchObject({
+      status: 200,
+      body: { success: false, reason: 'already_finalized' },
+    });
 
     expect((await readdir(artifactsDir)).sort()).toEqual(artifactsBefore);
     const [runAfterRollback] = await sql`

--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -399,9 +399,7 @@ describe('MCP media resources', () => {
     });
     const oversizedBody = await oversizedResponse.json();
     expect(oversizedBody.result).toBeUndefined();
-    expect(oversizedBody.error?.message).toContain(
-      `MCP resource is too large to inline (${oversizedBytes.length} bytes; limit ${5 * 1024 * 1024})`
-    );
+    expect(oversizedBody.error?.message).toContain('Unknown resource');
   });
 
   it('cleans action artifacts when finalization rolls back or commits zero rows', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -336,7 +336,8 @@ describe('MCP media resources', () => {
   });
 
   it('fails safely for invalid, missing, and oversized resources', async () => {
-    const oversizedBytes = Buffer.alloc(5 * 1024 * 1024 + 1, 1);
+    // One byte past the 20 MB inline cap this endpoint has always served.
+    const oversizedBytes = Buffer.alloc(20 * 1024 * 1024 + 1, 1);
     const artifact = await artifactStore.publish({
       buffer: oversizedBytes,
       filename: 'oversized.bin',
@@ -399,7 +400,12 @@ describe('MCP media resources', () => {
     });
     const oversizedBody = await oversizedResponse.json();
     expect(oversizedBody.result).toBeUndefined();
-    expect(oversizedBody.error?.message).toContain('Unknown resource');
+    // Distinguishable from an absent resource: the payload exists, it just
+    // cannot be inlined. A bounded read alone would report it as "Unknown".
+    expect(oversizedBody.error?.message).toContain('too large to inline');
+    expect(oversizedBody.error?.message).toContain(
+      String(oversizedBytes.length)
+    );
   });
 
   it('cleans action artifacts when finalization rolls back or commits zero rows', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-media-resources.test.ts
@@ -344,7 +344,7 @@ describe('MCP media resources', () => {
   });
 
   it('fails safely for invalid, missing, and oversized resources', async () => {
-    const oversizedBytes = Buffer.alloc(20 * 1024 * 1024 + 1, 1);
+    const oversizedBytes = Buffer.alloc(5 * 1024 * 1024 + 1, 1);
     const artifact = await artifactStore.publish({
       buffer: oversizedBytes,
       filename: 'oversized.bin',
@@ -407,7 +407,9 @@ describe('MCP media resources', () => {
     });
     const oversizedBody = await oversizedResponse.json();
     expect(oversizedBody.result).toBeUndefined();
-    expect(oversizedBody.error?.message).toContain('limit 20971520');
+    expect(oversizedBody.error?.message).toContain(
+      `MCP resource is too large to inline (${oversizedBytes.length} bytes; limit ${5 * 1024 * 1024})`
+    );
   });
 
   it('cleans action artifacts when finalization rolls back or commits zero rows', async () => {

--- a/packages/server/src/gateway/__tests__/agent-history-resign.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-resign.test.ts
@@ -14,8 +14,9 @@ describe("resignFileRefs", () => {
 	afterEach(() => env.cleanup());
 
 	test("rewrites a tokenless artifact ref into a fresh signed absolute URL", () => {
+		const artifactId = "00000000-0000-4000-8000-000000000123";
 		const out = resignFileRefs(
-			"See [report.pdf](/api/v1/files/abc123)",
+			`See [report.pdf](/api/v1/files/${artifactId})`,
 			env.artifactStore,
 			BASE,
 		) as string;
@@ -24,11 +25,11 @@ describe("resignFileRefs", () => {
 		const match = out.match(/\((https?:\/\/[^)]+)\)/);
 		expect(match).toBeTruthy();
 		const url = new URL(match?.[1] as string);
-		expect(url.pathname).toBe("/lobu/api/v1/files/abc123");
+		expect(url.pathname).toBe(`/lobu/api/v1/files/${artifactId}`);
 		const token = url.searchParams.get("token");
 		expect(token).toBeTruthy();
 		expect(
-			env.artifactStore.validateDownloadToken(token as string, "abc123").valid,
+			env.artifactStore.validateDownloadToken(token as string, artifactId).valid,
 		).toBe(true);
 	});
 

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   ArtifactStorageError,
   ArtifactStore,
+  MAX_ARTIFACT_BYTES,
   runArtifactBinding,
 } from "../files/artifact-store.js";
 import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
@@ -172,11 +173,13 @@ describe("ArtifactStore durable filesystem backend", () => {
   test("rejects artifacts larger than the bounded read contract", async () => {
     await expect(
       env.artifactStore.publish({
-        buffer: Buffer.alloc(50 * 1024 * 1024 + 1),
+        buffer: Buffer.alloc(MAX_ARTIFACT_BYTES + 1),
         filename: "too-large.bin",
         publicGatewayUrl: "https://lobu.example.com",
       }),
-    ).rejects.toThrow("Artifact exceeds the 52428800-byte storage limit");
+    ).rejects.toThrow(
+      `Artifact exceeds the ${MAX_ARTIFACT_BYTES}-byte storage limit`,
+    );
     expect(await fs.readdir(env.artifactsDir)).toEqual([]);
   });
 
@@ -262,6 +265,35 @@ describe("ArtifactStore durable filesystem backend", () => {
     expect(await env.artifactStore.read(published.artifactId)).toBeNull();
   });
 
+  test("propagates retained-storage I/O failures instead of reporting missing", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("still-present"),
+      filename: "present.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const realOpen = fs.open;
+    const openSpy = spyOn(fs, "open").mockImplementation(
+      async (target, ...args) => {
+        if (String(target).endsWith("/content")) {
+          const error = new Error("injected mount failure") as NodeJS.ErrnoException;
+          error.code = "EIO";
+          throw error;
+        }
+        return realOpen(target, ...args);
+      },
+    );
+
+    try {
+      const read = env.artifactStore.read(published.artifactId);
+      await expect(read).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(read).rejects.toMatchObject({
+        code: "ARTIFACT_STORAGE_UNAVAILABLE",
+      });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
   test("does not delete a pre-existing directory when publication collides", async () => {
     const realMkdir = fs.mkdir;
     let collidedDir: string | undefined;
@@ -296,6 +328,43 @@ describe("ArtifactStore durable filesystem backend", () => {
     expect(await fs.readFile(join(collidedDir!, "committed-marker"), "utf8")).toBe(
       "keep",
     );
+  });
+
+  test("keeps partial-publication failures on the typed storage contract", async () => {
+    const realOpen = fs.open;
+    const realRm = fs.rm;
+    const openSpy = spyOn(fs, "open").mockImplementation(
+      async (target, ...args) => {
+        if (String(target).endsWith("/content")) {
+          throw new Error("injected publication failure");
+        }
+        return realOpen(target, ...args);
+      },
+    );
+    const rmSpy = spyOn(fs, "rm").mockImplementation(
+      async (target, options) => {
+        if (String(target).includes(`${join(env.artifactsDir, ".trash")}/`)) {
+          throw new Error("injected quarantine cleanup failure");
+        }
+        return realRm(target, options);
+      },
+    );
+
+    try {
+      const publication = env.artifactStore.publish({
+        buffer: Buffer.from("partial"),
+        filename: "partial.bin",
+        publicGatewayUrl: "https://lobu.example.com",
+      });
+      await expect(publication).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(publication).rejects.toMatchObject({
+        code: "ARTIFACT_STORAGE_UNAVAILABLE",
+      });
+      await expect(publication).rejects.not.toThrow(env.artifactsDir);
+    } finally {
+      openSpy.mockRestore();
+      rmSpy.mockRestore();
+    }
   });
 
   test("quarantines a failed delete and drains the leftover before another publish", async () => {

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -8,7 +8,11 @@ import {
   MAX_ARTIFACT_BYTES,
   runArtifactBinding,
 } from "../files/artifact-store.js";
-import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
+import {
+  type ArtifactTestEnv,
+  createArtifactTestEnv,
+  TEST_GATEWAY_URL,
+} from "./setup.js";
 
 describe("ArtifactStore.buildDownloadUrl", () => {
   let env: ArtifactTestEnv;
@@ -98,6 +102,92 @@ describe("ArtifactStore.buildDownloadUrl", () => {
 
     await env.artifactStore.delete(artifactId);
     expect(await env.artifactStore.read(artifactId)).toBeNull();
+  });
+
+  test("carries the binding inside the token so the download route can enforce it", async () => {
+    const binding = runArtifactBinding(42);
+    const { artifactId } = await env.artifactStore.publish({
+      buffer: Buffer.from("bound"),
+      filename: "bound.txt",
+      contentType: "text/plain",
+      publicGatewayUrl: TEST_GATEWAY_URL,
+      binding,
+    });
+
+    const token = new URL(
+      env.artifactStore.buildDownloadUrl(
+        TEST_GATEWAY_URL,
+        artifactId,
+        undefined,
+        binding,
+      ),
+    ).searchParams.get("token") as string;
+
+    const validation = env.artifactStore.validateDownloadToken(
+      token,
+      artifactId,
+    );
+    expect(validation.valid).toBe(true);
+    expect(validation.binding).toBe(binding);
+  });
+
+  test("a bound token cannot be redeemed against another resource's artifact", async () => {
+    // The grafting attack the binding exists to stop: an id belonging to one
+    // Lobu resource, re-signed under the binding of a resource the caller can
+    // read. The mint side never touches the filesystem, so this is the only
+    // place the mismatch can be caught.
+    const { artifactId } = await env.artifactStore.publish({
+      buffer: Buffer.from("someone else's bytes"),
+      filename: "victim.txt",
+      publicGatewayUrl: TEST_GATEWAY_URL,
+      binding: runArtifactBinding(1),
+    });
+
+    const attackerBinding = runArtifactBinding(2);
+    const token = new URL(
+      env.artifactStore.buildDownloadUrl(
+        TEST_GATEWAY_URL,
+        artifactId,
+        undefined,
+        attackerBinding,
+      ),
+    ).searchParams.get("token") as string;
+
+    const validation = env.artifactStore.validateDownloadToken(
+      token,
+      artifactId,
+    );
+    // The token itself is well-formed — only the binding check refuses it.
+    expect(validation.valid).toBe(true);
+    expect(validation.binding).toBe(attackerBinding);
+    expect(
+      await env.artifactStore.read(artifactId, {
+        binding: validation.binding,
+      }),
+    ).toBeNull();
+  });
+
+  test("an unbound token stays as permissive as it is today", async () => {
+    // `resignFileRefs` mints unbound tokens from transcript text; changing
+    // their semantics would break agent-history downloads.
+    const { artifactId } = await env.artifactStore.publish({
+      buffer: Buffer.from("unbound"),
+      filename: "u.txt",
+      publicGatewayUrl: TEST_GATEWAY_URL,
+      binding: runArtifactBinding(7),
+    });
+
+    const token = new URL(
+      env.artifactStore.buildDownloadUrl(TEST_GATEWAY_URL, artifactId),
+    ).searchParams.get("token") as string;
+
+    const validation = env.artifactStore.validateDownloadToken(
+      token,
+      artifactId,
+    );
+    expect(validation.valid).toBe(true);
+    expect(validation.binding).toBeUndefined();
+    expect(await env.artifactStore.read(artifactId)).toBeTruthy();
   });
 });
 

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -1,5 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { runArtifactBinding } from "../files/artifact-store.js";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import { join } from "node:path";
+import {
+  ArtifactStorageError,
+  ArtifactStore,
+  runArtifactBinding,
+} from "../files/artifact-store.js";
 import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
 
 describe("ArtifactStore.buildDownloadUrl", () => {
@@ -19,7 +26,7 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     // `/api/v1/files/...` → 404 and inbound attachments never reached the agent.
     const url = env.artifactStore.buildDownloadUrl(
       "http://localhost:8954/lobu",
-      "artifact-123"
+      "artifact-123",
     );
     const parsed = new URL(url);
     expect(parsed.pathname).toBe("/lobu/api/v1/files/artifact-123");
@@ -29,7 +36,7 @@ describe("ArtifactStore.buildDownloadUrl", () => {
   test("works for a root-mounted gateway (no path prefix)", () => {
     const url = env.artifactStore.buildDownloadUrl(
       "https://gateway.example.com",
-      "artifact-456"
+      "artifact-456",
     );
     const parsed = new URL(url);
     expect(parsed.pathname).toBe("/api/v1/files/artifact-456");
@@ -38,9 +45,18 @@ describe("ArtifactStore.buildDownloadUrl", () => {
   test("tolerates a trailing slash on the base URL", () => {
     const url = env.artifactStore.buildDownloadUrl(
       "http://localhost:8954/lobu/",
-      "artifact-789"
+      "artifact-789",
     );
     expect(new URL(url).pathname).toBe("/lobu/api/v1/files/artifact-789");
+  });
+
+  test("rejects oversized download tokens before decryption", () => {
+    expect(
+      env.artifactStore.validateDownloadToken(
+        "x".repeat(4097),
+        "00000000-0000-4000-8000-000000000001",
+      ),
+    ).toEqual({ valid: false, error: "malformed" });
   });
 
   test("round-trips: a published artifact is served from its own URL path", async () => {
@@ -55,7 +71,8 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     const token = parsed.searchParams.get("token");
     expect(token).toBeTruthy();
     expect(
-      env.artifactStore.validateDownloadToken(token as string, artifactId).valid
+      env.artifactStore.validateDownloadToken(token as string, artifactId)
+        .valid,
     ).toBe(true);
     const read = await env.artifactStore.read(artifactId);
     expect(read?.metadata.filename).toBe("note.txt");
@@ -73,10 +90,292 @@ describe("ArtifactStore.buildDownloadUrl", () => {
 
     expect(await env.artifactStore.read(artifactId, { binding })).toBeTruthy();
     expect(
-      await env.artifactStore.read(artifactId, { binding: runArtifactBinding(43) })
+      await env.artifactStore.read(artifactId, {
+        binding: runArtifactBinding(43),
+      }),
     ).toBeNull();
 
     await env.artifactStore.delete(artifactId);
     expect(await env.artifactStore.read(artifactId)).toBeNull();
+  });
+});
+
+describe("ArtifactStore durable filesystem backend", () => {
+  let env: ArtifactTestEnv;
+
+  beforeEach(() => {
+    env = createArtifactTestEnv();
+  });
+
+  afterEach(() => env.cleanup());
+
+  test("fails closed when production has no durable artifacts directory", () => {
+    const previousEnvironment = process.env.ENVIRONMENT;
+    const previousArtifactsDir = process.env.LOBU_ARTIFACTS_DIR;
+    try {
+      process.env.ENVIRONMENT = "production";
+      delete process.env.LOBU_ARTIFACTS_DIR;
+      expect(() => new ArtifactStore()).toThrow(
+        "Production artifact storage requires LOBU_ARTIFACTS_DIR on a durable mounted filesystem",
+      );
+    } finally {
+      if (previousEnvironment === undefined) delete process.env.ENVIRONMENT;
+      else process.env.ENVIRONMENT = previousEnvironment;
+      if (previousArtifactsDir === undefined)
+        delete process.env.LOBU_ARTIFACTS_DIR;
+      else process.env.LOBU_ARTIFACTS_DIR = previousArtifactsDir;
+    }
+  });
+
+  test("shares verified private artifacts across store instances", async () => {
+    const writer = new ArtifactStore(env.artifactsDir);
+    const reader = new ArtifactStore(env.artifactsDir);
+    const binding = runArtifactBinding(314);
+    const bytes = Buffer.from("shared-image-bytes");
+
+    const published = await writer.publish({
+      buffer: bytes,
+      filename: "mémory photo.webp",
+      contentType: "image/webp",
+      publicGatewayUrl: "https://lobu.example.com",
+      binding,
+    });
+
+    expect(
+      await reader.read(published.artifactId, {
+        binding,
+        maxBytes: bytes.length - 1,
+      }),
+    ).toBeNull();
+    expect(
+      await reader.read(published.artifactId, {
+        binding: runArtifactBinding(315),
+      }),
+    ).toBeNull();
+
+    const stored = await reader.read(published.artifactId, { binding });
+    expect(stored?.metadata).toEqual(
+      expect.objectContaining({
+        filename: "mémory photo.webp",
+        contentType: "image/webp",
+        size: bytes.length,
+        binding,
+        sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+    expect(stored?.bytes).toEqual(bytes);
+
+    await writer.delete(published.artifactId);
+    expect(await reader.read(published.artifactId)).toBeNull();
+  });
+
+  test("rejects artifacts larger than the bounded read contract", async () => {
+    await expect(
+      env.artifactStore.publish({
+        buffer: Buffer.alloc(50 * 1024 * 1024 + 1),
+        filename: "too-large.bin",
+        publicGatewayUrl: "https://lobu.example.com",
+      }),
+    ).rejects.toThrow("Artifact exceeds the 52428800-byte storage limit");
+    expect(await fs.readdir(env.artifactsDir)).toEqual([]);
+  });
+
+  test("rejects metadata without the required checksum", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("verified-bytes"),
+      filename: "verified.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+      binding: runArtifactBinding(314),
+    });
+    const metadataPath = join(
+      env.artifactsDir,
+      published.artifactId,
+      "metadata.json",
+    );
+    const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+    delete metadata.sha256;
+    await fs.writeFile(metadataPath, JSON.stringify(metadata));
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+    expect(
+      await env.artifactStore.inspect(published.artifactId, {
+        binding: runArtifactBinding(314),
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps reserved metadata filenames separate from payload bytes", async () => {
+    const bytes = Buffer.from("not artifact metadata");
+    const published = await env.artifactStore.publish({
+      buffer: bytes,
+      filename: "metadata.json",
+      contentType: "application/json",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+
+    const stored = await env.artifactStore.read(published.artifactId);
+    expect(stored?.metadata.filename).toBe("metadata.json");
+    expect(stored?.bytes).toEqual(bytes);
+  });
+
+  test("rejects artifact ids that can escape the configured directory", async () => {
+    expect(await env.artifactStore.read("../outside")).toBeNull();
+    await expect(
+      env.artifactStore.delete("../outside"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects oversized metadata before parsing it", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("small"),
+      filename: "small.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    await fs.writeFile(
+      join(env.artifactsDir, published.artifactId, "metadata.json"),
+      JSON.stringify({
+        artifactId: published.artifactId,
+        filename: "x".repeat(128 * 1024),
+        contentType: "text/plain",
+        size: 5,
+        createdAt: Date.now(),
+        sha256: createHash("sha256").update("small").digest("hex"),
+      }),
+    );
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+  });
+
+  test("does not follow a replacement symlink even when bytes match", async () => {
+    const bytes = Buffer.from("same-secret-bytes");
+    const published = await env.artifactStore.publish({
+      buffer: bytes,
+      filename: "safe.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const outside = join(env.artifactsDir, "outside-secret");
+    await fs.writeFile(outside, bytes);
+    const payload = join(env.artifactsDir, published.artifactId, "content");
+    await fs.rm(payload);
+    await fs.symlink(outside, payload);
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+  });
+
+  test("does not delete a pre-existing directory when publication collides", async () => {
+    const realMkdir = fs.mkdir;
+    let collidedDir: string | undefined;
+    const mkdirSpy = spyOn(fs, "mkdir").mockImplementation(
+      async (target, options) => {
+        const targetPath = String(target);
+        if (/\/[0-9a-f-]{36}$/i.test(targetPath)) {
+          collidedDir = targetPath;
+          await realMkdir(target, options);
+          await fs.writeFile(join(targetPath, "committed-marker"), "keep");
+          const collision = new Error("injected UUID collision") as NodeJS.ErrnoException;
+          collision.code = "EEXIST";
+          throw collision;
+        }
+        return realMkdir(target, options);
+      },
+    );
+
+    try {
+      await expect(
+        env.artifactStore.publish({
+          buffer: Buffer.from("must-not-replace"),
+          filename: "collision.bin",
+          publicGatewayUrl: "https://lobu.example.com",
+        }),
+      ).rejects.toBeInstanceOf(ArtifactStorageError);
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+
+    expect(collidedDir).toBeDefined();
+    expect(await fs.readFile(join(collidedDir!, "committed-marker"), "utf8")).toBe(
+      "keep",
+    );
+  });
+
+  test("quarantines a failed delete and drains the leftover before another publish", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("abandoned"),
+      filename: "abandoned.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const realRm = fs.rm;
+    let failQuarantinedRemoval = true;
+    const rmSpy = spyOn(fs, "rm").mockImplementation(
+      async (target, options) => {
+        if (
+          failQuarantinedRemoval &&
+          String(target).includes(`${join(env.artifactsDir, ".trash")}/`)
+        ) {
+          failQuarantinedRemoval = false;
+          throw new Error("injected retained-PVC removal failure");
+        }
+        return realRm(target, options);
+      },
+    );
+
+    try {
+      const deletion = env.artifactStore.delete(published.artifactId);
+      await expect(deletion).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(deletion).rejects.toMatchObject({
+        code: "ARTIFACT_STORAGE_UNAVAILABLE",
+      });
+      await expect(deletion).rejects.not.toThrow(env.artifactsDir);
+    } finally {
+      rmSpy.mockRestore();
+    }
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+    const trashDir = join(env.artifactsDir, ".trash");
+    const [quarantined] = await fs.readdir(trashDir);
+    expect(quarantined).toContain(published.artifactId);
+
+    // A retained PVC has nothing else to reclaim the leftover. Publication
+    // cannot continue while known uncommitted bytes remain abandoned.
+    const next = await env.artifactStore.publish({
+      buffer: Buffer.from("next"),
+      filename: "next.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    expect(await fs.readdir(trashDir)).toEqual([]);
+
+    await env.artifactStore.delete(next.artifactId);
+    expect(await fs.readdir(trashDir)).toEqual([]);
+  });
+
+  test("fails closed when a quarantined orphan still cannot be removed", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("abandoned"),
+      filename: "abandoned.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const realRm = fs.rm;
+    const rmSpy = spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (String(target).includes(`${join(env.artifactsDir, ".trash")}/`)) {
+        throw new Error("retained PVC remains unavailable");
+      }
+      return realRm(target, options);
+    });
+
+    try {
+      const deletion = env.artifactStore.delete(published.artifactId);
+      await expect(deletion).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(deletion).rejects.not.toThrow(env.artifactsDir);
+      const publication = env.artifactStore.publish({
+        buffer: Buffer.from("must-not-publish"),
+        filename: "blocked.bin",
+        publicGatewayUrl: "https://lobu.example.com",
+      });
+      await expect(publication).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(publication).rejects.not.toThrow(env.artifactsDir);
+    } finally {
+      rmSpy.mockRestore();
+    }
+
+    expect(await fs.readdir(join(env.artifactsDir, ".trash"))).toHaveLength(1);
   });
 });

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -200,11 +200,6 @@ describe("ArtifactStore durable filesystem backend", () => {
     await fs.writeFile(metadataPath, JSON.stringify(metadata));
 
     expect(await env.artifactStore.read(published.artifactId)).toBeNull();
-    expect(
-      await env.artifactStore.inspect(published.artifactId, {
-        binding: runArtifactBinding(314),
-      }),
-    ).toBeNull();
   });
 
   test("keeps reserved metadata filenames separate from payload bytes", async () => {

--- a/packages/server/src/gateway/__tests__/file-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/file-routes.test.ts
@@ -227,7 +227,7 @@ describe("file routes", () => {
               '--artifact-boundary\r\nContent-Disposition: form-data; name="file"; filename="large.bin"\r\n\r\n',
             ),
           );
-        } else if (emitted <= 52) {
+        } else if (emitted <= 200) {
           controller.enqueue(chunk);
         } else {
           controller.enqueue(
@@ -251,7 +251,7 @@ describe("file routes", () => {
     const response = await app.fetch(request);
 
     expect(response.status).toBe(413);
-    expect(emitted).toBeLessThanOrEqual(53);
+    expect(emitted).toBeLessThan(60);
   });
 
   test("rejects a decoded single file over the storage limit", async () => {

--- a/packages/server/src/gateway/__tests__/file-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/file-routes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { generateWorkerToken } from "@lobu/core";
 import { Hono } from "hono";
+import { MAX_ARTIFACT_BYTES } from "../files/artifact-store.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { IFileHandler } from "../platform/file-handler.js";
 import { createFileRoutes } from "../routes/internal/files.js";
@@ -175,5 +176,35 @@ describe("file routes", () => {
     expect(seen?.threadTs).toBe("conv-1");
     expect(seen?.channelId).not.toBe("victim-channel");
     expect(seen?.threadTs).not.toBe("victim-conv");
+  });
+
+  test.each([
+    { path: "/internal/files/upload", field: "file" },
+    { path: "/internal/files/upload-batch", field: "files" },
+  ])("rejects an oversized file before $path materializes it", async ({
+    path,
+    field,
+  }) => {
+    const app = buildApp();
+    const token = generateWorkerToken("user-1", "conv-1", "worker-1", {
+      channelId: "channel-1",
+      platform: "telegram",
+    });
+    const form = new FormData();
+    form.set(
+      field,
+      new File([new Uint8Array(MAX_ARTIFACT_BYTES + 1)], "oversized.bin")
+    );
+
+    const response = await app.request(path, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error: "File exceeds the artifact storage limit",
+    });
   });
 });

--- a/packages/server/src/gateway/__tests__/file-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/file-routes.test.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import {
   ArtifactStorageError,
   MAX_ARTIFACT_BYTES,
+  runArtifactBinding,
 } from "../files/artifact-store.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { IFileHandler } from "../platform/file-handler.js";
@@ -296,6 +297,41 @@ describe("file routes", () => {
     expect(await response.json()).toEqual({
       error: "Batch exceeds the artifact storage limit",
     });
+  });
+
+  test("refuses a bound download URL pointed at another resource's artifact", async () => {
+    // Event attachment URLs are re-minted on every read without touching the
+    // store, so the binding travels inside the token and this route is where
+    // it is checked. Without that check the grafted id downloads fine.
+    const app = buildApp();
+    const { artifactId } = await env.artifactStore.publish({
+      buffer: Buffer.from("someone else's bytes"),
+      filename: "victim.txt",
+      contentType: "text/plain",
+      publicGatewayUrl: TEST_GATEWAY_URL,
+      binding: runArtifactBinding(1),
+    });
+
+    const grafted = env.artifactStore.buildDownloadUrl(
+      TEST_GATEWAY_URL,
+      artifactId,
+      undefined,
+      runArtifactBinding(2)
+    );
+    const denied = await app.request(new URL(grafted).pathname + new URL(grafted).search);
+    expect(denied.status).toBe(404);
+
+    const legitimate = env.artifactStore.buildDownloadUrl(
+      TEST_GATEWAY_URL,
+      artifactId,
+      undefined,
+      runArtifactBinding(1)
+    );
+    const allowed = await app.request(
+      new URL(legitimate).pathname + new URL(legitimate).search
+    );
+    expect(allowed.status).toBe(200);
+    expect(await allowed.text()).toBe("someone else's bytes");
   });
 
   test("returns a generic 503 when artifact storage is unavailable", async () => {

--- a/packages/server/src/gateway/__tests__/file-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/file-routes.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { generateWorkerToken } from "@lobu/core";
 import { Hono } from "hono";
-import { MAX_ARTIFACT_BYTES } from "../files/artifact-store.js";
+import {
+  ArtifactStorageError,
+  MAX_ARTIFACT_BYTES,
+} from "../files/artifact-store.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { IFileHandler } from "../platform/file-handler.js";
 import { createFileRoutes } from "../routes/internal/files.js";
@@ -181,7 +184,7 @@ describe("file routes", () => {
   test.each([
     { path: "/internal/files/upload", field: "file" },
     { path: "/internal/files/upload-batch", field: "files" },
-  ])("rejects an oversized file before $path materializes it", async ({
+  ])("rejects an oversized $path request before parsing multipart data", async ({
     path,
     field,
   }) => {
@@ -191,12 +194,99 @@ describe("file routes", () => {
       platform: "telegram",
     });
     const form = new FormData();
-    form.set(
-      field,
-      new File([new Uint8Array(MAX_ARTIFACT_BYTES + 1)], "oversized.bin")
-    );
+    form.set(field, new File(["small"], "oversized.bin"));
 
     const response = await app.request(path, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Length": String(MAX_ARTIFACT_BYTES + 1024 * 1024 + 1),
+      },
+      body: form,
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error: "File exceeds the artifact storage limit",
+    });
+  });
+
+  test("stops an unbounded multipart stream even without Content-Length", async () => {
+    const app = buildApp();
+    const token = generateWorkerToken("user-1", "conv-1", "worker-1", {
+      channelId: "channel-1",
+      platform: "telegram",
+    });
+    const chunk = new Uint8Array(1024 * 1024);
+    let emitted = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted === 0) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              '--artifact-boundary\r\nContent-Disposition: form-data; name="file"; filename="large.bin"\r\n\r\n',
+            ),
+          );
+        } else if (emitted <= 52) {
+          controller.enqueue(chunk);
+        } else {
+          controller.enqueue(
+            new TextEncoder().encode("\r\n--artifact-boundary--\r\n"),
+          );
+          controller.close();
+        }
+        emitted += 1;
+      },
+    });
+    const request = new Request("http://localhost/internal/files/upload", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "multipart/form-data; boundary=artifact-boundary",
+      },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const response = await app.fetch(request);
+
+    expect(response.status).toBe(413);
+    expect(emitted).toBeLessThanOrEqual(53);
+  });
+
+  test("rejects a decoded single file over the storage limit", async () => {
+    const app = buildApp();
+    const token = generateWorkerToken("user-1", "conv-1", "worker-1", {
+      channelId: "channel-1",
+      platform: "telegram",
+    });
+    const form = new FormData();
+    form.set(
+      "file",
+      new File([new Uint8Array(MAX_ARTIFACT_BYTES + 1)], "oversized.bin"),
+    );
+
+    const response = await app.request("/internal/files/upload", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+
+    expect(response.status).toBe(413);
+  });
+
+  test("rejects a batch whose aggregate decoded size exceeds the limit", async () => {
+    const app = buildApp();
+    const token = generateWorkerToken("user-1", "conv-1", "worker-1", {
+      channelId: "channel-1",
+      platform: "telegram",
+    });
+    const form = new FormData();
+    const halfLimit = Math.floor(MAX_ARTIFACT_BYTES / 2);
+    form.append("files", new File([new Uint8Array(halfLimit + 1)], "a.bin"));
+    form.append("files", new File([new Uint8Array(halfLimit + 1)], "b.bin"));
+
+    const response = await app.request("/internal/files/upload-batch", {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
       body: form,
@@ -204,7 +294,29 @@ describe("file routes", () => {
 
     expect(response.status).toBe(413);
     expect(await response.json()).toEqual({
-      error: "File exceeds the artifact storage limit",
+      error: "Batch exceeds the artifact storage limit",
+    });
+  });
+
+  test("returns a generic 503 when artifact storage is unavailable", async () => {
+    const app = new Hono();
+    app.route(
+      "",
+      createPublicFileRoutes({
+        validateDownloadToken: () => ({ valid: true }),
+        read: async () => {
+          throw new ArtifactStorageError("read", new Error("private path"));
+        },
+      } as unknown as ArtifactTestEnv["artifactStore"]),
+    );
+
+    const response = await app.request(
+      "/api/v1/files/00000000-0000-4000-8000-000000000000?token=valid",
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "File storage temporarily unavailable",
     });
   });
 });

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -420,20 +420,6 @@ export class ArtifactStore {
     return { metadata, bytes };
   }
 
-  /** Read validated metadata without loading the artifact payload. */
-  async inspect(
-    artifactId: string,
-    options?: { binding?: string },
-  ): Promise<StoredArtifactMetadata | null> {
-    const record = await this.readMetadataRecord(artifactId);
-    if (!record) return null;
-    if (options?.binding && record.metadata.binding !== options.binding) {
-      return null;
-    }
-    if (!(await this.directoryIsUnchanged(artifactId, record.dirStat))) return null;
-    return record.metadata;
-  }
-
   async delete(artifactId: string): Promise<void> {
     if (!ARTIFACT_ID_PATTERN.test(artifactId)) return;
     try {

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -15,7 +15,7 @@ const ARTIFACT_PAYLOAD_FILENAME = "content";
 const ARTIFACT_ID_PATTERN = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
 const ARTIFACT_SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const ARTIFACT_METADATA_MAX_BYTES = 16 * 1024;
-const MAX_ARTIFACT_BYTES = 50 * 1024 * 1024;
+export const MAX_ARTIFACT_BYTES = 50 * 1024 * 1024;
 const ARTIFACT_TRASH_DIRNAME = ".trash";
 const DOWNLOAD_TOKEN_MAX_CHARS = 4096;
 

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -3,7 +3,7 @@ import { constants as fsConstants, type Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { decrypt, encrypt, getErrorMessage } from "@lobu/core";
+import { decrypt, encrypt } from "@lobu/core";
 import baseLogger from "../../utils/logger";
 
 const logger = baseLogger.child({ module: "artifact-store" });
@@ -53,10 +53,21 @@ export class ArtifactStorageError extends Error {
 function storageFailure(operation: string, cause: unknown): ArtifactStorageError {
   if (cause instanceof ArtifactStorageError) return cause;
   logger.error(
-    { operation, error: getErrorMessage(cause) },
+    {
+      operation,
+      code:
+        cause && typeof cause === "object" && "code" in cause
+          ? String(cause.code)
+          : undefined,
+    },
     "Artifact storage operation failed",
   );
   return new ArtifactStorageError(operation, cause);
+}
+
+function isMissingOrUnsafe(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
 }
 
 function sanitizeFilename(filename: string): string {
@@ -146,10 +157,24 @@ async function readBoundedRegularFile(
       offset += bytesRead;
     }
     return buffer;
-  } catch {
-    return null;
+  } catch (error) {
+    if (isMissingOrUnsafe(error)) return null;
+    throw storageFailure("read", error);
   } finally {
     await handle?.close().catch(() => {});
+  }
+}
+
+async function writeDurableFile(
+  filePath: string,
+  contents: string | Buffer,
+): Promise<void> {
+  const handle = await fs.open(filePath, "wx", 0o600);
+  try {
+    await handle.writeFile(contents);
+    await handle.sync();
+  } finally {
+    await handle.close();
   }
 }
 
@@ -190,14 +215,20 @@ export class ArtifactStore {
     artifactId: string,
   ): Promise<{ metadata: StoredArtifactMetadata; dirStat: Stats } | null> {
     if (!ARTIFACT_ID_PATTERN.test(artifactId)) return null;
+    let dirStat: Stats;
     try {
-      const dirStat = await fs.lstat(this.artifactDir(artifactId));
-      if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return null;
-      const raw = await readBoundedRegularFile(
-        this.metadataPath(artifactId),
-        ARTIFACT_METADATA_MAX_BYTES,
-      );
-      if (!raw) return null;
+      dirStat = await fs.lstat(this.artifactDir(artifactId));
+    } catch (error) {
+      if (isMissingOrUnsafe(error)) return null;
+      throw storageFailure("read", error);
+    }
+    if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return null;
+    const raw = await readBoundedRegularFile(
+      this.metadataPath(artifactId),
+      ARTIFACT_METADATA_MAX_BYTES,
+    );
+    if (!raw) return null;
+    try {
       const parsed = JSON.parse(raw.toString("utf8")) as unknown;
       if (!isStoredArtifactMetadata(parsed, artifactId)) return null;
       return { metadata: parsed, dirStat };
@@ -218,8 +249,9 @@ export class ArtifactStore {
         final.dev === initial.dev &&
         final.ino === initial.ino
       );
-    } catch {
-      return false;
+    } catch (error) {
+      if (isMissingOrUnsafe(error)) return false;
+      throw storageFailure("read", error);
     }
   }
 
@@ -313,14 +345,10 @@ export class ArtifactStore {
       // not ours, so never adopt it.
       await fs.mkdir(dir, { recursive: false, mode: 0o700 });
       ownsDir = true;
-      await fs.writeFile(this.artifactFilePath(artifactId), params.buffer, {
-        flag: "wx",
-        mode: 0o600,
-      });
-      await fs.writeFile(
+      await writeDurableFile(this.artifactFilePath(artifactId), params.buffer);
+      await writeDurableFile(
         this.metadataPath(artifactId),
         JSON.stringify(metadata, null, 2),
-        { flag: "wx", mode: 0o600 },
       );
     } catch (error) {
       if (ownsDir) {
@@ -329,12 +357,12 @@ export class ArtifactStore {
         } catch (cleanupError) {
           // Message stays path-free like every other surface here: the causes
           // carry the detail, and the filesystem layout is not for callers.
-          throw new AggregateError(
-            [
-              storageFailure("publication", error),
-              storageFailure("quarantine", cleanupError),
-            ],
-            "Artifact publication failed and its partial directory could not be quarantined",
+          throw storageFailure(
+            "publication",
+            new AggregateError(
+              [error, cleanupError],
+              "Partial artifact directory could not be quarantined",
+            ),
           );
         }
       }
@@ -362,38 +390,34 @@ export class ArtifactStore {
     artifactId: string,
     options?: { binding?: string; maxBytes?: number },
   ): Promise<{ metadata: StoredArtifactMetadata; bytes: Buffer } | null> {
-    try {
-      const record = await this.readMetadataRecord(artifactId);
-      if (!record) return null;
-      const { metadata, dirStat } = record;
-      if (options?.binding && metadata.binding !== options.binding) {
-        return null;
-      }
-      const maxBytes = options?.maxBytes ?? MAX_ARTIFACT_BYTES;
-      if (
-        !Number.isSafeInteger(maxBytes) ||
-        maxBytes < 0 ||
-        metadata.size > maxBytes
-      ) {
-        return null;
-      }
-      const bytes = await readBoundedRegularFile(
-        this.artifactFilePath(artifactId),
-        maxBytes,
-      );
-      if (
-        !bytes ||
-        bytes.length !== metadata.size ||
-        sha256(bytes) !== metadata.sha256
-      ) {
-        logger.warn(`Artifact ${artifactId} failed size/checksum verification`);
-        return null;
-      }
-      if (!(await this.directoryIsUnchanged(artifactId, dirStat))) return null;
-      return { metadata, bytes };
-    } catch {
+    const record = await this.readMetadataRecord(artifactId);
+    if (!record) return null;
+    const { metadata, dirStat } = record;
+    if (options?.binding && metadata.binding !== options.binding) {
       return null;
     }
+    const maxBytes = options?.maxBytes ?? MAX_ARTIFACT_BYTES;
+    if (
+      !Number.isSafeInteger(maxBytes) ||
+      maxBytes < 0 ||
+      metadata.size > maxBytes
+    ) {
+      return null;
+    }
+    const bytes = await readBoundedRegularFile(
+      this.artifactFilePath(artifactId),
+      maxBytes,
+    );
+    if (
+      !bytes ||
+      bytes.length !== metadata.size ||
+      sha256(bytes) !== metadata.sha256
+    ) {
+      logger.warn(`Artifact ${artifactId} failed size/checksum verification`);
+      return null;
+    }
+    if (!(await this.directoryIsUnchanged(artifactId, dirStat))) return null;
+    return { metadata, bytes };
   }
 
   /** Read validated metadata without loading the artifact payload. */

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -382,6 +382,7 @@ export class ArtifactStore {
         normalizeBaseUrl(params.publicGatewayUrl),
         artifactId,
         params.ttlMs,
+        params.binding,
       ),
     };
   }
@@ -420,6 +421,26 @@ export class ArtifactStore {
     return { metadata, bytes };
   }
 
+  /**
+   * Validated metadata without loading the payload. Lets a caller tell
+   * "too large to inline" apart from "absent", which a bounded `read` alone
+   * reports identically.
+   */
+  async inspect(
+    artifactId: string,
+    options?: { binding?: string },
+  ): Promise<StoredArtifactMetadata | null> {
+    const record = await this.readMetadataRecord(artifactId);
+    if (!record) return null;
+    if (options?.binding && record.metadata.binding !== options.binding) {
+      return null;
+    }
+    if (!(await this.directoryIsUnchanged(artifactId, record.dirStat))) {
+      return null;
+    }
+    return record.metadata;
+  }
+
   async delete(artifactId: string): Promise<void> {
     if (!ARTIFACT_ID_PATTERN.test(artifactId)) return;
     try {
@@ -430,11 +451,27 @@ export class ArtifactStore {
     logger.info(`Deleted artifact ${artifactId}`);
   }
 
-  createDownloadToken(artifactId: string, ttlMs = this.defaultTtlMs): string {
+  /**
+   * A token carries the binding it was minted for so the download route can
+   * enforce it without the minting side touching the filesystem. Only this
+   * process can mint one (the payload is encrypted with the app key), so the
+   * binding inside is as trustworthy as the artifact id beside it.
+   *
+   * A tokenless-ref re-sign (`resignFileRefs`) still mints unbound tokens: the
+   * ids come from a transcript the caller is already authorized to read, and
+   * there is no per-ref binding to carry. Unbound stays exactly as permissive
+   * as it is today; bound is strictly tighter.
+   */
+  createDownloadToken(
+    artifactId: string,
+    ttlMs = this.defaultTtlMs,
+    binding?: string,
+  ): string {
     return encrypt(
       JSON.stringify({
         artifactId,
         exp: Date.now() + ttlMs,
+        ...(binding ? { binding } : {}),
       }),
     );
   }
@@ -445,6 +482,7 @@ export class ArtifactStore {
   ): {
     valid: boolean;
     error?: string;
+    binding?: string;
   } {
     if (
       token.length === 0 ||
@@ -457,6 +495,7 @@ export class ArtifactStore {
       const payload = JSON.parse(decrypt(token)) as {
         artifactId?: string;
         exp?: number;
+        binding?: unknown;
       };
       if (payload.artifactId !== artifactId) {
         return { valid: false, error: "artifact_mismatch" };
@@ -464,7 +503,11 @@ export class ArtifactStore {
       if (!payload.exp || Date.now() > payload.exp) {
         return { valid: false, error: "expired" };
       }
-      return { valid: true };
+      const binding =
+        typeof payload.binding === "string" && payload.binding.length > 0
+          ? payload.binding
+          : undefined;
+      return { valid: true, ...(binding ? { binding } : {}) };
     } catch {
       return { valid: false, error: "malformed" };
     }
@@ -474,6 +517,7 @@ export class ArtifactStore {
     publicGatewayUrl: string,
     artifactId: string,
     ttlMs = this.defaultTtlMs,
+    binding?: string,
   ): string {
     const baseUrl = normalizeBaseUrl(publicGatewayUrl);
     // Concatenate onto the base rather than `new URL("/api/v1/...", baseUrl)`:
@@ -483,7 +527,10 @@ export class ArtifactStore {
     const url = new URL(
       `${baseUrl}/api/v1/files/${encodeURIComponent(artifactId)}`,
     );
-    url.searchParams.set("token", this.createDownloadToken(artifactId, ttlMs));
+    url.searchParams.set(
+      "token",
+      this.createDownloadToken(artifactId, ttlMs, binding),
+    );
     return url.toString();
   }
 }

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -1,18 +1,23 @@
-import { randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, type Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import {
-	createLogger,
-	decrypt,
-	getErrorMessage,
-	encrypt,
-} from "@lobu/core";
+import { decrypt, encrypt, getErrorMessage } from "@lobu/core";
+import baseLogger from "../../utils/logger";
 
-const logger = createLogger("artifact-store");
+const logger = baseLogger.child({ module: "artifact-store" });
+
 const DEFAULT_ARTIFACTS_DIR = path.join(os.tmpdir(), "lobu-artifacts");
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+// Keep payload bytes separate from reserved metadata regardless of filename.
+const ARTIFACT_PAYLOAD_FILENAME = "content";
+const ARTIFACT_ID_PATTERN = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+const ARTIFACT_SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const ARTIFACT_METADATA_MAX_BYTES = 16 * 1024;
+const MAX_ARTIFACT_BYTES = 50 * 1024 * 1024;
+const ARTIFACT_TRASH_DIRNAME = ".trash";
+const DOWNLOAD_TOKEN_MAX_CHARS = 4096;
 
 interface StoredArtifactMetadata {
   artifactId: string;
@@ -20,6 +25,7 @@ interface StoredArtifactMetadata {
   contentType: string;
   size: number;
   createdAt: number;
+  sha256: string;
   /** Immutable Lobu resource identity allowed to read this artifact internally. */
   binding?: string;
 }
@@ -30,6 +36,27 @@ interface PublishArtifactResult {
   size: number;
   contentType: string;
   downloadUrl: string;
+}
+
+export class ArtifactStorageError extends Error {
+  readonly code = "ARTIFACT_STORAGE_UNAVAILABLE";
+
+  constructor(operation: string, cause: unknown) {
+    super(
+      `Artifact storage ${operation} failed; operator intervention is required`,
+      { cause },
+    );
+    this.name = "ArtifactStorageError";
+  }
+}
+
+function storageFailure(operation: string, cause: unknown): ArtifactStorageError {
+  if (cause instanceof ArtifactStorageError) return cause;
+  logger.error(
+    { operation, error: getErrorMessage(cause) },
+    "Artifact storage operation failed",
+  );
+  return new ArtifactStorageError(operation, cause);
 }
 
 function sanitizeFilename(filename: string): string {
@@ -64,23 +91,186 @@ function normalizeBaseUrl(publicGatewayUrl: string): string {
   return trimmed.replace(/\/$/, "");
 }
 
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function isStoredArtifactMetadata(
+  value: unknown,
+  artifactId: string,
+): value is StoredArtifactMetadata {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const metadata = value as Record<string, unknown>;
+  return (
+    metadata.artifactId === artifactId &&
+    typeof metadata.filename === "string" &&
+    metadata.filename.length > 0 &&
+    metadata.filename.length <= 1024 &&
+    typeof metadata.contentType === "string" &&
+    metadata.contentType.length > 0 &&
+    metadata.contentType.length <= 512 &&
+    typeof metadata.size === "number" &&
+    Number.isSafeInteger(metadata.size) &&
+    metadata.size >= 0 &&
+    typeof metadata.createdAt === "number" &&
+    Number.isFinite(metadata.createdAt) &&
+    typeof metadata.sha256 === "string" &&
+    ARTIFACT_SHA256_PATTERN.test(metadata.sha256) &&
+    (metadata.binding === undefined ||
+      (typeof metadata.binding === "string" && metadata.binding.length <= 2048))
+  );
+}
+
+async function readBoundedRegularFile(
+  filePath: string,
+  maxBytes: number,
+): Promise<Buffer | null> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(
+      filePath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > maxBytes) return null;
+    const buffer = Buffer.allocUnsafe(stat.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        offset,
+        buffer.length - offset,
+        offset,
+      );
+      if (bytesRead === 0) return null;
+      offset += bytesRead;
+    }
+    return buffer;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function resolveArtifactsDir(baseDir: string | undefined): string {
+  const configured = baseDir?.trim() || process.env.LOBU_ARTIFACTS_DIR?.trim();
+  if (configured) return configured;
+  if (process.env.ENVIRONMENT === "production") {
+    throw new Error(
+      "Production artifact storage requires LOBU_ARTIFACTS_DIR on a durable mounted filesystem",
+    );
+  }
+  return DEFAULT_ARTIFACTS_DIR;
+}
+
 export class ArtifactStore {
+  private readonly baseDir: string;
+
   constructor(
-    private readonly baseDir = process.env.LOBU_ARTIFACTS_DIR ||
-      DEFAULT_ARTIFACTS_DIR,
-    private readonly defaultTtlMs = DEFAULT_TTL_MS
-  ) {}
+    baseDir?: string,
+    private readonly defaultTtlMs = DEFAULT_TTL_MS,
+  ) {
+    this.baseDir = resolveArtifactsDir(baseDir);
+  }
 
   private artifactDir(artifactId: string): string {
     return path.join(this.baseDir, artifactId);
   }
 
-  private artifactFilePath(artifactId: string, filename: string): string {
-    return path.join(this.artifactDir(artifactId), sanitizeFilename(filename));
+  private artifactFilePath(artifactId: string): string {
+    return path.join(this.artifactDir(artifactId), ARTIFACT_PAYLOAD_FILENAME);
   }
 
   private metadataPath(artifactId: string): string {
     return path.join(this.artifactDir(artifactId), "metadata.json");
+  }
+
+  private async readMetadataRecord(
+    artifactId: string,
+  ): Promise<{ metadata: StoredArtifactMetadata; dirStat: Stats } | null> {
+    if (!ARTIFACT_ID_PATTERN.test(artifactId)) return null;
+    try {
+      const dirStat = await fs.lstat(this.artifactDir(artifactId));
+      if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return null;
+      const raw = await readBoundedRegularFile(
+        this.metadataPath(artifactId),
+        ARTIFACT_METADATA_MAX_BYTES,
+      );
+      if (!raw) return null;
+      const parsed = JSON.parse(raw.toString("utf8")) as unknown;
+      if (!isStoredArtifactMetadata(parsed, artifactId)) return null;
+      return { metadata: parsed, dirStat };
+    } catch {
+      return null;
+    }
+  }
+
+  private async directoryIsUnchanged(
+    artifactId: string,
+    initial: Stats,
+  ): Promise<boolean> {
+    try {
+      const final = await fs.lstat(this.artifactDir(artifactId));
+      return (
+        final.isDirectory() &&
+        !final.isSymbolicLink() &&
+        final.dev === initial.dev &&
+        final.ino === initial.ino
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Inside `baseDir` so the quarantine rename stays on one filesystem — the
+   * configured directory is the PVC mount root, and a sibling would land on
+   * the pod's ephemeral layer and fail with EXDEV. The name cannot collide
+   * with an artifact directory because those are always UUIDs.
+   */
+  private trashDir(): string {
+    return path.join(this.baseDir, ARTIFACT_TRASH_DIRNAME);
+  }
+
+  private async drainTrash(): Promise<void> {
+    try {
+      const trashDir = this.trashDir();
+      await fs.mkdir(trashDir, { recursive: true, mode: 0o700 });
+      for (const stale of await fs.readdir(trashDir)) {
+        await fs.rm(path.join(trashDir, stale), {
+          recursive: true,
+          force: true,
+        });
+      }
+    } catch (error) {
+      throw storageFailure("cleanup", error);
+    }
+  }
+
+  /**
+   * Delete by rename-then-remove so a concurrent reader either sees the whole
+   * artifact or nothing — never a directory losing its files underneath it.
+   * The quarantined copy is removed immediately; one only lingers when that
+   * removal fails. Every later publish drains earlier leftovers first and
+   * fails closed if that is still impossible; the retained PVC has no other
+   * process that can safely infer which directories are uncommitted.
+   */
+  private async quarantineAndDelete(artifactId: string): Promise<void> {
+    const trashDir = this.trashDir();
+    await fs.mkdir(trashDir, { recursive: true, mode: 0o700 });
+    const source = this.artifactDir(artifactId);
+    const quarantined = path.join(trashDir, `${artifactId}-${randomUUID()}`);
+    try {
+      await fs.rename(source, quarantined);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        await this.drainTrash();
+        return;
+      }
+      throw storageFailure("quarantine", error);
+    }
+    await this.drainTrash();
   }
 
   async publish(params: {
@@ -91,35 +281,66 @@ export class ArtifactStore {
     ttlMs?: number;
     binding?: string;
   }): Promise<PublishArtifactResult> {
+    if (params.buffer.length > MAX_ARTIFACT_BYTES) {
+      throw new RangeError(
+        `Artifact exceeds the ${MAX_ARTIFACT_BYTES}-byte storage limit`,
+      );
+    }
     const artifactId = randomUUID();
     const filename = sanitizeFilename(params.filename);
     const contentType = params.contentType || "application/octet-stream";
     const createdAt = Date.now();
-    const dir = this.artifactDir(artifactId);
+    const checksum = sha256(params.buffer);
+    const metadata: StoredArtifactMetadata = {
+      artifactId,
+      filename,
+      contentType,
+      size: params.buffer.length,
+      createdAt,
+      sha256: checksum,
+      ...(params.binding ? { binding: params.binding } : {}),
+    };
 
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      this.artifactFilePath(artifactId, filename),
-      params.buffer
-    );
-    await fs.writeFile(
-      this.metadataPath(artifactId),
-      JSON.stringify(
-        {
-          artifactId,
-          filename,
-          contentType,
-          size: params.buffer.length,
-          createdAt,
-          ...(params.binding ? { binding: params.binding } : {}),
-        } satisfies StoredArtifactMetadata,
-        null,
-        2
-      )
-    );
+    const dir = this.artifactDir(artifactId);
+    let ownsDir = false;
+    try {
+      // Also creates `baseDir` itself, which the non-recursive mkdir below
+      // relies on: a first publish onto an empty mount must not ENOENT.
+      await this.drainTrash();
+      // Exclusive: a collision on a freshly minted UUID means the directory is
+      // not ours, so never adopt it.
+      await fs.mkdir(dir, { recursive: false, mode: 0o700 });
+      ownsDir = true;
+      await fs.writeFile(this.artifactFilePath(artifactId), params.buffer, {
+        flag: "wx",
+        mode: 0o600,
+      });
+      await fs.writeFile(
+        this.metadataPath(artifactId),
+        JSON.stringify(metadata, null, 2),
+        { flag: "wx", mode: 0o600 },
+      );
+    } catch (error) {
+      if (ownsDir) {
+        try {
+          await this.quarantineAndDelete(artifactId);
+        } catch (cleanupError) {
+          // Message stays path-free like every other surface here: the causes
+          // carry the detail, and the filesystem layout is not for callers.
+          throw new AggregateError(
+            [
+              storageFailure("publication", error),
+              storageFailure("quarantine", cleanupError),
+            ],
+            "Artifact publication failed and its partial directory could not be quarantined",
+          );
+        }
+      }
+      throw storageFailure("publication", error);
+    }
 
     logger.info(
-      `Published artifact ${artifactId} (${filename}, ${params.buffer.length} bytes)`
+      `Published artifact ${artifactId} (${filename}, ${params.buffer.length} bytes)`,
     );
 
     return {
@@ -130,32 +351,70 @@ export class ArtifactStore {
       downloadUrl: this.buildDownloadUrl(
         normalizeBaseUrl(params.publicGatewayUrl),
         artifactId,
-        params.ttlMs
+        params.ttlMs,
       ),
     };
   }
 
   async read(
     artifactId: string,
-    options?: { binding?: string }
-  ): Promise<{
-    metadata: StoredArtifactMetadata;
-    filePath: string;
-  } | null> {
+    options?: { binding?: string; maxBytes?: number },
+  ): Promise<{ metadata: StoredArtifactMetadata; bytes: Buffer } | null> {
     try {
-      const raw = await fs.readFile(this.metadataPath(artifactId), "utf8");
-      const metadata = JSON.parse(raw) as StoredArtifactMetadata;
-      if (options?.binding && metadata.binding !== options.binding) return null;
-      const filePath = this.artifactFilePath(artifactId, metadata.filename);
-      await fs.access(filePath);
-      return { metadata, filePath };
+      const record = await this.readMetadataRecord(artifactId);
+      if (!record) return null;
+      const { metadata, dirStat } = record;
+      if (options?.binding && metadata.binding !== options.binding) {
+        return null;
+      }
+      const maxBytes = options?.maxBytes ?? MAX_ARTIFACT_BYTES;
+      if (
+        !Number.isSafeInteger(maxBytes) ||
+        maxBytes < 0 ||
+        metadata.size > maxBytes
+      ) {
+        return null;
+      }
+      const bytes = await readBoundedRegularFile(
+        this.artifactFilePath(artifactId),
+        maxBytes,
+      );
+      if (
+        !bytes ||
+        bytes.length !== metadata.size ||
+        sha256(bytes) !== metadata.sha256
+      ) {
+        logger.warn(`Artifact ${artifactId} failed size/checksum verification`);
+        return null;
+      }
+      if (!(await this.directoryIsUnchanged(artifactId, dirStat))) return null;
+      return { metadata, bytes };
     } catch {
       return null;
     }
   }
 
+  /** Read validated metadata without loading the artifact payload. */
+  async inspect(
+    artifactId: string,
+    options?: { binding?: string },
+  ): Promise<StoredArtifactMetadata | null> {
+    const record = await this.readMetadataRecord(artifactId);
+    if (!record) return null;
+    if (options?.binding && record.metadata.binding !== options.binding) {
+      return null;
+    }
+    if (!(await this.directoryIsUnchanged(artifactId, record.dirStat))) return null;
+    return record.metadata;
+  }
+
   async delete(artifactId: string): Promise<void> {
-    await fs.rm(this.artifactDir(artifactId), { recursive: true, force: true });
+    if (!ARTIFACT_ID_PATTERN.test(artifactId)) return;
+    try {
+      await this.quarantineAndDelete(artifactId);
+    } catch (error) {
+      throw storageFailure("cleanup", error);
+    }
     logger.info(`Deleted artifact ${artifactId}`);
   }
 
@@ -164,17 +423,24 @@ export class ArtifactStore {
       JSON.stringify({
         artifactId,
         exp: Date.now() + ttlMs,
-      })
+      }),
     );
   }
 
   validateDownloadToken(
     token: string,
-    artifactId: string
+    artifactId: string,
   ): {
     valid: boolean;
     error?: string;
   } {
+    if (
+      token.length === 0 ||
+      token.length > DOWNLOAD_TOKEN_MAX_CHARS ||
+      !ARTIFACT_ID_PATTERN.test(artifactId)
+    ) {
+      return { valid: false, error: "malformed" };
+    }
     try {
       const payload = JSON.parse(decrypt(token)) as {
         artifactId?: string;
@@ -187,18 +453,15 @@ export class ArtifactStore {
         return { valid: false, error: "expired" };
       }
       return { valid: true };
-    } catch (error) {
-      return {
-        valid: false,
-        error: getErrorMessage(error),
-      };
+    } catch {
+      return { valid: false, error: "malformed" };
     }
   }
 
   buildDownloadUrl(
     publicGatewayUrl: string,
     artifactId: string,
-    ttlMs = this.defaultTtlMs
+    ttlMs = this.defaultTtlMs,
   ): string {
     const baseUrl = normalizeBaseUrl(publicGatewayUrl);
     // Concatenate onto the base rather than `new URL("/api/v1/...", baseUrl)`:
@@ -206,13 +469,9 @@ export class ArtifactStore {
     // drops a base path prefix (e.g. the embedded/local gateway is mounted
     // under `/lobu`, so the worker must fetch `/lobu/api/v1/files/...`).
     const url = new URL(
-      `${baseUrl}/api/v1/files/${encodeURIComponent(artifactId)}`
+      `${baseUrl}/api/v1/files/${encodeURIComponent(artifactId)}`,
     );
     url.searchParams.set("token", this.createDownloadToken(artifactId, ttlMs));
     return url.toString();
-  }
-
-  createReadStream(artifactId: string, filename: string) {
-    return createReadStream(this.artifactFilePath(artifactId, filename));
   }
 }

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -241,6 +241,8 @@ export class ArtifactStore {
         await fs.rm(path.join(trashDir, stale), {
           recursive: true,
           force: true,
+          maxRetries: 3,
+          retryDelay: 10,
         });
       }
     } catch (error) {

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -6,7 +6,10 @@ import {
 	getErrorMessage,
 } from "@lobu/core";
 import { Hono } from "hono";
-import type { ArtifactStore } from "../../files/artifact-store.js";
+import {
+  type ArtifactStore,
+  MAX_ARTIFACT_BYTES,
+} from "../../files/artifact-store.js";
 import type { PlatformRegistry } from "../../platform.js";
 import type { IFileHandler } from "../../platform/file-handler.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
@@ -108,6 +111,9 @@ export function createFileRoutes(
 
       if (!file) {
         return errorResponse(c, "No file provided", 400);
+      }
+      if (file.size > MAX_ARTIFACT_BYTES) {
+        return errorResponse(c, "File exceeds the artifact storage limit", 413);
       }
 
       const filename = (formData.get("filename") as string) || file.name;
@@ -225,6 +231,13 @@ export function createFileRoutes(
 
       if (!fileEntries || fileEntries.length === 0) {
         return errorResponse(c, "No files provided", 400);
+      }
+      if (
+        fileEntries.some(
+          (entry) => entry instanceof File && entry.size > MAX_ARTIFACT_BYTES
+        )
+      ) {
+        return errorResponse(c, "File exceeds the artifact storage limit", 413);
       }
 
       const captured = await captureSideEffect(c, "files.upload_batch", {

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -6,6 +6,7 @@ import {
 	getErrorMessage,
 } from "@lobu/core";
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import {
   type ArtifactStore,
   MAX_ARTIFACT_BYTES,
@@ -18,6 +19,16 @@ import { captureSideEffect } from "./capture-mode.js";
 import type { WorkerContext } from "./types.js";
 
 const logger = createLogger("file-routes");
+// The wire body carries multipart boundaries, part headers, and the other
+// form fields on top of the file itself, so allow 1 MiB of framing over the
+// decoded artifact limit; the exact decoded size is re-checked after parsing.
+const MAX_ARTIFACT_UPLOAD_REQUEST_BYTES = MAX_ARTIFACT_BYTES + 1024 * 1024;
+
+const limitArtifactUploadBody = bodyLimit({
+  maxSize: MAX_ARTIFACT_UPLOAD_REQUEST_BYTES,
+  onError: (c) =>
+    errorResponse(c, "File exceeds the artifact storage limit", 413),
+});
 
 /**
  * Resolve the file handler for a given platform from the registry.
@@ -80,7 +91,7 @@ export function createFileRoutes(
    * Upload file endpoint for workers
    * POST /upload
    */
-  router.post("/upload", authenticateWorker, async (c) => {
+  router.post("/upload", limitArtifactUploadBody, authenticateWorker, async (c) => {
     try {
       const worker = getVerifiedWorker(c);
       // SECURITY: the channel/conversation a worker may upload to is fixed by
@@ -193,6 +204,9 @@ export function createFileRoutes(
         artifactId: result.artifactId,
       });
     } catch (error) {
+      if (error instanceof Error && error.name === "BodyLimitError") {
+        return errorResponse(c, "File exceeds the artifact storage limit", 413);
+      }
       logger.error("Failed to upload file", {
         error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,
@@ -205,7 +219,7 @@ export function createFileRoutes(
    * Batch upload endpoint for multiple files
    * POST /upload-batch
    */
-  router.post("/upload-batch", authenticateWorker, async (c) => {
+  router.post("/upload-batch", limitArtifactUploadBody, authenticateWorker, async (c) => {
     try {
       const worker = getVerifiedWorker(c);
       // SECURITY: token-bound channel/conversation (see /upload above) — never
@@ -232,31 +246,36 @@ export function createFileRoutes(
       if (!fileEntries || fileEntries.length === 0) {
         return errorResponse(c, "No files provided", 400);
       }
+      const files = fileEntries.filter(
+        (entry): entry is File => entry instanceof File
+      );
+      if (files.length !== fileEntries.length) {
+        return errorResponse(c, "Every upload entry must be a file", 400);
+      }
+      // The batch buffers every entry concurrently below, so the aggregate —
+      // not just each file — has to stay inside the artifact storage limit.
       if (
-        fileEntries.some(
-          (entry) => entry instanceof File && entry.size > MAX_ARTIFACT_BYTES
-        )
+        files.reduce((total, file) => total + file.size, 0) >
+        MAX_ARTIFACT_BYTES
       ) {
-        return errorResponse(c, "File exceeds the artifact storage limit", 413);
+        return errorResponse(
+          c,
+          "Batch exceeds the artifact storage limit",
+          413
+        );
       }
 
       const captured = await captureSideEffect(c, "files.upload_batch", {
-        count: fileEntries.length,
-        filenames: fileEntries
-          .filter((entry): entry is File => entry instanceof File)
-          .map((entry) => entry.name),
+        count: files.length,
+        filenames: files.map((entry) => entry.name),
       });
       if (captured) return captured;
 
       logger.info(
-        `Worker uploading ${fileEntries.length} files for conversation ${worker.conversationId}`
+        `Worker uploading ${files.length} files for conversation ${worker.conversationId}`
       );
 
-      const uploadPromises = fileEntries.map(async (entry, index) => {
-        if (!(entry instanceof File)) {
-          throw new Error(`Entry ${index} is not a file`);
-        }
-
+      const uploadPromises = files.map(async (entry) => {
         const filename = entry.name;
         const fileBuffer = Buffer.from(await entry.arrayBuffer());
 
@@ -317,6 +336,9 @@ export function createFileRoutes(
 
       return c.json({ results });
     } catch (error) {
+      if (error instanceof Error && error.name === "BodyLimitError") {
+        return errorResponse(c, "File exceeds the artifact storage limit", 413);
+      }
       logger.error("Failed to batch upload files", {
         error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -204,6 +204,8 @@ export function createFileRoutes(
         artifactId: result.artifactId,
       });
     } catch (error) {
+      // Hono does not export `BodyLimitError`, so its name is the only handle
+      // on it; `instanceof` has no class to test against.
       if (error instanceof Error && error.name === "BodyLimitError") {
         return errorResponse(c, "File exceeds the artifact storage limit", 413);
       }
@@ -336,6 +338,8 @@ export function createFileRoutes(
 
       return c.json({ results });
     } catch (error) {
+      // Hono does not export `BodyLimitError`, so its name is the only handle
+      // on it; `instanceof` has no class to test against.
       if (error instanceof Error && error.name === "BodyLimitError") {
         return errorResponse(c, "File exceeds the artifact storage limit", 413);
       }

--- a/packages/server/src/gateway/routes/public/files.ts
+++ b/packages/server/src/gateway/routes/public/files.ts
@@ -36,7 +36,13 @@ export function createPublicFileRoutes(artifactStore: ArtifactStore): Hono {
 
     let artifact: Awaited<ReturnType<ArtifactStore["read"]>>;
     try {
-      artifact = await artifactStore.read(artifactId);
+      // When the token names a binding, the artifact must still belong to that
+      // exact Lobu resource. This is the single enforcement point for bound
+      // links, so a re-signed event attachment cannot be pointed at another
+      // workspace's artifact by grafting its id into a readable row.
+      artifact = await artifactStore.read(artifactId, {
+        ...(validation.binding ? { binding: validation.binding } : {}),
+      });
     } catch (error) {
       logger.error("Artifact storage unavailable during download", {
         code: error instanceof ArtifactStorageError ? error.code : "UNKNOWN",

--- a/packages/server/src/gateway/routes/public/files.ts
+++ b/packages/server/src/gateway/routes/public/files.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-import { readFile } from "node:fs/promises";
 import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
 import type { ArtifactStore } from "../../files/artifact-store.js";
@@ -60,7 +59,7 @@ export function createPublicFileRoutes(artifactStore: ArtifactStore): Hono {
     );
     c.header("Cache-Control", "private, max-age=60");
 
-    return new Response(await readFile(artifact.filePath), {
+    return new Response(artifact.bytes, {
       headers: c.res.headers,
     });
   });

--- a/packages/server/src/gateway/routes/public/files.ts
+++ b/packages/server/src/gateway/routes/public/files.ts
@@ -2,7 +2,10 @@
 
 import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
-import type { ArtifactStore } from "../../files/artifact-store.js";
+import {
+  ArtifactStorageError,
+  type ArtifactStore,
+} from "../../files/artifact-store.js";
 
 const logger = createLogger("public-files");
 
@@ -31,7 +34,18 @@ export function createPublicFileRoutes(artifactStore: ArtifactStore): Hono {
       );
     }
 
-    const artifact = await artifactStore.read(artifactId);
+    let artifact: Awaited<ReturnType<ArtifactStore["read"]>>;
+    try {
+      artifact = await artifactStore.read(artifactId);
+    } catch (error) {
+      logger.error("Artifact storage unavailable during download", {
+        code: error instanceof ArtifactStorageError ? error.code : "UNKNOWN",
+      });
+      return c.json(
+        { success: false, error: "File storage temporarily unavailable" },
+        503
+      );
+    }
     if (!artifact) {
       return c.json({ success: false, error: "File not found" }, 404);
     }

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   ArtifactStore,
@@ -6,9 +5,12 @@ import {
   runArtifactBinding,
 } from './gateway/files/artifact-store';
 import type { Env } from './index';
+import { getLobuCoreServices } from './lobu/gateway';
 import { type AuthContext, executeTool } from './tools/execute';
 
-const MAX_MCP_RESOURCE_BYTES = 20 * 1024 * 1024;
+// resources/read embeds base64 in one JSON-RPC response, so keep the decoded
+// cap bounded below the point where concurrent reads amplify app memory.
+const MAX_MCP_RESOURCE_BYTES = 5 * 1024 * 1024;
 
 type ResourceLink = Extract<
   CallToolResult['content'][number],
@@ -222,24 +224,28 @@ export async function readMcpAttachmentResource(
     throw new Error(`Unknown resource: ${uri}`);
   }
 
-  const artifactStore = new ArtifactStore();
-  const stored = await artifactStore.read(attachment.artifact_id, {
+  const artifactStore =
+    getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore();
+  const metadata = await artifactStore.inspect(attachment.artifact_id, {
     binding: loaded.binding,
   });
-  if (!stored) throw new Error(`Unknown resource: ${uri}`);
-  if (stored.metadata.size > MAX_MCP_RESOURCE_BYTES) {
+  if (!metadata) throw new Error(`Unknown resource: ${uri}`);
+  if (metadata.size > MAX_MCP_RESOURCE_BYTES) {
     throw new Error(
-      `MCP resource is too large to inline (${stored.metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
+      `MCP resource is too large to inline (${metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
     );
   }
-
-  const data = await readFile(stored.filePath);
+  const stored = await artifactStore.read(attachment.artifact_id, {
+    binding: loaded.binding,
+    maxBytes: MAX_MCP_RESOURCE_BYTES,
+  });
+  if (!stored) throw new Error(`Unknown resource: ${uri}`);
   return {
     contents: [
       {
         uri,
         mimeType: stored.metadata.contentType,
-        blob: data.toString('base64'),
+        blob: stored.bytes.toString('base64'),
       },
     ],
   };

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,5 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
+  ArtifactStore,
   eventArtifactBinding,
   runArtifactBinding,
 } from './gateway/files/artifact-store';
@@ -7,9 +8,11 @@ import type { Env } from './index';
 import { getLobuCoreServices } from './lobu/gateway';
 import { type AuthContext, executeTool } from './tools/execute';
 
-// resources/read embeds base64 in one JSON-RPC response, so keep the decoded
-// cap bounded below the point where concurrent reads amplify app memory.
-const MAX_MCP_RESOURCE_BYTES = 5 * 1024 * 1024;
+// resources/read embeds base64 in one JSON-RPC response, so the decoded cap
+// bounds how much a single read can amplify app memory. Kept at the limit
+// this endpoint already served: lowering it would silently start rejecting
+// media that reads fine today.
+const MAX_MCP_RESOURCE_BYTES = 20 * 1024 * 1024;
 
 type ResourceLink = Extract<
   CallToolResult['content'][number],
@@ -223,9 +226,21 @@ export async function readMcpAttachmentResource(
     throw new Error(`Unknown resource: ${uri}`);
   }
 
-  const coreServices = getLobuCoreServices();
-  if (!coreServices) throw new Error('MCP resource service unavailable');
-  const artifactStore = coreServices.getArtifactStore();
+  const artifactStore =
+    getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore();
+  // Metadata first: a bounded `read` reports an oversized artifact as simply
+  // absent, and the caller needs to be told the payload exists but cannot be
+  // inlined.
+  const metadata = await artifactStore.inspect(attachment.artifact_id, {
+    binding: loaded.binding,
+  });
+  if (!metadata) throw new Error(`Unknown resource: ${uri}`);
+  if (metadata.size > MAX_MCP_RESOURCE_BYTES) {
+    throw new Error(
+      `MCP resource is too large to inline (${metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
+    );
+  }
+
   const stored = await artifactStore.read(attachment.artifact_id, {
     binding: loaded.binding,
     maxBytes: MAX_MCP_RESOURCE_BYTES,

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,6 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
-  ArtifactStore,
   eventArtifactBinding,
   runArtifactBinding,
 } from './gateway/files/artifact-store';
@@ -225,9 +224,8 @@ export async function readMcpAttachmentResource(
   }
 
   const coreServices = getLobuCoreServices();
-  const artifactStore = coreServices
-    ? coreServices.getArtifactStore()
-    : new ArtifactStore();
+  if (!coreServices) throw new Error('MCP resource service unavailable');
+  const artifactStore = coreServices.getArtifactStore();
   const metadata = await artifactStore.inspect(attachment.artifact_id, {
     binding: loaded.binding,
   });

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -224,8 +224,10 @@ export async function readMcpAttachmentResource(
     throw new Error(`Unknown resource: ${uri}`);
   }
 
-  const artifactStore =
-    getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore();
+  const coreServices = getLobuCoreServices();
+  const artifactStore = coreServices
+    ? coreServices.getArtifactStore()
+    : new ArtifactStore();
   const metadata = await artifactStore.inspect(attachment.artifact_id, {
     binding: loaded.binding,
   });

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -226,15 +226,6 @@ export async function readMcpAttachmentResource(
   const coreServices = getLobuCoreServices();
   if (!coreServices) throw new Error('MCP resource service unavailable');
   const artifactStore = coreServices.getArtifactStore();
-  const metadata = await artifactStore.inspect(attachment.artifact_id, {
-    binding: loaded.binding,
-  });
-  if (!metadata) throw new Error(`Unknown resource: ${uri}`);
-  if (metadata.size > MAX_MCP_RESOURCE_BYTES) {
-    throw new Error(
-      `MCP resource is too large to inline (${metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
-    );
-  }
   const stored = await artifactStore.read(attachment.artifact_id, {
     binding: loaded.binding,
     maxBytes: MAX_MCP_RESOURCE_BYTES,

--- a/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
+++ b/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
@@ -2,6 +2,10 @@ import type { ContentItem } from '@lobu/connector-sdk';
 import { describe, expect, test } from 'vitest';
 import { refreshEventArtifactDownloadUrls } from '../render';
 
+/** A URL shaped like one this gateway actually minted. */
+const OURS = (artifactId: string) =>
+  `https://gateway.example.test/lobu/api/v1/files/${artifactId}?token=stale`;
+
 /** Records what it was asked to sign; never touches a filesystem. */
 function recordingStore() {
   const calls: Array<{ artifactId: string; binding?: string }> = [];
@@ -29,8 +33,8 @@ describe('refreshEventArtifactDownloadUrls', () => {
         connection_id: 42,
         feed_id: null,
         attachments: [
-          { artifact_id: 'a1', download_url: 'https://expired.example.test' },
-          { artifact_id: 'a2', download_url: 'https://expired.example.test' },
+          { artifact_id: 'a1', download_url: OURS('a1') },
+          { artifact_id: 'a2', download_url: OURS('a2') },
         ],
       },
     ] as unknown as ContentItem[];
@@ -60,7 +64,7 @@ describe('refreshEventArtifactDownloadUrls', () => {
         origin_id: 'origin-1',
         connection_id: null,
         feed_id: 7,
-        attachments: [{ artifact_id: 'a1', download_url: 'https://expired.example.test' }],
+        attachments: [{ artifact_id: 'a1', download_url: OURS('a1') }],
       },
     ] as unknown as ContentItem[];
 
@@ -90,7 +94,9 @@ describe('refreshEventArtifactDownloadUrls', () => {
           // Names an artifact but carries no URL to refresh.
           { artifact_id: 'a1' },
           // Non-string artifact id.
-          { artifact_id: 42, download_url: 'https://expired.example.test' },
+          { artifact_id: 42, download_url: OURS('42') },
+          // Ours by id, but the URL is somebody else's host/path shape.
+          { artifact_id: 'a9', download_url: 'https://files.slack.example/a9' },
         ],
       },
       // No origin_id means no binding can be derived; skip the whole item
@@ -98,7 +104,7 @@ describe('refreshEventArtifactDownloadUrls', () => {
       {
         id: 2,
         origin_id: '',
-        attachments: [{ artifact_id: 'orphan', download_url: 'https://expired.example.test' }],
+        attachments: [{ artifact_id: 'orphan', download_url: OURS('orphan') }],
       },
     ] as unknown as ContentItem[];
 
@@ -113,10 +119,11 @@ describe('refreshEventArtifactDownloadUrls', () => {
     expect(items[0].attachments).toEqual([
       { url: 'https://files.slack.example/x.png' },
       { artifact_id: 'a1' },
-      { artifact_id: 42, download_url: 'https://expired.example.test' },
+      { artifact_id: 42, download_url: OURS('42') },
+      { artifact_id: 'a9', download_url: 'https://files.slack.example/a9' },
     ]);
     expect(items[1].attachments).toEqual([
-      { artifact_id: 'orphan', download_url: 'https://expired.example.test' },
+      { artifact_id: 'orphan', download_url: OURS('orphan') },
     ]);
   });
 });

--- a/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
+++ b/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
@@ -1,0 +1,122 @@
+import type { ContentItem } from '@lobu/connector-sdk';
+import { describe, expect, test } from 'vitest';
+import { refreshEventArtifactDownloadUrls } from '../render';
+
+/** Records what it was asked to sign; never touches a filesystem. */
+function recordingStore() {
+  const calls: Array<{ artifactId: string; binding?: string }> = [];
+  return {
+    calls,
+    buildDownloadUrl: (
+      _publicGatewayUrl: string,
+      artifactId: string,
+      _ttlMs?: number,
+      binding?: string
+    ) => {
+      calls.push({ artifactId, binding });
+      return `https://fresh.example.test/${artifactId}?token=t`;
+    },
+  };
+}
+
+describe('refreshEventArtifactDownloadUrls', () => {
+  test('re-mints each attachment URL under the event binding', () => {
+    const store = recordingStore();
+    const items = [
+      {
+        id: 1,
+        origin_id: 'origin-1',
+        connection_id: 42,
+        feed_id: null,
+        attachments: [
+          { artifact_id: 'a1', download_url: 'https://expired.example.test' },
+          { artifact_id: 'a2', download_url: 'https://expired.example.test' },
+        ],
+      },
+    ] as unknown as ContentItem[];
+
+    refreshEventArtifactDownloadUrls({
+      items,
+      organizationId: 'org-1',
+      publicGatewayUrl: 'https://gateway.example.test',
+      artifactStore: store,
+    });
+
+    expect(store.calls).toEqual([
+      { artifactId: 'a1', binding: 'event:org-1:connection:42:origin-1' },
+      { artifactId: 'a2', binding: 'event:org-1:connection:42:origin-1' },
+    ]);
+    expect(items[0].attachments).toEqual([
+      { artifact_id: 'a1', download_url: 'https://fresh.example.test/a1?token=t' },
+      { artifact_id: 'a2', download_url: 'https://fresh.example.test/a2?token=t' },
+    ]);
+  });
+
+  test('falls back to the feed scope when there is no connection', () => {
+    const store = recordingStore();
+    const items = [
+      {
+        id: 1,
+        origin_id: 'origin-1',
+        connection_id: null,
+        feed_id: 7,
+        attachments: [{ artifact_id: 'a1', download_url: 'https://expired.example.test' }],
+      },
+    ] as unknown as ContentItem[];
+
+    refreshEventArtifactDownloadUrls({
+      items,
+      organizationId: 'org-1',
+      publicGatewayUrl: 'https://gateway.example.test',
+      artifactStore: store,
+    });
+
+    expect(store.calls).toEqual([
+      { artifactId: 'a1', binding: 'event:org-1:feed:7:origin-1' },
+    ]);
+  });
+
+  test('leaves attachments it does not own untouched', () => {
+    const store = recordingStore();
+    const items = [
+      {
+        id: 1,
+        origin_id: 'origin-1',
+        connection_id: 42,
+        feed_id: null,
+        attachments: [
+          // Connector-supplied external link: no artifact_id, not ours to sign.
+          { url: 'https://files.slack.example/x.png' },
+          // Names an artifact but carries no URL to refresh.
+          { artifact_id: 'a1' },
+          // Non-string artifact id.
+          { artifact_id: 42, download_url: 'https://expired.example.test' },
+        ],
+      },
+      // No origin_id means no binding can be derived; skip the whole item
+      // rather than sign something unverifiable.
+      {
+        id: 2,
+        origin_id: '',
+        attachments: [{ artifact_id: 'orphan', download_url: 'https://expired.example.test' }],
+      },
+    ] as unknown as ContentItem[];
+
+    refreshEventArtifactDownloadUrls({
+      items,
+      organizationId: 'org-1',
+      publicGatewayUrl: 'https://gateway.example.test',
+      artifactStore: store,
+    });
+
+    expect(store.calls).toEqual([]);
+    expect(items[0].attachments).toEqual([
+      { url: 'https://files.slack.example/x.png' },
+      { artifact_id: 'a1' },
+      { artifact_id: 42, download_url: 'https://expired.example.test' },
+    ]);
+    expect(items[1].attachments).toEqual([
+      { artifact_id: 'orphan', download_url: 'https://expired.example.test' },
+    ]);
+  });
+});

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -15,8 +15,10 @@ import { hasRequiredMcpScope } from '../../auth/tool-access';
 import { isInProcessSystemCall } from '../../tools/access-control';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import { AUTOMATION_RUN_SOURCE } from '../../gateway/automation-run-session';
+import { ArtifactStore } from '../../gateway/files/artifact-store';
 import { parseAutomationRunConversationId } from '../../gateway/permissions/automation-run-intent';
 import type { Env } from '../../index';
+import { getLobuCoreServices } from '../../lobu/gateway';
 import { ToolUserError } from '../../utils/errors';
 import {
   getNormalizedScoreContent,
@@ -26,6 +28,7 @@ import { searchContentByText } from '../../utils/content-search';
 import { parseDateAlias, toEndOfDay } from '../../utils/date-aliases';
 import logger from '../../utils/logger';
 import { requireReadAccess } from '../../utils/organization-access';
+import { resolvePublicGatewayUrl } from '../../utils/public-origin';
 import { rewriteQueries } from '../../utils/query-rewriter';
 import {
   buildContentUrl,
@@ -43,6 +46,7 @@ import {
   buildContentItems,
   fetchClassificationExcerpts,
   hydrateToolInvocationRequests,
+  refreshEventArtifactDownloadUrls,
 } from './render';
 import { GetContentSchema, type GetContentArgs, getIncludeSupersededValidationErrors } from './schema';
 import type { ContentRow, GetContentResult, IdRow } from './types';
@@ -719,6 +723,13 @@ async function getContentImpl(
       baseUrl,
       excerptsMap,
       includePrivateAttribution: ctx.memberRole != null,
+    });
+    refreshEventArtifactDownloadUrls({
+      items: contentItems,
+      organizationId: ctx.organizationId,
+      publicGatewayUrl: resolvePublicGatewayUrl(),
+      artifactStore:
+        getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore(),
     });
     // Verbatim requests are served ONLY on an explicit `content_ids` read. A
     // list or search page is an ambient read — inlining every retained request

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -21,6 +21,21 @@ import type { ContentRow } from './types';
 import { parseRecordArray, toNumberOrUndefined } from './types';
 
 /**
+ * True when `url` is this deployment's own download link for `artifactId`.
+ * Path-suffix match, so it holds across the gateway's base-path mounts
+ * (`/lobu/api/v1/files/...`) without depending on the configured origin.
+ */
+function isOwnArtifactUrl(url: string, artifactId: string): boolean {
+  try {
+    return new URL(url).pathname.endsWith(
+      `/api/v1/files/${encodeURIComponent(artifactId)}`
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Persisted attachment `download_url`s carry an expiring token, so a row read
  * back after the TTL hands out a dead link. Re-mint each one against the
  * event's own binding.
@@ -49,9 +64,15 @@ export function refreshEventArtifactDownloadUrls(opts: {
     });
     item.attachments = item.attachments.map((attachment) => {
       const artifactId = attachment.artifact_id;
-      // Only rows that name a stored artifact are ours to re-sign. A
-      // connector-supplied external URL has no `artifact_id` and is left alone.
-      if (typeof artifactId !== 'string' || !attachment.download_url) {
+      // Only re-sign a URL this gateway minted for this exact artifact.
+      // `attachments` is free-form on the save_content path, so an agent can
+      // put anything here; a connector-supplied external link must survive
+      // untouched rather than be replaced by a Lobu URL.
+      if (
+        typeof artifactId !== 'string' ||
+        typeof attachment.download_url !== 'string' ||
+        !isOwnArtifactUrl(attachment.download_url, artifactId)
+      ) {
         return attachment;
       }
       return {

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -7,6 +7,10 @@
 import type { ContentItem } from '@lobu/connector-sdk';
 import { parseJsonObject } from '@lobu/core';
 import { type DbClient, parsePgNumberArray, pgBigintArray, pgTextArray } from '../../db/client';
+import {
+  type ArtifactStore,
+  eventArtifactBinding,
+} from '../../gateway/files/artifact-store';
 import { resolveEntityRender } from '../../utils/default-entity-template';
 import { resolveEventKindDefinition } from '../../utils/event-kind-validation';
 import logger from '../../utils/logger';
@@ -15,6 +19,53 @@ import { isAdminOrOwnerRole } from '../access-control';
 import { AUDIT_SEMANTIC_TYPE } from '../constants';
 import type { ContentRow } from './types';
 import { parseRecordArray, toNumberOrUndefined } from './types';
+
+/**
+ * Persisted attachment `download_url`s carry an expiring token, so a row read
+ * back after the TTL hands out a dead link. Re-mint each one against the
+ * event's own binding.
+ *
+ * Deliberately no filesystem access: `buildDownloadUrl` only encrypts
+ * `{artifactId, exp, binding}` with the app key, and the download route
+ * verifies the binding against stored metadata when the bytes are actually
+ * requested. Verifying here instead would put an lstat + metadata read + JSON
+ * parse on every attachment of every listing page — per-row I/O on a
+ * user-facing read path, for an answer the download route has to recompute
+ * anyway.
+ */
+export function refreshEventArtifactDownloadUrls(opts: {
+  items: ContentItem[];
+  organizationId: string;
+  publicGatewayUrl: string;
+  artifactStore: Pick<ArtifactStore, 'buildDownloadUrl'>;
+}): void {
+  for (const item of opts.items) {
+    if (!Array.isArray(item.attachments) || !item.origin_id) continue;
+    const binding = eventArtifactBinding({
+      organizationId: opts.organizationId,
+      connectionId: item.connection_id,
+      feedId: item.feed_id,
+      originId: item.origin_id,
+    });
+    item.attachments = item.attachments.map((attachment) => {
+      const artifactId = attachment.artifact_id;
+      // Only rows that name a stored artifact are ours to re-sign. A
+      // connector-supplied external URL has no `artifact_id` and is left alone.
+      if (typeof artifactId !== 'string' || !attachment.download_url) {
+        return attachment;
+      }
+      return {
+        ...attachment,
+        download_url: opts.artifactStore.buildDownloadUrl(
+          opts.publicGatewayUrl,
+          artifactId,
+          undefined,
+          binding
+        ),
+      };
+    });
+  }
+}
 
 /**
  * Gated payload keys: the request itself and its size. `request_status` is

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, rmSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -73,7 +72,7 @@ describe('materializeActionOutputAttachments', () => {
       binding: runArtifactBinding(42),
     });
     expect(stored).toBeTruthy();
-    expect(await readFile(stored!.filePath)).toEqual(bytes);
+    expect(stored!.bytes).toEqual(bytes);
   });
 
   it('deletes partial publishes when a later attachment publish fails', async () => {

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -331,14 +331,6 @@ async function transcribeOne(
   const transcriptionService = coreServices!.getTranscriptionService();
   if (!artifactStore || !transcriptionService) return;
 
-  const metadata = await artifactStore.inspect(job.artifactId);
-  if (metadata && metadata.size > MAX_INLINE_ATTACHMENT_BYTES) {
-    logger.info(
-      { artifact_id: job.artifactId, size: metadata.size },
-      '[inline-attachments] artifact exceeds the inline limit — skipping transcription'
-    );
-    return;
-  }
   const stored = await artifactStore.read(job.artifactId, {
     maxBytes: MAX_INLINE_ATTACHMENT_BYTES,
   });

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -331,6 +331,14 @@ async function transcribeOne(
   const transcriptionService = coreServices!.getTranscriptionService();
   if (!artifactStore || !transcriptionService) return;
 
+  const metadata = await artifactStore.inspect(job.artifactId);
+  if (metadata && metadata.size > MAX_INLINE_ATTACHMENT_BYTES) {
+    logger.info(
+      { artifact_id: job.artifactId, size: metadata.size },
+      '[inline-attachments] artifact exceeds the inline limit — skipping transcription'
+    );
+    return;
+  }
   const stored = await artifactStore.read(job.artifactId, {
     maxBytes: MAX_INLINE_ATTACHMENT_BYTES,
   });

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -20,7 +20,6 @@
  * `current_event_records` view exposes the transcribed text. Failures are
  * swallowed — the unsuperseded `[voice note]` placeholder remains usable.
  */
-import { readFile } from "node:fs/promises";
 import { getDb } from "../db/client";
 import { getLobuCoreServices } from "../lobu/gateway";
 import {
@@ -332,7 +331,9 @@ async function transcribeOne(
   const transcriptionService = coreServices!.getTranscriptionService();
   if (!artifactStore || !transcriptionService) return;
 
-  const stored = await artifactStore.read(job.artifactId);
+  const stored = await artifactStore.read(job.artifactId, {
+    maxBytes: MAX_INLINE_ATTACHMENT_BYTES,
+  });
   if (!stored) {
     logger.warn(
       { artifact_id: job.artifactId },
@@ -340,10 +341,8 @@ async function transcribeOne(
     );
     return;
   }
-  const buffer = await readFile(stored.filePath);
-
   const result = await transcriptionService.transcribe(
-    buffer,
+    stored.bytes,
     agentId,
     job.mimeType
   );


### PR DESCRIPTION
## Summary

Consolidates the durable-artifact work that was split across #3013, #3037, and #3043 into one branch. The infrastructure half (chart PVC topology #3036, prod Owletto overlay #3042) is already on `main`; this is the server-side half.

- Harden the filesystem `ArtifactStore`: SHA-256 verification, bounded reads, path and symlink defenses, immutable resource bindings, generic failure surfaces.
- Make cleanup fail closed on retained storage: quarantine partial publications, propagate deletion failures, drain known orphans before accepting another publish.
- Keep direct uploads and MCP reads inside explicit byte limits, with 413s returned before the extra upload buffer allocation.
- **Re-mint expiring attachment download URLs at the read boundary.** Persisted `download_url`s carry an expiring token, so an event read back after the TTL handed out a dead link.

## The binding design (differs from #3043)

#3043 verified each attachment's binding at *mint* time, which put an `lstat` + metadata read + JSON parse on **every attachment of every `get_content` page** — per-row filesystem I/O on a user-facing read path, which `AGENTS.md` bars.

Here the binding travels inside the encrypted token and is enforced **once, in the download route**. Only this process can mint a token, so the binding inside it is as trustworthy as the artifact id beside it, and the download route has to load metadata anyway. Net effect: same guarantee, N fewer filesystem round-trips per listing page.

Unbound tokens keep today's semantics, so `resignFileRefs` (which recovers ids from transcript text and has no per-ref binding to carry) is unchanged.

## Superseded PRs

- **#3013** — its chart/helm/owletto half is already merged via #3036 and #3042, which is why it conflicts. Its remaining unique content is a 367-line `applied-action-reconciliation.ts` slice, a separate concern that should land on its own.
- **#3043** — its two unique wins are folded in here: the 20 MB MCP inline cap with its real "too large to inline" error, and read-boundary URL refresh (redesigned as above).

## Test plan

- [x] `ArtifactStore`, public/internal file routes, history re-signing, oversized uploads: 35 pass (bun:test)
- [x] MCP media resources against throwaway Postgres, inline attachments, URL refresh: 12 pass (Vitest)
- [x] **Red to green:** removing the download route's binding check makes `refuses a bound download URL pointed at another resource's artifact` fail — a grafted binding returns 200 instead of 404. Restored: 10/10 pass.
- [x] `make pre-pr` clean on the rebased head (build, typecheck, knip, biome, naming, funnel gates)
- [x] `make review-fix` on the settled diff — no findings met the bar for a fix
- [ ] Exact-head GitHub CI
- [ ] Exact-head `make review` and `ui-review`

## Notes

- Clean cutover from the old process-local format (payload renamed to `content`, `sha256` now required). Harmless today: chart 15.6.0 is unreleased, so the retained PVC is not live yet and there is nothing on it to migrate.
- `writeDurableFile` fsyncs the payload but not the parent directory. On power loss a directory entry could vanish; the failure mode is benign (the artifact reads as absent, checksums prevent serving corrupt bytes). Left as a follow-up rather than changing publish semantics here.
- Production stays on the single-replica RWO overlay. Multi-node RWX behavior remains an operational verification item.
- No S3 abstraction. The `ArtifactStore` interface remains the seam for a future topology-driven backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure, durable artifact storage with checksum validation, bounded reads, and safer file handling.
  - Added download-token binding and refreshed gateway artifact URLs for event-scoped access.
  - Added clear download filenames, including UTF-8 filename support.

- **Bug Fixes**
  - Enforced 50 MB limits for individual and batch uploads.
  - Limited inline media resources to 20 MiB.
  - Improved handling of invalid, corrupted, missing, oversized, or unavailable artifacts with clearer errors and service-unavailable responses.
  - Preserved external and unrelated artifact URLs during refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->