### PR TITLE
fix(auth): scope direct MCP worker credentials

### DIFF
--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -9,7 +9,9 @@ import {
   generateWorkerToken,
   generateWorkerTokenPair,
   looksLikeWorkerToken,
+  mintGatewayMcpToken,
   verifyEgressProxyToken,
+  verifyGatewayMcpToken,
   verifyWorkerToken,
   type WorkerTokenData,
   type WorkerTokenOptions,
@@ -305,15 +307,41 @@ describe("worker auth token", () => {
     expect(verifyWorkerToken(t2)).not.toBeNull();
   });
 
-  test("worker and egress-proxy credentials are accepted only on their own surfaces", () => {
+  test("worker, egress-proxy, and gateway-MCP credentials are accepted only on their own surfaces", () => {
     const pair = generateWorkerTokenPair("u", "c", "d", {
       channelId: "ch",
     });
+    const gatewayMcpToken = mintGatewayMcpToken(pair.workerToken);
 
     expect(verifyWorkerToken(pair.workerToken)).not.toBeNull();
     expect(verifyEgressProxyToken(pair.egressProxyToken)).not.toBeNull();
+    expect(verifyGatewayMcpToken(gatewayMcpToken ?? "")).not.toBeNull();
     expect(verifyWorkerToken(pair.egressProxyToken)).toBeNull();
     expect(verifyEgressProxyToken(pair.workerToken)).toBeNull();
+    expect(verifyWorkerToken(gatewayMcpToken ?? "")).toBeNull();
+    expect(verifyEgressProxyToken(gatewayMcpToken ?? "")).toBeNull();
+    expect(verifyGatewayMcpToken(pair.workerToken)).toBeNull();
+  });
+
+  test("gateway-MCP narrowing preserves every signed claim and its lifetime", () => {
+    const workerToken = generateWorkerToken(
+      "user-2",
+      "conv-2",
+      "deploy-B",
+      ALL_CLAIMS
+    );
+    const worker = verifyWorkerToken(workerToken) as WorkerTokenData;
+    const gatewayMcpToken = mintGatewayMcpToken(workerToken);
+    const narrowed = verifyGatewayMcpToken(gatewayMcpToken ?? "");
+
+    expect(narrowed).toEqual({ ...worker, tokenKind: "gateway-mcp" });
+    expect(narrowed?.timestamp).toBe(worker.timestamp);
+    expect(narrowed?.jti).toBe(worker.jti);
+  });
+
+  test("gateway-MCP narrowing refuses a non-worker credential", () => {
+    const pair = generateWorkerTokenPair("u", "c", "d", { channelId: "ch" });
+    expect(mintGatewayMcpToken(pair.egressProxyToken)).toBeNull();
   });
 
   test("a deployment token pair shares one revocation id", () => {

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -21,12 +21,13 @@ export function looksLikeWorkerToken(token: string): boolean {
 
 export interface WorkerTokenData {
   /**
-   * Separates the bearer accepted by worker-facing gateway routes from the
-   * credential exposed to agent subprocesses through HTTP_PROXY.
+   * Separates worker-facing bearers, credentials exposed to agent subprocesses
+   * through HTTP_PROXY, and the server-only embedded MCP credential.
    *
-   * Absent means "worker" for tokens minted before this discriminator existed.
+   * Absent means "worker" for tokens minted before this discriminator existed;
+   * `gateway-mcp` is never returned to or minted inside an agent process.
    */
-  tokenKind?: "worker" | "egress-proxy";
+  tokenKind?: "worker" | "egress-proxy" | "gateway-mcp";
   userId: string;
   conversationId: string;
   channelId: string;
@@ -296,6 +297,25 @@ export function generateWorkerTokenPair(
   };
 }
 
+/**
+ * Narrow a verified worker credential to the embedded MCP hop.
+ *
+ * The gateway derives this only for its internal upstream hop. For tool calls,
+ * that happens after worker authentication and pre-tool policy. The derived
+ * credential preserves the original token's timestamp, revocation id, and
+ * identity claims, but worker-facing routes reject its distinct token kind.
+ */
+export function mintGatewayMcpToken(workerToken: string): string | null {
+  const data = verifyWorkerToken(workerToken);
+  if (!data) return null;
+  return encrypt(
+    JSON.stringify({
+      ...data,
+      tokenKind: "gateway-mcp" satisfies WorkerTokenData["tokenKind"],
+    })
+  );
+}
+
 function parsePositiveIntEnv(
   name: string,
   fallback: number,
@@ -312,7 +332,7 @@ function parsePositiveIntEnv(
  */
 function verifyToken(
   token: string,
-  expectedKind: "worker" | "egress-proxy"
+  expectedKind: "worker" | "egress-proxy" | "gateway-mcp"
 ): WorkerTokenData | null {
   try {
     const parsed: unknown = JSON.parse(decrypt(token));
@@ -329,7 +349,9 @@ function verifyToken(
 
     const tokenKind = data.tokenKind ?? "worker";
     if (
-      (tokenKind !== "worker" && tokenKind !== "egress-proxy") ||
+      (tokenKind !== "worker" &&
+        tokenKind !== "egress-proxy" &&
+        tokenKind !== "gateway-mcp") ||
       tokenKind !== expectedKind
     ) {
       logger.error(`Token rejected: expected ${expectedKind} credential`);
@@ -538,4 +560,8 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
 
 export function verifyEgressProxyToken(token: string): WorkerTokenData | null {
   return verifyToken(token, "egress-proxy");
+}
+
+export function verifyGatewayMcpToken(token: string): WorkerTokenData | null {
+  return verifyToken(token, "gateway-mcp");
 }

--- a/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
@@ -1,4 +1,4 @@
-import { generateWorkerToken } from '@lobu/core';
+import { generateWorkerToken, mintGatewayMcpToken } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -37,20 +37,32 @@ describe('worker MCP session agent identity', () => {
       agentId: OTHER_AGENT_ID,
       ownerUserId: user.id,
     });
-    workerToken = generateWorkerToken(user.id, 'conv-agent-turn-1', 'test-deployment', {
-      channelId: 'api-conv-agent-turn-1',
-      agentId: AGENT_ID,
-      organizationId: org.id,
-      platform: 'api',
-      source: 'internal',
-    });
-    otherWorkerToken = generateWorkerToken(user.id, 'conv-agent-turn-2', 'test-deployment', {
+    const rawWorkerToken = generateWorkerToken(
+      user.id,
+      'conv-agent-turn-1',
+      'test-deployment',
+      {
+        channelId: 'api-conv-agent-turn-1',
+        agentId: AGENT_ID,
+        organizationId: org.id,
+        platform: 'api',
+        source: 'internal',
+      }
+    );
+    const rawOtherWorkerToken = generateWorkerToken(user.id, 'conv-agent-turn-2', 'test-deployment', {
       channelId: 'api-conv-agent-turn-2',
       agentId: OTHER_AGENT_ID,
       organizationId: org.id,
       platform: 'api',
       source: 'internal',
     });
+    const narrowedWorkerToken = mintGatewayMcpToken(rawWorkerToken);
+    const narrowedOtherWorkerToken = mintGatewayMcpToken(rawOtherWorkerToken);
+    if (!narrowedWorkerToken || !narrowedOtherWorkerToken) {
+      throw new Error('failed to narrow test worker credentials for the MCP hop');
+    }
+    workerToken = narrowedWorkerToken;
+    otherWorkerToken = narrowedOtherWorkerToken;
   });
 
   /** Mirror the gateway proxy handshake, whose initialize metadata omits agentId. */

--- a/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
@@ -11,6 +11,7 @@
 import { generateWorkerToken, verifyWorkerToken } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getRevokedTokenStore } from '../../../gateway/auth/revoked-token-store';
+import { buildDeploymentWorkerToken } from '../../../gateway/orchestration/deployment-identity';
 import { buildAutomationRunWorkerAccess } from '../../../gateway/services/automation-run-worker-token';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
@@ -118,6 +119,44 @@ describe('worker-token MCP auth without the direct-auth header', () => {
     expect(response.status).toBe(401);
     const body = (await response.json()) as { error?: string };
     expect(body.error).toBe('invalid_token');
+  });
+
+  it('refuses a chat deployment token with or without the request-controlled direct-auth header', async () => {
+    const deploymentToken = buildDeploymentWorkerToken({
+      userId: 'api-user',
+      conversationId: 'interactive-conversation',
+      deploymentName: 'api-headerless-agent',
+      channelId: 'api-user',
+      agentId: AGENT_ID,
+      organizationId: org.id,
+      platform: 'api',
+    });
+
+    const headerlessResponse = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: deploymentToken,
+    });
+    expect(headerlessResponse.status).toBe(403);
+    expect(await headerlessResponse.json()).toMatchObject({ error: 'insufficient_scope' });
+
+    const explicitHeaderResponse = await post(`/mcp/${org.slug}`, {
+      body: INITIALIZE_BODY,
+      token: deploymentToken,
+      headers: { 'X-Lobu-Memory-Direct-Auth': '1' },
+    });
+    expect(explicitHeaderResponse.status).toBe(403);
+    expect(await explicitHeaderResponse.json()).toMatchObject({
+      error: 'insufficient_scope',
+    });
+  });
+
+  it('does not promote a worker token on non-MCP routes', async () => {
+    const response = await post(`/api/${org.slug}/query_sdk`, {
+      body: { sql: 'return lobu.organization.id' },
+      token: workerToken,
+      headers: { 'X-Lobu-Memory-Direct-Auth': '1' },
+    });
+    expect(response.status).toBe(401);
   });
 
   it('a bearer that is not a worker token still falls through to OAuth auth', async () => {

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -21,7 +21,12 @@ import {
   expect,
   test,
 } from "bun:test";
-import { generateWorkerToken, MCP_PROTOCOL_VERSION, verifyWorkerToken } from "@lobu/core";
+import {
+  generateWorkerToken,
+  MCP_PROTOCOL_VERSION,
+  verifyGatewayMcpToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import type { DirectToolExecutionOptions } from "../auth/mcp/proxy.js";
@@ -271,8 +276,16 @@ describe("SSRF guard", () => {
     const proxy = new McpProxy(configSource, {    });
     const app = proxy.getApp();
 
-    globalThis.fetch = async () =>
-      new Response(
+    let forwardedAuthorization: string | null = null;
+    globalThis.fetch = async (_input, init) => {
+      forwardedAuthorization = new Headers(init?.headers).get("authorization");
+      const gatewayToken = verifyGatewayMcpToken(
+        forwardedAuthorization?.slice("Bearer ".length) ?? "",
+      );
+      expect(gatewayToken).toMatchObject({ userId: "user1" });
+      expect(gatewayToken?.source).toBe(verifyWorkerToken(agent1Token)?.source);
+      expect(verifyWorkerToken(forwardedAuthorization?.slice("Bearer ".length) ?? "")).toBeNull();
+      return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
           id: 1,
@@ -280,6 +293,7 @@ describe("SSRF guard", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    };
 
     const res = await app.request("/lobu-memory/tools/search_memory", {
       method: "POST",
@@ -290,6 +304,8 @@ describe("SSRF guard", () => {
       body: JSON.stringify({ query: "test" }),
     });
     expect(res.status).toBe(200);
+    expect(forwardedAuthorization).toMatch(/^Bearer /);
+    expect(forwardedAuthorization).not.toBe(`Bearer ${agent1Token}`);
   });
 
   test("blocks GET /tools to reserved-IP MCP via list-all endpoint", async () => {
@@ -1230,7 +1246,7 @@ describe("executeToolDirect", () => {
     expect(requestHeaders.get("x-lobu-memory-direct-auth")).toBe("1");
     const authorization = requestHeaders.get("authorization");
     expect(authorization).toMatch(/^Bearer /);
-    const token = verifyWorkerToken(authorization?.slice("Bearer ".length) ?? "");
+    const token = verifyGatewayMcpToken(authorization?.slice("Bearer ".length) ?? "");
     expect(token).toMatchObject({
       userId: "approving-user",
       agentId: "agent1",
@@ -1295,7 +1311,7 @@ describe("executeToolDirect", () => {
 
     expect(result.isError).toBe(false);
     const authorization = requestHeaders.get("authorization");
-    const token = verifyWorkerToken(authorization?.slice("Bearer ".length) ?? "");
+    const token = verifyGatewayMcpToken(authorization?.slice("Bearer ".length) ?? "");
     // Minting the unpaired claims produces a token the verifier rejects
     // outright (401 on resume); pairing drops the admin tier and the resumed
     // call still authenticates as a plain, non-admin worker.

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -1,5 +1,6 @@
 import {
 	MCP_PROTOCOL_VERSION,
+	mintGatewayMcpToken,
 	verifyWorkerToken,
 	type WorkerTokenData,
 } from "@lobu/core";
@@ -138,7 +139,13 @@ export function buildUpstreamHeaders(
 		Accept: "application/json, text/event-stream",
 	};
 
-	if (credentialToken) {
+	if (credentialToken && internal) {
+		const gatewayMcpToken = mintGatewayMcpToken(credentialToken);
+		if (!gatewayMcpToken) {
+			throw new Error("Internal MCP credential must be a verified worker token");
+		}
+		headers.Authorization = `Bearer ${gatewayMcpToken}`;
+	} else if (credentialToken) {
 		headers.Authorization = `Bearer ${credentialToken}`;
 	}
 

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -1,4 +1,8 @@
-import { looksLikeWorkerToken, verifyWorkerToken } from '@lobu/core';
+import {
+  looksLikeWorkerToken,
+  verifyGatewayMcpToken,
+  verifyWorkerToken,
+} from '@lobu/core';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
@@ -11,6 +15,7 @@ import type { AuthInfo } from '../auth/oauth/types';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { isPublicReadable } from '../auth/tool-access';
 import { getDb } from '../db/client';
+import { AUTOMATION_RUN_SOURCE } from '../gateway/automation-run-session';
 import { getRevokedTokenStore } from '../gateway/auth/revoked-token-store';
 import { resolveRestToolGetRoute } from '../http/rest-tool-routes';
 import type { Env } from '../index';
@@ -294,21 +299,27 @@ export class MultiTenantProvider implements WorkspaceProvider {
     }
 
     // 1) Worker-token direct-auth for the in-process lobu-memory MCP. The
-    // gateway proxy marks this lane explicitly; spawned Automation CLIs cannot
-    // attach that internal header, so a verified worker bearer on an MCP route
-    // enters the same lane. Non-worker bearers still fall through to PAT,
-    // OAuth, or session auth.
+    // gateway narrows a verified worker token to the server-only gateway-mcp
+    // kind before forwarding internally, and stamps the internal header. Tool
+    // calls reach that forwarding step only after pre-tool policy.
+    // Spawned Automation CLIs instead use their signed automation-run source
+    // without that header. Ordinary worker tokens are rejected on both paths;
+    // non-worker bearers still fall through to PAT, OAuth, or session auth.
     const directAuthHeader = c.req.header('x-lobu-memory-direct-auth') === '1';
     const directAuthBearer =
-      authHeader?.startsWith('Bearer ') && (directAuthHeader || isMcpRoute)
+      authHeader?.startsWith('Bearer ') && isMcpRoute
         ? authHeader.slice(7)
         : null;
-    const directAuthTokenData =
-      directAuthBearer && looksLikeWorkerToken(directAuthBearer)
+    const gatewayMcpTokenData =
+      directAuthBearer && directAuthHeader && looksLikeWorkerToken(directAuthBearer)
+        ? verifyGatewayMcpToken(directAuthBearer)
+        : null;
+    const workerTokenData =
+      directAuthBearer && !gatewayMcpTokenData && looksLikeWorkerToken(directAuthBearer)
         ? verifyWorkerToken(directAuthBearer)
         : null;
-    if (directAuthBearer && (directAuthHeader || directAuthTokenData)) {
-      const tokenData = directAuthTokenData;
+    if (directAuthBearer && (directAuthHeader || workerTokenData)) {
+      const tokenData = gatewayMcpTokenData ?? workerTokenData;
       if (!tokenData) {
         return c.json(
           { error: 'invalid_token', error_description: 'Invalid or expired worker token' },
@@ -358,6 +369,18 @@ export class MultiTenantProvider implements WorkspaceProvider {
           {
             'WWW-Authenticate': bearerChallenge('invalid_token'),
           }
+        );
+      }
+      if (
+        !gatewayMcpTokenData &&
+        workerTokenData?.source !== AUTOMATION_RUN_SOURCE
+      ) {
+        return c.json(
+          {
+            error: 'insufficient_scope',
+            error_description: 'Worker token is not scoped to direct MCP access',
+          },
+          403
         );
       }
       const agentRows = await sql`


### PR DESCRIPTION
## Summary

- Accept direct `/mcp/<orgSlug>` worker authentication only for signed Automation-run tokens or a new server-only `gateway-mcp` credential kind.
- Narrow ordinary worker tokens to `gateway-mcp` only on the embedded gateway-to-memory loopback hop, preserving the original timestamp, revocation id, identity, source, execution, and admin claims.
- Reject chat deployment tokens when used directly, with or without the request-controlled internal header, while keeping ordinary chat traffic behind gateway pre-tool policy.
- Restrict the internal direct-auth header to MCP routes so it cannot promote a worker token on REST endpoints.

## Rollout boundary

- Automation-run source stamps shipped first in #2998 (`553411dd707d71af4905e06bea0e37fbf7ae0aec`) and have aged beyond the production worker-token TTL plus skew window.
- The Lobu-memory upstream is derived from the internal gateway URL and loops back to the same embedded server process. Each new instance therefore both mints and requires `gateway-mcp`; rolling deployments do not create a cross-version upstream dependency.
- The narrowed credential retains the original token timestamp and revocation id, and its distinct token kind is rejected by worker-facing and egress-proxy verifiers.

## Verification

- Red proof: the production chat deployment-token builder opened direct MCP with HTTP 200 before the gate.
- Core worker-auth suite: 47/47 passed.
- Gateway MCP proxy edge suite: 41/41 passed.
- Focused MCP integrations: 13/13 passed, including Automation headerless access, chat-token denial, gateway agent identity/session recovery, and non-MCP denial.
- `make review-fix`: fixed the REST-route boundary and unsafe test casts; no remaining findings.
- `make pre-pr`: all five gates clean.
- Pre-commit Biome and TypeScript checks: clean.

Closes #2979
