### PR TITLE
feat(staging): route public host to local tailnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1264,11 +1264,17 @@ jobs:
           bash scripts/lib/__tests__/review-cache.test.sh
           bash scripts/lib/__tests__/install-bubblewrap.test.sh
 
-      - name: Preview workflow guards
+      - name: Preview and staging workflow guards
         # The preview deploy's mid-flight teardown decides whether to delete a
         # namespace out from under a running PR. It only ever executes on a
         # close/unlabel race, so without this it would first run in anger.
-        run: bash scripts/lib/__tests__/preview-teardown.test.sh
+        # Staging routing is the same shape: its release path runs on an
+        # unlabel, a close, or a manual dispatch, and a wrong answer there hands
+        # staging.lobu.ai to production's wildcard ingress or steals the host
+        # from its holder.
+        run: |
+          bash scripts/lib/__tests__/preview-teardown.test.sh
+          bash scripts/lib/__tests__/staging-routing.test.sh
 
       - name: Kubeconfig workflow guards
         # Mutating deploy workflows must fail closed before their first cluster

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,8 @@ jobs:
   preview:
     runs-on: ubuntu-24.04
     if: github.event.action != 'closed' && (github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'preview')))
+    outputs:
+      preview_wanted: ${{ steps.preview-wanted.outputs.wanted }}
     concurrency:
       group: preview-deploy-${{ github.event.pull_request.number || inputs.pr_number }}
       cancel-in-progress: true
@@ -374,6 +376,79 @@ jobs:
                 body,
               });
             }
+
+      - name: Remove kubeconfig
+        if: always()
+        run: ./scripts/lib/kubeconfig-preflight.sh cleanup
+
+  # nginx resolves the preview Service name when the router config loads, while
+  # this workflow recreates that ClusterIP Service on every deploy. Reconcile
+  # only after the replacement is ready, under the same global lock used by
+  # label and manual staging changes.
+  reconcile-staging:
+    needs: preview
+    runs-on: ubuntu-24.04
+    if: needs.preview.result == 'success' && needs.preview.outputs.preview_wanted != 'false' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'staging')
+    concurrency:
+      group: staging-lock
+      cancel-in-progress: false
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      STAGING_HOST: ${{ vars.STAGING_HOST || 'staging.lobu.ai' }}
+      # No tailnet knobs: this job only reconciles the `preview` target, and
+      # those are read solely by staging-route.sh's local-tailnet path.
+      STAGING_SKIP_COMMENT: '1'
+      WILDCARD_TLS_NS: summaries-prod
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
+      KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
+      KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
+      KUBE_REQUIRED_CAPABILITIES: |
+        get|namespaces|
+        create|namespaces|
+        patch|namespaces|
+        list|ingresses.networking.k8s.io|@ALL_NAMESPACES
+        delete|ingresses.networking.k8s.io|@ALL_NAMESPACES
+        get|services|@ALL_NAMESPACES
+        get|deployments.apps|@ALL_NAMESPACES
+        patch|deployments.apps|@ALL_NAMESPACES
+        watch|deployments.apps|@ALL_NAMESPACES
+        get|configmaps|lobu-staging
+        create|configmaps|lobu-staging
+        patch|configmaps|lobu-staging
+        get|deployments.apps|lobu-staging
+        create|deployments.apps|lobu-staging
+        patch|deployments.apps|lobu-staging
+        watch|deployments.apps|lobu-staging
+        get|services|lobu-staging
+        create|services|lobu-staging
+        patch|services|lobu-staging
+        delete|services|lobu-staging
+        watch|services|lobu-staging
+        get|pods|lobu-staging
+        create|pods|lobu-staging
+        delete|pods|lobu-staging
+        watch|pods|lobu-staging
+        get|pods/log|lobu-staging
+        get|ingresses.networking.k8s.io|lobu-staging
+        create|ingresses.networking.k8s.io|lobu-staging
+        patch|ingresses.networking.k8s.io|lobu-staging
+        get|secrets|@WILDCARD_TLS_NS
+        get|secrets|lobu-staging
+        create|secrets|lobu-staging
+        patch|secrets|lobu-staging
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup and preflight kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
+        run: |
+          ./scripts/lib/kubeconfig-preflight.sh setup
+
+      - name: Reconcile staging to the recreated preview Service
+        run: bash scripts/staging-route.sh preview "$PR_NUMBER"
 
       - name: Remove kubeconfig
         if: always()

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,77 +1,112 @@
 name: Staging lock
 
-# The 'staging' label pins the rolling staging URL (STAGING_HOST, public) to one PR.
-# Adding the label acquires the lock (strips it from other open PRs, moves the
-# staging ingress to this PR's namespace); removing it releases the lock.
-# Also dispatchable manually (workflow_dispatch) for manual lock control.
+# A staging label routes the public staging host to that PR preview. Manual
+# dispatch can instead route to the allowlisted local Tailscale endpoint or the
+# permanent offline sink. The exact-host Ingress is never deleted: without it,
+# production's *.lobu.ai Ingress accepts staging.lobu.ai.
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    # Closing a PR fires no `unlabeled` event, so a merged or abandoned holder
+    # would keep the public host pointed at the namespace preview.yml deletes on
+    # that same event.
+    types: [labeled, unlabeled, closed]
+  # A TLS secret is only readable from its own namespace, so the *.lobu.ai
+  # wildcard is copied out of the production namespace into lobu-staging. It is
+  # copied, not watched — re-run daily so a renewed certificate lands even while
+  # nobody changes a staging route.
+  schedule:
+    - cron: '17 3 * * *'
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: 'PR to lock/unlock the staging URL'
-        required: true
-        type: string
-      action:
-        description: 'labeled = acquire the lock, unlabeled = release'
+      target:
+        description: Route staging to the configured local tailnet endpoint or offline
         required: true
         type: choice
-        options: [labeled, unlabeled]
+        options: [local-tailnet, offline]
+      pr_number:
+        description: Optional current-owner PR number for an offline release
+        required: false
+        type: string
 
 permissions:
   contents: read
   pull-requests: write
 
-# Global: serializes all staging-lock operations so concurrent label changes
-# converge instead of racing.
+# Global, and deliberately non-cancelling: a queued release must not kill the
+# acquire still in flight, or it would take the host away from whoever had just
+# been given it. GitHub still keeps only one *pending* run per group, so a
+# dropped release is survivable only because every release is owner-scoped.
 concurrency:
   group: staging-lock
+  cancel-in-progress: false
 
 jobs:
   reconcile:
     runs-on: ubuntu-24.04
     # Fork guard (same shape as preview.yml): a 'staging' label on a fork PR
     # would run this job without secrets - empty kubeconfig, noisy failures.
-    if: (github.event.label.name == 'staging' || github.event_name == 'workflow_dispatch') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+    #
+    # `closed` is gated on the label as well. The concurrency group is global
+    # and GitHub keeps only one pending run in a group, so a run queued by an
+    # unrelated PR closing would cancel a release already waiting behind the
+    # run in flight - and then no-op, because it does not own the lock.
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'staging')) || github.event.label.name == 'staging') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     env:
-      PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number || inputs.pr_number }}
-      PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number || inputs.pr_number }}
-      STAGING_INGRESS: lobu-staging
-      # Public DNS, not the tailnet name: an MCP host (claude.ai, ChatGPT)
-      # resolves and calls /mcp from its own backend, so a tailnet-only name
-      # is unreachable to it and the connector fails at discovery.
+      PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
+      # A label event is the two-value case: adding it acquires, removing it
+      # releases. Manual dispatch is the only way to reach local-tailnet.
+      STAGING_TARGET: ${{ github.event_name == 'schedule' && 'refresh-tls' || github.event_name == 'workflow_dispatch' && inputs.target || (github.event.action == 'labeled' && 'preview' || 'offline') }}
+      # Only the operator-configurable knobs are set here; the namespace,
+      # Ingress, router, egress Service and wildcard-secret names all default
+      # to the same literals inside scripts/staging-route.sh.
       STAGING_HOST: ${{ vars.STAGING_HOST || 'staging.lobu.ai' }}
-      # cert-manager issues the *.lobu.ai wildcard into the prod namespace;
-      # the staging ingress lives in the preview namespace and needs its own
-      # copy of that secret.
-      WILDCARD_TLS_NS: summaries-prod
-      WILDCARD_TLS_SECRET: wildcard-lobu-ai-tls
+      STAGING_LOCAL_TAILNET_FQDN: ${{ vars.STAGING_LOCAL_TAILNET_FQDN }}
+      STAGING_LOCAL_TAILNET_PORT: ${{ vars.STAGING_LOCAL_TAILNET_PORT || '10080' }}
+      TAILNET_DOMAIN: ${{ vars.TAILNET_DOMAIN }}
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
-      # Deploy identity, checked before the first cluster write. KUBE_SERVER
-      # and KUBE_CLUSTER_UID have no default: until an operator sets both repo
-      # variables this job stops at the preflight (see the script's header).
+      # Deploy identity is pinned before any cluster read or write. The route
+      # script owns a permanent system namespace and may restore the displaced
+      # preview holder, so the preflight covers both those bounded resources
+      # and the cross-namespace preview operations it can perform.
       KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
       KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
       KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
+      WILDCARD_TLS_NS: summaries-prod
       KUBE_REQUIRED_CAPABILITIES: |
         get|namespaces|
+        create|namespaces|
+        patch|namespaces|
         list|ingresses.networking.k8s.io|@ALL_NAMESPACES
         delete|ingresses.networking.k8s.io|@ALL_NAMESPACES
-        get|ingresses.networking.k8s.io|@PREVIEW_NS
-        create|ingresses.networking.k8s.io|@PREVIEW_NS
-        patch|ingresses.networking.k8s.io|@PREVIEW_NS
-        get|services|@PREVIEW_NS
-        get|deployments.apps|@PREVIEW_NS
-        patch|deployments.apps|@PREVIEW_NS
-        watch|deployments.apps|@PREVIEW_NS
+        get|services|@ALL_NAMESPACES
+        get|deployments.apps|@ALL_NAMESPACES
+        patch|deployments.apps|@ALL_NAMESPACES
+        watch|deployments.apps|@ALL_NAMESPACES
+        get|configmaps|lobu-staging
+        create|configmaps|lobu-staging
+        patch|configmaps|lobu-staging
+        get|deployments.apps|lobu-staging
+        create|deployments.apps|lobu-staging
+        patch|deployments.apps|lobu-staging
+        watch|deployments.apps|lobu-staging
+        get|services|lobu-staging
+        create|services|lobu-staging
+        patch|services|lobu-staging
+        delete|services|lobu-staging
+        watch|services|lobu-staging
+        get|pods|lobu-staging
+        create|pods|lobu-staging
+        delete|pods|lobu-staging
+        watch|pods|lobu-staging
+        get|pods/log|lobu-staging
+        get|ingresses.networking.k8s.io|lobu-staging
+        create|ingresses.networking.k8s.io|lobu-staging
+        patch|ingresses.networking.k8s.io|lobu-staging
         get|secrets|@WILDCARD_TLS_NS
