### PR TITLE
docs(cli): point memory help at lobu connect

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,6 +29,7 @@ docker run -d --name lobu-pg -p 5432:5432 \
 - `lobu init [name]` — scaffold a project. Interactive by default; pass `--yes` (with any of `--port` / `--provider` / `--platform` / `--memory` / `--no-sentry` / etc.) for non-interactive / CI scaffolding. `lobu init .` or `--here` scaffolds into the current directory.
 - `lobu run` (aliases: `lobu dev`, `lobu start`) — boot the embedded stack. Pre-flights the gateway port and accepts `--port` / `--quiet` / `--verbose` / `--log-level`.
 - `lobu chat <prompt>` — send one prompt and stream the response. `-C/--continue` resumes the last thread (per context+agent); `--auto-approve` skips tool prompts in trusted runs; `--json` emits raw SSE events for piping.
+- `lobu connect [agent]` — wire an external client (Claude Code, Codex, OpenCode, Cursor, …) to your Lobu MCP endpoint: installs the supported MCP + skill bundle, or prints the exact native handoff when the host requires UI setup.
 - `lobu doctor` — Postgres connectivity, pgvector extension, port availability, provider API keys, workspace dir.
 - `lobu link` / `lobu unlink` — bind this directory to a (context, org) at `.lobu/project.json`. `lobu apply` refuses to push mismatched targets unless `--force` is set.
 - `lobu apply` (alias: `lobu deploy`) — idempotent sync of `lobu.config.ts` to Lobu Cloud.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1307,7 +1307,7 @@ Memory:
   // ─── memory ─────────────────────────────────────────────────────────
   const memory = program
     .command("memory")
-    .description("Lobu memory MCP — tools, seeding, and client configuration");
+    .description("Lobu memory MCP — tools, seeding, and browser-auth capture");
 
   const memoryOrg = memory
     .command("org")


### PR DESCRIPTION
## Summary
- `lobu memory` group help still advertised "client configuration", a leftover from the removed `memory init` command (deleted in #3059); no memory subcommand configures clients anymore. Now: "tools, seeding, and browser-auth capture" — the actual surface.
- CLI README command highlights omitted `lobu connect` entirely; added a bullet so the package README matches the root README and the landing docs.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (local fast gates)
- [x] Real invocation of the built binary (per packages/cli AGENTS.md): `node bin/lobu.js memory --help` prints "Lobu memory MCP — tools, seeding, and browser-auth capture"; top-level help lists `connect [agent]` and no `memory init`
- [x] Grep of packages/cli + scripts for "memory init" / "client configuration": zero hits
- N/A red→fix→green (wording-only change; before-state on origin/main: `.description("Lobu memory MCP — tools, seeding, and client configuration")`)
- N/A bot runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for connecting external clients through the Lobu MCP endpoint, including supported handoff options.

- **Documentation**
  - Updated CLI help text to clarify that the `memory` command captures browser authentication.
  - Added `lobu connect [agent]` to the CLI command highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->