### PR TITLE
fix(ci): preflight kubeconfig before deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1270,6 +1270,11 @@ jobs:
         # close/unlabel race, so without this it would first run in anger.
         run: bash scripts/lib/__tests__/preview-teardown.test.sh
 
+      - name: Kubeconfig workflow guards
+        # Mutating deploy workflows must fail closed before their first cluster
+        # write when the credential, cluster identity, or RBAC scope is stale.
+        run: sh scripts/lib/__tests__/kubeconfig-preflight.test.sh
+
       - name: Remote CI wrapper guards
         # Depot rewrites .github/actions paths to .depot/actions for local runs.
         # Pin the duplicate action and the fail-closed run-status parser so a

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,6 +41,9 @@ jobs:
       PREVIEW_IMAGE: ghcr.io/${{ github.repository }}/preview
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # Deploy identity, checked before the first cluster write. KUBE_SERVER
+      # and KUBE_CLUSTER_UID have no default: until an operator sets both repo
+      # variables this job stops at the preflight (see the script's header).
       KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
       KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
       KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
@@ -387,6 +390,9 @@ jobs:
     env:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number }}
+      # Deploy identity, checked before the first cluster write. KUBE_SERVER
+      # and KUBE_CLUSTER_UID have no default: until an operator sets both repo
+      # variables this job stops at the preflight (see the script's header).
       KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
       KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
       KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,7 +23,6 @@ permissions:
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-  KUBECONFIG: /tmp/kubeconfig
 
 jobs:
   # Previews are opt-in: deploy only when the PR carries the `preview` label
@@ -42,6 +41,32 @@ jobs:
       PREVIEW_IMAGE: ghcr.io/${{ github.repository }}/preview
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
+      KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
+      KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
+      KUBE_REQUIRED_CAPABILITIES: |
+        get|namespaces|
+        create|namespaces|
+        patch|namespaces|
+        delete|namespaces|
+        get|priorityclasses.scheduling.k8s.io|
+        create|priorityclasses.scheduling.k8s.io|
+        patch|priorityclasses.scheduling.k8s.io|
+        get|resourcequotas|@PREVIEW_NS
+        create|resourcequotas|@PREVIEW_NS
+        patch|resourcequotas|@PREVIEW_NS
+        get|secrets|@PREVIEW_NS
+        create|secrets|@PREVIEW_NS
+        get|deployments.apps|@PREVIEW_NS
+        create|deployments.apps|@PREVIEW_NS
+        patch|deployments.apps|@PREVIEW_NS
+        delete|deployments.apps|@PREVIEW_NS
+        watch|deployments.apps|@PREVIEW_NS
+        create|services|@PREVIEW_NS
+        delete|services|@PREVIEW_NS
+        get|ingresses.networking.k8s.io|@PREVIEW_NS
+        create|ingresses.networking.k8s.io|@PREVIEW_NS
+        patch|ingresses.networking.k8s.io|@PREVIEW_NS
     steps:
       - uses: actions/checkout@v7
 
@@ -49,6 +74,13 @@ jobs:
         uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      - name: Setup and preflight kubeconfig
+        id: kube-preflight
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
+        run: |
+          ./scripts/lib/kubeconfig-preflight.sh setup
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -72,12 +104,6 @@ jobs:
           tags: ${{ env.PREVIEW_IMAGE }}:pr-${{ env.PR_NUMBER }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Setup kubeconfig
-        env:
-          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
-        run: |
-          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
 
       - name: Create preview namespace
         run: |
@@ -267,7 +293,7 @@ jobs:
       # about to delete in this same run.
       - name: Tear down if the PR closed or lost the preview label mid-deploy
         id: preview-wanted
-        if: always() && github.event_name == 'pull_request'
+        if: always() && steps.kube-preflight.outcome == 'success' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -346,6 +372,10 @@ jobs:
               });
             }
 
