### PR TITLE
fix(mcp): cap diagnostic preview allocation

### DIFF
--- a/packages/server/src/mcp-proxy/__tests__/http-response.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/http-response.test.ts
@@ -6,6 +6,7 @@ import {
 	getMcpAbortReason,
 	inspectMcpJsonRpcBody,
 	logMcpTerminalOutcome,
+	MCP_DIAGNOSTIC_PREVIEW_LIMIT,
 	MCP_REQUEST_BODY_LIMIT,
 	MCP_SSE_FRAME_LIMIT,
 	McpTransportError,
@@ -58,6 +59,44 @@ test("does not parse an oversized or malformed JSON response", async () => {
 
 	const malformed = new Response("{\"jsonrpc\":", { headers: { "content-type": "application/json" } });
 	await expect(parseJsonRpcResponse(malformed)).rejects.toMatchObject({ kind: "malformed_json" });
+});
+
+test("caps diagnostic allocations for oversized and interrupted bodies", async () => {
+	const chunk = new TextEncoder().encode("x".repeat(MCP_DIAGNOSTIC_PREVIEW_LIMIT));
+	let pulls = 0;
+	const interrupted = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			pulls++;
+			if (pulls <= 2) controller.enqueue(chunk);
+			else controller.error(new Error("upstream closed"));
+		},
+	});
+	const oversized = streamFrom([chunk, chunk]);
+	const nativeUint8Array = globalThis.Uint8Array;
+	const allocations: number[] = [];
+	globalThis.Uint8Array = new Proxy(nativeUint8Array, {
+		construct(target, args, newTarget) {
+			if (typeof args[0] === "number") allocations.push(args[0]);
+			return Reflect.construct(target, args, newTarget);
+		},
+	}) as Uint8ArrayConstructor;
+
+	try {
+		await expect(
+			readBoundedBody(interrupted, MCP_DIAGNOSTIC_PREVIEW_LIMIT * 3, {
+				kind: "response",
+			}),
+		).rejects.toMatchObject({ kind: "upstream_abort" });
+		await expect(
+			readBoundedBody(oversized, MCP_DIAGNOSTIC_PREVIEW_LIMIT * 2 - 1, {
+				kind: "response",
+			}),
+		).rejects.toMatchObject({ kind: "oversized_response" });
+	} finally {
+		globalThis.Uint8Array = nativeUint8Array;
+	}
+
+	expect(Math.max(...allocations)).toBe(MCP_DIAGNOSTIC_PREVIEW_LIMIT);
 });
 
 test("bounds SSE frames and cancels the upstream stream on downstream disconnect", async () => {

--- a/packages/server/src/mcp-proxy/http-response.ts
+++ b/packages/server/src/mcp-proxy/http-response.ts
@@ -169,7 +169,13 @@ export async function readBoundedBody(
 				throw new McpTransportError(
 					options.kind === "request" ? "oversized_request" : "oversized_response",
 					`MCP ${options.kind ?? "response"} body exceeds ${limit} bytes`,
-					{ bytes: total + value.byteLength, limit, preview: previewText(concat([...chunks, value], limit)) },
+					{
+						bytes: total + value.byteLength,
+						limit,
+						preview: previewText(
+							concat([...chunks, value], MCP_DIAGNOSTIC_PREVIEW_LIMIT),
+						),
+					},
 				);
 			}
 			chunks.push(value);
@@ -178,7 +184,7 @@ export async function readBoundedBody(
 	} catch (error) {
 		const progress = {
 			bytes: total,
-			preview: previewText(concat(chunks, total)),
+			preview: previewText(concat(chunks, MCP_DIAGNOSTIC_PREVIEW_LIMIT)),
 		};
 		if (options.signal?.aborted) {
 			const normalized = abortError(options.signal, error);


### PR DESCRIPTION
## Summary
- Follow up #3091 by capping diagnostic preview concatenation at the configured 4 KiB preview limit on oversized and interrupted bodies.
- Add a focused allocation regression for both oversized and interrupted streaming bodies.
- Preserve all MCP public error contracts and transport behavior.

## Test plan
- [x] Intended two-file server-only diff verified; `make pre-pr` clean.
- [x] `cd packages/server && bun run test -- run src/mcp-proxy/__tests__/http-response.test.ts` (13/13 passed).
- [x] Pre-commit Biome and root TypeScript checks passed.
- [ ] Full required CI graph (rerunning on final SHA).
- [ ] Bug fix red→green: review-found allocation issue; regression asserts all diagnostic `Uint8Array` allocations remain at or below 4 KiB.
- [ ] Bot runtime eval not applicable.

## Notes
Follow-up to merged PR #3091 for the remaining review finding. No public API, database, SDK, configuration, or Owletto changes.