### PR TITLE
fix(dev): resolve a remote-only branch in task-setup

### DIFF
--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -129,8 +129,16 @@ fi
 if [[ $refresh_only -eq 0 ]]; then
   echo "→ creating lobu worktree: $worktree_dir on $branch"
   (cd "$repo" && git fetch origin --quiet)
+  # Same three-way resolution the submodule block below already uses: a local
+  # branch, else the remote one, else fresh off main. Without the middle case,
+  # picking up an existing PR whose branch lives only on origin silently starts
+  # the worktree at origin/main — the branch name matches, so it looks correct
+  # right up until the PR's commits are missing.
   if (cd "$repo" && git show-ref --verify --quiet "refs/heads/$branch"); then
     (cd "$repo" && git worktree add "$worktree_dir" "$branch")
+  elif (cd "$repo" && git show-ref --verify --quiet "refs/remotes/origin/$branch"); then
+    echo "→ tracking existing remote branch origin/$branch"
+    (cd "$repo" && git worktree add --track -b "$branch" "$worktree_dir" "origin/$branch")
   else
     (cd "$repo" && git worktree add "$worktree_dir" -b "$branch" origin/main)
   fi


### PR DESCRIPTION
## Summary

`scripts/task-setup.sh` checked only `refs/heads/` when resolving the slug's branch. Picking up an existing PR whose branch lives only on `origin` fell through to the `else` and started the worktree at `origin/main` — with the correct branch name, so it looked right until the PR's commits turned out to be missing and the work appeared to have vanished.

Adds the middle case, matching the three-way resolution the **submodule block a few lines below already used**: local branch → remote branch → fresh off `main`. `--track` sets upstream so a later `git push` targets the PR's branch rather than opening a second head.

Hit this for real while consolidating the artifact PRs (#3037): `feat/pr3013-storage-foundation` existed only on origin, and `make task-setup` handed back an empty worktree off main.

## Test plan

Fixture: a bare origin with `main` plus `feat/only-remote` (carrying `feature.txt`), with the local branch deleted so it exists only on the remote. Both variants run against a freshly rebuilt fixture.

- [x] **Red** — current logic: `feature.txt: NO   <-- work missing`
- [x] **Green** — fixed logic: `feature.txt: YES (THE FEATURE WORK)`, `upstream: origin/feat/only-remote`, `branch: feat/only-remote`
- [x] **Regression** — a slug with no branch anywhere still starts clean off `origin/main`
- [x] `bash -n scripts/task-setup.sh` clean
- [x] `make pre-pr` clean

The first red run was invalid — `git worktree add -b` had created the local branch, so the green run reported "reuse local" and proved nothing. Both runs above use a fixture rebuilt from scratch.

## Notes

Behaviour is unchanged for the two existing paths; this only fills the gap between them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing commits when creating task worktrees from remote task branches.
  * Added fallback to the main branch when no matching remote task branch is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->