### PR TITLE
fix(server): route Slack channel automations

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -12,6 +12,7 @@ import {
   isSenderAllowed,
   MessageHandlerBridge,
   parsePreviewLinkCode,
+  registerMessageHandlers,
 } from "../connections/message-handler-bridge.js";
 import type { PlatformConnection } from "../connections/types.js";
 import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
@@ -384,6 +385,201 @@ function makeThread(adapter: unknown) {
     startTyping: mock(async () => undefined),
   };
 }
+
+describe("registerMessageHandlers linked-channel ingress", () => {
+  test("does not add a catch-all to non-Slack adapters", () => {
+    const onNewMessage = mock(() => undefined);
+    registerMessageHandlers(
+      {
+        onNewMention: mock(() => undefined),
+        onDirectMessage: mock(() => undefined),
+        onSubscribedMessage: mock(() => undefined),
+        onNewMessage,
+      },
+      { ...buildConnection(), platform: "telegram" },
+      {
+        getArtifactStore: () => null,
+        getPublicGatewayUrl: () => "https://gateway.example.com",
+      } as any,
+      { getInstance: () => null } as any,
+    );
+
+    expect(onNewMessage).not.toHaveBeenCalled();
+  });
+
+  test("Enterprise Grid ordinary channel events reach the Automation bridge", async () => {
+    let unmatchedHandler:
+      | ((thread: unknown, message: unknown) => Promise<void>)
+      | undefined;
+    const chat = {
+      onNewMention: mock(() => undefined),
+      onDirectMessage: mock(() => undefined),
+      onSubscribedMessage: mock(() => undefined),
+      onNewMessage: mock(
+        (
+          _pattern: RegExp,
+          handler: (thread: unknown, message: unknown) => Promise<void>,
+        ) => {
+          unmatchedHandler = handler;
+        },
+      ),
+    };
+    const channelHasMessageSubscription = mock(async () => true);
+    const connection: PlatformConnection = {
+      ...buildConnection(),
+      id: "slackinst-grid",
+      organizationId: "org-grid",
+      agentId: undefined,
+      metadata: {
+        teamId: "E0ENTERPRISE",
+        enterpriseId: "E0ENTERPRISE",
+        isEnterpriseInstall: true,
+        botUserId: "U_BOT",
+      },
+    };
+    const services = {
+      getArtifactStore: () => null,
+      getPublicGatewayUrl: () => "https://gateway.example.com",
+      getAutomationSubscriptionService: () => ({
+        channelHasMessageSubscription,
+      }),
+    } as any;
+    const bridge = registerMessageHandlers(
+      chat,
+      connection,
+      services,
+      { getInstance: () => null } as any,
+    );
+    const handleMessage = mock(async () => undefined);
+    bridge.handleMessage = handleMessage as typeof bridge.handleMessage;
+    // Real adapter shape: `channelIdFromThreadId` returns the prefixed
+    // `slack:C…`, which the subscription reader normalizes to native `C…`.
+    const thread = {
+      id: "slack:C0CHANNEL:1787290503.806889",
+      channelId: "slack:C0CHANNEL",
+    };
+    const message = makeMessage({
+      id: "1787290503.806889",
+      isMention: false,
+      raw: { team_id: "T0WORKSPACE" },
+    });
+
+    expect(unmatchedHandler).toBeDefined();
+    await unmatchedHandler!(thread, message);
+
+    expect(channelHasMessageSubscription).toHaveBeenCalledWith(
+      "slackinst-grid",
+      "slack:C0CHANNEL",
+      "org-grid",
+      false,
+    );
+    expect(handleMessage).toHaveBeenCalledWith(thread, message, "subscribed");
+  });
+
+  test("ordinary messages in unlinked channels stay silent", async () => {
+    let unmatchedHandler:
+      | ((thread: unknown, message: unknown) => Promise<void>)
+      | undefined;
+    const chat = {
+      onNewMention: mock(() => undefined),
+      onDirectMessage: mock(() => undefined),
+      onSubscribedMessage: mock(() => undefined),
+      onNewMessage: mock(
+        (
+          _pattern: RegExp,
+          handler: (thread: unknown, message: unknown) => Promise<void>,
+        ) => {
+          unmatchedHandler = handler;
+        },
+      ),
+    };
+    const channelHasMessageSubscription = mock(async () => false);
+    const connection: PlatformConnection = {
+      ...buildConnection(),
+      id: "slackinst-grid",
+      organizationId: "org-grid",
+      agentId: undefined,
+    };
+    const bridge = registerMessageHandlers(
+      chat,
+      connection,
+      {
+        getArtifactStore: () => null,
+        getPublicGatewayUrl: () => "https://gateway.example.com",
+        getAutomationSubscriptionService: () => ({
+          channelHasMessageSubscription,
+        }),
+      } as any,
+      { getInstance: () => null } as any,
+    );
+    const handleMessage = mock(async () => undefined);
+    bridge.handleMessage = handleMessage as typeof bridge.handleMessage;
+
+    await unmatchedHandler!(
+      { id: "slack:C_OTHER:1", channelId: "slack:C_OTHER" },
+      makeMessage({ id: "1", text: "unlinked" }),
+    );
+
+    expect(channelHasMessageSubscription).toHaveBeenCalledTimes(1);
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  test("bot-authored catch-all messages cannot create reply loops", async () => {
+    let unmatchedHandler:
+      | ((thread: unknown, message: unknown) => Promise<void>)
+      | undefined;
+    const chat = {
+      onNewMention: mock(() => undefined),
+      onDirectMessage: mock(() => undefined),
+      onSubscribedMessage: mock(() => undefined),
+      onNewMessage: mock(
+        (
+          _pattern: RegExp,
+          handler: (thread: unknown, message: unknown) => Promise<void>,
+        ) => {
+          unmatchedHandler = handler;
+        },
+      ),
+    };
+    const channelHasMessageSubscription = mock(async () => true);
+    const connection: PlatformConnection = {
+      ...buildConnection(),
+      id: "slackinst-grid",
+      organizationId: "org-grid",
+      agentId: undefined,
+    };
+    const bridge = registerMessageHandlers(
+      chat,
+      connection,
+      {
+        getArtifactStore: () => null,
+        getPublicGatewayUrl: () => "https://gateway.example.com",
+        getAutomationSubscriptionService: () => ({
+          channelHasMessageSubscription,
+        }),
+      } as any,
+      { getInstance: () => null } as any,
+    );
+    const handleMessage = mock(async () => undefined);
+    bridge.handleMessage = handleMessage as typeof bridge.handleMessage;
+
+    await unmatchedHandler!(
+      { id: "slack:C_LINKED:2", channelId: "slack:C_LINKED" },
+      makeMessage({
+        id: "2",
+        author: {
+          userId: "B_OTHER",
+          userName: "otherbot",
+          isBot: true,
+          isMe: false,
+        },
+      }),
+    );
+
+    expect(channelHasMessageSubscription).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+});
 
 function priorMessage(id: string, text: string, isMe: boolean, whenMs: number) {
   return {

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Assembled Slack chat-automation regression.
+ *
+ * Fakes stop at Slack's network boundary. The test drives a signed Events API
+ * request through the real Slack adapter and Chat SDK, then uses the real
+ * channel subscription reader, Automation planner, transcript writer,
+ * Postgres run queue, and Slack completion strategy.
+ */
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { createHmac } from "node:crypto";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { Chat, type StateAdapter } from "chat";
+import { createTestAutomationSubscription } from "../../__tests__/setup/automation-subscriptions.js";
+import { getDb } from "../../db/client.js";
+import { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
+import { ConversationStateStore } from "../connections/conversation-state-store.js";
+import { registerMessageHandlers } from "../connections/message-handler-bridge.js";
+import { getResponseStrategy } from "../connections/platform-strategies/index.js";
+import { createConnectedGatewayStateAdapter } from "../connections/state-adapter.js";
+import type { PlatformConnection } from "../connections/types.js";
+import { QueueProducer } from "../infrastructure/queue/queue-producer.js";
+import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const SIGNING_SECRET = "slack-e2e-signing-secret-20260821";
+const BOT_USER_ID = "U_LOBU_BOT";
+const ENTERPRISE_ID = "E0ENTERPRISE";
+const WORKSPACE_TEAM_ID = "T0WORKSPACE";
+const CHANNEL_ID = "C0CHANNEL";
+const DM_ID = "D0DIRECT";
+const RUNTIME_CONNECTION_ID = "slackinst-grid-message-e2e";
+
+setDefaultTimeout(30_000);
+
+function signedEventRequest(
+  payload: Record<string, unknown>,
+  retryNum?: number,
+): Request {
+  const body = JSON.stringify(payload);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+  return new Request("https://gateway.example.test/slack/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+      ...(retryNum === undefined
+        ? {}
+        : {
+            "x-slack-retry-num": String(retryNum),
+            "x-slack-retry-reason": "http_timeout",
+          }),
+    },
+    body,
+  });
+}
+
+function slackEvent(options: {
+  eventId: string;
+  channel: string;
+  ts: string;
+  text: string;
+  user?: string;
+  botId?: string;
+  channelType?: "channel" | "im";
+}) {
+  return {
+    token: "legacy-verification-token",
+    type: "event_callback",
+    api_app_id: "A_LOBU",
+    event_id: options.eventId,
+    event_time: Math.floor(Number(options.ts)),
+    team_id: WORKSPACE_TEAM_ID,
+    enterprise_id: ENTERPRISE_ID,
+    is_enterprise_install: true,
+    event: {
+      type: "message",
+      team: WORKSPACE_TEAM_ID,
+      team_id: WORKSPACE_TEAM_ID,
+      channel: options.channel,
+      channel_type: options.channelType ?? "channel",
+      ts: options.ts,
+      text: options.text,
+      ...(options.user ? { user: options.user, username: "burak" } : {}),
+      ...(options.botId
+        ? { bot_id: options.botId, username: "another-app" }
+        : {}),
+    },
+  };
+}
+
+async function waitFor(
+  check: () => void | Promise<void>,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      await check();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+  throw lastError;
+}
+
+describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => {
+  let chat: Chat;
+  let state: StateAdapter;
+  let queue: RunsQueue;
+  let connectionDbId: number;
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+
+    const organizationId = "org-slack-grid-e2e";
+    const agentId = "agent-slack-grid-e2e";
+    await seedAgentRow(agentId, { organizationId });
+    const sql = getDb();
+    const [connectionRow] = await sql<{ id: number }[]>`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        credential_mode, external_tenant_id, config
+      ) VALUES (
+        ${organizationId}, 'slack', ${RUNTIME_CONNECTION_ID}, 'Grid Slack',
+        'active', 'managed', ${ENTERPRISE_ID},
+        ${sql.json({
+          platform: "slack",
+          settings: { allowGroups: true },
+          chatMetadata: {
+            teamId: ENTERPRISE_ID,
+            enterpriseId: ENTERPRISE_ID,
+            isEnterpriseInstall: true,
+            botUserId: BOT_USER_ID,
+          },
+        })}
+      )
+      RETURNING id
+    `;
+    if (!connectionRow) throw new Error("Slack E2E connection was not seeded");
+    connectionDbId = Number(connectionRow.id);
+
+    await createTestAutomationSubscription({
+      organizationId,
+      agentId,
+      connectionId: connectionDbId,
+      platform: "slack",
+      channelId: CHANNEL_ID,
+      teamId: WORKSPACE_TEAM_ID,
+    });
+    await createTestAutomationSubscription({
+      organizationId,
+      agentId,
+      connectionId: connectionDbId,
+      platform: "slack",
+      channelId: DM_ID,
+      teamId: WORKSPACE_TEAM_ID,
+    });
+
+    queue = new RunsQueue();
+    await queue.start();
+    const producer = new QueueProducer(queue);
+    await producer.start();
+
+    state = await createConnectedGatewayStateAdapter();
+    const adapter = createSlackAdapter({
+      signingSecret: SIGNING_SECRET,
+      botToken: "xoxb-test-boundary-token",
+      botUserId: BOT_USER_ID,
+      userName: "lobu",
+    });
+    // Slack API reads/status writes are the external boundary too. Keep the
+    // assembled server path hermetic while still exercising its calls.
+    (adapter as any).fetchMessages = mock(async () => ({ messages: [] }));
+    (adapter as any).startTyping = mock(async () => undefined);
+    chat = new Chat({
+      userName: "lobu",
+      adapters: { slack: adapter },
+      state,
+      logger: "silent",
+    });
+
+    const connection: PlatformConnection = {
+      id: RUNTIME_CONNECTION_ID,
+      platform: "slack",
+      organizationId,
+      config: {
+        platform: "slack",
+        signingSecret: SIGNING_SECRET,
+        botToken: "xoxb-test-boundary-token",
+        botUserId: BOT_USER_ID,
+      },
+      settings: { allowGroups: true },
+      metadata: {
+        teamId: ENTERPRISE_ID,
+        enterpriseId: ENTERPRISE_ID,
+        isEnterpriseInstall: true,
+        botUserId: BOT_USER_ID,
+      },
+      status: "active",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const conversationState = new ConversationStateStore(state);
+    const subscriptions = new AutomationSubscriptionService();
+    const manager = {
+      has: (connectionId: string) => connectionId === RUNTIME_CONNECTION_ID,
+      getInstance: (connectionId: string) =>
+        connectionId === RUNTIME_CONNECTION_ID
+          ? { connection, conversationState, chat }
+          : undefined,
+    };
+    const services = {
+      getArtifactStore: () => null,
+      getPublicGatewayUrl: () => "https://gateway.example.test",
+      getAutomationSubscriptionService: () => subscriptions,
+      getAgentMetadataStore: () => undefined,
+      getUserAgentsStore: () => undefined,
+      getTranscriptionService: () => undefined,
+      getAgentSettingsStore: () => undefined,
+      getDeclaredAgentRegistry: () => undefined,
+      getProviderCatalogService: () => undefined,
+      getQueueProducer: () => producer,
+    };
+    registerMessageHandlers(
+      chat,
+      connection,
+      services as never,
+      manager as never,
+    );
+  });
+
+  afterEach(async () => {
+    await chat?.shutdown();
+    await queue?.stop();
+  });
+
+  test("workspace-stamped channel and DM events persist, activate once, and reply", async () => {
+    const sql = getDb();
+    const channelTs = "1787292000.000821";
+    const channelPayload = slackEvent({
+      eventId: "Ev_GRID_CHANNEL_20260821",
+      channel: CHANNEL_ID,
+      ts: channelTs,
+      text: "LOBU_SLACK_E2E_20260821 integration channel",
+      user: "U_BURAK",
+    });
+
+    const first = await chat.webhooks.slack(signedEventRequest(channelPayload));
+    expect(first.status).toBe(200);
+
+    await waitFor(async () => {
+      const rows = await sql`
+        SELECT id, action_input
+        FROM runs
+        WHERE run_type = 'chat_message'
+        ORDER BY id
+      `;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.action_input).toMatchObject({
+        agentId: "agent-slack-grid-e2e",
+        organizationId: "org-slack-grid-e2e",
+        messageText: "LOBU_SLACK_E2E_20260821 integration channel",
+        platformMetadata: {
+          automationId: expect.any(Number),
+          teamId: WORKSPACE_TEAM_ID,
+          connectionId: RUNTIME_CONNECTION_ID,
+        },
+      });
+    });
+    await waitFor(async () => {
+      const rows = await sql`
+        SELECT platform_message_id, team_id, text
+        FROM channel_messages
+        WHERE organization_id = 'org-slack-grid-e2e'
+          AND connection_id = ${RUNTIME_CONNECTION_ID}
+          AND channel_id = ${CHANNEL_ID}
+      `;
+      expect(rows).toEqual([
+        {
+          platform_message_id: channelTs,
+          team_id: WORKSPACE_TEAM_ID,
+          text: "LOBU_SLACK_E2E_20260821 integration channel",
+        },
+      ]);
+    });
+
+    // Delayed Events and normal Slack retries carry the same event_id. The
+    // durable adapter marker and message idempotency must leave one transcript
+    // row and one pending agent turn.
+    await waitFor(async () => {
+      expect(
+        await state.get("slack:event-delivered:Ev_GRID_CHANNEL_20260821"),
+      ).toBe(true);
+    });
+    const retry = await chat.webhooks.slack(
+      signedEventRequest(channelPayload, 1),
+    );
+    expect(retry.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const afterRetry = await sql`
+      SELECT id FROM runs WHERE run_type = 'chat_message'
+    `;
+    expect(afterRetry).toHaveLength(1);
+    const transcriptAfterRetry = await sql`
+      SELECT id FROM channel_messages
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND connection_id = ${RUNTIME_CONNECTION_ID}
+        AND channel_id = ${CHANNEL_ID}
+    `;
+    expect(transcriptAfterRetry).toHaveLength(1);
+
+    // DM ingress remains on the dedicated Chat SDK branch and routes through
+    // the same workspace-scoped Automation planner.
+    const dmTs = "1787292001.000821";
+    const dmResponse = await chat.webhooks.slack(
+      signedEventRequest(
+        slackEvent({
+          eventId: "Ev_GRID_DM_20260821",
+          channel: DM_ID,
+          channelType: "im",
+          ts: dmTs,
+          text: "LOBU_SLACK_E2E_20260821 integration dm",
+          user: "U_BURAK",
+        }),
+      ),
+    );
+    expect(dmResponse.status).toBe(200);
+    await waitFor(async () => {
+      const rows = await sql`
+        SELECT id FROM runs WHERE run_type = 'chat_message' ORDER BY id
+      `;
+      expect(rows).toHaveLength(2);
+    });
+    await waitFor(async () => {
+      const rows = await sql`
+        SELECT platform_message_id, team_id
+        FROM channel_messages
+        WHERE organization_id = 'org-slack-grid-e2e'
+          AND connection_id = ${RUNTIME_CONNECTION_ID}
+          AND channel_id = ${DM_ID}
+      `;
+      expect(rows).toEqual([
+        { platform_message_id: dmTs, team_id: WORKSPACE_TEAM_ID },
+      ]);
+    });
+
+    // The bot's own Slack echo is filtered by Chat SDK before the catch-all;
+    // another app's bot message is rejected by the bridge's loop guard.
+    for (const ownOrBot of [
+      slackEvent({
+        eventId: "Ev_GRID_SELF_20260821",
+        channel: CHANNEL_ID,
+        ts: "1787292002.000821",
+        text: "self echo",
+        user: BOT_USER_ID,
+      }),
+      slackEvent({
+        eventId: "Ev_GRID_OTHER_BOT_20260821",
+        channel: CHANNEL_ID,
+        ts: "1787292003.000821",
+        text: "another bot",
+        botId: "B_OTHER_APP",
+      }),
+    ]) {
+      const response = await chat.webhooks.slack(signedEventRequest(ownOrBot));
+      expect(response.status).toBe(200);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const afterBots = await sql`
+      SELECT id FROM runs WHERE run_type = 'chat_message'
+    `;
+    expect(afterBots).toHaveLength(2);
+
+    // Feed the authoritative terminal text into the real Slack transport. The
+    // only fake is chat.postMessage itself, Slack's external HTTP boundary.
+    const [channelRun] = await sql<{ action_input: Record<string, any> }[]>`
+      SELECT action_input
+      FROM runs
+      WHERE run_type = 'chat_message'
+      ORDER BY id
+      LIMIT 1
+    `;
+    if (!channelRun) throw new Error("Channel agent turn was not queued");
+    expect(channelRun.action_input.channelId).toBe(`slack:${CHANNEL_ID}`);
+    const postMessage = mock(async () => ({ ok: true }));
+    await getResponseStrategy("slack").handleCompletion({
+      ctx: {
+        connectionId: RUNTIME_CONNECTION_ID,
+        platform: "slack",
+        channelId: String(channelRun.action_input.channelId),
+        instance: {
+          chat: {
+            getAdapter: () => ({ client: { chat: { postMessage } } }),
+          },
+        },
+      },
+      payload: {
+        messageId: String(channelRun.action_input.messageId),
+        channelId: String(channelRun.action_input.channelId),
+        conversationId: String(channelRun.action_input.conversationId),
+        userId: String(channelRun.action_input.userId),
+        teamId: WORKSPACE_TEAM_ID,
+        platform: "slack",
+        timestamp: Date.now(),
+        finalText: "ACK_LOBU_SLACK_E2E_20260821 integration channel",
+      },
+      stream: null,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0]?.[0]).toMatchObject({
+      channel: CHANNEL_ID,
+      thread_ts: channelTs,
+      markdown_text: "ACK_LOBU_SLACK_E2E_20260821 integration channel",
+    });
+
+    // The connection is enterprise-scoped (`external_tenant_id` = E…), but
+    // routing and durable state must retain the real workspace T id. An E id
+    // in either place would cross the Grid boundary.
+    const teamStamps = await sql<{ team_id: string }[]>`
+      SELECT DISTINCT team_id
+      FROM channel_messages
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND connection_id = ${RUNTIME_CONNECTION_ID}
+    `;
+    expect(teamStamps).toEqual([{ team_id: WORKSPACE_TEAM_ID }]);
+    const runStamps = await sql<{ action_input: Record<string, any> }[]>`
+      SELECT action_input FROM runs WHERE run_type = 'chat_message'
+    `;
+    for (const row of runStamps) {
+      expect(row.action_input.platformMetadata.teamId).toBe(WORKSPACE_TEAM_ID);
+    }
+  });
+});

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -440,6 +440,21 @@ export function registerMessageHandlers(
     await handler.handleMessage(thread, message, "subscribed");
   });
 
+  // Chat SDK subscriptions are thread-scoped. Slack gives every top-level
+  // channel message a fresh thread id (`slack:C…:<message-ts>`), so an
+  // Automation linked to the CHANNEL can never pre-subscribe the ids of future
+  // messages. Those ordinary `message.channels` events therefore fall through
+  // the SDK's mention/DM/subscribed branches into its pattern handlers. The
+  // SDK routes subscribed → mention → patterns and returns at the first match,
+  // so this catch-all only ever sees events the branches above declined; it
+  // cannot double-dispatch a mention. Admit only channels that already have a
+  // durable message Automation — unlinked channels stay silent.
+  if (connection.platform === "slack") {
+    chat.onNewMessage(/[\s\S]*/, async (thread: any, message: any) => {
+      await handler.handleUnmatchedChannelMessage(thread, message);
+    });
+  }
+
   return handler;
 }
 
@@ -468,6 +483,44 @@ export class MessageHandlerBridge {
     return (
       this.manager.getInstance(this.connection.id)?.conversationState ?? null
     );
+  }
+
+  /**
+   * Route an ordinary channel message that Chat SDK could not classify as a
+   * DM, mention, or subscribed THREAD. Lobu's chat-link contract is
+   * channel-scoped, so the canonical Automation subscription is the admission
+   * check. Trigger filters (team, mention_only, and so on) remain authoritative
+   * in {@link handleMessage}; this method only decides whether the otherwise
+   * unmatched event is worth sending through that planner.
+   */
+  async handleUnmatchedChannelMessage(
+    thread: { id: string; channelId: string },
+    message: { author?: { isBot?: boolean | "unknown"; isMe?: boolean } },
+  ): Promise<void> {
+    // The catch-all pattern sees bot-authored channel events too. Chat SDK
+    // already suppresses this installation's own posts before dispatch, but
+    // rejecting every bot author here also prevents two apps from answering
+    // each other forever in a linked channel.
+    if (message.author?.isBot === true || message.author?.isMe === true) return;
+
+    const organizationId = this.connection.organizationId;
+    const subscriptions = this.services.getAutomationSubscriptionService();
+    if (!organizationId || !subscriptions) return;
+
+    // `thread.channelId` is the adapter's `channelIdFromThreadId(thread.id)` —
+    // for Slack, `slack:C…`, which the subscription reader normalizes to the
+    // native `C…`. Never fall back to `thread.id`: a top-level Slack message's
+    // thread id is `slack:C…:<ts>`, and that reader strips only one prefix
+    // segment, so the lookup key would become `C…:<ts>` and match nothing.
+    const linked = await subscriptions.channelHasMessageSubscription(
+      this.connection.id,
+      thread.channelId,
+      organizationId,
+      this.connection.settings?.previewMode === true,
+    );
+    if (!linked) return;
+
+    await this.handleMessage(thread, message, "subscribed");
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix ordinary Slack channel events never reaching channel-linked Automations. Chat SDK subscriptions are thread-scoped, while every top-level Slack message has a new `slack:C…:<ts>` thread id.
- Add a Slack-only catch-all that admits only channels with a durable, org-scoped message Automation, then delegates to the existing team-aware trigger planner. Unlinked channels remain silent.
- Reject bot-authored catch-all messages, while retaining the SDK self-message filter and retry dedupe.

## Test plan

- [x] Intended files staged explicitly and `make pre-pr` clean
- [x] Targeted tests and relevant integration suites run
- [x] Bug fix red → green outputs reproduced
- [x] Bot runtime path covered by an assembled signed-webhook integration test

Red: `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts` failed because no unmatched channel handler was registered (`received: undefined`). The first assembled attempt also failed at runtime on the incorrect `onMessage` API, pinning the real SDK seam as `onNewMessage`.

Green:

- `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts` — 68 pass
- `bun test packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts` — 1 pass
- `bun test packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts` — 24 pass
- `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts packages/server/src/gateway/__tests__/slack-completion-delivery.test.ts` — 72 pass
- `bun test packages/server/src/gateway/__tests__/` during review-fix — 1885 pass, 2 skip
- `make pre-pr` — clean

The assembled test uses a real signed Slack Events API request, Chat SDK dispatch, Automation subscription reader/planner, Postgres transcript state, Postgres `chat_message` run queue, retry marker, DM branch, self/other-bot loop guards, and Slack response strategy. Slack network calls are the only faked boundary. It explicitly stores and routes workspace `T…` while the managed connection metadata is enterprise `E…`.

## Notes

No schema, public API, SDK, connector contract, UI, or generic runner changes.