+      - name: Remove kubeconfig
+        if: always()
+        run: ./scripts/lib/kubeconfig-preflight.sh cleanup
+
   cleanup:
     runs-on: ubuntu-24.04
     if: (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview')) && github.event.pull_request.head.repo.full_name == github.repository
@@ -357,12 +387,20 @@ jobs:
     env:
       PREVIEW_NS: lobu-preview-${{ github.event.pull_request.number }}
       PREVIEW_NAME: lobu-pr-${{ github.event.pull_request.number }}
+      KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
+      KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
+      KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
+      KUBE_REQUIRED_CAPABILITIES: |
+        get|namespaces|
+        delete|namespaces|
     steps:
-      - name: Setup kubeconfig
+      - uses: actions/checkout@v7
+
+      - name: Setup and preflight kubeconfig
         env:
           KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
         run: |
-          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
+          ./scripts/lib/kubeconfig-preflight.sh setup
 
       - name: Delete preview namespace
         run: |
@@ -384,6 +422,10 @@ jobs:
           else
             echo "no preview image tag pr-$PR_NUM to delete"
           fi
+
+      - name: Remove kubeconfig
+        if: always()
+        run: ./scripts/lib/kubeconfig-preflight.sh cleanup
 
       - name: Comment on PR
         uses: actions/github-script@v7

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,9 +28,6 @@ permissions:
 concurrency:
   group: staging-lock
 
-env:
-  KUBECONFIG: /tmp/kubeconfig
-
 jobs:
   reconcile:
     runs-on: ubuntu-24.04
@@ -52,14 +49,34 @@ jobs:
       WILDCARD_TLS_SECRET: wildcard-lobu-ai-tls
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
+      KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
+      KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}
+      KUBE_REQUIRED_CAPABILITIES: |
+        get|namespaces|
+        list|ingresses.networking.k8s.io|@ALL_NAMESPACES
+        delete|ingresses.networking.k8s.io|@ALL_NAMESPACES
+        get|ingresses.networking.k8s.io|@PREVIEW_NS
+        create|ingresses.networking.k8s.io|@PREVIEW_NS
+        patch|ingresses.networking.k8s.io|@PREVIEW_NS
+        get|services|@PREVIEW_NS
+        get|deployments.apps|@PREVIEW_NS
+        patch|deployments.apps|@PREVIEW_NS
+        watch|deployments.apps|@PREVIEW_NS
+        get|secrets|@WILDCARD_TLS_NS
+        get|secrets|@PREVIEW_NS
+        create|secrets|@PREVIEW_NS
+        patch|secrets|@PREVIEW_NS
       # labeled = acquire, unlabeled = release (label event or manual dispatch)
       STAGING_ACTION: ${{ github.event_name == 'workflow_dispatch' && inputs.action || github.event.action }}
     steps:
-      - name: Setup kubeconfig
+      - uses: actions/checkout@v7
+
+      - name: Setup and preflight kubeconfig
         env:
           KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
         run: |
-          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$KUBECONFIG"
+          ./scripts/lib/kubeconfig-preflight.sh setup
 
       - name: Release lock (unlabeled)
         if: env.STAGING_ACTION == 'unlabeled'
@@ -174,3 +191,7 @@ jobs:
             "Removing the \`staging\` label releases the lock and takes the public host down.")
           gh pr comment "$PR_NUM" --body "$STAGING_BODY"
           echo "staging locked to PR #$PR_NUM at https://$STAGING_HOST"
+
+      - name: Remove kubeconfig
+        if: always()
+        run: ./scripts/lib/kubeconfig-preflight.sh cleanup

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,6 +49,9 @@ jobs:
       WILDCARD_TLS_SECRET: wildcard-lobu-ai-tls
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # Deploy identity, checked before the first cluster write. KUBE_SERVER
+      # and KUBE_CLUSTER_UID have no default: until an operator sets both repo
+      # variables this job stops at the preflight (see the script's header).
       KUBE_EXPECTED_CONTEXT: ${{ vars.KUBE_CONTEXT || 'lobu-prod' }}
       KUBE_EXPECTED_SERVER: ${{ vars.KUBE_SERVER }}
       KUBE_EXPECTED_CLUSTER_UID: ${{ vars.KUBE_CLUSTER_UID }}

--- a/scripts/lib/__tests__/kubeconfig-preflight.test.sh
+++ b/scripts/lib/__tests__/kubeconfig-preflight.test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-ROOT=$(CDPATH= cd -- "$(dirname "$0")/../../.." && pwd)
+ROOT=$(CDPATH='' cd -- "$(dirname "$0")/../../.." && pwd)
 SCRIPT=$ROOT/scripts/lib/kubeconfig-preflight.sh
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/lobu-kubeconfig-test.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT HUP INT TERM
@@ -15,25 +15,17 @@ cat >"$STUBS/kubectl" <<'STUB'
 #!/bin/sh
 set -eu
 printf '%s\n' "$*" >>"$KUBECTL_LOG"
-if grep -q 'not base64' "${KUBECONFIG:-/dev/null}" 2>/dev/null; then
-  exit 1
-fi
 case "${KUBE_STUB_MODE:-happy}:$*" in
   wrong-context:config\ current-context) printf '%s\n' wrong-context ;;
   wrong-server:config\ view*) printf '%s\n' https://old.example.test ;;
-  *:config\ current-context) printf '%s\n' "${KUBE_STUB_CONTEXT:-lobu-prod}" ;;
-  *:config\ view*) printf '%s\n' "${KUBE_STUB_SERVER:-https://api.example.test}" ;;
+  *:config\ current-context) printf '%s\n' lobu-prod ;;
+  *:config\ view*) printf '%s\n' https://api.example.test ;;
   stale-ca:get\ --raw=/readyz*) exit 1 ;;
   stale-auth:get\ --raw=/readyz*) exit 1 ;;
   wrong-uid:get\ namespace*) printf '%s\n' old-cluster-uid ;;
-  *:get\ namespace*) printf '%s\n' "${KUBE_STUB_UID:-cluster-uid}" ;;
+  *:get\ namespace*) printf '%s\n' cluster-uid ;;
   insufficient-rbac:auth\ can-i*) exit 1 ;;
   *:auth\ can-i*) printf '%s\n' yes ;;
-  *:*)
-    case "$*" in
-      *apply*|*create*|*delete*|*patch*|*set\ env*) : >>"$KUBECTL_LOG" ;;
-    esac
-    ;;
 esac
 STUB
 chmod 700 "$STUBS/kubectl"
