### PR TITLE
fix(mcp): support admin scope upgrades

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1148,6 +1148,13 @@ describe('MCP Authentication', () => {
         scope: 'mcp:read mcp:write',
       });
 
+      const listed = await mcpListTools({ token, orgSlug: roleOrg.slug });
+      const runSdk = listed.tools.find((tool: any) => tool.name === 'run_sdk');
+      expect(runSdk?.securitySchemes).toEqual([
+        { type: 'oauth2', scopes: ['mcp:write', 'mcp:admin'] },
+      ]);
+      expect(runSdk?._meta?.securitySchemes).toEqual(runSdk?.securitySchemes);
+
       const discovery = await mcpToolsCall(
         'search_sdk',
         { query: 'connections.installConnector' },
@@ -1177,7 +1184,7 @@ describe('MCP Authentication', () => {
         { path: 'connections.installConnector', access: 'admin', count: 1 },
       ]);
       expect(challenge).toContain('error="insufficient_scope"');
-      expect(challenge).toContain('scope="mcp:admin"');
+      expect(challenge).toContain('scope="mcp:read mcp:write mcp:admin"');
     });
 
     it('does not challenge when an owner catches a nested admin denial and run_sdk succeeds', async () => {
@@ -1254,6 +1261,12 @@ describe('MCP Authentication', () => {
       const { token } = await createTestPAT(member.id, roleOrg.id, {
         scope: 'mcp:read mcp:write',
       });
+
+      const listed = await mcpListTools({ token, orgSlug: roleOrg.slug });
+      const runSdk = listed.tools.find((tool: any) => tool.name === 'run_sdk');
+      expect(runSdk?.securitySchemes).toEqual([
+        { type: 'oauth2', scopes: ['mcp:write'] },
+      ]);
 
       const discovery = await mcpToolsCall(
         'search_sdk',

--- a/packages/server/src/__tests__/integration/oauth/progressive-admin-consent.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/progressive-admin-consent.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Progressive `mcp:admin` consent — re-authorizing REPLACES a narrower grant.
+ *
+ * When `run_sdk` hits a nested admin-only SDK method, the MCP result carries an
+ * `insufficient_scope` challenge naming the COMPLETE replacement grant
+ * (`mcp:read mcp:write mcp:admin`), not just the missing `mcp:admin` delta —
+ * hosts that replace rather than merge grants would otherwise drop read/write
+ * on the upgrade. That contract only holds if the authorization-code path
+ * actually issues the wider grant on a second consent for a client that already
+ * holds a narrower one.
+ *
+ * This drives the real `oauthRoutes`: register → consent → token at
+ * `mcp:read mcp:write`, then consent → token again at
+ * `mcp:read mcp:write mcp:admin`, asserting the token response reports the
+ * elevated scope.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { oauthRoutes } from '../../../auth/oauth/routes';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestSession,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+  RATE_LIMIT_ENABLED: 'false',
+} as unknown as Env;
+
+// The consent handler enforces `isAllowedConsentOrigin`: the request must carry
+// an Origin matching the app's own base URL. The test app is served at
+// http://localhost, so send that as Origin.
+const ORIGIN = 'http://localhost';
+
+function buildApp(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route('/', oauthRoutes);
+  return app;
+}
+
+function call(
+  app: Hono<{ Bindings: Env }>,
+  method: string,
+  path: string,
+  opts?: { body?: unknown; headers?: Record<string, string> }
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Origin: ORIGIN,
+    ...opts?.headers,
+  };
+  return app.fetch(
+    new Request(`${ORIGIN}${path}`, {
+      method,
+      headers,
+      ...(opts?.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+    }),
+    TEST_ENV
+  );
+}
+
+async function authorizeCodeGrant(params: {
+  app: Hono<{ Bindings: Env }>;
+  clientId: string;
+  redirectUri: string;
+  resource: string;
+  scope: string;
+  sessionCookie: string;
+}): Promise<{ access_token: string; scope?: string }> {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  const authorize = await call(params.app, 'POST', '/oauth/authorize/consent', {
+    body: {
+      client_id: params.clientId,
+      redirect_uri: params.redirectUri,
+      scope: params.scope,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      resource: params.resource,
+      approved: true,
+    },
+    headers: { Cookie: params.sessionCookie },
+  });
+  expect(authorize.status).toBe(200);
+  const { redirect_url } = (await authorize.json()) as { redirect_url: string };
+  const code = new URL(redirect_url).searchParams.get('code');
+  expect(code).toBeTruthy();
+
+  const token = await call(params.app, 'POST', '/oauth/token', {
+    body: {
+      grant_type: 'authorization_code',
+      code,
+      client_id: params.clientId,
+      redirect_uri: params.redirectUri,
+      code_verifier: verifier,
+      resource: params.resource,
+    },
+  });
+  expect(token.status).toBe(200);
+  return token.json() as Promise<{ access_token: string; scope?: string }>;
+}
+
+beforeAll(async () => {
+  await initWorkspaceProvider();
+});
+
+afterAll(async () => {
+  // app is in-process; nothing to tear down
+});
+
+describe('Progressive mcp:admin consent', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  // The grant path never branches on `client_name`, so one registered client
+  // covers every MCP host that walks this flow (ChatGPT, Claude Desktop, …).
+  it('replaces a read/write grant with a cumulative admin grant', async () => {
+    const app = buildApp();
+    const org = await createTestOrganization({ name: 'Progressive Admin Org' });
+    const user = await createTestUser({ name: 'Progressive Admin User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const session = await createTestSession(user.id);
+    const redirectUri = `${ORIGIN}/callback`;
+    const resource = `${ORIGIN}/mcp/${org.slug}`;
+
+    const registration = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Progressive Admin Client',
+        redirect_uris: [redirectUri],
+        grant_types: ['authorization_code', 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(registration.status).toBe(201);
+    const client = (await registration.json()) as { client_id: string };
+
+    const initial = await authorizeCodeGrant({
+      app,
+      clientId: client.client_id,
+      redirectUri,
+      resource,
+      scope: 'mcp:read mcp:write',
+      sessionCookie: session.cookieHeader,
+    });
+    expect(initial.scope).toBe('mcp:read mcp:write');
+
+    const elevated = await authorizeCodeGrant({
+      app,
+      clientId: client.client_id,
+      redirectUri,
+      resource,
+      scope: 'mcp:read mcp:write mcp:admin',
+      sessionCookie: session.cookieHeader,
+    });
+    expect(elevated.scope).toBe('mcp:read mcp:write mcp:admin');
+  });
+});

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -89,6 +89,24 @@ describe("tool registry split", () => {
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 
+	it("advertises progressive admin scope only to role-eligible MCP sessions", () => {
+		const eligibleRun = getMcpTools({
+			maxAccessLevel: "write",
+			adminScopeEligible: true,
+		}).find((tool) => tool.name === "run_sdk");
+		const memberRun = getMcpTools({
+			maxAccessLevel: "write",
+			adminScopeEligible: false,
+		}).find((tool) => tool.name === "run_sdk");
+
+		expect(eligibleRun?.securitySchemes).toEqual([
+			{ type: "oauth2", scopes: ["mcp:write", "mcp:admin"] },
+		]);
+		expect(memberRun?.securitySchemes).toEqual([
+			{ type: "oauth2", scopes: ["mcp:write"] },
+		]);
+	});
+
 	it("maps internal flat tools to ClientSDK methods for run_sdk/query_sdk parity", () => {
 		const { namespaceMethods, topLevelMethods } = (() => {
 			const sdk = buildClientSDK(testCtx, testEnv);

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -51,6 +51,7 @@ import {
 import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
 import { LOBU_SKILL_MARKDOWN } from './skills/lobu-skill.generated';
 import { readMcpAttachmentResource } from './mcp-media-resources';
+import { isAdminOrOwnerRole } from './tools/access-control';
 import {
   type AuthContext,
   executeTool,
@@ -59,8 +60,8 @@ import {
 } from './tools/execute';
 import { getMcpResultContent } from './tools/mcp-result-content';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
-import { toMcpPublicSdkScriptResult } from './tools/sdk_run';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
+import { toMcpPublicSdkScriptResult } from './tools/sdk_run';
 import { validateToolResult } from './tools/validate-args';
 import { renderMcpAppTemplate } from './utils/mcp-app-bundle';
 import { resolvePublicOrigin } from './utils/public-origin';
@@ -314,6 +315,7 @@ function createServerForContext(
     const allTools = getMcpTools({
       publicOnly,
       maxAccessLevel,
+      adminScopeEligible: isAdminOrOwnerRole(authCtx.memberRole),
     })
       .filter((t) => {
         const visibility = (t._meta?.ui as { visibility?: unknown } | undefined)?.visibility;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -623,6 +623,12 @@ const listedToolsCache = new Map<string, ReturnType<typeof computeListedTools>>(
 type ListedToolOptions = {
   publicOnly?: boolean;
   maxAccessLevel?: 'read' | 'write' | 'admin';
+  /**
+   * Advertise the progressive `mcp:admin` elevation on `run_sdk` only when
+   * the authenticated organization role can actually receive that scope.
+   * Regular members keep the existing write-only contract.
+   */
+  adminScopeEligible?: boolean;
 };
 
 /**
@@ -684,11 +690,12 @@ export function getRawDispatchTools(): RawDispatchTool[] {
 function getListedTools(source: ToolDefinition[], options?: ListedToolOptions) {
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
+  const adminScopeEligible = options?.adminScopeEligible ?? false;
   const sourceKey = source === ALL_MCP_TOOLS ? 'mcp' : 'all';
-  const cacheKey = `${sourceKey}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
+  const cacheKey = `${sourceKey}:${publicOnly ? 1 : 0}:${maxAccessLevel}:${adminScopeEligible ? 1 : 0}`;
   let cached = listedToolsCache.get(cacheKey);
   if (!cached) {
-    cached = computeListedTools(source, publicOnly, maxAccessLevel);
+    cached = computeListedTools(source, publicOnly, maxAccessLevel, adminScopeEligible);
     listedToolsCache.set(cacheKey, cached);
   }
   return cached;
@@ -697,7 +704,8 @@ function getListedTools(source: ToolDefinition[], options?: ListedToolOptions) {
 function computeListedTools(
   source: ToolDefinition[],
   publicOnly: boolean,
-  maxAccessLevel: 'read' | 'write' | 'admin'
+  maxAccessLevel: 'read' | 'write' | 'admin',
+  adminScopeEligible: boolean
 ) {
   return source
     .filter((tool) => !publicOnly || getPublicReadableActions(tool.name) !== undefined)
@@ -713,6 +721,17 @@ function computeListedTools(
         inputSchema = filterSchemaForPublicActions(tool.name, inputSchema);
       }
       if (!inputSchema) return null;
+
+      // `run_sdk` is a write tool whose nested SDK surface also contains
+      // admin methods. OpenAI hosts require that possible elevation in the
+      // tool's securitySchemes before they will act on an insufficient-scope
+      // challenge. Keep it role-aware: advertising an ungrantable admin scope
+      // to regular members makes strict clients reject an otherwise valid
+      // read/write connection.
+      const securityScopes =
+        tool.name === 'run_sdk' && adminScopeEligible
+          ? Array.from(new Set([...(tool.securityScopes ?? []), 'mcp:admin']))
+          : tool.securityScopes;
 
       inputSchema = filterSchemaForAccessLevel(
         tool.name,
@@ -735,8 +754,8 @@ function computeListedTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
-        ...(tool.securityScopes && {
-          securitySchemes: [{ type: 'oauth2' as const, scopes: tool.securityScopes }],
+        ...(securityScopes && {
+          securitySchemes: [{ type: 'oauth2' as const, scopes: securityScopes }],
         }),
         ...(tool.mcpMeta && { _meta: tool.mcpMeta }),
         // outputSchema keeps its discriminated variants (no flattening, no

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -2,6 +2,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { classifyToolError, isRetryable } from "@lobu/core";
 import { resolveSdkMaxAccessLevel } from "../auth/tool-access";
 import { buildMcpBearerChallenge } from "../auth/oauth/resource-indicator";
+import { DISCOVERY_SCOPES } from "../auth/oauth/scopes";
 import { isAdminOrOwnerRole } from "./access-control";
 import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
@@ -402,13 +403,25 @@ async function runSandbox(
     (ctx.tokenType === "oauth" || ctx.tokenType === "pat") &&
     challengeRequestUrl
   ) {
+    // Scope on a progressive OAuth challenge is the complete replacement
+    // grant the client should request, not merely the missing delta. Sending
+    // only `mcp:admin` can discard read/write on clients that replace rather
+    // than merge grants. Restrict the carried-forward set to public auth-code
+    // scopes so first-party device/PAT grants never leak into a third-party
+    // authorization request.
+    const upgradeScopes = Array.from(
+      new Set([
+        ...(ctx.scopes ?? []).filter((scope) => DISCOVERY_SCOPES.includes(scope)),
+        "mcp:admin",
+      ]),
+    );
     return attachMcpResultMeta(mcpOutput, {
       "mcp/www_authenticate": [
         buildMcpBearerChallenge(challengeRequestUrl, {
           error: "insufficient_scope",
           errorDescription:
             result.error?.message ?? "The token lacks the required MCP admin scope.",
-          scope: "mcp:admin",
+          scope: upgradeScopes.join(" "),
         }),
       ],
     });


### PR DESCRIPTION
## Summary

- advertise cumulative `mcp:write` and `mcp:admin` requirements for owner/admin MCP sessions
- return a cumulative OAuth challenge so ChatGPT can reconnect and upgrade an existing read/write grant
- add selectable OAuth permission checkboxes while preserving Claude read/write compatibility

## Test plan

- [x] Intended seven paths staged explicitly; `make pre-pr` clean before commit and again after rebase
- [x] Targeted server tests: tool registry 6 passed; MCP auth/progressive OAuth 49 passed, 2 skipped
- [x] Owletto: 1,633 tests passed; build and TypeScript checks passed
- [x] Bug fix red to green:
  - red: production and pre-fix staging `run_sdk` returned `McpScopeRequiredError` with zero side effects while issued tokens remained `mcp:read mcp:write`
  - green: native ChatGPT reconnect requested cumulative `mcp:read mcp:write mcp:admin`; an admin SDK call crossed authorization and reached the expected not-found domain error, with no test data created
- [x] Native Claude compatibility: discovery, read/write OAuth, connection, and tool invocation passed; Claude did not auto-upgrade to admin, but its existing grant remained functional

## Notes

- Owletto consent UI: https://github.com/lobu-ai/owletto/pull/926
- ChatGPT Free plan entitlement is not independently proven because the available logged-in test account is Pro; the MCP protocol and native ChatGPT reconnect flow are proven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive consent for MCP administrator access, allowing eligible users to authorize elevated capabilities after initial access.
  * MCP tools now advertise administrator scopes only to eligible callers.
  * Authorization challenges now request the complete applicable scope set, preserving previously granted public scopes.

* **Tests**
  * Added coverage for scoped authorization, administrator consent, and role-based tool visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->