### PR TITLE
fix(server): sanitize NUL at persistence boundaries

### DIFF
--- a/packages/server/src/__tests__/integration/complete-worker-job-status-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-worker-job-status-guard.test.ts
@@ -287,4 +287,49 @@ describe('completeWorkerJob status guard (late-completion-after-timeout)', () =>
     expect(Number(after[0].items_collected)).toBe(10); // not bumped
     expect(after[0].last_sync_at).toBeNull();
   });
+
+  it('strips NUL bytes from the subprocess output tail and error message', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId);
+
+    const sql = getTestDb();
+    const runRows = (await sql`
+      INSERT INTO runs
+        (organization_id, run_type, feed_id, connection_id, connector_key,
+         connector_version, status, claimed_by, claimed_at, created_at)
+      VALUES
+        (${org.id}, 'sync', ${feedId}, ${connId}, 'chrome', '0.2.0',
+         'running', ${WORKER_ID}, NOW(), NOW())
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const runId = runRows[0].id;
+
+    // Pre-fix, Postgres rejects the NUL in either text column with
+    // "invalid byte sequence for encoding UTF8: 0x00" and the handler 500s.
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      items_collected: 0,
+      error_message: 'spawn\u0000 ENOENT',
+      output_tail: 'line one\u0000line two',
+      exit_code: 1,
+      exit_reason: 'crash',
+    });
+    await completeWorkerJob(ctx);
+
+    expect(result().body).toEqual({ success: true });
+
+    const runAfter = (await sql`
+      SELECT status, error_message, output_tail FROM runs WHERE id = ${runId}
+    `) as Array<{
+      status: string;
+      error_message: string | null;
+      output_tail: string | null;
+    }>;
+    expect(runAfter[0].status).toBe('failed');
+    expect(runAfter[0].error_message).toBe('spawn ENOENT');
+    expect(runAfter[0].output_tail).toBe('line oneline two');
+  });
 });

--- a/packages/server/src/__tests__/integration/events/insert-event-nul-sanitization.test.ts
+++ b/packages/server/src/__tests__/integration/events/insert-event-nul-sanitization.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+describe('insertEvent NUL sanitization', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('strips NUL from scalar and nested connector fields before persistence', async () => {
+    const org = await createTestOrganization();
+    const occurredAt = new Date('2026-08-21T22:00:00.000Z');
+
+    const inserted = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'source\u0000item',
+      title: 'ti\u0000tle',
+      content: 'pay\u0000load',
+      payloadData: {
+        'nul\u0000key': 'nested\u0000value',
+        array: ['a\u0000b'],
+      },
+      attachments: [{ filename: 'fi\u0000le.txt' }],
+      metadata: { source: 'con\u0000nector' },
+      authorName: 'au\u0000thor',
+      occurredAt,
+      semanticType: 'obser\u0000vation',
+    });
+
+    const [row] = await getTestDb()<{
+      origin_id: string;
+      title: string;
+      payload_text: string;
+      payload_data: Record<string, unknown>;
+      attachments: Array<Record<string, unknown>>;
+      metadata: Record<string, unknown>;
+      author_name: string;
+      semantic_type: string;
+      occurred_at: Date;
+    }>`
+      SELECT origin_id, title, payload_text, payload_data, attachments, metadata,
+             author_name, semantic_type, occurred_at
+      FROM events
+      WHERE id = ${inserted.id}
+    `;
+
+    expect(row).toMatchObject({
+      origin_id: 'sourceitem',
+      title: 'title',
+      payload_text: 'payload',
+      payload_data: { nulkey: 'nestedvalue', array: ['ab'] },
+      attachments: [{ filename: 'file.txt' }],
+      metadata: { source: 'connector' },
+      author_name: 'author',
+      semantic_type: 'observation',
+    });
+    expect(row.occurred_at.toISOString()).toBe(occurredAt.toISOString());
+  });
+});

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -742,6 +742,54 @@ describe("worker completeActionRun card atomicity", () => {
 		expect(run.action_output).toEqual({ ok: true });
 	});
 
+	it("strips NUL bytes from worker action output before persisting it", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "auto",
+			withCard: false,
+		});
+		const { ctx, result } = mockWorkerCtx({
+			run_id: runId,
+			worker_id: "worker-complete-test",
+			status: "success",
+			action_output: {
+				["std\u0000out"]: "before\u0000after",
+				nested: ["x\u0000y"],
+			},
+		});
+		await completeActionRun(ctx);
+		expect((result().body as { success?: boolean }).success).toBe(true);
+
+		const [run] = await getTestDb()`
+			SELECT status, action_output FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("completed");
+		expect(run.action_output).toEqual({
+			stdout: "beforeafter",
+			nested: ["xy"],
+		});
+	});
+
+	it("strips NUL bytes from worker action errors before persisting them", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "auto",
+			withCard: false,
+		});
+		const { ctx, result } = mockWorkerCtx({
+			run_id: runId,
+			worker_id: "worker-complete-test",
+			status: "failed",
+			error_message: "Bad\u0000 file descriptor",
+		});
+		await completeActionRun(ctx);
+		expect((result().body as { success?: boolean }).success).toBe(true);
+
+		const [run] = await getTestDb()`
+			SELECT status, error_message FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("failed");
+		expect(run.error_message).toBe("Bad file descriptor");
+	});
+
 	it("approval run terminal card write failure rolls the terminal state back", async () => {
 		const runId = await seedClaimedRun({
 			approvalStatus: "approved",

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -128,6 +128,12 @@ describe("operations.execute backend lifecycle", () => {
 				class ConnectorRuntime {
 					async sync() { return { items: [] }; }
 					async execute(ctx) {
+						if (ctx.input.value === 'nul-output') {
+							return { success: true, output: { backend: 'local_action', tail: 'before\\u0000after' } };
+						}
+						if (ctx.input.value === 'nul-error') {
+							throw new Error('local\\u0000boom');
+						}
 						if (ctx.actionKey === 'stage_browser') {
 							await ctx.sessionState.chrome_dispatcher.dispatch('navigate', {
 								url: 'https://example.test/',
@@ -248,6 +254,15 @@ describe("operations.execute backend lifecycle", () => {
 				}
 				if (url === "https://api.example.test/items") {
 					const body = JSON.parse(String(init?.body)) as { value?: string };
+					if (body.value === "nul-success") {
+						return new Response('{"nul\\u0000key":"value\\u0000with-nul"}', {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						});
+					}
+					if (body.value === "nul-failure") {
+						return new Response("upstream\u0000failed", { status: 500 });
+					}
 					if (
 						body.value === "wait-for-abort" ||
 						body.value === "wait-for-timeout"
@@ -317,6 +332,19 @@ describe("operations.execute backend lifecycle", () => {
 						});
 					}
 					if (request.method === "tools/call") {
+						if (
+							(request.params?.arguments as Record<string, unknown> | undefined)
+								?.value === "nul-output"
+						) {
+							return jsonResponse({
+								jsonrpc: "2.0",
+								id: request.id,
+								result: {
+									content: [{ type: "text", text: "remote\u0000echo" }],
+									isError: false,
+								},
+							});
+						}
 						if (
 							(request.params?.arguments as Record<string, unknown> | undefined)
 								?.fail_transport === true
@@ -935,6 +963,129 @@ describe("operations.execute backend lifecycle", () => {
 			output: {
 				body: { created: true, body: { value: "http-ok" } },
 			},
+		});
+	});
+
+	it("strips NUL from local action output", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "nul-output" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: { backend: "local_action", tail: "beforeafter" },
+		});
+		const [run] = await getTestDb()`
+			SELECT action_output FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run.action_output).toEqual({
+			backend: "local_action",
+			tail: "beforeafter",
+		});
+	});
+
+	it("strips NUL from a local action failure message", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "nul-error" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "failed",
+			error_message: "localboom",
+		});
+		const [run] = await getTestDb()`
+			SELECT error_message FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run.error_message).toBe("localboom");
+	});
+
+	it("strips NUL from upstream MCP tool output", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: mcpConnectionId,
+				operation_key: "remote_echo",
+				input: { value: "nul-output" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: { content: [{ type: "text", text: "remoteecho" }] },
+		});
+		const [run] = await getTestDb()`
+			SELECT action_output FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run.action_output).toEqual({
+			content: [{ type: "text", text: "remoteecho" }],
+		});
+	});
+
+	it("strips NUL from successful HTTP operation output", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: httpConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "nul-success" } },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: { body: { nulkey: "valuewith-nul" } },
+		});
+		const [run] = await getTestDb()`
+			SELECT action_output FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run.action_output).toEqual({ body: { nulkey: "valuewith-nul" } });
+	});
+
+	it("strips NUL from failed HTTP operation output and error", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: httpConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "nul-failure" } },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "failed",
+			error_message: "upstreamfailed",
+		});
+		const [run] = await getTestDb()`
+			SELECT action_output, error_message FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run).toMatchObject({
+			action_output: { body: "upstreamfailed" },
+			error_message: "upstreamfailed",
 		});
 	});
 

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -1,6 +1,7 @@
 import { getErrorMessage } from "@lobu/core";
 import { getDb } from "../db/client";
 import { resolveCredentialsByConnectionId } from "../mcp-proxy/credential-resolver";