@@ -47,7 +39,6 @@ users:
 
 run_setup() {
   mode=$1
-  expected_uid=${2:-cluster-uid}
   runner_dir=$TMP/runner-$mode
   github_env=$TMP/github-env-$mode
   mkdir -p "$runner_dir"
@@ -59,7 +50,7 @@ run_setup() {
     KUBECONFIG_B64="$config_b64" \
     KUBE_EXPECTED_CONTEXT=lobu-prod \
     KUBE_EXPECTED_SERVER=https://api.example.test \
-    KUBE_EXPECTED_CLUSTER_UID="$expected_uid" \
+    KUBE_EXPECTED_CLUSTER_UID=cluster-uid \
     KUBE_REQUIRED_CAPABILITIES='get|namespaces|
 list|ingresses.networking.k8s.io|@ALL_NAMESPACES
 get|services|@PREVIEW_NS
@@ -70,15 +61,34 @@ get|secrets|@WILDCARD_TLS_NS' \
     "$SCRIPT" setup
 }
 
+assert_cleanup_refuses() {
+  label=$1
+  config=$2
+  sentinel=$3
+  if RUNNER_TEMP="$TMP/runner-happy" KUBECONFIG="$config" \
+    "$SCRIPT" cleanup >"$TMP/stdout" 2>"$TMP/stderr"; then
+    echo "expected cleanup to reject $label" >&2
+    exit 1
+  fi
+  grep -q 'refusing to remove a non-temporary kubeconfig path' "$TMP/stderr"
+  grep -q "$sentinel" "$config"
+}
+
 assert_fails_without_mutation() {
   mode=$1
   if run_setup "$mode" >"$TMP/stdout" 2>"$TMP/stderr"; then
-    kubectl apply -f /dev/null
+    echo "expected $mode to fail the kubeconfig preflight" >&2
+    exit 1
   fi
-  [ "$mode" != happy ]
-  ! grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"
-  ! grep -Eq 'apiVersion|clusters:|users:|BEGIN |token|certificate|kubeconfig-secret-sentinel' \
-    "$TMP/stdout" "$TMP/stderr"
+  if grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"; then
+    echo 'preflight attempted a Kubernetes mutation after validation failed' >&2
+    exit 1
+  fi
+  if grep -Eq 'apiVersion|clusters:|users:|BEGIN |token|certificate|kubeconfig-secret-sentinel' \
+    "$TMP/stdout" "$TMP/stderr"; then
+    echo 'preflight leaked kubeconfig material after validation failed' >&2
+    exit 1
+  fi
   grep -q 'refusing Kubernetes mutation' "$TMP/stderr"
   [ -z "$(find "$TMP/runner-$mode" -type f -name 'lobu-kubeconfig.*' -print)" ]
 }
@@ -105,8 +115,14 @@ if env \
   exit 1
 fi
 grep -q 'valid base64' "$TMP/stderr"
-! grep -q 'not base64' "$TMP/stdout" "$TMP/stderr"
-! grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"
+if grep -q 'not base64' "$TMP/stdout" "$TMP/stderr"; then
+  echo 'preflight leaked malformed credential input' >&2
+  exit 1
+fi
+if grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"; then
+  echo 'preflight attempted a Kubernetes mutation for malformed credentials' >&2
+  exit 1
+fi
 [ -z "$(find "$TMP/runner-malformed" -type f -name 'lobu-kubeconfig.*' -print)" ]
 
 mkdir -p "$TMP/runner-empty"
@@ -130,23 +146,31 @@ grep -q 'refusing Kubernetes mutation' "$TMP/stderr"
 run_setup happy >"$TMP/stdout" 2>"$TMP/stderr"
 config_path=$(sed -n 's/^KUBECONFIG=//p' "$TMP/github-env-happy")
 [ -n "$config_path" ]
-[ "$(ls -ld "$config_path" | awk '{print $1}')" = '-rw-------' ]
+[ -n "$(find "$config_path" -prune -perm 600 -print)" ]
 [ -f "$config_path" ]
 grep -q 'Kubernetes kubeconfig preflight passed' "$TMP/stdout"
+grep -q 'auth can-i get namespaces --quiet' "$KUBECTL_LOG"
 grep -q 'auth can-i list ingresses.networking.k8s.io --all-namespaces --quiet' "$KUBECTL_LOG"
 grep -q 'auth can-i get services -n lobu-preview-1 --quiet' "$KUBECTL_LOG"
 grep -q 'auth can-i get secrets -n summaries-prod --quiet' "$KUBECTL_LOG"
 RUNNER_TEMP="$TMP/runner-happy" KUBECONFIG="$config_path" "$SCRIPT" cleanup
 [ ! -e "$config_path" ]
 
-protected_config=$TMP/operator-config
-printf '%s\n' keep-me >"$protected_config"
-if RUNNER_TEMP="$TMP/runner-happy" KUBECONFIG="$protected_config" \
-  "$SCRIPT" cleanup >"$TMP/stdout" 2>"$TMP/stderr"; then
-  echo 'expected cleanup to reject a non-temporary kubeconfig path' >&2
-  exit 1
-fi
-grep -q 'refusing to remove a non-temporary kubeconfig path' "$TMP/stderr"
-grep -q 'keep-me' "$protected_config"
+# Both cleanup guards have to refuse on their own, so exercise each in
+# isolation: a foreign name inside RUNNER_TEMP, then our own name outside it.
+foreign_name=$TMP/runner-happy/operator-config
+printf '%s\n' keep-foreign-name >"$foreign_name"
+assert_cleanup_refuses 'a foreign filename inside RUNNER_TEMP' "$foreign_name" keep-foreign-name
+
+foreign_dir=$TMP/lobu-kubeconfig.decoy
+printf '%s\n' keep-foreign-dir >"$foreign_dir"
+assert_cleanup_refuses 'a matching filename outside RUNNER_TEMP' "$foreign_dir" keep-foreign-dir
+
+# ..and the directory comparison must be exact, not a prefix match.
+mkdir "$TMP/runner-happy/lobu-kubeconfig.escape"
+escaped_config=$TMP/operator-config-escape
+printf '%s\n' keep-escaped >"$escaped_config"
+assert_cleanup_refuses 'a traversal-shaped kubeconfig path' \
+  "$TMP/runner-happy/lobu-kubeconfig.escape/../../operator-config-escape" keep-escaped
 
 echo 'kubeconfig preflight tests passed'

--- a/scripts/lib/__tests__/kubeconfig-preflight.test.sh
+++ b/scripts/lib/__tests__/kubeconfig-preflight.test.sh
@@ -74,16 +74,20 @@ assert_cleanup_refuses() {
   grep -q "$sentinel" "$config"
 }
 
+assert_kubectl_log_is_read_only() {
+  if grep -Ev '^(config|get|auth can-i)( |$)' "$KUBECTL_LOG" | grep -q .; then
+    echo 'preflight attempted a Kubernetes mutation after validation failed' >&2
+    exit 1
+  fi
+}
+
 assert_fails_without_mutation() {
   mode=$1
   if run_setup "$mode" >"$TMP/stdout" 2>"$TMP/stderr"; then
     echo "expected $mode to fail the kubeconfig preflight" >&2
     exit 1
   fi
-  if grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"; then
-    echo 'preflight attempted a Kubernetes mutation after validation failed' >&2
-    exit 1
-  fi
+  assert_kubectl_log_is_read_only
   if grep -Eq 'apiVersion|clusters:|users:|BEGIN |token|certificate|kubeconfig-secret-sentinel' \
     "$TMP/stdout" "$TMP/stderr"; then
     echo 'preflight leaked kubeconfig material after validation failed' >&2
@@ -119,12 +123,10 @@ if grep -q 'not base64' "$TMP/stdout" "$TMP/stderr"; then
   echo 'preflight leaked malformed credential input' >&2
   exit 1
 fi
-if grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"; then
-  echo 'preflight attempted a Kubernetes mutation for malformed credentials' >&2
-  exit 1
-fi
+assert_kubectl_log_is_read_only
 [ -z "$(find "$TMP/runner-malformed" -type f -name 'lobu-kubeconfig.*' -print)" ]
 
+: >"$KUBECTL_LOG"
 mkdir -p "$TMP/runner-empty"
 if env \
   RUNNER_TEMP="$TMP/runner-empty" \
@@ -140,6 +142,7 @@ if env \
 fi
 grep -q 'credential secret is empty' "$TMP/stderr"
 grep -q 'refusing Kubernetes mutation' "$TMP/stderr"
+[ ! -s "$KUBECTL_LOG" ]
 [ -z "$(find "$TMP/runner-empty" -type f -name 'lobu-kubeconfig.*' -print)" ]
 
 : >"$KUBECTL_LOG"

--- a/scripts/lib/__tests__/kubeconfig-preflight.test.sh
+++ b/scripts/lib/__tests__/kubeconfig-preflight.test.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/../../.." && pwd)
+SCRIPT=$ROOT/scripts/lib/kubeconfig-preflight.sh
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/lobu-kubeconfig-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+STUBS=$TMP/stubs
+mkdir "$STUBS"
+KUBECTL_LOG=$TMP/kubectl.log
+export KUBECTL_LOG
+
+cat >"$STUBS/kubectl" <<'STUB'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$KUBECTL_LOG"
+if grep -q 'not base64' "${KUBECONFIG:-/dev/null}" 2>/dev/null; then
+  exit 1
+fi
+case "${KUBE_STUB_MODE:-happy}:$*" in
+  wrong-context:config\ current-context) printf '%s\n' wrong-context ;;
+  wrong-server:config\ view*) printf '%s\n' https://old.example.test ;;
+  *:config\ current-context) printf '%s\n' "${KUBE_STUB_CONTEXT:-lobu-prod}" ;;
+  *:config\ view*) printf '%s\n' "${KUBE_STUB_SERVER:-https://api.example.test}" ;;
+  stale-ca:get\ --raw=/readyz*) exit 1 ;;
+  stale-auth:get\ --raw=/readyz*) exit 1 ;;
+  wrong-uid:get\ namespace*) printf '%s\n' old-cluster-uid ;;
+  *:get\ namespace*) printf '%s\n' "${KUBE_STUB_UID:-cluster-uid}" ;;
+  insufficient-rbac:auth\ can-i*) exit 1 ;;
+  *:auth\ can-i*) printf '%s\n' yes ;;
+  *:*)
+    case "$*" in
+      *apply*|*create*|*delete*|*patch*|*set\ env*) : >>"$KUBECTL_LOG" ;;
+    esac
+    ;;
+esac
+STUB
+chmod 700 "$STUBS/kubectl"
+export PATH="$STUBS:$PATH"
+
+config_b64=$(printf '%s' 'apiVersion: v1
+clusters: []
+contexts: []
+users:
+  - token: kubeconfig-secret-sentinel' | base64 | tr -d '\n')
+
+run_setup() {
+  mode=$1
+  expected_uid=${2:-cluster-uid}
+  runner_dir=$TMP/runner-$mode
+  github_env=$TMP/github-env-$mode
+  mkdir -p "$runner_dir"
+  : >"$KUBECTL_LOG"
+  : >"$github_env"
+  env \
+    RUNNER_TEMP="$runner_dir" \
+    KUBE_STUB_MODE="$mode" \
+    KUBECONFIG_B64="$config_b64" \
+    KUBE_EXPECTED_CONTEXT=lobu-prod \
+    KUBE_EXPECTED_SERVER=https://api.example.test \
+    KUBE_EXPECTED_CLUSTER_UID="$expected_uid" \
+    KUBE_REQUIRED_CAPABILITIES='get|namespaces|
+list|ingresses.networking.k8s.io|@ALL_NAMESPACES
+get|services|@PREVIEW_NS
+get|secrets|@WILDCARD_TLS_NS' \
+    PREVIEW_NS=lobu-preview-1 \
+    WILDCARD_TLS_NS=summaries-prod \
+    GITHUB_ENV="$github_env" \
+    "$SCRIPT" setup
+}
+
+assert_fails_without_mutation() {
+  mode=$1
+  if run_setup "$mode" >"$TMP/stdout" 2>"$TMP/stderr"; then
+    kubectl apply -f /dev/null
+  fi
+  [ "$mode" != happy ]
+  ! grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"
+  ! grep -Eq 'apiVersion|clusters:|users:|BEGIN |token|certificate|kubeconfig-secret-sentinel' \
+    "$TMP/stdout" "$TMP/stderr"
+  grep -q 'refusing Kubernetes mutation' "$TMP/stderr"
+  [ -z "$(find "$TMP/runner-$mode" -type f -name 'lobu-kubeconfig.*' -print)" ]
+}
+
+assert_fails_without_mutation wrong-context
+assert_fails_without_mutation wrong-server
+assert_fails_without_mutation stale-ca
+assert_fails_without_mutation stale-auth
+assert_fails_without_mutation wrong-uid
+assert_fails_without_mutation insufficient-rbac
+
+: >"$KUBECTL_LOG"
+mkdir -p "$TMP/runner-malformed"
+if env \
+  RUNNER_TEMP="$TMP/runner-malformed" \
+  KUBECONFIG_B64='not base64' \
+  KUBE_EXPECTED_CONTEXT=lobu-prod \
+  KUBE_EXPECTED_SERVER=https://api.example.test \
+  KUBE_EXPECTED_CLUSTER_UID=cluster-uid \
+  KUBE_REQUIRED_CAPABILITIES='get|namespaces|' \
+  GITHUB_ENV="$TMP/github-env-malformed" \
+  "$SCRIPT" setup >"$TMP/stdout" 2>"$TMP/stderr"; then
+  echo 'expected malformed base64 to fail' >&2
+  exit 1
+fi
+grep -q 'valid base64' "$TMP/stderr"
+! grep -q 'not base64' "$TMP/stdout" "$TMP/stderr"
+! grep -Eq 'apply|create|delete|patch|set env' "$KUBECTL_LOG"
+[ -z "$(find "$TMP/runner-malformed" -type f -name 'lobu-kubeconfig.*' -print)" ]
+
+mkdir -p "$TMP/runner-empty"
+if env \
+  RUNNER_TEMP="$TMP/runner-empty" \
+  KUBECONFIG_B64='' \
+  KUBE_EXPECTED_CONTEXT=lobu-prod \
+  KUBE_EXPECTED_SERVER=https://api.example.test \
+  KUBE_EXPECTED_CLUSTER_UID=cluster-uid \
+  KUBE_REQUIRED_CAPABILITIES='get|namespaces|' \
+  GITHUB_ENV="$TMP/github-env-empty" \
+  "$SCRIPT" setup >"$TMP/stdout" 2>"$TMP/stderr"; then
+  echo 'expected empty base64 to fail' >&2
+  exit 1
+fi
+grep -q 'credential secret is empty' "$TMP/stderr"
+grep -q 'refusing Kubernetes mutation' "$TMP/stderr"
+[ -z "$(find "$TMP/runner-empty" -type f -name 'lobu-kubeconfig.*' -print)" ]
+
+: >"$KUBECTL_LOG"
+run_setup happy >"$TMP/stdout" 2>"$TMP/stderr"
+config_path=$(sed -n 's/^KUBECONFIG=//p' "$TMP/github-env-happy")
+[ -n "$config_path" ]
+[ "$(ls -ld "$config_path" | awk '{print $1}')" = '-rw-------' ]
+[ -f "$config_path" ]
+grep -q 'Kubernetes kubeconfig preflight passed' "$TMP/stdout"
+grep -q 'auth can-i list ingresses.networking.k8s.io --all-namespaces --quiet' "$KUBECTL_LOG"
+grep -q 'auth can-i get services -n lobu-preview-1 --quiet' "$KUBECTL_LOG"
+grep -q 'auth can-i get secrets -n summaries-prod --quiet' "$KUBECTL_LOG"
+RUNNER_TEMP="$TMP/runner-happy" KUBECONFIG="$config_path" "$SCRIPT" cleanup
+[ ! -e "$config_path" ]
+
+protected_config=$TMP/operator-config
+printf '%s\n' keep-me >"$protected_config"
+if RUNNER_TEMP="$TMP/runner-happy" KUBECONFIG="$protected_config" \
+  "$SCRIPT" cleanup >"$TMP/stdout" 2>"$TMP/stderr"; then
+  echo 'expected cleanup to reject a non-temporary kubeconfig path' >&2
+  exit 1
+fi
+grep -q 'refusing to remove a non-temporary kubeconfig path' "$TMP/stderr"
+grep -q 'keep-me' "$protected_config"
+
+echo 'kubeconfig preflight tests passed'

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -190,6 +190,7 @@ gate_format_lint() {
   bash scripts/lib/__tests__/review-upstream-guard.test.sh || return 1
   bash scripts/lib/__tests__/review-skip.test.sh || return 1
   bash scripts/lib/__tests__/review-cache.test.sh || return 1
+  sh scripts/lib/__tests__/kubeconfig-preflight.test.sh || return 1
   cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml || return 1
   bash scripts/lib/__tests__/remote-ci.test.sh || return 1
   bash scripts/lib/__tests__/submodule-drift.test.sh || return 1

--- a/scripts/lib/kubeconfig-preflight.sh
+++ b/scripts/lib/kubeconfig-preflight.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 set -eu
+# Never trace: the decoded credential would otherwise land in the step log.
+set +x
 
 # Securely install and validate the kubeconfig used by mutating workflows.
 # Secret material is accepted only through KUBECONFIG_B64 and is never placed
 # in an argument, log line, GitHub output, or GitHub environment value.
-set +x
+#
+# KUBE_EXPECTED_SERVER and KUBE_EXPECTED_CLUSTER_UID pin which cluster the
+# credential is allowed to write to, and have no default - a workflow whose
+# repo variables are unset stops here instead of deploying blind. Read the
+# expected values off the intended cluster once:
+#   kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'
+#   kubectl get namespace kube-system -o jsonpath='{.metadata.uid}'
 
 usage() {
   echo "usage: $0 setup|cleanup" >&2
@@ -29,8 +37,8 @@ setup() {
 
   [ -n "${KUBECONFIG_B64:-}" ] || fail "credential secret is empty"
   [ -n "${KUBE_EXPECTED_CONTEXT:-}" ] || fail "expected context is not configured"
-  [ -n "${KUBE_EXPECTED_SERVER:-}" ] || fail "expected API server is not configured"
-  [ -n "${KUBE_EXPECTED_CLUSTER_UID:-}" ] || fail "expected cluster fingerprint is not configured"
+  [ -n "${KUBE_EXPECTED_SERVER:-}" ] || fail "repo variable KUBE_SERVER is not set"
+  [ -n "${KUBE_EXPECTED_CLUSTER_UID:-}" ] || fail "repo variable KUBE_CLUSTER_UID is not set"
   [ -n "${KUBE_REQUIRED_CAPABILITIES:-}" ] || fail "required RBAC capabilities are not configured"
   [ -n "${GITHUB_ENV:-}" ] || fail "GITHUB_ENV is not available"
 
@@ -65,7 +73,7 @@ setup() {
     fail "credential secret decoded to an empty kubeconfig"
   }
 
-  export KUBECONFIG=$config_path
+  export KUBECONFIG="$config_path"
 
   kubectl config view >/dev/null 2>&1 || {
     fail "decoded credential is not a valid kubeconfig"
@@ -107,7 +115,7 @@ setup() {
     if [ "$all_namespaces" -eq 1 ]; then
       kubectl auth can-i "$verb" "$resource" --all-namespaces --quiet >/dev/null 2>&1 ||
         fail "required Kubernetes access is not granted"
-    elif [ -n "${namespace:-}" ]; then
+    elif [ -n "$namespace" ]; then
       kubectl auth can-i "$verb" "$resource" -n "$namespace" --quiet >/dev/null 2>&1 ||
         fail "required Kubernetes access is not granted"
     else
@@ -128,8 +136,11 @@ cleanup() {
   config_path=${KUBECONFIG:-}
   if [ -n "$config_path" ] && [ -f "$config_path" ]; then
     temp_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
-    case "$config_path" in
-      "$temp_root"/lobu-kubeconfig.*) ;;
+    config_dir=${config_path%/*}
+    config_name=${config_path##*/}
+    [ "$config_dir" = "$temp_root" ] || fail "refusing to remove a non-temporary kubeconfig path"
+    case "$config_name" in
+      lobu-kubeconfig.*) ;;
       *) fail "refusing to remove a non-temporary kubeconfig path" ;;
     esac
     rm -f "$config_path"

--- a/scripts/lib/kubeconfig-preflight.sh
+++ b/scripts/lib/kubeconfig-preflight.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+set -eu
+
+# Securely install and validate the kubeconfig used by mutating workflows.
+# Secret material is accepted only through KUBECONFIG_B64 and is never placed
+# in an argument, log line, GitHub output, or GitHub environment value.
+set +x
+
+usage() {
+  echo "usage: $0 setup|cleanup" >&2
+  exit 2
+}
+
+fail() {
+  echo "kubeconfig preflight failed: $1; refusing Kubernetes mutation" >&2
+  exit 1
+}
+
+decode_base64() {
+  if base64 --decode </dev/null >/dev/null 2>&1; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+setup() {
+  umask 077
+
+  [ -n "${KUBECONFIG_B64:-}" ] || fail "credential secret is empty"
+  [ -n "${KUBE_EXPECTED_CONTEXT:-}" ] || fail "expected context is not configured"
+  [ -n "${KUBE_EXPECTED_SERVER:-}" ] || fail "expected API server is not configured"
+  [ -n "${KUBE_EXPECTED_CLUSTER_UID:-}" ] || fail "expected cluster fingerprint is not configured"
+  [ -n "${KUBE_REQUIRED_CAPABILITIES:-}" ] || fail "required RBAC capabilities are not configured"
+  [ -n "${GITHUB_ENV:-}" ] || fail "GITHUB_ENV is not available"
+
+  temp_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+  config_path=
+  capabilities_file=
+  keep_config=0
+  cleanup_setup() {
+    [ -z "$capabilities_file" ] || rm -f "$capabilities_file"
+    if [ "$keep_config" -eq 0 ] && [ -n "$config_path" ]; then
+      rm -f "$config_path"
+    fi
+  }
+  trap cleanup_setup 0
+  trap 'cleanup_setup; exit 1' HUP INT TERM
+
+  config_path=$(mktemp "$temp_root/lobu-kubeconfig.XXXXXX") ||
+    fail "cannot create secure kubeconfig file"
+  chmod 600 "$config_path" || fail "cannot protect kubeconfig file"
+
+  if ! printf '%s' "$KUBECONFIG_B64" | decode_base64 >"$config_path" 2>/dev/null; then
+    fail "credential secret is not valid base64"
+  fi
+  normalized_b64=$(printf '%s' "$KUBECONFIG_B64" | tr -d '\r\n')
+  roundtrip_b64=$(base64 <"$config_path" 2>/dev/null | tr -d '\r\n') || {
+    fail "credential secret is not valid base64"
+  }
+  [ "$roundtrip_b64" = "$normalized_b64" ] || {
+    fail "credential secret is not valid base64"
+  }
+  [ -s "$config_path" ] || {
+    fail "credential secret decoded to an empty kubeconfig"
+  }
+
+  export KUBECONFIG=$config_path
+
+  kubectl config view >/dev/null 2>&1 || {
+    fail "decoded credential is not a valid kubeconfig"
+  }
+
+  current_context=$(kubectl config current-context 2>/dev/null) || fail "cannot read kubeconfig context"
+  [ "$current_context" = "$KUBE_EXPECTED_CONTEXT" ] || fail "unexpected kubeconfig context"
+
+  server=$(kubectl config view --minify -o 'jsonpath={.clusters[0].cluster.server}' 2>/dev/null) ||
+    fail "cannot read kubeconfig server"
+  [ "$server" = "$KUBE_EXPECTED_SERVER" ] || fail "unexpected Kubernetes API server"
+
+  kubectl get --raw=/readyz --request-timeout=15s >/dev/null 2>&1 ||
+    fail "Kubernetes API TLS/auth reachability check failed"
+
+  cluster_uid=$(kubectl get namespace kube-system -o 'jsonpath={.metadata.uid}' --request-timeout=15s 2>/dev/null) ||
+    fail "cannot read cluster identity fingerprint"
+  [ -n "$cluster_uid" ] || fail "cluster identity fingerprint is empty"
+  [ "$cluster_uid" = "$KUBE_EXPECTED_CLUSTER_UID" ] || fail "unexpected cluster identity fingerprint"
+
+  capabilities_file=$(mktemp "$temp_root/lobu-kube-capabilities.XXXXXX") ||
+    fail "cannot prepare RBAC preflight"
+  printf '%s\n' "$KUBE_REQUIRED_CAPABILITIES" >"$capabilities_file"
+  while IFS='|' read -r verb resource namespace; do
+    [ -n "$verb$resource$namespace" ] || continue
+    all_namespaces=0
+    case "$namespace" in
+      @PREVIEW_NS)
+        [ -n "${PREVIEW_NS:-}" ] || fail "preview namespace is not configured"
+        namespace=$PREVIEW_NS
+        ;;
+      @WILDCARD_TLS_NS)
+        [ -n "${WILDCARD_TLS_NS:-}" ] || fail "wildcard TLS namespace is not configured"
+        namespace=$WILDCARD_TLS_NS
+        ;;
+      @ALL_NAMESPACES) namespace=; all_namespaces=1 ;;
+    esac
+    [ -n "$verb" ] && [ -n "$resource" ] || fail "invalid RBAC preflight configuration"
+    if [ "$all_namespaces" -eq 1 ]; then
+      kubectl auth can-i "$verb" "$resource" --all-namespaces --quiet >/dev/null 2>&1 ||
+        fail "required Kubernetes access is not granted"
+    elif [ -n "${namespace:-}" ]; then
+      kubectl auth can-i "$verb" "$resource" -n "$namespace" --quiet >/dev/null 2>&1 ||
+        fail "required Kubernetes access is not granted"
+    else
+      kubectl auth can-i "$verb" "$resource" --quiet >/dev/null 2>&1 ||
+        fail "required Kubernetes access is not granted"
+    fi
+  done <"$capabilities_file"
+
+  rm -f "$capabilities_file"
+  capabilities_file=
+  # GitHub persists only the path for later steps; never persist the secret.
+  printf 'KUBECONFIG=%s\n' "$config_path" >>"$GITHUB_ENV"
+  keep_config=1
+  echo "Kubernetes kubeconfig preflight passed for $KUBE_EXPECTED_CONTEXT"
+}
+
+cleanup() {
+  config_path=${KUBECONFIG:-}
+  if [ -n "$config_path" ] && [ -f "$config_path" ]; then
+    temp_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+    case "$config_path" in
+      "$temp_root"/lobu-kubeconfig.*) ;;
+      *) fail "refusing to remove a non-temporary kubeconfig path" ;;
+    esac
+    rm -f "$config_path"
+  fi
+}
+
+[ "$#" -eq 1 ] || usage
+case "$1" in
+  setup) setup ;;
+  cleanup) cleanup ;;
+  *) usage ;;
+esac


