### PR TITLE
fix(server): allow dry runs on paused feeds

### DIFF
--- a/packages/server/src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts
@@ -22,7 +22,10 @@ import {
   seedOwnerContext,
 } from '../setup/test-fixtures';
 
-async function seedFeed(slug: string): Promise<{
+async function seedFeed(
+  slug: string,
+  status: 'active' | 'paused' = 'active'
+): Promise<{
   feedId: number;
   ctx: Awaited<ReturnType<typeof seedOwnerContext>>['ctx'];
 }> {
@@ -49,7 +52,7 @@ async function seedFeed(slug: string): Promise<{
       (organization_id, connection_id, feed_key, status, checkpoint,
        created_at, updated_at)
     VALUES
-      (${org.id}, ${conn.id}, 'items', 'active', ${sql.json({ cursor: 'c0' })},
+      (${org.id}, ${conn.id}, 'items', ${status}, ${sql.json({ cursor: 'c0' })},
        NOW(), NOW())
     RETURNING id
   `) as Array<{ id: number }>;
@@ -75,6 +78,37 @@ describe('client.feeds.trigger dry_run', () => {
 
     expect(runs).toHaveLength(1);
     expect(runs[0].dry_run).toBe(true);
+  });
+
+  it('allows a dry run while the feed stays paused with its checkpoint intact', async () => {
+    const sql = getTestDb();
+    const { feedId, ctx } = await seedFeed('rss-sdk-paused-dry', 'paused');
+
+    const feeds = buildFeedsNamespace(ctx, {} as Env);
+    await feeds.trigger({ feed_id: feedId, dry_run: true });
+
+    const runs = (await sql`
+      SELECT dry_run FROM runs WHERE feed_id = ${feedId}
+    `) as Array<{ dry_run: boolean }>;
+    const feed = (await sql`
+      SELECT status, checkpoint FROM feeds WHERE id = ${feedId}
+    `) as Array<{ status: string; checkpoint: { cursor: string } }>;
+
+    expect(runs).toEqual([{ dry_run: true }]);
+    expect(feed).toEqual([{ status: 'paused', checkpoint: { cursor: 'c0' } }]);
+  });
+
+  it('still rejects a persistent trigger while the feed is paused', async () => {
+    const sql = getTestDb();
+    const { feedId, ctx } = await seedFeed('rss-sdk-paused-wet', 'paused');
+
+    const feeds = buildFeedsNamespace(ctx, {} as Env);
+    await expect(feeds.trigger({ feed_id: feedId })).rejects.toThrow(
+      'Feed is paused, must be active to trigger sync'
+    );
+
+    const runs = await sql`SELECT id FROM runs WHERE feed_id = ${feedId}`;
+    expect(runs).toHaveLength(0);
   });
 
   it('leaves the run persistent when dry_run is omitted', async () => {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -1039,11 +1039,14 @@ async function handleTriggerFeed(
   if (feed.kind !== 'collected') {
     return { error: `Feed is ${feed.kind}, only collected feeds can be triggered` };
   }
-  if (feed.status !== 'active') {
+  const dryRun = args.dry_run === true;
+  // A dry run is the safe validation lane for a paused feed: it executes the
+  // connector but leaves feed state, checkpoints, and collected data untouched.
+  // Persistent runs still require an active feed.
+  if (feed.status !== 'active' && !(dryRun && feed.status === 'paused')) {
     return { error: `Feed is ${feed.status}, must be active to trigger sync` };
   }
 
-  const dryRun = args.dry_run === true;
   const created = await createSyncRun(args.feed_id, env, undefined, { dryRun });
   if (!created.ok) {
     return { action: 'trigger_feed', message: describeSyncRunSkip(created.reason) };


### PR DESCRIPTION
## Summary

- Allow non-persistent connector dry-runs while a collected feed is paused.
- Keep persistent manual triggers restricted to active feeds.
- Cover paused-feed state, checkpoint preservation, and wet-run rejection.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun run test -- run src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts src/__tests__/integration/feed-dry-run-persists-nothing.test.ts`
- [x] Bug fix: production `client.feeds.trigger({ feed_id: 389, dry_run: true })` returned `Feed is paused, must be active to trigger sync`; focused suites pass 12/12 after the fix
- [ ] If bot runtime changed: not applicable

## Notes

No schema, SDK signature, scheduler, connector, or UI changes. `make review-fix` was attempted but its external Claude session was rate-limited and made no changes.
