### PR TITLE
fix(server): accept Slack Grid org-wide auth identity

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connection-test-slack-upstream.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-test-slack-upstream.test.ts
@@ -146,6 +146,173 @@ describe("connections.test — live Slack identity", () => {
 		expect(JSON.stringify(result)).not.toContain(token);
 	});
 
+	it("rejects an org-wide workspace identity with malformed matching enterprise ids", async () => {
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Slack Grid Malformed Workspace Enterprise Org",
+		});
+		const { connectionId, token } = await seedManagedSlackConnection({
+			organizationId: org.id,
+			runtimeId: "slackinst-grid-malformed-workspace-enterprise",
+			externalTenantId: "T0WORKSPACE",
+			teamId: "T0WORKSPACE",
+			enterpriseId: "NOT_SLACK_ENTERPRISE",
+			isEnterpriseInstall: true,
+		});
+		globalThis.fetch = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					ok: true,
+					team_id: "T0WORKSPACE",
+					enterprise_id: "NOT_SLACK_ENTERPRISE",
+					is_enterprise_install: true,
+				}),
+			),
+		) as typeof fetch;
+
+		const result = await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		);
+
+		expect(result).toMatchObject({
+			action: "test",
+			status: "error",
+			error_code: "AUTH_INVALID",
+			retryable: false,
+		});
+		expect(String((result as { message: string }).message)).toContain(
+			"upstream enterprise 'NOT_SLACK_ENTERPRISE' is not a Slack E id",
+		);
+		expect(JSON.stringify(result)).not.toContain(token);
+	});
+
+	it("accepts an org-wide auth.test identity with no concrete workspace", async () => {
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Slack Grid Enterprise Probe Org",
+		});
+		const { connectionId, token } = await seedManagedSlackConnection({
+			organizationId: org.id,
+			runtimeId: "slackinst-grid-enterprise-probe",
+			externalTenantId: "E0BQ0T88H3R",
+			teamId: "E0BQ0T88H3R",
+			enterpriseId: "E0BQ0T88H3R",
+			isEnterpriseInstall: true,
+		});
+		globalThis.fetch = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					ok: true,
+					team_id: "E0BQ0T88H3R",
+					enterprise_id: "E0BQ0T88H3R",
+					is_enterprise_install: true,
+				}),
+			),
+		) as typeof fetch;
+
+		const result = await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		);
+
+		expect(result).toMatchObject({
+			action: "test",
+			status: "ok",
+		});
+		expect(String((result as { message: string }).message)).toContain(
+			"org-wide enterprise E0BQ0T88H3R",
+		);
+		expect(String((result as { message: string }).message)).toContain(
+			"no separate concrete workspace",
+		);
+		expect(JSON.stringify(result)).not.toContain(token);
+	});
+
+	it.each([
+		{
+			slug: "upstream-disagrees",
+			name: "the upstream org-wide id and enterprise disagree",
+			storedEnterpriseId: "E0STORED",
+			upstreamTeamId: "E0UPSTREAM",
+			upstreamEnterpriseId: "E0OTHER",
+			upstreamEnterpriseInstall: true,
+			expected: "does not match upstream enterprise",
+		},
+		{
+			slug: "malformed-enterprise",
+			name: "the upstream enterprise is malformed",
+			storedEnterpriseId: "E0STORED",
+			upstreamTeamId: "E0STORED",
+			upstreamEnterpriseId: "T0WORKSPACE",
+			upstreamEnterpriseInstall: true,
+			expected: "is not a Slack E id",
+		},
+		{
+			slug: "stored-differs",
+			name: "the stored enterprise differs",
+			storedEnterpriseId: "E0STORED",
+			upstreamTeamId: "E0UPSTREAM",
+			upstreamEnterpriseId: "E0UPSTREAM",
+			upstreamEnterpriseInstall: true,
+			expected: "does not match stored enterprise",
+		},
+		{
+			slug: "enterprise-id-without-org-wide-install",
+			name: "an enterprise id arrives on a workspace-scoped install",
+			storedEnterpriseId: "E0STORED",
+			upstreamTeamId: "E0STORED",
+			upstreamEnterpriseId: "E0STORED",
+			upstreamEnterpriseInstall: false,
+			expected:
+				"upstream reports workspace-scoped install but named enterprise 'E0STORED' as its workspace",
+		},
+	])("rejects an org-wide enterprise-only identity when $name", async ({
+		slug,
+		storedEnterpriseId,
+		upstreamTeamId,
+		upstreamEnterpriseId,
+		upstreamEnterpriseInstall,
+		expected,
+	}) => {
+		const { org, ctx } = await seedOwnerContext({
+			orgName: `Slack Grid Rejected Probe ${slug}`,
+		});
+		const { connectionId, token } = await seedManagedSlackConnection({
+			organizationId: org.id,
+			runtimeId: `slackinst-grid-rejected-${slug}`,
+			externalTenantId: storedEnterpriseId,
+			teamId: storedEnterpriseId,
+			enterpriseId: storedEnterpriseId,
+			isEnterpriseInstall: true,
+		});
+		globalThis.fetch = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					ok: true,
+					team_id: upstreamTeamId,
+					enterprise_id: upstreamEnterpriseId,
+					is_enterprise_install: upstreamEnterpriseInstall,
+				}),
+			),
+		) as typeof fetch;
+
+		const result = await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		);
+
+		expect(result).toMatchObject({
+			action: "test",
+			status: "error",
+			error_code: "AUTH_INVALID",
+			retryable: false,
+		});
+		expect(String((result as { message: string }).message)).toContain(expected);
+		expect(JSON.stringify(result)).not.toContain(token);
+	});
+
 	it("rejects a sibling workspace for a workspace-scoped install", async () => {
 		const { org, ctx } = await seedOwnerContext({
 			orgName: "Slack Workspace Probe Org",

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -64,13 +64,14 @@ export interface SlackWebApi {
   revokeToken(botToken: string): Promise<boolean>;
   /**
    * `auth.test` — identify the workspace and Enterprise installation semantics
-   * a bot token belongs to. Returns the concrete `T…` workspace separately
-   * from the optional `E…` enterprise id; callers must never compare them as
-   * aliases. Used by `connections.test` to prove a stored credential is live and
-   * still names the workspace we routed it to, and by the ACL sync to self-heal a
-   * BYO connection created without an OAuth install (so it never persisted a
-   * `teamId`): we resolve the token's REAL team from Slack, verify it matches the
-   * channel binding's team before graphing, and backfill it onto the connection row.
+   * a bot token belongs to. Workspace installs return a concrete `T…` team id;
+   * an org-wide install may instead return its `E…` enterprise id as `team_id`
+   * with no concrete workspace. Used by `connections.test` to prove a stored
+   * credential is live and still names the stored scope, and by the ACL sync to
+   * self-heal a workspace-scoped BYO connection created without an OAuth install
+   * (so it never persisted a `teamId`): we resolve the token's real team from
+   * Slack, verify it matches the channel binding's team before graphing, and
+   * backfill it onto the connection row.
    * Throws on a Slack-level error (an invalid/revoked token yields `invalid_auth`).
    */
   authTest(botToken: string): Promise<{

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -222,16 +222,15 @@ export async function handleTest(
           ...testErrorFields('AUTH_INVALID'),
         });
       }
+      // `slackIdentityMismatch` has already proven the shape: an `E…` team id
+      // here is an org-wide install whose enterprise id is present and equal.
+      const scope = SLACK_ENTERPRISE_ID.test(identity.teamId)
+        ? `org-wide enterprise ${identity.teamId}, no separate concrete workspace`
+        : `workspace ${identity.teamId}, ${identity.enterpriseId ? `enterprise ${identity.enterpriseId}` : 'no enterprise'}`;
       return withDeviceHealth({
         action: 'test',
         status: 'ok',
-        message: [
-          `Slack auth.test succeeded: workspace ${identity.teamId}`,
-          identity.enterpriseId
-            ? `enterprise ${identity.enterpriseId}`
-            : 'no enterprise',
-          `enterprise_install=${identity.isEnterpriseInstall}`,
-        ].join(', '),
+        message: `Slack auth.test succeeded: ${scope}, enterprise_install=${identity.isEnterpriseInstall}`,
       });
     } catch (error) {
       const message = getErrorMessage(error);
@@ -485,8 +484,9 @@ function connectorSupportsNoAuth(authSchema: unknown): boolean {
   return Array.isArray(methods) && methods.some((m) => m?.type === 'none');
 }
 
-/** Slack workspace ids are `T…`; an enterprise id is `E…`. Never interchangeable. */
+/** Slack workspace ids are `T…`; enterprise ids are `E…`. Never interchangeable. */
 const SLACK_WORKSPACE_ID = /^T[A-Z0-9]+$/i;
+const SLACK_ENTERPRISE_ID = /^E[A-Z0-9]+$/i;
 
 function slackIdentityMismatch(
   conn: {
@@ -517,12 +517,37 @@ function slackIdentityMismatch(
       typeof value === 'string' && SLACK_WORKSPACE_ID.test(value)
   );
   const storedEnterpriseId =
-    typeof metadata.enterpriseId === 'string'
+    typeof metadata.enterpriseId === 'string' &&
+    SLACK_ENTERPRISE_ID.test(metadata.enterpriseId)
       ? metadata.enterpriseId
-      : storedTenantId?.startsWith('E')
+      : storedTenantId && SLACK_ENTERPRISE_ID.test(storedTenantId)
         ? storedTenantId
         : null;
   const storedEnterpriseInstall = metadata.isEnterpriseInstall === true;
+
+  // An ORG-WIDE Grid install has no concrete workspace, so `auth.test` reports
+  // the `E…` enterprise id in `team_id` — the same identity key the OAuth
+  // install path persists (`slack-web.ts` falls back to `enterprise.id` when
+  // `oauth.v2.access` returns no `team`). Validate that shape on its own terms
+  // instead of failing it as a malformed `T…`.
+  if (SLACK_ENTERPRISE_ID.test(upstream.teamId)) {
+    if (!upstream.isEnterpriseInstall) {
+      return `upstream reports workspace-scoped install but named enterprise '${upstream.teamId}' as its workspace`;
+    }
+    if (!storedEnterpriseInstall) {
+      return 'upstream credential is org-wide but stored connection is workspace-scoped';
+    }
+    if (!upstream.enterpriseId || !SLACK_ENTERPRISE_ID.test(upstream.enterpriseId)) {
+      return `upstream enterprise '${upstream.enterpriseId ?? 'none'}' is not a Slack E id`;
+    }
+    if (upstream.teamId !== upstream.enterpriseId) {
+      return `upstream org-wide identity '${upstream.teamId}' does not match upstream enterprise '${upstream.enterpriseId}'`;
+    }
+    if (upstream.enterpriseId !== storedEnterpriseId) {
+      return `upstream enterprise '${upstream.enterpriseId}' does not match stored enterprise '${storedEnterpriseId ?? 'none'}'`;
+    }
+    return null;
+  }
 
   if (!SLACK_WORKSPACE_ID.test(upstream.teamId)) {
     return `upstream workspace id '${upstream.teamId}' is not a Slack T id`;
@@ -531,7 +556,10 @@ function slackIdentityMismatch(
     if (!storedEnterpriseInstall) {
       return 'upstream credential is org-wide but stored connection is workspace-scoped';
     }
-    if (!upstream.enterpriseId || upstream.enterpriseId !== storedEnterpriseId) {
+    if (!upstream.enterpriseId || !SLACK_ENTERPRISE_ID.test(upstream.enterpriseId)) {
+      return `upstream enterprise '${upstream.enterpriseId ?? 'none'}' is not a Slack E id`;
+    }
+    if (upstream.enterpriseId !== storedEnterpriseId) {
       return `upstream enterprise '${upstream.enterpriseId ?? 'none'}' does not match stored enterprise '${storedEnterpriseId ?? 'none'}'`;
     }
     return null;


### PR DESCRIPTION
## Summary
- Accept Slack org-wide `auth.test` responses that return the enterprise E id in `team_id` only when the upstream and stored enterprise identities match and `is_enterprise_install=true`.
- Keep workspace installs pinned to an exact Slack T id, and require valid matching E enterprise identities for org-wide T+E responses.
- Report that enterprise-only responses expose no separate concrete workspace, without leaking tokens or masking selected-device health.

## Test plan
- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: focused Slack identity, BYO auth, and connection device-health integration suites (19 tests)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval (not applicable; bot runtime unchanged)

Initial production-shape red:
```
Test Files  1 failed (1)
Tests  1 failed | 2 passed (3)
Expected status ok; received status error for the E0BQ0T88H3R / E0BQ0T88H3R / true provider shape.
```

Review-thread red before enterprise format validation:
```
Test Files  1 failed (1)
Tests  1 failed | 7 passed (8)
Malformed matching enterprise ids on an org-wide T workspace returned status ok.
```

Green on final head:
```
Test Files  3 passed (3)
Tests  19 passed (19)
```

Additional gates:
- server `bun run typecheck` clean
- final `make pre-pr` clean
- `make review-fix` completed once; no late writer remained
- rebased onto `origin/main` containing OAuth squash `03899b82c05cb6e7af47ee85d2bff91525fd8aca`

## Notes
No database, public API, SDK, endpoint, compatibility, UI, or bot-runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating Slack organization-wide credentials using enterprise identity information.
  * Slack connection test results now distinguish enterprise-scoped and workspace-scoped credentials.

* **Bug Fixes**
  * Improved validation for mismatched, malformed, or incorrectly scoped Slack identities.
  * Invalid connections now fail without retrying or exposing authentication tokens.

* **Documentation**
  * Clarified Slack authentication behavior for organization-wide installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->