### PR TITLE
feat(cli)!: drop legacy --inside-claude daemon flag

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -159,7 +159,9 @@ describe("lobu daemon", () => {
     );
   });
 
-  test("--inside-claude bypasses cache and wizard so the daemon derives a per-session id", async () => {
+  test("an explicit --worker-id wins over both the cache and the session lane", async () => {
+    process.env.CODEX_THREAD_ID = "thread-exact";
+    process.env.CODEX_SESSION_ID = "thread-exact";
     const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
       workerId: "macos:cached-host",
     });
@@ -173,39 +175,15 @@ describe("lobu daemon", () => {
 
     await daemonCommand({
       apiUrl: "http://127.0.0.1:9564",
-      insideClaude: true,
+      workerId: "headless:attached-explicit",
     });
 
     expect(start.mock.calls[0]?.[0]).toMatchObject({
-      apiUrl: "http://127.0.0.1:9564",
+      workerId: "headless:attached-explicit",
       platform: "headless",
-      defaultPlatform: "headless",
-      insideClaude: true,
     });
-    expect(start.mock.calls[0]?.[0]?.workerId).toMatch(/^headless:claude:/);
     expect(load).not.toHaveBeenCalled();
     expect(wizard).not.toHaveBeenCalled();
-  });
-
-  test("an explicit --worker-id wins over both the cache and the session lane", async () => {
-    const load = spyOn(deviceState, "loadDeviceState").mockResolvedValue({
-      workerId: "macos:cached-host",
-    });
-    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
-      undefined as never
-    );
-
-    await daemonCommand({
-      apiUrl: "http://127.0.0.1:9564",
-      workerId: "headless:attached-explicit",
-      insideClaude: true,
-    });
-
-    expect(start.mock.calls[0]?.[0]).toMatchObject({
-      workerId: "headless:attached-explicit",
-      insideClaude: true,
-    });
-    expect(load).not.toHaveBeenCalled();
   });
 
   test("auto-detected Codex bypasses the host cache and remains in the centralized session lane", async () => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -34,7 +34,6 @@ export interface DaemonOptions {
   capabilities?: string;
   label?: string;
   debug?: boolean;
-  insideClaude?: boolean;
   interactiveSession?: boolean;
 }
 
@@ -110,20 +109,14 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     ...(options.interactiveSession === false
       ? { interactiveSession: false as const }
       : {}),
-    ...(options.insideClaude === true ? { insideClaude: true } : {}),
   });
   const platform = launchContext.platform ?? defaultPlatform;
-  const sessionLane =
-    launchContext.interactiveSession !== undefined ||
-    options.insideClaude === true;
+  const sessionLane = launchContext.interactiveSession !== undefined;
   const shortHost = hostname().split(".")[0] || hostname();
   const explicitWorkerId = options.workerId?.trim() || undefined;
   const sessionWorkerId = sessionLane
     ? resolveDaemonWorkerId(
-        {
-          workerId: explicitWorkerId,
-          ...(options.insideClaude === true ? { insideClaude: true } : {}),
-        },
+        { workerId: explicitWorkerId },
         platform,
         shortHost,
         launchContext.interactiveSession
@@ -255,7 +248,6 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     ...(options.interactiveSession === false
       ? { interactiveSession: false as const }
       : {}),
-    ...(options.insideClaude === true ? { insideClaude: true } : {}),
   });
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1193,10 +1193,6 @@ Memory:
       "Device platform (defaults to headless; native macOS uses Owletto)"
     )
     .option(
-      "--inside-claude",
-      "Legacy Claude-only interactive delivery opt-in (supported sessions are now detected automatically)"
-    )
-    .option(
       "--no-interactive-session",
       "Disable automatic delivery into an inherited Claude, Codex, or OpenCode session"
     )

