### PR TITLE
fix(server): verify Slack chat reliability

### DIFF
--- a/packages/server/src/__tests__/integration/automations/event-trigger-cooldown.test.ts
+++ b/packages/server/src/__tests__/integration/automations/event-trigger-cooldown.test.ts
@@ -520,6 +520,59 @@ describe("min_cooldown_seconds debounces event-triggered Automations", () => {
 			expect(row.last_event_activation_at).toBeNull();
 		});
 
+		it("clears a zero-cooldown activation stamp when cooldown is enabled", async () => {
+			const fixture = await automationWithCooldown(0);
+			await priorActivation(fixture, 60);
+
+			await manageAutomations(
+				{
+					action: "update",
+					automation_id: String(fixture.automationId),
+					min_cooldown_seconds: 300,
+				},
+				{} as Env,
+				fixture.workspace.ctx,
+			);
+
+			const [row] = await getTestDb()`
+				SELECT min_cooldown_seconds, last_event_activation_at
+				FROM automations
+				WHERE id = ${fixture.automationId}
+			`;
+			expect(Number(row.min_cooldown_seconds)).toBe(300);
+			expect(row.last_event_activation_at).toBeNull();
+		});
+
+		it("preserves the activation cursor across positive cooldown changes", async () => {
+			const fixture = await automationWithCooldown(300);
+			await priorActivation(fixture, 60);
+			const [before] = await getTestDb()`
+				SELECT last_event_activation_at
+				FROM automations
+				WHERE id = ${fixture.automationId}
+			`;
+
+			await manageAutomations(
+				{
+					action: "update",
+					automation_id: String(fixture.automationId),
+					min_cooldown_seconds: 600,
+				},
+				{} as Env,
+				fixture.workspace.ctx,
+			);
+
+			const [after] = await getTestDb()`
+				SELECT min_cooldown_seconds, last_event_activation_at
+				FROM automations
+				WHERE id = ${fixture.automationId}
+			`;
+			expect(Number(after.min_cooldown_seconds)).toBe(600);
+			expect(after.last_event_activation_at).toEqual(
+				before.last_event_activation_at,
+			);
+		});
+
 		it("suppresses a reply when a background activation just consumed the window", async () => {
 			// One Automation, one window: a background firing must debounce a reply
 			// firing and vice versa, or a mixed-trigger Automation would get two

--- a/packages/server/src/__tests__/integration/connectors/connection-test-slack-upstream.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-test-slack-upstream.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Slack connections.test must cross the provider boundary. Stored metadata is
+ * useful for routing, but it cannot prove that the managed bot credential is
+ * live or which Grid workspace/enterprise Slack currently assigns to it.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../../../index";
+import { ChatInstanceManager } from "../../../gateway/connections/chat-instance-manager";
+import { SecretStoreRegistry } from "../../../gateway/secrets";
+import {
+	__setChatInstanceManagerForTests,
+} from "../../../lobu/gateway";
+import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import { createPostgresAgentConnectionStore } from "../../../lobu/stores/postgres-stores";
+import { orgContext } from "../../../lobu/stores/org-context";
+import { manageConnections } from "../../../tools/admin/manage_connections";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { seedOwnerContext } from "../../setup/test-fixtures";
+
+const ENCRYPTION_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const realFetch = globalThis.fetch;
+
+async function seedManagedSlackConnection(options: {
+	organizationId: string;
+	runtimeId: string;
+	externalTenantId: string;
+	teamId: string;
+	enterpriseId?: string;
+	isEnterpriseInstall: boolean;
+}): Promise<{ connectionId: number; token: string }> {
+	const connectionStore = createPostgresAgentConnectionStore();
+	const postgresSecrets = new PostgresSecretStore();
+	const secretStore = new SecretStoreRegistry(postgresSecrets, {
+		secret: postgresSecrets,
+	});
+	const token = `xoxb-${options.runtimeId}-secret`;
+	const botToken = await orgContext.run(
+		{ organizationId: options.organizationId },
+		() => secretStore.put(`connections/${options.runtimeId}/botToken`, token),
+	);
+	const manager = new ChatInstanceManager() as unknown as {
+		services: unknown;
+		connectionStore: unknown;
+	};
+	manager.services = { getSecretStore: () => secretStore };
+	manager.connectionStore = connectionStore;
+	__setChatInstanceManagerForTests(manager);
+
+	await orgContext.run({ organizationId: options.organizationId }, () =>
+		connectionStore.saveConnection({
+			id: options.runtimeId,
+			platform: "slack",
+			organizationId: options.organizationId,
+			config: {
+				platform: "slack",
+				botToken,
+			},
+			settings: { allowGroups: true },
+			metadata: {
+				teamId: options.teamId,
+				...(options.enterpriseId
+					? { enterpriseId: options.enterpriseId }
+					: {}),
+				isEnterpriseInstall: options.isEnterpriseInstall,
+			},
+			status: "active",
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		}),
+	);
+	await getTestDb()`
+		UPDATE connections
+		SET external_tenant_id = ${options.externalTenantId}
+		WHERE slug = ${options.runtimeId}
+		  AND organization_id = ${options.organizationId}
+	`;
+	const [row] = await getTestDb()<{ id: number }[]>`
+		SELECT id
+		FROM connections
+		WHERE slug = ${options.runtimeId}
+		  AND organization_id = ${options.organizationId}
+	`;
+	if (!row) throw new Error("Managed Slack test connection was not seeded");
+	return { connectionId: Number(row.id), token };
+}
+
+describe("connections.test — live Slack identity", () => {
+	beforeAll(() => {
+		process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+		__setChatInstanceManagerForTests(null);
+	});
+
+	it("probes an org-wide token and keeps workspace T distinct from enterprise E", async () => {
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Slack Grid Probe Org",
+		});
+		const { connectionId, token } = await seedManagedSlackConnection({
+			organizationId: org.id,
+			runtimeId: "slackinst-grid-probe",
+			externalTenantId: "E0ENTERPRISE",
+			teamId: "E0ENTERPRISE",
+			enterpriseId: "E0ENTERPRISE",
+			isEnterpriseInstall: true,
+		});
+		globalThis.fetch = vi.fn(async (url, init) => {
+			expect(url).toBe("https://slack.com/api/auth.test");
+			expect((init?.headers as Record<string, string>).Authorization).toBe(
+				`Bearer ${token}`,
+			);
+			return new Response(
+				JSON.stringify({
+					ok: true,
+					team_id: "T0WORKSPACE",
+					enterprise_id: "E0ENTERPRISE",
+					is_enterprise_install: true,
+				}),
+			);
+		}) as typeof fetch;
+
+		const result = await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		);
+
+		expect(result).toMatchObject({
+			action: "test",
+			status: "ok",
+		});
+		expect(String((result as { message: string }).message)).toContain(
+			"workspace T0WORKSPACE",
+		);
+		expect(String((result as { message: string }).message)).toContain(
+			"enterprise E0ENTERPRISE",
+		);
+		expect(JSON.stringify(result)).not.toContain(token);
+	});
+
+	it("rejects a sibling workspace for a workspace-scoped install", async () => {
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Slack Workspace Probe Org",
+		});
+		const { connectionId } = await seedManagedSlackConnection({
+			organizationId: org.id,
+			runtimeId: "slackinst-workspace-probe",
+			externalTenantId: "T0EXPECTED",
+			teamId: "T0EXPECTED",
+			enterpriseId: "E0ENTERPRISE",
+			isEnterpriseInstall: false,
+		});
+		globalThis.fetch = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					ok: true,
+					team_id: "T0SIBLING",
+					enterprise_id: "E0ENTERPRISE",
+					is_enterprise_install: false,
+				}),
+			),
+		) as typeof fetch;
+
+		const result = await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		);
+
+		expect(result).toMatchObject({
+			action: "test",
+			status: "error",
+			error_code: "AUTH_INVALID",
+			retryable: false,
+		});
+		expect(String((result as { message: string }).message)).toContain(
+			"T0SIBLING",
+		);
+	});
+});

