### PR TITLE
feat(mac): bundle native device daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1681,7 +1681,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/connector-worker/|packages/core/|scripts/(build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/connector-worker/|packages/core/|scripts/(build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph|verify-mac-device-daemon|with-owletto-mac-daemon)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "mac=true" >> "$GITHUB_OUTPUT"
           else
             echo "mac=false" >> "$GITHUB_OUTPUT"
@@ -1702,10 +1702,13 @@ jobs:
   # notarize) is enough to prove the Xcode project + submodule layout still
   # compose.
   #
-  # Runner cost is bounded by the filter job above — the macOS runner is
-  # only allocated when the submodule pointer, the release workflow, this
-  # workflow, the submodule setup action, or `.gitmodules` changes. This
-  # workflow is in the filter so a PR editing this job can't skip it.
+  # Runner cost is bounded by the filter job above — the macOS runner is only
+  # allocated when something the Mac build actually consumes changes: the
+  # submodule pointer, the device-daemon sources (`packages/connector-worker/`,
+  # `packages/core/`) or its build/verify scripts, the workspace manifest or
+  # lockfile, the release workflow, this workflow, the submodule setup action,
+  # or `.gitmodules`. This workflow is in the filter so a PR editing this job
+  # can't skip it.
   mac-build-smoke:
     needs: optional-smoke-filter
     if: needs.optional-smoke-filter.outputs.mac == 'true'
@@ -1758,13 +1761,22 @@ jobs:
         if: steps.submodule.outputs.stubbed != 'true'
         run: packages/owletto/apps/mac/Tests/run-tests.sh
 
+      # The wrapper compiles the device daemon into the submodule's resource
+      # directory for the duration of the build, then removes it. The verify
+      # afterwards is a different assertion from the wrapper's own: it proves
+      # Xcode's resource copy landed the daemon inside the built bundle still
+      # executable and still arm64, which is what the app resolves at launch.
       - name: Build (unsigned, no archive)
         if: steps.submodule.outputs.stubbed != 'true'
         run: |
-          xcodebuild \
+          DERIVED_DATA="$RUNNER_TEMP/owletto-derived"
+          scripts/with-owletto-mac-daemon.sh xcodebuild \
             -project packages/owletto/apps/mac/Owletto.xcodeproj \
             -scheme Owletto -configuration Release build \
+            -derivedDataPath "$DERIVED_DATA" \
             CODE_SIGNING_ALLOWED=NO
+          scripts/verify-mac-device-daemon.sh \
+            "$DERIVED_DATA/Build/Products/Release/Owletto.app/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
 
   # Connector-runtime parity smoke gate. Guards against the packaging/parity
   # drift that broke prod: the worker image shipped missing `COPY packages/core`,

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -90,6 +90,13 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
+      # The bundled device daemon is compiled by `build-mac-device-daemon.sh`
+      # during the Xcode build. Bun 1.3.5 silently ignores --metafile, which
+      # the packaging graph guard depends on; pin the measured toolchain.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       # Release contract — fail fast rather than build a wrong/missing artifact:
       #   1. The deploy key must work. The setup-submodule action writes a stub
       #      package.json when the key is absent; that's fine for CI on forks but
@@ -100,7 +107,10 @@ jobs:
       #   3. The Mac Xcode project + bundle paths the rest of this workflow
       #      assumes must actually exist at the pinned SHA. Otherwise the
       #      `lobster-mark.svg` → `owletto-mark.svg` style of silent rename on
-      #      the owletto side would only surface inside `xcodebuild`.
+      #      the owletto side would only surface inside `xcodebuild`. This
+      #      includes the `lobu-device-daemon` resource directory the app
+      #      copies the compiled daemon into — without it the archive builds
+      #      an app that cannot launch its worker runtime.
       #   4-7. The scheme name, app display name, bundle identifier, and
       #      Sparkle public key must match what the rest of the workflow and
       #      installed apps depend on. A rename inside owletto (e.g. scheme
@@ -126,6 +136,7 @@ jobs:
           for required in \
             packages/owletto/apps/mac/Owletto.xcodeproj \
             packages/owletto/apps/mac/Owletto/Info.plist \
+            packages/owletto/apps/mac/Owletto/lobu-device-daemon \
             scripts/sparkle/update-appcast.py
           do
             if [ ! -e "$required" ]; then
@@ -198,6 +209,9 @@ jobs:
             echo "::error::SUPublicEDKey missing from Info.plist — installed apps cannot verify updates"
             exit 1
           fi
+
+      - name: Install workspace dependencies for Mac daemon build
+        run: bun install --frozen-lockfile
 
       # workflow_dispatch carries the version as an input; release-triggered
       # runs carry it on github.event.release.tag_name in the form
@@ -350,7 +364,7 @@ jobs:
           if [ "${{ steps.profile.outputs.installed }}" = "true" ]; then
             ARGS+=("PROVISIONING_PROFILE_SPECIFIER=$PROFILE_NAME")
           fi
-          xcodebuild "${ARGS[@]}"
+          scripts/with-owletto-mac-daemon.sh xcodebuild "${ARGS[@]}"
 
       # Re-sign Sparkle's nested helpers — Xcode's archive doesn't apply
       # Developer ID + secure-timestamp to them when Sparkle is integrated
@@ -365,7 +379,11 @@ jobs:
           set -e
           APP="$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
           SPARKLE="$APP/Contents/Frameworks/Sparkle.framework/Versions/B"
+          DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
           OPTS=(--force --options runtime --timestamp --sign "Developer ID Application")
+
+          scripts/verify-mac-device-daemon.sh "$DAEMON"
+          codesign "${OPTS[@]}" "$DAEMON"
 
           # XPC services (each has an inner Mach-O + an outer bundle).
           if [ -d "$SPARKLE/XPCServices/Downloader.xpc" ]; then
@@ -397,7 +415,7 @@ jobs:
       - name: Archive (unsigned, ad-hoc)
         if: steps.mode.outputs.signed != 'true'
         run: |
-          xcodebuild \
+          scripts/with-owletto-mac-daemon.sh xcodebuild \
             -project packages/owletto/apps/mac/Owletto.xcodeproj -scheme Owletto -configuration Release \
             -archivePath "$RUNNER_TEMP/Owletto.xcarchive" archive \
             CODE_SIGNING_ALLOWED=NO \
@@ -406,7 +424,11 @@ jobs:
           # arm64 apps must carry at least an ad-hoc signature to launch at all;
           # this also lets users do right-click → Open past "unidentified
           # developer". A real Developer ID + notarization removes that prompt.
-          codesign --force --deep --sign - "$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
+          APP="$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
+          DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
+          scripts/verify-mac-device-daemon.sh "$DAEMON"
+          codesign --force --sign - "$DAEMON"
+          codesign --force --deep --sign - "$APP"
 
       - name: Build DMG
         run: |

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -294,7 +294,16 @@ function loadOwlettoManifests(kind: 'mac' | 'chrome'): Array<Record<string, unkn
   return readdirSync(dir)
     .filter((file) => file.endsWith('.json'))
     .sort()
-    .map((file) => JSON.parse(readFileSync(join(dir, file), 'utf8')) as Record<string, unknown>);
+    .flatMap((file) => {
+      const parsed = JSON.parse(readFileSync(join(dir, file), 'utf8')) as unknown;
+      const manifests = Array.isArray(parsed) ? parsed : [parsed];
+      return manifests.map((manifest) => {
+        if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+          throw new Error(`invalid Owletto connector manifest in ${file}`);
+        }
+        return manifest as Record<string, unknown>;
+      });
+    });
 }
 
 function capabilitiesFor(manifests: Array<Record<string, unknown>>): Record<string, boolean> {

--- a/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
+++ b/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
@@ -14,21 +14,33 @@ import { post } from '../setup/test-helpers';
 const CONNECTOR_KEY = 'apple.computer_use';
 const OPERATION_KEY = 'permissions';
 
-const COMPUTER_USE_MANIFEST_PATH = resolve(
+const MAC_MANIFESTS_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
-  '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
+  '../../../../owletto/apps/mac/Owletto/ConnectorManifests/macos-device-connector-manifests.json',
 );
 
 // Private-submodule guard: skip in sandboxes without owletto access, but in
 // CI a missing manifest must fail loudly, not silently skip.
-const itWithManifest = existsSync(COMPUTER_USE_MANIFEST_PATH)
+const itWithManifest = existsSync(MAC_MANIFESTS_PATH)
   ? it
   : process.env.CI
     ? it
     : it.skip;
 
 function loadComputerUseManifest(): Record<string, unknown> {
-  return JSON.parse(readFileSync(COMPUTER_USE_MANIFEST_PATH, 'utf8')) as Record<string, unknown>;
+  const manifests = JSON.parse(readFileSync(MAC_MANIFESTS_PATH, 'utf8')) as unknown;
+  if (!Array.isArray(manifests)) {
+    throw new Error('canonical Owletto Mac manifest artifact must be an array');
+  }
+  const manifest = manifests.find(
+    (candidate): candidate is Record<string, unknown> =>
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      !Array.isArray(candidate) &&
+      candidate.key === CONNECTOR_KEY,
+  );
+  if (!manifest) throw new Error(`${CONNECTOR_KEY} missing from canonical Owletto Mac manifests`);
+  return manifest;
 }
 
 async function seedDeviceOwner() {

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -50,7 +50,8 @@ fi
 echo ">> Building Owletto (Release, $SIGN_ID, version $VERSION)..."
 (
   cd "$MAC"
-  xcodebuild -scheme Owletto -configuration Release \
+  "$ROOT/scripts/with-owletto-mac-daemon.sh" \
+    xcodebuild -scheme Owletto -configuration Release \
     -derivedDataPath "$DERIVED" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$SIGN_ID" \
@@ -63,11 +64,17 @@ echo ">> Building Owletto (Release, $SIGN_ID, version $VERSION)..."
 
 APP="$DERIVED/Build/Products/Release/Owletto.app"
 [ -d "$APP" ] || die "build succeeded but $APP is missing"
+DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
+"$ROOT/scripts/verify-mac-device-daemon.sh" "$DAEMON" >/dev/null
 
 # Xcode + SPM Sparkle: re-seal nested helpers (same leaf-first order as CI).
 echo ">> Re-signing Sparkle helpers..."
 SPARKLE="$APP/Contents/Frameworks/Sparkle.framework/Versions/B"
 OPTS=(--force --options runtime --timestamp --sign "$SIGN_ID")
+
+# Xcode treats the daemon as a resource, so seal its Mach-O explicitly before
+# re-signing the umbrella app that records the nested signature.
+codesign "${OPTS[@]}" "$DAEMON"
 
 resign_xpc() {
   local name="$1"

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -17,7 +17,6 @@ OUTPUT="$ARTIFACT" "$ROOT/scripts/build-mac-device-daemon.sh" >"$WORK/build.log"
 cp "$ARTIFACT" "$CLEAN/lobu-device-daemon"
 chmod 0755 "$CLEAN/lobu-device-daemon"
 
-file "$CLEAN/lobu-device-daemon" | grep -q 'Mach-O 64-bit executable arm64'
 [[ "$(find "$CLEAN" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" == 1 ]]
 
 SAFE_ENV=(env -i PATH=/usr/bin:/bin HOME="$WORK/home" TMPDIR="$WORK/tmp")
@@ -33,11 +32,12 @@ run_clean_with_token() (
   "${SAFE_ENV[@]}" WORKER_API_TOKEN=not-a-pat ./lobu-device-daemon "$@"
 )
 
+# Shared packaging assertion (arm64 Mach-O + `--version` metadata), run against
+# the copied artifact so the release workflows and this smoke agree on what a
+# publishable daemon looks like.
+run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-device-daemon >/dev/null
+
 VERSION_JSON="$(run_clean ./lobu-device-daemon --version)"
-case "$VERSION_JSON" in
-  *'"name":"lobu-device-daemon"'*'"protocol":"device-daemon/v1"'*'"platform":"macos"'*) ;;
-  *) echo "error: --version did not emit expected metadata: $VERSION_JSON" >&2; exit 1 ;;
-esac
 
 run_clean ./lobu-device-daemon --help | grep -q 'Usage:'
 

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -34,10 +34,9 @@ run_clean_with_token() (
 
 # Shared packaging assertion (arm64 Mach-O + `--version` metadata), run against
 # the copied artifact so the release workflows and this smoke agree on what a
-# publishable daemon looks like.
-run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-device-daemon >/dev/null
-
-VERSION_JSON="$(run_clean ./lobu-device-daemon --version)"
+# publishable daemon looks like. It echoes the validated `--version` JSON, which
+# the `--no-poll` parity check below compares against.
+VERSION_JSON="$(run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-device-daemon)"
 
 run_clean ./lobu-device-daemon --help | grep -q 'Usage:'
 

--- a/scripts/verify-mac-device-daemon.sh
+++ b/scripts/verify-mac-device-daemon.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DAEMON="${1:-}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+[[ -n "$DAEMON" ]] || die "usage: verify-mac-device-daemon.sh <path>"
+[[ -x "$DAEMON" ]] || die "Mac device daemon is missing or not executable: $DAEMON"
+
+file "$DAEMON" | grep -q 'Mach-O 64-bit executable arm64' \
+  || die "Mac device daemon is not an arm64 Mach-O: $DAEMON"
+
+VERSION_JSON="$("$DAEMON" --version)"
+case "$VERSION_JSON" in
+  *'"name":"lobu-device-daemon"'*'"protocol":"device-daemon/v1"'*'"platform":"macos"'*) ;;
+  *) die "Mac device daemon reported unexpected metadata: $VERSION_JSON" ;;
+esac
+
+echo "$VERSION_JSON"

--- a/scripts/with-owletto-mac-daemon.sh
+++ b/scripts/with-owletto-mac-daemon.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESOURCE_DIR="$ROOT/packages/owletto/apps/mac/Owletto/lobu-device-daemon"
+DAEMON="$RESOURCE_DIR/lobu-device-daemon"
+
+die() { echo "error: $*" >&2; exit 1; }
+cleanup() { rm -f -- "$DAEMON"; }
+
+[[ $# -gt 0 ]] || die "usage: with-owletto-mac-daemon.sh <command> [args...]"
+[[ -d "$RESOURCE_DIR" ]] \
+  || die "Owletto daemon resource directory is missing; update packages/owletto"
+
+# The resource is generated from this root checkout and must never be committed
+# as submodule state. Clean up on every exit path we can trap; SIGKILL and a
+# lost machine still bypass the traps, so clear a leftover artifact up front
+# rather than trusting the previous run to have unwound.
+cleanup
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+OUTPUT="$DAEMON" "$ROOT/scripts/build-mac-device-daemon.sh"
+"$ROOT/scripts/verify-mac-device-daemon.sh" "$DAEMON"
+"$@"


### PR DESCRIPTION
## Summary

- advance Owletto through the merged native-daemon cutover and its focused Mac follow-ups (#937, #940, #941)
- compile the standalone arm64 daemon into Owletto's resource directory only for each Xcode build/archive, then clean it up
- verify the daemon before and after bundling, and sign the embedded Mach-O before the umbrella app in local and release builds
- load the new canonical Mac manifest array in root integration coverage

## Test plan

- [x] Final nine-file diff inspected; `make pre-pr` clean
- [x] `bun test packages/connector-worker/src --timeout 30000` - 227 passed, 0 failed
- [x] `packages/owletto/apps/mac/Tests/run-tests.sh` - 18 passed, 0 failed
- [x] `bun test scripts/__tests__/mac-device-daemon-graph.test.ts` - 3 passed, 0 failed
- [x] `scripts/test-mac-device-daemon-package.sh` - arm64 package smoke passed
- [x] Root manifest integration suites - 31 passed, 0 failed
- [x] Staging wrapper success, failure, and SIGTERM paths removed the generated submodule artifact

Mac mini process E2E against the merged daemon and Swift supervisor source passed: exact hello/ACK protocol, capabilities and identity reconciliation, ordered jobs, isolated failure, 2 MiB screenshot payload, 31-second heartbeat, timeout/abandon cancellation, clean restart, and same worker identity after restart.

## Notes

This Mac only has Command Line Tools, not full Xcode or a Developer ID identity, so the local run cannot produce or sign `Owletto.app`. The gated `mac-build-smoke` job performs that Xcode build and asserts the helper exists, is executable, is arm64, and reports `device-daemon/v1` from inside the built app bundle.

Owletto #943 independently added a generated-daemon ignore rule after this pointer. This PR deliberately remains pinned to #941 because advancing farther would also import the unrelated hosted OAuth UI change in #942, which is outside this daemon migration slice and requires its own visual proof.
