### PR TITLE
fix(server): contain browser OAuth callback secrets

### DIFF
--- a/packages/server/src/__tests__/integration/events/browser-ingestion-containment.test.ts
+++ b/packages/server/src/__tests__/integration/events/browser-ingestion-containment.test.ts
@@ -1,0 +1,465 @@
+import type { Context } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../../../index';
+import { insertEvent } from '../../../utils/insert-event';
+import {
+  completeActionRun,
+  completeAuthRun,
+  completeWorkerJob,
+  fetchEventsForEmbedding,
+  streamContent,
+} from '../../../worker-api';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestOrganization,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const WORKER_ID = 'browser-containment-worker';
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (value: unknown, status?: number) => {
+      captured = { body: value, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
+
+describe('browser ingestion containment', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'Browser Containment Org' });
+  });
+
+  async function createBrowserRun(
+    dryRun: boolean,
+    runType: 'sync' | 'auth' | 'action' = 'sync'
+  ): Promise<{
+    connectionId: number;
+    runId: number;
+  }> {
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'chrome',
+    });
+    const rows = (await getTestDb()`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key,
+        connector_version, status, claimed_by, dry_run,
+        approval_status, action_key, created_at
+      ) VALUES (
+        ${org.id}, ${runType}, ${connection.id}, 'chrome',
+        '1.0.0', 'running', ${WORKER_ID}, ${dryRun},
+        ${runType === 'action' ? 'auto' : null},
+        ${runType === 'action' ? 'navigate' : null}, NOW()
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+    return { connectionId: Number(connection.id), runId: Number(rows[0].id) };
+  }
+
+  it('sanitizes retries before persistence, FTS generation, and embedding backfill', async () => {
+    const chrome = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'chrome',
+    });
+    const raw = 'browser-callback-value-for-test';
+    const nonUrlField = 'ordinary prose code=not-a-url';
+    const originId = `https://example.test/tab?code=${raw}`;
+    const params = {
+      entityIds: [],
+      organizationId: org.id,
+      originId,
+      parentOriginId: `https://example.test/parent?state=${raw}`,
+      title: `https://example.test/tab?code=${raw}`,
+      content: `Opened https://example.test/tab?access_token=${raw}`,
+      sourceUrl: `https://example.test/tab?refresh_token=${raw}`,
+      payloadData: {
+        open_tabs: { href: `https://example.test/tab?id_token=${raw}` },
+        tab_events: { from_url: `https://example.test/tab?state=${raw}` },
+        watch: { url: `https://example.test/tab?token=${raw}` },
+        history: { page_url: `https://example.test/tab?client_secret=${raw}` },
+        bookmarks: { target_url: `https://example.test/tab?user_code=${raw}` },
+        downloads: { download_url: `https://example.test/tab?code_verifier=${raw}` },
+        watch_form: {
+          form_action: `https://example.test/form?code=${raw}`,
+          referrer: `https://example.test/referrer?state=${raw}`,
+          origin_id: `https://example.test/watch?token=${raw}`,
+        },
+        arbitrary: nonUrlField,
+      },
+      attachments: [{ download_url: `https://example.test/tab?token=${raw}` }],
+      metadata: {
+        from_url: `https://example.test/tab?user_code=${raw}`,
+        content_preview: `Callback https://example.test/tab?code=${raw}`,
+        fields: [
+          {
+            label: `https://example.test/label?state=${raw}`,
+            value: `https://example.test/value?token=${raw}`,
+          },
+        ],
+      },
+      interactionInput: { url: `https://example.test/tab?state=${raw}` },
+      interactionOutput: { href: `https://example.test/tab?code=${raw}` },
+      interactionError: `Failed at https://example.test/tab?token=${raw}`,
+      embedding: [0.1, 0.2],
+      embeddingModel: 'test-browser-model',
+      semanticType: 'browser_tab',
+      connectorKey: 'chrome',
+      connectionId: Number(chrome.id),
+      occurredAt: new Date('2026-04-09T00:00:00Z'),
+    };
+
+    const first = await insertEvent(params, { onConflictUpdate: true });
+    const retry = await insertEvent(params, { onConflictUpdate: true });
+    expect(retry.id).toBe(first.id);
+    expect(retry.change).toBe('unchanged');
+
+    const inheritedRaw = 'inherited-browser-lineage-value';
+    const successor = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'browser-successor',
+      title: `https://example.test/tab?code=${inheritedRaw}`,
+      content: `https://example.test/tab?state=${inheritedRaw}`,
+      payloadData: { url: `https://example.test/tab?token=${inheritedRaw}` },
+      semanticType: 'browser_tab',
+      supersedesEventId: Number(first.id),
+    });
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT origin_id, origin_parent_id, title, payload_text, source_url,
+             payload_data, attachments, metadata,
+             interaction_input, interaction_output, interaction_error,
+             search_tsv::text AS search_text
+      FROM events
+      WHERE id = ${first.id}
+    `) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(JSON.stringify(rows[0])).not.toContain(raw);
+    expect((rows[0].payload_data as Record<string, unknown>).arbitrary).toBe(nonUrlField);
+    const successorRows = (await sql`
+      SELECT connector_key, title, payload_text, payload_data
+      FROM events
+      WHERE id = ${successor.id}
+    `) as Array<Record<string, unknown>>;
+    expect(successorRows[0].connector_key).toBe('chrome');
+    expect(JSON.stringify(successorRows[0])).not.toContain(inheritedRaw);
+
+    const embeddings = await sql`
+      SELECT 1 FROM event_embeddings WHERE event_id = ${first.id}
+    `;
+    expect(embeddings).toHaveLength(0);
+
+    const fetched = mockWorkerCtx({ event_ids: [Number(first.id)] });
+    await fetchEventsForEmbedding(fetched.ctx);
+    expect(fetched.result().status).toBe(200);
+    expect(JSON.stringify(fetched.result().body)).not.toContain(raw);
+    expect(JSON.stringify(fetched.result().body)).toContain('REDACTED');
+  });
+
+  it('leaves unrelated connector records byte-for-byte unchanged', async () => {
+    const github = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+    });
+    const rawUrl = 'https://example.test/callback?code=unrelated-record-value';
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'unrelated-record',
+      title: rawUrl,
+      content: rawUrl,
+      sourceUrl: rawUrl,
+      payloadData: { url: rawUrl },
+      metadata: { href: rawUrl },
+      semanticType: 'content',
+      connectorKey: 'github',
+      connectionId: Number(github.id),
+    });
+
+    const rows = (await getTestDb()`
+      SELECT title, payload_text, source_url, payload_data, metadata
+      FROM events
+      WHERE organization_id = ${org.id} AND origin_id = 'unrelated-record'
+    `) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      title: rawUrl,
+      payload_text: rawUrl,
+      source_url: rawUrl,
+      payload_data: { url: rawUrl },
+      metadata: { href: rawUrl },
+    });
+  });
+
+  it('supersedes a pre-containment browser row via a NUL-safe raw source origin', async () => {
+    const chrome = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'chrome',
+    });
+    const raw = 'legacy-origin-only-callback-value';
+    const rawOriginId = `https://example.test/callback?code=${raw}`;
+    const containedOriginId = 'https://example.test/callback?code=REDACTED';
+    const workerSourceOriginId = rawOriginId.replace('callback', 'call\0back');
+    const legacyRows = (await getTestDb()`
+      INSERT INTO events (
+        organization_id, origin_id, origin_parent_id, title, payload_text, semantic_type,
+        connector_key, connection_id
+      ) VALUES (
+        ${org.id}, ${rawOriginId}, ${`https://example.test/parent?state=${raw}`},
+        'Already safe', 'Already safe', 'browser_tab',
+        'chrome', ${chrome.id}
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    const contained = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId: containedOriginId,
+        title: 'Already safe',
+        content: 'Already safe',
+        semanticType: 'browser_tab',
+        connectorKey: 'chrome',
+        connectionId: Number(chrome.id),
+      },
+      { onConflictUpdate: true, sourceOriginId: workerSourceOriginId }
+    );
+
+    expect(contained.change).toBe('superseded');
+    expect(contained.id).not.toBe(Number(legacyRows[0].id));
+    const retry = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId: containedOriginId,
+        title: 'Already safe',
+        content: 'Already safe',
+        semanticType: 'browser_tab',
+        connectorKey: 'chrome',
+        connectionId: Number(chrome.id),
+      },
+      { onConflictUpdate: true, sourceOriginId: workerSourceOriginId }
+    );
+    expect(retry).toMatchObject({ id: contained.id, change: 'unchanged' });
+    const rows = (await getTestDb()`
+      SELECT id, origin_id, origin_parent_id, superseded_by
+      FROM events
+      WHERE id IN (${legacyRows[0].id}, ${contained.id})
+      ORDER BY id
+    `) as Array<{
+      id: number;
+      origin_id: string;
+      origin_parent_id: string | null;
+      superseded_by: number | null;
+    }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].superseded_by).toBe(contained.id);
+    expect(rows[1].origin_id).not.toContain(raw);
+    expect(rows[1].origin_parent_id).toBe(
+      'https://example.test/parent?state=REDACTED'
+    );
+
+    const parentOnlyRows = (await getTestDb()`
+      INSERT INTO events (
+        organization_id, origin_id, origin_parent_id, title, payload_text,
+        semantic_type, connector_key, connection_id
+      ) VALUES (
+        ${org.id}, 'legacy-parent-only',
+        ${`https://example.test/parent?state=${raw}`},
+        'Already safe', 'Already safe', 'browser_tab', 'chrome', ${chrome.id}
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const parentContained = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId: 'legacy-parent-only',
+        title: 'Already safe',
+        content: 'Already safe',
+        semanticType: 'browser_tab',
+        connectorKey: 'chrome',
+        connectionId: Number(chrome.id),
+      },
+      { onConflictUpdate: true }
+    );
+    expect(parentContained).toMatchObject({ change: 'superseded' });
+    expect(parentContained.id).not.toBe(Number(parentOnlyRows[0].id));
+    const parentContainedRows = (await getTestDb()`
+      SELECT origin_parent_id FROM events WHERE id = ${parentContained.id}
+    `) as Array<{ origin_parent_id: string | null }>;
+    expect(parentContainedRows[0].origin_parent_id).toBe(
+      'https://example.test/parent?state=REDACTED'
+    );
+  });
+
+  it('sanitizes the browser stream before dry-run preview and checkpoint persistence', async () => {
+    const { runId } = await createBrowserRun(true);
+    const raw = 'dry-run-callback-value';
+    const streamed = mockWorkerCtx({
+      type: 'batch',
+      run_id: runId,
+      worker_id: WORKER_ID,
+      checkpoint: { url: `https://example.test/cursor?state=${raw}` },
+      items: [
+        {
+          id: `https://example.test/watch?code=${raw}`,
+          title: `https://example.test/tab?code=${raw}`,
+          payload_text: `Opened https://example.test/tab?access_token=${raw}`,
+          source_url: `https://example.test/tab?refresh_token=${raw}`,
+          payload_data: {
+            href: `https://example.test/tab?id_token=${raw}`,
+            form_action: `https://example.test/form?code=${raw}`,
+            referrer: `https://example.test/referrer?state=${raw}`,
+          },
+          occurred_at: new Date().toISOString(),
+        },
+      ],
+    });
+    await streamContent(streamed.ctx);
+    expect(streamed.result()).toMatchObject({ status: 200, body: { dry_run: true } });
+
+    const runRows = (await getTestDb()`
+      SELECT checkpoint, dry_run_preview FROM runs WHERE id = ${runId}
+    `) as Array<Record<string, unknown>>;
+    expect(runRows[0].checkpoint).toBeNull();
+    expect(JSON.stringify(runRows[0].dry_run_preview)).not.toContain(raw);
+    const events = await getTestDb()`SELECT 1 FROM events WHERE organization_id = ${org.id}`;
+    expect(events).toHaveLength(0);
+
+    const live = await createBrowserRun(false);
+    const liveStream = mockWorkerCtx({
+      type: 'batch',
+      run_id: live.runId,
+      worker_id: WORKER_ID,
+      checkpoint: { current_url: `https://example.test/cursor?state=${raw}` },
+      items: [
+        {
+          id: `https://example.test/live?code=${raw}`,
+          title: `https://example.test/tab?code=${raw}`,
+          payload_text: 'Live tab',
+          occurred_at: new Date().toISOString(),
+        },
+      ],
+    });
+    await streamContent(liveStream.ctx);
+    expect(liveStream.result().status).toBe(200);
+    const liveRows = (await getTestDb()`
+      SELECT checkpoint FROM runs WHERE id = ${live.runId}
+    `) as Array<Record<string, unknown>>;
+    expect(JSON.stringify(liveRows[0].checkpoint)).not.toContain(raw);
+    expect(JSON.stringify(liveRows[0].checkpoint)).toContain('REDACTED');
+  });
+
+  it('sanitizes persisted browser failure diagnostics and retry checkpoints', async () => {
+    const { runId } = await createBrowserRun(false);
+    const raw = 'failed-run-callback-value';
+    const completed = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      error_message: `Failed at https://example.test/?code=${raw}`,
+      output_tail: `Last page https://example.test/?access_token=${raw}`,
+      checkpoint: { from_url: `https://example.test/?state=${raw}` },
+    });
+    await completeWorkerJob(completed.ctx);
+    expect(completed.result()).toMatchObject({ status: 200, body: { success: true } });
+
+    const rows = (await getTestDb()`
+      SELECT error_message, output_tail, checkpoint FROM runs WHERE id = ${runId}
+    `) as Array<Record<string, unknown>>;
+    expect(JSON.stringify(rows[0])).not.toContain(raw);
+    expect(JSON.stringify(rows[0])).toContain('REDACTED');
+  });
+
+  it('sanitizes browser auth diagnostics and action results', async () => {
+    const auth = await createBrowserRun(false, 'auth');
+    const action = await createBrowserRun(false, 'action');
+    const raw = 'terminal-browser-callback-value';
+
+    const completedAuth = mockWorkerCtx({
+      run_id: auth.runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      error_message: `Auth failed at https://example.test/?code=${raw}`,
+      output_tail: `Last redirect https://example.test/?state=${raw}`,
+    });
+    await completeAuthRun(completedAuth.ctx);
+    expect(completedAuth.result()).toMatchObject({ status: 200, body: { success: true } });
+
+    const completedAction = mockWorkerCtx({
+      run_id: action.runId,
+      worker_id: WORKER_ID,
+      status: 'success',
+      action_output: {
+        final_url: `https://example.test/?access_token=${raw}`,
+        value: `https://example.test/?code=${raw}`,
+        result: { rows: [{ callback: `https://example.test/?state=${raw}` }] },
+        responses: [{ body: `Callback https://example.test/?token=${raw}` }],
+        tree: [{ name: `https://example.test/?code=${raw}` }],
+        unrelated: 'unrelated action output',
+      },
+    });
+    await completeActionRun(completedAction.ctx);
+    expect(completedAction.result()).toMatchObject({ status: 200, body: { success: true } });
+
+    const rows = (await getTestDb()`
+      SELECT id, error_message, output_tail, action_output
+      FROM runs
+      WHERE id IN (${auth.runId}, ${action.runId})
+      ORDER BY id
+    `) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(JSON.stringify(rows)).not.toContain(raw);
+    expect(JSON.stringify(rows)).toContain('REDACTED');
+  });
+
+  it('does not echo or log raw browser values when stream ingestion fails', async () => {
+    const { runId } = await createBrowserRun(false);
+    const raw = 'stream-failure-callback-value';
+    const failed = mockWorkerCtx({
+      type: 'batch',
+      run_id: runId,
+      worker_id: WORKER_ID,
+      items: [
+        {
+          id: 'broken-browser-item',
+          title: 'Broken item',
+          payload_text: 'body',
+          payload_type: `https://example.test/?code=${raw}`,
+          occurred_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await streamContent(failed.ctx);
+      expect(failed.result().status).toBe(500);
+      expect(JSON.stringify(failed.result().body)).not.toContain(raw);
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(raw);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts
+++ b/packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isBrowserConnectorKey,
+	sanitizeBrowserActionOutput,
+	sanitizeBrowserIngestionFields,
+	sanitizeBrowserPayload,
+	sanitizeBrowserText,
+} from "../../utils/browser-ingestion-sanitizer";
+
+const callbackValue = "old-client-callback-value";
+
+describe("browser ingestion sanitizer", () => {
+	test("redacts mixed-case, duplicate, encoded, query, and fragment values", () => {
+		const url =
+			`https://example.test/callback?Code=${callbackValue}&keep=1&code=second#STATE=fragment&keep=2`;
+		const out = sanitizeBrowserText(url);
+
+		expect(out).toBe(
+			"https://example.test/callback?Code=REDACTED&keep=1&code=REDACTED#STATE=REDACTED&keep=2",
+		);
+		expect(out).not.toContain(callbackValue);
+	});
+
+	test("handles encoded keys, malformed URLs, and already-redacted values idempotently", () => {
+		const input =
+			"https://example.test/cb?%63%6f%64%65=encoded&access_token=REDACTED&x=1#broken%ZZ=value";
+		const once = sanitizeBrowserText(input);
+		expect(once).toContain("%63%6f%64%65=REDACTED");
+		expect(sanitizeBrowserText(once)).toBe(once);
+		expect(sanitizeBrowserText("opaque-callback?code=not-a-url")).toBe(
+			"opaque-callback?code=REDACTED",
+		);
+		expect(sanitizeBrowserText("about:blank#access_token=fragment-secret")).toBe(
+			"about:blank#access_token=REDACTED",
+		);
+		expect(sanitizeBrowserText("opaque-callback#state=fragment-secret")).toBe(
+			"opaque-callback#state=REDACTED",
+		);
+		expect(
+			sanitizeBrowserText("https://example.test/?%2563%256f%2564%2565=secret"),
+		).toBe("https://example.test/?%2563%256f%2564%2565=REDACTED");
+		expect(sanitizeBrowserText("Open https://example.test/?code=secret, then continue.")).toBe(
+			"Open https://example.test/?code=REDACTED, then continue.",
+		);
+		expect(sanitizeBrowserText("https://example.test/?keep=1&amp;code=secret")).toBe(
+			"https://example.test/?keep=1&amp;code=REDACTED",
+		);
+		expect(sanitizeBrowserText("code%3Dencoded-query-secret")).toBe("REDACTED");
+		expect(sanitizeBrowserText("https://example.test/?next=code%3Dnested-secret")).toBe(
+			"https://example.test/?next=REDACTED",
+		);
+		expect(
+			sanitizeBrowserText(
+				"https://example.test/?redirect=https%3A%2F%2Finner.test%2F%3Fcode%3Dsecret",
+			),
+		).toBe(
+			"https://example.test/?redirect=https%3A%2F%2Finner.test%2F%3Fcode%3DREDACTED",
+		);
+		const encoded = sanitizeBrowserText(
+			"https%3A%2F%2Finner.test%2F%3Fcode%3Dsecret",
+		);
+		expect(encoded).toBe(
+			"https%3A%2F%2Finner.test%2F%3Fcode%3DREDACTED",
+		);
+		expect(sanitizeBrowserText(encoded)).toBe(encoded);
+		const longBenignText = "a".repeat(100_000);
+		expect(sanitizeBrowserText(longBenignText)).toBe(longBenignText);
+		const doubleEncoded = encodeURIComponent(
+			"https%3A%2F%2Finner.test%2F%3Fstate%3Ddouble-secret",
+		);
+		expect(sanitizeBrowserText(doubleEncoded)).not.toContain("double-secret");
+		let overEncoded = "https://inner.test/?code=bounded-secret";
+		for (let i = 0; i < 5; i++) overEncoded = encodeURIComponent(overEncoded);
+		expect(sanitizeBrowserText(overEncoded)).not.toContain("bounded-secret");
+		let benignEncoded = "https://inner.test/?keep=ordinary-value";
+		for (let i = 0; i < 5; i++) benignEncoded = encodeURIComponent(benignEncoded);
+		expect(sanitizeBrowserText(benignEncoded)).toBe(benignEncoded);
+	});
+
+	test("sanitizes browser fields before nested derivation, preview, and attachment persistence", () => {
+		const input = {
+			originId: `https://example.test/item?code=${callbackValue}`,
+			parentOriginId: `https://example.test/parent?state=${callbackValue}`,
+			title: `https://example.test/item?token=${callbackValue}`,
+			content: `Opened https://example.test/?refresh_token=${callbackValue}`,
+			sourceUrl: `https://example.test/?id_token=${callbackValue}`,
+			payloadData: {
+				url: `https://example.test/?client_secret=${callbackValue}`,
+				form_action: `https://example.test/?code=${callbackValue}`,
+				referrer: `https://example.test/?state=${callbackValue}`,
+				origin_id: `https://example.test/?token=${callbackValue}`,
+				nested: [{ href: `https://example.test/?user_code=${callbackValue}` }],
+				unrelated: "unchanged",
+			},
+			attachments: [{ download_url: `https://example.test/?code=${callbackValue}` }],
+			metadata: { from_url: `https://example.test/?state=${callbackValue}` },
+		};
+		const once = sanitizeBrowserIngestionFields(input);
+		const twice = sanitizeBrowserIngestionFields(once);
+
+		expect(twice).toEqual(once);
+		expect(JSON.stringify(once)).not.toContain(callbackValue);
+		expect(once.payloadData?.unrelated).toBe("unchanged");
+		expect((once.payloadData?.nested as Array<Record<string, string>>)[0]?.href).toContain(
+			"user_code=REDACTED",
+		);
+		expect(
+			sanitizeBrowserPayload({ arbitrary: "https://example.test/?code=deep-secret" }),
+		).toEqual({ arbitrary: "https://example.test/?code=deep-secret" });
+		expect(sanitizeBrowserPayload({ value: "ordinary prose code=not-a-url" })).toEqual({
+			value: "ordinary prose code=not-a-url",
+		});
+		expect(
+			sanitizeBrowserPayload({ nested: { content_preview: "https://x.test/?code=secret" } }),
+		).toEqual({ nested: { content_preview: "https://x.test/?code=REDACTED" } });
+		expect(
+			sanitizeBrowserPayload({ nested: { Source_URL: "https://x.test/#STATE=secret" } }),
+		).toEqual({ nested: { Source_URL: "https://x.test/#STATE=REDACTED" } });
+		let deep: Record<string, unknown> = { url: "https://x.test/?code=too-deep" };
+		for (let i = 0; i < 18; i++) deep = { nested: deep };
+		expect(JSON.stringify(sanitizeBrowserPayload(deep))).not.toContain("too-deep");
+		const many = Array.from({ length: 10_001 }, (_, index) =>
+			index === 10_000
+				? { url: "https://x.test/?code=too-wide" }
+				: { value: "ordinary" },
+		);
+		expect(JSON.stringify(sanitizeBrowserPayload({ records: many }))).not.toContain(
+			"too-wide",
+		);
+		const separatelyBounded = sanitizeBrowserIngestionFields({
+			payloadData: { records: many },
+			attachments: [{ url: "https://x.test/?code=after-wide-field" }],
+		});
+		expect(separatelyBounded.attachments).toEqual([
+			{ url: "https://x.test/?code=REDACTED" },
+		]);
+	});
+
+	test("does not rewrite unrelated records and recognizes browser connector variants", () => {
+		expect(isBrowserConnectorKey("chrome")).toBe(true);
+		expect(isBrowserConnectorKey("chrome.tabs")).toBe(true);
+		expect(isBrowserConnectorKey("Chrome.History")).toBe(true);
+		expect(isBrowserConnectorKey("chromecast.demo")).toBe(false);
+		expect(isBrowserConnectorKey("github")).toBe(false);
+		expect(sanitizeBrowserPayload({ plain: "unchanged" })).toEqual({ plain: "unchanged" });
+		expect(sanitizeBrowserPayload({ url: `chrome://callback?code=${callbackValue}` })).toEqual({
+			url: "chrome://callback?code=REDACTED",
+		});
+	});
+
+	test("deep-scans only known Chrome action result branches", () => {
+		const arbitrary = `https://example.test/?code=${callbackValue}`;
+		const once = sanitizeBrowserActionOutput({
+			value: arbitrary,
+			result: { rows: [{ arbitrary_key: arbitrary }] },
+			responses: [{ body: arbitrary }],
+			tree: [{ name: arbitrary }],
+			observation: { value: arbitrary, result: { arbitrary_key: arbitrary } },
+			unrelated: arbitrary,
+		});
+		const twice = sanitizeBrowserActionOutput(once);
+
+		expect(twice).toEqual(once);
+		expect(once.value).toBe("https://example.test/?code=REDACTED");
+		expect(JSON.stringify(once.result)).not.toContain(callbackValue);
+		expect(JSON.stringify(once.responses)).not.toContain(callbackValue);
+		expect(JSON.stringify(once.tree)).not.toContain(callbackValue);
+		expect(JSON.stringify(once.observation)).not.toContain(callbackValue);
+		expect(once.unrelated).toBe(arbitrary);
+	});
+
+	test("sanitizes page-derived labels and values in browser payloads", () => {
+		const arbitrary = `https://example.test/?code=${callbackValue}`;
+		const out = sanitizeBrowserPayload({
+			field_label: arbitrary,
+			parent_folder_path: arbitrary,
+			fields: [{ label: arbitrary, value: arbitrary }],
+			automation_signals: [
+				{
+					url: arbitrary,
+					resource_ref: arbitrary,
+					input_text: arbitrary,
+					attributes: { callback: arbitrary },
+				},
+			],
+		});
+
+		expect(JSON.stringify(out)).not.toContain(callbackValue);
+	});
+});

--- a/packages/server/src/utils/browser-ingestion-sanitizer.ts
+++ b/packages/server/src/utils/browser-ingestion-sanitizer.ts
@@ -1,0 +1,354 @@
+/**
+ * Server-side containment for browser connector ingestion and run output.
+ *
+ * This walks only payloads already identified as browser-owned. It is not a
+ * general JSON redactor: non-browser connectors remain byte-identical.
+ */
+
+const BROWSER_REDACTED_MARKER = "REDACTED";
+
+/** Shared, case-insensitive OAuth callback parameter vocabulary. */
+const BROWSER_SENSITIVE_URL_KEYS = [
+	"code",
+	"state",
+	"token",
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"client_secret",
+	"user_code",
+	"code_verifier",
+] as const;
+
+const SENSITIVE_KEYS = new Set<string>(BROWSER_SENSITIVE_URL_KEYS);
+const MAX_NESTED_CALLBACK_DEPTH = 3;
+const MAX_ENCODED_CALLBACK_PROBE_DEPTH = 8;
+const MAX_NESTED_BROWSER_DEPTH = 16;
+const MAX_BROWSER_CONTAINERS = 10_000;
+const BROWSER_TEXT_TOKEN_RE = /[^\s<>'"`]+/g;
+const URL_FIELD_KEYS = new Set([
+	"url",
+	"urls",
+	"href",
+	"hrefs",
+	"sourceurl",
+	"fromurl",
+	"browserurl",
+	"resourceurl",
+	"downloadurl",
+	"callbackurl",
+	"redirecturl",
+	"currenturl",
+	"pageurl",
+	"taburl",
+	"targeturl",
+	"openerurl",
+	"referrerurl",
+	"documenturl",
+	"finalurl",
+	"originid",
+	"parentoriginid",
+	"resourceref",
+	"formaction",
+	"referrer",
+]);
+const TEXT_FIELD_KEYS = new Set([
+	"title",
+	"name",
+	"label",
+	"text",
+	"body",
+	"content",
+	"fields",
+	"inputtext",
+	"fieldlabel",
+	"parentfolderpath",
+	"attributes",
+	"payloadtext",
+	"contentpreview",
+	"description",
+	"summary",
+	"message",
+	"error",
+	"errormessage",
+	"outputtail",
+]);
+
+function decodeParamKey(value: string): string {
+	let decoded = value.replace(/\+/g, " ");
+	for (let depth = 0; depth < MAX_NESTED_CALLBACK_DEPTH; depth++) {
+		try {
+			const next = decodeURIComponent(decoded);
+			if (next === decoded) break;
+			decoded = next;
+		} catch {
+			break;
+		}
+	}
+	return decoded.toLowerCase();
+}
+
+function decodeValue(value: string): string | null {
+	if (!value.includes("%") && !value.includes("+")) return value;
+	try {
+		return decodeURIComponent(value.replace(/\+/g, " "));
+	} catch {
+		return null;
+	}
+}
+
+function encodeNestedValue(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function containsSensitiveParameter(value: string): boolean {
+	for (const match of value.matchAll(
+		/(?:^|[?#]|&(?:amp;)?)([^=&?#\s]+)=([^&#\s<>'"`]*)/g,
+	)) {
+		if (!SENSITIVE_KEYS.has(decodeParamKey(match[1] ?? ""))) continue;
+		const decodedValue = decodeValue(match[2] ?? "");
+		if (decodedValue && decodedValue !== BROWSER_REDACTED_MARKER) return true;
+	}
+	return false;
+}
+
+function containsNestedSensitiveParameter(value: string): boolean {
+	let decoded = value;
+	for (let depth = 0; depth < MAX_ENCODED_CALLBACK_PROBE_DEPTH; depth++) {
+		if (containsSensitiveParameter(decoded)) return true;
+		const next = decodeValue(decoded);
+		if (next === null || next === decoded) return false;
+		decoded = next;
+	}
+	return false;
+}
+
+function redactNestedValue(rawValue: string, depth: number): string {
+	if (containsSensitiveParameter(rawValue)) return BROWSER_REDACTED_MARKER;
+	const decoded = decodeValue(rawValue);
+	if (decoded === null || decoded === rawValue) return rawValue;
+	const sanitized = redactBrowserUrlInternal(decoded, depth + 1);
+	if (sanitized !== decoded) return encodeNestedValue(sanitized);
+	return containsSensitiveParameter(decoded) || depth >= MAX_NESTED_CALLBACK_DEPTH
+		? BROWSER_REDACTED_MARKER
+		: rawValue;
+}
+
+function redactParameterPart(part: string, depth: number): string {
+	const equals = part.indexOf("=");
+	if (equals < 0) return part;
+	const key = part.slice(0, equals);
+	const rawValue = part.slice(equals + 1);
+	if (SENSITIVE_KEYS.has(decodeParamKey(key))) {
+		return `${key}=${BROWSER_REDACTED_MARKER}`;
+	}
+	const nested = redactNestedValue(rawValue, depth);
+	return nested === rawValue ? part : `${key}=${nested}`;
+}
+
+function redactUrlPart(url: string, depth: number): string {
+	return url.replace(
+		/(^|[?#]|&(?:amp;)?)([^=&?#\s]+)=([^&#\s<>'"`]+)/g,
+		(_match, separator: string, key: string, value: string) =>
+			`${separator}${redactParameterPart(`${key}=${value}`, depth)}`,
+	);
+}
+
+function redactBrowserUrlInternal(value: string, depth: number): string {
+	if (!value) return value;
+	// Scan URL-like and opaque callback-shaped strings without requiring a valid
+	// URL object. The delimiter requirement avoids rewriting ordinary prose such
+	// as "code=an-example", while still covering malformed and scheme-less URLs.
+	const sanitized = value.replace(BROWSER_TEXT_TOKEN_RE, (match) => {
+		if (!match.includes("?") && !match.includes("#") && !match.includes("//")) {
+			return match;
+		}
+		const trailing = match.match(/[),.;:!?\]}]+$/)?.[0] ?? "";
+		const url = trailing ? match.slice(0, -trailing.length) : match;
+		return `${redactUrlPart(url, depth)}${trailing}`;
+	});
+	if (sanitized !== value) return sanitized;
+	if (depth >= MAX_NESTED_CALLBACK_DEPTH) {
+		return containsNestedSensitiveParameter(value) ? BROWSER_REDACTED_MARKER : value;
+	}
+
+	// A complete callback URL can itself be percent-encoded (and occasionally
+	// double-encoded). Decode only to the small bound above, then restore the
+	// same nesting level around the sanitized URL.
+	const decoded = decodeValue(value);
+	if (decoded === null || decoded === value) return value;
+	const nested = redactBrowserUrlInternal(decoded, depth + 1);
+	if (nested !== decoded) return encodeNestedValue(nested);
+	return containsSensitiveParameter(decoded) ? BROWSER_REDACTED_MARKER : value;
+}
+
+/** Redact query/fragment values while preserving parameter order and duplicates. */
+function redactBrowserUrl(value: string): string {
+	return redactBrowserUrlInternal(value, 0);
+}
+
+function normalizeFieldKey(key: string): string {
+	return key.toLowerCase().replace(/[_-]/g, "");
+}
+
+function sanitizeKnownBrowserFields(
+	value: unknown,
+	depth: number,
+	state: { containers: number },
+	scanStrings = false,
+): unknown {
+	if (typeof value === "string") return scanStrings ? redactBrowserUrl(value) : value;
+	if (value === null || typeof value !== "object") return value;
+	state.containers += 1;
+	if (depth > MAX_NESTED_BROWSER_DEPTH || state.containers > MAX_BROWSER_CONTAINERS) {
+		// Browser payloads are untrusted. If the bounded walk cannot inspect a
+		// branch, discard that branch rather than letting an attacker hide a URL
+		// beyond the traversal budget.
+		return BROWSER_REDACTED_MARKER;
+	}
+	if (Array.isArray(value)) {
+		let changed = false;
+		const out = value.map((item) => {
+			const next = sanitizeKnownBrowserFields(item, depth + 1, state, scanStrings);
+			if (next !== item) changed = true;
+			return next;
+		});
+		return changed ? out : value;
+	}
+
+	const record = value as Record<string, unknown>;
+	let changed = false;
+	const out: Record<string, unknown> = { ...record };
+	for (const [key, child] of Object.entries(record)) {
+		const normalized = normalizeFieldKey(key);
+		const childScansStrings =
+			scanStrings || URL_FIELD_KEYS.has(normalized) || TEXT_FIELD_KEYS.has(normalized);
+		const next = sanitizeKnownBrowserFields(child, depth + 1, state, childScansStrings);
+		if (next !== child) {
+			out[key] = next;
+			changed = true;
+		}
+	}
+	return changed ? out : value;
+}
+
+export function isBrowserConnectorKey(connectorKey: string | null | undefined): boolean {
+	if (typeof connectorKey !== "string") return false;
+	const normalized = connectorKey.toLowerCase();
+	return normalized === "chrome" || normalized.startsWith("chrome.");
+}
+
+interface BrowserIngestionFields {
+	originId?: string | null;
+	parentOriginId?: string | null;
+	title?: string | null;
+	content?: string | null;
+	sourceUrl?: string | null;
+	payloadData?: Record<string, unknown>;
+	payloadTemplate?: Record<string, unknown> | null;
+	attachments?: unknown[];
+	metadata?: Record<string, unknown>;
+	interactionInput?: Record<string, unknown> | null;
+	interactionOutput?: Record<string, unknown> | null;
+	interactionError?: string | null;
+}
+
+/** Sanitize only known browser ingestion fields; return the same object when unchanged. */
+export function sanitizeBrowserIngestionFields<T extends BrowserIngestionFields>(
+	fields: T,
+): T {
+	const out = { ...fields } as T;
+	let changed = false;
+	for (const [key, value] of [
+		["originId", fields.originId],
+		["parentOriginId", fields.parentOriginId],
+		["title", fields.title],
+		["content", fields.content],
+		["sourceUrl", fields.sourceUrl],
+	] as const) {
+		if (typeof value !== "string") continue;
+		const redacted = redactBrowserUrl(value);
+		if (redacted !== value) {
+			(out as Record<string, unknown>)[key] = redacted;
+			changed = true;
+		}
+	}
+	for (const key of [
+		"payloadData",
+		"payloadTemplate",
+		"attachments",
+		"metadata",
+		"interactionInput",
+		"interactionOutput",
+	] as const) {
+		const value = fields[key];
+		if (!value) continue;
+		const redacted = sanitizeKnownBrowserFields(value, 0, { containers: 0 });
+		if (redacted !== value) {
+			(out as Record<string, unknown>)[key] = redacted;
+			changed = true;
+		}
+	}
+	if (typeof fields.interactionError === "string") {
+		const redacted = redactBrowserUrl(fields.interactionError);
+		if (redacted !== fields.interactionError) {
+			(out as Record<string, unknown>).interactionError = redacted;
+			changed = true;
+		}
+	}
+	return changed ? out : fields;
+}
+
+export function sanitizeBrowserText(value: string | null | undefined): string | null | undefined {
+	return typeof value === "string" ? redactBrowserUrl(value) : value;
+}
+
+export function sanitizeBrowserPayload<T>(value: T): T {
+	return sanitizeKnownBrowserFields(value, 0, { containers: 0 }) as T;
+}
+
+/**
+ * Evaluate and generic scrape return arbitrary page-derived data under `value`
+ * or `result`. Deep-scan those unstructured branches; declared browser fields
+ * elsewhere keep the narrow known-field policy used for browser payloads.
+ */
+export function sanitizeBrowserActionOutput<T>(value: T): T {
+	const knownFields = sanitizeBrowserPayload(value);
+	if (knownFields === null || typeof knownFields !== "object" || Array.isArray(knownFields)) {
+		return knownFields;
+	}
+
+	const record = knownFields as Record<string, unknown>;
+	let changed = false;
+	const out: Record<string, unknown> = { ...record };
+	const sanitizeResultBranch = (
+		target: Record<string, unknown>,
+		key: "value" | "result",
+	): boolean => {
+		if (!Object.hasOwn(target, key)) return false;
+		const current = target[key];
+		const sanitized = sanitizeKnownBrowserFields(current, 0, { containers: 0 }, true);
+		if (sanitized !== current) {
+			target[key] = sanitized;
+			return true;
+		}
+		return false;
+	};
+
+	changed = sanitizeResultBranch(out, "value") || changed;
+	changed = sanitizeResultBranch(out, "result") || changed;
+	if (
+		record.observation &&
+		typeof record.observation === "object" &&
+		!Array.isArray(record.observation)
+	) {
+		const observation = { ...(record.observation as Record<string, unknown>) };
+		let observationChanged = sanitizeResultBranch(observation, "value");
+		observationChanged = sanitizeResultBranch(observation, "result") || observationChanged;
+		if (observationChanged) {
+			out.observation = observation;
+			changed = true;
+		}
+	}
+	return changed ? (out as T) : knownFields;
+}

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -35,6 +35,11 @@ import {
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
 import { stripNul, stripNulDeep } from './strip-nul';
+import {
+  isBrowserConnectorKey,
+  sanitizeBrowserIngestionFields,
+  sanitizeBrowserText,
+} from './browser-ingestion-sanitizer';
 
 /**
  * Single bounded retry for the fire-and-forget audit writers below
@@ -486,7 +491,8 @@ function nullableNumber(value: number | string | null): number | null {
 /**
  * Resolve lineage for a new stored version. Connector/feed and identity belong
  * to the chain and are always copied. Producer, run, and parent copy unless
- * the caller supplies a replacement value — null cannot clear them. Identity
+ * the caller supplies a replacement value — null cannot clear them; browser
+ * containment may redact the inherited parent before insertion. Identity
  * cannot first appear on a successor: uniqueness is rooted at
  * supersedes_event_id NULL.
  */
@@ -567,16 +573,73 @@ export async function insertEvent(
   options?: {
     onConflictUpdate?: boolean;
     sql?: DbClient;
+    /** Raw browser identity used only to supersede a pre-containment row. */
+    sourceOriginId?: string;
     /** Transactional hook for durable derived work such as Automation runs. */
     afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
   }
 ): Promise<InsertedEvent> {
   // This is the physical write funnel for event content. Connector items,
-  // Automation output, and approval metadata all converge here, so sanitize
-  // the complete input once before any lookup, comparison, or Postgres write.
-  // stripNulDeep preserves Dates and other class instances.
+  // Automation output, and approval metadata all converge here. stripNulDeep
+  // preserves Dates and other class instances.
   params = stripNulDeep(params) as InsertEventParams;
+  const sourceOriginId = stripNul(options?.sourceOriginId ?? params.originId);
   const sql = options?.sql ?? getDb();
+  // Explicit successors inherit connector lineage from their predecessor even
+  // when the caller omits (or disagrees about) connectorKey.
+  const inheritedConnectorRows = params.supersedesEventId != null
+    ? ((await sql`
+        SELECT connector_key FROM events
+        WHERE id = ${params.supersedesEventId}
+          AND organization_id = ${params.organizationId}
+        LIMIT 1
+      `) as Array<{ connector_key: string | null }>)
+    : [];
+  const browserConnector = isBrowserConnectorKey(
+    inheritedConnectorRows[0]?.connector_key ?? params.connectorKey
+  );
+  if (browserConnector) {
+    const sanitized = sanitizeBrowserIngestionFields({
+      originId: params.originId,
+      parentOriginId: params.parentOriginId,
+      title: params.title,
+      content: params.content,
+      sourceUrl: params.sourceUrl,
+      payloadData: params.payloadData,
+      payloadTemplate: params.payloadTemplate,
+      attachments: params.attachments,
+      metadata: params.metadata,
+      interactionInput: params.interactionInput,
+      interactionOutput: params.interactionOutput,
+      interactionError: params.interactionError,
+    });
+    params = {
+      ...params,
+      originId: sanitized.originId ?? params.originId,
+      parentOriginId: sanitized.parentOriginId,
+      title: sanitized.title,
+      content: sanitized.content,
+      sourceUrl: sanitized.sourceUrl,
+      payloadData: sanitized.payloadData,
+      payloadTemplate: sanitized.payloadTemplate,
+      attachments: sanitized.attachments,
+      metadata: sanitized.metadata,
+      interactionInput: sanitized.interactionInput,
+      interactionOutput: sanitized.interactionOutput,
+      interactionError: sanitized.interactionError,
+      // A worker may have embedded the unsanitized payload before it reached
+      // the gateway. Force the normal server backfill from sanitized
+      // payload_text instead of persisting/indexing that vector.
+      embedding: undefined,
+    };
+  }
+  // A pre-containment row may still be keyed by the raw browser URL. Use the
+  // source identity once for lookup so a fresh sanitized version supersedes
+  // it append-only; subsequent retries fall back to the sanitized identity.
+  const hasDistinctSourceOrigin = browserConnector && sourceOriginId !== params.originId;
+  const sourceOriginLookupParams = hasDistinctSourceOrigin
+    ? { ...params, originId: sourceOriginId }
+    : params;
 
   // Reverse-geocode lat/lng → city / admin1 / country once per event,
   // before insert. Silent no-op when the connector hasn't supplied
@@ -602,9 +665,20 @@ export async function insertEvent(
     let supersedesEventId = params.supersedesEventId ?? null;
 
     if (options?.onConflictUpdate) {
-      const existing = await findCurrentEventByOrigin(activeSql, params);
+      let existing = await findCurrentEventByOrigin(activeSql, sourceOriginLookupParams);
+      const existingHasRawBrowserOrigin = existing != null && hasDistinctSourceOrigin;
+      if (!existing && hasDistinctSourceOrigin) {
+        existing = await findCurrentEventByOrigin(activeSql, params);
+      }
       if (existing) {
-        if (isSemanticallyEqual(existing, params)) {
+        const existingHasRawBrowserParent =
+          browserConnector &&
+          sanitizeBrowserText(existing.origin_parent_id) !== existing.origin_parent_id;
+        if (
+          !existingHasRawBrowserOrigin &&
+          !existingHasRawBrowserParent &&
+          isSemanticallyEqual(existing, params)
+        ) {
           // Reread before touching the embedding. If the row got
           // deleted / tombstoned between findCurrentEventByOrigin and
           // here, upsertEmbedding would FK-fail instead of letting us
@@ -646,7 +720,10 @@ export async function insertEvent(
           // through into the INSERT path with `supersedesEventId` unset so we
           // create a fresh row instead of crashing on `undefined.id`.
           logger.warn(
-            { existingId: existing.id, originId: params.originId },
+            {
+              existingId: existing.id,
+              originId: browserConnector ? '[browser-origin]' : params.originId,
+            },
             '[insert-event] existing row vanished between find and reread — proceeding with fresh insert'
           );
         } else {
@@ -662,7 +739,7 @@ export async function insertEvent(
     sql: DbClient,
     supersedesEventId: number | null
   ): Promise<InsertedEvent> => {
-    const lineage: EventLineage =
+    let lineage: EventLineage =
       supersedesEventId != null
         ? await loadEventLineage(sql, supersedesEventId, params)
         : {
@@ -677,6 +754,12 @@ export async function insertEvent(
             identityNs: params.identity?.ns ?? null,
             identityKey: params.identity?.key ?? null,
           };
+    if (browserConnector) {
+      lineage = {
+        ...lineage,
+        parentOriginId: sanitizeBrowserText(lineage.parentOriginId) ?? null,
+      };
+    }
 
     const insertWithClientId = (activeSql: DbClient, clientId: string | null) => activeSql`
     INSERT INTO events (
@@ -781,7 +864,7 @@ export async function insertEvent(
     // diagnostic context so we can root-cause when it next happens.
     logger.error(
       {
-        originId: params.originId,
+        originId: browserConnector ? '[browser-origin]' : params.originId,
         connectionId: params.connectionId,
         organizationId: params.organizationId,
         semanticType: params.semanticType,
@@ -792,7 +875,8 @@ export async function insertEvent(
     );
     throw new Error(
       `insertEvent: INSERT RETURNING came back empty for ` +
-        `origin_id=${params.originId} connection_id=${params.connectionId}. ` +
+        `origin_id=${browserConnector ? '[browser-origin]' : params.originId} ` +
+        `connection_id=${params.connectionId}. ` +
         `Row was not persisted; check server logs for diagnostic context.`
     );
   }

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -61,6 +61,13 @@ import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import {
+	isBrowserConnectorKey,
+	sanitizeBrowserActionOutput,
+	sanitizeBrowserIngestionFields,
+	sanitizeBrowserPayload,
+	sanitizeBrowserText,
+} from "../utils/browser-ingestion-sanitizer";
+import {
 	bumpDeviceFinalizeNudge,
 	resolveFinalizeNudgeBudget,
 } from "../automations/run-completion";
@@ -118,6 +125,13 @@ async function finalizeRun(
       AND claimed_by = ${params.workerId}
     RETURNING ${returning}
   `) as unknown as Array<Record<string, unknown>>;
+}
+
+async function runUsesBrowserConnector(sql: DbClient, runId: number): Promise<boolean> {
+	const rows = (await sql`
+    SELECT connector_key FROM runs WHERE id = ${runId} LIMIT 1
+  `) as unknown as Array<{ connector_key: string | null }>;
+	return isBrowserConnectorKey(rows[0]?.connector_key);
 }
 
 /**
@@ -218,8 +232,10 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
  * Worker streams content batch for a sync run.
  */
 export async function streamContent(c: Context<{ Bindings: Env }>) {
+	let browserRun = false;
+	const browserSourceOriginIds = new WeakMap<object, string>();
 	try {
-		const batch = await c.req.json<StreamBatch>();
+		let batch = await c.req.json<StreamBatch>();
 
 		// Connector-supplied checkpoints (LinkedIn takeout cursors, browser
 		// scrapes) can carry stray NUL (0x00), which Postgres rejects when written
@@ -266,6 +282,42 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 
 		const run = runRows[0];
 		const entityIds = parsePgNumberArray(run.entity_ids);
+		browserRun = isBrowserConnectorKey(run.connector_key);
+		if (browserRun) {
+			batch = {
+				...batch,
+				items: batch.items.map((item) => {
+					const sanitized = sanitizeBrowserIngestionFields({
+						originId: item.id,
+						parentOriginId: item.origin_parent_id,
+						title: item.title,
+						content: item.payload_text,
+						sourceUrl: item.source_url,
+						payloadData: item.payload_data,
+						payloadTemplate: item.payload_template,
+						attachments: item.attachments,
+						metadata: item.metadata,
+					});
+					const next = {
+						...item,
+						id: sanitized.originId ?? item.id,
+						origin_parent_id: sanitized.parentOriginId,
+						title: sanitized.title,
+						payload_text: sanitized.content ?? item.payload_text,
+						source_url: sanitized.sourceUrl,
+						payload_data: sanitized.payloadData,
+						payload_template: sanitized.payloadTemplate,
+						attachments: sanitized.attachments,
+						metadata: sanitized.metadata,
+						automation_signals: sanitizeBrowserPayload(item.automation_signals),
+						embedding: undefined,
+					};
+					if (next.id !== item.id) browserSourceOriginIds.set(next, item.id);
+					return next;
+				}),
+				checkpoint: sanitizeBrowserPayload(batch.checkpoint),
+			};
+		}
 
 		// A dry run executes the connector for real — same code, same credentials,
 		// same validation, the same INSERTs — and then throws the writes away by
@@ -351,6 +403,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			}
 
 			for (let item of batch.items) {
+				const sourceOriginId = browserSourceOriginIds.get(item);
 				let publishedArtifactIds: string[] = [];
 				let artifactCommitted = false;
 			try {
@@ -372,7 +425,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 						logger.warn(
 							{
 								run_id: batch.run_id,
-								item_id: item.id,
+								item_id: browserRun ? "[browser-item]" : item.id,
 								semantic_type: validationType,
 								errors: kindResult.errors,
 							},
@@ -392,7 +445,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 					logger.warn(
 						{
 							run_id: batch.run_id,
-							item_id: item.id,
+							item_id: browserRun ? "[browser-item]" : item.id,
 							connector: run.connector_key,
 						},
 						"[stream] Skipping event with empty payload_text and title"
@@ -450,6 +503,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 					},
 					{
 						onConflictUpdate: true,
+						sourceOriginId,
 						// Dry path only: the tx that gets rolled back — the INSERT
 						// genuinely executes, so every constraint, trigger and NOT NULL
 						// is exercised for real. The real path must NOT pass `db` even
@@ -564,7 +618,14 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 					}
 				}
 			} catch (err) {
-				console.error("[stream] Insert failed for item", item.id, ":", err);
+				if (browserRun) {
+					console.error(
+						"[stream] Insert failed for browser item:",
+						sanitizeBrowserText(errorMessage(err)),
+					);
+				} else {
+					console.error("[stream] Insert failed for item", item.id, ":", err);
+				}
 				throw err;
 			} finally {
 				if (!artifactCommitted) {
@@ -683,9 +744,12 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			...(rejectedItems.length > 0 && { rejected_items: rejectedItems }),
 		});
 	} catch (err: unknown) {
-		const stack = err instanceof Error ? err.stack : undefined;
-		console.error("[stream] Error:", errorMessage(err), stack);
-		return c.json({ error: errorMessage(err), stack }, 500);
+		const rawMessage = errorMessage(err);
+		const rawStack = err instanceof Error ? err.stack : undefined;
+		const message = browserRun ? sanitizeBrowserText(rawMessage) : rawMessage;
+		const stack = browserRun ? sanitizeBrowserText(rawStack) : rawStack;
+		console.error("[stream] Error:", message, stack);
+		return c.json({ error: message, stack }, 500);
 	}
 }
 
@@ -719,6 +783,12 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
+		const isBrowserRun = await runUsesBrowserConnector(sql, req.run_id);
+		if (isBrowserRun) {
+			req.error_message = sanitizeBrowserText(req.error_message) ?? undefined;
+			req.output_tail = sanitizeBrowserText(req.output_tail) ?? undefined;
+			req.checkpoint = sanitizeBrowserPayload(req.checkpoint);
+		}
 
 		// Atomic terminal-state transition with the shared F2 guard (see
 		// finalizeRun). A no-op (0 rows) means the run was already finalized by
@@ -1876,6 +1946,11 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
+		const isBrowserAuth = await runUsesBrowserConnector(sql, req.run_id);
+		if (isBrowserAuth) {
+			req.error_message = sanitizeBrowserText(req.error_message) ?? undefined;
+			req.output_tail = sanitizeBrowserText(req.output_tail) ?? undefined;
+		}
 
 		// Atomic terminal transition with the shared F2 guard (see finalizeRun), so
 		// a late/reaped completion is a no-op rather than resurrecting the run and
@@ -1996,6 +2071,11 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
+		const isBrowserAction = await runUsesBrowserConnector(sql, req.run_id);
+		if (isBrowserAction) {
+			req.action_output = sanitizeBrowserActionOutput(req.action_output);
+			req.error_message = sanitizeBrowserText(req.error_message) ?? undefined;
+		}
 		const materializedActionOutput = req.action_output
 			? await materializeActionOutputAttachments(req.run_id, req.action_output)
 			: undefined;


### PR DESCRIPTION
## Summary

- Add one server-owned browser ingestion sanitizer with the shared OAuth callback key list, stable redaction marker, bounded nested decoding, and known URL/title/text field traversal.
- Apply containment to chrome and chrome.* stream, direct event, preview, checkpoint, retry, failure/auth diagnostics, action results, and browser-derived automation signals before attribution, attachment materialization, FTS, embedding, or activation work.
- Cover current Chrome watch fields/forms, bookmarks, accessibility node names, network response bodies, evaluate/generic scrape output, and equivalent known browser URL/text keys without recursively rewriting unrelated fields or connectors.
- Sanitize browser origin and inherited parent identities while retaining a lookup-only raw source identity so new ingestion supersedes pre-containment rows append-only and retries stabilize on the sanitized row.
- Drop worker-provided browser embeddings so server backfill reads sanitized stored content.

## Test plan

- [x] Intended five files staged explicitly; make pre-pr clean on the settled diff
- [x] bun test packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts (6 tests, 45 assertions)
- [x] cd packages/server && bun run test -- run src/__tests__/integration/events/browser-ingestion-containment.test.ts (7 tests)
- [x] Browser/device-worker, dry-run, lineage, FTS, and embedding focused integration group (31 tests)
- [x] packages/server TypeScript, pre-commit TypeScript/Biome, and git diff --check
- [ ] Bug fix red-to-green output: not captured; this is forward-looking ingestion containment with new regression coverage
- [ ] If bot runtime changed: not applicable

## Notes

- No public API, SDK, database schema, migration, or Owletto change.
- Events remain append-only. Existing historical browser events and embeddings are deliberately not rewritten; historical remediation is a separate risk-reduction PR.
- Browser scope follows the existing server convention: connector key chrome or chrome.* (including browser feed/device keys such as chrome.history).