### PR TITLE
fix(server): bind save_memory media and stop re-sync supersede loops

### DIFF
--- a/packages/server/src/__tests__/integration/events/insert-event-attachment-resync.test.ts
+++ b/packages/server/src/__tests__/integration/events/insert-event-attachment-resync.test.ts
@@ -1,0 +1,204 @@
+/**
+ * A re-sync republishes the same bytes, so the artifact reference is fresh
+ * every time: `materializeInlineAttachments` mints a new `artifact_id` and a
+ * new signed `download_url` per publication. Those two fields therefore say
+ * nothing about whether the attachment CHANGED, and comparing them raw makes
+ * every re-sync of an attachment-bearing item look like a new version —
+ * superseding forever and growing `events` without bound.
+ *
+ * The dedup path is connector ingest (`insertEvent(..., { onConflictUpdate: true })`,
+ * used by run-lifecycle); `save_memory` does not take it.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestConnection, createTestOrganization } from '../../setup/test-fixtures';
+
+function materializedAttachment(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'image',
+    filename: 'photo.jpg',
+    mime_type: 'image/jpeg',
+    artifact_id: '11111111-1111-4111-8111-111111111111',
+    download_url:
+      'https://gw.example/lobu/api/v1/files/11111111-1111-4111-8111-111111111111?token=first',
+    size_bytes: 2048,
+    duration_ms: null,
+    sha256: 'a'.repeat(64),
+    ...overrides,
+  };
+}
+
+describe('insertEvent attachment re-sync', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  async function seed() {
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+    const base = {
+      entityIds: [] as number[],
+      organizationId: org.id,
+      originId: 'attachment-resync',
+      title: 'item',
+      content: 'body',
+      semanticType: 'observation',
+      connectorKey: 'reddit',
+      connectionId: Number(connection.id),
+    };
+    const first = await insertEvent(
+      { ...base, attachments: [materializedAttachment()] },
+      { onConflictUpdate: true }
+    );
+    expect(first.change).toBe('inserted');
+    return { base, first };
+  }
+
+  it('does not supersede when only artifact_id and download_url were re-minted', async () => {
+    const { base, first } = await seed();
+
+    // Same bytes, republished: a fresh artifact id and a fresh signed URL.
+    const resync = await insertEvent(
+      {
+        ...base,
+        attachments: [
+          materializedAttachment({
+            artifact_id: '22222222-2222-4222-8222-222222222222',
+            download_url:
+              'https://gw.example/lobu/api/v1/files/22222222-2222-4222-8222-222222222222?token=second',
+          }),
+        ],
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(resync.change).toBe('unchanged');
+    expect(Number(resync.id)).toBe(Number(first.id));
+  });
+
+  it('still supersedes when the attachment itself changed', async () => {
+    const { base, first } = await seed();
+
+    const changed = await insertEvent(
+      {
+        ...base,
+        attachments: [
+          materializedAttachment({
+            artifact_id: '33333333-3333-4333-8333-333333333333',
+            download_url:
+              'https://gw.example/lobu/api/v1/files/33333333-3333-4333-8333-333333333333?token=third',
+            filename: 'replacement.jpg',
+            size_bytes: 4096,
+            sha256: 'c'.repeat(64),
+          }),
+        ],
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(changed.change).toBe('superseded');
+    expect(Number(changed.id)).not.toBe(Number(first.id));
+  });
+
+  it('does not supersede when the connector renamed the same bytes', async () => {
+    const { base, first } = await seed();
+
+    // The real prod shape: whatsapp.local names each voice note with a fresh
+    // UUID, so a re-sync of identical bytes arrives under a different filename.
+    const renamed = await insertEvent(
+      {
+        ...base,
+        attachments: [
+          materializedAttachment({
+            artifact_id: '55555555-5555-4555-8555-555555555555',
+            download_url:
+              'https://gw.example/lobu/api/v1/files/55555555-5555-4555-8555-555555555555?token=fifth',
+            filename: 'cc9eab3c-1944-47ac-bd84-255473e48343.jpg',
+          }),
+        ],
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(renamed.change).toBe('unchanged');
+    expect(Number(renamed.id)).toBe(Number(first.id));
+  });
+
+  it('still supersedes when the bytes changed but the envelope did not', async () => {
+    const { base, first } = await seed();
+
+    // Same filename, same size, same mime — only the content hash differs.
+    // Envelope-only comparison would call this unchanged and strand the edit.
+    const edited = await insertEvent(
+      {
+        ...base,
+        attachments: [
+          materializedAttachment({
+            artifact_id: '44444444-4444-4444-8444-444444444444',
+            download_url:
+              'https://gw.example/lobu/api/v1/files/44444444-4444-4444-8444-444444444444?token=fourth',
+            sha256: 'b'.repeat(64),
+          }),
+        ],
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(edited.change).toBe('superseded');
+    expect(Number(edited.id)).not.toBe(Number(first.id));
+  });
+
+  it('treats a hashless attachment id as durable identity', async () => {
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+    const base = {
+      entityIds: [] as number[],
+      organizationId: org.id,
+      originId: 'attachment-referenced',
+      title: 'item',
+      content: 'body',
+      semanticType: 'observation',
+      connectorKey: 'reddit',
+      connectionId: Number(connection.id),
+    };
+    // A connector referencing an artifact it already owns publishes nothing, so
+    // there is no hash and the id is the only identity the row carries.
+    const referenced = { kind: 'image', artifact_id: 'external-a' };
+    const first = await insertEvent(
+      { ...base, attachments: [referenced] },
+      { onConflictUpdate: true }
+    );
+    expect(first.change).toBe('inserted');
+
+    const repointed = await insertEvent(
+      { ...base, attachments: [{ kind: 'image', artifact_id: 'external-b' }] },
+      { onConflictUpdate: true }
+    );
+    expect(repointed.change).toBe('superseded');
+
+    const same = await insertEvent(
+      { ...base, attachments: [{ kind: 'image', artifact_id: 'external-b' }] },
+      { onConflictUpdate: true }
+    );
+    expect(same.change).toBe('unchanged');
+  });
+
+  it('still supersedes when an attachment is dropped', async () => {
+    const { base } = await seed();
+
+    const dropped = await insertEvent(
+      { ...base, attachments: [] },
+      { onConflictUpdate: true }
+    );
+
+    expect(dropped.change).toBe('superseded');
+  });
+});

--- a/packages/server/src/__tests__/integration/events/save-content-artifact-materialization.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-artifact-materialization.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration test: save_memory materializes inline media into the
+ * ArtifactStore before writing the event, the way connector ingest already
+ * does.
+ *
+ * Two things were wrong before. `events` was the binary store for anything an
+ * agent saved with attachments — the base64 stayed in the row. And the
+ * attachment was whatever the caller handed us, so an agent could write an
+ * arbitrary `artifact_id` into an event it controls; nothing bound the
+ * reference to the event it lived on.
+ */
+
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  ArtifactStore,
+  eventArtifactBinding,
+} from '../../../gateway/files/artifact-store';
+import * as lobuGateway from '../../../lobu/gateway';
+import * as insertEventModule from '../../../utils/insert-event';
+import type { ToolContext } from '../../../tools/registry';
+import { saveContent } from '../../../tools/save_content';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > inline attachment materialization', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entityId: number;
+  let artifactsDir: string;
+  let artifactStore: ArtifactStore;
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Artifact Materialization Org' });
+    user = await createTestUser({ email: 'artifact-materialize@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({
+      name: 'Artifact Materialization Entity',
+      organization_id: org.id,
+    });
+    entityId = entity.id;
+
+    artifactsDir = mkdtempSync(join(tmpdir(), 'lobu-save-content-artifacts-'));
+    process.env.ENCRYPTION_KEY = Buffer.from(
+      '12345678901234567890123456789012'
+    ).toString('base64');
+    artifactStore = new ArtifactStore(artifactsDir);
+    vi.spyOn(lobuGateway, 'getLobuCoreServices').mockReturnValue({
+      getArtifactStore: () => artifactStore,
+    } as ReturnType<typeof lobuGateway.getLobuCoreServices>);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    rmSync(artifactsDir, { recursive: true, force: true });
+  });
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+      sourceContext: null,
+    } as ToolContext;
+  }
+
+  it('stores the bytes as a bound artifact and leaves a reference on the event', async () => {
+    const bytes = Buffer.from('saved-memory-image-bytes');
+
+    const result = await saveContent(
+      {
+        entity_ids: [entityId],
+        title: 'photo note',
+        content: 'a photo',
+        semantic_type: 'note',
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'note.jpg',
+            mime_type: 'image/jpeg',
+            data: bytes.toString('base64'),
+            size_bytes: bytes.length,
+          },
+        ],
+      } as never,
+      {} as never,
+      ctx()
+    );
+
+    const eventId = Number((result as { id: number | string }).id);
+    const sql = getTestDb();
+    const [row] = await sql`
+      SELECT origin_id, attachments FROM events WHERE id = ${eventId}
+    `;
+    const stored = (row.attachments as Array<Record<string, unknown>>)[0];
+
+    // The bytes are gone from the row.
+    expect(stored).not.toHaveProperty('data');
+    expect(stored.artifact_id).toEqual(expect.any(String));
+    expect(stored.sha256).toEqual(expect.any(String));
+    expect(stored.size_bytes).toBe(bytes.length);
+
+    // …and readable from the store only under this event's binding.
+    const binding = eventArtifactBinding({
+      organizationId: org.id,
+      originId: String(row.origin_id),
+    });
+    const bound = await artifactStore.read(String(stored.artifact_id), { binding });
+    expect(bound?.bytes.equals(bytes)).toBe(true);
+
+    const wrongBinding = await artifactStore.read(String(stored.artifact_id), {
+      binding: eventArtifactBinding({
+        organizationId: org.id,
+        originId: 'some-other-event',
+      }),
+    });
+    expect(wrongBinding).toBeNull();
+  });
+
+  it('deletes what it published when the insert fails', async () => {
+    // Publishing escapes the insert, so a row that never lands leaves bytes on
+    // the volume with no owner unless the failure path reclaims them.
+    const before = readdirSync(artifactsDir);
+    const bytes = Buffer.from('bytes-for-a-doomed-insert');
+    const insertSpy = vi
+      .spyOn(insertEventModule, 'insertEvent')
+      .mockRejectedValueOnce(new Error('insert exploded'));
+
+    await expect(
+      saveContent(
+        {
+          entity_ids: [entityId],
+          title: 'doomed',
+          content: 'doomed',
+          semantic_type: 'note',
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'doomed.jpg',
+              mime_type: 'image/jpeg',
+              data: bytes.toString('base64'),
+              size_bytes: bytes.length,
+            },
+          ],
+        } as never,
+        {} as never,
+        ctx()
+      )
+    ).rejects.toThrow('insert exploded');
+
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(readdirSync(artifactsDir).sort()).toEqual(before.sort());
+    insertSpy.mockRestore();
+  });
+
+  it('passes through an attachment that carries no inline bytes', async () => {
+    const result = await saveContent(
+      {
+        entity_ids: [entityId],
+        title: 'link note',
+        content: 'a link',
+        semantic_type: 'note',
+        attachments: [{ kind: 'file', filename: 'remote.pdf', url: 'https://example/remote.pdf' }],
+      } as never,
+      {} as never,
+      ctx()
+    );
+
+    const eventId = Number((result as { id: number | string }).id);
+    const sql = getTestDb();
+    const [row] = await sql`SELECT attachments FROM events WHERE id = ${eventId}`;
+    const stored = (row.attachments as Array<Record<string, unknown>>)[0];
+
+    expect(stored).toEqual({
+      kind: 'file',
+      filename: 'remote.pdf',
+      url: 'https://example/remote.pdf',
+    });
+  });
+});

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -36,6 +36,12 @@ interface PublishArtifactResult {
   size: number;
   contentType: string;
   downloadUrl: string;
+  /**
+   * Content hash of the stored bytes. `artifactId` is per-publication, so this
+   * is the only field a caller can use to ask "are these the same bytes?"
+   * across two publications of the same source attachment.
+   */
+  sha256: string;
 }
 
 export class ArtifactStorageError extends Error {
@@ -172,6 +178,26 @@ async function writeDurableFile(
   const handle = await fs.open(filePath, "wx", 0o600);
   try {
     await handle.writeFile(contents);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * fsync a directory so the entries created inside it survive a crash.
+ *
+ * Syncing a file only promises its CONTENTS are on disk; the link that makes it
+ * findable lives in the parent directory and is durable only once that
+ * directory is itself synced. Without this an unclean shutdown can leave an
+ * artifact dir holding `metadata.json` but not `content`, or leave the artifact
+ * dir missing entirely while both files are on the platters — exactly the
+ * half-written states `read()`'s checksum and metadata checks then report as a
+ * corrupt artifact.
+ */
+async function syncDirectoryEntry(dirPath: string): Promise<void> {
+  const handle = await fs.open(dirPath, "r");
+  try {
     await handle.sync();
   } finally {
     await handle.close();
@@ -350,6 +376,10 @@ export class ArtifactStore {
         this.metadataPath(artifactId),
         JSON.stringify(metadata, null, 2),
       );
+      // Both files, then the directory that links them, then the directory that
+      // links THAT — a publish that returns has survived power loss end to end.
+      await syncDirectoryEntry(dir);
+      await syncDirectoryEntry(this.baseDir);
     } catch (error) {
       if (ownsDir) {
         try {
@@ -384,6 +414,7 @@ export class ArtifactStore {
         params.ttlMs,
         params.binding,
       ),
+      sha256: checksum,
     };
   }
 

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -19,6 +19,11 @@ import { autoLinkEvent } from '../utils/auto-linker';
 import { ToolUserError } from '../utils/errors';
 import { validateSaveContentSemanticType } from '../utils/event-kind-validation';
 import { getConfiguredEmbeddingModel, needsEmbeddingSql } from '../utils/embeddings';
+import { eventArtifactBinding } from '../gateway/files/artifact-store';
+import {
+  deleteMaterializedArtifacts,
+  materializeInlineAttachments,
+} from '../utils/inline-attachments';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import {
@@ -598,6 +603,34 @@ async function saveContentImpl(
     inserted = false;
     persistedMetadata = prior.metadata;
   } else {
+    // Inline media becomes a bound artifact BEFORE the row is written, exactly
+    // as connector ingest does it (run-lifecycle → materializeInlineAttachments).
+    // Without this, `events` is the binary store for anything arriving through
+    // save_memory, and the attachment carries no binding for the download route
+    // to check.
+    //
+    // Publishing escapes the insert: every path below that does not end in a row
+    // referencing these artifacts has to delete them, or a failed save leaks bytes
+    // onto the volume with no owner.
+    let attachments = args.attachments;
+    let publishedArtifactIds: string[] = [];
+    if (Array.isArray(attachments) && attachments.length > 0) {
+      const materialized = await materializeInlineAttachments(
+        [{ id: externalId, attachments }],
+        () =>
+          eventArtifactBinding({
+            organizationId: ctx.organizationId,
+            originId: externalId,
+          })
+      );
+      attachments = materialized.items[0]?.attachments ?? [];
+      publishedArtifactIds = materialized.publishedArtifactIds;
+      // pendingTranscriptions is deliberately dropped: transcription is wired to
+      // connector ingest, and save_memory has never enqueued it. Wiring it here
+      // would change what save_memory DOES; this change only fixes where the
+      // bytes live.
+    }
+
     try {
       row = await insertEvent({
         entityIds: finalEntityIds,
@@ -608,7 +641,7 @@ async function saveContentImpl(
         content: args.content ?? null,
         payloadData: args.payload_data,
         payloadTemplate: args.payload_template ?? null,
-        attachments: args.attachments,
+        attachments,
         authorName: args.author,
         sourceUrl: args.source_url ?? parentSourceUrl,
         // The schema promises "Defaults to now if omitted" — honor it. A NULL
@@ -623,6 +656,10 @@ async function saveContentImpl(
         supersedesEventId: args.supersedes_event_id ?? null,
       });
     } catch (error) {
+      // No row of ours references these artifacts on any branch below — the
+      // idempotency loser returns the winner's event, and everything else
+      // rethrows — so they are unreachable bytes unless we delete them here.
+      await deleteMaterializedArtifacts(publishedArtifactIds);
       // Two replicas may race after the preflight read. The unique index is the
       // lock; the loser resolves and returns the winner's durable event.
       if (

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -13,7 +13,7 @@
  *
  *   { kind: 'audio', filename: '…', mime_type: '…', artifact_id: '<uuid>',
  *     download_url: 'https://…/lobu/api/v1/files/<id>?token=…',
- *     size_bytes: 23456 }
+ *     size_bytes: 23456, sha256: '<hex>' }
  *
  * Audio attachments additionally enqueue background transcription via
  * TranscriptionService. On success a superseding event is written so the
@@ -57,6 +57,14 @@ interface MaterializedAttachment {
   download_url: string;
   size_bytes: number;
   duration_ms?: number | null;
+  /**
+   * Content hash of the published bytes. `artifact_id` and `download_url` are
+   * minted fresh on every publication of the same source attachment, so this is
+   * the field that answers "did the attachment actually change?" — see
+   * `semanticAttachmentState` in insert-event.ts, which relies on its presence
+   * to tell a re-publication apart from a genuine edit.
+   */
+  sha256: string;
 }
 
 interface StreamItemLike {
@@ -174,6 +182,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
         download_url: published.downloadUrl,
         size_bytes: published.size,
         duration_ms: att.duration_ms ?? null,
+        sha256: published.sha256,
       };
       rewritten.push(materialized);
 

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -178,6 +178,57 @@ export function stableJson(value: unknown): string {
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(',')}}`;
 }
 
+/**
+ * The fields of a materialized attachment that survive re-publication.
+ *
+ * Everything else on the reference is minted per publication and says nothing
+ * about whether the attachment changed. `artifact_id` and `download_url` are
+ * obviously so. `filename` is too, and less obviously: the whatsapp.local
+ * bridge names voice notes with a fresh UUID each time, so prod carries
+ * supersede chains where the same 18623 bytes were stored as
+ * `1c692a09-….opus` and then `cc9eab3c-….opus`. `size_bytes` and `duration_ms`
+ * are derived from the bytes, so `sha256` already covers them.
+ */
+const DURABLE_ATTACHMENT_KEYS = ['kind', 'mime_type', 'sha256'] as const;
+
+/**
+ * Dedup view of `events.attachments`.
+ *
+ * A re-sync re-publishes the same bytes, so comparing attachments raw makes
+ * every re-sync look like a new version and supersedes forever — prod has
+ * three stored versions of one voice note that differ only by re-publication.
+ * An attachment IS its bytes, so a materialized one is compared on its content
+ * hash and how it is presented, and nothing else.
+ *
+ * Reducing to those keys is conditional on `sha256` being present, and the
+ * condition is load-bearing rather than defensive. An attachment without one
+ * was not published by us (a connector may reference an artifact it already
+ * owns), so its `artifact_id` is durable identity, not a per-publication
+ * accident — dropping it would collapse two distinct references into one. Rows
+ * written before this field existed also land here, so the first re-sync after
+ * deploy supersedes once and is stable from then on.
+ *
+ * Deliberate consequence: renaming an attachment without changing its bytes no
+ * longer mints a new stored version.
+ */
+function semanticAttachmentState(attachments: unknown[] | undefined): string {
+  if (!Array.isArray(attachments)) return stableJson([]);
+  return stableJson(
+    attachments.map((attachment) => {
+      if (!attachment || typeof attachment !== 'object' || Array.isArray(attachment)) {
+        return attachment;
+      }
+      const record = attachment as Record<string, unknown>;
+      if (typeof record.sha256 !== 'string' || record.sha256.length === 0) return record;
+      const durable: Record<string, unknown> = {};
+      for (const key of DURABLE_ATTACHMENT_KEYS) {
+        if (record[key] !== undefined) durable[key] = record[key];
+      }
+      return durable;
+    })
+  );
+}
+
 function normalizedTimestamp(value?: Date | string | null): string | null {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
@@ -245,7 +296,8 @@ function isSemanticallyEqual(
     existing.payload_type === (params.payloadType ?? 'text') &&
     stableJson(existing.payload_data ?? {}) === stableJson(params.payloadData ?? {}) &&
     stableJson(existing.payload_template ?? null) === stableJson(params.payloadTemplate ?? null) &&
-    stableJson(existing.attachments ?? []) === stableJson(params.attachments ?? []) &&
+    semanticAttachmentState(existing.attachments) ===
+      semanticAttachmentState(params.attachments) &&
     (existing.author_name ?? null) === (params.authorName ?? null) &&
     (existing.source_url ?? null) === (params.sourceUrl ?? null) &&
     // Only compare occurred_at when the caller supplied one. Insert defaults a


### PR DESCRIPTION
## Summary

- `save_memory` stored inline base64 in the `events` row and left the attachment unbound; it now materializes into a bound artifact first, like connector ingest, and every failure path deletes what it published.
- Connector re-syncs superseded an attachment-bearing event forever, because a re-publication mints a fresh `artifact_id`, `download_url` and filename. A materialized attachment is now compared on its content hash.
- `publish()` fsynced its files but never the directory linking them.

Closes #3050.

### save_memory materialization
`save_content.ts` passed `args.attachments` straight to `insertEvent`. Every
other writer materializes first, so the same base64 image became a durable
artifact through a connector feed and stayed raw in the `events` row through
`save_memory`. Attachments were also unbound, so an agent could write an
arbitrary `artifact_id` into an event it controls.

Publishing escapes the insert, so every failure path — including the
idempotency-race loser, whose artifacts have no owner — deletes what it
published.

### Re-sync no longer supersedes forever
`isSemanticallyEqual` compared `attachments` raw. A re-publication mints a fresh
`artifact_id` and a freshly signed `download_url`, so every re-sync of an
attachment-bearing item looked like a new version.

**This is a pre-existing bug on main, not a consequence of the change above.**
`save_content` does not pass `onConflictUpdate`, so it never takes the dedup
path at all; the affected caller is connector ingest (`run-lifecycle.ts`).

Prod has the chain — connection 361, one whatsapp.local voice note:

```
id       created_at            artifact_id   filename           size    text_hash
4761561  2026-08-03 01:49:29   aa6aa33e…     1c692a09-….opus    18623   aab9c635
4936814  2026-08-10 08:03:25   1e51c664…     cc9eab3c-….opus    18623   aab9c635   supersedes 4761561
4944298  2026-08-10 13:07:50   1de2f336…     cc9eab3c-….m4a    230921   aab9c635   supersedes 4936814
```

v1→v2 is the bug: same bytes, same payload text, new stored version. Note the
`filename` moves too — the bridge names each voice note with a fresh UUID — so
stripping only `artifact_id`/`download_url` would NOT have deduped it. An
attachment is its bytes, so a materialized attachment is now compared on
`{kind, mime_type, sha256}` and nothing else.

`publish()` already computed a checksum and discarded it; it now returns it, and
`materializeInlineAttachments` records it as `sha256` on the reference.

### Durability
`writeDurableFile` fsynced the file but never the directory linking it, so an
unclean shutdown could leave an artifact dir holding `metadata.json` but not
`content`. The publish path now syncs the artifact dir and its parent.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate)
- [x] Tests run: targeted vitest + bun suites, see below
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

## Red → green

Red, before the fix (`insert-event-attachment-resync.test.ts`):

```
× does not supersede when only artifact_id and download_url were re-minted
  → expected 'superseded' to be 'unchanged'
✓ still supersedes when the attachment itself changed
✓ still supersedes when an attachment is dropped
```

Green, after:

```
✓ does not supersede when only artifact_id and download_url were re-minted
✓ does not supersede when the connector renamed the same bytes
✓ still supersedes when the attachment itself changed
✓ still supersedes when the bytes changed but the envelope did not
✓ treats a hashless attachment id as durable identity
✓ still supersedes when an attachment is dropped
```

`save-content-artifact-materialization.test.ts` was mutation-tested: reverting
`save_content.ts` to `attachments: args.attachments` fails it with
`expected {…} to not have property "data"`.

Full run: 50 files / 236 tests green across `integration/events`,
`inline-attachments`, `artifact-url-refresh`, `mcp-media-resources`; 32 bun
tests across `artifact-store-download-url` + `file-routes`.

## Notes

### Deliberate consequences
- Renaming an attachment without changing its bytes no longer mints a new
  stored version.
- Rows written before `sha256` existed compare raw, so the first re-sync after
  deploy supersedes once and is stable from then on.
- `pendingTranscriptions` is dropped in `save_memory`. Transcription is wired to
  connector ingest and `save_memory` has never enqueued it; wiring it here would
  change what the tool does, not where bytes live.
- `attachments` gains a `sha256` field, additively. Flagging it because it is
  visible in `get_content` output.

### Review
`make review-fix` found one defect (an unused `export` knip would have failed) and flagged that the failure-path cleanup had no executing test; that test was then added and mutation-tested.
