### PR TITLE
fix(cli): finish authenticated daemon onboarding

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,6 +70,12 @@ inside a supported Claude Code, Codex, or OpenCode session, that session
 receives its own identity so interactive delivery does not replace the
 machine's durable device mapping; pass `--no-interactive-session` to opt out.
 
+Older CLI releases registered a terminal daemon as `macos` when run on a Mac.
+The terminal and Docker methods now register as `headless` so they cannot
+impersonate the native Mac app. The first upgraded run creates a new Worker
+device; reselect that Worker for any connection or Automation pinned to the old
+CLI-created Mac device.
+
 ## License
 
 Apache-2.0

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,12 +63,14 @@ per context and platform. Reusing a device keeps its existing server-side
 workspace attachment. Team workspaces reach a personal device through a pinned
 connection or Automation; `lobu daemon` therefore has no `--org` flag.
 
-An explicit `--worker-id` always wins. Direct `--api-url` and `LOBU_API_URL`
-targets match only a context on the same URL origin; when none exists, the
-login path creates one for that installation. When the daemon starts
-inside a supported Claude Code, Codex, or OpenCode session, that session
-receives its own identity so interactive delivery does not replace the
-machine's durable device mapping; pass `--no-interactive-session` to opt out.
+An explicit `--worker-id` overrides both the wizard and the cached identity; on
+the login path it must start with `headless:` so it cannot claim another
+platform's device. Direct `--api-url` and `LOBU_API_URL` targets match only a
+context on the same URL origin; when none exists, the login path creates one for
+that installation. When the daemon starts inside a supported Claude Code, Codex,
+or OpenCode session, that session receives its own identity so interactive
+delivery does not replace the machine's durable device mapping; pass
+`--no-interactive-session` to opt out.
 
 Older CLI releases registered a terminal daemon as `macos` when run on a Mac.
 The terminal and Docker methods now register as `headless` so they cannot

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,28 +42,33 @@ docker run -d --name lobu-pg -p 5432:5432 \
 ## Device workers
 
 Run `lobu daemon` on a machine that should execute local connector work or
-device-pinned Automations. The daemon requires a durable, org-scoped personal
-access token; a stored OAuth login is intentionally not used for this
-long-running process.
+device-pinned Automations. A normal interactive login automatically authorizes
+the daemon with a worker-bound child credential; you do not need to create or
+export a personal access token.
 
 ```bash
-lobu login
-WORKER_API_TOKEN="$(lobu token create --raw --org <slug> --scope mcp:write)" \
-  lobu daemon
+npx -y @lobu/cli@latest daemon --api-url https://your-lobu.example.com
 ```
+
+If that installation is not logged in yet, the command creates an
+origin-specific context and, on a TTY, runs its device-code login; a
+non-interactive start prints the `lobu login` command to run first. A login for
+another URL is never reused. `WORKER_API_TOKEN` remains available as an explicit
+unattended/advanced override.
 
 On the first interactive boot for a named context, the CLI confirms the
 `<platform>:<hostname>` identity and can reuse an offline device from the same
-platform. The choice is stored per context and platform. Reusing a device keeps
-its existing server-side workspace attachment; a new device is attached by the
-PAT on its first poll.
+platform. The identity and worker-bound child credential are stored owner-only,
+per context and platform. Reusing a device keeps its existing server-side
+workspace attachment. Team workspaces reach a personal device through a pinned
+connection or Automation; `lobu daemon` therefore has no `--org` flag.
 
 An explicit `--worker-id` always wins. Direct `--api-url` and `LOBU_API_URL`
-overrides stay stateless and use the deterministic host identity instead of
-borrowing a named context's cached device. When the daemon starts inside a
-supported Claude Code, Codex, or OpenCode session, that session receives its own
-identity so interactive delivery does not replace the machine's durable device
-mapping; pass `--no-interactive-session` to opt out.
+targets match only a context on the same URL origin; when none exists, the
+login path creates one for that installation. When the daemon starts
+inside a supported Claude Code, Codex, or OpenCode session, that session
+receives its own identity so interactive delivery does not replace the
+machine's durable device mapping; pass `--no-interactive-session` to opt out.
 
 ## License
 

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -358,7 +358,7 @@ describe("lobu daemon", () => {
     spyOn(deviceState, "loadDeviceState").mockResolvedValue({
       workerId: "headless:cached",
       workerApiToken: "owl_pat_cached-child",
-      expiresAt: Date.now() + 30 * 86_400_000,
+      expiresAt: Date.now() + 60 * 86_400_000,
     });
     const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
       "oauth-should-not-be-read"
@@ -484,6 +484,44 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.workerApiToken).toBe(
       "owl_pat_refreshed-child"
     );
+  });
+
+  test("a 403 that re-authenticating cannot clear surfaces instead of forcing a new login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    const login = spyOn(loginModule, "loginCommand").mockResolvedValue();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(
+        {
+          error: "personal_org_missing",
+          error_description: "User has no personal org to bind the device to.",
+        },
+        403
+      )
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await expect(
+      daemonCommand({ workerId: "headless:test-host" })
+    ).rejects.toThrow(/User has no personal org to bind the device to/);
+
+    // `lobu login --force` revokes the stored credential on its way in, so a
+    // 403 that a fresh grant cannot clear must never be retried that way.
+    expect(login).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
   });
 
   test("a non-interactive start without a stored login refuses instead of polling unauthenticated", async () => {

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -9,8 +9,10 @@ import {
 } from "bun:test";
 import * as daemonModule from "@lobu/connector-worker/daemon";
 import { daemonCommand } from "../commands/daemon";
+import * as loginModule from "../commands/login";
 import { apiUrlToGatewayOrigin } from "../internal/context";
 import * as context from "../internal/context";
+import * as credentials from "../internal/credentials";
 import * as deviceState from "../internal/device-state";
 import * as deviceWizardModule from "../commands/_lib/device-wizard";
 
@@ -64,6 +66,9 @@ describe("lobu daemon", () => {
   const originalEnv = new Map<string, string | undefined>();
   let originalStdinIsTTY: boolean | undefined;
   let originalStdoutIsTTY: boolean | undefined;
+  let findContextByOriginSpy: ReturnType<
+    typeof spyOn<typeof context, "findContextByOrigin">
+  >;
 
   beforeEach(() => {
     for (const key of SESSION_ENV_KEYS) {
@@ -75,6 +80,10 @@ describe("lobu daemon", () => {
     process.env.WORKER_API_TOKEN = "owl_pat_durable-device-token";
     (process.stdin as { isTTY?: boolean }).isTTY = false;
     (process.stdout as { isTTY?: boolean }).isTTY = false;
+    findContextByOriginSpy = spyOn(
+      context,
+      "findContextByOrigin"
+    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -170,10 +179,10 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]).toMatchObject({
       apiUrl: "http://127.0.0.1:9564",
       platform: "headless",
-      defaultPlatform: process.platform === "darwin" ? "macos" : "headless",
-      workerId: undefined,
+      defaultPlatform: "headless",
       insideClaude: true,
     });
+    expect(start.mock.calls[0]?.[0]?.workerId).toMatch(/^headless:claude:/);
     expect(load).not.toHaveBeenCalled();
     expect(wizard).not.toHaveBeenCalled();
   });
@@ -215,10 +224,53 @@ describe("lobu daemon", () => {
 
     await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
 
-    expect(start.mock.calls[0]?.[0]?.workerId).toBeUndefined();
+    expect(start.mock.calls[0]?.[0]?.workerId).toMatch(/^headless:codex:/);
     expect(start.mock.calls[0]?.[0]?.platform).toBe("headless");
     expect(load).not.toHaveBeenCalled();
     expect(wizard).not.toHaveBeenCalled();
+  });
+
+  test("an authenticated Codex session keeps its minted child PAT in memory only", async () => {
+    delete process.env.WORKER_API_TOKEN;
+    process.env.CODEX_THREAD_ID = "thread-exact";
+    process.env.CODEX_SESSION_ID = "thread-exact";
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    findContextByOriginSpy.mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+    });
+    spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const save = spyOn(deviceState, "saveDeviceState").mockResolvedValue();
+    const update = spyOn(deviceState, "updateDeviceState").mockResolvedValue();
+    spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const workerId = JSON.parse(String(init?.body)).worker_id as string;
+      return jsonResponse({
+        worker_id: workerId,
+        access_token: "owl_pat_session-child",
+        expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+      });
+    });
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "http://127.0.0.1:8787" });
+
+    expect(load).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(start.mock.calls[0]?.[0]).toMatchObject({
+      workerApiToken: "owl_pat_session-child",
+      platform: "headless",
+    });
+    expect(start.mock.calls[0]?.[0]?.workerId).toMatch(/^headless:codex:/);
   });
 
   test("interactive boot with a cached device id does not re-prompt via the wizard", async () => {
@@ -228,7 +280,7 @@ describe("lobu daemon", () => {
       source: "config",
     });
     spyOn(deviceState, "loadDeviceState").mockResolvedValue({
-      workerId: "macos:confirmed-box",
+      workerId: "headless:confirmed-box",
     });
     const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
       workerId: "macos:should-not-run",
@@ -243,23 +295,254 @@ describe("lobu daemon", () => {
 
     // The cached id wins and the wizard never runs once a device is configured.
     expect(wizard).not.toHaveBeenCalled();
-    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:confirmed-box");
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe("headless:confirmed-box");
   });
 
-  test("a stored OAuth login never substitutes for a durable worker PAT", async () => {
+  test("a stored installation login mints a worker-bound child PAT before daemon start", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
       url: "http://127.0.0.1:8787",
       source: "config",
     });
     delete process.env.WORKER_API_TOKEN;
+    spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const save = spyOn(deviceState, "saveDeviceState").mockResolvedValue();
+    const expiresAt = new Date(Date.now() + 90 * 86_400_000).toISOString();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        worker_id: "headless:test-host",
+        access_token: "owl_pat_minted-child",
+        expires_at: expiresAt,
+      })
+    );
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
       undefined as never
     );
-    await expect(daemonCommand({})).rejects.toThrow(
-      /durable.*WORKER_API_TOKEN.*lobu token create --raw/s
+
+    await daemonCommand({ workerId: "headless:test-host" });
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "http://127.0.0.1:8787/api/me/devices/mint-child-token"
     );