+import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import type { OperationDescriptor } from "./types";
 
 const DEFAULT_HTTP_OPERATION_FETCH_TIMEOUT_MS = 120_000;
@@ -74,10 +75,13 @@ async function failRun(
 	errorMessage: string,
 	deferTerminalWrite = false,
 ): Promise<HttpOperationExecutionResult> {
+	// Upstream response text reaches here through getErrorMessage, so the
+	// message can carry NUL (0x00) that Postgres rejects (see streamContent).
+	const message = stripNul(errorMessage);
 	if (!deferTerminalWrite) {
-		await getDb()`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		await getDb()`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId}`;
 	}
-	return { status: "failed", error_message: errorMessage };
+	return { status: "failed", error_message: message };
 }
 
 function requestAbortSignal(parent?: AbortSignal): {
@@ -201,7 +205,7 @@ export async function executeHttpOperation(
 				redirect: "manual",
 				signal: requestAbort.signal,
 			});
-			text = await response.text();
+			text = stripNul(await response.text());
 		} finally {
 			requestAbort.cleanup();
 		}
@@ -212,6 +216,7 @@ export async function executeHttpOperation(
 		} catch {
 			// Keep non-JSON responses as text.
 		}
+		parsedBody = stripNulDeep(parsedBody);
 		const output = { body: parsedBody } as Record<string, unknown>;
 		const metadata: Record<string, unknown> = {
 			http_status: response.status,

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -31,6 +31,7 @@ import { ToolUserError } from "../../../../utils/errors";
 import { resolveExecutionAuth } from "../../../../utils/execution-context";
 import { insertEvent } from "../../../../utils/insert-event";
 import logger from "../../../../utils/logger";
+import { stripNul, stripNulDeep } from "../../../../utils/strip-nul";
 import { buildResourcePermalink } from "../../../../utils/url-builder";
 import { trackAutomationReaction } from "../../../../utils/automation-reactions";
 import { dispatchChromeActionToExtension } from "../../../../worker-api/dispatch-chrome-action";
@@ -53,11 +54,16 @@ async function failRunInline(
 	errorMsg: string,
 	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
+	// Connector code, scraped pages and upstream MCP servers all reach here as
+	// raw text, so the message can carry NUL (0x00) that Postgres rejects (see
+	// streamContent). Strip it at the terminal write the local_action and
+	// mcp_tool backends share; executeHttpOperation sanitizes its own response.
+	const message = stripNul(errorMsg);
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMsg} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId}`;
 	}
