### PR TITLE
fix(server): raise the inline attachment cap so screenshots survive it

### DIFF
--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -118,6 +118,32 @@ describe('materializeActionOutputAttachments', () => {
     expect(await artifactStore.read(firstArtifactId!)).toBeNull();
   });
 
+  it('materializes a screenshot-sized payload the old 2MB cap would have dropped', async () => {
+    // Prod's largest Chrome screenshot decodes to ~3.1MB. Over the cap,
+    // materializeInlineAttachments warns and CONTINUES — the attachment is
+    // dropped, not rejected — so a too-low cap loses screenshots silently.
+    const bytes = Buffer.alloc(3 * 1024 * 1024 + 1024, 0x41);
+    const { output, publishedArtifactIds } = await materializeActionOutputAttachments(99, {
+      tab_id: 7,
+      attachments: [
+        {
+          kind: 'image',
+          filename: 'screenshot.png',
+          mime_type: 'image/png',
+          size_bytes: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    });
+
+    expect(publishedArtifactIds).toHaveLength(1);
+    const attachment = (output.attachments as Array<Record<string, unknown>>)[0];
+    expect(attachment).not.toHaveProperty('data');
+    expect(attachment.artifact_id).toEqual(expect.any(String));
+    const stored = await artifactStore.read(String(attachment.artifact_id));
+    expect(stored?.bytes.length).toBe(bytes.length);
+  });
+
   it('deletes materialized action artifacts when finalization is abandoned', async () => {
     const { publishedArtifactIds } = await materializeActionOutputAttachments(
       88,

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -33,11 +33,16 @@ import logger from "./logger";
 /**
  * Hard cap on a single decoded attachment we'll publish. Server-side guard so
  * a compromised or buggy worker can't force unbounded memory + artifact-store
- * writes. Matches the Mac bridge's client-side 2MB cap for voice notes; if a
- * future connector legitimately needs to ship something larger, push it
- * through a multipart upload endpoint instead of inline base64.
+ * writes.
+ *
+ * 8MB, not the 2MB the Mac bridge caps voice notes at, because screenshots go
+ * through here too and a 2MB cap silently DROPS them (see the `buffer.length >`
+ * branch below — it warns and continues). Measured against prod: the Chrome
+ * extension's largest screenshot decodes to ~3.1MB and 12 of 424 exceed 2MB,
+ * and the Mac capture path peaks at ~1.9MB, within 5% of the old cap. Anything
+ * legitimately larger than 8MB belongs in a multipart upload, not inline base64.
  */
-const MAX_INLINE_ATTACHMENT_BYTES = 2 * 1024 * 1024;
+const MAX_INLINE_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 
 interface InlineAttachment {
   kind?: string;


### PR DESCRIPTION
## Summary

- Raises the decoded inline attachment cap from 2 MiB to 8 MiB so screenshot attachments are materialized instead of silently dropped.
- Adds a regression test that round-trips a 3 MiB screenshot through the ArtifactStore.

Current main already pins Owletto at 446971da, a descendant of f78348a8 where screenshots were changed to connector-standard attachments. The obsolete Owletto pointer hunk from the original PR is therefore no longer part of this diff.

Closes #3049.

## Why the cap has to move

materializeInlineAttachments warns and continues when an attachment exceeds the cap. At the old 2 MiB limit, routing screenshots through the standard attachment path silently loses real screenshots.

Measured against production data:

| producer | largest decoded payload | over 2 MiB |
|---|---:|---:|
| Chrome screenshot | about 3.1 MiB | 12 of 424 |
| Mac screenshot | about 1.9 MiB | 0 |

An 8 MiB cap clears the observed screenshot payloads with headroom and remains well below the ArtifactStore 50 MiB limit. Larger payloads still belong in a multipart upload path.

## Refreshed diff

- packages/server/src/utils/inline-attachments.ts: 2 MiB to 8 MiB cap and rationale.
- packages/server/src/utils/__tests__/inline-attachments.test.ts: 3 MiB screenshot materialization regression test.
- No submodule, API, schema, migration, or UI changes.

## Verification

- inline-attachments.test.ts: 4 of 4 passed.
- device-action-wait.test.ts: 13 of 13 passed.
- Commit hook: Biome and root TypeScript checks passed.
- make pre-pr passed.
- GitHub CI passed, including unit, integration, frontend, migrations, SDK and CLI end-to-end checks, typecheck, formatting, and dead-code reporting.
- Independent review: bug-free confidence 96, simplicity 97, zero blockers.