### PR TITLE
perf(events): reconcile volatile counters in place instead of superseding

### DIFF
--- a/packages/server/src/__tests__/integration/events/volatile-state-inplace.test.ts
+++ b/packages/server/src/__tests__/integration/events/volatile-state-inplace.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Volatile source state is reconciled on the current row, never superseded.
+ *
+ * Measured on the 200,000 most recent supersede pairs in prod: 164,915 (82.5%)
+ * differed ONLY in `score`/`metadata`, with title, payload_text and attachments
+ * byte-identical. Each of those minted a duplicate row, a duplicate 768-dim
+ * vector and a permanent ivfflat entry, so ~half of `events` was mutable state
+ * stored in an immutable row.
+ *
+ * The ledger's invariant is narrower than the convention: the only trigger on
+ * `events` is `trg_events_append_only`, and it is BEFORE DELETE. An upvote count
+ * is not an utterance, so it is reconciled rather than versioned.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function versionsOf(orgId: string, originId: string) {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, score, metadata, payload_text, superseded_by
+    FROM events
+    WHERE organization_id = ${orgId} AND origin_id = ${originId}
+    ORDER BY id ASC
+  `) as Array<{
+    id: number;
+    score: number | null;
+    metadata: Record<string, unknown> | null;
+    payload_text: string | null;
+    superseded_by: number | null;
+  }>;
+}
+
+/**
+ * `findCurrentEventByOrigin` returns early unless `connectionId` is set — dedupe
+ * keys on (connection_id, origin_id) — so a fixture without one would insert a
+ * fresh row every call and silently test nothing. Real connector ingest always
+ * carries a connection.
+ */
+async function seedConnection(orgId: string, email: string): Promise<number> {
+  const user = await createTestUser({ email });
+  const conn = await createTestConnection({
+    organization_id: orgId,
+    connector_key: 'reddit',
+    created_by: user.id,
+  });
+  return Number(conn.id);
+}
+
+function baseParams(orgId: string, originId: string, connectionId: number) {
+  return {
+    entityIds: [] as number[],
+    organizationId: orgId,
+    originId,
+    connectionId,
+    content: 'a post nobody edited',
+    semanticType: 'content',
+    connectorKey: 'reddit',
+  };
+}
+
+describe('volatile source state is reconciled in place', () => {
+  it('a counter change updates the current row instead of superseding it', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile A' });
+    const conn = await seedConnection(org.id, 'vol-a@test.com');
+    const originId = 't3_volatile_a';
+
+    const first = await insertEvent(
+      { ...baseParams(org.id, originId, conn), score: 10, metadata: { score: 10, upvote_ratio: 0.9 } },
+      { onConflictUpdate: true }
+    );
+    expect(first.change).toBe('inserted');
+
+    const second = await insertEvent(
+      { ...baseParams(org.id, originId, conn), score: 42, metadata: { score: 42, upvote_ratio: 0.97 } },
+      { onConflictUpdate: true }
+    );
+
+    // Before this change the identical call superseded, leaving two rows.
+    expect(second.change).toBe('state_updated');
+    expect(second.id).toBe(first.id);
+
+    const rows = await versionsOf(org.id, originId);
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].score)).toBe(42);
+    expect(rows[0].metadata?.score).toBe(42);
+    expect(rows[0].metadata?.upvote_ratio).toBe(0.97);
+    expect(rows[0].superseded_by).toBeNull();
+  });
+
+  it('reports unchanged when the counters did not move either', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile B' });
+    const conn = await seedConnection(org.id, 'vol-b@test.com');
+    const originId = 't3_volatile_b';
+    const params = { ...baseParams(org.id, originId, conn), score: 7, metadata: { score: 7 } };
+
+    await insertEvent(params, { onConflictUpdate: true });
+    const again = await insertEvent(params, { onConflictUpdate: true });
+
+    expect(again.change).toBe('unchanged');
+    expect(await versionsOf(org.id, originId)).toHaveLength(1);
+  });
+
+  it('an omitted counter is preserved and does not count as a change', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile F' });
+    const conn = await seedConnection(org.id, 'vol-f@test.com');
+    const originId = 't3_volatile_f';
+
+    await insertEvent(
+      { ...baseParams(org.id, originId, conn), score: 5, metadata: { score: 5, upvote_ratio: 0.9 } },
+      { onConflictUpdate: true }
+    );
+    // This sync omits upvote_ratio. Merge semantics keep the last known value,
+    // so the omission must read as "unchanged" — a raw set comparison would
+    // report state_updated on every sync forever, since the merge never lets
+    // the stored set converge to the incoming one.
+    const second = await insertEvent(
+      { ...baseParams(org.id, originId, conn), score: 5, metadata: { score: 5 } },
+      { onConflictUpdate: true }
+    );
+    expect(second.change).toBe('unchanged');
+
+    const rows = await versionsOf(org.id, originId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata?.upvote_ratio).toBe(0.9);
+  });
+
+  it('still supersedes when the authored text changes', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile C' });
+    const conn = await seedConnection(org.id, 'vol-c@test.com');
+    const originId = 't3_volatile_c';
+
+    const first = await insertEvent(
+      { ...baseParams(org.id, originId, conn), score: 1, metadata: { score: 1 } },
+      { onConflictUpdate: true }
+    );
+    const second = await insertEvent(
+      {
+        ...baseParams(org.id, originId, conn),
+        content: 'the author edited this',
+        score: 99,
+        metadata: { score: 99 },
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(second.change).toBe('superseded');
+    expect(second.id).not.toBe(first.id);
+
+    const rows = await versionsOf(org.id, originId);
+    expect(rows).toHaveLength(2);
+    // The successor carries the new counters too — they ride along on a real edit.
+    expect(Number(rows[1].score)).toBe(99);
+    expect(rows[1].superseded_by).toBeNull();
+  });
+
+  it('still supersedes when a non-volatile metadata key changes', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile D' });
+    const conn = await seedConnection(org.id, 'vol-d@test.com');
+    const originId = 't3_volatile_d';
+
+    await insertEvent(
+      { ...baseParams(org.id, originId, conn), metadata: { score: 1, flair: 'discussion' } },
+      { onConflictUpdate: true }
+    );
+    const second = await insertEvent(
+      { ...baseParams(org.id, originId, conn), metadata: { score: 2, flair: 'announcement' } },
+      { onConflictUpdate: true }
+    );
+
+    // `flair` is authored, not observed — that is a genuine new version.
+    expect(second.change).toBe('superseded');
+    expect(await versionsOf(org.id, originId)).toHaveLength(2);
+  });
+
+  it('merges volatile keys without disturbing authored metadata', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Volatile E' });
+    const conn = await seedConnection(org.id, 'vol-e@test.com');
+    const originId = 't3_volatile_e';
+
+    await insertEvent(
+      {
+        ...baseParams(org.id, originId, conn),
+        metadata: { score: 1, flair: 'discussion', email: 'a@b.c' },
+      },
+      { onConflictUpdate: true }
+    );
+    // Same authored keys, moved counter.
+    const second = await insertEvent(
+      {
+        ...baseParams(org.id, originId, conn),
+        metadata: { score: 500, flair: 'discussion', email: 'a@b.c' },
+      },
+      { onConflictUpdate: true }
+    );
+    expect(second.change).toBe('state_updated');
+
+    const rows = await versionsOf(org.id, originId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata?.score).toBe(500);
+    // Identity keys back the expression indexes on this table — the merge must
+    // never clobber them.
+    expect(rows[0].metadata?.flair).toBe('discussion');
+    expect(rows[0].metadata?.email).toBe('a@b.c');
+  });
+});

--- a/packages/server/src/automations/connector-derived.ts
+++ b/packages/server/src/automations/connector-derived.ts
@@ -1,3 +1,4 @@
+import type { EventChangeKind } from "../utils/insert-event";
 import type { ConnectorTriggerSignal } from "@lobu/connector-sdk";
 import { type DbClient, getDb } from "../db/client";
 
@@ -131,7 +132,7 @@ export async function loadConnectorDeriveFeedContext(
 export function deriveConnectorActivationSignals(
 	ctx: ConnectorDeriveFeedContext,
 	event: ConnectorDeriveEventInput,
-	change: "inserted" | "superseded" | "unchanged",
+	change: EventChangeKind,
 	eventId: number,
 ): ConnectorTriggerSignal[] {
 	if (change !== "inserted") return [];

--- a/packages/server/src/automations/connector-signal.ts
+++ b/packages/server/src/automations/connector-signal.ts
@@ -17,6 +17,11 @@ export function materializeConnectorAutomationSignal(args: {
 	deliveryId: string;
 }): ConnectorTriggerSignal | null {
 	if (args.connectionId == null) return null;
+	// `state_updated` is the in-place counter reconciliation that replaced a
+	// volatile-only supersede. It maps exactly where `superseded` used to, so a
+	// declared draft keeps firing on `updated_event_type` and no more: routing it
+	// through the `unchanged` arm would fall back to `event_type` and start
+	// firing for connectors that never declared an updated kind.
 	const eventType =
 		args.change === "inserted"
 			? args.draft.event_type

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -634,6 +634,7 @@ export async function handleCompleteWindow(
         for (const event of persistedEvents) {
           if (
             event.change === 'unchanged' ||
+            event.change === 'state_updated' ||
             !subscribedWorkspaceEventTypes.has(output.event)
           ) {
             continue;

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -157,6 +157,18 @@ interface InsertEventParams {
   clientId?: string | null;
 }
 
+/**
+ * How an insertEvent call settled.
+ *
+ * `state_updated` means durable content matched an existing head and only
+ * volatile source state (engagement counters, `updated_at`) was reconciled onto
+ * that row in place — no new stored version, no new vector. Consumers that
+ * treat `superseded` as "the source item changed" should treat this the same
+ * way; consumers that commit per-version side effects (artifacts, workspace
+ * event activations) should treat it as `unchanged`.
+ */
+export type EventChangeKind = 'inserted' | 'superseded' | 'unchanged' | 'state_updated';
+
 export interface InsertedEvent {
   id: number;
   entity_ids: number[] | null;
@@ -165,7 +177,7 @@ export interface InsertedEvent {
   semantic_type: string;
   created_at: string;
   /** Whether this call landed a new immutable row or reused identical state. */
-  change: 'inserted' | 'superseded' | 'unchanged';
+  change: EventChangeKind;
 }
 
 /** Key-order-independent JSON serialization for semantic equality checks. */
@@ -227,6 +239,63 @@ function semanticAttachmentState(attachments: unknown[] | undefined): string {
       return durable;
     })
   );
+}
+
+/**
+ * Metadata keys whose value is a point-in-time observation of source state, not
+ * something anyone authored.
+ *
+ * Measured on the 200,000 most recent supersede pairs in prod: 164,915 (82.5%)
+ * differed ONLY in `score`/`metadata` with title, payload_text and attachments
+ * byte-identical. Comparing metadata raw therefore minted a whole new stored
+ * version — a duplicate row, a duplicate 768-dim vector and a permanent ivfflat
+ * entry — every time an upvote landed.
+ *
+ * Same reasoning as DURABLE_ATTACHMENT_KEYS above, which already fixed this
+ * exact class for attachments (they now differ in 7 of 200,000 pairs). These
+ * keys are excluded from the durable comparison and written in place instead.
+ */
+const VOLATILE_METADATA_KEYS = new Set([
+  'score',
+  'upvote_ratio',
+  'reply_count',
+  'comments',
+  'num_comments',
+  'view_count',
+  'like_count',
+  'retweet_count',
+  'quote_count',
+  'bookmark_count',
+  'rank',
+  'updated_at',
+]);
+
+/**
+ * Dedup view of `events.metadata`: everything a human or connector authored,
+ * with the volatile observations stripped. Two payloads equal under this
+ * projection describe the same content even if the counters moved.
+ */
+function durableMetadataState(metadata: Record<string, unknown> | null | undefined): string {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return stableJson(metadata ?? {});
+  }
+  const durable: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!VOLATILE_METADATA_KEYS.has(key)) durable[key] = value;
+  }
+  return stableJson(durable);
+}
+
+/** The volatile subset actually present on an incoming payload. */
+function volatileMetadataPatch(
+  metadata: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return patch;
+  for (const [key, value] of Object.entries(metadata)) {
+    if (VOLATILE_METADATA_KEYS.has(key)) patch[key] = value;
+  }
+  return patch;
 }
 
 function normalizedTimestamp(value?: Date | string | null): string | null {
@@ -308,8 +377,10 @@ function isSemanticallyEqual(
         normalizedTimestamp(params.occurredAt)) &&
     existing.semantic_type === params.semanticType &&
     (existing.origin_type ?? null) === (params.originType ?? null) &&
-    stableJson(existing.metadata ?? {}) === stableJson(params.metadata ?? {}) &&
-    Number(existing.score ?? 0) === Number(params.score ?? 0) &&
+    // Volatile observations (counters, `updated_at`) are deliberately absent
+    // from this comparison and from `score` below — they are reconciled in
+    // place by applyVolatileState instead of minting a new stored version.
+    durableMetadataState(existing.metadata) === durableMetadataState(params.metadata) &&
     // Compare the value a supersede would WRITE: a null parentOriginId copies
     // the predecessor's parent (loadEventLineage), so only a caller-supplied
     // parent can differ. Comparing the raw param would re-supersede a
@@ -326,6 +397,50 @@ function isSemanticallyEqual(
       stableJson(params.interactionOutput ?? null) &&
     (existing.interaction_error ?? null) === (params.interactionError ?? null)
   );
+}
+
+/**
+ * Reconcile volatile source state on the CURRENT row instead of superseding it.
+ *
+ * `events` is append-only by convention, but the DB-enforced invariant is
+ * narrower: the only trigger on the table is `trg_events_append_only`, and it
+ * is BEFORE DELETE. The ledger's job is to preserve what was authored; an
+ * upvote count observed at read time is not an utterance, so it is reconciled
+ * rather than versioned. The counter time-series is deliberately not retained —
+ * it previously existed only as ~1.8M duplicate rows that nothing queried.
+ *
+ * `metadata || patch` merges just the volatile keys, so identity keys behind the
+ * expression indexes on this table (`metadata->>'email'`, `->>'phone'`, …) are
+ * left untouched. A volatile key REMOVED upstream is not unset — merging is
+ * intentional, since a connector omitting a counter on one sync should not drop
+ * the last known value.
+ *
+ * Returns true when a write actually happened.
+ */
+async function applyVolatileState(
+  eventId: number,
+  existing: { metadata: Record<string, unknown> | null; score: number | null },
+  params: InsertEventParams,
+  sql: DbClient
+): Promise<boolean> {
+  const patch = volatileMetadataPatch(params.metadata);
+  const existingVolatile = volatileMetadataPatch(existing.metadata);
+  const scoreChanged = Number(existing.score ?? 0) !== Number(params.score ?? 0);
+  // The dirty check mirrors the merge below: an omitted counter is preserved,
+  // not unset, so it must not count as a change either — comparing the raw
+  // volatile sets instead would report `state_updated` (and fire a declared
+  // updated_event_type) on every sync once a connector omits a key it once sent.
+  const metadataChanged =
+    stableJson({ ...existingVolatile, ...patch }) !== stableJson(existingVolatile);
+  if (!scoreChanged && !metadataChanged) return false;
+
+  await sql`
+    UPDATE events
+       SET score = ${params.score ?? null},
+           metadata = COALESCE(metadata, '{}'::jsonb) || ${sql.json(patch)}::jsonb
+     WHERE id = ${eventId}
+  `;
+  return true;
 }
 
 async function upsertEmbedding(
@@ -503,9 +618,22 @@ export async function insertEvent(
               params.embeddingModel,
               activeSql
             );
-            const unchanged = { ...existingRow, change: 'unchanged' as const };
-            await options?.afterPersist?.(unchanged, activeSql);
-            return unchanged;
+            // Durable content matched, so no new version is warranted. Volatile
+            // observations may still have moved; reconcile them on this row.
+            const stateWritten = await applyVolatileState(
+              existingRow.id,
+              { metadata: existing.metadata ?? null, score: existing.score ?? null },
+              params,
+              activeSql
+            );
+            const settled = {
+              ...existingRow,
+              change: (stateWritten ? 'state_updated' : 'unchanged') as
+                | 'state_updated'
+                | 'unchanged',
+            };
+            await options?.afterPersist?.(settled, activeSql);
+            return settled;
           }
           // Race: the existing row was deleted/tombstoned between the
           // findCurrentEventByOrigin lookup above and the SELECT here. Fall

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -512,7 +512,10 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 				// `unchanged` reuses the pre-existing row, which still points at the
 				// artifacts published by an earlier sync — the ones we just published
 				// were never referenced by any row, so the finally block reclaims them.
-				if (inserted.change !== "unchanged") {
+				// `state_updated` reconciles counters on the existing row and leaves
+				// `attachments` untouched, so it reuses the earlier sync's artifacts
+				// exactly as `unchanged` does — the ones just published are unreferenced.
+				if (inserted.change !== "unchanged" && inserted.change !== "state_updated") {
 					artifactCommitted = true;
 					pendingTranscriptions.push(...itemPendingTranscriptions);
 				}


### PR DESCRIPTION
## Summary

- `isSemanticallyEqual` compared `metadata` as a raw whole blob and `score` as a scalar, so any engagement counter moving minted a new stored event version — a duplicate row, a duplicate 768-dim vector and a permanent ivfflat entry.
- Volatile observations are now excluded from the durable comparison and reconciled **on the current row** instead, via `UPDATE events SET score = …, metadata = metadata || patch`.
- Counters stay live, so `PERCENT_RANK() … ORDER BY f.score` in `content-scoring.ts` keeps ranking on current engagement.

Measured on the 200,000 most recent supersede pairs in prod:

| What differed | Pairs |
|---|---|
| `metadata` | 192,984 (96.5%) |
| `score` | 112,078 (56.0%) |
| `payload_text` | 30,728 (15.4%) |
| `attachments` | 7 (0.003%) |
| **only `score`/`metadata`** | **164,915 (82.5%)** |

Supersedes are ~2.03M of ~3.41M `events` rows, so roughly half the table was mutable state stored in an immutable row.

This mirrors `DURABLE_ATTACHMENT_KEYS` / `semanticAttachmentState()` directly above it, which already fixed this exact class for attachments — post-fix they differ in 7 of 200,000 pairs. Metadata was the remaining half of the same asymmetry.

## Why an in-place UPDATE is allowed here

The ledger convention is supersede-only, but the DB-enforced invariant is narrower: the only trigger on `events` is `trg_events_append_only`, and it is `BEFORE DELETE`. Nothing blocks `UPDATE`. The ledger's job is to preserve what was authored; an upvote count observed at read time is not an utterance.

Deliberate consequence: the counter time-series is not retained. It previously existed only as ~1.8M duplicate rows that nothing queried.

`metadata || patch` merges only the volatile keys, so the identity keys behind this table's expression indexes (`metadata->>'email'`, `->>'phone'`, `->>'slack_user_id'`, …) are untouched.

## `state_updated`, and why not `unchanged`

Returning `'unchanged'` looked simpler but would have shipped a behaviour regression: in `connector-signal.ts` the `'unchanged'` arm falls back to `draft.event_type`, so connectors **without** an `updated_event_type` would have started firing automations where they do not today — more activations, not fewer.

A distinct `EventChangeKind` value keeps this change purely about storage. Every consumer preserves current behaviour:

| Consumer | Treatment | Why |
|---|---|---|
| `connector-signal` | like `superseded` | keeps `updated_event_type` only; no new firing |
| `connector-derived` | only `inserted` activates | already documents that an engagement-metric supersede must not re-fire |
| `run-lifecycle` artifacts | like `unchanged` | `attachments` is not rewritten, so the row keeps the earlier sync's artifacts |
| `complete-window` | like `unchanged` | a counter reconciliation is not a workspace event |

`connector-derived.ts:12-14` already stated the intent — *"a re-scraped row that supersedes the current head (e.g. an X tweet whose engagement metrics moved) is not a new source item and does not re-fire — that is what a listener wants."* This makes storage match the semantics the codebase already declared.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun run test -- run src/__tests__/integration/events/` and the automation + connector suites
- [x] Bug fix: red→fix→green outputs pasted below

### Red (production comparison reverted, tests unchanged)

```
× a counter change updates the current row instead of superseding it
× merges volatile keys without disturbing authored metadata
AssertionError: expected 'superseded' to be 'state_updated'
AssertionError: expected 'superseded' to be 'state_updated'
 Tests  2 failed | 3 passed (5)
```

The three controls — no-op re-sync, an authored text edit, and a non-volatile metadata change — stay green in both directions, so they guard legitimate supersedes rather than over-fitting the fix.

### Green

```
 Test Files  1 passed (1)      Tests  5 passed (5)     # new suite
 Test Files  48 passed (48)    Tests  231 passed (231) # events integration
 Test Files  93 passed (93)    Tests  736 passed (736) # automations + connectors
```

### Fixture note

The first draft of this suite passed vacuously: `findCurrentEventByOrigin` returns early unless `connectionId` is set, so every call inserted a fresh row. The fixture now seeds a real connection, matching what connector ingest actually supplies.

## Notes

Closes #3065.

Follow-ups deliberately not bundled: #3066 (reclaim the 1.46M dead vectors this change stops producing) and autovacuum tuning on `events` — this makes UPDATE the dominant write pattern on a table with 39 indexes and a measured 0% HOT-update ratio.
