### PR TITLE
fix(worker): validate poll request bodies at runtime

### DIFF
--- a/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
@@ -47,4 +47,35 @@ describe("worker daemon capacity polling", () => {
 
     expect(calls).toEqual([2]);
   });
+
+  test("releases one slot when the executor rejects asynchronously", async () => {
+    const capacities: number[] = [];
+    let firstPoll = true;
+    const client = {
+      poll: async (capacity?: number) => {
+        capacities.push(capacity ?? -1);
+        if (firstPoll) {
+          firstPoll = false;
+          return { run_id: 42, run_type: "sync" };
+        }
+        return { next_poll_seconds: 1 };
+      },
+    } as never;
+    const loop = new WorkerPollLoop({
+      client,
+      maxConcurrentJobs: 1,
+      execute: async () => {
+        throw new Error("asynchronous executor failure");
+      },
+    });
+    const pollAndExecute = (loop as unknown as {
+      pollAndExecute: () => Promise<number | undefined>;
+    }).pollAndExecute.bind(loop);
+
+    await pollAndExecute();
+    expect(await loop.waitForActiveJobs(1000, 1)).toBe(true);
+    await pollAndExecute();
+
+    expect(capacities).toEqual([1, 1]);
+  });
 });

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -957,6 +957,107 @@ describe('device connector manifests', () => {
     expect(afterRun).toEqual(beforePoll[0]);
   });
 
+  it('rejects invalid poll bodies before changing worker or run state', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const manifestPayload = manifest();
+
+    expect(
+      (
+        await poll(
+          workerId,
+          [manifestPayload],
+          'macos',
+          { screentime: true },
+          { capacityAvailable: 0 },
+        )
+      ).status,
+    ).toBe(200);
+    await settleRunsAndFeeds(orgId);
+
+    const [connectionFeed] = (await sql`
+      SELECT c.id AS connection_id, f.id AS feed_id
+      FROM connections c
+      JOIN feeds f ON f.connection_id = c.id
+      WHERE c.organization_id = ${orgId}
+        AND c.connector_key = ${CONNECTOR_KEY}
+        AND f.feed_key = 'snapshots'
+      LIMIT 1
+    `) as unknown as Array<{ connection_id: number; feed_id: number }>;
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, feed_id, connection_id, connector_key,
+        connector_version, approval_status, status, created_at
+      ) VALUES (
+        ${orgId}, 'sync', ${connectionFeed.feed_id}, ${connectionFeed.connection_id},
+        ${CONNECTOR_KEY}, '0.1.0', 'auto', 'pending', NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const validBody = {
+      worker_id: workerId,
+      platform: 'macos',
+      app_version: '9.9.0',
+      label: 'Test Device',
+      capabilities: { screentime: true },
+      connector_manifests: [manifestPayload],
+    };
+    const invalidBodies: unknown[] = [-1, 1.5, 1025, '1', null, {}].map(
+      (capacity_available) => ({ ...validBody, capacity_available }),
+    );
+    invalidBodies.push([], null);
+
+    const [beforeDevice] = (await sql`
+      SELECT app_version, capabilities, label, agent_kinds, connector_manifests,
+             last_seen_at::text AS last_seen_at
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+    `) as unknown as Array<Record<string, unknown>>;
+    const beforeFeeds = await sql`
+      SELECT id, status, next_run_at::text AS next_run_at
+      FROM feeds
+      WHERE organization_id = ${orgId}
+      ORDER BY id
+    `;
+    const [beforeRun] = (await sql`
+      SELECT status, claimed_by, claimed_at, last_heartbeat_at
+      FROM runs
+      WHERE id = ${run.id}
+    `) as unknown as Array<Record<string, unknown>>;
+
+    for (const body of invalidBodies) {
+      const response =
+        body === null
+          ? await post('/api/workers/poll')
+          : await post('/api/workers/poll', { body });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: expect.any(String) });
+    }
+
+    const [afterDevice] = (await sql`
+      SELECT app_version, capabilities, label, agent_kinds, connector_manifests,
+             last_seen_at::text AS last_seen_at
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+    `) as unknown as Array<Record<string, unknown>>;
+    const afterFeeds = await sql`
+      SELECT id, status, next_run_at::text AS next_run_at
+      FROM feeds
+      WHERE organization_id = ${orgId}
+      ORDER BY id
+    `;
+    const [afterRun] = (await sql`
+      SELECT status, claimed_by, claimed_at, last_heartbeat_at
+      FROM runs
+      WHERE id = ${run.id}
+    `) as unknown as Array<Record<string, unknown>>;
+
+    expect(afterDevice).toEqual(beforeDevice);
+    expect(afterFeeds).toEqual(beforeFeeds);
+    expect(afterRun).toEqual(beforeRun);
+  });
+
   it('keeps manifest inventory separate from live permission state so revoked capabilities pause feeds', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const connectorManifest = manifest();

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -6,7 +6,11 @@
  */
 
 import { authorizeCapabilities, isKnownPlatform } from '@lobu/core';
-import type { PollRequest } from '@lobu/core/contracts/worker/protocol';
+import { Value } from '@sinclair/typebox/value';
+import {
+  PollRequestSchema,
+  type PollRequest,
+} from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
 import {
   automationTriggerSignals,
@@ -180,7 +184,19 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // can run nothing.
   let agentKinds: string[] | null = null;
   try {
-    const body = await c.req.json<PollRequest>();
+    const rawBody = await c.req.json<unknown>();
+    if (!Value.Check(PollRequestSchema, rawBody)) {
+      const first = Value.Errors(PollRequestSchema, rawBody).First();
+      return c.json(
+        {
+          error: first
+            ? `${first.path || '(root)'} ${first.message}`.trim()
+            : 'Invalid request body',
+        },
+        400
+      );
+    }
+    const body = rawBody as PollRequest;
     worker_id = body.worker_id;
     capabilities = body.capabilities ?? {};
     platform = body.platform ?? null;


### PR DESCRIPTION
## Summary
- Validate the complete `/api/workers/poll` JSON body with the canonical `PollRequestSchema` before any poll state or claim work.
- Return the normal structured 400 response for malformed bodies and invalid `capacity_available` values.
- Add DB-backed regression coverage proving worker liveness, manifest inventory, feeds, and pending runs remain unchanged.
- Add direct coverage for async WorkerPollLoop executor failure slot release; merged main already contains the full-capacity zero-poll and server-delay behavior.

This is a new follow-up PR that closes the post-merge review gap identified after #3087 was squash-merged. It does not duplicate or alter the merged capacity contract.

## Test plan
- [x] `bun test packages/core/src/__tests__/worker-poll-capacity.test.ts`
- [x] `bun test packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts packages/connector-worker/src/__tests__/mac-device-daemon.test.ts packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts`
- [x] `node ../../node_modules/.bin/vitest run src/__tests__/integration/device-connector-manifests.test.ts` from `packages/server` (26 passed, 2 skipped)
- [x] `make pre-pr`
- [x] pre-commit Biome and TypeScript checks
- [ ] `make review-fix` — configured reviewer weekly quota exhausted; no fixer changes were applied

No schema, migration, SDK, connector, or UI changes.