### PR TITLE
fix(automations): support run-bound external completion

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4474,9 +4474,9 @@ export type ManageAutomationsData = {
         }
     >;
     /**
-     * [create/update] Agent ID that owns/executes this Automation. [list] Optional owner filter.
+     * [create/update] Optional managed agent for this Automation. Null clears the assignment; agentless manual Automations may be completed by an external MCP client. [list] Optional owner filter.
      */
-    agent_id?: string;
+    agent_id?: string | null;
     /**
      * [list] Optional status filter. Omit to include active Automations only.
      */

--- a/packages/core/src/__tests__/automation-event-trigger.test.ts
+++ b/packages/core/src/__tests__/automation-event-trigger.test.ts
@@ -153,3 +153,22 @@ describe("automation event trigger", () => {
     ).toBe(false);
   });
 });
+
+describe("manage Automations agent assignment", () => {
+  test("accepts null to clear agent_id and rejects an empty-string workaround", () => {
+    expect(
+      Value.Check(ManageAutomationsSchema, {
+        action: "update",
+        automation_id: "1",
+        agent_id: null,
+      })
+    ).toBe(true);
+    expect(
+      Value.Check(ManageAutomationsSchema, {
+        action: "update",
+        automation_id: "1",
+        agent_id: "",
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -674,9 +674,9 @@ export const ManageAutomationsSchema = Type.Object(
       })
     ),
     agent_id: Type.Optional(
-      Type.String({
+      Type.Union([Type.String({ minLength: 1 }), Type.Null()], {
         description:
-          "[create/update] Agent ID that owns/executes this Automation. [list] Optional owner filter.",
+          "[create/update] Optional managed agent for this Automation. Null clears the assignment; agentless manual Automations may be completed by an external MCP client. [list] Optional owner filter.",
       })
     ),
     status: Type.Optional(

--- a/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
@@ -348,16 +348,27 @@ describe("automation contract", () => {
 			);
 		}
 
-		const page1 = (await api.knowledge.read({
+		const preview = (await api.knowledge.read({
 			automation_id: automationId,
 			since: "2026-01-02",
 			until: "2026-01-02",
+			limit: 1,
+		})) as { window_start: string; window_end: string };
+		const run = await createAutomationRun({
+			organizationId: workspace.org.id,
+			automationId,
+			windowStart: preview.window_start,
+			windowEnd: preview.window_end,
+			dispatchSource: "manual",
+		});
+
+		const page1 = (await api.knowledge.read({
+			automation_id: automationId,
+			run_id: run.runId,
 			limit: 2,
 		})) as {
 			content: Array<{ id: number; occurred_at: string }>;
 			window_token: string;
-			window_start: string;
-			window_end: string;
 			page: {
 				has_more: boolean;
 				next_cursor?: { occurred_at: string; id: number };
@@ -373,8 +384,7 @@ describe("automation contract", () => {
 
 		const page2 = (await api.knowledge.read({
 			automation_id: automationId,
-			since: "2026-01-02",
-			until: "2026-01-02",
+			run_id: run.runId,
 			limit: 2,
 			before_occurred_at: page1.page.next_cursor!.occurred_at,
 			before_id: page1.page.next_cursor!.id,
@@ -394,8 +404,7 @@ describe("automation contract", () => {
 		expect(page2.page.has_more).toBe(true);
 		const page3 = (await api.knowledge.read({
 			automation_id: automationId,
-			since: "2026-01-02",
-			until: "2026-01-02",
+			run_id: run.runId,
 			limit: 2,
 			before_occurred_at: page2.page.next_cursor!.occurred_at,
 			before_id: page2.page.next_cursor!.id,
@@ -406,13 +415,6 @@ describe("automation contract", () => {
 		};
 		expect(page3.content.map((item) => item.id)).toEqual([events[4].id]);
 		expect(page3.page.has_more).toBe(false);
-		const run = await createAutomationRun({
-			organizationId: workspace.org.id,
-			automationId,
-			windowStart: page1.window_start,
-			windowEnd: page1.window_end,
-			dispatchSource: "manual",
-		});
 		const completion = (await api.automations.completeWindow({
 			automation_id: String(automationId),
 			run_id: run.runId,
@@ -451,9 +453,17 @@ describe("automation contract", () => {
 		const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
 		const windowEnd = new Date().toISOString();
 
+		const run = await createAutomationRun({
+			organizationId: workspace.org.id,
+			automationId,
+			windowStart,
+			windowEnd,
+			dispatchSource: "manual",
+		});
 		const windowToken = await generateWindowToken(
 			{
 				automation_id: automationId,
+				run_id: run.runId,
 				window_start: windowStart,
 				window_end: windowEnd,
 				granularity: "daily",
@@ -462,13 +472,6 @@ describe("automation contract", () => {
 			},
 			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env
 		);
-		const run = await createAutomationRun({
-			organizationId: workspace.org.id,
-			automationId,
-			windowStart,
-			windowEnd,
-			dispatchSource: "manual",
-		});
 		const completion = (await api.automations.completeWindow({
 			automation_id: String(automationId),
 			run_id: run.runId,

--- a/packages/server/src/__tests__/integration/automations/automation-output-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-output-visibility.test.ts
@@ -155,18 +155,21 @@ describe("An Automation's output is visible when written and still not its own i
 		});
 	});
 
-	const dispatch = async (automationId: number): Promise<AutomationContent> =>
-		(await handleAutomationMode({ automation_id: automationId }, ENV, sql, {
+	const dispatch = async (
+		automationId: number,
+		args: Record<string, unknown> = {},
+	): Promise<AutomationContent> =>
+		(await handleAutomationMode({ automation_id: automationId, ...args }, ENV, sql, {
 			organizationId: orgId,
 			userId,
 		})) as unknown as AutomationContent;
 
-	/** The claimed run that owns the dispatched period — completion writes its
-	 *  result onto this row, so it must exist and be active first. */
-	const claimRunForWindow = async (
+	/** Create the run that owns the dispatched period and read the run-bound token
+	 *  that may atomically claim it during completion. */
+	const bindRunToWindow = async (
 		automationId: number,
 		dispatched: AutomationContent,
-	): Promise<number> => {
+	): Promise<{ runId: number; windowToken: string }> => {
 		const queued = await createAutomationRun({
 			organizationId: orgId,
 			automationId,
@@ -174,11 +177,10 @@ describe("An Automation's output is visible when written and still not its own i
 			windowEnd: dispatched.window_end,
 			dispatchSource: "scheduled",
 		});
-		await sql`
-			UPDATE runs SET status = 'running', claimed_at = NOW()
-			WHERE id = ${queued.runId}
-		`;
-		return queued.runId;
+		const runBound = await dispatch(automationId, { run_id: queued.runId });
+		expect(runBound.window_start).toBe(dispatched.window_start);
+		expect(runBound.window_end).toBe(dispatched.window_end);
+		return { runId: queued.runId, windowToken: runBound.window_token };
 	};
 
 	const complete = async (
@@ -186,12 +188,13 @@ describe("An Automation's output is visible when written and still not its own i
 		dispatched: AutomationContent,
 		signals: Array<{ content: string; title: string }>,
 	) => {
+		const runBound = await bindRunToWindow(automationId, dispatched);
 		const completion = await manageAutomations(
 			{
 				action: "complete_window",
 				automation_id: String(automationId),
-				run_id: await claimRunForWindow(automationId, dispatched),
-				window_token: dispatched.window_token,
+				run_id: runBound.runId,
+				window_token: runBound.windowToken,
 				extracted_data: {
 					signals: signals.map((s) => ({
 						...s,

--- a/packages/server/src/__tests__/integration/automations/automation-owner-escalation.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-owner-escalation.test.ts
@@ -94,6 +94,55 @@ describe("manage_automations owner-escalation guard", () => {
 		);
 	});
 
+	it("blocks agent A from creating an agentless Automation", async () => {
+		await expect(
+			executeTool(
+				"manage_automations",
+				{
+					action: "create",
+					slug: "agentless-escalation-attempt",
+					name: "agentless-escalation-attempt",
+					prompt: "Track things.",
+					agent_id: null,
+				},
+				TEST_ENV,
+				agentCtx(workspace.org.id, workspace.users.owner.id, agentA)
+			)
+		).rejects.toThrow(
+			/cannot install an Automation owned by another agent/i
+		);
+	});
+
+	it("blocks agent A from explicitly clearing its own Automation owner", async () => {
+		const owned = (await workspace.owner.automations.create({
+			slug: "agent-a-owned-before-clear",
+			name: "agent-a-owned-before-clear",
+			prompt: "Track things.",
+			agent_id: agentA,
+		})) as { automation_id: string };
+
+		await expect(
+			executeTool(
+				"manage_automations",
+				{
+					action: "update",
+					automation_id: owned.automation_id,
+					agent_id: null,
+				},
+				TEST_ENV,
+				agentCtx(workspace.org.id, workspace.users.owner.id, agentA)
+			)
+		).rejects.toThrow(
+			/cannot install an Automation owned by another agent/i
+		);
+
+		const [row] = await getTestDb()<{ agent_id: string | null }>`
+			SELECT agent_id FROM automations
+			WHERE id = ${Number(owned.automation_id)}
+		`;
+		expect(row.agent_id).toBe(agentA);
+	});
+
 	it("a HUMAN may assign an automation to any agent (ungoverned)", async () => {
 		const created = (await workspace.owner.automations.create({
 			slug: "human-assigns-b",

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -539,6 +539,78 @@ describe('external manual Automation execution', () => {
     })) as { completed_now: boolean };
     expect(sameClaimRetry.completed_now).toBe(true);
 
+    const legacyWindowStart = new Date(
+      new Date(queuedWindowStart).getTime() + 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const legacyWindowEnd = new Date(
+      new Date(queuedWindowEnd).getTime() + 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const inProcessRun = await createAutomationRun({
+      organizationId: workspace.org.id,
+      automationId,
+      agentId: null,
+      windowStart: legacyWindowStart,
+      windowEnd: legacyWindowEnd,
+      dispatchSource: 'manual',
+    });
+    await sql`
+      UPDATE runs
+      SET approved_input = approved_input - 'granularity'
+      WHERE id = ${inProcessRun.runId}
+    `;
+
+    // An external pending read has no authoritative claim context and must not
+    // reconstruct a missing durable snapshot from the live schedule.
+    await expect(
+      handleAutomationMode(
+        { automation_id: automationId, run_id: inProcessRun.runId },
+        TEST_ENV,
+        sql,
+        {
+          organizationId: workspace.org.id,
+          userId: workspace.users.owner.id,
+        }
+      )
+    ).rejects.toThrow(/missing a valid queued granularity snapshot/);
+    const [pendingWithoutGranularity] = await sql<{
+      status: string;
+      claimed_by: string | null;
+    }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${inProcessRun.runId}
+    `;
+    expect(pendingWithoutGranularity).toEqual({ status: 'pending', claimed_by: null });
+
+    // origin/main already resolves trusted claimedWindow context for the
+    // matching claimed/running in-process run. Preserve that established lane
+    // without adding a general schedule-based fallback for external callers.
+    await sql`
+      UPDATE runs
+      SET status = 'running'
+      WHERE id = ${inProcessRun.runId}
+    `;
+    const inProcessRead = await handleAutomationMode(
+      { automation_id: automationId, run_id: inProcessRun.runId },
+      TEST_ENV,
+      sql,
+      {
+        organizationId: workspace.org.id,
+        userId: null,
+        claimedWindow: {
+          runId: inProcessRun.runId,
+          windowStart: legacyWindowStart,
+          windowEnd: legacyWindowEnd,
+          templateVersionId: queuedVersionId,
+          granularity: 'weekly',
+        },
+      }
+    );
+    expect(inProcessRead.window_lag?.granularity).toBe('weekly');
+    const inProcessToken = await verifyWindowToken(inProcessRead.window_token, TEST_ENV);
+    expect(inProcessToken).toMatchObject({
+      run_id: inProcessRun.runId,
+      granularity: 'weekly',
+    });
+
     const promoted = await sql<{
       parent_id: number | null;
       metadata: Record<string, unknown>;

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -283,6 +283,16 @@ describe('external manual Automation execution', () => {
       claimed_by: `user:${workspace.users.owner.id}`,
       model_used: 'chatgpt/test',
     });
+    const completedReplay = (await workspace.owner.automations.completeWindow({
+      automation_id: created.automation_id,
+      run_id: triggered.run_id,
+      window_token: read.window_token,
+      extracted_data: {
+        tasks: [{ task_key: 'invoice-review', action: 'Review invoice' }],
+      },
+      model: 'chatgpt/test',
+    })) as { completed_now: boolean };
+    expect(completedReplay.completed_now).toBe(false);
 
     // A token minted for run A must not authorize run B even when both runs
     // deliberately cover the same Automation period.
@@ -367,6 +377,44 @@ describe('external manual Automation execution', () => {
         model: 'chatgpt/test',
       })
     ).rejects.toThrow(/already claimed by another executor/);
+
+    // A running row without durable claimant attribution is invalid state. An
+    // external caller must not adopt it by supplying a valid run-bound token.
+    await sql`
+      UPDATE runs
+      SET claimed_by = NULL
+      WHERE id = ${secondRun.runId}
+    `;
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_token: secondRead.window_token,
+        extracted_data: {
+          findings: [{ task_key: 'unclaimed-running', action: 'Must not persist' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/could not be claimed/);
+    const [invalidRunning] = await sql<{ status: string; claimed_by: string | null }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${secondRun.runId}
+    `;
+    expect(invalidRunning).toEqual({ status: 'running', claimed_by: null });
+
+    // Retrying a claim already durably owned by this caller remains valid.
+    await sql`
+      UPDATE runs
+      SET claimed_by = ${`user:${workspace.users.owner.id}`}
+      WHERE id = ${secondRun.runId}
+    `;
+    const sameClaimRetry = (await workspace.owner.automations.completeWindow({
+      automation_id: created.automation_id,
+      run_id: secondRun.runId,
+      window_token: secondRead.window_token,
+      extracted_data: { findings: [] },
+      model: 'chatgpt/test',
+    })) as { completed_now: boolean };
+    expect(sameClaimRetry.completed_now).toBe(true);
 
     const promoted = await sql<{
       parent_id: number | null;

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -3,9 +3,13 @@ import type { Env } from '../../../index';
 import { createAutomationRun } from '../../../runs/queue-service';
 import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
 import type { ToolContext } from '../../../tools/registry';
-import { generateWindowToken } from '../../../utils/jwt';
+import { generateWindowToken, verifyWindowToken } from '../../../utils/jwt';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
-import { createTestEntity, createTestEvent } from '../../setup/test-fixtures';
+import {
+  createTestAgent,
+  createTestEntity,
+  createTestEvent,
+} from '../../setup/test-fixtures';
 import { TestWorkspace } from '../../setup/test-mcp-client';
 
 const TASK_SCHEMA = {
@@ -99,6 +103,7 @@ describe('external manual Automation execution', () => {
     const queuedWindowStart = String(queued.approved_input.window_start);
     const queuedWindowEnd = String(queued.approved_input.window_end);
     expect(queuedVersionId).toBeGreaterThan(0);
+    expect(queued.approved_input.granularity).toBe('weekly');
 
     // A workspace event-window run stores exact durable pointers in its run
     // snapshot. The caller should not have to repeat content_ids when reading
@@ -132,12 +137,22 @@ describe('external manual Automation execution', () => {
       WHERE id = ${triggered.run_id}
     `;
 
-    // Change the live Automation to an incompatible output name after the run
-    // is queued. The run-bound read must keep the original version and schema.
+    // Change the live Automation to an incompatible output name and daily
+    // cadence after the run is queued. The run-bound read must keep the
+    // original version, schema, and weekly period semantics.
     await workspace.owner.automations.createVersion({
       automation_id: created.automation_id,
       prompt: 'Extract findings instead.',
       outputs: EDITED_OUTPUTS,
+    });
+    const liveAgent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId: workspace.users.owner.id,
+    });
+    await workspace.owner.automations.update({
+      automation_id: created.automation_id,
+      agent_id: liveAgent.agentId,
+      triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     });
     const [edited] = await sql<{ current_version_id: number }>`
       SELECT current_version_id
@@ -159,6 +174,7 @@ describe('external manual Automation execution', () => {
         required?: string[];
         properties?: Record<string, unknown>;
       };
+      window_lag?: { granularity?: string };
     };
     expect(read.window_start).toBe(queuedWindowStart);
     expect(read.window_end).toBe(queuedWindowEnd);
@@ -167,6 +183,8 @@ describe('external manual Automation execution', () => {
     expect(read.extraction_schema?.properties?.findings).toBeUndefined();
     expect(read.content.map((item) => Number(item.id))).toContain(triggerEvent.id);
     if (!read.window_token) throw new Error('run-bound read returned no window token');
+    expect(read.window_lag?.granularity).toBe('weekly');
+    expect((await verifyWindowToken(read.window_token, TEST_ENV)).granularity).toBe('weekly');
 
     const unrelatedEvent = await createTestEvent({
       entity_id: parent.id,
@@ -273,16 +291,18 @@ describe('external manual Automation execution', () => {
       status: string;
       claimed_by: string | null;
       model_used: string | null;
+      approved_input: Record<string, unknown>;
     }>`
-      SELECT status, claimed_by, model_used
+      SELECT status, claimed_by, model_used, approved_input
       FROM runs
       WHERE id = ${triggered.run_id}
     `;
-    expect(completed).toEqual({
+    expect(completed).toMatchObject({
       status: 'completed',
       claimed_by: `user:${workspace.users.owner.id}`,
       model_used: 'chatgpt/test',
     });
+    expect(completed.approved_input.granularity).toBe('weekly');
     const completedReplay = (await workspace.owner.automations.completeWindow({
       automation_id: created.automation_id,
       run_id: triggered.run_id,

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -402,6 +402,62 @@ describe('external manual Automation execution', () => {
     })) as { window_token?: string };
     if (!secondRead.window_token) throw new Error('second run returned no window token');
 
+    const secondTokenPayload = await verifyWindowToken(secondRead.window_token, TEST_ENV);
+    if (secondTokenPayload.run_id == null) {
+      throw new Error('second run returned an unbound window token');
+    }
+    const pageCursor = {
+      occurred_at: queuedWindowStart,
+      id: 1,
+    };
+    const boundRootToken = await generateWindowToken(
+      {
+        automation_id: secondTokenPayload.automation_id,
+        run_id: secondTokenPayload.run_id,
+        window_start: secondTokenPayload.window_start,
+        window_end: secondTokenPayload.window_end,
+        granularity: secondTokenPayload.granularity,
+        content_count: 0,
+        content_ids: [],
+        page_next_occurred_at: pageCursor.occurred_at,
+        page_next_id: pageCursor.id,
+        page_has_more: true,
+      },
+      TEST_ENV
+    );
+    const unboundContinuationToken = await generateWindowToken(
+      {
+        automation_id: secondTokenPayload.automation_id,
+        window_start: secondTokenPayload.window_start,
+        window_end: secondTokenPayload.window_end,
+        granularity: secondTokenPayload.granularity,
+        content_count: 0,
+        content_ids: [],
+        page_before_occurred_at: pageCursor.occurred_at,
+        page_before_id: pageCursor.id,
+        page_has_more: false,
+      },
+      TEST_ENV
+    );
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_tokens: [boundRootToken, unboundContinuationToken],
+        extracted_data: {
+          findings: [{ task_key: 'mixed-fence', action: 'Must not persist' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/must all carry the same Automation run fence/);
+    const [stillPendingAfterMixedFence] = await sql<{
+      status: string;
+      claimed_by: string | null;
+    }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${secondRun.runId}
+    `;
+    expect(stillPendingAfterMixedFence).toEqual({ status: 'pending', claimed_by: null });
+
     // The external claim is part of the completion transaction. A failure
     // after pending -> running must roll the claim back with every output write.
     await expect(

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -304,7 +304,7 @@ describe('external manual Automation execution', () => {
         },
         model: 'chatgpt/test',
       })
-    ).rejects.toThrow(/window_token belongs to Automation run/);
+    ).rejects.toThrow(/window_token is fenced to Automation run/);
     const [stillPending] = await sql<{ status: string }>`
       SELECT status FROM runs WHERE id = ${secondRun.runId}
     `;

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { createAutomationRun } from '../../../runs/queue-service';
+import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
+import type { ToolContext } from '../../../tools/registry';
+import { generateWindowToken } from '../../../utils/jwt';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEntity, createTestEvent } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const TASK_SCHEMA = {
+  type: 'object',
+  properties: {
+    task_key: { type: 'string' },
+    action: { type: 'string' },
+  },
+  required: ['task_key', 'action'],
+  additionalProperties: true,
+};
+
+const TASK_OUTPUTS = {
+  tasks: {
+    entity: 'task',
+    key: ['task_key'],
+    name: ['action'],
+  },
+};
+
+const EDITED_OUTPUTS = {
+  findings: {
+    entity: 'task',
+    key: ['task_key'],
+    name: ['action'],
+  },
+};
+
+const TEST_ENV: Env = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+};
+
+describe('external manual Automation execution', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('triggers without the gateway, reads the queued run after a version edit, and persists keyed output', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'External Automation Org' });
+    const parent = await createTestEntity({
+      name: 'Task Board',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+
+    await sql`
+      INSERT INTO entity_types (
+        organization_id, slug, name, metadata_schema, created_at, updated_at
+      ) VALUES (
+        ${workspace.org.id}, 'task', 'Task', ${sql.json(TASK_SCHEMA)}, NOW(), NOW()
+      )
+    `;
+
+    const created = (await workspace.owner.automations.create({
+      entity_id: parent.id,
+      slug: 'external-task-builder',
+      name: 'External Task Builder',
+      prompt: 'Extract durable tasks.',
+      sources: [
+        {
+          name: 'signals',
+          query: 'SELECT id, payload_text, occurred_at FROM events WHERE false',
+        },
+      ],
+      outputs: TASK_OUTPUTS,
+      agent_id: null,
+    })) as { automation_id: string };
+    const automationId = Number(created.automation_id);
+
+    // Vitest has no embedded Lobu gateway. An agentless manual run must still
+    // materialize and remain pending for the external MCP completion path.
+    const triggered = (await workspace.owner.automations.trigger({
+      automation_id: created.automation_id,
+    })) as { run_id: number; status: string };
+    expect(triggered.status).toBe('pending');
+
+    const [queued] = await sql<{
+      status: string;
+      approved_input: Record<string, unknown>;
+    }>`
+      SELECT status, approved_input
+      FROM runs
+      WHERE id = ${triggered.run_id}
+    `;
+    expect(queued.status).toBe('pending');
+    const queuedVersionId = Number(queued.approved_input.version_id);
+    const queuedWindowStart = String(queued.approved_input.window_start);
+    const queuedWindowEnd = String(queued.approved_input.window_end);
+    expect(queuedVersionId).toBeGreaterThan(0);
+
+    // A workspace event-window run stores exact durable pointers in its run
+    // snapshot. The caller should not have to repeat content_ids when reading
+    // that run later.
+    const triggerOccurredAt = new Date(
+      (Date.parse(queuedWindowStart) + Date.parse(queuedWindowEnd)) / 2
+    );
+    const triggerEvent = await createTestEvent({
+      entity_id: parent.id,
+      organization_id: workspace.org.id,
+      content: 'A durable workspace signal for the task builder.',
+      occurred_at: triggerOccurredAt,
+    });
+    const workspaceSignal = {
+      kind: 'event',
+      source: 'workspace',
+      event_id: triggerEvent.id,
+      event_type: 'observation',
+      delivery_id: `workspace-event:${triggerEvent.id}`,
+      occurred_at: triggerOccurredAt.toISOString(),
+      root_event_ids: [triggerEvent.id],
+      causal_automation_ids: [99],
+      depth: 1,
+    };
+    await sql`
+      UPDATE runs
+      SET approved_input = approved_input
+        || jsonb_build_object('dispatch_source', 'event')
+        || jsonb_build_object('trigger_signal', ${sql.json(workspaceSignal)}::jsonb)
+        || jsonb_build_object('trigger_signals', ${sql.json([workspaceSignal])}::jsonb)
+      WHERE id = ${triggered.run_id}
+    `;
+
+    // Change the live Automation to an incompatible output name after the run
+    // is queued. The run-bound read must keep the original version and schema.
+    await workspace.owner.automations.createVersion({
+      automation_id: created.automation_id,
+      prompt: 'Extract findings instead.',
+      outputs: EDITED_OUTPUTS,
+    });
+    const [edited] = await sql<{ current_version_id: number }>`
+      SELECT current_version_id
+      FROM automations
+      WHERE id = ${automationId}
+    `;
+    expect(Number(edited.current_version_id)).not.toBe(queuedVersionId);
+
+    const read = (await workspace.owner.knowledge.read({
+      automation_id: automationId,
+      run_id: triggered.run_id,
+      limit: 25,
+    })) as {
+      window_token?: string;
+      window_start?: string;
+      window_end?: string;
+      content: Array<{ id?: number }>;
+      extraction_schema?: {
+        required?: string[];
+        properties?: Record<string, unknown>;
+      };
+    };
+    expect(read.window_start).toBe(queuedWindowStart);
+    expect(read.window_end).toBe(queuedWindowEnd);
+    expect(read.extraction_schema?.required).toContain('tasks');
+    expect(read.extraction_schema?.properties?.tasks).toBeDefined();
+    expect(read.extraction_schema?.properties?.findings).toBeUndefined();
+    expect(read.content.map((item) => Number(item.id))).toContain(triggerEvent.id);
+    if (!read.window_token) throw new Error('run-bound read returned no window token');
+
+    const unrelatedEvent = await createTestEvent({
+      entity_id: parent.id,
+      organization_id: workspace.org.id,
+      content: 'Not part of the queued run trigger snapshot.',
+      occurred_at: triggerOccurredAt,
+    });
+    await expect(
+      workspace.owner.knowledge.read({
+        automation_id: automationId,
+        run_id: triggered.run_id,
+        content_ids: [unrelatedEvent.id],
+      })
+    ).rejects.toThrow(/does not include trigger content id/);
+
+    const other = (await workspace.owner.automations.create({
+      entity_id: parent.id,
+      slug: 'other-external-automation',
+      name: 'Other External Automation',
+      prompt: 'Do something else.',
+      sources: [
+        {
+          name: 'signals',
+          query: 'SELECT id, payload_text, occurred_at FROM events WHERE false',
+        },
+      ],
+    })) as { automation_id: string };
+    await expect(
+      workspace.owner.knowledge.read({
+        automation_id: Number(other.automation_id),
+        run_id: triggered.run_id,
+      })
+    ).rejects.toThrow(/does not belong to Automation/);
+
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: triggered.run_id,
+        window_token: read.window_token,
+        extracted_data: {
+          tasks: [{ task_key: 'invalid-before-claim' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/extracted_data does not match/);
+    const [stillPendingAfterInvalid] = await sql<{
+      status: string;
+      claimed_by: string | null;
+    }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${triggered.run_id}
+    `;
+    expect(stillPendingAfterInvalid).toEqual({
+      status: 'pending',
+      claimed_by: null,
+    });
+
+    const identitylessContext: ToolContext = {
+      organizationId: workspace.org.id,
+      userId: null,
+      memberRole: 'owner',
+      agentId: null,
+      isAuthenticated: true,
+      clientId: null,
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      tokenType: 'session',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+      executionMode: 'live',
+    };
+    await expect(
+      handleCompleteWindow(
+        {
+          action: 'complete_window',
+          automation_id: created.automation_id,
+          run_id: triggered.run_id,
+          window_token: read.window_token,
+          extracted_data: {
+            tasks: [{ task_key: 'identityless', action: 'Must not persist' }],
+          },
+          model: 'chatgpt/test',
+        } as never,
+        TEST_ENV,
+        identitylessContext
+      )
+    ).rejects.toThrow(/requires an authenticated MCP client or user/);
+    const [stillUnclaimed] = await sql<{ status: string; claimed_by: string | null }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${triggered.run_id}
+    `;
+    expect(stillUnclaimed).toEqual({ status: 'pending', claimed_by: null });
+
+    const completion = (await workspace.owner.automations.completeWindow({
+      automation_id: created.automation_id,
+      run_id: triggered.run_id,
+      window_token: read.window_token,
+      extracted_data: {
+        tasks: [{ task_key: 'invoice-review', action: 'Review invoice' }],
+      },
+      model: 'chatgpt/test',
+    })) as { action: string; run_id: number };
+    expect(completion.action).toBe('complete_window');
+    expect(completion.run_id).toBe(triggered.run_id);
+
+    const [completed] = await sql<{
+      status: string;
+      claimed_by: string | null;
+      model_used: string | null;
+    }>`
+      SELECT status, claimed_by, model_used
+      FROM runs
+      WHERE id = ${triggered.run_id}
+    `;
+    expect(completed).toEqual({
+      status: 'completed',
+      claimed_by: `user:${workspace.users.owner.id}`,
+      model_used: 'chatgpt/test',
+    });
+
+    // A token minted for run A must not authorize run B even when both runs
+    // deliberately cover the same Automation period.
+    const secondRun = await createAutomationRun({
+      organizationId: workspace.org.id,
+      automationId,
+      agentId: null,
+      windowStart: queuedWindowStart,
+      windowEnd: queuedWindowEnd,
+      dispatchSource: 'manual',
+    });
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_token: read.window_token,
+        extracted_data: {
+          findings: [{ task_key: 'wrong-run', action: 'Must not persist' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/window_token belongs to Automation run/);
+    const [stillPending] = await sql<{ status: string }>`
+      SELECT status FROM runs WHERE id = ${secondRun.runId}
+    `;
+    expect(stillPending.status).toBe('pending');
+
+    const legacyToken = await generateWindowToken(
+      {
+        automation_id: automationId,
+        window_start: queuedWindowStart,
+        window_end: queuedWindowEnd,
+        granularity: 'weekly',
+        content_count: 0,
+        content_ids: [],
+      },
+      TEST_ENV
+    );
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_token: legacyToken,
+        extracted_data: {
+          findings: [{ task_key: 'legacy-token', action: 'Must not persist' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/requires a run-bound window_token/);
+    const [stillPendingAfterLegacyToken] = await sql<{
+      status: string;
+      claimed_by: string | null;
+    }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${secondRun.runId}
+    `;
+    expect(stillPendingAfterLegacyToken).toEqual({
+      status: 'pending',
+      claimed_by: null,
+    });
+
+    const secondRead = (await workspace.owner.knowledge.read({
+      automation_id: automationId,
+      run_id: secondRun.runId,
+      limit: 25,
+    })) as { window_token?: string };
+    if (!secondRead.window_token) throw new Error('second run returned no window token');
+    await sql`
+      UPDATE runs
+      SET status = 'running',
+          claimed_by = 'mcp:other-client',
+          claimed_at = NOW()
+      WHERE id = ${secondRun.runId}
+    `;
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_token: secondRead.window_token,
+        extracted_data: {
+          findings: [{ task_key: 'other-claim', action: 'Must not persist' }],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/already claimed by another executor/);
+
+    const promoted = await sql<{
+      parent_id: number | null;
+      metadata: Record<string, unknown>;
+    }>`
+      SELECT e.parent_id, e.metadata
+      FROM entity_identities ei
+      JOIN entities e ON e.id = ei.entity_id
+      WHERE ei.organization_id = ${workspace.org.id}
+        AND ei.namespace = 'automation_key'
+        AND e.deleted_at IS NULL
+    `;
+    expect(promoted).toHaveLength(1);
+    expect(Number(promoted[0].parent_id)).toBe(parent.id);
+    expect(promoted[0].metadata).toMatchObject({
+      task_key: 'invoice-review',
+      action: 'Review invoice',
+      automation_id: automationId,
+      run_id: triggered.run_id,
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../../index';
 import { createAutomationRun } from '../../../runs/queue-service';
 import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
+import { handleAutomationMode } from '../../../tools/get_content/automation-mode';
 import type { ToolContext } from '../../../tools/registry';
 import { generateWindowToken, verifyWindowToken } from '../../../utils/jwt';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -325,6 +326,27 @@ describe('external manual Automation execution', () => {
       dispatchSource: 'manual',
     });
     await expect(
+      handleAutomationMode(
+        {
+          automation_id: automationId,
+          run_id: secondRun.runId,
+        },
+        TEST_ENV,
+        sql,
+        {
+          organizationId: workspace.org.id,
+          userId: workspace.users.owner.id,
+          claimedWindow: {
+            runId: triggered.run_id,
+            windowStart: queuedWindowStart,
+            windowEnd: queuedWindowEnd,
+            templateVersionId: queuedVersionId,
+            granularity: 'weekly',
+          },
+        }
+      )
+    ).rejects.toThrow(/does not match claimed run/);
+    await expect(
       workspace.owner.automations.completeWindow({
         automation_id: created.automation_id,
         run_id: secondRun.runId,
@@ -379,6 +401,31 @@ describe('external manual Automation execution', () => {
       limit: 25,
     })) as { window_token?: string };
     if (!secondRead.window_token) throw new Error('second run returned no window token');
+
+    // The external claim is part of the completion transaction. A failure
+    // after pending -> running must roll the claim back with every output write.
+    await expect(
+      workspace.owner.automations.completeWindow({
+        automation_id: created.automation_id,
+        run_id: secondRun.runId,
+        window_token: secondRead.window_token,
+        extracted_data: {
+          findings: [
+            { task_key: 'duplicate', action: 'Same key' },
+            { task_key: 'duplicate', action: 'Same key' },
+          ],
+        },
+        model: 'chatgpt/test',
+      })
+    ).rejects.toThrow(/duplicate exact key/);
+    const [rolledBackClaim] = await sql<{
+      status: string;
+      claimed_by: string | null;
+    }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${secondRun.runId}
+    `;
+    expect(rolledBackClaim).toEqual({ status: 'pending', claimed_by: null });
+
     await sql`
       UPDATE runs
       SET status = 'running',

--- a/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
@@ -175,12 +175,12 @@ describe("Automation window lag is visible and actionable", () => {
 			windowEnd: dispatched.window_end,
 			dispatchSource: "manual",
 		});
-		await sql`UPDATE runs SET status = 'running', claimed_at = NOW() WHERE id = ${createdRun.runId}`;
+		const runBound = await read({ run_id: createdRun.runId });
 		const completion = await manageAutomations(
 			{
 				action: "complete_window",
 				automation_id: String(automationId),
-				window_token: dispatched.window_token,
+				window_token: runBound.window_token,
 				run_id: createdRun.runId,
 				extracted_data: { summary: "Analysed the dispatched window." },
 			},
@@ -271,12 +271,12 @@ describe("Automation window lag is visible and actionable", () => {
 			windowEnd: dispatched.window_end,
 			dispatchSource: "manual",
 		});
-		await sql`UPDATE runs SET status = 'running', claimed_at = NOW() WHERE id = ${currentRun.runId}`;
+		const currentRunBound = await read({ run_id: currentRun.runId });
 		await manageAutomations(
 			{
 				action: "complete_window",
 				automation_id: String(automationId),
-				window_token: dispatched.window_token,
+				window_token: currentRunBound.window_token,
 				run_id: currentRun.runId,
 				extracted_data: { summary: "current" },
 			},
@@ -293,12 +293,12 @@ describe("Automation window lag is visible and actionable", () => {
 			windowEnd: backfill.window_end,
 			dispatchSource: "manual",
 		});
-		await sql`UPDATE runs SET status = 'running', claimed_at = NOW() WHERE id = ${backfillRun.runId}`;
+		const backfillRunBound = await read({ run_id: backfillRun.runId });
 		await manageAutomations(
 			{
 				action: "complete_window",
 				automation_id: String(automationId),
-				window_token: backfill.window_token,
+				window_token: backfillRunBound.window_token,
 				run_id: backfillRun.runId,
 				extracted_data: { summary: "backfilled" },
 			},

--- a/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
@@ -160,11 +160,16 @@ describe('eval complete_window capture', () => {
     `;
     expect(live.action_output).toEqual(LIVE_EXTRACTION);
     const [evalResult] = await ctx.sql<
-      { dry_run: boolean; dry_run_preview: { captured: string; extracted_data: unknown } }[]
+      {
+        dry_run: boolean;
+        dry_run_preview: { captured: string; extracted_data: unknown };
+        claimed_by: string | null;
+      }[]
     >`
-      SELECT dry_run, dry_run_preview FROM runs WHERE id = ${ctx.evalRunId}
+      SELECT dry_run, dry_run_preview, claimed_by FROM runs WHERE id = ${ctx.evalRunId}
     `;
     expect(evalResult.dry_run).toBe(true);
+    expect(evalResult.claimed_by).toBeNull();
     expect(evalResult.dry_run_preview).toMatchObject({
       captured: 'complete_window',
       extracted_data: EVAL_EXTRACTION,

--- a/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
+++ b/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
@@ -63,7 +63,7 @@ describe("automation dispatch message", () => {
 			},
 		});
 
-		expect(message).toContain("content_ids: [40]");
+		expect(message).toContain("client.knowledge.read({ automation_id: 21, run_id: 89, limit: 25 })");
 		expect(message).toContain("signs its exact id into the window_token");
 		expect(message).toContain("Analyze each trigger input exactly once");
 	});
@@ -90,10 +90,10 @@ describe("automation dispatch message", () => {
 			"Treat the Automation as having no data only when `content` and every array in `sources` are empty.",
 		);
 		expect(message).toContain(
-			'client.knowledge.read({ automation_id: 13, since: "2026-07-15", until: "2026-07-15", limit: 25 })',
+			'client.knowledge.read({ automation_id: 13, run_id: 647146, limit: 25 })',
 		);
 		expect(message).toContain(
-			"If page.has_more is true and you need more evidence, call knowledge.read again with page.next_cursor as before_occurred_at/before_id.",
+			"If page.has_more is true and you need more evidence, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id.",
 		);
 		expect(message).toContain(
 			"Keep the returned window_token from every page you actually analyze.",

--- a/packages/server/src/authz/__tests__/resolve-acting-principal.test.ts
+++ b/packages/server/src/authz/__tests__/resolve-acting-principal.test.ts
@@ -16,11 +16,10 @@ function stubSql(
 		const text = strings.join(" ");
 		if (text.includes("FROM automations")) {
 			if (!automationExists) return Promise.resolve([]);
-			const normalizedOwner = ownerAgentId?.trim() || null;
 			return Promise.resolve([
 				{
-					agent_id: normalizedOwner,
-					owner_resolved: normalizedOwner == null ? true : agentExists,
+					agent_id: ownerAgentId,
+					owner_resolved: ownerAgentId == null ? true : agentExists,
 				},
 			]);
 		}
@@ -151,16 +150,16 @@ describe("resolveActingPrincipal", () => {
 		});
 	});
 
-	it("a legacy empty-string agent assignment resolves like null", async () => {
-		const actor = await resolveActingPrincipal(stubSql(""), {
+	it("an invalid empty-string agent assignment fails closed", async () => {
+		const actor = await resolveActingPrincipal(stubSql("", false), {
 			organizationId: ORG,
 			sessionAutomationId: 9,
 		});
 		expect(actor).toEqual({
 			kind: "automation",
 			id: "automation:9",
-			ownerAgentId: null,
-			ownerResolved: true,
+			ownerAgentId: "",
+			ownerResolved: false,
 		});
 	});
 

--- a/packages/server/src/authz/__tests__/resolve-acting-principal.test.ts
+++ b/packages/server/src/authz/__tests__/resolve-acting-principal.test.ts
@@ -3,28 +3,26 @@ import type { DbClient } from "../../db/client";
 import { resolveActingPrincipal } from "../entity-policy";
 
 /**
- * The single seam every write surface resolves identity through. It merges the
- * two channels an acting automation arrives on (an explicit `automation_source` and the
- * reaction session's own automation), looks up the owning agent —
- * so no call site has to merge them and a reaction can't dodge its agent's
- * envelope by omitting attribution.
- *
- * The stub routes by query text: the automation-owner JOIN (`FROM automations`) returns a
- * row iff `ownerAgentId` is set; the direct-agent existence probe (`FROM agents`,
- * no join) returns a row iff `agentExists`. This lets a test model an agent that was
- * deleted out from under a live session (agentExists=false) distinctly from a
- * missing automation.
+ * The single seam every write surface resolves identity through. The stub
+ * models the two independent facts the production query returns: whether the
+ * Automation row exists and whether its optional managed agent still exists.
  */
 function stubSql(
 	ownerAgentId: string | null,
 	agentExists = true,
+	automationExists = true,
 ): DbClient {
 	const sql = (strings: TemplateStringsArray) => {
 		const text = strings.join(" ");
 		if (text.includes("FROM automations")) {
-			return Promise.resolve(
-				ownerAgentId == null ? [] : [{ agent_id: ownerAgentId }],
-			);
+			if (!automationExists) return Promise.resolve([]);
+			const normalizedOwner = ownerAgentId?.trim() || null;
+			return Promise.resolve([
+				{
+					agent_id: normalizedOwner,
+					owner_resolved: normalizedOwner == null ? true : agentExists,
+				},
+			]);
 		}
 		// Direct-agent existence probe: SELECT 1 AS one FROM agents ...
 		return Promise.resolve(agentExists ? [{ one: 1 }] : []);
@@ -32,9 +30,9 @@ function stubSql(
 	return sql as unknown as DbClient;
 }
 
-/** A stub where the automation row is GONE — the owner JOIN returns no rows. */
+/** A stub where the Automation row itself is gone. */
 function stubSqlNoAutomation(): DbClient {
-	return stubSql(null);
+	return stubSql(null, true, false);
 }
 
 const ORG = "org-1";
@@ -63,6 +61,20 @@ describe("resolveActingPrincipal", () => {
 		// nonexistent id) to null out ownerAgentId and skip its own deny rows. The
 		// explicit tag must NOT override the authenticated agent identity.
 		const actor = await resolveActingPrincipal(stubSql("other-owner"), {
+			organizationId: ORG,
+			agentId: "agent-1",
+			explicitAutomationId: 7,
+		});
+		expect(actor).toEqual({
+			kind: "agent",
+			id: "agent-1",
+			ownerAgentId: null,
+			ownerResolved: true,
+		});
+	});
+
+	it("an authed agent cannot tag an agentless Automation to shed its own policy", async () => {
+		const actor = await resolveActingPrincipal(stubSql(null), {
 			organizationId: ORG,
 			agentId: "agent-1",
 			explicitAutomationId: 7,
@@ -126,6 +138,32 @@ describe("resolveActingPrincipal", () => {
 		expect(actor.id).toBe("automation:9");
 	});
 
+	it("an agentless session Automation remains a resolved Automation principal", async () => {
+		const actor = await resolveActingPrincipal(stubSql(null), {
+			organizationId: ORG,
+			sessionAutomationId: 9,
+		});
+		expect(actor).toEqual({
+			kind: "automation",
+			id: "automation:9",
+			ownerAgentId: null,
+			ownerResolved: true,
+		});
+	});
+
+	it("a legacy empty-string agent assignment resolves like null", async () => {
+		const actor = await resolveActingPrincipal(stubSql(""), {
+			organizationId: ORG,
+			sessionAutomationId: 9,
+		});
+		expect(actor).toEqual({
+			kind: "automation",
+			id: "automation:9",
+			ownerAgentId: null,
+			ownerResolved: true,
+		});
+	});
+
 	it("a plain user turn has no owner to fold", async () => {
 		const actor = await resolveActingPrincipal(stubSql(null), {
 			organizationId: ORG,
@@ -178,7 +216,7 @@ describe("resolveActingPrincipal", () => {
 		// after the owner is deleted. The owner JOIN requires the agent row, so the
 		// lookup returns no rows → ownerResolved=false → gate denies. (stubSql(null)
 		// models the JOIN finding nothing because the agent side is gone.)
-		const actor = await resolveActingPrincipal(stubSql(null), {
+		const actor = await resolveActingPrincipal(stubSql("deleted-owner", false), {
 			organizationId: ORG,
 			sessionAutomationId: 9,
 		});

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -307,42 +307,44 @@ export function automationIdFromPrincipalId(
 }
 
 /**
- * The agent that owns an automation (`automations.agent_id`, NOT NULL in schema). Every
- * automation write is governed by its owning agent's envelope — an automation is that
- * agent's autonomous mode — so the resolver folds the agent's rows in via
- * `ownerAgentId`. Shared by every automation write surface (entity promotion, reaction
- * scripts, automation CRUD) so the linkage is resolved ONE way.
+ * Resolve the optional managed agent attached to an Automation.
  *
- * Returns `{ ownerAgentId, resolved }`. `resolved` is false when the automation row is
- * GONE (hard-deleted mid-reaction, or a bad id) OR its owning AGENT no longer exists
- * (deleted out from under an in-flight automation — there is no automation→agent FK, so the
- * agent_id can dangle) — both are the same security-relevant state: the acting
- * automation's agent envelope can't be folded, so proceeding as an unowned automation would
- * let the reaction slip its owning agent's deny/approval rules and fall back to the
- * (looser) org default. Callers acting on a TRUSTED automation must FAIL CLOSED on
- * `resolved === false` (see the gate resolvers).
+ * The Automation itself is always the write principal (`automation:<id>`). When
+ * `agent_id` is present, its agent policy is folded in as a restrictive ancestor.
+ * Agentless manual Automations are still valid principals and resolve with no
+ * ancestor. Only a missing Automation row, or a non-empty `agent_id` whose agent
+ * row no longer exists, is unresolved and must fail closed.
  *
- * `organizationId` scopes both the automation AND the owning-agent existence check so a
- * caller can't resolve against another org's rows.
+ * Empty strings are tolerated as a legacy representation of NULL so existing
+ * manual-open rows remain safe while callers migrate to the nullable contract.
  */
 export async function resolveAutomationOwner(
 	sql: DbClient,
 	automationId: number,
 	organizationId: string,
 ): Promise<{ ownerAgentId: string | null; resolved: boolean }> {
-	// INNER JOIN agents: the row resolves ONLY when the owning agent still exists in
-	// this org. A dangling agent_id (agent deleted mid-flight) yields zero rows →
-	// resolved:false → gates deny, closing the fail-open where a deleted agent's
-	// automation would fall back to the looser org default.
-	const rows = await sql<{ agent_id: string }>`
-    SELECT w.agent_id
+	const rows = await sql<{ agent_id: string | null; owner_resolved: boolean }>`
+    SELECT
+      NULLIF(BTRIM(w.agent_id), '') AS agent_id,
+      CASE
+        WHEN NULLIF(BTRIM(w.agent_id), '') IS NULL THEN true
+        ELSE EXISTS (
+          SELECT 1
+          FROM agents a
+          WHERE a.id = w.agent_id
+            AND a.organization_id = w.organization_id
+        )
+      END AS owner_resolved
     FROM automations w
-    JOIN agents a ON a.id = w.agent_id AND a.organization_id = ${organizationId}
-    WHERE w.id = ${automationId} AND w.organization_id = ${organizationId}
+    WHERE w.id = ${automationId}
+      AND w.organization_id = ${organizationId}
     LIMIT 1
   `;
 	if (rows.length === 0) return { ownerAgentId: null, resolved: false };
-	return { ownerAgentId: rows[0].agent_id, resolved: true };
+	return {
+		ownerAgentId: rows[0].agent_id ?? null,
+		resolved: rows[0].owner_resolved === true,
+	};
 }
 
 /** The fully-resolved acting principal for one write, ready to hand to the gate. */
@@ -350,14 +352,13 @@ export interface ActingPrincipal {
 	kind: EntityPolicyPrincipalKind;
 	/** `automation:<id>` / agent id / null ("any of this kind"). */
 	id: string | null;
-	/** The automation's owning agent, folded max-restrictive; null unless an automation. */
+	/** Optional attached agent, folded max-restrictive for an Automation. */
 	ownerAgentId: string | null;
 	/**
-	 * False ONLY when this is an automation whose owning-agent lookup FAILED (the automation
-	 * row is gone). The gate must FAIL CLOSED (deny) rather than run the write as an
-	 * unowned automation against the looser org default — otherwise a reaction whose
-	 * automation was hard-deleted mid-flight escapes its agent's envelope. True for every
-	 * agent/user turn and every automation whose owner resolved (incl. legitimately null).
+	 * False only when an Automation row is missing, its non-empty attached agent no longer
+	 * exists, or an authenticated agent session points at a deleted agent. The gate must
+	 * fail closed in those cases. An existing agentless Automation is resolved and carries
+	 * no agent ancestor.
 	 */
 	ownerResolved: boolean;
 }
@@ -375,8 +376,9 @@ export interface ActingPrincipal {
  * loosen, its agent), so there's no way to "spoof an automation tag" to escape agent
  * policy.
  *
- * When an automation acts, this looks up its owning agent (folded max-restrictive).
- * This is THE seam every write surface (manage_entity/agents/operations/automations,
+ * When an Automation acts, this resolves its optional attached agent and folds that
+ * agent's policy max-restrictively. This is THE seam every write surface
+ * (manage_entity/agents/operations/automations,
  * promotion) resolves identity through.
  */
 /** An automation acting principal, folding its (already-resolved) owner agent. */

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -315,8 +315,6 @@ export function automationIdFromPrincipalId(
  * ancestor. Only a missing Automation row, or a non-empty `agent_id` whose agent
  * row no longer exists, is unresolved and must fail closed.
  *
- * Empty strings are tolerated as a legacy representation of NULL so existing
- * manual-open rows remain safe while callers migrate to the nullable contract.
  */
 export async function resolveAutomationOwner(
 	sql: DbClient,
@@ -325,9 +323,9 @@ export async function resolveAutomationOwner(
 ): Promise<{ ownerAgentId: string | null; resolved: boolean }> {
 	const rows = await sql<{ agent_id: string | null; owner_resolved: boolean }>`
     SELECT
-      NULLIF(BTRIM(w.agent_id), '') AS agent_id,
+      w.agent_id,
       CASE
-        WHEN NULLIF(BTRIM(w.agent_id), '') IS NULL THEN true
+        WHEN w.agent_id IS NULL THEN true
         ELSE EXISTS (
           SELECT 1
           FROM agents a

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -1022,14 +1022,6 @@ export function buildDispatchMessage(params: {
 		].join("\n");
 	}
 
-	const readKnowledgeSince = new Date(params.payload.window_start)
-		.toISOString()
-		.split("T")[0];
-	const readKnowledgeUntil = new Date(
-		new Date(params.payload.window_end).getTime() - 1
-	)
-		.toISOString()
-		.split("T")[0];
 	const workspaceContentIds = workspaceSignals.map((signal) => signal.event_id);
 
 	return [
@@ -1051,9 +1043,9 @@ export function buildDispatchMessage(params: {
 			"Analyze the window's content and extract findings per the extraction schema.",
 		"",
 		"Required steps:",
-		`1. Call query_sdk with a script that runs client.knowledge.read({ automation_id: ${params.automationId}, since: "${readKnowledgeSince}", until: "${readKnowledgeUntil}", limit: 25${workspaceContentIds.length > 0 ? `, content_ids: [${workspaceContentIds.join(", ")}]` : ""}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }). Keep the returned window_token from every page you actually analyze.`,
-		`2. Follow the Automation instructions above against the returned payload — content, sources, entities, extraction_schema, reactions_guidance, past_reactions, and past_feedback. If page.has_more is true and you need more evidence, call knowledge.read again with page.next_cursor as before_occurred_at/before_id. Collect that page's window_token too; do this for every additional page you actually analyze.`,
-		`3. Call run_sdk with a script that runs client.automations.completeWindow({ window_tokens: [all window_token values from pages you actually analyzed], extracted_data, run_id: ${params.runId}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }). Pass exactly one token per page you actually analyzed, including the first page.`,
+		`1. Call query_sdk with a script that runs client.knowledge.read({ automation_id: ${params.automationId}, run_id: ${params.runId}, limit: 25 }). The run ID binds the queued version, window, and trigger inputs. Keep the returned window_token from every page you actually analyze.`,
+		`2. Follow the Automation instructions above against the returned payload — content, sources, entities, extraction_schema, reactions_guidance, past_reactions, and past_feedback. If page.has_more is true and you need more evidence, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id. Collect that page's window_token too; do this for every additional page you actually analyze.`,
+		`3. Call run_sdk with a script that runs client.automations.completeWindow({ window_tokens: [all window_token values from pages you actually analyzed], extracted_data, run_id: ${params.runId} }). Pass exactly one token per page you actually analyzed, including the first page.`,
 		"4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:",
 		JSON.stringify(
 			{

--- a/packages/server/src/sandbox/namespaces/automations.ts
+++ b/packages/server/src/sandbox/namespaces/automations.ts
@@ -55,7 +55,7 @@ export interface AutomationCreateInput {
 	classifiers?: Record<string, unknown>;
 	reactions_guidance?: string;
 	reaction_script?: string;
-	agent_id?: string;
+	agent_id?: string | null;
 	device_worker_id?: string;
 	agent_kind?: AgentKind;
 	model_config?: Record<string, unknown>;
@@ -76,9 +76,9 @@ export interface AutomationUpdateInput {
 
 export interface AutomationCompleteWindowInput {
 	automation_id: AutomationId;
-	/** JWT obtained from read_knowledge(automation_id, since, until). */
+	/** JWT obtained from knowledge.read for this Automation run/window. */
 	window_token?: string;
-	/** Multiple page JWTs obtained from read_knowledge for the same Automation window. */
+	/** Multiple page JWTs obtained from knowledge.read for the same Automation run/window. */
 	window_tokens?: string[];
 	extracted_data: Record<string, unknown>;
 	client_id?: string;

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -355,11 +355,11 @@ function automationWriteAction(
  * ignore it). The guard requires all of them to be the actor itself. Returns `[]`
  * when there's nothing to check.
  *
- *  - `create`: the supplied `args.agent_id` (handleCreate requires it).
+ *  - `create`: the supplied `args.agent_id`, including an explicit null.
  *  - `create_from_version`: IGNORES args.agent_id — the clone inherits the SOURCE
  *    version's automation.agent_id.
- *  - `update`: DOES apply args.agent_id → the target's new owner is
- *    `args.agent_id ?? current owner`.
+ *  - `update`: an explicit args.agent_id (including null) becomes the new owner;
+ *    omission preserves the current owner.
  *  - `create_version` / `set_reaction_script`: IGNORE args.agent_id and write
  *    GROUP-WIDE (WHERE automation_group_id = …) → EVERY owner in the target's group is
  *    affected; a mixed-owner group means A editing its assignment also rewrites B's
@@ -374,7 +374,10 @@ async function resolveEffectiveAutomationOwners(
   const sql = getDb();
   switch (args.action) {
     case 'create':
-      return args.agent_id != null ? [args.agent_id] : [];
+      // Explicitly preserve the ownerless state. Humans bypass this guard, but
+      // a non-human principal must not be able to shed its policy ancestry by
+      // creating an Automation with agent_id: null.
+      return [args.agent_id ?? null];
     case 'create_from_version': {
       if (!args.version_id) return [];
       const rows = await sql<{ agent_id: string | null }>`
@@ -386,7 +389,10 @@ async function resolveEffectiveAutomationOwners(
       return rows.length > 0 ? [rows[0].agent_id ?? null] : [];
     }
     case 'update': {
-      if (args.agent_id != null) return [args.agent_id];
+      // `undefined` means ownership is unchanged; `null` is an explicit clear
+      // and must be checked as the effective owner rather than treated as
+      // omission. Otherwise an agent could drop its own policy ancestor.
+      if (args.agent_id !== undefined) return [args.agent_id];
       if (args.automation_id == null) return [];
       const rows = await sql<{ agent_id: string | null }>`
         SELECT agent_id FROM automations

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -262,11 +262,17 @@ export async function handleCompleteWindow(
 
   const firstToken = tokenPayloads[0];
   const { automation_id: automationId, window_start, window_end, granularity } = firstToken;
-  const claimToken = tokenPayloads.find((token) => token.run_id != null);
-  const tokenRunId = claimToken?.run_id ?? null;
-  if (claimToken?.run_id !== undefined && claimToken.run_id !== runId) {
+  const tokenRunIds = new Set(tokenPayloads.map((token) => token.run_id ?? null));
+  if (tokenRunIds.size !== 1) {
     throw new ToolUserError(
-      `window_token is fenced to Automation run ${claimToken.run_id}, not ${runId}.`,
+      'window_tokens must all carry the same Automation run fence.',
+      409
+    );
+  }
+  const tokenRunId = firstToken.run_id ?? null;
+  if (tokenRunId !== null && tokenRunId !== runId) {
+    throw new ToolUserError(
+      `window_token is fenced to Automation run ${tokenRunId}, not ${runId}.`,
       409
     );
   }
@@ -281,13 +287,13 @@ export async function handleCompleteWindow(
       throw new ToolUserError('All window_tokens must belong to the same Automation run/window.', 400);
     }
   }
-  for (const token of tokenPayloads) {
-    if (token.run_id != null && token.run_id !== runId) {
-      throw new ToolUserError('window_tokens are fenced to different run attempts.', 409);
-    }
-  }
   const terminalPageToken = assertCompleteWindowPageChain(tokenPayloads);
-  const leaseFenceToken = terminalPageToken?.run_id != null ? terminalPageToken : claimToken;
+  const leaseFenceToken =
+    terminalPageToken?.run_id != null
+      ? terminalPageToken
+      : tokenRunId !== null
+        ? firstToken
+        : undefined;
 
   const pgSql = createDbClientFromEnv(env);
   await requireAutomationAccess(pgSql, [String(automationId)], ctx, 'write');

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -47,6 +47,7 @@ import type { ManageAutomationsArgs } from '../manage_automations';
 import { normalizeExtractedData, parseJson, requireAutomationAccess } from './shared';
 import { getErrorMessage } from '@lobu/core';
 import { classifyRunOutcome } from "../../../runs/run-outcome";
+import { claimPendingAutomationRun } from '../../../runs/queue-service';
 import { AUTOMATION_EVAL_RUN_TYPE, AUTOMATION_RUN_TYPE } from "../../../runs/run-types.js";
 import {
   advanceExpectedAutomationWindow,
@@ -262,6 +263,7 @@ export async function handleCompleteWindow(
   const firstToken = tokenPayloads[0];
   const { automation_id: automationId, window_start, window_end, granularity } = firstToken;
   const claimToken = tokenPayloads.find((token) => token.run_id != null);
+  const tokenRunId = claimToken?.run_id ?? null;
   if (claimToken?.run_id !== undefined && claimToken.run_id !== runId) {
     throw new ToolUserError(
       `window_token is fenced to Automation run ${claimToken.run_id}, not ${runId}.`,
@@ -276,7 +278,7 @@ export async function handleCompleteWindow(
       token.window_end !== window_end ||
       token.granularity !== granularity
     ) {
-      throw new ToolUserError('All window_tokens must belong to the same Automation window.', 400);
+      throw new ToolUserError('All window_tokens must belong to the same Automation run/window.', 400);
     }
   }
   for (const token of tokenPayloads) {
@@ -335,10 +337,24 @@ export async function handleCompleteWindow(
     );
   }
 
+  const approvedInput = runRows[0].approved_input;
+  const approvedInputRecord =
+    approvedInput && typeof approvedInput === 'object' && !Array.isArray(approvedInput)
+      ? (approvedInput as Record<string, unknown>)
+      : {};
+  const assignedAgentId =
+    typeof approvedInputRecord.agent_id === 'string'
+      ? approvedInputRecord.agent_id.trim()
+      : '';
+  const assignedDeviceWorkerId =
+    typeof approvedInputRecord.device_worker_id === 'string'
+      ? approvedInputRecord.device_worker_id.trim()
+      : '';
+  const manualOpenRun = !assignedAgentId && !assignedDeviceWorkerId;
+
   if (snapshotVersionId == null && runRows[0].version_id != null) {
     snapshotVersionId = Number(runRows[0].version_id);
   }
-  const approvedInput = runRows[0].approved_input;
   if (approvedInput && typeof approvedInput === 'object') {
     const input = approvedInput as {
       trigger_signal?: unknown;
@@ -572,6 +588,82 @@ export async function handleCompleteWindow(
     };
   }
 
+  // Manual-open runs pend for an external MCP client. Only claim after every
+  // payload/token/schema validation above succeeds, so recoverable bad output
+  // cannot strand the durable run in running state.
+  let externalClaimedBy: string | null = null;
+  if (manualOpenRun) {
+    const claimedBy = ctx.clientId
+      ? `mcp:${ctx.clientId}`
+      : ctx.userId
+        ? `user:${ctx.userId}`
+        : null;
+    if (!claimedBy) {
+      throw new ToolUserError(
+        `Automation run ${runId} requires an authenticated MCP client or user to claim it.`,
+        401
+      );
+    }
+    externalClaimedBy = claimedBy;
+
+    // Only a run-bound token may perform pending -> running. Unbound legacy
+    // tokens remain usable solely for already-running in-process rows.
+    const claimed =
+      tokenRunId != null
+        ? await sql.begin(async (tx) =>
+            claimPendingAutomationRun(tx, {
+              runId,
+              automationId,
+              claimedBy,
+              status: 'running',
+            })
+          )
+        : false;
+    if (!claimed) {
+      // Before durable external claimant attribution existed, complete_window
+      // transitioned manual-open runs to running with claimed_by left NULL. A
+      // retry of one of those rows must remain completable, but only one caller
+      // may adopt it. The conditional UPDATE is the claim.
+      await sql`
+        UPDATE runs
+        SET claimed_by = ${claimedBy},
+            claimed_at = COALESCE(claimed_at, current_timestamp),
+            last_heartbeat_at = COALESCE(last_heartbeat_at, current_timestamp)
+        WHERE id = ${runId}
+          AND automation_id = ${automationId}
+          AND run_type = ${callerRunType}
+          AND status IN ('claimed', 'running')
+          AND claimed_by IS NULL
+      `;
+      const [state] = await sql<{ status: string; claimed_by: string | null }>`
+        SELECT status, claimed_by
+        FROM runs
+        WHERE id = ${runId}
+          AND automation_id = ${automationId}
+          AND run_type = ${callerRunType}
+        LIMIT 1
+      `;
+      if (state?.status === 'pending' && tokenRunId == null) {
+        throw new ToolUserError(
+          `Automation run ${runId} requires a run-bound window_token. Read it with knowledge.read({ automation_id: ${automationId}, run_id: ${runId} }).`,
+          409
+        );
+      }
+      const retryingOwnClaim =
+        (state?.status === 'claimed' || state?.status === 'running') &&
+        state.claimed_by === claimedBy;
+      const alreadyCompleted = state?.status === 'completed';
+      if (!retryingOwnClaim && !alreadyCompleted) {
+        throw new ToolUserError(
+          state?.claimed_by
+            ? `Automation run ${runId} is already claimed by another executor.`
+            : `Automation run ${runId} could not be claimed; retry after the active run clears.`,
+          409
+        );
+      }
+    }
+  }
+
   // ============================================
   // STEP 6: Wrap all DB operations in a transaction
   // If classification processing fails (e.g., embeddings service unavailable),
@@ -593,12 +685,9 @@ export async function handleCompleteWindow(
     const [lockedRun] = await tx<{
       status: string;
       expires_at: string | Date | null;
-      agent_id: string | null;
-      device_worker_id: string | null;
+      claimed_by: string | null;
     }>`
-      SELECT status, expires_at,
-             approved_input->>'agent_id' AS agent_id,
-             approved_input->>'device_worker_id' AS device_worker_id
+      SELECT status, expires_at, claimed_by
       FROM runs
       WHERE id = ${runId}
         AND organization_id = ${automationOrgId}
@@ -620,21 +709,6 @@ export async function handleCompleteWindow(
         completed_now: false,
       };
     }
-    if (lockedRun.status === 'pending') {
-      const isManualOpenRun =
-        claimToken == null &&
-        !lockedRun.agent_id &&
-        !lockedRun.device_worker_id;
-      if (isManualOpenRun) {
-        await tx`
-          UPDATE runs
-          SET status = 'running',
-              claimed_at = COALESCE(claimed_at, current_timestamp)
-          WHERE id = ${runId} AND status = 'pending'
-        `;
-        lockedRun.status = 'running';
-      }
-    }
     if (lockedRun.expires_at != null) {
       const leaseExpiresAt = new Date(lockedRun.expires_at).toISOString();
       if (!leaseFenceToken?.lease_expires_at || leaseFenceToken.lease_expires_at !== leaseExpiresAt) {
@@ -646,6 +720,12 @@ export async function handleCompleteWindow(
     }
     if (lockedRun.status !== 'running' && lockedRun.status !== 'claimed') {
       throw new ToolUserError(`Automation run ${runId} is no longer completable.`, 409);
+    }
+    if (externalClaimedBy !== null && lockedRun.claimed_by !== externalClaimedBy) {
+      throw new ToolUserError(
+        `Automation run ${runId} is already claimed by another executor.`,
+        409
+      );
     }
 
     // ============================================
@@ -849,6 +929,10 @@ export async function handleCompleteWindow(
         AND automation_id = ${automationId}
         AND run_type = ${AUTOMATION_RUN_TYPE}
         AND status IN ('running', 'claimed')
+        AND (
+          ${externalClaimedBy}::text IS NULL
+          OR claimed_by = ${externalClaimedBy}
+        )
       RETURNING approved_input->>'dispatch_source' AS dispatch_source
     `;
     if (!completedRun) {

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -606,8 +606,7 @@ export async function handleCompleteWindow(
     }
     externalClaimedBy = claimedBy;
 
-    // Only a run-bound token may perform pending -> running. Unbound legacy
-    // tokens remain usable solely for already-running in-process rows.
+    // Only a run-bound token may perform pending -> running.
     const claimed =
       tokenRunId != null
         ? await sql.begin(async (tx) =>
@@ -620,21 +619,6 @@ export async function handleCompleteWindow(
           )
         : false;
     if (!claimed) {
-      // Before durable external claimant attribution existed, complete_window
-      // transitioned manual-open runs to running with claimed_by left NULL. A
-      // retry of one of those rows must remain completable, but only one caller
-      // may adopt it. The conditional UPDATE is the claim.
-      await sql`
-        UPDATE runs
-        SET claimed_by = ${claimedBy},
-            claimed_at = COALESCE(claimed_at, current_timestamp),
-            last_heartbeat_at = COALESCE(last_heartbeat_at, current_timestamp)
-        WHERE id = ${runId}
-          AND automation_id = ${automationId}
-          AND run_type = ${callerRunType}
-          AND status IN ('claimed', 'running')
-          AND claimed_by IS NULL
-      `;
       const [state] = await sql<{ status: string; claimed_by: string | null }>`
         SELECT status, claimed_by
         FROM runs

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -605,47 +605,6 @@ export async function handleCompleteWindow(
       );
     }
     externalClaimedBy = claimedBy;
-
-    // Only a run-bound token may perform pending -> running.
-    const claimed =
-      tokenRunId != null
-        ? await sql.begin(async (tx) =>
-            claimPendingAutomationRun(tx, {
-              runId,
-              automationId,
-              claimedBy,
-              status: 'running',
-            })
-          )
-        : false;
-    if (!claimed) {
-      const [state] = await sql<{ status: string; claimed_by: string | null }>`
-        SELECT status, claimed_by
-        FROM runs
-        WHERE id = ${runId}
-          AND automation_id = ${automationId}
-          AND run_type = ${callerRunType}
-        LIMIT 1
-      `;
-      if (state?.status === 'pending' && tokenRunId == null) {
-        throw new ToolUserError(
-          `Automation run ${runId} requires a run-bound window_token. Read it with knowledge.read({ automation_id: ${automationId}, run_id: ${runId} }).`,
-          409
-        );
-      }
-      const retryingOwnClaim =
-        (state?.status === 'claimed' || state?.status === 'running') &&
-        state.claimed_by === claimedBy;
-      const alreadyCompleted = state?.status === 'completed';
-      if (!retryingOwnClaim && !alreadyCompleted) {
-        throw new ToolUserError(
-          state?.claimed_by
-            ? `Automation run ${runId} is already claimed by another executor.`
-            : `Automation run ${runId} could not be claimed; retry after the active run clears.`,
-          409
-        );
-      }
-    }
   }
 
   // ============================================
@@ -660,6 +619,49 @@ export async function handleCompleteWindow(
   // the window commits.
   let deferredApprovals: DeferredMutation[] = [];
   const result = await sql.begin(async (tx) => {
+    if (externalClaimedBy !== null) {
+      // Claim and complete in one transaction. A downstream write failure must
+      // return an externally opened run to pending instead of stranding it as
+      // running until stale-run recovery.
+      const claimed =
+        tokenRunId != null
+          ? await claimPendingAutomationRun(tx, {
+              runId,
+              automationId,
+              claimedBy: externalClaimedBy,
+              status: 'running',
+            })
+          : false;
+      if (!claimed) {
+        const [state] = await tx<{ status: string; claimed_by: string | null }>`
+          SELECT status, claimed_by
+          FROM runs
+          WHERE id = ${runId}
+            AND automation_id = ${automationId}
+            AND run_type = ${callerRunType}
+          LIMIT 1
+        `;
+        if (state?.status === 'pending' && tokenRunId == null) {
+          throw new ToolUserError(
+            `Automation run ${runId} requires a run-bound window_token. Read it with knowledge.read({ automation_id: ${automationId}, run_id: ${runId} }).`,
+            409
+          );
+        }
+        const retryingOwnClaim =
+          (state?.status === 'claimed' || state?.status === 'running') &&
+          state.claimed_by === externalClaimedBy;
+        const alreadyCompleted = state?.status === 'completed';
+        if (!retryingOwnClaim && !alreadyCompleted) {
+          throw new ToolUserError(
+            state?.claimed_by
+              ? `Automation run ${runId} is already claimed by another executor.`
+              : `Automation run ${runId} could not be claimed; retry after the active run clears.`,
+            409
+          );
+        }
+      }
+    }
+
     const [lockedAutomation] = await tx<{ schedule: string | null }>`
       SELECT schedule FROM automations
       WHERE id = ${automationId} AND organization_id = ${automationOrgId}

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -23,6 +23,7 @@ import type { ToolContext } from "../../registry";
 import { recordToolConfigChange } from "../helpers/config-audit";
 import { requireExists } from "../helpers/db-helpers";
 import type { ManageAutomationsArgs } from "../manage_automations";
+import { resolveAutomationExecutor } from "./executors";
 
 // ============================================
 // handleTrigger
@@ -43,9 +44,27 @@ export async function handleTrigger(
     throw new ToolUserError("automation_id is required for trigger action", 400);
   }
 
-  if (!isLobuGatewayRunning()) {
+  const [automation] = await sql<{
+    agent_id: string | null;
+    device_worker_id: string | null;
+    agent_kind: string | null;
+  }>`
+    SELECT agent_id, device_worker_id::text AS device_worker_id, agent_kind
+    FROM automations
+    WHERE id = ${Number(args.automation_id)}
+    LIMIT 1
+  `;
+  const executor = automation
+    ? resolveAutomationExecutor({
+        agentId: automation.agent_id,
+        deviceWorkerId: automation.device_worker_id,
+        agentKind: automation.agent_kind,
+      })
+    : null;
+  if (executor?.kind === "agent" && !isLobuGatewayRunning()) {
     throw new Error("Embedded Lobu is not available.");
   }
+
   const dispatchResult = await queueAndDispatchAutomationRun(
     Number(args.automation_id),
     "manual",

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -520,6 +520,16 @@ export async function handleAutomationMode(
   const { generateWindowToken } = await import('../../utils/jwt');
 
   const automationId = args.automation_id!;
+  if (
+    context.claimedWindow &&
+    args.run_id != null &&
+    Number(args.run_id) !== context.claimedWindow.runId
+  ) {
+    throw new ToolUserError(
+      `Automation run ${args.run_id} does not match claimed run ${context.claimedWindow.runId}.`,
+      409
+    );
+  }
   const boundRun =
     args.run_id != null
       ? await loadBoundAutomationRun(

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -427,7 +427,8 @@ async function loadBoundAutomationRun(
   sql: DbClient,
   organizationId: string,
   automationId: number,
-  runId: number
+  runId: number,
+  claimedGranularity?: AutomationTimeGranularity
 ): Promise<BoundAutomationRun> {
   const rows = await sql<{ approved_input: unknown }>`
     SELECT approved_input
@@ -466,7 +467,13 @@ async function loadBoundAutomationRun(
       409
     );
   }
-  if (!isAutomationTimeGranularity(input.granularity)) {
+  // claimedGranularity comes only from the server-resolved matching
+  // claimed/running run. Pending external runs must carry their own durable
+  // snapshot; do not infer a live schedule fallback here.
+  const granularity = isAutomationTimeGranularity(input.granularity)
+    ? input.granularity
+    : claimedGranularity;
+  if (!granularity) {
     throw new ToolUserError(
       `Automation run ${runId} is missing a valid queued granularity snapshot.`,
       409
@@ -489,7 +496,7 @@ async function loadBoundAutomationRun(
     versionId,
     windowStart,
     windowEnd,
-    granularity: input.granularity,
+    granularity,
     triggerContentIds: automationTriggerSignals(input)
       .filter(isWorkspaceEventTriggerSignal)
       .map((signal) => signal.event_id),
@@ -536,7 +543,8 @@ export async function handleAutomationMode(
           sql,
           context.organizationId,
           automationId,
-          Number(args.run_id)
+          Number(args.run_id),
+          context.claimedWindow?.granularity
         )
       : null;
 

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -8,7 +8,10 @@
 
 import { createHash } from 'node:crypto';
 import type { AutomationTimeGranularity, ContentItem } from '@lobu/connector-sdk';
-import { inferAutomationGranularityFromSchedule } from '@lobu/connector-sdk';
+import {
+  inferAutomationGranularityFromSchedule,
+  isAutomationTimeGranularity,
+} from '@lobu/connector-sdk';
 import {
   automationTriggerSignals,
   isWorkspaceEventTriggerSignal,
@@ -410,6 +413,7 @@ interface BoundAutomationRun {
   versionId: number | null;
   windowStart: Date;
   windowEnd: Date;
+  granularity: AutomationTimeGranularity;
   triggerContentIds: number[];
 }
 
@@ -462,6 +466,12 @@ async function loadBoundAutomationRun(
       409
     );
   }
+  if (!isAutomationTimeGranularity(input.granularity)) {
+    throw new ToolUserError(
+      `Automation run ${runId} is missing a valid queued granularity snapshot.`,
+      409
+    );
+  }
 
   const rawVersionId = input.version_id;
   const parsedVersionId =
@@ -479,6 +489,7 @@ async function loadBoundAutomationRun(
     versionId,
     windowStart,
     windowEnd,
+    granularity: input.granularity,
     triggerContentIds: automationTriggerSignals(input)
       .filter(isWorkspaceEventTriggerSignal)
       .map((signal) => signal.event_id),
@@ -570,6 +581,7 @@ export async function handleAutomationMode(
     versionSources.length > 0 ? versionSources : parseJson(automation.sources) || [];
   const timeGranularity =
     context.claimedWindow?.granularity ??
+    boundRun?.granularity ??
     inferAutomationGranularityFromSchedule(automation.schedule as string | null);
   // The extraction contract is composed from versioned outputs and the
   // optional reaction input contract.

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -9,7 +9,11 @@
 import { createHash } from 'node:crypto';
 import type { AutomationTimeGranularity, ContentItem } from '@lobu/connector-sdk';
 import { inferAutomationGranularityFromSchedule } from '@lobu/connector-sdk';
-import { MAX_COALESCED_AUTOMATION_EVENT_INPUTS } from '../../automations/workspace-event-contract';
+import {
+  automationTriggerSignals,
+  isWorkspaceEventTriggerSignal,
+  MAX_COALESCED_AUTOMATION_EVENT_INPUTS,
+} from '../../automations/workspace-event-contract';
 import { type DbClient, parsePgNumberArray } from '../../db/client';
 import type { Env } from '../../index';
 import type { Outputs, UnprocessedRange, AutomationSource } from '../../types/automations';
@@ -402,6 +406,85 @@ export async function fingerprintAutomationSources(args: {
 // Automation Mode Handler
 // ============================================
 
+interface BoundAutomationRun {
+  versionId: number | null;
+  windowStart: Date;
+  windowEnd: Date;
+  triggerContentIds: number[];
+}
+
+/**
+ * Resolve execution inputs already snapshotted on a durable run.
+ *
+ * In Automation mode the existing run_id argument binds the read to the queued
+ * run instead of recomputing the live cursor or current version.
+ */
+async function loadBoundAutomationRun(
+  sql: DbClient,
+  organizationId: string,
+  automationId: number,
+  runId: number
+): Promise<BoundAutomationRun> {
+  const rows = await sql<{ approved_input: unknown }>`
+    SELECT approved_input
+    FROM runs
+    WHERE id = ${runId}
+      AND organization_id = ${organizationId}
+      AND automation_id = ${automationId}
+      AND run_type IN ('automation', 'automation_eval')
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(
+      `Automation run ${runId} does not belong to Automation ${automationId}.`,
+      404
+    );
+  }
+
+  const raw = rows[0].approved_input;
+  const input =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {};
+  const windowStart = new Date(
+    typeof input.window_start === 'string' ? input.window_start : ''
+  );
+  const windowEnd = new Date(
+    typeof input.window_end === 'string' ? input.window_end : ''
+  );
+  if (
+    Number.isNaN(windowStart.getTime()) ||
+    Number.isNaN(windowEnd.getTime()) ||
+    windowEnd.getTime() <= windowStart.getTime()
+  ) {
+    throw new ToolUserError(
+      `Automation run ${runId} is missing a valid queued window snapshot.`,
+      409
+    );
+  }
+
+  const rawVersionId = input.version_id;
+  const parsedVersionId =
+    typeof rawVersionId === 'number'
+      ? rawVersionId
+      : typeof rawVersionId === 'string' && rawVersionId.trim()
+        ? Number(rawVersionId)
+        : Number.NaN;
+  const versionId =
+    Number.isSafeInteger(parsedVersionId) && parsedVersionId > 0
+      ? parsedVersionId
+      : null;
+
+  return {
+    versionId,
+    windowStart,
+    windowEnd,
+    triggerContentIds: automationTriggerSignals(input)
+      .filter(isWorkspaceEventTriggerSignal)
+      .map((signal) => signal.event_id),
+  };
+}
+
 export async function handleAutomationMode(
   args: GetContentArgs,
   env: Env,
@@ -426,14 +509,35 @@ export async function handleAutomationMode(
   const { generateWindowToken } = await import('../../utils/jwt');
 
   const automationId = args.automation_id!;
+  const boundRun =
+    args.run_id != null
+      ? await loadBoundAutomationRun(
+          sql,
+          context.organizationId,
+          automationId,
+          Number(args.run_id)
+        )
+      : null;
 
-  // Workers pass `template_version_id` (snapshotted at run-creation time)
-  // so the prompt/schema we hand back matches the version this run was
-  // queued for, even if the group has been edited since. The version row
-  // is owned by the group root (automation_id = i.automation_group_id), and we
-  // require it to live in the same group to prevent cross-automation pinning.
+  if (
+    boundRun?.versionId != null &&
+    args.template_version_id != null &&
+    Number(args.template_version_id) !== boundRun.versionId
+  ) {
+    throw new ToolUserError(
+      `Automation run ${args.run_id} is pinned to template version ${boundRun.versionId}, not ${args.template_version_id}.`,
+      409
+    );
+  }
+
+  // A verified lease or bound run snapshot wins over the live Automation and
+  // a caller-provided version. The version row is still constrained to this
+  // Automation group by the join below.
   const pinnedVersionId =
-    context.claimedWindow?.templateVersionId ?? args.template_version_id ?? null;
+    context.claimedWindow?.templateVersionId ??
+    boundRun?.versionId ??
+    args.template_version_id ??
+    null;
   const automationResult = await sql`
     SELECT
       i.id,
@@ -494,13 +598,28 @@ export async function handleAutomationMode(
   // outside the Automation's scope resolves to no row rather than to unscoped
   // data. The exact ids travel through the data-source placeholder compiler so
   // they remain bound parameters instead of executable SQL text.
-  const triggerContentIds = [
+  const requestedTriggerContentIds = [
     ...new Set(
       (args.content_ids ?? [])
         .map((id) => Number(id))
         .filter((id) => Number.isSafeInteger(id) && id > 0)
     ),
   ];
+  if (boundRun) {
+    const queuedTriggerIds = new Set(boundRun.triggerContentIds);
+    const unexpected = requestedTriggerContentIds.filter(
+      (id) => !queuedTriggerIds.has(id)
+    );
+    if (unexpected.length > 0) {
+      throw new ToolUserError(
+        `Automation run ${args.run_id} does not include trigger content id${unexpected.length === 1 ? '' : 's'} ${unexpected.join(', ')}.`,
+        409
+      );
+    }
+  }
+  const triggerContentIds = boundRun
+    ? [...new Set(boundRun.triggerContentIds)]
+    : requestedTriggerContentIds;
   let triggerInputSourceName: string | null = null;
   if (triggerContentIds.length > MAX_COALESCED_AUTOMATION_EVENT_INPUTS) {
     throw new ToolUserError(
@@ -544,11 +663,16 @@ export async function handleAutomationMode(
     attribute_values: row.attribute_values as ClassifierConfig['attribute_values'],
   }));
 
-  // Compute window dates - use since/until if provided, else compute pending window
+  // A bound run owns its queued window. Interactive previews may still request
+  // an explicit range or fall back to the Automation's pending cursor.
   let windowStart: Date, windowEnd: Date, windowCursor: Date | null;
   if (context.claimedWindow) {
     windowStart = new Date(context.claimedWindow.windowStart);
     windowEnd = new Date(context.claimedWindow.windowEnd);
+    windowCursor = await readWindowCursor(sql, automationId, timeGranularity);
+  } else if (boundRun) {
+    windowStart = boundRun.windowStart;
+    windowEnd = boundRun.windowEnd;
     windowCursor = await readWindowCursor(sql, automationId, timeGranularity);
   } else if (args.since && args.until) {
     // An agent-chosen range, aligned to the granularity so an agent-written
@@ -637,11 +761,16 @@ export async function handleAutomationMode(
   // Generate signed JWT window token with the exact content IDs returned to
   // the worker. complete_window uses these IDs directly, so window bookkeeping
   // matches what the agent actually saw.
-  // Claimed/internal execution tokens also carry the run attempt and optional
-  // external lease fence. Interactive ad-hoc reads remain unbound.
+  // Claimed/internal execution tokens carry the run attempt and optional lease
+  // fence. External run-bound reads carry the run whose snapshot supplied the
+  // version, window, and content set. Interactive ad-hoc reads remain unbound.
+  const tokenRunId =
+    context.claimedWindow?.runId ??
+    (boundRun && args.run_id != null ? Number(args.run_id) : null);
   const windowToken = await generateWindowToken(
     {
       automation_id: automationId,
+      ...(tokenRunId != null ? { run_id: tokenRunId } : {}),
       window_start: windowStartIso,
       window_end: windowEndIso,
       granularity: timeGranularity,
@@ -649,7 +778,6 @@ export async function handleAutomationMode(
       content_ids: contentIds,
       ...(context.claimedWindow
         ? {
-            run_id: context.claimedWindow.runId,
             ...(context.claimedWindow.leaseExpiresAt
               ? { lease_expires_at: context.claimedWindow.leaseExpiresAt }
               : {}),

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -25,13 +25,13 @@ export const GetContentSchema = Type.Object({
   automation_id: Type.Optional(
     Type.Number({
       description:
-        "Persisted Automation ID (`automation_id`) to fetch content for. When provided, uses the Automation's sources and computes its pending window. Returns window_token for complete_window action.",
+        "Persisted Automation ID (`automation_id`) to fetch content for. With run_id, uses that run's queued version/window; otherwise computes the Automation's pending window. Returns window_token for complete_window action.",
     })
   ),
   template_version_id: Type.Optional(
     Type.Number({
       description:
-        "Pin to a specific persisted Automation version when reading the prompt/schema. Workers receive this from runs.approved_input.version_id and pass it back so a group edit landing mid-run can't make extraction use a different schema. When omitted, defaults to the Automation's current version.",
+        "Pin an interactive or legacy Automation read to a persisted version. When run_id is present, the run's snapshotted version is authoritative and a conflicting value is rejected. Without run_id, omission defaults to the Automation's current version.",
     })
   ),
   connection_ids: Type.Optional(
@@ -75,7 +75,8 @@ export const GetContentSchema = Type.Object({
   ),
   run_id: Type.Optional(
     Type.Number({
-      description: 'Automation run ID to filter by (shows only content analyzed in this run)',
+      description:
+        'Run ID. With automation_id, binds the Automation read to that run\'s queued version, window, and trigger inputs. Without automation_id, filters to content analyzed in this run.',
     })
   ),
   analyzed_by_automation_id: Type.Optional(

--- a/packages/server/src/utils/jwt.ts
+++ b/packages/server/src/utils/jwt.ts
@@ -24,6 +24,8 @@ export function deriveJwtSecret(encryptionKey: string): string {
 
 interface WindowTokenPayload {
   automation_id: number;
+  /** Durable Automation run this read was bound to. Omitted on legacy/preview reads. */
+  run_id?: number;
   window_start: string;
   window_end: string;
   granularity: string; // Required for window creation

--- a/packages/server/src/utils/jwt.ts
+++ b/packages/server/src/utils/jwt.ts
@@ -31,7 +31,6 @@ interface WindowTokenPayload {
   granularity: string; // Required for window creation
   content_count: number; // Content count at token generation - for staleness detection
   content_ids: number[]; // Exact event IDs returned to the worker; complete_window links these deterministically
-  run_id?: number;
   lease_expires_at?: string;
   page_before_occurred_at?: string;
   page_before_id?: number;


### PR DESCRIPTION
## Summary
- make the existing `knowledge.read` `automation_id + run_id` call use the run's snapshotted version, window, and queued workspace-event inputs
- allow agentless manual Automations to trigger and complete through existing MCP SDK calls without requiring the managed Lobu gateway
- treat an existing agentless Automation as a valid `automation:<id>` write principal while still failing closed for missing Automations, invalid owners, or dangling assigned agents
- reuse the shared durable Automation-run claim primitive and enforce claimant ownership
- bind newly minted window tokens to the selected run and reject trigger-input injection
- make the existing `agent_id` contract genuinely nullable instead of relying on an empty-string workaround

## External client flow
1. `client.automations.trigger({ automation_id: "5" })`
2. `client.knowledge.read({ automation_id: 5, run_id })`
3. `client.automations.completeWindow({ automation_id: "5", run_id, window_token, extracted_data, model })`

No new SDK method, assignee, executor kind, queue, or checkpoint abstraction is introduced.

## Rebase notes
- rebased onto `8afcda302` (`origin/main`)
- retained the current fenced claim, lease, and paginated window recovery behavior from #3090
- removed the duplicate `run_id` token-field declaration created by the old-branch overlap
- removed the old empty-string owner compatibility path; only SQL `NULL` is agentless, and invalid or dangling owners fail closed
- removed adoption of running rows without durable claimant attribution; only a fresh pending claim, the same persisted claimant, or an already-completed replay is accepted

## Review hardening
Independent review found and this PR fixes three race/input-integrity issues:
1. cross-run window-token replay when two runs share a period
2. continuing after losing the durable run claim
3. injecting extra `content_ids` into a run-bound read

Each has a regression assertion in the external manual-run E2E.

## Validation
- `make pre-pr`
- focused external/manual/Automation/window regression matrix: 73/73
- Automation output visibility integration suite: 7/7
- adjacent manual trigger, daemon claim-gate, and Automation window matrix: 23/23
- core Automation schema and update-contract units: 19/19
- acting-principal authz units: 13/13
- pre-commit Biome and root TypeScript checks on every rebase-resolution commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automations can run without an assigned agent, and assignments can be cleared.
  - Manual automation runs support secure claiming, leasing, pagination, and completion, including external runs without a gateway.
  - Knowledge reads remain tied to the specific run, queued version, trigger content, and time window.
  - Automation configuration supports device workers and executor types.
  - Run-bound window tokens preserve pagination and lease details.

- **Bug Fixes**
  - Improved authorization for agentless automations and missing or deleted agents.
  - Prevented conflicting claims, expired leases, and mismatched run data during automation execution.
  - Executor availability is now validated according to the selected executor type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

