### PR TITLE
feat(connector-worker): package lean macOS device daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1737,7 +1737,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: steps.submodule.outputs.stubbed != 'true'
         with:
-          bun-version: 1.3.5
+          # Bun 1.3.5 silently ignores --metafile; the packaging graph guard
+          # requires the measured Bun 1.3.14 toolchain.
+          bun-version: 1.3.14
 
       - name: Install workspace dependencies for Mac daemon smoke
         if: steps.submodule.outputs.stubbed != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1681,7 +1681,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/owletto($|/)|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/connector-worker/|packages/core/|scripts/(build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "mac=true" >> "$GITHUB_OUTPUT"
           else
             echo "mac=false" >> "$GITHUB_OUTPUT"
@@ -1733,6 +1733,19 @@ jobs:
       - name: Skip on fork PRs without submodule access
         if: steps.submodule.outputs.stubbed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: echo "::notice::Submodule stubbed on fork PR — skipping Mac smoke build."
+
+      - uses: oven-sh/setup-bun@v2
+        if: steps.submodule.outputs.stubbed != 'true'
+        with:
+          bun-version: 1.3.5
+
+      - name: Install workspace dependencies for Mac daemon smoke
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Build and smoke standalone Mac device daemon
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: scripts/test-mac-device-daemon-package.sh
 
       # The Mac app has no XCTest target, so xcodebuild does not discover the
       # standalone @main tests under apps/mac/Tests — before this step they ran

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -26,6 +26,9 @@ const config: KnipConfig = {
       // back to source — list the real source entries here.
       entry: [
         "src/bin.ts",
+        // Standalone arm64 Mach-O entrypoint invoked by the root Mac packaging
+        // script; it is not part of the published connector-worker bin.
+        "src/mac-device-daemon.ts",
         "src/daemon/index.ts",
         "src/compile-connector.ts",
         // child-runner is fork()ed by absolute path, not imported.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "lobu:feeds:sync": "bun run scripts/lobu/sync-local.ts",
     "lobu:guidance:sync": "bun run scripts/lobu/sync-lobu-guidance.ts",
     "lobu:connectors:install": "bun run scripts/lobu/install-connectors.ts",
-    "lobu:connectors:dry-run": "bun run scripts/lobu/dry-run-connector.ts"
+    "lobu:connectors:dry-run": "bun run scripts/lobu/dry-run-connector.ts",
+    "build:mac-device-daemon": "./scripts/build-mac-device-daemon.sh",
+    "test:mac-device-daemon": "./scripts/test-mac-device-daemon-package.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/packages/connector-worker/README.md
+++ b/packages/connector-worker/README.md
@@ -8,6 +8,12 @@ Self-hosted Lobu memory worker. Polls the backend for sync jobs, executes connec
 connector-worker daemon --api-url https://api.example.com
 ```
 
+The lean macOS device artifact is built on an arm64 Mac with
+`bun run build:mac-device-daemon`. It is a standalone `lobu-device-daemon`
+Mach-O; `--no-poll` validates the packaged executable without server access.
+The artifact advertises no native connector capabilities and only runs the
+canonical device Automation arm.
+
 ## Development
 
 ```bash

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -51,6 +51,8 @@
     "dev": "tsx watch --tsconfig tsconfig.json src/bin.ts",
     "start": "node dist/bin.js",
     "daemon": "tsx --tsconfig tsconfig.json src/bin.ts daemon",
+    "build:mac-device-daemon": "bash ../../scripts/build-mac-device-daemon.sh",
+    "test:mac-device-daemon": "bash ../../scripts/test-mac-device-daemon-package.sh",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
+++ b/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
@@ -40,7 +40,7 @@ function binDirWith(names: string[]): string {
 }
 
 describe("resolveRunnableAgentKinds", () => {
-  test("reports only kinds whose binary resolves, in spec order", () => {
+  test("reports only kinds whose binary resolves, in canonical AGENT_KINDS order", () => {
     // `claude` → claude-code, `pi` → pi. codex/opencode/agy are absent.
     const dirs = [binDirWith(["pi", "claude"])];
     expect(resolveRunnableAgentKinds(undefined, dirs)).toEqual(["claude-code", "pi"]);

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import type { ChildProcess } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { DEVICE_AGENT_SPECS_BY_KIND } from '@lobu/core/contracts/worker/device-automation';
 import type {
   CompleteAutomationResponse,
@@ -9,6 +12,7 @@ import {
   buildArguments,
   deliverExitReport,
   dispatchAutomationResumeLoop,
+  runCli,
   type ExecutorResult,
 } from '../daemon/automation.js';
 import {
@@ -35,6 +39,46 @@ function okResult(): ExecutorResult {
 }
 
 describe('POSIX process-group ownership', () => {
+  test('shutdown abort terminates the supervised CLI and reports cancellation', async () => {
+    if (process.platform === 'win32') return;
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-shutdown-cli-'));
+    const terminated = path.join(dir, 'terminated');
+    const fake = path.join(dir, 'pi');
+    writeFileSync(
+      fake,
+      `#!${process.execPath}
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(path.join(dir, 'started'))}, 'started');
+process.on('SIGTERM', () => { fs.writeFileSync(${JSON.stringify(terminated)}, 'terminated'); process.exit(0); });
+setInterval(() => {}, 1000);
+`
+    );
+    chmodSync(fake, 0o755);
+    const controller = new AbortController();
+    try {
+      const running = runCli(
+        DEVICE_AGENT_SPECS_BY_KIND.get('pi')!,
+        'run',
+        undefined,
+        { wiring: undefined, env: {} },
+        10_000,
+        fake,
+        controller.signal,
+        controller.signal
+      );
+      for (let attempt = 0; attempt < 80 && !existsSync(path.join(dir, 'started')); attempt += 1) {
+        await Bun.sleep(25);
+      }
+      expect(existsSync(path.join(dir, 'started'))).toBe(true);
+      controller.abort();
+      const result = await running;
+      expect(result.exitReason).toBe('cancelled');
+      expect(readFileSync(terminated, 'utf8')).toBe('terminated');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   test('an exited supervisor never signals a numerically reused process group', () => {
     if (process.platform === 'win32') return;
     const signals: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import {
   MAC_DEVICE_DAEMON_PROTOCOL,
+  createMacDeviceDaemonShutdown,
   macDeviceDaemonMetadata,
+  selectMacDeviceDaemonAgentKind,
   validateMacDeviceDaemonOptions,
 } from '../daemon/mac-device-daemon';
+import { executeAutomationRun } from '../daemon/automation';
 import {
   createWorkerPollLoopShutdownHandler,
   WorkerPollLoop,
@@ -34,7 +37,7 @@ describe('Mac device daemon options', () => {
       validateMacDeviceDaemonOptions({
         version: '15.8.0',
         apiUrl: 'file:///tmp/api',
-        workerApiToken: 'owl_pat_test',
+        workerApiToken: 'owl_pat_1234567890123456789012345678',
       })
     ).toThrow('expected an http(s) URL');
     expect(() =>
@@ -50,7 +53,7 @@ describe('Mac device daemon options', () => {
     const base = {
       version: '15.8.0',
       apiUrl: 'https://example.test',
-      workerApiToken: 'owl_pat_test',
+      workerApiToken: 'owl_pat_12345678901234567890123456789012',
     };
     expect(() => validateMacDeviceDaemonOptions({ ...base, workerId: 'bad id' })).toThrow(
       'invalid --worker-id'
@@ -61,10 +64,69 @@ describe('Mac device daemon options', () => {
     expect(() =>
       validateMacDeviceDaemonOptions({ ...base, defaultAgentKind: 'not-an-agent' as never })
     ).toThrow('--default-agent-kind');
+    expect(() =>
+      validateMacDeviceDaemonOptions({ ...base, workerApiToken: 'owl_pat_' })
+    ).toThrow('32 base64url characters');
+  });
+
+  test('selects the first runnable kind in canonical order and rejects unavailable overrides', () => {
+    expect(selectMacDeviceDaemonAgentKind(['pi', 'codex'])).toBe('pi');
+    expect(selectMacDeviceDaemonAgentKind(['codex', 'pi'], 'pi')).toBe('pi');
+    expect(() => selectMacDeviceDaemonAgentKind(['codex'], 'pi')).toThrow('not runnable');
+  });
+
+  test('supports explicit supervised stdio without making it the default', () => {
+    const base = {
+      version: '15.8.0',
+      apiUrl: 'https://example.test',
+      workerApiToken: 'owl_pat_12345678901234567890123456789012',
+    };
+    expect(validateMacDeviceDaemonOptions({ ...base }).supervisedStdio).toBeUndefined();
+    expect(validateMacDeviceDaemonOptions({ ...base, supervisedStdio: true }).supervisedStdio).toBe(
+      true
+    );
+  });
+
+  test('aborts Automation execution before stopping the poll loop', () => {
+    const events: string[] = [];
+    const controller = new AbortController();
+    controller.signal.addEventListener('abort', () => events.push('abort'));
+    const loop = { stop: () => events.push('stop') } as never;
+
+    createMacDeviceDaemonShutdown(controller, loop)();
+
+    expect(events).toEqual(['abort', 'stop']);
   });
 });
 
 describe('WorkerPollLoop', () => {
+  test('fails closed when a capable daemon receives no run-scoped session', async () => {
+    let report: Record<string, unknown> | undefined;
+    const client = {
+      id: 'mac-worker',
+      completeAutomation: async (_runId: number, req: Record<string, unknown>) => {
+        report = req;
+        return { status: 'completed' } as never;
+      },
+    } as never;
+    const result = await executeAutomationRun(
+      client,
+      {
+        run_id: 7,
+        run_type: 'automation',
+        payload: {
+          automation: { id: 'automation-7', agent_kind: 'pi' },
+          event: { fired_at: '2026-08-22T00:00:00Z' },
+          context: { device: { worker_id: 'mac-worker' }, user: {} },
+        },
+      } as never,
+      { requireRunScopedSession: true }
+    );
+
+    expect(result.error).toContain('required run-scoped agent session');
+    expect(report?.error).toContain('required run-scoped agent session');
+  });
+
   test('honors the server idle delay instead of hot-looping at the local interval', async () => {
     let polls = 0;
     const client = {

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -116,6 +116,35 @@ describe('WorkerPollLoop', () => {
     await started;
   });
 
+  test('releases the active-job slot when execution throws synchronously', async () => {
+    let polled = false;
+    const client = {
+      healthCheck: async () => true,
+      poll: async () => {
+        if (!polled) {
+          polled = true;
+          return { run_id: 1, run_type: 'automation' } as never;
+        }
+        return { next_poll_seconds: 1 } as never;
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      pollIntervalMs: 1,
+      maxConcurrentJobs: 1,
+      execute: () => {
+        throw new Error('synchronous executor failure');
+      },
+    });
+
+    const started = loop.start();
+    await Bun.sleep(10);
+    loop.stop();
+    await started;
+
+    expect(await loop.waitForActiveJobs(10, 1)).toBe(true);
+  });
+
   test('runs the daemon stop callback before draining active jobs', async () => {
     const events: string[] = [];
     const loop = {

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -9,6 +9,7 @@ import {
 import { executeAutomationRun } from '../daemon/automation';
 import {
   createWorkerPollLoopShutdownHandler,
+  shouldHandleWorkerPollLoopStdinEof,
   WorkerPollLoop,
 } from '../daemon/poll-loop';
 
@@ -85,6 +86,12 @@ describe('Mac device daemon options', () => {
     expect(validateMacDeviceDaemonOptions({ ...base, supervisedStdio: true }).supervisedStdio).toBe(
       true
     );
+  });
+
+  test('treats stdin EOF as opt-in for the signal installer', () => {
+    expect(shouldHandleWorkerPollLoopStdinEof()).toBe(false);
+    expect(shouldHandleWorkerPollLoopStdinEof({ stdinEof: false })).toBe(false);
+    expect(shouldHandleWorkerPollLoopStdinEof({ stdinEof: true })).toBe(true);
   });
 
   test('aborts Automation execution before stopping the poll loop', () => {

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -4,7 +4,10 @@ import {
   macDeviceDaemonMetadata,
   validateMacDeviceDaemonOptions,
 } from '../daemon/mac-device-daemon';
-import { WorkerPollLoop } from '../daemon/poll-loop';
+import {
+  createWorkerPollLoopShutdownHandler,
+  WorkerPollLoop,
+} from '../daemon/poll-loop';
 
 describe('Mac device daemon options', () => {
   test('emits versioned protocol metadata', () => {
@@ -62,6 +65,28 @@ describe('Mac device daemon options', () => {
 });
 
 describe('WorkerPollLoop', () => {
+  test('honors the server idle delay instead of hot-looping at the local interval', async () => {
+    let polls = 0;
+    const client = {
+      healthCheck: async () => true,
+      poll: async () => {
+        polls++;
+        return { next_poll_seconds: 0.05 } as never;
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      pollIntervalMs: 1,
+      execute: async () => undefined,
+    });
+
+    const started = loop.start();
+    await Bun.sleep(10);
+    expect(polls).toBe(1);
+    loop.stop();
+    await started;
+  });
+
   test('stops polling and waits for the active job during shutdown', async () => {
     let polls = 0;
     let release!: () => void;
@@ -89,5 +114,24 @@ describe('WorkerPollLoop', () => {
     release();
     expect(await loop.waitForActiveJobs(1000, 1)).toBe(true);
     await started;
+  });
+
+  test('runs the daemon stop callback before draining active jobs', async () => {
+    const events: string[] = [];
+    const loop = {
+      waitForActiveJobs: async () => {
+        events.push('wait');
+        return true;
+      },
+    } as unknown as WorkerPollLoop;
+    const handler = createWorkerPollLoopShutdownHandler(
+      loop,
+      () => events.push('daemon-stop'),
+      (code) => events.push(`exit:${code}`)
+    );
+
+    await handler('SIGTERM');
+
+    expect(events).toEqual(['daemon-stop', 'wait', 'exit:0']);
   });
 });

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MAC_DEVICE_DAEMON_PROTOCOL,
+  macDeviceDaemonMetadata,
+  validateMacDeviceDaemonOptions,
+} from '../daemon/mac-device-daemon';
+import { WorkerPollLoop } from '../daemon/poll-loop';
+
+describe('Mac device daemon options', () => {
+  test('emits versioned protocol metadata', () => {
+    expect(macDeviceDaemonMetadata('15.8.0')).toMatchObject({
+      name: 'lobu-device-daemon',
+      version: '15.8.0',
+      protocol: MAC_DEVICE_DAEMON_PROTOCOL,
+      platform: 'macos',
+      artifact: 'standalone-bun-macho-arm64',
+    });
+  });
+
+  test('allows no-poll metadata mode without credentials', () => {
+    expect(
+      validateMacDeviceDaemonOptions({ version: '15.8.0', noPoll: true })
+    ).toMatchObject({ noPoll: true, apiUrl: '', workerApiToken: '' });
+  });
+
+  test('requires an absolute HTTP URL and durable PAT for polling', () => {
+    expect(() =>
+      validateMacDeviceDaemonOptions({ version: '15.8.0' })
+    ).toThrow('--api-url or API_URL is required');
+    expect(() =>
+      validateMacDeviceDaemonOptions({
+        version: '15.8.0',
+        apiUrl: 'file:///tmp/api',
+        workerApiToken: 'owl_pat_test',
+      })
+    ).toThrow('expected an http(s) URL');
+    expect(() =>
+      validateMacDeviceDaemonOptions({
+        version: '15.8.0',
+        apiUrl: 'https://example.test',
+        workerApiToken: 'session-token',
+      })
+    ).toThrow('owl_pat_');
+  });
+
+  test('rejects malformed identity and concurrency settings', () => {
+    const base = {
+      version: '15.8.0',
+      apiUrl: 'https://example.test',
+      workerApiToken: 'owl_pat_test',
+    };
+    expect(() => validateMacDeviceDaemonOptions({ ...base, workerId: 'bad id' })).toThrow(
+      'invalid --worker-id'
+    );
+    expect(() =>
+      validateMacDeviceDaemonOptions({ ...base, maxConcurrentJobs: 0 })
+    ).toThrow('--max-concurrent-jobs');
+    expect(() =>
+      validateMacDeviceDaemonOptions({ ...base, defaultAgentKind: 'not-an-agent' as never })
+    ).toThrow('--default-agent-kind');
+  });
+});
+
+describe('WorkerPollLoop', () => {
+  test('stops polling and waits for the active job during shutdown', async () => {
+    let polls = 0;
+    let release!: () => void;
+    const jobFinished = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const client = {
+      healthCheck: async () => true,
+      poll: async () => {
+        polls++;
+        return { run_id: 1, run_type: 'automation' } as never;
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      pollIntervalMs: 1,
+      maxConcurrentJobs: 1,
+      execute: async () => jobFinished,
+    });
+
+    const started = loop.start();
+    await Bun.sleep(10);
+    expect(polls).toBe(1);
+    loop.stop();
+    release();
+    expect(await loop.waitForActiveJobs(1000, 1)).toBe(true);
+    await started;
+  });
+});

--- a/packages/connector-worker/src/daemon/agent-binaries.ts
+++ b/packages/connector-worker/src/daemon/agent-binaries.ts
@@ -16,7 +16,10 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
-import { DEVICE_AGENT_SPECS } from '@lobu/core/contracts/worker/device-automation';
+import {
+  AGENT_KINDS,
+  DEVICE_AGENT_SPECS_BY_KIND,
+} from '@lobu/core/contracts/worker/device-automation';
 
 /** Search prefixes for CLI discovery — mirrors the Mac app's detector list. */
 export function searchDirs(): string[] {
@@ -59,9 +62,11 @@ export function resolveRunnableAgentKinds(
   overrides?: Partial<Record<AgentKind, string>>,
   dirs?: string[]
 ): AgentKind[] {
-  return DEVICE_AGENT_SPECS.filter((spec) => {
-    const override = overrides?.[spec.kind];
+  return AGENT_KINDS.filter((kind) => {
+    const spec = DEVICE_AGENT_SPECS_BY_KIND.get(kind);
+    if (!spec) return false;
+    const override = overrides?.[kind];
     if (override) return existsSync(override);
     return locateBinary(spec.binaryName, dirs) !== null;
-  }).map((spec) => spec.kind);
+  });
 }

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -21,8 +21,8 @@
  * Its Lobu credential is the poll envelope's per-run `agent_session` when the
  * server minted one (see `resolveAutomationRunAccess`): the run authenticates
  * as the Automation's assigned agent, not as the daemon or the user's ambient
- * CLI session. The daemon's own bearer remains only the fallback for a run the
- * server sent no session for — an older server, or one that could not mint.
+ * CLI session. Capable standalone Mac daemons fail closed when that session is
+ * absent; legacy workers retain the pre-session fallback.
  */
 
 import type { ChildProcess } from 'node:child_process';
@@ -78,6 +78,8 @@ export interface AutomationExecutorConfig {
   insideClaude?: boolean;
   /** Stops a pending interactive handoff during daemon shutdown. */
   shutdownSignal?: AbortSignal;
+  /** Standalone Mac daemons must never use the device PAT for MCP writes. */
+  requireRunScopedSession?: boolean;
   /** Test-only override; production deliberately uses the 15-second default. */
   terminalHeartbeatGraceMs?: number;
   /**
@@ -367,7 +369,7 @@ export function isInteractiveSessionEligible(
 }
 
 /** Spawn one CLI run and classify how it ended. */
-async function runCli(
+export async function runCli(
   spec: AgentSpec,
   prompt: string,
   config: AutomationPollPayload['automation']['execution_config'],
@@ -375,6 +377,7 @@ async function runCli(
   timeoutMs: number,
   binaryPath?: string,
   abortSignal?: AbortSignal,
+  shutdownSignal?: AbortSignal,
   terminalHeartbeatGraceMs = TERMINAL_HEARTBEAT_GRACE_MS
 ): Promise<ExecutorResult> {
   // One AbortController spans every finalize/resume round. If a terminal 409
@@ -467,6 +470,7 @@ async function runCli(
     const { timedOut, aborted } = initialExit;
     let target = initialExit.target;
     let cancelled = false;
+    let intentionalCancellation = false;
     let killedSignal: string | null = null;
     let cleanupSignal: string | null = null;
     let diagnosticSignal: string | null = null;
@@ -481,18 +485,19 @@ async function runCli(
         (await waitForTargetExitAfterTermination(supervised.targetExit)) ?? undefined;
       diagnosticSignal = target && target.signalCode !== 'SIGKILL' ? 'SIGTERM' : treeSignal;
     } else if (aborted) {
+      const shutdownCancelled = shutdownSignal?.aborted === true;
+      intentionalCancellation = shutdownCancelled;
       // A 409 is also the normal post-complete_window state. Let a CLI that is
       // already winding down exit and report its device-side metadata. The
       // supervisor remains the non-reusable tree owner throughout the grace,
       // so a normally exiting leader cannot orphan its remaining descendants.
-      const gracefulExit = await waitForTargetExit(
-        supervised.targetExit,
-        terminalHeartbeatGraceMs
-      );
+      const gracefulExit = shutdownCancelled
+        ? { target: undefined }
+        : await waitForTargetExit(supervised.targetExit, terminalHeartbeatGraceMs);
       target = gracefulExit.target;
       // Either way the tree must go: a CLI that exited still leaves the
       // supervisor and any descendants it spawned holding the group.
-      cancelled = !target;
+      cancelled = shutdownCancelled || !target;
       const treeSignal = await terminateChild(proc);
       supervisorSettled = true;
       target ??=
@@ -567,7 +572,7 @@ async function runCli(
       // The server owns the terminal outcome, but complete-automation remains
       // terminal-safe so it can retain device provenance and duration. Report
       // this intentional local stop as clean instead of inventing a failure.
-      exitReason = 'ok';
+      exitReason = intentionalCancellation ? 'cancelled' : 'ok';
       errorMessage = null;
     } else if (timedOut) {
       exitReason = 'timeout';
@@ -666,6 +671,12 @@ export async function executeAutomationRun(
     return { itemsCollected: 0, error: message };
   }
 
+  if (cfg.requireRunScopedSession && !payload.context.agent_session) {
+    const message = 'macOS Automation run is missing its required run-scoped agent session';
+    await completeAutomationWithError(client, runId, message, 'error_message');
+    return { itemsCollected: 0, error: message };
+  }
+
   // The Automation's explicit kind wins; the caller's device-level default is
   // the fallback, matching how the Mac app has always resolved an unset kind.
   const kind = payload.automation.agent_kind ?? cfg.defaultAgentKind ?? null;
@@ -708,6 +719,13 @@ export async function executeAutomationRun(
   // Heartbeat the run while the CLI executes so the server's stale-run sweeper
   // can distinguish a live turn from an abandoned one.
   const runAbort = new AbortController();
+  let shutdownRequested = false;
+  const onShutdown = () => {
+    shutdownRequested = true;
+    runAbort.abort();
+  };
+  cfg.shutdownSignal?.addEventListener('abort', onShutdown, { once: true });
+  if (cfg.shutdownSignal?.aborted) onShutdown();
   const heartbeat = setInterval(() => {
     client.heartbeat(runId).catch((err) => {
       if (err instanceof WorkerHttpError && err.status === 409) {
@@ -728,6 +746,17 @@ export async function executeAutomationRun(
 
   const io: AutomationRunIo = {
     run: async (finalizeNudge) => {
+      if (runAbort.signal.aborted) {
+        if (!shutdownRequested) throw new AutomationRunNoLongerActiveError();
+        return {
+          output: '',
+          error: null,
+          exitCode: null,
+          exitSignal: 'SIGTERM',
+          exitReason: 'cancelled',
+          durationMs: 0,
+        };
+      }
       let prompt = buildDeviceAutomationPrompt(payload, runId);
       if (finalizeNudge && finalizeNudge !== '') {
         prompt += `\n\n---\nFINALIZE NUDGE (prior attempt did not complete the window):\n${finalizeNudge}\n`;
@@ -798,6 +827,7 @@ export async function executeAutomationRun(
         timeoutMs,
         cfg.binaryOverrides?.[spec.kind],
         runAbort.signal,
+        cfg.shutdownSignal,
         cfg.terminalHeartbeatGraceMs
       );
     },
@@ -811,6 +841,7 @@ export async function executeAutomationRun(
     return await dispatchAutomationResumeLoop(io);
   } finally {
     clearInterval(heartbeat);
+    cfg.shutdownSignal?.removeEventListener('abort', onShutdown);
   }
 }
 

--- a/packages/connector-worker/src/daemon/mac-device-daemon.ts
+++ b/packages/connector-worker/src/daemon/mac-device-daemon.ts
@@ -1,0 +1,205 @@
+import { hostname } from 'node:os';
+import {
+  AGENT_KINDS,
+  type AgentKind,
+} from '@lobu/core/contracts/worker/device-automation';
+import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
+import { executeAutomationRun, type AutomationExecutorConfig } from './automation.js';
+import { WorkerClient, type WorkerCapabilities } from './client.js';
+import { installWorkerPollLoopSignals, WorkerPollLoop } from './poll-loop.js';
+import { setDebug } from './log.js';
+
+export const MAC_DEVICE_DAEMON_PROTOCOL = 'device-daemon/v1';
+export const MAC_DEVICE_PLATFORM = 'macos';
+const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+const DEFAULT_POLL_INTERVAL_MS = 10000;
+const DEFAULT_MAX_CONCURRENT_JOBS = 1;
+
+export interface MacDeviceDaemonOptions {
+  apiUrl?: string;
+  workerId?: string;
+  workerApiToken?: string;
+  version: string;
+  pollIntervalMs?: number;
+  maxConcurrentJobs?: number;
+  defaultAgentKind?: AgentKind;
+  debug?: boolean;
+  noPoll?: boolean;
+}
+
+export interface MacDeviceDaemonMetadata {
+  name: 'lobu-device-daemon';
+  version: string;
+  protocol: typeof MAC_DEVICE_DAEMON_PROTOCOL;
+  platform: typeof MAC_DEVICE_PLATFORM;
+  artifact: 'standalone-bun-macho-arm64';
+}
+
+export function macDeviceDaemonMetadata(version: string): MacDeviceDaemonMetadata {
+  return {
+    name: 'lobu-device-daemon',
+    version,
+    protocol: MAC_DEVICE_DAEMON_PROTOCOL,
+    platform: MAC_DEVICE_PLATFORM,
+    artifact: 'standalone-bun-macho-arm64',
+  };
+}
+
+function defaultWorkerId(): string {
+  const shortHostname = hostname().split('.')[0] || hostname();
+  return `${MAC_DEVICE_PLATFORM}:${shortHostname}`;
+}
+
+function validateNumber(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer (got '${value}')`);
+  }
+  return value;
+}
+
+function validateAgentKind(value: AgentKind | undefined): AgentKind | undefined {
+  if (value === undefined) return undefined;
+  if (!(AGENT_KINDS as readonly string[]).includes(value)) {
+    throw new Error(`invalid --default-agent-kind '${value}' (expected ${AGENT_KINDS.join(', ')})`);
+  }
+  return value;
+}
+
+export function validateMacDeviceDaemonOptions(
+  options: MacDeviceDaemonOptions
+): Required<Pick<MacDeviceDaemonOptions, 'apiUrl' | 'workerId' | 'workerApiToken'>> &
+  Omit<MacDeviceDaemonOptions, 'apiUrl' | 'workerId' | 'workerApiToken'> {
+  const workerId = options.workerId?.trim() || defaultWorkerId();
+  if (!WORKER_ID_PATTERN.test(workerId)) {
+    throw new Error(
+      `invalid --worker-id '${workerId}': expected 1-128 characters of letters, digits, dot, underscore, colon or hyphen`
+    );
+  }
+  const pollIntervalMs = validateNumber(options.pollIntervalMs, '--poll-interval-ms');
+  const maxConcurrentJobs = validateNumber(
+    options.maxConcurrentJobs,
+    '--max-concurrent-jobs'
+  );
+  const defaultAgentKind = validateAgentKind(options.defaultAgentKind);
+
+  const apiUrl = options.apiUrl?.trim();
+  if (apiUrl) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(apiUrl);
+    } catch {
+      throw new Error(`invalid --api-url '${apiUrl}': expected an absolute http(s) URL`);
+    }
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw new Error(`invalid --api-url '${apiUrl}': expected an http(s) URL`);
+    }
+  }
+
+  if (options.noPoll) {
+    return {
+      ...options,
+      apiUrl: apiUrl ?? '',
+      workerId,
+      workerApiToken: options.workerApiToken?.trim() ?? '',
+      ...(pollIntervalMs ? { pollIntervalMs } : {}),
+      ...(maxConcurrentJobs ? { maxConcurrentJobs } : {}),
+      ...(defaultAgentKind ? { defaultAgentKind } : {}),
+    };
+  }
+
+  if (!apiUrl) throw new Error('--api-url or API_URL is required unless --no-poll is set');
+
+  const workerApiToken = options.workerApiToken?.trim();
+  if (!workerApiToken?.startsWith('owl_pat_')) {
+    throw new Error(
+      'device mode requires WORKER_API_TOKEN with an owl_pat_ prefix; session OAuth tokens are not durable'
+    );
+  }
+
+  return {
+    ...options,
+    apiUrl,
+    workerId,
+    workerApiToken,
+    pollIntervalMs: pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    maxConcurrentJobs: maxConcurrentJobs ?? DEFAULT_MAX_CONCURRENT_JOBS,
+    ...(defaultAgentKind ? { defaultAgentKind } : {}),
+  };
+}
+
+function rejectUnsupportedRun(client: WorkerClient, job: PollResponse): Promise<void> {
+  const message = `macOS device daemon does not execute run_type '${job.run_type ?? 'unknown'}'; no native connector capabilities are advertised`;
+  if (job.run_id == null) return Promise.resolve();
+  if (job.run_type === 'action') {
+    return client.completeAction({
+      run_id: job.run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: message,
+    });
+  }
+  if (job.run_type === 'auth') {
+    return client.completeAuth({
+      run_id: job.run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: message,
+    });
+  }
+  if (job.run_type === 'automation') {
+    return client.completeAutomation(job.run_id, {
+      worker_id: client.id,
+      output: '',
+      error: message,
+      duration_ms: 0,
+      exit_reason: 'error_message',
+    }).then(() => undefined);
+  }
+  return client.complete({
+    run_id: job.run_id,
+    worker_id: client.id,
+    status: 'failed',
+    error_message: message,
+    items_collected: 0,
+  });
+}
+
+export function createMacDeviceDaemon(options: MacDeviceDaemonOptions): WorkerPollLoop {
+  const validated = validateMacDeviceDaemonOptions(options);
+  if (validated.noPoll) throw new Error('cannot create a polling daemon with --no-poll');
+
+  const client = new WorkerClient({
+    apiUrl: validated.apiUrl,
+    workerId: validated.workerId,
+    authToken: validated.workerApiToken,
+    capabilities: {} satisfies WorkerCapabilities,
+    version: validated.version,
+    platform: MAC_DEVICE_PLATFORM,
+  });
+  const automationConfig: AutomationExecutorConfig = {
+    heartbeatIntervalMs: 30000,
+    timeoutMs: 600000,
+    ...(validated.defaultAgentKind ? { defaultAgentKind: validated.defaultAgentKind } : {}),
+  };
+  const loop = new WorkerPollLoop({
+    client,
+    pollIntervalMs: validated.pollIntervalMs,
+    maxConcurrentJobs: validated.maxConcurrentJobs,
+    execute: async (job) => {
+      if (job.run_type === 'automation') {
+        return executeAutomationRun(client, job, automationConfig);
+      }
+      return rejectUnsupportedRun(client, job);
+    },
+  });
+  installWorkerPollLoopSignals(loop);
+  return loop;
+}
+
+export async function runMacDeviceDaemon(options: MacDeviceDaemonOptions): Promise<void> {
+  setDebug(options.debug === true);
+  const validated = validateMacDeviceDaemonOptions(options);
+  if (validated.noPoll) return;
+  await createMacDeviceDaemon(validated).start();
+}

--- a/packages/connector-worker/src/daemon/mac-device-daemon.ts
+++ b/packages/connector-worker/src/daemon/mac-device-daemon.ts
@@ -5,6 +5,7 @@ import {
 } from '@lobu/core/contracts/worker/device-automation';
 import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
 import { executeAutomationRun, type AutomationExecutorConfig } from './automation.js';
+import { resolveRunnableAgentKinds } from './agent-binaries.js';
 import { WorkerClient, type WorkerCapabilities } from './client.js';
 import { installWorkerPollLoopSignals, WorkerPollLoop } from './poll-loop.js';
 import { setDebug } from './log.js';
@@ -12,6 +13,7 @@ import { setDebug } from './log.js';
 export const MAC_DEVICE_DAEMON_PROTOCOL = 'device-daemon/v1';
 export const MAC_DEVICE_PLATFORM = 'macos';
 const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+const WORKER_PAT_PATTERN = /^owl_pat_[A-Za-z0-9_-]{32}$/;
 const DEFAULT_POLL_INTERVAL_MS = 10000;
 const DEFAULT_MAX_CONCURRENT_JOBS = 1;
 
@@ -25,6 +27,7 @@ export interface MacDeviceDaemonOptions {
   defaultAgentKind?: AgentKind;
   debug?: boolean;
   noPoll?: boolean;
+  supervisedStdio?: boolean;
 }
 
 export interface MacDeviceDaemonMetadata {
@@ -64,6 +67,31 @@ function validateAgentKind(value: AgentKind | undefined): AgentKind | undefined 
     throw new Error(`invalid --default-agent-kind '${value}' (expected ${AGENT_KINDS.join(', ')})`);
   }
   return value;
+}
+
+export function selectMacDeviceDaemonAgentKind(
+  runnableAgentKinds: readonly AgentKind[],
+  explicitAgentKind?: AgentKind
+): AgentKind | undefined {
+  if (explicitAgentKind !== undefined) {
+    if (!runnableAgentKinds.includes(explicitAgentKind)) {
+      throw new Error(
+        `--default-agent-kind '${explicitAgentKind}' is not runnable on this machine (available: ${runnableAgentKinds.join(', ') || 'none'})`
+      );
+    }
+    return explicitAgentKind;
+  }
+  return runnableAgentKinds[0];
+}
+
+export function createMacDeviceDaemonShutdown(
+  controller: AbortController,
+  loop: WorkerPollLoop
+): () => void {
+  return () => {
+    controller.abort();
+    loop.stop();
+  };
 }
 
 export function validateMacDeviceDaemonOptions(
@@ -111,9 +139,9 @@ export function validateMacDeviceDaemonOptions(
   if (!apiUrl) throw new Error('--api-url or API_URL is required unless --no-poll is set');
 
   const workerApiToken = options.workerApiToken?.trim();
-  if (!workerApiToken?.startsWith('owl_pat_')) {
+  if (!workerApiToken || !WORKER_PAT_PATTERN.test(workerApiToken)) {
     throw new Error(
-      'device mode requires WORKER_API_TOKEN with an owl_pat_ prefix; session OAuth tokens are not durable'
+      'device mode requires WORKER_API_TOKEN in the form owl_pat_<32 base64url characters>; session OAuth tokens are not durable'
     );
   }
 
@@ -169,18 +197,28 @@ export function createMacDeviceDaemon(options: MacDeviceDaemonOptions): WorkerPo
   const validated = validateMacDeviceDaemonOptions(options);
   if (validated.noPoll) throw new Error('cannot create a polling daemon with --no-poll');
 
+  const runnableAgentKinds = resolveRunnableAgentKinds();
+  const defaultAgentKind = selectMacDeviceDaemonAgentKind(
+    runnableAgentKinds,
+    validated.defaultAgentKind
+  );
+  const shutdownController = new AbortController();
+
   const client = new WorkerClient({
     apiUrl: validated.apiUrl,
     workerId: validated.workerId,
     authToken: validated.workerApiToken,
-    capabilities: {} satisfies WorkerCapabilities,
+    capabilities: { 'automations.execute': true } satisfies WorkerCapabilities,
     version: validated.version,
     platform: MAC_DEVICE_PLATFORM,
+    agentKinds: runnableAgentKinds,
   });
   const automationConfig: AutomationExecutorConfig = {
     heartbeatIntervalMs: 30000,
     timeoutMs: 600000,
-    ...(validated.defaultAgentKind ? { defaultAgentKind: validated.defaultAgentKind } : {}),
+    ...(defaultAgentKind ? { defaultAgentKind } : {}),
+    requireRunScopedSession: true,
+    shutdownSignal: shutdownController.signal,
   };
   const loop = new WorkerPollLoop({
     client,
@@ -193,7 +231,9 @@ export function createMacDeviceDaemon(options: MacDeviceDaemonOptions): WorkerPo
       return rejectUnsupportedRun(client, job);
     },
   });
-  installWorkerPollLoopSignals(loop);
+  installWorkerPollLoopSignals(loop, createMacDeviceDaemonShutdown(shutdownController, loop), {
+    stdinEof: validated.supervisedStdio === true,
+  });
   return loop;
 }
 

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared worker poll lifecycle.
+ *
+ * The full connector worker and the lean device daemon use the same health,
+ * polling, concurrency, and graceful-shutdown lifecycle. Run execution stays
+ * injected so the device build does not import fleet connector machinery.
+ */
+
+import type { PollResponse, WorkerClient } from './client.js';
+import { log } from './log.js';
+
+export interface WorkerPollLoopOptions {
+  client: WorkerClient;
+  pollIntervalMs?: number;
+  maxConcurrentJobs?: number;
+  execute: (job: PollResponse) => Promise<unknown>;
+}
+
+export class WorkerPollLoop {
+  private readonly client: WorkerClient;
+  private readonly pollIntervalMs: number;
+  private readonly maxConcurrentJobs: number;
+  private readonly execute: (job: PollResponse) => Promise<unknown>;
+  private running = false;
+  private activeJobs = 0;
+
+  constructor(options: WorkerPollLoopOptions) {
+    this.client = options.client;
+    this.pollIntervalMs = options.pollIntervalMs ?? 10000;
+    this.maxConcurrentJobs = Math.max(1, options.maxConcurrentJobs ?? 1);
+    this.execute = options.execute;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) {
+      log.info('[daemon] Already running');
+      return;
+    }
+
+    if (!(await this.client.healthCheck())) {
+      throw new Error('Backend health check failed');
+    }
+
+    log.info('[daemon] Starting worker daemon...');
+    this.running = true;
+    while (this.running) {
+      try {
+        await this.pollAndExecute();
+      } catch (err) {
+        log.info('[daemon] Poll error:', err);
+      }
+      await this.sleep(this.pollIntervalMs);
+    }
+    log.info('[daemon] Stopped');
+  }
+
+  stop(): void {
+    log.info('[daemon] Stopping...');
+    this.running = false;
+  }
+
+  async waitForActiveJobs(timeoutMs = 30000, pollMs = 500): Promise<boolean> {
+    if (this.activeJobs === 0) return true;
+
+    log.debug(`[daemon] Waiting for ${this.activeJobs} active job(s) to finish...`);
+    const deadline = Date.now() + timeoutMs;
+    while (this.activeJobs > 0 && Date.now() < deadline) {
+      await this.sleep(pollMs);
+    }
+
+    if (this.activeJobs > 0) {
+      log.info(
+        `[daemon] Timed out after ${timeoutMs}ms waiting for ${this.activeJobs} active job(s)`
+      );
+      return false;
+    }
+
+    log.debug('[daemon] All active jobs completed');
+    return true;
+  }
+
+  private async pollAndExecute(): Promise<void> {
+    if (this.activeJobs >= this.maxConcurrentJobs) return;
+
+    const job = await this.client.poll();
+    if (!job.run_id) {
+      const nextPoll = job.next_poll_seconds ?? 30;
+      log.debug(`[daemon] No runs available, next poll in ${nextPoll}s`);
+      return;
+    }
+
+    this.activeJobs++;
+    this.execute(job)
+      .catch((err) => {
+        log.info(`[daemon] Run ${job.run_id} crashed:`, err);
+      })
+      .finally(() => {
+        this.activeJobs--;
+      });
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export function installWorkerPollLoopSignals(loop: WorkerPollLoop): void {
+  let shuttingDown = false;
+  const gracefulShutdown = async (signal: string) => {
+    if (shuttingDown) {
+      console.error(`[daemon] Received ${signal} during shutdown, forcing exit`);
+      process.exit(130);
+    }
+    shuttingDown = true;
+    log.info(`\n[daemon] Received ${signal}, shutting down...`);
+    loop.stop();
+    const allDone = await loop.waitForActiveJobs();
+    if (!allDone) log.info('[daemon] Forcing exit with active jobs still running');
+    process.exit(allDone ? 0 : 1);
+  };
+
+  process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
+  process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
+  process.stdin.once('end', () => void gracefulShutdown('EOF'));
+  process.stdin.resume();
+}
+
+export async function startWorkerPollLoop(
+  options: WorkerPollLoopOptions
+): Promise<WorkerPollLoop> {
+  const loop = new WorkerPollLoop(options);
+  installWorkerPollLoopSignals(loop);
+  await loop.start();
+  return loop;
+}

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -16,6 +16,8 @@ export interface WorkerPollLoopOptions {
   execute: (job: PollResponse) => Promise<unknown>;
 }
 
+export type WorkerPollLoopExit = (code: number) => void;
+
 export class WorkerPollLoop {
   private readonly client: WorkerClient;
   private readonly pollIntervalMs: number;
@@ -44,12 +46,13 @@ export class WorkerPollLoop {
     log.info('[daemon] Starting worker daemon...');
     this.running = true;
     while (this.running) {
+      let nextDelayMs: number | undefined;
       try {
-        await this.pollAndExecute();
+        nextDelayMs = await this.pollAndExecute();
       } catch (err) {
         log.info('[daemon] Poll error:', err);
       }
-      await this.sleep(this.pollIntervalMs);
+      await this.sleep(nextDelayMs ?? this.pollIntervalMs);
     }
     log.info('[daemon] Stopped');
   }
@@ -79,14 +82,14 @@ export class WorkerPollLoop {
     return true;
   }
 
-  private async pollAndExecute(): Promise<void> {
-    if (this.activeJobs >= this.maxConcurrentJobs) return;
+  private async pollAndExecute(): Promise<number | undefined> {
+    if (this.activeJobs >= this.maxConcurrentJobs) return undefined;
 
     const job = await this.client.poll();
     if (!job.run_id) {
       const nextPoll = job.next_poll_seconds ?? 30;
       log.debug(`[daemon] No runs available, next poll in ${nextPoll}s`);
-      return;
+      return Number.isFinite(nextPoll) && nextPoll > 0 ? nextPoll * 1000 : 1000;
     }
 
     this.activeJobs++;
@@ -104,21 +107,32 @@ export class WorkerPollLoop {
   }
 }
 
-export function installWorkerPollLoopSignals(loop: WorkerPollLoop): void {
+export function createWorkerPollLoopShutdownHandler(
+  loop: WorkerPollLoop,
+  onShutdown: () => void = () => loop.stop(),
+  exit: WorkerPollLoopExit = process.exit
+): (signal: string) => Promise<void> {
   let shuttingDown = false;
-  const gracefulShutdown = async (signal: string) => {
+  return async (signal: string) => {
     if (shuttingDown) {
       console.error(`[daemon] Received ${signal} during shutdown, forcing exit`);
-      process.exit(130);
+      exit(130);
+      return;
     }
     shuttingDown = true;
     log.info(`\n[daemon] Received ${signal}, shutting down...`);
-    loop.stop();
+    onShutdown();
     const allDone = await loop.waitForActiveJobs();
     if (!allDone) log.info('[daemon] Forcing exit with active jobs still running');
-    process.exit(allDone ? 0 : 1);
+    exit(allDone ? 0 : 1);
   };
+}
 
+export function installWorkerPollLoopSignals(
+  loop: WorkerPollLoop,
+  onShutdown: () => void = () => loop.stop()
+): void {
+  const gracefulShutdown = createWorkerPollLoopShutdownHandler(loop, onShutdown);
   process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
   process.stdin.once('end', () => void gracefulShutdown('EOF'));

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -93,7 +93,8 @@ export class WorkerPollLoop {
     }
 
     this.activeJobs++;
-    this.execute(job)
+    Promise.resolve()
+      .then(() => this.execute(job))
       .catch((err) => {
         log.info(`[daemon] Run ${job.run_id} crashed:`, err);
       })

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -23,6 +23,12 @@ export interface WorkerPollLoopSignalOptions {
   stdinEof?: boolean;
 }
 
+export function shouldHandleWorkerPollLoopStdinEof(
+  options: WorkerPollLoopSignalOptions = {}
+): boolean {
+  return options.stdinEof === true;
+}
+
 export class WorkerPollLoop {
   private readonly client: WorkerClient;
   private readonly pollIntervalMs: number;
@@ -137,12 +143,12 @@ export function createWorkerPollLoopShutdownHandler(
 export function installWorkerPollLoopSignals(
   loop: WorkerPollLoop,
   onShutdown: () => void = () => loop.stop(),
-  options: WorkerPollLoopSignalOptions = { stdinEof: true }
+  options: WorkerPollLoopSignalOptions = { stdinEof: false }
 ): void {
   const gracefulShutdown = createWorkerPollLoopShutdownHandler(loop, onShutdown);
   process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
-  if (options.stdinEof === true) {
+  if (shouldHandleWorkerPollLoopStdinEof(options)) {
     process.stdin.once('end', () => void gracefulShutdown('EOF'));
     process.stdin.resume();
   }

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -18,6 +18,11 @@ export interface WorkerPollLoopOptions {
 
 export type WorkerPollLoopExit = (code: number) => void;
 
+export interface WorkerPollLoopSignalOptions {
+  /** Only a supervised parent/child launch treats stdin EOF as shutdown. */
+  stdinEof?: boolean;
+}
+
 export class WorkerPollLoop {
   private readonly client: WorkerClient;
   private readonly pollIntervalMs: number;
@@ -131,13 +136,16 @@ export function createWorkerPollLoopShutdownHandler(
 
 export function installWorkerPollLoopSignals(
   loop: WorkerPollLoop,
-  onShutdown: () => void = () => loop.stop()
+  onShutdown: () => void = () => loop.stop(),
+  options: WorkerPollLoopSignalOptions = { stdinEof: true }
 ): void {
   const gracefulShutdown = createWorkerPollLoopShutdownHandler(loop, onShutdown);
   process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
-  process.stdin.once('end', () => void gracefulShutdown('EOF'));
-  process.stdin.resume();
+  if (options.stdinEof === true) {
+    process.stdin.once('end', () => void gracefulShutdown('EOF'));
+    process.stdin.resume();
+  }
 }
 
 export async function startWorkerPollLoop(

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -12,7 +12,7 @@ import {
   attachedInteractiveSession,
   attachInteractiveSession,
 } from './interactive-session.js';
-import { log } from './log.js';
+import { installWorkerPollLoopSignals, WorkerPollLoop } from './poll-loop.js';
 
 export interface DaemonConfig {
   apiUrl: string;
@@ -44,13 +44,8 @@ const DEFAULT_EXECUTOR_TIMEOUT_MS = 600000;
 export class WorkerDaemon {
   private client: WorkerClient;
   private env: Env;
-  private config: {
-    pollIntervalMs: number;
-    maxConcurrentJobs: number;
-    executor: Partial<ExecutorConfig>;
-  };
-  private running = false;
-  private activeJobs = 0;
+  private config: { executor: Partial<ExecutorConfig> };
+  private pollLoop: WorkerPollLoop;
   private shutdownController?: AbortController;
 
   constructor(daemonConfig: DaemonConfig, env: Env) {
@@ -84,51 +79,32 @@ export class WorkerDaemon {
     };
     if (interactiveSession) attachInteractiveSession(executor, interactiveSession);
     this.config = {
-      pollIntervalMs: daemonConfig.pollIntervalMs ?? 10000,
-      maxConcurrentJobs: daemonConfig.maxConcurrentJobs ?? 1,
       executor,
     };
+    this.pollLoop = new WorkerPollLoop({
+      client: this.client,
+      pollIntervalMs: daemonConfig.pollIntervalMs,
+      maxConcurrentJobs: daemonConfig.maxConcurrentJobs,
+      execute: (job) => executeRun(this.client, job, this.env, this.config.executor),
+    });
   }
 
   /**
    * Start the daemon
    */
   async start(): Promise<void> {
-    if (this.running) {
-      log.info('[daemon] Already running');
-      return;
-    }
+    await this.pollLoop.start();
+  }
 
-    // Health check
-    const healthy = await this.client.healthCheck();
-    if (!healthy) {
-      throw new Error('Backend health check failed');
-    }
-
-    log.info('[daemon] Starting worker daemon...');
-    this.running = true;
-
-    // Main poll loop
-    while (this.running) {
-      try {
-        await this.pollAndExecute();
-      } catch (err) {
-        log.info('[daemon] Poll error:', err);
-      }
-
-      // Wait before next poll
-      await this.sleep(this.config.pollIntervalMs);
-    }
-
-    log.info('[daemon] Stopped');
+  installShutdownSignals(): void {
+    installWorkerPollLoopSignals(this.pollLoop);
   }
 
   /**
    * Stop the daemon
    */
   stop(): void {
-    log.info('[daemon] Stopping...');
-    this.running = false;
+    this.pollLoop.stop();
     this.shutdownController?.abort();
   }
 
@@ -137,58 +113,7 @@ export class WorkerDaemon {
    * Returns true if all jobs completed, false if timed out.
    */
   async waitForActiveJobs(timeoutMs = 30000, pollMs = 500): Promise<boolean> {
-    if (this.activeJobs === 0) return true;
-
-    log.debug(`[daemon] Waiting for ${this.activeJobs} active job(s) to finish...`);
-    const deadline = Date.now() + timeoutMs;
-
-    while (this.activeJobs > 0 && Date.now() < deadline) {
-      await this.sleep(pollMs);
-    }
-
-    if (this.activeJobs > 0) {
-      log.info(
-        `[daemon] Timed out after ${timeoutMs}ms waiting for ${this.activeJobs} active job(s)`
-      );
-      return false;
-    }
-
-    log.debug('[daemon] All active jobs completed');
-    return true;
-  }
-
-  /**
-   * Poll for a job and execute it
-   */
-  private async pollAndExecute(): Promise<void> {
-    // Skip if at max capacity
-    if (this.activeJobs >= this.config.maxConcurrentJobs) {
-      return;
-    }
-
-    // Poll for job
-    const job = await this.client.poll();
-
-    // No run available
-    if (!job.run_id) {
-      const nextPoll = job.next_poll_seconds ?? 30;
-      log.debug(`[daemon] No runs available, next poll in ${nextPoll}s`);
-      return;
-    }
-
-    // Execute run (fire-and-forget so the poll loop can claim more jobs in parallel)
-    this.activeJobs++;
-    executeRun(this.client, job, this.env, this.config.executor)
-      .catch((err) => {
-        log.info(`[daemon] Run ${job.run_id} crashed:`, err);
-      })
-      .finally(() => {
-        this.activeJobs--;
-      });
-  }
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return this.pollLoop.waitForActiveJobs(timeoutMs, pollMs);
   }
 }
 
@@ -197,32 +122,7 @@ export class WorkerDaemon {
  */
 export async function startDaemon(config: DaemonConfig, env: Env): Promise<WorkerDaemon> {
   const daemon = new WorkerDaemon(config, env);
-
-  let shuttingDown = false;
-  const gracefulShutdown = async (signal: string) => {
-    if (shuttingDown) {
-      // Second signal — operator wants out now. Hard exit.
-      console.error(`[daemon] Received ${signal} during shutdown, forcing exit`);
-      process.exit(130);
-    }
-    shuttingDown = true;
-    log.info(`\n[daemon] Received ${signal}, shutting down...`);
-    daemon.stop();
-    const allDone = await daemon.waitForActiveJobs();
-    if (!allDone) {
-      log.info('[daemon] Forcing exit with active jobs still running');
-    }
-    process.exit(allDone ? 0 : 1);
-  };
-
-  // Handle shutdown signals
-  process.on('SIGINT', () => {
-    void gracefulShutdown('SIGINT');
-  });
-  process.on('SIGTERM', () => {
-    void gracefulShutdown('SIGTERM');
-  });
-
+  daemon.installShutdownSignals();
   await daemon.start();
   return daemon;
 }

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -97,7 +97,7 @@ export class WorkerDaemon {
   }
 
   installShutdownSignals(): void {
-    installWorkerPollLoopSignals(this.pollLoop, () => this.stop());
+    installWorkerPollLoopSignals(this.pollLoop, () => this.stop(), { stdinEof: false });
   }
 
   /**

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -97,7 +97,7 @@ export class WorkerDaemon {
   }
 
   installShutdownSignals(): void {
-    installWorkerPollLoopSignals(this.pollLoop);
+    installWorkerPollLoopSignals(this.pollLoop, () => this.stop());
   }
 
   /**

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -26,6 +26,7 @@ Options:
   --poll-interval-ms <ms>     Poll interval (default: 10000)
   --max-concurrent-jobs <n>   Maximum active Automations (default: 1)
   --default-agent-kind <kind> Agent fallback for Automations without a kind
+  --supervised-stdio         Treat stdin EOF as a supervised-parent shutdown
   --no-poll                   Validate the executable without contacting a server
   --debug                     Enable poll and heartbeat diagnostics
   --help                      Show this help
@@ -46,6 +47,7 @@ function parseArgs(args: string[]): Record<string, string | true> {
     'poll-interval-ms',
     'max-concurrent-jobs',
     'default-agent-kind',
+    'supervised-stdio',
     'no-poll',
     'debug',
     'help',
@@ -104,10 +106,14 @@ async function main(): Promise<void> {
   const maxConcurrent =
     option(raw, 'max-concurrent-jobs') ?? process.env.WORKER_MAX_CONCURRENT_JOBS;
   const defaultAgentKind = option(raw, 'default-agent-kind');
+  const supervisedStdio = raw['supervised-stdio'] === true;
   const debug = raw.debug === true;
   if (raw.debug !== undefined && !debug) throw new Error('--debug does not accept a value');
   if (raw['no-poll'] !== undefined && !noPoll) {
     throw new Error('--no-poll does not accept a value');
+  }
+  if (raw['supervised-stdio'] !== undefined && !supervisedStdio) {
+    throw new Error('--supervised-stdio does not accept a value');
   }
 
   const options = {
@@ -120,6 +126,7 @@ async function main(): Promise<void> {
     ...(defaultAgentKind ? { defaultAgentKind: defaultAgentKind as AgentKind } : {}),
     debug,
     noPoll,
+    supervisedStdio,
   };
   if (pollInterval) {
     if (!/^[1-9]\d*$/.test(pollInterval)) {

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env bun
+
+import packageJson from '../package.json' with { type: 'json' };
+import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
+import {
+  MAC_DEVICE_DAEMON_PROTOCOL,
+  macDeviceDaemonMetadata,
+  runMacDeviceDaemon,
+  validateMacDeviceDaemonOptions,
+} from './daemon/mac-device-daemon.js';
+
+const VERSION = packageJson.version;
+
+function printHelp(): void {
+  process.stdout.write(`lobu-device-daemon ${VERSION}
+
+Usage:
+  lobu-device-daemon [options]
+
+Runs the lean macOS device daemon. It advertises no native connector
+capabilities and executes only device Automations through local agent CLIs.
+
+Options:
+  --api-url <url>             Worker API origin (or API_URL)
+  --worker-id <id>            Device identity (default: macos:<hostname>)
+  --poll-interval-ms <ms>     Poll interval (default: 10000)
+  --max-concurrent-jobs <n>   Maximum active Automations (default: 1)
+  --default-agent-kind <kind> Agent fallback for Automations without a kind
+  --no-poll                   Validate the executable without contacting a server
+  --debug                     Enable poll and heartbeat diagnostics
+  --help                      Show this help
+  --version                   Print machine-readable version metadata
+
+Required for polling:
+  WORKER_API_TOKEN=owl_pat_... (durable device token)
+
+Protocol: ${MAC_DEVICE_DAEMON_PROTOCOL}
+`);
+}
+
+function parseArgs(args: string[]): Record<string, string | true> {
+  const options: Record<string, string | true> = {};
+  const known = new Set([
+    'api-url',
+    'worker-id',
+    'poll-interval-ms',
+    'max-concurrent-jobs',
+    'default-agent-kind',
+    'no-poll',
+    'debug',
+    'help',
+    'version',
+  ]);
+  const valued = new Set([
+    'api-url',
+    'worker-id',
+    'poll-interval-ms',
+    'max-concurrent-jobs',
+    'default-agent-kind',
+  ]);
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg.startsWith('--')) throw new Error(`unexpected argument '${arg}'`);
+    const key = arg.slice(2);
+    if (!key) throw new Error('empty option name');
+    if (!known.has(key)) throw new Error(`unknown option '--${key}'`);
+    const next = args[index + 1];
+    if (valued.has(key)) {
+      if (!next || next.startsWith('--')) throw new Error(`--${key} requires a value`);
+      options[key] = next;
+      index++;
+    } else if (next && !next.startsWith('--')) {
+      throw new Error(`--${key} does not accept a value`);
+    } else {
+      options[key] = true;
+    }
+  }
+  return options;
+}
+
+function option(options: Record<string, string | true>, key: string): string | undefined {
+  const value = options[key];
+  if (value === true) throw new Error(`--${key} requires a value`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const raw = parseArgs(args);
+  if (raw.help) {
+    printHelp();
+    return;
+  }
+  if (raw.version) {
+    if (raw.version !== true) throw new Error('--version does not accept a value');
+    process.stdout.write(`${JSON.stringify(macDeviceDaemonMetadata(VERSION))}\n`);
+    return;
+  }
+
+  const noPoll = raw['no-poll'] === true;
+  const apiUrl = option(raw, 'api-url') ?? process.env.API_URL;
+  const workerId = option(raw, 'worker-id') ?? process.env.WORKER_ID;
+  const pollInterval = option(raw, 'poll-interval-ms') ?? process.env.WORKER_POLL_INTERVAL_MS;
+  const maxConcurrent =
+    option(raw, 'max-concurrent-jobs') ?? process.env.WORKER_MAX_CONCURRENT_JOBS;
+  const defaultAgentKind = option(raw, 'default-agent-kind');
+  const debug = raw.debug === true;
+  if (raw.debug !== undefined && !debug) throw new Error('--debug does not accept a value');
+  if (raw['no-poll'] !== undefined && !noPoll) {
+    throw new Error('--no-poll does not accept a value');
+  }
+
+  const options = {
+    apiUrl,
+    workerId,
+    workerApiToken: process.env.WORKER_API_TOKEN,
+    version: VERSION,
+    ...(pollInterval ? { pollIntervalMs: Number(pollInterval) } : {}),
+    ...(maxConcurrent ? { maxConcurrentJobs: Number(maxConcurrent) } : {}),
+    ...(defaultAgentKind ? { defaultAgentKind: defaultAgentKind as AgentKind } : {}),
+    debug,
+    noPoll,
+  };
+  if (pollInterval) {
+    if (!/^[1-9]\d*$/.test(pollInterval)) {
+      throw new Error(`--poll-interval-ms must be a positive integer (got '${pollInterval}')`);
+    }
+    options.pollIntervalMs = Number(pollInterval);
+  }
+  if (maxConcurrent) {
+    if (!/^[1-9]\d*$/.test(maxConcurrent)) {
+      throw new Error(`--max-concurrent-jobs must be a positive integer (got '${maxConcurrent}')`);
+    }
+    options.maxConcurrentJobs = Number(maxConcurrent);
+  }
+  validateMacDeviceDaemonOptions(options);
+  if (noPoll) {
+    process.stdout.write(`${JSON.stringify(macDeviceDaemonMetadata(VERSION))}\n`);
+    return;
+  }
+  await runMacDeviceDaemon(options);
+}
+
+main().catch((error) => {
+  process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
+++ b/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
@@ -46,6 +46,9 @@ describe("platform allowlist lookups ignore inherited keys", () => {
     expect(authorizeCapabilities("macos", ["os.files"]).authorized).toContain(
       "os.files"
     );
+    expect(
+      authorizeCapabilities("macos", ["automations.execute"]).authorized
+    ).toContain("automations.execute");
   });
 
   test("headless devices authorize shell+files+automation execution but nothing browser-ish", () => {

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -42,6 +42,10 @@ export const IOS_CAPABILITIES = [
 // connector means adding its capability string here so the gateway lets
 // the device claim its runs.
 export const MAC_DEVICE_CAPABILITIES = [
+  // The standalone Mac daemon opts into run-scoped Automation sessions by
+  // advertising this capability. Legacy Swift workers omit it and retain the
+  // existing instructions-only/legacy session handling.
+  "automations.execute",
   "screentime",
   "local_directory",
   "healthkit",

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -68,6 +68,7 @@ export const RunTypeSchema = Type.Union([
 /** Categorized subprocess exit reason on the failed-run path. */
 export const WorkerExitReasonSchema = Type.Union([
   Type.Literal("ok"),
+  Type.Literal("cancelled"),
   Type.Literal("error_message"),
   Type.Literal("timeout"),
   Type.Literal("oom"),
@@ -173,7 +174,8 @@ export const AutomationPollContextSchema = Type.Object({
   user: Type.Object({
     user_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   }),
-  // Non-macOS device execution only: the per-run lobu-memory MCP session.
+  // Device execution: the per-run lobu-memory MCP session when the worker
+  // advertises automations.execute. Legacy Mac bridge workers omit it.
   // `token` is a WorkerToken minted for the automation's ASSIGNED AGENT via
   // buildAutomationRunWorkerAccess — never the polling device's PAT (a child
   // PAT is bound to the user's personal org and can't authenticate to a
@@ -181,9 +183,9 @@ export const AutomationPollContextSchema = Type.Object({
   // (`<public origin>/mcp/<orgSlug>`), where the bearer opens its own session.
   // The daemon hands both to the spawned CLI as its MCP wiring and as
   // LOBU_API_TOKEN / LOBU_MEMORY_URL so `lobu memory` runs as the automation's
-  // agent for this run. Absent when the run has no usable assigned agent, or
-  // when minting failed — the daemon then falls back to its own wiring. macOS
-  // is exempt: Owletto's bridge dispatches with its own credential machinery.
+  // agent for this run. Absent when the run has no usable assigned agent or
+  // when the legacy worker did not advertise automations.execute. A capable
+  // standalone daemon fails closed instead of falling back to its device PAT.
   agent_session: Type.Optional(
     Type.Object({
       conversation_id: Type.String(),

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -364,6 +364,76 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(String(run.status)).toBe('failed');
   });
 
+  it('macOS daemon cancellation is terminal and idempotent', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'mac-cancelled',
+      platform: 'macos',
+      capabilities: { 'automations.execute': true },
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'mac-cancelled'
+    );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'mac-cancelled',
+        platform: 'macos',
+        capabilities: { 'automations.execute': true },
+        agent_kinds: ['opencode'],
+      },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as { run_id?: number };
+    expect(job.run_id).toBeGreaterThan(0);
+
+    const report = {
+      worker_id: 'mac-cancelled',
+      output: 'daemon stopped by supervisor',
+      exit_code: 143,
+      exit_signal: 'SIGTERM',
+      exit_reason: 'cancelled' as const,
+    };
+    const response = await post(
+      `/api/workers/me/runs/${job.run_id}/complete-automation`,
+      { token, body: report }
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: 'cancelled',
+      reason_code: 'device_daemon_shutdown',
+      run_id: job.run_id,
+    });
+
+    const [run] = await ctx.sql`
+      SELECT status, completed_at, output_tail, exit_code, exit_signal, exit_reason
+      FROM runs
+      WHERE id = ${job.run_id}
+    `;
+    expect(String(run.status)).toBe('cancelled');
+    expect(run.completed_at).not.toBeNull();
+    expect(String(run.output_tail)).toContain('daemon stopped by supervisor');
+    expect(Number(run.exit_code)).toBe(143);
+    expect(String(run.exit_signal)).toBe('SIGTERM');
+    expect(String(run.exit_reason)).toBe('cancelled');
+
+    const duplicate = await post(
+      `/api/workers/me/runs/${job.run_id}/complete-automation`,
+      { token, body: { ...report, output: 'duplicate report' } }
+    );
+    expect(duplicate.status).toBe(200);
+    await expect(duplicate.json()).resolves.toEqual({
+      ok: true,
+      status: 'cancelled',
+      idempotent: true,
+    });
+  });
+
   it('macOS device with capabilities:{} still claims (pre-capability exemption)', async () => {
     const ctx = await setupDevicePinnedAutomation({
       workerId: 'mac-exempt',

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -26,7 +26,7 @@ import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
 import { resolvePublicOrigin } from '../../../utils/public-origin';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
-import { post } from '../../setup/test-helpers';
+import { mcpToolsCall, post } from '../../setup/test-helpers';
 import { TestWorkspace } from '../../setup/test-mcp-client';
 
 async function createWorkerBoundPat(
@@ -268,6 +268,100 @@ describe('headless Automation claim gate (automations.execute)', () => {
       SELECT status FROM runs WHERE id = ${job.run_id}
     `;
     expect(String(run.status)).toBe('running');
+  });
+
+  it('capable macOS daemon receives team-org session and can complete the window over MCP', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'mac-capable',
+      platform: 'macos',
+      capabilities: { 'automations.execute': true },
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'mac-capable'
+    );
+
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'mac-capable',
+        platform: 'macos',
+        capabilities: { 'automations.execute': true },
+        agent_kinds: ['opencode'],
+      },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as {
+      run_id: number;
+      payload?: {
+        context?: {
+          agent_session?: { token: string; mcp_url: string; conversation_id: string };
+        };
+      };
+    };
+    const session = job.payload?.context?.agent_session;
+    expect(session?.mcp_url).toContain(`/mcp/${ctx.workspace.org.slug}`);
+    expect(session?.conversation_id).toBe(
+      `claim-gate-agent_automation_${ctx.automationId}_run_${job.run_id}`
+    );
+
+    const completion = await mcpToolsCall(
+      'run_sdk',
+      {
+        script: `export default async (_c, client) => {
+          const window = await client.knowledge.read({ automation_id: '${ctx.automationId}' });
+          return client.automations.completeWindow({
+            automation_id: '${ctx.automationId}',
+            run_id: ${job.run_id},
+            window_token: window.window_token,
+            extracted_data: { summary: 'completed by the Mac daemon session' },
+            model: 'device-cli:opencode',
+          });
+        }`,
+      },
+      { token: session!.token, orgSlug: ctx.workspace.org.slug }
+    );
+    expect(completion.success).toBe(true);
+
+    const [run] = await ctx.sql`
+      SELECT status FROM runs WHERE id = ${job.run_id}
+    `;
+    expect(String(run.status)).toBe('completed');
+  });
+
+  it('capable macOS daemon fails closed when no assigned agent can mint a session', async () => {
+    const ctx = await setupDevicePinnedAutomation({
+      workerId: 'mac-agentless',
+      platform: 'macos',
+      capabilities: { 'automations.execute': true },
+    });
+    await ctx.sql`UPDATE automations SET agent_id = NULL WHERE id = ${ctx.automationId}`;
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'mac-agentless'
+    );
+    const trig = await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: {
+        worker_id: 'mac-agentless',
+        platform: 'macos',
+        capabilities: { 'automations.execute': true },
+        agent_kinds: ['opencode'],
+      },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as { skipped_run_id?: number; error?: string };
+    expect(job.skipped_run_id).toBeGreaterThan(0);
+    expect(job.error).toContain('no assigned agent');
+    const [run] = await ctx.sql`SELECT status FROM runs WHERE id = ${job.skipped_run_id}`;
+    expect(String(run.status)).toBe('failed');
   });
 
   it('macOS device with capabilities:{} still claims (pre-capability exemption)', async () => {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -954,7 +954,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     }
     let devicePrompt = automationInstructions;
     let agentSession: { conversation_id: string; mcp_url: string; token: string; expires_at: number } | undefined;
-    if (effectivePlatform !== 'macos' && row.automation_id != null) {
+    const requiresRunScopedAgentSession =
+      effectivePlatform === 'macos' && authorizedCapabilities.includes('automations.execute');
+    if (
+      row.automation_id != null &&
+      (effectivePlatform !== 'macos' || requiresRunScopedAgentSession)
+    ) {
       const runPayload = parseAutomationRunPayload(approved);
       const agentId =
         typeof approved['agent_id'] === 'string' && approved['agent_id'].trim()
@@ -985,7 +990,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         // Minting encrypts, so it can throw (missing/short ENCRYPTION_KEY). The
         // run is ALREADY claimed by this point, so letting that escape would 500
         // the poll and strand it `running` — the exact wedge the claim gate
-        // exists to prevent. Degrade to the pre-session dispatch instead.
+        // exists to prevent. Legacy workers retain the pre-session dispatch;
+        // the new standalone Mac capability fails closed instead.
         try {
           if (!row.organization_slug) {
             throw new Error(
@@ -1005,6 +1011,24 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             expires_at: access.expiresAt,
           };
         } catch (err) {
+          if (requiresRunScopedAgentSession) {
+            const message = 'failed to mint the required Automation run session';
+            await failClaimedWorkerRun({
+              runId: row.run_id,
+              workerId: worker_id,
+              errorMessage: message,
+            });
+            logger.error(
+              { run_id: row.run_id, automation_id: row.automation_id, agent_id: agentId, err },
+              '[poll] failed to mint the required macOS Automation run session'
+            );
+            return c.json({
+              next_poll_seconds: 1,
+              skipped_run_id: row.run_id,
+              error: message,
+              ...pollMetadata,
+            });
+          }
           devicePrompt = automationInstructions;
           logger.error(
             { run_id: row.run_id, automation_id: row.automation_id, agent_id: agentId, err },
@@ -1012,6 +1036,20 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           );
         }
       } else {
+        if (requiresRunScopedAgentSession) {
+          const message = 'macOS Automation run has no assigned agent for its required run session';
+          await failClaimedWorkerRun({
+            runId: row.run_id,
+            workerId: worker_id,
+            errorMessage: message,
+          });
+          return c.json({
+            next_poll_seconds: 1,
+            skipped_run_id: row.run_id,
+            error: message,
+            ...pollMetadata,
+          });
+        }
         // No assigned agent (or no parseable run payload): dispatch the
         // pre-session shape — instructions prompt + exit-report completion on
         // the daemon's own wiring — rather than failing a run that used to

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -1313,6 +1313,40 @@ export async function completeAutomationRun(c: Context<{ Bindings: Env }>) {
 		return c.json({ ok: true, status: "failed" });
 	}
 
+	// A standalone device daemon can be intentionally stopped while its local
+	// CLI is still running. Preserve that terminal intent instead of sending the
+	// run through the missing-completeWindow resume budget or failure taxonomy.
+	if (body.exit_reason === "cancelled") {
+		const cancelledRows = (await sql`
+      UPDATE runs
+      SET status = 'cancelled',
+          completed_at = current_timestamp,
+          error_message = NULL,
+          output_tail = ${output ? output.slice(-2000) : null},
+          exit_code = ${body.exit_code ?? null},
+          exit_signal = ${body.exit_signal ?? null},
+          exit_reason = 'cancelled'
+      WHERE id = ${runId}
+        AND status = 'running'
+        AND claimed_by = ${body.worker_id}
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		if (cancelledRows.length === 0) {
+			return c.json({ ok: true, status: run.status, idempotent: true });
+		}
+		await sql`
+      UPDATE automations
+      SET last_fired_at = NOW(), updated_at = NOW()
+      WHERE id = ${automationId}
+    `;
+		return c.json({
+			ok: true,
+			status: "cancelled",
+			reason_code: "device_daemon_shutdown",
+			run_id: runId,
+		});
+	}
+
 	// Clean exit + run already completed: the agent finished the job over MCP
 	// (query_sdk → completeWindow) before the subprocess exited. Stamp
 	// the device-side provenance the pipeline can't know — exit metadata and

--- a/scripts/__tests__/mac-device-daemon-graph.test.ts
+++ b/scripts/__tests__/mac-device-daemon-graph.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertMacDeviceDaemonGraph,
+  forbiddenMacDeviceDaemonGraphInputs,
+} from "../check-mac-device-daemon-graph.mjs";
+
+describe("Mac device-daemon package graph guard", () => {
+  test("allows the canonical automation and narrow redaction paths", () => {
+    expect(
+      forbiddenMacDeviceDaemonGraphInputs({
+        "packages/connector-worker/src/daemon/automation.ts": {},
+        "packages/connector-worker/src/daemon/client.ts": {},
+        "packages/connector-worker/src/executor/redact.ts": {},
+      })
+    ).toEqual([]);
+  });
+
+  test("rejects fleet connector and heavy runtime paths", () => {
+    expect(() =>
+      assertMacDeviceDaemonGraph({
+        "packages/connector-worker/src/compile/index.ts": {},
+        "packages/connector-worker/src/executor/child-runner.ts": {},
+        "packages/embeddings/src/index.ts": {},
+        "node_modules/@xenova/transformers/src/pipelines.js": {},
+        "node_modules/onnxruntime-node/dist/index.js": {},
+        "node_modules/playwright/index.js": {},
+        "node_modules/sharp/dist/index.js": {},
+        "node_modules/jimp/index.js": {},
+      })
+    ).toThrow("forbidden fleet/runtime modules");
+  });
+});

--- a/scripts/__tests__/mac-device-daemon-graph.test.ts
+++ b/scripts/__tests__/mac-device-daemon-graph.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
   assertMacDeviceDaemonGraph,
   forbiddenMacDeviceDaemonGraphInputs,
 } from "../check-mac-device-daemon-graph.mjs";
@@ -28,5 +39,33 @@ describe("Mac device-daemon package graph guard", () => {
         "node_modules/jimp/index.js": {},
       })
     ).toThrow("forbidden fleet/runtime modules");
+  });
+
+  test("runs the CLI guard when the checkout path contains spaces", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "lobu graph guard "));
+    const checker = join(tempRoot, "check-mac-device-daemon-graph.mjs");
+    const metafile = join(tempRoot, "metafile.json");
+    try {
+      copyFileSync(
+        fileURLToPath(
+          new URL("../check-mac-device-daemon-graph.mjs", import.meta.url)
+        ),
+        checker
+      );
+      writeFileSync(
+        metafile,
+        JSON.stringify({ inputs: { "daemon/automation.ts": {} } })
+      );
+      const result = spawnSync(process.execPath, [checker, metafile], {
+        encoding: "utf8",
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Mac device-daemon graph clean");
+      expect(readFileSync(checker, "utf8")).toContain("fileURLToPath");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/build-mac-device-daemon.sh
+++ b/scripts/build-mac-device-daemon.sh
@@ -18,6 +18,17 @@ BUILD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-build.XXXXXX")"
 ARTIFACT_TMP="$OUTPUT.tmp.$$"
 trap 'rm -rf "$BUILD_TMP" "$ARTIFACT_TMP"' EXIT
 META="$BUILD_TMP/metafile.json"
+GRAPH_BUNDLE="$BUILD_TMP/graph.js"
+
+(
+  cd "$BUILD_TMP"
+  bun build "$ENTRY" \
+    --target=bun \
+    --metafile="$META" \
+    --outfile="$GRAPH_BUNDLE"
+)
+
+bun "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
 
 (
   cd "$BUILD_TMP"
@@ -27,11 +38,9 @@ META="$BUILD_TMP/metafile.json"
     --no-compile-autoload-dotenv \
     --no-compile-autoload-bunfig \
     --no-compile-autoload-package-json \
-    --metafile="$META" \
     --outfile="$ARTIFACT_TMP"
 )
 
-bun "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
 chmod 0755 "$ARTIFACT_TMP"
 mv -f "$ARTIFACT_TMP" "$OUTPUT"
 file "$OUTPUT"

--- a/scripts/build-mac-device-daemon.sh
+++ b/scripts/build-mac-device-daemon.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRY="$ROOT/packages/connector-worker/src/mac-device-daemon.ts"
+OUTPUT="${OUTPUT:-$ROOT/.tmp/mac-device-daemon/lobu-device-daemon}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || die "Mac device-daemon builds require macOS"
+[[ "$(uname -m)" == "arm64" ]] || die "Mac device-daemon builds require an arm64 Mac mini"
+command -v bun >/dev/null 2>&1 || die "bun is required only while building the standalone artifact"
+
+mkdir -p "$(dirname "$OUTPUT")"
+BUILD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-build.XXXXXX")"
+trap 'rm -rf "$BUILD_TMP"' EXIT
+META="$BUILD_TMP/metafile.json"
+
+(
+  cd "$BUILD_TMP"
+  bun build "$ENTRY" \
+    --compile \
+    --target=bun-darwin-arm64 \
+    --no-compile-autoload-dotenv \
+    --no-compile-autoload-bunfig \
+    --no-compile-autoload-package-json \
+    --metafile="$META" \
+    --outfile="$OUTPUT"
+)
+
+node "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
+chmod 0755 "$OUTPUT"
+file "$OUTPUT"
+stat -f 'artifact_bytes=%z' "$OUTPUT"
+echo "artifact=$OUTPUT"

--- a/scripts/build-mac-device-daemon.sh
+++ b/scripts/build-mac-device-daemon.sh
@@ -5,15 +5,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENTRY="$ROOT/packages/connector-worker/src/mac-device-daemon.ts"
 OUTPUT="${OUTPUT:-$ROOT/.tmp/mac-device-daemon/lobu-device-daemon}"
 
+mkdir -p "$(dirname "$OUTPUT")"
+OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
+
 die() { echo "error: $*" >&2; exit 1; }
 
 [[ "$(uname -s)" == "Darwin" ]] || die "Mac device-daemon builds require macOS"
 [[ "$(uname -m)" == "arm64" ]] || die "Mac device-daemon builds require an arm64 Mac mini"
 command -v bun >/dev/null 2>&1 || die "bun is required only while building the standalone artifact"
 
-mkdir -p "$(dirname "$OUTPUT")"
 BUILD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-build.XXXXXX")"
-trap 'rm -rf "$BUILD_TMP"' EXIT
+ARTIFACT_TMP="$OUTPUT.tmp.$$"
+trap 'rm -rf "$BUILD_TMP" "$ARTIFACT_TMP"' EXIT
 META="$BUILD_TMP/metafile.json"
 
 (
@@ -25,11 +28,12 @@ META="$BUILD_TMP/metafile.json"
     --no-compile-autoload-bunfig \
     --no-compile-autoload-package-json \
     --metafile="$META" \
-    --outfile="$OUTPUT"
+    --outfile="$ARTIFACT_TMP"
 )
 
 bun "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
-chmod 0755 "$OUTPUT"
+chmod 0755 "$ARTIFACT_TMP"
+mv -f "$ARTIFACT_TMP" "$OUTPUT"
 file "$OUTPUT"
 stat -f 'artifact_bytes=%z' "$OUTPUT"
 echo "artifact=$OUTPUT"

--- a/scripts/build-mac-device-daemon.sh
+++ b/scripts/build-mac-device-daemon.sh
@@ -28,7 +28,7 @@ META="$BUILD_TMP/metafile.json"
     --outfile="$OUTPUT"
 )
 
-node "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
+bun "$ROOT/scripts/check-mac-device-daemon-graph.mjs" "$META"
 chmod 0755 "$OUTPUT"
 file "$OUTPUT"
 stat -f 'artifact_bytes=%z' "$OUTPUT"

--- a/scripts/check-mac-device-daemon-graph.mjs
+++ b/scripts/check-mac-device-daemon-graph.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const FORBIDDEN_GRAPH_PATTERNS = [
+  /packages\/connector-worker\/src\/(?:compile(?:-connector)?|embeddings(?:[-/]|\.))/,
+  /packages\/embeddings\//,
+  /packages\/connector-worker\/src\/executor\/(?!redact(?:\.ts|\.js)?$)/,
+  /packages\/connector-worker\/src\/self-check\//,
+  /node_modules\/(?:@lobu\/embeddings|@xenova\/transformers|onnxruntime(?:-[^/]+)?|playwright|patchright|sharp|jimp)(?:\/|$)/,
+];
+
+export function forbiddenMacDeviceDaemonGraphInputs(inputs) {
+  return Object.keys(inputs).filter((input) =>
+    FORBIDDEN_GRAPH_PATTERNS.some((pattern) => pattern.test(input))
+  );
+}
+
+export function assertMacDeviceDaemonGraph(inputs) {
+  const forbidden = forbiddenMacDeviceDaemonGraphInputs(inputs);
+  if (forbidden.length > 0) {
+    throw new Error(
+      `lean Mac device-daemon graph contains forbidden fleet/runtime modules:\n${forbidden
+        .map((input) => `- ${input}`)
+        .join("\n")}`
+    );
+  }
+  return inputs;
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const metafile = process.argv[2];
+  if (!metafile)
+    throw new Error("usage: check-mac-device-daemon-graph.mjs <metafile.json>");
+  const graph = JSON.parse(readFileSync(metafile, "utf8"));
+  assertMacDeviceDaemonGraph(graph.inputs ?? {});
+  console.log(
+    `Mac device-daemon graph clean (${Object.keys(graph.inputs ?? {}).length} modules)`
+  );
+}

--- a/scripts/check-mac-device-daemon-graph.mjs
+++ b/scripts/check-mac-device-daemon-graph.mjs
@@ -1,6 +1,8 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const FORBIDDEN_GRAPH_PATTERNS = [
   /packages\/connector-worker\/src\/(?:compile(?:-connector)?|embeddings(?:[-/]|\.))/,
@@ -28,7 +30,11 @@ export function assertMacDeviceDaemonGraph(inputs) {
   return inputs;
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+const isMain =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
   const metafile = process.argv[2];
   if (!metafile)
     throw new Error("usage: check-mac-device-daemon-graph.mjs <metafile.json>");

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ "$(uname -s)" == "Darwin" ]] || { echo "error: Mac packaging smoke requires macOS" >&2; exit 1; }
+[[ "$(uname -m)" == "arm64" ]] || { echo "error: Mac packaging smoke requires arm64" >&2; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-smoke.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+ARTIFACT="$WORK/build/lobu-device-daemon"
+CLEAN="$WORK/clean"
+mkdir -p "$CLEAN"
+
+OUTPUT="$ARTIFACT" "$ROOT/scripts/build-mac-device-daemon.sh" >"$WORK/build.log"
+cp "$ARTIFACT" "$CLEAN/lobu-device-daemon"
+chmod 0755 "$CLEAN/lobu-device-daemon"
+
+file "$CLEAN/lobu-device-daemon" | grep -q 'Mach-O 64-bit executable arm64'
+[[ "$(find "$CLEAN" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" == 1 ]]
+
+SAFE_ENV=(env -i PATH=/usr/bin:/bin HOME="$WORK/home" TMPDIR="$WORK/tmp")
+mkdir -p "$WORK/home" "$WORK/tmp"
+
+VERSION_JSON="$(${SAFE_ENV[@]} "$CLEAN/lobu-device-daemon" --version)"
+case "$VERSION_JSON" in
+  *'"name":"lobu-device-daemon"'*'"protocol":"device-daemon/v1"'*'"platform":"macos"'*) ;;
+  *) echo "error: --version did not emit expected metadata: $VERSION_JSON" >&2; exit 1 ;;
+esac
+
+"${SAFE_ENV[@]}" "$CLEAN/lobu-device-daemon" --help | grep -q 'Usage:'
+
+if "${SAFE_ENV[@]}" "$CLEAN/lobu-device-daemon" >/dev/null 2>"$WORK/missing-config.err"; then
+  echo "error: missing launch configuration unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q -- '--api-url or API_URL is required' "$WORK/missing-config.err"
+
+if "${SAFE_ENV[@]}" WORKER_API_TOKEN=not-a-pat "$CLEAN/lobu-device-daemon" --api-url https://example.test >/dev/null 2>"$WORK/invalid-token.err"; then
+  echo "error: invalid PAT unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'owl_pat_' "$WORK/invalid-token.err"
+
+NO_POLL_JSON="$(${SAFE_ENV[@]} "$CLEAN/lobu-device-daemon" --no-poll)"
+[[ "$NO_POLL_JSON" == "$VERSION_JSON" ]]
+
+echo "Mac device-daemon package smoke passed"
+echo "$VERSION_JSON"
+stat -f 'artifact_bytes=%z' "$CLEAN/lobu-device-daemon"

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -5,8 +5,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 [[ "$(uname -s)" == "Darwin" ]] || { echo "error: Mac packaging smoke requires macOS" >&2; exit 1; }
 [[ "$(uname -m)" == "arm64" ]] || { echo "error: Mac packaging smoke requires arm64" >&2; exit 1; }
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-smoke.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/lobu-device-daemon-smoke.XXXXXX")"
+WORK="$WORK_ROOT/work with spaces"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK_ROOT"' EXIT
 ARTIFACT="$WORK/build/lobu-device-daemon"
 CLEAN="$WORK/clean"
 mkdir -p "$CLEAN"
@@ -21,27 +23,37 @@ file "$CLEAN/lobu-device-daemon" | grep -q 'Mach-O 64-bit executable arm64'
 SAFE_ENV=(env -i PATH=/usr/bin:/bin HOME="$WORK/home" TMPDIR="$WORK/tmp")
 mkdir -p "$WORK/home" "$WORK/tmp"
 
-VERSION_JSON="$(${SAFE_ENV[@]} "$CLEAN/lobu-device-daemon" --version)"
+run_clean() (
+  cd "$CLEAN"
+  "${SAFE_ENV[@]}" "$@"
+)
+
+run_clean_with_token() (
+  cd "$CLEAN"
+  "${SAFE_ENV[@]}" WORKER_API_TOKEN=not-a-pat ./lobu-device-daemon "$@"
+)
+
+VERSION_JSON="$(run_clean ./lobu-device-daemon --version)"
 case "$VERSION_JSON" in
   *'"name":"lobu-device-daemon"'*'"protocol":"device-daemon/v1"'*'"platform":"macos"'*) ;;
   *) echo "error: --version did not emit expected metadata: $VERSION_JSON" >&2; exit 1 ;;
 esac
 
-"${SAFE_ENV[@]}" "$CLEAN/lobu-device-daemon" --help | grep -q 'Usage:'
+run_clean ./lobu-device-daemon --help | grep -q 'Usage:'
 
-if "${SAFE_ENV[@]}" "$CLEAN/lobu-device-daemon" >/dev/null 2>"$WORK/missing-config.err"; then
+if run_clean ./lobu-device-daemon >/dev/null 2>"$WORK/missing-config.err"; then
   echo "error: missing launch configuration unexpectedly succeeded" >&2
   exit 1
 fi
 grep -q -- '--api-url or API_URL is required' "$WORK/missing-config.err"
 
-if "${SAFE_ENV[@]}" WORKER_API_TOKEN=not-a-pat "$CLEAN/lobu-device-daemon" --api-url https://example.test >/dev/null 2>"$WORK/invalid-token.err"; then
+if run_clean_with_token --api-url https://example.test >/dev/null 2>"$WORK/invalid-token.err"; then
   echo "error: invalid PAT unexpectedly succeeded" >&2
   exit 1
 fi
 grep -q 'owl_pat_' "$WORK/invalid-token.err"
 
-NO_POLL_JSON="$(${SAFE_ENV[@]} "$CLEAN/lobu-device-daemon" --no-poll)"
+NO_POLL_JSON="$(run_clean ./lobu-device-daemon --no-poll)"
 [[ "$NO_POLL_JSON" == "$VERSION_JSON" ]]
 
 echo "Mac device-daemon package smoke passed"


### PR DESCRIPTION
## Summary
- Add a versioned lean macOS arm64 device-daemon entrypoint that reuses WorkerClient and the canonical Automation arm.
- Build one Bun-compiled standalone Mach-O with a metafile graph guard excluding embeddings, ONNX/transformers, connector compiler/child-runner, Playwright, sharp, and jimp.
- Add root/package build hooks, strict CLI validation, graceful EOF/SIGTERM shutdown, and clean-directory packaging smoke coverage.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Focused tests: 23 passing in daemon/graph/poll-body/agent-kind suites; automation-arm and executor-automation suites passed previously in the focused regression run (37 tests)
- [x] Mac mini smoke: `scripts/test-mac-device-daemon-package.sh` passed with one clean artifact, version/help/no-poll, missing-config, and invalid-PAT checks
- [x] Artifact: arm64 Mach-O, 62,123,730 bytes; graph guard clean with 286 modules; only `/usr/lib` macOS system dylibs from `otool -L`
- [ ] `make pr-full` (not run; CI is the canonical full graph)
- [ ] `make review-fix` (attempted; reviewer quota exhausted without edits)

## Notes
This is root-repo only. Owletto, server poll contracts, DB schema, Connector SDK, public ClientSDK, and the full fleet executor were not modified. Native Swift bridging, native Mac connector capabilities, and the Owletto release-workflow call site remain follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone macOS arm64 device daemon for Automation jobs.
  * Added CLI options for help, version, configuration, and metadata-only validation.
  * Added configurable polling, concurrency limits, and graceful shutdown behavior.
  * Added run-scoped session support and capability-based Automation execution.
* **Bug Fixes**
  * Improved polling lifecycle and active-job handling during shutdown.
  * Canceled runs now receive the correct final status.
* **Documentation**
  * Added macOS daemon build, validation, and runtime guidance.
* **Tests**
  * Added coverage for validation, packaging, cancellation, and dependency boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->