-        get|secrets|@PREVIEW_NS
-        create|secrets|@PREVIEW_NS
-        patch|secrets|@PREVIEW_NS
-      # labeled = acquire, unlabeled = release (label event or manual dispatch)
-      STAGING_ACTION: ${{ github.event_name == 'workflow_dispatch' && inputs.action || github.event.action }}
+        get|secrets|lobu-staging
+        create|secrets|lobu-staging
+        patch|secrets|lobu-staging
     steps:
       - uses: actions/checkout@v7
 
@@ -81,119 +116,8 @@ jobs:
         run: |
           ./scripts/lib/kubeconfig-preflight.sh setup
 
-      - name: Release lock (unlabeled)
-        if: env.STAGING_ACTION == 'unlabeled'
-        run: |
-          # Only release if THIS PR holds the lock (scoped to this namespace).
-          kubectl delete ingress "$STAGING_INGRESS" -n "$PREVIEW_NS" --ignore-not-found
-          # The preview keeps running on its own private host; hand back the
-          # settings the public host required.
-          kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
-            PUBLIC_GATEWAY_URL- LOBU_LOCAL_INIT_ALLOW_PROXY=1 2>/dev/null || true
-          echo "staging lock released ($STAGING_HOST no longer mapped)"
-
-      - name: Acquire lock (labeled)
-        if: env.STAGING_ACTION == 'labeled'
-        run: |
-          set -euo pipefail
-          PR_NUM="${{ github.event.pull_request.number || inputs.pr_number }}"
-
-          # Single-holder enforcement: strip the label from every other open PR.
-          for n in $(gh pr list --state open --limit 200 --json number --jq '.[].number'); do
-            if [ "$n" != "$PR_NUM" ] \
-              && gh pr view "$n" --json labels --jq '.labels[].name' | grep -qx staging; then
-              gh pr edit "$n" --remove-label staging
-              echo "stripped staging label from PR #$n"
-            fi
-          done
-
-          # Wait for the preview namespace + service (the preview workflow may
-          # still be building when the label lands).
-          for i in $(seq 1 36); do
-            kubectl get svc "$PREVIEW_NAME" -n "$PREVIEW_NS" >/dev/null 2>&1 && break
-            echo "waiting for $PREVIEW_NAME service... ($i)"
-            sleep 10
-          done
-          kubectl get svc "$PREVIEW_NAME" -n "$PREVIEW_NS" >/dev/null 2>&1 || {
-            echo "preview service $PREVIEW_NAME not found in $PREVIEW_NS" >&2
-            exit 1
-          }
-
-          # Move the staging ingress: delete it from any other namespace.
-          for ns in $(kubectl get ingress "$STAGING_INGRESS" -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null); do
-            if [ "$ns" != "$PREVIEW_NS" ]; then
-              kubectl delete ingress "$STAGING_INGRESS" -n "$ns" --ignore-not-found
-              echo "moved staging ingress out of $ns"
-            fi
-          done
-
-          # Staging is PUBLIC (the ingress below), so the passwordless bootstrap
-          # endpoint must not be reachable through it. preview.yml sets
-          # LOBU_LOCAL_INIT_ALLOW_PROXY=1 because a plain preview is
-          # tailnet-only; on a public host that same setting would let anyone on
-          # the internet mint an owner session (auth/routes.ts names public
-          # tunnels as the case it refuses by default). Strip it before the host
-          # goes public. The rollout restarts the pod, and the preview's data volume
-          # is an emptyDir — so bootstrap AFTER the lock, from inside the pod
-          # where the peer really is loopback:
-          #   kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \
-          #     curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' \
-          #     http://127.0.0.1:8787/api/local-init
-          # PUBLIC_GATEWAY_URL: resolvePublicOrigin otherwise falls back to the
-          # request URL, which behind the ingress reads as http://<host>; OAuth
-          # metadata and the MCP App asset URLs would both be stamped http.
-          kubectl -n "$PREVIEW_NS" set env "deploy/$PREVIEW_NAME" \
-            LOBU_LOCAL_INIT_ALLOW_PROXY- \
-            "PUBLIC_GATEWAY_URL=https://$STAGING_HOST/lobu"
-          kubectl -n "$PREVIEW_NS" rollout status "deploy/$PREVIEW_NAME" --timeout=600s
-
-          # The wildcard cert lives in the prod namespace; a TLS secret is only
-          # readable from its own namespace, so copy it next to the ingress.
-          kubectl -n "$WILDCARD_TLS_NS" get secret "$WILDCARD_TLS_SECRET" -o json \
-            | jq --arg ns "$PREVIEW_NS" \
-                '{apiVersion, kind, type, data, metadata: {name: .metadata.name, namespace: $ns}}' \
-            | kubectl apply -f -
-
-          # Pin the staging ingress to this PR's preview, on the public
-          # (traefik) class rather than the tailnet one.
-          kubectl apply -f - <<EOF
-          apiVersion: networking.k8s.io/v1
-          kind: Ingress
-          metadata:
-            name: $STAGING_INGRESS
-            namespace: $PREVIEW_NS
-          spec:
-            ingressClassName: traefik
-            tls:
-              - hosts: ["$STAGING_HOST"]
-                secretName: $WILDCARD_TLS_SECRET
-            rules:
-              - host: $STAGING_HOST
-                http:
-                  paths:
-                    - path: /
-                      pathType: Prefix
-                      backend:
-                        service:
-                          name: $PREVIEW_NAME
-                          port: { number: 80 }
-          EOF
-
-          STAGING_BODY=$(printf "%s\n" \
-            "## Staging URL locked to this PR" \
-            "- **App**: https://$STAGING_HOST" \
-            "- **MCP endpoint**: https://$STAGING_HOST/mcp" \
-            "" \
-            "This host is publicly reachable, so a cloud MCP host can call it. Passwordless bootstrap is disabled on it; sign in once from inside the pod:" \
-            "" \
-            "\`\`\`" \
-            "kubectl -n $PREVIEW_NS exec deploy/$PREVIEW_NAME -- \\" \
-            "  curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' http://127.0.0.1:8787/api/local-init" \
-            "\`\`\`" \
-            "" \
-            "Removing the \`staging\` label releases the lock and takes the public host down.")
-          gh pr comment "$PR_NUM" --body "$STAGING_BODY"
-          echo "staging locked to PR #$PR_NUM at https://$STAGING_HOST"
+      - name: Reconcile staging target
+        run: bash scripts/staging-route.sh "$STAGING_TARGET" "$PR_NUM"
 
       - name: Remove kubeconfig
         if: always()

