### PR TITLE
feat(connectors): declare attributed entity relationships

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -387,6 +387,89 @@ describe("executePlan — managed MCP connector install", () => {
   });
 });
 
+describe("executePlan — connector relationship schema ordering", () => {
+  test("creates desired relationship types before installing a connector that references them", async () => {
+    const calls: string[] = [];
+    const relationship = {
+      slug: "invoice_customer",
+      name: "Invoice customer",
+    };
+    const connection: DesiredConnection = {
+      slug: "erp",
+      connector: "erp",
+      feeds: [],
+      sourceFile: "lobu.config.ts",
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [connection],
+    });
+    state.memorySchema.relationshipTypes = [relationship];
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "relationship-type",
+          verb: "create",
+          id: relationship.slug,
+          desired: relationship,
+        },
+      ],
+      counts: { create: 1, update: 0, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      automations: [],
+      connectorDefinitions: [
+        {
+          key: "erp",
+          installed: false,
+          installable: true,
+          source_uri: "file:///catalog/erp.ts",
+          auth_schema: { methods: [{ type: "none" }] },
+        },
+      ],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const client = {
+      upsertRelationshipType: mock(async () => {
+        calls.push("relationship-type");
+        return {};
+      }),
+      installConnector: mock(async () => {
+        calls.push("connector");
+        return {
+          connectorKey: "erp",
+          name: "ERP",
+          version: "1.0.0",
+          codeHash: "hash",
+          updated: false,
+        };
+      }),
+      listConnectors: mock(async () => [
+        {
+          key: "erp",
+          installed: true,
+          installable: true,
+          source_uri: "file:///catalog/erp.ts",
+          auth_schema: { methods: [{ type: "none" }] },
+        },
+      ]),
+    } as unknown as ApplyClient;
+
+    await executePlan({ client, state, plan, remote }, []);
+
+    expect(calls).toEqual(["relationship-type", "connector"]);
+  });
+});
+
 describe("executePlan — entity-type schema fidelity", () => {
   test("carries the live type's out-of-band metadata_schema keys into the upsert", async () => {
     const desired = {

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -795,61 +795,8 @@ export async function executePlan(
 
   let connectorVersions: Record<string, string> = {};
 
-  // 0) Connector definitions FIRST — install/update them (the plan was already
-  //    confirmed), refetch the catalog, then re-validate connection/feed config
-  //    against the now-current schemas. Doing this before any other resource
-  //    means a post-install schema rejection halts apply before mutating
-  //    anything unrelated.
-  if (hasDesiredConnectors(ctx.state)) {
-    const installed = await installConnectorDefinitions(
-      ctx.client,
-      ctx.state,
-      ctx.remote.connectorDefinitions,
-      ctx.plan
-    );
-    const freshCatalog = installed.catalog;
-    connectorVersions = installed.connectorVersions;
-    for (const warning of validateConnectorState(ctx.state, freshCatalog, {
-      requireInstalled: true,
-    })) {
-      printText(chalk.yellow(`Warning: ${warning}`));
-    }
-  }
-
-  // 1) Agents
-  for (const row of rowsByKind("agent")) {
-    if (row.kind !== "agent") continue;
-    if (!row.desired) continue;
-    const desired = ctx.state.agents.find((a) => a.metadata.agentId === row.id);
-    if (!desired) continue;
-    if (row.verb === "create") {
-      await ctx.client.upsertAgent(desired.metadata);
-    } else {
-      await ctx.client.patchAgentMetadata(row.id, {
-        name: desired.metadata.name,
-        description: desired.metadata.description,
-      });
-    }
-    printText(renderProgress(row.verb, "agent", row.id));
-  }
-
-  // 2) Settings
-  for (const row of rowsByKind("settings")) {
-    if (row.kind !== "settings") continue;
-    const desired = ctx.state.agents.find((a) => a.metadata.agentId === row.id);
-    if (!desired) continue;
-    await ctx.client.patchAgentSettings(row.id, desired.settings);
-    printText(
-      renderProgress(
-        row.verb,
-        "settings",
-        row.id,
-        row.changedFields ? `(${row.changedFields.join(", ")})` : undefined
-      )
-    );
-  }
-
-  // 4) Entity types
+  // 0) Entity types first: relationship-type rules may reference types created
+  //    by this same desired apply.
   for (const row of rowsByKind("entity-type")) {
     if (row.kind !== "entity-type") continue;
     if (!row.desired) continue;
@@ -901,12 +848,65 @@ export async function executePlan(
     printText(renderProgress(row.verb, "entity-type", row.id));
   }
 
-  // 5) Relationship types
+  // 1) Relationship types before connector definitions: server preflight
+  //    resolves connector-declared relationship slugs against the active org
+  //    schema, so a type created by this same apply must already exist.
   for (const row of rowsByKind("relationship-type")) {
     if (row.kind !== "relationship-type") continue;
     if (!row.desired) continue;
     await ctx.client.upsertRelationshipType(row.desired);
     printText(renderProgress(row.verb, "relationship-type", row.id));
+  }
+
+  // 2) Connector definitions — install/update them, refetch the catalog, then
+  //    re-validate connection/feed config against the now-current schemas.
+  if (hasDesiredConnectors(ctx.state)) {
+    const installed = await installConnectorDefinitions(
+      ctx.client,
+      ctx.state,
+      ctx.remote.connectorDefinitions,
+      ctx.plan
+    );
+    const freshCatalog = installed.catalog;
+    connectorVersions = installed.connectorVersions;
+    for (const warning of validateConnectorState(ctx.state, freshCatalog, {
+      requireInstalled: true,
+    })) {
+      printText(chalk.yellow(`Warning: ${warning}`));
+    }
+  }
+
+  // 3) Agents
+  for (const row of rowsByKind("agent")) {
+    if (row.kind !== "agent") continue;
+    if (!row.desired) continue;
+    const desired = ctx.state.agents.find((a) => a.metadata.agentId === row.id);
+    if (!desired) continue;
+    if (row.verb === "create") {
+      await ctx.client.upsertAgent(desired.metadata);
+    } else {
+      await ctx.client.patchAgentMetadata(row.id, {
+        name: desired.metadata.name,
+        description: desired.metadata.description,
+      });
+    }
+    printText(renderProgress(row.verb, "agent", row.id));
+  }
+
+  // 4) Settings
+  for (const row of rowsByKind("settings")) {
+    if (row.kind !== "settings") continue;
+    const desired = ctx.state.agents.find((a) => a.metadata.agentId === row.id);
+    if (!desired) continue;
+    await ctx.client.patchAgentSettings(row.id, desired.settings);
+    printText(
+      renderProgress(
+        row.verb,
+        "settings",
+        row.id,
+        row.changedFields ? `(${row.changedFields.join(", ")})` : undefined
+      )
+    );
   }
 
   // Automations are applied after connections so declarative connection slugs

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -552,6 +552,19 @@ export interface FeedDefinition {
        * identities (see `identities` on the entity-link rule), not as facts.
        */
       attributions?: EventAttributionRule[];
+      /**
+       * Relationships between entities resolved by named attributions in this
+       * event kind. The attribution declarations remain the only identity
+       * resolution surface; these entries reference them by name.
+       */
+      relationships?: Array<{
+        /** Relationship-type slug, preserved verbatim. */
+        type: string;
+        /** Name of the source attribution in this event kind. */
+        from: string;
+        /** Name of the target attribution in this event kind. */
+        to: string;
+      }>;
     }
   >;
 }
@@ -577,6 +590,8 @@ export interface EventAttributionTargetSpec {
  * connected to for recall, ACL, and world-model traversal".
  */
 export interface EventAttributionRule {
+  /** Stable local name when another declaration in this event kind references this rule. */
+  name?: string;
   role: EventAttributionRole;
   target: EventAttributionTargetSpec;
   /** Whether an unmatched target may be materialized by the attribution engine. */

--- a/packages/server/src/__tests__/integration/connectors/connector-relationship-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-relationship-preflight.test.ts
@@ -86,9 +86,12 @@ describe('connector relationship-type preflight', () => {
   });
 
   it('rejects a missing relationship type with connector/feed/event context', async () => {
-    await expect(install('missing-relationship', 'missing_type')).rejects.toThrow(
-      /missing-relationship.*feed 'invoices'.*event kind 'invoice'.*missing_type/i
-    );
+    await expect(install('missing-relationship', 'missing_type')).rejects.toMatchObject({
+      httpStatus: 400,
+      message: expect.stringMatching(
+        /missing-relationship.*feed 'invoices'.*event kind 'invoice'.*missing_type/i
+      ),
+    });
   });
 
   it.each([
@@ -97,9 +100,10 @@ describe('connector relationship-type preflight', () => {
   ])('rejects an %s relationship type', async (label, values) => {
     const slug = `${label}_relationship`;
     await createRelationshipType(slug, values);
-    await expect(install(`${label}-connector`, slug)).rejects.toThrow(
-      new RegExp(`${label}-connector.*${slug}.*not active`, 'i')
-    );
+    await expect(install(`${label}-connector`, slug)).rejects.toMatchObject({
+      httpStatus: 400,
+      message: expect.stringMatching(new RegExp(`${label}-connector.*${slug}.*not active`, 'i')),
+    });
   });
 
   it('resolves the active row past a newer same-slug tombstone', async () => {

--- a/packages/server/src/__tests__/integration/connectors/connector-relationship-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-relationship-preflight.test.ts
@@ -1,0 +1,142 @@
+import { COMPILE_CONFIG_HASH } from '@lobu/connector-worker/compile';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createTestOrganization } from '../../setup/test-fixtures';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { upsertConnectorDefinitionRecords } from '../../../utils/connector-definition-install';
+import type { ConnectorMetadata } from '../../../utils/connector-compiler';
+
+function metadataFor(key: string, relationshipType: string): ConnectorMetadata {
+  return {
+    key,
+    name: key,
+    version: '1.0.0',
+    authSchema: null,
+    webhook: null,
+    feeds: {
+      invoices: {
+        key: 'invoices',
+        name: 'Invoices',
+        eventKinds: {
+          invoice: {
+            attributions: [
+              { name: 'invoice', role: 'belongs_to', target: { entityType: 'invoice' } },
+              { name: 'customer', role: 'about', target: { entityType: 'customer' } },
+            ],
+            relationships: [
+              { type: relationshipType, from: 'invoice', to: 'customer' },
+            ],
+          },
+        },
+      },
+    },
+    actions: null,
+    automationEvents: null,
+    optionsSchema: null,
+  };
+}
+
+function versionRecord(key: string) {
+  return {
+    compiledCode: `// compiled ${key}`,
+    compiledCodeHash: `hash-${key}`,
+    compileConfigHash: COMPILE_CONFIG_HASH,
+    sourceCode: `// source ${key}`,
+    sourcePath: `${key}.ts`,
+  };
+}
+
+describe('connector relationship-type preflight', () => {
+  let orgId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    orgId = (await createTestOrganization({ name: 'Connector Relationship Preflight' })).id;
+  });
+
+  async function install(key: string, relationshipType: string) {
+    return upsertConnectorDefinitionRecords({
+      sql: getTestDb(),
+      organizationId: orgId,
+      metadata: metadataFor(key, relationshipType),
+      versionRecord: versionRecord(key),
+      versionScope: 'organization',
+    });
+  }
+
+  async function createRelationshipType(
+    slug: string,
+    values: { status?: 'active' | 'archived'; deleted?: boolean; purpose?: string } = {}
+  ) {
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_relationship_types (
+        organization_id, slug, name, status, deleted_at, purpose
+      ) VALUES (
+        ${orgId}, ${slug}, ${slug}, ${values.status ?? 'active'},
+        ${values.deleted ? new Date() : null}, ${values.purpose ?? null}
+      )
+    `;
+  }
+
+  it('accepts an active ordinary relationship type', async () => {
+    await createRelationshipType('invoice_customer');
+    await expect(install('ordinary-relationship', 'invoice_customer')).resolves.toMatchObject({
+      updated: false,
+    });
+  });
+
+  it('rejects a missing relationship type with connector/feed/event context', async () => {
+    await expect(install('missing-relationship', 'missing_type')).rejects.toThrow(
+      /missing-relationship.*feed 'invoices'.*event kind 'invoice'.*missing_type/i
+    );
+  });
+
+  it.each([
+    ['archived', { status: 'archived' as const }],
+    ['deleted', { deleted: true }],
+  ])('rejects an %s relationship type', async (label, values) => {
+    const slug = `${label}_relationship`;
+    await createRelationshipType(slug, values);
+    await expect(install(`${label}-connector`, slug)).rejects.toThrow(
+      new RegExp(`${label}-connector.*${slug}.*not active`, 'i')
+    );
+  });
+
+  it('resolves the active row past a newer same-slug tombstone', async () => {
+    // The unique index is partial on status='active', so an archived row can
+    // carry a HIGHER id than the live one — selecting by id alone would report
+    // an active type as archived.
+    await createRelationshipType('tombstoned_relationship');
+    await createRelationshipType('tombstoned_relationship', {
+      status: 'archived',
+      deleted: true,
+    });
+    await expect(install('tombstone-connector', 'tombstoned_relationship')).resolves.toMatchObject(
+      { updated: false }
+    );
+  });
+
+  it('rejects a purpose-classified authorization relationship type', async () => {
+    await createRelationshipType('authorization_edge', { purpose: 'authorization' });
+    // Carries the ACL guard's 403 rather than a bare Error: a connector whose
+    // vocabulary is refused is a caller-fixable install, not a server fault.
+    await expect(install('authorization-connector', 'authorization_edge')).rejects.toMatchObject({
+      httpStatus: 403,
+      message: expect.stringMatching(/authorization_edge.*authorization-bearing/i),
+    });
+  });
+
+  it('rejects the staged member_of compatibility slug before classification', async () => {
+    await createRelationshipType('member_of');
+    await expect(install('member-of-connector', 'member_of')).rejects.toThrow(
+      /member_of.*authorization-bearing/i
+    );
+  });
+
+  it('allows an ordinary slug even when its name resembles authorization vocabulary', async () => {
+    await createRelationshipType('authorization_note');
+    await expect(install('authorization-note-connector', 'authorization_note')).resolves.toMatchObject(
+      { updated: false }
+    );
+  });
+});

--- a/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
+++ b/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
@@ -26,16 +26,32 @@ import {
 } from '../connector-compiler';
 
 const CONNECTOR_SOURCE = `
-import { ConnectorRuntime } from '@lobu/connector-sdk';
+import { ConnectorRuntime, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 export default class MetaResolutionProbeConnector extends ConnectorRuntime {
-  definition = {
+  definition: ConnectorDefinition = {
     key: 'meta_resolution_probe',
     name: 'Metadata Resolution Probe',
     description: 'Synthetic connector for the #1181 extraction reproducer.',
     version: '0.0.1',
     authSchema: { methods: [{ type: 'none' }] },
-    feeds: {},
+    feeds: {
+      invoices: {
+        key: 'invoices',
+        name: 'Invoices',
+        eventKinds: {
+          invoice: {
+            attributions: [
+              { name: 'invoice', role: 'belongs_to', target: { entityType: 'invoice' } },
+              { name: 'customer', role: 'about', target: { entityType: 'customer' } },
+            ],
+            relationships: [
+              { type: 'invoice_customer', from: 'invoice', to: 'customer' },
+            ],
+          },
+        },
+      },
+    },
   };
 
   async sync() {
@@ -78,6 +94,21 @@ describe('extractConnectorMetadata in a project dir without node_modules', () =>
       expect(metadata.key).toBe('meta_resolution_probe');
       expect(metadata.name).toBe('Metadata Resolution Probe');
       expect(metadata.version).toBe('0.0.1');
+      expect(metadata.feeds).toMatchObject({
+        invoices: {
+          eventKinds: {
+            invoice: {
+              attributions: [
+                { name: 'invoice' },
+                { name: 'customer' },
+              ],
+              relationships: [
+                { type: 'invoice_customer', from: 'invoice', to: 'customer' },
+              ],
+            },
+          },
+        },
+      });
     } finally {
       process.chdir(originalCwd);
     }

--- a/packages/server/src/utils/__tests__/connector-relationship-declarations.test.ts
+++ b/packages/server/src/utils/__tests__/connector-relationship-declarations.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import {
+  type ConnectorMetadata,
+  validateConnectorMetadata,
+} from '../connector-compiler';
+
+function metadataWithEventKind(eventKind: Record<string, unknown>): ConnectorMetadata {
+  return {
+    key: 'relationship-declaration-probe',
+    name: 'Relationship Declaration Probe',
+    version: '1.0.0',
+    authSchema: null,
+    webhook: null,
+    feeds: {
+      invoices: {
+        key: 'invoices',
+        name: 'Invoices',
+        eventKinds: { invoice: eventKind },
+      },
+    },
+    actions: null,
+    automationEvents: null,
+    optionsSchema: null,
+  };
+}
+
+const invoiceAttribution = {
+  name: 'invoice',
+  role: 'belongs_to',
+  target: {
+    entityType: 'invoice',
+    identities: [{ namespace: 'erp_invoice', eventPath: 'metadata.invoice_id' }],
+  },
+};
+
+const customerAttribution = {
+  name: 'customer',
+  role: 'about',
+  target: {
+    entityType: 'customer',
+    identities: [{ namespace: 'erp_customer', eventPath: 'metadata.customer_id' }],
+  },
+};
+
+describe('connector relationship declaration validation', () => {
+  test('keeps existing unnamed attributions valid when no relationships are declared', () => {
+    const metadata = metadataWithEventKind({
+      attributions: [{ role: 'about', target: { entityType: 'invoice' } }],
+    });
+    expect(() => validateConnectorMetadata(metadata)).not.toThrow();
+  });
+
+  test('accepts named attributions referenced by one relationship', () => {
+    const metadata = metadataWithEventKind({
+      attributions: [invoiceAttribution, customerAttribution],
+      relationships: [{ type: 'invoice_customer', from: 'invoice', to: 'customer' }],
+    });
+    expect(() => validateConnectorMetadata(metadata)).not.toThrow();
+  });
+
+  test('rejects empty attribution names with event-kind context', () => {
+    const metadata = metadataWithEventKind({
+      attributions: [{ ...invoiceAttribution, name: '   ' }],
+    });
+    expect(() => validateConnectorMetadata(metadata)).toThrow(
+      /feed 'invoices'.*event kind 'invoice'.*attribution name.*non-empty/i
+    );
+  });
+
+  test('rejects duplicate attribution names within one event kind', () => {
+    const metadata = metadataWithEventKind({
+      attributions: [invoiceAttribution, { ...customerAttribution, name: 'invoice' }],
+    });
+    expect(() => validateConnectorMetadata(metadata)).toThrow(
+      /event kind 'invoice'.*duplicate attribution name 'invoice'/i
+    );
+  });
+
+  test.each(['from', 'to'] as const)('rejects an unknown %s reference by name', (side) => {
+    const relationship = {
+      type: 'invoice_customer',
+      from: 'invoice',
+      to: 'customer',
+      [side]: 'missing',
+    };
+    const metadata = metadataWithEventKind({
+      attributions: [invoiceAttribution, customerAttribution],
+      relationships: [relationship],
+    });
+    expect(() => validateConnectorMetadata(metadata)).toThrow(
+      new RegExp(`event kind 'invoice'.*${side} reference 'missing'.*named attribution`, 'i')
+    );
+  });
+
+  test('rejects duplicate relationship declarations', () => {
+    const relationship = { type: 'invoice_customer', from: 'invoice', to: 'customer' };
+    const metadata = metadataWithEventKind({
+      attributions: [invoiceAttribution, customerAttribution],
+      relationships: [relationship, { ...relationship }],
+    });
+    expect(() => validateConnectorMetadata(metadata)).toThrow(
+      /event kind 'invoice'.*duplicate relationship.*invoice_customer/i
+    );
+  });
+
+  test.each(['type', 'from', 'to'] as const)('rejects an empty relationship %s', (field) => {
+    const relationship = {
+      type: 'invoice_customer',
+      from: 'invoice',
+      to: 'customer',
+      [field]: '  ',
+    };
+    const metadata = metadataWithEventKind({
+      attributions: [invoiceAttribution, customerAttribution],
+      relationships: [relationship],
+    });
+    expect(() => validateConnectorMetadata(metadata)).toThrow(
+      new RegExp(`event kind 'invoice'.*relationship ${field}.*non-empty`, 'i')
+    );
+  });
+});

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -9,6 +9,7 @@ import { EXTERNAL_RUNTIME_DEPS } from '@lobu/connector-worker/compile';
 import type { ConnectorAgentTooling } from '@lobu/connector-sdk';
 import { type CompileResult, compileSource, extractMetadata } from './compiler-core';
 import { isReservedConnectorKey } from './reserved';
+import { validateConnectorRelationshipDeclarations } from './connector-relationship-declarations';
 
 export interface ConnectorMetadata {
   key: string;
@@ -202,4 +203,5 @@ export function validateConnectorMetadata(metadata: ConnectorMetadata): void {
       `Connector key '${metadata.key}' is reserved by a /connectors/ route. Pick another key.`
     );
   }
+  validateConnectorRelationshipDeclarations(metadata);
 }

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -19,6 +19,7 @@ import {
 } from './connector-compiler';
 import { isInternalUrl } from '../gateway/proxy/ssrf-guard';
 import type { McpOAuthMetadata } from '../mcp-proxy/types';
+import { preflightConnectorRelationshipTypes } from './connector-relationship-declarations';
 
 type SqlClient = ReturnType<typeof getDb>;
 
@@ -319,6 +320,17 @@ export async function upsertConnectorDefinitionRecords(params: {
 }): Promise<{ updated: boolean }> {
   const { sql } = params;
   const { metadata } = params;
+
+  // This is the shared definition writer for bundled, custom, rollback, and
+  // device-manifest connectors, so the relationship gate sits here rather than
+  // on the compile path some of them skip. The preflight validates the local
+  // declaration graph and resolves it against the org's own relationship
+  // vocabulary before any definition or version row can become active.
+  await preflightConnectorRelationshipTypes({
+    sql,
+    organizationId: params.organizationId,
+    metadata,
+  });
 
   const authSchemaJson = metadata.authSchema ? sql.json(metadata.authSchema) : null;
   const feedsSchemaJson = metadata.feeds ? sql.json(metadata.feeds) : null;

--- a/packages/server/src/utils/connector-relationship-declarations.ts
+++ b/packages/server/src/utils/connector-relationship-declarations.ts
@@ -152,10 +152,13 @@ export async function preflightConnectorRelationshipTypes(params: {
     const label = context(params.metadata, reference.feedKey, reference.eventKind);
     const row = rows[0];
     if (!row) {
-      throw new Error(`${label}: relationship type '${type}' does not exist in this organization.`);
+      throw new ToolUserError(
+        `${label}: relationship type '${type}' does not exist in this organization.`,
+        400
+      );
     }
     if (row.status !== 'active' || row.deleted_at !== null) {
-      throw new Error(`${label}: relationship type '${type}' is not active.`);
+      throw new ToolUserError(`${label}: relationship type '${type}' is not active.`, 400);
     }
     try {
       assertNotAclManagedEdge(row, 'connector relationship preflight');

--- a/packages/server/src/utils/connector-relationship-declarations.ts
+++ b/packages/server/src/utils/connector-relationship-declarations.ts
@@ -1,0 +1,172 @@
+import type { DbClient } from '../db/client';
+import { ToolUserError, errorMessage } from './errors';
+import { assertNotAclManagedEdge } from './relationship-validation';
+
+type UnknownRecord = Record<string, unknown>;
+
+interface ConnectorRelationshipReference {
+  feedKey: string;
+  eventKind: string;
+  type: string;
+}
+
+interface ConnectorRelationshipMetadata {
+  key: string;
+  feeds: UnknownRecord | null;
+}
+
+function record(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function context(metadata: ConnectorRelationshipMetadata, feedKey: string, eventKind: string): string {
+  return `Connector '${metadata.key}' feed '${feedKey}' event kind '${eventKind}'`;
+}
+
+/**
+ * Validate the connector-local declaration graph and return the relationship
+ * type references the organization-scoped preflight must resolve.
+ */
+export function validateConnectorRelationshipDeclarations(
+  metadata: ConnectorRelationshipMetadata
+): ConnectorRelationshipReference[] {
+  const references: ConnectorRelationshipReference[] = [];
+  if (!metadata.feeds) return references;
+
+  for (const [feedKey, feedValue] of Object.entries(metadata.feeds)) {
+    const feed = record(feedValue);
+    if (!feed) continue;
+    const eventKinds = record(feed.eventKinds);
+    if (!eventKinds) continue;
+
+    for (const [eventKind, eventKindValue] of Object.entries(eventKinds)) {
+      const declaration = record(eventKindValue);
+      if (!declaration) continue;
+      const label = context(metadata, feedKey, eventKind);
+      const names = new Set<string>();
+
+      if (declaration.attributions !== undefined) {
+        if (!Array.isArray(declaration.attributions)) {
+          throw new Error(`${label}: attributions must be an array.`);
+        }
+        for (const attributionValue of declaration.attributions) {
+          const attribution = record(attributionValue);
+          if (!attribution) {
+            throw new Error(`${label}: every attribution must be an object.`);
+          }
+          if (!Object.hasOwn(attribution, 'name')) continue;
+          if (typeof attribution.name !== 'string' || attribution.name.trim().length === 0) {
+            throw new Error(`${label}: attribution name must be a non-empty string.`);
+          }
+          if (names.has(attribution.name)) {
+            throw new Error(`${label}: duplicate attribution name '${attribution.name}'.`);
+          }
+          names.add(attribution.name);
+        }
+      }
+
+      if (declaration.relationships === undefined) continue;
+      if (!Array.isArray(declaration.relationships)) {
+        throw new Error(`${label}: relationships must be an array.`);
+      }
+
+      const triples = new Set<string>();
+      for (const relationshipValue of declaration.relationships) {
+        const relationship = record(relationshipValue);
+        if (!relationship) {
+          throw new Error(`${label}: every relationship must be an object.`);
+        }
+        for (const field of ['type', 'from', 'to'] as const) {
+          const value = relationship[field];
+          if (typeof value !== 'string' || value.trim().length === 0) {
+            throw new Error(`${label}: relationship ${field} must be a non-empty string.`);
+          }
+        }
+
+        const type = relationship.type as string;
+        const from = relationship.from as string;
+        const to = relationship.to as string;
+        for (const [side, name] of [
+          ['from', from],
+          ['to', to],
+        ] as const) {
+          if (!names.has(name)) {
+            throw new Error(
+              `${label}: relationship ${side} reference '${name}' does not resolve to a named attribution.`
+            );
+          }
+        }
+
+        const triple = `${type}\u0000${from}\u0000${to}`;
+        if (triples.has(triple)) {
+          throw new Error(
+            `${label}: duplicate relationship declaration '${type}' (${from} -> ${to}).`
+          );
+        }
+        triples.add(triple);
+        references.push({ feedKey, eventKind, type });
+      }
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Resolve every declared relationship type against the target organization's
+ * active schema and refuse authorization-bearing edge vocabularies.
+ */
+export async function preflightConnectorRelationshipTypes(params: {
+  sql: DbClient;
+  organizationId: string;
+  metadata: ConnectorRelationshipMetadata;
+}): Promise<void> {
+  const references = validateConnectorRelationshipDeclarations(params.metadata);
+  const firstReferenceByType = new Map<string, ConnectorRelationshipReference>();
+  for (const reference of references) {
+    if (!firstReferenceByType.has(reference.type)) {
+      firstReferenceByType.set(reference.type, reference);
+    }
+  }
+
+  for (const [type, reference] of firstReferenceByType) {
+    // Only ACTIVE rows are unique per (organization_id, slug) — the unique index
+    // is partial — so a slug can carry several archived rows alongside the live
+    // one, in any id order. Rank the live row first and fall back to the newest
+    // so a same-slug tombstone cannot mask an active type.
+    const rows = (await params.sql`
+      SELECT slug, status, deleted_at, purpose
+      FROM entity_relationship_types
+      WHERE organization_id = ${params.organizationId}
+        AND slug = ${type}
+      ORDER BY (status = 'active' AND deleted_at IS NULL) DESC, id DESC
+      LIMIT 1
+    `) as unknown as Array<{
+      slug: string;
+      status: string;
+      deleted_at: Date | string | null;
+      purpose: string | null;
+    }>;
+    const label = context(params.metadata, reference.feedKey, reference.eventKind);
+    const row = rows[0];
+    if (!row) {
+      throw new Error(`${label}: relationship type '${type}' does not exist in this organization.`);
+    }
+    if (row.status !== 'active' || row.deleted_at !== null) {
+      throw new Error(`${label}: relationship type '${type}' is not active.`);
+    }
+    try {
+      assertNotAclManagedEdge(row, 'connector relationship preflight');
+    } catch (error) {
+      // Keep the status the ACL guard chose. Re-wrapping as a bare Error would
+      // turn its deliberate 403 into a 500 plus a Sentry alert, for what is a
+      // caller-fixable connector definition.
+      throw new ToolUserError(
+        `${label}: ${errorMessage(error)}`,
+        error instanceof ToolUserError ? error.httpStatus : 403
+      );
+    }
+  }
+}

--- a/packages/server/src/utils/relationship-validation.ts
+++ b/packages/server/src/utils/relationship-validation.ts
@@ -135,7 +135,9 @@ export function assertNotAuthorizationType(
  * Deliberately NOT used on the relationship-TYPE surfaces: configs legitimately
  * declare `member_of` (`examples/personal-agent/lobu.config.ts`), and refusing
  * the declaration would break every such apply. Declaring a type grants nobody
- * access; creating an edge on it does.
+ * access; creating an edge on it does — which is why the connector install
+ * preflight uses this variant even though it only reads type rows: a connector
+ * that declares a relationship is declaring the edges it will write.
  */
 export function assertNotAclManagedEdge(
   type: { slug?: string | null; purpose?: string | null },


### PR DESCRIPTION
## Summary
- Add optional attribution names and declarative relationship mappings to connector event kinds.
- Validate declaration shape locally and preflight relationship types, status, and ACL ownership against the target organization before connector installation.
- Apply relationship types before connector definitions so one desired-state apply can declare and use them safely.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean as the documented local fallback.
- [x] Targeted server declaration, metadata, install-preflight, and device reconcile tests pass.
- [x] Targeted CLI apply tests pass.
- [x] Bug fix: tests first failed on invalid declarations, missing/inactive/ACL-managed relationship types, and apply ordering; the same suites pass after the implementation.
- [ ] If bot runtime changed: not applicable; bot runtime is unchanged.

## Notes
- This is declaration and installation preflight only. It deliberately does not write `entity_relationships`; runtime edge materialization remains #2857.
- Additive connector metadata contract; no breaking change.

Closes #2856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connectors can now declare named relationships between event attributions.
  * Connector setup validates relationship declarations and confirms referenced relationship types are available and active.
* **Bug Fixes**
  * Relationship types are created before connectors are installed, preventing valid connectors from failing when they reference newly created types.
  * Improved validation catches missing, inactive, duplicate, or malformed relationship declarations with clearer contextual errors.
  * Existing access-control protections remain enforced during connector installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->