### PR TITLE
fix(automation): fail fast on OpenCode quota waits

### DIFF
--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -29,6 +29,9 @@ const fakeBinary = path.join(tmp, 'pi');
 const heartbeatConflictBinary = path.join(tmp, 'pi-heartbeat-conflict');
 const heartbeatConflictGrandchildBinary = path.join(tmp, 'pi-heartbeat-grandchild');
 const transientHeartbeatBinary = path.join(tmp, 'pi-transient-heartbeat');
+const openCodeQuotaBinary = path.join(tmp, 'opencode-quota-stall');
+const openCodeGenericErrorBinary = path.join(tmp, 'opencode-generic-error-stall');
+const openCodeQuotaThenExitBinary = path.join(tmp, 'opencode-quota-then-exit');
 const argsLog = path.join(tmp, 'args.log');
 const heartbeatConflictPid = path.join(tmp, 'heartbeat-conflict.pid');
 const heartbeatConflictTerminated = path.join(tmp, 'heartbeat-conflict-terminated.log');
@@ -67,6 +70,16 @@ function automationJob(): PollResponse {
       context: { device: { worker_id: 'wrk_1' }, user: { user_id: 'usr_1' } },
     },
   };
+}
+
+function openCodeAutomationJob(): PollResponse {
+  const job = automationJob();
+  if (!job.payload) throw new Error('automation test payload missing');
+  job.payload.automation.agent_kind = 'opencode';
+  job.payload.automation.execution_config = {
+    model: 'opencode-go/deepseek-v4-flash',
+  };
+  return job;
 }
 
 let server: http.Server;