--- a/packages/server/src/automations/cooldown.ts
+++ b/packages/server/src/automations/cooldown.ts
@@ -9,7 +9,7 @@ import logger from "../utils/logger";
  * become durable `automation` runs via `createAutomationEventRun`, and
  * `reply_to_source` targets are handed to the chat transport and never write a
  * run row at all. A predicate over `runs` would therefore be a silent no-op on
- * exactly one half of the feature, so both paths claim the same cursor
+ * exactly one half of the feature, so both paths update the same cursor
  * (`automations.last_event_activation_at`) through this module.
  *
  * The claim must be serialized, or two concurrent deliveries both read "no
@@ -114,6 +114,45 @@ export async function claimAutomationCooldownStandalone(
     logger.error(
       { error, automationId },
       "[cooldown] Could not claim an Automation cooldown window — activation failed",
+    );
+    throw error;
+  }
+}
+
+/**
+ * Record an accepted reply-to-source activation for the zero-cooldown path.
+ *
+ * Zero-cooldown chat Automations intentionally skip the serialized cooldown
+ * claim above. Stamp their canonical activation cursor only after the agent
+ * turn is durably enqueued, so rejected matches and failed queue writes remain
+ * observationally distinct from accepted dispatches. The predicate keeps this
+ * helper from changing the existing positive-cooldown claim semantics.
+ */
+export async function markZeroCooldownAutomationActivation(
+  automationId: number,
+  db?: DbClient,
+): Promise<boolean> {
+  const sql = db ?? getDb();
+  try {
+    const rows = await sql`
+      UPDATE automations
+      SET last_event_activation_at = clock_timestamp()
+      WHERE id = ${automationId}
+        AND min_cooldown_seconds = 0
+      RETURNING id
+    `;
+    if (rows.length === 0) {
+      logger.warn(
+        { automationId },
+        "[cooldown] Zero-cooldown Automation row missing or changed before activation stamp",
+      );
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logger.error(
+      { error, automationId },
+      "[cooldown] Could not stamp a zero-cooldown Automation activation",
     );
     throw error;
   }

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -22,22 +22,22 @@ import {
   TEST_GATEWAY_URL,
 } from "./setup.js";
 
-/**
- * The reply path consults the cooldown claim, which is Postgres-backed. Stub
- * the module so this suite stays DB-free; `cooldownAllows` defaults to true so
- * every other test behaves exactly as before (they all use the 0 default, which
- * the bridge never claims for anyway).
- */
+/** The reply cooldown operations are injected so this unit suite stays DB-free. */
 const cooldownClaims: number[] = [];
+const activationMarks: number[] = [];
 let cooldownAllows = true;
-mock.module("../../automations/cooldown.js", () => ({
-  claimAutomationCooldownStandalone: async (automationId: number) => {
+let markZeroThrows = false;
+const automationCooldown = {
+  claim: async (automationId: number) => {
     cooldownClaims.push(automationId);
     return cooldownAllows;
   },
-  claimAutomationCooldown: async () => true,
-  lockAutomationForActivation: async () => undefined,
-}));
+  markZero: async (automationId: number) => {
+    if (markZeroThrows) throw new Error("activation stamp unavailable");
+    activationMarks.push(automationId);
+    return true;
+  },
+};
 
 describe("buildAttachmentTranscriptText", () => {
   const file = (id: string, name: string, mimetype: string) => ({
@@ -913,6 +913,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
               }).length > 0,
           ),
         ),
+      automationCooldown,
     );
     return {
       bridge,
@@ -1084,6 +1085,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       },
     ];
     cooldownClaims.length = 0;
+    activationMarks.length = 0;
     cooldownAllows = false;
     try {
       const { bridge, enqueueMessage } = makePreviewHarness({ automations });
@@ -1096,6 +1098,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       );
 
       expect(cooldownClaims).toEqual([81]);
+      expect(activationMarks).toEqual([]);
       expect(enqueueMessage).not.toHaveBeenCalled();
       // A suppressed Automation must not fall through to the connection owner —
       // that would answer the message with a plain chat turn and defeat the
@@ -1136,6 +1139,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       },
     ];
     cooldownClaims.length = 0;