--- a/scripts/lib/__tests__/staging-routing.test.sh
+++ b/scripts/lib/__tests__/staging-routing.test.sh
@@ -1,0 +1,691 @@
+#!/usr/bin/env bash
+#
+# scripts/staging-route.sh decides where the one public staging host points,
+# executed rather than read. Two of its decisions are load-bearing:
+#
+#   - The exact-host Ingress must survive a release. Delete it and
+#     staging.lobu.ai falls through to production's *.lobu.ai Ingress, so an
+#     apparently idle test URL silently becomes production.
+#   - A release is owner-scoped. An `unlabeled` event for a PR that no longer
+#     holds the lock arrives *after* the new holder acquired it (the workflow
+#     serializes on one concurrency group), so an unscoped release would tear
+#     down whoever just took the host.
+#
+# `kubectl`, `gh`, `curl` and `sleep` are stubbed on PATH. Stub invocations and
+# the script's own output share one log, so an assertion can read both what the
+# script issued and why it refused.
+#
+# A few assertions read .github/workflows/staging.yml directly: the script only
+# ever reconciles the target it is handed, so which events reach it — and with
+# which target — is a decision only the workflow makes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROUTER="$SCRIPT_DIR/../../staging-route.sh"
+STAGING_WORKFLOW="$SCRIPT_DIR/../../../.github/workflows/staging.yml"
+PREVIEW_WORKFLOW="$SCRIPT_DIR/../../../.github/workflows/preview.yml"
+
+fail() {
+  echo "not ok - $1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required (staging-route.sh parses kubectl/curl JSON with it)"
+
+STUBS="$(mktemp -d)"
+LOG="$(mktemp)"
+trap 'rm -rf "$STUBS" "$LOG"' EXIT
+
+cat >"$STUBS/kubectl" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+printf 'kubectl %s\n' "$args" >>"$KUBECTL_LOG"
+case "$args" in
+  *"apply -f -"*)
+    # Manifests arrive on stdin; fold them into the same log so assertions can
+    # read what was actually applied, not just that an apply happened.
+    manifest="$(cat)"
+    { echo '--- applied'; printf '%s\n' "$manifest"; } >>"$KUBECTL_LOG"
+    if grep -Fq 'name: lobu-staging-tailnet' <<<"$manifest"; then
+      [ "$FAKE_TAILSCALE_APPLY" = ok ] || exit 1
+    fi
+    ;;
+  "create namespace"*)
+    printf 'apiVersion: v1\nkind: Namespace\n'
+    ;;
+  *"get configmap"*)
+    [ "$FAKE_CONFIGMAP" = present ] || exit 1
+    ;;
+  *"get ingress -A --field-selector metadata.name=lobu-staging"*)
+    printf '%s' "$FAKE_STRAY_INGRESS_NS"
+    exit "$FAKE_STRAY_INGRESS_STATUS"
+    ;;
+  *"get ingress lobu-staging -o json --ignore-not-found"*)
+    [ "$FAKE_ENSURE_INGRESS_STATUS" = 0 ] || exit "$FAKE_ENSURE_INGRESS_STATUS"
+    if [ "$FAKE_ENSURE_INGRESS_STATE" = present ]; then
+      printf '{"metadata":{"annotations":{"lobu.ai/staging-owner":"%s","lobu.ai/staging-target":"%s"}}}\n' \
+        "$FAKE_OWNER" "$FAKE_TARGET"
+    fi
+    ;;
+  *"get ingress lobu-staging -o json"*)
+    printf '{"metadata":{"annotations":{"lobu.ai/staging-owner":"%s","lobu.ai/staging-target":"%s"}}}\n' \
+      "$FAKE_OWNER" "$FAKE_TARGET"
+    exit "$FAKE_OWNER_LOOKUP_STATUS"
+    ;;
+  *"get secret"*)
+    printf '{"apiVersion":"v1","kind":"Secret","type":"kubernetes.io/tls","data":{"tls.crt":"eA=="},"metadata":{"name":"wildcard-lobu-ai-tls","namespace":"summaries-prod"}}\n'
+    ;;
+  *"get service"*)
+    [ "$FAKE_PREVIEW_SERVICE" = present ] || exit 1
+    ;;
+  *"wait --for=condition=TailscaleProxyReady"*)
+    [ "$FAKE_TAILSCALE" = ready ] || exit 1
+    ;;
+  *"wait --for=jsonpath"*)
+    [ "$FAKE_HEALTH_POD" = ok ] || exit 1
+    ;;
+  *"rollout status deployment/lobu-pr-"*)
+    [ "$FAKE_PREVIEW_ROLLOUT" = ready ] || exit 1
+    ;;
+  *"rollout status deployment/lobu-staging-router"*)
+    rollout_count="$(grep -Fc 'rollout status deployment/lobu-staging-router' "$KUBECTL_LOG")"
+    if [ "$FAKE_ROUTER_ROLLOUT" = fail-second ] && [ "$rollout_count" = 2 ]; then
+      exit 1
+    fi
+    ;;
+  *" logs "*)
+    printf '%s' "$FAKE_BACKEND_HEALTH"
+    ;;
+esac
+exit 0
+STUB
+
+cat >"$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >>"$KUBECTL_LOG"
+case "$1 $2" in
+  "pr list") printf '%s' "$FAKE_OPEN_PRS"; exit "$FAKE_GH_LIST_STATUS" ;;
+  "pr view") printf '%s' "$FAKE_PR_LABELS"; exit "$FAKE_GH_VIEW_STATUS" ;;
+esac
+exit 0
+STUB
+
+cat >"$STUBS/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >>"$KUBECTL_LOG"
+url=''
+outfile=''
+want_code=0
+fail_on_error=0
+expect_outfile=0
+for arg in "$@"; do
+  if [ "$expect_outfile" = 1 ]; then
+    outfile="$arg"
+    expect_outfile=0
+    continue
+  fi
+  case "$arg" in
+    -o) expect_outfile=1 ;;
+    '%{http_code}') want_code=1 ;;
+    -f | -fsS) fail_on_error=1 ;;
+    http://* | https://*) url="$arg" ;;
+  esac
+done
+
+status=200
+body=''
+case "$url" in
+  *'/.well-known/oauth-authorization-server'*)
+    body="$FAKE_OAUTH_METADATA"
+    ;;
+  *'/api/local-init'*)
+    status="$FAKE_LOCAL_INIT_STATUS"
+    body='{"error":"proxied_request_refused"}'
+    ;;
+  *'/api/health'*)
+    status="$FAKE_PUBLIC_STATUS"
+    body="$FAKE_PUBLIC_HEALTH"
+    ;;
+esac
+
+if [ -n "$outfile" ]; then
+  printf '%s' "$body" >"$outfile"
+else
+  printf '%s' "$body"
+fi
+[ "$want_code" = 1 ] && printf '%s' "$status"
+if [ "$fail_on_error" = 1 ] && [ "$status" -ge 400 ]; then
+  exit 22
+fi
+exit 0
+STUB
+
+# The script's retry loops sleep between attempts; the decisions under test do
+# not depend on wall-clock time.
+cat >"$STUBS/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+chmod +x "$STUBS/kubectl" "$STUBS/gh" "$STUBS/curl" "$STUBS/sleep"
+
+HEALTHY='{"status":"healthy","service":"lobu-api","environment":"development"}'
+PRODUCTION='{"status":"healthy","service":"lobu-api","environment":"production"}'
+OFFLINE_BODY='{"status":"offline","service":"lobu-staging-router","environment":"staging"}'
+OAUTH_METADATA='{"issuer":"https://staging.lobu.ai"}'
+
+# Run the real script with a fully specified fake cluster. Callers override a
+# single fact by exporting the matching FAKE_* before calling.
+run_route() {
+  : >"$LOG"
+  # The public probe reads whatever the router now serves, so the fake host
+  # answers as the sink for a release and as a backend for a route.
+  local default_public_health="$HEALTHY" default_public_status=200
+  if [ "${1:-}" = offline ]; then
+    default_public_health="$OFFLINE_BODY"
+    default_public_status=503
+  fi
+  set +e
+  env \
+    PATH="$STUBS:$PATH" \
+    KUBECTL_LOG="$LOG" \
+    GH_TOKEN=fake-token \
+    FAKE_CONFIGMAP="${FAKE_CONFIGMAP:-present}" \
+    FAKE_OWNER="${FAKE_OWNER:-none}" \
+    FAKE_OWNER_LOOKUP_STATUS="${FAKE_OWNER_LOOKUP_STATUS:-0}" \
+    FAKE_ENSURE_INGRESS_STATUS="${FAKE_ENSURE_INGRESS_STATUS:-0}" \
+    FAKE_ENSURE_INGRESS_STATE="${FAKE_ENSURE_INGRESS_STATE:-present}" \
+    FAKE_TARGET="${FAKE_TARGET:-offline}" \
+    FAKE_STRAY_INGRESS_NS="${FAKE_STRAY_INGRESS_NS:-}" \
+    FAKE_STRAY_INGRESS_STATUS="${FAKE_STRAY_INGRESS_STATUS:-0}" \
+    FAKE_PREVIEW_SERVICE="${FAKE_PREVIEW_SERVICE:-present}" \
+    FAKE_TAILSCALE_APPLY="${FAKE_TAILSCALE_APPLY:-ok}" \
+    FAKE_TAILSCALE="${FAKE_TAILSCALE:-ready}" \
+    FAKE_ROUTER_ROLLOUT="${FAKE_ROUTER_ROLLOUT:-ready}" \
+    FAKE_PREVIEW_ROLLOUT="${FAKE_PREVIEW_ROLLOUT:-ready}" \
+    FAKE_HEALTH_POD="${FAKE_HEALTH_POD:-ok}" \
+    FAKE_BACKEND_HEALTH="${FAKE_BACKEND_HEALTH:-$HEALTHY}" \
+    FAKE_PUBLIC_HEALTH="${FAKE_PUBLIC_HEALTH:-$default_public_health}" \
+    FAKE_PUBLIC_STATUS="${FAKE_PUBLIC_STATUS:-$default_public_status}" \
+    FAKE_OAUTH_METADATA="${FAKE_OAUTH_METADATA:-$OAUTH_METADATA}" \
+    FAKE_LOCAL_INIT_STATUS="${FAKE_LOCAL_INIT_STATUS:-403}" \
+    FAKE_OPEN_PRS="${FAKE_OPEN_PRS:-}" \
+    FAKE_PR_LABELS="${FAKE_PR_LABELS-staging}" \
+    FAKE_GH_LIST_STATUS="${FAKE_GH_LIST_STATUS:-0}" \
+    FAKE_GH_VIEW_STATUS="${FAKE_GH_VIEW_STATUS:-0}" \
+    STAGING_LOCAL_TAILNET_FQDN="${STAGING_LOCAL_TAILNET_FQDN:-}" \
+    STAGING_LOCAL_TAILNET_PORT="${STAGING_LOCAL_TAILNET_PORT:-10080}" \
+    TAILNET_DOMAIN="${TAILNET_DOMAIN:-}" \
+    bash "$ROUTER" "$@" >>"$LOG" 2>&1
+  local code=$?
+  set -e
+  return $code
+}
+
+assert_ok() {
+  run_route "${@:2}" || fail "$1: script exited nonzero"
+}
+
+assert_fails() {
+  run_route "${@:2}" && fail "$1: script exited 0 where it must refuse"
+  return 0
+}
+
+assert_logged() {
+  grep -Fq -- "$2" "$LOG" || {
+    sed 's/^/  | /' "$LOG" >&2
+    fail "$1: expected to see '$2'"
+  }
+}
+
+assert_not_logged() {
+  grep -Fq -- "$2" "$LOG" && fail "$1: must not have issued '$2'"
+  return 0
+}
+
+# route_preview pins the public-host settings and restore_private_preview hands
+# them back with the same `set env` verb on the same deployment — only the
+# argument list separates them, so assertions name the restore by its arguments.
+restored_private() {
+  printf 'set env deployment/lobu-pr-%s PUBLIC_GATEWAY_URL- LOBU_LOCAL_INIT_ALLOW_PROXY=1' "$1"
+}
+
+# The log is append-ordered, so "before" is a line-number comparison. Both
+# needles must appear, or the ordering claim is vacuous.
+assert_logged_before() {
+  local first second
+  first="$(grep -nF -- "$2" "$LOG" | head -1 | cut -d: -f1)"
+  second="$(grep -nF -- "$3" "$LOG" | head -1 | cut -d: -f1)"
+  [ -n "$first" ] || fail "$1: expected to see '$2'"
+  [ -n "$second" ] || fail "$1: expected to see '$3'"
+  [ "$first" -lt "$second" ] || fail "$1: '$2' must be issued before '$3'"
+}
+
+# `service:` appears only in the Ingress backend, so the line after it is the
+# Service the public host actually resolves to.
+assert_ingress_backend() {
+  grep -A1 -F 'service:' "$LOG" | grep -Fq "name: $2" ||
+    fail "$1: staging Ingress does not point at $2"
+}
+
+assert_workflow_contains() {
+  grep -Fq -- "$2" "$STAGING_WORKFLOW" ||
+    fail "$1: staging workflow must contain '$2'"
+}
+
+assert_preview_workflow_contains() {
+  grep -Fq -- "$2" "$PREVIEW_WORKFLOW" ||
+    fail "$1: preview workflow must contain '$2'"
+}
+
+# --- the workflow reaches the script on the right events -------------------
+
+# Closing a PR fires no `unlabeled` event, so without the `closed` type a merged
+# holder would keep the public host pointed at the namespace preview.yml deletes
+# on that same event.
+assert_workflow_contains "closed PR release" 'types: [labeled, unlabeled, closed]'
+assert_workflow_contains "closed PR reconcile" "github.event.action == 'closed'"
+# ...but only for the holder. The concurrency group is global and GitHub keeps
+# one pending run per group, so a run queued by an unrelated PR closing would
+# cancel a release already waiting behind the run in flight.
+assert_workflow_contains "closed PR label gate" \
+  "github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'staging')"
+# Preview ownership is label-driven, including the closed-event release above.
+# Manual dispatch therefore exposes only the two non-label targets.
+assert_workflow_contains "manual targets" 'options: [local-tailnet, offline]'
+# The wildcard secret is copied, not watched, so nothing re-copies a renewed
+# certificate while staging sits idle for a full renewal cycle.
+assert_workflow_contains "scheduled TLS refresh" '- cron:'
+assert_workflow_contains "scheduled TLS target" "github.event_name == 'schedule' && 'refresh-tls'"
+
+# Preview redeploys recreate the ClusterIP Service. nginx resolves the static
+# Service hostname when its config loads, so a successful staging-labelled
+# preview deploy must reconcile the router again under the same global lock.
+assert_preview_workflow_contains "post-deploy staging reconcile" 'reconcile-staging:'
+assert_preview_workflow_contains "post-deploy dependency" 'needs: preview'
+assert_preview_workflow_contains "post-deploy staging lock" 'group: staging-lock'
+assert_preview_workflow_contains "post-deploy PR number" \
+  "PR_NUMBER: \${{ github.event.pull_request.number }}"
+assert_preview_workflow_contains "post-deploy route command" \
+  "bash scripts/staging-route.sh preview \"\$PR_NUMBER\""
+assert_preview_workflow_contains "post-deploy current-label reconciliation" \
+  'contains(github.event.pull_request.labels.*.name, '\''staging'\'')'
+
+# --- the exact-host Ingress is permanent -----------------------------------
+
+# A fresh cluster has no router config yet, and the Deployment mounts that
+# ConfigMap by name — so the first reconcile has to create it, pointed at the
+# sink. An existing one is left alone: rewriting it here would drop whatever
+# target the current owner is published on.
+FAKE_CONFIGMAP=absent assert_ok "first router config" refresh-tls
+assert_logged "first router config" 'kind: ConfigMap'
+assert_logged "first router config" '"status":"offline"'
+assert_ok "existing router config" refresh-tls
+assert_not_logged "existing router config" 'kind: ConfigMap'
+
+# A genuinely absent first-run Ingress bootstraps offline. An API read failure
+# is different: it must abort before overwriting a possibly live owner with the
+# bootstrap defaults.
+FAKE_ENSURE_INGRESS_STATE=missing assert_ok "first reconcile" refresh-tls
+assert_logged "first reconcile" 'lobu.ai/staging-owner: "none"'
+assert_logged "first reconcile" 'lobu.ai/staging-target: "offline"'
+
+FAKE_ENSURE_INGRESS_STATUS=1 assert_fails "ensure ingress outage" refresh-tls
+assert_not_logged "ensure ingress outage" 'kind: Ingress'
+
+assert_ok "offline" offline
+# Released staging still owns staging.lobu.ai explicitly, backed by the router.
+assert_logged "offline" 'kind: Ingress'
+assert_logged "offline" '- host: staging.lobu.ai'
+assert_ingress_backend "offline" 'lobu-staging-router'
+assert_logged "offline" 'staging-owner=none'
+assert_logged "offline" 'staging-target=offline'
+# Deleting it is exactly the fall-through-to-production bug.
+assert_not_logged "offline" 'delete ingress lobu-staging'
+
+# A pre-router Ingress parked in a preview namespace is the one that must go —
+# and only after the permanent route exists.
+FAKE_STRAY_INGRESS_NS=$'lobu-preview-9\n' assert_ok "stray cleanup" offline
+assert_logged "stray cleanup" '-n lobu-preview-9 delete ingress lobu-staging'
+
+# A list outage is not equivalent to an empty list: continuing would allow a
+# pre-router Ingress to keep competing for the public hostname.
+FAKE_STRAY_INGRESS_STATUS=1 assert_fails "stray ingress list outage" refresh-tls
+assert_logged "stray ingress list outage" 'could not list staging Ingress claims'
+
+# --- releasing is owner-scoped ---------------------------------------------
+
+# PR 7 drops its label after PR 8 took the host: PR 8 keeps it.
+FAKE_OWNER=pr-8 FAKE_TARGET=preview assert_ok "stale release" offline 7
+assert_not_logged "stale release" 'staging-owner=none'
+# The stale PR's own preview is still handed back its private-host settings.
+assert_logged "stale release" "$(restored_private 7)"
+
+# The holder releasing its own lock does take the host offline.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview assert_ok "owner release" offline 7
+assert_logged "owner release" 'staging-owner=none'
+assert_logged "owner release" "$(restored_private 7)"
+assert_logged_before "owner release" 'staging-owner=none' "$(restored_private 7)"
+
+# A manual force-off has no PR event payload. It still restores the displaced
+# preview and clears the label whose later event would otherwise surprise the
+# next operator.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview FAKE_OPEN_PRS=$'7\n' FAKE_PR_LABELS='staging' \
+  assert_ok "manual force-off" offline
+assert_logged "manual force-off" "$(restored_private 7)"
+assert_logged_before "manual force-off" 'staging-owner=none' "$(restored_private 7)"
+assert_logged "manual force-off" 'pr edit 7 --remove-label staging'
+
+# GitHub label cleanup cannot block the emergency action itself. The workflow
+# may fail so the cleanup can be retried, but the host is already offline and
+# the displaced preview has its private settings back.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview FAKE_GH_LIST_STATUS=1 \
+  assert_fails "manual force-off gh outage" offline
+assert_logged "manual force-off gh outage" 'staging-owner=none'
+assert_logged "manual force-off gh outage" 'staging-target=offline'
+assert_logged "manual force-off gh outage" \
+  "$(restored_private 7)"
+
+# --- the health gate -------------------------------------------------------
+
+# A backend that reports itself as production must never be published, however
+# it got selected.
+FAKE_BACKEND_HEALTH="$PRODUCTION" assert_fails "prod backend" preview 12
+assert_logged "prod backend" 'refusing to route staging to production'
+# Refused before the router or the Ingress ever named it.
+assert_not_logged "prod backend" 'proxy_pass http://lobu-pr-12'
+assert_not_logged "prod backend" 'staging-owner=pr-12'
+
+# Same gate on the public side: the host itself answering as production.
+FAKE_PUBLIC_HEALTH="$PRODUCTION" assert_fails "prod public" preview 12
+assert_logged "prod public" 'refusing to route staging to production'
+
+# An unreachable or unhealthy backend is not a route either.
+FAKE_HEALTH_POD=failed FAKE_OPEN_PRS=$'11\n12\n' FAKE_PR_LABELS='staging' \
+  assert_fails "unhealthy backend" preview 12
+assert_logged "unhealthy backend" 'backend health probe could not complete'
+# The current holder keeps its label until the replacement is proved healthy.
+assert_not_logged "unhealthy backend" 'pr edit 11 --remove-label staging'
+FAKE_PREVIEW_SERVICE=missing assert_fails "missing preview service" preview 12
+assert_logged "missing preview service" 'preview service lobu-preview-12/lobu-pr-12 was not found'
+
+# Public-host settings are provisional until the preview deployment is healthy.
+# A failed rollout for a preview that does not own the route hands the private
+# settings back before exiting.
+FAKE_PREVIEW_ROLLOUT=failed assert_fails "preview deployment rollout" preview 12
+assert_logged "preview deployment rollout" "$(restored_private 12)"
+assert_not_logged "preview deployment rollout" 'proxy_pass http://lobu-pr-12'
+
+# If this preview already owns the public route, restoring passwordless proxy
+# bootstrap while the router still points at it would expose /api/local-init.
+# Take the exact host offline first, then restore its private-host settings.
+FAKE_OWNER=pr-12 FAKE_TARGET=preview FAKE_PREVIEW_ROLLOUT=failed \
+  assert_fails "current owner preview rollout" preview 12
+assert_logged "current owner preview rollout" 'staging target publication failed; rolling staging back to offline'
+assert_logged "current owner preview rollout" 'staging-owner=none'
+assert_logged_before "current owner preview rollout" \
+  'staging-owner=none' "$(restored_private 12)"
+
+# --- preview ---------------------------------------------------------------
+
+# A post-deploy reconcile can replace the one pending label-event job. It reads
+# current desired state, so an event captured before an unlabel performs the
+# canceled scoped release instead of re-acquiring from stale payload data.
+FAKE_OWNER=pr-12 FAKE_TARGET=preview FAKE_PR_LABELS='' \
+  FAKE_PUBLIC_STATUS=503 FAKE_PUBLIC_HEALTH="$OFFLINE_BODY" \
+  assert_ok "stale post-deploy reconcile releases" preview 12
+assert_logged "stale post-deploy reconcile releases" 'PR #12 no longer has the staging label'
+assert_logged "stale post-deploy reconcile releases" 'staging-owner=none'
+assert_logged "stale post-deploy reconcile releases" "$(restored_private 12)"
+assert_not_logged "stale post-deploy reconcile releases" 'proxy_pass http://lobu-pr-12'
+
+# If another PR already owns the host, the same stale reconcile is a scoped
+# release and must leave that owner unchanged.
+FAKE_OWNER=pr-11 FAKE_TARGET=preview FAKE_PR_LABELS='' \
+  assert_ok "displaced stale reconcile" preview 12
+assert_logged "displaced stale reconcile" 'lock owner is pr-11; leaving it unchanged'
+assert_not_logged "displaced stale reconcile" 'staging-owner=none'
+
+# Conversely, if a post-deploy job replaces a pending acquisition while the
+# label is still present, it performs the acquisition itself.
+FAKE_OWNER=pr-11 FAKE_TARGET=preview FAKE_PR_LABELS=staging \
+  assert_ok "post-deploy replaces pending acquire" preview 12
+assert_logged "post-deploy replaces pending acquire" 'staging-owner=pr-12'
+assert_logged "post-deploy replaces pending acquire" 'proxy_pass http://lobu-pr-12.lobu-preview-12.svc.cluster.local:80'
+
+FAKE_OPEN_PRS=$'11\n12\n' FAKE_PR_LABELS='staging' assert_ok "preview" preview 12
+assert_logged "preview" 'proxy_pass http://lobu-pr-12.lobu-preview-12.svc.cluster.local:80'
+assert_logged "preview" 'staging-owner=pr-12'
+# Public host, so the passwordless bootstrap env must be stripped before the
+# rollout, and PUBLIC_GATEWAY_URL pinned to the public name.
+assert_logged "preview" 'LOBU_LOCAL_INIT_ALLOW_PROXY-'
+assert_logged "preview" 'PUBLIC_GATEWAY_URL=https://staging.lobu.ai/lobu'
+# Single holder: every other labelled PR loses the label, this one keeps it.
+assert_logged "preview" 'pr edit 11 --remove-label staging'
+assert_not_logged "preview" 'pr edit 12 --remove-label staging'
+
+# The PR losing the host still has PUBLIC_GATEWAY_URL pinned and passwordless
+# bootstrap off, and the label strip above runs on GITHUB_TOKEN — which fires no
+# `unlabeled` run to hand them back. So this run has to do it.
+FAKE_OWNER=pr-11 FAKE_TARGET=preview FAKE_OPEN_PRS=$'11\n12\n' FAKE_PR_LABELS='staging' \
+  assert_ok "preview displaces holder" preview 12
+assert_logged "preview displaces holder" "$(restored_private 11)"
+# ...but only once the route has moved. Those settings put
+# LOBU_LOCAL_INIT_ALLOW_PROXY=1 back on PR 11, and until the router points at
+# PR 12 the public host still resolves to PR 11 — handing them back first
+# reopens passwordless bootstrap on staging.lobu.ai for the length of the
+# rollout.
+assert_logged_before "preview displaces holder" \
+  'proxy_pass http://lobu-pr-12' "$(restored_private 11)"
+
+# Re-acquiring for the PR that already holds the route displaces nobody: handing
+# back the private-host settings would undo the ones this run just applied.
+FAKE_OWNER=pr-12 FAKE_TARGET=preview FAKE_OPEN_PRS=$'12\n' FAKE_PR_LABELS='staging' \
+  assert_ok "preview re-acquire" preview 12
+assert_not_logged "preview re-acquire" "$(restored_private 12)"
+
+# A public host that still mints passwordless sessions is the failure this
+# check exists to catch.
+FAKE_LOCAL_INIT_STATUS=200 assert_fails "open bootstrap" preview 12
+assert_logged "open bootstrap" 'public /api/local-init returned 200'
+assert_logged "open bootstrap" 'staging target publication failed; rolling staging back to offline'
+assert_logged "open bootstrap" 'staging-owner=none'
+assert_logged "open bootstrap" 'staging-target=offline'
+assert_logged "open bootstrap" "$(restored_private 12)"
+# ...and that 403-vs-200 reading is only worth anything because the probe sends
+# the header a real client sends. The CSRF check is the LAST of
+# assertLoopbackClient's layers, so a probe without it is refused as
+# missing_client_header even with the forwarded-* boundary wide open - a 403
+# indistinguishable from the closed-boundary one.
+assert_logged "open bootstrap" '-H X-Lobu-Client: staging-probe'
+
+# The router is what makes the issuer right: OAuth discovery skips
+# PUBLIC_GATEWAY_URL (skipEnvOverride, auth/oauth/routes.ts) and derives the
+# issuer from the X-Forwarded-* pair nginx sets. A router that drops them
+# publishes a host whose discovery document points somewhere else, which every
+# cloud MCP host reads before it ever calls /mcp.
+FAKE_OAUTH_METADATA='{"issuer":"https://lobu-pr-12.tail1234.ts.net"}' \
+  assert_fails "wrong OAuth issuer" preview 12
+assert_logged "wrong OAuth issuer" 'OAuth issuer does not match https://staging.lobu.ai'
+assert_logged "wrong OAuth issuer" 'staging-target=offline'
+assert_logged "wrong OAuth issuer" "$(restored_private 12)"
+
+# Changing the ConfigMap is provisional too: if the router rollout times out,
+# it may still converge later. The public host therefore has to be rolled back
+# before that unverified target can become reachable.
+FAKE_ROUTER_ROLLOUT=fail-second assert_fails "preview router rollout" preview 12
+assert_logged "preview router rollout" 'staging target publication failed; rolling staging back to offline'
+assert_logged "preview router rollout" 'staging-owner=none'
+assert_logged "preview router rollout" 'staging-target=offline'
+assert_logged "preview router rollout" "$(restored_private 12)"
+
+# Single-holder rests on gh answering. A rate limit or 5xx read through a pipe
+# would take grep's status and pass for "that PR is not labelled", leaving two
+# PRs labelled `staging` while one holds the route — so it has to abort instead,
+# and abort before the host is pointed anywhere. By then this PR's preview is
+# already carrying the public-host settings, so the run also has to hand them
+# back on its way out.
+FAKE_OPEN_PRS=$'11\n' FAKE_GH_VIEW_STATUS=1 assert_fails "gh outage reading labels" preview 12
+assert_not_logged "gh outage reading labels" 'staging-owner=pr-12'
+assert_not_logged "gh outage reading labels" 'PUBLIC_GATEWAY_URL=https://staging.lobu.ai/lobu'
+FAKE_GH_LIST_STATUS=1 assert_fails "gh outage listing PRs" preview 12
+assert_not_logged "gh outage listing PRs" 'staging-owner=pr-12'
+assert_logged "gh outage listing PRs" "$(restored_private 12)"
+
+# A lock-transfer failure after a successful public-safe rollout must not hand
+# passwordless proxy bootstrap back to the preview that still owns the host.
+FAKE_OWNER=pr-12 FAKE_TARGET=preview FAKE_GH_LIST_STATUS=1 \
+  assert_fails "current owner lock transfer outage" preview 12
+assert_logged "current owner lock transfer outage" 'current owner retains public-safe settings'
+assert_not_logged "current owner lock transfer outage" "$(restored_private 12)"
+assert_logged "current owner lock transfer outage" 'LOBU_LOCAL_INIT_ALLOW_PROXY-'
+
+# Reading who currently holds the route is the same kind of dependency: an
+# unreadable annotation must not pass for "nobody holds it", or the displaced
+# holder would keep the public-host settings this run never released it from.
+FAKE_OWNER_LOOKUP_STATUS=1 assert_fails "owner lookup outage" preview 12
+assert_not_logged "owner lookup outage" 'staging-owner=pr-12'
+assert_not_logged "owner lookup outage" 'PUBLIC_GATEWAY_URL=https://staging.lobu.ai/lobu'
+
+assert_fails "non-numeric PR" preview not-a-number
+assert_logged "non-numeric PR" 'preview target requires a numeric PR number'
+assert_fails "preview without a PR" preview
+assert_logged "preview without a PR" 'preview target requires a numeric PR number'
+
+# Same class on the release path, where reading it wrong is worst: an owner
+# that cannot be read must not pass for "this PR is not the holder", or the
+# run would report a successful no-op with the host still published.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview FAKE_OWNER_LOOKUP_STATUS=1 \
+  assert_fails "release owner lookup outage" offline 7
+assert_not_logged "release owner lookup outage" 'leaving it unchanged'
+assert_not_logged "release owner lookup outage" 'staging-owner=none'
+
+# The dispatch input is free text. A typed owner scope that is not a PR number
+# matches no annotation, so an unvalidated release would report success while
+# leaving the public host published.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview assert_fails "non-numeric owner scope" offline 'pr-7'
+assert_logged "non-numeric owner scope" 'offline owner scope must be a numeric PR number'
+assert_not_logged "non-numeric owner scope" 'staging-owner=none'
+
+# A certificate refresh is route-neutral: ensure_system_route copies the
+# wildcard secret and preserves the current owner/target annotations.
+FAKE_OWNER=pr-7 FAKE_TARGET=preview assert_ok "TLS refresh" refresh-tls
+assert_logged "TLS refresh" '"kind": "Secret"'
+assert_logged "TLS refresh" 'lobu.ai/staging-owner: "pr-7"'
+assert_logged "TLS refresh" 'lobu.ai/staging-target: "preview"'
+assert_not_logged "TLS refresh" 'delete service lobu-staging-tailnet'
+assert_logged "TLS refresh" 'route unchanged'
+
+# --- local tailnet ---------------------------------------------------------
+
+# The target is a repository variable, but it is still checked against the
+# configured tailnet so a mistyped value cannot turn the cluster into an
+# arbitrary outbound proxy.
+STAGING_LOCAL_TAILNET_FQDN='box.evil.example' TAILNET_DOMAIN='tail1234.ts.net' \
+  assert_fails "off-tailnet target" local-tailnet
+assert_logged "off-tailnet target" 'outside the configured tailnet domain'
+assert_not_logged "off-tailnet target" 'tailscale.com/tailnet-fqdn'
+
+STAGING_LOCAL_TAILNET_FQDN='' assert_fails "unset tailnet target" local-tailnet
+assert_logged "unset tailnet target" 'STAGING_LOCAL_TAILNET_FQDN repository variable is required'
+STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' TAILNET_DOMAIN='' \
+  assert_fails "unset tailnet domain" local-tailnet
+assert_logged "unset tailnet domain" 'TAILNET_DOMAIN repository variable is required'
+assert_not_logged "unset tailnet domain" 'tailscale.com/tailnet-fqdn'
+STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' STAGING_LOCAL_TAILNET_PORT='80' \
+  TAILNET_DOMAIN='tail1234.ts.net' \
+  assert_fails "privileged port" local-tailnet
+assert_logged "privileged port" 'STAGING_LOCAL_TAILNET_PORT must be between 1024 and 65535'
+
+STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' TAILNET_DOMAIN='tail1234.ts.net' \
+  assert_ok "local tailnet" local-tailnet
+assert_logged "local tailnet" 'tailscale.com/tailnet-fqdn: "box.tail1234.ts.net"'
+assert_logged "local tailnet" 'type: ExternalName'
+assert_logged "local tailnet" 'wait --for=condition=TailscaleProxyReady'
+assert_logged "local tailnet" 'proxy_pass http://lobu-staging-tailnet.lobu-staging.svc.cluster.local:10080'
+assert_logged "local tailnet" 'staging-owner=local-tailnet'
+
+# Taking the host to a local machine displaces a PR holder the same way.
+FAKE_OWNER=pr-11 FAKE_TARGET=preview STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_ok "local tailnet displaces holder" local-tailnet
+assert_logged "local tailnet displaces holder" "$(restored_private 11)"
+assert_logged_before "local tailnet displaces holder" \
+  'proxy_pass http://lobu-staging-tailnet' "$(restored_private 11)"
+
+# A lock-transfer metadata outage happens after the egress Service proved
+# healthy but before publication. It must still remove that unused egress.
+FAKE_GH_LIST_STATUS=1 STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "local gh outage" local-tailnet
+assert_not_logged "local gh outage" 'staging-owner=local-tailnet'
+assert_logged "local gh outage" 'delete service lobu-staging-tailnet'
+
+FAKE_OWNER_LOOKUP_STATUS=1 STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "local owner outage" local-tailnet
+assert_not_logged "local owner outage" 'staging-owner=local-tailnet'
+assert_logged "local owner outage" 'delete service lobu-staging-tailnet'
+
+# A machine that does not become healthy is never allowed to steal the lock,
+# and its cluster egress Service is cleaned up on the error path.
+FAKE_HEALTH_POD=failed FAKE_OPEN_PRS=$'12\n' FAKE_PR_LABELS='staging' \
+  STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' TAILNET_DOMAIN='tail1234.ts.net' \
+  assert_fails "unhealthy local tailnet" local-tailnet
+assert_not_logged "unhealthy local tailnet" 'pr edit 12 --remove-label staging'
+assert_logged "unhealthy local tailnet" 'delete service lobu-staging-tailnet'
+
+# The apply and readiness checks are both gates. Because the subshell is the
+# condition of `if !`, Bash disables errexit inside it; each command therefore
+# has to short-circuit explicitly instead of falling through to a health probe.
+FAKE_TAILSCALE_APPLY=failed STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "tailnet apply failure" local-tailnet
+assert_not_logged "tailnet apply failure" 'wait --for=condition=TailscaleProxyReady'
+assert_not_logged "tailnet apply failure" 'run staging-health-'
+assert_logged "tailnet apply failure" 'delete service lobu-staging-tailnet'
+
+FAKE_TAILSCALE=failed STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "tailnet readiness failure" local-tailnet
+assert_logged "tailnet readiness failure" 'wait --for=condition=TailscaleProxyReady'
+assert_not_logged "tailnet readiness failure" 'run staging-health-'
+assert_logged "tailnet readiness failure" 'delete service lobu-staging-tailnet'
+
+# The target is only provisional until its public path proves the bootstrap
+# guard. If that post-publish check fails, the exact host must be put back on
+# the 503 sink and the personal-machine egress removed before the run exits.
+FAKE_LOCAL_INIT_STATUS=200 STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "open local bootstrap" local-tailnet
+assert_logged "open local bootstrap" 'public /api/local-init returned 200'
+assert_logged "open local bootstrap" 'staging target publication failed; rolling staging back to offline'
+assert_logged "open local bootstrap" 'staging-owner=none'
+assert_logged "open local bootstrap" 'staging-target=offline'
+assert_logged "open local bootstrap" 'delete service lobu-staging-tailnet'
+
+FAKE_ROUTER_ROLLOUT=fail-second STAGING_LOCAL_TAILNET_FQDN='box.tail1234.ts.net' \
+  TAILNET_DOMAIN='tail1234.ts.net' assert_fails "local router rollout" local-tailnet
+assert_logged "local router rollout" 'staging target publication failed; rolling staging back to offline'
+assert_logged "local router rollout" 'staging-owner=none'
+assert_logged "local router rollout" 'staging-target=offline'
+assert_logged "local router rollout" 'delete service lobu-staging-tailnet'
+
+# Egress to a personal machine must not outlive the route that needed it.
+assert_ok "offline cleanup" offline
+assert_logged "offline cleanup" 'delete service lobu-staging-tailnet'
+
+# A release that leaves the host still serving a backend is not a release.
+FAKE_PUBLIC_STATUS=200 FAKE_PUBLIC_HEALTH="$HEALTHY" assert_fails "release not applied" offline
+assert_logged "release not applied" 'offline staging returned HTTP 200 instead of 503'
+
+# The status code alone cannot tell the sink apart from anyone else answering
+# for the host - production's *.lobu.ai Ingress serves a 503 of its own. Only
+# the body identifies the exact-host route, so releasing has to read it.
+FAKE_PUBLIC_STATUS=503 FAKE_PUBLIC_HEALTH='<html>503 Service Unavailable</html>' \
+  assert_fails "release answered by someone else" offline
+assert_logged "release answered by someone else" 'offline staging returned an unexpected body'
+
+# --- input validation ------------------------------------------------------
+
+assert_fails "unknown target" someone-elses-cluster
+assert_logged "unknown target" 'target must be preview, local-tailnet, offline, or refresh-tls'
+assert_fails "no target"
+assert_logged "no target" 'target must be preview, local-tailnet, offline, or refresh-tls'
+
+echo "ok - staging routing keeps an exact-host route, scopes releases to the lock owner, and health-gates every target"