+    const request = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect((request.headers as Record<string, string>).Authorization).toBe(
+      "Bearer oauth-installation-login"
+    );
+    expect(JSON.parse(String(request.body))).toMatchObject({
+      platform: "headless",
+      worker_id: "headless:test-host",
+    });
+    expect(save).toHaveBeenCalledWith(
+      "local",
+      "headless-worker-headless:test-host",
+      expect.objectContaining({
+        workerId: "headless:test-host",
+        workerApiToken: "owl_pat_minted-child",
+      })
+    );
+    expect(start.mock.calls[0]?.[0]?.workerApiToken).toBe(
+      "owl_pat_minted-child"
+    );
+  });
+
+  test("a valid cached child PAT starts without OAuth or another mint", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_cached-child",
+      expiresAt: Date.now() + 30 * 86_400_000,
+    });
+    const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-should-not-be-read"
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({})
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(getToken).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(start.mock.calls[0]?.[0]).toMatchObject({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_cached-child",
+    });
+  });
+
+  test("a rejected child-PAT rotation retries with this installation's OAuth login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_revoked-child",
+      expiresAt: Date.now() + 30 * 60_000,
+    });
+    const update = spyOn(deviceState, "updateDeviceState").mockResolvedValue();
+    const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ error: "revoked" }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          worker_id: "headless:cached",
+          access_token: "owl_pat_rotated-child",
+          expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+        })
+      );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(
+      (
+        (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<
+          string,
+          string
+        >
+      ).Authorization
+    ).toBe("Bearer owl_pat_revoked-child");
+    expect(
+      (
+        (fetchSpy.mock.calls[1]?.[1] as RequestInit).headers as Record<
+          string,
+          string
+        >
+      ).Authorization
+    ).toBe("Bearer oauth-installation-login");
+    expect(getToken).toHaveBeenCalledWith("local");
+    expect(update).toHaveBeenCalledWith(
+      "local",
+      "headless",
+      expect.objectContaining({ workerApiToken: "owl_pat_rotated-child" })
+    );
+    expect(start.mock.calls[0]?.[0]?.workerApiToken).toBe(
+      "owl_pat_rotated-child"
+    );
+  });
+
+  test("a non-interactive start without a stored login refuses instead of polling unauthenticated", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    spyOn(credentials, "getContextToken").mockResolvedValue(null);
+    const login = spyOn(loginModule, "loginCommand").mockResolvedValue();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({})
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await expect(daemonCommand({})).rejects.toThrow(
+      /not logged in.*lobu login --force --context local/s
+    );
+    // Without a TTY the device-code flow cannot be completed, so the command
+    // names the login to run rather than hanging on a prompt.
+    expect(login).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(start).not.toHaveBeenCalled();
+  });
+
+  test("a non-headless platform override refuses before saving an installation context", async () => {
+    delete process.env.WORKER_API_TOKEN;
+    findContextByOriginSpy.mockResolvedValue(undefined);
+    const add = spyOn(context, "addContext").mockResolvedValue({
+      currentContext: "lobu",
+      contexts: {},
+    } as Awaited<ReturnType<typeof context.addContext>>);
+    const getToken = spyOn(credentials, "getContextToken");
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await expect(
+      daemonCommand({ apiUrl: "https://buremba.lobu.ai", platform: "macos" })
+    ).rejects.toThrow(/supports the headless platform, not "macos"/);
+
+    // The mint endpoint only issues headless/chrome-extension credentials, so
+    // this start is doomed — it must not leave a context behind on the way out.
+    expect(add).not.toHaveBeenCalled();
+    expect(getToken).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test("an explicit installation URL creates and logs into its own context instead of borrowing the active one", async () => {
+    delete process.env.WORKER_API_TOKEN;
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    findContextByOriginSpy.mockResolvedValue(undefined);
+    spyOn(context, "loadContextConfig").mockResolvedValue({
+      currentContext: "lobu",
+      contexts: {
+        lobu: { url: "https://app.lobu.ai/api/v1" },
+      },
+    } as Awaited<ReturnType<typeof context.loadContextConfig>>);
+    const add = spyOn(context, "addContext").mockResolvedValue({
+      currentContext: "lobu",
+      contexts: {},
+    } as Awaited<ReturnType<typeof context.addContext>>);
+    const getToken = spyOn(credentials, "getContextToken")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("oauth-buremba");
+    const login = spyOn(loginModule, "loginCommand").mockResolvedValue();
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    spyOn(deviceState, "saveDeviceState").mockResolvedValue();
+    spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
+      workerId: "headless:buremba-box",
+      source: "created",
+    });
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        worker_id: "headless:buremba-box",
+        access_token: "owl_pat_buremba-child",
+        expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+      })
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ apiUrl: "https://buremba.lobu.ai" });
+
+    expect(add).toHaveBeenCalledWith(
+      "buremba.lobu.ai",
+      "https://buremba.lobu.ai"
+    );
+    expect(login).toHaveBeenCalledWith({
+      context: "buremba.lobu.ai",
+      force: true,
+    });
+    expect(
+      getToken.mock.calls.every(([name]) => name === "buremba.lobu.ai")
+    ).toBe(true);
+    expect(start.mock.calls[0]?.[0]).toMatchObject({
+      apiUrl: "https://buremba.lobu.ai",
+      workerId: "headless:buremba-box",
+      workerApiToken: "owl_pat_buremba-child",
+    });
   });
 
   test("a fresh TTY runs the wizard once and forwards its chosen identity", async () => {
@@ -272,7 +555,7 @@ describe("lobu daemon", () => {
     });
     spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
     const wizard = spyOn(deviceWizardModule, "deviceWizard").mockResolvedValue({
-      workerId: "macos:chosen-by-wizard",
+      workerId: "headless:chosen-by-wizard",
       source: "created",
     });
     const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
@@ -285,9 +568,11 @@ describe("lobu daemon", () => {
     expect(wizard.mock.calls[0]?.[0]).toMatchObject({
       context: "local",
       gatewayOrigin: "http://127.0.0.1:9564",
-      platform: process.platform === "darwin" ? "macos" : "headless",
+      platform: "headless",
     });
-    expect(start.mock.calls[0]?.[0]?.workerId).toBe("macos:chosen-by-wizard");
+    expect(start.mock.calls[0]?.[0]?.workerId).toBe(
+      "headless:chosen-by-wizard"
+    );
   });
 
   test("CI never prompts even when attached to a pseudo-TTY", async () => {
@@ -331,4 +616,14 @@ describe("lobu daemon", () => {
 function restoreEnv(name: string, value: string | undefined): void {
   if (value === undefined) delete process.env[name];
   else process.env[name] = value;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
 }

--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -439,6 +439,53 @@ describe("lobu daemon", () => {
     );
   });
 
+  test("a stale installation login reruns device-code auth before retrying the mint", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const save = spyOn(deviceState, "saveDeviceState").mockResolvedValue();
+    const getToken = spyOn(credentials, "getContextToken")
+      .mockResolvedValueOnce("oauth-stale-scope")
+      .mockResolvedValueOnce("oauth-refreshed-scope");
+    const login = spyOn(loginModule, "loginCommand").mockResolvedValue();
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ error: "insufficient_scope" }, 403))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          worker_id: "headless:test-host",
+          access_token: "owl_pat_refreshed-child",
+          expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+        })
+      );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({ workerId: "headless:test-host" });
+
+    expect(login).toHaveBeenCalledWith({ context: "local", force: true });
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(
+      (
+        (fetchSpy.mock.calls[1]?.[1] as RequestInit).headers as Record<
+          string,
+          string
+        >
+      ).Authorization
+    ).toBe("Bearer oauth-refreshed-scope");
+    expect(save).toHaveBeenCalled();
+    expect(start.mock.calls[0]?.[0]?.workerApiToken).toBe(
+      "owl_pat_refreshed-child"
+    );
+  });
+
   test("a non-interactive start without a stored login refuses instead of polling unauthenticated", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
@@ -486,6 +533,30 @@ describe("lobu daemon", () => {
     // this start is doomed — it must not leave a context behind on the way out.
     expect(add).not.toHaveBeenCalled();
     expect(getToken).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test("a mismatched login-based worker id refuses before minting", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    const load = spyOn(deviceState, "loadDeviceState");
+    const getToken = spyOn(credentials, "getContextToken");
+    const fetchSpy = spyOn(globalThis, "fetch");
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await expect(
+      daemonCommand({ workerId: "chrome-extension:wrong-platform" })
+    ).rejects.toThrow(/does not match platform "headless"/);
+
+    expect(load).not.toHaveBeenCalled();
+    expect(getToken).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(start).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/__tests__/device-state.test.ts
+++ b/packages/cli/src/__tests__/device-state.test.ts
@@ -10,7 +10,11 @@ import {
 import { tmpdir } from "node:os";
 import * as os from "node:os";
 import { join } from "node:path";
-import { loadDeviceState, saveDeviceState } from "../internal/device-state";
+import {
+  loadDeviceState,
+  saveDeviceState,
+  updateDeviceState,
+} from "../internal/device-state";
 
 describe("device-state cache", () => {
   let home: string | undefined;
@@ -58,6 +62,44 @@ describe("device-state cache", () => {
     await expect(
       saveDeviceState("local", "macos", { workerId: "macos:myhost" })
     ).rejects.toThrow(/already exists or is unreadable/);
+  });
+
+  test("stores and rotates an owner-only worker credential for the same identity", async () => {
+    const dir = useTemporaryHome();
+    await saveDeviceState("buremba", "headless", {
+      workerId: "headless:herdr",
+    });
+
+    await updateDeviceState("buremba", "headless", {
+      workerId: "headless:herdr",
+      workerApiToken: "owl_pat_child-one",
+      expiresAt: 4_000_000_000_000,
+    });
+
+    expect(await loadDeviceState("buremba", "headless")).toEqual({
+      workerId: "headless:herdr",
+      workerApiToken: "owl_pat_child-one",
+      expiresAt: 4_000_000_000_000,
+    });
+    const [file] = readdirSync(join(dir, ".config", "lobu", "devices"));
+    expect(
+      statSync(join(dir, ".config", "lobu", "devices", file as string)).mode &
+        0o777
+    ).toBe(0o600);
+  });
+
+  test("refuses to rotate credentials onto a different saved worker identity", async () => {
+    useTemporaryHome();
+    await saveDeviceState("buremba", "headless", {
+      workerId: "headless:first",
+    });
+
+    await expect(
+      updateDeviceState("buremba", "headless", {
+        workerId: "headless:second",
+        workerApiToken: "owl_pat_child-two",
+      })
+    ).rejects.toThrow(/saved worker id changed/);
   });
 
   test("rejects a concurrent first setup instead of starting two daemons", async () => {

--- a/packages/cli/src/commands/__tests__/device-wizard.test.ts
+++ b/packages/cli/src/commands/__tests__/device-wizard.test.ts
@@ -24,7 +24,7 @@ function wizardOptions(
     gatewayOrigin: GATEWAY_ORIGIN,
     platform: "macos",
     suggestedWorkerId: "macos:Mac",
-    workerApiToken: WORKER_TOKEN,
+    authorizationToken: WORKER_TOKEN,
     prompts: fakePrompts(),
     ...overrides,
   };

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -17,7 +17,12 @@ export interface DeviceWizardOptions {
   gatewayOrigin: string;
   platform: string;
   suggestedWorkerId: string;
-  workerApiToken: string;
+  /**
+   * Bearer for `GET /api/me/devices`. Either the installation's OAuth login
+   * (login-based setup) or an explicit `WORKER_API_TOKEN` — the wizard only
+   * lists devices, so it never depends on which one it was handed.
+   */
+  authorizationToken: string;
   prompts?: DeviceWizardPrompts;
 }
 
@@ -47,7 +52,7 @@ export async function deviceWizard(
   const prompts = options.prompts ?? { select, confirm, input };
   const devices = await fetchRemoteDevices(
     options.gatewayOrigin,
-    options.workerApiToken
+    options.authorizationToken
   );
   const reusable = devices.filter(
     (device) => device.platform === options.platform && !device.online

--- a/packages/cli/src/commands/_lib/device-wizard.ts
+++ b/packages/cli/src/commands/_lib/device-wizard.ts
@@ -141,7 +141,7 @@ export async function deviceWizard(
   } else {
     console.log(
       chalk.dim(
-        "  WORKER_API_TOKEN determines its workspace attachment on first poll."
+        "  Its workspace attachment is decided when this device is first authorized."
       )
     );
   }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -60,14 +60,24 @@ interface MintDeviceCredentialOptions {
 class DeviceMintError extends Error {
   constructor(
     message: string,
-    readonly status: number
+    readonly status: number,
+    readonly code?: string
   ) {
     super(message);
     this.name = "DeviceMintError";
   }
 }
 
-const CHILD_TOKEN_REFRESH_BUFFER_MS = 24 * 60 * 60 * 1000;
+/**
+ * How much of a cached child PAT's life must remain for this start to reuse it
+ * instead of re-minting. The daemon snapshots its bearer for the whole process
+ * lifetime and polls for weeks, so the buffer has to outlast a realistic run:
+ * with a shorter one, a start that reuses a nearly-expired token leaves the
+ * worker polling 401 forever a day or two later — the exact silent failure
+ * `startDaemonCommand`'s boot check exists to prevent. A third of the server's
+ * 90-day child expiry keeps re-mints rare while staying well past that.
+ */
+const CHILD_TOKEN_REFRESH_BUFFER_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Shown when `lobu daemon` can't find anything to authorize against. */
 const SETUP_MESSAGE =
@@ -221,7 +231,9 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     }
   }
 
-  // Both are set on every path above; this narrows them for the call below.
+  // Every path above assigns both. Asserted at the package boundary because
+  // the fallthrough is `startDaemonCommand`'s own boot check, whose message
+  // tells the user to set WORKER_API_TOKEN — the wrong advice on the login path.
   if (!workerId || !workerApiToken) {
     throw new Error(
       `Could not resolve a device identity and credential for ${target.gatewayOrigin}.`
@@ -369,11 +381,18 @@ async function mintDeviceCredentialWithReauth({
   }
 }
 
+/**
+ * True only for a refusal that re-authenticating can actually clear: an expired
+ * or revoked bearer (401), or a bearer the endpoint refuses to mint from
+ * (`insufficient_scope` — a missing `device_worker:run`, an MCP resource-bound
+ * token, or a child reaching past its own worker id). Every other 403 is a
+ * standing account condition (`personal_org_missing`); retrying it would
+ * force-revoke a working login through `lobu login --force` and still fail.
+ */
 function isDeviceMintAuthError(error: unknown): error is DeviceMintError {
-  return (
-    error instanceof DeviceMintError &&
-    (error.status === 401 || error.status === 403)
-  );
+  if (!(error instanceof DeviceMintError)) return false;
+  if (error.status === 401) return true;
+  return error.status === 403 && error.code === "insufficient_scope";
 }
 
 function hasUsableCachedWorkerToken(state: DeviceState): boolean {
@@ -406,10 +425,15 @@ async function mintDeviceCredential(
     throw new DeviceMintError(message, res.status);
   })) as Record<string, unknown> | undefined;
   if (!res.ok) {
-    const { message } = extractApiError(parsed, res.status, res.statusText);
+    const { message, code } = extractApiError(
+      parsed,
+      res.status,
+      res.statusText
+    );
     throw new DeviceMintError(
       `Could not authorize this device: ${message}`,
-      res.status
+      res.status,
+      code
     );
   }
 
@@ -481,7 +505,7 @@ async function resolveHostWorkerId(
     gatewayOrigin,
     platform,
     suggestedWorkerId: suggested,
-    workerApiToken: authorizationToken,
+    authorizationToken,
   });
   return result.workerId;
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,11 +1,31 @@
 import {
   resolveDaemonLaunchContext,
+  resolveDaemonWorkerId,
   startDaemonCommand,
 } from "@lobu/connector-worker/daemon";
 import { hostname } from "node:os";
-import { apiUrlToGatewayOrigin, resolveContext } from "../internal/context.js";
-import { loadDeviceState } from "../internal/device-state.js";
+import {
+  addContext,
+  apiUrlToGatewayOrigin,
+  findContextByOrigin,
+  loadContextConfig,
+  type ResolvedContext,
+  resolveContext,
+} from "../internal/context.js";
+import { getContextToken } from "../internal/credentials.js";
+import {
+  type DeviceState,
+  loadDeviceState,
+  saveDeviceState,
+  updateDeviceState,
+} from "../internal/device-state.js";
+import {
+  extractApiError,
+  fetchWithRetry,
+  parseJsonResponse,
+} from "../internal/http.js";
 import { deviceWizard } from "./_lib/device-wizard.js";
+import { loginCommand } from "./login.js";
 
 export interface DaemonOptions {
   apiUrl?: string;
@@ -18,103 +38,201 @@ export interface DaemonOptions {
   interactiveSession?: boolean;
 }
 
+interface DaemonTarget {
+  gatewayOrigin: string;
+  contextName?: string;
+}
+
+interface MintedDeviceCredential {
+  workerId: string;
+  workerApiToken: string;
+  expiresAt?: number;
+}
+
+class DeviceMintError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = "DeviceMintError";
+  }
+}
+
+const CHILD_TOKEN_REFRESH_BUFFER_MS = 24 * 60 * 60 * 1000;
+
 /** Shown when `lobu daemon` can't find anything to authorize against. */
 const SETUP_MESSAGE =
   "Could not determine a gateway to poll. Configure one of:\n" +
   "  - run `lobu login` to configure a context, or\n" +
   "  - pass --api-url <origin>.";
 
-// `device_worker:run` is NOT mintable as a PAT scope (see `AVAILABLE_PAT_SCOPES`
-// server-side); the `/api/workers/*` gate accepts the mintable `mcp:write`
-// scope, so the remediation requests that least-privilege alternative.
-const TOKEN_SETUP_MESSAGE =
-  "A device daemon requires a durable owl_pat_ token in WORKER_API_TOKEN; " +
-  "a stored OAuth login expires and is never used as daemon authentication.\n" +
-  "Mint a device PAT, then start the daemon:\n" +
-  "  WORKER_API_TOKEN=$(lobu token create --raw --org <slug> --scope mcp:write) lobu daemon";
+const LOGIN_SETUP_MESSAGE = (contextName: string) =>
+  `This Lobu installation is not logged in. Run \`lobu login --force --context ${contextName}\` in an interactive terminal, then retry.`;
 
 /**
- * `lobu daemon` — run a device worker that polls the gateway for jobs
- * (connector syncs/actions, and device Automations via the local agent CLIs).
+ * Run a headless device worker against one Lobu installation.
  *
- * Everything except the token auto-discovers from where it is running:
- *   - api-url  → the logged-in context (`lobu login`), else `--api-url`
- *   - platform → `macos` on darwin, `headless` otherwise
- *   - worker id → `<platform>:<short-hostname>` outside a supported interactive
- *     agent, or a provider/session-derived id when one is inherited
- *   - label → hostname
- *   - capabilities → `os.shell,os.files`
- *
- * Org binding is the token, not a flag: pass a durable `owl_pat_…` PAT in
- * `WORKER_API_TOKEN` (`lobu token create --raw`); the server anchors the worker
- * to that token's org (an org-scoped PAT → that org, personal/session → the
- * personal org).
- *
- * On a named context's first interactive boot, a short wizard confirms the
- * device identity. Explicit URL overrides stay stateless and use the same
- * deterministic default as other non-interactive starts.
+ * WORKER_API_TOKEN remains an escape hatch for unattended setups. Ordinarily
+ * the command uses the target installation's named OAuth context to mint and
+ * cache a worker-bound child PAT. The short-lived OAuth bearer is never handed
+ * to the long-running worker and never crosses URL origins.
  */
 export async function daemonCommand(options: DaemonOptions): Promise<void> {
-  let apiUrl = options.apiUrl?.trim();
-  let contextName: string | undefined;
-  if (!apiUrl) {
-    try {
-      // The worker API is mounted at the ORIGIN, not under the context's
-      // `/api/v1` SDK path — see `apiUrlToGatewayOrigin`.
-      const context = await resolveContext();
-      apiUrl = apiUrlToGatewayOrigin(context.url);
-      // LOBU_API_URL is an override just like --api-url: it must not inherit
-      // device state from the otherwise-current named context.
-      if (context.source !== "env") contextName = context.name;
-    } catch {
-      // No context configured — surface the explicit requirement below.
-    }
-  }
-  if (!apiUrl) {
-    throw new Error(SETUP_MESSAGE);
-  }
+  const explicitWorkerToken = process.env.WORKER_API_TOKEN?.trim();
+  const target = await resolveDaemonTarget(options.apiUrl);
 
-  // Stored login credentials are short-lived admin/session auth. A daemon polls
-  // for weeks and snapshots its bearer at boot, so only the explicitly exported
-  // worker PAT is accepted here (the shared daemon bootstrap validates again).
-  const workerApiToken = process.env.WORKER_API_TOKEN?.trim();
-  if (!workerApiToken?.startsWith("owl_pat_")) {
-    throw new Error(TOKEN_SETUP_MESSAGE);
-  }
-
-  const platform = options.platform?.trim() || undefined;
-  const defaultPlatform = process.platform === "darwin" ? "macos" : "headless";
+  const requestedPlatform = options.platform?.trim() || undefined;
+  // The native macOS app owns the `macos` platform. A terminal daemon is a
+  // headless device on every host, including a Mac running Herdr.
+  const defaultPlatform = "headless";
   const launchContext = resolveDaemonLaunchContext({
-    platform,
+    platform: requestedPlatform,
     defaultPlatform,
     ...(options.interactiveSession === false
       ? { interactiveSession: false as const }
       : {}),
     ...(options.insideClaude === true ? { insideClaude: true } : {}),
   });
-  const explicitWorkerId = options.workerId?.trim() || undefined;
-  // Centralized session detection must own the per-session id. Passing a cache
-  // or wizard id here would override Claude/Codex/OpenCode routing in the shared
-  // daemon bootstrap. The legacy flag stays headless even when its startup
-  // metadata is temporarily absent and detection retries per run.
+  const platform = launchContext.platform ?? defaultPlatform;
   const sessionLane =
     launchContext.interactiveSession !== undefined ||
     options.insideClaude === true;
-  const workerId =
-    explicitWorkerId ??
-    (sessionLane
-      ? undefined
-      : await resolveWorkerId(
-          launchContext.platform ?? defaultPlatform,
+  const shortHost = hostname().split(".")[0] || hostname();
+  const explicitWorkerId = options.workerId?.trim() || undefined;
+  const sessionWorkerId = sessionLane
+    ? resolveDaemonWorkerId(
+        {
+          workerId: explicitWorkerId,
+          ...(options.insideClaude === true ? { insideClaude: true } : {}),
+        },
+        platform,
+        shortHost,
+        launchContext.interactiveSession
+      )
+    : undefined;
+
+  let contextName = target.contextName;
+  if (!explicitWorkerToken) {
+    // Checked before any context is saved: an advanced platform override has no
+    // login-based path, so a doomed start must not leave a new context behind.
+    if (platform !== "headless") {
+      throw new Error(
+        `Login-based daemon setup supports the headless platform, not "${platform}". Omit --platform, or provide an explicit WORKER_API_TOKEN for this advanced platform override.`
+      );
+    }
+    if (!contextName) {
+      contextName = await ensureInstallationContext(target.gatewayOrigin);
+    }
+  }
+
+  // One cache slot per persisted identity: the host default shares the bare
+  // platform key the wizard writes, while an explicit --worker-id gets its own.
+  const statePlatform = explicitWorkerId
+    ? `${platform}-worker-${explicitWorkerId}`
+    : platform;
+  // Agent-session identities are deterministic but ephemeral, so they get no
+  // cache slot at all. Keep their PAT in this process only: a restart can mint
+  // the same worker id again, while the server reaper owns cleanup of
+  // abandoned unbound devices and tokens.
+  const cachedState =
+    contextName && !sessionLane
+      ? await loadDeviceState(contextName, statePlatform)
+      : null;
+
+  let workerId = explicitWorkerId ?? sessionWorkerId ?? cachedState?.workerId;
+  let workerApiToken = explicitWorkerToken;
+
+  if (workerApiToken) {
+    if (!workerApiToken.startsWith("owl_pat_")) {
+      throw new Error(
+        "WORKER_API_TOKEN must be a Lobu personal access token with an owl_pat_ prefix."
+      );
+    }
+    if (!workerId) {
+      workerId = await resolveHostWorkerId(
+        platform,
+        contextName,
+        target.gatewayOrigin,
+        workerApiToken
+      );
+    }
+  } else {
+    // Assigned above whenever WORKER_API_TOKEN is unset; restated so the mint
+    // helpers below see a `string`.
+    if (!contextName) throw new Error(SETUP_MESSAGE);
+
+    if (
+      workerId &&
+      cachedState?.workerId === workerId &&
+      hasUsableCachedWorkerToken(cachedState)
+    ) {
+      workerApiToken = cachedState.workerApiToken;
+    } else {
+      let mintBearer = cachedState?.workerApiToken;
+      if (!workerId) {
+        mintBearer = await requireInstallationLogin(contextName);
+        workerId = await resolveHostWorkerId(
+          platform,
           contextName,
-          apiUrl,
-          workerApiToken
-        ));
-  const daemonPlatform = sessionLane ? "headless" : platform;
+          target.gatewayOrigin,
+          mintBearer
+        );
+      }
+
+      let minted: MintedDeviceCredential;
+      try {
+        const bearer =
+          mintBearer ?? (await requireInstallationLogin(contextName));
+        minted = await mintDeviceCredential({
+          gatewayOrigin: target.gatewayOrigin,
+          bearer,
+          platform,
+          workerId,
+          label: options.label?.trim() || shortHost,
+        });
+      } catch (error) {
+        // A cached child can rotate only itself and may have expired or been
+        // revoked. Fall back to this installation's login, never another
+        // context's token.
+        if (
+          !mintBearer?.startsWith("owl_pat_") ||
+          !(error instanceof DeviceMintError) ||
+          (error.status !== 401 && error.status !== 403)
+        ) {
+          throw error;
+        }
+        minted = await mintDeviceCredential({
+          gatewayOrigin: target.gatewayOrigin,
+          bearer: await requireInstallationLogin(contextName),
+          platform,
+          workerId,
+          label: options.label?.trim() || shortHost,
+        });
+      }
+
+      if (minted.workerId !== workerId) {
+        throw new Error(
+          `The gateway registered worker id "${minted.workerId}" instead of "${workerId}"; refusing to start with a mismatched credential.`
+        );
+      }
+      if (!sessionLane) {
+        await persistDeviceCredential(contextName, statePlatform, minted);
+      }
+      workerApiToken = minted.workerApiToken;
+    }
+  }
+
+  // Both are set on every path above; this narrows them for the call below.
+  if (!workerId || !workerApiToken) {
+    throw new Error(
+      `Could not resolve a device identity and credential for ${target.gatewayOrigin}.`
+    );
+  }
 
   await startDaemonCommand({
-    apiUrl,
-    platform: daemonPlatform,
+    apiUrl: target.gatewayOrigin,
+    platform: sessionLane ? "headless" : requestedPlatform,
     defaultPlatform,
     workerId,
     label: options.label?.trim() || undefined,
@@ -131,43 +249,198 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
   });
 }
 
+async function resolveDaemonTarget(
+  explicitApiUrl: string | undefined
+): Promise<DaemonTarget> {
+  const explicit = explicitApiUrl?.trim();
+  if (explicit) {
+    const gatewayOrigin = requireGatewayOrigin(explicit);
+    const matched = await findContextByOrigin(gatewayOrigin);
+    return {
+      gatewayOrigin,
+      ...(matched ? { contextName: matched.name } : {}),
+    };
+  }
+
+  // Only the lookup itself falls back to the setup message: an unusable URL has
+  // to keep reporting the address the user actually configured.
+  let context: ResolvedContext;
+  try {
+    context = await resolveContext();
+  } catch {
+    throw new Error(SETUP_MESSAGE);
+  }
+  const gatewayOrigin = requireGatewayOrigin(context.url);
+  // LOBU_API_URL is an override just like --api-url: it must not inherit the
+  // device state of the otherwise-current named context, only of a context
+  // configured for that same origin.
+  if (context.source !== "env") {
+    return { gatewayOrigin, contextName: context.name };
+  }
+  const matched = await findContextByOrigin(gatewayOrigin);
+  return {
+    gatewayOrigin,
+    ...(matched ? { contextName: matched.name } : {}),
+  };
+}
+
+function requireGatewayOrigin(value: string): string {
+  const origin = apiUrlToGatewayOrigin(value);
+  try {
+    return new URL(origin).origin;
+  } catch {
+    throw new Error(`Invalid gateway URL: ${value}`);
+  }
+}
+
+async function ensureInstallationContext(
+  gatewayOrigin: string
+): Promise<string> {
+  const matched = await findContextByOrigin(gatewayOrigin);
+  if (matched) return matched.name;
+
+  const config = await loadContextConfig();
+  const host = new URL(gatewayOrigin).hostname.toLowerCase();
+  const baseName = host || "lobu-installation";
+  let name = baseName;
+  let suffix = 2;
+  while (config.contexts[name]) {
+    name = `${baseName}-${suffix}`;
+    suffix += 1;
+  }
+  await addContext(name, gatewayOrigin);
+  console.log(
+    `\n  Saved Lobu installation context "${name}" (${gatewayOrigin}).`
+  );
+  return name;
+}
+
+async function requireInstallationLogin(contextName: string): Promise<string> {
+  const existing = await getContextToken(contextName);
+  if (existing) return existing;
+  if (!canPrompt()) throw new Error(LOGIN_SETUP_MESSAGE(contextName));
+
+  // `getContextToken` already returned null, so any stored credential is
+  // expired and unrefreshable. Without --force `lobu login` short-circuits on
+  // it with "Already logged in" and authorizes nothing.
+  await loginCommand({ context: contextName, force: true });
+  const authenticated = await getContextToken(contextName);
+  if (!authenticated) throw new Error(LOGIN_SETUP_MESSAGE(contextName));
+  return authenticated;
+}
+
+function hasUsableCachedWorkerToken(state: DeviceState): boolean {
+  return Boolean(
+    state.workerApiToken?.startsWith("owl_pat_") &&
+      typeof state.expiresAt === "number" &&
+      state.expiresAt > Date.now() + CHILD_TOKEN_REFRESH_BUFFER_MS
+  );
+}
+
+async function mintDeviceCredential(options: {
+  gatewayOrigin: string;
+  bearer: string;
+  platform: string;
+  workerId: string;
+  label: string;
+}): Promise<MintedDeviceCredential> {
+  const url = `${options.gatewayOrigin}/api/me/devices/mint-child-token`;
+  const res = await fetchWithRetry(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${options.bearer}`,
+      "Content-Type": "application/json",
+      "X-Lobu-Client": "cli",
+    },
+    body: JSON.stringify({
+      platform: options.platform,
+      worker_id: options.workerId,
+      label: options.label,
+    }),
+  });
+  const parsed = (await parseJsonResponse(res, url, (message: string) => {
+    throw new DeviceMintError(message, res.status);
+  })) as Record<string, unknown> | undefined;
+  if (!res.ok) {
+    const { message } = extractApiError(parsed, res.status, res.statusText);
+    throw new DeviceMintError(
+      `Could not authorize this device: ${message}`,
+      res.status
+    );
+  }
+
+  const workerId =
+    typeof parsed?.worker_id === "string" ? parsed.worker_id : "";
+  const workerApiToken =
+    typeof parsed?.access_token === "string" ? parsed.access_token : "";
+  const expiresAt =
+    typeof parsed?.expires_at === "string"
+      ? Date.parse(parsed.expires_at)
+      : Number.NaN;
+  if (!workerId || !workerApiToken.startsWith("owl_pat_")) {
+    throw new DeviceMintError(
+      "The gateway returned an invalid device credential.",
+      res.status
+    );
+  }
+  return {
+    workerId,
+    workerApiToken,
+    ...(Number.isFinite(expiresAt) ? { expiresAt } : {}),
+  };
+}
+
+async function persistDeviceCredential(
+  contextName: string,
+  statePlatform: string,
+  credential: MintedDeviceCredential
+): Promise<void> {
+  const state: DeviceState = {
+    workerId: credential.workerId,
+    workerApiToken: credential.workerApiToken,
+    ...(credential.expiresAt ? { expiresAt: credential.expiresAt } : {}),
+  };
+  const existing = await loadDeviceState(contextName, statePlatform);
+  if (existing) {
+    await updateDeviceState(contextName, statePlatform, state);
+    return;
+  }
+  try {
+    await saveDeviceState(contextName, statePlatform, state);
+  } catch (error) {
+    const winner = await loadDeviceState(contextName, statePlatform);
+    if (winner?.workerId !== state.workerId) throw error;
+    await updateDeviceState(contextName, statePlatform, state);
+  }
+}
+
 /**
- * Resolve an ordinary host device's `worker_id` after explicit and inherited
- * session identities have already been handled by the caller: a URL override
- * takes `<platform>:<hostname>` outright, and a named context takes its cached
- * identity, then the TTY-only first-run wizard, then `<platform>:<hostname>`.
- *
- * The wizard only runs on a TTY, only when the id is absent, and only when there
- * is no cached device yet — so a fully-configured daemon never prompts.
+ * Resolve a normal host identity for a device that has no cached one yet: the
+ * TTY first-run wizard, else the deterministic `<platform>:<hostname>`. Callers
+ * consume the cache themselves, so reaching here means there is nothing saved.
  */
-async function resolveWorkerId(
+async function resolveHostWorkerId(
   platform: string,
   contextName: string | undefined,
-  apiUrl: string,
-  workerApiToken: string
+  gatewayOrigin: string,
+  authorizationToken: string
 ): Promise<string> {
   const shortHost = hostname().split(".")[0] || hostname();
   const suggested = `${platform}:${shortHost}`;
-
-  // URL overrides are intentionally stateless: they are commonly temporary
-  // local/self-hosted targets and must never borrow another context's identity.
+  // A URL override with no matching context is stateless: it has no context to
+  // save the wizard's choice under, so take the deterministic id.
   if (!contextName) return suggested;
+  if (!canPrompt()) return suggested;
 
-  const cached = await loadDeviceState(contextName, platform);
-  if (cached?.workerId) return cached.workerId;
-
-  if (canPrompt()) {
-    const result = await deviceWizard({
-      context: contextName,
-      gatewayOrigin: apiUrl,
-      platform,
-      suggestedWorkerId: suggested,
-      workerApiToken,
-    });
-    return result.workerId;
-  }
-
-  return suggested;
+  const result = await deviceWizard({
+    context: contextName,
+    gatewayOrigin,
+    platform,
+    suggestedWorkerId: suggested,
+    workerApiToken: authorizationToken,
+  });
+  return result.workerId;
 }
 
 function canPrompt(): boolean {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -49,6 +49,14 @@ interface MintedDeviceCredential {
   expiresAt?: number;
 }
 
+interface MintDeviceCredentialOptions {
+  gatewayOrigin: string;
+  bearer: string;
+  platform: string;
+  workerId: string;
+  label: string;
+}
+
 class DeviceMintError extends Error {
   constructor(
     message: string,
@@ -121,6 +129,11 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
         `Login-based daemon setup supports the headless platform, not "${platform}". Omit --platform, or provide an explicit WORKER_API_TOKEN for this advanced platform override.`
       );
     }
+    if (explicitWorkerId && !explicitWorkerId.startsWith(`${platform}:`)) {
+      throw new Error(
+        `Login-based daemon worker id "${explicitWorkerId}" does not match platform "${platform}". Use an id beginning with "${platform}:", or omit --worker-id.`
+      );
+    }
     if (!contextName) {
       contextName = await ensureInstallationContext(target.gatewayOrigin);
     }
@@ -180,36 +193,21 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
         );
       }
 
-      let minted: MintedDeviceCredential;
-      try {
-        const bearer =
-          mintBearer ?? (await requireInstallationLogin(contextName));
-        minted = await mintDeviceCredential({
+      const bearer =
+        mintBearer ?? (await requireInstallationLogin(contextName));
+      const minted = await mintDeviceCredentialWithReauth({
+        contextName,
+        initialBearerIsChild:
+          mintBearer !== undefined &&
+          mintBearer === cachedState?.workerApiToken,
+        options: {
           gatewayOrigin: target.gatewayOrigin,
           bearer,
           platform,
           workerId,
           label: options.label?.trim() || shortHost,
-        });
-      } catch (error) {
-        // A cached child can rotate only itself and may have expired or been
-        // revoked. Fall back to this installation's login, never another
-        // context's token.
-        if (
-          !mintBearer?.startsWith("owl_pat_") ||
-          !(error instanceof DeviceMintError) ||
-          (error.status !== 401 && error.status !== 403)
-        ) {
-          throw error;
-        }
-        minted = await mintDeviceCredential({
-          gatewayOrigin: target.gatewayOrigin,
-          bearer: await requireInstallationLogin(contextName),
-          platform,
-          workerId,
-          label: options.label?.trim() || shortHost,
-        });
-      }
+        },
+      });
 
       if (minted.workerId !== workerId) {
         throw new Error(
@@ -318,15 +316,64 @@ async function ensureInstallationContext(
 async function requireInstallationLogin(contextName: string): Promise<string> {
   const existing = await getContextToken(contextName);
   if (existing) return existing;
+  return refreshInstallationLogin(contextName);
+}
+
+async function refreshInstallationLogin(contextName: string): Promise<string> {
   if (!canPrompt()) throw new Error(LOGIN_SETUP_MESSAGE(contextName));
 
-  // `getContextToken` already returned null, so any stored credential is
-  // expired and unrefreshable. Without --force `lobu login` short-circuits on
-  // it with "Already logged in" and authorizes nothing.
+  // The stored credential is absent, expired, revoked, or predates the daemon's
+  // device_worker:run scope. Without --force `lobu login` can short-circuit on
+  // that same credential with "Already logged in" and authorize nothing.
   await loginCommand({ context: contextName, force: true });
   const authenticated = await getContextToken(contextName);
   if (!authenticated) throw new Error(LOGIN_SETUP_MESSAGE(contextName));
   return authenticated;
+}
+
+async function mintDeviceCredentialWithReauth({
+  contextName,
+  initialBearerIsChild,
+  options,
+}: {
+  contextName: string;
+  initialBearerIsChild: boolean;
+  options: MintDeviceCredentialOptions;
+}): Promise<MintedDeviceCredential> {
+  try {
+    return await mintDeviceCredential(options);
+  } catch (error) {
+    if (!isDeviceMintAuthError(error)) throw error;
+
+    // A cached child may have expired or been revoked. Retry with this exact
+    // installation's stored login first; never borrow a different context.
+    if (initialBearerIsChild) {
+      const installationBearer = await requireInstallationLogin(contextName);
+      try {
+        return await mintDeviceCredential({
+          ...options,
+          bearer: installationBearer,
+        });
+      } catch (loginError) {
+        if (!isDeviceMintAuthError(loginError)) throw loginError;
+      }
+    }
+
+    // A stored login can be valid for ordinary MCP work but lack the newer
+    // device_worker:run scope. Interactive starts repair it through the same
+    // device-code flow; non-interactive starts receive the exact login command.
+    return mintDeviceCredential({
+      ...options,
+      bearer: await refreshInstallationLogin(contextName),
+    });
+  }
+}
+
+function isDeviceMintAuthError(error: unknown): error is DeviceMintError {
+  return (
+    error instanceof DeviceMintError &&
+    (error.status === 401 || error.status === 403)
+  );
 }
 
 function hasUsableCachedWorkerToken(state: DeviceState): boolean {
@@ -337,13 +384,9 @@ function hasUsableCachedWorkerToken(state: DeviceState): boolean {
   );
 }
 
-async function mintDeviceCredential(options: {
-  gatewayOrigin: string;
-  bearer: string;
-  platform: string;
-  workerId: string;
-  label: string;
-}): Promise<MintedDeviceCredential> {
+async function mintDeviceCredential(
+  options: MintDeviceCredentialOptions
+): Promise<MintedDeviceCredential> {
   const url = `${options.gatewayOrigin}/api/me/devices/mint-child-token`;
   const res = await fetchWithRetry(url, {
     method: "POST",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1172,7 +1172,7 @@ Memory:
     )
     .option(
       "--platform <name>",
-      "Device platform (defaults to macos/headless by host)"
+      "Device platform (defaults to headless; native macOS uses Owletto)"
     )
     .option(
       "--inside-claude",

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -12,6 +12,7 @@ import {
   addContext,
   DEFAULT_CONTEXT_NAME,
   findContextByMemoryUrl,
+  findContextByOrigin,
   findContextByUrl,
   getActiveOrg,
   getMemoryUrl,
@@ -89,6 +90,59 @@ describe("context management", () => {
 
     const none = await findContextByUrl("https://unknown.ai");
     expect(none).toBeUndefined();
+  });
+
+  test("finds a context by gateway origin across SDK path spellings", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        currentContext: "lobu",
+        contexts: {
+          lobu: { url: "https://app.lobu.ai/api/v1" },
+          buremba: { url: "https://buremba.lobu.ai/api/v1" },
+        },
+      })
+    );
+
+    expect((await findContextByOrigin("https://buremba.lobu.ai"))?.name).toBe(
+      "buremba"
+    );
+    expect(
+      await findContextByOrigin("https://different.lobu.ai/api/v1")
+    ).toBeUndefined();
+  });
+
+  test("prefers the current context over the built-in one on the same origin", async () => {
+    // The built-in "lobu" context is always materialized at the hosted origin.
+    // Matching it ahead of the user's own context for that installation would
+    // read credentials from a slot they never logged into.
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        currentContext: "prod",
+        contexts: {
+          prod: { url: "https://app.lobu.ai/api/v1" },
+        },
+      })
+    );
+
+    expect((await findContextByOrigin("https://app.lobu.ai"))?.name).toBe(
+      "prod"
+    );
+  });
+
+  test("prefers a user-named matching context when current points elsewhere", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        currentContext: "local",
+        contexts: {
+          local: { url: "http://127.0.0.1:8787" },
+          prod: { url: "https://app.lobu.ai/api/v1" },
+        },
+      })
+    );
+
+    expect((await findContextByOrigin("https://app.lobu.ai"))?.name).toBe(
+      "prod"
+    );
   });
 
   test("reads legacy apiUrl contexts and saves the new url shape", async () => {

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -487,11 +487,12 @@ export async function findContextByUrl(
 /**
  * Find the named context whose API URL belongs to the same gateway origin.
  *
- * Device endpoints live at the origin while older hosted contexts commonly
- * retain an `/api/v1` suffix. Matching those two spellings is safe because an
- * OAuth bearer never crosses the URL origin boundary. The current context wins
- * ties; otherwise user-named contexts win over the always-present built-in
- * context, because that is normally where the installation login is stored.
+ * Device endpoints live at the origin while a hosted context carries the
+ * `/api/v1` SDK suffix — the built-in `lobu` context included. Matching those
+ * two spellings is safe because an OAuth bearer never crosses the URL origin
+ * boundary. The current context wins ties; otherwise user-named contexts win
+ * over the always-present built-in context, because that is normally where the
+ * installation login is stored.
  */
 export async function findContextByOrigin(
   apiUrl: string

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -484,6 +484,49 @@ export async function findContextByUrl(
   return undefined;
 }
 
+/**
+ * Find the named context whose API URL belongs to the same gateway origin.
+ *
+ * Device endpoints live at the origin while older hosted contexts commonly
+ * retain an `/api/v1` suffix. Matching those two spellings is safe because an
+ * OAuth bearer never crosses the URL origin boundary. The current context wins
+ * ties; otherwise user-named contexts win over the always-present built-in
+ * context, because that is normally where the installation login is stored.
+ */
+export async function findContextByOrigin(
+  apiUrl: string
+): Promise<ResolvedContext | undefined> {
+  const config = await loadContextConfig();
+  let searchOrigin: string;
+  try {
+    searchOrigin = new URL(apiUrl).origin;
+  } catch {
+    return undefined;
+  }
+
+  // The built-in "lobu" context is always materialized at the hosted origin, so
+  // it would shadow a context the user named themselves for that same
+  // installation — and it is not normally where their credentials live. Try
+  // the current context first, then user-named contexts, and leave the built-in
+  // fallback last. This also covers `currentContext=local` with a logged-in
+  // `prod` context targeting the hosted origin.
+  const entries = Object.entries(config.contexts);
+  const priority = (name: string): number => {
+    if (name === config.currentContext) return 0;
+    if (name === DEFAULT_CONTEXT_NAME) return 2;
+    return 1;
+  };
+  entries.sort(([a], [b]) => priority(a) - priority(b));
+
+  for (const [name, context] of entries) {
+    if (new URL(context.url).origin === searchOrigin) {
+      return contextToResolvedContext(name, context);
+    }
+  }
+
+  return undefined;
+}
+
 export async function findContextByMemoryUrl(
   memoryUrl: string
 ): Promise<ResolvedContext | undefined> {

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -1,4 +1,12 @@
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -6,6 +14,10 @@ export const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
 
 export interface DeviceState {
   workerId: string;
+  /** Worker-bound child PAT minted by the installation login. */
+  workerApiToken?: string;
+  /** Epoch ms hard expiry for workerApiToken. */
+  expiresAt?: number;
 }
 
 // Resolve lazily so home-directory overrides use the matching config root.
@@ -32,9 +44,61 @@ export async function loadDeviceState(
     ) {
       return null;
     }
-    return { workerId: parsed.workerId };
+    const workerApiToken =
+      typeof parsed.workerApiToken === "string" &&
+      parsed.workerApiToken.startsWith("owl_pat_")
+        ? parsed.workerApiToken
+        : undefined;
+    const expiresAt =
+      typeof parsed.expiresAt === "number" &&
+      Number.isFinite(parsed.expiresAt) &&
+      parsed.expiresAt > 0
+        ? parsed.expiresAt
+        : undefined;
+    return {
+      workerId: parsed.workerId,
+      ...(workerApiToken ? { workerApiToken } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
+    };
   } catch {
     return null;
+  }
+}
+
+/** Replace credentials for an already-saved identity without changing its id. */
+export async function updateDeviceState(
+  context: string,
+  platform: string,
+  state: DeviceState
+): Promise<void> {
+  if (!WORKER_ID_PATTERN.test(state.workerId)) {
+    throw new Error(`invalid device worker id '${state.workerId}'`);
+  }
+  if (
+    state.workerApiToken !== undefined &&
+    !state.workerApiToken.startsWith("owl_pat_")
+  ) {
+    throw new Error("invalid device worker token");
+  }
+
+  const current = await loadDeviceState(context, platform);
+  if (!current || current.workerId !== state.workerId) {
+    throw new Error(
+      `Refusing to replace device state for context "${context}" on ${platform}: the saved worker id changed.`
+    );
+  }
+
+  const file = statePath(context, platform);
+  const tmp = `${file}.tmp-${process.pid}-${randomBytes(6).toString("hex")}`;
+  try {
+    await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    await rename(tmp, file);
+  } catch (error) {
+    await rm(tmp).catch(() => undefined);
+    throw error;
   }
 }
 
@@ -46,6 +110,12 @@ export async function saveDeviceState(
 ): Promise<void> {
   if (!WORKER_ID_PATTERN.test(state.workerId)) {
     throw new Error(`invalid device worker id '${state.workerId}'`);
+  }
+  if (
+    state.workerApiToken !== undefined &&
+    !state.workerApiToken.startsWith("owl_pat_")
+  ) {
+    throw new Error("invalid device worker token");
   }
 
   const dir = devicesDir();

--- a/packages/cli/src/internal/device-state.ts
+++ b/packages/cli/src/internal/device-state.ts
@@ -84,7 +84,7 @@ export async function updateDeviceState(
   const current = await loadDeviceState(context, platform);
   if (!current || current.workerId !== state.workerId) {
     throw new Error(
-      `Refusing to replace device state for context "${context}" on ${platform}: the saved worker id changed.`
+      `Refusing to replace device state at ${statePath(context, platform)}: the saved worker id changed or became unreadable. Delete that file to redo setup.`
     );
   }
 

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -18,6 +18,7 @@ export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
 export {
   resolveDaemonLaunchContext,
+  resolveDaemonWorkerId,
   startDaemonCommand,
   type DaemonStartOptions,
 } from './start.js';

--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -93,6 +93,168 @@ describe('headless device mint (mint-child-token)', () => {
     expect(rows[0].organization_id).toBe(personalOrg.id);
   });
 
+  it('uses a first-party login caller requested worker_id for a new headless device', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Requested ID' });
+    const user = await createTestUser({ email: 'headless-requested-id@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'headless',
+          worker_id: 'headless:herdr-session',
+          label: 'Herdr session',
+        }),
+      },
+      TEST_ENV
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      worker_id: string;
+      access_token: string;
+      session_token: string | null;
+    };
+    expect(body.worker_id).toBe('headless:herdr-session');
+    expect(body.access_token.startsWith('owl_pat_')).toBe(true);
+    expect(body.session_token).toBeNull();
+
+    const rows = (await sql`
+      SELECT worker_id, platform, organization_id FROM device_workers
+      WHERE user_id = ${user.id}
+    `) as unknown as Array<{
+      worker_id: string;
+      platform: string;
+      organization_id: string;
+    }>;
+    expect(rows).toEqual([
+      {
+        worker_id: 'headless:herdr-session',
+        platform: 'headless',
+        organization_id: personalOrg.id,
+      },
+    ]);
+  });
+
+  it('rejects an invalid requested worker_id before minting a child token', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Invalid ID' });
+    const user = await createTestUser({ email: 'headless-invalid-id@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          platform: 'headless',
+          worker_id: 'headless id with spaces',
+        }),
+      },
+      TEST_ENV
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'invalid_worker_id' });
+    const pats = (await sql`
+      SELECT id FROM personal_access_tokens WHERE user_id = ${user.id}
+    `) as unknown as Array<{ id: number }>;
+    expect(pats).toHaveLength(0);
+  });
+
+  it('serializes concurrent first mint for the same requested worker_id', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Concurrent ID' });
+    const user = await createTestUser({ email: 'headless-concurrent-id@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    const app = mintApp(user.id);
+    const request = () =>
+      app.request(
+        '/api/me/devices/mint-child-token',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            platform: 'headless',
+            worker_id: 'headless:concurrent-herdr',
+          }),
+        },
+        TEST_ENV
+      );
+
+    // In-process requests against one pool serialize: each caller observes the
+    // previous device row and takes the ordinary re-mint path, so this asserts
+    // the CONVERGENCE contract (one device row, one live PAT) rather than the
+    // multi-replica race the handler's advisory lock exists for — that one
+    // needs two writers past the optimistic lookup at once, which a single
+    // process cannot stage.
+    const responses = await Promise.all(Array.from({ length: 4 }, request));
+    expect(responses.map((response) => response.status)).toEqual([200, 200, 200, 200]);
+    const bodies = await Promise.all(
+      responses.map(
+        (response) => response.json() as Promise<{ worker_id: string; access_token: string }>
+      )
+    );
+    expect(bodies.map((body) => body.worker_id)).toEqual(
+      Array.from({ length: 4 }, () => 'headless:concurrent-herdr')
+    );
+
+    const devices = (await sql`
+      SELECT worker_id FROM device_workers
+      WHERE user_id = ${user.id} AND worker_id = 'headless:concurrent-herdr'
+    `) as unknown as Array<{ worker_id: string }>;
+    expect(devices).toHaveLength(1);
+    const pats = (await sql`
+      SELECT revoked_at FROM personal_access_tokens
+      WHERE user_id = ${user.id} AND worker_id = 'headless:concurrent-herdr'
+    `) as unknown as Array<{ revoked_at: Date | null }>;
+    expect(pats).toHaveLength(4);
+    expect(pats.filter((pat) => pat.revoked_at === null)).toHaveLength(1);
+  });
+
+  it('revokes an orphaned child PAT when a deleted identity is re-registered', async () => {
+    const sql = getTestDb();
+    const personalOrg = await createTestOrganization({ name: 'Personal Orphan' });
+    const user = await createTestUser({ email: 'headless-orphan-pat@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    const app = mintApp(user.id);
+    const body = JSON.stringify({ platform: 'headless', worker_id: 'headless:forgotten-box' });
+    const mint = () =>
+      app.request(
+        '/api/me/devices/mint-child-token',
+        { method: 'POST', headers: { 'content-type': 'application/json' }, body },
+        TEST_ENV
+      );
+
+    expect((await mint()).status).toBe(200);
+
+    // `deleteDeviceWorker` ("forget this device" on the Devices page) drops the
+    // row WITHOUT revoking the PAT bound to that worker_id. Re-registering the
+    // same id must not then leave two live credentials polling as one device.
+    await sql`
+      DELETE FROM device_workers
+      WHERE user_id = ${user.id} AND worker_id = 'headless:forgotten-box'
+    `;
+
+    expect((await mint()).status).toBe(200);
+
+    const pats = (await sql`
+      SELECT revoked_at FROM personal_access_tokens
+      WHERE user_id = ${user.id} AND worker_id = 'headless:forgotten-box'
+    `) as unknown as Array<{ revoked_at: Date | null }>;
+    expect(pats).toHaveLength(2);
+    expect(pats.filter((pat) => pat.revoked_at === null)).toHaveLength(1);
+  });
+
   it('reuses a headless worker_id on re-mint and revokes the previous child PAT', async () => {
     const sql = getTestDb();
     const personalOrg = await createTestOrganization({ name: 'Personal Reuse' });
@@ -214,7 +376,11 @@ describe('headless device mint (mint-child-token)', () => {
       TEST_ENV
     );
     expect(chrome.status).toBe(200);
-    const chromeBody = (await chrome.json()) as { worker_id: string };
+    const chromeBody = (await chrome.json()) as {
+      worker_id: string;
+      session_token: string | null;
+    };
+    expect(typeof chromeBody.session_token).toBe('string');
 
     const headless = await app.request(
       '/api/me/devices/mint-child-token',
@@ -226,8 +392,12 @@ describe('headless device mint (mint-child-token)', () => {
       TEST_ENV
     );
     expect(headless.status).toBe(200);
-    const headlessBody = (await headless.json()) as { worker_id: string };
+    const headlessBody = (await headless.json()) as {
+      worker_id: string;
+      session_token: string | null;
+    };
     expect(headlessBody.worker_id).not.toBe(chromeBody.worker_id);
+    expect(headlessBody.session_token).toBeNull();
 
     const rows = (await sql`
       SELECT worker_id, platform FROM device_workers WHERE user_id = ${user.id} ORDER BY platform ASC

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -309,7 +309,7 @@ export async function createAuth(
 					// whose auto-provisioned org was deleted, or who manually created
 					// their first org via the UI, ends up with NULL `workerOrgIds`
 					// in the device-worker auth middleware (index.ts:602-607), so
-					// their Lobu bridge gets a 403 on every poll.
+					// their personal worker gets a 403 on every poll.
 					afterCreateOrganization: async ({ organization: org, user }) => {
 						// The org row is already committed when this hook fires. Audit
 						// first so the creation trail survives a personal-org marker

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -30,6 +30,8 @@ import { getWorkspaceRole } from '../utils/organization-access';
 import { parseJsonBody } from '../gateway/routes/shared/helpers';
 import { buildAutomationUrl, getPublicWebUrl } from '../utils/url-builder';
 
+const DEVICE_WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
 /** One of the caller's registered devices, as both readers return it. */
 export interface DeviceWorkerSummary {
   id: string;
@@ -168,13 +170,15 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
  * Child PATs expire, so an orphaned or leaked one stops working on its own
  * instead of living until someone revokes it by hand. A device refreshes by
  * re-minting through this endpoint with its stored worker_id (the reuse branch
- * keeps the device identity and revokes the old token) — which for a headless
- * daemon means a re-register, since nothing rotates the PAT in place today.
+ * keeps the device identity and revokes the old token). `lobu daemon` does this
+ * for itself: on start it re-mints from its cached child PAT once that token is
+ * within a day of expiring. A bearer is still snapshotted for the process
+ * lifetime, so a daemon left running past day 90 rotates only on its next start.
  *
  * Forward-only: legacy children (minted before this shipped) keep their null
  * expiry until they rotate. A retroactive backfill would hard-kill working
- * devices at day 90 with no rotation client shipped — an owner decision, not
- * one this change takes.
+ * devices at day 90 — the Mac bridge's chrome children still have no rotation
+ * client — an owner decision, not one this change takes.
  */
 const CHILD_PAT_EXPIRES_IN_DAYS = 90;
 /** Refusal body for both arms of the depth-1 gate (see `mintDeviceChildToken`). */
@@ -185,13 +189,15 @@ const CHILD_SELF_MINT_ONLY = {
 } as const;
 
 /**
- * POST /api/me/devices/mint-child-token  { platform, label? }
+ * POST /api/me/devices/mint-child-token  { platform, label?, worker_id? }
  *
- * Hand-off path for the Mac bridge to pair a sibling device (today: the
- * Owletto Chrome extension) without a second OAuth dance. The Mac app's
- * bearer authenticates the caller; we mint a fresh PAT in the same user's
- * personal org, generate a new worker_id, and return both for the sibling
- * to use as if it had completed device-authorization on its own.
+ * Hand-off path for a first-party device grant to authorize a worker without a
+ * second OAuth dance: the Mac bridge pairing a sibling device (today: the
+ * Owletto Chrome extension), or `lobu daemon` authorizing this host from its
+ * stored login. The caller's bearer authenticates the user; we mint a PAT in
+ * that user's personal org bound to a worker_id — the one the caller asked for,
+ * else a fresh uuid — and return both for the device to use as if it had
+ * completed device-authorization on its own.
  *
  * The child token carries the same `device_worker:run` scope the regular Mac
  * OAuth flow ends up with. Its stored worker_id binding stops the mint chain at
@@ -233,13 +239,12 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     platform?: string;
     label?: string;
     /**
-     * Optional: the caller's previously-stored worker_id — the Mac bridge
-     * forwarding the extension's id, or a headless daemon re-registering after
-     * a restart. Reused only when that id already belongs to this user on the
-     * SAME platform being requested, in which case we keep the device identity
-     * (re-mint the bound PAT, keep the same row) instead of minting a fresh
-     * one, so a re-register doesn't churn the device id and accumulate orphaned
-     * `device_workers` rows. See the reuse branch below.
+     * Optional: the worker_id the first-party caller wants this device to use.
+     * A Mac bridge normally forwards the extension's stored id, while the CLI
+     * daemon sends the identity its first-run wizard selected. When the id
+     * already belongs to this user on the SAME platform, re-mint the bound PAT
+     * and keep the row; when it is new for this user, create that exact identity.
+     * A bound child token is still limited to rotating its own existing id.
      */
     worker_id?: string;
   }>(c, 'Invalid or missing JSON body');
@@ -259,8 +264,19 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
   const label = body.label?.toString().trim() || null;
   // The caller's previously-stored worker_id, if it forwarded one. Trimmed;
   // validated against ownership + the requested platform in the reuse branch
-  // below, so a stale/garbage value just falls through to a fresh mint.
+  // below. Validate its public worker-id shape before it reaches either the
+  // device row or PAT binding.
   const requestedWorkerId = (body.worker_id ?? '').trim();
+  if (requestedWorkerId && !DEVICE_WORKER_ID_PATTERN.test(requestedWorkerId)) {
+    return c.json(
+      {
+        error: 'invalid_worker_id',
+        error_description:
+          'worker_id must be 1-128 characters of letters, digits, dot, underscore, colon, or hyphen',
+      },
+      400
+    );
+  }
 
   // The chain stops at depth 1: a PAT this endpoint minted may ROTATE itself —
   // re-mint its own bound worker_id, which revokes the old PAT in the same
@@ -299,33 +315,32 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       );
     }
 
-    // Identity reuse: when the caller forwards its existing worker_id AND it
-    // already belongs to this user as a device of the SAME platform being
-    // requested, keep that identity stable — re-mint the PAT bound to the same
-    // worker_id (revoking the previous child PAT first) and reuse the existing
-    // device_workers row. This is what stops each re-register (Mac-bridge
-    // re-pair, headless daemon restart) from minting a fresh uuid and orphaning
-    // the previous row plus its still-live PAT (the source of the duplicate
-    // "chrome" entries on the Devices page). Matching on the requested platform
-    // rather than a fixed one keeps cross-platform reuse refused: a
-    // chrome-extension worker_id cannot be re-minted as headless or vice versa.
-    // Falls through to a fresh mint for the first-ever register, a
-    // stale/garbage id, or an id owned by another user/platform — i.e. any case
-    // where reuse would be unsafe or a no-op.
+    // Identity reuse/creation: an unbound first-party device grant may create
+    // the exact requested id (the CLI wizard/session identity) or re-mint it
+    // when the same user already owns it on this platform. If the same user has
+    // that id on another platform, preserve the established cross-platform
+    // isolation by falling back to a fresh UUID. Child PAT callers cannot reach
+    // either fresh path because the depth-1 check below requires `reused`.
     let workerId: string;
+    let reused = false;
     if (requestedWorkerId) {
       const existing = (await sql`
-        SELECT worker_id FROM device_workers
+        SELECT worker_id, platform FROM device_workers
         WHERE user_id = ${userId}
           AND worker_id = ${requestedWorkerId}
-          AND platform = ${platform}
         LIMIT 1
-      `) as unknown as Array<{ worker_id: string }>;
-      workerId = existing[0]?.worker_id ?? crypto.randomUUID();
+      `) as unknown as Array<{ worker_id: string; platform: string | null }>;
+      if (existing[0]?.platform === platform) {
+        workerId = existing[0].worker_id;
+        reused = true;
+      } else if (existing.length === 0) {
+        workerId = requestedWorkerId;
+      } else {
+        workerId = crypto.randomUUID();
+      }
     } else {
       workerId = crypto.randomUUID();
     }
-    const reused = workerId === requestedWorkerId;
     // Matching the caller's own worker_id is not enough: the reuse lookup also
     // requires the SAME platform, so a child re-declaring its worker_id under a
     // different platform falls through to a fresh uuid — i.e. a brand-new
@@ -335,18 +350,18 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       return c.json(CHILD_SELF_MINT_ONLY, 403);
     }
 
-    const patService = new PersonalAccessTokenService(sql);
     // Upsert the device_workers row (exists on reuse, created on first mint).
     // On the reuse path this MUST run inside the same transaction as the PAT
     // mint/revoke (see below) so last_seen_at refresh + new-PAT-visibility
     // commit atomically — otherwise a concurrent reaper could see the reused
     // row still stale (30+ days unseen) and the freshly-minted PAT as already
     // committed, then delete the row and revoke that brand-new PAT. The helper
-    // takes the db handle (sql for fresh-mint, tx for reuse) so both paths run
-    // the identical statement. Platform is bound once and never changed here
-    // (poll's ON CONFLICT preserves it via COALESCE + a SELECT-then-reject
-    // check, and the gateway's capability authorization uses the stored
-    // platform rather than whatever the bearer self-reports).
+    // takes the db handle so both paths run the identical statement: a
+    // random-id fresh mint passes `sql`, while an exact requested identity
+    // passes `tx` whether it is new or reused. Platform is bound once and never
+    // changed here (poll's ON CONFLICT preserves it via COALESCE + a
+    // SELECT-then-reject check, and the gateway's capability authorization uses
+    // the stored platform rather than whatever the bearer self-reports).
     // The label is recorded on insert only: a re-mint carries whatever the
     // client self-reports (a headless daemon sends its hostname), which must
     // not clobber a name the user set on the Devices page — same reason poll's
@@ -359,10 +374,33 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
         SET last_seen_at = NOW()
     `;
 
-    let created: { id: number; token: string; expires_at: Date | null };
-    if (reused) {
+    let created: { id: number; token: string; expires_at: Date | null } | null;
+    // Any exact requested identity — fresh or reused — takes the same advisory
+    // lock and re-checks under it. Without this, two replicas can both observe
+    // a new CLI wizard id as absent, mint two live PATs, and only then race the
+    // device-row upsert. The second caller must instead observe the first row
+    // and take the normal re-mint path that revokes the first PAT.
+    if (requestedWorkerId && workerId === requestedWorkerId) {
       created = await sql.begin(async (tx) => {
         await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:mint-child'), hashtext(${workerId}))`;
+        const current = (await tx`
+          SELECT platform FROM device_workers
+          WHERE user_id = ${userId} AND worker_id = ${workerId}
+          LIMIT 1
+        `) as unknown as Array<{ platform: string | null }>;
+        reused = current[0]?.platform === platform;
+        // Re-check the depth-1 boundary after acquiring the identity lock. A
+        // device row can be deleted between the optimistic lookup above and
+        // this transaction; a child whose own row disappeared must not recreate
+        // it as though it were an unbound first-party login.
+        if (callerIsMintedChild && !reused) return null;
+        // The optimistic lookup's third case can also land here: another
+        // registration may have claimed this id for a DIFFERENT platform while
+        // we waited on the lock. The upsert below only refreshes last_seen_at,
+        // so reusing the id would bind this platform's PAT to a row whose
+        // stored platform is the other one — the exact confusion the
+        // cross-platform fallback exists to prevent. Take a fresh uuid instead.
+        if (current.length > 0 && !reused) workerId = crypto.randomUUID();
         // Refresh last_seen_at in the SAME transaction so the reaper can never
         // observe a committed, valid PAT bound to a still-stale reused row. Do
         // this BEFORE the PAT mint/revoke so this tx acquires the device_workers
@@ -382,6 +420,12 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
             expiresInDays: CHILD_PAT_EXPIRES_IN_DAYS,
           }
         );
+        // Revoke on EVERY exact-identity path, not just the reuse one: a device
+        // deleted from the Devices page drops its `device_workers` row without
+        // revoking the PAT bound to that worker_id, so re-registering the same
+        // id would otherwise leave two live credentials polling as one device.
+        // When the cross-platform fallback above swapped in a fresh uuid this
+        // matches nothing, which is exactly right.
         await tx`
           UPDATE personal_access_tokens
           SET revoked_at = NOW(), updated_at = NOW()
@@ -393,7 +437,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
         return minted;
       });
     } else {
-      created = await patService.create(
+      created = await new PersonalAccessTokenService(sql).create(
         userId,
         organizationId,
         `device:${platform}:${workerId.slice(0, 8)}`,
@@ -408,26 +452,32 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       // transaction (the INSERT sets last_seen_at = NOW() via the column default).
       await upsertDeviceWorker(sql);
     }
+    if (!created) {
+      return c.json(CHILD_SELF_MINT_ONLY, 403);
+    }
 
-    // Also mint a Better Auth session token for the same user. The sibling
-    // device's iframe needs a session cookie (not a PAT) to land signed-in;
-    // the extension installs this via /api/exchange-token. Without it the
-    // user has to type their password a second time after auto-pair.
+    // Also mint a Better Auth session token for a Chrome sibling. Its iframe
+    // needs a session cookie (not a PAT) to land signed-in; the extension
+    // installs this via /api/exchange-token. A headless daemon has no iframe,
+    // so minting a browser session for every daemon start would create an
+    // unused credential.
     let sessionToken: string | null = null;
-    try {
-      const auth = await createAuth(c.env, c.req.raw);
-      const ctx = await auth.$context;
-      const session = await ctx.internalAdapter.createSession(userId);
-      sessionToken = session?.token ?? null;
-    } catch (err) {
-      // Session mint is best-effort — child PAT is the primary credential.
-      // Falling back to no session_token means the iframe shows sign-in,
-      // matching pre-existing semantics for siblings that haven't adopted
-      // the handoff.
-      logger.warn(
-        { err: errorMessage(err), userId },
-        '[mintDeviceChildToken] session mint failed; returning child PAT only'
-      );
+    if (platform === 'chrome-extension') {
+      try {
+        const auth = await createAuth(c.env, c.req.raw);
+        const ctx = await auth.$context;
+        const session = await ctx.internalAdapter.createSession(userId);
+        sessionToken = session?.token ?? null;
+      } catch (err) {
+        // Session mint is best-effort — child PAT is the primary credential.
+        // Falling back to no session_token means the iframe shows sign-in,
+        // matching pre-existing semantics for siblings that haven't adopted
+        // the handoff.
+        logger.warn(
+          { err: errorMessage(err), userId },
+          '[mintDeviceChildToken] session mint failed; returning child PAT only'
+        );
+      }
     }
 
     const gatewayUrl = new URL(c.req.url).origin;

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -171,9 +171,10 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
  * instead of living until someone revokes it by hand. A device refreshes by
  * re-minting through this endpoint with its stored worker_id (the reuse branch
  * keeps the device identity and revokes the old token). `lobu daemon` does this
- * for itself: on start it re-mints from its cached child PAT once that token is
- * within a day of expiring. A bearer is still snapshotted for the process
- * lifetime, so a daemon left running past day 90 rotates only on its next start.
+ * for itself: on start it re-mints from its cached child PAT once less than a
+ * third of that token's life remains. A bearer is still snapshotted for the
+ * process lifetime, so a daemon left running past day 90 rotates only on its
+ * next start.
  *
  * Forward-only: legacy children (minted before this shipped) keep their null
  * expiry until they rotate. A retroactive backfill would hard-kill working


### PR DESCRIPTION
## Summary

- replace the published daemon manual-PAT gate with installation-scoped login, worker-bound child-token minting, rotation, and owner-only host caching
- preserve per-session Claude/Codex/OpenCode routing without persisting session PATs; keep `WORKER_API_TOKEN` only as the unattended/advanced override
- present `Lobu worker (CLI)` and `Lobu worker (Docker)` as two install methods for the same headless worker in both the empty state and Add catalog; both run the personalized installation-scoped daemon wizard with no `--org` or PAT
- make exact requested device identities concurrency-safe, personal-org bound, depth-1 limited, and revoke stale credentials when a deleted identity is re-registered

Owletto UI changes were reviewed and merged independently in [lobu-ai/owletto#921](https://github.com/lobu-ai/owletto/pull/921), [#922](https://github.com/lobu-ai/owletto/pull/922), and [#923](https://github.com/lobu-ai/owletto/pull/923), building on the personalized command from [#919](https://github.com/lobu-ai/owletto/pull/919).

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted CLI, connector-worker, Owletto, and embedded-Postgres server integration suites
- [x] Bug fix: red to green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Published red:

```text
$ env -u WORKER_API_TOKEN bunx @lobu/cli@latest --version
15.6.0
$ env -u WORKER_API_TOKEN bunx @lobu/cli@latest daemon --api-url https://buremba.lobu.ai
A device daemon requires a durable owl_pat_ token in WORKER_API_TOKEN ...
```

Fixed local interactive path:

```text
$ env -u WORKER_API_TOKEN packages/cli/bin/lobu.js daemon --api-url https://buremba.lobu.ai
Saved Lobu installation context "buremba.lobu.ai" ...
Device-code login started against https://buremba.lobu.ai
```

The login was deliberately allowed to expire without approval; the published post-merge command will be left running in Herdr for an authenticated live test.

Green:

```text
bun test packages/cli/src/__tests__/daemon-gateway-origin.test.ts packages/cli/src/__tests__/device-state.test.ts packages/cli/src/commands/__tests__/device-wizard.test.ts
37 pass, 0 fail

cd packages/server && bun run test -- run src/__tests__/integration/device-management-mint.test.ts
9 pass, 0 fail

cd packages/owletto && bun run test -- src/lib/connectors/app-catalog.test.tsx src/components/devices/device-display.test.tsx
9 pass, 0 fail

cd packages/owletto && bun run build
success

make pre-pr
all package builds/typechecks, knip, naming, gateway LLM, and entity-write funnel gates clean
```

## Notes

- UI proof is required because the Owletto pointer changes hosted connector UI; this PR will receive a preview comparison artifact before merge.
- The Docker command uses the published `ghcr.io/lobu-ai/lobu-worker:latest` image, persists the image's non-root `/home/worker`, and removes the foreground setup container on exit while preserving the named volume. Loopback installation URLs are translated to `host.docker.internal` so the container can reach the host.
- The canonical Docker detail route is `/connectors/app/lobu-docker`; the retired `/connectors/app/lobu-bridge` route remains a compatibility alias.
- On macOS, terminal `lobu daemon` now defaults to the `headless` platform because the native Owletto app owns `macos`. An existing CLI-only `macos:<host>` device is not migrated automatically; pinned connections and Automations must target the new headless worker after first start.
- `--api-url` is retained on both cards to bind the command to the installation origin. There is intentionally no `--org`: the device is personal and team workspaces reach it through pinned connections or Automations.
