### PR TITLE
feat(cli): rotate headless device credentials

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -327,6 +327,8 @@ describe("lobu daemon", () => {
   });
 
   test("a valid cached child PAT starts without OAuth or another mint", async () => {
+    const now = Date.now();
+    const nowSpy = spyOn(Date, "now").mockReturnValue(now);
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
       url: "http://127.0.0.1:8787",
@@ -336,7 +338,7 @@ describe("lobu daemon", () => {
     spyOn(deviceState, "loadDeviceState").mockResolvedValue({
       workerId: "headless:cached",
       workerApiToken: "owl_pat_cached-child",
-      expiresAt: Date.now() + 60 * 86_400_000,
+      expiresAt: now + 60 * 86_400_000,
     });
     const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
       "oauth-should-not-be-read"
@@ -356,9 +358,44 @@ describe("lobu daemon", () => {
       workerId: "headless:cached",
       workerApiToken: "owl_pat_cached-child",
     });
+
+    const maintenance = start.mock.calls[0]?.[0]?.workerCredentialMaintenance;
+    expect(maintenance).toBeDefined();
+    nowSpy.mockReturnValue(now + 31 * 86_400_000);
+    const order: string[] = [];
+    const update = spyOn(deviceState, "updateDeviceState").mockImplementation(
+      async () => {
+        order.push("save");
+      }
+    );
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        worker_id: "headless:cached",
+        access_token: "owl_pat_rotated-child",
+        expires_at: new Date(now + 121 * 86_400_000).toISOString(),
+      })
+    );
+
+    await maintenance?.((token) => order.push(`activate:${token}`));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<
+          string,
+          string
+        >
+      ).Authorization
+    ).toBe("Bearer owl_pat_cached-child");
+    expect(update).toHaveBeenCalledWith(
+      "local",
+      "headless",
+      expect.objectContaining({ workerApiToken: "owl_pat_rotated-child" })
+    );
+    expect(order).toEqual(["save", "activate:owl_pat_rotated-child"]);
   });
 
-  test("a rejected child-PAT rotation retries with this installation's OAuth login", async () => {
+  test("an unexpired rejected child PAT fails closed instead of undoing revocation with OAuth", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "local",
       url: "http://127.0.0.1:8787",
@@ -369,6 +406,37 @@ describe("lobu daemon", () => {
       workerId: "headless:cached",
       workerApiToken: "owl_pat_revoked-child",
       expiresAt: Date.now() + 30 * 60_000,
+    });
+    const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "revoked" }, 401)
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await expect(daemonCommand({})).rejects.toThrow(
+      /rejected before its local expiry.*possibly revoked/s
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getToken).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test("a locally expired child PAT retries with this installation's OAuth login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_expired-child",
+      expiresAt: Date.now() - 1,
     });
     const update = spyOn(deviceState, "updateDeviceState").mockResolvedValue();
     const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
