### PR TITLE
fix(mcp): bound proxy transport responses

### DIFF
--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -31,6 +31,7 @@ import { orgContext } from "../../lobu/stores/org-context.js";
 import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import type { DirectToolExecutionOptions } from "../auth/mcp/proxy.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
+import { buildSessionKey, computeScopeKey } from "../auth/mcp/proxy-shared.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
 
@@ -92,6 +93,20 @@ function initializeResponse(sessionId: string) {
         "Mcp-Session-Id": sessionId,
       },
     }
+  );
+}
+
+function seedRestSession(
+  proxy: McpProxy,
+  mcpId: string,
+  agentId = "agent1",
+  userId = "user1",
+) {
+  orgContext.run({ organizationId: "test-org" }, () =>
+    proxy.upstream.setSession(
+      buildSessionKey(agentId, mcpId, computeScopeKey(userId)),
+      `${mcpId}-session`,
+    ),
   );
 }
 
@@ -241,6 +256,7 @@ describe("SSRF guard", () => {
       "pub-mcp": { id: "pub-mcp", upstreamUrl: "http://public-mcp.example.com:9000/mcp" },
     });
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "pub-mcp");
     const app = proxy.getApp();
 
     globalThis.fetch = async () =>
@@ -274,6 +290,7 @@ describe("SSRF guard", () => {
       },
     });
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "lobu-memory");
     const app = proxy.getApp();
 
     let forwardedAuthorization: string | null = null;
@@ -391,6 +408,7 @@ describe("cross-agent JWT isolation", () => {
     };
 
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "secure-mcp");
     const app = proxy.getApp();
 
     globalThis.fetch = async () =>