--- a/packages/connector-worker/src/__tests__/interactive-automation.test.ts
+++ b/packages/connector-worker/src/__tests__/interactive-automation.test.ts
@@ -10,7 +10,7 @@ function payload(agentKind: 'claude-code' | 'pi' = 'claude-code'): AutomationPol
   return {
     automation: {
       id: 'automation-1',
-      name: 'Inside Claude test',
+      name: 'Interactive session test',
       agent_kind: agentKind,
       prompt: 'Do the bounded work',
     },
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe('interactive-session routing', () => {
-  test('an explicit worker id wins over the inside-Claude derived identity', () => {
+  test('an explicit worker id wins over the session-derived identity', () => {
     expect(
       resolveDaemonWorkerId(
         { workerId: 'headless:operator-selected' },
@@ -70,7 +70,6 @@ describe('interactive-session routing', () => {
       messagingToken: 'messaging-token',
       registryPath: '/private/unused-session.json',
     };
-    spyOn(interactive, 'detectInteractiveSession').mockReturnValue({ ok: true, session });
     let finishParent!: () => void;
     const parentCompletion = new Promise<interactive.InteractiveSessionCompletion>((resolve) => {
       finishParent = () =>
@@ -106,11 +105,17 @@ describe('interactive-session routing', () => {
       payload: payload(),
     };
 
-    const execution = executeAutomationRun(client as never, job, {
-      insideClaude: true,
-      heartbeatIntervalMs: 5,
-      binaryOverrides: { 'claude-code': '/definitely/not/a/claude/binary' },
-    });
+    const execution = executeAutomationRun(
+      client as never,
+      job,
+      interactive.attachInteractiveSession(
+        {
+          heartbeatIntervalMs: 5,
+          binaryOverrides: { 'claude-code': '/definitely/not/a/claude/binary' },
+        },
+        session
+      )
+    );
     await new Promise((resolve) => setTimeout(resolve, 20));
     finishParent();
     await execution;
@@ -135,7 +140,6 @@ describe('interactive-session routing', () => {
       messagingToken: 'messaging-token',
       registryPath: '/private/unused-session.json',
     };
-    spyOn(interactive, 'detectInteractiveSession').mockReturnValue({ ok: true, session });
     const handoff = spyOn(interactive, 'handoffToInteractiveSession').mockResolvedValue({
       kind: 'handed-off',
       certainty: 'possible',
@@ -163,7 +167,10 @@ describe('interactive-session routing', () => {
     await executeAutomationRun(
       client as never,
       { run_id: 93, run_type: 'automation', payload: turnPayload } satisfies PollResponse,
-      { insideClaude: true, binaryOverrides: { 'claude-code': '/never/spawned' } }
+      interactive.attachInteractiveSession(
+        { binaryOverrides: { 'claude-code': '/never/spawned' } },
+        session
+      )
     );
 
     expect(handoff).toHaveBeenCalledTimes(1);
@@ -181,7 +188,6 @@ describe('interactive-session routing', () => {
       messagingToken: 'messaging-token',
       registryPath: '/private/unused-session.json',
     };
-    spyOn(interactive, 'detectInteractiveSession').mockReturnValue({ ok: true, session });
     spyOn(interactive, 'handoffToInteractiveSession').mockResolvedValue({
       kind: 'handed-off',
       certainty: 'possible',
@@ -207,7 +213,10 @@ describe('interactive-session routing', () => {
     await executeAutomationRun(
       client as never,
       { run_id: 92, run_type: 'automation', payload: payload() } satisfies PollResponse,
-      { insideClaude: true, binaryOverrides: { 'claude-code': '/definitely/not/a/claude/binary' } }
+      interactive.attachInteractiveSession(
+        { binaryOverrides: { 'claude-code': '/definitely/not/a/claude/binary' } },
+        session
+      )
     );
 
     expect(reports).toHaveLength(1);

--- a/packages/connector-worker/src/__tests__/interactive-session.test.ts
+++ b/packages/connector-worker/src/__tests__/interactive-session.test.ts
@@ -342,34 +342,6 @@ describe('interactive daemon launch context', () => {
     expect(() => resolveDaemonLaunchContext({ platform: 'macos' }, env)).toThrow(
       /registers as --platform headless.*Pass --no-interactive-session/s
     );
-    // The legacy flag has a different escape hatch, so the hint must name it.
-    expect(() =>
-      resolveDaemonLaunchContext({ platform: 'macos', insideClaude: true }, env)
-    ).toThrow(/registers as --platform headless.*Drop --inside-claude/s);
-  });
-
-  test('legacy inside-Claude detects only the exact inherited Claude parent', async () => {
-    const fixture = await parentFixture();
-    const env = {
-      CLAUDE_PID: String(process.pid),
-      CLAUDE_CODE_SESSION_ID: fixture.session.sessionId,
-      CLAUDE_CODE_MESSAGING_SOCKET: fixture.session.socketPath,
-      CLAUDE_CODE_MESSAGING_TOKEN: fixture.session.messagingToken,
-      CODEX_THREAD_ID: 'nested-codex',
-      CODEX_SESSION_ID: 'nested-codex',
-    };
-    expect(
-      resolveDaemonLaunchContext({ insideClaude: true, defaultPlatform: 'macos' }, env, fixture.dir)
-    ).toMatchObject({
-      platform: 'headless',
-      interactiveSession: { kind: 'claude-code', sessionId: fixture.session.sessionId },
-    });
-  });
-
-  test('legacy inside-Claude remains headless and retryable when startup metadata is absent', () => {
-    expect(
-      resolveDaemonLaunchContext({ insideClaude: true, defaultPlatform: 'macos' }, {})
-    ).toEqual({ platform: 'headless', interactiveSession: undefined });
   });
 });
 

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -57,7 +57,6 @@ import { WorkerDecodeError, WorkerHttpError } from './client.js';
 import { log } from './log.js';
 import {
   attachedInteractiveSession,
-  detectInteractiveSession,
   handoffToInteractiveSession,
   type InteractiveSession,
 } from './interactive-session.js';
@@ -74,8 +73,6 @@ import {
 export interface AutomationExecutorConfig {
   timeoutMs?: number;
   heartbeatIntervalMs?: number;
-  /** Legacy explicit Claude opt-in; normal startup detects a session once internally. */
-  insideClaude?: boolean;
   /** Stops a pending interactive handoff during daemon shutdown. */
   shutdownSignal?: AbortSignal;
   /** Standalone Mac daemons must never use the device PAT for MCP writes. */
@@ -698,16 +695,9 @@ export async function executeAutomationRun(
       ? configuredTimeout * 1000
       : (cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
-  // `--inside-claude` remains accepted for callers that construct this config
-  // directly. Normal daemon startup detects once and attaches it internally.
-  const interactiveSession =
-    attachedInteractiveSession(cfg) ??
-    (cfg.insideClaude
-      ? (() => {
-          const detected = detectInteractiveSession({ claudeOnly: true });
-          return detected.ok ? detected.session : undefined;
-        })()
-      : undefined);
+  // Daemon startup detects the inherited session once and attaches it
+  // internally; per-run detection is not repeated here.
+  const interactiveSession = attachedInteractiveSession(cfg);
   const agentSession = payload.context.agent_session;
   const selectedSession = isInteractiveSessionEligible(spec.kind, interactiveSession, payload)
     ? interactiveSession

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -69,8 +69,6 @@ export interface ExecutorConfig {
   generateEmbeddings: boolean;
   timeoutMs: number;
   maxOldSpaceSize: number;
-  /** Legacy explicit Claude-only delivery. */
-  insideClaude?: boolean;
   /** Daemon lifecycle signal used only by pending interactive handoffs. */
   shutdownSignal?: AbortSignal;
   /** Local agent kind used when an Automation omits agent_kind. */

--- a/packages/connector-worker/src/daemon/interactive-session.ts
+++ b/packages/connector-worker/src/daemon/interactive-session.ts
@@ -254,10 +254,8 @@ export function detectOpenCodeInteractiveSession(
 export function detectInteractiveSession(opts: {
   env?: NodeJS.ProcessEnv;
   sessionsDir?: string;
-  claudeOnly?: boolean;
 } = {}): { ok: true; session: InteractiveSession } | { ok: false; reason: string } {
   const env = opts.env ?? process.env;
-  if (opts.claudeOnly) return detectParentClaudeSession({ env, sessionsDir: opts.sessionsDir });
 
   const candidates: InteractiveSession[] = [];
   if (env.CLAUDE_PID || env.CLAUDE_CODE_SESSION_ID) {
@@ -284,14 +282,6 @@ export function detectInteractiveSession(opts: {
 export function deriveInteractiveWorkerId(session: InteractiveSession): string {
   const provider = session.kind === 'claude-code' ? 'claude' : session.kind;
   return `headless:${provider}:${createHash('sha256').update(session.sessionId).digest('hex').slice(0, 24)}`;
-}
-
-export function deriveLegacyClaudeWorkerId(
-  env: NodeJS.ProcessEnv = process.env,
-  fallbackSeed = randomBytes(16).toString('hex')
-): string {
-  const seed = env.CLAUDE_CODE_SESSION_ID?.trim() || env.CLAUDE_PID?.trim() || fallbackSeed;
-  return `headless:claude:${createHash('sha256').update(seed).digest('hex').slice(0, 24)}`;
 }
 
 function sessionLabel(session: InteractiveSession): string {

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -16,15 +16,14 @@ import { log, setDebug } from './log.js';
 import {
   attachInteractiveSession,
   deriveInteractiveWorkerId,
-  deriveLegacyClaudeWorkerId,
   detectInteractiveSession,
   type InteractiveSession,
 } from './interactive-session.js';
 
 /**
  * Accepted `--worker-id` shape. Deliberately narrow: the default is
- * `<platform>:<short-hostname>` (or a session-derived id under
- * `--inside-claude`), and anything a shell, a URL path, or a JSON payload
+ * `<platform>:<short-hostname>` (or a session-derived id in a supported
+ * interactive agent), and anything a shell, a URL path, or a JSON payload
  * would mangle has no business being a durable device identity.
  */
 const WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
@@ -45,23 +44,18 @@ export interface DaemonStartOptions {
   debug?: boolean;
   /** False only when the operator explicitly disables inherited-session delivery. */
   interactiveSession?: false;
-  /** Legacy explicit Claude-only detection. */
-  insideClaude?: boolean;
 }
 
 export function resolveDaemonWorkerId(
-  opts: Pick<DaemonStartOptions, 'workerId' | 'insideClaude'>,
+  opts: Pick<DaemonStartOptions, 'workerId'>,
   platform: string | undefined,
   shortHostname: string,
-  interactiveSession?: InteractiveSession,
-  env: NodeJS.ProcessEnv = process.env
+  interactiveSession?: InteractiveSession
 ): string {
   return (
     opts.workerId ??
     (interactiveSession
       ? deriveInteractiveWorkerId(interactiveSession)
-      : opts.insideClaude
-        ? deriveLegacyClaudeWorkerId(env)
       : platform
         ? `${platform}:${shortHostname}`
         : `worker-${randomUUID().slice(0, 8)}`)
@@ -71,14 +65,11 @@ export function resolveDaemonWorkerId(
 export function resolveDaemonLaunchContext(
   opts: Pick<
     DaemonStartOptions,
-    'platform' | 'defaultPlatform' | 'insideClaude' | 'interactiveSession'
+    'platform' | 'defaultPlatform' | 'interactiveSession'
   >,
   env: NodeJS.ProcessEnv = process.env,
   sessionsDir?: string
 ): { platform: string | undefined; interactiveSession: InteractiveSession | undefined } {
-  if (opts.insideClaude && opts.interactiveSession === false) {
-    throw new Error('--inside-claude cannot be combined with --no-interactive-session');
-  }
   const detected =
     opts.interactiveSession === false
       ? undefined
@@ -86,23 +77,18 @@ export function resolveDaemonLaunchContext(
           const result = detectInteractiveSession({
             env,
             ...(sessionsDir ? { sessionsDir } : {}),
-            claudeOnly: opts.insideClaude === true,
           });
           return result.ok ? result.session : undefined;
         })();
-  if ((detected || opts.insideClaude) && opts.platform && opts.platform !== 'headless') {
+  if (detected && opts.platform && opts.platform !== 'headless') {
     // Interactive delivery registers a per-session headless device, so it can
     // never also claim the host's own platform identity.
-    const optOut = opts.insideClaude ? 'Drop --inside-claude' : 'Pass --no-interactive-session';
     throw new Error(
-      `an inherited interactive agent session registers as --platform headless, so it cannot be combined with --platform ${opts.platform}. ${optOut} to register this host as a ${opts.platform} device instead.`
+      `an inherited interactive agent session registers as --platform headless, so it cannot be combined with --platform ${opts.platform}. Pass --no-interactive-session to register this host as a ${opts.platform} device instead.`
     );
   }
   return {
-    platform:
-      detected || opts.insideClaude
-        ? 'headless'
-        : (opts.platform ?? opts.defaultPlatform),
+    platform: detected ? 'headless' : (opts.platform ?? opts.defaultPlatform),
     interactiveSession: detected,
   };
 }
@@ -182,8 +168,6 @@ export async function startDaemonCommand(
     log.info(
       `[cli] interactive-session delivery enabled for ${detected.kind}`
     );
-  } else if (opts.insideClaude) {
-    log.info('[cli] legacy inside-Claude delivery enabled; parent detection will retry per run');
   }
 
   const daemonConfig = {
@@ -203,9 +187,7 @@ export async function startDaemonCommand(
             defaultAgentKind: detected.kind,
           }
         }
-      : opts.insideClaude
-        ? { executor: { insideClaude: true } }
-        : {}),
+      : {}),
   };
   if (detected) attachInteractiveSession(daemonConfig, detected);
   return startDaemon(daemonConfig, env);

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -66,10 +66,9 @@ export class WorkerDaemon {
     });
 
     this.env = env;
-    this.shutdownController =
-      interactiveSession || daemonConfig.executor?.insideClaude
-        ? new AbortController()
-        : undefined;
+    this.shutdownController = interactiveSession
+      ? new AbortController()
+      : undefined;
     const executor = {
       timeoutMs: DEFAULT_EXECUTOR_TIMEOUT_MS,
       ...(daemonConfig.executor ?? {}),


### PR DESCRIPTION
## Summary
- Auto-detection of inherited Claude Code, Codex, and OpenCode sessions fully supersedes the Claude-only opt-in, so `--inside-claude` and its whole lane are removed: the CLI flag + `DaemonOptions.insideClaude`, `DaemonStartOptions.insideClaude` (launch-context conflict hint, legacy worker-id derivation via the deleted `deriveLegacyClaudeWorkerId`, the legacy log line), the `executor.insideClaude` config field, the automation arm's per-run `claudeOnly` re-detection fallback, and `detectInteractiveSession`'s `claudeOnly` parameter.
- Structural evidence for the deletion: `detectInteractiveSession` already detects Claude from the environment (`CLAUDE_PID`/`CLAUDE_CODE_SESSION_ID`), so the forced lane only duplicated what boot-time detection handles; an `origin/main` grep shows no other consumers (no server/Owletto/docs references outside these two packages).

## Test plan
- [x] Intended files staged explicitly (10 files, verified `git diff --name-only origin/main...HEAD`); `make pre-pr` clean (typecheck, knip, biome, naming, funnel gates)
- [x] Tests run: targeted `bun test` — daemon-gateway-origin.test.ts (22 pass), interactive-session.test.ts + interactive-automation.test.ts (29 pass), worker-capacity-daemon.test.ts + mac-device-daemon.test.ts (19 pass)
- N/A red→green: removal task, not a bug fix

## Notes
**Breaking change** for anyone scripting `lobu daemon --inside-claude`: drop the flag — sessions are detected automatically. Docs row on lobu.ai/reference/cli is removed in a companion landing PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interactive-session handling across supported environments.
  * Explicit worker IDs now take precedence over cached or session-derived identities.
  * Added an explicit opt-out for automatic interactive-session detection.

* **Bug Fixes**
  * Prevented unnecessary device-state loading and setup prompts when an explicit worker ID is provided.
  * Improved daemon behavior for headless sessions and interactive handoffs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->