### PR TITLE
fix(server): persist and verify media artifacts

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-resign.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-resign.test.ts
@@ -3,6 +3,8 @@ import { resignFileRefs } from "../routes/public/agent-history.js";
 import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
 
 const BASE = "http://localhost:8954/lobu";
+const ARTIFACT_ID = "11111111-1111-4111-8111-111111111111";
+const NESTED_ARTIFACT_ID = "22222222-2222-4222-8222-222222222222";
 
 describe("resignFileRefs", () => {
 	let env: ArtifactTestEnv;
@@ -15,7 +17,7 @@ describe("resignFileRefs", () => {
 
 	test("rewrites a tokenless artifact ref into a fresh signed absolute URL", () => {
 		const out = resignFileRefs(
-			"See [report.pdf](/api/v1/files/abc123)",
+			`See [report.pdf](/api/v1/files/${ARTIFACT_ID})`,
 			env.artifactStore,
 			BASE,
 		) as string;
@@ -24,22 +26,22 @@ describe("resignFileRefs", () => {
 		const match = out.match(/\((https?:\/\/[^)]+)\)/);
 		expect(match).toBeTruthy();
 		const url = new URL(match?.[1] as string);
-		expect(url.pathname).toBe("/lobu/api/v1/files/abc123");
+		expect(url.pathname).toBe(`/lobu/api/v1/files/${ARTIFACT_ID}`);
 		const token = url.searchParams.get("token");
 		expect(token).toBeTruthy();
 		expect(
-			env.artifactStore.validateDownloadToken(token as string, "abc123").valid,
+			env.artifactStore.validateDownloadToken(token as string, ARTIFACT_ID).valid,
 		).toBe(true);
 	});
 
 	test("walks nested content arrays and text parts", () => {
 		const out = resignFileRefs(
-			[{ type: "text", text: "[a.csv](/api/v1/files/xyz)" }],
+			[{ type: "text", text: `[a.csv](/api/v1/files/${NESTED_ARTIFACT_ID})` }],
 			env.artifactStore,
 			BASE,
 		) as Array<{ text: string }>;
 		expect(out[0].text).toContain("token=");
-		expect(out[0].text).toContain("/lobu/api/v1/files/xyz");
+		expect(out[0].text).toContain(`/lobu/api/v1/files/${NESTED_ARTIFACT_ID}`);
 	});
 
 	test("leaves non-artifact text and already-signed links untouched", () => {

--- a/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
+++ b/packages/server/src/gateway/__tests__/artifact-store-download-url.test.ts
@@ -1,5 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { runArtifactBinding } from "../files/artifact-store.js";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import { join } from "node:path";
+import {
+  ArtifactStorageError,
+  ArtifactStore,
+  runArtifactBinding,
+} from "../files/artifact-store.js";
 import { type ArtifactTestEnv, createArtifactTestEnv } from "./setup.js";
 
 describe("ArtifactStore.buildDownloadUrl", () => {
@@ -43,6 +50,15 @@ describe("ArtifactStore.buildDownloadUrl", () => {
     expect(new URL(url).pathname).toBe("/lobu/api/v1/files/artifact-789");
   });
 
+  test("rejects oversized download tokens before decryption", () => {
+    expect(
+      env.artifactStore.validateDownloadToken(
+        "x".repeat(4097),
+        "00000000-0000-4000-8000-000000000001",
+      ),
+    ).toEqual({ valid: false, error: "malformed" });
+  });
+
   test("round-trips: a published artifact is served from its own URL path", async () => {
     const { artifactId, downloadUrl } = await env.artifactStore.publish({
       buffer: Buffer.from("hello world"),
@@ -73,10 +89,272 @@ describe("ArtifactStore.buildDownloadUrl", () => {
 
     expect(await env.artifactStore.read(artifactId, { binding })).toBeTruthy();
     expect(
-      await env.artifactStore.read(artifactId, { binding: runArtifactBinding(43) })
+      await env.artifactStore.read(artifactId, {
+        binding: runArtifactBinding(43),
+      }),
+    ).toBeNull();
+
+    const freshUrl = await env.artifactStore.mintBoundDownloadUrl({
+      artifactId,
+      binding,
+      publicGatewayUrl: "https://lobu.example.com/lobu",
+    });
+    expect(freshUrl).not.toBeNull();
+    expect(new URL(freshUrl as string).pathname).toBe(
+      `/lobu/api/v1/files/${artifactId}`,
+    );
+    expect(
+      await env.artifactStore.mintBoundDownloadUrl({
+        artifactId,
+        binding: runArtifactBinding(43),
+        publicGatewayUrl: "https://lobu.example.com/lobu",
+      }),
     ).toBeNull();
 
     await env.artifactStore.delete(artifactId);
     expect(await env.artifactStore.read(artifactId)).toBeNull();
+  });
+});
+
+describe("ArtifactStore durable filesystem backend", () => {
+  let env: ArtifactTestEnv;
+
+  beforeEach(() => {
+    env = createArtifactTestEnv();
+  });
+
+  afterEach(() => env.cleanup());
+
+  test("fails closed when production has no durable artifacts directory", () => {
+    const previousEnvironment = process.env.ENVIRONMENT;
+    const previousArtifactsDir = process.env.LOBU_ARTIFACTS_DIR;
+    try {
+      process.env.ENVIRONMENT = "production";
+      delete process.env.LOBU_ARTIFACTS_DIR;
+      expect(() => new ArtifactStore()).toThrow(
+        "Production artifact storage requires LOBU_ARTIFACTS_DIR on a durable mounted filesystem",
+      );
+    } finally {
+      if (previousEnvironment === undefined) delete process.env.ENVIRONMENT;
+      else process.env.ENVIRONMENT = previousEnvironment;
+      if (previousArtifactsDir === undefined)
+        delete process.env.LOBU_ARTIFACTS_DIR;
+      else process.env.LOBU_ARTIFACTS_DIR = previousArtifactsDir;
+    }
+  });
+
+  test("shares verified private artifacts across store instances", async () => {
+    const writer = new ArtifactStore(env.artifactsDir);
+    const reader = new ArtifactStore(env.artifactsDir);
+    const binding = runArtifactBinding(314);
+    const bytes = Buffer.from("shared-image-bytes");
+
+    const published = await writer.publish({
+      buffer: bytes,
+      filename: "mémory photo.webp",
+      contentType: "image/webp",
+      publicGatewayUrl: "https://lobu.example.com",
+      binding,
+    });
+
+    expect(
+      await reader.read(published.artifactId, {
+        binding,
+        maxBytes: bytes.length - 1,
+      }),
+    ).toBeNull();
+    expect(
+      await reader.read(published.artifactId, {
+        binding: runArtifactBinding(315),
+      }),
+    ).toBeNull();
+
+    // No `maxBytes` means "serve what was published" — the public download
+    // route relies on it, and no publish path caps upload size.
+    const unbounded = await reader.read(published.artifactId, { binding });
+    expect(unbounded?.bytes).toEqual(bytes);
+
+    const stored = await reader.read(published.artifactId, {
+      binding,
+      maxBytes: bytes.length,
+    });
+    expect(stored?.metadata).toEqual(
+      expect.objectContaining({
+        filename: "mémory photo.webp",
+        contentType: "image/webp",
+        size: bytes.length,
+        binding,
+        sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+    expect(stored?.bytes).toEqual(bytes);
+
+    await writer.delete(published.artifactId);
+    expect(await reader.read(published.artifactId)).toBeNull();
+  });
+
+  test("rejects metadata without the required checksum", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("verified-bytes"),
+      filename: "verified.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+      binding: runArtifactBinding(314),
+    });
+    const metadataPath = join(
+      env.artifactsDir,
+      published.artifactId,
+      "metadata.json",
+    );
+    const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+    delete metadata.sha256;
+    await fs.writeFile(metadataPath, JSON.stringify(metadata));
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+    expect(
+      await env.artifactStore.mintBoundDownloadUrl({
+        artifactId: published.artifactId,
+        binding: runArtifactBinding(314),
+        publicGatewayUrl: "https://lobu.example.com",
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps reserved metadata filenames separate from payload bytes", async () => {
+    const bytes = Buffer.from("not artifact metadata");
+    const published = await env.artifactStore.publish({
+      buffer: bytes,
+      filename: "metadata.json",
+      contentType: "application/json",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+
+    const stored = await env.artifactStore.read(published.artifactId);
+    expect(stored?.metadata.filename).toBe("metadata.json");
+    expect(stored?.bytes).toEqual(bytes);
+  });
+
+  test("rejects artifact ids that can escape the configured directory", async () => {
+    expect(await env.artifactStore.read("../outside")).toBeNull();
+    await expect(
+      env.artifactStore.delete("../outside"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects oversized metadata before parsing it", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("small"),
+      filename: "small.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    await fs.writeFile(
+      join(env.artifactsDir, published.artifactId, "metadata.json"),
+      JSON.stringify({
+        artifactId: published.artifactId,
+        filename: "x".repeat(128 * 1024),
+        contentType: "text/plain",
+        size: 5,
+        createdAt: Date.now(),
+        sha256: createHash("sha256").update("small").digest("hex"),
+      }),
+    );
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+  });
+
+  test("does not follow a replacement symlink even when bytes match", async () => {
+    const bytes = Buffer.from("same-secret-bytes");
+    const published = await env.artifactStore.publish({
+      buffer: bytes,
+      filename: "safe.txt",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const outside = join(env.artifactsDir, "outside-secret");
+    await fs.writeFile(outside, bytes);
+    const payload = join(env.artifactsDir, published.artifactId, "content");
+    await fs.unlink(payload);
+    await fs.symlink(outside, payload);
+
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+  });
+
+  test("quarantines a failed delete and drains the leftover before another publish", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("abandoned"),
+      filename: "abandoned.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const realRm = fs.rm;
+    let failQuarantinedRemoval = true;
+    const rmSpy = spyOn(fs, "rm").mockImplementation(
+      async (target, options) => {
+        if (
+          failQuarantinedRemoval &&
+          String(target).includes(`${join(env.artifactsDir, ".trash")}/`)
+        ) {
+          failQuarantinedRemoval = false;
+          throw new Error("injected retained-PVC removal failure");
+        }
+        return realRm(target, options);
+      },
+    );
+
+    try {
+      const deletion = env.artifactStore.delete(published.artifactId);
+      await expect(deletion).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(deletion).rejects.toMatchObject({
+        code: "ARTIFACT_STORAGE_UNAVAILABLE",
+      });
+      await expect(deletion).rejects.not.toThrow(env.artifactsDir);
+    } finally {
+      rmSpy.mockRestore();
+    }
+    expect(await env.artifactStore.read(published.artifactId)).toBeNull();
+    const trashDir = join(env.artifactsDir, ".trash");
+    const [quarantined] = await fs.readdir(trashDir);
+    expect(quarantined).toContain(published.artifactId);
+
+    // A retained PVC has nothing else to reclaim the leftover. Publication
+    // cannot continue while known uncommitted bytes remain abandoned.
+    const next = await env.artifactStore.publish({
+      buffer: Buffer.from("next"),
+      filename: "next.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    expect(await fs.readdir(trashDir)).toEqual([]);
+
+    await env.artifactStore.delete(next.artifactId);
+    expect(await fs.readdir(trashDir)).toEqual([]);
+  });
+
+  test("fails closed when a quarantined orphan still cannot be removed", async () => {
+    const published = await env.artifactStore.publish({
+      buffer: Buffer.from("abandoned"),
+      filename: "abandoned.bin",
+      publicGatewayUrl: "https://lobu.example.com",
+    });
+    const realRm = fs.rm;
+    const rmSpy = spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (String(target).includes(`${join(env.artifactsDir, ".trash")}/`)) {
+        throw new Error("retained PVC remains unavailable");
+      }
+      return realRm(target, options);
+    });
+
+    try {
+      const deletion = env.artifactStore.delete(published.artifactId);
+      await expect(deletion).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(deletion).rejects.not.toThrow(env.artifactsDir);
+      const publication = env.artifactStore.publish({
+        buffer: Buffer.from("must-not-publish"),
+        filename: "blocked.bin",
+        publicGatewayUrl: "https://lobu.example.com",
+      });
+      await expect(publication).rejects.toBeInstanceOf(ArtifactStorageError);
+      await expect(publication).rejects.not.toThrow(env.artifactsDir);
+    } finally {
+      rmSpy.mockRestore();
+    }
+
+    expect(await fs.readdir(join(env.artifactsDir, ".trash"))).toHaveLength(1);
   });
 });

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -1,18 +1,19 @@
-import { randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, type Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import {
-	createLogger,
-	decrypt,
-	getErrorMessage,
-	encrypt,
-} from "@lobu/core";
+import { decrypt, encrypt, getErrorMessage } from "@lobu/core";
+import logger from "../../utils/logger";
 
-const logger = createLogger("artifact-store");
 const DEFAULT_ARTIFACTS_DIR = path.join(os.tmpdir(), "lobu-artifacts");
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const ARTIFACT_PAYLOAD_FILENAME = "content";
+const ARTIFACT_ID_PATTERN = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+const ARTIFACT_SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const ARTIFACT_METADATA_MAX_BYTES = 16 * 1024;
+const ARTIFACT_TRASH_DIRNAME = ".trash";
+const DOWNLOAD_TOKEN_MAX_CHARS = 4096;
 
 interface StoredArtifactMetadata {
   artifactId: string;
@@ -20,6 +21,7 @@ interface StoredArtifactMetadata {
   contentType: string;
   size: number;
   createdAt: number;
+  sha256: string;
   /** Immutable Lobu resource identity allowed to read this artifact internally. */
   binding?: string;
 }
@@ -30,6 +32,27 @@ interface PublishArtifactResult {
   size: number;
   contentType: string;
   downloadUrl: string;
+}
+
+export class ArtifactStorageError extends Error {
+  readonly code = "ARTIFACT_STORAGE_UNAVAILABLE";
+
+  constructor(operation: string, cause: unknown) {
+    super(
+      `Artifact storage ${operation} failed; operator intervention is required`,
+      { cause },
+    );
+    this.name = "ArtifactStorageError";
+  }
+}
+
+function storageFailure(
+  operation: string,
+  cause: unknown,
+): ArtifactStorageError {
+  if (cause instanceof ArtifactStorageError) return cause;
+  logger.error({ operation, error: cause }, "Artifact storage operation failed");
+  return new ArtifactStorageError(operation, cause);
 }
 
 function sanitizeFilename(filename: string): string {
@@ -64,23 +87,188 @@ function normalizeBaseUrl(publicGatewayUrl: string): string {
   return trimmed.replace(/\/$/, "");
 }
 
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function isStoredArtifactMetadata(
+  value: unknown,
+  artifactId: string,
+): value is StoredArtifactMetadata {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const metadata = value as Record<string, unknown>;
+  return (
+    metadata.artifactId === artifactId &&
+    typeof metadata.filename === "string" &&
+    metadata.filename.length > 0 &&
+    metadata.filename.length <= 1024 &&
+    typeof metadata.contentType === "string" &&
+    metadata.contentType.length > 0 &&
+    metadata.contentType.length <= 512 &&
+    typeof metadata.size === "number" &&
+    Number.isSafeInteger(metadata.size) &&
+    metadata.size >= 0 &&
+    typeof metadata.createdAt === "number" &&
+    Number.isFinite(metadata.createdAt) &&
+    typeof metadata.sha256 === "string" &&
+    ARTIFACT_SHA256_PATTERN.test(metadata.sha256) &&
+    (metadata.binding === undefined ||
+      (typeof metadata.binding === "string" && metadata.binding.length <= 2048))
+  );
+}
+
+/** Reads a regular file, refusing symlinks and anything over `maxBytes`. */
+async function readRegularFile(
+  filePath: string,
+  maxBytes?: number,
+): Promise<Buffer | null> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(
+      filePath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
+    const stat = await handle.stat();
+    if (!stat.isFile()) return null;
+    if (maxBytes !== undefined && stat.size > maxBytes) return null;
+    const buffer = Buffer.allocUnsafe(stat.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        offset,
+        buffer.length - offset,
+        offset,
+      );
+      if (bytesRead === 0) return null;
+      offset += bytesRead;
+    }
+    return buffer;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function resolveArtifactsDir(baseDir: string | undefined): string {
+  const configured = baseDir?.trim() || process.env.LOBU_ARTIFACTS_DIR?.trim();
+  if (configured) return configured;
+  if (process.env.ENVIRONMENT === "production") {
+    throw new Error(
+      "Production artifact storage requires LOBU_ARTIFACTS_DIR on a durable mounted filesystem",
+    );
+  }
+  return DEFAULT_ARTIFACTS_DIR;
+}
+
 export class ArtifactStore {
+  private readonly baseDir: string;
+
   constructor(
-    private readonly baseDir = process.env.LOBU_ARTIFACTS_DIR ||
-      DEFAULT_ARTIFACTS_DIR,
-    private readonly defaultTtlMs = DEFAULT_TTL_MS
-  ) {}
+    baseDir?: string,
+    private readonly defaultTtlMs = DEFAULT_TTL_MS,
+  ) {
+    this.baseDir = resolveArtifactsDir(baseDir);
+  }
 
   private artifactDir(artifactId: string): string {
     return path.join(this.baseDir, artifactId);
   }
 
-  private artifactFilePath(artifactId: string, filename: string): string {
-    return path.join(this.artifactDir(artifactId), sanitizeFilename(filename));
+  private artifactFilePath(artifactId: string): string {
+    return path.join(this.artifactDir(artifactId), ARTIFACT_PAYLOAD_FILENAME);
   }
 
   private metadataPath(artifactId: string): string {
     return path.join(this.artifactDir(artifactId), "metadata.json");
+  }
+
+  private async readMetadataRecord(
+    artifactId: string,
+  ): Promise<{ metadata: StoredArtifactMetadata; dirStat: Stats } | null> {
+    if (!ARTIFACT_ID_PATTERN.test(artifactId)) return null;
+    try {
+      const dirStat = await fs.lstat(this.artifactDir(artifactId));
+      if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return null;
+      const raw = await readRegularFile(
+        this.metadataPath(artifactId),
+        ARTIFACT_METADATA_MAX_BYTES,
+      );
+      if (!raw) return null;
+      const parsed = JSON.parse(raw.toString("utf8")) as unknown;
+      if (!isStoredArtifactMetadata(parsed, artifactId)) return null;
+      return { metadata: parsed, dirStat };
+    } catch {
+      return null;
+    }
+  }
+
+  private async directoryIsUnchanged(
+    artifactId: string,
+    initial: Stats,
+  ): Promise<boolean> {
+    try {
+      const final = await fs.lstat(this.artifactDir(artifactId));
+      return (
+        final.isDirectory() &&
+        !final.isSymbolicLink() &&
+        final.dev === initial.dev &&
+        final.ino === initial.ino
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Inside `baseDir` so the quarantine rename stays on one filesystem — the
+   * configured directory is the PVC mount root, and a sibling would land on
+   * the pod's ephemeral layer and fail with EXDEV. The name cannot collide
+   * with an artifact directory because those are always UUIDs.
+   */
+  private trashDir(): string {
+    return path.join(this.baseDir, ARTIFACT_TRASH_DIRNAME);
+  }
+
+  private async drainTrash(): Promise<void> {
+    try {
+      const trashDir = this.trashDir();
+      await fs.mkdir(trashDir, { recursive: true, mode: 0o700 });
+      for (const stale of await fs.readdir(trashDir)) {
+        await fs.rm(path.join(trashDir, stale), {
+          recursive: true,
+          force: true,
+        });
+      }
+    } catch (error) {
+      throw storageFailure("cleanup", error);
+    }
+  }
+
+  /**
+   * Delete by rename-then-remove so a concurrent reader either sees the whole
+   * artifact or nothing — never a directory losing its files underneath it.
+   * The quarantined copy is removed immediately; one only lingers when that
+   * removal fails. Every later publish drains earlier leftovers first and
+   * fails closed if that is still impossible; the retained PVC has no other
+   * process that can safely infer which directories are uncommitted.
+   */
+  private async quarantineAndDelete(artifactId: string): Promise<void> {
+    const trashDir = this.trashDir();
+    await fs.mkdir(trashDir, { recursive: true, mode: 0o700 });
+    const source = this.artifactDir(artifactId);
+    const quarantined = path.join(trashDir, `${artifactId}-${randomUUID()}`);
+    try {
+      await fs.rename(source, quarantined);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        await this.drainTrash();
+        return;
+      }
+      throw storageFailure("quarantine", error);
+    }
+    await this.drainTrash();
   }
 
   async publish(params: {
@@ -95,31 +283,49 @@ export class ArtifactStore {
     const filename = sanitizeFilename(params.filename);
     const contentType = params.contentType || "application/octet-stream";
     const createdAt = Date.now();
-    const dir = this.artifactDir(artifactId);
+    const checksum = sha256(params.buffer);
+    const metadata: StoredArtifactMetadata = {
+      artifactId,
+      filename,
+      contentType,
+      size: params.buffer.length,
+      createdAt,
+      sha256: checksum,
+      ...(params.binding ? { binding: params.binding } : {}),
+    };
 
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      this.artifactFilePath(artifactId, filename),
-      params.buffer
-    );
-    await fs.writeFile(
-      this.metadataPath(artifactId),
-      JSON.stringify(
-        {
-          artifactId,
-          filename,
-          contentType,
-          size: params.buffer.length,
-          createdAt,
-          ...(params.binding ? { binding: params.binding } : {}),
-        } satisfies StoredArtifactMetadata,
-        null,
-        2
-      )
-    );
+    const dir = this.artifactDir(artifactId);
+    let createdDir = false;
+    try {
+      await this.drainTrash();
+      // Exclusive: a collision on a freshly minted UUID means the directory is
+      // not ours, so never adopt it.
+      await fs.mkdir(dir, { recursive: false, mode: 0o700 });
+      createdDir = true;
+      await fs.writeFile(this.artifactFilePath(artifactId), params.buffer, {
+        flag: "wx",
+        mode: 0o600,
+      });
+      await fs.writeFile(
+        this.metadataPath(artifactId),
+        JSON.stringify(metadata, null, 2),
+        { flag: "wx", mode: 0o600 },
+      );
+    } catch (error) {
+      if (!createdDir) throw storageFailure("publication", error);
+      try {
+        await this.quarantineAndDelete(artifactId);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [storageFailure("publication", error), cleanupError],
+          `Artifact publication failed and its partial directory could not be quarantined: ${getErrorMessage(cleanupError)}`,
+        );
+      }
+      throw storageFailure("publication", error);
+    }
 
     logger.info(
-      `Published artifact ${artifactId} (${filename}, ${params.buffer.length} bytes)`
+      `Published artifact ${artifactId} (${filename}, ${params.buffer.length} bytes)`,
     );
 
     return {
@@ -130,32 +336,98 @@ export class ArtifactStore {
       downloadUrl: this.buildDownloadUrl(
         normalizeBaseUrl(params.publicGatewayUrl),
         artifactId,
-        params.ttlMs
+        params.ttlMs,
       ),
     };
   }
 
+  /**
+   * `maxBytes` is the caller's own inlining budget — an artifact over it reads
+   * as absent. Omit it to serve whatever was published: no publish path caps
+   * upload size, so a default bound here would turn a legitimate large
+   * download into a "file not found".
+   */
   async read(
     artifactId: string,
-    options?: { binding?: string }
-  ): Promise<{
-    metadata: StoredArtifactMetadata;
-    filePath: string;
-  } | null> {
+    options?: { binding?: string; maxBytes?: number },
+  ): Promise<{ metadata: StoredArtifactMetadata; bytes: Buffer } | null> {
     try {
-      const raw = await fs.readFile(this.metadataPath(artifactId), "utf8");
-      const metadata = JSON.parse(raw) as StoredArtifactMetadata;
-      if (options?.binding && metadata.binding !== options.binding) return null;
-      const filePath = this.artifactFilePath(artifactId, metadata.filename);
-      await fs.access(filePath);
-      return { metadata, filePath };
+      const record = await this.readMetadataRecord(artifactId);
+      if (!record) return null;
+      const { metadata, dirStat } = record;
+      if (options?.binding && metadata.binding !== options.binding) {
+        return null;
+      }
+      const maxBytes = options?.maxBytes;
+      if (maxBytes !== undefined) {
+        if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) return null;
+        if (metadata.size > maxBytes) return null;
+      }
+      const bytes = await readRegularFile(
+        this.artifactFilePath(artifactId),
+        maxBytes,
+      );
+      if (
+        !bytes ||
+        bytes.length !== metadata.size ||
+        sha256(bytes) !== metadata.sha256
+      ) {
+        logger.warn(`Artifact ${artifactId} failed size/checksum verification`);
+        return null;
+      }
+      if (!(await this.directoryIsUnchanged(artifactId, dirStat))) return null;
+      return { metadata, bytes };
     } catch {
       return null;
     }
   }
 
+  /** Read validated metadata without loading the artifact payload. */
+  async inspect(
+    artifactId: string,
+    options?: { binding?: string },
+  ): Promise<StoredArtifactMetadata | null> {
+    const record = await this.readMetadataRecord(artifactId);
+    if (!record) return null;
+    if (options?.binding && record.metadata.binding !== options.binding) {
+      return null;
+    }
+    if (!(await this.directoryIsUnchanged(artifactId, record.dirStat))) {
+      return null;
+    }
+    return record.metadata;
+  }
+
+  /**
+   * Mint a fresh public URL only when the persisted artifact still belongs to
+   * the exact Lobu resource being returned. This is the read-boundary refresh
+   * for expiring URLs; verifying the immutable binding prevents a caller from
+   * grafting another workspace's artifact id into a readable event.
+   */
+  async mintBoundDownloadUrl(params: {
+    artifactId: string;
+    binding: string;
+    publicGatewayUrl: string;
+    ttlMs?: number;
+  }): Promise<string | null> {
+    const metadata = await this.inspect(params.artifactId, {
+      binding: params.binding,
+    });
+    if (!metadata) return null;
+    return this.buildDownloadUrl(
+      params.publicGatewayUrl,
+      params.artifactId,
+      params.ttlMs,
+    );
+  }
+
   async delete(artifactId: string): Promise<void> {
-    await fs.rm(this.artifactDir(artifactId), { recursive: true, force: true });
+    if (!ARTIFACT_ID_PATTERN.test(artifactId)) return;
+    try {
+      await this.quarantineAndDelete(artifactId);
+    } catch (error) {
+      throw storageFailure("cleanup", error);
+    }
     logger.info(`Deleted artifact ${artifactId}`);
   }
 
@@ -164,17 +436,24 @@ export class ArtifactStore {
       JSON.stringify({
         artifactId,
         exp: Date.now() + ttlMs,
-      })
+      }),
     );
   }
 
   validateDownloadToken(
     token: string,
-    artifactId: string
+    artifactId: string,
   ): {
     valid: boolean;
     error?: string;
   } {
+    if (
+      token.length === 0 ||
+      token.length > DOWNLOAD_TOKEN_MAX_CHARS ||
+      !ARTIFACT_ID_PATTERN.test(artifactId)
+    ) {
+      return { valid: false, error: "malformed" };
+    }
     try {
       const payload = JSON.parse(decrypt(token)) as {
         artifactId?: string;
@@ -187,18 +466,15 @@ export class ArtifactStore {
         return { valid: false, error: "expired" };
       }
       return { valid: true };
-    } catch (error) {
-      return {
-        valid: false,
-        error: getErrorMessage(error),
-      };
+    } catch {
+      return { valid: false, error: "malformed" };
     }
   }
 
   buildDownloadUrl(
     publicGatewayUrl: string,
     artifactId: string,
-    ttlMs = this.defaultTtlMs
+    ttlMs = this.defaultTtlMs,
   ): string {
     const baseUrl = normalizeBaseUrl(publicGatewayUrl);
     // Concatenate onto the base rather than `new URL("/api/v1/...", baseUrl)`:
@@ -206,13 +482,9 @@ export class ArtifactStore {
     // drops a base path prefix (e.g. the embedded/local gateway is mounted
     // under `/lobu`, so the worker must fetch `/lobu/api/v1/files/...`).
     const url = new URL(
-      `${baseUrl}/api/v1/files/${encodeURIComponent(artifactId)}`
+      `${baseUrl}/api/v1/files/${encodeURIComponent(artifactId)}`,
     );
     url.searchParams.set("token", this.createDownloadToken(artifactId, ttlMs));
     return url.toString();
-  }
-
-  createReadStream(artifactId: string, filename: string) {
-    return createReadStream(this.artifactFilePath(artifactId, filename));
   }
 }

--- a/packages/server/src/gateway/routes/public/files.ts
+++ b/packages/server/src/gateway/routes/public/files.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-import { readFile } from "node:fs/promises";
 import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
 import type { ArtifactStore } from "../../files/artifact-store.js";
@@ -60,7 +59,7 @@ export function createPublicFileRoutes(artifactStore: ArtifactStore): Hono {
     );
     c.header("Cache-Control", "private, max-age=60");
 
-    return new Response(await readFile(artifact.filePath), {
+    return new Response(artifact.bytes, {
       headers: c.res.headers,
     });
   });

--- a/packages/server/src/mcp-media-resources.ts
+++ b/packages/server/src/mcp-media-resources.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   ArtifactStore,
@@ -6,6 +5,7 @@ import {
   runArtifactBinding,
 } from './gateway/files/artifact-store';
 import type { Env } from './index';
+import { getLobuCoreServices } from './lobu/gateway';
 import { type AuthContext, executeTool } from './tools/execute';
 
 const MAX_MCP_RESOURCE_BYTES = 20 * 1024 * 1024;
@@ -222,24 +222,32 @@ export async function readMcpAttachmentResource(
     throw new Error(`Unknown resource: ${uri}`);
   }
 
-  const artifactStore = new ArtifactStore();
-  const stored = await artifactStore.read(attachment.artifact_id, {
+  const artifactStore =
+    getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore();
+  // Metadata first: `read` would report an oversized artifact as simply
+  // absent, and the caller needs to be told the payload exists but cannot be
+  // inlined.
+  const metadata = await artifactStore.inspect(attachment.artifact_id, {
     binding: loaded.binding,
   });
-  if (!stored) throw new Error(`Unknown resource: ${uri}`);
-  if (stored.metadata.size > MAX_MCP_RESOURCE_BYTES) {
+  if (!metadata) throw new Error(`Unknown resource: ${uri}`);
+  if (metadata.size > MAX_MCP_RESOURCE_BYTES) {
     throw new Error(
-      `MCP resource is too large to inline (${stored.metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
+      `MCP resource is too large to inline (${metadata.size} bytes; limit ${MAX_MCP_RESOURCE_BYTES})`
     );
   }
 
-  const data = await readFile(stored.filePath);
+  const stored = await artifactStore.read(attachment.artifact_id, {
+    binding: loaded.binding,
+    maxBytes: MAX_MCP_RESOURCE_BYTES,
+  });
+  if (!stored) throw new Error(`Unknown resource: ${uri}`);
   return {
     contents: [
       {
         uri,
         mimeType: stored.metadata.contentType,
-        blob: data.toString('base64'),
+        blob: stored.bytes.toString('base64'),
       },
     ],
   };

--- a/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
+++ b/packages/server/src/tools/get_content/__tests__/artifact-url-refresh.test.ts
@@ -1,0 +1,112 @@
+import type { ContentItem } from '@lobu/connector-sdk';
+import { describe, expect, test } from 'vitest';
+import { refreshEventArtifactDownloadUrls } from '../render';
+
+describe('refreshEventArtifactDownloadUrls', () => {
+  test('bounds metadata verification concurrency while replacing expired URLs', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const bindings: string[] = [];
+    const items = [1, 2].map(
+      (id) =>
+        ({
+          id,
+          origin_id: `origin-${id}`,
+          connection_id: 42,
+          feed_id: null,
+          attachments: [0, 1].map((index) => ({
+            artifact_id: `artifact-${id}-${index}`,
+            download_url: 'https://expired.example.test',
+          })),
+        }) as unknown as ContentItem
+    );
+
+    await refreshEventArtifactDownloadUrls({
+      items,
+      organizationId: 'org-1',
+      publicGatewayUrl: 'https://gateway.example.test',
+      artifactStore: {
+        mintBoundDownloadUrl: async ({ artifactId, binding }) => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          bindings.push(binding);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          active -= 1;
+          return `https://fresh.example.test/${artifactId}`;
+        },
+      },
+    });
+
+    expect(maxActive).toBe(1);
+    expect(bindings).toEqual([
+      'event:org-1:connection:42:origin-1',
+      'event:org-1:connection:42:origin-1',
+      'event:org-1:connection:42:origin-2',
+      'event:org-1:connection:42:origin-2',
+    ]);
+    expect(items.flatMap((item) => item.attachments ?? [])).toEqual([
+      {
+        artifact_id: 'artifact-1-0',
+        download_url: 'https://fresh.example.test/artifact-1-0',
+      },
+      {
+        artifact_id: 'artifact-1-1',
+        download_url: 'https://fresh.example.test/artifact-1-1',
+      },
+      {
+        artifact_id: 'artifact-2-0',
+        download_url: 'https://fresh.example.test/artifact-2-0',
+      },
+      {
+        artifact_id: 'artifact-2-1',
+        download_url: 'https://fresh.example.test/artifact-2-1',
+      },
+    ]);
+  });
+
+  test('drops an unmintable URL and leaves unbindable attachments alone', async () => {
+    const seen: string[] = [];
+    const items = [
+      {
+        id: 1,
+        origin_id: 'origin-1',
+        connection_id: null,
+        feed_id: 7,
+        attachments: [
+          { artifact_id: 'revoked', download_url: 'https://expired.example.test' },
+          { artifact_id: 42, download_url: 'https://expired.example.test' },
+        ],
+      },
+      // No `origin_id` means no binding can be derived, so the whole item is
+      // left untouched rather than silently stripped.
+      {
+        id: 2,
+        origin_id: '',
+        attachments: [
+          { artifact_id: 'orphan', download_url: 'https://expired.example.test' },
+        ],
+      },
+    ] as unknown as ContentItem[];
+
+    await refreshEventArtifactDownloadUrls({
+      items,
+      organizationId: 'org-1',
+      publicGatewayUrl: 'https://gateway.example.test',
+      artifactStore: {
+        mintBoundDownloadUrl: async ({ artifactId, binding }) => {
+          seen.push(`${binding}|${artifactId}`);
+          return null;
+        },
+      },
+    });
+
+    expect(seen).toEqual(['event:org-1:feed:7:origin-1|revoked']);
+    expect(items[0].attachments).toEqual([
+      { artifact_id: 'revoked' },
+      { artifact_id: 42, download_url: 'https://expired.example.test' },
+    ]);
+    expect(items[1].attachments).toEqual([
+      { artifact_id: 'orphan', download_url: 'https://expired.example.test' },
+    ]);
+  });
+});

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -15,8 +15,10 @@ import { hasRequiredMcpScope } from '../../auth/tool-access';
 import { isInProcessSystemCall } from '../../tools/access-control';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import { AUTOMATION_RUN_SOURCE } from '../../gateway/automation-run-session';
+import { ArtifactStore } from '../../gateway/files/artifact-store';
 import { parseAutomationRunConversationId } from '../../gateway/permissions/automation-run-intent';
 import type { Env } from '../../index';
+import { getLobuCoreServices } from '../../lobu/gateway';
 import { ToolUserError } from '../../utils/errors';
 import {
   getNormalizedScoreContent,
@@ -26,6 +28,7 @@ import { searchContentByText } from '../../utils/content-search';
 import { parseDateAlias, toEndOfDay } from '../../utils/date-aliases';
 import logger from '../../utils/logger';
 import { requireReadAccess } from '../../utils/organization-access';
+import { resolvePublicGatewayUrl } from '../../utils/public-origin';
 import { rewriteQueries } from '../../utils/query-rewriter';
 import {
   buildContentUrl,
@@ -43,6 +46,7 @@ import {
   buildContentItems,
   fetchClassificationExcerpts,
   hydrateToolInvocationRequests,
+  refreshEventArtifactDownloadUrls,
 } from './render';
 import { GetContentSchema, type GetContentArgs, getIncludeSupersededValidationErrors } from './schema';
 import type { ContentRow, GetContentResult, IdRow } from './types';
@@ -719,6 +723,13 @@ async function getContentImpl(
       baseUrl,
       excerptsMap,
       includePrivateAttribution: ctx.memberRole != null,
+    });
+    await refreshEventArtifactDownloadUrls({
+      items: contentItems,
+      organizationId: ctx.organizationId,
+      publicGatewayUrl: resolvePublicGatewayUrl(),
+      artifactStore:
+        getLobuCoreServices()?.getArtifactStore() ?? new ArtifactStore(),
     });
     // Verbatim requests are served ONLY on an explicit `content_ids` read. A
     // list or search page is an ambient read — inlining every retained request

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -7,6 +7,10 @@
 import type { ContentItem } from '@lobu/connector-sdk';
 import { parseJsonObject } from '@lobu/core';
 import { type DbClient, parsePgNumberArray, pgBigintArray, pgTextArray } from '../../db/client';
+import {
+  type ArtifactStore,
+  eventArtifactBinding,
+} from '../../gateway/files/artifact-store';
 import { resolveEntityRender } from '../../utils/default-entity-template';
 import { resolveEventKindDefinition } from '../../utils/event-kind-validation';
 import logger from '../../utils/logger';
@@ -15,6 +19,47 @@ import { isAdminOrOwnerRole } from '../access-control';
 import { AUDIT_SEMANTIC_TYPE } from '../constants';
 import type { ContentRow } from './types';
 import { parseRecordArray, toNumberOrUndefined } from './types';
+
+/** Replace persisted expiring URLs with a fresh, binding-verified URL. */
+export async function refreshEventArtifactDownloadUrls(opts: {
+  items: ContentItem[];
+  organizationId: string;
+  publicGatewayUrl: string;
+  artifactStore: Pick<ArtifactStore, 'mintBoundDownloadUrl'>;
+}): Promise<void> {
+  // Keep metadata verification sequential. Exact reads can return a large
+  // bounded page, and one Promise per attachment would amplify request memory
+  // even though each metadata file is itself size-capped.
+  for (const item of opts.items) {
+    if (!Array.isArray(item.attachments) || !item.origin_id) continue;
+    const binding = eventArtifactBinding({
+      organizationId: opts.organizationId,
+      connectionId: item.connection_id,
+      feedId: item.feed_id,
+      originId: item.origin_id,
+    });
+    const refreshed: typeof item.attachments = [];
+    for (const attachment of item.attachments) {
+      const artifactId = attachment.artifact_id;
+      if (typeof artifactId !== 'string') {
+        refreshed.push(attachment);
+        continue;
+      }
+      const { download_url: _expiredUrl, ...withoutExpiredUrl } = attachment;
+      const freshUrl = await opts.artifactStore.mintBoundDownloadUrl({
+        artifactId,
+        binding,
+        publicGatewayUrl: opts.publicGatewayUrl,
+      });
+      refreshed.push(
+        freshUrl
+          ? { ...withoutExpiredUrl, download_url: freshUrl }
+          : withoutExpiredUrl
+      );
+    }
+    item.attachments = refreshed;
+  }
+}
 
 /**
  * Gated payload keys: the request itself and its size. `request_status` is

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, rmSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -73,7 +72,7 @@ describe('materializeActionOutputAttachments', () => {
       binding: runArtifactBinding(42),
     });
     expect(stored).toBeTruthy();
-    expect(await readFile(stored!.filePath)).toEqual(bytes);
+    expect(stored!.bytes).toEqual(bytes);
   });
 
   it('deletes partial publishes when a later attachment publish fails', async () => {

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -20,7 +20,6 @@
  * `current_event_records` view exposes the transcribed text. Failures are
  * swallowed — the unsuperseded `[voice note]` placeholder remains usable.
  */
-import { readFile } from "node:fs/promises";
 import { getDb } from "../db/client";
 import { getLobuCoreServices } from "../lobu/gateway";
 import {
@@ -340,10 +339,8 @@ async function transcribeOne(
     );
     return;
   }
-  const buffer = await readFile(stored.filePath);
-
   const result = await transcriptionService.transcribe(
-    buffer,
+    stored.bytes,
     agentId,
     job.mimeType
   );


### PR DESCRIPTION
## Summary

- Replace the process-temporary artifact layout with a persistent, SHA-256-verified store rooted at `LOBU_ARTIFACTS_DIR`.
- Bind artifacts to their owning run or event, reject malformed paths and symlinks, and preserve readable bytes across pod replacement on the retained PVC from #3036.
- Mint fresh download URLs on reads while native MCP resources continue to use stable `lobu://` identities.

## Test plan

- [x] Intended files committed explicitly, then `make pre-pr` clean on the rebased head.
- [x] Exact-head focused ArtifactStore, history, URL refresh, inline attachment, MCP resource, and exact-read tests: 29 passing.
- [x] Bug fix red to green: current main accepted an artifact after payload tampering; this branch rejects the same artifact after checksum verification.

## Notes

- This is a clean cutover from the old 24-hour process-local artifact format; those legacy files were not durable and are not migrated.
- No S3 abstraction is added. Application artifacts use the single-replica RWO PVC; R2 remains dedicated to database backups.