-	return { status: "failed", error_message: errorMsg };
+	return { status: "failed", error_message: message };
 }
 
 // Update the run to completed status and return the output in one call.
@@ -67,11 +73,15 @@ async function completeRunInline(
 	output: Record<string, unknown>,
 	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
+	// Same NUL strip as failRunInline — `output` is connector- or upstream-MCP-
+	// produced and lands in the jsonb `action_output` column. Sanitize before
+	// returning too: approve's deferred phase 2 persists this value itself.
+	const sanitized = stripNulDeep(output) as Record<string, unknown>;
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
 	}
-	return { status: "completed", output };
+	return { status: "completed", output: sanitized };
 }
 
 /**

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -34,6 +34,7 @@ import {
 } from './geo-enrichment';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
+import { stripNul, stripNulDeep } from './strip-nul';
 
 /**
  * Single bounded retry for the fire-and-forget audit writers below
@@ -570,6 +571,11 @@ export async function insertEvent(
     afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
   }
 ): Promise<InsertedEvent> {
+  // This is the physical write funnel for event content. Connector items,
+  // Automation output, and approval metadata all converge here, so sanitize
+  // the complete input once before any lookup, comparison, or Postgres write.
+  // stripNulDeep preserves Dates and other class instances.
+  params = stripNulDeep(params) as InsertEventParams;
   const sql = options?.sql ?? getDb();
 
   // Reverse-geocode lat/lng → city / admin1 / country once per event,
@@ -1033,7 +1039,10 @@ export async function insertConnectionlessAuditEvent(
   eventType: AuditEventType,
   options?: ConnectionlessAuditInsertOptions
 ): Promise<InsertedEvent> {
-  const idempotencyKey = `audit:${params.originId}`;
+  // insertEvent strips NUL from originId, so derive the key from the stripped
+  // value: the unique index and the reconciliation SELECT below both read the
+  // persisted `_lobu_idempotency_key`, which is the stripped form.
+  const idempotencyKey = `audit:${stripNul(params.originId)}`;
   const formattedEventType = formatAuditEventType(eventType);
   const metadata: Record<string, unknown> = {
     ...(params.metadata ?? {}),

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -59,7 +59,7 @@ import {
 } from "../utils/inline-attachments";
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
-import { stripNulDeep } from "../utils/strip-nul";
+import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import {
 	bumpDeviceFinalizeNudge,
 	resolveFinalizeNudgeBudget,
@@ -698,9 +698,11 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 	try {
 		const req = await c.req.json<CompleteRequest>();
 
-		// Strip NUL (0x00) from connector-supplied jsonb payloads before they hit
-		// Postgres (see streamContent). The final checkpoint and refreshed browser
-		// auth_update are written via raw sql.json below.
+		// Strip NUL (0x00) from connector- and worker-supplied payloads before they
+		// hit Postgres (see streamContent). The final checkpoint and refreshed
+		// browser auth_update are written via raw sql.json below; output_tail is
+		// the raw subprocess stdout tail and error_message its failure text, so
+		// both carry whatever bytes the OS shell emitted.
 		if (req.checkpoint) {
 			req.checkpoint = stripNulDeep(req.checkpoint) as Record<string, unknown>;
 		}
@@ -710,6 +712,8 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 				unknown
 			>;
 		}
+		if (req.error_message) req.error_message = stripNul(req.error_message);
+		if (req.output_tail) req.output_tail = stripNul(req.output_tail);
 
 		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
 		if (denied) return denied;
@@ -1215,8 +1219,13 @@ export async function completeAutomationRun(c: Context<{ Bindings: Env }>) {
 		}
 	}
 
+	// The device CLI's stdout/stderr reach us verbatim, so both can carry NUL
+	// (0x00) that Postgres rejects (see streamContent). Strip once here: these
+	// two feed every downstream write — output_tail, the resume nudge's tail,
+	// error_message, and the completion lifecycle event.
+	if (typeof body.error === "string") body.error = stripNul(body.error);
 	const hasError = typeof body.error === "string" && body.error.trim() !== "";
-	const output = typeof body.output === "string" ? body.output : "";
+	const output = typeof body.output === "string" ? stripNul(body.output) : "";
 	const durationMs =
 		typeof body.duration_ms === "number" && Number.isFinite(body.duration_ms)
 			? Math.max(0, Math.floor(body.duration_ms))
@@ -1653,7 +1662,9 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
 			if (req.error_message) {
 				// Guarded terminal transition (the status='running' AND claimed_by guard
 				// inside finalizeRun won't resurrect a reaped run). Ownership is already
-				// enforced by authorizeRunForWorker above.
+				// enforced by authorizeRunForWorker above. The message is worker-
+				// reported text, so strip NUL first (see streamContent).
+				req.error_message = stripNul(req.error_message);
 				await finalizeRun(sql, {
 					runId: req.run_id,
 					workerId: req.worker_id,
@@ -1816,6 +1827,12 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
 	try {
 		const req = await c.req.json<CompleteAuthRequest>();
 
+		// Strip NUL (0x00) from the worker-reported exit diagnostics before they
+		// hit Postgres (see streamContent): output_tail is the raw subprocess
+		// stdout tail and error_message its failure text.
+		if (req.error_message) req.error_message = stripNul(req.error_message);
+		if (req.output_tail) req.output_tail = stripNul(req.output_tail);
+
 		// Ownership gate — a worker can only finalize runs it claimed. Mirrors the
 		// other /complete handlers. Without it a leaked worker token could finalize
 		// an arbitrary auth run and inject credentials into the linked auth_profiles
@@ -1925,6 +1942,18 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 	let publishedActionArtifactIds: string[] = [];
 	try {
 		const req = await c.req.json<CompleteActionRequest>();
+
+		// Strip NUL (0x00) from worker-reported output before it reaches Postgres
+		// (see streamContent). An action's output and error text carry raw
+		// subprocess bytes, so both the jsonb action_output and the text
+		// error_message can arrive with a NUL an OS shell emitted.
+		if (req.action_output) {
+			req.action_output = stripNulDeep(req.action_output) as Record<
+				string,
+				unknown
+			>;
+		}
+		if (req.error_message) req.error_message = stripNul(req.error_message);
 
 		// Same ownership check as the other /complete endpoints — a worker
 		// can only finalize runs it claimed. Without this, a leaked worker


### PR DESCRIPTION
## Summary

- Prevent PostgreSQL JSON/text persistence failures when device, HTTP, MCP, local-action, automation, auth, embedding, or audit payloads contain NUL bytes.
- Sanitize centrally in `insertEvent` and at terminal operation/run boundaries so returned values match persisted values.
- Preserve dates and non-plain objects while recursively sanitizing JSON strings, values, arrays, and object keys.

## Test plan

- [x] Intended eight files staged explicitly; `make pre-pr` clean.
- [x] Targeted server Vitest paths: 6 files, 53 tests passed.
- [x] `bun test ./packages/server/src/utils/__tests__/strip-nul.test.ts`: 6 passed.
- [x] Bug fix: before the fix, direct event insertion and operation completion reproduced PostgreSQL `invalid byte sequence for encoding UTF8: 0x00` / `unsupported Unicode escape sequence`; after the fix, event, worker, HTTP, local action, MCP, approval-transition, and failure-output cases passed.
- [x] `make review-fix` completed on the settled diff.

## Notes

The production incident was triggered by shell output containing NUL bytes. This change fixes the persistence class rather than special-casing `os.shell`.
