### PR TITLE
fix: validate run_sdk dry-run actions

### DIFF
--- a/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
+++ b/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
@@ -49,6 +49,100 @@ describe("ClientSDK business failure boundary", () => {
 		expect(result.error?.message).not.toContain('{"');
 	});
 
+	it.each([
+		["feeds.delete", "client.feeds.delete({ id: 589 })", "feed_id"],
+		[
+			"connections.delete",
+			"client.connections.delete({ id: 546 })",
+			"connection_id",
+		],
+	])(
+		"validates malformed skipped %s calls before previewing them",
+		async (publicMethod, call, field) => {
+			const result = await runScript({
+				source: `export default async (_ctx, client) => ${call};`,
+				sdk: workspace.owner,
+				sdkMode: "full",
+				dryRun: true,
+				maxAccessLevel: "admin",
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error?.message).toContain(publicMethod);
+			expect(result.error?.message).toContain(field);
+			expect(result.sideEffectPreview).toEqual([]);
+			expect(result.skippedCalls).toBe(0);
+		},
+	);
+
+	it("previews canonical args across access classes without executing handlers", async () => {
+		const result = await runScript({
+			source: `export default async (_ctx, client) => Promise.all([
+				client.feeds.delete({ feed_id: 589 }),
+				client.connections.delete(546),
+				client.connections.update({ connection_id: 547, status: "error" }),
+				client.operations.execute({ connection_id: 549, operation_key: "dry_run_probe" }),
+			]);`,
+			sdk: workspace.owner,
+			sdkMode: "full",
+			dryRun: true,
+			maxAccessLevel: "admin",
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.success).toBe(true);
+		expect(result.skippedCalls).toBe(4);
+		expect(result.sideEffectPreview).toMatchObject([
+			{
+				path: "feeds.delete",
+				args: [{ feed_id: 589 }],
+				required_access: "admin",
+				authorization_status: "not_evaluated",
+			},
+			{
+				path: "connections.delete",
+				args: [{ connection_id: 546 }],
+				required_access: "admin",
+				authorization_status: "not_evaluated",
+			},
+			{
+				path: "connections.update",
+				args: [{ connection_id: 547, status: "error" }],
+				required_access: "write",
+				authorization_status: "not_evaluated",
+			},
+			{
+				path: "operations.execute",
+				args: [{ connection_id: 549, operation_key: "dry_run_probe" }],
+				required_access: "external",
+				authorization_status: "not_evaluated",
+			},
+		]);
+		expect(result.returnValue).toEqual([
+			{ dry_run: true, skipped_call: "feeds.delete", access: "admin" },
+			{ dry_run: true, skipped_call: "connections.delete", access: "admin" },
+			{ dry_run: true, skipped_call: "connections.update", access: "write" },
+			{ dry_run: true, skipped_call: "operations.execute", access: "external" },
+		]);
+	});
+
+	it("keeps reads live during dry-run", async () => {
+		const result = await runScript({
+			source: `export default async (_ctx, client) => client.connections.list({ limit: 1 });`,
+			sdk: workspace.owner,
+			sdkMode: "full",
+			dryRun: true,
+			maxAccessLevel: "admin",
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.skippedCalls).toBe(0);
+		expect(result.sideEffectPreview).toEqual([]);
+		expect(result.sdkCallTrace).toMatchObject([
+			{ path: "connections.list", skipped: false },
+		]);
+	});
+
 	it("redacts secrets and bounds structured error details", () => {
 		expect(
 			safeErrorDetails({

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -17,8 +17,31 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { Type } from "@sinclair/typebox";
 import type { ClientSDK } from "../../../sandbox/client-sdk";
+import { METHOD_METADATA } from "../../../sandbox/method-metadata";
 import { runScript } from "../../../sandbox/run-script";
+import { createValidatedSdkMethod } from "../../../sandbox/sdk-preflight";
+import { withValidatedArgs } from "../../../tools/validate-args";
+
+const StubArgsSchema = Type.Object({ args: Type.Array(Type.Unknown()) });
+
+function createTestSdkMethod(
+  path: string,
+  method: (...args: unknown[]) => unknown,
+): (...args: unknown[]) => Promise<unknown> {
+  const handler = withValidatedArgs(
+    `test.${path}`,
+    StubArgsSchema,
+    async ({ args }) => method(...args),
+  );
+  return createValidatedSdkMethod(handler, [], {
+    path,
+    prepareArgs: (...args) => ({ args }),
+    projectArgs: (validated) =>
+      (validated as { args: unknown[] }).args,
+  });
+}
 
 // Counts compiles so the memo is asserted by call count rather than by
 // wall-clock timing, which is unassertable at the ~3ms scale a warm run costs.
@@ -315,6 +338,19 @@ describe("compiled-source memo", () => {
 });
 
 function stubSDK(partial: Partial<ClientSDK> = {}): ClientSDK {
+  for (const [namespaceName, namespace] of Object.entries(partial)) {
+    if (!namespace || typeof namespace !== "object") continue;
+    for (const [methodName, method] of Object.entries(namespace)) {
+      const metadata = METHOD_METADATA[`${namespaceName}.${methodName}`];
+      if (!metadata || metadata.access === "read" || typeof method !== "function") {
+        continue;
+      }
+      (namespace as Record<string, unknown>)[methodName] = createTestSdkMethod(
+        `${namespaceName}.${methodName}`,
+        method as (...args: unknown[]) => unknown,
+      );
+    }
+  }
   return { log: () => undefined, ...partial } as ClientSDK;
 }
 

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -210,8 +210,20 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 			},
 			skipped_calls: 2,
 			side_effect_preview: [
-				{ path: "entities.create", access: "write", args: [{}] },
-				{ path: "connections.connect", access: "admin", args: [{}] },
+				{
+					path: "entities.create",
+					access: "write",
+					args: [{}],
+					required_access: "write",
+					authorization_status: "not_evaluated",
+				},
+				{
+					path: "connections.connect",
+					access: "admin",
+					args: [{}],
+					required_access: "admin",
+					authorization_status: "not_evaluated",
+				},
 			],
 			side_effect_preview_truncated: { dropped_entries: 3 },
 			dry_run: true,

--- a/packages/server/src/__tests__/unit/sandbox/_helpers.ts
+++ b/packages/server/src/__tests__/unit/sandbox/_helpers.ts
@@ -1,7 +1,30 @@
 import { expect } from "bun:test";
+import { Type } from "@sinclair/typebox";
 import type { ClientSDK } from "../../../sandbox/client-sdk";
+import { METHOD_METADATA } from "../../../sandbox/method-metadata";
 import { runScript, type RunScriptOptions } from "../../../sandbox/run-script";
+import { createValidatedSdkMethod } from "../../../sandbox/sdk-preflight";
 import type { ToolContext } from "../../../tools/registry";
+import { withValidatedArgs } from "../../../tools/validate-args";
+
+const StubArgsSchema = Type.Object({ args: Type.Array(Type.Unknown()) });
+
+function createTestSdkMethod(
+  path: string,
+  method: (...args: unknown[]) => unknown,
+): (...args: unknown[]) => Promise<unknown> {
+  const handler = withValidatedArgs(
+    `test.${path}`,
+    StubArgsSchema,
+    async ({ args }) => method(...args),
+  );
+  return createValidatedSdkMethod(handler, [], {
+    path,
+    prepareArgs: (...args) => ({ args }),
+    projectArgs: (validated) =>
+      (validated as { args: unknown[] }).args,
+  });
+}
 
 export const baseCtx: ToolContext = {
   organizationId: "org_test",
@@ -18,6 +41,19 @@ export function ctx(overrides: Partial<ToolContext>): ToolContext {
 }
 
 export function stubSDK(partial: Partial<ClientSDK> = {}): ClientSDK {
+  for (const [namespaceName, namespace] of Object.entries(partial)) {
+    if (!namespace || typeof namespace !== "object") continue;
+    for (const [methodName, method] of Object.entries(namespace)) {
+      const metadata = METHOD_METADATA[`${namespaceName}.${methodName}`];
+      if (!metadata || metadata.access === "read" || typeof method !== "function") {
+        continue;
+      }
+      (namespace as Record<string, unknown>)[methodName] = createTestSdkMethod(
+        `${namespaceName}.${methodName}`,
+        method as (...args: unknown[]) => unknown,
+      );
+    }
+  }
   return { log: () => undefined, ...partial } as ClientSDK;
 }
 

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from "bun:test";
+import { Type } from "@sinclair/typebox";
 import {
 	ClientSdkActionError,
 	createActionCaller,
 } from "../../../sandbox/namespaces/action-call";
+import { getSdkPreflight } from "../../../sandbox/sdk-preflight";
 import { ToolUserError } from "../../../utils/errors";
+import { withValidatedArgs } from "../../../tools/validate-args";
+
+const PassthroughSchema = Type.Object({}, { additionalProperties: true });
+
+function createTestCaller(
+	handler: (payload: never) => Promise<unknown>,
+	namespace: string,
+) {
+	return createActionCaller(
+		withValidatedArgs(`manage_${namespace}`, PassthroughSchema, handler),
+		{} as never,
+		{} as never,
+		namespace,
+	);
+}
 
 describe("createActionCaller", () => {
 	it("forces the action discriminator, ignoring a caller-supplied `action` key", async () => {
@@ -12,14 +29,10 @@ describe("createActionCaller", () => {
 			calls.push(payload);
 			return payload;
 		};
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
+		const { method } = createTestCaller(handler as never, "entities");
 
 		// A read-only caller tries to smuggle `action: "delete"` into a "list" call.
-		await action("list", { action: "delete", entity_id: 42 });
+		await method("list")({ action: "delete", entity_id: 42 });
 
 		expect(calls).toHaveLength(1);
 		expect((calls[0] as Record<string, unknown>).action).toBe("list");
@@ -32,12 +45,8 @@ describe("createActionCaller", () => {
 			calls.push(payload);
 			return payload;
 		};
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
-		await action("get", { entity_id: 7 });
+		const { method } = createTestCaller(handler as never, "entities");
+		await method("get")({ entity_id: 7 });
 		expect(calls[0]).toEqual({ entity_id: 7, action: "get" });
 	});
 
@@ -47,13 +56,9 @@ describe("createActionCaller", () => {
 			setup_url: "/connections",
 		};
 		const handler = async () => failure;
-		const { manage, action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
+		const { manage, method } = createTestCaller(handler as never, "connections");
 
-		const thrown = await action("connect", {
+		const thrown = await method("connect")({
 			connector_key: "missing",
 		}).catch((error: unknown) => error);
 		expect(thrown).toBeInstanceOf(ClientSdkActionError);
@@ -77,13 +82,9 @@ describe("createActionCaller", () => {
 			message: "Automation not found: 404",
 			data: { automation_id: 404 },
 		});
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
+		const { method } = createTestCaller(handler as never, "classifiers");
 
-		const thrown = await action("create", {
+		const thrown = await method("create")({
 			automation_id: 404,
 		}).catch((error: unknown) => error);
 		expect(thrown).toBeInstanceOf(ClientSdkActionError);
@@ -103,13 +104,9 @@ describe("createActionCaller", () => {
 				error_message: `Operation ended with status ${status}`,
 			};
 			const handler = async () => failure;
-			const { action } = createActionCaller(
-				handler as never,
-				{} as never,
-				{} as never,
-			);
+			const { method } = createTestCaller(handler as never, "operations");
 
-			await expect(action("execute", {})).rejects.toMatchObject({
+			await expect(method("execute")({})).rejects.toMatchObject({
 				name: "ClientSdkActionError",
 				action: "execute",
 				message: failure.error_message,
@@ -124,13 +121,9 @@ describe("createActionCaller", () => {
 			error_message: "Device action run timed out",
 		};
 		const handler = async () => failure;
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
+		const { method } = createTestCaller(handler as never, "operations");
 
-		await expect(action("execute", {})).rejects.toMatchObject({
+		await expect(method("execute")({})).rejects.toMatchObject({
 			name: "ClientSdkActionError",
 			action: "execute",
 			message: failure.error_message,
@@ -151,13 +144,9 @@ describe("createActionCaller", () => {
 			summary: { total: 1, successful: 0, failed: 1 },
 		};
 		const handler = async () => failure;
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-		);
+		const { method } = createTestCaller(handler as never, "automations");
 
-		await expect(action("delete", {})).rejects.toMatchObject({
+		await expect(method("delete")({})).rejects.toMatchObject({
 			name: "ClientSdkActionError",
 			action: "delete",
 			message: failure.results[0].message,
@@ -174,15 +163,10 @@ describe("createActionCaller", () => {
 				"Invalid arguments for manage_feeds: unknown argument(s): limit — valid arguments for action 'read_feed' are: action, feed_id, connection_id",
 			);
 		};
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-			"feeds",
-		);
-		const thrown = (await action("read_feed", { id: 1 }, "get").catch(
-			(e: unknown) => e,
-		)) as ToolUserError;
+		const { method } = createTestCaller(handler as never, "feeds");
+		const thrown = (await method("read_feed", { publicMethod: "get" })({
+			id: 1,
+		}).catch((e: unknown) => e)) as ToolUserError;
 		expect(thrown).toBeInstanceOf(ToolUserError);
 		expect(thrown.message).not.toMatch(/manage_feeds/);
 		expect(thrown.message).toMatch(/client\.feeds\.get/);
@@ -200,28 +184,13 @@ describe("createActionCaller", () => {
 				"Invalid arguments for manage_classifiers: /entity_type: Expected required property",
 			);
 		};
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-			"classifiers",
-		);
-		const thrown = (await action("generate_embeddings", {}).catch(
+		const { method } = createTestCaller(handler as never, "classifiers");
+		const thrown = (await method("generate_embeddings")({}).catch(
 			(e: unknown) => e,
 		)) as ToolUserError;
 		expect(thrown.message).not.toMatch(/manage_classifiers/);
 		expect(thrown.message).not.toMatch(/generate_embeddings/);
 		expect(thrown.message).toMatch(/client\.classifiers\.generateEmbeddings/);
-	});
-
-	it("leaves errors from callers with no declared namespace untouched", async () => {
-		const handler = async () => {
-			throw new ToolUserError("Invalid arguments for manage_feeds: boom");
-		};
-		const { action } = createActionCaller(handler as never, {} as never, {} as never);
-		const thrown = (await action("read_feed", {}).catch((e: unknown) => e)) as ToolUserError;
-		// No namespace → nothing to rewrite to; message passes through.
-		expect(thrown.message).toBe("Invalid arguments for manage_feeds: boom");
 	});
 
 	it("leaves non-validator errors from namespaced callers untouched", async () => {
@@ -230,13 +199,10 @@ describe("createActionCaller", () => {
 		const handler = async () => {
 			throw new ToolUserError(message);
 		};
-		const { action } = createActionCaller(
-			handler as never,
-			{} as never,
-			{} as never,
-			"feeds",
-		);
-		const thrown = (await action("trigger_feed", {}).catch(
+		const { method } = createTestCaller(handler as never, "feeds");
+		const thrown = (await method("trigger_feed", {
+			publicMethod: "trigger",
+		})({}).catch(
 			(e: unknown) => e,
 		)) as ToolUserError;
 		expect(thrown.message).toBe(message);
@@ -250,12 +216,45 @@ describe("createActionCaller", () => {
 			approval_run_id: 42,
 		};
 		const handler = async () => queued;
-		const { action } = createActionCaller(
+		const { method } = createTestCaller(handler as never, "entities");
+
+		await expect(method("delete")({ entity_id: 7 })).resolves.toEqual(queued);
+	});
+
+	it("preflights through the handler schema without entering the handler or inspecting its result", async () => {
+		let executed = false;
+		const handler = withValidatedArgs(
+			"manage_connections",
+			Type.Object({
+				action: Type.Literal("update"),
+				connection_id: Type.Number(),
+				status: Type.Optional(Type.String()),
+			}),
+			async () => {
+				executed = true;
+				return { status: "error" };
+			},
+		);
+		const { method } = createActionCaller(
 			handler as never,
 			{} as never,
 			{} as never,
+			"connections",
 		);
+		const update = method("update");
+		const preflight = getSdkPreflight(update);
 
-		await expect(action("delete", { entity_id: 7 })).resolves.toEqual(queued);
+		expect(preflight).toBeDefined();
+		expect(preflight?.({ connection_id: "9", status: "error" })).toEqual({
+			args: [{ connection_id: 9, status: "error" }],
+			required_access: "write",
+			authorization_status: "not_evaluated",
+		});
+		expect(executed).toBe(false);
+
+		await expect(update({ connection_id: "not-a-number" })).rejects.toThrow(
+			/client\.connections\.update/,
+		);
+		expect(executed).toBe(false);
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/action-discriminator-source.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-discriminator-source.test.ts
@@ -12,8 +12,9 @@ import { describe, expect, it } from "bun:test";
  *   callEntity({ action: "list", ...input }, "listTypes")
  *   // -> action(payload.action as string, …)   // caller picks the handler
  *
- * `action()` strips a caller-supplied `action` key for exactly this reason,
- * which only holds if the name it is handed is a literal from the call site.
+ * The named-method adapter strips a caller-supplied `action` key for exactly
+ * this reason, which only holds if its action name is a literal from the call
+ * site.
  */
 
 const NAMESPACE_DIR = join(__dirname, "../../../sandbox/namespaces");

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../sandbox/method-metadata";
 import { SDK_FIELD_ALIASES } from "../../../sandbox/sdk-aliases";
 import { buildClientSDK } from "../../../sandbox/client-sdk";
+import { getSdkPreflight } from "../../../sandbox/sdk-preflight";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
 
@@ -79,6 +80,23 @@ describe("method-metadata", () => {
 			}
 			void path;
 		}
+	});
+
+	it("gives every non-read namespace method a schema-backed dry-run preflight", () => {
+		const sdk = buildClientSDK(testCtx, testEnv) as unknown as Record<
+			string,
+			Record<string, unknown>
+		>;
+		const missing = Object.entries(METHOD_METADATA)
+			.filter(([, metadata]) => metadata.access !== "read")
+			.filter(([path]) => path.includes("."))
+			.filter(([path]) => {
+				const [namespace, method] = path.split(".");
+				return !getSdkPreflight(sdk[namespace]?.[method]);
+			})
+			.map(([path]) => path);
+
+		expect(missing).toEqual([]);
 	});
 
 	it("uses dotted path keys", () => {

--- a/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { beforeAll, describe, expect, it, mock } from "bun:test";
+import { Type } from "@sinclair/typebox";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
+import { withValidatedArgs } from "../../../tools/validate-args";
 
 const listCalls: Array<Record<string, unknown>> = [];
 const markCalls: Array<{ organizationId: string; userId: string; id: number }> =
@@ -39,19 +41,23 @@ mock.module("../../../notifications/service", () => ({
 }));
 
 mock.module("../../../tools/admin/notify", () => ({
-	notify: async (
-		args: Record<string, unknown>,
-		notifyEnv: Env,
-		notifyCtx: ToolContext,
-	) => {
-		notifyCalls.push({ args, env: notifyEnv, ctx: notifyCtx });
-		return {
-			notified_count: 1,
-			event_id: 41,
-			url: "/atlas/activity?event=41",
-			run_id: 42,
-		};
-	},
+	notify: withValidatedArgs(
+		"notify",
+		Type.Object({}, { additionalProperties: true }),
+		async (
+			args: Record<string, unknown>,
+			notifyEnv: Env,
+			notifyCtx: ToolContext,
+		) => {
+			notifyCalls.push({ args, env: notifyEnv, ctx: notifyCtx });
+			return {
+				notified_count: 1,
+				event_id: 41,
+				url: "/atlas/activity?event=41",
+				run_id: 42,
+			};
+		}
+	),
 }));
 
 const env = { ENVIRONMENT: "test" } as Env;

--- a/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
@@ -178,6 +178,8 @@ describe("guest-side proxy traps", () => {
           },
         ],
         skipped: true,
+        required_access: "write",
+        authorization_status: "not_evaluated",
       },
     ]);
   });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
@@ -6,17 +6,23 @@ import {
 	it,
 	mock,
 } from "bun:test";
+import { Type } from "@sinclair/typebox";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
+import { withValidatedArgs } from "../../../tools/validate-args";
 
 const calls: Array<{ action: string; input?: Record<string, unknown> }> = [];
 const automationGets: Array<Record<string, unknown>> = [];
 
-const captureAction = async (input: Record<string, unknown>) => {
-	const { action, ...rest } = input;
-	calls.push({ action: String(action), input: rest });
-	return input;
-};
+const captureAction = withValidatedArgs(
+	"capture_action",
+	Type.Object({}, { additionalProperties: true }),
+	async (input: Record<string, unknown>) => {
+		const { action, ...rest } = input;
+		calls.push({ action: String(action), input: rest });
+		return input;
+	},
+);
 
 mock.module("../../../tools/admin/manage_entity", () => ({
 	manageEntity: captureAction,

--- a/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
+++ b/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
@@ -38,6 +38,8 @@ describe("SDK MCP public result", () => {
 					access: "write",
 					args: [{ name: "A" }],
 					skipped: true,
+					required_access: "write",
+					authorization_status: "not_evaluated",
 				},
 			],
 			dry_run: true,
@@ -52,7 +54,13 @@ describe("SDK MCP public result", () => {
 		expect(publicResult.skipped_calls).toBe(1);
 		expect(publicResult.return_value).toEqual({ answer: 42 });
 		expect(publicResult.side_effect_preview).toEqual([
-			{ path: "entities.create", access: "write", args: [{ name: "A" }] },
+			{
+				path: "entities.create",
+				access: "write",
+				args: [{ name: "A" }],
+				required_access: "write",
+				authorization_status: "not_evaluated",
+			},
 		]);
 		expect(publicResult.error).toEqual({
 			name: "TypeError",
@@ -95,7 +103,13 @@ describe("SDK MCP public result", () => {
 			success: true,
 			skipped_calls: 3,
 			side_effect_preview: [
-				{ path: "entities.create", access: "mystery", args: [] },
+				{
+					path: "entities.create",
+					access: "mystery",
+					args: [],
+					required_access: "write",
+					authorization_status: "not_evaluated",
+				},
 				{ path: 42, args: [] },
 			],
 			return_value_preview: "head",
@@ -105,7 +119,13 @@ describe("SDK MCP public result", () => {
 
 		expect(validateToolResult(SdkScriptResultSchema, publicResult)).not.toBeNull();
 		expect(publicResult.side_effect_preview).toEqual([
-			{ path: "entities.create", access: "unknown", args: [] },
+			{
+				path: "entities.create",
+				access: "unknown",
+				args: [],
+				required_access: "write",
+				authorization_status: "not_evaluated",
+			},
 		]);
 		expect(publicResult.side_effect_preview_truncated).toEqual({ dropped_entries: 2 });
 		expect(publicResult.return_value_preview).toBe("head");

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -22,6 +22,7 @@
  */
 
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { Type } from "@sinclair/typebox";
 import {
 	MEMBER_WRITE_ACTIONS,
 	OWNER_ADMIN_ACTIONS,
@@ -30,6 +31,7 @@ import {
 } from "../tool-access";
 import { METHOD_METADATA } from "../../sandbox/method-metadata";
 import { AGENTS_SDK_ACTION } from "../../tools/sdk_search";
+import { withValidatedArgs } from "../../tools/validate-args";
 
 /**
  * The `manage_*` tool the SDK namespace delegates to, per namespace prefix.
@@ -105,8 +107,14 @@ async function captureActionMap(): Promise<void> {
 		}
 		return {};
 	};
-	for (const [, , mod, exportName] of TIERED_NAMESPACES) {
-		vi.doMock(mod, () => ({ [exportName]: stub }));
+	for (const [, tool, mod, exportName] of TIERED_NAMESPACES) {
+		vi.doMock(mod, () => ({
+			[exportName]: withValidatedArgs(
+				tool,
+				Type.Object({}, { additionalProperties: true }),
+				stub,
+			),
+		}));
 	}
 
 	const ctx = { organizationId: "o", userId: "u" } as never;

--- a/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
+++ b/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
@@ -3,11 +3,11 @@
  *
  * `send` returns a discriminated result whose `status` may be "error" or
  * "timeout" — NON-throwing outcomes the caller must branch on. The generic
- * `action()` wrapper (createActionCaller) runs failureMessage(), which turns a
- * result with `status:"error"` / `status:"timeout"` (or an `error` field) into a
- * thrown ClientSdkActionError. So `send` must route through `manage()` (raw),
- * NOT `action()`. This test pins that: a mocked handler returning each status
- * comes back as a VALUE, and a genuine handler throw still propagates.
+ * named-method wrapper runs failureMessage(), which turns a result with
+ * `status:"error"` / `status:"timeout"` (or an `error` field) into a thrown
+ * ClientSdkActionError. `send` disables that conversion. This test pins that:
+ * a mocked handler returning each status comes back as a VALUE, and a genuine
+ * handler throw still propagates.
  *
  * Uses vi.doMock + vi.resetModules + dynamic import (NOT hoisted vi.mock): the
  * integration suite shares a module registry across files, where a hoisted
@@ -18,8 +18,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Type } from "@sinclair/typebox";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
+import { withValidatedArgs } from "../../../tools/validate-args";
 
 const env = { ENVIRONMENT: "test" } as Env;
 const ctx = { organizationId: "o", userId: "u" } as ToolContext;
@@ -28,7 +30,11 @@ const ctx = { organizationId: "o", userId: "u" } as ToolContext;
 async function loadNamespaceWith(handler: () => Promise<unknown>) {
 	vi.resetModules();
 	vi.doMock("../../../tools/admin/manage_conversations", () => ({
-		manageConversations: handler,
+		manageConversations: withValidatedArgs(
+			"manage_conversations",
+			Type.Object({}, { additionalProperties: true }),
+			handler,
+		),
 	}));
 	const { buildConversationsNamespace } = await import("../conversations.js");
 	return buildConversationsNamespace(ctx, env);

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -1,9 +1,18 @@
 import type { Env } from "../../index";
 import type { ToolContext } from "../../tools/registry";
+import { getArgsValidator } from "../../tools/validate-args";
 import { ToolUserError } from "../../utils/errors";
 import { applyFieldAliases } from "../sdk-aliases";
+import { METHOD_METADATA } from "../method-metadata";
+import { createValidatedSdkMethod } from "../sdk-preflight";
 
 type AdminHandler = (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
+
+interface ActionMethodOptions {
+	publicMethod?: string;
+	mapArgs?: (...args: any[]) => object | undefined;
+	checkFailure?: boolean;
+}
 
 /**
  * Consistent failure raised by named ClientSDK namespace methods when a legacy
@@ -130,16 +139,16 @@ function snakeToCamel(name: string): string {
  * method the caller actually invoked. An arg-validation failure raised deep in
  * an admin handler reads `Invalid arguments for manage_feeds: …`, but a fresh
  * agent only ever called `client.feeds.get` — `manage_feeds` is internal
- * plumbing it cannot search or recover against. When the namespace is known,
- * swap `manage_<x>` for `client.<namespace>.<method>` and keep the field-level
- * detail (`/feed_id: Expected required property`) intact.
+ * plumbing it cannot search or recover against. Swap `manage_<x>` for
+ * `client.<namespace>.<method>` and keep the field-level detail
+ * (`/feed_id: Expected required property`) intact.
  */
 function rewriteInternalToolName(
 	err: unknown,
-	sdkNamespace: string | undefined,
+	sdkNamespace: string,
 	publicMethod: string,
 ): unknown {
-	if (!sdkNamespace || !(err instanceof ToolUserError)) return err;
+	if (!(err instanceof ToolUserError)) return err;
 	const internalValidatorPrefix = /Invalid arguments for manage_[a-z_]+/;
 	if (!internalValidatorPrefix.test(err.message)) return err;
 	const rewritten = err.message
@@ -171,55 +180,72 @@ export function createActionCaller(
 	handler: AdminHandler,
 	env: Env,
 	ctx: ToolContext,
-	/**
-	 * Public ClientSDK namespace (e.g. `"feeds"`) this caller belongs to. When
-	 * set, arg-validation errors that leak the internal `manage_*` tool name are
-	 * rewritten to `client.<namespace>.<method>`. Omit for callers with no public
-	 * SDK surface (errors then pass through unchanged).
-	 */
-	sdkNamespace?: string,
+	/** Public ClientSDK namespace (for example, `"feeds"`). */
+	sdkNamespace: string,
 ) {
-	const manage = <T>(payload: object): Promise<T> =>
-		handler(payload as never, env, ctx) as Promise<T>;
-
-	const action = async <T>(
+	if (!getArgsValidator(handler)) {
+		throw new Error(
+			`SDK namespace '${sdkNamespace}' requires a withValidatedArgs handler`,
+		);
+	}
+	const prepareActionPayload = (
 		actionName: string,
-		input: object = {},
-		/**
-		 * Public SDK method name. Defaults to the CAMEL-CASE of the internal
-		 * action (`generate_embeddings` → `generateEmbeddings`), which is the
-		 * actual method on most namespaces — a bare snake_case default would
-		 * render a nonexistent path like `client.classifiers.generate_embeddings`.
-		 * Namespaces whose public name diverges from the action (e.g. feeds
-		 * `read_feed` → `get`) pass it explicitly.
-		 */
-		publicMethod: string = snakeToCamel(actionName),
-	): Promise<T> => {
+		input: object | undefined,
+		publicMethod: string,
+	): Record<string, unknown> => {
 		// Spread caller input FIRST, then force `action` so a caller-supplied
-		// `action` key (e.g. from a read-only query_sdk script) can never override
-		// the discriminator and reach a write/delete handler.
-		const { action: _ignored, ...rest } = input as Record<string, unknown>;
-		// Rewrite accepted field aliases (sdk-aliases.ts) to their canonical
-		// names — the same registry search_sdk renders, so discovery == runtime.
-		const canonical = sdkNamespace
-			? applyFieldAliases(`${sdkNamespace}.${publicMethod}`, rest)
-			: rest;
-		let result: T;
-		try {
-			result = await manage<T>({ ...canonical, action: actionName });
-		} catch (err) {
-			throw rewriteInternalToolName(err, sdkNamespace, publicMethod);
-		}
-		const failure = failureMessage(actionName, result);
-		if (failure) {
-			throw new ClientSdkActionError(
-				actionName,
-				failure.message,
-				failure.result,
-			);
-		}
-		return result;
+		// discriminator can never select a different handler branch.
+		const { action: _ignored, ...rest } = (input ?? {}) as Record<
+			string,
+			unknown
+		>;
+		const canonical = applyFieldAliases(`${sdkNamespace}.${publicMethod}`, rest);
+		return { ...canonical, action: actionName };
+	};
+	const managePath = `${sdkNamespace}.manage`;
+	const manage =
+		METHOD_METADATA[managePath]
+			? createValidatedSdkMethod(handler, [env, ctx], {
+					path: managePath,
+					prepareArgs: (payload) => payload,
+				})
+			: (<T>(payload: object): Promise<T> =>
+					handler(payload as never, env, ctx) as Promise<T>);
+	const method = (
+		actionName: string,
+		options: ActionMethodOptions = {},
+	): ((...args: any[]) => Promise<any>) => {
+		const publicMethod = options.publicMethod ?? snakeToCamel(actionName);
+		const mapArgs = options.mapArgs ?? ((input?: object) => input ?? {});
+		return createValidatedSdkMethod(handler, [env, ctx], {
+			path: `${sdkNamespace}.${publicMethod}`,
+			prepareArgs: (...args) =>
+				prepareActionPayload(actionName, mapArgs(...args), publicMethod),
+			projectArgs: (validated) => {
+				const { action: _action, ...publicArgs } = validated as Record<
+					string,
+					unknown
+				>;
+				return [publicArgs];
+			},
+			rewriteError: (error) =>
+				rewriteInternalToolName(error, sdkNamespace, publicMethod),
+			transformResult: (result) => {
+				const failure =
+					options.checkFailure === false
+						? null
+						: failureMessage(actionName, result);
+				if (failure) {
+					throw new ClientSdkActionError(
+						actionName,
+						failure.message,
+						failure.result,
+					);
+				}
+				return result;
+			},
+		});
 	};
 
-	return { manage, action };
+	return { manage, method };
 }

--- a/packages/server/src/sandbox/namespaces/agents.ts
+++ b/packages/server/src/sandbox/namespaces/agents.ts
@@ -34,20 +34,22 @@ export function buildAgentsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): AgentsNamespace {
-	const { manage, action } = createActionCaller(manageAgents, env, ctx, "agents");
+	const { manage, method } = createActionCaller(manageAgents, env, ctx, "agents");
 
 	return {
 		manage,
-		list: () => action("list", {}),
-		get: (agent_id) =>
-			action("get", {
+		list: method("list"),
+		get: method("get", {
+			mapArgs: (agent_id) => ({
 				agent_id: idArg("agents.get", "agent_id", agent_id, "string"),
 			}),
-		create: (input) => action("create", input),
-		update: (input) => action("update", input),
-		delete: (agent_id) =>
-			action("delete", {
+		}),
+		create: method("create"),
+		update: method("update"),
+		delete: method("delete", {
+			mapArgs: (agent_id) => ({
 				agent_id: idArg("agents.delete", "agent_id", agent_id, "string"),
 			}),
+		}),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -65,7 +65,7 @@ export function buildAuthProfilesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): AuthProfilesNamespace {
-	const { manage, action } = createActionCaller(
+	const { manage, method } = createActionCaller(
 		manageAuthProfiles,
 		env,
 		ctx,
@@ -74,48 +74,42 @@ export function buildAuthProfilesNamespace(
 
 	return {
 		manage,
-		list: (input) => action("list_auth_profiles", input, "list"),
-		get: async (auth_profile_slug) =>
-			action(
-				"get_auth_profile",
-				{
-					auth_profile_slug: idArg(
-						"authProfiles.get",
-						"auth_profile_slug",
-						auth_profile_slug,
-						"string",
-					),
-				},
-				"get",
-			),
-		test: async (auth_profile_slug) =>
-			action(
-				"test_auth_profile",
-				{
-					auth_profile_slug: idArg(
-						"authProfiles.test",
-						"auth_profile_slug",
-						auth_profile_slug,
-						"string",
-					),
-				},
-				"test",
-			),
-		create: (input) => action("create_auth_profile", input, "create"),
-		update: (input) => action("update_auth_profile", input, "update"),
-		delete: async (auth_profile_slug, options) =>
-			action(
-				"delete_auth_profile",
-				{
-					auth_profile_slug: idArg(
-						"authProfiles.delete",
-						"auth_profile_slug",
-						auth_profile_slug,
-						"string",
-					),
-					...options,
-				},
-				"delete",
-			),
+		list: method("list_auth_profiles", { publicMethod: "list" }),
+		get: method("get_auth_profile", {
+			publicMethod: "get",
+			mapArgs: (auth_profile_slug) => ({
+				auth_profile_slug: idArg(
+					"authProfiles.get",
+					"auth_profile_slug",
+					auth_profile_slug,
+					"string",
+				),
+			}),
+		}),
+		test: method("test_auth_profile", {
+			publicMethod: "test",
+			mapArgs: (auth_profile_slug) => ({
+				auth_profile_slug: idArg(
+					"authProfiles.test",
+					"auth_profile_slug",
+					auth_profile_slug,
+					"string",
+				),
+			}),
+		}),
+		create: method("create_auth_profile", { publicMethod: "create" }),
+		update: method("update_auth_profile", { publicMethod: "update" }),
+		delete: method("delete_auth_profile", {
+			publicMethod: "delete",
+			mapArgs: (auth_profile_slug, options) => ({
+				auth_profile_slug: idArg(
+					"authProfiles.delete",
+					"auth_profile_slug",
+					auth_profile_slug,
+					"string",
+				),
+				...options,
+			}),
+		}),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/automations.ts
+++ b/packages/server/src/sandbox/namespaces/automations.ts
@@ -144,11 +144,11 @@ export function buildAutomationsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): AutomationsNamespace {
-	const { manage, action } = createActionCaller(manageAutomations, env, ctx, "automations");
+	const { manage, method } = createActionCaller(manageAutomations, env, ctx, "automations");
 
 	return {
-		manage: (input) => manage(input as Record<string, unknown>),
-		list: (filter) => action("list", filter ?? {}),
+		manage,
+		list: method("list"),
 		get(input) {
 			return getAutomation(
 				input as never,
@@ -156,15 +156,15 @@ export function buildAutomationsNamespace(
 				ctx,
 			) as Promise<unknown>;
 		},
-		create: (input) => action("create", input),
-		update: (input) => action("update", input),
-		createVersion: (input) => action("create_version", input),
-		completeWindow: (input) => action("complete_window", input),
-		trigger: (input) => action("trigger", input),
-		delete: (input) => action("delete", input),
-		setReactionScript: (input) => action("set_reaction_script", input),
-		getVersions: (automation_id) =>
-			action("get_versions", {
+		create: method("create"),
+		update: method("update"),
+		createVersion: method("create_version"),
+		completeWindow: method("complete_window"),
+		trigger: method("trigger"),
+		delete: method("delete"),
+		setReactionScript: method("set_reaction_script"),
+		getVersions: method("get_versions", {
+			mapArgs: (automation_id) => ({
 				automation_id: idArg(
 					"automations.getVersions",
 					"automation_id",
@@ -172,11 +172,13 @@ export function buildAutomationsNamespace(
 					"string",
 				),
 			}),
-		getVersionDetails: (input) =>
-			action("get_version_details", normalizeVersionDetailsInput(input)),
-		getComponentReference: () => action("get_component_reference"),
-		submitFeedback: (input) => action("submit_feedback", input),
-		getFeedback: (input) => action("get_feedback", input),
-		createFromVersion: (input) => action("create_from_version", input),
+		}),
+		getVersionDetails: method("get_version_details", {
+			mapArgs: normalizeVersionDetailsInput,
+		}),
+		getComponentReference: method("get_component_reference"),
+		submitFeedback: method("submit_feedback"),
+		getFeedback: method("get_feedback"),
+		createFromVersion: method("create_from_version"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/catalog.ts
+++ b/packages/server/src/sandbox/namespaces/catalog.ts
@@ -16,11 +16,10 @@ export function buildCatalogNamespace(
 	ctx: ToolContext,
 	env: Env
 ): CatalogNamespace {
-	const { action } = createActionCaller(manageCatalog, env, ctx, "catalog");
+	const { method } = createActionCaller(manageCatalog, env, ctx, "catalog");
 
 	return {
-		listCatalog: (input) => action("list_catalog", input ?? {}, "listCatalog"),
-		listInstalled: (input) =>
-			action("list_installed", input ?? {}, "listInstalled"),
+		listCatalog: method("list_catalog", { publicMethod: "listCatalog" }),
+		listInstalled: method("list_installed", { publicMethod: "listInstalled" }),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/classifiers.ts
+++ b/packages/server/src/sandbox/namespaces/classifiers.ts
@@ -87,15 +87,15 @@ export function buildClassifiersNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ClassifiersNamespace {
-	const { manage, action } = createActionCaller(manageClassifiers, env, ctx, "classifiers");
+	const { manage, method } = createActionCaller(manageClassifiers, env, ctx, "classifiers");
 
 	return {
 		manage,
-		list: (input) => action("list", input),
-		create: (input) => action("create", input),
-		generateEmbeddings: (input) => action("generate_embeddings", input),
-		delete: (input) => action("delete", input),
-		classify: (input) => action("classify", input),
-		apply: (input) => action("apply", input),
+		list: method("list"),
+		create: method("create"),
+		generateEmbeddings: method("generate_embeddings"),
+		delete: method("delete"),
+		classify: method("classify"),
+		apply: method("apply"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -78,7 +78,7 @@ export function buildConnectionsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ConnectionsNamespace {
-	const { manage, action } = createActionCaller(
+	const { manage, method } = createActionCaller(
 		manageConnections,
 		env,
 		ctx,
@@ -87,9 +87,9 @@ export function buildConnectionsNamespace(
 
 	return {
 		manage,
-		list: (input) => action("list", input),
-		get: async (connection_id) =>
-			action("get", {
+		list: method("list"),
+		get: method("get", {
+			mapArgs: (connection_id) => ({
 				connection_id: idArg(
 					"connections.get",
 					"connection_id",
@@ -97,13 +97,15 @@ export function buildConnectionsNamespace(
 					"number",
 				),
 			}),
-		create: (input) => action("create", input),
-		connect: (input) => action("connect", input),
-		connectManaged: (input) =>
-			action("connect_managed", input, "connectManaged"),
-		update: (input) => action("update", input),
-		delete: async (connection_id) =>
-			action("delete", {
+		}),
+		create: method("create"),
+		connect: method("connect"),
+		connectManaged: method("connect_managed", {
+			publicMethod: "connectManaged",
+		}),
+		update: method("update"),
+		delete: method("delete", {
+			mapArgs: (connection_id) => ({
 				connection_id: idArg(
 					"connections.delete",
 					"connection_id",
@@ -111,8 +113,9 @@ export function buildConnectionsNamespace(
 					"number",
 				),
 			}),
-		reauthenticate: async (connection_id) =>
-			action("reauthenticate", {
+		}),
+		reauthenticate: method("reauthenticate", {
+			mapArgs: (connection_id) => ({
 				connection_id: idArg(
 					"connections.reauthenticate",
 					"connection_id",
@@ -120,8 +123,9 @@ export function buildConnectionsNamespace(
 					"number",
 				),
 			}),
-		test: async (connection_id) =>
-			action("test", {
+		}),
+		test: method("test", {
+			mapArgs: (connection_id) => ({
 				connection_id: idArg(
 					"connections.test",
 					"connection_id",
@@ -129,23 +133,34 @@ export function buildConnectionsNamespace(
 					"number",
 				),
 			}),
-		installConnector: (input) =>
-			action("install_connector", input, "installConnector"),
-		uninstallConnector: (connector_key) =>
-			action("uninstall_connector", { connector_key }, "uninstallConnector"),
-		getConnectorSource: (input) =>
-			action("get_connector_source", input, "getConnectorSource"),
-		validateConnectorSource: (input) =>
-			action("validate_connector_source", input, "validateConnectorSource"),
-		updateConnectorSource: (input) =>
-			action("update_connector_source", input, "updateConnectorSource"),
-		rollbackConnectorVersion: (input) =>
-			action("rollback_connector_version", input, "rollbackConnectorVersion"),
-		toggleConnectorLogin: (input) =>
-			action("toggle_connector_login", input, "toggleConnectorLogin"),
-		updateConnectorAuth: (input) =>
-			action("update_connector_auth", input, "updateConnectorAuth"),
-		updateConnectorDefaultConfig: (input) =>
-			action("update_connector_default_config", input, "updateConnectorDefaultConfig"),
+		}),
+		installConnector: method("install_connector", {
+			publicMethod: "installConnector",
+		}),
+		uninstallConnector: method("uninstall_connector", {
+			publicMethod: "uninstallConnector",
+			mapArgs: (connector_key) => ({ connector_key }),
+		}),
+		getConnectorSource: method("get_connector_source", {
+			publicMethod: "getConnectorSource",
+		}),
+		validateConnectorSource: method("validate_connector_source", {
+			publicMethod: "validateConnectorSource",
+		}),
+		updateConnectorSource: method("update_connector_source", {
+			publicMethod: "updateConnectorSource",
+		}),
+		rollbackConnectorVersion: method("rollback_connector_version", {
+			publicMethod: "rollbackConnectorVersion",
+		}),
+		toggleConnectorLogin: method("toggle_connector_login", {
+			publicMethod: "toggleConnectorLogin",
+		}),
+		updateConnectorAuth: method("update_connector_auth", {
+			publicMethod: "updateConnectorAuth",
+		}),
+		updateConnectorDefaultConfig: method("update_connector_default_config", {
+			publicMethod: "updateConnectorDefaultConfig",
+		}),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/conversations.ts
+++ b/packages/server/src/sandbox/namespaces/conversations.ts
@@ -6,11 +6,16 @@
  * turn against one; the reply reads back on the same conversation id.
  */
 
+import { Type } from "@sinclair/typebox";
 import type { Env } from "../../index";
 import { setCurrentMcpConversationTitle } from "../../lobu/stores/mcp-client-conversations";
 import { manageConversations } from "../../tools/admin/manage_conversations";
 import type { ToolContext } from "../../tools/registry";
+import { withValidatedArgs } from "../../tools/validate-args";
+import { createValidatedSdkMethod } from "../sdk-preflight";
 import { createActionCaller } from "./action-call";
+
+const SetTitleSchema = Type.Object({ title: Type.String() });
 
 export interface ConversationsListInput {
   agent_id: string;
@@ -51,24 +56,31 @@ export function buildConversationsNamespace(
   ctx: ToolContext,
   env: Env,
 ): ConversationsNamespace {
-  const { manage, action } = createActionCaller(
+  const { manage, method } = createActionCaller(
     manageConversations,
     env,
     ctx,
     "conversations",
   );
+  const setTitle = withValidatedArgs(
+    "client.conversations.setTitle",
+    SetTitleSchema,
+    async (input: { title: string }) =>
+      setCurrentMcpConversationTitle(ctx, input.title),
+  );
 
   return {
-    setTitle: (input) => setCurrentMcpConversationTitle(ctx, input.title),
+    setTitle: createValidatedSdkMethod(setTitle, [], {
+      path: "conversations.setTitle",
+      prepareArgs: (input) => input,
+    }),
     manage,
-    list: (input) => action("list", input),
-    get: (input) => action("get", input),
+    list: method("list"),
+    get: method("get"),
     // `send` returns a discriminated result whose `status` is part of the
     // contract — "error" and "timeout" are NON-throwing outcomes the caller
-    // must branch on. Route it through `manage` (the raw handler) rather than
-    // `action`, whose failureMessage() turns status:"error"/"timeout" into a
-    // thrown ClientSdkActionError. A genuine fault (bad input, agent-not-found)
-    // still throws — the handler raises ToolUserError for those.
-    send: (input) => manage({ ...input, action: "send" }),
+    // must branch on. Disable the named-method failure conversion for this one
+    // method; genuine handler faults still throw.
+    send: method("send", { checkFailure: false }),
   };
 }

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -97,18 +97,14 @@ export function buildEntitiesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): EntitiesNamespace {
-	const { manage, action } = createActionCaller(manageEntity, env, ctx, "entities");
+	const { manage, method } = createActionCaller(manageEntity, env, ctx, "entities");
 
 	return {
 		manage,
-		list(filter) {
-			return action("list", filter);
-		},
-		get(input) {
-			return action("get", input);
-		},
-		create(input) {
-			return action("create", {
+		list: method("list"),
+		get: method("get"),
+		create: method("create", {
+			mapArgs: (input) => ({
 				entity_type: input.type,
 				name: input.name,
 				slug: input.slug,
@@ -116,26 +112,14 @@ export function buildEntitiesNamespace(
 				parent_id: input.parent_id,
 				metadata: input.metadata,
 				enabled_classifiers: input.enabled_classifiers,
-			});
-		},
-		update(input) {
-			return action("update", input);
-		},
-		delete(input) {
-			return action("delete", input);
-		},
-		link(input) {
-			return action("link", input);
-		},
-		unlink(input) {
-			return action("unlink", input);
-		},
-		updateLink(input) {
-			return action("update_link", input);
-		},
-		listLinks(input) {
-			return action("list_links", input);
-		},
+			}),
+		}),
+		update: method("update"),
+		delete: method("delete"),
+		link: method("link"),
+		unlink: method("unlink"),
+		updateLink: method("update_link"),
+		listLinks: method("list_links"),
 		search(query, options) {
 			return search(
 				{ query, limit: options?.limit } as never,

--- a/packages/server/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/server/src/sandbox/namespaces/entity-schema.ts
@@ -84,72 +84,60 @@ export function buildEntitySchemaNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): EntitySchemaNamespace {
-	const { manage, action } = createActionCaller(
+	const { manage, method } = createActionCaller(
 		manageEntitySchema,
 		env,
 		ctx,
 		"entitySchema",
 	);
-	// Keep both handler discriminators independent of caller input.
-	const callEntity = <T>(
+	const entityMethod = (
 		actionName: string,
-		payload: object | undefined,
 		publicMethod: string,
-	): Promise<T> =>
-		action(
-			actionName,
-			{ ...payload, schema_type: "entity_type" },
+		mapArgs: (...args: any[]) => object = (input) => input ?? {},
+	) =>
+		method(actionName, {
 			publicMethod,
-		);
-	const callRel = <T>(
+			mapArgs: (...args) => ({
+				...mapArgs(...args),
+				schema_type: "entity_type",
+			}),
+		});
+	const relationshipMethod = (
 		actionName: string,
-		payload: object | undefined,
 		publicMethod: string,
-	): Promise<T> =>
-		action(
-			actionName,
-			{ ...payload, schema_type: "relationship_type" },
+		mapArgs: (...args: any[]) => object = (input) => input ?? {},
+	) =>
+		method(actionName, {
 			publicMethod,
-		);
+			mapArgs: (...args) => ({
+				...mapArgs(...args),
+				schema_type: "relationship_type",
+			}),
+		});
 
 	return {
 		manage,
-		listTypes: (input) => callEntity("list", input, "listTypes"),
-		getType: (slug) =>
-			callEntity(
-				"get",
-				{
-					slug: idArg("entitySchema.getType", "slug", slug, "string"),
-				},
-				"getType",
-			),
-		createType: (input) => callEntity("create", input, "createType"),
-		updateType: (input) => callEntity("update", input, "updateType"),
-		deleteType: (input) => callEntity("delete", input, "deleteType"),
-		auditType: (slug) =>
-			callEntity(
-				"audit",
-				{
-					slug: idArg("entitySchema.auditType", "slug", slug, "string"),
-				},
-				"auditType",
-			),
+		listTypes: entityMethod("list", "listTypes"),
+		getType: entityMethod("get", "getType", (slug) => ({
+			slug: idArg("entitySchema.getType", "slug", slug, "string"),
+		})),
+		createType: entityMethod("create", "createType"),
+		updateType: entityMethod("update", "updateType"),
+		deleteType: entityMethod("delete", "deleteType"),
+		auditType: entityMethod("audit", "auditType", (slug) => ({
+			slug: idArg("entitySchema.auditType", "slug", slug, "string"),
+		})),
 
-		listRelTypes: (input) => callRel("list", input, "listRelTypes"),
-		getRelType: (slug) =>
-			callRel(
-				"get",
-				{
-					slug: idArg("entitySchema.getRelType", "slug", slug, "string"),
-				},
-				"getRelType",
-			),
-		createRelType: (input) => callRel("create", input, "createRelType"),
-		updateRelType: (input) => callRel("update", input, "updateRelType"),
-		deleteRelType: (input) => callRel("delete", input, "deleteRelType"),
+		listRelTypes: relationshipMethod("list", "listRelTypes"),
+		getRelType: relationshipMethod("get", "getRelType", (slug) => ({
+			slug: idArg("entitySchema.getRelType", "slug", slug, "string"),
+		})),
+		createRelType: relationshipMethod("create", "createRelType"),
+		updateRelType: relationshipMethod("update", "updateRelType"),
+		deleteRelType: relationshipMethod("delete", "deleteRelType"),
 
-		addRule: (input) => callRel("add_rule", input, "addRule"),
-		removeRule: (input) => callRel("remove_rule", input, "removeRule"),
-		listRules: (input) => callRel("list_rules", input, "listRules"),
+		addRule: relationshipMethod("add_rule", "addRule"),
+		removeRule: relationshipMethod("remove_rule", "removeRule"),
+		listRules: relationshipMethod("list_rules", "listRules"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -75,16 +75,16 @@ export function buildFeedsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): FeedsNamespace {
-	const { manage, action } = createActionCaller(manageFeeds, env, ctx, "feeds");
+	const { manage, method } = createActionCaller(manageFeeds, env, ctx, "feeds");
 
 	return {
 		manage,
-		list: (input) => action("list_feeds", input, "list"),
-		get: (input) => action("read_feed", input, "get"),
-		readMany: (input) => action("read_feeds", input, "readMany"),
-		create: (input) => action("create_feed", input, "create"),
-		update: (input) => action("update_feed", input, "update"),
-		delete: (input) => action("delete_feed", input, "delete"),
-		trigger: (input) => action("trigger_feed", input, "trigger"),
+		list: method("list_feeds", { publicMethod: "list" }),
+		get: method("read_feed", { publicMethod: "get" }),
+		readMany: method("read_feeds", { publicMethod: "readMany" }),
+		create: method("create_feed", { publicMethod: "create" }),
+		update: method("update_feed", { publicMethod: "update" }),
+		delete: method("delete_feed", { publicMethod: "delete" }),
+		trigger: method("trigger_feed", { publicMethod: "trigger" }),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -12,6 +12,7 @@ import { getContent } from "../../tools/get_content";
 import type { ToolContext } from "../../tools/registry";
 import { saveContent } from "../../tools/save_content";
 import { search } from "../../tools/search";
+import { createValidatedSdkMethod } from "../sdk-preflight";
 import type {} from "./knowledge.typecheck";
 
 export interface KnowledgeSearchInput {
@@ -88,20 +89,30 @@ export function buildKnowledgeNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): KnowledgeNamespace {
+	const prepareDelete = (input: KnowledgeDeleteInput) =>
+		typeof input === "number" ? { content_id: input } : (input ?? {});
 	return {
 		search(input) {
 			return search(input as never, env, ctx) as Promise<unknown>;
 		},
-		save(input) {
-			return saveContent(input as never, env, ctx) as Promise<unknown>;
-		},
+		save: createValidatedSdkMethod(
+			saveContent,
+			[env, ctx],
+			{
+				path: "knowledge.save",
+				prepareArgs: (input) => input,
+			},
+		),
 		read(input) {
 			return getContent(input as never, env, ctx) as Promise<unknown>;
 		},
-		delete(input) {
-			const args =
-				typeof input === "number" ? { content_id: input } : (input ?? {});
-			return deleteContent(args as never, env, ctx) as Promise<unknown>;
-		},
+		delete: createValidatedSdkMethod(
+			deleteContent,
+			[env, ctx],
+			{
+				path: "knowledge.delete",
+				prepareArgs: prepareDelete,
+			},
+		),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -9,6 +9,7 @@
  */
 
 import type { CardElement } from "chat";
+import { type Static, Type } from "@sinclair/typebox";
 import type {
 	NotificationsSendInput as ReactionNotificationsSendInput,
 	NotificationsSendResult,
@@ -17,8 +18,13 @@ import type { Env } from "../../index";
 import { listNotifications, markAsRead } from "../../notifications/service";
 import { notify } from "../../tools/admin/notify";
 import type { ToolContext } from "../../tools/registry";
+import { withValidatedArgs } from "../../tools/validate-args";
 import { ToolUserError } from "../../utils/errors";
+import { createValidatedSdkMethod } from "../sdk-preflight";
 import { createActionCaller, idArg } from "./action-call";
+
+const MarkReadSchema = Type.Object({ notification_id: Type.Number() });
+type MarkReadArgs = Static<typeof MarkReadSchema>;
 
 export type NotificationsSendInput = Omit<
 	ReactionNotificationsSendInput,
@@ -68,10 +74,36 @@ export function buildNotificationsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): NotificationsNamespace {
-	const { action } = createActionCaller(notify, env, ctx, "notifications");
+	const { method } = createActionCaller(notify, env, ctx, "notifications");
+	const prepareMarkRead = (
+		notificationId: number | { notification_id: number },
+	): MarkReadArgs => ({
+		notification_id: idArg(
+			"notifications.markRead",
+			"notification_id",
+			notificationId,
+			"number",
+		) as number,
+	});
+	const markRead = withValidatedArgs(
+		"client.notifications.markRead",
+		MarkReadSchema,
+		async ({ notification_id }: MarkReadArgs) => {
+			const userId = requireUserId(ctx);
+			const updated = await markAsRead(
+				ctx.organizationId,
+				userId,
+				notification_id,
+			);
+			if (!updated) {
+				throw new ToolUserError("Not found or already read", 404);
+			}
+			return { success: true as const };
+		},
+	);
 
 	return {
-		send: (input) => action("send", input),
+		send: method("send"),
 		async list(input) {
 			const userId = requireUserId(ctx);
 			return listNotifications({
@@ -82,19 +114,13 @@ export function buildNotificationsNamespace(
 				unreadOnly: input?.unread_only ?? false,
 			});
 		},
-		async markRead(notificationId) {
-			const userId = requireUserId(ctx);
-			const id = idArg(
-				"notifications.markRead",
-				"notification_id",
-				notificationId,
-				"number",
-			) as number;
-			const updated = await markAsRead(ctx.organizationId, userId, id);
-			if (!updated) {
-				throw new ToolUserError("Not found or already read", 404);
-			}
-			return { success: true as const };
-		},
+		markRead: createValidatedSdkMethod(
+			markRead,
+			[],
+			{
+				path: "notifications.markRead",
+				prepareArgs: prepareMarkRead,
+			},
+		),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -80,7 +80,7 @@ export function buildOperationsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): OperationsNamespace {
-	const { manage, action } = createActionCaller(
+	const { manage, method } = createActionCaller(
 		manageOperations,
 		env,
 		ctx,
@@ -89,16 +89,16 @@ export function buildOperationsNamespace(
 
 	return {
 		manage,
-		listAvailable: (input) => action("list_available", input, "listAvailable"),
-		execute: (input) => action("execute", input, "execute"),
-		listRuns: (input) => action("list_runs", input, "listRuns"),
-		getRun: (run_id) =>
-			action(
-				"get_run",
-				{ run_id: idArg("operations.getRun", "run_id", run_id, "number") },
-				"getRun",
-			),
-		approve: (input) => action("approve", input, "approve"),
-		reject: (input) => action("reject", input, "reject"),
+		listAvailable: method("list_available", { publicMethod: "listAvailable" }),
+		execute: method("execute"),
+		listRuns: method("list_runs", { publicMethod: "listRuns" }),
+		getRun: method("get_run", {
+			publicMethod: "getRun",
+			mapArgs: (run_id) => ({
+				run_id: idArg("operations.getRun", "run_id", run_id, "number"),
+			}),
+		}),
+		approve: method("approve"),
+		reject: method("reject"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/schedules.ts
+++ b/packages/server/src/sandbox/namespaces/schedules.ts
@@ -46,14 +46,14 @@ export function buildSchedulesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): SchedulesNamespace {
-	const { manage, action } = createActionCaller(manageSchedules, env, ctx, "schedules");
+	const { manage, method } = createActionCaller(manageSchedules, env, ctx, "schedules");
 
 	return {
 		manage,
-		list: (input) => action("list", input ?? {}),
-		create: (input) => action("create", input),
-		update: (input) => action("update", input),
-		pause: (input) => action("pause", input),
-		cancel: (input) => action("cancel", input),
+		list: method("list"),
+		create: method("create"),
+		update: method("update"),
+		pause: method("pause"),
+		cancel: method("cancel"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/view-templates.ts
+++ b/packages/server/src/sandbox/namespaces/view-templates.ts
@@ -50,13 +50,18 @@ export function buildViewTemplatesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ViewTemplatesNamespace {
-	const { manage, action } = createActionCaller(manageViewTemplates, env, ctx, "viewTemplates");
+	const { manage, method } = createActionCaller(
+		manageViewTemplates,
+		env,
+		ctx,
+		"viewTemplates",
+	);
 
 	return {
 		manage,
-		get: (input) => action("get", input),
-		set: (input) => action("set", input),
-		rollback: (input) => action("rollback", input),
-		removeTab: (input) => action("remove_tab", input),
+		get: method("get"),
+		set: method("set"),
+		rollback: method("rollback"),
+		removeTab: method("remove_tab"),
 	};
 }

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -21,6 +21,7 @@ import { METHOD_METADATA, type MethodAccess } from "./method-metadata";
 import type { ToolAccessLevel } from "../auth/tool-access";
 import { enumerateSDKManifest, type SDKMode } from "./sdk-manifest";
 import { McpScopeRequiredError } from "../tools/access-control";
+import { getSdkPreflight } from "./sdk-preflight";
 
 export interface RunLimits {
 	memoryMb?: number;
@@ -122,6 +123,8 @@ interface SdkCallTraceEntry {
 	access: MethodAccess | "unknown";
 	args: unknown[];
 	skipped: boolean;
+	required_access?: MethodAccess;
+	authorization_status?: "not_evaluated";
 }
 
 interface RunScriptResult {
@@ -1087,8 +1090,17 @@ export async function runScript(
 					// Skipped (dry-run) calls live only in `side_effect_preview`;
 					// dispatched calls only in `sdk_call_trace` — no double shipping.
 					if (trace.skipped) {
+						const preflight = getSdkPreflight(namespace[method]);
+						if (!preflight) throw new Error(`Missing SDK preflight adapter: '${path}'`);
+						const result = await preflight(...args);
+						const preview = {
+							...trace,
+							args: traceArgs(result.args),
+							required_access: result.required_access,
+							authorization_status: result.authorization_status,
+						};
 						skippedCalls++;
-						appendPreview.append(sideEffectPreview, trace);
+						appendPreview.append(sideEffectPreview, preview);
 						return { dry_run: true, skipped_call: path, access };
 					}
 					// Count change-capable dispatches separately from the trace. The

--- a/packages/server/src/sandbox/sdk-preflight.ts
+++ b/packages/server/src/sandbox/sdk-preflight.ts
@@ -1,0 +1,87 @@
+import type { MethodAccess } from "./method-metadata";
+import { METHOD_METADATA } from "./method-metadata";
+import { getArgsValidator } from "../tools/validate-args";
+
+export interface SdkPreflightResult {
+	args: unknown[];
+	required_access: MethodAccess;
+	authorization_status: "not_evaluated";
+}
+
+export type SdkPreflight = (
+	...args: unknown[]
+) => SdkPreflightResult | Promise<SdkPreflightResult>;
+
+const SDK_PREFLIGHT = Symbol("lobu.sdk-preflight");
+
+interface ValidatedSdkMethodOptions<TArgs extends unknown[]> {
+	path: string;
+	prepareArgs: (...args: TArgs) => unknown;
+	projectArgs?: (validated: unknown) => unknown[];
+	rewriteError?: (error: unknown) => unknown;
+	transformResult?: (result: unknown) => unknown;
+}
+
+/**
+ * Build an SDK method and its dry-run adapter from the same `withValidatedArgs`
+ * handler. Live calls always enter that handler; preflight calls run only its
+ * exposed validator after pure public-to-handler canonicalization.
+ */
+export function createValidatedSdkMethod<
+	TArgs extends unknown[] = any[],
+	TResult = unknown,
+>(
+	validatedHandler: unknown,
+	handlerArgs: readonly unknown[],
+	options: ValidatedSdkMethodOptions<TArgs>,
+): (...args: TArgs) => Promise<TResult> {
+	const validate = getArgsValidator(validatedHandler);
+	if (!validate) {
+		throw new Error(
+			`SDK preflight source for '${options.path}' is not wrapped with withValidatedArgs`,
+		);
+	}
+	const metadata = METHOD_METADATA[options.path];
+	if (!metadata) {
+		throw new Error(`Missing SDK method metadata for '${options.path}'`);
+	}
+	const preflight: SdkPreflight = (...args) => {
+		let validated: unknown;
+		try {
+			validated = validate(options.prepareArgs(...(args as TArgs)));
+		} catch (error) {
+			throw options.rewriteError?.(error) ?? error;
+		}
+		return {
+			args: options.projectArgs?.(validated) ?? [validated],
+			required_access: metadata.access,
+			authorization_status: "not_evaluated",
+		};
+	};
+	const method = async (...args: TArgs): Promise<TResult> => {
+		try {
+			const result = await (validatedHandler as (
+				input: unknown,
+				...rest: unknown[]
+			) => unknown)(options.prepareArgs(...args), ...handlerArgs);
+			return (options.transformResult
+				? options.transformResult(result)
+				: result) as TResult;
+		} catch (error) {
+			throw options.rewriteError?.(error) ?? error;
+		}
+	};
+	Object.defineProperty(method, SDK_PREFLIGHT, {
+		value: preflight,
+		enumerable: false,
+	});
+	return method;
+}
+
+export function getSdkPreflight(value: unknown): SdkPreflight | undefined {
+	return typeof value === "function"
+		? (value as unknown as Record<symbol, SdkPreflight | undefined>)[
+				SDK_PREFLIGHT
+			]
+		: undefined;
+}

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -42,7 +42,7 @@ export const RunSchema = Type.Object({
   dry_run: Type.Optional(
     Type.Boolean({
       description:
-        "Preview mode. Read SDK calls still execute, but write/admin/external SDK calls are skipped and returned in side_effect_preview. Dry-run validates the SDK method path and access tier, but it does not execute the skipped handler or fully validate that handler's payload shape.",
+        "Preview mode. Read SDK calls still execute, but write/admin/external SDK calls are canonicalized and validated, then skipped and returned in side_effect_preview without executing their handlers.",
     }),
   ),
 });
@@ -63,6 +63,19 @@ const PublicSideEffectPreviewEntrySchema = Type.Object({
   ),
   args: Type.Array(Type.Unknown(), {
     description: "Redacted, bounded arguments for the proposed action.",
+  }),
+  required_access: Type.Union(
+    [
+      Type.Literal("read"),
+      Type.Literal("write"),
+      Type.Literal("external"),
+      Type.Literal("admin"),
+    ],
+    { description: "Access tier required by the proposed SDK method." },
+  ),
+  authorization_status: Type.Literal("not_evaluated", {
+    description:
+      "Dry-run validates arguments but does not execute live authorization or approval policy.",
   }),
 });
 
@@ -167,7 +180,23 @@ function asPublicPreviewEntry(value: unknown): PublicSideEffectPreviewEntry | nu
     row.access === "unknown"
       ? row.access
       : "unknown";
-  return { path: row.path, access, args: row.args };
+  const requiredAccess =
+    row.required_access === "read" ||
+    row.required_access === "write" ||
+    row.required_access === "external" ||
+    row.required_access === "admin"
+      ? row.required_access
+      : null;
+  if (!requiredAccess || row.authorization_status !== "not_evaluated") {
+    return null;
+  }
+  return {
+    path: row.path,
+    access,
+    args: row.args,
+    required_access: requiredAccess,
+    authorization_status: row.authorization_status,
+  };
 }
 
 type StartedSideEffect = Static<typeof StartedSideEffectSchema>;

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -365,6 +365,18 @@ export function validateToolResult(schema: TSchema, result: unknown): unknown | 
 }
 
 const VALIDATED_BRAND = Symbol.for('lobu.validated-tool-handler');
+// Vitest's resetModules() and bundled tool graphs can instantiate this module
+// more than once in one process. The validator metadata must survive that
+// module boundary; the SDK preflight marker itself remains module-private.
+const VALIDATE_ARGS = Symbol.for('lobu.validated-tool-args');
+
+export type ArgsValidator = (args: unknown) => unknown;
+
+export function getArgsValidator(handler: unknown): ArgsValidator | undefined {
+  return typeof handler === 'function'
+    ? (handler as unknown as Record<symbol, ArgsValidator | undefined>)[VALIDATE_ARGS]
+    : undefined;
+}
 
 interface BrandedHandler {
   [VALIDATED_BRAND]?: string;
@@ -392,6 +404,10 @@ export function withValidatedArgs<A, R extends unknown[], T>(
   // them.
   const wrapped = async (args: A, ...rest: R): Promise<T> =>
     handler(validateToolArgs(toolName, schema, args) as A, ...rest);
+  Object.defineProperty(wrapped, VALIDATE_ARGS, {
+    value: (args: unknown) => validateToolArgs(toolName, schema, args),
+    enumerable: false,
+  });
   (wrapped as BrandedHandler)[VALIDATED_BRAND] = toolName;
   return wrapped;
 }


### PR DESCRIPTION
## Summary
- Build every non-read ClientSDK namespace method from the same `withValidatedArgs` handler used for live execution and dry-run preflight.
- Canonicalize and validate skipped calls without entering business handlers; malformed calls produce no preview/count, while valid previews expose canonical args, required access, and `authorization_status: not_evaluated`.
- Remove the validation-only AsyncLocalStorage/result-cast approach and add a mechanical invariant covering every current and future non-read namespace method.

## Test plan
- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted Bun unit suites (115 passing), Vitest integration/namespace suites (14 passing), and production isolated-vm runtime suite (35 passing)
- [ ] Bug fix: red→fix→green outputs pasted below
- [x] If bot runtime changed: relevant eval was `bun run test:sandbox-runtime`

Additional gates:
- `make pre-pr` clean after rebasing onto current `origin/main`
- server production bundle clean (no warnings/errors)
- server typecheck clean
- `git diff --check` clean

The original uncommitted implementation was replaced after code tracing showed that returning validated args as a fake handler result could enter namespace post-processing, and direct/custom methods did not share one mechanically enforced path. No standalone executable red output was preserved before that replacement, so the red/green checkbox is intentionally left unchecked.

## Notes
- No database migration, credential flow, approval policy, access tier, read behavior, or cross-org policy changes.
- The public dry-run preview gains `required_access` and `authorization_status`.
- `make review-fix` was attempted on the settled diff but its configured Claude reviewer had exhausted its weekly quota; deterministic gates and focused tests completed cleanly.