### PR DESCRIPTION
## Summary
- Centralize secure GitHub Actions kubeconfig decoding, temporary-file handling, context/API-server/cluster-UID validation, `/readyz`, workflow-specific RBAC checks, and cleanup.
- Require the preflight before every preview/staging Kubernetes mutation, including preview cleanup and the `always()` mid-deploy teardown path.
- Run the fail-closed regression suite in canonical CI and the local CI mirror.
- Keep the PR workflow-only: the accidental Owletto pointer change was removed while syncing current `main`; PR #3063 is untouched.

## Red to green evidence
- Original GitHub integration shards 1/3 and 2/3 failed 4 actual-Owletto-manifest tests because the PR commit downgraded `packages/owletto` from current-main `e55b8ee5` to `80b54a3a`. Restoring the current-main pointer made both focused suites green: 2 files, 31 tests.
- The focused shell suite failed on macOS because `ls -l` reported an extended-attribute suffix on the mode. The assertion now uses a portable exact `find -perm 600` check and passes under `sh`, `bash`, and `dash`.
- A new traversal-shaped cleanup regression failed against the original helper. Cleanup now requires both the exact temporary directory and managed filename; independently load-bearing tests cover foreign name, foreign directory, and traversal cases.
- The original negative `! grep` checks could skip `errexit`; explicit failure branches now enforce no mutation and no credential leakage.
- Failure-path tests now reject every `kubectl` family except `config`, `get`, and `auth can-i`; the empty-secret path proves zero `kubectl` calls.