@@ -425,6 +443,7 @@ describe("cross-agent JWT isolation", () => {
     const proxy = new McpProxy(configSource, {      toolCache,
       grantStore,
     });
+    seedRestSession(proxy, "shared-mcp");
     const app = proxy.getApp();
 
     // Seed destructive tool in cache for both agents (org-scoped cache → seed
@@ -489,6 +508,8 @@ describe("tool registry collision — same tool name on two MCPs", () => {
       teams: { id: "teams", upstreamUrl: "http://teams.example.com/mcp" },
     });
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "slack");
+    seedRestSession(proxy, "teams");
     const app = proxy.getApp();
 
     let lastUrl = "";
@@ -685,6 +706,7 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
     const proxy = new McpProxy(configSource, {      toolCache,
       grantStore,
     });
+    seedRestSession(proxy, "gh-mcp");
     const app = proxy.getApp();
 
     globalThis.fetch = async () =>
@@ -856,6 +878,7 @@ describe("SSE-framed JSON-RPC response", () => {
       "sse-mcp": { id: "sse-mcp", upstreamUrl: "http://sse.example.com/mcp" },
     });
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "sse-mcp");
     const app = proxy.getApp();
 
     const sseBody = [
@@ -934,6 +957,7 @@ describe("concurrent tool calls", () => {
       "conc-mcp": { id: "conc-mcp", upstreamUrl: "http://conc.example.com/mcp" },
     });
     const proxy = new McpProxy(configSource, {    });
+    seedRestSession(proxy, "conc-mcp");
     const app = proxy.getApp();
 
     let callCount = 0;
@@ -1047,7 +1071,7 @@ describe("executeToolDirect", () => {
     expect(requestHeaders[2]?.get("mcp-protocol-version")).toBe(MCP_PROTOCOL_VERSION);
   });
 
-  test("approved execution re-initializes and retries once when the cached session went stale mid-call", async () => {
+  test("approved execution does not replay after a post-dispatch JSON-RPC session error", async () => {
     const configSource = createConfigSource({
       "lobu-memory": {
         id: "lobu-memory",
@@ -1069,18 +1093,15 @@ describe("executeToolDirect", () => {
         return new Response(null, { status: 202 });
       }
       toolCalls++;
-      // The first session the upstream handed out is already gone by the time
-      // the tool call arrives — only the re-initialized session succeeds.
-      const sessionId = new Headers(init?.headers).get("mcp-session-id");
       return new Response(
         JSON.stringify(
-          sessionId === "session-2"
-            ? {
+          toolCalls === 1
+            ? { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "Session not found" } }
+            : {
                 jsonrpc: "2.0",
                 id: 1,
                 result: { content: [{ type: "text", text: "approved" }], isError: false },
-              }
-            : { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "Session not found" } },
+              },
         ),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
@@ -1099,7 +1120,24 @@ describe("executeToolDirect", () => {
       },
     );
 
-    expect(result).toEqual({
+    expect(result).toEqual({ content: [{ type: "text", text: "Session not found" }], isError: true });
+    expect(initCount).toBe(1);
+    expect(toolCalls).toBe(1);
+
+    const nextResult = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+      },
+    );
+
+    expect(nextResult).toEqual({
       content: [{ type: "text", text: "approved" }],
       isError: false,
     });
@@ -1107,7 +1145,7 @@ describe("executeToolDirect", () => {
     expect(toolCalls).toBe(2);
   });
 
-  test("approved execution re-initializes and retries once on an upstream 404 (unknown session)", async () => {
+  test("approved execution invalidates an upstream 404 session without replaying the call", async () => {
     const configSource = createConfigSource({
       "lobu-memory": {
         id: "lobu-memory",
@@ -1129,10 +1167,7 @@ describe("executeToolDirect", () => {
         return new Response(null, { status: 202 });
       }
       toolCalls++;
-      const sessionId = new Headers(init?.headers).get("mcp-session-id");
-      if (sessionId !== "session-2") {
-        return new Response("Session not found", { status: 404 });
-      }
+      if (toolCalls === 1) return new Response("Session not found", { status: 404 });
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -1156,7 +1191,24 @@ describe("executeToolDirect", () => {
       },
     );
 
-    expect(result).toEqual({
+    expect(result).toEqual({ content: [{ type: "text", text: "Tool call failed: 404 Session not found" }], isError: true });
+    expect(initCount).toBe(1);
+    expect(toolCalls).toBe(1);
+
+    const nextResult = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+      },
+    );
+
+    expect(nextResult).toEqual({
       content: [{ type: "text", text: "approved" }],
       isError: false,
     });

--- a/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
@@ -8,7 +8,12 @@ import {
 } from "bun:test";
 import { generateWorkerToken, MCP_PROTOCOL_VERSION } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import {
+  MCP_RESPONSE_BODY_LIMIT,
+  MCP_SSE_FRAME_LIMIT,
+} from "../../mcp-proxy/http-response.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
+import { McpUpstreamClient } from "../auth/mcp/proxy-upstream.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
 
@@ -470,62 +475,245 @@ describe("McpProxy", () => {
       const body = await res.json();
       expect(body.error).toContain("Failed to connect");
     });
+
+    test("cancels initialize body reads when the downstream request aborts", async () => {
+      const configSource = createMockConfigSource({
+        "test-mcp": TEST_SERVER,
+      });
+      const proxy = new McpProxy(configSource, {});
+      const app = proxy.getApp();
+      const downstream = new AbortController();
+      let resolveFetchStarted: (() => void) | undefined;
+      const fetchStarted = new Promise<void>((resolve) => {
+        resolveFetchStarted = resolve;
+      });
+      let upstreamSignal: AbortSignal | null = null;
+
+      globalThis.fetch = async (_input, init) => {
+        upstreamSignal = init?.signal ?? null;
+        resolveFetchStarted?.();
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              return new Promise(() => undefined);
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      };
+
+      const responsePromise = app.request(
+        new Request("http://localhost/test-mcp/tools", {
+          headers: { Authorization: `Bearer ${validToken}` },
+          signal: downstream.signal,
+        }),
+      );
+      await fetchStarted;
+      downstream.abort();
+
+      const response = await responsePromise;
+      expect(response.status).toBe(502);
+      expect(upstreamSignal?.aborted).toBe(true);
+      expect(upstreamSignal?.reason).toMatchObject({ kind: "caller_abort" });
+    });
+
+    test("cancels oversized upstream bodies and logs observed response bytes", async () => {
+      const outcomes: unknown[] = [];
+      const upstream = new McpUpstreamClient({
+        info: (outcome) => outcomes.push(outcome),
+      });
+      let cancelled = false;
+      let emitted = false;
+      globalThis.fetch = async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (!emitted) {
+                emitted = true;
+                controller.enqueue(new Uint8Array(MCP_RESPONSE_BODY_LIMIT + 1));
+              }
+              return new Promise(() => undefined);
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+
+      await expect(
+        orgContext.run({ organizationId: "test-org" }, () =>
+          upstream.sendUpstreamRequest(
+            {
+              id: "bounded-mcp",
+              upstreamUrl: "http://bounded.internal/mcp",
+              internal: true,
+            },
+            "agent1",
+            "bounded-mcp",
+            "POST",
+            JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          ),
+        ),
+      ).rejects.toMatchObject({
+        kind: "oversized_response",
+        bytes: MCP_RESPONSE_BODY_LIMIT + 1,
+      });
+
+      expect(cancelled).toBe(true);
+      expect(outcomes).toHaveLength(1);
+      expect(outcomes[0]).toMatchObject({
+        response_bytes: MCP_RESPONSE_BODY_LIMIT + 1,
+        response_limit: MCP_RESPONSE_BODY_LIMIT,
+        truncated: true,
+        aborted: false,
+        abort_reason: null,
+      });
+    });
+
+    test("rejects oversized POST SSE frames below the response body limit", async () => {
+      const outcomes: unknown[] = [];
+      const upstream = new McpUpstreamClient({
+        info: (outcome) => outcomes.push(outcome),
+      });
+      const body = `data: ${"x".repeat(MCP_SSE_FRAME_LIMIT)}\n\n`;
+      expect(new TextEncoder().encode(body).byteLength).toBeLessThan(
+        MCP_RESPONSE_BODY_LIMIT,
+      );
+      globalThis.fetch = async () =>
+        new Response(body, {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+
+      await expect(
+        orgContext.run({ organizationId: "test-org" }, () =>
+          upstream.sendUpstreamRequest(
+            {
+              id: "bounded-mcp",
+              upstreamUrl: "http://bounded.internal/mcp",
+              internal: true,
+            },
+            "agent1",
+            "bounded-mcp",
+            "POST",
+            JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          ),
+        ),
+      ).rejects.toMatchObject({
+        kind: "oversized_response",
+        limit: MCP_SSE_FRAME_LIMIT,
+      });
+
+      expect(outcomes).toHaveLength(1);
+      expect(outcomes[0]).toMatchObject({
+        response_bytes: MCP_SSE_FRAME_LIMIT + 1,
+        jsonrpc_status: "unknown",
+        truncated: true,
+      });
+    });
+
+    test("relays POST SSE before EOF and cancels it at the POST deadline", async () => {
+      const outcomes: unknown[] = [];
+      const upstream = new McpUpstreamClient(
+        {
+          info: (outcome) => outcomes.push(outcome),
+        },
+        100,
+      );
+      const frame = new TextEncoder().encode(
+        'data: {"jsonrpc":"2.0","id":1,"result":{}}\n\n',
+      );
+      let cancelled = false;
+      globalThis.fetch = async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(frame);
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+
+      const response = await orgContext.run(
+        { organizationId: "test-org" },
+        () =>
+          upstream.sendUpstreamRequest(
+            {
+              id: "streaming-mcp",
+              upstreamUrl: "http://streaming.internal/mcp",
+              internal: true,
+            },
+            "agent1",
+            "streaming-mcp",
+            "POST",
+            JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+          ),
+      );
+      const reader = response.body!.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+        new TextDecoder().decode(frame),
+      );
+      await expect(reader.read()).rejects.toMatchObject({ kind: "timeout" });
+
+      expect(cancelled).toBe(true);
+      expect(outcomes).toHaveLength(1);
+      expect(outcomes[0]).toMatchObject({
+        response_bytes: frame.byteLength,
+        jsonrpc_status: "unknown",
+        aborted: true,
+        abort_reason: "timeout",
+      });
+    });
   });
 
   // ---------- Session re-init ----------
 
   describe("session re-initialization", () => {
-    test("retries on 'Server not initialized' error", async () => {
+    test("does not replay after a post-dispatch JSON-RPC session error", async () => {
       const configSource = createMockConfigSource({
         "test-mcp": TEST_SERVER,
       });
       const proxy = new McpProxy(configSource, {      });
       const app = proxy.getApp();
 
-      let callCount = 0;
+      const methods: string[] = [];
       globalThis.fetch = async (_input, init) => {
-        callCount++;
         const request = init?.body ? JSON.parse(String(init.body)) : {};
-        // The first call is the tool call that triggers the error.
-        // After that, reinitializeSession sends initialize + notifications/initialized (2 calls).
-        // Then the retry tool call is the 4th call.
-        if (callCount === 1) {
-          return new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: 1,
-              error: { code: -32000, message: "Server not initialized" },
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
-        }
+        methods.push(request.method);
         if (request.method === "initialize") {
           return new Response(
             JSON.stringify({
               jsonrpc: "2.0",
               id: 0,
-              result: {
-                protocolVersion: MCP_PROTOCOL_VERSION,
-                capabilities: { tools: {} },
-              },
+              result: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} } },
             }),
             {
               status: 200,
-              headers: {
-                "Content-Type": "application/json",
-                "Mcp-Session-Id": "reinitialized-session" } }
+              headers: { "Content-Type": "application/json", "Mcp-Session-Id": "initial-session" },
+            },
           );
         }
-        // Re-init calls (initialize + notifications/initialized) and retry
+        if (request.method === "notifications/initialized") return new Response(null, { status: 202 });
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
             id: 1,
-            result: {
-              content: [{ type: "text", text: "Success after re-init" }],
-            },
+            error: { code: -32000, message: "Server not initialized" },
           }),
-          { status: 200, headers: { "Content-Type": "application/json" } }
+          { status: 200, headers: { "Content-Type": "application/json" } },
         );
       };
 
@@ -537,11 +725,14 @@ describe("McpProxy", () => {
         },
         body: JSON.stringify({}),
       });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(502);
       const body = await res.json();
-      expect(body.content[0].text).toBe("Success after re-init");
-      // At least 4 fetch calls: original + initialize + notify + retry
-      expect(callCount).toBeGreaterThanOrEqual(4);
+      expect(body.error).toContain("Server not initialized");
+      expect(methods).toEqual([
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+      ]);
     });
   });
 

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -7,18 +7,19 @@ import type { Context } from "hono";
 import type { McpProxy } from "./proxy.js";
 import {
 	buildSessionKey,
-	buildUpstreamHeaders,
 	computeScopeKey,
 	extractSessionToken,
 	getRequestBodyAsText,
 	type HttpMcpServerConfig,
-	MAX_BODY_SIZE,
 	runWithWorkerOrgContext,
 	sendJsonRpcError,
-	UPSTREAM_FETCH_TIMEOUT_MS,
-	upstreamTimeoutSignal,
 } from "./proxy-shared.js";
 import { ssrfBlockResponse } from "./proxy-upstream.js";
+import {
+	isReplaySafeMcpRequest,
+	McpTransportError,
+	utf8ByteLength,
+} from "../../../mcp-proxy/http-response.js";
 
 const logger = createLogger("mcp-proxy");
 
@@ -71,17 +72,28 @@ async function handleProxyRequestAuthenticated(
 		return sendJsonRpcError(c, -32601, `MCP server '${mcpId}' not found`);
 	}
 
+	let requestBodyText = "";
+	if (c.req.method === "POST") {
+		try {
+			requestBodyText = await getRequestBodyAsText(c);
+		} catch (error) {
+			if (error instanceof McpTransportError && error.kind === "oversized_request") {
+				return new Response("Request body too large", { status: 413 });
+			}
+			logger.warn("Failed to read MCP request body", { mcpId, error });
+			return sendJsonRpcError(c, -32700, "Failed to read request body");
+		}
+	}
+
 	// Pre-tool guardrails + tool approval for tools/call JSON-RPC requests.
-	// Clone the request so the body can be read twice (once here, once in
-	// forwardRequest). NOTE: this runs on any POST, NOT gated on grantStore —
+	// The bounded body is read once and shared with forwarding. NOTE: this runs
+	// on any POST, NOT gated on grantStore —
 	// guardrail enforcement must not depend on the approval subsystem being
 	// configured (the approval check below is what's gated on grantStore).
 	if (c.req.method === "POST") {
 		try {
-			const clonedReq = c.req.raw.clone();
-			const bodyText = await clonedReq.text();
-			if (bodyText) {
-				const jsonRpc = JSON.parse(bodyText);
+			if (requestBodyText) {
+				const jsonRpc = JSON.parse(requestBodyText);
 
 				// JSON-RPC 2.0 / the MCP streamable-HTTP transport permit BATCH
 				// requests: a top-level ARRAY of request objects. The single-request
@@ -166,7 +178,7 @@ async function handleProxyRequestAuthenticated(
 	const scopeKey = computeScopeKey(tokenData.userId);
 
 	try {
-		return await forwardRequest(proxy, c, httpServer, agentId, mcpId, scopeKey, {
+		return await forwardRequest(proxy, c, httpServer, agentId, mcpId, scopeKey, requestBodyText, {
 			workerToken: sessionToken,
 		});
 	} catch (error) {
@@ -186,6 +198,7 @@ async function forwardRequest(
 	agentId: string,
 	mcpId: string,
 	scopeKey?: string,
+	bodyText = "",
 	authContext?: {
 		workerToken?: string;
 	},
@@ -202,18 +215,6 @@ async function forwardRequest(
 	const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
 	let sessionId = proxy.upstream.getSession(sessionKey);
 
-	const bodyText = await getRequestBodyAsText(c);
-
-	// Body size validation
-	if (bodyText.length > MAX_BODY_SIZE) {
-		logger.warn("Request body too large", {
-			mcpId,
-			agentId,
-			size: bodyText.length,
-		});
-		return new Response("Request body too large", { status: 413 });
-	}
-
 	// Internal MCPs (lobu-memory) accept the worker JWT directly.
 	const credentialToken = httpServer.internal
 		? authContext?.workerToken
@@ -228,9 +229,11 @@ async function forwardRequest(
 				mcpId,
 				scopeKey,
 				credentialToken,
+				c.req.raw.signal,
 			);
 			sessionId = proxy.upstream.getSession(sessionKey);
 		} catch (error) {
+			if (c.req.raw.signal.aborted) throw error;
 			logger.warn("Pre-emptive MCP re-initialization failed", {
 				mcpId,
 				error: getErrorMessage(error),
@@ -243,32 +246,30 @@ async function forwardRequest(
 		agentId,
 		method: c.req.method,
 		hasSession: !!sessionId,
-		bodyLength: bodyText.length,
+		bodyLength: utf8ByteLength(bodyText),
 	});
 
-	const headers = buildUpstreamHeaders(
-		sessionId,
+	let response = await proxy.upstream.sendUpstreamRequest(
+		httpServer,
+		agentId,
+		mcpId,
+		c.req.method,
+		bodyText,
+		scopeKey,
 		credentialToken,
-		httpServer.internal === true,
-		proxy.upstream.getProtocolVersion(sessionKey),
+		undefined,
+		c.req.raw.signal,
+		true,
 	);
 
-	let response = await fetch(httpServer.upstreamUrl, {
-		method: c.req.method,
-		headers,
-		body: bodyText || undefined,
-		signal: upstreamTimeoutSignal(c.req.method),
-	});
-
-	// Stale-session recovery: if upstream returns 404 we sent a session id
-	// it no longer recognizes (e.g. server restart). Drop the cached id,
-	// re-init, and retry once with the same payload. Only meaningful for
-	// POST — GET/DELETE on an unknown session should surface the 404 as-is.
+	// Only protocol setup/catalog requests may be replayed after a 404. A
+	// tools/call or any unknown POST may already have executed upstream.
 	if (
 		response.status === 404 &&
 		sessionId &&
 		c.req.method === "POST" &&
-		bodyText
+		bodyText &&
+		isReplaySafeMcpRequest(bodyText)
 	) {
 		logger.info(
 			"Upstream 404 on cached session id — re-initializing and retrying",
@@ -281,22 +282,23 @@ async function forwardRequest(
 				mcpId,
 				scopeKey,
 				credentialToken,
+				c.req.raw.signal,
 			);
 			sessionId = proxy.upstream.getSession(sessionKey);
-			const retryHeaders = buildUpstreamHeaders(
-				sessionId,
+			response = await proxy.upstream.sendUpstreamRequest(
+				httpServer,
+				agentId,
+				mcpId,
+				c.req.method,
+				bodyText,
+				scopeKey,
 				credentialToken,
-				httpServer.internal === true,
-				proxy.upstream.getProtocolVersion(sessionKey),
+				undefined,
+				c.req.raw.signal,
+				true,
 			);
-			response = await fetch(httpServer.upstreamUrl, {
-				method: c.req.method,
-				headers: retryHeaders,
-				body: bodyText,
-				// Retry path is POST-only (guarded above) — always bounded.
-				signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
-			});
 		} catch (error) {
+			if (c.req.raw.signal.aborted) throw error;
 			logger.warn("Stale-session recovery failed on forward", {
 				mcpId,
 				error: getErrorMessage(error),
@@ -323,8 +325,5 @@ async function forwardRequest(
 		responseHeaders.set("Mcp-Session-Id", newSessionId);
 	}
 
-	return new Response(response.body, {
-		status: response.status,
-		headers: responseHeaders,
-	});
+	return new Response(response.body, { status: response.status, headers: responseHeaders });
 }

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -1,12 +1,16 @@
 import { createLogger } from "@lobu/core";
 import type { Context } from "hono";
-import { parseJsonRpcResponse } from "../../../mcp-proxy/http-response.js";
+import {
+	McpTransportError,
+	parseJsonRpcResponse,
+} from "../../../mcp-proxy/http-response.js";
 import type { McpProxy } from "./proxy.js";
 import {
 	authenticateRequest,
+	buildSessionKey,
 	computeScopeKey,
+	getRequestBodyAsText,
 	type JsonRpcResponse,
-	MAX_BODY_SIZE,
 	runWithWorkerOrgContext,
 } from "./proxy-shared.js";
 import { ssrfBlockResponse } from "./proxy-upstream.js";
@@ -59,7 +63,7 @@ async function handleListToolsAuthenticated(
 			agentId,
 			auth.tokenData,
 			httpServer.internal === true ? auth.token : undefined,
-			{ surfaceErrors: true },
+			{ surfaceErrors: true, callerSignal: c.req.raw.signal },
 		);
 		return c.json({ tools, instructions });
 	} catch (error) {
@@ -114,14 +118,14 @@ async function handleCallToolAuthenticated(
 	// Parse body early so tool arguments are available for the approval message.
 	let toolArguments: Record<string, unknown> = {};
 	try {
-		const body = await c.req.text();
+		const body = await getRequestBodyAsText(c);
 		if (body) {
-			if (body.length > MAX_BODY_SIZE) {
-				return c.json({ error: "Request body too large" }, 413);
-			}
 			toolArguments = JSON.parse(body);
 		}
-	} catch {
+	} catch (error) {
+		if (error instanceof McpTransportError && error.kind === "oversized_request") {
+			return c.json({ error: "Request body too large" }, 413);
+		}
 		return c.json({ error: "Invalid JSON body" }, 400);
 	}
 
@@ -181,6 +185,18 @@ async function handleCallToolAuthenticated(
 	}
 
 	try {
+		const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
+		if (!proxy.upstream.getSession(sessionKey)) {
+			await proxy.upstream.reinitializeSession(
+				httpServer,
+				agentId,
+				mcpId,
+				scopeKey,
+				auth.token,
+				c.req.raw.signal,
+			);
+		}
+
 		const jsonRpcBody = JSON.stringify({
 			jsonrpc: "2.0",
 			method: "tools/call",
@@ -207,48 +223,11 @@ async function handleCallToolAuthenticated(
 			scopeKey,
 			auth.token,
 			extraHeaders,
+			c.req.raw.signal,
+			false,
 		);
 
 		let data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;
-
-		// Re-initialize session and retry on stale-session errors.
-		//
-		// Primary signal: MCP streamable-HTTP transport mandates HTTP 404 when
-		// the `Mcp-Session-Id` header names a session the server no longer
-		// knows (e.g. upstream restarted while we held the id cached).
-		//
-		// Fallback signal: some MCP servers return 200 with a JSON-RPC error
-		// whose message is "Server not initialized" or "Session not found…".
-		// We match both wordings rather than chase specific upstream phrasing.
-		if (
-			response.status === 404 ||
-			(data?.error &&
-				/not initialized|session not found/i.test(data.error.message || ""))
-		) {
-			logger.info("MCP session expired, re-initializing before retry", {
-				mcpId,
-				toolName,
-			});
-			await proxy.upstream.reinitializeSession(
-				httpServer,
-				agentId,
-				mcpId,
-				scopeKey,
-				auth.token,
-			);
-
-			response = await proxy.upstream.sendUpstreamRequest(
-				httpServer,
-				agentId,
-				mcpId,
-				"POST",
-				jsonRpcBody,
-				scopeKey,
-				auth.token,
-				extraHeaders,
-			);
-			data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;
-		}
 
 		if (data?.error) {
 			const errorMsg =
@@ -323,6 +302,7 @@ async function handleListAllToolsAuthenticated(
 				agentId,
 				auth.tokenData,
 				auth.token,
+				{ callerSignal: c.req.raw.signal },
 			);
 			return { mcpId, tools };
 		}),

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -8,8 +8,12 @@ import type { Context } from "hono";
 import { getOrgId, orgContext } from "../../../lobu/stores/org-context.js";
 import { getRevokedTokenStore } from "../revoked-token-store.js";
 import type { McpTool } from "./tool-cache.js";
-
-export const MAX_BODY_SIZE = 1024 * 1024; // 1MB
+import {
+	MCP_REQUEST_BODY_LIMIT,
+	assertRequestBodySize,
+	createMcpAbortScope,
+	readBoundedBody,
+} from "../../../mcp-proxy/http-response.js";
 
 // Bound upstream MCP calls so a slow/hung third-party server can't pin a
 // worker turn (and the gateway request serving it) indefinitely. Applies to
@@ -19,12 +23,6 @@ export const MAX_BODY_SIZE = 1024 * 1024; // 1MB
 export const UPSTREAM_FETCH_TIMEOUT_MS = Number(
 	process.env.MCP_PROXY_FETCH_TIMEOUT_MS ?? 120_000,
 );
-
-export function upstreamTimeoutSignal(method: string): AbortSignal | undefined {
-	return method.toUpperCase() === "GET"
-		? undefined
-		: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS);
-}
 
 /** Standard MCP `initialize` request body. */
 export const INITIALIZE_BODY = JSON.stringify({
@@ -198,10 +196,23 @@ export async function getRequestBodyAsText(c: Context): Promise<string> {
 		return "";
 	}
 
+	// Hono may expose a framework-materialized body as a consumed/null stream;
+	// in that case the framework has already paid the buffering cost. We still
+	// enforce the UTF-8 byte cap before JSON parsing at every caller.
+	if (!c.req.raw.body) {
+		const text = await c.req.text();
+		assertRequestBodySize(text, MCP_REQUEST_BODY_LIMIT);
+		return text;
+	}
+	const abortScope = createMcpAbortScope({ callerSignal: c.req.raw.signal });
 	try {
-		return await c.req.text();
-	} catch {
-		return "";
+		const body = await readBoundedBody(c.req.raw.body, MCP_REQUEST_BODY_LIMIT, {
+			signal: abortScope.signal,
+			kind: "request",
+		});
+		return new TextDecoder().decode(body.bytes);
+	} finally {
+		abortScope.cleanup();
 	}
 }
 

--- a/packages/server/src/gateway/auth/mcp/proxy-upstream.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-upstream.ts
@@ -1,5 +1,20 @@
 import { createLogger, MCP_PROTOCOL_VERSION } from "@lobu/core";
-import { parseJsonRpcResponse } from "../../../mcp-proxy/http-response.js";
+import {
+	boundStreamingResponse,
+	createMcpAbortScope,
+	getMcpAbortReason,
+	logMcpTerminalOutcome,
+	MCP_REQUEST_BODY_LIMIT,
+	MCP_RESPONSE_BODY_LIMIT,
+	assertRequestBodySize,
+	isMcpToolCallRequest,
+	inspectMcpJsonRpcBody,
+	newMcpCallId,
+	normalizeMcpAbortError,
+	readResponseBody,
+	McpTransportError,
+	parseJsonRpcResponse,
+} from "../../../mcp-proxy/http-response.js";
 import { isInternalUrl } from "../../proxy/ssrf-guard.js";
 import {
 	buildSessionKey,
@@ -7,10 +22,14 @@ import {
 	type HttpMcpServerConfig,
 	INITIALIZE_BODY,
 	INITIALIZED_NOTIFICATION_BODY,
-	upstreamTimeoutSignal,
+	UPSTREAM_FETCH_TIMEOUT_MS,
 } from "./proxy-shared.js";
 
 const logger = createLogger("mcp-proxy");
+
+type McpTerminalLogger = {
+	info: (message: unknown, ...args: unknown[]) => void;
+};
 
 /**
  * SSRF guard: if the upstream URL resolves to an internal/reserved network
@@ -49,6 +68,11 @@ export async function ssrfBlockResponse(
  * non-streamed JSON-RPC egress to MCP upstreams.
  */
 export class McpUpstreamClient {
+	constructor(
+		private readonly terminalLogger: McpTerminalLogger = logger,
+		private readonly requestTimeoutMs = UPSTREAM_FETCH_TIMEOUT_MS,
+	) {}
+
 	private readonly SESSION_TTL_SECONDS = 30 * 60; // 30 minutes
 	/**
 	 * Per-process MCP upstream session-id cache. The session id is opaque to
@@ -92,9 +116,11 @@ export class McpUpstreamClient {
 	}
 
 	/**
-	 * Single egress point for non-streamed JSON-RPC calls to an MCP upstream.
+	 * Single egress point for JSON-RPC calls to an MCP upstream.
 	 * The internal lobu-memory server accepts the worker JWT directly; runs the
-	 * SSRF guard and tracks the upstream session id.
+	 * SSRF guard and tracks the upstream session id. Successful SSE responses
+	 * stream by default; finite REST/tool callers opt into bounded buffering
+	 * under the POST deadline.
 	 */
 	async sendUpstreamRequest(
 		httpServer: HttpMcpServerConfig,
@@ -105,6 +131,8 @@ export class McpUpstreamClient {
 		scopeKey?: string,
 		directAuthToken?: string,
 		extraHeaders?: Record<string, string>,
+		callerSignal?: AbortSignal,
+		streamResponse = true,
 	): Promise<Response> {
 		const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
 		const sessionId = this.getSession(sessionKey);
@@ -129,12 +157,66 @@ export class McpUpstreamClient {
 			}
 		}
 
-		const response = await fetch(httpServer.upstreamUrl, {
-			method,
-			headers,
-			body: body || undefined,
-			signal: upstreamTimeoutSignal(method),
+		const callId = newMcpCallId();
+		const requestBytes = body ? new TextEncoder().encode(body).byteLength : 0;
+		const startedAt = Date.now();
+		const abortScope = createMcpAbortScope({
+			timeoutMs: method.toUpperCase() === "GET" ? undefined : this.requestTimeoutMs,
+			callerSignal,
 		});
+		const finish = (
+			status: number | null,
+			responseBytes: number,
+			preview?: string,
+			error?: unknown,
+			jsonRpcStatus: "success" | "error" | "unknown" = "unknown",
+		) => {
+			const transportError =
+				error instanceof McpTransportError
+					? error
+					: abortScope.signal.reason instanceof McpTransportError
+						? abortScope.signal.reason
+						: undefined;
+			const abortReason = getMcpAbortReason(transportError, abortScope.signal);
+			logMcpTerminalOutcome(this.terminalLogger, {
+				call_id: callId,
+				request_bytes: requestBytes,
+				response_bytes: responseBytes,
+				request_limit: MCP_REQUEST_BODY_LIMIT,
+				response_limit: MCP_RESPONSE_BODY_LIMIT,
+				duration_ms: Date.now() - startedAt,
+				http_status: status,
+				jsonrpc_status: jsonRpcStatus,
+				truncated: transportError?.kind === "oversized_response" || transportError?.kind === "oversized_request",
+				aborted: abortReason !== null,
+				abort_reason: abortReason,
+				retryable: false,
+				ambiguous_execution: body ? isMcpToolCallRequest(body) : false,
+				...(preview && (error || status === null || status >= 400) ? { diagnostic_preview: preview } : {}),
+			});
+		};
+
+		let response: Response;
+		try {
+			if (body) assertRequestBodySize(body);
+			response = await fetch(httpServer.upstreamUrl, {
+				method,
+				headers,
+				body: body || undefined,
+				signal: abortScope.signal,
+			});
+		} catch (error) {
+			const normalized = normalizeMcpAbortError(error, abortScope.signal);
+			abortScope.cleanup();
+			finish(null, 0, undefined, normalized);
+			throw normalized;
+		}
+
+		// An unknown-session response makes the cached handle unusable for future
+		// calls. Invalidate it without replaying the request that received the 404.
+		if (response.status === 404 && sessionId) {
+			this.deleteSession(sessionKey);
+		}
 
 		// Track session
 		const newSessionId = response.headers.get("Mcp-Session-Id");
@@ -142,7 +224,53 @@ export class McpUpstreamClient {
 			this.setSession(sessionKey, newSessionId);
 		}
 
-		return response;
+		const isSse = (response.headers.get("content-type") ?? "")
+			.toLowerCase()
+			.includes("text/event-stream");
+		if (method.toUpperCase() === "GET" || (streamResponse && response.ok && isSse)) {
+			// POST SSE is relayed immediately, but the POST/tool-call deadline stays
+			// active through body consumption. GET streams have no deadline.
+			return boundStreamingResponse(response, {
+				signal: abortScope.signal,
+				cleanup: (error, bytes) => {
+					abortScope.cleanup();
+					finish(response.status, bytes ?? 0, undefined, error);
+				},
+				onCancel: () => abortScope.abort("caller_abort"),
+			});
+		}
+		try {
+			const responseHadBody = response.body !== null;
+			const bounded = await readResponseBody(response, { signal: abortScope.signal });
+			const inspection = inspectMcpJsonRpcBody(
+				bounded.bytes,
+				response.headers.get("content-type"),
+			);
+			if (inspection.sessionError) this.deleteSession(sessionKey);
+			finish(
+				response.status,
+				bounded.byteLength,
+				bounded.preview,
+				undefined,
+				inspection.status,
+			);
+			return new Response(responseHadBody ? bounded.bytes : null, {
+				status: response.status,
+				statusText: response.statusText,
+				headers: response.headers,
+			});
+		} catch (error) {
+			const transportError = error instanceof McpTransportError ? error : undefined;
+			finish(
+				response.status,
+				transportError?.bytes ?? 0,
+				transportError?.preview,
+				error,
+			);
+			throw error;
+		} finally {
+			abortScope.cleanup();
+		}
 	}
 
 	/** Send the MCP `initialize` request to an upstream and return the raw response. */
@@ -152,6 +280,7 @@ export class McpUpstreamClient {
 		mcpId: string,
 		scopeKey?: string,
 		directAuthToken?: string,
+		callerSignal?: AbortSignal,
 	): Promise<Response> {
 		const response = await this.sendUpstreamRequest(
 			httpServer,
@@ -161,6 +290,9 @@ export class McpUpstreamClient {
 			INITIALIZE_BODY,
 			scopeKey,
 			directAuthToken,
+			undefined,
+			callerSignal,
+			false,
 		);
 		// Discovery deliberately treats an authentication challenge as an empty
 		// unauthenticated catalog. Preserve the raw response so the caller can
@@ -192,18 +324,25 @@ export class McpUpstreamClient {
 		mcpId: string,
 		scopeKey?: string,
 		directAuthToken?: string,
+		callerSignal?: AbortSignal,
 	): Promise<void> {
-		await this.sendUpstreamRequest(
-			httpServer,
-			agentId,
-			mcpId,
-			"POST",
-			INITIALIZED_NOTIFICATION_BODY,
-			scopeKey,
-			directAuthToken,
-		).catch(() => {
-			/* noop */
-		});
+		try {
+			await this.sendUpstreamRequest(
+				httpServer,
+				agentId,
+				mcpId,
+				"POST",
+				INITIALIZED_NOTIFICATION_BODY,
+				scopeKey,
+				directAuthToken,
+				undefined,
+				callerSignal,
+				false,
+			);
+		} catch (error) {
+			if (callerSignal?.aborted) throw error;
+			// Notification delivery is best-effort.
+		}
 	}
 
 	/**
@@ -216,6 +355,7 @@ export class McpUpstreamClient {
 		mcpId: string,
 		scopeKey?: string,
 		directAuthToken?: string,
+		callerSignal?: AbortSignal,
 	): Promise<void> {
 		// Clear stale session
 		this.deleteSession(buildSessionKey(agentId, mcpId, scopeKey));
@@ -226,6 +366,7 @@ export class McpUpstreamClient {
 			mcpId,
 			scopeKey,
 			directAuthToken,
+			callerSignal,
 		);
 		await initResponse.text(); // consume response (may be JSON or SSE-framed)
 
@@ -235,6 +376,7 @@ export class McpUpstreamClient {
 			mcpId,
 			scopeKey,
 			directAuthToken,
+			callerSignal,
 		);
 
 		logger.info("Re-initialized MCP session", { mcpId, agentId });

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -41,6 +41,21 @@ import type { CachedMcpServer, McpTool, McpToolCache } from "./tool-cache.js";
 
 const logger = createLogger("mcp-proxy");
 
+async function waitForMcpRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) throw signal.reason ?? new Error("MCP request caller_abort");
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, delayMs);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal?.reason ?? new Error("MCP request caller_abort"));
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
 export type DirectToolExecutionOptions = {
 	organizationId: string;
 	conversationId?: string;
@@ -221,21 +236,11 @@ export class McpProxy {
 					jsonRpcBody,
 					scopeKey,
 					directAuthToken,
+					undefined,
+					undefined,
+					false,
 				);
 			let response = await sendToolCall();
-			if (response.status === 404) {
-				await response.body?.cancel().catch(() => {
-					/* noop */
-				});
-				await this.upstream.reinitializeSession(
-					httpServer,
-					agentId,
-					mcpId,
-					scopeKey,
-					directAuthToken,
-				);
-				response = await sendToolCall();
-			}
 
 			if (!response.ok) {
 				const text = await response.text();
@@ -259,24 +264,6 @@ export class McpProxy {
 				isError?: boolean;
 				error?: { code?: number; message?: string };
 			};
-			if (json.error && /not initialized|session not found/i.test(json.error.message ?? "")) {
-				await this.upstream.reinitializeSession(
-					httpServer,
-					agentId,
-					mcpId,
-					scopeKey,
-					directAuthToken,
-				);
-				response = await sendToolCall();
-				if (!response.ok) {
-					const text = await response.text();
-					return {
-						content: [{ type: "text", text: `Tool call failed: ${response.status} ${text}` }],
-						isError: true,
-					};
-				}
-				json = (await parseJsonRpcResponse(response)) as typeof json;
-			}
 			if (json.error) {
 				return {
 					content: [{ type: "text", text: json.error.message ?? JSON.stringify(json.error) }],
@@ -321,7 +308,7 @@ export class McpProxy {
 		agentId: string,
 		tokenData: WorkerTokenData,
 		workerToken?: string,
-		options?: { surfaceErrors?: boolean },
+		options?: { surfaceErrors?: boolean; callerSignal?: AbortSignal },
 	): Promise<{ tools: McpTool[]; instructions?: string }> {
 		return runWithOrganizationContext(tokenData.organizationId, () =>
 			this.fetchToolsForMcpScoped(
@@ -339,7 +326,7 @@ export class McpProxy {
 		agentId: string,
 		tokenData: WorkerTokenData,
 		workerToken?: string,
-		options?: { surfaceErrors?: boolean },
+		options?: { surfaceErrors?: boolean; callerSignal?: AbortSignal },
 	): Promise<{ tools: McpTool[]; instructions?: string }> {
 		if (this.toolCache) {
 			const cached = this.toolCache.getServerInfo(mcpId, agentId);
@@ -367,6 +354,7 @@ export class McpProxy {
 				mcpId,
 				scopeKey,
 				workerToken,
+				options?.callerSignal,
 			);
 			if (initResponse.status === 401) {
 				await initResponse.body?.cancel().catch(() => {
@@ -397,6 +385,7 @@ export class McpProxy {
 				mcpId,
 				scopeKey,
 				workerToken,
+				options?.callerSignal,
 			);
 
 			// A server that did not advertise the tools capability is valid and
@@ -419,6 +408,9 @@ export class McpProxy {
 				}),
 				scopeKey,
 				workerToken,
+				undefined,
+				options?.callerSignal,
+				false,
 			);
 			if (response.status === 401) {
 				await response.body?.cancel().catch(() => {
@@ -447,13 +439,14 @@ export class McpProxy {
 			cacheServerInfo(serverInfo);
 			return serverInfo;
 		} catch (error) {
+			if (options?.callerSignal?.aborted) throw error;
 			logger.warn("MCP discovery failed, retrying once", {
 				mcpId,
 				error: getErrorMessage(error),
 			});
 
 			// Retry once after a short delay (upstream may still be starting)
-			await new Promise((r) => setTimeout(r, 2000));
+			await waitForMcpRetry(2000, options?.callerSignal);
 			try {
 				const serverInfo = await discoverOnce();
 				cacheServerInfo(serverInfo);

--- a/packages/server/src/mcp-proxy/__tests__/http-response.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/http-response.test.ts
@@ -1,0 +1,297 @@
+import { expect, test } from "vitest";
+import {
+	assertRequestBodySize,
+	boundStreamingResponse,
+	createMcpAbortScope,
+	getMcpAbortReason,
+	inspectMcpJsonRpcBody,
+	logMcpTerminalOutcome,
+	MCP_REQUEST_BODY_LIMIT,
+	MCP_SSE_FRAME_LIMIT,
+	McpTransportError,
+	isMcpToolCallRequest,
+	normalizeMcpAbortError,
+	parseJsonRpcResponse,
+	readBoundedBody,
+	readResponseBody,
+	utf8ByteLength,
+} from "../http-response";
+
+function streamFrom(chunks: Uint8Array[], waitMs = 0): ReadableStream<Uint8Array> {
+	let index = 0;
+	return new ReadableStream({
+		async pull(controller) {
+			if (waitMs) await new Promise((resolve) => setTimeout(resolve, waitMs));
+			const chunk = chunks[index++];
+			if (chunk) controller.enqueue(chunk);
+			else controller.close();
+		},
+	});
+}
+
+test("counts request bytes, not UTF-16 characters", () => {
+	const value = "🙂".repeat(Math.floor(MCP_REQUEST_BODY_LIMIT / 4) + 1);
+	expect(utf8ByteLength(value)).toBeGreaterThan(MCP_REQUEST_BODY_LIMIT);
+	expect(() => assertRequestBodySize(value)).toThrow(McpTransportError);
+	const short = "🙂".repeat(10);
+	expect(() => assertRequestBodySize(short)).not.toThrow();
+});
+
+test("cancels a slow body after the deadline, including after headers", async () => {
+	const scope = createMcpAbortScope({ timeoutMs: 15 });
+	await expect(
+		readBoundedBody(streamFrom([new TextEncoder().encode("{"), new TextEncoder().encode("}")], 100), 100, {
+			signal: scope.signal,
+			kind: "response",
+		}),
+	).rejects.toMatchObject({ kind: "timeout" });
+	scope.cleanup();
+});
+
+test("does not parse an oversized or malformed JSON response", async () => {
+	const oversized = new Response(streamFrom([new TextEncoder().encode("{" + "x".repeat(100) + "}")]), {
+		headers: { "content-type": "application/json" },
+	});
+	await expect(parseJsonRpcResponse(oversized, undefined, { limit: 10 })).rejects.toMatchObject({
+		kind: "oversized_response",
+	});
+
+	const malformed = new Response("{\"jsonrpc\":", { headers: { "content-type": "application/json" } });
+	await expect(parseJsonRpcResponse(malformed)).rejects.toMatchObject({ kind: "malformed_json" });
+});
+
+test("bounds SSE frames and cancels the upstream stream on downstream disconnect", async () => {
+	const tooLarge = new Response(streamFrom([new TextEncoder().encode(`data: ${"x".repeat(MCP_SSE_FRAME_LIMIT)}\n\n`)]), {
+		headers: { "content-type": "text/event-stream" },
+	});
+	const bounded = boundStreamingResponse(tooLarge, { frameLimit: MCP_SSE_FRAME_LIMIT });
+	await expect(bounded.body?.getReader().read()).rejects.toMatchObject({ kind: "oversized_response" });
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(tooLarge.body?.locked).toBe(false);
+
+	let cancelled = false;
+	const scope = createMcpAbortScope({});
+	const upstream = new ReadableStream<Uint8Array>({
+		pull() {
+			return new Promise(() => undefined);
+		},
+		cancel() {
+			cancelled = true;
+		},
+	});
+	const response = boundStreamingResponse(new Response(upstream), {
+		signal: scope.signal,
+		onCancel: () => scope.abort("caller_abort"),
+	});
+	await response.body?.cancel("caller disconnected");
+	expect(cancelled).toBe(true);
+	expect(upstream.locked).toBe(false);
+	expect(scope.signal.aborted).toBe(true);
+	expect(scope.signal.reason).toMatchObject({ kind: "caller_abort" });
+	scope.cleanup();
+});
+
+test("resets CRLF-delimited SSE frames and applies downstream backpressure", async () => {
+	const crlfFrames = new Response(streamFrom([
+		new TextEncoder().encode("data: first\r\n\r\ndata: second\r\n\r\n"),
+	]));
+	const boundedFrames = boundStreamingResponse(crlfFrames, { frameLimit: 16 });
+	expect(new TextDecoder().decode(await boundedFrames.arrayBuffer())).toBe(
+		"data: first\r\n\r\ndata: second\r\n\r\n",
+	);
+	const crOnlyFrames = boundStreamingResponse(new Response(streamFrom([
+		new TextEncoder().encode("data: first\r\rdata: second\r\r"),
+	])), { frameLimit: 14 });
+	expect(new TextDecoder().decode(await crOnlyFrames.arrayBuffer())).toBe(
+		"data: first\r\rdata: second\r\r",
+	);
+
+	let pulls = 0;
+	const upstream = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			pulls++;
+			if (pulls <= 5) controller.enqueue(new TextEncoder().encode(`data: ${pulls}\n\n`));
+			else controller.close();
+		},
+	});
+	const response = boundStreamingResponse(new Response(upstream));
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	expect(pulls).toBeLessThan(5);
+	await response.body?.cancel();
+});
+
+test("settles an empty streaming response", () => {
+	let cleanups = 0;
+	boundStreamingResponse(new Response(null, { status: 204 }), {
+		cleanup: () => cleanups++,
+	});
+	expect(cleanups).toBe(1);
+});
+
+test("distinguishes caller, timeout, and upstream aborts", async () => {
+	for (const [field, expected] of [
+		["callerSignal", "caller_abort"],
+		["upstreamSignal", "upstream_abort"],
+	] as const) {
+		const controller = new AbortController();
+		const scope = createMcpAbortScope({ [field]: controller.signal });
+		controller.abort();
+		await expect(readBoundedBody(streamFrom([], 50), 100, { signal: scope.signal, kind: "response" })).rejects.toMatchObject({ kind: expected });
+		scope.cleanup();
+	}
+	const timeout = createMcpAbortScope({ timeoutMs: 1 });
+	await expect(readBoundedBody(streamFrom([], 20), 100, { signal: timeout.signal, kind: "response" })).rejects.toMatchObject({ kind: "timeout" });
+	timeout.cleanup();
+
+	const failedUpstream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.error(new Error("upstream closed"));
+		},
+	});
+	await expect(readBoundedBody(failedUpstream, 100, { kind: "response" })).rejects.toMatchObject({
+		kind: "upstream_abort",
+	});
+
+	const unscopedAbort = normalizeMcpAbortError(
+		new DOMException("upstream closed", "AbortError"),
+		new AbortController().signal,
+	);
+	expect(unscopedAbort).toMatchObject({ kind: "upstream_abort" });
+	expect(getMcpAbortReason(unscopedAbort)).toBe("upstream_abort");
+	expect(getMcpAbortReason(new Error("ordinary failure"))).toBeNull();
+});
+
+test("classifies tool-call telemetry from parsed JSON, never a substring", () => {
+	expect(isMcpToolCallRequest('{"jsonrpc":"2.0","method":"tools/call"}')).toBe(true);
+	expect(isMcpToolCallRequest('{"method":"tools/call"}')).toBe(false);
+	expect(isMcpToolCallRequest('{"jsonrpc":"2.0","result":{"text":"tools/call error"}}')).toBe(false);
+	expect(isMcpToolCallRequest('{"jsonrpc":')).toBe(false);
+});
+
+test("derives JSON-RPC status only from a complete parsed body", () => {
+	const encode = (value: string) => new TextEncoder().encode(value);
+	expect(
+		inspectMcpJsonRpcBody(
+			encode('{"jsonrpc":"2.0","id":1,"result":{"text":"an error occurred"}}'),
+			"application/json",
+		),
+	).toEqual({ status: "success", sessionError: false });
+	expect(
+		inspectMcpJsonRpcBody(
+			encode('{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Session not found"}}'),
+			"application/json",
+		),
+	).toEqual({ status: "error", sessionError: true });
+	expect(
+		inspectMcpJsonRpcBody(
+			encode('data: {"jsonrpc":"2.0","id":1,"result":{}}\r\r'),
+			"text/event-stream",
+		),
+	).toEqual({ status: "success", sessionError: false });
+	expect(inspectMcpJsonRpcBody(encode('{"jsonrpc":'), "application/json")).toEqual({
+		status: "unknown",
+		sessionError: false,
+	});
+	expect(inspectMcpJsonRpcBody(encode('{"error":"invalid_token"}'), "application/json")).toEqual({
+		status: "unknown",
+		sessionError: false,
+	});
+	let oversizedFrameError: unknown;
+	try {
+		inspectMcpJsonRpcBody(
+			encode(`data: ${"x".repeat(MCP_SSE_FRAME_LIMIT)}\n\n`),
+			"text/event-stream",
+		);
+	} catch (error) {
+		oversizedFrameError = error;
+	}
+	expect(oversizedFrameError).toMatchObject({
+		kind: "oversized_response",
+		limit: MCP_SSE_FRAME_LIMIT,
+	});
+});
+
+test("terminal outcome logging is structured and previews redact secrets", () => {
+	const calls: unknown[][] = [];
+	logMcpTerminalOutcome({ info: (...args) => calls.push(args) }, {
+		call_id: "call-1",
+		request_bytes: 12,
+		response_bytes: 20,
+		request_limit: MCP_REQUEST_BODY_LIMIT,
+		response_limit: 100,
+		duration_ms: 3,
+		http_status: 200,
+		jsonrpc_status: "success",
+		truncated: false,
+		aborted: false,
+		abort_reason: null,
+		retryable: false,
+		ambiguous_execution: false,
+		diagnostic_preview: "cookie=secret-cookie password=secret-password Bearer secret-token",
+	});
+	expect(calls[0]?.[0]).toMatchObject({ call_id: "call-1", response_limit: 100 });
+	expect(calls[0]?.[0]).toMatchObject({ diagnostic_preview: "[REDACTED]" });
+	for (const secret of ["secret-cookie", "secret-password", "secret-token"]) {
+		expect(JSON.stringify(calls[0])).not.toContain(secret);
+	}
+});
+
+test("diagnostic previews redact form, query, cookie, password, secret, and token values", async () => {
+	const body = new TextEncoder().encode(
+		"form=FORM-VALUE&query=QUERY-VALUE&cookie=COOKIE-VALUE password=PASSWORD-VALUE secret=SECRET-VALUE access_token=ACCESS-TOKEN refreshToken=REFRESH-TOKEN",
+	);
+	const bounded = await readBoundedBody(new ReadableStream({
+		start(controller) {
+			controller.enqueue(body);
+			controller.close();
+		},
+	}), 4096, { kind: "response" });
+	expect(bounded.preview).toContain("form=[REDACTED]");
+	expect(bounded.preview).toContain("query=[REDACTED]");
+	expect(bounded.preview).toContain("cookie=[REDACTED]");
+	expect(bounded.preview).toContain("password=[REDACTED]");
+	expect(bounded.preview).toContain("secret=[REDACTED]");
+	expect(bounded.preview).toContain("access_token=[REDACTED]");
+	expect(bounded.preview).toContain("refreshToken=[REDACTED]");
+	for (const value of ["FORM-VALUE", "QUERY-VALUE", "COOKIE-VALUE", "PASSWORD-VALUE", "SECRET-VALUE", "ACCESS-TOKEN", "REFRESH-TOKEN"]) {
+		expect(bounded.preview).not.toContain(value);
+	}
+
+	const headers = await readBoundedBody(new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(
+				"Authorization: Basic AUTH-VALUE\nSet-Cookie: session=COOKIE-HEADER-VALUE",
+			));
+			controller.close();
+		},
+	}), 4096, { kind: "response" });
+	expect(headers.preview).toBe(
+		"Authorization: [REDACTED]\nCookie: [REDACTED]",
+	);
+	expect(headers.preview).not.toContain("AUTH-VALUE");
+	expect(headers.preview).not.toContain("COOKIE-HEADER-VALUE");
+
+	try {
+		assertRequestBodySize(`token=REQUEST-TOKEN ${"x".repeat(MCP_REQUEST_BODY_LIMIT)}`);
+		throw new Error("expected oversized request");
+	} catch (error) {
+		expect(error).toBeInstanceOf(McpTransportError);
+		expect((error as McpTransportError).preview).not.toContain("REQUEST-TOKEN");
+	}
+});
+
+test("preserves public ID mismatch and empty SSE errors", async () => {
+	const mismatch = new Response(JSON.stringify({ jsonrpc: "2.0", id: 8, result: {} }), {
+		headers: { "content-type": "application/json" },
+	});
+	await expect(parseJsonRpcResponse(mismatch, 7)).rejects.toEqual(
+		new Error("MCP response omitted JSON-RPC id 7"),
+	);
+
+	const emptySse = new Response("event: message\n\n", {
+		headers: { "content-type": "text/event-stream" },
+	});
+	await expect(parseJsonRpcResponse(emptySse)).rejects.toEqual(
+		new Error("SSE response contained no data payload"),
+	);
+});

--- a/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
@@ -18,6 +18,7 @@ import {
   probeMcpServer,
   registerMcpOAuthClient,
 } from '../client';
+import { MCP_REQUEST_BODY_LIMIT } from '../http-response';
 
 const jsonResponse = (body: unknown, sessionId?: string) =>
   new Response(JSON.stringify(body), {
@@ -337,6 +338,19 @@ describe('MCP OAuth dynamic client registration', () => {
     ).rejects.toThrow(/HTTPS or HTTP on a loopback host/);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  it('rejects an oversized generated DCR body before fetch', async () => {
+    globalThis.fetch = vi.fn();
+
+    await expect(
+      registerMcpOAuthClient({
+        metadata,
+        redirectUris: ['https://lobu.example.com/connect/oauth/callback'],
+        clientName: 'x'.repeat(MCP_REQUEST_BODY_LIMIT),
+      }),
+    ).rejects.toMatchObject({ kind: 'oversized_request' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
 });
 
 describe('discoverTools capability discovery', () => {
@@ -465,7 +479,7 @@ describe('callTool session recovery', () => {
       sessionId
     );
 
-  it('rehandshakes when the upstream rejects a cached session id', async () => {
+  it('does not replay a tools/call when the upstream rejects a cached session id', async () => {
     const { connectionId, organizationId } = await createMcpTestConnection('recovery-connector');
     const sent: Array<{ method: unknown; sessionId: string | null }> = [];
     const expired = new Set<string>();
@@ -479,7 +493,8 @@ describe('callTool session recovery', () => {
         return initializeResponse(`session-live-${issued}`);
       }
       // MCP Streamable HTTP requires a 404 for a session id the upstream no
-      // longer knows. The tool never ran, so a replay cannot double-execute.
+      // longer knows. The gateway cannot prove the tool did not execute across
+      // that transport boundary, so replay is forbidden.
       if (sessionId && expired.has(sessionId)) {
         return new Response('Session not found', { status: 404 });
       }
@@ -506,19 +521,16 @@ describe('callTool session recovery', () => {
     );
     expect(first.isError).toBe(false);
 
-    // Second call reuses the now-stale cached session and must recover.
-    const second = await callTool(
+    await expect(callTool(
       'recovery-connector',
       config,
       organizationId,
       'do_thing',
       {},
       connectionId
-    );
-    expect(second.content).toEqual([{ type: 'text', text: 'ok' }]);
-    expect(sent.filter((entry) => entry.method === 'initialize')).toHaveLength(2);
-    // One rejected attempt, then exactly one replay — never a blind retry loop.
-    expect(sent.filter((entry) => entry.method === 'tools/call')).toHaveLength(3);
+    )).rejects.toThrow(/Upstream MCP returned 404/);
+    expect(sent.filter((entry) => entry.method === 'initialize')).toHaveLength(1);
+    expect(sent.filter((entry) => entry.method === 'tools/call')).toHaveLength(2);
   });
 
   it('never replays a tools/call after an ambiguous transport failure', async () => {
@@ -540,6 +552,61 @@ describe('callTool session recovery', () => {
       callTool('ambiguous-connector', config, organizationId, 'charge_card', {}, connectionId)
     ).rejects.toThrow(/Upstream MCP returned 504/);
     expect(toolCalls).toBe(1);
+  });
+
+  it('invalidates a JSON-RPC session error without replaying the tool call', async () => {
+    const { connectionId, organizationId } = await createMcpTestConnection('json-session-connector');
+    let initializations = 0;
+    let toolCalls = 0;
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (body.method === 'initialize') {
+        initializations += 1;
+        return initializeResponse(`session-json-${initializations}`);
+      }
+      if (body.method === 'tools/call') {
+        toolCalls += 1;
+        return toolCalls === 1
+          ? jsonResponse({
+              jsonrpc: '2.0',
+              id: 1,
+              error: { code: -32000, message: 'Session not found' },
+            })
+          : jsonResponse({
+              jsonrpc: '2.0',
+              id: 1,
+              result: { content: [{ type: 'text', text: 'ok' }], isError: false },
+            });
+      }
+      return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
+    }) as typeof fetch;
+
+    const first = await callTool(
+      'json-session-connector',
+      config,
+      organizationId,
+      'do_thing',
+      {},
+      connectionId
+    );
+    expect(first).toEqual({
+      content: [{ type: 'text', text: 'Session not found' }],
+      isError: true,
+    });
+    expect(initializations).toBe(1);
+    expect(toolCalls).toBe(1);
+
+    const second = await callTool(
+      'json-session-connector',
+      config,
+      organizationId,
+      'do_thing',
+      {},
+      connectionId
+    );
+    expect(second).toEqual({ content: [{ type: 'text', text: 'ok' }], isError: false });
+    expect(initializations).toBe(2);
+    expect(toolCalls).toBe(2);
   });
 });
 
@@ -670,8 +737,8 @@ describe('MCP refresh-on-401 (dead access token)', () => {
         });
       }
       if (href === config.upstream_url) {
-        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
         const headers = new Headers(init?.headers);
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
         if (body.method === 'initialize') {
           return initializeResponse('session-refresh');
         }
@@ -897,13 +964,11 @@ describe('MCP refresh-on-401 (dead access token)', () => {
     ).rejects.toThrow(/Upstream MCP returned 401/);
   });
 
-  it('refreshes once when the session expires AND the token is revoked during recovery', async () => {
+  it('does not refresh or replay when a tools/call gets an ambiguous 404', async () => {
     const { connectionId, organizationId } = await seedOAuthMcpConnection();
 
-    // Session is established with the stale token; the first tools/call gets a
-    // 404 (session expired), and the reinitialize is rejected with a 401
-    // (token also revoked). The recovery path must route that 401 through the
-    // refresh and succeed — previously it surfaced the 401 with no refresh.
+    // The first tools/call gets a 404. No recovery initialize or credential
+    // refresh is allowed after that side-effecting request boundary.
     const initializeResponse = (sessionId: string) =>
       jsonResponse(
         {
@@ -932,49 +997,29 @@ describe('MCP refresh-on-401 (dead access token)', () => {
       }
       if (href === config.upstream_url) {
         const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
-        const headers = new Headers(init?.headers);
         if (body.method === 'initialize') {
           initializeHits += 1;
-          // Initial initialize succeeds with the stale token (session cached);
-          // only the recovery reinitialize is rejected with a 401, and only
-          // while it still carries the stale token.
-          if (initializeHits > 1 && headers.get('authorization') === 'Bearer stale-access-token') {
-            return new Response(JSON.stringify({ error: 'invalid_token' }), { status: 401 });
-          }
           return initializeResponse(`session-${initializeHits}`);
         }
         if (body.method === 'tools/call') {
           toolCalls += 1;
-          if (headers.get('authorization') === 'Bearer stale-access-token') {
-            // First call: session expired (404) — call never ran.
-            return new Response('Session not found', { status: 404 });
-          }
-          return jsonResponse({
-            jsonrpc: '2.0',
-            id: 1,
-            result: { content: [{ type: 'text', text: 'ok' }], isError: false },
-          });
+          return new Response('Session not found', { status: 404 });
         }
         return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
       }
       throw new Error(`Unexpected fetch: ${href}`);
     }) as typeof fetch;
 
-    const result = await callTool(
+    await expect(callTool(
       'mcp.refresh-demo',
       config,
       organizationId,
       'do_thing',
       {},
       connectionId
-    );
-
-    expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
-    expect(result.isError).toBe(false);
-    expect(refreshHits).toBe(1);
-    // initialize: 1 (initial) + 1 (session recovery) + 1 (after refresh) = 3
-    expect(initializeHits).toBe(3);
-    // tools/call: 1 (404) + 1 (fresh token success) = 2 — no blind replay loop
-    expect(toolCalls).toBe(2);
+    )).rejects.toThrow(/Upstream MCP returned 404/);
+    expect(refreshHits).toBe(0);
+    expect(initializeHits).toBe(1);
+    expect(toolCalls).toBe(1);
   });
 });

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -15,7 +15,22 @@ import {
   type ResolvedCredentials,
   resolveCredentialsByConnectionId,
 } from './credential-resolver';
-import { parseJsonRpcResponse } from './http-response';
+import {
+  assertRequestBodySize,
+  createMcpAbortScope,
+  getMcpAbortReason,
+  isMcpToolCallRequest,
+  inspectMcpJsonRpcBody,
+  MCP_REQUEST_BODY_LIMIT,
+  MCP_RESPONSE_BODY_LIMIT,
+  isMcpSessionError,
+  logMcpTerminalOutcome,
+  newMcpCallId,
+  McpTransportError,
+  normalizeMcpAbortError,
+  parseJsonRpcResponse,
+  readResponseBody,
+} from './http-response';
 import type {
   DiscoveredTool,
   JsonRpcResponse,
@@ -29,10 +44,84 @@ const FETCH_TIMEOUT_TOOL_MS = 30_000;
 const TOOL_CACHE_TTL_MS = 5 * 60 * 1000;
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
-function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...init, signal: controller.signal }).finally(() => clearTimeout(timer));
+async function fetchMcpResponse(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  callerSignal?: AbortSignal,
+): Promise<Response> {
+  const callId = newMcpCallId();
+  const requestBytes = typeof init.body === 'string' ? new TextEncoder().encode(init.body).byteLength : 0;
+  const startedAt = Date.now();
+  let responseStatus: number | null = null;
+  let responseBytes = 0;
+  let diagnosticPreview: string | undefined;
+  let jsonRpcStatus: 'success' | 'error' | 'unknown' = 'unknown';
+  let failure: unknown;
+  const scope = createMcpAbortScope({
+    timeoutMs,
+    callerSignal,
+    upstreamSignal: init.signal ?? undefined,
+  });
+  try {
+    if (typeof init.body === 'string') assertRequestBodySize(init.body);
+    const response = await fetch(url, { ...init, signal: scope.signal });
+    responseStatus = response.status;
+    const responseHadBody = response.body !== null;
+    const bounded = await readResponseBody(response, {
+      signal: scope.signal,
+      limit: MCP_RESPONSE_BODY_LIMIT,
+    });
+    responseBytes = bounded.byteLength;
+    diagnosticPreview = bounded.preview;
+    jsonRpcStatus = inspectMcpJsonRpcBody(
+      bounded.bytes,
+      response.headers.get('content-type')
+    ).status;
+    return new Response(responseHadBody ? bounded.bytes : null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  } catch (error) {
+    const normalized = normalizeMcpAbortError(error, scope.signal);
+    failure = normalized;
+    if (
+      normalized instanceof McpTransportError &&
+      normalized.kind !== 'oversized_request'
+    ) {
+      responseBytes = normalized.bytes ?? responseBytes;
+      diagnosticPreview = normalized.preview ?? diagnosticPreview;
+    }
+    throw normalized;
+  } finally {
+    const normalized =
+      failure instanceof McpTransportError
+        ? failure
+        : scope.signal.reason instanceof McpTransportError
+          ? scope.signal.reason
+          : undefined;
+    const abortReason = getMcpAbortReason(normalized, scope.signal);
+    logMcpTerminalOutcome(logger, {
+      call_id: callId,
+      request_bytes: requestBytes,
+      response_bytes: responseBytes,
+      request_limit: MCP_REQUEST_BODY_LIMIT,
+      response_limit: MCP_RESPONSE_BODY_LIMIT,
+      duration_ms: Date.now() - startedAt,
+      http_status: responseStatus,
+      jsonrpc_status: jsonRpcStatus,
+      truncated: normalized?.kind === 'oversized_response' || normalized?.kind === 'oversized_request',
+      aborted: abortReason !== null,
+      abort_reason: abortReason,
+      retryable: false,
+      ambiguous_execution: typeof init.body === 'string' && isMcpToolCallRequest(init.body),
+      ...(diagnosticPreview && (failure || responseStatus === null || responseStatus >= 400)
+        ? { diagnostic_preview: diagnosticPreview }
+        : {}),
+    });
+    scope.cleanup();
+  }
 }
 
 /**
@@ -43,14 +132,6 @@ function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Pr
  */
 type McpSessionState = { sessionId: string; protocolVersion: string };
 const sessions = new TtlCache<McpSessionState>(SESSION_TTL_MS);
-
-/**
- * The upstream rejected the request because it does not recognize our session
- * id (MCP Streamable HTTP: an unknown/expired session MUST get a 404). The
- * upstream never reached the tool, so replaying after a fresh handshake cannot
- * double-execute an action — unlike a timeout or a 5xx, which stay fatal.
- */
-class McpSessionExpiredError extends Error {}
 
 class McpOAuthRequiredError extends Error {
   constructor(readonly metadata: McpOAuthMetadata) {
@@ -148,7 +229,7 @@ async function sendRequest(
   const session = sessions.get(key) ?? null;
   const headers = buildHeaders(credentials, session);
 
-  const response = await fetchWithTimeout(
+  const response = await fetchMcpResponse(
     upstreamUrl,
     { method: 'POST', headers, body },
     timeoutMs
@@ -164,10 +245,10 @@ async function sendRequest(
   }
 
   if (!response.ok) {
-    const text = await response.text();
+    const text = new TextDecoder().decode((await readResponseBody(response)).bytes);
     if (response.status === 404 && session) {
       sessions.delete(key);
-      throw new McpSessionExpiredError(`Upstream MCP returned 404: ${text}`);
+      throw new Error(`Upstream MCP returned 404: ${text}`);
     }
     if (response.status === 401) {
       throw new McpAuthRejectedError(`Upstream MCP returned 401: ${text}`);
@@ -177,7 +258,9 @@ async function sendRequest(
 
   const request = JSON.parse(body) as { id?: unknown };
   const expectedId = Object.hasOwn(request, 'id') ? request.id : undefined;
-  return (await parseJsonRpcResponse(response, expectedId)) as JsonRpcResponse;
+  const parsed = (await parseJsonRpcResponse(response, expectedId)) as JsonRpcResponse;
+  if (isMcpSessionError(parsed.error?.message)) sessions.delete(key);
+  return parsed;
 }
 
 /**
@@ -372,7 +455,8 @@ export async function discoverTools(
 
 /**
  * Call a tool on an upstream MCP server.
- * Handles stale session recovery: reinitialize + retry once.
+ * Establishes a session before dispatch and only refreshes a rejected credential
+ * before one retry; ambiguous tool outcomes are never replayed.
  */
 export async function callTool(
   connectorKey: string,
@@ -434,79 +518,31 @@ export async function callTool(
       connectionId
     );
 
-  // One bounded recovery loop for every safe-to-retry outcome. The ONLY
-  // retried cases are explicit no-execution signals: a 401 auth rejection
-  // (first attempt never produced a response), a 404 session rejection, or a
-  // JSON-RPC "not initialized" error. A timeout/5xx is ambiguous (the upstream
-  // may have executed the action) and must surface, never replay. Each
-  // recovery can rotate the token at most once (canRefreshAfter401) and
-  // rehandshake at most once per class, so the loop cannot spin. Every
-  // initializeSession call runs INSIDE the try so a 401 from a recovery
-  // reinitialize routes back through the refresh path instead of escaping.
+  // Only a credential rejection is retried: it is rejected before dispatch.
+  // A 404/session error, timeout, abort, 5xx, or any other post-dispatch
+  // failure is ambiguous for tools/call and must never replay the action.
   let response: JsonRpcResponse;
-  let phase: 'send' | 'reinitialize' = 'send';
-  let sessionRecovered = false;
-  while (true) {
-    try {
-      if (phase === 'reinitialize') {
-        await initializeSession(
-          config.upstream_url,
-          credentials,
-          orgId,
-          connectorKey,
-          connectionId
-        );
-      }
-      response = await send();
-    } catch (error) {
-      // Refresh-on-401: the upstream rejected the access token even though its
-      // stored expiry looked valid (tokens get revoked upstream). Re-resolve
-      // against the exact rejected token under the per-account lock, drop the
-      // stale session, reinitialize, and retry once. A still-failing 401 means
-      // the refresh token itself is dead — surface it rather than loop.
-      if (canRefreshAfter401 && error instanceof McpAuthRejectedError) {
-        canRefreshAfter401 = false;
-        logger.info(
-          { connectorKey, originalToolName, connectionId },
-          '[McpProxy] Upstream rejected access token; refreshing and retrying once'
-        );
-        const refreshed = await refreshRejectedCredentials(connectionId, orgId, credentials);
-        if (!refreshed?.accessToken) throw error;
-        credentials = refreshed;
-        sessions.delete(sessionKey(orgId, connectorKey, connectionId));
-        phase = 'reinitialize';
-        continue;
-      }
-      // A rejected session id means the call never ran upstream; rehandshake
-      // and replay. This reinitialize may itself 401 (both an expired session
-      // AND a revoked token) — the loop routes that through the refresh above.
-      if (!sessionRecovered && error instanceof McpSessionExpiredError) {
-        sessionRecovered = true;
-        logger.info(
-          { connectorKey, originalToolName },
-          '[McpProxy] Session rejected, reinitializing'
-        );
-        phase = 'reinitialize';
-        continue;
-      }
-      // Ambiguous transport failure — the upstream may have executed the action.
-      throw error;
-    }
-
-    // Stale-session response recovery ("not initialized"): the call never ran,
-    // so rehandshake and replay — same uniform path as the thrown 404 above.
-    if (response.error && /not initialized/i.test(response.error.message || '')) {
-      if (!sessionRecovered) {
-        sessionRecovered = true;
-        logger.info(
-          { connectorKey, originalToolName },
-          '[McpProxy] Session expired, reinitializing'
-        );
-        phase = 'reinitialize';
-        continue;
-      }
-    }
-    break;
+  try {
+    response = await send();
+  } catch (error) {
+    if (!(canRefreshAfter401 && error instanceof McpAuthRejectedError)) throw error;
+    canRefreshAfter401 = false;
+    logger.info(
+      { connectorKey, originalToolName, connectionId },
+      '[McpProxy] Upstream rejected access token; refreshing and retrying once'
+    );
+    const refreshed = await refreshRejectedCredentials(connectionId, orgId, credentials);
+    if (!refreshed?.accessToken) throw error;
+    credentials = refreshed;
+    sessions.delete(sessionKey(orgId, connectorKey, connectionId));
+    await initializeSession(
+      config.upstream_url,
+      credentials,
+      orgId,
+      connectorKey,
+      connectionId
+    );
+    response = await send();
   }
 
   if (response.error) {
@@ -613,13 +649,13 @@ function assertSafeOAuthEndpoint(url: string): void {
 
 async function fetchJsonObject(url: string): Promise<Record<string, unknown> | null> {
   assertSafeOAuthEndpoint(url);
-  const response = await fetchWithTimeout(
+  const response = await fetchMcpResponse(
     url,
     { headers: { Accept: 'application/json' } },
     FETCH_TIMEOUT_INIT_MS
   );
   if (!response.ok) return null;
-  const value = (await response.json()) as unknown;
+  const value = JSON.parse(new TextDecoder().decode((await readResponseBody(response)).bytes)) as unknown;
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
@@ -771,7 +807,7 @@ export async function registerMcpOAuthClient(params: {
   for (const redirectUri of redirectUris) assertSafeOAuthRedirectUri(redirectUri);
 
   const requestedMethod = selectMcpOAuthClientAuthMethod(params.metadata);
-  const response = await fetchWithTimeout(
+  const response = await fetchMcpResponse(
     registrationUrl,
     {
       method: 'POST',
@@ -790,11 +826,11 @@ export async function registerMcpOAuthClient(params: {
     FETCH_TIMEOUT_INIT_MS
   );
   if (!response.ok) {
-    const text = await response.text();
+    const text = new TextDecoder().decode((await readResponseBody(response)).bytes);
     throw new Error(`MCP OAuth dynamic registration returned ${response.status}: ${text}`);
   }
 
-  const body = (await response.json()) as Record<string, unknown>;
+  const body = JSON.parse(new TextDecoder().decode((await readResponseBody(response)).bytes)) as Record<string, unknown>;
   const clientId = typeof body.client_id === 'string' ? body.client_id : null;
   if (!clientId) throw new Error('MCP OAuth dynamic registration omitted client_id');
   const returnedMethod =
@@ -842,9 +878,10 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
       headers['MCP-Protocol-Version'] = protocolVersion ?? MCP_PROTOCOL_VERSION;
     }
 
-    const response = await fetchWithTimeout(
+    const serializedBody = JSON.stringify(body);
+    const response = await fetchMcpResponse(
       upstreamUrl,
-      { method: 'POST', headers, body: JSON.stringify(body) },
+      { method: 'POST', headers, body: serializedBody },
       FETCH_TIMEOUT_INIT_MS
     );
 
@@ -859,7 +896,7 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
         );
         if (metadata) throw new McpOAuthRequiredError(metadata);
       }
-      const text = await response.text();
+      const text = new TextDecoder().decode((await readResponseBody(response)).bytes);
       throw new Error(`MCP server returned ${response.status}: ${text}`);
     }
 

--- a/packages/server/src/mcp-proxy/http-response.ts
+++ b/packages/server/src/mcp-proxy/http-response.ts
@@ -1,55 +1,527 @@
-/**
- * Parse one MCP Streamable HTTP response.
- *
- * A server may answer a JSON-RPC request as plain JSON or as one or more SSE
- * events. SSE streams may contain notifications before the response, so a
- * caller that sent an id must select the matching response instead of trusting
- * whichever event happened to arrive last.
- */
+import { randomUUID } from "node:crypto";
+
+export const MCP_REQUEST_BODY_LIMIT = 1024 * 1024;
+export const MCP_RESPONSE_BODY_LIMIT = 4 * 1024 * 1024;
+export const MCP_SSE_FRAME_LIMIT = 1024 * 1024;
+export const MCP_DIAGNOSTIC_PREVIEW_LIMIT = 4096;
+
+export type McpAbortReason = "timeout" | "caller_abort" | "upstream_abort";
+
+export class McpTransportError extends Error {
+	readonly kind:
+		| "timeout"
+		| "caller_abort"
+		| "upstream_abort"
+		| "oversized_request"
+		| "oversized_response"
+		| "malformed_json";
+	readonly bytes?: number;
+	readonly limit?: number;
+	readonly preview?: string;
+
+	constructor(
+		kind: McpTransportError["kind"],
+		message: string,
+		options: { bytes?: number; limit?: number; preview?: string; cause?: unknown } = {},
+	) {
+		super(message, { cause: options.cause });
+		this.name = "McpTransportError";
+		this.kind = kind;
+		this.bytes = options.bytes;
+		this.limit = options.limit;
+		this.preview = options.preview;
+	}
+}
+
+export interface McpAbortScope {
+	signal: AbortSignal;
+	abort: (reason: McpAbortReason) => void;
+	cleanup: () => void;
+}
+
+/** Compose signals without retaining listeners after the request completes. */
+export function createMcpAbortScope(options: {
+	timeoutMs?: number;
+	callerSignal?: AbortSignal;
+	upstreamSignal?: AbortSignal;
+}): McpAbortScope {
+	const controller = new AbortController();
+	const listeners: Array<() => void> = [];
+
+	const abort = (reason: McpAbortReason) => {
+		if (controller.signal.aborted) return;
+		controller.abort(new McpTransportError(reason, `MCP request ${reason}`));
+	};
+	const bind = (signal: AbortSignal | undefined, reason: McpAbortReason) => {
+		if (!signal) return;
+		const listener = () => abort(reason);
+		signal.addEventListener("abort", listener, { once: true });
+		listeners.push(() => signal.removeEventListener("abort", listener));
+		if (signal.aborted) listener();
+	};
+
+	bind(options.callerSignal, "caller_abort");
+	bind(options.upstreamSignal, "upstream_abort");
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	if (options.timeoutMs !== undefined) timer = setTimeout(() => abort("timeout"), options.timeoutMs);
+
+	return {
+		signal: controller.signal,
+		abort,
+		cleanup: () => {
+			if (timer) clearTimeout(timer);
+			for (const remove of listeners) remove();
+		},
+	};
+}
+
+function previewText(bytes: Uint8Array): string {
+	return new TextDecoder()
+		.decode(bytes.subarray(0, MCP_DIAGNOSTIC_PREVIEW_LIMIT))
+		.replace(/\bAuthorization\s*:\s*[^\r\n]*/gi, "Authorization: [REDACTED]")
+		.replace(/\b(?:Set-)?Cookie\s*:\s*[^\r\n]*/gi, "Cookie: [REDACTED]")
+		.replace(/Bearer\s+[^\s"']+/gi, "Bearer [REDACTED]")
+		.replace(/(([\w.-]*(?:form|query|cookie|password|secret|token|authorization|api[_-]?key|session)[\w.-]*)\s*[=:]\s*)([^&\s,;"']+)/gi, "$1[REDACTED]")
+		.replace(/("[^"]*(?:form|query|cookie|password|secret|token|authorization|api[_-]?key|session)[^"]*"\s*:\s*")[^"]*(")/gi, "$1[REDACTED]$2")
+		.slice(0, MCP_DIAGNOSTIC_PREVIEW_LIMIT);
+}
+
+function concat(chunks: Uint8Array[], length: number): Uint8Array {
+	const result = new Uint8Array(Math.min(length, chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)));
+	let offset = 0;
+	for (const chunk of chunks) {
+		if (offset >= result.byteLength) break;
+		const copyLength = Math.min(chunk.byteLength, result.byteLength - offset);
+		result.set(chunk.subarray(0, copyLength), offset);
+		offset += copyLength;
+	}
+	return result;
+}
+
+function abortError(signal: AbortSignal, cause?: unknown): McpTransportError {
+	const reason = signal.reason;
+	const kind: McpAbortReason =
+		reason instanceof McpTransportError &&
+		(reason.kind === "timeout" || reason.kind === "caller_abort" || reason.kind === "upstream_abort")
+			? reason.kind
+			: "upstream_abort";
+	return new McpTransportError(kind, `MCP request ${kind}`, { cause });
+}
+
+export function normalizeMcpAbortError(error: unknown, signal: AbortSignal): unknown {
+	if (signal.aborted) return abortError(signal, error);
+	if (
+		(error instanceof DOMException && error.name === "AbortError") ||
+		(error instanceof Error && (error.name === "AbortError" || (error as Error & { code?: unknown }).code === "ABORT_ERR"))
+	) {
+		return new McpTransportError("upstream_abort", "MCP request upstream_abort", { cause: error });
+	}
+	return error;
+}
+
+export function getMcpAbortReason(
+	error: unknown,
+	signal?: AbortSignal,
+): McpAbortReason | null {
+	const transportError =
+		error instanceof McpTransportError
+			? error
+			: signal?.reason instanceof McpTransportError
+				? signal.reason
+				: undefined;
+	return transportError &&
+		(transportError.kind === "timeout" ||
+			transportError.kind === "caller_abort" ||
+			transportError.kind === "upstream_abort")
+		? transportError.kind
+		: null;
+}
+
+export interface BoundedBody {
+	bytes: Uint8Array;
+	byteLength: number;
+	preview: string;
+}
+
+/** Read a body by UTF-8 byte count and cancel the source when the limit is exceeded. */
+export async function readBoundedBody(
+	body: ReadableStream<Uint8Array> | null,
+	limit: number,
+	options: { signal?: AbortSignal; kind?: "request" | "response" } = {},
+): Promise<BoundedBody> {
+	if (options.signal?.aborted) throw abortError(options.signal);
+	if (!body) return { bytes: new Uint8Array(), byteLength: 0, preview: "" };
+	const reader = body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	const onAbort = () => {
+		void reader.cancel(options.signal?.reason).catch(() => undefined);
+	};
+	options.signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		while (true) {
+			if (options.signal?.aborted) throw abortError(options.signal);
+			const { done, value } = await reader.read();
+			if (options.signal?.aborted) throw abortError(options.signal);
+			if (done) break;
+			if (total + value.byteLength > limit) {
+				await reader.cancel("MCP body limit exceeded").catch(() => undefined);
+				throw new McpTransportError(
+					options.kind === "request" ? "oversized_request" : "oversized_response",
+					`MCP ${options.kind ?? "response"} body exceeds ${limit} bytes`,
+					{ bytes: total + value.byteLength, limit, preview: previewText(concat([...chunks, value], limit)) },
+				);
+			}
+			chunks.push(value);
+			total += value.byteLength;
+		}
+	} catch (error) {
+		const progress = {
+			bytes: total,
+			preview: previewText(concat(chunks, total)),
+		};
+		if (options.signal?.aborted) {
+			const normalized = abortError(options.signal, error);
+			throw new McpTransportError(normalized.kind, normalized.message, {
+				...progress,
+				cause: error,
+			});
+		}
+		if (!(error instanceof McpTransportError)) {
+			const reason: McpAbortReason = options.kind === "request" ? "caller_abort" : "upstream_abort";
+			throw new McpTransportError(reason, `MCP request ${reason}`, {
+				...progress,
+				cause: error,
+			});
+		}
+		throw error;
+	} finally {
+		options.signal?.removeEventListener("abort", onAbort);
+		reader.releaseLock();
+	}
+	const bytes = concat(chunks, total);
+	return { bytes, byteLength: bytes.byteLength, preview: previewText(bytes) };
+}
+
+export function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+export function assertRequestBodySize(body: string, limit = MCP_REQUEST_BODY_LIMIT): void {
+	const encoded = new TextEncoder().encode(body);
+	const bytes = encoded.byteLength;
+	if (bytes > limit) {
+		throw new McpTransportError("oversized_request", `MCP request body exceeds ${limit} bytes`, {
+			bytes,
+			limit,
+			preview: previewText(encoded),
+		});
+	}
+}
+
+/** Only protocol setup/catalog requests are safe to replay after an ambiguous 404. */
+export function isReplaySafeMcpRequest(body: string): boolean {
+	try {
+		const parsed = JSON.parse(body) as { jsonrpc?: unknown; method?: unknown };
+		return (
+			!Array.isArray(parsed) &&
+			parsed?.jsonrpc === "2.0" &&
+			(parsed.method === "initialize" ||
+				parsed.method === "notifications/initialized" ||
+				parsed.method === "tools/list")
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function isMcpToolCallRequest(body: string): boolean {
+	try {
+		const parsed = JSON.parse(body) as { jsonrpc?: unknown; method?: unknown };
+		return !Array.isArray(parsed) && parsed?.jsonrpc === "2.0" && parsed.method === "tools/call";
+	} catch {
+		return false;
+	}
+}
+
+export function isMcpSessionError(message: unknown): boolean {
+	return typeof message === "string" && /not initialized|session not found/i.test(message);
+}
+
+export async function readResponseBody(
+	response: Response,
+	options: { signal?: AbortSignal; limit?: number } = {},
+): Promise<BoundedBody> {
+	return readBoundedBody(response.body, options.limit ?? MCP_RESPONSE_BODY_LIMIT, {
+		signal: options.signal,
+		kind: "response",
+	});
+}
+
+class McpSseFrameCounter {
+	private frameBytes = 0;
+	private lineBytes = 0;
+	private previousWasCr = false;
+	private previousCrEndedFrame = false;
+
+	constructor(private readonly limit: number) {}
+
+	consume(bytes: Uint8Array): void {
+		for (const byte of bytes) {
+			this.frameBytes++;
+			if (this.frameBytes > this.limit) {
+				throw new McpTransportError("oversized_response", "MCP SSE frame exceeds limit", {
+					bytes: this.frameBytes,
+					limit: this.limit,
+				});
+			}
+
+			if (byte === 13) {
+				const endedFrame = this.lineBytes === 0;
+				this.lineBytes = 0;
+				this.previousWasCr = true;
+				this.previousCrEndedFrame = endedFrame;
+				if (endedFrame) this.frameBytes = 0;
+				continue;
+			}
+
+			if (byte === 10) {
+				if (this.previousWasCr) {
+					if (this.previousCrEndedFrame) this.frameBytes = 0;
+				} else {
+					if (this.lineBytes === 0) this.frameBytes = 0;
+					this.lineBytes = 0;
+				}
+				this.previousWasCr = false;
+				this.previousCrEndedFrame = false;
+				continue;
+			}
+
+			this.previousWasCr = false;
+			this.previousCrEndedFrame = false;
+			this.lineBytes++;
+		}
+	}
+}
+
+export interface McpJsonRpcInspection {
+	status: "success" | "error" | "unknown";
+	sessionError: boolean;
+}
+
+/** Inspect only a complete bounded body; malformed or non-JSON bodies remain unknown. */
+export function inspectMcpJsonRpcBody(
+	bytes: Uint8Array,
+	contentType: string | null,
+): McpJsonRpcInspection {
+	try {
+		const text = new TextDecoder().decode(bytes);
+		let values: unknown[];
+		if ((contentType ?? "").toLowerCase().includes("text/event-stream")) {
+			new McpSseFrameCounter(MCP_SSE_FRAME_LIMIT).consume(bytes);
+			const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+			values = normalizedText
+				.split("\n\n")
+				.map((frame) =>
+					frame
+						.split("\n")
+						.filter((line) => line.startsWith("data:"))
+						.map((line) => line.slice(5).trimStart())
+						.join("\n"),
+				)
+				.filter(Boolean)
+				.map((data) => JSON.parse(data));
+		} else {
+			values = [JSON.parse(text)];
+		}
+
+		const messages = values.flatMap((value) => (Array.isArray(value) ? value : [value]));
+		let sawSuccess = false;
+		let sawError = false;
+		let sessionError = false;
+		for (const message of messages) {
+			if (!message || typeof message !== "object") continue;
+			if ((message as { jsonrpc?: unknown }).jsonrpc !== "2.0") continue;
+			if (Object.hasOwn(message, "error")) {
+				sawError = true;
+				const error = (message as { error?: unknown }).error;
+				if (error && typeof error === "object") {
+					sessionError ||= isMcpSessionError((error as { message?: unknown }).message);
+				}
+			} else if (Object.hasOwn(message, "result")) {
+				sawSuccess = true;
+			}
+		}
+		return {
+			status: sawError ? "error" : sawSuccess ? "success" : "unknown",
+			sessionError,
+		};
+	} catch (error) {
+		if (error instanceof McpTransportError) throw error;
+		return { status: "unknown", sessionError: false };
+	}
+}
+
+/** Bound long-lived SSE/raw responses without buffering them. */
+export function boundStreamingResponse(
+	response: Response,
+	options: { signal?: AbortSignal; frameLimit?: number; cleanup?: (error?: unknown, bytes?: number) => void; onCancel?: () => void } = {},
+): Response {
+	if (!response.body) {
+		options.cleanup?.(undefined, 0);
+		return response;
+	}
+	const upstreamReader = response.body.getReader();
+	const frameLimit = options.frameLimit ?? MCP_SSE_FRAME_LIMIT;
+	const frameCounter = new McpSseFrameCounter(frameLimit);
+	let totalBytes = 0;
+	let settled = false;
+	let removeAbort: (() => void) | undefined;
+	let readerReleased = false;
+	const releaseReader = () => {
+		if (readerReleased) return;
+		readerReleased = true;
+		upstreamReader.releaseLock();
+	};
+	const cancelAndRelease = async (reason?: unknown) => {
+		try {
+			await upstreamReader.cancel(reason);
+		} finally {
+			releaseReader();
+		}
+	};
+	const settle = (error?: unknown) => {
+		if (settled) return false;
+		settled = true;
+		removeAbort?.();
+		options.cleanup?.(error, totalBytes);
+		return true;
+	};
+
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			const abort = () => {
+				const error = abortError(options.signal!);
+				if (!settle(error)) return;
+				void cancelAndRelease(options.signal?.reason).catch(() => undefined);
+				controller.error(error);
+			};
+			if (options.signal) {
+				options.signal.addEventListener("abort", abort, { once: true });
+				removeAbort = () => options.signal?.removeEventListener("abort", abort);
+				if (options.signal.aborted) abort();
+			}
+		},
+		async pull(controller) {
+			try {
+				const { done, value } = await upstreamReader.read();
+				if (settled) return;
+				if (done) {
+					settle();
+					releaseReader();
+					controller.close();
+					return;
+				}
+				totalBytes += value.byteLength;
+				frameCounter.consume(value);
+				controller.enqueue(value);
+			} catch (error) {
+				const normalized =
+					error instanceof McpTransportError
+						? error
+						: options.signal?.aborted
+							? abortError(options.signal, error)
+							: new McpTransportError("upstream_abort", "MCP request upstream_abort", { cause: error });
+				if (!settle(normalized)) return;
+				void cancelAndRelease(normalized).catch(() => undefined);
+				controller.error(normalized);
+			}
+		},
+		cancel(reason) {
+			if (settled) return;
+			settled = true;
+			options.onCancel?.();
+			options.cleanup?.(undefined, totalBytes);
+			removeAbort?.();
+			return cancelAndRelease(reason);
+		},
+	});
+	return new Response(stream, { status: response.status, statusText: response.statusText, headers: response.headers });
+}
+
+/** Parse only a complete, bounded JSON or SSE response. */
 export async function parseJsonRpcResponse(
-  response: Response,
-  expectedId?: unknown
+	response: Response,
+	expectedId?: unknown,
+	options: { signal?: AbortSignal; limit?: number } = {},
 ): Promise<unknown> {
-  if (response.status === 202 || response.status === 204) {
-    if (expectedId !== undefined) {
-      throw new Error(`MCP response omitted JSON-RPC id ${String(expectedId)}`);
-    }
-    return { jsonrpc: '2.0', id: null, result: {} };
-  }
-
-  const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
-  if (!contentType.includes('text/event-stream')) {
-    const value = (await response.json()) as unknown;
-    return selectExpectedResponse([value], expectedId);
-  }
-
-  const text = await response.text();
-  const values: unknown[] = [];
-  for (const frame of text.split(/\r?\n\r?\n/)) {
-    const data = frame
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith('data:'))
-      .map((line) => line.slice(5).trimStart())
-      .join('\n');
-    if (!data) continue;
-    values.push(JSON.parse(data));
-  }
-
-  if (values.length === 0) {
-    throw new Error('SSE response contained no data payload');
-  }
-  return selectExpectedResponse(values, expectedId);
+	if (response.status === 202 || response.status === 204) {
+		if (expectedId !== undefined) throw new Error(`MCP response omitted JSON-RPC id ${String(expectedId)}`);
+		return { jsonrpc: "2.0", id: null, result: {} };
+	}
+	const body = await readResponseBody(response, options);
+	const text = new TextDecoder().decode(body.bytes);
+	const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+	try {
+		if (!contentType.includes("text/event-stream")) return selectExpectedResponse([JSON.parse(text)], expectedId);
+		const values: unknown[] = [];
+		new McpSseFrameCounter(MCP_SSE_FRAME_LIMIT).consume(body.bytes);
+		const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		for (const frame of normalizedText.split("\n\n")) {
+			const data = frame
+				.split(/\r?\n/)
+				.filter((line) => line.startsWith("data:"))
+				.map((line) => line.slice(5).trimStart())
+				.join("\n");
+			if (data) values.push(JSON.parse(data));
+		}
+		if (values.length === 0) throw new Error("SSE response contained no data payload");
+		return selectExpectedResponse(values, expectedId);
+	} catch (error) {
+		if (error instanceof McpTransportError) throw error;
+		if (error instanceof Error && (/^MCP response omitted JSON-RPC id /.test(error.message) || error.message === "SSE response contained no data payload")) {
+			throw error;
+		}
+		throw new McpTransportError("malformed_json", "MCP response contained malformed JSON", { preview: body.preview, cause: error });
+	}
 }
 
 function selectExpectedResponse(values: unknown[], expectedId: unknown): unknown {
-  if (expectedId === undefined) return values.at(-1);
-  const match = values.find(
-    (value) =>
-      value !== null &&
-      typeof value === 'object' &&
-      Object.hasOwn(value, 'id') &&
-      Object.is((value as { id?: unknown }).id, expectedId)
-  );
-  if (match !== undefined) return match;
-  throw new Error(`MCP response omitted JSON-RPC id ${String(expectedId)}`);
+	if (expectedId === undefined) return values.at(-1);
+	const match = values.find((value) => value !== null && typeof value === "object" && Object.hasOwn(value, "id") && Object.is((value as { id?: unknown }).id, expectedId));
+	if (match !== undefined) return match;
+	throw new Error(`MCP response omitted JSON-RPC id ${String(expectedId)}`);
+}
+
+export function newMcpCallId(): string {
+	return randomUUID();
+}
+
+export interface McpTerminalOutcome {
+	call_id: string;
+	request_bytes: number;
+	response_bytes: number;
+	request_limit: number;
+	response_limit: number;
+	duration_ms: number;
+	http_status: number | null;
+	jsonrpc_status: "success" | "error" | "unknown";
+	truncated: boolean;
+	aborted: boolean;
+	abort_reason: McpAbortReason | null;
+	retryable: boolean;
+	ambiguous_execution: boolean;
+	diagnostic_preview?: string;
+}
+
+export function logMcpTerminalOutcome(
+	logger: { info: (message: unknown, ...args: unknown[]) => void },
+	outcome: McpTerminalOutcome,
+): void {
+	const { diagnostic_preview: diagnosticPreview, ...safeOutcome } = outcome;
+	logger.info({
+		...safeOutcome,
+		...(diagnosticPreview ? { diagnostic_preview: "[REDACTED]" } : {}),
+		msg: "MCP terminal outcome",
+	});
 }


### PR DESCRIPTION
## Summary
- Enforce UTF-8 request/response and DCR caps before JSON parsing, with deadlines that remain active through finite body reads and bounded, backpressured SSE streaming.
- Preserve caller/timeout/upstream abort distinctions and public errors while cancelling upstream work, releasing readers, and avoiding duplicate or truncated response reads.
- Never replay ambiguous tool dispatches, initialize REST tool sessions before dispatch, invalidate bad sessions for the next request, infer JSON-RPC status only from complete parsed payloads, and keep terminal logs payload-free.

## Test plan
- [x] `make pre-pr` clean after the final fix and rebase
- [x] `bun test packages/server/src/mcp-proxy/__tests__/http-response.test.ts` — 12 pass, 0 fail
- [x] `bun test packages/server/src/gateway/__tests__/mcp-proxy.test.ts` — 27 pass, 0 fail
- [x] `bun test packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts` — 41 pass, 0 fail
- [x] `cd packages/server && bun run test -- run src/mcp-proxy/__tests__/probe-discovery.test.ts` — 21 pass, 0 fail
- [x] Bug fixes include retained red → green evidence below
- [ ] `make pr-full` not run; GitHub CI is the canonical full graph
- [x] Bot runtime eval not applicable; no bot runtime changed

Red evidence:
```
(fail) terminal outcome logging is structured and previews redact secrets
Expected diagnostic_preview: "[REDACTED]"; received a payload-derived sanitized preview
11 pass, 1 fail

Semantic review blocker: a non-closing POST text/event-stream response emitted a complete frame, but sendUpstreamRequest did not return before caller abort.

Focused gateway red run after adding regressions:
24 pass, 3 fail — POST SSE relay, streamed frame overflow, and missing REST pre-initialization

Second semantic review blocker: successful POST SSE relay cleared the POST deadline and could pin the gateway indefinitely.
```

Green evidence:
```
12 pass, 0 fail — shared transport
27 pass, 0 fail — gateway MCP proxy, including POST SSE deadline cancellation
41 pass, 0 fail — gateway MCP edge cases
21 pass, 0 fail — connector discovery/tool suite
make pre-pr — clean
```

## Notes
- Successful raw POST SSE responses stream before EOF with per-frame bounds and backpressure, while retaining the POST deadline through body consumption. GET SSE remains deadline-free for normal long-lived listening.
- REST tool calls initialize a missing replica-local session before dispatch and still never replay a dispatched tools/call.
- `make review-fix` was attempted on the settled follow-up; its Claude reviewer hit the weekly quota after applying only an unused-import cleanup and a clarifying comment, both rechecked by focused tests and `make pre-pr`.
- Limits are 1 MiB request bodies, 4 MiB finite buffered responses, and 1 MiB per SSE frame. Terminal diagnostic payloads are replaced with a literal `[REDACTED]` marker.
- No database, schema, SDK, Owletto, or public API changes. Existing JSON-RPC, ID-mismatch, and empty-SSE public errors are preserved.