@@ -202,6 +215,21 @@ beforeAll(async () => {
     `#!/usr/bin/env node\nsetTimeout(() => {\n  process.stdout.write('TRANSIENT_HEARTBEAT_OUTPUT');\n  process.exit(0);\n}, 150);\n`
   );
   chmodSync(transientHeartbeatBinary, 0o755);
+  writeFileSync(
+    openCodeQuotaBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nif (process.env.FAKE_CLI_PID_LOG) fs.appendFileSync(process.env.FAKE_CLI_PID_LOG, process.pid + '\\n');\nif (process.env.FAKE_CLI_LOG) fs.appendFileSync(process.env.FAKE_CLI_LOG, process.argv.slice(2).join('\\n') + '\\n');\nconsole.error('timestamp=2026-08-21T04:25:04.987Z level=ERROR run=389ea1b7 message="stream error" providerID=opencode-go modelID=deepseek-v4-flash error.error="AI_APICallError: Monthly usage limit reached. Resets in 14 days. To continue using this model now, enable usage from your available balance"');\nsetTimeout(() => {\n  if (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\n}, 100);\nprocess.on('SIGTERM', () => {\n  if (process.env.FAKE_CLI_TERMINATED) fs.writeFileSync(process.env.FAKE_CLI_TERMINATED, 'SIGTERM');\n  process.exit(0);\n});\nsetInterval(() => {}, 1000);\n`
+  );
+  chmodSync(openCodeQuotaBinary, 0o755);
+  writeFileSync(
+    openCodeGenericErrorBinary,
+    `#!/usr/bin/env node\nconst fs = require('node:fs');\nconsole.error('timestamp=2026-08-21T04:25:04.987Z level=ERROR run=389ea1b7 message="stream error" providerID=opencode-go modelID=deepseek-v4-flash error.error="AI_APICallError: Provider service temporarily unavailable"');\nif (process.env.FAKE_CLI_PID) fs.writeFileSync(process.env.FAKE_CLI_PID, String(process.pid));\nsetInterval(() => {}, 1000);\n`
+  );
+  chmodSync(openCodeGenericErrorBinary, 0o755);
+  writeFileSync(
+    openCodeQuotaThenExitBinary,
+    `#!/usr/bin/env node\nconsole.error('timestamp=2026-08-21T04:25:04.987Z level=ERROR run=389ea1b7 message="stream error" providerID=opencode-go modelID=deepseek-v4-flash error.error="AI_APICallError: Monthly usage limit reached. Resets in 14 days."');\nsetTimeout(() => {\n  process.stdout.write('RECOVERED_AND_SUCCEEDED');\n  process.exit(0);\n}, 400);\n`
+  );
+  chmodSync(openCodeQuotaThenExitBinary, 0o755);
   writeFileSync(
     parentLossHarness,
     `const fs = require('node:fs');\nconst { spawn } = require('node:child_process');\nconst supervisor = spawn(process.execPath, ['-e', ${JSON.stringify(CLI_SUPERVISOR_SOURCE)}, '--', process.env.FAKE_CLI_BINARY], { detached: true, env: process.env, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });\nfs.writeFileSync(process.env.FAKE_CLI_SUPERVISOR_PID_FILE, String(supervisor.pid));\nconst deadline = Date.now() + 3000;\nconst ready = setInterval(() => {\n  if (fs.existsSync(process.env.FAKE_CLI_PID) && fs.existsSync(process.env.FAKE_CLI_GRANDCHILD_PID)) {\n    clearInterval(ready);\n    process.exit(0);\n  }\n  if (Date.now() >= deadline) process.exit(2);\n}, 25);\n`
@@ -689,6 +717,93 @@ describe('automation arm failure diagnosis', () => {
     expect(completions[0].body.exit_reason).toBe('error_message');
     expect(completions[0].body.error).toContain('Credit balance is too low');
   });
+
+  test('terminates an OpenCode account-limit retry instead of waiting for the outer timeout', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const quotaStall = cfg();
+    quotaStall.timeoutMs = 8000;
+    quotaStall.binaryOverrides = { opencode: openCodeQuotaBinary };
+
+    const startedAt = Date.now();
+    await executeAutomationRun(client(), openCodeAutomationJob(), quotaStall);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('error_message');
+    expect(completions[0].body.error).toContain(
+      'Monthly usage limit reached. Resets in 14 days.'
+    );
+    expect(completions[0].body.error).not.toContain('timeout');
+    expect(readArgsLog()).toContain('--print-logs');
+    expect(readArgsLog()).toContain('ERROR');
+    expect(readFileSync(heartbeatConflictTerminated, 'utf8')).toBe('SIGTERM');
+    const childPid = Number(readFileSync(heartbeatConflictPid, 'utf8'));
+    expect(() => process.kill(childPid, 0)).toThrow();
+    // The fixture's outer deadline plus tree cleanup is ~11s on current main.
+    expect(elapsedMs).toBeLessThan(6000);
+  }, 20_000);
+
+  test('leaves generic OpenCode stream retries on the normal timeout path', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const genericStall = cfg();
+    // Long enough that process spawn cannot beat the deadline: the fixture must
+    // actually have written its stderr line for the assertion below to mean
+    // anything. At 300ms this raced spawn latency and failed under suite load.
+    genericStall.timeoutMs = 2000;
+    genericStall.binaryOverrides = { opencode: openCodeGenericErrorBinary };
+
+    await executeAutomationRun(client(), openCodeAutomationJob(), genericStall);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('timeout');
+    expect(completions[0].body.error).toContain('Provider service temporarily unavailable');
+    // The generic class must never take the diagnostic stop: no early kill.
+    expect(existsSync(heartbeatConflictTerminated)).toBe(false);
+  }, 15_000);
+
+  /**
+   * OpenCode logs the account-limit line and then recovers on its own. The
+   * diagnostic must not interrupt a CLI that is still making progress: killing
+   * it discarded the output it went on to produce and reported the successful
+   * run as `error_message` with an empty `output`.
+   */
+  test('keeps the real exit when the CLI logs an account limit and then succeeds', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const recovers = cfg();
+    recovers.timeoutMs = 8000;
+    recovers.binaryOverrides = { opencode: openCodeQuotaThenExitBinary };
+
+    await executeAutomationRun(client(), openCodeAutomationJob(), recovers);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('ok');
+    expect(completions[0].body.error).toBeFalsy();
+    expect(completions[0].body.output).toContain('RECOVERED_AND_SUCCEEDED');
+  }, 20_000);
+
+  test('a server cancellation wins when it races the OpenCode account-limit stop', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    heartbeatStatus = 409;
+    heartbeatReadyFiles = [heartbeatConflictPid];
+    const conflict = cfg();
+    conflict.heartbeatIntervalMs = 10;
+    conflict.timeoutMs = 8000;
+    conflict.terminalHeartbeatGraceMs = 100;
+    conflict.binaryOverrides = { opencode: openCodeQuotaBinary };
+
+    const result = await executeAutomationRun(client(), openCodeAutomationJob(), conflict);
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    expect(heartbeatRequests).toBeGreaterThan(0);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].body.exit_reason).toBe('ok');
+    expect(completions[0].body.error).toBeFalsy();
+    expect(readFileSync(heartbeatConflictTerminated, 'utf8')).toBe('SIGTERM');
+  }, 15_000);
 });
 
 /**

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -294,6 +294,8 @@ describe('buildArguments (ported AgentSpec table)', () => {
   test('opencode: positional after `run`, model flag is `-m`', () => {
     const args = buildArguments(opencode, 'the prompt', { model: 'gpt-5' }, [], 600);
     expect(args[0]).toBe('run');
+    expect(args).toContain('--print-logs');
+    expect(args).toContain('ERROR');
     expect(args).toContain('-m');
     expect(args).toContain('gpt-5');
     expect(args.at(-1)).toBe('the prompt');

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -30,6 +30,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Readable } from 'node:stream';
+import { PROVIDER_BALANCE_EXHAUSTED } from '@lobu/core';
 import {
   type AgentKind,
   type AgentSpec,
@@ -42,6 +43,7 @@ import type {
   PollResponse,
   WorkerExitReason,
 } from '@lobu/core/contracts/worker/protocol';
+import { redactOutput } from '../executor/redact.js';
 import { locateBinary, searchDirs } from './agent-binaries.js';
 import {
   releaseSupervisor,
@@ -109,6 +111,17 @@ export interface ExecutorResult {
 
 const STDOUT_CAP = 4 * 1024 * 1024;
 const STDERR_CAP = 1 * 1024 * 1024;
+/** Rolling OpenCode diagnostics needed only until a terminal retry is found. */
+const OPENCODE_DIAGNOSTIC_CAP = 32 * 1024;
+/**
+ * How long the account-limit diagnostic must go unanswered before the run is
+ * interrupted. OpenCode logs the line and then sleeps for the provider's reset
+ * window, so silence is the actual stall signal. A CLI that writes anything
+ * further — or exits — inside this window was still making progress and keeps
+ * its own exit; without the window, a run that logged the line and recovered
+ * was killed and its output discarded.
+ */
+const OPENCODE_DIAGNOSTIC_SETTLE_MS = 1_500;
 const DEFAULT_TIMEOUT_MS = 600_000;
 /** Cap on the CLI-output tail folded into `runs.error_message`. */
 const DETAIL_TAIL_CHARS = 500;