## Verification
- [x] `sh`, `bash`, and `dash` runs of `scripts/lib/__tests__/kubeconfig-preflight.test.sh`
- [x] `shellcheck -s sh` and shell syntax checks
- [x] Ruby YAML parse and `actionlint` for CI, preview, and staging workflows
- [x] Exact failed manifest suites: 2 files / 31 tests passed
- [x] Read-only live preflight against `lobu-prod`: context, API server, `/readyz`, cluster UID, union of preview/staging `auth can-i` checks, and cleanup passed; no Kubernetes resource mutation was performed
- [x] `make review-fix` with Claude Opus; accepted edits re-read and reverified
- [x] `make pre-pr`
- [x] Required GitHub CI for final HEAD
- [x] `ui-review`
- [ ] Posted semantic review

## Operational preparation
- Repository variables `KUBE_SERVER` and `KUBE_CLUSTER_UID` are configured from the verified live `lobu-prod` identity. `KUBE_CONTEXT` intentionally retains its `lobu-prod` default.
- GitHub does not expose the existing `KUBECONFIG` secret for readback. The first real workflow invocation will validate that secret against the pinned identity and fail before mutation if it is stale or non-canonical.

No application runtime, database, API, SDK, Owletto content, or PR #3063 changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added pre-deployment validation for Kubernetes identity, cluster, connectivity, and required permissions.
  * Prevented deployment actions when credentials or cluster checks fail.
  * Ensured temporary deployment credentials are securely managed and removed after workflows complete.

* **Reliability**
  * Added safeguards for preview, cleanup, and staging deployments to avoid unintended cluster changes.

* **Tests**
  * Added comprehensive coverage for credential validation, permission checks, cleanup, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
