### PR TITLE
fix(search): reclaim a superseded event's vectors

### DIFF
--- a/packages/server/src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts
+++ b/packages/server/src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts
@@ -58,11 +58,12 @@ async function vectorRowsFor(eventId: number) {
   `) as Array<{ embedding_model: string; chunk_index: number }>;
 }
 
-// Both embedding writers take the same liveness lock (SELECT ... superseded_by
-// IS NULL ... FOR SHARE) before touching event_embeddings, so either that
-// SELECT or — if the lock were dropped — the DELETE behind it must be waiting
-// on `blockingPid`. Accept both so a regression reaches the row assertion
-// instead of dying here with a misleading timeout.
+// Both embedding writers lock liveness before touching event_embeddings:
+// completion uses FOR SHARE, while insertEvent uses FOR NO KEY UPDATE because
+// it may later update volatile event state. Either SELECT or — if the lock were
+// dropped — the DELETE behind it must be waiting on `blockingPid`. Accept all
+// three forms so a regression reaches the row assertion instead of dying here
+// with a misleading timeout.
 async function waitForBlockedEmbeddingWriter(
   sql: ReturnType<typeof getTestDb>,
   blockingPid: number,
@@ -85,7 +86,10 @@ async function waitForBlockedEmbeddingWriter(
           OR (
             query ILIKE '%FROM events%'
             AND query ILIKE '%superseded_by IS NULL%'
-            AND query ILIKE '%FOR SHARE%'
+            AND (
+              query ILIKE '%FOR SHARE%'
+              OR query ILIKE '%FOR NO KEY UPDATE%'
+            )
           )
         )
         AND ${blockingPid} = ANY(pg_blocking_pids(pid))
@@ -448,6 +452,109 @@ describe('supersede reclaims event_embeddings (issue #3066)', () => {
     await Promise.all([superseding, refreshing]);
 
     expect(await vectorRowsFor(first.id)).toEqual([]);
+  });
+
+  it('does not deadlock a volatile refresh with embedding completion', async () => {
+    const sql = getTestDb();
+    const originId = `reclaim-writer-deadlock-${Date.now()}`;
+    const occurredAt = new Date();
+    const firstParams = {
+      entityIds: [entityId],
+      organizationId: orgId,
+      originId,
+      title: 'writer deadlock',
+      content: 'unchanged content with volatile state',
+      occurredAt,
+      semanticType: 'content' as const,
+      originType: 'content',
+      connectorKey: 'vector-reclaim-connector',
+      connectionId,
+      embedding: unitVec(13),
+      embeddingModel: MODEL,
+    };
+    const first = await insertEvent(firstParams, { onConflictUpdate: true });
+
+    let blockerReady!: () => void;
+    const blockerHasVectorLock = new Promise<void>((resolve) => {
+      blockerReady = resolve;
+    });
+    let releaseBlocker!: () => void;
+    const blockerMayCommit = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    let blockerPid = 0;
+    const blocking = sql.begin(async (tx) => {
+      const [backend] = await tx<{ pid: number | string }>`SELECT pg_backend_pid()::int AS pid`;
+      blockerPid = Number(backend!.pid);
+      await tx`
+        SELECT event_id
+        FROM event_embeddings
+        WHERE event_id = ${first.id}
+          AND embedding_model = ${MODEL}
+        FOR UPDATE
+      `;
+      blockerReady();
+      await blockerMayCommit;
+    });
+    await blockerHasVectorLock;
+
+    // Queue the refresh first. It holds the event liveness lock while waiting
+    // for the vector row, then updates volatile event state after replacing the
+    // vector. Completion queues second and must not retain a compatible event
+    // lock that turns the refresh's later UPDATE into a lock cycle.
+    const refreshing = insertEvent(
+      { ...firstParams, score: 1, embedding: unitVec(14) },
+      { onConflictUpdate: true }
+    );
+    let refreshSettled = false;
+    void refreshing.then(
+      () => {
+        refreshSettled = true;
+      },
+      () => {
+        refreshSettled = true;
+      }
+    );
+    await waitForBlockedEmbeddingWriter(sql, blockerPid, 'refresh', () => refreshSettled);
+
+    const completing = completeEmbeddings(
+      mockEmbeddingsCtx({
+        run_id: -1,
+        worker_id: 'test-worker',
+        embeddings: [
+          { event_id: first.id, chunk_index: 0, embedding: unitVec(15), embedding_model: MODEL },
+        ],
+      })
+    );
+    let completionSettled = false;
+    void completing.then(
+      () => {
+        completionSettled = true;
+      },
+      () => {
+        completionSettled = true;
+      }
+    );
+    try {
+      await waitForBlockedEmbeddingWriter(
+        sql,
+        blockerPid,
+        'completion',
+        () => completionSettled
+      );
+    } finally {
+      releaseBlocker();
+      await Promise.allSettled([blocking, refreshing, completing]);
+    }
+
+    const [refreshed, completion] = await Promise.all([refreshing, completing]);
+    expect(refreshed.change).toBe('state_updated');
+    expect(
+      (completion as unknown as { b: { success: boolean; updated: number; failed: number } }).b
+    ).toMatchObject({ success: true, updated: 1, failed: 0 });
+    expect(await vectorRowsFor(first.id)).toEqual([
+      { embedding_model: MODEL, chunk_index: 0 },
+    ]);
   });
 
   it('leaves an ordinary insert with no predecessor alone', async () => {

--- a/packages/server/src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts
+++ b/packages/server/src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Issue #3066 reproducer: superseding an event must reclaim its vectors.
+ *
+ * Nothing used to remove a superseded event's `event_embeddings` rows — both
+ * DELETE sites key on the row's OWN `event_id` before rewriting its vector, so
+ * the predecessor's vector survived forever. Vector retrieval excludes
+ * superseded events, yet `idx_events_embedding` is a plain ivfflat over the
+ * whole table with no partial predicate, so the unreachable vectors can consume
+ * ANN scan budget.
+ *
+ * The cases cover both supersede entry points, late worker completion, and the
+ * transaction interleaving between completion and supersede.
+ */
+
+import type { Context } from 'hono';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { insertEvent } from '../../../utils/insert-event';
+import { completeEmbeddings } from '../../../worker-api';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+const MODEL = 'Xenova/bge-base-en-v1.5';
+const OTHER_MODEL = 'test/replacement-768d';
+
+function unitVec(seed: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[seed % EMBEDDING_DIM] = 1;
+  return v;
+}
+
+// Minimal Hono Context: completeEmbeddings only reads the JSON body, calls
+// c.json(), and consults c.var.workerAuthMode (no-op unless 'user').
+function mockEmbeddingsCtx(body: unknown): Context<{ Bindings: Env }> {
+  return {
+    req: { json: async () => body },
+    var: {},
+    json: (b: unknown, status?: number) => ({ b, status }) as unknown as Response,
+  } as unknown as Context<{ Bindings: Env }>;
+}
+
+async function vectorRowsFor(eventId: number) {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT embedding_model, chunk_index
+    FROM event_embeddings
+    WHERE event_id = ${eventId}
+    ORDER BY embedding_model, chunk_index
+  `) as Array<{ embedding_model: string; chunk_index: number }>;
+}
+
+// Both embedding writers take the same liveness lock (SELECT ... superseded_by
+// IS NULL ... FOR SHARE) before touching event_embeddings, so either that
+// SELECT or — if the lock were dropped — the DELETE behind it must be waiting
+// on `blockingPid`. Accept both so a regression reaches the row assertion
+// instead of dying here with a misleading timeout.
+async function waitForBlockedEmbeddingWriter(
+  sql: ReturnType<typeof getTestDb>,
+  blockingPid: number,
+  writer: string,
+  isSettled: () => boolean,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isSettled()) {
+      throw new Error(`embedding ${writer} passed an in-flight supersede`);
+    }
+    const [row] = await sql<{ count: number }>`
+      SELECT count(*)::int AS count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND (
+          query ILIKE '%DELETE FROM event_embeddings%'
+          OR (
+            query ILIKE '%FROM events%'
+            AND query ILIKE '%superseded_by IS NULL%'
+            AND query ILIKE '%FOR SHARE%'
+          )
+        )
+        AND ${blockingPid} = ANY(pg_blocking_pids(pid))
+    `;
+    if ((row?.count ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`embedding ${writer} never blocked behind the supersede`);
+}
+
+describe('supersede reclaims event_embeddings (issue #3066)', () => {
+  let orgId: string;
+  let entityId: number;
+  let connectionId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Vector Reclaim Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'vector-reclaim-test@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({ name: 'Reclaim Target', organization_id: org.id });
+    entityId = entity.id;
+
+    await createTestConnectorDefinition({
+      key: 'vector-reclaim-connector',
+      name: 'Vector Reclaim',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'vector-reclaim-connector',
+      entity_ids: [entity.id],
+    });
+    connectionId = connection.id;
+  });
+
+  it('drops every model and every chunk of the predecessor on the dedup supersede path', async () => {
+    const sql = getTestDb();
+    const originId = `reclaim-dedup-${Date.now()}`;
+
+    const first = await insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId,
+        title: 'v1',
+        content: 'first version of the content',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+        embedding: unitVec(1),
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+
+    // A real backfill writes N chunks per (event, model) and old/new models
+    // coexist during a swap. The reclaim must take all of them, not just the
+    // configured model's chunk 0.
+    await sql`
+      INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
+      VALUES
+        (${first.id}, 1, ${`[${unitVec(2).join(',')}]`}::vector, ${MODEL}),
+        (${first.id}, 0, ${`[${unitVec(3).join(',')}]`}::vector, ${OTHER_MODEL})
+    `;
+    expect(await vectorRowsFor(first.id)).toHaveLength(3);
+
+    const second = await insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId,
+        title: 'v2',
+        content: 'second version of the content',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+        embedding: unitVec(4),
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(second.change).toBe('superseded');
+    expect(second.id).not.toBe(first.id);
+
+    expect(await vectorRowsFor(first.id)).toEqual([]);
+    expect(await vectorRowsFor(second.id)).toEqual([{ embedding_model: MODEL, chunk_index: 0 }]);
+
+    // The ledger itself is untouched: the predecessor row still exists, stamped.
+    const [ledger] = (await sql`
+      SELECT id, payload_text, superseded_by FROM events WHERE id = ${first.id}
+    `) as Array<{
+      id: string | number;
+      payload_text: string | null;
+      superseded_by: string | number | null;
+    }>;
+    expect(ledger).toBeDefined();
+    expect(ledger!.payload_text).toBe('first version of the content');
+    expect(Number(ledger!.superseded_by)).toBe(Number(second.id));
+    const [successor] = (await sql`
+      SELECT supersedes_event_id FROM events WHERE id = ${second.id}
+    `) as Array<{ supersedes_event_id: string | number | null }>;
+    expect(Number(successor!.supersedes_event_id)).toBe(Number(first.id));
+  });
+
+  it('drops the predecessor on the explicit supersedesEventId path', async () => {
+    const first = await insertEvent({
+      entityIds: [entityId],
+      organizationId: orgId,
+      originId: `reclaim-explicit-${Date.now()}`,
+      title: 'explicit v1',
+      content: 'explicit first version',
+      occurredAt: new Date(),
+      semanticType: 'content',
+      originType: 'content',
+      connectorKey: 'vector-reclaim-connector',
+      connectionId,
+      embedding: unitVec(5),
+      embeddingModel: MODEL,
+    });
+    expect(await vectorRowsFor(first.id)).toHaveLength(1);
+
+    const second = await insertEvent({
+      entityIds: [entityId],
+      organizationId: orgId,
+      originId: `reclaim-explicit-v2-${Date.now()}`,
+      title: 'explicit v2',
+      content: 'explicit second version',
+      occurredAt: new Date(),
+      semanticType: 'content',
+      originType: 'content',
+      connectorKey: 'vector-reclaim-connector',
+      connectionId,
+      embedding: unitVec(6),
+      embeddingModel: MODEL,
+      supersedesEventId: first.id,
+    });
+
+    expect(second.change).toBe('superseded');
+    expect(await vectorRowsFor(first.id)).toEqual([]);
+    expect(await vectorRowsFor(second.id)).toEqual([{ embedding_model: MODEL, chunk_index: 0 }]);
+  });
+
+  it('does not let a raced embed job re-create a superseded event\'s vector', async () => {
+    // The backfill selects live events, but the event can be superseded between
+    // selection and the worker reporting its vector. Without a completion-time
+    // liveness guard the dead row comes straight back.
+    const originId = `reclaim-race-${Date.now()}`;
+    const first = await insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId,
+        title: 'race v1',
+        content: 'race first version',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+    const second = await insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId,
+        title: 'race v2',
+        content: 'race second version',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+    expect(second.change).toBe('superseded');
+
+    await completeEmbeddings(
+      mockEmbeddingsCtx({
+        run_id: -1,
+        worker_id: 'test-worker',
+        embeddings: [
+          { event_id: first.id, chunk_index: 0, embedding: unitVec(8), embedding_model: MODEL },
+          { event_id: second.id, chunk_index: 0, embedding: unitVec(9), embedding_model: MODEL },
+        ],
+      })
+    );
+
+    expect(await vectorRowsFor(first.id)).toEqual([]);
+    expect(await vectorRowsFor(second.id)).toEqual([{ embedding_model: MODEL, chunk_index: 0 }]);
+  });
+
+  it('serializes embedding completion with an in-flight supersede', async () => {
+    const sql = getTestDb();
+    const first = await insertEvent({
+      entityIds: [entityId],
+      organizationId: orgId,
+      originId: `reclaim-concurrent-v1-${Date.now()}`,
+      title: 'concurrent v1',
+      content: 'concurrent first version',
+      occurredAt: new Date(),
+      semanticType: 'content',
+      originType: 'content',
+      connectorKey: 'vector-reclaim-connector',
+      connectionId,
+    });
+
+    let supersedeStarted!: () => void;
+    const supersedeHasRowLock = new Promise<void>((resolve) => {
+      supersedeStarted = resolve;
+    });
+    let releaseSupersede!: () => void;
+    const supersedeMayCommit = new Promise<void>((resolve) => {
+      releaseSupersede = resolve;
+    });
+    let supersederPid = 0;
+    const superseding = insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId: `reclaim-concurrent-v2-${Date.now()}`,
+        title: 'concurrent v2',
+        content: 'concurrent second version',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+        supersedesEventId: first.id,
+      },
+      {
+        afterPersist: async (_event, tx) => {
+          const [backend] = await tx<{ pid: number | string }>`SELECT pg_backend_pid()::int AS pid`;
+          supersederPid = Number(backend!.pid);
+          supersedeStarted();
+          await supersedeMayCommit;
+        },
+      }
+    );
+    await supersedeHasRowLock;
+
+    const completing = completeEmbeddings(
+      mockEmbeddingsCtx({
+        run_id: -1,
+        worker_id: 'test-worker',
+        embeddings: [
+          { event_id: first.id, chunk_index: 0, embedding: unitVec(10), embedding_model: MODEL },
+        ],
+      })
+    );
+    let completionSettled = false;
+    void completing.then(
+      () => {
+        completionSettled = true;
+      },
+      () => {
+        completionSettled = true;
+      }
+    );
+    try {
+      await waitForBlockedEmbeddingWriter(
+        sql,
+        supersederPid,
+        'completion',
+        () => completionSettled
+      );
+    } finally {
+      releaseSupersede();
+      await Promise.allSettled([superseding, completing]);
+    }
+    await Promise.all([superseding, completing]);
+
+    expect(await vectorRowsFor(first.id)).toEqual([]);
+  });
+
+  it('does not let an unchanged-content refresh re-create a superseded event\'s vector', async () => {
+    const sql = getTestDb();
+    const originId = `reclaim-refresh-race-${Date.now()}`;
+    const occurredAt = new Date();
+    const firstParams = {
+      entityIds: [entityId],
+      organizationId: orgId,
+      originId,
+      title: 'refresh race v1',
+      content: 'unchanged content whose embedding is refreshed',
+      occurredAt,
+      semanticType: 'content' as const,
+      originType: 'content',
+      connectorKey: 'vector-reclaim-connector',
+      connectionId,
+      embedding: unitVec(11),
+      embeddingModel: MODEL,
+    };
+    const first = await insertEvent(firstParams, { onConflictUpdate: true });
+
+    let supersedeStarted!: () => void;
+    const supersedeHasDeletedVector = new Promise<void>((resolve) => {
+      supersedeStarted = resolve;
+    });
+    let releaseSupersede!: () => void;
+    const supersedeMayCommit = new Promise<void>((resolve) => {
+      releaseSupersede = resolve;
+    });
+    let supersederPid = 0;
+    const superseding = insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId: `${originId}-v2`,
+        title: 'refresh race v2',
+        content: 'new content',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+        supersedesEventId: first.id,
+      },
+      {
+        afterPersist: async (_event, tx) => {
+          const [backend] = await tx<{ pid: number | string }>`SELECT pg_backend_pid()::int AS pid`;
+          supersederPid = Number(backend!.pid);
+          supersedeStarted();
+          await supersedeMayCommit;
+        },
+      }
+    );
+    await supersedeHasDeletedVector;
+
+    const refreshing = insertEvent(
+      { ...firstParams, embedding: unitVec(12) },
+      { onConflictUpdate: true }
+    );
+    let refreshSettled = false;
+    void refreshing.then(
+      () => {
+        refreshSettled = true;
+      },
+      () => {
+        refreshSettled = true;
+      }
+    );
+    try {
+      await waitForBlockedEmbeddingWriter(sql, supersederPid, 'refresh', () => refreshSettled);
+    } finally {
+      releaseSupersede();
+      await Promise.allSettled([superseding, refreshing]);
+    }
+    await Promise.all([superseding, refreshing]);
+
+    expect(await vectorRowsFor(first.id)).toEqual([]);
+  });
+
+  it('leaves an ordinary insert with no predecessor alone', async () => {
+    const inserted = await insertEvent(
+      {
+        entityIds: [entityId],
+        organizationId: orgId,
+        originId: `reclaim-plain-${Date.now()}`,
+        title: 'plain',
+        content: 'a plain insert that supersedes nothing',
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'vector-reclaim-connector',
+        connectionId,
+        embedding: unitVec(7),
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+
+    expect(inserted.change).toBe('inserted');
+    expect(await vectorRowsFor(inserted.id)).toEqual([
+      { embedding_model: MODEL, chunk_index: 0 },
+    ]);
+  });
+});

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -465,13 +465,16 @@ async function upsertEmbedding(
     // Serialize every runtime embedding writer with the supersede UPDATE. A
     // refresh of semantically unchanged content can otherwise block behind the
     // predecessor deletion, then recreate that dead row after the supersede
-    // commits. Keep the lock order events -> event_embeddings everywhere.
+    // commits. This path can later update volatile event state, so take the
+    // stronger lock before touching event_embeddings; upgrading FOR SHARE after
+    // a completion writer takes its own SHARE lock creates a lock cycle. Keep
+    // the lock order events -> event_embeddings everywhere.
     const liveEvent = await activeSql`
       SELECT id
       FROM events
       WHERE id = ${eventId}
         AND superseded_by IS NULL
-      FOR SHARE
+      FOR NO KEY UPDATE
     `;
     // Replace this (event, model)'s chunk set with a single chunk-0 row, scoped
     // to the model so old/new models can coexist during a zero-downtime swap

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -461,14 +461,40 @@ async function upsertEmbedding(
   // stamped one.
   if (!embeddingModel) return;
   const vectorLiteral = `[${embedding.join(',')}]`;
-  // Replace this (event, model)'s chunk set with a single chunk-0 row:
-  // delete-then-insert scoped to the model so old/new models can coexist
-  // during a zero-downtime swap (PK is event_id + embedding_model + chunk_index).
-  await sql`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${embeddingModel}`;
-  await sql`
-    INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
-    VALUES (${eventId}, 0, ${vectorLiteral}::vector, ${embeddingModel})
-  `;
+  const replaceIfLive = async (activeSql: DbClient): Promise<void> => {
+    // Serialize every runtime embedding writer with the supersede UPDATE. A
+    // refresh of semantically unchanged content can otherwise block behind the
+    // predecessor deletion, then recreate that dead row after the supersede
+    // commits. Keep the lock order events -> event_embeddings everywhere.
+    const liveEvent = await activeSql`
+      SELECT id
+      FROM events
+      WHERE id = ${eventId}
+        AND superseded_by IS NULL
+      FOR SHARE
+    `;
+    // Replace this (event, model)'s chunk set with a single chunk-0 row, scoped
+    // to the model so old/new models can coexist during a zero-downtime swap
+    // (PK is event_id + embedding_model + chunk_index). Delete first even when
+    // the event is already dead, so this path also heals a stale row left by an
+    // older writer; the liveness lock keeps a writer that saw the event live
+    // from racing a superseder past the INSERT below.
+    await activeSql`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${embeddingModel}`;
+    if (liveEvent.length === 0) return;
+    await activeSql`
+      INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
+      VALUES (${eventId}, 0, ${vectorLiteral}::vector, ${embeddingModel})
+    `;
+  };
+
+  // Existing insertEvent supersede/dedup callers already pass a transaction
+  // handle. Plain inserts use the pool, so open a short transaction here to
+  // keep the liveness lock through delete + insert.
+  if (typeof sql.savepoint === 'function') {
+    await replaceIfLive(sql);
+  } else {
+    await sql.begin(async (tx) => replaceIfLive(tx));
+  }
 }
 
 type EventLineage = {
@@ -905,6 +931,14 @@ export async function insertEvent(
         WHERE id = ${supersedesEventId}
           AND superseded_by IS NULL
       `;
+      // Vector readers exclude superseded events, but the unfiltered ivfflat
+      // index still carries their vectors. That is a recall loss, not only
+      // wasted storage: `ivfflat.probes` is 1 with `iterative_scan` off, so a
+      // probe list spent on rows the live-row join then discards simply yields
+      // fewer live candidates. Reclaim every model and chunk in the same
+      // transaction as the supersede stamp; event_embeddings is derived data,
+      // not the append-only events ledger.
+      await sql`DELETE FROM event_embeddings WHERE event_id = ${supersedesEventId}`;
     }
 
     await upsertEmbedding(inserted.id, params.embedding, params.embeddingModel, sql);

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -1808,7 +1808,23 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
 			const model = items[0]!.embedding_model!;
 			try {
 				await sql.begin(async (tx) => {
+					// Serialize with insertEvent's supersede UPDATE before replacing the
+					// vectors. FOR SHARE lets different model writers coexist, but makes a
+					// concurrent superseder wait and delete anything written here after it
+					// acquires the row.
+					const liveEvent = await tx`
+						SELECT id
+						FROM events
+						WHERE id = ${eventId}
+						  AND superseded_by IS NULL
+						FOR SHARE
+					`;
 					await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${model}`;
+					// Superseded between backfill selection and now: the delete above is the
+					// whole job. It counts toward `updated`, not `failed` — the event is
+					// finished work (discovery already skips superseded rows), so failing
+					// the run over it would re-queue a healthy backfill.
+					if (liveEvent.length === 0) return;
 					for (const item of items) {
 						const vectorStr = `[${item.embedding.join(",")}]`;
 						await tx.unsafe(

--- a/scripts/bench-vector-recall.sql
+++ b/scripts/bench-vector-recall.sql
@@ -1,0 +1,246 @@
+-- Recall benchmark for `idx_events_embedding` (ivfflat, vector_cosine_ops).
+--
+-- WHY: the ANN index is built over the whole `event_embeddings` table with no
+-- partial predicate, while production retrieval excludes rows with a non-NULL
+-- `superseded_by`. Superseded vectors can therefore consume scan budget. The
+-- benchmark pins the default `ivfflat.probes = 1` and disables iterative scan
+-- to expose that loss.
+--
+-- WHAT IT MEASURES, per sampled query vector:
+--   recall@k        |ANN top-k ∩ exact top-k| / |exact top-k|, live rows only.
+--                   ANN mirrors the index/live-filter order of the candidate
+--                   branch in packages/server/src/utils/content-search/search-path.ts
+--                   (inner `LIMIT CANDIDATE_VECTOR_LIMIT * 3` over chunk rows
+--                   joined to live events, collapsed to distinct events by
+--                   their nearest chunk).
+--   probed          rows the ivfflat scan produced before the inner LIMIT.
+--   live_probed     how many of those survived the live-row join.
+--   exact_n/ann_n   how many rows each leg actually returned (k unless the
+--                   corpus is smaller).
+--
+-- The exact leg defeats the index with `+ 0.0` on the distance expression, so
+-- it is a brute-force sort over live rows (verify with EXPLAIN if in doubt).
+--
+-- READ-ONLY: no DDL, no temp tables, no writes. Safe against a replica or prod.
+-- Cost: one full scan of the live vectors per sampled query (~7-10s each on the
+-- 2026-08 prod shape, measured). Keep :n_queries modest against a live primary.
+--
+-- USAGE
+--   psql "$DATABASE_URL" -f scripts/bench-vector-recall.sql
+--   psql "$DATABASE_URL" -v n_queries=20 -v k=20 -v probes=1 \
+--        -f scripts/bench-vector-recall.sql
+--
+-- Against prod (read-only recipe; run from a shell with kubectl access):
+--   kubectl exec -i -n summaries-prod lobu-db-prod-1 -c postgres -- \
+--     env PGPASSWORD="$PW" psql -U summaries -h 127.0.0.1 -d owletto \
+--     -v n_queries=20 < scripts/bench-vector-recall.sql
+--
+-- PAIRED BEFORE/AFTER. The default query set is drawn by a seeded TABLESAMPLE,
+-- which is stable only while the table content is — and the reclaim changes the
+-- content. For a true paired comparison, copy the `query_event_id` column from
+-- the BEFORE run and pin it on the AFTER run:
+--   psql ... -v query_ids='1159435,1752302,1808609' -v n_queries=3 \
+--        -f scripts/bench-vector-recall.sql
+-- Reclaim leaves these query vectors alone as long as the sampled events remain
+-- live between runs.
+
+\set ON_ERROR_STOP on
+
+\if :{?model}
+\else
+\set model 'Xenova/bge-base-en-v1.5'
+\endif
+\if :{?n_queries}
+\else
+\set n_queries 20
+\endif
+\if :{?k}
+\else
+\set k 20
+\endif
+-- CANDIDATE_VECTOR_LIMIT (= 200, packages/server/src/utils/content-search/fts.ts)
+-- times the 3x chunk over-fetch applied in search-path.ts.
+\if :{?ann_limit}
+\else
+\set ann_limit 600
+\endif
+\if :{?probes}
+\else
+\set probes 1
+\endif
+-- TABLESAMPLE percentage used to draw the query set cheaply from the heap.
+-- SYSTEM sampling picks whole BLOCKS, so on a small table 2% can draw nothing
+-- and the recall table comes back as a single all-NULL MEAN row. That is an
+-- empty sample, not a zero score — raise :sample_pct or pin :query_ids.
+\if :{?sample_pct}
+\else
+\set sample_pct 2
+\endif
+\if :{?seed}
+\else
+\set seed 0.42
+\endif
+-- TABLESAMPLE has its own PRNG; REPEATABLE pins it so the query set is stable.
+\if :{?tablesample_seed}
+\else
+\set tablesample_seed 42
+\endif
+-- Optional comma-separated event ids to use as the query set instead of the
+-- seeded sample — the paired before/after knob described above.
+\if :{?query_ids}
+\else
+\set query_ids ''
+\endif
+
+-- The exact leg is a brute-force scan per query, so the whole statement runs for
+-- minutes. Raise the timeout the app role ships with rather than inheriting it.
+\if :{?statement_timeout}
+\else
+\set statement_timeout '900s'
+\endif
+
+-- Force the `vector` library to load so its GUCs are registered before SET.
+SELECT '[1]'::vector IS NOT NULL AS vector_loaded \gset
+SET ivfflat.probes = :probes;
+SET ivfflat.iterative_scan = off;
+SET statement_timeout = :'statement_timeout';
+
+\echo '── configuration ─────────────────────────────────────────────'
+SELECT :'model'      AS embedding_model,
+       :n_queries    AS n_queries,
+       :k            AS k,
+       :ann_limit    AS ann_inner_limit,
+       current_setting('ivfflat.probes')         AS probes,
+       current_setting('ivfflat.iterative_scan') AS iterative_scan,
+       (SELECT reloptions FROM pg_class WHERE relname = 'idx_events_embedding') AS index_opts;
+
+\echo '── corpus ────────────────────────────────────────────────────'
+SELECT count(*)                                            AS vectors_total,
+       count(*) FILTER (WHERE e.superseded_by IS NULL)     AS vectors_live,
+       count(*) FILTER (WHERE e.superseded_by IS NOT NULL) AS vectors_dead,
+       round(100.0 * count(*) FILTER (WHERE e.superseded_by IS NOT NULL)
+             / nullif(count(*), 0), 2)                     AS pct_dead
+FROM event_embeddings emb
+JOIN events e ON e.id = emb.event_id
+WHERE emb.embedding_model = :'model';
+
+\echo '── recall ────────────────────────────────────────────────────'
+SELECT setseed(:seed) \gset
+
+WITH sample_pool AS (
+  -- Use chunk 0 so qid uniquely identifies one query vector per event.
+  -- Default: a cheap seeded TABLESAMPLE over the heap, live rows only.
+  SELECT emb.event_id AS qid, emb.embedding AS vec
+  FROM event_embeddings emb TABLESAMPLE SYSTEM (:sample_pct) REPEATABLE (:tablesample_seed)
+  JOIN events e ON e.id = emb.event_id
+  WHERE emb.embedding_model = :'model'
+    AND emb.chunk_index = 0
+    AND e.superseded_by IS NULL
+    AND :'query_ids' = ''
+  UNION ALL
+  -- Pinned: the explicit query set, for a paired before/after run.
+  SELECT emb.event_id, emb.embedding
+  FROM event_embeddings emb
+  JOIN events e ON e.id = emb.event_id
+  WHERE emb.embedding_model = :'model'
+    AND emb.chunk_index = 0
+    AND e.superseded_by IS NULL
+    AND :'query_ids' <> ''
+    AND emb.event_id = ANY(string_to_array(:'query_ids', ',')::bigint[])
+),
+sample AS MATERIALIZED (
+  SELECT qid, vec FROM sample_pool
+  ORDER BY random()
+  LIMIT :n_queries
+),
+-- Brute-force ground truth over live rows, collapsed to distinct events by
+-- their nearest chunk. `+ 0.0` makes the sort key non-indexable.
+exact AS MATERIALIZED (
+  SELECT s.qid, x.event_id
+  FROM sample s
+  CROSS JOIN LATERAL (
+    SELECT emb.event_id, min((emb.embedding <=> s.vec) + 0.0) AS dist
+    FROM event_embeddings emb
+    JOIN events e ON e.id = emb.event_id
+    WHERE emb.embedding_model = :'model'
+      AND e.superseded_by IS NULL
+    GROUP BY emb.event_id
+    ORDER BY dist
+    LIMIT :k
+  ) x
+),
+-- Production candidate branch's index/live-filter order.
+ann AS MATERIALIZED (
+  SELECT s.qid, a.event_id
+  FROM sample s
+  CROSS JOIN LATERAL (
+    SELECT id AS event_id
+    FROM (
+      SELECT emb.event_id AS id, (emb.embedding <=> s.vec) AS dist
+      FROM event_embeddings emb
+      JOIN events f ON f.id = emb.event_id
+      WHERE emb.embedding_model = :'model'
+        AND f.superseded_by IS NULL
+      ORDER BY emb.embedding <=> s.vec
+      LIMIT :ann_limit
+    ) c
+    GROUP BY id
+    ORDER BY min(dist)
+    LIMIT :k
+  ) a
+),
+-- What the probe budget actually bought: how many of the raw ANN candidates
+-- were live at all.
+probe AS MATERIALIZED (
+  SELECT s.qid,
+         count(*)                                  AS probed,
+         count(*) FILTER (WHERE f.id IS NOT NULL)  AS live_probed
+  FROM sample s
+  CROSS JOIN LATERAL (
+    SELECT emb.event_id
+    FROM event_embeddings emb
+    WHERE emb.embedding_model = :'model'
+    ORDER BY emb.embedding <=> s.vec
+    LIMIT :ann_limit
+  ) p
+  LEFT JOIN events f ON f.id = p.event_id AND f.superseded_by IS NULL
+  GROUP BY s.qid
+),
+per_query AS (
+  SELECT s.qid,
+         (SELECT count(*) FROM exact x WHERE x.qid = s.qid)::int AS exact_n,
+         (SELECT count(*) FROM ann a   WHERE a.qid = s.qid)::int AS ann_n,
+         (SELECT count(*) FROM ann a
+           WHERE a.qid = s.qid
+             AND EXISTS (SELECT 1 FROM exact x
+                          WHERE x.qid = s.qid AND x.event_id = a.event_id))::int AS hits,
+         pr.probed::int      AS probed,
+         pr.live_probed::int AS live_probed
+  FROM sample s
+  JOIN probe pr ON pr.qid = s.qid
+)
+SELECT query_event_id, exact_n, ann_n, hits, recall_pct, probed, live_probed, probe_live_pct
+FROM (
+  SELECT 0                                                             AS ord,
+         qid::text                                                     AS query_event_id,
+         exact_n::numeric                                              AS exact_n,
+         ann_n::numeric                                                AS ann_n,
+         hits::numeric                                                 AS hits,
+         round(100.0 * hits / nullif(exact_n, 0), 1)                   AS recall_pct,
+         probed::numeric                                               AS probed,
+         live_probed::numeric                                          AS live_probed,
+         round(100.0 * live_probed / nullif(probed, 0), 1)             AS probe_live_pct
+  FROM per_query
+  UNION ALL
+  SELECT 1,
+         'MEAN',
+         round(avg(exact_n), 1),
+         round(avg(ann_n), 1),
+         round(avg(hits), 1),
+         round(avg(100.0 * hits / nullif(exact_n, 0)), 1),
+         round(avg(probed), 1),
+         round(avg(live_probed), 1),
+         round(avg(100.0 * live_probed / nullif(probed, 0)), 1)
+  FROM per_query
+) r
+ORDER BY ord, query_event_id;

--- a/scripts/reclaim-dead-event-embeddings.ts
+++ b/scripts/reclaim-dead-event-embeddings.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env bun
+
+/**
+ * One-time reclaim of `event_embeddings` rows belonging to superseded events
+ * (issue #3066).
+ *
+ * ─── Why this exists ─────────────────────────────────────────────────────────
+ * Until the insertEvent fix that ships alongside this script, nothing removed a
+ * predecessor's vectors when it was superseded: both `DELETE FROM
+ * event_embeddings` sites key on the row's OWN `event_id` before rewriting its
+ * vector. Vector retrieval excludes superseded events, making those rows
+ * unreachable, but `idx_events_embedding` is a plain ivfflat over the whole
+ * table. With no partial predicate, they can still consume ANN scan budget.
+ * The runtime fix stops the growth; this clears the backlog.
+ *
+ * ─── Exactly what it does ────────────────────────────────────────────────────
+ * Walks `event_embeddings` forward by `event_id` and deletes every row whose
+ * event has a non-NULL `superseded_by`. Each batch takes a whole event's rows
+ * (all models, all chunks), so a batch boundary can never split one event and
+ * strand half of it behind the cursor.
+ *
+ * `events` is append-only and is NOT touched. `event_embeddings` is a derived
+ * index, so deleting from it does not touch the ledger invariant.
+ *
+ * ─── Safety ──────────────────────────────────────────────────────────────────
+ *   - DRY-RUN by default; pass --execute to delete.
+ *   - Idempotent and resumable: re-running is a no-op for rows already gone,
+ *     and --from-event-id resumes from the cursor the last run printed.
+ *   - Batched autocommit deletes with an optional --sleep-ms pause; no long
+ *     transaction, no lock buildup, no table rewrite.
+ *   - A regular VACUUM/autovacuum must reap the deleted tuples before their heap
+ *     and index space is reusable. Physically shrinking relation files is a
+ *     separate operator decision; this script does neither automatically.
+ *
+ * ─── Usage ───────────────────────────────────────────────────────────────────
+ *   DATABASE_URL=... bun scripts/reclaim-dead-event-embeddings.ts
+ *   DATABASE_URL=... bun scripts/reclaim-dead-event-embeddings.ts --execute
+ *   DATABASE_URL=... bun scripts/reclaim-dead-event-embeddings.ts --execute \
+ *     --batch 2000 --sleep-ms 250 --from-event-id 1234567 --max-batches 100
+ *
+ * Measure recall before and after with scripts/bench-vector-recall.sql.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { getDb } from "../packages/server/src/db/client";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    execute: { type: "boolean", default: false },
+    batch: { type: "string", default: "1000" },
+    "sleep-ms": { type: "string", default: "0" },
+    "from-event-id": { type: "string", default: "0" },
+    "max-batches": { type: "string" },
+  },
+});
+
+const EXECUTE = Boolean(args.execute);
+
+function integerOption(
+  name: string,
+  value: string | undefined,
+  minimum: number
+): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`--${name} must be an integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+function eventIdOption(value: string | undefined): string {
+  if (value === undefined || !/^\d+$/.test(value)) {
+    throw new Error("--from-event-id must be a non-negative integer");
+  }
+  return BigInt(value).toString();
+}
+
+const BATCH = integerOption("batch", args.batch, 1);
+const SLEEP_MS = integerOption("sleep-ms", args["sleep-ms"], 0);
+const FROM_EVENT_ID = eventIdOption(args["from-event-id"]);
+const MAX_BATCHES =
+  args["max-batches"] === undefined
+    ? Number.POSITIVE_INFINITY
+    : integerOption("max-batches", args["max-batches"], 1);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const sql = getDb();
+
+  const [before] = await sql<{
+    total: string;
+    live: string;
+    dead: string;
+  }>`
+		SELECT count(*)::text AS total,
+		       count(*) FILTER (WHERE e.superseded_by IS NULL)::text AS live,
+		       count(*) FILTER (WHERE e.superseded_by IS NOT NULL)::text AS dead
+		FROM event_embeddings emb
+		JOIN events e ON e.id = emb.event_id
+	`;
+  console.log(
+    `event_embeddings: ${before.total} rows — ${before.live} live, ${before.dead} dead (superseded)`
+  );
+  if (!EXECUTE) {
+    console.log("DRY RUN — pass --execute to delete. Nothing was written.");
+  }
+
+  let cursor = FROM_EVENT_ID;
+  let deleted = 0;
+  let batches = 0;
+  const startedAt = Date.now();
+
+  for (;;) {
+    if (batches >= MAX_BATCHES) {
+      console.log(`stopping at --max-batches=${MAX_BATCHES}`);
+      break;
+    }
+
+    // DISTINCT event_id, not raw rows: taking a whole event's chunk/model set
+    // per batch keeps the cursor safe to advance to max(event_id) — a raw-row
+    // window could split one event across the boundary and leave the remainder
+    // permanently behind the cursor.
+    const victims = await sql<{ event_id: string }>`
+			SELECT DISTINCT emb.event_id
+			FROM event_embeddings emb
+			JOIN events e ON e.id = emb.event_id
+			WHERE emb.event_id > ${cursor}
+			  AND e.superseded_by IS NOT NULL
+			ORDER BY emb.event_id
+			LIMIT ${BATCH}
+		`;
+    if (victims.length === 0) break;
+
+    const ids = victims.map((v) => v.event_id);
+    const nextCursor = ids[ids.length - 1] as string;
+    // The pool runs with fetch_types:false, so a raw JS array bound as a param
+    // serializes to a malformed literal even with a ::bigint[] cast.
+    const idsLiteral = `{${ids.join(",")}}`;
+
+    if (EXECUTE) {
+      const removed = await sql<{ event_id: string }>`
+				DELETE FROM event_embeddings
+				WHERE event_id = ANY(${idsLiteral}::bigint[])
+				RETURNING event_id::text AS event_id
+			`;
+      deleted += removed.length;
+    } else {
+      const [counted] = await sql<{ n: string }>`
+				SELECT count(*)::text AS n
+				FROM event_embeddings
+				WHERE event_id = ANY(${idsLiteral}::bigint[])
+			`;
+      deleted += Number(counted.n);
+    }
+
+    cursor = nextCursor;
+    batches++;
+    if (batches % 25 === 0) {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      console.log(
+        `  batch ${batches}: ${deleted} rows ${EXECUTE ? "deleted" : "would be deleted"}, cursor=${cursor} (${elapsed}s)`
+      );
+    }
+    if (SLEEP_MS > 0) await sleep(SLEEP_MS);
+  }
+
+  const elapsed = Math.round((Date.now() - startedAt) / 1000);
+  console.log(
+    `${EXECUTE ? "deleted" : "would delete"} ${deleted} vector row(s) across ${batches} batch(es) in ${elapsed}s`
+  );
+  if (EXECUTE) {
+    console.log(`resume with --from-event-id ${cursor}`);
+    const [after] = await sql<{ total: string; dead: string }>`
+			SELECT count(*)::text AS total,
+			       count(*) FILTER (WHERE e.superseded_by IS NOT NULL)::text AS dead
+			FROM event_embeddings emb
+			JOIN events e ON e.id = emb.event_id
+		`;
+    console.log(
+      `event_embeddings now: ${after.total} rows, ${after.dead} dead`
+    );
+    console.log(
+      "run VACUUM (ANALYZE) event_embeddings before the after-benchmark so deleted index tuples are reaped; physical file shrinking is a separate operator decision."
+    );
+  }
+
+  await sql.end();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Nothing ever removed a superseded event's embedding.** Both `DELETE FROM event_embeddings` sites key on the row's OWN `event_id` before rewriting its vector, so a predecessor's vectors survived forever. Prod: 683,670 live vs 1,464,415 superseded (68.2% dead), 20 GB of a 33 GB database.
- Every vector reader fences on the live view, so those rows are unreachable — but `idx_events_embedding` is a plain `ivfflat (vector_cosine_ops) WITH (lists='1000')` over the **whole** table with no partial predicate, and `ivfflat.probes` is `1` with `iterative_scan` off. A dead vector consumes probe budget and is discarded only *after* the index scan. **This is a recall bug, not only a storage bug** — measured below.
- Fix: delete the predecessor's `event_embeddings` rows (all models, all chunks) in the same transaction as the supersede, plus `FOR SHARE` liveness fences in both runtime embedding writers so neither an unchanged-content refresh nor a raced embed job can re-create one. Backlog cleared by a batched, resumable script — **not run against prod; that stays the owner's call.**

`events` is append-only and is untouched. `event_embeddings` is a derived index, so deleting there does not touch the ledger rule.

## Phase 1 — recall baseline (prod, read-only)

`scripts/bench-vector-recall.sql` compares the production ANN candidate branch against an exact brute-force scan over live rows, for 25 seeded query vectors sampled from live rows. `recall@k = |ANN top-k ∩ exact top-k| / k`. Read-only: no DDL, no temp tables, no writes.

Corpus at measurement time (`Xenova/bge-base-en-v1.5`):

```
 vectors_total | vectors_live | vectors_dead | pct_dead
---------------+--------------+--------------+----------
       2148085 |       683670 |      1464415 |    68.17
```

| config | mean recall | mean live share of the ANN candidate window |
|---|---|---|
| k=10, probes=1 (production) | **62.4 %** | 61.8 % |
| k=20, probes=1 (production) | **58.0 %** | 57.6 % |
| k=20, probes=4 | 83.8 % | 59.0 % |

Per-query recall@20 at the production setting ranges 10 %–100 % (median 60 %). Roughly **40 % of every ANN candidate window is spent on rows no reader can ever return**, and one query's probe list ran dry at 340 candidates instead of the 600 the branch asks for.

The 25-query baseline set, for a paired after-run (`-v query_ids=...`, `-v n_queries=25`):

```
1159435,1752302,1808609,1868407,2048901,2054879,2091406,2092599,2652843,2972023,
3116308,3130158,3215078,3469139,3742739,38017,4213893,4367736,4508157,4648384,
4662309,4864666,4945823,5017418,5168476
```

Pinning reproduces the run exactly — re-running the final committed script against those 25 ids gives the same 58.0 % mean and the same per-query rows — so the before/after comparison is paired rather than statistical.

`lists` is deliberately **not** changed here — the owner wants that value chosen from measurement. This is the before-number; re-run the same file unchanged after the reclaim (and after a `REINDEX`) for a comparable after-number.

## Phase 2 — the fix

`packages/server/src/utils/insert-event.ts` — right after the `superseded_by` stamp, on the same `sql` handle (so it is atomic with the supersede, in the dedup advisory-lock tx, the explicit-supersede tx, or a caller-supplied tx):

```ts
await sql`DELETE FROM event_embeddings WHERE event_id = ${supersedesEventId}`;
```

`insertEvent`'s unchanged-content path is itself an embedding writer. An explicit supersede can delete the predecessor, commit, and then let that refresh recreate the dead vector. `upsertEmbedding` now takes the same live-row `FOR SHARE` fence and keeps it through the model-scoped delete/insert (opening a short transaction for plain pool callers).

`packages/server/src/worker-api/run-lifecycle.ts` is the other runtime writer: the embed backfill selects live events, but an event can be superseded between selection and the worker reporting its vector. A plain re-read is not enough (READ COMMITTED lets the supersede commit between the check and the INSERT), so the transaction now takes the row first:

```sql
SELECT id FROM events WHERE id = $1 AND superseded_by IS NULL FOR SHARE
```

then deletes this `(event, model)`'s rows and skips the INSERT when the row is gone. Lock order is `events` → `event_embeddings` in both this path and the supersede path, so there is no deadlock cycle.

`insert-event.ts` is the only writer of `superseded_by` in `packages/*/src` on `origin/main` (`git grep 'superseded_by =' origin/main -- 'packages/*/src'` returns nothing else); the only other writers are the two Stage-2 rollout migrations.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted Vitest + the full `src/__tests__/integration/` suite
- [x] Bug fix: red→fix→green outputs pasted below

### RED (fix disabled in both files)

```
 ❯ src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts (4 tests | 3 failed) 250ms
   × drops every model and every chunk of the predecessor on the dedup supersede path 22ms
     → expected [ { …(2) }, { …(2) }, { …(2) } ] to deeply equal []
   × drops the predecessor on the explicit supersedesEventId path 5ms
     → expected [ { …(2) } ] to deeply equal []
   × does not let a raced embed job re-create a superseded event's vector 7ms
     → expected [ { …(2) } ] to deeply equal []
   ✓ leaves an ordinary insert with no predecessor alone 2ms

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

### GREEN

```
 ✓ src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts (6 tests) 301ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Green three times in a row (no flake). After the current-main follow-up, a focused cross-suite run covering lineage, dedup concurrency, embedding-model swap, worker completion, and browser-ingestion containment passed: **6 files, 34 tests, 0 failed**. GitHub CI owns the full integration graph for this head.

The two concurrency cases cover both runtime embedding writers. Mutation-tested: dropping `FOR SHARE` from `completeEmbeddings` turns only its interleaving red; dropping `FOR SHARE` from `upsertEmbedding` recreates the predecessor vector in the unchanged-content refresh race. The original worker mutation produced:

```
   ✓ drops every model and every chunk of the predecessor on the dedup supersede path
   ✓ drops the predecessor on the explicit supersedesEventId path
   ✓ does not let a raced embed job re-create a superseded event's vector
   × serializes embedding completion with an in-flight supersede
     → embedding completion passed an in-flight supersede
   ✓ leaves an ordinary insert with no predecessor alone
```

`cd packages/server && bun run test -- run src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts`

### Current-main follow-up: second writer race (RED → GREEN)

The current-main audit found a concrete race not covered by the first head: while an explicit supersede held its deletion open, a semantically unchanged `insertEvent(..., { onConflictUpdate: true })` refresh could wait on that deletion and then insert the predecessor vector after the supersede committed.

Before fencing `upsertEmbedding`:

```
 ❯ src/__tests__/integration/events/supersede-reclaims-embeddings.test.ts (6 tests | 1 failed)
   × does not let an unchanged-content refresh re-create a superseded event's vector
     → expected [ { …(2) } ] to deeply equal []

 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

After the shared-writer fence: **6/6 passed three consecutive runs**. The append-only assertion also reads the predecessor's original `payload_text`, its `superseded_by` stamp, and the successor's `supersedes_event_id`; only derived `event_embeddings` rows are deleted.


## Phase 3 — backfill script (NOT run against prod)

`scripts/reclaim-dead-event-embeddings.ts`. Dry-run by default, `--execute` to write. Batched autocommit deletes keyed on a forward `event_id` cursor; each batch takes a whole event's `(model, chunk)` set so a boundary can never split one event and strand the remainder behind the cursor. `--batch`, `--sleep-ms`, `--from-event-id`, `--max-batches`.

Exercised against a local Postgres seeded with 40 supersede chains × 4 versions (160 events, 294 vectors, 240 of them dead), with two models and a second chunk sprinkled across rows:

```
=== dry run ===
event_embeddings: 294 rows — 54 live, 240 dead (superseded)
DRY RUN — pass --execute to delete. Nothing was written.
would delete 240 vector row(s) across 2 batch(es) in 0s

=== --execute --max-batches 1 (interrupted mid-way) ===
deleted 201 vector row(s) across 1 batch(es) in 0s
resume with --from-event-id 133
event_embeddings now: 93 rows, 39 dead

=== resume ===
deleted 39 vector row(s) across 1 batch(es) in 0s
event_embeddings now: 54 rows, 0 dead

=== idempotent re-run ===
event_embeddings: 54 rows — 54 live, 0 dead (superseded)
deleted 0 vector row(s) across 0 batch(es) in 0s
```

Ledger intact afterwards: 160 events, 120 still `superseded_by IS NOT NULL`, 54 live vectors.

## Notes

Refs #3066. Left open deliberately — the issue also asks for the prod run and the `REINDEX`, which are destructive and stay with the owner.

Suggested prod sequence, for the owner:

1. Re-run `scripts/bench-vector-recall.sql` to re-baseline right before.
2. `bun scripts/reclaim-dead-event-embeddings.ts` (dry run) to confirm the count.
3. `--execute --batch 2000 --sleep-ms 250` during a quiet window; resumable if interrupted.
4. `VACUUM (ANALYZE) event_embeddings` — until the deleted tuples are reaped the ivfflat lists still carry them, so an after-benchmark run before this measures nothing.
5. `REINDEX INDEX CONCURRENTLY idx_events_embedding` — rebuilding also re-centroids the lists over live-only data, which the reclaim alone does not do.
6. Re-run the benchmark pinned to the same `query_ids` for the after-number, then decide `lists` from it.

Deleting frees space for **reuse**; it will not shrink the relation files without `VACUUM FULL` / reindex.

One diagnostic reads `has_embedding` for arbitrary event ids (`tools/admin/manage_classifiers.ts`): for a superseded row it now computes `false`. The reported skip reason is unchanged — the loop checks `is_live` first and returns `superseded`, never `not_embedded`.

Complementary to #3071 (volatile counters reconciled in place), which stops ~82.5 % of supersedes: that halts the growth, this clears the backlog.