@@ -164,6 +177,40 @@ function drain(stream: Readable, capBytes: number): Promise<{ data: Buffer; trun
     // `close` covers the forced-destroy path below, which emits neither.
     stream.on('close', settle);
   });
+}
+
+/**
+ * Extract the provider reason from OpenCode's structured error log, but only
+ * for deterministic account limits. Generic stream errors remain owned by the
+ * CLI and its own retry loop.
+ *
+ * The wording accepted here must stay a subset of what the server's
+ * `deviceProviderQuotaResetNotBefore` recognizes as quota evidence. Killing a
+ * run the server will not park just moves the same failure to the next cron
+ * tick, which is the waste this path exists to stop.
+ */
+function openCodeTerminalRetryDiagnostic(output: string): string | null {
+  const lines = output.split(/\r?\n/);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (!/\blevel=ERROR\b/.test(line) || !/\bmessage="stream error"/.test(line)) continue;
+    const encoded = line.match(/\berror\.error=("(?:\\.|[^"\\])*")/)?.[1];
+    if (!encoded) continue;
+
+    let detail: string;
+    try {
+      detail = JSON.parse(encoded);
+    } catch {
+      continue;
+    }
+    detail = detail.replace(/^AI_[A-Za-z]+Error:\s*/, '').trim();
+    const isTerminalAccountLimit =
+      PROVIDER_BALANCE_EXHAUSTED.test(detail) ||
+      (/\b(?:daily|weekly|monthly) usage limit reached\b/i.test(detail) &&
+        /\breset(?:s)?\s+in\s+\d+(?:\.\d+)?\s*(?:hours?|days?|weeks?)\b/i.test(detail));
+    if (isTerminalAccountLimit) return redactOutput(detail);
+  }
+  return null;
 }
 
 /**
@@ -371,13 +418,69 @@ async function runCli(
     const stdoutPromise = drain(stdout, STDOUT_CAP);
     const stderrPromise = drain(stderr, STDERR_CAP);
 
-    const initialExit = await waitForTargetExit(supervised.targetExit, timeoutMs, abortSignal);
+    // OpenCode can sleep for the provider's full account reset window and
+    // otherwise emits no headless progress. Observe its error-level diagnostic
+    // while the normal capped drain keeps collecting output, then interrupt
+    // only the deterministic account-limit class.
+    //
+    // The wait is aborted by two unrelated causes that end the run differently:
+    // the server's 409 is an intentional stop that keeps the graceful grace
+    // window and reports `ok`, while a diagnostic stop is a provider failure.
+    // `diagnosticStop` records which one fired, so a 409 that races a quota log
+    // is still handled as a cancellation.
+    let terminalDiagnostic: string | null = null;
+    let diagnosticStop = false;
+    let diagnosticBuffer = '';
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    const waitAbort = new AbortController();
+    const forwardAbort = () => waitAbort.abort();
+    abortSignal?.addEventListener('abort', forwardAbort, { once: true });
+    if (abortSignal?.aborted) forwardAbort();
+    const observeDiagnostic = (chunk: Buffer | string) => {
+      // Any stderr byte after the diagnostic is progress: cancel the pending
+      // stop, then re-arm only while the rolling diagnostics still contain the
+      // account-limit reason.
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+        settleTimer = undefined;
+      }
+      diagnosticBuffer = (diagnosticBuffer + chunk.toString()).slice(-OPENCODE_DIAGNOSTIC_CAP);
+      terminalDiagnostic = openCodeTerminalRetryDiagnostic(diagnosticBuffer);
+      if (!terminalDiagnostic || abortSignal?.aborted) return;
+      settleTimer = setTimeout(() => {
+        if (abortSignal?.aborted) return;
+        diagnosticStop = true;
+        waitAbort.abort();
+      }, OPENCODE_DIAGNOSTIC_SETTLE_MS);
+      settleTimer.unref?.();
+    };
+    const initialExit = await (async () => {
+      if (spec.kind === 'opencode') stderr.on('data', observeDiagnostic);
+      try {
+        return await waitForTargetExit(supervised.targetExit, timeoutMs, waitAbort.signal);
+      } finally {
+        stderr.off('data', observeDiagnostic);
+        if (settleTimer) clearTimeout(settleTimer);
+        abortSignal?.removeEventListener('abort', forwardAbort);
+      }
+    })();
     const { timedOut, aborted } = initialExit;
     let target = initialExit.target;
     let cancelled = false;
     let killedSignal: string | null = null;
     let cleanupSignal: string | null = null;
-    if (aborted) {
+    let diagnosticSignal: string | null = null;
+    // Authoritative: the wait must actually have been aborted BY the diagnostic.
+    // A late stderr chunk can set `diagnosticStop` after the target already
+    // exited on its own, and that run keeps its real exit.
+    const diagnosticInterrupted = aborted && diagnosticStop && terminalDiagnostic != null;
+    if (diagnosticInterrupted) {
+      const treeSignal = await terminateChild(proc);
+      supervisorSettled = true;
+      target =
+        (await waitForTargetExitAfterTermination(supervised.targetExit)) ?? undefined;
+      diagnosticSignal = target && target.signalCode !== 'SIGKILL' ? 'SIGTERM' : treeSignal;
+    } else if (aborted) {
       // A 409 is also the normal post-complete_window state. Let a CLI that is
       // already winding down exit and report its device-side metadata. The
       // supervisor remains the non-reusable tree owner throughout the grace,
@@ -408,7 +511,12 @@ async function runCli(
 
     // A SIGKILLed child gets a short flush window; a clean exit gets a long one.
     const drainDeadlineMs =
-      cancelled || killedSignal === 'SIGKILL' || cleanupSignal === 'SIGKILL' ? 2000 : 60_000;
+      cancelled ||
+      killedSignal === 'SIGKILL' ||
+      cleanupSignal === 'SIGKILL' ||
+      diagnosticSignal === 'SIGKILL'
+        ? 2000
+        : 60_000;
     // Both pipes must race the SAME clock. Awaiting them in sequence gave
     // stderr a fresh deadline only after stdout's had expired, so a grandchild
     // holding both ends cost 2x the deadline (measured: 120s for a child that
@@ -427,6 +535,7 @@ async function runCli(
     // Once the target exits, cleanupSignal belongs only to its supervisor or
     // descendants and must not overwrite the target's own exit metadata.
     const exitSignal =
+      diagnosticSignal ??
       killedSignal ??
       (cancelled ? cleanupSignal : null) ??
       (targetSignal != null ? `signal:${targetSignal}` : null);
@@ -448,7 +557,13 @@ async function runCli(
       target?.error ||
       ''
     ).slice(-DETAIL_TAIL_CHARS);
-    if (cancelled) {
+    if (diagnosticInterrupted) {
+      // Only the diagnostic-interrupted run is reclassified. A CLI that logged
+      // the same line and then exited on its own — recovering, or failing for
+      // another reason — keeps the exit it actually reported.
+      exitReason = 'error_message';
+      errorMessage = `${label} provider error: ${terminalDiagnostic}`;
+    } else if (cancelled) {
       // The server owns the terminal outcome, but complete-automation remains
       // terminal-safe so it can retain device provenance and duration. Report
       // this intentional local stop as clean instead of inventing a failure.

--- a/packages/core/src/contracts/worker/device-automation.ts
+++ b/packages/core/src/contracts/worker/device-automation.ts
@@ -118,7 +118,12 @@ export const DEVICE_AGENT_SPECS: readonly AgentSpec[] = [
       kind: "opencode-config-env",
       variable: "OPENCODE_CONFIG_CONTENT",
     },
-    headlessArgs: ["--auto"],
+    // OpenCode retries a provider account limit whose reset window is far
+    // longer than an Automation's wall-clock budget (600s by default). Its
+    // error-level log is the only headless signal it emits while waiting, so
+    // the connector-worker supervisor reads it to end deterministic
+    // account-limit waits instead of burning the whole budget.
+    headlessArgs: ["--auto", "--print-logs", "--log-level", "ERROR"],
     modelFlag: "-m",
     effortFlag: "--variant",
     permissionModeFlag: null,

--- a/packages/server/src/__tests__/integration/automations/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/automations/failed-run-advances-schedule.test.ts
@@ -243,6 +243,31 @@ describe("provider quota reset parsing", () => {
     ).toBe("2026-08-05T12:01:00.000Z");
   });
 
+  it("honors OpenCode Go's relative account-limit reset", () => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+    const message =
+      "Monthly usage limit reached. Resets in 14 days. " +
+      "To continue using this model now, enable usage from your available balance";
+
+    expect(
+      deviceProviderQuotaResetNotBefore(message, now)?.toISOString()
+    ).toBe("2026-08-19T10:01:00.000Z");
+  });
+
+  // A CLI's own limits reuse the "limit reached" phrasing but are not provider
+  // quota, and a relative "resets in" would otherwise park a durable schedule
+  // for hours or days on a run that should simply retry next tick.
+  it.each([
+    "Context limit reached. Please start a new session.",
+    "Session limit reached. Resets in 5 hours.",
+    "Tool call limit reached after 50 iterations",
+    "File size limit reached, resets in 2 days",
+  ])("does not park a non-quota CLI limit (%s)", (message) => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+
+    expect(deviceProviderQuotaResetNotBefore(message, now)).toBeNull();
+  });
+
   it.each([
     "Gemini returned an error: 429 status code (no body)",
     "429 Too Many Requests",

--- a/packages/server/src/__tests__/integration/automations/schedule-skip-unchanged.test.ts
+++ b/packages/server/src/__tests__/integration/automations/schedule-skip-unchanged.test.ts
@@ -68,11 +68,18 @@ describe("scheduled Automation unchanged gate", () => {
 		});
 		const runs = await sql`
 			SELECT id, approved_input->>'window_start' AS window_start,
-			       approved_input->>'window_end' AS window_end, run_metadata
+			       approved_input->>'window_end' AS window_end, run_metadata,
+			       action_output, output_tail, outcome, status
 			FROM runs
 			WHERE automation_id = ${automationId} AND run_type = 'automation'
 		`;
 		expect(runs).toHaveLength(1);
+		expect(runs[0]).toMatchObject({
+			status: "completed",
+			outcome: "scoreable",
+			action_output: {},
+			output_tail: "No-op: scheduled source content is unchanged.",
+		});
 		expect(runs[0].run_metadata).toMatchObject({
 			content_analyzed: 0,
 			skipped_unchanged: true,

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -294,11 +294,15 @@ async function completeSkippedAutomationRun(
 	runId: number,
 	granularity: AutomationTimeGranularity,
 ): Promise<void> {
+	// A server-side skip has no child stdout. Preserve the historical `{}`
+	// action_output for consumers, while output_tail makes the terminal no-op
+	// intentional to humans and run_metadata remains the machine-readable signal.
 	await sql`
 		UPDATE runs
 		SET status = 'completed',
 		    outcome = ${classifyRunOutcome({ status: "completed" })},
 		    action_output = '{}'::jsonb,
+		    output_tail = 'No-op: scheduled source content is unchanged.',
 		    approved_input = COALESCE(approved_input, '{}'::jsonb)
 		      || jsonb_build_object('granularity', ${granularity}::text),
 		    run_metadata = COALESCE(run_metadata, '{}'::jsonb)

--- a/packages/server/src/automations/schedule-cursor.ts
+++ b/packages/server/src/automations/schedule-cursor.ts
@@ -6,6 +6,7 @@ import logger from "../utils/logger";
 const PROVIDER_RESET_GRACE_MS = 60_000;
 const PROVIDER_RETRY_GRACE_MS = 1_000;
 const PROVIDER_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+const PROVIDER_RELATIVE_RESET_MAX_MS = 90 * 24 * 60 * 60 * 1000;
 
 /**
  * Extract the reset timestamp from provider quota errors such as:
@@ -160,6 +161,35 @@ export function parseProviderRetryAfter(
 }
 
 /**
+ * Extract a long account-window boundary such as OpenCode Go's
+ * "Monthly usage limit reached. Resets in 14 days." These are not transient
+ * Retry-After delays: they exceed an Automation's process budget and should
+ * park the cron cursor until the provider says the account window resets.
+ */
+function parseProviderQuotaResetIn(
+	message: string,
+	now: Date = new Date()
+): Date | null {
+	const match = message.match(
+		/\breset(?:s)?\s+in\s+(\d+(?:\.\d+)?)\s*(hours?|days?|weeks?)\b/i
+	);
+	if (!match) return null;
+	const value = Number(match[1]);
+	if (!Number.isFinite(value) || value <= 0) return null;
+	const unit = match[2].toLowerCase();
+	const unitMs = unit.startsWith("week")
+		? 7 * 24 * 60 * 60 * 1000
+		: unit.startsWith("day")
+			? 24 * 60 * 60 * 1000
+			: 60 * 60 * 1000;
+	const delayMs = value * unitMs;
+	if (!Number.isFinite(delayMs) || delayMs > PROVIDER_RELATIVE_RESET_MAX_MS) {
+		return null;
+	}
+	return new Date(now.getTime() + delayMs + PROVIDER_RESET_GRACE_MS);
+}
+
+/**
  * How long a depleted balance parks a schedule.
  *
  * A depleted balance is not a rate limit: it does not tick back on a timer, so
@@ -239,15 +269,21 @@ export function deviceProviderQuotaResetNotBefore(
 	// Balance wording is quota evidence by definition; composing the matchers
 	// keeps them in lockstep so a new balance alternate cannot silently fail to
 	// park on this path.
+	// "limit reached" is qualified by `usage`: OpenCode Go reports an account
+	// window as "Monthly usage limit reached", while a CLI's own "context limit
+	// reached" / "session limit reached" / "tool call limit reached" are not
+	// provider quota and must not park a durable schedule — the same hazard the
+	// doc comment above names for "session resets at ...".
 	const hasQuotaEvidence =
 		PROVIDER_BALANCE_EXHAUSTED.test(message) ||
-		/limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
+		/limit exhausted|usage limit reached|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
 			message
 		);
 	if (!hasQuotaEvidence) return null;
 	return (
 		parseProviderQuotaResetAt(message, now) ??
 		parseProviderRetryAfter(message, now) ??
+		parseProviderQuotaResetIn(message, now) ??
 		balanceExhaustedNotBefore(message, now)
 	);
 }


### PR DESCRIPTION
## Summary
- expose OpenCode error diagnostics in headless mode and terminate only deterministic provider account-limit stalls, with recovery and cancellation race guards
- park device Automation schedules through provider-reported relative reset windows without changing chat/server-model paths
- preserve `{}` action output compatibility for unchanged schedules while recording an explicit scoreable no-op terminal message

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Targeted core, connector-worker, and DB-backed Automation tests
- [x] Bug fix: red→fix→green outputs pasted below

Red evidence:
- real subprocess boundary: 16 passed / 1 failed; quota fixture consumed the 8s outer deadline plus cleanup (11.0s) and reported `timeout` instead of `error_message`
- scheduled no-op integration: `output_tail` was null instead of an intentional outcome
- OpenCode reset parser: returned no boundary for `Monthly usage limit reached. Resets in 14 days.`

Green evidence:
- connector-worker process boundary: 20 passed, including quota stall (4.86s), recovery, generic-error timeout, 409 race, and dead-process cleanup
- connector-worker relevant suite: 57 passed before review-fix; fixer full package run: 183 passed
- server Automation integration: 89 passed locally; fixer Automation suite: 354 passed across 41 files
- core AgentSpec: 17 passed
- `make pre-pr`: all 7 gates clean

## Notes
- Root cause: OpenCode 1.18.19 treats OpenCode Go monthly quota errors as retryable and honors the provider reset delay, so it sleeps for 14 days while Lobu heartbeats correctly until the 600s outer timeout kills it. Prompt delivery, headless mode, MCP/plugins, parsing, and heartbeat were excluded by direct plugin-free reproduction and an OpenAI control.
- Historical `Run missing connector_key for run_type=automation` does not reproduce on current main; no speculative connector-key patch is included.
- Automation 71 has a bounded prompt/source window; no production Automation configuration is changed by this PR.