+    activationMarks.length = 0;
     const { bridge, enqueueMessage } = makePreviewHarness({ automations });
     const thread = makeThread(undefined);
 
@@ -1145,10 +1149,97 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       "mention",
     );
 
-    // Ordinary chat must not pay a round-trip per message or encounter a
-    // cooldown-claim failure.
+    // Ordinary chat must not enter the serialized pre-enqueue cooldown claim.
     expect(cooldownClaims).toEqual([]);
     expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(activationMarks).toEqual([82]);
+  });
+
+  test("a failed zero-cooldown enqueue does not stamp activation", async () => {
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "slack",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const automations: MatchingAutomationActivation[] = [
+      {
+        automationId: 83,
+        organizationId: "org-a",
+        agentId: "agent-a",
+        deviceWorkerId: null,
+        agentKind: null,
+        model: null,
+        instructions: "Handle support messages.",
+        minCooldownSeconds: 0,
+        trigger,
+      },
+    ];
+    activationMarks.length = 0;
+    const { bridge, enqueueMessage } = makePreviewHarness({ automations });
+    enqueueMessage.mockImplementationOnce(async () => {
+      throw new Error("queue unavailable");
+    });
+
+    await expect(
+      bridge.handleMessage(
+        makeThread(undefined),
+        makeMessage({ raw: { team_id: "TREAL" } }),
+        "mention",
+      ),
+    ).rejects.toThrow("queue unavailable");
+
+    expect(activationMarks).toEqual([]);
+  });
+
+  test("a failed activation stamp still dispatches every matched Automation", async () => {
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "slack",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const base = {
+      organizationId: "org-a",
+      agentId: "agent-a",
+      deviceWorkerId: null,
+      agentKind: null,
+      model: null,
+      instructions: "Handle support messages.",
+      minCooldownSeconds: 0,
+      trigger,
+    };
+    const automations: MatchingAutomationActivation[] = [
+      { ...base, automationId: 84 },
+      { ...base, automationId: 85 },
+    ];
+    activationMarks.length = 0;
+    markZeroThrows = true;
+    try {
+      const { bridge, enqueueMessage } = makePreviewHarness({ automations });
+
+      // The stamp is observability only — the first target's failure must not
+      // abort the loop and strand the second Automation's turn.
+      await bridge.handleMessage(
+        makeThread(undefined),
+        makeMessage({ raw: { team_id: "TREAL" } }),
+        "mention",
+      );
+
+      expect(enqueueMessage).toHaveBeenCalledTimes(2);
+    } finally {
+      markZeroThrows = false;
+    }
   });
 
   test("a rejected Automation filter cannot be bypassed by channel fallback", async () => {
@@ -1163,6 +1254,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       output: "reply_to_source" as const,
       skip_if_unchanged: false,
     };
+    activationMarks.length = 0;
     const { bridge, enqueueMessage, resolveForConnection } = makePreviewHarness({
       agentId: undefined,
       previewMode: false,
@@ -1193,6 +1285,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     );
 
     expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(activationMarks).toEqual([]);
     expect(resolveForConnection).not.toHaveBeenCalled();
     // Linked + filter-rejected must not spam the "link your agent" notice.
     expect(thread.post).not.toHaveBeenCalled();

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -128,6 +128,7 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
   let state: StateAdapter;
   let queue: RunsQueue;
   let connectionDbId: number;
+  let slackPostMessage: ReturnType<typeof mock>;
 
   beforeAll(async () => {
     await ensureDbForGatewayTests();
@@ -171,15 +172,6 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
       channelId: CHANNEL_ID,
       teamId: WORKSPACE_TEAM_ID,
     });
-    await createTestAutomationSubscription({
-      organizationId,
-      agentId,
-      connectionId: connectionDbId,
-      platform: "slack",
-      channelId: DM_ID,
-      teamId: WORKSPACE_TEAM_ID,
-    });
-
     queue = new RunsQueue();
     await queue.start();
     const producer = new QueueProducer(queue);
@@ -196,6 +188,8 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     // assembled server path hermetic while still exercising its calls.
     (adapter as any).fetchMessages = mock(async () => ({ messages: [] }));
     (adapter as any).startTyping = mock(async () => undefined);
+    slackPostMessage = mock(async () => ({ ts: "1787292000.999999" }));
+    (adapter as any).postMessage = slackPostMessage;
     chat = new Chat({
       userName: "lobu",
       adapters: { slack: adapter },
@@ -258,6 +252,50 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     await queue?.stop();
   });
 
+  test("first-contact message.im posts a setup notice without a DM Automation", async () => {
+    const sql = getDb();
+    const dmTs = "1787292001.000821";
+    const response = await chat.webhooks.slack(
+      signedEventRequest(
+        slackEvent({
+          eventId: "Ev_GRID_DM_FIRST_CONTACT_20260821",
+          channel: DM_ID,
+          channelType: "im",
+          ts: dmTs,
+          text: "LOBU_SLACK_E2E_20260821 first contact dm",
+          user: "U_BURAK",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => {
+      expect(slackPostMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(slackPostMessage.mock.calls[0]?.[0]).toBe(`slack:${DM_ID}:`);
+    expect(String(slackPostMessage.mock.calls[0]?.[1])).toContain(
+      "isn't linked to one of your agents yet",
+    );
+    const runs = await sql`
+      SELECT id FROM runs WHERE run_type = 'chat_message'
+    `;
+    expect(runs).toHaveLength(0);
+    const transcript = await sql`
+      SELECT id
+      FROM channel_messages
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND connection_id = ${RUNTIME_CONNECTION_ID}
+        AND channel_id = ${DM_ID}
+    `;
+    expect(transcript).toHaveLength(0);
+    const activationCursors = await sql`
+      SELECT last_event_activation_at
+      FROM automations
+      WHERE organization_id = 'org-slack-grid-e2e'
+    `;
+    expect(activationCursors).toEqual([{ last_event_activation_at: null }]);
+  });
+
   test("workspace-stamped channel and DM events persist, activate once, and reply", async () => {
     const sql = getDb();
     const channelTs = "1787292000.000821";
@@ -307,6 +345,24 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
         },
       ]);
     });
+    const [channelAutomation] = await sql<{ id: number }[]>`
+      SELECT id
+      FROM automations
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND triggers->0->'match'->>'channel_id' = ${CHANNEL_ID}
+      LIMIT 1
+    `;
+    if (!channelAutomation) throw new Error("Channel Automation was not seeded");
+    let channelActivationAt: Date | null = null;
+    await waitFor(async () => {
+      const [row] = await sql<{ last_event_activation_at: Date | null }[]>`
+        SELECT last_event_activation_at
+        FROM automations
+        WHERE id = ${channelAutomation.id}
+      `;
+      expect(row?.last_event_activation_at).not.toBeNull();
+      channelActivationAt = row?.last_event_activation_at ?? null;
+    });
 
     // Delayed Events and normal Slack retries carry the same event_id. The
     // durable adapter marker and message idempotency must leave one transcript
@@ -332,23 +388,41 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
         AND channel_id = ${CHANNEL_ID}
     `;
     expect(transcriptAfterRetry).toHaveLength(1);
+    const [channelAfterRetry] = await sql<
+      { last_event_activation_at: Date | null }[]
+    >`
+      SELECT last_event_activation_at
+      FROM automations
+      WHERE id = ${channelAutomation.id}
+    `;
+    expect(channelAfterRetry?.last_event_activation_at).toEqual(
+      channelActivationAt,
+    );
 
-    // DM ingress remains on the dedicated Chat SDK branch and routes through
-    // the same workspace-scoped Automation planner.
-    const dmTs = "1787292001.000821";
-    const dmResponse = await chat.webhooks.slack(
+    // Linked DM ingress remains on the dedicated Chat SDK branch and routes
+    // through the same workspace-scoped Automation planner.
+    await createTestAutomationSubscription({
+      organizationId: "org-slack-grid-e2e",
+      agentId: "agent-slack-grid-e2e",
+      connectionId: connectionDbId,
+      platform: "slack",
+      channelId: DM_ID,
+      teamId: WORKSPACE_TEAM_ID,
+    });
+    const linkedDmTs = "1787292001.100821";
+    const linkedDmResponse = await chat.webhooks.slack(
       signedEventRequest(
         slackEvent({
-          eventId: "Ev_GRID_DM_20260821",
+          eventId: "Ev_GRID_DM_LINKED_20260821",
           channel: DM_ID,
           channelType: "im",
-          ts: dmTs,
-          text: "LOBU_SLACK_E2E_20260821 integration dm",
+          ts: linkedDmTs,
+          text: "LOBU_SLACK_E2E_20260821 linked dm",
           user: "U_BURAK",
         }),
       ),
     );
-    expect(dmResponse.status).toBe(200);
+    expect(linkedDmResponse.status).toBe(200);
     await waitFor(async () => {
       const rows = await sql`
         SELECT id FROM runs WHERE run_type = 'chat_message' ORDER BY id
@@ -364,9 +438,28 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
           AND channel_id = ${DM_ID}
       `;
       expect(rows).toEqual([
-        { platform_message_id: dmTs, team_id: WORKSPACE_TEAM_ID },
+        { platform_message_id: linkedDmTs, team_id: WORKSPACE_TEAM_ID },
       ]);
     });
+    const [dmAutomation] = await sql<
+      { id: number; last_event_activation_at: Date | null }[]
+    >`
+      SELECT id, last_event_activation_at
+      FROM automations
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND triggers->0->'match'->>'channel_id' = ${DM_ID}
+      LIMIT 1
+    `;
+    expect(dmAutomation?.last_event_activation_at).not.toBeNull();
+    const activationTimesBeforeBots = new Map(
+      (
+        await sql<{ id: number; last_event_activation_at: Date | null }[]>`
+          SELECT id, last_event_activation_at
+          FROM automations
+          WHERE organization_id = 'org-slack-grid-e2e'
+        `
+      ).map((row) => [Number(row.id), row.last_event_activation_at]),
+    );
 
     // The bot's own Slack echo is filtered by Chat SDK before the catch-all;
     // another app's bot message is rejected by the bridge's loop guard.
@@ -394,6 +487,18 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
       SELECT id FROM runs WHERE run_type = 'chat_message'
     `;
     expect(afterBots).toHaveLength(2);
+    const activationTimesAfterBots = await sql<
+      { id: number; last_event_activation_at: Date | null }[]
+    >`
+      SELECT id, last_event_activation_at
+      FROM automations
+      WHERE organization_id = 'org-slack-grid-e2e'
+    `;
+    for (const row of activationTimesAfterBots) {
+      expect(row.last_event_activation_at).toEqual(
+        activationTimesBeforeBots.get(Number(row.id)),
+      );
+    }
 
     // Feed the authoritative terminal text into the real Slack transport. The
     // only fake is chat.postMessage itself, Slack's external HTTP boundary.

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -181,6 +181,41 @@ export async function getChatConnectionRow(
 }
 
 /**
+ * Resolve one stored Slack connection's bot credential through the same
+ * secret-aware gateway path used to boot its adapter, then probe Slack itself.
+ * The token never leaves this function; callers receive provider identity only.
+ */
+export async function probeSlackConnectionIdentity(
+	organizationId: string,
+	connectionId: number,
+): Promise<{
+	teamId: string;
+	enterpriseId: string | null;
+	isEnterpriseInstall: boolean;
+}> {
+	const row = await getChatConnectionRow(organizationId, connectionId);
+	if (!row || row.connector_key !== "slack") {
+		throw new Error("Slack connection not found");
+	}
+	const runtimeId = slugToRuntimeConnectionId(row.slug);
+	const manager = requireManager();
+	const config = await orgContext.run({ organizationId }, () =>
+		manager.resolveConnectionConfig(
+			runtimeId,
+			row.config as PlatformAdapterConfig,
+		),
+	);
+	if (!isSlackConfig(config)) {
+		throw new Error("Stored Slack connection config is invalid");
+	}
+	const configured = config.botToken;
+	if (!configured) throw new Error("Slack bot token is missing");
+	const botToken =
+		typeof configured === "function" ? await configured() : configured;
+	return createSlackWebApi().authTest(botToken);
+}
+
+/**
  * Unwind the two placeholder layers on an incoming BYO chat config, in order,
  * before anything treats it as credentials.
  *

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -35,7 +35,10 @@ import {
   queueAutomationActivations,
   type RuntimeConnectionAutomationLookup,
 } from "../../automations/activation.js";
-import { claimAutomationCooldownStandalone } from "../../automations/cooldown.js";
+import {
+  claimAutomationCooldownStandalone,
+  markZeroCooldownAutomationActivation,
+} from "../../automations/cooldown.js";
 import {
   buildAgentSettingsUrl,
   buildProviderConnectUrl,
@@ -469,7 +472,11 @@ export class MessageHandlerBridge {
     private commandDispatcher?: CommandDispatcher,
     private automationPlanner: (
       args: RuntimeConnectionAutomationLookup
-    ) => Promise<AutomationActivationPlan> = planAutomationActivationsForRuntimeConnection
+    ) => Promise<AutomationActivationPlan> = planAutomationActivationsForRuntimeConnection,
+    private automationCooldown = {
+      claim: claimAutomationCooldownStandalone,
+      markZero: markZeroCooldownAutomationActivation,
+    },
   ) {
     this.artifactStore = services.getArtifactStore();
     this.publicGatewayUrl = services.getPublicGatewayUrl();
@@ -1229,13 +1236,13 @@ export class MessageHandlerBridge {
     const replyTargetsOffCooldown: ChatReplyActivation[] = [];
     for (const candidate of replyAutomations) {
       // `minCooldownSeconds` is a feature-enabled hint carried on the match, so
-      // an ordinary chat Automation (the 0 default) costs no extra round-trip and
-      // cannot be dropped by a cooldown claim. Automations that opted in re-read
-      // and consume the window under the per-Automation lock; claim failures
-      // propagate out of this handler.
+      // an ordinary chat Automation (the 0 default) skips the serialized
+      // pre-enqueue claim and cannot be dropped by it. Automations that opted in
+      // re-read and consume the window under the per-Automation lock; claim
+      // failures propagate out of this handler.
       if (
         candidate.minCooldownSeconds > 0 &&
-        !(await claimAutomationCooldownStandalone(candidate.automationId))
+        !(await this.automationCooldown.claim(candidate.automationId))
       ) {
         continue;
       }
@@ -1255,6 +1262,7 @@ export class MessageHandlerBridge {
             organizationId: candidate.organizationId,
             model: candidate.model ?? undefined,
             automationId: candidate.automationId,
+            minCooldownSeconds: candidate.minCooldownSeconds,
             instructions: candidate.instructions,
             activeRun: candidate.trigger.active_run ?? "queue",
           }))
@@ -1334,6 +1342,14 @@ export class MessageHandlerBridge {
         spanName: "message_received",
         logMessage: "Message enqueued via Chat SDK bridge",
       });
+      if ("automationId" in target && target.minCooldownSeconds === 0) {
+        // The turn is already durably enqueued, so this cursor is pure
+        // observability: a stamp failure must not abort the remaining targets
+        // in this loop, which would silently drop a co-matched Automation.
+        await this.automationCooldown
+          .markZero(target.automationId)
+          .catch(() => undefined);
+      }
     }
   }
 

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -63,14 +63,21 @@ export interface SlackWebApi {
    */
   revokeToken(botToken: string): Promise<boolean>;
   /**
-   * `auth.test` — identify the workspace a bot token belongs to. Returns the
-   * `T…` team id. Used by the ACL sync to self-heal a BYO connection that was
-   * created without an OAuth install (so it never persisted a `teamId`): we
-   * resolve the token's REAL team from Slack, verify it matches the channel
-   * binding's team before graphing, and backfill it onto the connection row.
+   * `auth.test` — identify the workspace and Enterprise installation semantics
+   * a bot token belongs to. Returns the concrete `T…` workspace separately
+   * from the optional `E…` enterprise id; callers must never compare them as
+   * aliases. Used by `connections.test` to prove a stored credential is live and
+   * still names the workspace we routed it to, and by the ACL sync to self-heal a
+   * BYO connection created without an OAuth install (so it never persisted a
+   * `teamId`): we resolve the token's REAL team from Slack, verify it matches the
+   * channel binding's team before graphing, and backfill it onto the connection row.
    * Throws on a Slack-level error (an invalid/revoked token yields `invalid_auth`).
    */
-  authTest(botToken: string): Promise<{ teamId: string }>;
+  authTest(botToken: string): Promise<{
+    teamId: string;
+    enterpriseId: string | null;
+    isEnterpriseInstall: boolean;
+  }>;
   /**
    * `oauth.v2.access` — exchange an OAuth `code` for the workspace bot token +
    * tenant/installer identity. Unlike the other methods this authenticates with
@@ -216,7 +223,14 @@ export function createSlackWebApi(): SlackWebApi {
       if (typeof teamId !== "string" || !teamId) {
         throw new Error("Slack auth.test returned no team_id");
       }
-      return { teamId };
+      return {
+        teamId,
+        enterpriseId:
+          typeof json.enterprise_id === "string" && json.enterprise_id
+            ? json.enterprise_id
+            : null,
+        isEnterpriseInstall: json.is_enterprise_install === true,
+      };
     },
     async exchangeOAuthCode({ clientId, clientSecret, code, redirectUri }) {
       const form = new URLSearchParams({

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -677,6 +677,16 @@ export async function handleUpdate(
       device_worker_id = CASE WHEN ${has('device_worker_id')} THEN ${patch.device_worker_id ?? null}::uuid ELSE device_worker_id END,
       agent_kind = CASE WHEN ${has('agent_kind')} THEN ${patch.agent_kind ?? null} ELSE agent_kind END,
       delivery_target = CASE WHEN ${has('delivery_target')} THEN ${toJsonParam(sql, patch.delivery_target)} ELSE delivery_target END,
+      -- A 0-cooldown reply Automation stamps this cursor for observability.
+      -- Enabling debounce must start with a fresh window, exactly as it did
+      -- before zero-cooldown stamping; positive -> positive keeps its window.
+      last_event_activation_at = CASE
+        WHEN ${has('min_cooldown_seconds')}
+          AND min_cooldown_seconds = 0
+          AND ${patch.min_cooldown_seconds ?? 0} > 0
+        THEN NULL
+        ELSE last_event_activation_at
+      END,
       min_cooldown_seconds = CASE WHEN ${has('min_cooldown_seconds')} THEN ${patch.min_cooldown_seconds ?? 0} ELSE min_cooldown_seconds END
     WHERE id = ${args.automation_id} AND organization_id = ${ctx.organizationId}
     RETURNING *

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -2,7 +2,8 @@
  * Auth-related action handlers: reauthenticate, test.
  */
 
-import { isRetryable, type ToolErrorCode } from '@lobu/core';
+import { getErrorMessage, isRetryable, type ToolErrorCode } from '@lobu/core';
+import { probeSlackConnectionIdentity } from '../../../../gateway/connections/chat-connection-service';
 import { getDb } from '../../../../db/client';
 import {
   DEVICE_ONLINE_WINDOW_SECONDS,
@@ -172,6 +173,10 @@ export async function handleTest(
 
   const rows = await sql`
     SELECT c.connector_key,
+           c.slug,
+           c.credential_mode,
+           c.external_tenant_id,
+           c.config,
            c.auth_profile_id,
            c.app_auth_profile_id,
            c.status,
@@ -201,6 +206,47 @@ export async function handleTest(
   const conn = rows[0] as any;
   const withDeviceHealth = (result: ConnectionTestResult): ConnectionTestResult =>
     applySelectedDeviceHealth(conn, result);
+
+  if (conn.connector_key === 'slack' && conn.credential_mode) {
+    try {
+      const identity = await probeSlackConnectionIdentity(
+        organizationId,
+        Number(args.connection_id)
+      );
+      const mismatch = slackIdentityMismatch(conn, identity);
+      if (mismatch) {
+        return withDeviceHealth({
+          action: 'test',
+          status: 'error',
+          message: `Slack auth.test identity mismatch: ${mismatch}`,
+          ...testErrorFields('AUTH_INVALID'),
+        });
+      }
+      return withDeviceHealth({
+        action: 'test',
+        status: 'ok',
+        message: [
+          `Slack auth.test succeeded: workspace ${identity.teamId}`,
+          identity.enterpriseId
+            ? `enterprise ${identity.enterpriseId}`
+            : 'no enterprise',
+          `enterprise_install=${identity.isEnterpriseInstall}`,
+        ].join(', '),
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      const authFailure = /invalid_auth|token_(?:expired|revoked)|account_inactive/i.test(
+        message
+      );
+      return withDeviceHealth({
+        action: 'test',
+        status: 'error',
+        message: `Slack auth.test failed: ${message}`,
+        ...testErrorFields(authFailure ? 'AUTH_INVALID' : 'NETWORK'),
+      });
+    }
+  }
+
   const authProfile = await getAuthProfileById(
     organizationId,
     Number(conn.auth_profile_id) || null
@@ -437,4 +483,67 @@ function testErrorFields(code: ToolErrorCode): { error_code: ToolErrorCode; retr
 function connectorSupportsNoAuth(authSchema: unknown): boolean {
   const methods = (authSchema as { methods?: Array<{ type?: string }> } | null)?.methods;
   return Array.isArray(methods) && methods.some((m) => m?.type === 'none');
+}
+
+/** Slack workspace ids are `T…`; an enterprise id is `E…`. Never interchangeable. */
+const SLACK_WORKSPACE_ID = /^T[A-Z0-9]+$/i;
+
+function slackIdentityMismatch(
+  conn: {
+    external_tenant_id?: unknown;
+    config?: unknown;
+  },
+  upstream: {
+    teamId: string;
+    enterpriseId: string | null;
+    isEnterpriseInstall: boolean;
+  }
+): string | null {
+  const config =
+    conn.config && typeof conn.config === 'object'
+      ? (conn.config as Record<string, unknown>)
+      : {};
+  const metadata =
+    config.chatMetadata && typeof config.chatMetadata === 'object'
+      ? (config.chatMetadata as Record<string, unknown>)
+      : {};
+  const storedTenantId =
+    typeof conn.external_tenant_id === 'string' ? conn.external_tenant_id : null;
+  // An ORG-WIDE Grid install is keyed on its `E…` enterprise id, so both
+  // `external_tenant_id` and `chatMetadata.teamId` hold an `E…` there. Only a
+  // `T…` value names a concrete workspace worth comparing against `auth.test`.
+  const storedTeamId = [metadata.teamId, storedTenantId].find(
+    (value): value is string =>
+      typeof value === 'string' && SLACK_WORKSPACE_ID.test(value)
+  );
+  const storedEnterpriseId =
+    typeof metadata.enterpriseId === 'string'
+      ? metadata.enterpriseId
+      : storedTenantId?.startsWith('E')
+        ? storedTenantId
+        : null;
+  const storedEnterpriseInstall = metadata.isEnterpriseInstall === true;
+
+  if (!SLACK_WORKSPACE_ID.test(upstream.teamId)) {
+    return `upstream workspace id '${upstream.teamId}' is not a Slack T id`;
+  }
+  if (upstream.isEnterpriseInstall) {
+    if (!storedEnterpriseInstall) {
+      return 'upstream credential is org-wide but stored connection is workspace-scoped';
+    }
+    if (!upstream.enterpriseId || upstream.enterpriseId !== storedEnterpriseId) {
+      return `upstream enterprise '${upstream.enterpriseId ?? 'none'}' does not match stored enterprise '${storedEnterpriseId ?? 'none'}'`;
+    }
+    return null;
+  }
+  if (storedEnterpriseInstall) {
+    return 'stored connection is org-wide but upstream credential is workspace-scoped';
+  }
+  if (!storedTeamId || upstream.teamId !== storedTeamId) {
+    return `upstream workspace '${upstream.teamId}' does not match stored workspace '${storedTeamId ?? 'none'}'`;
+  }
+  if (storedEnterpriseId && upstream.enterpriseId !== storedEnterpriseId) {
+    return `upstream enterprise '${upstream.enterpriseId ?? 'none'}' does not match stored enterprise '${storedEnterpriseId}'`;
+  }
+  return null;
 }

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -488,9 +488,11 @@ export const QUERYABLE_SCHEMA = {
         'delivery_target',
         'min_cooldown_seconds',
         'last_fired_at',
-        // Dispatch-time cursor for the min_cooldown_seconds debounce. Distinct
-        // from last_fired_at, which is stamped when a run reaches a terminal
-        // state.
+        // Dispatch-time activation cursor. A positive min_cooldown_seconds
+        // consumes it as the debounce window; a zero-cooldown chat reply stamps
+        // it purely for observability, since that path writes no run row.
+        // Distinct from last_fired_at, which is stamped when a run reaches a
+        // terminal state.
         'last_event_activation_at',
         // Materialized ordering stamp: the completion time of this Automation's
         // most recent `completed` run, written by a trigger on `runs`. Plain


### PR DESCRIPTION
## Summary

- Make `connections.test` resolve the stored Slack bot credential through the existing gateway secret path, call upstream `auth.test`, and report the actual `T…` workspace plus `E…` enterprise/install semantics without exposing the token.
- Stamp zero-cooldown reply Automations only after durable enqueue. Clear the shared activation cursor only on a `0 -> positive` cooldown transition; preserve positive cooldown windows.
- Lock signed first-contact `message.im`, linked DM/channel delivery, Enterprise Grid `T != E` routing, Slack retry idempotency, bot/self-loop suppression, agent enqueue, persisted transcript state, and outbound Slack reply behavior in assembled tests.

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted Bun/Vitest suites plus `make pre-pr`
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot runtime changed: ran the assembled signed Slack webhook -> stored state -> agent queue -> Slack reply test

Red baselines:

- Slack upstream probe expected `status: ok`; old `handleTest` returned `status: warning`, `AUTH_MISSING`, and made zero Slack calls.
- `0 -> positive` cooldown update expected `last_event_activation_at = null`; old update preserved the timestamp.
- Successful zero-cooldown chat enqueue expected a non-null activation cursor; old bridge left it null.
- The new signed first-contact DM regression was already green on current main and reached the existing external setup-notice boundary, so this PR does not add a speculative DM classification workaround.

Green evidence:

- `bun test ...slack-web.test.ts ...slack-automation-message-e2e.test.ts ...message-handler-bridge.test.ts`: 77 passed.
- Postgres integration batch covering cooldown, Slack upstream probe, auth-free/device-aware tests, Automation health, and BYO Slack identity: 47 passed.
- `make pre-pr`: all seven gates clean.
- `make review-fix`: run once on the fresh branch; its edits were inspected and retested.

## Notes

No schema, migration, public endpoint/action, SDK surface, generic Automation health calculation, or agent subprocess changes.

The upstream test fake is only `https://slack.com/api/auth.test`; credential storage and resolution use the real Postgres store, registry, gateway manager, and connection handler.

Pre-deploy live baseline retained for central verification: first-contact DM `LOBU_SLACK_E2E_20260821_DM_0648`, channel `D0BQ0U28NHM`, Slack ts `1787290948.145269`, had no run and no notice. After deployment, central should run read-only `connections.test(541)` and confirm it reports workspace `T0BQE9WT3N2`, enterprise `E0BQ0T88H3R`, and enterprise-install semantics from upstream Slack.