### PR TITLE
fix(server): serialize edge audits with force-delete

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
@@ -7,6 +7,10 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  insertConnectionlessAuditEvent,
+  recordEdgeChangeEvent,
+} from '../../../utils/insert-event';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestEvent } from '../../setup/test-fixtures';
 import { TestWorkspace } from '../../setup/test-mcp-client';
@@ -56,6 +60,39 @@ async function waitForEdgeChangeEvent(relationshipId: number, op: 'link' | 'unli
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`Timed out waiting for ${op} audit event on relationship ${relationshipId}`);
+}
+
+/**
+ * Wait until `count` other backends in this database are parked on a lock.
+ *
+ * Keyed on the count rather than on a query fragment: exactly which statement
+ * each side parks on is an implementation detail of the delete path, and a test
+ * that pinned the text would keep passing — vacuously — the day that path grows
+ * a lock earlier or renames a column in an unrelated SELECT.
+ */
+async function waitForLockWaiters(count: number) {
+  const sql = getTestDb();
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const rows = await sql<{ waiting: number }[]>`
+      SELECT COUNT(*)::int AS waiting
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND pid <> pg_backend_pid()
+        AND wait_event_type = 'Lock'
+    `;
+    if (rows[0].waiting >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  const active = await sql`
+    SELECT wait_event_type, wait_event, LEFT(query, 300) AS query
+    FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND pid <> pg_backend_pid()
+      AND state <> 'idle'
+  `;
+  throw new Error(
+    `Timed out waiting for ${count} lock waiters: ${JSON.stringify(active)}`
+  );
 }
 
 describe('entity history contracts', () => {
@@ -238,6 +275,163 @@ describe('entity history contracts', () => {
         AND ${a.entity.id} = ANY(entity_ids)
     `;
     expect(changeEvents).toHaveLength(0);
+  });
+
+  it('does not attach a late edge audit to an already hard-deleted endpoint (#2812)', async () => {
+    const deleted = (await workspace.owner.entities.create({
+      type: 'brand',
+      name: 'Deleted Before Audit',
+    })) as { entity: { id: number } };
+    const survivor = (await workspace.owner.entities.create({
+      type: 'brand',
+      name: 'Surviving Audit Endpoint',
+    })) as { entity: { id: number } };
+
+    await workspace.owner.entities.delete({
+      entity_id: deleted.entity.id,
+      force_delete_tree: true,
+    });
+
+    // Drive the audit writer directly with a synthetic edge: no
+    // `entity_relationships` row is needed (or wanted — the real one would have
+    // been cascaded by the delete above), and the writer FKs on none of these
+    // ids. The offset only keeps the id clear of relationships other tests mint.
+    const relationshipId = deleted.entity.id + 1_000_000_000;
+    recordEdgeChangeEvent({
+      organizationId: workspace.org.id,
+      relationshipId,
+      fromEntityId: deleted.entity.id,
+      toEntityId: survivor.entity.id,
+      relationshipTypeId: 1,
+      relationshipTypeSlug: 'related-brand',
+      op: 'unlink',
+      changes: [{ field: 'exists', old: true, new: false }],
+      createdBy: workspace.users.owner.id,
+    });
+    await waitForEdgeChangeEvent(relationshipId, 'unlink');
+
+    const rows = await getTestDb()<{
+      deleted_still_linked: boolean;
+      survivor_linked: boolean;
+    }[]>`
+      SELECT
+        ${deleted.entity.id} = ANY(entity_ids) AS deleted_still_linked,
+        ${survivor.entity.id} = ANY(entity_ids) AS survivor_linked
+      FROM events
+      WHERE semantic_type = 'change'
+        AND metadata->>'category' = 'relationship'
+        AND metadata->>'relationshipId' = ${String(relationshipId)}
+        AND metadata->>'op' = 'unlink'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      deleted_still_linked: false,
+      survivor_linked: true,
+    });
+  });
+
+  /**
+   * The force-delete dependency report is computed BEFORE the transaction takes
+   * any lock, so an edge audit can commit inside that window and be detached by
+   * a sweep the preflight never counted — the `events_detached` undercount in
+   * #2812. Freeze `events` against writes (EXCLUSIVE still permits the delete's
+   * own SELECTs, so its preflight really does read zero), park the audit on its
+   * INSERT while it holds the org and entity locks, and let the delete queue
+   * behind it.
+   *
+   * Doubles as the regression test for the audit's lock ORDER: it must claim
+   * `organization` before `entities`, the order `lockOrgForAclInvalidation`
+   * documents, because `events_organization_id_fkey` takes the org lock at
+   * INSERT time. Reversed, this interleaving deadlocks and Postgres aborts one
+   * of the two transactions instead of either assertion below being reached.
+   */
+  it('reports the event rows its transaction actually detached, not the preflight (#2812)', async () => {
+    const deleted = (await workspace.owner.entities.create({
+      type: 'brand',
+      name: 'Deleted During Audit',
+    })) as { entity: { id: number } };
+    const survivor = (await workspace.owner.entities.create({
+      type: 'brand',
+      name: 'Concurrent Audit Survivor',
+    })) as { entity: { id: number } };
+    const sql = getTestDb();
+
+    let signalEventsLocked!: () => void;
+    const eventsLocked = new Promise<void>((resolve) => {
+      signalEventsLocked = resolve;
+    });
+    let releaseEventsLock!: () => void;
+    const eventsLockReleased = new Promise<void>((resolve) => {
+      releaseEventsLock = resolve;
+    });
+    const tableBlocker = sql.begin(async (tx) => {
+      await tx`LOCK TABLE events IN EXCLUSIVE MODE`;
+      signalEventsLocked();
+      await eventsLockReleased;
+    });
+
+    await eventsLocked;
+    // Distinct offset from the synthetic edge above, so the two tests' audit
+    // rows can never be mistaken for each other.
+    const relationshipId = deleted.entity.id + 2_000_000_000;
+    const originId = `edge-race-test:${relationshipId}`;
+    let auditPromise: Promise<unknown> | undefined;
+    let deletePromise: Promise<unknown> | undefined;
+    try {
+      auditPromise = insertConnectionlessAuditEvent(
+        {
+          entityIds: [deleted.entity.id, survivor.entity.id],
+          organizationId: workspace.org.id,
+          originId,
+          semanticType: 'change',
+          title: 'Concurrent relationship audit',
+          metadata: {
+            category: 'relationship',
+            op: 'unlink',
+            relationshipId: String(relationshipId),
+          },
+          createdBy: workspace.users.owner.id,
+        },
+        { subject: 'relationship', op: 'unlinked' },
+        { lockAndPruneEntityRefs: true }
+      );
+      await waitForLockWaiters(1);
+
+      deletePromise = workspace.owner.entities.delete({
+        entity_id: deleted.entity.id,
+        force_delete_tree: true,
+      });
+      await waitForLockWaiters(2);
+
+      // Both sides are now frozen, so this is exactly what the delete's
+      // preflight counted. Asserting it pins the discriminator: the report
+      // below can only say 1 if it was recomputed from the sweep.
+      const preflight = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count
+        FROM events
+        WHERE ${deleted.entity.id} = ANY(entity_ids)
+      `;
+      expect(preflight[0].count).toBe(0);
+
+      releaseEventsLock();
+      await tableBlocker;
+      await auditPromise;
+      const result = (await deletePromise) as { tree?: Record<string, number> };
+      expect(result.tree?.events_detached).toBe(1);
+    } finally {
+      releaseEventsLock();
+      await tableBlocker.catch(() => undefined);
+      await auditPromise?.catch(() => undefined);
+      await deletePromise?.catch(() => undefined);
+    }
+
+    const rows = await sql<{ deleted_still_linked: boolean }[]>`
+      SELECT ${deleted.entity.id} = ANY(entity_ids) AS deleted_still_linked
+      FROM events
+      WHERE origin_id = ${originId}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted_still_linked).toBe(false);
   });
 
   it('hard-deletes a descendant tree with no event history', async () => {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1537,9 +1537,10 @@ export async function getEntity(
 
 /**
  * Force-delete dependency report: what a hard delete of the tree removes or
- * detaches. Computed up front so `dry_run` can return it without mutating and
- * the real delete can echo exactly what it touched. Event rows are append-only
- * and are only ever detached, never deleted.
+ * detaches. Computed up front so `dry_run` can return it without mutating; a
+ * real delete refreshes `events_detached` from the rows its transaction
+ * actually changed. Event rows are append-only and are only ever detached,
+ * never deleted.
  */
 export interface ForceDeleteTreeReport {
   entities: number;
@@ -1899,6 +1900,7 @@ export async function deleteEntity(
       // Batched so a large history can't push one UPDATE past
       // statement_timeout; still atomic (all batches share this transaction).
       const EVENT_DETACH_BATCH = 5000;
+      let eventsDetached = 0;
       for (;;) {
         const detached = await tx<{ id: number }>`
           UPDATE events e
@@ -1914,8 +1916,13 @@ export async function deleteEntity(
           )
           RETURNING e.id
         `;
+        eventsDetached += detached.length;
         if (detached.length < EVENT_DETACH_BATCH) break;
       }
+      // The preflight count is a useful preview, but an edge audit holding the
+      // org/entity locks this transaction waited on can commit in between.
+      // Report what this transaction actually detached, not the earlier snapshot.
+      report.events_detached = eventsDetached;
 
       await hardDeleteEntityRows({ tx, ids: entityTreeIds });
     });

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -781,6 +781,57 @@ async function queueWorkspaceEventActivation(args: {
 
 const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
 
+interface ConnectionlessAuditInsertOptions {
+  /**
+   * Serialize this insert against a concurrent force-delete of the entities it
+   * references, and omit ids that lost the race. Whichever side commits first
+   * wins cleanly: if the audit does, the delete's `entity_ids` sweep sees and
+   * detaches it; if the delete does, the immutable audit row still lands, just
+   * without the ids it would otherwise dangle on.
+   */
+  lockAndPruneEntityRefs?: boolean;
+}
+
+/**
+ * Insert an audit row under the same row locks the force-delete path takes,
+ * dropping any referenced entity that has already been hard-deleted.
+ *
+ * `organization` is claimed BEFORE `entities`, matching
+ * `lockOrgForAclInvalidation`'s documented order. That order is not optional
+ * here: `events_organization_id_fkey` makes the INSERT take a KEY SHARE on the
+ * org row, so locking the entities first and only reaching the org row through
+ * the foreign key inverts the order and deadlocks against a force-delete, which
+ * holds the org row and is waiting for those same entity rows.
+ *
+ * Both locks are the weakest mode that still conflicts with `FOR UPDATE`, so
+ * ordinary readers and non-key updates never wait on an audit write.
+ */
+async function insertAuditEventPruningDeletedEntityRefs(
+  params: InsertEventParams
+): Promise<InsertedEvent> {
+  const entityIdsLiteral = `{${params.entityIds.join(',')}}`;
+  return getDb().begin(async (tx) => {
+    await tx`
+      SELECT 1 FROM organization WHERE id = ${params.organizationId} FOR KEY SHARE
+    `;
+    const surviving = await tx<{ id: number | string }>`
+      SELECT id
+      FROM entities
+      WHERE id = ANY(${entityIdsLiteral}::bigint[])
+      ORDER BY id
+      FOR KEY SHARE
+    `;
+    const survivingIds = new Set(surviving.map((row) => Number(row.id)));
+    return insertEvent(
+      {
+        ...params,
+        entityIds: params.entityIds.filter((id) => survivingIds.has(id)),
+      },
+      { sql: tx }
+    );
+  }) as Promise<InsertedEvent>;
+}
+
 /**
  * Persist a connectionless audit/change event with DB-enforced idempotency.
  *
@@ -799,7 +850,8 @@ const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
  */
 export async function insertConnectionlessAuditEvent(
   params: InsertEventParams,
-  eventType: AuditEventType
+  eventType: AuditEventType,
+  options?: ConnectionlessAuditInsertOptions
 ): Promise<InsertedEvent> {
   const idempotencyKey = `audit:${params.originId}`;
   const formattedEventType = formatAuditEventType(eventType);
@@ -816,12 +868,16 @@ export async function insertConnectionlessAuditEvent(
     params.automationId ?? actingScope?.automationId ?? null;
 
   try {
-    const inserted = await insertEvent({
+    const eventParams = {
       ...params,
       connectionId: null,
       automationId: producerAutomationId,
       metadata,
-    });
+    };
+    const inserted =
+      options?.lockAndPruneEntityRefs && params.entityIds.length > 0
+        ? await insertAuditEventPruningDeletedEntityRefs(eventParams)
+        : await insertEvent(eventParams);
     await queueWorkspaceEventActivation({
       organizationId: params.organizationId,
       eventId: inserted.id,
@@ -984,7 +1040,8 @@ export function recordEdgeChangeEvent(params: EdgeChangeEventParams): void {
       },
       // `verb` not `op`: the stored op is imperative (link/unlink/update_link)
       // while the shared vocabulary is past-tense.
-      { subject: 'relationship', op: verb }),
+      { subject: 'relationship', op: verb },
+      { lockAndPruneEntityRefs: true }),
     AUDIT_EVENT_RETRY
   ).catch((err) => {
     logger.error(


### PR DESCRIPTION
Fixes #2812

## Summary
- serialize edge-audit insertion against force-delete with organization-first, then entity row locks
- preserve the immutable audit row while pruning endpoint ids that were already hard-deleted
- report the event rows the delete transaction actually detached rather than its earlier preflight snapshot
- add deterministic regressions for both delete-first and audit-first interleavings, including lock-order deadlock coverage

## Verification
- entity history integration contract: 6/6 passed
- related integration event and entity suites: 285 passed
- related authz and relationship suites: 258 passed
- platform event and workspace-root suites: 16 passed
- server typecheck passed
- make pre-pr passed

## Scope note
The general recordChangeEvent writer also uses fire-and-forget entity references. It is not changed here because putting every entity update through this transaction and lock path needs separate throughput measurement; this PR remains scoped to the edge-audit race reported in #2812.