--- a/scripts/staging-route.sh
+++ b/scripts/staging-route.sh
@@ -1,0 +1,653 @@
+#!/usr/bin/env bash
+#
+# Reconcile the single public staging host to one of four targets:
+#   preview        a PR preview Service
+#   local-tailnet  an allowlisted tailnet device reached through the operator
+#   offline        a stable 503 sink
+#   refresh-tls    reconcile the shared objects (the wildcard TLS secret among
+#                  them) and leave the current route exactly as it is
+#
+# The Ingress itself is permanent and always points at a small router in the
+# lobu-staging namespace. That exact-host route prevents staging.lobu.ai from
+# ever falling through to production's *.lobu.ai Ingress.
+
+set -euo pipefail
+
+TARGET="${1:-}"
+PR_NUM="${2:-}"
+
+# Public DNS, not the tailnet name: an MCP host (claude.ai, ChatGPT) resolves
+# and calls /mcp from its own backend, so a tailnet-only name is unreachable to
+# it and the connector fails at discovery.
+STAGING_HOST="${STAGING_HOST:-staging.lobu.ai}"
+STAGING_SYSTEM_NS="${STAGING_SYSTEM_NS:-lobu-staging}"
+STAGING_INGRESS="${STAGING_INGRESS:-lobu-staging}"
+STAGING_ROUTER="${STAGING_ROUTER:-lobu-staging-router}"
+LOCAL_EGRESS_SERVICE="${LOCAL_EGRESS_SERVICE:-lobu-staging-tailnet}"
+WILDCARD_TLS_NS="${WILDCARD_TLS_NS:-summaries-prod}"
+WILDCARD_TLS_SECRET="${WILDCARD_TLS_SECRET:-wildcard-lobu-ai-tls}"
+RUN_KEY="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+
+fail() {
+  echo "staging-route: $*" >&2
+  exit 1
+}
+
+assert_non_prod_health() {
+  local body="$1"
+  if jq -e '.environment == "production"' >/dev/null 2>&1 <<<"$body"; then
+    fail "refusing to route staging to production"
+  fi
+  jq -e '.status == "healthy" and .environment != "production"' >/dev/null 2>&1 <<<"$body" ||
+    fail "backend health was not a healthy non-production response: $body"
+}
+
+verify_non_prod_health() {
+  local url="$1"
+  local attempt body pod_name
+  for attempt in $(seq 1 5); do
+    pod_name="staging-health-${RUN_KEY//[^a-zA-Z0-9-]/-}-$attempt"
+    # A Pod name is a DNS-1123 label, so it has to stay under 63 characters.
+    pod_name="${pod_name:0:62}"
+    kubectl -n "$STAGING_SYSTEM_NS" delete pod "$pod_name" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl -n "$STAGING_SYSTEM_NS" run "$pod_name" \
+      --image="curlimages/curl:8.17.0" \
+      --restart=Never \
+      --command -- curl -fsS --max-time 20 "$url" >/dev/null
+    if kubectl -n "$STAGING_SYSTEM_NS" wait \
+      --for=jsonpath='{.status.phase}'=Succeeded \
+      "pod/$pod_name" --timeout=30s >/dev/null 2>&1; then
+      body="$(kubectl -n "$STAGING_SYSTEM_NS" logs "$pod_name")"
+      kubectl -n "$STAGING_SYSTEM_NS" delete pod "$pod_name" --wait=false >/dev/null
+      assert_non_prod_health "$body"
+      return 0
+    fi
+    kubectl -n "$STAGING_SYSTEM_NS" logs "$pod_name" >&2 || true
+    kubectl -n "$STAGING_SYSTEM_NS" delete pod "$pod_name" --ignore-not-found >/dev/null 2>&1 || true
+    echo "backend health probe failed; retrying ($attempt/5)" >&2
+    sleep 2
+  done
+  fail "backend health probe could not complete after 5 attempts"
+}
+
+write_router_config() {
+  local target="$1"
+  local upstream="${2:-}"
+
+  if [ "$target" = "offline" ]; then
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $STAGING_ROUTER
+  namespace: $STAGING_SYSTEM_NS
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      server_name _;
+      location = /__staging_router_ready { return 204; }
+      location = /api/health {
+        default_type application/json;
+        return 503 '{"status":"offline","service":"lobu-staging-router","environment":"staging"}';
+      }
+      location / { return 503; }
+    }
+EOF
+  else
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $STAGING_ROUTER
+  namespace: $STAGING_SYSTEM_NS
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      server_name _;
+      client_max_body_size 50m;
+      location = /__staging_router_ready { return 204; }
+      location / {
+        proxy_pass http://$upstream;
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_set_header Connection "";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-Host \$host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP \$remote_addr;
+      }
+    }
+EOF
+  fi
+}
+
+roll_router() {
+  kubectl -n "$STAGING_SYSTEM_NS" patch deployment "$STAGING_ROUTER" --type merge \
+    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"lobu.ai/config-revision\":\"$RUN_KEY-$RANDOM\"}}}}}" >/dev/null &&
+    kubectl -n "$STAGING_SYSTEM_NS" rollout status "deployment/$STAGING_ROUTER" --timeout=180s
+}
+
+current_owner() {
+  kubectl -n "$STAGING_SYSTEM_NS" get ingress "$STAGING_INGRESS" -o json 2>/dev/null |
+    jq -r '.metadata.annotations["lobu.ai/staging-owner"] // ""'
+}
+
+set_ingress_state() {
+  local owner="$1"
+  local target="$2"
+  kubectl -n "$STAGING_SYSTEM_NS" annotate ingress "$STAGING_INGRESS" \
+    "lobu.ai/staging-owner=$owner" \
+    "lobu.ai/staging-target=$target" \
+    --overwrite >/dev/null
+}
+
+cleanup_local_egress() {
+  kubectl -n "$STAGING_SYSTEM_NS" delete service "$LOCAL_EGRESS_SERVICE" \
+    --ignore-not-found >/dev/null
+}
+
+rollback_to_offline() {
+  local failed=0
+  echo "staging target publication failed; rolling staging back to offline" >&2
+  write_router_config offline || failed=1
+  roll_router || failed=1
+  set_ingress_state none offline || failed=1
+  cleanup_local_egress || failed=1
+  return "$failed"
+}
+
+ensure_system_route() {
+  kubectl create namespace "$STAGING_SYSTEM_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+  if ! kubectl -n "$STAGING_SYSTEM_NS" get configmap "$STAGING_ROUTER" >/dev/null 2>&1; then
+    write_router_config offline
+  fi
+
+  kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $STAGING_ROUTER
+  namespace: $STAGING_SYSTEM_NS
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: $STAGING_ROUTER }
+  template:
+    metadata:
+      labels: { app: $STAGING_ROUTER }
+    spec:
+      containers:
+        - name: router
+          image: nginxinc/nginx-unprivileged:1.27.4-alpine
+          ports:
+            - { name: http, containerPort: 8080 }
+          readinessProbe:
+            httpGet: { path: /__staging_router_ready, port: http }
+            periodSeconds: 3
+            failureThreshold: 20
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 250m, memory: 128Mi }
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap: { name: $STAGING_ROUTER }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $STAGING_ROUTER
+  namespace: $STAGING_SYSTEM_NS
+spec:
+  selector: { app: $STAGING_ROUTER }
+  ports:
+    - { name: http, port: 80, targetPort: http }
+EOF
+
+  # cert-manager issues the *.lobu.ai wildcard into the prod namespace, and a
+  # TLS secret is only readable from its own namespace — copy it next to the
+  # ingress that references it.
+  kubectl -n "$WILDCARD_TLS_NS" get secret "$WILDCARD_TLS_SECRET" -o json |
+    jq --arg ns "$STAGING_SYSTEM_NS" \
+      '{apiVersion, kind, type, data, metadata: {name: .metadata.name, namespace: $ns}}' |
+    kubectl apply -f -
+
+  # `--ignore-not-found` distinguishes first-run absence (success with no body)
+  # from an API read failure. Only real absence may initialize the annotations;
+  # a transient read error must not overwrite a live owner with bootstrap state.
+  local ingress_json owner target
+  ingress_json="$(
+    kubectl -n "$STAGING_SYSTEM_NS" get ingress "$STAGING_INGRESS" \
+      -o json --ignore-not-found
+  )" || fail "could not read the current staging Ingress"
+  if [ -n "$ingress_json" ]; then
+    owner="$(jq -r '.metadata.annotations["lobu.ai/staging-owner"] // "none"' <<<"$ingress_json")"
+    target="$(jq -r '.metadata.annotations["lobu.ai/staging-target"] // "offline"' <<<"$ingress_json")"
+  else
+    owner=none
+    target=offline
+  fi
+
+  kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: $STAGING_INGRESS
+  namespace: $STAGING_SYSTEM_NS
+  annotations:
+    lobu.ai/staging-owner: "$owner"
+    lobu.ai/staging-target: "$target"
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: ["$STAGING_HOST"]
+      secretName: $WILDCARD_TLS_SECRET
+  rules:
+    - host: $STAGING_HOST
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: $STAGING_ROUTER
+                port: { number: 80 }
+EOF
+
+  kubectl -n "$STAGING_SYSTEM_NS" rollout status "deployment/$STAGING_ROUTER" --timeout=180s
+
+  # Two Ingresses claiming the same host leave the backend up to whichever one
+  # traefik picks, so sweep every other namespace's copy — the pre-router
+  # workflow left one there — but only once the permanent route is ready.
+  local namespaces
+  namespaces="$(
+    kubectl get ingress -A \
+      --field-selector "metadata.name=$STAGING_INGRESS" \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}'
+  )" || fail "could not list staging Ingress claims"
+  while IFS= read -r namespace; do
+    [ -z "$namespace" ] && continue
+    if [ "$namespace" != "$STAGING_SYSTEM_NS" ]; then
+      kubectl -n "$namespace" delete ingress "$STAGING_INGRESS" --ignore-not-found
+    fi
+  done <<<"$namespaces"
+}
+
+strip_other_staging_labels() {
+  local keep="${1:-}"
+  [ -n "${GH_TOKEN:-}" ] || return 0
+  # Each gh call gets its own assignment and its own `|| return 1`. Read
+  # straight from a pipe or a process substitution, this shell would take
+  # grep's status (or an empty list): a rate limit or 5xx would read as "no
+  # other PR is labelled" and leave two PRs holding `staging` while one holds
+  # the route. The explicit return is what carries that failure out: the
+  # routing callers run this inside the condition of an `if !`, where Bash
+  # disables errexit, so `-e` alone would let a gh outage pass for "nobody
+  # else holds the label" and route anyway.
+  local numbers number labels
+  numbers="$(gh pr list --state open --limit 200 --json number --jq '.[].number')" || return 1
+  while IFS= read -r number; do
+    [ -z "$number" ] && continue
+    [ -n "$keep" ] && [ "$number" = "$keep" ] && continue
+    labels="$(gh pr view "$number" --json labels --jq '.labels[].name')" || return 1
+    if printf '%s\n' "$labels" | grep -qx staging; then
+      gh pr edit "$number" --remove-label staging || return 1
+      echo "stripped staging label from PR #$number"
+    fi
+  done <<<"$numbers"
+}
+
+pr_has_staging_label() {
+  local number="$1"
+  local labels
+  [ -n "${GH_TOKEN:-}" ] || return 2
+  labels="$(gh pr view "$number" --json labels --jq '.labels[].name')" || return 2
+  printf '%s\n' "$labels" | grep -qx staging
+}
+
+# Best-effort on purpose: the commonest caller is the `closed` release, and by
+# then preview.yml has already deleted the namespace this would write to.
+restore_private_preview() {
+  local number="$1"
+  local namespace="lobu-preview-$number"
+  local name="lobu-pr-$number"
+  kubectl -n "$namespace" set env "deployment/$name" \
+    PUBLIC_GATEWAY_URL- LOBU_LOCAL_INIT_ALLOW_PROXY=1 >/dev/null 2>&1 || true
+}
+
+# Whoever holds the route is about to lose it, and its preview is still carrying
+# the public-host settings route_preview gave it. Stripping that PR's `staging`
+# label does not hand them back: the edit runs on GITHUB_TOKEN, which fires no
+# workflow run, so no owner-scoped release ever follows it.
+#
+# Reading and restoring are separate steps because they belong on opposite sides
+# of publication. set_ingress_state overwrites the annotation read here, so the
+# lookup has to happen first; the restore must not, because it hands the
+# outgoing holder LOBU_LOCAL_INIT_ALLOW_PROXY=1 back and until the route has
+# moved the public host still resolves to that preview.
+displaced_pr_holder() {
+  local keep="${1:-}"
+  local current
+  current="$(current_owner)" || return 1
+  if [[ "$current" =~ ^pr-([0-9]+)$ ]] && [ "${BASH_REMATCH[1]}" != "$keep" ]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+  return 0
+}
+
+# Empty means nothing was displaced, so callers can call this unconditionally.
+restore_displaced_preview() {
+  [ -n "${1:-}" ] || return 0
+  restore_private_preview "$1"
+}
+
+# Refuses by exiting, so both callers invoke it in a subshell: the exit has to
+# stop at that boundary or it would skip the rollback that puts the host back on
+# the offline sink.
+verify_public_target() {
+  local body=""
+  local attempt
+  for attempt in $(seq 1 20); do
+    body="$(curl -fsS --max-time 15 "https://$STAGING_HOST/api/health?staging_probe=$RUN_KEY" 2>/dev/null || true)"
+    if jq -e '.status == "healthy" and .environment != "production"' >/dev/null 2>&1 <<<"$body"; then
+      break
+    fi
+    if jq -e '.environment == "production"' >/dev/null 2>&1 <<<"$body"; then
+      fail "refusing to route staging to production"
+    fi
+    sleep 3
+  done
+  assert_non_prod_health "$body"
+
+  local metadata
+  metadata="$(curl -fsS --max-time 15 "https://$STAGING_HOST/.well-known/oauth-authorization-server")"
+  [ "$(jq -r '.issuer' <<<"$metadata")" = "https://$STAGING_HOST" ] ||
+    fail "OAuth issuer does not match https://$STAGING_HOST"
+
+  # Send the header a real client sends. The CSRF header is the LAST of
+  # assertLoopbackClient's checks, so a probe without it is refused as
+  # missing_client_header even when the forwarded-* boundary is wide open — a
+  # 403 indistinguishable from the closed-boundary one, masking exactly the
+  # open boundary this check exists to catch.
+  local local_init_status
+  local_init_status="$(
+    curl -sS --max-time 15 -o /dev/null -w '%{http_code}' \
+      -H 'X-Lobu-Client: staging-probe' \
+      -X POST "https://$STAGING_HOST/api/local-init"
+  )"
+  [ "$local_init_status" = "403" ] ||
+    fail "public /api/local-init returned $local_init_status instead of 403"
+}
+
+verify_public_offline() {
+  local response_file status body attempt
+  response_file="$(mktemp)"
+  status=""
+  body=""
+  # The router just went through a Recreate rollout, so traefik's endpoints can
+  # lag it by a second or two. Retry on the same budget as verify_public_target
+  # rather than reading that lag as a failed release.
+  for attempt in $(seq 1 20); do
+    status="$(
+      curl -sS --max-time 15 -o "$response_file" -w '%{http_code}' \
+        "https://$STAGING_HOST/api/health?staging_probe=$RUN_KEY" 2>/dev/null || true
+    )"
+    body="$(<"$response_file")"
+    [ "$status" = "503" ] && break
+    sleep 3
+  done
+  rm -f "$response_file"
+  [ "$status" = "503" ] || fail "offline staging returned HTTP $status instead of 503"
+  jq -e '.status == "offline" and .environment == "staging"' >/dev/null 2>&1 <<<"$body" ||
+    fail "offline staging returned an unexpected body: $body"
+}
+
+route_preview() {
+  [[ "$PR_NUM" =~ ^[0-9]+$ ]] || fail "preview target requires a numeric PR number"
+  # GitHub keeps only one pending job per concurrency group. A post-deploy
+  # reconcile can therefore replace an older label-event run before that run
+  # starts. Read the current label instead of trusting either event payload: the
+  # surviving job must perform the canceled acquire or scoped release, never a
+  # route-neutral no-op.
+  if pr_has_staging_label "$PR_NUM"; then
+    :
+  else
+    local label_status=$?
+    [ "$label_status" -eq 1 ] ||
+      fail "could not read the current staging label for PR #$PR_NUM"
+    echo "PR #$PR_NUM no longer has the staging label; reconciling its release"
+    route_offline
+    return 0
+  fi
+  local owner_before_prepare
+  owner_before_prepare="$(current_owner)" ||
+    fail "could not read the current staging lock owner"
+  local namespace="lobu-preview-$PR_NUM"
+  local name="lobu-pr-$PR_NUM"
+
+  local attempt
+  for attempt in $(seq 1 36); do
+    kubectl -n "$namespace" get service "$name" >/dev/null 2>&1 && break
+    echo "waiting for $namespace/$name service... ($attempt)"
+    sleep 10
+  done
+  kubectl -n "$namespace" get service "$name" >/dev/null 2>&1 ||
+    fail "preview service $namespace/$name was not found"
+
+  # preview.yml sets LOBU_LOCAL_INIT_ALLOW_PROXY=1 because a plain preview is
+  # tailnet-only; on this public host that same setting would let anyone on the
+  # internet mint an owner session (auth/routes.ts names public tunnels as the
+  # case it refuses by default). PUBLIC_GATEWAY_URL pins resolvePublicOrigin —
+  # the MCP App asset URLs — which otherwise falls back to the request URL and
+  # reads as http behind the ingress. OAuth discovery deliberately ignores it
+  # (skipEnvOverride, auth/oauth/routes.ts) and derives its issuer from the
+  # X-Forwarded-* pair the router sets, which is what verify_public_target
+  # checks.
+  local upstream="$name.$namespace.svc.cluster.local:80"
+  if ! (
+    kubectl -n "$namespace" set env "deployment/$name" \
+      LOBU_LOCAL_INIT_ALLOW_PROXY- \
+      "PUBLIC_GATEWAY_URL=https://$STAGING_HOST/lobu" &&
+      kubectl -n "$namespace" rollout status "deployment/$name" --timeout=600s &&
+      verify_non_prod_health "http://$upstream/api/health"
+  ); then
+    if [ "$owner_before_prepare" = "pr-$PR_NUM" ]; then
+      if rollback_to_offline; then
+        restore_private_preview "$PR_NUM"
+        fail "preview backend $namespace/$name never became healthy; staging rolled back to offline"
+      fi
+      fail "preview backend $namespace/$name never became healthy and offline rollback failed; public-safe settings retained"
+    fi
+    restore_private_preview "$PR_NUM"
+    fail "preview backend $namespace/$name never became healthy; private settings restored"
+  fi
+  # Same rule as route_local_tailnet: leave the current holder's label alone
+  # until the replacement target has proved healthy, or a preview that never
+  # comes up strips the label off a PR that still owns the route.
+  local displaced=''
+  if ! displaced="$(displaced_pr_holder "$PR_NUM")" ||
+    ! strip_other_staging_labels "$PR_NUM"; then
+    if [ "$owner_before_prepare" = "pr-$PR_NUM" ]; then
+      fail "could not prepare staging lock transfer; current owner retains public-safe settings"
+    fi
+    restore_private_preview "$PR_NUM"
+    fail "could not prepare staging lock transfer; private preview settings restored"
+  fi
+  if ! (
+    write_router_config preview "$upstream" &&
+      roll_router &&
+      set_ingress_state "pr-$PR_NUM" preview &&
+      cleanup_local_egress &&
+      verify_public_target
+  ); then
+    rollback_to_offline ||
+      fail "preview publication failed and offline rollback also failed"
+    restore_private_preview "$PR_NUM"
+    restore_displaced_preview "$displaced"
+    fail "preview publication failed; staging rolled back to offline"
+  fi
+  # The public host resolves to this PR now, so the outgoing holder can have its
+  # passwordless bootstrap back.
+  restore_displaced_preview "$displaced"
+
+  # preview.yml's post-deploy reconcile sets STAGING_SKIP_COMMENT: it re-points
+  # the router at a Service its own deploy just recreated, and the lock it
+  # announces is one this PR already held.
+  if [ -n "${GH_TOKEN:-}" ] && [ "${STAGING_SKIP_COMMENT:-0}" != 1 ]; then
+    # The rollout above restarted the pod and the preview's data volume is an
+    # emptyDir, so the sign-in has to happen after the lock — and from inside
+    # the pod, where the peer really is loopback.
+    gh pr comment "$PR_NUM" --body "$(printf "%s\n" \
+      "## Staging URL locked to this PR" \
+      "- **App**: https://$STAGING_HOST" \
+      "- **MCP endpoint**: https://$STAGING_HOST/mcp" \
+      "" \
+      "This host is publicly reachable, so a cloud MCP host can call it. Passwordless bootstrap is disabled on it; sign in once from inside the pod:" \
+      "" \
+      "\`\`\`" \
+      "kubectl -n $namespace exec deploy/$name -- \\" \
+      "  curl -sS -X POST -H 'X-Lobu-Client: staging-bootstrap' http://127.0.0.1:8787/api/local-init" \
+      "\`\`\`" \
+      "" \
+      "Removing the \`staging\` label takes the public host back to its offline sink.")"
+  fi
+  echo "staging locked to PR #$PR_NUM at https://$STAGING_HOST"
+}
+
+route_local_tailnet() {
+  local fqdn="${STAGING_LOCAL_TAILNET_FQDN:-}"
+  local tailnet_domain="${TAILNET_DOMAIN:-}"
+  local port="${STAGING_LOCAL_TAILNET_PORT:-}"
+  fqdn="${fqdn%.}"
+  tailnet_domain="${tailnet_domain%.}"
+  [ -n "$fqdn" ] || fail "STAGING_LOCAL_TAILNET_FQDN repository variable is required"
+  [ -n "$tailnet_domain" ] || fail "TAILNET_DOMAIN repository variable is required"
+  [[ "$port" =~ ^[0-9]+$ ]] || fail "STAGING_LOCAL_TAILNET_PORT must be numeric"
+  [ "$port" -ge 1024 ] && [ "$port" -le 65535 ] ||
+    fail "STAGING_LOCAL_TAILNET_PORT must be between 1024 and 65535"
+  if [ "$fqdn" != "$tailnet_domain" ] &&
+    [[ "$fqdn" != *."$tailnet_domain" ]]; then
+    fail "local target $fqdn is outside the configured tailnet domain"
+  fi
+
+  # The egress Service is private to the cluster, but it still reaches a
+  # developer machine. Remove it if any readiness or health check fails, and
+  # do not disturb the current staging label until the replacement target has
+  # proved healthy.
+  local upstream="$LOCAL_EGRESS_SERVICE.$STAGING_SYSTEM_NS.svc.cluster.local:$port"
+  if ! (
+    kubectl apply -f - <<EOF || exit 1
+apiVersion: v1
+kind: Service
+metadata:
+  name: $LOCAL_EGRESS_SERVICE
+  namespace: $STAGING_SYSTEM_NS
+  annotations:
+    tailscale.com/tailnet-fqdn: "$fqdn"
+spec:
+  type: ExternalName
+  externalName: placeholder.invalid
+  ports:
+    - name: http
+      protocol: TCP
+      port: $port
+      targetPort: $port
+EOF
+
+    kubectl -n "$STAGING_SYSTEM_NS" wait \
+      --for=condition=TailscaleProxyReady \
+      "service/$LOCAL_EGRESS_SERVICE" \
+      --timeout=180s || exit 1
+
+    verify_non_prod_health "http://$upstream/api/health"
+  ); then
+    cleanup_local_egress
+    fail "local tailnet target $fqdn did not become ready and healthy; cluster egress removed"
+  fi
+  local displaced=''
+  if ! displaced="$(displaced_pr_holder)" || ! strip_other_staging_labels; then
+    cleanup_local_egress
+    fail "could not prepare staging lock transfer; local egress removed"
+  fi
+  if ! (
+    write_router_config local-tailnet "$upstream" &&
+      roll_router &&
+      set_ingress_state local-tailnet local-tailnet &&
+      verify_public_target
+  ); then
+    rollback_to_offline ||
+      fail "local-tailnet publication failed and offline rollback also failed"
+    restore_displaced_preview "$displaced"
+    fail "local-tailnet publication failed; staging rolled back to offline"
+  fi
+  restore_displaced_preview "$displaced"
+  echo "staging locked to local tailnet target at https://$STAGING_HOST"
+}
+
+route_offline() {
+  # An owner scope that is not a PR number can never match the annotation, so
+  # without this a typo in the dispatch input would silently exit 0 with the
+  # public host still published.
+  [ -z "$PR_NUM" ] || [[ "$PR_NUM" =~ ^[0-9]+$ ]] ||
+    fail "offline owner scope must be a numeric PR number"
+  local displaced=''
+  if [ -n "$PR_NUM" ]; then
+    local current
+    current="$(current_owner)" ||
+      fail "could not read the current staging lock owner"
+    if [ "$current" != "pr-$PR_NUM" ]; then
+      # The public host does not resolve to this preview, so handing back its
+      # private-host settings now opens nothing.
+      restore_private_preview "$PR_NUM"
+      echo "lock owner is $current; leaving it unchanged"
+      return 0
+    fi
+    displaced="$PR_NUM"
+  else
+    # A manual force-off has no pull-request event to remove the displaced
+    # holder's label either. Queued unlabeled events remain harmless because
+    # their owner-scoped release will observe owner=none.
+    displaced="$(displaced_pr_holder)" ||
+      fail "could not read the current staging lock owner"
+  fi
+
+  write_router_config offline
+  roll_router
+  set_ingress_state none offline
+  cleanup_local_egress
+  verify_public_offline
+  # Only now is the public host off that preview.
+  restore_displaced_preview "$displaced"
+  if [ -z "$PR_NUM" ]; then
+    strip_other_staging_labels ||
+      fail "staging is offline but its PR labels could not be cleaned up"
+  fi
+  echo "staging is offline at https://$STAGING_HOST (exact-host 503 sink)"
+}
+
+case "$TARGET" in
+  preview | local-tailnet | offline | refresh-tls) ;;
+  *) fail "target must be preview, local-tailnet, offline, or refresh-tls" ;;
+esac
+
+ensure_system_route
+
+case "$TARGET" in
+  preview) route_preview ;;
+  local-tailnet) route_local_tailnet ;;
+  offline) route_offline ;;
+  refresh-tls) echo "staging wildcard TLS secret refreshed; route unchanged" ;;
+esac


