### PR TITLE
fix(oauth): enforce device verifier ownership

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -27,6 +27,14 @@ import {
 } from '../../setup/test-fixtures';
 import { del, get, mcpListTools, mcpRequest, mcpToolsCall, post } from '../../setup/test-helpers';
 
+async function verifyDeviceCode(userCode: string, cookie: string): Promise<void> {
+  const response = await get(
+    `/oauth/device/info?user_code=${encodeURIComponent(userCode)}`,
+    { cookie }
+  );
+  expect(response.status).toBe(200);
+}
+
 describe('MCP Authentication', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let publicOrg: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -1401,6 +1409,7 @@ describe('MCP Authentication', () => {
     it('should approve device code with explicit organization_id', async () => {
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
+      await verifyDeviceCode(dc.userCode, sessionCookie);
       const response = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,
@@ -1419,6 +1428,7 @@ describe('MCP Authentication', () => {
     it('should return org_selection_required without organization_id (no resource slug)', async () => {
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
+      await verifyDeviceCode(dc.userCode, sessionCookie);
       const response = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,
@@ -1443,6 +1453,7 @@ describe('MCP Authentication', () => {
         resource: `http://localhost/mcp/${org.slug}`,
       });
 
+      await verifyDeviceCode(dc.userCode, sessionCookie);
       const response = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,
@@ -1460,6 +1471,7 @@ describe('MCP Authentication', () => {
     it('should reject device approve with invalid organization_id', async () => {
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
+      await verifyDeviceCode(dc.userCode, sessionCookie);
       const response = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,
@@ -1499,6 +1511,7 @@ describe('MCP Authentication', () => {
       const pSession = await createTestSession(pUser.id);
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
+      await verifyDeviceCode(dc.userCode, pSession.cookieHeader);
       const response = await post('/oauth/device/approve', {
         body: { user_code: dc.userCode, approved: true },
         cookie: pSession.cookieHeader,
@@ -1534,6 +1547,7 @@ describe('MCP Authentication', () => {
       const pSession = await createTestSession(pUser.id);
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
+      await verifyDeviceCode(dc.userCode, pSession.cookieHeader);
       const response = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,
@@ -1553,6 +1567,7 @@ describe('MCP Authentication', () => {
       const dc = await createTestDeviceCode(deviceClient.client_id);
 
       // User approves the device on the OAuth page, picking `org`.
+      await verifyDeviceCode(dc.userCode, sessionCookie);
       const approveRes = await post('/oauth/device/approve', {
         body: {
           user_code: dc.userCode,

--- a/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
@@ -199,7 +199,13 @@ describe('user_claimed flow — full loop', () => {
     });
     expect(email.status).toBe(202);
 
-    // 4. User clicks the magic link (modelled by the session) and approves.
+    // 4. User clicks the magic link (modelled by the session). Loading the
+    // consent page verifies and binds the exact code before approval.
+    const info = await call(app, 'GET', `/oauth/device/info?user_code=${user_code}`, {
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(info.status).toBe(200);
+
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code, approved: true },
       headers: { Cookie: session.cookieHeader },

--- a/packages/server/src/__tests__/integration/oauth/device-code-ownership.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-code-ownership.test.ts
@@ -1,0 +1,256 @@
+import { Hono } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { oauthRoutes } from '../../../auth/oauth/routes';
+import { hashToken } from '../../../auth/oauth/utils';
+import type { Env } from '../../../index';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestDeviceCode,
+  createTestOAuthClient,
+  createTestSession,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const ORIGIN = 'http://localhost';
+const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+  RATE_LIMIT_ENABLED: 'false',
+} as unknown as Env;
+
+function buildApp(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route('/', oauthRoutes);
+  return app;
+}
+
+function call(
+  app: Hono<{ Bindings: Env }>,
+  method: string,
+  path: string,
+  options?: { body?: unknown; cookie?: string }
+): Promise<Response> {
+  return app.fetch(
+    new Request(`${ORIGIN}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: ORIGIN,
+        ...(options?.cookie ? { Cookie: options.cookie } : {}),
+      },
+      ...(options?.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+    }),
+    TEST_ENV
+  );
+}
+
+async function createPendingCode() {
+  const client = await createTestOAuthClient({
+    grant_types: [DEVICE_GRANT, 'refresh_token'],
+  });
+  return createTestDeviceCode(client.client_id, { scope: 'profile:read' });
+}
+
+async function readDeviceCode(userCode: string) {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT user_id, status
+    FROM oauth_device_codes
+    WHERE user_code = ${userCode}
+  `) as unknown as Array<{ user_id: string | null; status: string }>;
+  return rows[0];
+}
+
+beforeAll(async () => {
+  await initWorkspaceProvider();
+});
+
+beforeEach(async () => {
+  await cleanupTestDatabase();
+});
+
+describe('OAuth device verifier ownership', () => {
+  it('claims a pending code for one user and lets that user verify it idempotently', async () => {
+    const app = buildApp();
+    const user = await createTestUser({ name: 'Verifier' });
+    const session = await createTestSession(user.id);
+    const device = await createPendingCode();
+    const path = `/oauth/device/info?user_code=${device.userCode}`;
+
+    const first = await call(app, 'GET', path, { cookie: session.cookieHeader });
+    const second = await call(app, 'GET', path, { cookie: session.cookieHeader });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await readDeviceCode(device.userCode)).toEqual({
+      user_id: user.id,
+      status: 'pending',
+    });
+  });
+
+  it('allows only one of two concurrent users to claim a code', async () => {
+    const app = buildApp();
+    const firstUser = await createTestUser({ name: 'First verifier' });
+    const secondUser = await createTestUser({ name: 'Second verifier' });
+    const firstSession = await createTestSession(firstUser.id);
+    const secondSession = await createTestSession(secondUser.id);
+    const device = await createPendingCode();
+    const path = `/oauth/device/info?user_code=${device.userCode}`;
+
+    const responses = await Promise.all([
+      call(app, 'GET', path, { cookie: firstSession.cookieHeader }),
+      call(app, 'GET', path, { cookie: secondSession.cookieHeader }),
+    ]);
+
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 400]);
+    const winner = responses[0].status === 200 ? firstUser : secondUser;
+    expect((await readDeviceCode(device.userCode))?.user_id).toBe(winner.id);
+    const rejected = responses.find((response) => response.status === 400);
+    expect(await rejected?.json()).toEqual({
+      error: 'invalid_grant',
+      error_description: 'Invalid or expired user code',
+    });
+  });
+
+  it.each([
+    { approved: true, finalStatus: 'approved' },
+    { approved: false, finalStatus: 'denied' },
+  ])(
+    'rejects an unverified consent decision before it can set status=$finalStatus',
+    async ({ approved }) => {
+      const app = buildApp();
+      const user = await createTestUser({ name: 'Direct submitter' });
+      const session = await createTestSession(user.id);
+      const device = await createPendingCode();
+
+      const response = await call(app, 'POST', '/oauth/device/approve', {
+        cookie: session.cookieHeader,
+        body: { user_code: device.userCode, approved },
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: 'invalid_grant',
+        error_description: 'Invalid or expired user code',
+      });
+      expect(await readDeviceCode(device.userCode)).toEqual({
+        user_id: null,
+        status: 'pending',
+      });
+    }
+  );
+
+  it.each([
+    { approved: true, finalStatus: 'approved' },
+    { approved: false, finalStatus: 'denied' },
+  ])(
+    'lets only the verifier set status=$finalStatus',
+    async ({ approved, finalStatus }) => {
+      const app = buildApp();
+      const verifier = await createTestUser({ name: 'Verifier' });
+      const attacker = await createTestUser({ name: 'Other user' });
+      const verifierSession = await createTestSession(verifier.id);
+      const attackerSession = await createTestSession(attacker.id);
+      const device = await createPendingCode();
+      const infoPath = `/oauth/device/info?user_code=${device.userCode}`;
+
+      const verified = await call(app, 'GET', infoPath, {
+        cookie: verifierSession.cookieHeader,
+      });
+      expect(verified.status).toBe(200);
+
+      const hidden = await call(app, 'GET', infoPath, {
+        cookie: attackerSession.cookieHeader,
+      });
+      expect(hidden.status).toBe(400);
+
+      const rejected = await call(app, 'POST', '/oauth/device/approve', {
+        cookie: attackerSession.cookieHeader,
+        body: { user_code: device.userCode, approved },
+      });
+      expect(rejected.status).toBe(400);
+      expect(await readDeviceCode(device.userCode)).toEqual({
+        user_id: verifier.id,
+        status: 'pending',
+      });
+
+      const accepted = await call(app, 'POST', '/oauth/device/approve', {
+        cookie: verifierSession.cookieHeader,
+        body: { user_code: device.userCode, approved },
+      });
+      expect(accepted.status).toBe(200);
+      expect(await readDeviceCode(device.userCode)).toEqual({
+        user_id: verifier.id,
+        status: finalStatus,
+      });
+    }
+  );
+
+  it('cannot exchange a token attributed to a user who lost the verifier claim', async () => {
+    const app = buildApp();
+    const verifier = await createTestUser({ name: 'Token verifier' });
+    const attacker = await createTestUser({ name: 'Token attacker' });
+    const verifierSession = await createTestSession(verifier.id);
+    const attackerSession = await createTestSession(attacker.id);
+    const client = await createTestOAuthClient({
+      grant_types: [DEVICE_GRANT, 'refresh_token'],
+    });
+    const device = await createTestDeviceCode(client.client_id, { scope: 'profile:read' });
+
+    const info = await call(
+      app,
+      'GET',
+      `/oauth/device/info?user_code=${device.userCode}`,
+      { cookie: verifierSession.cookieHeader }
+    );
+    expect(info.status).toBe(200);
+
+    const rejected = await call(app, 'POST', '/oauth/device/approve', {
+      cookie: attackerSession.cookieHeader,
+      body: { user_code: device.userCode, approved: true },
+    });
+    expect(rejected.status).toBe(400);
+
+    const pending = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: DEVICE_GRANT,
+        device_code: device.deviceCode,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      },
+    });
+    expect(pending.status).toBe(400);
+    expect((await pending.json()) as { error: string }).toMatchObject({
+      error: 'authorization_pending',
+    });
+
+    const approved = await call(app, 'POST', '/oauth/device/approve', {
+      cookie: verifierSession.cookieHeader,
+      body: { user_code: device.userCode, approved: true },
+    });
+    expect(approved.status).toBe(200);
+
+    const exchanged = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: DEVICE_GRANT,
+        device_code: device.deviceCode,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      },
+    });
+    expect(exchanged.status).toBe(200);
+    const tokens = (await exchanged.json()) as { access_token: string };
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT user_id FROM oauth_tokens
+      WHERE token_hash = ${hashToken(tokens.access_token)}
+        AND token_type = 'access'
+    `) as unknown as Array<{ user_id: string }>;
+    expect(rows).toEqual([{ user_id: verifier.id }]);
+    expect(rows[0]?.user_id).not.toBe(attacker.id);
+  });
+});

--- a/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
@@ -17,8 +17,8 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { render } from '@react-email/render';
 import { MagicLinkEmail } from '../../../email/templates/magic-link';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
-import { createTestUser } from '../../setup/test-fixtures';
-import { post } from '../../setup/test-helpers';
+import { createTestSession, createTestUser } from '../../setup/test-fixtures';
+import { get, post } from '../../setup/test-helpers';
 
 const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
 
@@ -94,6 +94,22 @@ describe('POST /oauth/device/email — agent account claim', () => {
   it('rejects an unknown or expired user_code with 400 (the agent\'s own error)', async () => {
     const res = await post('/oauth/device/email', {
       body: { user_code: 'NOPE-NOPE', email: 'x@example.com' },
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_grant');
+  });
+
+  it('rejects email delivery after a user has claimed the code', async () => {
+    const userCode = await pendingUserCode();
+    const user = await createTestUser({ name: 'Claimed verifier' });
+    const session = await createTestSession(user.id);
+    const info = await get(`/oauth/device/info?user_code=${encodeURIComponent(userCode)}`, {
+      cookie: session.cookieHeader,
+    });
+    expect(info.status).toBe(200);
+
+    const res = await post('/oauth/device/email', {
+      body: { user_code: userCode, email: `late-${Date.now()}@example.com` },
     });
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe('invalid_grant');

--- a/packages/server/src/__tests__/integration/oauth/device-worker-personal-org.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-worker-personal-org.test.ts
@@ -67,6 +67,20 @@ function call(
   );
 }
 
+async function verifyDeviceCode(
+  app: Hono<{ Bindings: Env }>,
+  userCode: string,
+  cookie: string
+): Promise<void> {
+  const response = await call(
+    app,
+    'GET',
+    `/oauth/device/info?user_code=${encodeURIComponent(userCode)}`,
+    { headers: { Cookie: cookie } }
+  );
+  expect(response.status).toBe(200);
+}
+
 async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
   const sql = getTestDb();
   // Match personal-org-provisioning.ts: store the marker as plain JSON text
@@ -130,6 +144,7 @@ describe('device-worker grant always binds to the personal org', () => {
 
     // Approve — note NO organization_id is sent. The handler must force the
     // personal org; it must NOT bounce with org_selection_required.
+    await verifyDeviceCode(app, da.user_code, session.cookieHeader);
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code: da.user_code, approved: true },
       headers: { Cookie: session.cookieHeader },
@@ -188,6 +203,7 @@ describe('device-worker grant always binds to the personal org', () => {
     });
     const da = (await deviceAuth.json()) as { device_code: string; user_code: string };
 
+    await verifyDeviceCode(app, da.user_code, session.cookieHeader);
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code: da.user_code, approved: true },
       headers: { Cookie: session.cookieHeader },
@@ -246,6 +262,7 @@ describe('device-worker grant always binds to the personal org', () => {
     });
     const da = (await deviceAuth.json()) as { user_code: string };
 
+    await verifyDeviceCode(app, da.user_code, session.cookieHeader);
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code: da.user_code, approved: true },
       headers: { Cookie: session.cookieHeader },

--- a/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
@@ -79,6 +79,20 @@ function call(
   );
 }
 
+async function verifyDeviceCode(
+  app: Hono<{ Bindings: Env }>,
+  userCode: string,
+  cookie: string
+): Promise<void> {
+  const response = await call(
+    app,
+    'GET',
+    `/oauth/device/info?user_code=${encodeURIComponent(userCode)}`,
+    { headers: { Cookie: cookie } }
+  );
+  expect(response.status).toBe(200);
+}
+
 beforeAll(async () => {
   await initWorkspaceProvider();
 });
@@ -128,7 +142,8 @@ describe('Stage 1 — login token carries connections:token', () => {
     expect(deviceAuth.status).toBe(200);
     const da = (await deviceAuth.json()) as { device_code: string; user_code: string };
 
-    // 3. Approve the device code as the logged-in user (session cookie).
+    // 3. Verify, then approve the device code as the logged-in user.
+    await verifyDeviceCode(app, da.user_code, session.cookieHeader);
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code: da.user_code, approved: true },
       headers: { Cookie: session.cookieHeader },
@@ -275,6 +290,7 @@ describe('Stage 1 — login token carries connections:token', () => {
     });
     const da = (await deviceAuth.json()) as { device_code: string; user_code: string };
 
+    await verifyDeviceCode(app, da.user_code, session.cookieHeader);
     const approve = await call(app, 'POST', '/oauth/device/approve', {
       body: { user_code: da.user_code, approved: true },
       headers: { Cookie: session.cookieHeader },

--- a/packages/server/src/auth/oauth/auth-md.ts
+++ b/packages/server/src/auth/oauth/auth-md.ts
@@ -55,10 +55,12 @@ agent-attested (ID-JAG) zero-touch flow; do not attempt one.
 
    { "user_code": "<user_code>", "email": "<user email>" }
    \`\`\`
-   Always returns \`202\` once the \`user_code\` is valid. The response never
-   reveals whether the email already has an account. Lobu emails the user a
-   magic link; one click signs them in (creating the account on first use) and
-   lands them on the consent screen for this request.
+   Returns \`202\` while the \`user_code\` is still pending and unclaimed; once
+   someone has opened its consent screen the code is bound to them and this
+   returns \`invalid_grant\`. The response never reveals whether the email
+   already has an account. Lobu emails the user a magic link; one click signs
+   them in (creating the account on first use) and lands them on the consent
+   screen for this request.
 
 4. Poll the token endpoint until the user approves:
    \`\`\`http
@@ -83,7 +85,7 @@ with the standard \`refresh_token\` grant at \`${baseUrl}/oauth/token\`.
 | \`authorization_pending\` | token poll | user has not approved yet; keep polling |
 | \`slow_down\` | token poll | poll less often |
 | \`expired_token\` | token poll | the device_code expired; start over |
-| \`invalid_grant\` | device/email, token | unknown or expired \`user_code\`/\`device_code\` |
+| \`invalid_grant\` | device/email, token | invalid code; device/email also rejects a \`user_code\` already claimed by a verifier |
 | \`access_denied\` | token poll | the user denied the request |
 `;
 }

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -654,10 +654,10 @@ export class OAuthProvider {
       const result = await this.sql`
         UPDATE oauth_device_codes
         SET status = 'approved',
-            user_id = ${userId},
             organization_id = ${organizationId},
             scope = ${scopeOverride}
         WHERE user_code = ${userCode}
+          AND user_id = ${userId}
           AND status = 'pending'
           AND expires_at > NOW()
         RETURNING device_code
@@ -667,9 +667,9 @@ export class OAuthProvider {
     const result = await this.sql`
       UPDATE oauth_device_codes
       SET status = 'approved',
-          user_id = ${userId},
           organization_id = ${organizationId}
       WHERE user_code = ${userCode}
+        AND user_id = ${userId}
         AND status = 'pending'
         AND expires_at > NOW()
       RETURNING device_code
@@ -678,13 +678,14 @@ export class OAuthProvider {
   }
 
   /**
-   * Deny a device code
+   * Deny a device code owned by the authenticated verifier.
    */
-  async denyDeviceCode(userCode: string): Promise<boolean> {
+  async denyDeviceCode(userCode: string, userId: string): Promise<boolean> {
     const result = await this.sql`
       UPDATE oauth_device_codes
       SET status = 'denied'
       WHERE user_code = ${userCode}
+        AND user_id = ${userId}
         AND status = 'pending'
         AND expires_at > NOW()
       RETURNING device_code
@@ -693,12 +694,56 @@ export class OAuthProvider {
   }
 
   /**
-   * Look up a pending device code by user_code for the consent page
+   * Validate an unclaimed pending code before sending its consent email.
+   *
+   * Unauthenticated, so it must not confirm a code another user already owns:
+   * once claimed, the email path reports the same miss as an unknown code.
    */
-  async getDeviceCodeByUserCode(userCode: string): Promise<StoredDeviceCode | null> {
+  async isUnclaimedDeviceCodePending(userCode: string): Promise<boolean> {
+    const result = await this.sql`
+      SELECT 1 FROM oauth_device_codes
+      WHERE user_code = ${userCode}
+        AND user_id IS NULL
+        AND status = 'pending'
+        AND expires_at > NOW()
+    `;
+    return result.length > 0;
+  }
+
+  /**
+   * Atomically bind an unclaimed pending code to the authenticated verifier.
+   *
+   * Repeated verification by the same user is idempotent. Every other user
+   * observes the same miss as an unknown or expired code.
+   */
+  async claimDeviceCodeForUser(
+    userCode: string,
+    userId: string
+  ): Promise<StoredDeviceCode | null> {
+    const result = await this.sql`
+      UPDATE oauth_device_codes
+      SET user_id = ${userId}
+      WHERE user_code = ${userCode}
+        AND (user_id IS NULL OR user_id = ${userId})
+        AND status = 'pending'
+        AND expires_at > NOW()
+      RETURNING *
+    `;
+    if (result.length === 0) return null;
+    return result[0] as StoredDeviceCode;
+  }
+
+  /**
+   * Read a pending code only when it belongs to the authenticated verifier.
+   */
+  async getDeviceCodeForUser(
+    userCode: string,
+    userId: string
+  ): Promise<StoredDeviceCode | null> {
     const result = await this.sql`
       SELECT * FROM oauth_device_codes
       WHERE user_code = ${userCode}
+        AND user_id = ${userId}
         AND status = 'pending'
         AND expires_at > NOW()
     `;

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -24,6 +24,7 @@ import { getConfiguredPublicOrigin } from '../../utils/public-origin';
 import { resolveSession } from '../resolve-session';
 
 const oauthRoutes = new Hono<{ Bindings: Env }>();
+const INVALID_DEVICE_CODE_MESSAGE = 'Invalid or expired user code';
 
 /**
  * Parse a request body that may be application/x-www-form-urlencoded or JSON.
@@ -878,9 +879,9 @@ oauthRoutes.post('/oauth/device/email', async (c) => {
   // The user_code is the agent's own pending authorization — a bad one is the
   // agent's error, not account-existence info, so it is safe to 400 here.
   const provider = getProvider(c);
-  const deviceCode = await provider.getDeviceCodeByUserCode(userCode);
-  if (!deviceCode) {
-    return c.json(createOAuthError('invalid_grant', 'Invalid or expired user code'), 400);
+  const codeIsPending = await provider.isUnclaimedDeviceCodePending(userCode);
+  if (!codeIsPending) {
+    return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
   }
 
   // Land the magic link on the existing device consent page for this code.
@@ -937,10 +938,14 @@ oauthRoutes.get('/oauth/device/info', requireAuth, async (c) => {
   if (!userCode) {
     return c.json(createOAuthError('invalid_request', 'user_code is required'), 400);
   }
+  const user = c.get('user');
+  if (!user) {
+    return c.json(createOAuthError('access_denied', 'Authentication required'), 401);
+  }
   const provider = getProvider(c);
-  const deviceCode = await provider.getDeviceCodeByUserCode(userCode);
+  const deviceCode = await provider.claimDeviceCodeForUser(userCode, user.id);
   if (!deviceCode) {
-    return c.json(createOAuthError('invalid_grant', 'Invalid or expired user code'), 400);
+    return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
   }
   const client = await provider.clientsStore.getClient(deviceCode.client_id);
   return c.json({
@@ -982,14 +987,18 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
   }
 
   if (!body.approved) {
-    await provider.denyDeviceCode(body.user_code);
+    const denied = await provider.denyDeviceCode(body.user_code, user.id);
+    if (!denied) {
+      return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
+    }
     return c.json({ status: 'denied' });
   }
 
-  // Look up the device code to check scope/resource
-  const deviceCode = await provider.getDeviceCodeByUserCode(body.user_code);
+  // Read scope/resource only after the verifier endpoint bound the code to
+  // this user. Consent decisions never create or overwrite ownership.
+  const deviceCode = await provider.getDeviceCodeForUser(body.user_code, user.id);
   if (!deviceCode) {
-    return c.json(createOAuthError('invalid_grant', 'Invalid or expired user code'), 400);
+    return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
   }
 
   const deviceHasMcpScopes = hasMcpScopes(deviceCode.scope);
@@ -1100,7 +1109,7 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
     scopeOverride
   );
   if (!approved) {
-    return c.json(createOAuthError('invalid_grant', 'Failed to approve device code'), 400);
+    return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
   }
 
   return c.json({ status: 'approved' });


### PR DESCRIPTION
## Summary

- atomically bind a pending device code to the authenticated verifier when the consent page verifies it
- require that same verifier for approve and deny without overwriting ownership
- reject email delivery after a code is claimed and migrate device-flow tests to the verifier-first contract

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: 77 passed, 2 skipped across the six focused OAuth/MCP integration files
- [x] Bug fix: before the fix, all 6 new ownership tests failed; after the fix, all 7 ownership tests pass
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Local `make pre-pr` is clean. Independent security review passed.

## Notes

Breaking change: direct approve or deny without prior authenticated `/oauth/device/info` verification now returns `invalid_grant`; no compatibility fallback is retained.

Do not merge until the Lobu Owletto pointer includes merged owletto#942. Current `main` points at Owletto `9f2d9bf6`, which predates that verifier-first UI.

No schema, SDK, or response-shape changes.