### PR TITLE
fix: defer device schedules until workers reconnect

### DIFF
--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -405,6 +405,47 @@ describe("automation health surfacing (#2033)", () => {
     expect(health.metrics.stalePendingAutomationRuns).toBeGreaterThanOrEqual(1);
     expect(health.issues.some((i) => /stuck pending/i.test(i))).toBe(true);
   });
+
+  it("3.2: reports an offline device deferral without a scheduler failure", async () => {
+    const { automationId, ctx } = await createScheduledAutomation();
+    const sql = getTestDb();
+    const [device] = await sql<{ id: string }>`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label, organization_id,
+        agent_kinds, last_seen_at
+      ) VALUES (
+        ${ctx.userId}, 'health-offline-mac', 'macos', ${sql.json({})}, 'Offline Mac',
+        ${ctx.organizationId}, ${"{claude-code}"}::text[],
+        current_timestamp - interval '10 minutes'
+      )
+      RETURNING id
+    `;
+    await sql`
+      UPDATE automations
+      SET device_worker_id = ${device.id}::uuid,
+          agent_kind = 'claude-code',
+          next_run_at = current_timestamp - interval '2 hours'
+      WHERE id = ${automationId}
+    `;
+    await sql`
+      INSERT INTO runs (
+        organization_id, run_type, automation_id, status, approval_status,
+        approved_input, created_at
+      ) VALUES (
+        ${ctx.organizationId}, 'automation', ${automationId}, 'pending', 'auto',
+        ${sql.json({ dispatch_source: "scheduled", device_worker_id: device.id })},
+        current_timestamp - interval '3 hours'
+      )
+    `;
+
+    const health = await getSchedulerHealth({} as Env);
+    expect(health.metrics.deferredDeviceAutomations).toBe(1);
+    expect(health.metrics.oldestDeviceDeferralHours).toBeGreaterThan(1);
+    expect(health.metrics.overdueAutomations).toBe(0);
+    expect(health.metrics.stalePendingAutomationRuns).toBe(0);
+    expect(health.healthy).toBe(true);
+    expect(health.issues).toEqual([]);
+  });
 });
 
 afterAll(() => {

--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -457,6 +457,15 @@ describe("automation health surfacing (#2033)", () => {
     expect(incapableHealth.metrics.overdueAutomations).toBe(0);
     expect(incapableHealth.metrics.stalePendingAutomationRuns).toBe(0);
     expect(incapableHealth.healthy).toBe(true);
+
+    await sql`
+      UPDATE device_workers SET platform = NULL, capabilities = ${sql.json({})}
+      WHERE id = ${device.id}::uuid
+    `;
+    const legacyHealth = await getSchedulerHealth({} as Env);
+    expect(legacyHealth.metrics.deferredDeviceAutomations).toBe(1);
+    expect(legacyHealth.metrics.overdueAutomations).toBe(0);
+    expect(legacyHealth.healthy).toBe(true);
   });
 });
 

--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -445,6 +445,18 @@ describe("automation health surfacing (#2033)", () => {
     expect(health.metrics.stalePendingAutomationRuns).toBe(0);
     expect(health.healthy).toBe(true);
     expect(health.issues).toEqual([]);
+
+    await sql`
+      UPDATE device_workers
+      SET platform = 'headless', last_seen_at = current_timestamp,
+          capabilities = ${sql.json(["os.shell"])}
+      WHERE id = ${device.id}::uuid
+    `;
+    const incapableHealth = await getSchedulerHealth({} as Env);
+    expect(incapableHealth.metrics.deferredDeviceAutomations).toBe(1);
+    expect(incapableHealth.metrics.overdueAutomations).toBe(0);
+    expect(incapableHealth.metrics.stalePendingAutomationRuns).toBe(0);
+    expect(incapableHealth.healthy).toBe(true);
   });
 });
 

--- a/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
@@ -24,10 +24,11 @@
 
 import type { Context } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
+import { materializeDueAutomationRuns } from '../../../automations/automation';
+import { parsePgTextArray } from '../../../db/client';
 import type { Env } from '../../../index';
 import { listDeviceWorkers } from '../../../worker-api/device-management';
