### PR TITLE
fix: make browser draft handoffs actionable

### DIFF
--- a/db/migrations/20260821222000_notification_targets_browser_run.sql
+++ b/db/migrations/20260821222000_notification_targets_browser_run.sql
@@ -1,0 +1,106 @@
+-- Link browser-handoff notifications to the durable page-activation run whose
+-- lifecycle decides whether the external page can still be populated.
+--
+-- The request path joins this exact FK by the runs primary key. Historical
+-- handoffs are backfilled once here from their Automation parent + target URL;
+-- no growing-history search is added to Activity reads.
+--
+-- The referencing column is indexed because runs ARE deleted in bulk (the
+-- stalled-run sweep prunes 1000 terminal runs per tick), and an unindexed
+-- ON DELETE SET NULL referent makes every one of those deletes scan
+-- notification_targets.
+--
+-- transaction:false for the CONCURRENTLY index build; every statement is
+-- individually rerunnable so a partial failure can retry.
+
+-- migrate:up transaction:false
+
+ALTER TABLE public.notification_targets
+  ADD COLUMN IF NOT EXISTS browser_run_id bigint;
+
+-- Heal an INVALID carcass from a failed CONCURRENTLY build so every retry can
+-- rebuild it (same shape as 20260815230000).
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_notification_targets_browser_run_id'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_notification_targets_browser_run_id';
+  END IF;
+END
+$heal$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_targets_browser_run_id
+  ON public.notification_targets (browser_run_id)
+  WHERE browser_run_id IS NOT NULL;
+
+-- Older Social Radar notifications already point at the producing Automation
+-- run through events.run_id, and its child page-activation run stores the
+-- NORMALIZED target URL. The join below reproduces only the query/hash strip of
+-- normalizePageActivationUrl, not its trailing-slash trim or the host/default-port
+-- canonicalization the URL parser does, so this backfill is best effort: a URL
+-- those steps would have rewritten stays NULL and renders as an unlinked handoff.
+-- It cannot mislink, because both branches are exact-equality tests.
+WITH matched AS (
+  SELECT DISTINCT ON (t.event_id, t.user_id)
+    t.event_id,
+    t.user_id,
+    r.id AS browser_run_id
+  FROM public.notification_targets t
+  JOIN public.events e ON e.id = t.event_id
+  JOIN public.runs r
+    ON r.organization_id = e.organization_id
+   AND r.parent_run_id = e.run_id
+   AND r.run_type = 'action'
+   AND r.activation_kind = 'page_visit'
+   AND r.created_by_user_id = t.user_id
+   AND (
+     t.browser_url = ANY(r.activation_target_urls)
+     OR split_part(split_part(t.browser_url, '#', 1), '?', 1)
+          = ANY(r.activation_target_urls)
+   )
+  WHERE t.browser_url IS NOT NULL
+    AND t.browser_run_id IS NULL
+  ORDER BY t.event_id, t.user_id, r.id DESC
+)
+UPDATE public.notification_targets t
+SET browser_run_id = matched.browser_run_id
+FROM matched
+WHERE t.event_id = matched.event_id
+  AND t.user_id = matched.user_id
+  AND t.browser_run_id IS NULL;
+
+-- ADD CONSTRAINT has no IF NOT EXISTS. Guard it so a partial-failure rerun can
+-- safely continue after the column/index/backfill statements above.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'notification_targets_browser_run_id_fkey'
+  ) THEN
+    ALTER TABLE public.notification_targets
+      ADD CONSTRAINT notification_targets_browser_run_id_fkey
+      FOREIGN KEY (browser_run_id) REFERENCES public.runs(id) ON DELETE SET NULL
+      NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE public.notification_targets
+  VALIDATE CONSTRAINT notification_targets_browser_run_id_fkey;
+
+-- migrate:down transaction:false
+
+ALTER TABLE public.notification_targets
+  DROP CONSTRAINT IF EXISTS notification_targets_browser_run_id_fkey;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_targets_browser_run_id;
+
+ALTER TABLE public.notification_targets
+  DROP COLUMN IF EXISTS browser_run_id;

--- a/db/migrations/20260821222000_notification_targets_browser_run.sql
+++ b/db/migrations/20260821222000_notification_targets_browser_run.sql
@@ -92,8 +92,10 @@ BEGIN
   END IF;
 END $$;
 
