### PR TITLE
fix(server): stop accepting HTTP work before gateway/db teardown

### DIFF
--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -381,8 +381,8 @@ describe("buildWrapperApp", () => {
 describe("createServerLifecycle (source-level contract)", () => {
 	// These assertions read the source file. They exist so a code reviewer
 	// (human or pi) can't silently reorder shutdown or drop a step without
-	// updating the test in the same change. Functional ordering is also
-	// exercised by an explicit grep-and-position check below.
+	// updating the test in the same change. Relative ordering is enforced by
+	// explicit source-position checks below.
 
 	function indexOf(needle: string): number {
 		const idx = LIFECYCLE_SOURCE.indexOf(needle);
@@ -430,6 +430,11 @@ describe("createServerLifecycle (source-level contract)", () => {
 		// Each step is wrapped in `safe("<step>", …)` so a failing teardown
 		// can't block the rest. Order-check by the step label which is stable
 		// across refactors of the wrapper.
+		//
+		// The embedded worker must get its bounded drain window while its local
+		// HTTP API is still reachable. The listener then gives accepted requests
+		// their close budget before gateway and database teardown.
+		const close = indexOf('safe("httpServer.close"');
 		const worker = indexOf('safe("embeddedWorker.stop"');
 		const vite = indexOf('safe("vite.close"');
 		const reaper = indexOf('safe("stopReaper"');
@@ -437,17 +442,14 @@ describe("createServerLifecycle (source-level contract)", () => {
 		const gateway = indexOf('safe("stopLobuGateway"');
 		const db = indexOf('safe("closeDbSingleton"');
 		const extra = indexOf("safe(`extraTeardown[");
-		// #1191 wrapped the close in the same safe() step pattern as the rest of
-		// teardown; match the stable step label, not the raw call.
-		const close = indexOf('safe("httpServer.close"');
 
-		expect(worker).toBeLessThan(vite);
+		expect(worker).toBeLessThan(close);
+		expect(close).toBeLessThan(vite);
 		expect(vite).toBeLessThan(reaper);
 		expect(reaper).toBeLessThan(scheduler);
 		expect(scheduler).toBeLessThan(gateway);
 		expect(gateway).toBeLessThan(db);
 		expect(db).toBeLessThan(extra);
-		expect(extra).toBeLessThan(close);
 	});
 
 	it("wraps every shutdown step in a safe() helper (one failing step does not skip the rest)", () => {

--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -505,7 +505,7 @@ describe("createServerLifecycle (source-level contract)", () => {
 	});
 });
 
-describe("shutdown ordering (behavioral)", () => {
+describe("shutdown ordering (live drain)", () => {
 	it(
 		"refuses new work and drains the in-flight request before gateway/db teardown",
 		async () => {

--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -18,6 +18,8 @@
  */
 
 import { readFileSync } from "node:fs";
+import http from "node:http";
+import net from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
@@ -25,6 +27,32 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@sentry/node", () => ({
 	captureException: vi.fn(),
 	captureMessage: vi.fn(),
+}));
+
+// --- heavy collaborators of createServerLifecycle, replaced so the spine
+// --- boots in-process against a real ephemeral HTTP server.
+vi.mock("../db/client", () => ({ closeDbSingleton: vi.fn(async () => {}) }));
+vi.mock("../dev-vite", () => ({ mountViteDev: vi.fn(async () => null) }));
+vi.mock("../workspace", () => ({
+	initWorkspaceProvider: vi.fn(async () => undefined),
+}));
+// initLobuGateway must return the SAME app instance the test wires routes
+// onto — Hono's `.route()` copies the sub-app's routes at mount time, so a
+// late-built app would silently 404.
+const gwAppSlot = vi.hoisted(() => ({ app: null as unknown }));
+vi.mock("../lobu/gateway", () => ({
+	initLobuGateway: vi.fn(async () => gwAppSlot.app),
+	stopLobuGateway: vi.fn(async () => {}),
+	getLobuCoreServices: vi.fn(() => ({})),
+}));
+vi.mock("../scheduled/check-stalled-executions", () => ({
+	startStaleRunReaper: vi.fn(() => vi.fn()),
+}));
+vi.mock("../scheduled/jobs", () => ({
+	bootTaskScheduler: vi.fn(async () => ({ stop: vi.fn(async () => {}) })),
+}));
+vi.mock("../scheduled/embedded-connector-worker", () => ({
+	startEmbeddedConnectorWorker: vi.fn(() => null),
 }));
 
 vi.mock("../utils/logger", () => {
@@ -475,4 +503,181 @@ describe("createServerLifecycle (source-level contract)", () => {
 		expect(/process\.on\(['"]SIGTERM['"]/.test(LIFECYCLE_SOURCE)).toBe(true);
 		expect(/process\.on\(['"]SIGINT['"]/.test(LIFECYCLE_SOURCE)).toBe(true);
 	});
+});
+
+describe("shutdown ordering (behavioral)", () => {
+	it(
+		"refuses new work and drains the in-flight request before gateway/db teardown",
+		async () => {
+			const events: string[] = [];
+			const { closeDbSingleton } = await import("../db/client");
+			const { stopLobuGateway } = await import("../lobu/gateway");
+			vi.mocked(closeDbSingleton).mockImplementation(async () => {
+				events.push("db-closed");
+			});
+			vi.mocked(stopLobuGateway).mockImplementation(async () => {
+				events.push("gateway-stopped");
+			});
+
+			const exited = new Promise<number | undefined>((resolveExit) => {
+				vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+					events.push("exit");
+					resolveExit(code);
+					return undefined as never;
+				}) as never);
+			});
+
+			const sigListenersBefore = {
+				SIGTERM: process.listeners("SIGTERM"),
+				SIGINT: process.listeners("SIGINT"),
+			};
+
+			const { Hono } = await import("hono");
+			const lobuApp = new Hono();
+			gwAppSlot.app = lobuApp;
+			const slowHandler = (c: {
+				json: (body: Record<string, string>) => unknown;
+			}) => {
+				events.push("inflight-start");
+				return new Promise<{ ok: string }>((resolve) =>
+					setTimeout(() => resolve({ ok: "slow" }), 700),
+				).then((body) => {
+					events.push("inflight-done");
+					return c.json(body);
+				});
+			};
+			lobuApp.get("/slow", slowHandler);
+			lobuApp.post("/slow", slowHandler);
+
+			const { createServerLifecycle } = await import("../server-lifecycle");
+			// Claim a free loopback port first: the spine logs its configured
+			// port, not the bound one, so port 0 can't be discovered afterwards.
+			const freePort = await new Promise<number>((resolve, reject) => {
+				const scout = net.createServer();
+				scout.unref();
+				scout.on("error", reject);
+				scout.listen(0, "127.0.0.1", () => {
+					const { port } = scout.address() as net.AddressInfo;
+					scout.close(() => resolve(port));
+				});
+			});
+			const lifecycle = createServerLifecycle({
+				mode: "postgres",
+				env: {} as never,
+				host: "127.0.0.1",
+				port: freePort,
+				databaseReadiness: async () => {},
+				extraTeardown: [
+					async () => {
+						events.push("extra-teardown");
+					},
+				],
+			});
+			await lifecycle.start();
+			const port = freePort;
+
+			let inflightError: unknown = null;
+			const inflight = new Promise<{ status: number }>((resolveInflight) => {
+				const req = http.request(
+					{ host: "127.0.0.1", port, path: "/lobu/slow", method: "GET" },
+					(res) => {
+						res.resume();
+						res.on("end", () => resolveInflight({ status: res.statusCode ?? 0 }));
+					},
+				);
+				req.on("error", (err: NodeJS.ErrnoException) => {
+					inflightError = err;
+					resolveInflight({ status: 599 });
+				});
+				req.end();
+			});
+			// Wait until THIS request is being handled before signalling — no
+			// other traffic has run, so "inflight-start" can only be ours.
+			await vi.waitFor(
+				() => expect(events).toContain("inflight-start"),
+				{ timeout: 3_000 },
+			);
+
+			process.emit("SIGTERM");
+
+			// A brand-new connection must be refused once the listener closed —
+			// and crucially BEFORE db teardown severs the dependency it would
+			// have needed (the drain-phase CONNECTION_ENDED 500 regression).
+			const probeOnce = (): Promise<string> =>
+				new Promise((resolve) => {
+					const socket = net.connect({ port, host: "127.0.0.1" });
+					const timer = setTimeout(() => {
+						socket.destroy();
+						resolve("timeout");
+					}, 250);
+					socket.on("connect", () => {
+						clearTimeout(timer);
+						socket.destroy();
+						resolve("connected");
+					});
+					socket.on("error", (err: NodeJS.ErrnoException) => {
+						clearTimeout(timer);
+						resolve(err.code ?? "error");
+					});
+				});
+			let refusal = "still-accepting";
+			for (let i = 0; i < 200 && !events.includes("exit"); i++) {
+				refusal = await probeOnce();
+				if (refusal !== "connected") break;
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			}
+			events.push(`new-conn:${refusal}`);
+			expect(refusal).not.toBe("connected");
+
+			const inflightRes = await inflight;
+			expect(
+				inflightRes.status,
+				JSON.stringify({
+					events,
+					err: inflightError
+						? {
+								msg: (inflightError as Error).message,
+								code: (inflightError as NodeJS.ErrnoException).code,
+							}
+						: null,
+				}),
+			).toBe(200);
+			await exited;
+
+			for (const signal of ["SIGTERM", "SIGINT"] as const) {
+				for (const listener of process.listeners(signal)) {
+					if (!sigListenersBefore[signal].includes(listener)) {
+						process.removeListener(signal, listener);
+					}
+				}
+			}
+
+			const indexOfEvent = (name: string): number => {
+				const idx = events.findIndex(
+					(event) => event === name || event.startsWith(`${name}:`),
+				);
+				expect(idx >= 0, `missing ${name} in ${JSON.stringify(events)}`).toBe(
+					true,
+				);
+				return idx;
+			};
+			// The in-flight request finished on its own terms, then — and only
+			// then — the dependency teardown ran; nothing was served after the
+			// dependencies were gone.
+			expect(indexOfEvent("inflight-done")).toBeLessThan(
+				indexOfEvent("gateway-stopped"),
+			);
+			expect(indexOfEvent("new-conn")).toBeLessThan(
+				indexOfEvent("db-closed"),
+			);
+			expect(indexOfEvent("gateway-stopped")).toBeLessThan(
+				indexOfEvent("db-closed"),
+			);
+			expect(indexOfEvent("db-closed")).toBeLessThan(
+				indexOfEvent("extra-teardown"),
+			);
+			expect(events[events.length - 1]).toBe("exit");
+		},
+		20_000,
+	);
 });

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -64,9 +64,10 @@ interface ServerLifecycleConfig {
 	 */
 	postListenHooks?: Array<() => void>;
 	/**
-	 * Runs during shutdown AFTER `stopLobuGateway` + `closeDbSingleton`, in
-	 * declared order, before `httpServer.close()`. The embedded backend uses
-	 * this to kill the embeddings child and stop the embedded Postgres.
+	 * Runs during shutdown after the HTTP listener stops accepting work and
+	 * after Lobu gateway and database-pool teardown, in declared order. The
+	 * embedded backend uses this to kill the embeddings child and stop the
+	 * embedded Postgres.
 	 */
 	extraTeardown?: Array<() => Promise<void> | void>;
 }
@@ -422,7 +423,9 @@ export function createServerLifecycle(
 				}
 			};
 			// Order matters:
-			//   a. Stop accepting new work from the embedded connector worker.
+			//   a. Stop the embedded connector worker from polling and give its active
+			//      job up to 15s to finish while the local HTTP API it uses for progress
+			//      and completion reports is still reachable.
 			if (embeddedWorker) {
 				const worker = embeddedWorker;
 				await safe("embeddedWorker.stop", async () => {
@@ -430,37 +433,17 @@ export function createServerLifecycle(
 					await worker.wait(15_000);
 				});
 			}
-			//   b. Close Vite (HMR sockets) before tearing down the http server
-			//      so dev-mode listeners detach cleanly.
-			await safe("vite.close", async () => {
-				await vite?.close();
-			});
-			//   c. Stop the reaper poll loop.
-			await safe("stopReaper", () => stopReaper());
-			//   d. Stop the task scheduler dispatch loop.
-			await safe("taskScheduler.stop", () => taskScheduler.stop());
-			//   e. Drain MCP sessions / DB listeners / secret-proxy. Gateway
-			//      holds postgres.js connections that must be released before
-			//      mode-specific db teardown runs.
-			await safe("stopLobuGateway", () => stopLobuGateway());
-			//   f. Close the postgres.js singleton pool.
-			await safe("closeDbSingleton", () => closeDbSingleton());
-			//   g. Mode-specific teardown (embedded kills embeddings child, stops
-			//      socket server, closes the in-process db).
-			for (let i = 0; i < extraTeardown.length; i++) {
-				await safe(`extraTeardown[${i}]`, extraTeardown[i]);
-			}
-			//   h. Finally, stop accepting new connections and wait for in-flight
-			//      requests to finish, instead of the historical fire-and-forget
-			//      close + immediate process.exit that severed open responses.
-			//      `close()` alone never completes while idle keep-alive sockets
-			//      (75s timeout above) are open, so close those proactively —
-			//      genuinely active requests/streams are not idle and get the
-			//      drain window. Bounded by HTTP_CLOSE_TIMEOUT_MS (default 10s)
-			//      so a long-lived SSE stream can't hold the exit past the pod's
-			//      termination grace period. SIGINT is the interactive path
-			//      (Ctrl-C in dev, Mac app quit) where there's no LB to drain —
-			//      cap it at 1s so local shutdown stays snappy.
+			//   b. Stop accepting new HTTP work after the readiness drain above has
+			//      let the LB drop this pod's endpoint.
+			//      `close()` refuses new connections while letting in-flight
+			//      requests finish. Await it before gateway and database teardown so
+			//      accepted requests retain those dependencies while draining.
+			//      `close()` alone never completes while non-idle sockets
+			//      such as SSE streams are open, so it is bounded by
+			//      HTTP_CLOSE_TIMEOUT_MS (default 10s). Requests still active after
+			//      that budget may be interrupted by the remaining teardown. SIGINT
+			//      is the interactive path (Ctrl-C in dev, Mac app quit), capped at
+			//      1s so local shutdown stays snappy.
 			await safe("httpServer.close", async () => {
 				const configuredMs = Number(env.HTTP_CLOSE_TIMEOUT_MS ?? 10_000);
 				const closeTimeoutMs =
@@ -477,6 +460,26 @@ export function createServerLifecycle(
 					setTimeout(done, closeTimeoutMs).unref?.();
 				});
 			});
+			//   c. Close Vite after the listener stops accepting new connections so
+			//      dev-mode HMR sockets detach cleanly.
+			await safe("vite.close", async () => {
+				await vite?.close();
+			});
+			//   d. Stop the reaper poll loop.
+			await safe("stopReaper", () => stopReaper());
+			//   e. Stop the task scheduler dispatch loop.
+			await safe("taskScheduler.stop", () => taskScheduler.stop());
+			//   f. Drain MCP sessions / DB listeners / secret-proxy. Gateway
+			//      holds postgres.js connections that must be released before
+			//      mode-specific db teardown runs.
+			await safe("stopLobuGateway", () => stopLobuGateway());
+			//   g. Close the postgres.js singleton pool.
+			await safe("closeDbSingleton", () => closeDbSingleton());
+			//   h. Mode-specific teardown (embedded kills embeddings child, stops
+			//      socket server, closes the in-process db).
+			for (let i = 0; i < extraTeardown.length; i++) {
+				await safe(`extraTeardown[${i}]`, extraTeardown[i]);
+			}
 			process.exit(0);
 		};
 		// Single-flight guard: SIGTERM+SIGINT or a double-tap on either must


### PR DESCRIPTION
## Problem

Every prod rollout served drain-phase 500s on `/api/workers/poll` (and any route): the shutdown sequence closed the postgres.js pool (step f) while the HTTP listener stayed open until the very last step (h). Any request served in that window failed with:

```
write CONNECTION_ENDED lobu-db-prod-pooler:5432 → 500 Unhandled error in HTTP handler
```

Loki shows ~5 per pod per deploy over 26h, across every pod generation, each reported to Sentry. The in-cluster worker daemon's poll loop logged them too (`[daemon] Poll error: ... 500 Internal Server Error`).

## Fix

Reorder shutdown so no served request can observe a torn-down dependency:

- **a.** embedded worker stops first — its active job keeps its ≤15s completion window against the still-live API
- **b.** `httpServer.close()` + `closeIdleConnections()` — new work refused from here on, in-flight drains bounded by `HTTP_CLOSE_TIMEOUT_MS`
- **c–g.** vite, reaper, scheduler, gateway drain, then the pool closes — unreachable by any new request

The readiness-drain window (`SHUTDOWN_READINESS_DRAIN_MS`) is unchanged and now also precedes listener close.

## Verification

- Red: updated source-level contract test asserting close-before-dependency order fails against old source (`expected 17868 to be less than 15991`)
- Green: 23/23 pass on `packages/server/src/__tests__/server-lifecycle.test.ts` after reorder
- Boot smoke: server up on :9697, SIGTERM → graceful path with zero `Shutdown step failed` log lines

```
Test Files  1 passed (1)
     Tests  23 passed (23)
```

## Notes for reviewer

- Traefik access logging was separately enabled on prod today (HelmChartConfig), so future drain-phase rejections will be directly observable.
- The remaining transient during rollouts is Traefik's `503 no available server` when the single replica's endpoint is mid-swap — expected and retried by daemons; not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown sequencing to stop background workers before closing the HTTP listener.
  * New connections are rejected while active requests are allowed to finish within a defined drain period.
  * Ensured remaining services and cleanup tasks complete in the correct order before shutdown exits.
  * Cleaned up signal listeners reliably during server termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->