### PR DESCRIPTION
## Summary

- Keep a permanent exact-host staging ingress so production's wildcard can never absorb staging.lobu.ai.
- Route staging explicitly to a label-owned PR preview, the configured Tailscale egress service, or an exact offline 503 sink.
- Health-gate replacements, preserve and restore displaced preview settings, and fail closed on GitHub, Kubernetes, rollout, or public-verification errors.
- Treat ConfigMap update, router rollout, ingress ownership, egress cleanup, OAuth issuer, and bootstrap-boundary verification as one rollback-protected publication.
- Reconcile the router after a preview Service is recreated, without allowing stale deploy events to reclaim the public host.
- Release a labelled holder on close as well as unlabel, while filtering unrelated closes from the global queue.
- Refresh the copied wildcard TLS secret daily without changing the current route.

## Test plan

- [x] Intended five files only; branch rebased onto current `origin/main`; clean worktree and exact Owletto pointer.
- [x] `make review-fix` on the settled diff; every fixer-touched hunk re-read.
- [x] `bash scripts/lib/__tests__/staging-routing.test.sh`; `bash scripts/lib/__tests__/preview-teardown.test.sh`.
- [x] Red to green: GitHub list/view failures, unreadable ingress state, invalid cross-namespace ingress lookup, tailnet apply/readiness failure, router rollout timeout, open bootstrap, closed-holder release, scheduled TLS refresh, unset tailnet allowlist, displaced-holder restoration, stale preview reconciliation, and unhealthy replacement label preservation.
- [x] The public bootstrap probe sends `X-Lobu-Client`, so its 403 proves the loopback/proxy boundary instead of only a missing-CSRF-header refusal.
- [x] Bash syntax, shellcheck, actionlint for all touched workflows, `git diff --check`, focused routing tests, and post-rebase `make pre-pr` are green.
- [x] Live pre-merge cluster exercise: staging.lobu.ai routed through the Tailscale operator to buraks-macbook-pro-1.brill-kanyu.ts.net:10080; health reported healthy/development, OAuth issuer was staging.lobu.ai, and `/api/local-init` returned 403.
- [x] Real-cluster field selector returned exactly the `lobu-staging` namespace.

## Notes

Post-merge verification will dispatch the merged workflow to `local-tailnet`, prove the public MCP/OAuth and Kubernetes route state, then dispatch `offline` and prove the exact-host 503 sink plus egress deletion before stopping the temporary local serve.