### PR TITLE
fix(classification): scope the parent-context join by org and connection

### DIFF
--- a/packages/server/src/__tests__/integration/classifiers/classification-parent-scope.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classification-parent-scope.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tenancy scoping for the parent-context join in fetchTargetContent.
+ *
+ * `classification-query.ts` blends a parent event's vector into the child's at
+ * PARENT_EMBEDDING_WEIGHT (0.3) before classifying. The parent was resolved as
+ *
+ *   LEFT JOIN current_event_records parent ON parent.origin_id = f.origin_parent_id
+ *
+ * with no tenancy predicate at all — while `f` itself is org-scoped. `origin_id`
+ * is the connector's own identifier and is NOT unique across tenants: a GitHub
+ * node id or Hacker News item id is the same string in every organization that
+ * syncs it. Prod carried 1,118 live cross-ORG parent matches (942 of them GitHub,
+ * every one with a chunk-0 vector) and 25,099 same-org cross-CONNECTION matches,
+ * so this join really did feed another tenant's vector into a classification.
+ *
+ * Vectors are 768-dim one-hot basis vectors, so every cosine here is exact:
+ *   unblended child basis(0)          → cosine 1.0 vs `positive`
+ *   blended 0.7*basis(0)+0.3*basis(1) → 0.7/sqrt(0.58) = 0.9191
+ * The two are distinguishable to 4dp, which is what `embedding_confidence` stores.
+ *
+ * The "still blends" case is load-bearing: scoping the join by connection alone
+ * would silently drop parent context for the 38,764 prod rows (17% of all
+ * parent-referencing rows) whose connection_id is NULL, so NULL must still match
+ * NULL within one organization.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { executeClassificationQuery } from '../../../utils/classification-query';
+import { getConfiguredEmbeddingModel } from '../../../utils/embeddings';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+/** Cosine of 0.7*basis(0)+0.3*basis(1) against basis(0) — i.e. a blended parent. */
+const BLENDED_CONFIDENCE = 0.9191;
+
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+async function seedFacet(opts: { orgId: string; createdBy: string; slug: string }): Promise<number> {
+  const sql = getTestDb();
+  const embedding_model = getConfiguredEmbeddingModel();
+  const attributeValues = {
+    positive: { embedding: basisVector(0), embedding_model },
+    negative: { embedding: basisVector(1), embedding_model },
+  };
+  const [row] = (await sql`
+    INSERT INTO classify_facet (
+      organization_id, slug, name, attribute_key, status, created_by,
+      automation_id, entity_ids, min_similarity, fallback_value, attribute_values
+    ) VALUES (
+      ${opts.orgId}, ${opts.slug}, ${`${opts.slug} classifier`}, ${opts.slug}, 'active', ${opts.createdBy},
+      NULL, NULL, 0.5, 'unknown', ${sql.json(attributeValues as never)}
+    )
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+/** `createTestEvent` has no origin_parent_id parameter; set it directly. */
+async function setParent(eventId: number, parentOriginId: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`UPDATE events SET origin_parent_id = ${parentOriginId} WHERE id = ${eventId}`;
+}
+
+async function confidenceFor(eventId: number, facetId: number): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT embedding_confidence::text AS conf
+    FROM event_classifications
+    WHERE event_id = ${eventId} AND classifier_id = ${facetId} AND source = 'embedding'
+  `) as Array<{ conf: string }>;
+  expect(rows).toHaveLength(1);
+  return Number(rows[0].conf);
+}
+
+describe('classification parent-context join is tenancy-scoped', () => {
+  it('does not blend a parent belonging to another organization', async () => {
+    await cleanupTestDatabase();
+    const orgA = await createTestOrganization({ name: 'Parent Scope A' });
+    const orgB = await createTestOrganization({ name: 'Parent Scope B' });
+    const user = await createTestUser({ email: 'parent-scope@test.com' });
+    const facetId = await seedFacet({ orgId: orgA.id, createdBy: user.id, slug: 'ps-cross-org' });
+
+    // The colliding id — the same string both tenants would see from GitHub.
+    const sharedOriginId = 'gh-node-shared-1';
+
+    // Org B owns the only event carrying that origin_id, and it leans `negative`.
+    await createTestEvent({
+      organization_id: orgB.id,
+      origin_id: sharedOriginId,
+      content: 'other tenant parent',
+      embedding: basisVector(1),
+    });
+
+    // Org A's child points at it by origin id but owns no such parent itself.
+    const child = await createTestEvent({
+      organization_id: orgA.id,
+      content: 'excellent and amazing',
+      embedding: basisVector(0),
+    });
+    await setParent(Number(child.id), sharedOriginId);
+
+    await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: orgA.id,
+      enabledClassifiers: ['ps-cross-org'],
+      content_ids: [Number(child.id)],
+    });
+
+    // Org A has no parent of its own, so the child vector must be used as-is.
+    // Before the fix this read 0.9191 — org B's vector blended in at 0.3.
+    expect(await confidenceFor(Number(child.id), facetId)).toBeCloseTo(1.0, 3);
+  });
+
+  it('does not blend a parent from a different connection in the same organization', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Parent Scope Conn' });
+    const user = await createTestUser({ email: 'parent-scope-conn@test.com' });
+    const facetId = await seedFacet({ orgId: org.id, createdBy: user.id, slug: 'ps-cross-conn' });
+
+    const connA = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: user.id,
+    });
+    const connB = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: user.id,
+    });
+
+    const sharedOriginId = 'gh-node-shared-2';
+    await createTestEvent({
+      organization_id: org.id,
+      connection_id: Number(connB.id),
+      origin_id: sharedOriginId,
+      content: 'other connection parent',
+      embedding: basisVector(1),
+    });
+
+    const child = await createTestEvent({
+      organization_id: org.id,
+      connection_id: Number(connA.id),
+      content: 'excellent and amazing',
+      embedding: basisVector(0),
+    });
+    await setParent(Number(child.id), sharedOriginId);
+
+    await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      enabledClassifiers: ['ps-cross-conn'],
+      content_ids: [Number(child.id)],
+    });
+
+    expect(await confidenceFor(Number(child.id), facetId)).toBeCloseTo(1.0, 3);
+  });
+
+  it('still blends a parent in the same organization and connection', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Parent Scope Same' });
+    const user = await createTestUser({ email: 'parent-scope-same@test.com' });
+    const facetId = await seedFacet({ orgId: org.id, createdBy: user.id, slug: 'ps-same' });
+
+    // Both rows leave connection_id NULL — the 17% of prod parent-referencing
+    // rows that a connection-equality join would strand without parent context.
+    const sharedOriginId = 'gh-node-shared-3';
+    await createTestEvent({
+      organization_id: org.id,
+      origin_id: sharedOriginId,
+      content: 'own parent',
+      embedding: basisVector(1),
+    });
+
+    const child = await createTestEvent({
+      organization_id: org.id,
+      content: 'excellent and amazing',
+      embedding: basisVector(0),
+    });
+    await setParent(Number(child.id), sharedOriginId);
+
+    await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      enabledClassifiers: ['ps-same'],
+      content_ids: [Number(child.id)],
+    });
+
+    // Genuinely this org's own parent → the 0.3 blend must still happen.
+    expect(await confidenceFor(Number(child.id), facetId)).toBeCloseTo(BLENDED_CONFIDENCE, 3);
+  });
+});

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -218,6 +218,23 @@ async function fetchTargetContent(
   const repEmbeddingJoins = `LEFT JOIN event_embeddings fe ON fe.event_id = f.id AND fe.chunk_index = 0 AND fe.embedding_model = ${embModel}
        LEFT JOIN event_embeddings pe ON pe.event_id = parent.id AND pe.chunk_index = 0 AND pe.embedding_model = ${embModel}`;
 
+  // Tenancy scoping for the parent join. `origin_id` is the connector's own
+  // identifier and is NOT unique across tenants — a GitHub node id or Hacker
+  // News item id is the same string in every org that syncs it — so joining on
+  // it alone resolved another tenant's row and blended that row's vector into
+  // this org's classification at PARENT_EMBEDDING_WEIGHT. Prod carried 1,118
+  // live cross-org matches and 25,099 same-org cross-connection ones.
+  //
+  // `IS NOT DISTINCT FROM` rather than `=` on connection_id: 17% of
+  // parent-referencing rows have a NULL connection, and plain equality would
+  // silently strand all of them without parent context. Org equality is what
+  // makes NULL-matches-NULL safe. Mirrors the thread-chain join in
+  // content-search/ctes.ts, which scopes by connection for the same reason.
+  const parentJoin = `LEFT JOIN current_event_records parent
+         ON parent.organization_id = f.organization_id
+        AND parent.origin_id = f.origin_parent_id
+        AND parent.connection_id IS NOT DISTINCT FROM f.connection_id`;
+
   if (mode === 'content_ids') {
     const contentIds = options.content_ids!;
     const contentPlaceholders = contentIds.map((_, i) => `$${i + 2}`).join(', ');
@@ -232,7 +249,7 @@ async function fetchTargetContent(
          fe.embedding,
          pe.embedding as parent_embedding
        FROM current_event_records f
-       LEFT JOIN current_event_records parent ON parent.origin_id = f.origin_parent_id
+       ${parentJoin}
        ${repEmbeddingJoins}
        WHERE f.organization_id = $1
          AND f.id IN (${contentPlaceholders})
@@ -265,7 +282,7 @@ async function fetchTargetContent(
          fe.embedding,
          pe.embedding as parent_embedding
        FROM current_event_records f
-       LEFT JOIN current_event_records parent ON parent.origin_id = f.origin_parent_id
+       ${parentJoin}
        ${repEmbeddingJoins}
        WHERE (
            ${entityLinkMatchSql('$1::bigint')}


### PR DESCRIPTION
## Summary

- `fetchTargetContent` resolved an event's parent with `LEFT JOIN current_event_records parent ON parent.origin_id = f.origin_parent_id` — no tenancy predicate, while `f` itself is org-scoped. `origin_id` is the connector's own identifier and is **not** unique across tenants, so this resolved another organization's row.
- The parent's vector is blended into the classification input at `PARENT_EMBEDDING_WEIGHT` (0.3), so this materially changed classification results, not just displayed context.
- Both query sites (`content_ids` and `entity` mode) carried the identical unscoped join; they are now one extracted `parentJoin` constant so they cannot drift.

Measured on prod before the fix:

| | Live matches |
|---|---|
| cross-**organization** parent matches | **1,118** (github 942, hackernews 168, x 8) |
| of those github parents holding a chunk-0 vector | **942 / 942** |
| same-org, **different-connection** matches | **25,099** |
| distinct colliding parent origin ids | 248 across 4 orgs |

GitHub node ids and Hacker News item ids are the same strings in every org that syncs them, which is why this fires in practice.

`IS NOT DISTINCT FROM` on `connection_id` rather than `=` is deliberate: **38,764 of 228,473** parent-referencing rows in prod (17%) have a NULL `connection_id`, and plain equality would silently strand every one of them without parent context. Organization equality is what makes NULL-matches-NULL safe here. This mirrors the thread-chain join in `content-search/ctes.ts:47-50`, which scopes by connection for the same reason.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun run test -- run src/__tests__/integration/classifiers/`
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before the fix)

```
FAIL  classification parent-context join is tenancy-scoped > does not blend a parent belonging to another organization
AssertionError: expected 0.9191 to be close to 1, received difference is 0.08089999999999997, but expected 0.0005

FAIL  classification parent-context join is tenancy-scoped > does not blend a parent from a different connection in the same organization
AssertionError: expected 0.9191 to be close to 1, received difference is 0.08089999999999997, but expected 0.0005

 Tests  2 failed | 1 passed (3)
```

`0.9191` is exactly `0.7/sqrt(0.58)` — the cosine of `0.7*basis(0) + 0.3*basis(1)` against `basis(0)`. The foreign parent blended in at precisely the predicted weight, so the test fails for the reason claimed.

### Green (after the fix)

```
 ✓ src/__tests__/integration/classifiers/classification-parent-scope.test.ts (3 tests) 719ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### No regressions across the classifier suite

```
 Test Files  17 passed (17)
      Tests  52 passed (52)
```

### Mutation check on the new guard

Replacing `IS NOT DISTINCT FROM` with `=` makes the third test fail, proving the NULL-connection case is genuinely covered rather than incidentally passing:

```
× still blends a parent in the same organization and connection
AssertionError: expected 1 to be close to 0.9191, received difference is 0.08089999999999997
```

## Notes

Closes #3068.

Found while investigating event supersede churn; the sibling issues from that work are #3065 (volatile counters superseding whole event versions) and #3066 (68% of `event_embeddings` vectors belong to superseded events and still occupy the ANN index). Neither overlaps this change.