-ALTER TABLE public.notification_targets
-  VALIDATE CONSTRAINT notification_targets_browser_run_id_fkey;
+-- Rerunnable: validating an already-valid constraint is a no-op. This migration
+-- must stay transaction:false because the index above is built CONCURRENTLY.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.notification_targets VALIDATE CONSTRAINT notification_targets_browser_run_id_fkey;
 
 -- migrate:down transaction:false
 

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -171,9 +171,11 @@ describe("social interest radar reaction", () => {
     expect(f.notifications).toHaveLength(1);
     expect(f.notifications[0]).toMatchObject({
       title: "Draft ready for Ada on LinkedIn",
+      recipients: "all",
       idempotency_key: "social-radar:draft-ready:601",
       resource_url: "/buremba/memory?content_ids=101,601",
       browser_url: "https://www.linkedin.com/feed/update/urn:li:activity:123",
+      browser_handoff_run_id: 900,
     });
     expect(f.notifications[0]).not.toHaveProperty("input_schema");
     expect(String(f.notifications[0]?.body)).toContain(

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -338,7 +338,10 @@ export default async (
         "",
         "Open the post in Chrome and Lobu will place this draft in the composer. You still choose whether to post it.",
       ]),
-      recipients: "admins",
+      // Page activation belongs to the connection's visibility user, who may
+      // not be an admin. "all" lets notify resolve that owner, then its handoff
+      // guard narrows delivery back to that single actionable recipient.
+      recipients: "all",
       resource_url: `/${encodeURIComponent(ctx.organization_slug)}/memory?content_ids=${[
         sourceEventId,
         draft.id,
@@ -346,6 +349,7 @@ export default async (
         .filter((id) => Number.isSafeInteger(id) && id > 0)
         .join(",")}`,
       browser_url: targetUrl,
+      browser_handoff_run_id: result.run_id,
       idempotency_key: `social-radar:draft-ready:${draft.id}`,
       automation_source: automationSource,
     });

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2145,7 +2145,7 @@ export type ManageConnectionsData = {
       }
     | {
         /**
-         * Probe a connection's credentials/token validity.
+         * Probe a connection's credentials/token validity and required selected-device availability.
          */
         action: "test";
         /**
@@ -3915,6 +3915,12 @@ export type ManageOperationsResponses = {
           unread?: boolean;
           notification_id?: number;
           browser_url?: string;
+          browser_handoff?: {
+            run_id: number | null;
+            state: "ready" | "expired" | "completed";
+            expires_at: string | null;
+            error_message: string | null;
+          };
           run_id?: number;
           interaction_type?: string;
           interaction_status?: string;
@@ -3995,6 +4001,10 @@ export type NotifyData = {
      * HTTP(S) page for an explicit browser-side "Open" action in the current user tab.
      */
     browser_url?: string;
+    /**
+     * Page-activated operation run that will populate browser_url when its owner visits the page. The run must belong to the same workspace, target the same normalized URL, and be owned by one of the resolved recipients; delivery then narrows to that owner, since nobody else can activate it.
+     */
+    browser_handoff_run_id?: number;
     /**
      * Stable producer key. Repeating a send with the same key returns success without creating or delivering a duplicate.
      */

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -124,6 +124,8 @@ export interface NotificationsSendInput {
   resource_url?: string;
   /** HTTP(S) page a browser-side notification action should open in the current user tab. */
   browser_url?: string;
+  /** Page-activated operation run that will populate browser_url when visited. */
+  browser_handoff_run_id?: number;
   /** Stable producer key used to collapse retried sends. */
   idempotency_key?: string;
   /** Deliver only through this specific bot connection (its id). */

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -416,6 +416,18 @@ export const ManageOperationsResultSchema = Type.Union([
         unread: Type.Optional(Type.Boolean()),
         notification_id: Type.Optional(Type.Integer()),
         browser_url: Type.Optional(Type.String()),
+        browser_handoff: Type.Optional(
+          Type.Object({
+            run_id: Type.Union([Type.Integer(), Type.Null()]),
+            state: Type.Union([
+              Type.Literal("ready"),
+              Type.Literal("expired"),
+              Type.Literal("completed"),
+            ]),
+            expires_at: Type.Union([Type.String(), Type.Null()]),
+            error_message: Type.Union([Type.String(), Type.Null()]),
+          })
+        ),
         run_id: Type.Optional(Type.Integer()),
         /**
          * Kind of pending interaction behind this notification (events

--- a/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
@@ -12,9 +12,9 @@
  *   - Requesting a superseded id returns its WHOLE lineage (pending → executing
  *     → completed), not a 404 and not just the head — the caller sees what
  *     happened.
- *   - Run/operation chains resolve via the shared `run_id` (the run arm).
- *   - run_id-less chains (e.g. an edited note) resolve by walking
- *     `superseded_by` / `supersedes_event_id` (the walk arm).
+ *   - Every chain resolves by walking explicit `superseded_by` /
+ *     `supersedes_event_id` edges. A shared `run_id` is not lineage: connector
+ *     feed runs can contain many unrelated items.
  *   - Requesting two ids from the same chain does not double-return it.
  *
  * Vitest CI gap note (mirrors neighbors): runs locally / in the CI integration
@@ -97,7 +97,7 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     } as ToolContext;
   });
 
-  it('run arm: a superseded permalink id returns the whole run chain (pending→executing→completed)', async () => {
+  it('a superseded permalink id returns its whole explicit chain (pending→executing→completed)', async () => {
     const sql = getTestDb();
     const [run] = await sql<{ id: number }[]>`
       INSERT INTO runs (run_type, status, organization_id)
@@ -151,7 +151,42 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     expect(byId.get(completed)?.is_superseded).toBe(false);
   });
 
-  it('walk arm: a run_id-less superseded id resolves via superseded_by/supersedes_event_id', async () => {
+  it('does not expand one content permalink to unrelated events from the same feed run', async () => {
+    const sql = getTestDb();
+    const [run] = await sql<{ id: number }[]>`
+      INSERT INTO runs (run_type, status, organization_id)
+      VALUES ('sync', 'completed', ${org.id}) RETURNING id`;
+    const runId = Number(run.id);
+    const t0 = new Date('2026-07-01T01:00:00Z');
+
+    const requested = await insertChainRow({
+      organizationId: org.id,
+      title: 'tweet requested by permalink',
+      content: 'requested tweet',
+      runId,
+      occurredAt: t0,
+    });
+    const unrelated = await insertChainRow({
+      organizationId: org.id,
+      title: 'different tweet in the same sync batch',
+      content: 'unrelated tweet',
+      runId,
+      occurredAt: new Date(t0.getTime() + 1000),
+    });
+
+    const result = await getContent(
+      { content_ids: [requested], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+
+    expect(result.content.map((item) => item.id)).toEqual([requested]);
+    expect(result.content.map((item) => item.id)).not.toContain(unrelated);
+    expect(result.total).toBe(1);
+    expect(result.chain_total).toBe(1);
+  });
+
+  it('a run_id-less superseded id resolves via superseded_by/supersedes_event_id', async () => {
     const t0 = new Date('2026-07-02T00:00:00Z');
     const v1 = await insertChainRow({
       organizationId: org.id,
@@ -184,7 +219,7 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     expect(walkById.get(v2)?.is_superseded).toBe(false);
   });
 
-  it('walk arm: entering from the HEAD id still returns the full history (backward walk)', async () => {
+  it('entering from the HEAD id still returns the full history (backward walk)', async () => {
     const t0 = new Date('2026-07-04T00:00:00Z');
     const v1 = await insertChainRow({
       organizationId: org.id,

--- a/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getDb } from "../../../db/client";
 import {
 	executeMigrationSection,
+	loadMigrationDown,
 	loadMigrationUp,
 } from "../../../db/migration-loader";
 import { initWorkspaceProvider } from "../../../workspace";
@@ -87,7 +88,15 @@ const HEAL_MIGRATIONS = [
 		index: "idx_events_org_origin",
 		seedSql: `
       CREATE INDEX IF NOT EXISTS idx_events_org_origin
-        ON events (id)
+			ON events (id)
+    `,
+	},
+	{
+		files: ["20260821222000_notification_targets_browser_run.sql"],
+		index: "idx_notification_targets_browser_run_id",
+		seedSql: `
+      CREATE INDEX IF NOT EXISTS idx_notification_targets_browser_run_id
+        ON notification_targets (event_id)
     `,
 	},
 ] as const;
@@ -139,17 +148,21 @@ describe("INVALID concurrent-index heal in transaction:false migrations", () => 
 		await cleanupTestDatabase();
 	});
 
-	it.each(HEAL_MIGRATIONS)(
-		"replays $files over an INVALID $index and leaves a VALID index",
-		async ({ files, index, seedSql }) => {
-			const migrationsDir = resolveMigrationsDir();
-			const sql = getDb();
+	it.each(
+		HEAL_MIGRATIONS,
+	)("replays $files over an INVALID $index and leaves a VALID index", async ({
+		files,
+		index,
+		seedSql,
+	}) => {
+		const migrationsDir = resolveMigrationsDir();
+		const sql = getDb();
 
-			// Drop any live index from prior suite setup, then seed a same-named
-			// INVALID carcass the way a crashed CREATE INDEX CONCURRENTLY would.
-			await sql.unsafe(`DROP INDEX IF EXISTS public.${index}`);
-			await sql.unsafe(seedSql);
-			await sql.unsafe(`
+		// Drop any live index from prior suite setup, then seed a same-named
+		// INVALID carcass the way a crashed CREATE INDEX CONCURRENTLY would.
+		await sql.unsafe(`DROP INDEX IF EXISTS public.${index}`);
+		await sql.unsafe(seedSql);
+		await sql.unsafe(`
         UPDATE pg_index
         SET indisvalid = false
         WHERE indexrelid = (
@@ -161,22 +174,76 @@ describe("INVALID concurrent-index heal in transaction:false migrations", () => 
         )
       `);
 
-			const before = await indexValidity(index);
-			expect(before).toEqual({ exists: true, valid: false });
+		const before = await indexValidity(index);
+		expect(before).toEqual({ exists: true, valid: false });
 
-			// Apply the pair in order: the companion heal migration drops the
-			// INVALID carcass, then the transaction:false migration rebuilds it
-			// CONCURRENTLY. Statement-at-a-time mirrors the runtime runner.
-			for (const file of files) {
-				const up = loadMigrationUp(migrationsDir, file);
-				await executeMigrationSection(
-					(statement) => sql.unsafe(statement),
-					up,
-				);
-			}
+		// Apply the pair in order: the companion heal migration drops the
+		// INVALID carcass, then the transaction:false migration rebuilds it
+		// CONCURRENTLY. Statement-at-a-time mirrors the runtime runner.
+		for (const file of files) {
+			const up = loadMigrationUp(migrationsDir, file);
+			await executeMigrationSection((statement) => sql.unsafe(statement), up);
+		}
 
-			const after = await indexValidity(index);
-			expect(after).toEqual({ exists: true, valid: true });
-		},
-	);
+		const after = await indexValidity(index);
+		expect(after).toEqual({ exists: true, valid: true });
+	});
+
+	it("round-trips the notification browser-run column, index, and foreign key", async () => {
+		const migrationsDir = resolveMigrationsDir();
+		const file = "20260821222000_notification_targets_browser_run.sql";
+		const sql = getDb();
+		const execute = (statement: string) => sql.unsafe(statement);
+
+		await executeMigrationSection(
+			execute,
+			loadMigrationDown(migrationsDir, file),
+		);
+
+		const [afterDown] = await sql<{
+			column_exists: boolean;
+			index_exists: boolean;
+		}>`
+			SELECT
+				EXISTS (
+					SELECT 1 FROM information_schema.columns
+					WHERE table_schema = 'public'
+					  AND table_name = 'notification_targets'
+					  AND column_name = 'browser_run_id'
+				) AS column_exists,
+				to_regclass('public.idx_notification_targets_browser_run_id') IS NOT NULL
+					AS index_exists
+		`;
+		expect(afterDown).toEqual({ column_exists: false, index_exists: false });
+
+		await executeMigrationSection(
+			execute,
+			loadMigrationUp(migrationsDir, file),
+		);
+
+		const [afterUp] = await sql<{
+			column_exists: boolean;
+			index_exists: boolean;
+			foreign_key_exists: boolean;
+		}>`
+			SELECT
+				EXISTS (
+					SELECT 1 FROM information_schema.columns
+					WHERE table_schema = 'public'
+					  AND table_name = 'notification_targets'
+					  AND column_name = 'browser_run_id'
+				) AS column_exists,
+				to_regclass('public.idx_notification_targets_browser_run_id') IS NOT NULL
+					AS index_exists,
+				EXISTS (
+					SELECT 1 FROM pg_constraint
+					WHERE conname = 'notification_targets_browser_run_id_fkey'
+				) AS foreign_key_exists
+		`;
+		expect(afterUp).toEqual({
+			column_exists: true,
+			index_exists: true,
+			foreign_key_exists: true,
+		});
+	});
 });

--- a/packages/server/src/__tests__/integration/page-activation.test.ts
+++ b/packages/server/src/__tests__/integration/page-activation.test.ts
@@ -1,12 +1,15 @@
 import { Hono } from "hono";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
+import { restRecreateBrowserHandoff } from "../../notifications/routes";
 import {
 	createNotificationForUsers,
 	listNotifications,
 } from "../../notifications/service";
 import { createConnectorOperationRun } from "../../runs/queue-service";
 import { listOrgActivity } from "../../tools/admin/manage_operations/activity-feed";
+import { notify } from "../../tools/admin/notify";
+import type { ToolContext } from "../../tools/registry";
 import { dispatchChromeActionToExtension } from "../../worker-api/dispatch-chrome-action";
 import { activatePageRun } from "../../worker-api/page-activation";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
@@ -29,6 +32,14 @@ async function seed() {
 		name: "X",
 		organization_id: org.id,
 	});
+	await sql`
+		UPDATE connector_definitions
+		SET actions_schema = ${sql.json({
+			prepare_reply: { name: "Prepare reply", kind: "write" },
+		})}
+		WHERE organization_id = ${org.id}
+		  AND key = 'x'
+	`;
 	await sql`
 		INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
 		VALUES (${`member-${Date.now()}`}, ${org.id}, ${user.id}, 'owner', NOW())
@@ -72,9 +83,15 @@ function appFor(userId: string, orgId: string) {
 		c.set("workerAuthMode", "user");
 		c.set("workerUserId", userId);
 		c.set("workerOrgIds", [orgId]);
+		c.set("organizationId", orgId);
+		c.set("user", { id: userId } as never);
 		await next();
 	});
 	app.post("/activate", activatePageRun);
+	app.post(
+		"/notifications/:id/browser-handoff/recreate",
+		restRecreateBrowserHandoff,
+	);
 	return app;
 }
 
@@ -396,14 +413,41 @@ describe("page-activated operation runs", () => {
 
 	it("carries the browser action URL through notifications and the shared activity feed", async () => {
 		const seeded = await seed();
-		await createNotificationForUsers([seeded.user.id], {
+		const ctx = {
 			organizationId: seeded.org.id,
-			type: "agent_message",
-			title: "Draft ready for Ada on X",
-			body: "Draft: Hello",
-			resourceUrl: `/${seeded.org.slug}/memory?content_ids=1`,
-			browserUrl: "https://x.com/ada/status/123",
-		});
+			userId: seeded.user.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: false,
+			allowCrossOrg: true,
+			scopes: ["mcp:admin"],
+			sourceContext: null,
+		} as ToolContext;
+		await expect(
+			notify(
+				{
+					action: "send",
+					title: "Mismatched draft",
+					browser_url: "https://x.com/home",
+					browser_handoff_run_id: seeded.run.id,
+				},
+				{} as never,
+				ctx,
+			),
+		).rejects.toThrow("must match the linked page-activation run");
+		const createdNotification = (await notify(
+			{
+				action: "send",
+				title: "Draft ready for Ada on X",
+				body: "Draft: Hello",
+				resource_url: `/${seeded.org.slug}/memory?content_ids=1`,
+				browser_url: "https://x.com/ada/status/123",
+				browser_handoff_run_id: seeded.run.id,
+			},
+			{} as never,
+			ctx,
+		)) as { event_id: number };
 		const listed = await listNotifications({
 			organizationId: seeded.org.id,
 			userId: seeded.user.id,
@@ -411,6 +455,10 @@ describe("page-activated operation runs", () => {
 		expect(listed.notifications[0]?.browser_url).toBe(
 			"https://x.com/ada/status/123",
 		);
+		expect(listed.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: seeded.run.id,
+			state: "ready",
+		});
 		const activity = await listOrgActivity({
 			organizationId: seeded.org.id,
 			userId: seeded.user.id,
@@ -418,6 +466,136 @@ describe("page-activated operation runs", () => {
 			includeRuns: false,
 		});
 		expect(activity.items[0]?.browser_url).toBe("https://x.com/ada/status/123");
+		expect(activity.items[0]?.browser_handoff).toMatchObject({
+			run_id: seeded.run.id,
+			state: "ready",
+		});
+
+		await sql`
+			UPDATE runs
+			SET status = 'failed',
+			    error_message = 'Composer controls changed',
+			    activated_at = NOW(),
+			    activated_by_device_worker_id = ${seeded.workers[0]?.id}::uuid,
+			    activation_tab_id = 17,
+			    completed_at = NOW(),
+			    expires_at = NOW() - interval '1 minute'
+			WHERE id = ${seeded.run.id}
+		`;
+		const expired = await listNotifications({
+			organizationId: seeded.org.id,
+			userId: seeded.user.id,
+		});
+		expect(expired.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: seeded.run.id,
+			state: "expired",
+			error_message: "Composer controls changed",
+		});
+
+		const recreatePath = `/notifications/${createdNotification.event_id}/browser-handoff/recreate`;
+		const recreateApp = appFor(seeded.user.id, seeded.org.id);
+		const recreateResponses = await Promise.all([
+			recreateApp.request(recreatePath, { method: "POST" }),
+			recreateApp.request(recreatePath, { method: "POST" }),
+		]);
+		expect(recreateResponses.map((response) => response.status)).toEqual([
+			200, 200,
+		]);
+		const recreatedResults = (await Promise.all(
+			recreateResponses.map((response) => response.json()),
+		)) as Array<{
+			browser_url: string;
+			browser_handoff: { run_id: number; state: string };
+		}>;
+		expect(recreatedResults[1]?.browser_handoff.run_id).toBe(
+			recreatedResults[0]?.browser_handoff.run_id,
+		);
+		const recreated = recreatedResults[0]!;
+		expect(recreated).toMatchObject({
+			browser_url: "https://x.com/ada/status/123",
+			browser_handoff: { state: "ready" },
+		});
+		expect(recreated.browser_handoff.run_id).not.toBe(seeded.run.id);
+		const [target] = await sql<{ browser_run_id: number }>`
+			SELECT browser_run_id
+			FROM notification_targets
+			WHERE event_id = ${createdNotification.event_id}
+			  AND user_id = ${seeded.user.id}
+		`;
+		expect(target?.browser_run_id).toBe(recreated.browser_handoff.run_id);
+		const recreatedList = await listNotifications({
+			organizationId: seeded.org.id,
+			userId: seeded.user.id,
+		});
+		expect(recreatedList.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: recreated.browser_handoff.run_id,
+			state: "ready",
+		});
+
+		await sql`
+			UPDATE runs
+			SET status = 'running',
+			    activated_at = NOW(),
+			    activated_by_device_worker_id = ${seeded.workers[0]?.id}::uuid,
+			    activation_tab_id = 29
+			WHERE id = ${recreated.browser_handoff.run_id}
+		`;
+		const completedList = await listNotifications({
+			organizationId: seeded.org.id,
+			userId: seeded.user.id,
+		});
+		expect(completedList.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: recreated.browser_handoff.run_id,
+			state: "completed",
+		});
+		const completedResponse = await appFor(
+			seeded.user.id,
+			seeded.org.id,
+		).request(
+			`/notifications/${createdNotification.event_id}/browser-handoff/recreate`,
+			{ method: "POST" },
+		);
+		expect(completedResponse.status).toBe(409);
+		await expect(completedResponse.json()).resolves.toMatchObject({
+			error: expect.stringContaining("already activated"),
+		});
+	});
+
+	it("reports a browser handoff with no linked run as expired, with nothing to retry", async () => {
+		const seeded = await seed();
+		const created = await createNotificationForUsers([seeded.user.id], {
+			organizationId: seeded.org.id,
+			type: "agent_message",
+			title: "Draft ready for Ada on X",
+			body: "Draft: Hello",
+			browserUrl: "https://x.com/ada/status/123",
+		});
+		const listed = await listNotifications({
+			organizationId: seeded.org.id,
+			userId: seeded.user.id,
+		});
+		expect(listed.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: null,
+			state: "expired",
+		});
+		// There is no saved action input to rebuild from, so the state's message
+		// must not offer a recreate the endpoint can only answer with 404.
+		expect(
+			String(
+				(listed.notifications[0]?.browser_handoff as { error_message: string })
+					.error_message,
+			),
+		).not.toMatch(/recreate/i);
+		if (created.eventId == null)
+			throw new Error("Notification was not created");
+		const missingResponse = await appFor(seeded.user.id, seeded.org.id).request(
+			`/notifications/${created.eventId}/browser-handoff/recreate`,
+			{ method: "POST" },
+		);
+		expect(missingResponse.status).toBe(404);
+		await expect(missingResponse.json()).resolves.toEqual({
+			error: "Browser handoff not found.",
+		});
 	});
 
 	it("keeps an undismissed browser-handoff draft beyond the recent-window cap", async () => {
@@ -458,9 +636,11 @@ describe("page-activated operation runs", () => {
 			includeRuns: false,
 			limit: 50,
 		});
-		expect(activity.items.some((item) => item.browser_url === "https://x.com/ada/status/123")).toBe(
-			true,
-		);
+		expect(
+			activity.items.some(
+				(item) => item.browser_url === "https://x.com/ada/status/123",
+			),
+		).toBe(true);
 		// Respects the declared limit even when the undismissed draft is pinned.
 		expect(activity.items.length).toBeLessThanOrEqual(50);
 		// Items stay in chronological order (oldest first).
@@ -492,9 +672,11 @@ describe("page-activated operation runs", () => {
 			kinds: ["sync"],
 			limit: 50,
 		});
-		expect(activity.items.some((item) => item.browser_url === "https://x.com/ada/status/123")).toBe(
-			false,
-		);
+		expect(
+			activity.items.some(
+				(item) => item.browser_url === "https://x.com/ada/status/123",
+			),
+		).toBe(false);
 	});
 
 	it("pins a draft that sits inside the window but outside the final limit", async () => {
@@ -526,9 +708,11 @@ describe("page-activated operation runs", () => {
 			includeRuns: false,
 			limit: 24,
 		});
-		expect(activity.items.some((item) => item.browser_url === "https://x.com/ada/status/123")).toBe(
-			true,
-		);
+		expect(
+			activity.items.some(
+				(item) => item.browser_url === "https://x.com/ada/status/123",
+			),
+		).toBe(true);
 		expect(activity.items.length).toBeLessThanOrEqual(24);
 	});
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -87,6 +87,7 @@ import {
 	restListNotifications,
 	restMarkAllAsRead,
 	restMarkAsRead,
+	restRecreateBrowserHandoff,
 } from "./notifications/routes";
 import { createPreviewClaim } from "./preview/slack";
 import {
@@ -1148,6 +1149,11 @@ app.get(
 	restGetUnreadCount,
 );
 app.patch("/api/:orgSlug/notifications/:id/read", mcpAuth, restMarkAsRead);
+app.post(
+	"/api/:orgSlug/notifications/:id/browser-handoff/recreate",
+	mcpAuth,
+	restRecreateBrowserHandoff,
+);
 app.post(
 	"/api/:orgSlug/notifications/mark-all-read",
 	mcpAuth,

--- a/packages/server/src/notifications/browser-handoff.ts
+++ b/packages/server/src/notifications/browser-handoff.ts
@@ -1,0 +1,258 @@
+import { compileConnectionRowVisibility } from "../authz/connection-visibility";
+import { getDb, parsePgTextArray } from "../db/client";
+import { emit } from "../events/emitter";
+import { resolveActionMode } from "../operations/action-modes";
+import { getOperationForConnection } from "../operations/connector-operations";
+import { validateOperationInput } from "../operations/input-validation";
+import { DEFAULT_PAGE_ACTIVATION_SECONDS } from "../runs/page-activation";
+import { createConnectorOperationRun } from "../runs/queue-service";
+import { ToolUserError } from "../utils/errors";
+
+type HandoffSource = {
+	event_id: number;
+	browser_url: string;
+	browser_run_id: number;
+	connection_id: number;
+	connector_key: string;
+	action_key: string;
+	action_input: Record<string, unknown> | null;
+	automation_id: number | null;
+	parent_run_id: number | null;
+	status: string;
+	approval_status: string;
+	activation_kind: string | null;
+	activation_target_urls: string | string[] | null;
+	activated_at: Date | string | null;
+	expires_at: Date | string | null;
+};
+
+async function loadHandoffSource(
+	organizationId: string,
+	userId: string,
+	eventId: number,
+): Promise<HandoffSource> {
+	const sql = getDb();
+	const visibility = compileConnectionRowVisibility(
+		{ organizationId, principal: userId },
+		"c",
+	);
+	let query = sql`
+		SELECT
+			t.event_id,
+			t.browser_url,
+			t.browser_run_id,
+			r.connection_id,
+			r.connector_key,
+			r.action_key,
+			r.action_input,
+			r.automation_id,
+			r.parent_run_id,
+			r.status,
+			r.approval_status,
+			r.activation_kind,
+			r.activation_target_urls,
+			r.activated_at,
+			r.expires_at
+		FROM notification_targets t
+		JOIN events e
+		  ON e.id = t.event_id
+		 AND e.organization_id = ${organizationId}
+		JOIN runs r
+		  ON r.id = t.browser_run_id
+		 AND r.organization_id = e.organization_id
+		JOIN connections c
+		  ON c.id = r.connection_id
+		 AND c.organization_id = e.organization_id
+		 AND c.deleted_at IS NULL
+		WHERE t.event_id = ${eventId}
+		  AND t.user_id = ${userId}
+		  AND t.browser_url IS NOT NULL
+		  AND r.created_by_user_id = ${userId}
+	`;
+	query = sql`${query} ${sql.unsafe(visibility)} LIMIT 1`;
+	const rows = (await query) as unknown as HandoffSource[];
+	const source = rows[0];
+	if (!source) {
+		throw new ToolUserError("Browser handoff not found.", 404);
+	}
+	return source;
+}
+
+function isReady(source: HandoffSource): boolean {
+	return (
+		source.status === "pending" &&
+		source.approval_status === "auto" &&
+		source.activation_kind === "page_visit" &&
+		source.activated_at == null &&
+		source.expires_at != null &&
+		new Date(source.expires_at).getTime() > Date.now()
+	);
+}
+
+function isFailed(source: HandoffSource): boolean {
+	return source.status === "failed" || source.status === "timeout";
+}
+
+/**
+ * Recreate an expired page-activation run from the exact notification the
+ * signed-in owner clicked. The target row is the serialization point: two app
+ * replicas racing the same click either reuse the newly-ready run or converge
+ * through the per-old-run idempotency key.
+ */
+export async function recreateBrowserHandoff(
+	organizationId: string,
+	userId: string,
+	eventId: number,
+	attempt = 0,
+): Promise<{
+	browser_url: string;
+	browser_handoff: {
+		run_id: number;
+		state: "ready";
+		expires_at: string;
+		error_message: null;
+	};
+}> {
+	const source = await loadHandoffSource(organizationId, userId, eventId);
+	if (isReady(source)) {
+		return {
+			browser_url: source.browser_url,
+			browser_handoff: {
+				run_id: source.browser_run_id,
+				state: "ready",
+				expires_at: new Date(source.expires_at!).toISOString(),
+				error_message: null,
+			},
+		};
+	}
+	if (
+		!isFailed(source) &&
+		(source.status === "completed" || source.activated_at != null)
+	) {
+		throw new ToolUserError(
+			"This draft handoff was already activated. Open the existing browser tab or dismiss the card.",
+			409,
+		);
+	}
+	if (
+		source.activation_kind !== "page_visit" ||
+		source.approval_status !== "auto" ||
+		!source.action_input
+	) {
+		throw new ToolUserError(
+			"This notification is not a recreatable page-activated draft.",
+			409,
+		);
+	}
+
+	const resolved = await getOperationForConnection(
+		organizationId,
+		source.connection_id,
+		source.action_key,
+	);
+	if (!resolved || resolved.connection.status !== "active") {
+		throw new ToolUserError(
+			"The connector for this draft is no longer available.",
+			409,
+		);
+	}
+	if (
+		resolved.operation.backend !== "local_action" ||
+		resolveActionMode(resolved.operation, resolved.connection.config) !== "auto"
+	) {
+		throw new ToolUserError(
+			"This draft action is no longer enabled for automatic page activation.",
+			409,
+		);
+	}
+	const validationError = validateOperationInput(
+		resolved.operation,
+		source.action_input,
+	);
+	if (validationError) {
+		throw new ToolUserError(
+			`This saved draft no longer matches the connector action: ${validationError}`,
+			409,
+		);
+	}
+	const activationUrls = parsePgTextArray(source.activation_target_urls);
+	if (activationUrls.length === 0) {
+		throw new ToolUserError("This draft has no page-activation target.", 409);
+	}
+
+	const sql = getDb();
+	const result = await sql.begin(async (tx) => {
+		const locked = await tx<{
+			browser_run_id: number | null;
+		}>`
+			SELECT browser_run_id
+			FROM notification_targets
+			WHERE event_id = ${eventId}
+			  AND user_id = ${userId}
+			FOR UPDATE
+		`;
+		if (locked.length === 0) {
+			throw new ToolUserError("Browser handoff not found.", 404);
+		}
+		if (locked[0]?.browser_run_id !== source.browser_run_id) {
+			return null;
+		}
+		const created = await createConnectorOperationRun({
+			organizationId,
+			connectionId: source.connection_id,
+			connectorKey: source.connector_key,
+			operationKey: source.action_key,
+			operationInput: source.action_input!,
+			approvalMode: "inline",
+			activation: {
+				kind: "page_visit",
+				urls: activationUrls,
+				expiresInSeconds: DEFAULT_PAGE_ACTIVATION_SECONDS,
+			},
+			requireCompiledCode: true,
+			createdByUserId: userId,
+			automationId: source.automation_id,
+			parentRunId: source.parent_run_id,
+			idempotencyKey: `notification-browser-handoff:${eventId}:retry:${source.browser_run_id}`,
+			db: tx,
+		});
+		await tx`
+			UPDATE notification_targets
+			SET browser_run_id = ${created.runId}
+			WHERE event_id = ${eventId}
+			  AND user_id = ${userId}
+		`;
+		const [newRun] = await tx<{ id: number; expires_at: Date | string }>`
+			SELECT id, expires_at
+			FROM runs
+			WHERE id = ${created.runId}
+		`;
+		if (!newRun?.expires_at) {
+			throw new Error("Recreated browser handoff has no expiry.");
+		}
+		return newRun;
+	});
+
+	if (result === null) {
+		// A concurrent click already swapped browser_run_id: re-read and settle on
+		// whatever that request created. Bounded so a pathological swap loop fails
+		// the request instead of spinning it.
+		if (attempt >= 3) {
+			throw new ToolUserError(
+				"This draft handoff is being recreated by another request. Reload and try again.",
+				409,
+			);
+		}
+		return recreateBrowserHandoff(organizationId, userId, eventId, attempt + 1);
+	}
+	emit(organizationId, { keys: ["notifications", "activity-feed"] });
+	return {
+		browser_url: source.browser_url,
+		browser_handoff: {
+			run_id: result.id,
+			state: "ready",
+			expires_at: new Date(result.expires_at).toISOString(),
+			error_message: null,
+		},
+	};
+}

--- a/packages/server/src/notifications/routes.ts
+++ b/packages/server/src/notifications/routes.ts
@@ -1,6 +1,9 @@
 import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { Env } from '../index';
+import { ToolUserError, parsePositiveIntegerId } from '../utils/errors';
 import { requireOrgUser } from '../utils/require-org-user';
+import { recreateBrowserHandoff } from './browser-handoff';
 import {
   deleteNotification,
   getUnreadCount,
@@ -90,4 +93,27 @@ export async function restDeleteNotification(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'Not found' }, 404);
   }
   return c.json({ success: true });
+}
+
+export async function restRecreateBrowserHandoff(c: Context<{ Bindings: Env }>) {
+  const auth = requireOrgUser(c);
+  if (!auth) return c.json({ error: 'Unauthorized' }, 401);
+
+  try {
+    const id = parsePositiveIntegerId(c.req.param('id') ?? '', 'notification id');
+    const result = await recreateBrowserHandoff(
+      auth.organizationId,
+      auth.userId,
+      id
+    );
+    return c.json(result);
+  } catch (error) {
+    if (error instanceof ToolUserError) {
+      return c.json(
+        { error: error.message },
+        error.httpStatus as ContentfulStatusCode
+      );
+    }
+    throw error;
+  }
 }

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -63,6 +63,8 @@ interface CreateNotificationParams {
 	resourceId?: string | null;
 	resourceUrl?: string | null;
 	browserUrl?: string | null;
+	/** Page-activated action run that makes browserUrl actionable. */
+	browserRunId?: number | null;
 	/** Stable producer key used to collapse retried notification sends. */
 	idempotencyKey?: string | null;
 	/** When set, deliver only through this specific bot connection */
@@ -837,6 +839,7 @@ export async function createNotificationForUsers(
 		resource_id: params.resourceId ?? null,
 		resource_url: params.resourceUrl ?? null,
 		browser_url: params.browserUrl ?? null,
+		browser_handoff_run_id: params.browserRunId ?? null,
 		// Persisted, not just handed to the fan-out: the card IS the notification's
 		// rendered form, and a connection that was offline at send time (or a
 		// surface that renders it later) has no other way to recover it.
@@ -891,8 +894,8 @@ export async function createNotificationForUsers(
 			);
 
 			await tx`
-      INSERT INTO notification_targets (event_id, user_id, browser_url)
-      SELECT ${event.id}, uid, ${params.browserUrl ?? null}
+      INSERT INTO notification_targets (event_id, user_id, browser_url, browser_run_id)
+      SELECT ${event.id}, uid, ${params.browserUrl ?? null}, ${params.browserRunId ?? null}
       FROM unnest(${pgTextArray(userIds)}::text[]) AS u(uid)
       ON CONFLICT DO NOTHING
     `;
@@ -965,6 +968,53 @@ export async function listNotifications(opts: {
       e.metadata->>'resource_id' AS resource_id,
       e.metadata->>'resource_url' AS resource_url,
       t.browser_url AS browser_url,
+      CASE
+        WHEN t.browser_url IS NULL THEN NULL
+        -- No linked run: nothing to recreate from, so the message must not
+        -- promise a retry the recreate endpoint would answer with 404.
+        WHEN browser_run.id IS NULL THEN jsonb_build_object(
+          'run_id', NULL,
+          'state', 'expired',
+          'expires_at', NULL,
+          'error_message', 'This browser handoff is no longer linked to a draft. Open the page yourself, or ask for a fresh draft.'
+        )
+        WHEN browser_run.status IN ('failed', 'timeout') THEN
+          jsonb_build_object(
+            'run_id', browser_run.id,
+            'state', 'expired',
+            'expires_at', browser_run.expires_at,
+            'error_message', COALESCE(
+              browser_run.error_message,
+              'The browser draft could not be populated. Recreate it to try again.'
+            )
+          )
+        WHEN browser_run.status = 'completed' OR browser_run.activated_at IS NOT NULL THEN
+          jsonb_build_object(
+            'run_id', browser_run.id,
+            'state', 'completed',
+            'expires_at', browser_run.expires_at,
+            'error_message', NULL
+          )
+        WHEN browser_run.status = 'pending'
+          AND browser_run.approval_status = 'auto'
+          AND browser_run.activation_kind = 'page_visit'
+          AND browser_run.expires_at > current_timestamp THEN
+          jsonb_build_object(
+            'run_id', browser_run.id,
+            'state', 'ready',
+            'expires_at', browser_run.expires_at,
+            'error_message', NULL
+          )
+        ELSE jsonb_build_object(
+          'run_id', browser_run.id,
+          'state', 'expired',
+          'expires_at', browser_run.expires_at,
+          'error_message', COALESCE(
+            browser_run.error_message,
+            'This draft expired before the page was opened. Recreate it to continue.'
+          )
+        )
+      END AS browser_handoff,
       e.connector_key AS platform,
       e.connection_id,
       source_connection.display_name AS connection_name,
@@ -1016,6 +1066,9 @@ export async function listNotifications(opts: {
     LEFT JOIN runs source_run
       ON source_run.id = e.run_id
      AND source_run.organization_id = e.organization_id
+    LEFT JOIN runs browser_run
+      ON browser_run.id = t.browser_run_id
+     AND browser_run.organization_id = e.organization_id
     LEFT JOIN agents agent
       ON agent.id = COALESCE(
         NULLIF(e.metadata->>'agent_id', ''),

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -55,6 +55,12 @@ export type ActivityCard = {
 	unread?: boolean;
 	notification_id?: number;
 	browser_url?: string;
+	browser_handoff?: {
+		run_id: number | null;
+		state: "ready" | "expired" | "completed";
+		expires_at: string | null;
+		error_message: string | null;
+	};
 	run_id?: number;
 	/**
 	 * Kind of pending interaction behind this notification (events
@@ -168,6 +174,33 @@ function buildNotificationCard(
 			: null;
 	const interactionInline =
 		familyAllowsInline && affordance != null && affordance.kind !== "form";
+	const rawBrowserHandoff =
+		n.browser_handoff && typeof n.browser_handoff === "object"
+			? (n.browser_handoff as Record<string, unknown>)
+			: null;
+	let browserHandoff: ActivityCard["browser_handoff"];
+	if (
+		rawBrowserHandoff &&
+		(rawBrowserHandoff.state === "ready" ||
+			rawBrowserHandoff.state === "expired" ||
+			rawBrowserHandoff.state === "completed")
+	) {
+		browserHandoff = {
+			run_id:
+				typeof rawBrowserHandoff.run_id === "number"
+					? rawBrowserHandoff.run_id
+					: null,
+			state: rawBrowserHandoff.state,
+			expires_at:
+				typeof rawBrowserHandoff.expires_at === "string"
+					? rawBrowserHandoff.expires_at
+					: null,
+			error_message:
+				typeof rawBrowserHandoff.error_message === "string"
+					? rawBrowserHandoff.error_message
+					: null,
+		};
+	}
 	return {
 		id: `n:${id}`,
 		kind: "notification",
@@ -182,6 +215,7 @@ function buildNotificationCard(
 		notification_id: id,
 		browser_url:
 			typeof n.browser_url === "string" ? n.browser_url : undefined,
+		browser_handoff: browserHandoff,
 		platform: typeof n.platform === "string" ? n.platform : undefined,
 		connection_id:
 			typeof n.connection_id === "number" ? n.connection_id : undefined,

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -9,7 +9,7 @@
 
 import { type Static, Type } from '@sinclair/typebox';
 import type { CardElement } from 'chat';
-import { getDb, pgTextArray } from '../../db/client';
+import { getDb, parsePgTextArray, pgTextArray } from '../../db/client';
 import { emit } from '../../events/emitter';
 import { currentMcpActivityAttribution } from '../../lobu/stores/mcp-client-conversations';
 import { resolveActionOrigin } from '../../notifications/action-origin';
@@ -26,6 +26,7 @@ import logger from '../../utils/logger';
 import { buildResourcePermalink } from '../../utils/url-builder';
 import { trackAutomationReaction } from '../../utils/automation-reactions';
 import { loadConfiguredAutomationDeliveryTarget } from '../../automations/delivery-target';
+import { normalizePageActivationUrl } from '../../runs/page-activation';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
 
@@ -58,6 +59,13 @@ const SendAction = Type.Object({
     Type.String({
       format: 'uri',
       description: 'HTTP(S) page for an explicit browser-side "Open" action in the current user tab.',
+    })
+  ),
+  browser_handoff_run_id: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      description:
+        'Page-activated operation run that will populate browser_url when its owner visits the page. The run must belong to the same workspace, target the same normalized URL, and be owned by one of the resolved recipients; delivery then narrows to that owner, since nobody else can activate it.',
     })
   ),
   idempotency_key: Type.Optional(
@@ -149,6 +157,12 @@ async function handleSend(
       throw new ToolUserError('notify: `browser_url` must be a valid HTTP(S) URL.', 422);
     }
   }
+  if (args.browser_handoff_run_id != null && !args.browser_url) {
+    throw new ToolUserError(
+      'notify: `browser_handoff_run_id` requires `browser_url`.',
+      422
+    );
+  }
 
   // Validate the request even when recipient resolution later produces no rows.
   if (kind) {
@@ -194,6 +208,54 @@ async function handleSend(
 
   if (userIds.length === 0) {
     return { notified_count: 0, event_id: null, url: null };
+  }
+
+  if (args.browser_handoff_run_id != null && args.browser_url) {
+    const handoffRows = await sql<{
+      id: number;
+      created_by_user_id: string | null;
+      activation_target_urls: string | string[] | null;
+    }>`
+      SELECT id, created_by_user_id, activation_target_urls
+      FROM runs
+      WHERE id = ${args.browser_handoff_run_id}
+        AND organization_id = ${ctx.organizationId}
+        AND run_type = 'action'
+        AND approval_status = 'auto'
+        AND activation_kind = 'page_visit'
+      LIMIT 1
+    `;
+    const handoffRun = handoffRows[0];
+    if (!handoffRun) {
+      throw new ToolUserError(
+        'notify: `browser_handoff_run_id` must reference a page-activated action in this workspace.',
+        422
+      );
+    }
+    const normalizedBrowserUrl = normalizePageActivationUrl(args.browser_url);
+    if (
+      !parsePgTextArray(handoffRun.activation_target_urls).includes(
+        normalizedBrowserUrl
+      )
+    ) {
+      throw new ToolUserError(
+        'notify: `browser_url` must match the linked page-activation run.',
+        422
+      );
+    }
+    if (
+      handoffRun.created_by_user_id == null ||
+      !userIds.includes(handoffRun.created_by_user_id)
+    ) {
+      throw new ToolUserError(
+        'notify: the page-activation run owner must be one of the notification recipients.',
+        422
+      );
+    }
+    // Only the run owner can activate this draft. A broader informational
+    // audience would receive dead cards, so materialize the handoff solely in
+    // the actionable owner's inbox even when recipients was "admins"/"all".
+    userIds = [handoffRun.created_by_user_id];
   }
 
   // Kind data renders separately; legacy untyped data remains appended to body.
@@ -344,6 +406,7 @@ async function handleSend(
     resourceId: ask ? String(ask.interactionEventId) : null,
     resourceUrl: args.resource_url ?? askReviewUrl ?? null,
     browserUrl: args.browser_url ?? null,
+    browserRunId: args.browser_handoff_run_id ?? null,
     idempotencyKey: args.idempotency_key ?? null,
     connectionId: args.connection_id ?? null,
     // An ask builds its chat card from the SAME schema the web row reads, via

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -147,13 +147,13 @@ function buildContentQuery(opts: {
  * shows the whole pending→executing→completed history, not just the head.
  *
  * Reads from `events` (not the masked view) because superseded rows are the
- * whole point. Two arms, UNIONed:
- *  - run arm: operation/approval chains all share one `run_id`, so a single
- *    indexed lookup returns pending + executing + completed together.
- *  - walk arm: seeds with `run_id IS NULL` (e.g. an edited note) have no run to
- *    key on, so we walk the `superseded_by` / `supersedes_event_id` linked list
- *    out from the seed in both directions. Bounded (chains are 2–3 hops; the
- *    forward edge is uniquely indexed), so the recursion terminates cheaply.
+ * whole point. Walk the `superseded_by` / `supersedes_event_id` linked list out
+ * from every seed in both directions. `run_id` is deliberately not a lineage
+ * key: a connector feed sync writes many unrelated source items under one run,
+ * so expanding by run would make a permalink for one item return the whole
+ * batch. Operation lifecycle rows already carry explicit supersede edges.
+ * Chains are bounded (normally 2–3 hops; the forward edge is uniquely indexed),
+ * so the recursion terminates cheaply.
  *
  * `$1` must be a bigint[] bind param of the requested ids. Emits a CTE named
  * `resolved_ids(id, chain_key)` — `id` is an event id in a resolved chain and
@@ -164,25 +164,17 @@ function buildContentQuery(opts: {
  */
 const RESOLVED_IDS_CTE = `
   resolved_ids AS (
-    -- run arm: every row of the seed's run (the common approval/operation case).
-    -- Chain key is the run id, text-prefixed so it can't collide with the walk
-    -- arm's event-id keys.
-    SELECT run_ev.id, 'run:' || seed.run_id AS chain_key
-    FROM events seed
-    JOIN events run_ev ON run_ev.run_id = seed.run_id
-    WHERE seed.id = ANY($1::bigint[]) AND seed.run_id IS NOT NULL
-    UNION
-    -- walk arm: run_id-less chains, transitive closure both directions. Chain
-    -- key is the lineage root (oldest ancestor), which every row in the chain
-    -- shares regardless of which id the caller entered from.
+    -- Transitive closure of each explicit supersede lineage in both directions.
+    -- Chain key is the lineage root (oldest ancestor), which every row in the
+    -- chain shares regardless of which id the caller entered from.
     SELECT walked.id, 'ev:' || walked.root AS chain_key
     FROM (
       WITH RECURSIVE lineage(id, root) AS (
-        -- Seed each run_id-less requested id with its own oldest ancestor as
-        -- the provisional root; MIN() over the component finalizes it below.
+        -- Seed each requested id with itself as the provisional root; MIN()
+        -- over the connected component finalizes the oldest ancestor below.
         SELECT s.id, s.id AS root
         FROM events s
-        WHERE s.id = ANY($1::bigint[]) AND s.run_id IS NULL
+        WHERE s.id = ANY($1::bigint[])
         UNION
         SELECT nxt.id, LEAST(l.root, nxt.id)
         FROM lineage l

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -109,12 +109,11 @@ const AUDIT_REQUEST_KEYS = ['request', 'request_bytes'] as const;
  * is the only thing re-read here; a failed re-read rejects rather than serving
  * a half-gated page.
  *
- * The strip index maps an id to a LIST of entries, not one: an exact-id read
- * expands the requested ids through `resolved_ids`, whose run arm and
- * supersede-walk arm can each claim the same event under a different (and
- * deliberately non-colliding) chain key, so the join emits that event twice and
- * `buildContentItems` parses a SEPARATE payload object for each row. Keying one
- * entry per id would restore only the last copy and leave the rest stripped.
+ * The strip index maps an id to a LIST of entries, not one. Exact reads normally
+ * collapse an explicitly linked supersede lineage to one copy of each row, but
+ * hydration is a security boundary and must restore every parsed copy if a
+ * caller supplies duplicates. Keying one entry per id would restore only the
+ * last copy and leave the rest stripped.
  */
 export async function hydrateToolInvocationRequests(opts: {
   sql: DbClient;


### PR DESCRIPTION
## Summary
- persist an exact page-activation run on browser-handoff notifications and expose ready, expired, recreated, and completed lifecycle state
- validate that draft cards are delivered only to the run owner and add a safe recreation endpoint for expired handoffs
- carry the lifecycle into Activity and Social Radar; the UI lands separately in lobu-ai/owletto#927
- keep `content_ids` permalinks scoped to explicit supersede lineage instead of expanding every unrelated event from the same connector sync run

## Test plan
- [x] Intended root files staged explicitly; `make pre-pr` clean
- [x] Tests run: targeted server migration/page-activation/event-lineage, client, Social Radar, and Owletto suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval (not applicable)

Red baseline:
- linked lifecycle state missing from notification/activity contracts
- notification row opened provenance instead of the provider target
- draft handoff run id missing from Social Radar notification
- exact event permalinks expanded all rows sharing a feed run, reproducing one clicked tweet showing the rest of its sync batch

Green proof:
- page activation + HTTP recreate/race: 15/15
- invalid-index heal and migration down/up: 9/9
- event supersede lineage + same-run isolation: 6/6
- tool-invocation exact-read authorization: 21/21
- event filter/permalink/peek UI: 36/36
- Recent, connected-app conversation, and scoped Activity navigation: 34/34
- Social Radar: 15/15
- client: 7/7
- Owletto focused browser-handoff UI/bridge: 29/29
- migration squawk lint: clean
- `make pre-pr`: clean
- GitHub CI required graph: green on `04cbaf77a`
- full Owletto production build and browser bundle check: clean
- live local browser: Why/how kept Activity open and showed Generated from; primary row click opened the exact provider target in a new tab

## Notes
Draft until lobu-ai/owletto#927 is reviewed and merged. After that, this branch will bump `packages/owletto` to the merged commit, run `make review` once on settled HEAD, and attach `make ui-review` proof. No draft is auto-submitted.

A remote hosted sandbox was unavailable because the local Daytona CLI token has expired; the real-browser proof above used a fresh local embedded stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser-handoff details and status indicators to activity notifications.
  - Added an authenticated option to recreate expired browser handoffs and receive a fresh browser link.
  - Notifications can now target the handoff owner and preserve the associated operation.
  - Social-interest notifications are delivered to all intended recipients.

- **Bug Fixes**
  - Improved notification handling for missing, expired, failed, and completed handoffs.
  - Content lineage now follows explicit supersede relationships, preventing unrelated events from being grouped together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->