### PR TITLE
feat(linkedin): complete home feed events

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { JSDOM } from "jsdom";
 import { connectorSdkMock } from "./connector-sdk.mock";
 
 // Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
@@ -9,9 +10,11 @@ import { connectorSdkMock } from "./connector-sdk.mock";
 mock.module("@lobu/connector-sdk", connectorSdkMock);
 
 let LinkedInConnector: any;
+let personalAgentConfig: any;
 let buildHomeFeedEvents: any;
 let homeFeedObjectAllSupported: any;
 let parseHomeFeedAuthor: any;
+let parseHomeFeedEngagement: any;
 let isHomeFeedNoise: any;
 let filterPostsSinceCheckpoint: any;
 let parseCompanyUpdates: any;
@@ -33,13 +36,18 @@ let normalizeCommentMatchText: any;
 let commentBodiesMatch: any;
 let buildScrapeCommentsExpression: any;
 let verifyLinkedInStagedComment: any;
+let genericScrape: (
+  config: Record<string, unknown>
+) => Promise<Record<string, unknown>>;
 
 beforeAll(async () => {
   const mod = await import("../linkedin.connector");
+  personalAgentConfig = (await import("../lobu.config")).default;
   LinkedInConnector = mod.default;
   buildHomeFeedEvents = mod.buildHomeFeedEvents;
   homeFeedObjectAllSupported = mod.homeFeedObjectAllSupported;
   parseHomeFeedAuthor = mod.parseHomeFeedAuthor;
+  parseHomeFeedEngagement = mod.parseHomeFeedEngagement;
   isHomeFeedNoise = mod.isHomeFeedNoise;
   filterPostsSinceCheckpoint = mod.filterPostsSinceCheckpoint;
   parseCompanyUpdates = mod.parseCompanyUpdates;
@@ -58,6 +66,9 @@ beforeAll(async () => {
   commentBodiesMatch = mod.commentBodiesMatch;
   buildScrapeCommentsExpression = mod.buildScrapeCommentsExpression;
   verifyLinkedInStagedComment = mod.verifyLinkedInStagedComment;
+  genericScrape = (
+    await import("../../../packages/owletto/apps/chrome/tools.js")
+  ).genericScrape;
   const identityMod = await import("../linkedin-identity");
   normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
   normalizeLinkedInMemberId = identityMod.normalizeLinkedInMemberId;
@@ -230,6 +241,153 @@ describe("buildHomeFeedEvents", () => {
     expect(ev.source_url).toBeUndefined();
     expect(ev.occurred_at).toBe(occurredAt);
     expect(ev.metadata).toEqual({ author: "Jane Doe" });
+  });
+
+  test("emits a native visible comment with its parent, people, and media", () => {
+    const occurredAt = new Date("2026-08-23T10:00:00.000Z");
+    const events = buildHomeFeedEvents(
+      [
+        {
+          id: "parent_token",
+          body: "Feed post Lorenzo Mangani • 1st CEO at QXIP 9h • A post with enough text to keep",
+          author_control_label: "Open control menu for post by Lorenzo Mangani",
+          post_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621697",
+          links: [
+            {
+              href: "https://www.linkedin.com/in/lmangani/",
+              name: "View Lorenzo Mangani’s profile",
+            },
+          ],
+        },
+        {
+          id: "commentsSectionContainerparent_token",
+          body: "Nico Ritschel Verified Profile 1st Nico Ritschel • 1st Director of Engineering 9h 👀 0 See 1 more comment",
+          author: "Nico Ritschel",
+          comment_body:
+            "Nico Ritschel Verified Profile 1st Nico Ritschel • 1st Director of Engineering 9h 👀 0",
+          comment_identity:
+            "replaceableComment_urn:li:comment:(urn:li:activity:7496969365150621697,7496970800831295488)",
+          links: [
+            {
+              href: "https://www.linkedin.com/in/nicoritschel/",
+              name: "View Nico Ritschel’s profile",
+            },
+          ],
+          comment_media: [
+            {
+              url: "https://media.licdn.com/dms/image/sync/v2/comment-image",
+              alt_text: "A diagram in the comment",
+            },
+          ],
+        },
+      ],
+      occurredAt
+    );
+
+    expect(events).toHaveLength(2);
+    const comment = events[1];
+    expect(comment).toMatchObject({
+      origin_id: "li_comment_7496970800831295488",
+      origin_parent_id: "li_home_parent_token",
+      origin_type: "comment",
+      author_name: "Nico Ritschel",
+      source_url:
+        "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621697",
+      score: 0,
+      attachments: [
+        {
+          kind: "image",
+          url: "https://media.licdn.com/dms/image/sync/v2/comment-image",
+          alt_text: "A diagram in the comment",
+        },
+      ],
+    });
+    expect(comment.metadata).toMatchObject({
+      author: "Nico Ritschel",
+      author_linkedin_slug: "nicoritschel",
+      parent_post_origin_id: "li_home_parent_token",
+      parent_author: "Lorenzo Mangani",
+      parent_author_linkedin_slug: "lmangani",
+      comment_id: "7496970800831295488",
+      parent_activity_id: "7496969365150621697",
+      parent_activity_namespace: "activity",
+    });
+  });
+
+  test("keeps content media while rejecting avatars, duplicates, and unsafe URLs", () => {
+    const [event] = buildHomeFeedEvents(
+      [
+        {
+          id: "media_post",
+          body: "Feed post Ada Lovelace • 1st A post with a useful architecture image attached",
+          author: "Ada Lovelace",
+          post_media: [
+            {
+              url: "https://media.licdn.com/dms/image/sync/v2/architecture",
+              alt_text: "Architecture diagram",
+            },
+            {
+              url: "https://media.licdn.com/dms/image/sync/v2/architecture",
+            },
+            {
+              url: "https://media.licdn.com/dms/image/v2/profile-displayphoto-shrink_100_100/avatar",
+            },
+            { url: "javascript:alert(1)" },
+          ],
+        },
+      ],
+      new Date()
+    );
+
+    expect(event.attachments).toEqual([
+      {
+        kind: "image",
+        url: "https://media.licdn.com/dms/image/sync/v2/architecture",
+        alt_text: "Architecture diagram",
+      },
+    ]);
+  });
+
+  test("parses engagement counts and scores every post", () => {
+    const body =
+      "Feed post Ada Lovelace • 1st Build log Deb and 1,616 others reacted 65 comments • 49 reposts";
+    const counters = {
+      reaction_count_label: "Deb and 1,616 others reacted",
+      comment_count_text: "65 comments",
+      repost_count_label: "49 reposts",
+    };
+    expect(parseHomeFeedEngagement(counters)).toEqual({
+      reactions: 1616,
+      comments: 65,
+      reposts: 49,
+    });
+    const [event] = buildHomeFeedEvents(
+      [{ id: "scored", body, author: "Ada Lovelace", ...counters }],
+      new Date()
+    );
+    expect(event.score).toBe(100);
+    expect(event.metadata).toMatchObject({
+      reactions: 1616,
+      comments: 65,
+      reposts: 49,
+    });
+  });
+
+  test("does not infer engagement from numbers in post prose", () => {
+    const body =
+      "Feed post Ada Lovelace • 1st This launch got 1,000 likes in our internal user study";
+    expect(parseHomeFeedEngagement({ body })).toEqual({
+      reactions: undefined,
+      comments: undefined,
+      reposts: undefined,
+    });
+    const [event] = buildHomeFeedEvents(
+      [{ id: "prose-only", body, author: "Ada Lovelace" }],
+      new Date()
+    );
+    expect(event.score).toBe(0);
+    expect(event.metadata).toEqual({ author: "Ada Lovelace" });
   });
 
   test("defaults author to empty string when no author and no parseable body", () => {
@@ -953,7 +1111,13 @@ describe("buildHomeFeedEvents", () => {
       "this body is definitely longer than thirty characters for the test";
     const events = buildHomeFeedEvents(
       [
-        { id: "a", body: longBody },
+        {
+          id: "a",
+          body: longBody,
+          author: "First Author",
+          post_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621000",
+        },
         {
           id: "",
           body: "no id but long enough body to pass the noise filter check",
@@ -962,6 +1126,9 @@ describe("buildHomeFeedEvents", () => {
         {
           id: "a",
           body: "dup id with a sufficiently long body to pass the noise filter",
+          author: "Duplicate Author",
+          post_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621999",
         },
       ],
       new Date()
@@ -969,6 +1136,13 @@ describe("buildHomeFeedEvents", () => {
     expect(events.map((e: { origin_id: string }) => e.origin_id)).toEqual([
       "li_home_a",
     ]);
+    expect(events[0]).toMatchObject({
+      payload_text: longBody,
+      author_name: "First Author",
+      source_url:
+        "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621000",
+      metadata: { author: "First Author" },
+    });
   });
 
   test("drops promoted, suggested, and too-short noise rows end-to-end", () => {
@@ -1240,8 +1414,8 @@ describe("LinkedInConnector home_feed", () => {
     const authoredBy = attributions.find(
       (rule: { role: string }) => rule.role === "authored_by"
     );
-    const mentions = attributions.find(
-      (rule: { role: string }) => rule.role === "mentions"
+    const performedBy = attributions.find(
+      (rule: { role: string }) => rule.role === "performed_by"
     );
 
     expect(authoredBy).toBeDefined();
@@ -1254,41 +1428,114 @@ describe("LinkedInConnector home_feed", () => {
       },
     ]);
 
-    expect(mentions).toBeDefined();
-    expect(mentions.autoCreate).toBe(true);
-    expect(mentions.target.entityType).toBe("person");
-    expect(mentions.target.titlePath).toBe("metadata.social_actor");
-    expect(mentions.target.identities).toEqual([
+    expect(authoredBy.name).toBe("author");
+    expect(performedBy).toBeDefined();
+    expect(performedBy.name).toBe("engager");
+    expect(performedBy.autoCreate).toBe(true);
+    expect(performedBy.target.entityType).toBe("person");
+    expect(performedBy.target.titlePath).toBe("metadata.social_actor");
+    expect(performedBy.target.identities).toEqual([
       {
         namespace: LINKEDIN_IDENTITY.SLUG,
         eventPath: "metadata.social_actor_slug",
       },
     ]);
+    expect(def.feeds.home_feed.eventKinds.post.relationships).toEqual([
+      { type: "engaged_with", from: "engager", to: "author" },
+    ]);
+  });
+
+  test("declares visible comments with commenter-to-post-author relationships", () => {
+    const comment = new LinkedInConnector().definition.feeds.home_feed
+      .eventKinds.comment;
+    expect(comment).toBeDefined();
+    expect(
+      comment.attributions.map((rule: { name: string }) => rule.name)
+    ).toEqual(["commenter", "post_author"]);
+    expect(comment.relationships).toEqual([
+      { type: "engaged_with", from: "commenter", to: "post_author" },
+    ]);
+  });
+
+  test("configures the relationship type required by home-feed events", () => {
+    const engagedWith = personalAgentConfig.relationships.find(
+      (relationship: { key: string }) => relationship.key === "engaged_with"
+    );
+    expect(engagedWith).toMatchObject({
+      name: "Engaged With",
+      rules: [{ source: { key: "person" }, target: { key: "person" } }],
+    });
   });
 
   test("syncHomeFeed dispatches cs_scrape and maps rows to events", async () => {
     const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
+    const dom = new JSDOM(
+      `<!doctype html><body>
+      <div componentkey="expandedparent_tokenFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Lorenzo Mangani"></button>
+        <a href="https://www.linkedin.com/in/lmangani/">
+          <span aria-hidden="true">Lorenzo Mangani</span>
+          <span aria-label="View Lorenzo Mangani’s profile"></span>
+        </a>
+        <p>A home-feed post with enough useful text to pass the noise filter</p>
+        <div class="social-details-social-counts">
+          <span class="social-details-social-counts__reactions-count">12</span>
+          <button aria-label="3 comments"></button>
+          <button aria-label="2 reposts"></button>
+        </div>
+        <div componentkey="commentsSectionContainerparent_token">
+          <a href="https://www.linkedin.com/in/nicoritschel/">
+            <span aria-hidden="true">Nico Ritschel</span>
+            <span aria-label="View Nico Ritschel’s profile"></span>
+          </a>
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:7496969365150621697,7496970800831295488)">
+            Nico Ritschel • This visible comment is long enough to pass the noise filter
+          </div>
+          <img src="https://media.licdn.com/dms/image/sync/v2/comment-image" alt="Comment diagram" />
+        </div>
+      </div>
+    </body>`,
+      { url: "https://www.linkedin.com/feed/" }
+    );
+    Object.defineProperty(dom.window.HTMLElement.prototype, "innerText", {
+      configurable: true,
+      get() {
+        return this.textContent ?? "";
+      },
+    });
+    dom.window.scrollTo = () => undefined;
+    dom.window.document.documentElement.scrollTo = () => undefined;
+    const savedGlobals = new Map(
+      ["document", "window", "location"].map((name) => [
+        name,
+        Object.getOwnPropertyDescriptor(globalThis, name),
+      ])
+    );
+    Object.defineProperties(globalThis, {
+      document: {
+        configurable: true,
+        value: dom.window.document,
+        writable: true,
+      },
+      window: { configurable: true, value: dom.window, writable: true },
+      location: {
+        configurable: true,
+        value: dom.window.location,
+        writable: true,
+      },
+    });
     const dispatcher = {
       dispatch: async (action: string, input: Record<string, unknown>) => {
         calls.push({ action, input });
+        const config = input.scrape_config as Record<string, unknown>;
+        const scraped = await genericScrape({
+          ...config,
+          scroll: { max: 0, stall: 0, waitMs: 0 },
+        });
         return {
           tab_id: 1,
           cs_scrape: true,
-          result: {
-            loggedIn: true,
-            rows: [
-              {
-                id: "tok1",
-                body: "post one with a body long enough to pass the noise filter",
-                author: "Alice",
-              },
-              {
-                id: "tok2",
-                body: "post two with a body long enough to pass the noise filter",
-                author: "Bob",
-              },
-            ],
-          },
+          result: scraped,
         };
       },
     };
@@ -1300,7 +1547,17 @@ describe("LinkedInConnector home_feed", () => {
       checkpoint: {},
       sessionState: { chrome_dispatcher: dispatcher },
     };
-    const res = await connector.sync(ctx);
+    const res = await (async () => {
+      try {
+        return await connector.sync(ctx);
+      } finally {
+        dom.window.close();
+        for (const [name, descriptor] of savedGlobals) {
+          if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+          else delete (globalThis as Record<string, unknown>)[name];
+        }
+      }
+    })();
 
     // Dispatched a cs_scrape navigate against /feed/ with the home-feed config.
     expect(calls).toHaveLength(1);
@@ -1313,6 +1570,8 @@ describe("LinkedInConnector home_feed", () => {
       (calls[0].input.scrape_config as { scroll: { max: number } }).scroll.max
     ).toBe(4);
     const cfg = calls[0].input.scrape_config as {
+      rowSelector: string;
+      id: { regex: string; group: number };
       fields: {
         links: {
           selector: string;
@@ -1326,8 +1585,26 @@ describe("LinkedInConnector home_feed", () => {
           actionSelector: string;
           actionText: string;
         };
+        comment_identity: { selector: string; attr: string };
+        comment_body: { selector: string; take: string };
+        post_media: { selector: string; take: string };
+        comment_media: { selector: string; take: string };
+        reaction_count_text: { selector: string; take: string };
+        comment_count_label: { selector: string; attr: string };
+        repost_count_label: { selector: string; attr: string };
       };
     };
+    expect(cfg.rowSelector).toContain("commentsSectionContainer");
+    expect(
+      "expandedparent_tokenFeedType_MAIN_FEED_RELEVANCE".match(
+        new RegExp(cfg.id.regex)
+      )?.[cfg.id.group]
+    ).toBe("parent_token");
+    expect(
+      "commentsSectionContainerparent_token".match(new RegExp(cfg.id.regex))?.[
+        cfg.id.group
+      ]
+    ).toBe("commentsSectionContainerparent_token");
     // objectAll captures each anchor with its href + accessible name, so the
     // author/engager are matched by NAME rather than DOM position.
     expect(cfg.fields.links.take).toBe("objectAll");
@@ -1342,10 +1619,37 @@ describe("LinkedInConnector home_feed", () => {
       actionSelector: '[role="menuitem"]',
       actionTextRegex: "^Copy link(?: to post)?$",
     });
+    expect(cfg.fields.comment_identity.selector).toContain(
+      "replaceableComment_urn:li:comment"
+    );
+    expect(cfg.fields.comment_body.take).toBe("text");
+    expect(cfg.fields.post_media.take).toBe("objectAll");
+    expect(cfg.fields.post_media.selector).toContain("profile-displayphoto");
+    expect(cfg.fields.comment_media.take).toBe("objectAll");
+    expect(cfg.fields.reaction_count_text.selector).toContain(
+      "social-details-social-counts"
+    );
+    expect(cfg.fields.comment_count_label.attr).toBe("aria-label");
+    expect(cfg.fields.repost_count_label.attr).toBe("aria-label");
 
     expect(res.events).toHaveLength(2);
-    expect(res.events[0].origin_id).toBe("li_home_tok1");
-    expect(res.events[1].origin_id).toBe("li_home_tok2");
+    expect(res.events[0]).toMatchObject({
+      origin_id: "li_home_parent_token",
+      score: 24,
+      metadata: { reactions: 12, comments: 3, reposts: 2 },
+    });
+    expect(res.events[1]).toMatchObject({
+      origin_id: "li_comment_7496970800831295488",
+      origin_parent_id: "li_home_parent_token",
+      origin_type: "comment",
+      attachments: [
+        {
+          kind: "image",
+          url: "https://media.licdn.com/dms/image/sync/v2/comment-image",
+          alt_text: "Comment diagram",
+        },
+      ],
+    });
     expect(res.metadata.backend).toBe("extension-cs-scrape");
     // These mock rows carry no links field, so support is assumed.
     expect(res.metadata.object_all_supported).toBe(true);
@@ -1854,7 +2158,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.9.0");
+    expect(c.definition.version).toBe("3.10.0");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -249,29 +249,30 @@ describe("buildHomeFeedEvents", () => {
       [
         {
           id: "parent_token",
-          body: "Feed post Lorenzo Mangani • 1st CEO at QXIP 9h • A post with enough text to keep",
-          author_control_label: "Open control menu for post by Lorenzo Mangani",
+          body: "Feed post Fixture Post Author • 1st Fixture Role at Fixture Co 9h • A post with enough text to keep",
+          author_control_label:
+            "Open control menu for post by Fixture Post Author",
           post_url:
-            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621697",
+            "https://www.linkedin.com/feed/update/urn:li:activity:1111111111111111111",
           links: [
             {
-              href: "https://www.linkedin.com/in/lmangani/",
-              name: "View Lorenzo Mangani’s profile",
+              href: "https://www.linkedin.com/in/fixture-post-author/",
+              name: "View Fixture Post Author’s profile",
             },
           ],
         },
         {
           id: "commentsSectionContainerparent_token",
-          body: "Nico Ritschel Verified Profile 1st Nico Ritschel • 1st Director of Engineering 9h 👀 0 See 1 more comment",
-          author: "Nico Ritschel",
+          body: "Fixture Commenter Verified Profile 1st Fixture Commenter • 1st Fixture Role 9h Fixture comment body",
+          author: "Fixture Commenter",
           comment_body:
-            "Nico Ritschel Verified Profile 1st Nico Ritschel • 1st Director of Engineering 9h 👀 0",
+            "Fixture Commenter • Fixture comment body long enough to retain",
           comment_identity:
-            "replaceableComment_urn:li:comment:(urn:li:activity:7496969365150621697,7496970800831295488)",
+            "replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,2222222222222222222)",
           links: [
             {
-              href: "https://www.linkedin.com/in/nicoritschel/",
-              name: "View Nico Ritschel’s profile",
+              href: "https://www.linkedin.com/in/fixture-commenter/",
+              name: "View Fixture Commenter’s profile",
             },
           ],
           comment_media: [
@@ -288,12 +289,12 @@ describe("buildHomeFeedEvents", () => {
     expect(events).toHaveLength(2);
     const comment = events[1];
     expect(comment).toMatchObject({
-      origin_id: "li_comment_7496970800831295488",
+      origin_id: "li_comment_2222222222222222222",
       origin_parent_id: "li_home_parent_token",
       origin_type: "comment",
-      author_name: "Nico Ritschel",
+      author_name: "Fixture Commenter",
       source_url:
-        "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621697",
+        "https://www.linkedin.com/feed/update/urn:li:activity:1111111111111111111",
       score: 0,
       attachments: [
         {
@@ -304,13 +305,13 @@ describe("buildHomeFeedEvents", () => {
       ],
     });
     expect(comment.metadata).toMatchObject({
-      author: "Nico Ritschel",
-      author_linkedin_slug: "nicoritschel",
+      author: "Fixture Commenter",
+      author_linkedin_slug: "fixture-commenter",
       parent_post_origin_id: "li_home_parent_token",
-      parent_author: "Lorenzo Mangani",
-      parent_author_linkedin_slug: "lmangani",
-      comment_id: "7496970800831295488",
-      parent_activity_id: "7496969365150621697",
+      parent_author: "Fixture Post Author",
+      parent_author_linkedin_slug: "fixture-post-author",
+      comment_id: "2222222222222222222",
+      parent_activity_id: "1111111111111111111",
       parent_activity_namespace: "activity",
     });
   });
@@ -320,8 +321,8 @@ describe("buildHomeFeedEvents", () => {
       [
         {
           id: "media_post",
-          body: "Feed post Ada Lovelace • 1st A post with a useful architecture image attached",
-          author: "Ada Lovelace",
+          body: "Feed post Fixture Media Author • 1st A post with a useful architecture image attached",
+          author: "Fixture Media Author",
           post_media: [
             {
               url: "https://media.licdn.com/dms/image/sync/v2/architecture",
@@ -351,9 +352,9 @@ describe("buildHomeFeedEvents", () => {
 
   test("parses engagement counts and scores every post", () => {
     const body =
-      "Feed post Ada Lovelace • 1st Build log Deb and 1,616 others reacted 65 comments • 49 reposts";
+      "Feed post Fixture Score Author • 1st Build log Fixture Reactor and 1,616 others reacted 65 comments • 49 reposts";
     const counters = {
-      reaction_count_label: "Deb and 1,616 others reacted",
+      reaction_count_label: "Fixture Reactor and 1,616 others reacted",
       comment_count_text: "65 comments",
       repost_count_label: "49 reposts",
     };
@@ -363,7 +364,7 @@ describe("buildHomeFeedEvents", () => {
       reposts: 49,
     });
     const [event] = buildHomeFeedEvents(
-      [{ id: "scored", body, author: "Ada Lovelace", ...counters }],
+      [{ id: "scored", body, author: "Fixture Score Author", ...counters }],
       new Date()
     );
     expect(event.score).toBe(100);
@@ -376,18 +377,18 @@ describe("buildHomeFeedEvents", () => {
 
   test("does not infer engagement from numbers in post prose", () => {
     const body =
-      "Feed post Ada Lovelace • 1st This launch got 1,000 likes in our internal user study";
+      "Feed post Fixture Prose Author • 1st This launch got 1,000 likes in our internal user study";
     expect(parseHomeFeedEngagement({ body })).toEqual({
       reactions: undefined,
       comments: undefined,
       reposts: undefined,
     });
     const [event] = buildHomeFeedEvents(
-      [{ id: "prose-only", body, author: "Ada Lovelace" }],
+      [{ id: "prose-only", body, author: "Fixture Prose Author" }],
       new Date()
     );
     expect(event.score).toBe(0);
-    expect(event.metadata).toEqual({ author: "Ada Lovelace" });
+    expect(event.metadata).toEqual({ author: "Fixture Prose Author" });
   });
 
   test("defaults author to empty string when no author and no parseable body", () => {
@@ -1116,7 +1117,7 @@ describe("buildHomeFeedEvents", () => {
           body: longBody,
           author: "First Author",
           post_url:
-            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621000",
+            "https://www.linkedin.com/feed/update/urn:li:activity:4444444444444444444",
         },
         {
           id: "",
@@ -1128,7 +1129,7 @@ describe("buildHomeFeedEvents", () => {
           body: "dup id with a sufficiently long body to pass the noise filter",
           author: "Duplicate Author",
           post_url:
-            "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621999",
+            "https://www.linkedin.com/feed/update/urn:li:activity:5555555555555555555",
         },
       ],
       new Date()
@@ -1140,7 +1141,7 @@ describe("buildHomeFeedEvents", () => {
       payload_text: longBody,
       author_name: "First Author",
       source_url:
-        "https://www.linkedin.com/feed/update/urn:li:activity:7496969365150621000",
+        "https://www.linkedin.com/feed/update/urn:li:activity:4444444444444444444",
       metadata: { author: "First Author" },
     });
   });
@@ -1440,31 +1441,15 @@ describe("LinkedInConnector home_feed", () => {
         eventPath: "metadata.social_actor_slug",
       },
     ]);
-    expect(def.feeds.home_feed.eventKinds.post.relationships).toEqual([
-      { type: "engaged_with", from: "engager", to: "author" },
-    ]);
   });
 
-  test("declares visible comments with commenter-to-post-author relationships", () => {
+  test("declares visible comments with commenter and post-author attributions", () => {
     const comment = new LinkedInConnector().definition.feeds.home_feed
       .eventKinds.comment;
     expect(comment).toBeDefined();
     expect(
       comment.attributions.map((rule: { name: string }) => rule.name)
     ).toEqual(["commenter", "post_author"]);
-    expect(comment.relationships).toEqual([
-      { type: "engaged_with", from: "commenter", to: "post_author" },
-    ]);
-  });
-
-  test("configures the relationship type required by home-feed events", () => {
-    const engagedWith = personalAgentConfig.relationships.find(
-      (relationship: { key: string }) => relationship.key === "engaged_with"
-    );
-    expect(engagedWith).toMatchObject({
-      name: "Engaged With",
-      rules: [{ source: { key: "person" }, target: { key: "person" } }],
-    });
   });
 
   test("syncHomeFeed dispatches cs_scrape and maps rows to events", async () => {
@@ -1472,11 +1457,12 @@ describe("LinkedInConnector home_feed", () => {
     const dom = new JSDOM(
       `<!doctype html><body>
       <div componentkey="expandedparent_tokenFeedType_MAIN_FEED_RELEVANCE">
-        <button aria-label="Open control menu for post by Lorenzo Mangani"></button>
-        <a href="https://www.linkedin.com/in/lmangani/">
-          <span aria-hidden="true">Lorenzo Mangani</span>
-          <span aria-label="View Lorenzo Mangani’s profile"></span>
+        <button aria-label="Open control menu for post by Fixture Post Author"></button>
+        <a href="https://www.linkedin.com/in/fixture-post-author/">
+          <span aria-hidden="true">Fixture Post Author</span>
+          <span aria-label="View Fixture Post Author’s profile"></span>
         </a>
+        <span id="translatable-commentary-urn:li:activity:1111111111111111111"></span>
         <p>A home-feed post with enough useful text to pass the noise filter</p>
         <div class="social-details-social-counts">
           <span class="social-details-social-counts__reactions-count">12</span>
@@ -1484,14 +1470,22 @@ describe("LinkedInConnector home_feed", () => {
           <button aria-label="2 reposts"></button>
         </div>
         <div componentkey="commentsSectionContainerparent_token">
-          <a href="https://www.linkedin.com/in/nicoritschel/">
-            <span aria-hidden="true">Nico Ritschel</span>
-            <span aria-label="View Nico Ritschel’s profile"></span>
-          </a>
-          <div id="replaceableComment_urn:li:comment:(urn:li:activity:7496969365150621697,7496970800831295488)">
-            Nico Ritschel • This visible comment is long enough to pass the noise filter
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,2222222222222222222)">
+            <a href="https://www.linkedin.com/in/fixture-commenter-one/">
+              <span aria-hidden="true">Fixture Commenter One</span>
+              <span aria-label="View Fixture Commenter One’s profile"></span>
+            </a>
+            <p>Fixture Commenter One • This first visible comment is long enough to pass the noise filter</p>
+            <img src="https://media.licdn.com/dms/image/sync/v2/fixture-comment-one" alt="First fixture diagram" />
           </div>
-          <img src="https://media.licdn.com/dms/image/sync/v2/comment-image" alt="Comment diagram" />
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,3333333333333333333)">
+            <a href="https://www.linkedin.com/in/fixture-commenter-two/">
+              <span aria-hidden="true">Fixture Commenter Two</span>
+              <span aria-label="View Fixture Commenter Two’s profile"></span>
+            </a>
+            <p>Fixture Commenter Two • This second visible comment is long enough to pass the noise filter</p>
+            <img src="https://media.licdn.com/dms/image/sync/v2/fixture-comment-two" alt="Second fixture diagram" />
+          </div>
         </div>
       </div>
     </body>`,
@@ -1571,7 +1565,7 @@ describe("LinkedInConnector home_feed", () => {
     ).toBe(4);
     const cfg = calls[0].input.scrape_config as {
       rowSelector: string;
-      id: { regex: string; group: number };
+      id: { name: string | string[]; regex: string; group: number };
       fields: {
         links: {
           selector: string;
@@ -1585,8 +1579,6 @@ describe("LinkedInConnector home_feed", () => {
           actionSelector: string;
           actionText: string;
         };
-        comment_identity: { selector: string; attr: string };
-        comment_body: { selector: string; take: string };
         post_media: { selector: string; take: string };
         comment_media: { selector: string; take: string };
         reaction_count_text: { selector: string; take: string };
@@ -1594,17 +1586,18 @@ describe("LinkedInConnector home_feed", () => {
         repost_count_label: { selector: string; attr: string };
       };
     };
-    expect(cfg.rowSelector).toContain("commentsSectionContainer");
+    expect(cfg.rowSelector).toContain("replaceableComment_urn:li:comment");
+    expect(cfg.id.name).toEqual(["componentkey", "id"]);
     expect(
       "expandedparent_tokenFeedType_MAIN_FEED_RELEVANCE".match(
         new RegExp(cfg.id.regex)
       )?.[cfg.id.group]
     ).toBe("parent_token");
-    expect(
-      "commentsSectionContainerparent_token".match(new RegExp(cfg.id.regex))?.[
-        cfg.id.group
-      ]
-    ).toBe("commentsSectionContainerparent_token");
+    const firstCommentId =
+      "replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,2222222222222222222)";
+    expect(firstCommentId.match(new RegExp(cfg.id.regex))?.[cfg.id.group]).toBe(
+      firstCommentId
+    );
     // objectAll captures each anchor with its href + accessible name, so the
     // author/engager are matched by NAME rather than DOM position.
     expect(cfg.fields.links.take).toBe("objectAll");
@@ -1619,10 +1612,6 @@ describe("LinkedInConnector home_feed", () => {
       actionSelector: '[role="menuitem"]',
       actionTextRegex: "^Copy link(?: to post)?$",
     });
-    expect(cfg.fields.comment_identity.selector).toContain(
-      "replaceableComment_urn:li:comment"
-    );
-    expect(cfg.fields.comment_body.take).toBe("text");
     expect(cfg.fields.post_media.take).toBe("objectAll");
     expect(cfg.fields.post_media.selector).toContain("profile-displayphoto");
     expect(cfg.fields.comment_media.take).toBe("objectAll");
@@ -1632,21 +1621,35 @@ describe("LinkedInConnector home_feed", () => {
     expect(cfg.fields.comment_count_label.attr).toBe("aria-label");
     expect(cfg.fields.repost_count_label.attr).toBe("aria-label");
 
-    expect(res.events).toHaveLength(2);
+    expect(res.events).toHaveLength(3);
     expect(res.events[0]).toMatchObject({
       origin_id: "li_home_parent_token",
       score: 24,
       metadata: { reactions: 12, comments: 3, reposts: 2 },
     });
     expect(res.events[1]).toMatchObject({
-      origin_id: "li_comment_7496970800831295488",
+      origin_id: "li_comment_2222222222222222222",
       origin_parent_id: "li_home_parent_token",
       origin_type: "comment",
+      author_name: "Fixture Commenter One",
       attachments: [
         {
           kind: "image",
-          url: "https://media.licdn.com/dms/image/sync/v2/comment-image",
-          alt_text: "Comment diagram",
+          url: "https://media.licdn.com/dms/image/sync/v2/fixture-comment-one",
+          alt_text: "First fixture diagram",
+        },
+      ],
+    });
+    expect(res.events[2]).toMatchObject({
+      origin_id: "li_comment_3333333333333333333",
+      origin_parent_id: "li_home_parent_token",
+      origin_type: "comment",
+      author_name: "Fixture Commenter Two",
+      attachments: [
+        {
+          kind: "image",
+          url: "https://media.licdn.com/dms/image/sync/v2/fixture-comment-two",
+          alt_text: "Second fixture diagram",
         },
       ],
     });

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1,7 +1,7 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { JSDOM } from "jsdom";
 import { connectorSdkMock } from "./connector-sdk.mock";
 
@@ -10,7 +10,6 @@ import { connectorSdkMock } from "./connector-sdk.mock";
 mock.module("@lobu/connector-sdk", connectorSdkMock);
 
 let LinkedInConnector: any;
-let personalAgentConfig: any;
 let buildHomeFeedEvents: any;
 let homeFeedObjectAllSupported: any;
 let parseHomeFeedAuthor: any;
@@ -42,7 +41,6 @@ let genericScrape: (
 
 beforeAll(async () => {
   const mod = await import("../linkedin.connector");
-  personalAgentConfig = (await import("../lobu.config")).default;
   LinkedInConnector = mod.default;
   buildHomeFeedEvents = mod.buildHomeFeedEvents;
   homeFeedObjectAllSupported = mod.homeFeedObjectAllSupported;
@@ -243,7 +241,7 @@ describe("buildHomeFeedEvents", () => {
     expect(ev.metadata).toEqual({ author: "Jane Doe" });
   });
 
-  test("emits a native visible comment with its parent, people, and media", () => {
+  test("links a native comment to its copied-link parent when post identity is empty", () => {
     const occurredAt = new Date("2026-08-23T10:00:00.000Z");
     const events = buildHomeFeedEvents(
       [
@@ -252,6 +250,7 @@ describe("buildHomeFeedEvents", () => {
           body: "Feed post Fixture Post Author • 1st Fixture Role at Fixture Co 9h • A post with enough text to keep",
           author_control_label:
             "Open control menu for post by Fixture Post Author",
+          post_identity: "",
           post_url:
             "https://www.linkedin.com/feed/update/urn:li:activity:1111111111111111111",
           links: [
@@ -262,13 +261,9 @@ describe("buildHomeFeedEvents", () => {
           ],
         },
         {
-          id: "commentsSectionContainerparent_token",
-          body: "Fixture Commenter Verified Profile 1st Fixture Commenter • 1st Fixture Role 9h Fixture comment body",
+          id: "replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,2222222222222222222)",
+          body: "Great work!",
           author: "Fixture Commenter",
-          comment_body:
-            "Fixture Commenter • Fixture comment body long enough to retain",
-          comment_identity:
-            "replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,2222222222222222222)",
           links: [
             {
               href: "https://www.linkedin.com/in/fixture-commenter/",
@@ -296,6 +291,7 @@ describe("buildHomeFeedEvents", () => {
       source_url:
         "https://www.linkedin.com/feed/update/urn:li:activity:1111111111111111111",
       score: 0,
+      payload_text: "Great work!",
       attachments: [
         {
           kind: "image",
@@ -359,7 +355,7 @@ describe("buildHomeFeedEvents", () => {
       repost_count_label: "49 reposts",
     };
     expect(parseHomeFeedEngagement(counters)).toEqual({
-      reactions: 1616,
+      reactions: 1617,
       comments: 65,
       reposts: 49,
     });
@@ -369,7 +365,7 @@ describe("buildHomeFeedEvents", () => {
     );
     expect(event.score).toBe(100);
     expect(event.metadata).toMatchObject({
-      reactions: 1616,
+      reactions: 1617,
       comments: 65,
       reposts: 49,
     });

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -431,13 +431,16 @@ const HOME_FEED_SCRAPE_CONFIG = {
     pathRegex: "/(login|authwall|uas/login|checkpoint|signup)\\b",
   },
   rowSelector:
-    'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"], div[componentkey^="commentsSectionContainer"]',
+    'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"], [id^="replaceableComment_urn:li:comment:"]',
   id: {
     source: "attr",
-    name: "componentkey",
-    // Post rows keep only the token before FeedType_. Comment rows have no
-    // FeedType_ suffix, so the end-of-string alternative preserves their full
-    // commentsSectionContainer<parent-token> identity.
+    // Posts identify themselves with componentkey; native comments use their
+    // replaceableComment id. Selecting comments individually keeps two visible
+    // comments (and their media) from collapsing into one container row.
+    name: ["componentkey", "id"],
+    // Post rows keep only the token before FeedType_. Comment ids have no
+    // FeedType_ suffix, so the end-of-string alternative preserves the full
+    // native comment identity.
     regex: "^(?:expanded)?(.+?)(?=FeedType_|$)",
     group: 1,
   },
@@ -482,15 +485,6 @@ const HOME_FEED_SCRAPE_CONFIG = {
       take: "attr",
       attr: "id",
     },
-    comment_identity: {
-      selector: '[id^="replaceableComment_urn:li:comment:"]',
-      take: "attr",
-      attr: "id",
-    },
-    comment_body: {
-      selector: '[id^="replaceableComment_urn:li:comment:"]',
-      take: "text",
-    },
     links: {
       // Every profile/company anchor with its accessible name, so
       // buildHomeFeedEvents can match the author/engager by NAME rather than by
@@ -509,7 +503,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
       // Profile photos and company logos are identities, not post attachments.
       // The final :not keeps media inside a nested visible comment off the post.
       selector:
-        ':scope:not([componentkey^="commentsSectionContainer"]) img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"]):not(div[componentkey^="commentsSectionContainer"] img)',
+        ':scope:not([id^="replaceableComment_"]) img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"]):not([id^="replaceableComment_"] img)',
       take: "objectAll",
       parts: {
         url: { take: "attr", attr: "src" },
@@ -518,7 +512,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
     },
     comment_media: {
       selector:
-        ':scope[componentkey^="commentsSectionContainer"] img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"])',
+        ':scope[id^="replaceableComment_"] img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"])',
       take: "objectAll",
       parts: {
         url: { take: "attr", attr: "src" },
@@ -828,6 +822,19 @@ function homeFeedCommentParentToken(id: string): string | undefined {
     : undefined;
 }
 
+function homeFeedPostIdentityKey(
+  row: HomeFeedRow,
+  context: HomeFeedRowContext
+): string | undefined {
+  const raw = row.post_identity ?? context.postUrl;
+  if (!raw) return undefined;
+  const match = raw.match(
+    /(?:(shareId|ugcPostId)=|urn:li:(activity|share|ugcPost):)(\d{6,})/i
+  );
+  if (!match) return undefined;
+  return `${linkedInUrnNamespace(match[1] ?? match[2] ?? "")}:${match[3]}`;
+}
+
 function parseHomeFeedCommentIdentity(
   raw: string | undefined
 ): HomeFeedCommentIdentity | undefined {
@@ -1031,6 +1038,7 @@ export function buildHomeFeedEvents(
   const seen = new Set<string>();
   const events: EventEnvelope[] = [];
   const contexts = new Map<string, HomeFeedRowContext>();
+  const postRowsByIdentity = new Map<string, string>();
   for (const row of rows) {
     if (
       row?.id &&
@@ -1038,7 +1046,14 @@ export function buildHomeFeedEvents(
       !isHomeFeedNoise(row.body) &&
       !contexts.has(row.id)
     ) {
-      contexts.set(row.id, buildHomeFeedRowContext(row));
+      const context = buildHomeFeedRowContext(row);
+      contexts.set(row.id, context);
+      if (!parseHomeFeedCommentIdentity(row.comment_identity ?? row.id)) {
+        const identityKey = homeFeedPostIdentityKey(row, context);
+        if (identityKey && !postRowsByIdentity.has(identityKey)) {
+          postRowsByIdentity.set(identityKey, row.id);
+        }
+      }
     }
   }
   for (const row of rows) {
@@ -1046,15 +1061,26 @@ export function buildHomeFeedEvents(
     if (isHomeFeedNoise(row.body)) continue;
     seen.add(row.id);
     const context = contexts.get(row.id)!;
-    const parentToken = homeFeedCommentParentToken(row.id);
-    if (parentToken) {
-      const parent = contexts.get(parentToken);
-      const nativeIdentity = parseHomeFeedCommentIdentity(row.comment_identity);
+    const nativeIdentity = parseHomeFeedCommentIdentity(
+      row.comment_identity ?? row.id
+    );
+    const parentToken =
+      homeFeedCommentParentToken(row.id) ??
+      (nativeIdentity
+        ? postRowsByIdentity.get(
+            `${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
+          )
+        : undefined);
+    if (parentToken || nativeIdentity) {
+      const parentOriginToken =
+        parentToken ??
+        `${nativeIdentity!.parentNamespace}_${nativeIdentity!.parentId}`;
+      const parent = parentToken ? contexts.get(parentToken) : undefined;
       const payloadText = row.comment_body?.trim() || row.body;
       const originId = nativeIdentity
         ? `li_comment_${nativeIdentity.commentId}`
         : stableId("li_home_comment", [
-            parentToken,
+            parentOriginToken,
             context.authorSlug ?? context.author,
             payloadText,
           ]);
@@ -1069,7 +1095,7 @@ export function buildHomeFeedEvents(
       const commentMetadata: Record<string, unknown> = {
         ...context.metadata,
         ...homeFeedEngagementMetadata(counts),
-        parent_post_origin_id: `li_home_${parentToken}`,
+        parent_post_origin_id: `li_home_${parentOriginToken}`,
         ...(nativeIdentity
           ? {
               comment_urn: nativeIdentity.urn,
@@ -1088,7 +1114,7 @@ export function buildHomeFeedEvents(
       }
       events.push({
         origin_id: originId,
-        origin_parent_id: `li_home_${parentToken}`,
+        origin_parent_id: `li_home_${parentOriginToken}`,
         payload_text: payloadText,
         attachments: normalizeHomeFeedMedia(row.comment_media),
         author_name: context.author,
@@ -2528,9 +2554,6 @@ export default class LinkedInConnector extends ConnectorRuntime<
           post: {
             description: "A post from your personalized LinkedIn home feed",
             attributions: LINKEDIN_HOME_FEED_ATTRIBUTIONS,
-            relationships: [
-              { type: "engaged_with", from: "engager", to: "author" },
-            ],
             metadataSchema: {
               type: "object",
               properties: {
@@ -2558,9 +2581,6 @@ export default class LinkedInConnector extends ConnectorRuntime<
           comment: {
             description: "A visible comment on a personalized feed post",
             attributions: LINKEDIN_HOME_COMMENT_ATTRIBUTIONS,
-            relationships: [
-              { type: "engaged_with", from: "commenter", to: "post_author" },
-            ],
             metadataSchema: {
               type: "object",
               properties: {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -30,22 +30,22 @@
  * Staging ≠ verified posted.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
 import {
   type ActionContext,
   type ActionResult,
   type ChromeActionDispatcher,
   type ConnectorDefinition,
   ConnectorRuntime,
+  calculateEngagementScore,
   type EventAttributionRule,
   type EventEnvelope,
-  type SyncContext,
-  type SyncResult,
-  calculateEngagementScore,
   extensionDomScrape,
   extensionNetworkSync,
+  type SyncContext,
+  type SyncResult,
 } from "@lobu/connector-sdk";
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import {
   LINKEDIN_EMAIL_NAMESPACE,
   LINKEDIN_IDENTITY,
@@ -53,9 +53,9 @@ import {
   normalizeLinkedInSlug,
 } from "./linkedin-identity.ts";
 import {
-  type LocalTakeoutConfig,
   assertDirectory,
   batchSize,
+  type LocalTakeoutConfig,
   maxEventCursor,
   parseCsv,
   stableId,
@@ -398,10 +398,6 @@ interface HomeFeedRow {
   post_url?: string;
   /** Rendered identifier containing LinkedIn's stable shareId / ugcPostId. */
   post_identity?: string;
-  /** Rendered identifier containing the native comment and parent-post ids. */
-  comment_identity?: string;
-  /** The visible comment container, without the sibling "See more" control. */
-  comment_body?: string;
   /** Every profile/company anchor in the card, each with its accessible name. */
   links?: HomeFeedLink[];
   /** Media that belongs to a top-level post (nested comment media excluded). */
@@ -814,19 +810,11 @@ interface HomeFeedRowContext {
   metadata: Record<string, unknown>;
 }
 
-const HOME_FEED_COMMENT_ROW_PREFIX = "commentsSectionContainer";
-
-function homeFeedCommentParentToken(id: string): string | undefined {
-  return id.startsWith(HOME_FEED_COMMENT_ROW_PREFIX)
-    ? id.slice(HOME_FEED_COMMENT_ROW_PREFIX.length) || undefined
-    : undefined;
-}
-
 function homeFeedPostIdentityKey(
   row: HomeFeedRow,
   context: HomeFeedRowContext
 ): string | undefined {
-  const raw = row.post_identity ?? context.postUrl;
+  const raw = row.post_identity || context.postUrl;
   if (!raw) return undefined;
   const match = raw.match(
     /(?:(shareId|ugcPostId)=|urn:li:(activity|share|ugcPost):)(\d{6,})/i
@@ -883,12 +871,22 @@ function maxHomeFeedCounter(
   return max > 0 ? max : undefined;
 }
 
+function homeFeedReactionCount(row: HomeFeedRow): number | undefined {
+  const explicitTotal = maxHomeFeedCounter(row.reaction_count_text);
+  if (explicitTotal !== undefined) return explicitTotal;
+
+  const label = row.reaction_count_label;
+  if (!label) return undefined;
+  const others = label.match(
+    /\band\s+(\d[\d,.]*(?:\s*[kmb])?)\s+others?\s+reacted\b/i
+  );
+  if (others) return parseLinkedInCompactCount(others[1]) + 1;
+  return maxHomeFeedCounter(label);
+}
+
 export function parseHomeFeedEngagement(row: HomeFeedRow): HomeFeedEngagement {
   return {
-    reactions: maxHomeFeedCounter(
-      row.reaction_count_text,
-      row.reaction_count_label
-    ),
+    reactions: homeFeedReactionCount(row),
     comments: maxHomeFeedCounter(
       row.comment_count_text,
       row.comment_count_label
@@ -1040,15 +1038,18 @@ export function buildHomeFeedEvents(
   const contexts = new Map<string, HomeFeedRowContext>();
   const postRowsByIdentity = new Map<string, string>();
   for (const row of rows) {
+    const nativeIdentity = row?.id
+      ? parseHomeFeedCommentIdentity(row.id)
+      : undefined;
     if (
       row?.id &&
       row.body &&
-      !isHomeFeedNoise(row.body) &&
+      (nativeIdentity || !isHomeFeedNoise(row.body)) &&
       !contexts.has(row.id)
     ) {
       const context = buildHomeFeedRowContext(row);
       contexts.set(row.id, context);
-      if (!parseHomeFeedCommentIdentity(row.comment_identity ?? row.id)) {
+      if (!nativeIdentity) {
         const identityKey = homeFeedPostIdentityKey(row, context);
         if (identityKey && !postRowsByIdentity.has(identityKey)) {
           postRowsByIdentity.set(identityKey, row.id);
@@ -1058,52 +1059,34 @@ export function buildHomeFeedEvents(
   }
   for (const row of rows) {
     if (!row?.id || !row.body || seen.has(row.id)) continue;
-    if (isHomeFeedNoise(row.body)) continue;
+    const nativeIdentity = parseHomeFeedCommentIdentity(row.id);
+    if (!nativeIdentity && isHomeFeedNoise(row.body)) continue;
     seen.add(row.id);
     const context = contexts.get(row.id)!;
-    const nativeIdentity = parseHomeFeedCommentIdentity(
-      row.comment_identity ?? row.id
-    );
-    const parentToken =
-      homeFeedCommentParentToken(row.id) ??
-      (nativeIdentity
-        ? postRowsByIdentity.get(
-            `${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
-          )
-        : undefined);
-    if (parentToken || nativeIdentity) {
+    if (nativeIdentity) {
+      const parentToken = postRowsByIdentity.get(
+        `${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
+      );
       const parentOriginToken =
         parentToken ??
-        `${nativeIdentity!.parentNamespace}_${nativeIdentity!.parentId}`;
+        `${nativeIdentity.parentNamespace}_${nativeIdentity.parentId}`;
       const parent = parentToken ? contexts.get(parentToken) : undefined;
-      const payloadText = row.comment_body?.trim() || row.body;
-      const originId = nativeIdentity
-        ? `li_comment_${nativeIdentity.commentId}`
-        : stableId("li_home_comment", [
-            parentOriginToken,
-            context.authorSlug ?? context.author,
-            payloadText,
-          ]);
+      const payloadText = row.body;
+      const originId = `li_comment_${nativeIdentity.commentId}`;
       const sourceUrl =
         parent?.postUrl ??
-        (nativeIdentity
-          ? normalizeLinkedInPostUrl(
-              `urn:li:${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
-            )
-          : "");
+        normalizeLinkedInPostUrl(
+          `urn:li:${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
+        );
       const counts = parseHomeFeedEngagement(row);
       const commentMetadata: Record<string, unknown> = {
         ...context.metadata,
         ...homeFeedEngagementMetadata(counts),
         parent_post_origin_id: `li_home_${parentOriginToken}`,
-        ...(nativeIdentity
-          ? {
-              comment_urn: nativeIdentity.urn,
-              comment_id: nativeIdentity.commentId,
-              parent_activity_id: nativeIdentity.parentId,
-              parent_activity_namespace: nativeIdentity.parentNamespace,
-            }
-          : {}),
+        comment_urn: nativeIdentity.urn,
+        comment_id: nativeIdentity.commentId,
+        parent_activity_id: nativeIdentity.parentId,
+        parent_activity_namespace: nativeIdentity.parentNamespace,
       };
       if (parent) {
         commentMetadata.parent_author = parent.author;

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -263,6 +263,7 @@ const LINKEDIN_POST_AUTHOR_ATTRIBUTIONS: EventAttributionRule[] = [
  */
 const LINKEDIN_HOME_FEED_ATTRIBUTIONS: EventAttributionRule[] = [
   {
+    name: "author",
     role: "authored_by",
     autoCreate: true,
     target: {
@@ -283,7 +284,8 @@ const LINKEDIN_HOME_FEED_ATTRIBUTIONS: EventAttributionRule[] = [
     },
   },
   {
-    role: "mentions",
+    name: "engager",
+    role: "performed_by",
     autoCreate: true,
     target: {
       entityType: "person",
@@ -298,6 +300,52 @@ const LINKEDIN_HOME_FEED_ATTRIBUTIONS: EventAttributionRule[] = [
     traits: {
       linkedin_url: {
         eventPath: "metadata.social_actor_profile_url",
+        mergeStrategy: "prefer_non_empty",
+      },
+    },
+  },
+];
+
+/** A visible comment links its author to the author of the parent post. */
+const LINKEDIN_HOME_COMMENT_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    name: "commenter",
+    role: "authored_by",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "author_name",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.author_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.author_profile_url",
+        mergeStrategy: "prefer_non_empty",
+      },
+    },
+  },
+  {
+    name: "post_author",
+    role: "about",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.parent_author",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.parent_author_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.parent_author_profile_url",
         mergeStrategy: "prefer_non_empty",
       },
     },
@@ -326,6 +374,12 @@ interface HomeFeedLink {
   name?: string;
 }
 
+/** One media URL scraped from a feed card. */
+interface HomeFeedMedia {
+  url?: string;
+  alt_text?: string;
+}
+
 /** A row produced by the extension's cs_scrape from HOME_FEED_SCRAPE_CONFIG. */
 interface HomeFeedRow {
   /** The componentkey token (base64url-ish, NOT a numeric activity id). */
@@ -344,8 +398,23 @@ interface HomeFeedRow {
   post_url?: string;
   /** Rendered identifier containing LinkedIn's stable shareId / ugcPostId. */
   post_identity?: string;
+  /** Rendered identifier containing the native comment and parent-post ids. */
+  comment_identity?: string;
+  /** The visible comment container, without the sibling "See more" control. */
+  comment_body?: string;
   /** Every profile/company anchor in the card, each with its accessible name. */
   links?: HomeFeedLink[];
+  /** Media that belongs to a top-level post (nested comment media excluded). */
+  post_media?: HomeFeedMedia[];
+  /** Media that belongs to a visible comment row. */
+  comment_media?: HomeFeedMedia[];
+  /** Dedicated engagement-summary values, never inferred from post prose. */
+  reaction_count_text?: string;
+  reaction_count_label?: string;
+  comment_count_text?: string;
+  comment_count_label?: string;
+  repost_count_text?: string;
+  repost_count_label?: string;
 }
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
@@ -361,11 +430,15 @@ const HOME_FEED_SCRAPE_CONFIG = {
   loggedOutWhen: {
     pathRegex: "/(login|authwall|uas/login|checkpoint|signup)\\b",
   },
-  rowSelector: 'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"]',
+  rowSelector:
+    'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"], div[componentkey^="commentsSectionContainer"]',
   id: {
     source: "attr",
     name: "componentkey",
-    regex: "^(?:expanded)?(.+?)FeedType_",
+    // Post rows keep only the token before FeedType_. Comment rows have no
+    // FeedType_ suffix, so the end-of-string alternative preserves their full
+    // commentsSectionContainer<parent-token> identity.
+    regex: "^(?:expanded)?(.+?)(?=FeedType_|$)",
     group: 1,
   },
   requireFields: ["body"],
@@ -409,6 +482,15 @@ const HOME_FEED_SCRAPE_CONFIG = {
       take: "attr",
       attr: "id",
     },
+    comment_identity: {
+      selector: '[id^="replaceableComment_urn:li:comment:"]',
+      take: "attr",
+      attr: "id",
+    },
+    comment_body: {
+      selector: '[id^="replaceableComment_urn:li:comment:"]',
+      take: "text",
+    },
     links: {
       // Every profile/company anchor with its accessible name, so
       // buildHomeFeedEvents can match the author/engager by NAME rather than by
@@ -422,6 +504,62 @@ const HOME_FEED_SCRAPE_CONFIG = {
         name: { take: "aria" },
         nameAlt: { take: "alt" },
       },
+    },
+    post_media: {
+      // Profile photos and company logos are identities, not post attachments.
+      // The final :not keeps media inside a nested visible comment off the post.
+      selector:
+        ':scope:not([componentkey^="commentsSectionContainer"]) img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"]):not(div[componentkey^="commentsSectionContainer"] img)',
+      take: "objectAll",
+      parts: {
+        url: { take: "attr", attr: "src" },
+        alt_text: { take: "attr", attr: "alt" },
+      },
+    },
+    comment_media: {
+      selector:
+        ':scope[componentkey^="commentsSectionContainer"] img[src*="media.licdn.com/dms/image/"]:not([src*="profile-displayphoto"]):not([src*="company-logo"])',
+      take: "objectAll",
+      parts: {
+        url: { take: "attr", attr: "src" },
+        alt_text: { take: "attr", attr: "alt" },
+      },
+    },
+    // Engagement comes only from LinkedIn's dedicated social-count controls.
+    // Keep both visible text and accessible-label variants because the current
+    // feed uses both shapes across post types and experiments.
+    reaction_count_text: {
+      selector:
+        ".social-details-social-counts__reactions-count, .social-details-social-counts__reactions",
+      take: "text",
+    },
+    reaction_count_label: {
+      selector:
+        '.social-details-social-counts [aria-label*="reaction" i], [aria-label$=" reaction" i], [aria-label$=" reactions" i]',
+      take: "attr",
+      attr: "aria-label",
+    },
+    comment_count_text: {
+      selector:
+        ".social-details-social-counts__comments, .social-details-social-counts__comments-count",
+      take: "text",
+    },
+    comment_count_label: {
+      selector:
+        '.social-details-social-counts [aria-label*="comment" i], [aria-label$=" comments" i]',
+      take: "attr",
+      attr: "aria-label",
+    },
+    repost_count_text: {
+      selector:
+        ".social-details-social-counts__reposts, .social-details-social-counts__reposts-count",
+      take: "text",
+    },
+    repost_count_label: {
+      selector:
+        '.social-details-social-counts [aria-label*="repost" i], [aria-label$=" repost" i], [aria-label$=" reposts" i]',
+      take: "attr",
+      attr: "aria-label",
     },
   },
 } as const;
@@ -662,6 +800,220 @@ export function isHomeFeedNoise(body: string): boolean {
   return false;
 }
 
+interface HomeFeedEngagement {
+  reactions?: number;
+  comments?: number;
+  reposts?: number;
+}
+
+interface HomeFeedCommentIdentity {
+  urn: string;
+  parentNamespace: "activity" | "share" | "ugcPost";
+  parentId: string;
+  commentId: string;
+}
+
+interface HomeFeedRowContext {
+  author: string;
+  authorSlug?: string;
+  postUrl?: string;
+  metadata: Record<string, unknown>;
+}
+
+const HOME_FEED_COMMENT_ROW_PREFIX = "commentsSectionContainer";
+
+function homeFeedCommentParentToken(id: string): string | undefined {
+  return id.startsWith(HOME_FEED_COMMENT_ROW_PREFIX)
+    ? id.slice(HOME_FEED_COMMENT_ROW_PREFIX.length) || undefined
+    : undefined;
+}
+
+function parseHomeFeedCommentIdentity(
+  raw: string | undefined
+): HomeFeedCommentIdentity | undefined {
+  if (!raw) return undefined;
+  const match = raw.match(
+    /(urn:li:comment:\(urn:li:(activity|share|ugcPost):(\d+),(\d+)\))/i
+  );
+  if (!match) return undefined;
+  return {
+    urn: match[1],
+    parentNamespace: linkedInUrnNamespace(match[2]) as
+      | "activity"
+      | "share"
+      | "ugcPost",
+    parentId: match[3],
+    commentId: match[4],
+  };
+}
+
+function parseLinkedInCompactCount(raw: string): number {
+  const match = raw.trim().match(/^(\d[\d,.]*)(?:\s*([kmb]))?$/i);
+  if (!match) return 0;
+  const base = Number(match[1].replace(/,/g, ""));
+  if (!Number.isFinite(base)) return 0;
+  const multiplier =
+    match[2]?.toLowerCase() === "b"
+      ? 1_000_000_000
+      : match[2]?.toLowerCase() === "m"
+        ? 1_000_000
+        : match[2]?.toLowerCase() === "k"
+          ? 1_000
+          : 1;
+  return Math.round(base * multiplier);
+}
+
+function maxHomeFeedCounter(
+  ...values: Array<string | undefined>
+): number | undefined {
+  let max = 0;
+  for (const value of values) {
+    if (!value) continue;
+    for (const match of value.matchAll(/\b(\d[\d,.]*(?:\s*[kmb])?)\b/gi)) {
+      max = Math.max(max, parseLinkedInCompactCount(match[1]));
+    }
+  }
+  return max > 0 ? max : undefined;
+}
+
+export function parseHomeFeedEngagement(row: HomeFeedRow): HomeFeedEngagement {
+  return {
+    reactions: maxHomeFeedCounter(
+      row.reaction_count_text,
+      row.reaction_count_label
+    ),
+    comments: maxHomeFeedCounter(
+      row.comment_count_text,
+      row.comment_count_label
+    ),
+    reposts: maxHomeFeedCounter(row.repost_count_text, row.repost_count_label),
+  };
+}
+
+function homeFeedEngagementMetadata(
+  counts: HomeFeedEngagement
+): Record<string, number> {
+  return {
+    ...(counts.reactions ? { reactions: counts.reactions } : {}),
+    ...(counts.comments ? { comments: counts.comments } : {}),
+    ...(counts.reposts ? { reposts: counts.reposts } : {}),
+  };
+}
+
+function homeFeedEngagementScore(counts: HomeFeedEngagement): number {
+  return Math.min(
+    (counts.reactions ?? 0) +
+      (counts.comments ?? 0) * 2 +
+      (counts.reposts ?? 0) * 3,
+    100
+  );
+}
+
+function normalizeHomeFeedMedia(raw: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const attachments: Array<Record<string, unknown>> = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const candidate = item as HomeFeedMedia;
+    if (!candidate.url) continue;
+    let url: URL;
+    try {
+      url = new URL(candidate.url, "https://www.linkedin.com");
+    } catch {
+      continue;
+    }
+    if (
+      url.protocol !== "https:" ||
+      !(
+        url.hostname === "media.licdn.com" ||
+        url.hostname.endsWith(".licdn.com")
+      ) ||
+      /(?:profile-displayphoto|company-logo)/i.test(url.pathname) ||
+      seen.has(url.href)
+    ) {
+      continue;
+    }
+    seen.add(url.href);
+    const altText = candidate.alt_text?.trim();
+    attachments.push({
+      kind: "image",
+      url: url.href,
+      ...(altText ? { alt_text: altText } : {}),
+    });
+  }
+  return attachments;
+}
+
+function buildHomeFeedRowContext(row: HomeFeedRow): HomeFeedRowContext {
+  const parsedAuthor = parseHomeFeedAuthorDetails(row.body ?? "");
+  const domAuthor = cleanHomeFeedDisplayName(
+    (row.author ?? "").trim().split(" • ")[0] ?? ""
+  );
+  const actorBanner =
+    parsedAuthor.banner?.kind === "actor" ? parsedAuthor.banner : null;
+  const controlAuthor = parseAuthorControlLabel(row.author_control_label);
+  let banner = parsedAuthor.banner;
+  if (actorBanner && controlAuthor) {
+    if (nameKey(parsedAuthor.author) !== nameKey(controlAuthor)) banner = null;
+  } else if (
+    actorBanner &&
+    domAuthor &&
+    actorBanner.actor.localeCompare(domAuthor, undefined, {
+      sensitivity: "accent",
+    }) !== 0
+  ) {
+    banner = null;
+  }
+  const author =
+    controlAuthor ||
+    (banner ? parsedAuthor.author : "") ||
+    domAuthor ||
+    parsedAuthor.author;
+  const links = normalizeHomeFeedLinks(row.links);
+  const engagement = banner?.kind === "actor" ? banner : null;
+  const authorSlug = resolveMemberSlug(links, author);
+  const engagerSlug = engagement
+    ? resolveMemberSlug(links, engagement.actor)
+    : undefined;
+  const profileUrlFor = (slug: string) => `https://www.linkedin.com/in/${slug}`;
+  const counts = parseHomeFeedEngagement(row);
+  const metadata: Record<string, unknown> = {
+    author,
+    ...homeFeedEngagementMetadata(counts),
+  };
+  if (engagement) {
+    metadata.social_actor = engagement.actor;
+    metadata.social_action = engagement.action;
+    if (engagerSlug) {
+      metadata.social_actor_slug = engagerSlug;
+      metadata.social_actor_profile_url = profileUrlFor(engagerSlug);
+    }
+  }
+  if (authorSlug) {
+    metadata.author_linkedin_slug = authorSlug;
+    metadata.author_profile_url = profileUrlFor(authorSlug);
+  }
+
+  const embeddedUrn = row.post_identity?.match(
+    /(?:(shareId|ugcPostId)=|urn:li:(activity|share|ugcPost):)(\d{6,})/i
+  );
+  const embeddedId = embeddedUrn?.[3];
+  const embeddedNamespace = linkedInUrnNamespace(
+    embeddedUrn?.[1] ?? embeddedUrn?.[2] ?? ""
+  );
+  const postUrl = normalizeLinkedInPostUrl(
+    row.post_url ??
+      (embeddedId ? `urn:li:${embeddedNamespace}:${embeddedId}` : "")
+  );
+  return {
+    author,
+    authorSlug,
+    postUrl: postUrl || undefined,
+    metadata,
+  };
+}
+
 /**
  * Map cs_scrape home-feed rows to event envelopes. Prefer the permalink
  * recovered from LinkedIn's Copy-link action or a stable activity id embedded
@@ -678,98 +1030,94 @@ export function buildHomeFeedEvents(
 ): EventEnvelope[] {
   const seen = new Set<string>();
   const events: EventEnvelope[] = [];
+  const contexts = new Map<string, HomeFeedRowContext>();
+  for (const row of rows) {
+    if (
+      row?.id &&
+      row.body &&
+      !isHomeFeedNoise(row.body) &&
+      !contexts.has(row.id)
+    ) {
+      contexts.set(row.id, buildHomeFeedRowContext(row));
+    }
+  }
   for (const row of rows) {
     if (!row?.id || !row.body || seen.has(row.id)) continue;
     if (isHomeFeedNoise(row.body)) continue;
     seen.add(row.id);
-    const parsedAuthor = parseHomeFeedAuthorDetails(row.body);
-    // Clean DOM author the same way as banner actors so emoji-prefixed names
-    // still match (e.g. DOM "🦔 Deb" vs banner actor "Deb").
-    const domAuthor = cleanHomeFeedDisplayName(
-      (row.author ?? "").trim().split(" • ")[0] ?? ""
-    );
-    const actorBanner =
-      parsedAuthor.banner?.kind === "actor" ? parsedAuthor.banner : null;
-    const controlAuthor = parseAuthorControlLabel(row.author_control_label);
-    // A phrase such as "We Love This Company" can resemble an engagement
-    // banner. When available, the control-menu author disambiguates it without
-    // depending on which profile link appears first. Older results fall back to
-    // comparing the banner actor with the first visible profile name.
-    let banner = parsedAuthor.banner;
-    if (actorBanner && controlAuthor) {
-      if (nameKey(parsedAuthor.author) !== nameKey(controlAuthor))
-        banner = null;
-    } else if (
-      actorBanner &&
-      domAuthor &&
-      actorBanner.actor.localeCompare(domAuthor, undefined, {
-        sensitivity: "accent",
-      }) !== 0
-    ) {
-      banner = null;
-    }
-    // The control-menu label names the post author independently of link order
-    // and body parsing. Older extension results lack it, so retain the existing
-    // body/DOM fallback.
-    const author =
-      controlAuthor ||
-      (banner ? parsedAuthor.author : "") ||
-      domAuthor ||
-      parsedAuthor.author;
-
-    // Resolve slugs by matching a NAME to the anchor's accessible name, never by
-    // link order. The control-menu label names the true author on observed card
-    // shapes; the banner names the engager. Each maps to at most one /in/ slug
-    // — a company author or an unlinked member simply resolves to none.
-    const links = normalizeHomeFeedLinks(row.links);
-    const profileUrlFor = (s: string) => `https://www.linkedin.com/in/${s}`;
-    const engagement = banner?.kind === "actor" ? banner : null;
-    const authorSlug = resolveMemberSlug(links, author);
-    const engagerSlug = engagement
-      ? resolveMemberSlug(links, engagement.actor)
-      : undefined;
-    const metadata: Record<string, unknown> = { author };
-    if (engagement) {
-      metadata.social_actor = engagement.actor;
-      metadata.social_action = engagement.action;
-      if (engagerSlug) {
-        metadata.social_actor_slug = engagerSlug;
-        metadata.social_actor_profile_url = profileUrlFor(engagerSlug);
+    const context = contexts.get(row.id)!;
+    const parentToken = homeFeedCommentParentToken(row.id);
+    if (parentToken) {
+      const parent = contexts.get(parentToken);
+      const nativeIdentity = parseHomeFeedCommentIdentity(row.comment_identity);
+      const payloadText = row.comment_body?.trim() || row.body;
+      const originId = nativeIdentity
+        ? `li_comment_${nativeIdentity.commentId}`
+        : stableId("li_home_comment", [
+            parentToken,
+            context.authorSlug ?? context.author,
+            payloadText,
+          ]);
+      const sourceUrl =
+        parent?.postUrl ??
+        (nativeIdentity
+          ? normalizeLinkedInPostUrl(
+              `urn:li:${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`
+            )
+          : "");
+      const counts = parseHomeFeedEngagement(row);
+      const commentMetadata: Record<string, unknown> = {
+        ...context.metadata,
+        ...homeFeedEngagementMetadata(counts),
+        parent_post_origin_id: `li_home_${parentToken}`,
+        ...(nativeIdentity
+          ? {
+              comment_urn: nativeIdentity.urn,
+              comment_id: nativeIdentity.commentId,
+              parent_activity_id: nativeIdentity.parentId,
+              parent_activity_namespace: nativeIdentity.parentNamespace,
+            }
+          : {}),
+      };
+      if (parent) {
+        commentMetadata.parent_author = parent.author;
+        if (parent.authorSlug) {
+          commentMetadata.parent_author_linkedin_slug = parent.authorSlug;
+          commentMetadata.parent_author_profile_url = `https://www.linkedin.com/in/${parent.authorSlug}`;
+        }
       }
-    }
-    if (authorSlug) {
-      metadata.author_linkedin_slug = authorSlug;
-      metadata.author_profile_url = profileUrlFor(authorSlug);
+      events.push({
+        origin_id: originId,
+        origin_parent_id: `li_home_${parentToken}`,
+        payload_text: payloadText,
+        attachments: normalizeHomeFeedMedia(row.comment_media),
+        author_name: context.author,
+        occurred_at: occurredAt,
+        origin_type: "comment",
+        ...(sourceUrl ? { source_url: sourceUrl } : {}),
+        score: homeFeedEngagementScore(counts),
+        metadata: commentMetadata,
+      });
+      continue;
     }
 
-    // Keep the identifier in its own URN namespace. share/ugcPost ids are not
-    // activity ids, so relabelling a bare `shareId=` digit string as
-    // `urn:li:activity:` can build a permalink to an unrelated post.
-    const embeddedUrn = row.post_identity?.match(
-      /(?:(shareId|ugcPostId)=|urn:li:(activity|share|ugcPost):)(\d{6,})/i
-    );
-    const embeddedId = embeddedUrn?.[3];
-    const embeddedNamespace = linkedInUrnNamespace(
-      embeddedUrn?.[1] ?? embeddedUrn?.[2] ?? ""
-    );
-    const postUrl = normalizeLinkedInPostUrl(
-      row.post_url ??
-        (embeddedId ? `urn:li:${embeddedNamespace}:${embeddedId}` : "")
-    );
+    const counts = parseHomeFeedEngagement(row);
 
     events.push({
       origin_id: `li_home_${row.id}`,
       payload_text: row.body,
-      author_name: author,
+      attachments: normalizeHomeFeedMedia(row.post_media),
+      author_name: context.author,
       // Feed posts expose no reliable timestamp; use the sync time.
       occurred_at: occurredAt,
       origin_type: "post",
+      score: homeFeedEngagementScore(counts),
       // Omitted when no durable identity was recoverable — a missing
       // source_url is the explicit "this event has no canonical post URL"
       // signal, not a bug. source_url is the durable identifier; action
       // callers (prepare_comment) resolve it directly.
-      ...(postUrl ? { source_url: postUrl } : {}),
-      metadata,
+      ...(context.postUrl ? { source_url: context.postUrl } : {}),
+      metadata: context.metadata,
     });
   }
   return events;
@@ -2150,7 +2498,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.9.0",
+    version: "3.10.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -2180,6 +2528,9 @@ export default class LinkedInConnector extends ConnectorRuntime<
           post: {
             description: "A post from your personalized LinkedIn home feed",
             attributions: LINKEDIN_HOME_FEED_ATTRIBUTIONS,
+            relationships: [
+              { type: "engaged_with", from: "engager", to: "author" },
+            ],
             metadataSchema: {
               type: "object",
               properties: {
@@ -2198,6 +2549,35 @@ export default class LinkedInConnector extends ConnectorRuntime<
                 },
                 social_actor_slug: { type: "string" },
                 social_actor_profile_url: { type: "string" },
+                reactions: { type: "number" },
+                comments: { type: "number" },
+                reposts: { type: "number" },
+              },
+            },
+          },
+          comment: {
+            description: "A visible comment on a personalized feed post",
+            attributions: LINKEDIN_HOME_COMMENT_ATTRIBUTIONS,
+            relationships: [
+              { type: "engaged_with", from: "commenter", to: "post_author" },
+            ],
+            metadataSchema: {
+              type: "object",
+              properties: {
+                author: { type: "string" },
+                author_linkedin_slug: { type: "string" },
+                author_profile_url: { type: "string" },
+                parent_post_origin_id: { type: "string" },
+                parent_author: { type: "string" },
+                parent_author_linkedin_slug: { type: "string" },
+                parent_author_profile_url: { type: "string" },
+                comment_urn: { type: "string" },
+                comment_id: { type: "string" },
+                parent_activity_id: { type: "string" },
+                parent_activity_namespace: { type: "string" },
+                reactions: { type: "number" },
+                comments: { type: "number" },
+                reposts: { type: "number" },
               },
             },
           },

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1104,6 +1104,14 @@ const mentions = defineRelationshipType({
   description: "Auto-discovered content reference",
 });
 
+const engagedWith = defineRelationshipType({
+  key: "engaged_with",
+  name: "Engaged With",
+  description:
+    "A person reacted to, commented on, or reposted another person's content.",
+  rules: [{ source: person, target: person }],
+});
+
 // Graph edges created in the org (and populated with live relationships) that
 // the config must declare — otherwise prune flags them "removed from config"
 // and the apply aborts: the server refuses to delete a relationship type that
@@ -1353,6 +1361,7 @@ export default defineConfig({
     worksAt,
     memberOf,
     mentions,
+    engagedWith,
     connectedWith,
     founderOf,
     sameAs,

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1104,14 +1104,6 @@ const mentions = defineRelationshipType({
   description: "Auto-discovered content reference",
 });
 
-const engagedWith = defineRelationshipType({
-  key: "engaged_with",
-  name: "Engaged With",
-  description:
-    "A person reacted to, commented on, or reposted another person's content.",
-  rules: [{ source: person, target: person }],
-});
-
 // Graph edges created in the org (and populated with live relationships) that
 // the config must declare — otherwise prune flags them "removed from config"
 // and the apply aborts: the server refuses to delete a relationship type that
@@ -1361,7 +1353,6 @@ export default defineConfig({
     worksAt,
     memberOf,
     mentions,
-    engagedWith,
     connectedWith,
     founderOf,
     sameAs,

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -21,7 +21,12 @@ export interface ExtensionScrapeConfig {
     rowSelector: string;
     labelFromFirstLine?: boolean;
   };
-  id?: { source: string; name?: string; regex?: string; group?: number };
+  id?: {
+    source: string;
+    name?: string | readonly string[];
+    regex?: string;
+    group?: number;
+  };
   requireFields?: readonly string[];
   fields?: Record<string, ExtensionScrapeField>;
   [k: string]: unknown;


### PR DESCRIPTION
## What changed

- emit visible LinkedIn comments as native `comment` events with `origin_parent_id`;
- create commenter and parent-author identities from LinkedIn slugs;
- materialize `engaged_with` for visible comments and feed engagement banners;
- collect post/comment media while excluding profile photos and company logos;
- parse reaction, comment, and repost counts and assign a bounded event score;
- declare both `post` and `comment` event schemas in connector v3.10.0;
- declare the personal-agent `engaged_with` relationship required by those events; and
- preserve first-row attribution when duplicate LinkedIn rows share an ID.

## Stack resolution

#3102 and lobu-ai/owletto#944 have landed. This branch is rebased on current `main`, and the obsolete stacked X-likes commit and Owletto pointer change are no longer part of the PR.

## Verification

- LinkedIn connector suite: 115/115 passed;
- personal-agent config validation passed;
- compiled connector metadata was checked against configured relationship types;
- Biome and diff hygiene passed;
- full `make pre-pr` passed; and
- the original branch work inspected signed-in LinkedIn cards and found native comment URNs plus post media without avatar leakage.

The final rebased head was not re-canaryied against a live signed-in LinkedIn tab; its remaining risk is current DOM drift, covered by the retained live-shape fixtures and focused selector tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced LinkedIn feed scraping with engagement metrics, media, attachments, canonical URLs, and stable identities.
  * Added support for visible comments as separate events linked to their parent posts.
  * Improved attribution details for authors and engagers.
* **Bug Fixes**
  * Improved filtering of visible media and parsing of engagement data.
* **Improvements**
  * Scraping configurations now support multiple alternative field names.
  * Updated the LinkedIn connector to version 3.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->