@@ -397,7 +465,7 @@ describe("lobu daemon", () => {
           string
         >
       ).Authorization
-    ).toBe("Bearer owl_pat_revoked-child");
+    ).toBe("Bearer owl_pat_expired-child");
     expect(
       (
         (fetchSpy.mock.calls[1]?.[1] as RequestInit).headers as Record<
@@ -415,6 +483,120 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.workerApiToken).toBe(
       "owl_pat_rotated-child"
     );
+  });
+
+  test("a post-mint save failure activates once and retries only the local write", async () => {
+    const now = Date.now();
+    const nowSpy = spyOn(Date, "now").mockReturnValue(now);
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_cached-child",
+      expiresAt: now + 60 * 86_400_000,
+    });
+    const update = spyOn(deviceState, "updateDeviceState")
+      .mockRejectedValueOnce(new Error("disk unavailable"))
+      .mockResolvedValue();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        worker_id: "headless:cached",
+        access_token: "owl_pat_rotated-child",
+        expires_at: new Date(now + 121 * 86_400_000).toISOString(),
+      })
+    );
+    spyOn(process.stderr, "write").mockImplementation(() => true);
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+    const maintenance = start.mock.calls[0]?.[0]?.workerCredentialMaintenance;
+    nowSpy.mockReturnValue(now + 31 * 86_400_000);
+    const activated: string[] = [];
+
+    await maintenance?.((token) => activated.push(token));
+    nowSpy.mockReturnValue(now + 31 * 86_400_000 + 60_001);
+    await maintenance?.((token) => activated.push(token));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(activated).toEqual(["owl_pat_rotated-child"]);
+  });
+
+  test("runtime rotation never falls back to installation OAuth after an expired child is rejected", async () => {
+    const now = Date.now();
+    const nowSpy = spyOn(Date, "now").mockReturnValue(now);
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_cached-child",
+      expiresAt: now + 60 * 86_400_000,
+    });
+    const getToken = spyOn(credentials, "getContextToken").mockResolvedValue(
+      "oauth-installation-login"
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "expired" }, 401)
+    );
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+    const maintenance = start.mock.calls[0]?.[0]?.workerCredentialMaintenance;
+    nowSpy.mockReturnValue(now + 61 * 86_400_000);
+
+    await expect(maintenance?.(() => undefined)).rejects.toThrow(
+      /Could not authorize this device/
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getToken).not.toHaveBeenCalled();
+  });
+
+  test("runtime rotation treats rate limiting as retryable while the child remains valid", async () => {
+    const now = Date.now();
+    const nowSpy = spyOn(Date, "now").mockReturnValue(now);
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "local",
+      url: "http://127.0.0.1:8787",
+      source: "config",
+    });
+    delete process.env.WORKER_API_TOKEN;
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue({
+      workerId: "headless:cached",
+      workerApiToken: "owl_pat_cached-child",
+      expiresAt: now + 60 * 86_400_000,
+    });
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "rate_limited" }, 429)
+    );
+    spyOn(process.stderr, "write").mockImplementation(() => true);
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+    const maintenance = start.mock.calls[0]?.[0]?.workerCredentialMaintenance;
+    nowSpy.mockReturnValue(now + 31 * 86_400_000);
+    await maintenance?.(() => {
+      throw new Error("must not activate");
+    });
+    nowSpy.mockReturnValue(now + 31 * 86_400_000 + 30_000);
+    await maintenance?.(() => {
+      throw new Error("must not activate");
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   test("a stale installation login reruns device-code auth before retrying the mint", async () => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -45,7 +45,7 @@ interface DaemonTarget {
 interface MintedDeviceCredential {
   workerId: string;
   workerApiToken: string;
-  expiresAt?: number;
+  expiresAt: number;
 }
 
 interface MintDeviceCredentialOptions {
@@ -68,15 +68,12 @@ class DeviceMintError extends Error {
 }
 
 /**
- * How much of a cached child PAT's life must remain for this start to reuse it
- * instead of re-minting. The daemon snapshots its bearer for the whole process
- * lifetime and polls for weeks, so the buffer has to outlast a realistic run:
- * with a shorter one, a start that reuses a nearly-expired token leaves the
- * worker polling 401 forever a day or two later — the exact silent failure
- * `startDaemonCommand`'s boot check exists to prevent. A third of the server's
- * 90-day child expiry keeps re-mints rare while staying well past that.
+ * How much of a child PAT's life must remain before a start or idle running
+ * daemon re-mints it. A third of the server's 90-day expiry keeps rotations
+ * rare while leaving time to ride out a temporary gateway outage.
  */
 const CHILD_TOKEN_REFRESH_BUFFER_MS = 30 * 24 * 60 * 60 * 1000;
+const CHILD_TOKEN_RETRY_MS = 60 * 1000;
 
 /** Shown when `lobu daemon` can't find anything to authorize against. */
 const SETUP_MESSAGE =
@@ -158,6 +155,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
 
   let workerId = explicitWorkerId ?? sessionWorkerId ?? cachedState?.workerId;
   let workerApiToken = explicitWorkerToken;
+  let workerCredentialExpiresAt: number | undefined;
 
   if (workerApiToken) {
     if (!workerApiToken.startsWith("owl_pat_")) {
@@ -184,6 +182,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
       hasUsableCachedWorkerToken(cachedState)
     ) {
       workerApiToken = cachedState.workerApiToken;
+      workerCredentialExpiresAt = cachedState.expiresAt;
     } else {
       let mintBearer = cachedState?.workerApiToken;
       if (!workerId) {
@@ -203,6 +202,8 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
         initialBearerIsChild:
           mintBearer !== undefined &&
           mintBearer === cachedState?.workerApiToken,
+        initialChildExpiresAt: cachedState?.expiresAt,
+        interactiveReauth: true,
         options: {
           gatewayOrigin: target.gatewayOrigin,
           bearer,
@@ -221,6 +222,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
         await persistDeviceCredential(contextName, statePlatform, minted);
       }
       workerApiToken = minted.workerApiToken;
+      workerCredentialExpiresAt = minted.expiresAt;
     }
   }
 
@@ -233,6 +235,26 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     );
   }
 
+  const workerCredentialMaintenance =
+    !explicitWorkerToken &&
+    !sessionLane &&
+    contextName &&
+    workerCredentialExpiresAt
+      ? createWorkerCredentialMaintenance({
+          contextName,
+          statePlatform,
+          gatewayOrigin: target.gatewayOrigin,
+          platform,
+          workerId,
+          label: options.label?.trim() || shortHost,
+          initialCredential: {
+            workerId,
+            workerApiToken,
+            expiresAt: workerCredentialExpiresAt,
+          },
+        })
+      : undefined;
+
   await startDaemonCommand({
     apiUrl: target.gatewayOrigin,
     platform: sessionLane ? "headless" : requestedPlatform,
@@ -244,6 +266,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
       .map((entry) => entry.trim())
       .filter(Boolean),
     workerApiToken,
+    ...(workerCredentialMaintenance ? { workerCredentialMaintenance } : {}),
     debug: options.debug === true,
     ...(options.interactiveSession === false
       ? { interactiveSession: false as const }
@@ -338,10 +361,14 @@ async function refreshInstallationLogin(contextName: string): Promise<string> {
 async function mintDeviceCredentialWithReauth({
   contextName,
   initialBearerIsChild,
+  initialChildExpiresAt,
+  interactiveReauth,
   options,
 }: {
   contextName: string;
   initialBearerIsChild: boolean;
+  initialChildExpiresAt?: number;
+  interactiveReauth: boolean;
   options: MintDeviceCredentialOptions;
 }): Promise<MintedDeviceCredential> {
   try {
@@ -349,9 +376,19 @@ async function mintDeviceCredentialWithReauth({
   } catch (error) {
     if (!isDeviceMintAuthError(error)) throw error;
 
-    // A cached child may have expired or been revoked. Retry with this exact
-    // installation's stored login first; never borrow a different context.
+    // Do not let OAuth silently undo revocation of a still-live child.
     if (initialBearerIsChild) {
+      if (!interactiveReauth) throw error;
+      if (
+        typeof initialChildExpiresAt !== "number" ||
+        initialChildExpiresAt > Date.now()
+      ) {
+        throw new DeviceMintError(
+          "The stored device credential was rejected before its local expiry; refusing to replace a possibly revoked device automatically. Re-pair this device explicitly.",
+          error.status,
+          error.code
+        );
+      }
       const installationBearer = await requireInstallationLogin(contextName);
       try {
         return await mintDeviceCredential({
@@ -366,6 +403,7 @@ async function mintDeviceCredentialWithReauth({
     // A stored login can be valid for ordinary MCP work but lack the newer
     // device_worker:run scope. Interactive starts repair it through the same
     // device-code flow; non-interactive starts receive the exact login command.
+    if (!interactiveReauth) throw error;
     return mintDeviceCredential({
       ...options,
       bearer: await refreshInstallationLogin(contextName),
@@ -391,7 +429,110 @@ function hasUsableCachedWorkerToken(state: DeviceState): boolean {
   return Boolean(
     state.workerApiToken?.startsWith("owl_pat_") &&
       typeof state.expiresAt === "number" &&
-      state.expiresAt > Date.now() + CHILD_TOKEN_REFRESH_BUFFER_MS
+      !childTokenNeedsRefresh(state.expiresAt)
+  );
+}
+
+function childTokenNeedsRefresh(expiresAt: number, now = Date.now()): boolean {
+  return expiresAt <= now + CHILD_TOKEN_REFRESH_BUFFER_MS;
+}
+
+function createWorkerCredentialMaintenance(options: {
+  contextName: string;
+  statePlatform: string;
+  gatewayOrigin: string;
+  platform: string;
+  workerId: string;
+  label: string;
+  initialCredential: MintedDeviceCredential & { expiresAt: number };
+}): (activate: (workerApiToken: string) => void) => Promise<void> {
+  const { contextName, statePlatform, initialCredential, ...mintTarget } =
+    options;
+  let current = initialCredential;
+  let persistencePending = false;
+  let retryAt = 0;
+
+  return async (activate) => {
+    const now = Date.now();
+    if (now < retryAt) return;
+
+    if (persistencePending) {
+      try {
+        await persistDeviceCredential(contextName, statePlatform, current);
+        persistencePending = false;
+        retryAt = 0;
+      } catch (error) {
+        if (current.expiresAt <= now) {
+          throw new Error(
+            `The rotated device credential could not be saved before it expired: ${String(error)}`
+          );
+        }
+        retryAt = now + CHILD_TOKEN_RETRY_MS;
+        warnCredentialMaintenance(
+          "Could not save the rotated device credential",
+          error
+        );
+      }
+      return;
+    }
+
+    const { expiresAt } = current;
+    if (!childTokenNeedsRefresh(expiresAt, now)) return;
+
+    let minted: MintedDeviceCredential;
+    try {
+      minted = await mintDeviceCredentialWithReauth({
+        contextName,
+        initialBearerIsChild: true,
+        initialChildExpiresAt: expiresAt,
+        interactiveReauth: false,
+        options: { ...mintTarget, bearer: current.workerApiToken },
+      });
+    } catch (error) {
+      const permanent =
+        error instanceof DeviceMintError &&
+        error.status >= 400 &&
+        error.status < 500 &&
+        error.status !== 429;
+      if (permanent || expiresAt <= now) throw error;
+      retryAt = Math.min(now + CHILD_TOKEN_RETRY_MS, expiresAt);
+      warnCredentialMaintenance(
+        "Could not rotate the device credential",
+        error
+      );
+      return;
+    }
+
+    if (minted.workerId !== mintTarget.workerId) {
+      throw new Error(
+        `The gateway rotated worker id "${mintTarget.workerId}" as "${minted.workerId}"; refusing to use a mismatched credential.`
+      );
+    }
+
+    let persistenceError: unknown;
+    try {
+      await persistDeviceCredential(contextName, statePlatform, minted);
+    } catch (error) {
+      persistenceError = error;
+    }
+
+    activate(minted.workerApiToken);
+    current = minted;
+    retryAt = 0;
+    if (persistenceError) {
+      persistencePending = true;
+      retryAt = Date.now() + CHILD_TOKEN_RETRY_MS;
+      warnCredentialMaintenance(
+        "Could not save the rotated device credential; it remains active in memory",
+        persistenceError
+      );
+    }
+  };
+}
+
+function warnCredentialMaintenance(message: string, error: unknown): void {
+  process.stderr.write(
+    `[daemon] ${message}; retrying: ${error instanceof Error ? error.message : String(error)}\n`
   );
 }
 
@@ -437,7 +578,11 @@ async function mintDeviceCredential(
     typeof parsed?.expires_at === "string"
       ? Date.parse(parsed.expires_at)
       : Number.NaN;
-  if (!workerId || !workerApiToken.startsWith("owl_pat_")) {
+  if (
+    !workerId ||
+    !workerApiToken.startsWith("owl_pat_") ||
+    !Number.isFinite(expiresAt)
+  ) {
     throw new DeviceMintError(
       "The gateway returned an invalid device credential.",
       res.status
@@ -446,7 +591,7 @@ async function mintDeviceCredential(
   return {
     workerId,
     workerApiToken,
-    ...(Number.isFinite(expiresAt) ? { expiresAt } : {}),
+    expiresAt,
   };
 }
 
@@ -458,7 +603,7 @@ async function persistDeviceCredential(
   const state: DeviceState = {
     workerId: credential.workerId,
     workerApiToken: credential.workerApiToken,
-    ...(credential.expiresAt ? { expiresAt: credential.expiresAt } : {}),
+    expiresAt: credential.expiresAt,
   };
   const existing = await loadDeviceState(contextName, statePlatform);
   if (existing) {

--- a/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
+++ b/packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts
@@ -117,6 +117,32 @@ describe("device worker poll body", () => {
     expect(calls[2].body.capacity_available).toBe(3);
   });
 
+  test("uses a replacement bearer for every request after idle rotation", async () => {
+    const authorizations: Array<string | null> = [];
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      authorizations.push(new Headers(init?.headers).get("authorization"));
+      return new Response(JSON.stringify({ next_poll_seconds: 5 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const client = new WorkerClient({
+      apiUrl: "https://app.example.com",
+      workerId: "w-rotate",
+      authToken: "owl_pat_old",
+      capabilities: {},
+    });
+
+    await client.poll();
+    client.replaceAuthToken("owl_pat_new");
+    await client.poll();
+
+    expect(authorizations).toEqual([
+      "Bearer owl_pat_old",
+      "Bearer owl_pat_new",
+    ]);
+  });
+
   test("a headless device advertises automations.execute without being told to", async () => {
     // The gateway's Automation claim lane matches this exact string, so the
     // build — not the operator's --capabilities flag — is what opts a headless

--- a/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
@@ -2,6 +2,69 @@ import { describe, expect, test } from "bun:test";
 import { WorkerPollLoop } from "../daemon/poll-loop";
 
 describe("worker daemon capacity polling", () => {
+  test("runs credential maintenance before polls only when no job is active", async () => {
+    const order: string[] = [];
+    let releaseJob: (() => void) | undefined;
+    const jobDone = new Promise<void>((resolve) => {
+      releaseJob = resolve;
+    });
+    let polls = 0;
+    let loop: WorkerPollLoop;
+    const client = {
+      healthCheck: async () => true,
+      poll: async () => {
+        polls++;
+        order.push(`poll:${polls}`);
+        if (polls === 1) return { run_id: 42, run_type: "sync" };
+        if (polls === 2) {
+          releaseJob?.();
+          return { next_poll_seconds: 0.001 };
+        }
+        loop.stop();
+        return { next_poll_seconds: 0.001 };
+      },
+    } as never;
+    loop = new WorkerPollLoop({
+      client,
+      pollIntervalMs: 1,
+      maxConcurrentJobs: 1,
+      execute: async () => jobDone,
+      beforeIdlePoll: async () => {
+        order.push("maintenance");
+      },
+    });
+
+    await loop.start();
+
+    expect(order).toEqual([
+      "maintenance",
+      "poll:1",
+      "poll:2",
+      "maintenance",
+      "poll:3",
+    ]);
+  });
+
+  test("treats credential maintenance refusal as fatal before polling", async () => {
+    let polls = 0;
+    const loop = new WorkerPollLoop({
+      client: {
+        healthCheck: async () => true,
+        poll: async () => {
+          polls++;
+          return {};
+        },
+      } as never,
+      execute: async () => {},
+      beforeIdlePoll: async () => {
+        throw new Error("device credential was revoked");
+      },
+    });
+
+    await expect(loop.start()).rejects.toThrow(/credential was revoked/);
+    expect(polls).toBe(0);
+  });
+
   test("polls at capacity with zero and does not execute a returned job", async () => {
     const calls: number[] = [];
     let executed = 0;

--- a/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { WorkerHttpError } from "../daemon/client";
 import { WorkerPollLoop } from "../daemon/poll-loop";
 
 describe("worker daemon capacity polling", () => {
@@ -63,6 +64,53 @@ describe("worker daemon capacity polling", () => {
 
     await expect(loop.start()).rejects.toThrow(/credential was revoked/);
     expect(polls).toBe(0);
+  });
+
+  for (const status of [401, 403]) {
+    test(`persisted credential mode treats poll ${status} as fatal`, async () => {
+      let polls = 0;
+      const loop = new WorkerPollLoop({
+        client: {
+          healthCheck: async () => true,
+          poll: async () => {
+            polls++;
+            throw new WorkerHttpError(status, "/api/workers/poll", "rejected");
+          },
+        } as never,
+        execute: async () => {},
+        failClosedOnPollAuthError: true,
+      });
+
+      await expect(loop.start()).rejects.toMatchObject({ status });
+      expect(polls).toBe(1);
+    });
+  }
+
+  test("persisted credential mode retries poll 429 and 5xx responses", async () => {
+    const statuses = [429, 503];
+    let polls = 0;
+    let loop: WorkerPollLoop;
+    loop = new WorkerPollLoop({
+      client: {
+        healthCheck: async () => true,
+        poll: async () => {
+          polls++;
+          const status = statuses.shift();
+          if (status) {
+            throw new WorkerHttpError(status, "/api/workers/poll", "retry");
+          }
+          loop.stop();
+          return { next_poll_seconds: 0.001 };
+        },
+      } as never,
+      pollIntervalMs: 1,
+      execute: async () => {},
+      failClosedOnPollAuthError: true,
+    });
+
+    await loop.start();
+
+    expect(polls).toBe(3);
   });
 
   test("polls at capacity with zero and does not execute a returned job", async () => {

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -277,6 +277,10 @@ export class WorkerClient implements ExecutorClient {
     return this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {};
   }
 
+  replaceAuthToken(authToken: string): void {
+    this.authToken = authToken;
+  }
+
   private async post<B = unknown>(path: string, body: B): Promise<Response> {
     const response = await fetch(`${this.apiUrl}${path}`, {
       method: 'POST',

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -14,6 +14,7 @@ export interface WorkerPollLoopOptions {
   pollIntervalMs?: number;
   maxConcurrentJobs?: number;
   execute: (job: PollResponse) => Promise<unknown>;
+  beforeIdlePoll?: () => Promise<void>;
 }
 
 export type WorkerPollLoopExit = (code: number) => void;
@@ -34,6 +35,7 @@ export class WorkerPollLoop {
   private readonly pollIntervalMs: number;
   private readonly maxConcurrentJobs: number;
   private readonly execute: (job: PollResponse) => Promise<unknown>;
+  private readonly beforeIdlePoll?: () => Promise<void>;
   private running = false;
   private admittingJobs = true;
   private activeJobs = 0;
@@ -43,6 +45,7 @@ export class WorkerPollLoop {
     this.pollIntervalMs = options.pollIntervalMs ?? 10000;
     this.maxConcurrentJobs = Math.max(1, options.maxConcurrentJobs ?? 1);
     this.execute = options.execute;
+    this.beforeIdlePoll = options.beforeIdlePoll;
   }
 
   async start(): Promise<void> {
@@ -59,6 +62,7 @@ export class WorkerPollLoop {
     log.info('[daemon] Starting worker daemon...');
     this.running = true;
     while (this.running) {
+      if (this.activeJobs === 0) await this.beforeIdlePoll?.();
       let nextDelayMs: number | undefined;
       try {
         nextDelayMs = await this.pollAndExecute();

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -6,7 +6,7 @@
  * injected so the device build does not import fleet connector machinery.
  */
 
-import type { PollResponse, WorkerClient } from './client.js';
+import { type PollResponse, WorkerHttpError, type WorkerClient } from './client.js';
 import { log } from './log.js';
 
 export interface WorkerPollLoopOptions {
@@ -15,6 +15,8 @@ export interface WorkerPollLoopOptions {
   maxConcurrentJobs?: number;
   execute: (job: PollResponse) => Promise<unknown>;
   beforeIdlePoll?: () => Promise<void>;
+  /** Persisted device credentials treat poll-time revocation as terminal. */
+  failClosedOnPollAuthError?: boolean;
 }
 
 export type WorkerPollLoopExit = (code: number) => void;
@@ -36,6 +38,7 @@ export class WorkerPollLoop {
   private readonly maxConcurrentJobs: number;
   private readonly execute: (job: PollResponse) => Promise<unknown>;
   private readonly beforeIdlePoll?: () => Promise<void>;
+  private readonly failClosedOnPollAuthError: boolean;
   private running = false;
   private admittingJobs = true;
   private activeJobs = 0;
@@ -46,6 +49,7 @@ export class WorkerPollLoop {
     this.maxConcurrentJobs = Math.max(1, options.maxConcurrentJobs ?? 1);
     this.execute = options.execute;
     this.beforeIdlePoll = options.beforeIdlePoll;
+    this.failClosedOnPollAuthError = options.failClosedOnPollAuthError === true;
   }
 
   async start(): Promise<void> {
@@ -67,6 +71,13 @@ export class WorkerPollLoop {
       try {
         nextDelayMs = await this.pollAndExecute();
       } catch (err) {
+        if (
+          this.failClosedOnPollAuthError &&
+          err instanceof WorkerHttpError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          throw err;
+        }
         log.info('[daemon] Poll error:', err);
       }
       if (this.running) await this.sleep(nextDelayMs ?? this.pollIntervalMs);

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -44,6 +44,7 @@ export interface DaemonStartOptions {
   debug?: boolean;
   /** False only when the operator explicitly disables inherited-session delivery. */
   interactiveSession?: false;
+  workerCredentialMaintenance?: (activate: (workerApiToken: string) => void) => Promise<void>;
 }
 
 export function resolveDaemonWorkerId(
@@ -180,6 +181,9 @@ export async function startDaemonCommand(
     ...(label ? { label } : {}),
     ...(platform ? { manifests: DEVICE_MANIFESTS_BY_PLATFORM[platform] ?? [] } : {}),
     ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
+    ...(opts.workerCredentialMaintenance
+      ? { workerCredentialMaintenance: opts.workerCredentialMaintenance }
+      : {}),
     ...(detected
       ? {
           agentKinds: [detected.kind],

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -91,6 +91,7 @@ export class WorkerDaemon {
         ? {
             beforeIdlePoll: () =>
               credentialMaintenance((token) => this.client.replaceAuthToken(token)),
+            failClosedOnPollAuthError: true,
           }
         : {}),
     });

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -31,6 +31,7 @@ export interface DaemonConfig {
   manifests?: unknown[];
   /** Fixed advertisement for an exact interactive session. */
   agentKinds?: AgentKind[];
+  workerCredentialMaintenance?: (activate: (workerApiToken: string) => void) => Promise<void>;
 }
 
 const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
@@ -50,6 +51,7 @@ export class WorkerDaemon {
 
   constructor(daemonConfig: DaemonConfig, env: Env) {
     const interactiveSession = attachedInteractiveSession(daemonConfig);
+    const credentialMaintenance = daemonConfig.workerCredentialMaintenance;
     this.client = new WorkerClient({
       apiUrl: daemonConfig.apiUrl,
       workerId: daemonConfig.workerId,
@@ -85,6 +87,12 @@ export class WorkerDaemon {
       pollIntervalMs: daemonConfig.pollIntervalMs,
       maxConcurrentJobs: daemonConfig.maxConcurrentJobs,
       execute: (job) => executeRun(this.client, job, this.env, this.config.executor),
+      ...(credentialMaintenance
+        ? {
+            beforeIdlePoll: () =>
+              credentialMaintenance((token) => this.client.replaceAuthToken(token)),
+          }
+        : {}),
     });
   }
 


### PR DESCRIPTION
Closes #2978

Summary

- rotate context-backed headless daemon child PATs at an idle polling boundary using the existing 30-day refresh window
- save the rotated credential before activating it, or keep it active in memory and retry only the local save after a persistence failure
- fail closed on runtime mint authorization failures and on startup rejection of a locally unexpired child PAT, so revocation is never silently undone through installation OAuth
- keep 429 and other transient failures retryable while the current child PAT remains valid

Checks

- focused CLI and connector-worker tests: 46 pass, 0 fail
- server child-token lifecycle and mint integration tests: 13 pass, 0 fail
- connector-worker and CLI TypeScript checks
- make pre-pr