-import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
-import { parsePgTextArray } from '../../../db/client';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
@@ -184,6 +185,36 @@ describe('device agent_kinds advertisement + automation claim gate', () => {
       SELECT agent_kinds FROM device_workers WHERE id = ${ctx.deviceWorkerId}::uuid
     `;
     expect(parsePgTextArray(afterOmit.agent_kinds)).toEqual(['claude-code', 'pi']);
+  });
+
+  it('conservatively defers scheduling after an incompatible advertisement survives a downgrade poll', async () => {
+    const ctx = await setup({ workerId: 'mac-kinds-downgrade', agentKind: 'claude-code' });
+    await poll(ctx, ['codex']);
+    await ctx.sql`
+      UPDATE automations
+      SET next_run_at = current_timestamp - interval '1 minute'
+      WHERE id = ${ctx.automationId}
+    `;
+    const [before] = await ctx.sql`
+      SELECT next_run_at FROM automations WHERE id = ${ctx.automationId}
+    `;
+
+    // Omission is the legacy/downgrade contract: the live claim is permissive,
+    // but the durable row retains the last authoritative advertisement. The
+    // scheduler therefore prefers a retryable deferral over creating a run the
+    // last capable client said this device could not execute.
+    await poll(ctx);
+    expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(0);
+
+    const [after] = await ctx.sql`
+      SELECT next_run_at FROM automations WHERE id = ${ctx.automationId}
+    `;
+    expect(new Date(after.next_run_at).toISOString()).toBe(
+      new Date(before.next_run_at).toISOString()
+    );
+    expect(
+      await ctx.sql`SELECT id FROM runs WHERE automation_id = ${ctx.automationId}`
+    ).toHaveLength(0);
   });
 
   it('claims a run whose agent_kind the device advertised', async () => {

--- a/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
@@ -154,6 +154,56 @@ describe("device-pinned scheduled Automation liveness (#2538)", () => {
 			(await sql`SELECT status FROM runs WHERE id = ${run.id}`)[0].status,
 		).toBe("pending");
 		expect(await cursor(sql, automationId)).toEqual(before);
+
+		const [replacement] = await sql<{ id: string }>`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, label, organization_id,
+				agent_kinds, last_seen_at
+			)
+			SELECT user_id, 'device-schedule-replacement', 'macos', ${sql.json({})},
+				'Replacement Mac', organization_id, ${"{claude-code}"}::text[],
+				current_timestamp
+			FROM device_workers WHERE id = ${deviceId}::uuid
+			RETURNING id
+		`;
+		await sql`
+			UPDATE automations SET device_worker_id = ${replacement.id}::uuid
+			WHERE id = ${automationId}
+		`;
+		expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(0);
+		const [retargetedRun] = await sql<{
+			status: string;
+			approved_input: Record<string, unknown>;
+		}>`SELECT status, approved_input FROM runs WHERE id = ${run.id}`;
+		expect(retargetedRun.status).toBe("pending");
+		expect(retargetedRun.approved_input.device_worker_id).toBe(deviceId);
+		expect(await cursor(sql, automationId)).toEqual(before);
+		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(0);
+	});
+
+	it("does not materialize for a fresh headless device that cannot claim Automations", async () => {
+		const { sql, automationId, deviceId } = await setupDeviceAutomation();
+		const before = await cursor(sql, automationId);
+		await sql`
+			UPDATE device_workers
+			SET platform = 'headless', last_seen_at = current_timestamp,
+				capabilities = ${sql.json(["os.shell"])},
+				agent_kinds = ${"{claude-code}"}::text[]
+			WHERE id = ${deviceId}::uuid
+		`;
+
+		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(0);
+		expect(await cursor(sql, automationId)).toEqual(before);
+		expect(
+			await sql`SELECT id FROM runs WHERE automation_id = ${automationId}`,
+		).toHaveLength(0);
+
+		await sql`
+			UPDATE device_workers
+			SET capabilities = ${sql.json(["automations.execute"])}
+			WHERE id = ${deviceId}::uuid
+		`;
+		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(1);
 	});
 
 	it("completes every missed period oldest-first, then advances to the next cron", async () => {

--- a/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
@@ -170,6 +170,10 @@ describe("device-pinned scheduled Automation liveness (#2538)", () => {
 			UPDATE automations SET device_worker_id = ${replacement.id}::uuid
 			WHERE id = ${automationId}
 		`;
+		await sql`
+			UPDATE device_workers SET last_seen_at = current_timestamp - interval '10 minutes'
+			WHERE id = ${deviceId}::uuid
+		`;
 		expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(0);
 		const [retargetedRun] = await sql<{
 			status: string;
@@ -179,6 +183,23 @@ describe("device-pinned scheduled Automation liveness (#2538)", () => {
 		expect(retargetedRun.approved_input.device_worker_id).toBe(deviceId);
 		expect(await cursor(sql, automationId)).toEqual(before);
 		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(0);
+
+		await sql`DELETE FROM device_workers WHERE id = ${deviceId}::uuid`;
+		expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(1);
+		expect(
+			(await sql`SELECT status FROM runs WHERE id = ${run.id}`)[0].status,
+		).toBe("timeout");
+		expect(await cursor(sql, automationId)).toEqual(before);
+
+		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(1);
+		const [retried] = await sql<{ approved_input: Record<string, unknown> }>`
+			SELECT approved_input FROM runs
+			WHERE automation_id = ${automationId} AND status = 'pending'
+		`;
+		expect(retried.approved_input.device_worker_id).toBe(replacement.id);
+		expect(
+			new Date(String(retried.approved_input.window_start)).toISOString(),
+		).toBe(before.nextWindowStart);
 	});
 
 	it("does not materialize for a fresh headless device that cannot claim Automations", async () => {

--- a/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
@@ -1,0 +1,243 @@
+import {
+	addAutomationPeriod,
+	alignToAutomationWindowStart,
+	subtractAutomationPeriod,
+} from "@lobu/connector-sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	materializeDueAutomationRuns,
+	sweepStaleAutomationRuns,
+} from "../../../automations/automation";
+import type { Env } from "../../../index";
+import { generateWindowToken } from "../../../utils/jwt";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
+import { TestApiClient, TestWorkspace } from "../../setup/test-mcp-client";
+
+async function setupDeviceAutomation() {
+	const sql = getTestDb();
+	const workspace = await TestWorkspace.create({ name: "Device Schedule Org" });
+	const userId = workspace.users.owner.id;
+	const entity = await createTestEntity({
+		name: "Device Schedule Entity",
+		organization_id: workspace.org.id,
+		created_by: userId,
+	});
+	const agent = await createTestAgent({
+		organizationId: workspace.org.id,
+		ownerUserId: userId,
+		agentId: "device-schedule-agent",
+		name: "Device Schedule Agent",
+	});
+	const created = (await workspace.owner.automations.create({
+		entity_id: entity.id,
+		slug: "device-schedule",
+		name: "Device Schedule",
+		prompt: "Summarize the oldest unfinished daily period.",
+		triggers: [
+			{
+				kind: "schedule",
+				cron: "0 9 * * *",
+				execution: "window",
+				active_run: "coalesce",
+				skip_if_unchanged: false,
+			},
+		],
+		agent_id: agent.agentId,
+	})) as { automation_id: string };
+	const automationId = Number(created.automation_id);
+	const [device] = await sql<{ id: string }>`
+		INSERT INTO device_workers (
+			user_id, worker_id, platform, capabilities, label, organization_id,
+			agent_kinds, last_seen_at
+		) VALUES (
+			${userId}, 'device-schedule-mac', 'macos', ${sql.json({})}, 'Schedule Mac',
+			${workspace.org.id}, ${"{claude-code}"}::text[],
+			current_timestamp - interval '10 minutes'
+		)
+		RETURNING id
+	`;
+	await sql`
+		UPDATE automations
+		SET device_worker_id = ${device.id}::uuid,
+			agent_kind = 'claude-code',
+			next_run_at = current_timestamp - interval '2 hours'
+		WHERE id = ${automationId}
+	`;
+	const api = await TestApiClient.for({
+		organizationId: workspace.org.id,
+		userId,
+		memberRole: "owner",
+	});
+	return { sql, api, automationId, deviceId: device.id };
+}
+
+async function cursor(sql: ReturnType<typeof getTestDb>, automationId: number) {
+	const [row] = await sql<{
+		next_run_at: string;
+		next_window_start: string;
+	}>`
+		SELECT next_run_at, next_window_start
+		FROM automations WHERE id = ${automationId}
+	`;
+	return {
+		nextRunAt: new Date(row.next_run_at).toISOString(),
+		nextWindowStart: new Date(row.next_window_start).toISOString(),
+	};
+}
+
+describe("device-pinned scheduled Automation liveness (#2538)", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("defers without a run or cursor movement until the exact compatible device reconnects", async () => {
+		const { sql, automationId, deviceId } = await setupDeviceAutomation();
+		const before = await cursor(sql, automationId);
+
+		const offline = await Promise.all([
+			materializeDueAutomationRuns({} as Env),
+			materializeDueAutomationRuns({} as Env),
+		]);
+		expect(offline.reduce((sum, result) => sum + result.runsCreated, 0)).toBe(
+			0,
+		);
+		expect(await cursor(sql, automationId)).toEqual(before);
+
+		await sql`
+			UPDATE device_workers
+			SET last_seen_at = current_timestamp, agent_kinds = ${"{codex}"}::text[]
+			WHERE id = ${deviceId}::uuid
+		`;
+		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(0);
+		expect(await cursor(sql, automationId)).toEqual(before);
+
+		await sql`
+			UPDATE device_workers
+			SET last_seen_at = current_timestamp,
+				agent_kinds = ${"{claude-code,codex}"}::text[]
+			WHERE id = ${deviceId}::uuid
+		`;
+		const reconnected = await Promise.all([
+			materializeDueAutomationRuns({} as Env),
+			materializeDueAutomationRuns({} as Env),
+		]);
+		expect(
+			reconnected.reduce((sum, result) => sum + result.runsCreated, 0),
+		).toBe(1);
+
+		const [run] = await sql<{
+			id: number;
+			status: string;
+			approved_input: Record<string, unknown>;
+		}>`
+			SELECT id, status, approved_input FROM runs
+			WHERE automation_id = ${automationId} AND run_type = 'automation'
+		`;
+		expect(run.status).toBe("pending");
+		expect(run.approved_input.device_worker_id).toBe(deviceId);
+		expect(run.approved_input.agent_kind).toBe("claude-code");
+		expect(
+			new Date(String(run.approved_input.window_start)).toISOString(),
+		).toBe(before.nextWindowStart);
+
+		await sql`
+			UPDATE runs SET created_at = current_timestamp - interval '3 hours'
+			WHERE id = ${run.id}
+		`;
+		const swept = await Promise.all([
+			sweepStaleAutomationRuns(sql),
+			sweepStaleAutomationRuns(sql),
+		]);
+		expect(swept.reduce((sum, result) => sum + result.timedOut, 0)).toBe(0);
+		expect(
+			(await sql`SELECT status FROM runs WHERE id = ${run.id}`)[0].status,
+		).toBe("pending");
+		expect(await cursor(sql, automationId)).toEqual(before);
+	});
+
+	it("completes every missed period oldest-first, then advances to the next cron", async () => {
+		const { sql, api, automationId, deviceId } = await setupDeviceAutomation();
+		await sql`
+			UPDATE device_workers SET last_seen_at = current_timestamp
+			WHERE id = ${deviceId}::uuid
+		`;
+		const closedBoundary = alignToAutomationWindowStart(new Date(), "daily");
+		let oldest = closedBoundary;
+		for (let count = 0; count < 3; count += 1) {
+			oldest = subtractAutomationPeriod(oldest, "daily");
+		}
+		await sql`
+			UPDATE automations
+			SET next_window_start = ${oldest.toISOString()}::timestamptz,
+				completed_window_coverage = '{}'::tstzmultirange,
+				window_projection_granularity = 'daily',
+				next_run_at = current_timestamp - interval '2 hours'
+			WHERE id = ${automationId}
+		`;
+
+		for (let period = 0; period < 3; period += 1) {
+			const materialized = await Promise.all([
+				materializeDueAutomationRuns({} as Env),
+				materializeDueAutomationRuns({} as Env),
+			]);
+			expect(
+				materialized.reduce((sum, result) => sum + result.runsCreated, 0),
+			).toBe(1);
+			const [run] = await sql<{
+				id: number;
+				approved_input: Record<string, unknown>;
+			}>`
+				SELECT id, approved_input FROM runs
+				WHERE automation_id = ${automationId} AND status = 'pending'
+			`;
+			const windowStart = new Date(
+				String(run.approved_input.window_start),
+			).toISOString();
+			const windowEnd = new Date(
+				String(run.approved_input.window_end),
+			).toISOString();
+			expect(windowStart).toBe(oldest.toISOString());
+
+			await sql`
+				UPDATE runs SET status = 'running', claimed_at = current_timestamp,
+					claimed_by = 'device-schedule-mac'
+				WHERE id = ${run.id}
+			`;
+			const windowToken = await generateWindowToken(
+				{
+					automation_id: automationId,
+					run_id: run.id,
+					window_start: windowStart,
+					window_end: windowEnd,
+					granularity: "daily",
+					content_count: 0,
+					content_ids: [],
+				},
+				{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+			);
+			await api.automations.completeWindow({
+				automation_id: String(automationId),
+				run_id: run.id,
+				window_token: windowToken,
+				extracted_data: { summary: `period ${period + 1}` },
+			});
+
+			oldest = addAutomationPeriod(oldest, "daily");
+			const after = await cursor(sql, automationId);
+			expect(after.nextWindowStart).toBe(oldest.toISOString());
+			if (period < 2) {
+				expect(new Date(after.nextRunAt).getTime()).toBeLessThanOrEqual(
+					Date.now(),
+				);
+			} else {
+				expect(new Date(after.nextRunAt).getTime()).toBeGreaterThan(Date.now());
+			}
+		}
+
+		expect(oldest.toISOString()).toBe(closedBoundary.toISOString());
+		expect(
+			await sql`SELECT id FROM runs WHERE automation_id = ${automationId}`,
+		).toHaveLength(3);
+	});
+});

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -601,6 +601,7 @@ async function finalizeStalePendingAutomationRuns(
         AND r.status = 'pending'
         AND r.created_at < current_timestamp - ${staleInterval}::interval
         AND COALESCE(r.approved_input->>'dispatch_source', 'scheduled') <> 'manual'
+        -- Ownership comes from approved_input; never reinterpret it via mutable w.device_worker_id.
         AND NOT (
           COALESCE(r.approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
           AND NULLIF(r.approved_input->>'device_worker_id', '') IS NOT NULL
@@ -748,6 +749,7 @@ export async function materializeDueAutomationRuns(
                   AND dw.last_seen_at > current_timestamp
                     - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
                   AND (dw.platform = 'macos' OR dw.capabilities ? 'automations.execute')
+                  -- agent_kinds is the last authoritative ad; omitted downgrade polls preserve it.
                   AND (
                     dw.agent_kinds IS NULL
                     OR CASE

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -30,6 +30,7 @@ import { materializeDueItems } from "../scheduled/due-materializer";
 import { markStaleRunsAsTimeout } from "../scheduled/stale-run-sweeper";
 import { fingerprintAutomationSources } from "../tools/get_content/automation-mode";
 import { nextRunAt } from "../utils/cron";
+import { DEVICE_ONLINE_WINDOW_SECONDS } from "../utils/device-liveness";
 import logger from "../utils/logger";
 import { ToolUserError } from "../utils/errors";
 import { classifyRunOutcome } from "../runs/run-outcome";
@@ -41,6 +42,7 @@ import {
 import {
 	advanceScheduleAfterTerminalFailure,
 	advanceAutomationSchedule,
+	advanceAutomationScheduleAfterSuccessfulWindow,
 } from "./schedule-cursor";
 import {
 	resolveAutomationRunsByMessageIds,
@@ -599,6 +601,10 @@ async function finalizeStalePendingAutomationRuns(
         AND r.status = 'pending'
         AND r.created_at < current_timestamp - ${staleInterval}::interval
         AND COALESCE(r.approved_input->>'dispatch_source', 'scheduled') <> 'manual'
+        AND NOT (
+          COALESCE(r.approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
+          AND NULLIF(r.approved_input->>'device_worker_id', '') IS NOT NULL
+        )
       ORDER BY r.created_at ASC
       FOR UPDATE OF r, w SKIP LOCKED
       LIMIT 100
@@ -715,9 +721,9 @@ export async function materializeDueAutomationRuns(
 	const counts = await materializeDueItems<DueAutomationRow>({
 		label: "automation",
 		fetchDue: async () => {
-			// Only schedule automations we can actually execute: either device-pinned (an
-			// external/device worker claims it via the poll lane — no cloud agent row
-			// needed) OR the assigned agent still exists in the org. An automation whose
+			// Only schedule automations we can actually execute: either a live, compatible
+			// device pin (claimed via the poll lane) OR an unpinned assignment whose agent
+			// still exists in the org. An automation whose
 			// `agents` row was deleted is otherwise materialized every cron tick and fails
 			// at dispatch ("Assigned agent ... does not exist"). Skipping at the source is
 			// self-healing: it resumes automatically if the agent is recreated. The
@@ -733,9 +739,27 @@ export async function materializeDueAutomationRuns(
           AND w.next_run_at IS NOT NULL
           AND w.next_run_at <= current_timestamp
           AND (
-            w.device_worker_id IS NOT NULL
+            (
+              w.device_worker_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM device_workers dw
+                WHERE dw.id = w.device_worker_id
+                  AND dw.last_seen_at > current_timestamp
+                    - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+                  AND (
+                    dw.agent_kinds IS NULL
+                    OR CASE
+                      WHEN NULLIF(w.agent_kind, '') IS NULL
+                        THEN cardinality(dw.agent_kinds) > 0
+                      ELSE w.agent_kind = ANY(dw.agent_kinds)
+                    END
+                  )
+              )
+            )
             OR (
-              w.agent_id IS NOT NULL
+              w.device_worker_id IS NULL
+              AND w.agent_id IS NOT NULL
               AND EXISTS (
                 SELECT 1 FROM agents a
                 WHERE a.id = w.agent_id
@@ -834,7 +858,12 @@ export async function materializeDueAutomationRuns(
 							granularity,
 						);
 					}
-					await advanceAutomationSchedule(sql, automation.id);
+					await advanceAutomationScheduleAfterSuccessfulWindow(
+						sql,
+						automation.id,
+						Boolean(automation.device_worker_id),
+						granularity
+					);
 					logger.info(
 						{ automationId: automation.id, empty: sourceState.empty },
 						"[automation] Skipped unchanged Automation sources before agent dispatch"

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -747,6 +747,7 @@ export async function materializeDueAutomationRuns(
                 WHERE dw.id = w.device_worker_id
                   AND dw.last_seen_at > current_timestamp
                     - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+                  AND (dw.platform = 'macos' OR dw.capabilities ? 'automations.execute')
                   AND (
                     dw.agent_kinds IS NULL
                     OR CASE

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -577,9 +577,9 @@ export async function sweepStaleAutomationRuns(
  * recreating the missed run.
  *
  * Manual runs are intentionally excluded: a manual caller owns retry policy.
- * Fresh rows are protected by the same generous TTL used for non-heartbeating
- * executions, allowing device-pinned Automations to wait for a temporarily
- * offline device without being churned.
+ * Scheduled device runs remain durable past the TTL while their exact snapshot
+ * owner exists. If that row is deleted, only the stale orphan times out; its
+ * schedule cursor stays due so current ownership retries the same window.
  */
 async function finalizeStalePendingAutomationRuns(
 	sql: DbClient,
@@ -592,19 +592,25 @@ async function finalizeStalePendingAutomationRuns(
 			schedule: string | null;
 			timezone: string | null;
 			dispatch_source: string | null;
+			device_worker_id: string | null;
 		}>`
       SELECT r.id, r.automation_id, w.schedule, w.timezone,
-             r.approved_input->>'dispatch_source' AS dispatch_source
+             r.approved_input->>'dispatch_source' AS dispatch_source,
+             NULLIF(r.approved_input->>'device_worker_id', '') AS device_worker_id
       FROM runs r
       JOIN automations w ON w.id = r.automation_id
       WHERE r.run_type = 'automation'
         AND r.status = 'pending'
         AND r.created_at < current_timestamp - ${staleInterval}::interval
         AND COALESCE(r.approved_input->>'dispatch_source', 'scheduled') <> 'manual'
-        -- Ownership comes from approved_input; never reinterpret it via mutable w.device_worker_id.
+        -- Snapshot ownership stays durable after retarget; only a missing exact row is orphaned.
         AND NOT (
           COALESCE(r.approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
           AND NULLIF(r.approved_input->>'device_worker_id', '') IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM device_workers dw
+            WHERE dw.id::text = r.approved_input->>'device_worker_id'
+          )
         )
       ORDER BY r.created_at ASC
       FOR UPDATE OF r, w SKIP LOCKED
@@ -635,6 +641,9 @@ async function finalizeStalePendingAutomationRuns(
 				continue;
 			}
 			if (!candidate.schedule) continue;
+			// An orphaned device snapshot must retry the same unfinished window under
+			// current ownership, so preserve both schedule and coverage cursors.
+			if (candidate.device_worker_id) continue;
 			const next = nextRunAt(
 				candidate.schedule,
 				new Date(),

--- a/packages/server/src/automations/schedule-cursor.ts
+++ b/packages/server/src/automations/schedule-cursor.ts
@@ -1,3 +1,7 @@
+import {
+	alignToAutomationWindowStart,
+	type AutomationTimeGranularity,
+} from "@lobu/connector-sdk";
 import { AgentErrorCode, PROVIDER_BALANCE_EXHAUSTED } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { nextRunAt } from "../utils/cron";
@@ -367,6 +371,30 @@ export async function advanceAutomationSchedule(
         updated_at = NOW()
     WHERE id = ${automationId}
   `;
+}
+
+/**
+ * Keep a device schedule due while its durable projection still has closed
+ * periods to catch up; otherwise retain the ordinary next-cron cursor.
+ */
+export async function advanceAutomationScheduleAfterSuccessfulWindow(
+	sql: DbClient,
+	automationId: number,
+	devicePinned: boolean,
+	granularity: AutomationTimeGranularity
+): Promise<void> {
+	if (devicePinned) {
+		const boundary = alignToAutomationWindowStart(new Date(), granularity);
+		const result = await sql`
+      UPDATE automations
+      SET next_run_at = LEAST(next_run_at, current_timestamp),
+          updated_at = current_timestamp
+      WHERE id = ${automationId}
+        AND next_window_start < ${boundary.toISOString()}::timestamptz
+    `;
+		if (Number(result.count ?? 0) > 0) return;
+	}
+	await advanceAutomationSchedule(sql, automationId);
 }
 
 /**

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -38,6 +38,8 @@ interface SchedulerHealthStatus {
     overdueAutomations: number;
     automationsOverdueByHours: number;
     stalePendingAutomationRuns: number;
+    deferredDeviceAutomations: number;
+    oldestDeviceDeferralHours: number;
     /** Approvals still undecided past PENDING_APPROVAL_TTL_DAYS. */
     stalePendingApprovals: number;
     /** Age of the oldest undecided approval, in days. */
@@ -207,25 +209,53 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
     // automations (by automations.next_run_at) and pending automation runs stuck past
     // the stale interval, feeding the SAME issues[] the feed path uses.
     const automationStats = await sql`
+      WITH scheduling AS (
+        SELECT a.status, a.schedule, a.next_run_at,
+          a.device_worker_id IS NOT NULL AND NOT (
+            d.id IS NOT NULL
+            AND d.last_seen_at > current_timestamp
+              - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+            AND (
+              d.agent_kinds IS NULL
+              OR CASE WHEN NULLIF(a.agent_kind, '') IS NULL
+                THEN cardinality(d.agent_kinds) > 0
+                ELSE a.agent_kind = ANY(d.agent_kinds)
+              END
+            )
+          ) AS device_deferred
+        FROM automations a
+        LEFT JOIN device_workers d ON d.id = a.device_worker_id
+      )
       SELECT
         CAST(COUNT(*) FILTER (WHERE status = 'active' AND schedule IS NOT NULL) AS INTEGER)
           AS active_automations,
         CAST(COUNT(*) FILTER (
           WHERE status = 'active' AND schedule IS NOT NULL
-            AND next_run_at < current_timestamp
+            AND next_run_at < current_timestamp AND NOT device_deferred
         ) AS INTEGER) AS overdue_automations,
-        MAX(CASE
-          WHEN status = 'active' AND schedule IS NOT NULL
-            AND next_run_at < current_timestamp
-            THEN EXTRACT(EPOCH FROM (current_timestamp - next_run_at)) / 3600.0
-          ELSE NULL
-        END) AS max_overdue_hours
-      FROM automations
+        MAX(CASE WHEN status = 'active' AND schedule IS NOT NULL
+          AND next_run_at < current_timestamp AND NOT device_deferred
+          THEN EXTRACT(EPOCH FROM (current_timestamp - next_run_at)) / 3600.0
+        END) AS max_overdue_hours,
+        CAST(COUNT(*) FILTER (WHERE status = 'active' AND schedule IS NOT NULL
+          AND next_run_at < current_timestamp AND device_deferred
+        ) AS INTEGER) AS deferred_device_automations,
+        MAX(CASE WHEN status = 'active' AND schedule IS NOT NULL
+          AND next_run_at < current_timestamp AND device_deferred
+          THEN EXTRACT(EPOCH FROM (current_timestamp - next_run_at)) / 3600.0
+        END) AS max_device_deferral_hours
+      FROM scheduling
     `;
 
     const activeAutomations = Number(automationStats[0]?.active_automations || 0);
     const overdueAutomations = Number(automationStats[0]?.overdue_automations || 0);
     const automationsOverdueByHours = Number(automationStats[0]?.max_overdue_hours || 0);
+    const deferredDeviceAutomations = Number(
+      automationStats[0]?.deferred_device_automations || 0
+    );
+    const oldestDeviceDeferralHours = Number(
+      automationStats[0]?.max_device_deferral_hours || 0
+    );
 
     // Pending automation runs stuck past AUTOMATION_RUN_STALE_INTERVAL — the reaper
     // should have timed these out; a growing count means the reaper/dispatch is
@@ -237,6 +267,10 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
       WHERE run_type = 'automation'
         AND status = 'pending'
         AND created_at < current_timestamp - INTERVAL '${intervals.automationRunStaleInterval}'
+        AND NOT (
+          COALESCE(approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
+          AND NULLIF(approved_input->>'device_worker_id', '') IS NOT NULL
+        )
     `
     );
     const stalePendingAutomationRuns = Number(
@@ -343,6 +377,8 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         overdueAutomations,
         automationsOverdueByHours: Math.round(automationsOverdueByHours * 10) / 10,
         stalePendingAutomationRuns,
+        deferredDeviceAutomations,
+        oldestDeviceDeferralHours: Math.round(oldestDeviceDeferralHours * 10) / 10,
         stalePendingApprovals,
         oldestPendingApprovalDays: Math.round(oldestPendingApprovalDays * 10) / 10,
       },
@@ -365,6 +401,8 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         overdueAutomations: 0,
         automationsOverdueByHours: 0,
         stalePendingAutomationRuns: 0,
+        deferredDeviceAutomations: 0,
+        oldestDeviceDeferralHours: 0,
         stalePendingApprovals: 0,
         oldestPendingApprovalDays: 0,
       },

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -215,7 +215,7 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
             d.id IS NOT NULL
             AND d.last_seen_at > current_timestamp
               - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
-            AND (d.platform = 'macos' OR d.capabilities ? 'automations.execute')
+            AND COALESCE(d.platform = 'macos' OR d.capabilities ? 'automations.execute', false)
             AND (
               d.agent_kinds IS NULL
               OR CASE WHEN NULLIF(a.agent_kind, '') IS NULL
@@ -271,6 +271,10 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         AND NOT (
           COALESCE(approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
           AND NULLIF(approved_input->>'device_worker_id', '') IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM device_workers dw
+            WHERE dw.id::text = approved_input->>'device_worker_id'
+          )
         )
     `
     );

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -215,6 +215,7 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
             d.id IS NOT NULL
             AND d.last_seen_at > current_timestamp
               - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
+            AND (d.platform = 'macos' OR d.capabilities ? 'automations.execute')
             AND (
               d.agent_kinds IS NULL
               OR CASE WHEN NULLIF(a.agent_kind, '') IS NULL

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -38,7 +38,7 @@ import {
   processAutomationClassifications,
   stripFields,
 } from '../../../automations/classifier-extraction';
-import { advanceAutomationSchedule } from '../../../automations/schedule-cursor';
+import { advanceAutomationScheduleAfterSuccessfulWindow } from '../../../automations/schedule-cursor';
 import { executeReaction } from '../../../automations/reaction-executor';
 import { getNextNumericId } from '../helpers/db-helpers';
 import type { Outputs } from '../../../types/automations';
@@ -867,7 +867,12 @@ export async function handleCompleteWindow(
           timeGranularity
         );
       }
-      await advanceAutomationSchedule(tx, automationId);
+      await advanceAutomationScheduleAfterSuccessfulWindow(
+        tx,
+        automationId,
+        Boolean(lockedRun.device_worker_id),
+        timeGranularity
+      );
     }
 
     logger.info(


### PR DESCRIPTION
Device-pinned scheduled Automations now materialize only when the exact pinned device is fresh and advertises a compatible agent kind. Offline or incompatible devices leave both the schedule cursor and oldest-unfinished window cursor due, so reconnect resumes the same period.

Scheduled device pending runs no longer hit the two-hour unclaimed reaper. After successful completion, the projection advances one period; backlog keeps the schedule due until coverage catches up, then returns to the ordinary next cron. Scheduler health reports the deferred count and oldest age without marking the scheduler unhealthy.

No schema, daemon, UI, public status enum, coalescing, or history dropping.

Tests:
- all 43 Automation integration files, 376 tests
- focused offline, reconnect, compatible-agent, durable-pending, multi-window, and concurrent-tick coverage
- scheduler health integration and Automation health unit suite
- server typecheck and make pre-pr

Closes #2538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Scheduled automations assigned to devices now wait safely when the device is offline, incompatible, or lacks automation capabilities.
  * Automations resume automatically when the assigned device becomes eligible again.
  * Missed scheduled windows are processed in order, preserving reliable catch-up behavior.
  * Device-related delays no longer trigger misleading scheduler failure or stale-run alerts.
  * Scheduler health now reports deferred automations and how long they have been waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->