### PR TITLE
feat(worker): advertise poll capacity

### DIFF
--- a/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
+++ b/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
@@ -100,6 +100,23 @@ describe("device worker poll body", () => {
     expect(calls[0].body).toMatchObject({ label: "Buraks-MacBook-Pro" });
   });
 
+  test("omits capacity for legacy callers and sends zero or positive capacity when supplied", async () => {
+    const { calls } = capturePoll();
+    const client = new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-capacity",
+      capabilities: {},
+    });
+
+    await client.poll();
+    await client.poll(0);
+    await client.poll(3);
+
+    expect(calls[0].body).not.toHaveProperty("capacity_available");
+    expect(calls[1].body.capacity_available).toBe(0);
+    expect(calls[2].body.capacity_available).toBe(3);
+  });
+
   test("a headless device advertises automations.execute without being told to", async () => {
     // The gateway's Automation claim lane matches this exact string, so the
     // build — not the operator's --capabilities flag — is what opts a headless

--- a/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/mac-device-daemon.test.ts
@@ -171,7 +171,7 @@ describe('WorkerPollLoop', () => {
     } as never;
     const loop = new WorkerPollLoop({
       client,
-      pollIntervalMs: 1,
+      pollIntervalMs: 1000,
       maxConcurrentJobs: 1,
       execute: async () => jobFinished,
     });

--- a/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { WorkerPollLoop } from "../daemon/poll-loop";
+
+describe("worker daemon capacity polling", () => {
+  test("polls at capacity with zero and does not execute a returned job", async () => {
+    const calls: number[] = [];
+    let executed = 0;
+    const client = {
+      poll: async (capacity?: number) => {
+        calls.push(capacity ?? -1);
+        return { run_id: 42, run_type: "sync", next_poll_seconds: 10 };
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      maxConcurrentJobs: 1,
+      execute: async () => {
+        executed++;
+      },
+    });
+    (loop as unknown as { activeJobs: number }).activeJobs = 1;
+
+    await (loop as unknown as { pollAndExecute: () => Promise<number | undefined> })
+      .pollAndExecute();
+
+    expect(calls).toEqual([0]);
+    expect(executed).toBe(0);
+  });
+
+  test("sends the number of free slots when below capacity", async () => {
+    const calls: number[] = [];
+    const client = {
+      poll: async (capacity?: number) => {
+        calls.push(capacity ?? -1);
+        return {};
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      maxConcurrentJobs: 3,
+      execute: async () => {},
+    });
+    (loop as unknown as { activeJobs: number }).activeJobs = 1;
+
+    await (loop as unknown as { pollAndExecute: () => Promise<number | undefined> })
+      .pollAndExecute();
+
+    expect(calls).toEqual([2]);
+  });
+});

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -22,7 +22,7 @@ function trimTrailingSlashes(value: string): string {
  */
 export interface ExecutorClient {
   readonly id: string;
-  poll(): Promise<PollResponse>;
+  poll(capacityAvailable?: number): Promise<PollResponse>;
   heartbeat(
     runId: number,
     progress?: {
@@ -243,11 +243,14 @@ export class WorkerClient implements ExecutorClient {
   /**
    * Poll for available runs
    */
-  async poll(): Promise<PollResponse> {
+  async poll(capacityAvailable?: number): Promise<PollResponse> {
     return this.requestJson<PollResponse>('/api/workers/poll', {
       worker_id: this.workerId,
       capabilities: this.advertisedCapabilities(),
       version: this.version,
+      ...(capacityAvailable === undefined
+        ? {}
+        : { capacity_available: capacityAvailable }),
       // app_version belongs to the device registration fields, so omit both for
       // fleet workers rather than sending empty values. A device worker also
       // advertises the agent kinds its automation arm can run.

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -94,13 +94,22 @@ export class WorkerPollLoop {
   }
 
   private async pollAndExecute(): Promise<number | undefined> {
-    if (this.activeJobs >= this.maxConcurrentJobs) return undefined;
-
-    const job = await this.client.poll();
+    const capacityAvailable = Math.max(0, this.maxConcurrentJobs - this.activeJobs);
+    const job = await this.client.poll(capacityAvailable);
     if (!job.run_id) {
       const nextPoll = job.next_poll_seconds ?? 30;
       log.debug(`[daemon] No runs available, next poll in ${nextPoll}s`);
       return Number.isFinite(nextPoll) && nextPoll > 0 ? nextPoll * 1000 : 1000;
+    }
+
+    // A zero-capacity response should be impossible: the server must not enter
+    // a claim lane when the worker truthfully reports no free slot. Do not
+    // execute a job if a server bug violates that contract.
+    if (capacityAvailable === 0) {
+      log.info(
+        `[daemon] Server returned run ${job.run_id} while worker is at capacity; leaving it untouched`
+      );
+      return undefined;
     }
 
     this.activeJobs++;

--- a/packages/core/src/__tests__/worker-poll-capacity.test.ts
+++ b/packages/core/src/__tests__/worker-poll-capacity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { Value } from "@sinclair/typebox/value";
+import { PollRequestSchema } from "../contracts/worker/protocol";
+
+const baseRequest = { worker_id: "worker-1" };
+
+describe("worker poll capacity", () => {
+  test("accepts omitted, zero, and positive capacity", () => {
+    expect(Value.Check(PollRequestSchema, baseRequest)).toBe(true);
+    expect(
+      Value.Check(PollRequestSchema, { ...baseRequest, capacity_available: 0 })
+    ).toBe(true);
+    expect(
+      Value.Check(PollRequestSchema, { ...baseRequest, capacity_available: 7 })
+    ).toBe(true);
+  });
+
+  test("rejects negative, fractional, and absurd capacity", () => {
+    for (const capacity_available of [-1, 1.5, 1025]) {
+      expect(
+        Value.Check(PollRequestSchema, { ...baseRequest, capacity_available })
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -102,6 +102,10 @@ export const OAuthCredentialsSchema = Type.Object({
 export const PollRequestSchema = Type.Object({
   worker_id: Type.String(),
   capabilities: Type.Optional(Type.Record(Type.String(), Type.Boolean())),
+  /** Number of additional runs the worker can accept at this instant. */
+  capacity_available: Type.Optional(
+    Type.Integer({ minimum: 0, maximum: 1024 })
+  ),
   platform: Type.Optional(Type.String()),
   app_version: Type.Optional(Type.String()),
   /**

--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -142,10 +142,13 @@ async function pollExtension(workerId: string) {
 
 async function pollFleet(
   workerId = 'fleet-affinity-worker',
-  capabilities: Record<string, boolean> = {}
+  capabilities: Record<string, boolean> = {},
+  capacityAvailable?: number,
 ) {
+  const body: Record<string, unknown> = { worker_id: workerId, capabilities };
+  if (capacityAvailable !== undefined) body.capacity_available = capacityAvailable;
   return post('/api/workers/poll', {
-    body: { worker_id: workerId, capabilities },
+    body,
     token: 'test-fleet-token',
     env: { WORKER_API_TOKEN: 'test-fleet-token' },
   });
@@ -178,7 +181,7 @@ describe('browser-affinity poll claim', () => {
       connectorKey: 'linkedin',
     });
 
-    const res = await pollFleet();
+    const res = await pollFleet('fleet-affinity-worker', {}, 1);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       run_id?: number;

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
+import { parsePgTextArray } from '../../db/client';
 import {
   deviceManifestHash,
   type DeviceConnectorManifest,
@@ -181,16 +182,22 @@ async function poll(
   connectorManifests: unknown[],
   platform = 'macos',
   capabilities: Record<string, boolean> = { screentime: true },
+  options: { capacityAvailable?: number; agentKinds?: string[] } = {},
 ) {
+  const body: Record<string, unknown> = {
+    worker_id: workerId,
+    platform,
+    app_version: '9.9.0',
+    label: 'Test Device',
+    capabilities,
+    connector_manifests: connectorManifests,
+  };
+  if (options.capacityAvailable !== undefined) {
+    body.capacity_available = options.capacityAvailable;
+  }
+  if (options.agentKinds !== undefined) body.agent_kinds = options.agentKinds;
   return post('/api/workers/poll', {
-    body: {
-      worker_id: workerId,
-      platform,
-      app_version: '9.9.0',
-      label: 'Test Device',
-      capabilities,
-      connector_manifests: connectorManifests,
-    },
+    body,
   });
 }
 
@@ -202,8 +209,12 @@ async function pollFleet(workerId: string) {
   });
 }
 
-async function pollClaimingDueFeed(workerId: string, connectorManifests: unknown[]) {
-  const response = await poll(workerId, connectorManifests);
+async function pollClaimingDueFeed(
+  workerId: string,
+  connectorManifests: unknown[],
+  options: { capacityAvailable?: number; agentKinds?: string[] } = {},
+) {
+  const response = await poll(workerId, connectorManifests, 'macos', { screentime: true }, options);
   expect(response.status).toBe(200);
   return response.json();
 }
@@ -308,7 +319,7 @@ describe('device connector manifests', () => {
   it('installs a metadata-only device connector from poll and claims its feed run without compiled_code', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 
-    const body = await pollClaimingDueFeed(workerId, [manifest()]);
+    const body = await pollClaimingDueFeed(workerId, [manifest()], { capacityAvailable: 1 });
 
     const def = await readDefinition(orgId);
     expect(def?.key).toBe(CONNECTOR_KEY);
@@ -806,7 +817,22 @@ describe('device connector manifests', () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
-    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    expect(
+      (
+        await poll(
+          workerId,
+          [manifest()],
+          'macos',
+          { screentime: true },
+          { capacityAvailable: 0 },
+        )
+      ).status,
+    ).toBe(200);
+    const before = (await sql`
+      SELECT connector_manifests
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+    `) as unknown as Array<{ connector_manifests: unknown }>;
     const invalidManifest = manifest({
       feeds_schema: {
         snapshots: {
@@ -819,7 +845,17 @@ describe('device connector manifests', () => {
       },
     });
 
-    expect((await poll(workerId, [invalidManifest])).status).toBe(200);
+    expect(
+      (
+        await poll(
+          workerId,
+          [invalidManifest],
+          'macos',
+          { screentime: true },
+          { capacityAvailable: 0 },
+        )
+      ).status,
+    ).toBe(200);
 
     const definitions = (await sql`
       SELECT status FROM connector_definitions
@@ -832,6 +868,93 @@ describe('device connector manifests', () => {
       WHERE worker_id = ${workerId}
     `) as unknown as Array<{ connector_manifests: Record<string, unknown> }>;
     expect(Object.keys(devices[0]?.connector_manifests ?? {})).toEqual([CONNECTOR_KEY]);
+    expect(devices[0]?.connector_manifests).toEqual(before[0]?.connector_manifests);
+  });
+
+  it('registers and reconciles a zero-capacity poll without claiming an eligible run', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const manifestPayload = manifest();
+
+    const first = await poll(
+      workerId,
+      [manifestPayload],
+      'macos',
+      { screentime: true },
+      { capacityAvailable: 0, agentKinds: ['claude-code'] },
+    );
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as Record<string, unknown>;
+    expect(firstBody.run_id).toBeUndefined();
+
+    const [connectionFeed] = (await sql`
+      SELECT c.id AS connection_id, f.id AS feed_id
+      FROM connections c
+      JOIN feeds f ON f.connection_id = c.id
+      WHERE c.organization_id = ${orgId}
+        AND c.connector_key = ${CONNECTOR_KEY}
+        AND f.feed_key = 'snapshots'
+      LIMIT 1
+    `) as unknown as Array<{ connection_id: number; feed_id: number }>;
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, feed_id, connection_id, connector_key,
+        connector_version, approval_status, status, created_at
+      ) VALUES (
+        ${orgId}, 'sync', ${connectionFeed.feed_id}, ${connectionFeed.connection_id},
+        ${CONNECTOR_KEY}, '0.1.0', 'auto', 'pending', NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const runId = Number(run.id);
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = current_timestamp - INTERVAL '1 hour'
+      WHERE worker_id = ${workerId}
+    `;
+    const beforePoll = (await sql`
+      SELECT status, claimed_by, claimed_at, last_heartbeat_at
+      FROM runs WHERE id = ${runId}
+    `) as unknown as Array<Record<string, unknown>>;
+
+    const second = await poll(
+      workerId,
+      [manifestPayload],
+      'macos',
+      { screentime: true },
+      { capacityAvailable: 0, agentKinds: ['pi'] },
+    );
+    expect(second.status).toBe(200);
+    expect(((await second.json()) as Record<string, unknown>).run_id).toBeUndefined();
+
+    const [device] = (await sql`
+      SELECT last_seen_at, capabilities, app_version, label, agent_kinds, connector_manifests
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+    `) as unknown as Array<{
+      last_seen_at: string | Date;
+      capabilities: unknown;
+      app_version: string;
+      label: string;
+      agent_kinds: string | string[] | null;
+      connector_manifests: unknown;
+    }>;
+    expect(new Date(String(device.last_seen_at)).getTime()).toBeGreaterThan(
+      Date.now() - 60_000,
+    );
+    expect(device.capabilities).toEqual(['screentime']);
+    expect(device.app_version).toBe('9.9.0');
+    expect(device.label).toBe('Test Device');
+    expect(parsePgTextArray(device.agent_kinds)).toEqual(['pi']);
+    expect(device.connector_manifests).toEqual(
+      expect.objectContaining({ [CONNECTOR_KEY]: expect.anything() }),
+    );
+
+    const [afterRun] = (await sql`
+      SELECT status, claimed_by, claimed_at, last_heartbeat_at
+      FROM runs WHERE id = ${runId}
+    `) as unknown as Array<Record<string, unknown>>;
+    expect(afterRun).toEqual(beforePoll[0]);
   });
 
   it('keeps manifest inventory separate from live permission state so revoked capabilities pause feeds', async () => {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -170,6 +170,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   let platform: string | null = null;
   let app_version: string | null = null;
   let label: string | null = null;
+  let capacityAvailable: number | null = null;
   let connectorManifestsProvided = false;
   let connectorManifestsRaw: unknown;
   // Agent CLIs this device can spawn. `null` is NOT the same as `[]`: null means
@@ -185,6 +186,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     platform = body.platform ?? null;
     app_version = body.app_version ?? null;
     label = body.label ?? null;
+    capacityAvailable = body.capacity_available ?? null;
     connectorManifestsProvided = Object.hasOwn(body, 'connector_manifests');
     connectorManifestsRaw = body.connector_manifests;
     agentKinds = normalizeAgentKinds(body.agent_kinds);
@@ -535,6 +537,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     worker_kind: workerKind,
     platform: platformLabel,
   });
+  if (capacityAvailable === 0) {
+    return c.json({
+      next_poll_seconds: 10,
+      ...(effectivePlatform === 'chrome-extension' ? { page_activations: [] } : {}),
+    });
+  }
   if (hasEmptyUserOrgScope) {
     // No org in scope — nothing this worker can ever claim. The rejection is
     // deferred to here (rather than returning at the check above) so the poll


### PR DESCRIPTION
## Summary
- Add optional `capacity_available` (0..1024) to the shared worker poll contract.
- Keep zero-capacity polls liveness/reconciliation-only while generic and lean Mac daemons continue polling at server cadence.
- Preserve omitted legacy behavior and positive-capacity claim lanes; no database migration or public SDK/platform changes.

## Test plan
- [x] Focused core schema contract tests: omitted, zero, positive, negative/fractional/over-bound rejection.
- [x] Worker client body tests: omitted field versus zero/positive field.
- [x] Shared poll-loop tests: full worker sends zero and does not execute a returned run; free slots advertise correctly.
- [x] Server integration: zero-capacity liveness, metadata, manifest reconciliation/invalid-manifest retention, no claim; omitted/positive claim lanes.
- [x] Browser affinity, scheduler liveness, device manifest, worker poll, and Mac daemon suites.
- [x] `make pre-pr`
- [ ] `make pr-full` (not run locally)

Focused results:
```
core worker-poll-capacity: 2 passed
connector-worker focused suites: 35 passed, 64 expects
server focused suites: 48 passed
make pre-pr: clean
```

## Notes
- `make review-fix` was attempted on the settled diff but the configured review quota is exhausted until Aug 26; no files were changed.
- Capacity/liveness and asynchronous caller waiting are separate follow-ups. This PR does not change the 60s `operations.execute` pre-claim waiter or run heartbeat semantics.
- The branch is based on merged shared poll-loop architecture from #3080/#3086 and contains no duplicate prerequisite commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worker polling now reports available capacity, including zero capacity.
  - Capacity values are validated between 0 and 1024.
  - Workers with available capacity can continue claiming eligible jobs.

- **Bug Fixes**
  - Workers at full capacity no longer claim or execute additional jobs.
  - Zero-capacity polls preserve device metadata and pending job state.
  - Polling responses provide a retry interval when no capacity is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->