### PR TITLE
fix(server): report truthful automation and feed health

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -302,7 +302,8 @@ export const ReauthenticateAction = Type.Object({
 
 export const TestAction = Type.Object({
   action: Type.Literal("test", {
-    description: "Probe a connection's credentials/token validity.",
+    description:
+      "Probe a connection's credentials/token validity and required selected-device availability.",
   }),
   connection_id: Type.Number({ description: "Connection ID to test" }),
 });
@@ -827,7 +828,7 @@ export const ManageConnectionsResultSchema = Type.Union([
     message: Type.String(),
     has_token: Type.Optional(Type.Boolean()),
     has_refresh: Type.Optional(Type.Boolean()),
-    /** Present when an auth-free connection is pinned to a device. */
+    /** Present when a connection is pinned to a device. */
     device_online: Type.Optional(Type.Boolean()),
     expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     // Structured error taxonomy (lobu#2051 Item 2), present on error/warning results.

--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -172,7 +172,7 @@ describe("automation health surfacing (#2033)", () => {
     expect(row?.last_scheduling_error).toBe("No model is configured");
   });
 
-  it("3.1 (integration): a never-fired event automation is configured but unverified", async () => {
+  it("3.1 (integration): an unstamped event automation without runs is unverified", async () => {
     const { automationId, ctx } = await createScheduledAutomation();
     await getTestDb()`
       UPDATE automations
@@ -184,7 +184,7 @@ describe("automation health surfacing (#2033)", () => {
           execution: "turn",
           active_run: "coalesce",
         },
-      ])}, next_run_at = NULL
+      ])}, next_run_at = NULL, last_event_activation_at = NULL
       WHERE id = ${automationId}
     `;
 
@@ -196,7 +196,55 @@ describe("automation health surfacing (#2033)", () => {
         String(automationId),
     ) as { health?: string; health_reasons?: string[] } | undefined;
     expect(row?.health).toBe("degraded");
-    expect(row?.health_reasons?.join(" ")).toContain("no runs observed");
+    expect(row?.health_reasons).toContain(
+      "event trigger configured, but no dispatch observed yet",
+    );
+
+    const detail = await getAutomation(
+      { automation_id: String(automationId) },
+      {} as Env,
+      ctx,
+    );
+    expect(detail.automation?.health).toBe("degraded");
+    expect(detail.automation?.health_reasons).toContain(
+      "event trigger configured, but no dispatch observed yet",
+    );
+  });
+
+  it("3.1 (integration): an activation stamp proves an event automation dispatched", async () => {
+    const { automationId, ctx } = await createScheduledAutomation();
+    await getTestDb()`
+      UPDATE automations
+      SET triggers = ${getTestDb().json([
+        {
+          kind: "event",
+          connector_key: "slack",
+          event_types: ["message.created"],
+          execution: "turn",
+          active_run: "coalesce",
+        },
+      ])}, next_run_at = NULL, last_event_activation_at = current_timestamp
+      WHERE id = ${automationId}
+    `;
+
+    const result = await manageAutomations({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.automations.find(
+      (automation) =>
+        String((automation as { automation_id?: unknown }).automation_id) ===
+        String(automationId),
+    ) as Record<string, unknown> | undefined;
+    expect(row?.health).toBe("healthy");
+    expect(row).not.toHaveProperty("health_reasons");
+    expect(row).not.toHaveProperty("health_last_event_activation_at");
+
+    const detail = await getAutomation(
+      { automation_id: String(automationId) },
+      {} as Env,
+      ctx,
+    );
+    expect(detail.automation?.health).toBe("healthy");
+    expect(detail.automation?.health_reasons).toBeUndefined();
   });
 
   it("3.1 (integration): a latest success does not hide 44 failures in 74 recent runs", async () => {

--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -172,6 +172,78 @@ describe("automation health surfacing (#2033)", () => {
     expect(row?.last_scheduling_error).toBe("No model is configured");
   });
 
+  it("3.1 (integration): a never-fired event automation is configured but unverified", async () => {
+    const { automationId, ctx } = await createScheduledAutomation();
+    await getTestDb()`
+      UPDATE automations
+      SET triggers = ${getTestDb().json([
+        {
+          kind: "event",
+          connector_key: "slack",
+          event_types: ["message.created"],
+          execution: "turn",
+          active_run: "coalesce",
+        },
+      ])}, next_run_at = NULL
+      WHERE id = ${automationId}
+    `;
+
+    const result = await manageAutomations({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.automations.find(
+      (automation) =>
+        String((automation as { automation_id?: unknown }).automation_id) ===
+        String(automationId),
+    ) as { health?: string; health_reasons?: string[] } | undefined;
+    expect(row?.health).toBe("degraded");
+    expect(row?.health_reasons?.join(" ")).toContain("no runs observed");
+  });
+
+  it("3.1 (integration): a latest success does not hide 44 failures in 74 recent runs", async () => {
+    const { automationId, ctx } = await createScheduledAutomation();
+    const sql = getTestDb();
+    await sql`
+      UPDATE automations
+      SET next_run_at = current_timestamp + interval '5 minutes'
+      WHERE id = ${automationId}
+    `;
+    await sql`
+      INSERT INTO runs (
+        organization_id, run_type, automation_id, status, approval_status,
+        created_at, completed_at
+      )
+      SELECT
+        ${ctx.organizationId}, 'automation', ${automationId},
+        CASE WHEN n <= 44 THEN 'failed' ELSE 'completed' END,
+        'auto',
+        current_timestamp - ((75 - n) * interval '1 minute'),
+        current_timestamp - ((75 - n) * interval '1 minute')
+      FROM generate_series(1, 74) AS n
+    `;
+
+    const result = await manageAutomations({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.automations.find(
+      (automation) =>
+        String((automation as { automation_id?: unknown }).automation_id) ===
+        String(automationId),
+    ) as { health?: string; health_reasons?: string[] } | undefined;
+    expect(row?.health).toBe("degraded");
+    expect(row?.health_reasons?.join(" ")).toContain(
+      "44 of 74 recent terminal runs failed or timed out",
+    );
+
+    const detail = await getAutomation(
+      { automation_id: String(automationId) },
+      {} as Env,
+      ctx,
+    );
+    expect(detail.automation?.health).toBe("degraded");
+    expect(detail.automation?.health_reasons?.join(" ")).toContain(
+      "44 of 74 recent terminal runs failed or timed out",
+    );
+  });
+
   it("3.3: list emits canonical automation lineage keys", async () => {
     const { automationId, ctx } = await createScheduledAutomation();
     await getTestDb()`

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -14,6 +14,7 @@ import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
+import { createAuthProfile } from "../../utils/auth-profiles";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestConnection,
@@ -105,6 +106,43 @@ describe("connections.test device availability", () => {
 		expect(result.status).toBe("warning");
 		expect(result.device_online).toBe(false);
 		expect(result.retryable).toBe(true);
+		expect(String(result.message)).toMatch(/offline/i);
+	});
+
+	it("does not let valid OAuth credentials mask an offline selected device", async () => {
+		const sql = getTestDb();
+		const accountId = `acct_hybrid_${Date.now()}`;
+		await sql`
+			INSERT INTO "account" (
+				id, "accountId", "providerId", "userId", "accessToken",
+				"refreshToken", "accessTokenExpiresAt", scope, "createdAt", "updatedAt"
+			) VALUES (
+				${accountId}, ${accountId}, 'x', ${userId}, 'valid-token',
+				'refresh-token', ${new Date(Date.now() + 60 * 60 * 1000).toISOString()},
+				'read', NOW(), NOW()
+			)
+		`;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: CONNECTOR_KEY,
+			displayName: "X OAuth",
+			profileKind: "oauth_account",
+			provider: "x",
+			accountId,
+			createdBy: userId,
+		});
+		const id = await seedDeviceConnection(false);
+		await sql`
+			UPDATE connections
+			SET auth_profile_id = ${profile.id}, visibility = 'private'
+			WHERE id = ${id}
+		`;
+
+		const result = await test(id);
+		expect(result.status).toBe("warning");
+		expect(result.device_online).toBe(false);
+		expect(result.retryable).toBe(true);
+		expect(String(result.message)).toContain("Credentials valid");
 		expect(String(result.message)).toMatch(/offline/i);
 	});
 });

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -227,4 +227,35 @@ describe("list_feeds health filter and true total", () => {
 			expect(f).not.toHaveProperty("incident_eligible");
 		}
 	});
+
+	it("distinguishes an overdue scheduled feed from an old no-schedule feed", async () => {
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "hackernews",
+			createDefaultFeed: false,
+		});
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO feeds (
+				organization_id, connection_id, feed_key, status, kind, schedule,
+				next_run_at, last_sync_status, last_sync_at, consecutive_failures,
+				entity_ids, created_at, updated_at
+			) VALUES
+				(
+					${orgId}, ${conn.id}, 'scheduled-overdue', 'active', 'collected',
+					'0 * * * *', current_timestamp - interval '2 hours', 'success',
+					current_timestamp - interval '3 hours', 0, ARRAY[]::bigint[], NOW(), NOW()
+				),
+				(
+					${orgId}, ${conn.id}, 'no-schedule-old', 'active', 'collected',
+					NULL, NULL, 'success', current_timestamp - interval '30 days', 0,
+					ARRAY[]::bigint[], NOW(), NOW()
+				)
+		`;
+
+		const listed = await runList({ connection_id: conn.id, limit: 10 });
+		const byKey = new Map(listed.feeds.map((feed) => [feed.feed_key, feed]));
+		expect(byKey.get("scheduled-overdue")?.attention).toBe("overdue");
+		expect(byKey.get("no-schedule-old")?.attention).toBe("healthy");
+	});
 });

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -228,7 +228,7 @@ describe("list_feeds health filter and true total", () => {
 		}
 	});
 
-	it("distinguishes an overdue scheduled feed from an old no-schedule feed", async () => {
+	it("keeps health filters aligned for overdue, active-run, and manual feeds", async () => {
 		const conn = await createTestConnection({
 			organization_id: orgId,
 			connector_key: "hackernews",
@@ -247,15 +247,42 @@ describe("list_feeds health filter and true total", () => {
 					current_timestamp - interval '3 hours', 0, ARRAY[]::bigint[], NOW(), NOW()
 				),
 				(
+					${orgId}, ${conn.id}, 'scheduled-active', 'active', 'collected',
+					'0 * * * *', current_timestamp - interval '2 hours', 'success',
+					current_timestamp - interval '3 hours', 0, ARRAY[]::bigint[], NOW(), NOW()
+				),
+				(
 					${orgId}, ${conn.id}, 'no-schedule-old', 'active', 'collected',
 					NULL, NULL, 'success', current_timestamp - interval '30 days', 0,
 					ARRAY[]::bigint[], NOW(), NOW()
 				)
 		`;
+		await sql`
+			INSERT INTO runs (
+				organization_id, run_type, feed_id, status, approval_status, created_at
+			)
+			SELECT ${orgId}, 'sync', id, 'running', 'auto', current_timestamp
+			FROM feeds
+			WHERE organization_id = ${orgId}
+			  AND connection_id = ${conn.id}
+			  AND feed_key = 'scheduled-active'
+		`;
 
 		const listed = await runList({ connection_id: conn.id, limit: 10 });
 		const byKey = new Map(listed.feeds.map((feed) => [feed.feed_key, feed]));
 		expect(byKey.get("scheduled-overdue")?.attention).toBe("overdue");
+		expect(byKey.get("scheduled-active")?.attention).toBe("healthy");
 		expect(byKey.get("no-schedule-old")?.attention).toBe("healthy");
+
+		const healthy = await runList({ connection_id: conn.id, health: "healthy" });
+		expect(healthy.feeds.map((feed) => feed.feed_key).sort()).toEqual([
+			"no-schedule-old",
+			"scheduled-active",
+		]);
+
+		const failing = await runList({ connection_id: conn.id, health: "failing" });
+		expect(failing.feeds.map((feed) => feed.feed_key)).toEqual([
+			"scheduled-overdue",
+		]);
 	});
 });

--- a/packages/server/src/__tests__/unit/automation-health.test.ts
+++ b/packages/server/src/__tests__/unit/automation-health.test.ts
@@ -75,6 +75,56 @@ describe("computeAutomationHealth", () => {
 		expect(result.reasons).toHaveLength(0);
 	});
 
+	it("does not call a never-fired event automation proven healthy", () => {
+		const result = computeAutomationHealth(
+			{
+				status: "active",
+				nextRunAt: null,
+				latestRunStatus: null,
+				hasEventTrigger: true,
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.reasons.join(" ")).toContain("no runs observed");
+	});
+
+	it("keeps a severe rolling failure pattern degraded after one success", () => {
+		const result = computeAutomationHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "completed",
+				recentTerminalRunStatuses: [
+					"completed",
+					...Array.from({ length: 99 }, () => "failed"),
+				],
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.reasons.join(" ")).toContain(
+			"99 of 100 recent terminal runs failed or timed out",
+		);
+	});
+
+	it("recovers once failures are below half of a meaningful recent window", () => {
+		const result = computeAutomationHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "completed",
+				recentTerminalRunStatuses: [
+					...Array.from({ length: 6 }, () => "completed"),
+					...Array.from({ length: 4 }, () => "failed"),
+				],
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+		expect(result.reasons).toHaveLength(0);
+	});
+
 	it("does not degrade an archived automation whose latest run failed", () => {
 		const result = computeAutomationHealth(
 			{

--- a/packages/server/src/__tests__/unit/automation-health.test.ts
+++ b/packages/server/src/__tests__/unit/automation-health.test.ts
@@ -75,18 +75,40 @@ describe("computeAutomationHealth", () => {
 		expect(result.reasons).toHaveLength(0);
 	});
 
-	it("does not call a never-fired event automation proven healthy", () => {
+	it("degrades an event automation with neither activation stamp nor run", () => {
 		const result = computeAutomationHealth(
 			{
 				status: "active",
 				nextRunAt: null,
 				latestRunStatus: null,
-				hasEventTrigger: true,
+				triggers: [
+					{ kind: "event", connector_key: "slack", event_types: ["message.created"] },
+				],
+				lastEventActivationAt: null,
 			},
 			NOW,
 		);
 		expect(result.health).toBe("degraded");
-		expect(result.reasons.join(" ")).toContain("no runs observed");
+		expect(result.reasons).toContain(
+			"event trigger configured, but no dispatch observed yet",
+		);
+	});
+
+	it("keeps a stamped event automation healthy without Automation run history", () => {
+		const result = computeAutomationHealth(
+			{
+				status: "active",
+				nextRunAt: null,
+				latestRunStatus: null,
+				triggers: [
+					{ kind: "event", connector_key: "slack", event_types: ["message.created"] },
+				],
+				lastEventActivationAt: new Date(NOW - 60_000).toISOString(),
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+		expect(result.reasons).toHaveLength(0);
 	});
 
 	it("keeps a severe rolling failure pattern degraded after one success", () => {

--- a/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
+++ b/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
@@ -223,6 +223,38 @@ describe("attention state", () => {
     ).toBe("healthy");
   });
 
+  test("an active scheduled feed overdue by more than an hour needs attention", () => {
+    const now = Date.parse("2026-08-21T12:00:00Z");
+    expect(
+      deriveFeedHealthSemantics({
+        kind: "collected",
+        schedule: "0 * * * *",
+        status: "active",
+        connection_status: "active",
+        last_sync_status: "success",
+        last_sync_at: "2026-08-21T09:00:00Z",
+        next_run_at: "2026-08-21T10:00:00Z",
+        active_runs: 0,
+      }, now).attention
+    ).toBe("overdue");
+  });
+
+  test("a no-schedule feed is not stale solely because its last sync is old", () => {
+    const now = Date.parse("2026-08-21T12:00:00Z");
+    expect(
+      deriveFeedHealthSemantics({
+        kind: "collected",
+        schedule: null,
+        status: "active",
+        connection_status: "active",
+        last_sync_status: "success",
+        last_sync_at: "2026-01-01T00:00:00Z",
+        next_run_at: null,
+        active_runs: 0,
+      }, now).attention
+    ).toBe("healthy");
+  });
+
   test("error connection status is misconfigured when not auth", () => {
     expect(
       deriveFeedHealthSemantics({

--- a/packages/server/src/automations/automation-health-history.ts
+++ b/packages/server/src/automations/automation-health-history.ts
@@ -1,0 +1,74 @@
+import { type DbClient, pgBigintArray } from '../db/client';
+
+/** Per-Automation rolling window used by the health verdict. */
+export const AUTOMATION_HEALTH_RUN_WINDOW = 100;
+
+/**
+ * Bound the request-path read to the newest global run-id range. `runs.id` is
+ * the primary key, so this range is indexed without a schema change. The
+ * per-Automation window below is smaller; this outer bound prevents an idle
+ * Automation from making a list request search its unbounded lifetime.
+ */
+const AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN = 100_000n;
+
+interface RecentRunRow {
+	automation_id: string;
+	status: string;
+}
+
+/**
+ * Load at most 100 recent scored terminal outcomes per requested Automation.
+ *
+ * The MATERIALIZED candidate set is bounded first by the indexed `runs.id`
+ * range. Ranking therefore never walks or aggregates unbounded history, and
+ * the result is capped at 100 rows per Automation for the JS classifier.
+ * Cancelled runs are terminal lifecycle rows but carry no success/failure
+ * outcome, so they are intentionally excluded from the health ratio.
+ */
+export async function loadRecentAutomationRunStatuses(
+	sql: DbClient,
+	automationIds: number[],
+): Promise<Map<number, string[]>> {
+	const ids = [...new Set(automationIds.filter(Number.isFinite).map(Math.trunc))];
+	const statuses = new Map<number, string[]>();
+	if (ids.length === 0) return statuses;
+
+	const [head] = (await sql`
+		SELECT COALESCE(MAX(id), 0)::text AS max_id FROM runs
+	`) as unknown as Array<{ max_id: string }>;
+	const maxId = BigInt(head?.max_id ?? '0');
+	const minId =
+		maxId > AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN
+			? maxId - AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN
+			: 0n;
+
+	const rows = (await sql`
+		WITH recent_global_runs AS MATERIALIZED (
+			SELECT id, automation_id, status
+			FROM runs
+			WHERE id > ${minId.toString()}::bigint
+			  AND id <= ${maxId.toString()}::bigint
+			ORDER BY id DESC
+		), ranked AS (
+			SELECT
+				automation_id,
+				status,
+				ROW_NUMBER() OVER (PARTITION BY automation_id ORDER BY id DESC) AS position
+			FROM recent_global_runs
+			WHERE automation_id = ANY(${pgBigintArray(ids)}::bigint[])
+			  AND status IN ('completed', 'failed', 'timeout')
+		)
+		SELECT automation_id::text, status
+		FROM ranked
+		WHERE position <= ${AUTOMATION_HEALTH_RUN_WINDOW}
+		ORDER BY automation_id, position
+	`) as unknown as RecentRunRow[];
+
+	for (const row of rows) {
+		const automationId = Number(row.automation_id);
+		const current = statuses.get(automationId);
+		if (current) current.push(row.status);
+		else statuses.set(automationId, [row.status]);
+	}
+	return statuses;
+}

--- a/packages/server/src/automations/automation-health-history.ts
+++ b/packages/server/src/automations/automation-health-history.ts
@@ -1,15 +1,6 @@
 import { type DbClient, pgBigintArray } from '../db/client';
 
-/** Per-Automation rolling window used by the health verdict. */
 export const AUTOMATION_HEALTH_RUN_WINDOW = 100;
-
-/**
- * Bound the request-path read to the newest global run-id range. `runs.id` is
- * the primary key, so this range is indexed without a schema change. The
- * per-Automation window below is smaller; this outer bound prevents an idle
- * Automation from making a list request search its unbounded lifetime.
- */
-const AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN = 100_000n;
 
 interface RecentRunRow {
 	automation_id: string;
@@ -17,13 +8,8 @@ interface RecentRunRow {
 }
 
 /**
- * Load at most 100 recent scored terminal outcomes per requested Automation.
- *
- * The MATERIALIZED candidate set is bounded first by the indexed `runs.id`
- * range. Ranking therefore never walks or aggregates unbounded history, and
- * the result is capped at 100 rows per Automation for the JS classifier.
- * Cancelled runs are terminal lifecycle rows but carry no success/failure
- * outcome, so they are intentionally excluded from the health ratio.
+ * Use idx_runs_automation_id to load at most 100 scored terminal outcomes for
+ * each requested Automation. Aggregate only after each per-ID read is bounded.
  */
 export async function loadRecentAutomationRunStatuses(
 	sql: DbClient,
@@ -33,35 +19,19 @@ export async function loadRecentAutomationRunStatuses(
 	const statuses = new Map<number, string[]>();
 	if (ids.length === 0) return statuses;
 
-	const [head] = (await sql`
-		SELECT COALESCE(MAX(id), 0)::text AS max_id FROM runs
-	`) as unknown as Array<{ max_id: string }>;
-	const maxId = BigInt(head?.max_id ?? '0');
-	const minId =
-		maxId > AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN
-			? maxId - AUTOMATION_HEALTH_GLOBAL_RUN_ID_SPAN
-			: 0n;
-
 	const rows = (await sql`
-		WITH recent_global_runs AS MATERIALIZED (
-			SELECT id, automation_id, status
-			FROM runs
-			WHERE id > ${minId.toString()}::bigint
-			  AND id <= ${maxId.toString()}::bigint
-			ORDER BY id DESC
-		), ranked AS (
-			SELECT
-				automation_id,
-				status,
-				ROW_NUMBER() OVER (PARTITION BY automation_id ORDER BY id DESC) AS position
-			FROM recent_global_runs
-			WHERE automation_id = ANY(${pgBigintArray(ids)}::bigint[])
-			  AND status IN ('completed', 'failed', 'timeout')
-		)
-		SELECT automation_id::text, status
-		FROM ranked
-		WHERE position <= ${AUTOMATION_HEALTH_RUN_WINDOW}
-		ORDER BY automation_id, position
+		SELECT requested.id::text AS automation_id, recent.status
+		FROM unnest(${pgBigintArray(ids)}::bigint[]) AS requested(id)
+		CROSS JOIN LATERAL (
+			SELECT r.id, r.status
+			FROM runs r
+			WHERE r.automation_id = requested.id
+			  AND r.run_type = 'automation'
+			  AND r.status IN ('completed', 'failed', 'timeout')
+			ORDER BY r.id DESC
+			LIMIT ${AUTOMATION_HEALTH_RUN_WINDOW}
+		) AS recent
+		ORDER BY requested.id, recent.id DESC
 	`) as unknown as RecentRunRow[];
 
 	for (const row of rows) {

--- a/packages/server/src/automations/automation-health.ts
+++ b/packages/server/src/automations/automation-health.ts
@@ -52,17 +52,6 @@ const IN_FLIGHT_RUN_STATUSES = new Set(['claimed', 'running']);
 /** Terminal execution failures that degrade an active automation. */
 const FAILED_RUN_STATUSES = new Set(['failed', 'timeout']);
 
-/**
- * Both the connector and the workspace event trigger use `kind: 'event'`, so
- * this one predicate covers every activation that fires off an event rather
- * than a cron. Shared by list and get_automation so their verdicts agree.
- */
-export function hasEventTrigger(
-  triggers: AutomationTrigger[] | null | undefined
-): boolean {
-  return (triggers ?? []).some((trigger) => trigger.kind === 'event');
-}
-
 export interface AutomationHealthInput {
   /** Automation `status` (only `active` automations can be degraded). */
   status: string | null | undefined;
@@ -81,8 +70,10 @@ export interface AutomationHealthInput {
    * July-2026 z.ai quota storm lacked. NULL on pre-backfill rows.
    */
   latestRunOutcome?: string | null;
-  /** Whether the persisted trigger set contains an event/chat activation. */
-  hasEventTrigger?: boolean;
+  /** Persisted triggers, used to distinguish event-driven Automations. */
+  triggers?: AutomationTrigger[] | null;
+  /** Canonical proof that an event/chat activation dispatched. */
+  lastEventActivationAt?: string | Date | null;
   /** Newest-first scored terminal outcomes from the bounded recent-run read. */
   recentTerminalRunStatuses?: string[];
 }
@@ -108,8 +99,7 @@ function toMs(value: string | Date | null | undefined): number | null {
  * Derive an automation's health from already-selected fields.
  *
  * `degraded` when the automation is `active` AND any of:
- *   - it activates on an event but has never produced a run — configured, not
- *     yet proven to fire; or
+ *   - it activates on an event but has neither a run nor an activation stamp;
  *   - its latest run ended in a terminal failure (`failed`/`timeout`) — the
  *     automation ran and broke, regardless of the scheduler cursor; or
  *   - at least half of a meaningful window of recent terminal runs failed — a
@@ -142,8 +132,15 @@ export function computeAutomationHealth(
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
 
-  if (input.hasEventTrigger && input.latestRunStatus == null) {
-    reasons.push('event trigger configured, but no runs observed yet');
+  const hasEventTrigger = (input.triggers ?? []).some(
+    (trigger) => trigger.kind === 'event'
+  );
+  if (
+    hasEventTrigger &&
+    input.latestRunStatus == null &&
+    input.lastEventActivationAt == null
+  ) {
+    reasons.push('event trigger configured, but no dispatch observed yet');
   }
 
   if (FAILED_RUN_STATUSES.has(input.latestRunStatus ?? '')) {

--- a/packages/server/src/automations/automation-health.ts
+++ b/packages/server/src/automations/automation-health.ts
@@ -8,11 +8,11 @@
  * into a single `health` verdict + a `last_scheduling_error` so the API and UI
  * can flag an automation that stopped firing or whose latest run failed.
  *
- * Pure + input-only: every field it reads is already selected by both
- * get_automation.ts and manage_automations/list.ts, so no migration and no extra
- * query — this is a projection, kept in one place so both call sites agree.
+ * Pure + input-only: the caller selects every field it reads, so this stays a
+ * projection kept in one place and both call sites agree on the verdict.
  */
 
+import type { AutomationTrigger } from '../types/automations';
 import { intervals } from '../config/intervals';
 
 export type AutomationHealthStatus = 'healthy' | 'degraded';
@@ -52,6 +52,17 @@ const IN_FLIGHT_RUN_STATUSES = new Set(['claimed', 'running']);
 /** Terminal execution failures that degrade an active automation. */
 const FAILED_RUN_STATUSES = new Set(['failed', 'timeout']);
 
+/**
+ * Both the connector and the workspace event trigger use `kind: 'event'`, so
+ * this one predicate covers every activation that fires off an event rather
+ * than a cron. Shared by list and get_automation so their verdicts agree.
+ */
+export function hasEventTrigger(
+  triggers: AutomationTrigger[] | null | undefined
+): boolean {
+  return (triggers ?? []).some((trigger) => trigger.kind === 'event');
+}
+
 export interface AutomationHealthInput {
   /** Automation `status` (only `active` automations can be degraded). */
   status: string | null | undefined;
@@ -70,6 +81,10 @@ export interface AutomationHealthInput {
    * July-2026 z.ai quota storm lacked. NULL on pre-backfill rows.
    */
   latestRunOutcome?: string | null;
+  /** Whether the persisted trigger set contains an event/chat activation. */
+  hasEventTrigger?: boolean;
+  /** Newest-first scored terminal outcomes from the bounded recent-run read. */
+  recentTerminalRunStatuses?: string[];
 }
 
 export interface AutomationHealth {
@@ -93,8 +108,12 @@ function toMs(value: string | Date | null | undefined): number | null {
  * Derive an automation's health from already-selected fields.
  *
  * `degraded` when the automation is `active` AND any of:
+ *   - it activates on an event but has never produced a run — configured, not
+ *     yet proven to fire; or
  *   - its latest run ended in a terminal failure (`failed`/`timeout`) — the
  *     automation ran and broke, regardless of the scheduler cursor; or
+ *   - at least half of a meaningful window of recent terminal runs failed — a
+ *     pattern one fresh success must not hide; or
  *   - its `next_run_at` is in the past by more than the missed-firing margin
  *     (a missed firing), UNLESS a run is currently in flight (claimed/running)
  *     — an active dispatch is healthy, we don't false-degrade mid-tick; or
@@ -123,11 +142,28 @@ export function computeAutomationHealth(
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
 
+  if (input.hasEventTrigger && input.latestRunStatus == null) {
+    reasons.push('event trigger configured, but no runs observed yet');
+  }
+
   if (FAILED_RUN_STATUSES.has(input.latestRunStatus ?? '')) {
     const label = lastOutcome
       ? `latest run ${input.latestRunStatus} (${lastOutcome})`
       : `latest run ${input.latestRunStatus}`;
     reasons.push(lastError ? `${label}: ${lastError}` : label);
+  }
+
+  const recentStatuses = input.recentTerminalRunStatuses ?? [];
+  const recentFailures = recentStatuses.filter((status) =>
+    FAILED_RUN_STATUSES.has(status)
+  ).length;
+  // Ten outcomes is enough evidence to avoid one-off noise; at least half
+  // failing is a severe, explainable pattern. A success recovers immediately
+  // only when it brings the bounded window below that threshold.
+  if (recentStatuses.length >= 10 && recentFailures * 2 >= recentStatuses.length) {
+    reasons.push(
+      `${recentFailures} of ${recentStatuses.length} recent terminal runs failed or timed out`
+    );
   }
 
   // Missed firing: next_run_at is well in the past and nothing is dispatching.

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -37,6 +37,8 @@
  *     within the liveness window.
  *   - `last_attempt_failed` — the most recent attempt failed (failing state,
  *     including backoff episodes).
+ *   - `overdue` — a scheduled feed has had no active run for more than an hour
+ *     past `next_run_at`.
  *   - `never_run` — never synced.
  *   - `healthy` — everything else.
  *
@@ -60,6 +62,7 @@ type FeedAttentionState =
   | "paused"
   | "needs_auth"
   | "last_attempt_failed"
+  | "overdue"
   | "never_run"
   | "device_offline"
   | "misconfigured";
@@ -80,6 +83,10 @@ interface FeedHealthSemanticsInput {
   last_sync_at?: Date | string | null;
   /** `feeds.consecutive_failures`. */
   consecutive_failures?: number | null;
+  /** `feeds.next_run_at` — only meaningful when schedule is present. */
+  next_run_at?: Date | string | null;
+  /** Number of pending/claimed/running sync runs selected by list_feeds. */
+  active_runs?: number | null;
   /** `connections.status` — 'active' | 'paused' | 'error' | 'revoked' |
    *  'pending_auth'. */
   connection_status?: string | null;
@@ -139,6 +146,21 @@ function lastAttemptFailed(input: FeedHealthSemanticsInput): boolean {
   );
 }
 
+const FEED_OVERDUE_MARGIN_MS = 60 * 60 * 1000;
+
+function scheduledExecutionOverdue(
+  input: FeedHealthSemanticsInput,
+  now: number
+): boolean {
+  if (!isScheduled(input) || (input.active_runs ?? 0) > 0) return false;
+  if (input.next_run_at == null) return false;
+  const nextRun =
+    input.next_run_at instanceof Date
+      ? input.next_run_at.getTime()
+      : new Date(input.next_run_at).getTime();
+  return Number.isFinite(nextRun) && nextRun < now - FEED_OVERDUE_MARGIN_MS;
+}
+
 /** The feed is paused, by operator or auto-pause. */
 function isPaused(input: FeedHealthSemanticsInput): boolean {
   return input.status === "paused" || input.connection_status === "paused";
@@ -164,7 +186,8 @@ function nonCollectorAttention(
  * state wins).
  */
 export function deriveFeedHealthSemantics(
-  input: FeedHealthSemanticsInput
+  input: FeedHealthSemanticsInput,
+  now: number = Date.now()
 ): FeedHealthSemantics {
   // Virtual feeds are evaluated on demand; they have no unattended runtime.
   if (isVirtual(input)) {
@@ -198,6 +221,8 @@ export function deriveFeedHealthSemantics(
     attention = "device_offline";
   } else if (lastAttemptFailed(input)) {
     attention = "last_attempt_failed";
+  } else if (scheduledExecutionOverdue(input, now)) {
+    attention = "overdue";
   } else if (
     input.last_sync_at == null &&
     input.last_sync_status !== "success"

--- a/packages/server/src/tools/admin/manage_automations/list.ts
+++ b/packages/server/src/tools/admin/manage_automations/list.ts
@@ -17,7 +17,11 @@ import {
 	getPublicWebUrl,
 } from "../../../utils/url-builder";
 import { buildLatestAutomationRunJoinSql } from "../../../automations/automation";
-import { computeAutomationHealth } from "../../../automations/automation-health";
+import {
+	computeAutomationHealth,
+	hasEventTrigger,
+} from "../../../automations/automation-health";
+import { loadRecentAutomationRunStatuses } from "../../../automations/automation-health-history";
 import type { ToolContext } from "../../registry";
 import { batchCountUnanalyzedContent } from "./shared";
 
@@ -186,6 +190,7 @@ export async function handleList(
 
 	const baseUrl = getPublicWebUrl(ctx.requestUrl, ctx.baseUrl);
 	const automationIds = (result as any[]).map((i) => Number(i.automation_id));
+	const recentRunStatuses = await loadRecentAutomationRunStatuses(sql, automationIds);
 
 	let counts: Map<number, { pending: number; historical: number }>;
 	try {
@@ -255,6 +260,8 @@ export async function handleList(
 				| null
 				| undefined,
 			latestRunOutcome: automation.automation_run_outcome,
+			hasEventTrigger: hasEventTrigger(automation.triggers),
+			recentTerminalRunStatuses: recentRunStatuses.get(automationId) ?? [],
 		});
 
 		return {

--- a/packages/server/src/tools/admin/manage_automations/list.ts
+++ b/packages/server/src/tools/admin/manage_automations/list.ts
@@ -17,10 +17,7 @@ import {
 	getPublicWebUrl,
 } from "../../../utils/url-builder";
 import { buildLatestAutomationRunJoinSql } from "../../../automations/automation";
-import {
-	computeAutomationHealth,
-	hasEventTrigger,
-} from "../../../automations/automation-health";
+import { computeAutomationHealth } from "../../../automations/automation-health";
 import { loadRecentAutomationRunStatuses } from "../../../automations/automation-health-history";
 import type { ToolContext } from "../../registry";
 import { batchCountUnanalyzedContent } from "./shared";
@@ -61,6 +58,7 @@ export async function handleList(
       i.updated_at,
       i.triggers,
       i.next_run_at,
+      i.last_event_activation_at AS health_last_event_activation_at,
       i.agent_id,
       i.device_worker_id,
       i.last_fired_at,
@@ -225,7 +223,11 @@ export async function handleList(
 			? buildAutomationUrl(orgSlug, automationId, baseUrl)
 			: undefined;
 
-		const { organization_id: _orgId, ...rest } = automation;
+		const {
+			organization_id: _orgId,
+			health_last_event_activation_at: lastEventActivationAt,
+			...rest
+		} = automation;
 
 		if (!args.include_details) {
 			delete (rest as Record<string, unknown>).prompt;
@@ -248,8 +250,6 @@ export async function handleList(
 			);
 		}
 
-		// Computed health (item 3, #2033) — derived from the
-		// already-selected schedule/run columns, no extra query.
 		const automationHealth = computeAutomationHealth({
 			status: automation.status,
 			nextRunAt: automation.next_run_at,
@@ -260,7 +260,8 @@ export async function handleList(
 				| null
 				| undefined,
 			latestRunOutcome: automation.automation_run_outcome,
-			hasEventTrigger: hasEventTrigger(automation.triggers),
+			triggers: automation.triggers,
+			lastEventActivationAt,
 			recentTerminalRunStatuses: recentRunStatuses.get(automationId) ?? [],
 		});
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -199,6 +199,8 @@ export async function handleTest(
   }
 
   const conn = rows[0] as any;
+  const withDeviceHealth = (result: ConnectionTestResult): ConnectionTestResult =>
+    applySelectedDeviceHealth(conn, result);
   const authProfile = await getAuthProfileById(
     organizationId,
     Number(conn.auth_profile_id) || null
@@ -218,29 +220,29 @@ export async function handleTest(
     `;
 
     if (accountRows.length === 0) {
-      return {
+      return withDeviceHealth({
         action: 'test',
         status: 'error',
         message: 'Linked OAuth account not found',
         ...testErrorFields('NOT_FOUND'),
-      };
+      });
     }
 
     const account = accountRows[0] as any;
     if (!account.has_token) {
-      return {
+      return withDeviceHealth({
         action: 'test',
         status: 'error',
         message: 'No access token available. Re-authenticate.',
         ...testErrorFields('AUTH_MISSING'),
-      };
+      });
     }
 
     const expiresAt = account.accessTokenExpiresAt ? new Date(account.accessTokenExpiresAt) : null;
     const isExpired = expiresAt && expiresAt.getTime() < Date.now();
     const hardExpired = isExpired && !account.has_refresh;
 
-    return {
+    return withDeviceHealth({
       action: 'test',
       status: hardExpired ? 'error' : 'ok',
       message: isExpired
@@ -252,7 +254,7 @@ export async function handleTest(
       has_refresh: account.has_refresh,
       expires_at: expiresAt?.toISOString() ?? null,
       ...(hardExpired ? testErrorFields('AUTH_INVALID') : {}),
-    };
+    });
   }
 
   const profileToTest =
@@ -266,14 +268,14 @@ export async function handleTest(
     const creds = normalizeAuthValues(profileToTest.auth_data);
     const label = profileToTest.profile_kind === 'oauth_app' ? 'App auth' : 'Auth';
     const hasKeys = Object.keys(creds).length > 0;
-    return {
+    return withDeviceHealth({
       action: 'test',
       status: hasKeys ? 'ok' : 'warning',
       message: hasKeys
         ? `${label} profile '${profileToTest.slug}' configured`
         : `${label} profile '${profileToTest.slug}' has no credentials`,
       ...(hasKeys ? {} : testErrorFields('AUTH_MISSING')),
-    };
+    });
   }
 
   if (authProfile?.profile_kind === 'browser_session') {
@@ -282,7 +284,7 @@ export async function handleTest(
       const readiness = await getBrowserSessionReadiness(authProfile.auth_data, conn.connector_key);
       // A configured-but-unreachable CDP endpoint is transient (the browser may
       // come back), so this warning is retryable — unlike the missing-cookie ones.
-      return {
+      return withDeviceHealth({
         action: 'test',
         status: readiness.usable ? 'ok' : 'warning',
         message: readiness.usable
@@ -290,27 +292,27 @@ export async function handleTest(
           : `Browser auth profile '${authProfile.slug}' CDP configured but endpoint not responding at ${summary.cdp_url}`,
         expires_at: summary.expires_at,
         ...(readiness.usable ? {} : testErrorFields('NETWORK')),
-      };
+      });
     }
     if (summary.cookie_count === 0) {
-      return {
+      return withDeviceHealth({
         action: 'test',
         status: 'warning',
         message: `Browser auth profile '${authProfile.slug}' has no cookies`,
         expires_at: summary.expires_at,
         ...testErrorFields('AUTH_MISSING'),
-      };
+      });
     }
     if (!summary.auth_cookie_name) {
-      return {
+      return withDeviceHealth({
         action: 'test',
         status: 'warning',
         message: `Browser auth profile '${authProfile.slug}' has no likely auth cookie`,
         expires_at: summary.expires_at,
         ...testErrorFields('AUTH_MISSING'),
-      };
+      });
     }
-    return {
+    return withDeviceHealth({
       action: 'test',
       status: summary.is_expired ? 'error' : 'ok',
       message: summary.is_expired
@@ -318,7 +320,7 @@ export async function handleTest(
         : `${summary.auth_cookie_name} valid`,
       expires_at: summary.expires_at,
       ...(summary.is_expired ? testErrorFields('AUTH_INVALID') : {}),
-    };
+    });
   }
 
   // Auth-free device connections such as apple.computer_use run on a paired
@@ -369,6 +371,53 @@ export async function handleTest(
     status: 'warning',
     message: 'No auth profile configured',
     ...testErrorFields('AUTH_MISSING'),
+  };
+}
+
+type ConnectionTestResult = Extract<ManageConnectionsResult, { action: 'test' }>;
+
+/**
+ * A credential-backed connection may still require its selected device to
+ * execute (for example X OAuth plus browser-backed feeds). Credential validity
+ * and execution availability are conjunctive: a successful auth probe cannot
+ * turn an offline required device into an overall `ok` result.
+ */
+function applySelectedDeviceHealth(
+  conn: {
+    device_worker_id?: unknown;
+    device_online?: unknown;
+    device_label?: unknown;
+    device_last_seen_at?: Date | string | null;
+  },
+  result: ConnectionTestResult
+): ConnectionTestResult {
+  if (!conn.device_worker_id) return result;
+  if (conn.device_online === true) {
+    return { ...result, device_online: true };
+  }
+
+  const deviceName =
+    typeof conn.device_label === 'string' && conn.device_label.trim()
+      ? conn.device_label
+      : 'paired device';
+  const deviceMessage = `Device '${deviceName}' is offline (${describeDeviceLastSeen(
+    conn.device_last_seen_at
+  )}) — bring it online to execute`;
+
+  // An auth finding the probe already made is the more actionable one and must
+  // survive: overwriting e.g. a non-retryable AUTH_MISSING with NETWORK would
+  // tell the caller to retry a connection only a human re-auth can fix. Only an
+  // otherwise-clean result takes the device's retryable NETWORK classification.
+  const deviceErrorFields = result.error_code
+    ? {}
+    : testErrorFields('NETWORK');
+
+  return {
+    ...result,
+    status: result.status === 'error' ? 'error' : 'warning',
+    message: `${result.message}; ${deviceMessage}`,
+    device_online: false,
+    ...deviceErrorFields,
   };
 }
 

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -185,17 +185,36 @@ async function handleListFeeds(
   // Once the feed or its parent connection is paused, its last outcome is
   // lifecycle history rather than current health, so the guard scopes BOTH
   // branches and such a row comes back as neither failing nor healthy. This
-  // mirrors `isPaused` in connectors/feed-health-semantics.ts, so the filter
-  // and the `attention` each row carries cannot disagree — a row the filter
-  // called 'healthy' never renders as attention 'paused'. `health` combined
-  // with `status: 'paused'` is therefore an empty intersection by
-  // construction.
+  // mirrors the lifecycle and execution-failure portions of
+  // `deriveFeedHealthSemantics`, so `healthy` never renders as paused,
+  // last_attempt_failed, or overdue. Auth/device/misconfiguration attention is
+  // intentionally separate from this sync-health filter.
   if (args.health) {
     where = sql`${where} AND f.status = 'active' AND c.status <> 'paused'`;
+    const overdue = sql`
+      COALESCE(f.kind, 'collected') NOT IN ('virtual', 'streaming')
+      AND NOT COALESCE(f.virtual, false)
+      AND COALESCE(f.schedule, '') <> ''
+      AND f.next_run_at IS NOT NULL
+      AND f.next_run_at < now() - interval '1 hour'
+      AND NOT EXISTS (
+        SELECT 1 FROM runs r
+        WHERE r.feed_id = f.id
+          AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+      )
+    `;
     if (args.health === 'failing') {
-      where = sql`${where} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
+      where = sql`${where} AND (
+        f.last_sync_status = 'failed'
+        OR COALESCE(f.consecutive_failures, 0) > 0
+        OR (${overdue})
+      )`;
     } else {
-      where = sql`${where} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
+      where = sql`${where}
+        AND f.last_sync_status IS DISTINCT FROM 'failed'
+        AND COALESCE(f.consecutive_failures, 0) = 0
+        AND NOT (${overdue})
+      `;
     }
   }
   if (args.feed_ids?.length) {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -321,6 +321,8 @@ async function handleListFeeds(
       last_sync_status: feed.last_sync_status as string | null,
       last_sync_at: feed.last_sync_at as Date | string | null,
       consecutive_failures: feed.consecutive_failures as number | null,
+      next_run_at: feed.next_run_at as Date | string | null,
+      active_runs: feed.active_runs as number | null,
       connection_status: feed.connection_status as string | null,
       auth_profile_status: feed.auth_profile_status as string | null,
       device_worker_id: feed.device_worker_id as string | null,

--- a/packages/server/src/tools/get_automation.ts
+++ b/packages/server/src/tools/get_automation.ts
@@ -59,10 +59,7 @@ import {
   parseBigintArray,
 } from '../utils/window-utils';
 import { buildLatestAutomationRunJoinSql } from '../automations/automation';
-import {
-  computeAutomationHealth,
-  hasEventTrigger,
-} from '../automations/automation-health';
+import { computeAutomationHealth } from '../automations/automation-health';
 import { loadRecentAutomationRunStatuses } from '../automations/automation-health-history';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
@@ -221,6 +218,7 @@ interface AutomationQueryRow {
   schedule: string | null;
   triggers: AutomationTrigger[] | null;
   next_run_at: string | null;
+  last_event_activation_at: string | null;
   agent_id: string | null;
   delivery_target: {
     connection_id: number;
@@ -559,6 +557,7 @@ async function getAutomationImpl(
         i.schedule,
         i.triggers,
         i.next_run_at,
+        i.last_event_activation_at,
         i.agent_id,
         i.delivery_target,
         i.device_worker_id,
@@ -804,7 +803,8 @@ async function getAutomationImpl(
       latestRunCreatedAt: automationRow.automation_run_created_at,
       latestRunError: automationRunError,
       latestRunOutcome: automationRow.automation_run_outcome,
-      hasEventTrigger: hasEventTrigger(automationRow.triggers),
+      triggers: automationRow.triggers,
+      lastEventActivationAt: automationRow.last_event_activation_at,
       recentTerminalRunStatuses: recentRunStatuses.get(automationId) ?? [],
     });
 

--- a/packages/server/src/tools/get_automation.ts
+++ b/packages/server/src/tools/get_automation.ts
@@ -59,7 +59,11 @@ import {
   parseBigintArray,
 } from '../utils/window-utils';
 import { buildLatestAutomationRunJoinSql } from '../automations/automation';
-import { computeAutomationHealth } from '../automations/automation-health';
+import {
+  computeAutomationHealth,
+  hasEventTrigger,
+} from '../automations/automation-health';
+import { loadRecentAutomationRunStatuses } from '../automations/automation-health-history';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 
@@ -788,9 +792,11 @@ async function getAutomationImpl(
     // Sources come from automation row (or version if present)
     const automationSources = parseAutomationSources(automationRow.sources);
 
-    // Computed health (item 3, #2033) — pure derivation over the
-    // already-selected schedule/run columns; no extra query.
+    // Computed health (item 3, #2033) — derived from the already-selected
+    // schedule/run columns plus one bounded recent-run read.
     const automationRunError = automationRow.automation_run_error ?? null;
+    const automationId = Number(automationRow.automation_id);
+    const recentRunStatuses = await loadRecentAutomationRunStatuses(sql, [automationId]);
     const automationHealth = computeAutomationHealth({
       status: automationRow.status,
       nextRunAt: automationRow.next_run_at,
@@ -798,6 +804,8 @@ async function getAutomationImpl(
       latestRunCreatedAt: automationRow.automation_run_created_at,
       latestRunError: automationRunError,
       latestRunOutcome: automationRow.automation_run_outcome,
+      hasEventTrigger: hasEventTrigger(automationRow.triggers),
+      recentTerminalRunStatuses: recentRunStatuses.get(automationId) ?? [],
     });
 
     automationMetadata = {

--- a/packages/server/src/types/automations.ts
+++ b/packages/server/src/types/automations.ts
@@ -156,9 +156,9 @@ export const AutomationMetadataSchema = Type.Object({
   available_versions: Type.Optional(Type.Array(AutomationVersionInfoSchema)),
   reaction_script: Type.Optional(Type.String()),
   automation_run: Type.Optional(AutomationRunSchema),
-  /** Computed health (item 3, #2033): `degraded` when an active
-   *  automation's latest run failed/timed out, it missed a firing, or its latest
-   *  run is stuck pending past the stale interval; else `healthy`. */
+  /** Computed health: `degraded` when an active Automation is unverified,
+   *  misses/stalls a firing, fails its latest run, or has a severe bounded
+   *  recent failure pattern; else `healthy`. */
   health: Type.Optional(
     Type.Union([Type.Literal('healthy'), Type.Literal('degraded')])
   ),


### PR DESCRIPTION
## Summary
- derive Automation health from the latest 100 scored terminal outcomes inside an indexed global run-id span; 50%+ failures across at least 10 outcomes stays degraded after one success
- report never-fired event Automations as configured but unverified, and surface failed/offline/overdue feed attention without marking no-schedule feeds stale
- compose credential tests with selected-device liveness so valid X OAuth no longer masks an offline required Chrome worker
- show the existing `health_reasons` and feed `attention` clearly in Owletto via merged lobu-ai/owletto#918

No database migration, table, index, public endpoint, SDK surface, or breaking health enum was added. The rolling read is bounded to 100,000 recent `runs.id` values using the existing primary key, then capped at 100 outcomes per Automation.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Focused server unit tests: 34 passed
- [x] Focused server integration tests: 23 passed
- [x] Owletto production build and focused tests: 17 passed
- [x] Bug fix reproduced red, then green

### Red reproduction
`bun test packages/server/src/__tests__/unit/automation-health.test.ts packages/server/src/__tests__/unit/feed-health-semantics.test.ts` initially failed 3 cases: never-fired event reported healthy, 99/100 rolling failures reported healthy, and scheduled-overdue feed reported healthy.

`cd packages/server && bun run test -- run src/__tests__/integration/automation-health-surfacing.test.ts src/__tests__/integration/connection-test-device-aware.test.ts src/__tests__/integration/feeds-list-health-and-count.test.ts` initially reproduced never-run and 44/74 Automations as healthy plus valid OAuth masking an offline selected device.

### Green proof
- same unit command: `34 pass, 0 fail`
- same integration command: `23 pass, 0 fail`
- `make pre-pr`: all 7 gates clean
- Owletto: `bun run build`; focused Vitest command: `17 passed`

## Notes
The old `feat/self-heal-orphan-feeds` branch contained only unrelated tombstoned streaming-feed coverage; no stale commits were cherry-picked. Visual proof will be attached by the required `make ui-review` gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation health now reflects missed event activations and repeated recent failures.
  * Scheduled feeds are marked **overdue** when they miss their expected run time.
  * Connection tests now account for the selected device’s online status, even when authentication succeeds.

* **Documentation**
  * Updated health and connection result descriptions to clarify device availability and degraded-status conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->