### PR TITLE
Require human approval for MCP entity type creation

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1683,6 +1683,23 @@ export type ManageEntitySchemaResponses = {
       }
     | {
         schema_type: "entity_type";
+        action: "create";
+        status: "pending_approval";
+        run_id: number;
+        event_id: number;
+        approval_url?: string;
+        message: string;
+        proposal: {
+          schema_type: "entity_type";
+          action: "create";
+          args: {
+            [key: string]: unknown;
+          };
+        };
+        current: null;
+      }
+    | {
+        schema_type: "entity_type";
         action: "update";
         entity_type: {
           id: number;

--- a/packages/core/src/contracts/tools/manage-entity-schema.ts
+++ b/packages/core/src/contracts/tools/manage-entity-schema.ts
@@ -39,10 +39,10 @@ export const ManageEntitySchemaSchema = Type.Object({
       Type.Literal("get", { description: "Fetch one type by slug." }),
       Type.Literal("create", {
         description:
-          "Create an entity type or relationship type (queued for approval).",
+          "Create an entity type or relationship type. MCP ClientSDK entity-type creates are queued for human approval; direct owner/admin calls and relationship-type creates apply immediately.",
       }),
       Type.Literal("update", {
-        description: "Patch a type (queued for approval).",
+        description: "Patch a type.",
       }),
       Type.Literal("delete", {
         description: "Soft-delete a type; refuses if rows still reference it.",
@@ -329,6 +329,16 @@ export type RelationshipTypeRuleRow = Static<
   typeof RelationshipTypeRuleRowSchema
 >;
 
+/** Held MCP-authored entity-type create, persisted until a human decides it. */
+export const ManageEntitySchemaProposalSchema = Type.Object({
+  schema_type: Type.Literal("entity_type"),
+  action: Type.Literal("create"),
+  args: Type.Record(Type.String(), Type.Unknown()),
+});
+export type ManageEntitySchemaProposal = Static<
+  typeof ManageEntitySchemaProposalSchema
+>;
+
 /**
  * Result of `manage_entity_schema` — discriminated union keyed on
  * `schema_type` + `action`. TypeBox-first: `Static<>` derives the TS type from
@@ -368,6 +378,17 @@ export const ManageEntitySchemaResultSchema = Type.Union([
     schema_type: Type.Literal("entity_type"),
     action: Type.Literal("create"),
     entity_type: EntityTypeRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal("entity_type"),
+    action: Type.Literal("create"),
+    status: Type.Literal("pending_approval"),
+    run_id: Type.Integer(),
+    event_id: Type.Integer(),
+    approval_url: Type.Optional(Type.String()),
+    message: Type.String(),
+    proposal: ManageEntitySchemaProposalSchema,
+    current: Type.Null(),
   }),
   Type.Object({
     schema_type: Type.Literal("entity_type"),

--- a/packages/server/src/__tests__/integration/mcp/entity-schema-create-approval.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/entity-schema-create-approval.test.ts
@@ -1,0 +1,299 @@
+/**
+ * MCP entitySchema.createType approval lifecycle.
+ *
+ * This is intentionally a wire-level test for proposal creation: the caller
+ * enters through JSON-RPC tools/call -> run_sdk -> ClientSDK, which is the same
+ * path MCP Inspector and ChatGPT use. Approval resolution enters through the
+ * existing MCP App tools, proving the held proposal is applied only after a
+ * human owner uses the capability-bound confirmation surface.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { clearInMemoryMcpSessionsForTests } from "../../../mcp-handler";
+import {
+	addUserToOrganization,
+	createTestAccessToken,
+	createTestOAuthClient,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import { mcpRequest, mcpToolsCall } from "../../setup/test-helpers";
+import { TestApiClient } from "../../setup/test-mcp-client";
+
+type PendingCreate = {
+	schema_type: "entity_type";
+	action: "create";
+	status: "pending_approval";
+	run_id: number;
+	event_id: number;
+	approval_url: string;
+	proposal: {
+		schema_type: "entity_type";
+		action: "create";
+		args: Record<string, unknown>;
+	};
+	current: null;
+};
+
+describe("MCP entitySchema.createType approval", () => {
+	let org: Awaited<ReturnType<typeof createTestOrganization>>;
+	let owner: Awaited<ReturnType<typeof createTestUser>>;
+	let member: Awaited<ReturnType<typeof createTestUser>>;
+	let memberToken: string;
+	let ownerWriteToken: string;
+	let ownerAdminToken: string;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		clearInMemoryMcpSessionsForTests();
+
+		org = await createTestOrganization({
+			name: "Entity schema MCP approval",
+			slug: "entity-schema-mcp-approval",
+		});
+		owner = await createTestUser({ email: "entity-schema-owner@test.example.com" });
+		member = await createTestUser({ email: "entity-schema-member@test.example.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		await addUserToOrganization(member.id, org.id, "member");
+
+		const oauthClient = await createTestOAuthClient();
+		memberToken = (
+			await createTestAccessToken(member.id, org.id, oauthClient.client_id, {
+				scope: "mcp:read mcp:write profile:read",
+			})
+		).token;
+		ownerWriteToken = (
+			await createTestAccessToken(owner.id, org.id, oauthClient.client_id, {
+				scope: "mcp:read mcp:write profile:read",
+			})
+		).token;
+		ownerAdminToken = (
+			await createTestAccessToken(owner.id, org.id, oauthClient.client_id, {
+				scope: "mcp:read mcp:write mcp:admin profile:read",
+			})
+		).token;
+	});
+
+	async function entityTypeExists(slug: string): Promise<boolean> {
+		const rows = await getDb()`
+			SELECT 1 FROM entity_types
+			WHERE organization_id = ${org.id} AND slug = ${slug} AND deleted_at IS NULL
+		`;
+		return rows.length > 0;
+	}
+
+	async function propose(slug: string, token = memberToken): Promise<PendingCreate> {
+		const result = await mcpToolsCall<{
+			success: boolean;
+			return_value: PendingCreate;
+		}>(
+			"run_sdk",
+			{
+				script: `export default async (_ctx, client) => client.entitySchema.createType({ slug: ${JSON.stringify(slug)}, name: ${JSON.stringify(slug)} });`,
+			},
+			{ token, orgSlug: org.slug },
+		);
+		expect(result.success).toBe(true);
+		return result.return_value;
+	}
+
+	async function resolveInApp(
+		runId: number,
+		decision: "approve" | "reject",
+		token = ownerWriteToken,
+	) {
+		const viewResponse = await mcpRequest<any>(
+			"tools/call",
+			{
+				name: "get_approval",
+				arguments: { run_id: runId },
+			},
+			{ token, orgSlug: org.slug },
+		);
+		expect(viewResponse.result?.isError).not.toBe(true);
+		expect(viewResponse.result?.structuredContent?.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "approve", tool: "resolve_approval" }),
+				expect.objectContaining({ id: "reject", tool: "resolve_approval" }),
+				expect.objectContaining({ id: "review", href: expect.stringMatching(/^https?:\/\//) }),
+			]),
+		);
+		const capability = viewResponse.result?._meta?.["lobu/approval-capability"];
+		expect(typeof capability).toBe("string");
+
+		const response = await mcpRequest<any>(
+			"tools/call",
+			{
+				name: "resolve_approval",
+				arguments: {
+					run_id: runId,
+					decision,
+					_meta: { "lobu/approval-capability": capability },
+				},
+			},
+			{ token, orgSlug: org.slug },
+		);
+		return { response, capability };
+	}
+
+	it("keeps a direct human owner create immediate", async () => {
+		const client = await TestApiClient.for({
+			organizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		});
+		const result = (await client.entity_schema.createType({
+			slug: "direct-human-type",
+			name: "Direct human type",
+		})) as Record<string, unknown>;
+		expect(result.status).toBeUndefined();
+		expect(await entityTypeExists("direct-human-type")).toBe(true);
+
+		const directMember = await TestApiClient.for({
+			organizationId: org.id,
+			userId: member.id,
+			memberRole: "member",
+			scopes: ["mcp:read", "mcp:write"],
+		});
+		await expect(
+			directMember.entity_schema.createType({
+				slug: "direct-member-type",
+				name: "Direct member type",
+			}),
+		).rejects.toThrow(/admin or owner/i);
+		expect(await entityTypeExists("direct-member-type")).toBe(false);
+	});
+
+	it("lets an mcp:write member propose and applies only after embedded human approval", async () => {
+		const pending = await propose("member-proposed-type");
+		expect(pending).toMatchObject({
+			schema_type: "entity_type",
+			action: "create",
+			status: "pending_approval",
+			run_id: expect.any(Number),
+			event_id: expect.any(Number),
+			approval_url: expect.stringMatching(/^https?:\/\//),
+			proposal: {
+				schema_type: "entity_type",
+				action: "create",
+				args: { slug: "member-proposed-type", name: "member-proposed-type" },
+			},
+			current: null,
+		});
+		expect(await entityTypeExists("member-proposed-type")).toBe(false);
+
+		const [run] = await getDb()<
+			[{ approval_status: string; status: string; action_key: string; created_by_user_id: string }]
+		>`
+			SELECT approval_status, status, action_key, created_by_user_id
+			FROM runs WHERE id = ${pending.run_id} AND organization_id = ${org.id}
+		`;
+		expect(run).toEqual({
+			approval_status: "pending",
+			status: "pending",
+			action_key: "manage_entity_schema",
+			created_by_user_id: member.id,
+		});
+		const unauthorized = await resolveInApp(pending.run_id, "approve", memberToken);
+		expect(unauthorized.response.result?.isError).toBe(true);
+		expect(unauthorized.response.result?.content?.[0]?.text).toMatch(/admin or owner/i);
+		expect(await entityTypeExists("member-proposed-type")).toBe(false);
+
+		const { response: resolved } = await resolveInApp(pending.run_id, "approve");
+		expect(resolved.result?.isError).not.toBe(true);
+		expect(resolved.result?.structuredContent).toEqual(
+			expect.objectContaining({ actions: [], title: expect.stringMatching(/completed/i) }),
+		);
+		expect(await entityTypeExists("member-proposed-type")).toBe(true);
+
+		const [created] = await getDb()<[{ created_by: string }]>`
+			SELECT created_by FROM entity_types
+			WHERE organization_id = ${org.id} AND slug = 'member-proposed-type'
+		`;
+		expect(created.created_by).toBe(member.id);
+	});
+
+	it("queues even with mcp:admin, rejects without applying, and refuses replay", async () => {
+		const pending = await propose("admin-token-proposed-type", ownerAdminToken);
+		expect(pending.status).toBe("pending_approval");
+		expect(await entityTypeExists("admin-token-proposed-type")).toBe(false);
+
+		const { response: rejected, capability } = await resolveInApp(
+			pending.run_id,
+			"reject",
+			ownerAdminToken,
+		);
+		expect(rejected.result?.isError).not.toBe(true);
+		expect(rejected.result?.structuredContent?.title).toMatch(/rejected/i);
+		expect(await entityTypeExists("admin-token-proposed-type")).toBe(false);
+
+		const replay = await mcpRequest<any>(
+			"tools/call",
+			{
+				name: "resolve_approval",
+				arguments: {
+					run_id: pending.run_id,
+					decision: "reject",
+					_meta: { "lobu/approval-capability": capability },
+				},
+			},
+			{ token: ownerAdminToken, orgSlug: org.slug },
+		);
+		expect(replay.result?.isError).toBe(true);
+		expect(replay.result?.content?.[0]?.text).toMatch(/stale|pending/i);
+	});
+
+	it("keeps dry_run preview-only with no durable approval", async () => {
+		const [{ count: before }] = await getDb()<[{ count: number }]>`
+			SELECT count(*)::int AS count FROM runs
+			WHERE organization_id = ${org.id} AND action_key = 'manage_entity_schema'
+		`;
+		const result = await mcpToolsCall<Record<string, unknown>>(
+			"run_sdk",
+			{
+				dry_run: true,
+				script:
+					"export default async (_ctx, client) => client.entitySchema.createType({ slug: 'dry-run-type', name: 'Dry run type' });",
+			},
+			{ token: memberToken, orgSlug: org.slug },
+		);
+		expect(result.side_effect_preview).toEqual(expect.any(Array));
+		expect(await entityTypeExists("dry-run-type")).toBe(false);
+		const [{ count: after }] = await getDb()<[{ count: number }]>`
+			SELECT count(*)::int AS count FROM runs
+			WHERE organization_id = ${org.id} AND action_key = 'manage_entity_schema'
+		`;
+		expect(after).toBe(before);
+	});
+
+	it("fails a stale duplicate approval without creating another row", async () => {
+		const pending = await propose("stale-duplicate-type");
+		const direct = await TestApiClient.for({
+			organizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		});
+		await direct.entity_schema.createType({
+			slug: "stale-duplicate-type",
+			name: "Human won the race",
+		});
+
+		const { response: resolved } = await resolveInApp(pending.run_id, "approve");
+		expect(resolved.result?.isError).not.toBe(true);
+		expect(resolved.result?.structuredContent?.title).toMatch(/failed/i);
+		const [{ count }] = await getDb()<[{ count: number }]>`
+			SELECT count(*)::int AS count FROM entity_types
+			WHERE organization_id = ${org.id} AND slug = 'stale-duplicate-type'
+		`;
+		expect(count).toBe(1);
+		const [run] = await getDb()<[{ status: string; approval_status: string }]>`
+			SELECT status, approval_status FROM runs
+			WHERE id = ${pending.run_id} AND organization_id = ${org.id}
+		`;
+		expect(run).toEqual({ status: "failed", approval_status: "approved" });
+	});
+});

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -323,6 +323,10 @@ describe("method-metadata", () => {
 	});
 
 	it("documents destructive event-kind replacement and structured-event rendering", () => {
+		expect(METHOD_METADATA["entitySchema.createType"].access).toBe("write");
+		expect(METHOD_METADATA["entitySchema.createType"].summary).toContain(
+			"human approval",
+		);
 		expect(METHOD_METADATA["entitySchema.updateType"].summary).toContain(
 			"replaces the entire registry",
 		);

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -24,6 +24,7 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { Type } from "@sinclair/typebox";
 import {
+	getRequiredAccessLevel,
 	MEMBER_WRITE_ACTIONS,
 	OWNER_ADMIN_ACTIONS,
 	PUBLIC_READ_ACTIONS,
@@ -82,7 +83,7 @@ const NO_TOOL_ACTION = new Set([
  * namespace builder against a stub handler and recording the action payload it
  * receives.
  */
-const observed = new Map<string, string>();
+const observed = new Map<string, Record<string, unknown>>();
 
 /**
  * Build every tiered namespace against a stub handler and invoke each method so
@@ -101,9 +102,9 @@ const observed = new Map<string, string>();
 async function captureActionMap(): Promise<void> {
 	vi.resetModules();
 	let activePath: string | null = null;
-	const stub = async (payload: { action?: unknown }) => {
+	const stub = async (payload: Record<string, unknown>) => {
 		if (activePath && typeof payload.action === "string") {
-			observed.set(activePath, payload.action);
+			observed.set(activePath, payload);
 		}
 		return {};
 	};
@@ -169,12 +170,19 @@ beforeAll(captureActionMap);
  */
 function declaredRuntimeTier(
 	tool: string,
-	action: string,
+	payload: Record<string, unknown>,
 ): ToolAccessLevel | null {
-	if (OWNER_ADMIN_ACTIONS[tool]?.has(action)) return "admin";
-	if (MEMBER_WRITE_ACTIONS[tool]?.has(action)) return "write";
-	if (PUBLIC_READ_ACTIONS[tool]?.has(action)) return "read";
-	return null;
+	const action = payload.action;
+	if (typeof action !== "string") return null;
+	const isExplicitlyDeclared =
+		OWNER_ADMIN_ACTIONS[tool]?.has(action) ||
+		MEMBER_WRITE_ACTIONS[tool]?.has(action) ||
+		PUBLIC_READ_ACTIONS[tool]?.has(action);
+	if (!isExplicitlyDeclared) return null;
+	// Evaluate the real payload because a shared internal action can have a
+	// discriminator-specific tier (entity-type create proposes at write tier,
+	// while relationship-type create still mutates at admin tier).
+	return getRequiredAccessLevel(tool, payload, false);
 }
 
 describe("access-model cross-check", () => {
@@ -232,14 +240,15 @@ describe("access-model cross-check", () => {
 			// which the old camel→snake guess turned into `manage_feeds.list` — a
 			// key present in no tier map, so the method was skipped instead of
 			// checked.
-			const action = observed.get(path);
-			if (!action) {
+			const payload = observed.get(path);
+			if (!payload || typeof payload.action !== "string") {
 				mismatches.push(
 					`${path}: no action recorded — the SDK method is gone, renamed, or no longer routes through createActionCaller. Fix the wiring or add it to NO_TOOL_ACTION with a reason.`,
 				);
 				continue;
 			}
-			const runtimeTier = declaredRuntimeTier(tool, action);
+			const action = payload.action;
+			const runtimeTier = declaredRuntimeTier(tool, payload);
 			if (runtimeTier === null) {
 				mismatches.push(
 					`${path}: ${tool}.${action} is in no tier map and implicitly falls through to read; declare it explicitly in tool-access.ts`,
@@ -313,9 +322,9 @@ describe("access-model cross-check", () => {
 
 			const method = path.split(".")[1];
 			if (method === "manage") continue;
-			const action = observed.get(path);
+			const action = observed.get(path)?.action;
 			expect(action, `${path} dispatched no recorded action`).toBeDefined();
-			if (!action) continue;
+			if (typeof action !== "string") continue;
 			if (isRead) {
 				expect(
 					readAgentActions?.has(action),

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -609,10 +609,26 @@ describe('checkToolAccess', () => {
     ).not.toThrow();
   });
 
-  it('keeps genuinely admin-only actions admin-tier (manage_entity_schema create)', () => {
+  it('makes only entity-type create proposals write-tier', () => {
     // Opening query_sql to read-tier must not have widened the real admin
-    // actions — these go through SDK wrappers / action-router, gated by policy.
+    // actions. The inner action-router receives no schema discriminator and
+    // keeps direct creates admin-only; relationship-type creates also remain
+    // admin because they still mutate immediately.
     expect(requiresOwnerAdmin('manage_entity_schema', { action: 'create' }, false)).toBe(true);
+    expect(
+      getRequiredAccessLevel(
+        'manage_entity_schema',
+        { action: 'create', schema_type: 'entity_type' },
+        false
+      )
+    ).toBe('write');
+    expect(
+      getRequiredAccessLevel(
+        'manage_entity_schema',
+        { action: 'create', schema_type: 'relationship_type' },
+        false
+      )
+    ).toBe('admin');
   });
 
   it('returns the exact access tier that was authorized', () => {
@@ -625,6 +641,13 @@ describe('checkToolAccess', () => {
     expect(checkToolAccess('manage_entity_schema', { action: 'list' }, owner)).toBe('read');
     expect(checkToolAccess('save_memory', {}, owner)).toBe('write');
     expect(checkToolAccess('manage_entity_schema', { action: 'create' }, owner)).toBe('admin');
+    expect(
+      checkToolAccess(
+        'manage_entity_schema',
+        { action: 'create', schema_type: 'entity_type' },
+        owner
+      )
+    ).toBe('write');
   });
 });
 

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -231,6 +231,21 @@ function actionMatches(
 	return !!action && allowedActions.has(action);
 }
 
+/**
+ * Entity-type creation is write-visible because an MCP call only creates an
+ * approval proposal. Relationship-type creation shares the same internal
+ * `create` action but still mutates immediately and therefore remains admin.
+ * The handler's inner action gate receives only `{ action }`, so direct
+ * browser/CLI calls continue through the canonical admin check.
+ */
+function isEntityTypeCreateProposal(toolName: string, args: unknown): boolean {
+	if (toolName !== "manage_entity_schema" || !args || typeof args !== "object") {
+		return false;
+	}
+	const input = args as { action?: unknown; schema_type?: unknown };
+	return input.action === "create" && input.schema_type === "entity_type";
+}
+
 export function requiresMemberWrite(
 	toolName: string,
 	args: unknown,
@@ -264,6 +279,7 @@ export function getRequiredAccessLevel(
 	readOnlyHint: boolean
 ): ToolAccessLevel {
 	if (toolName === "list_organizations") return "read";
+	if (isEntityTypeCreateProposal(toolName, args)) return "write";
 	if (requiresOwnerAdmin(toolName, args, readOnlyHint)) return "admin";
 	if (requiresMemberWrite(toolName, args, readOnlyHint)) return "write";
 	return "read";

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -216,8 +216,8 @@ export default async (_ctx, client) => {
 	},
 	"entitySchema.createType": {
 		summary:
-			"Create an entity type. The metadata shape goes in `metadata_schema` (a JSON Schema), NOT `properties` — a top-level `properties` key is silently ignored.",
-		access: "admin",
+			"Propose an entity type for human approval. Returns a run_id for `get_approval` plus an approval_url. The metadata shape goes in `metadata_schema` (a JSON Schema), NOT top-level `properties`.",
+		access: "write",
 		example:
 			"await client.entitySchema.createType({ slug: 'widget', name: 'Widget', metadata_schema: { type: 'object', properties: { color: { type: 'string' } } } });",
 	},

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -11,14 +11,17 @@
 import {
   ManageEntitySchemaResultSchema,
   ManageEntitySchemaSchema,
+  ManageEntitySchemaProposalSchema,
   type AuditEntry,
   type EntityTypeRow,
   type ManageEntitySchemaArgs,
+  type ManageEntitySchemaProposal,
   type ManageEntitySchemaResult,
   type RelationshipTypeRow,
   type RelationshipTypeRuleRow,
   type ViewTemplateTab,
 } from '@lobu/core/contracts/tools/manage-entity-schema';
+import { Value } from '@sinclair/typebox/value';
 import { validateEntityMetrics } from '@lobu/connector-sdk';
 import {
   isPlatformEventType,
@@ -26,7 +29,13 @@ import {
 } from '../../automations/platform-event-catalog';
 import { compileEntityRule } from '../../authz/entity-rule-executor';
 import { type DbClient, getDb } from '../../db/client';
+import {
+  currentMcpActivityAttribution,
+  currentMcpActivityEventMetadata,
+} from '../../lobu/stores/mcp-client-conversations';
 import { validateMetricReadModes } from '../../metrics/read-mode';
+import { resolveActionOrigin } from '../../notifications/action-origin';
+import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { recordToolConfigChange } from './helpers/config-audit';
 import {
   type DataSourceContext,
@@ -41,6 +50,7 @@ import {
 import { measureColumns } from '../../utils/infer-measures';
 import type { Env } from '../../index';
 import logger from '../../utils/logger';
+import { insertEvent } from '../../utils/insert-event';
 import { ensureMemberEntityType } from '../../utils/member-entity-type';
 import {
   countEntitiesOfType,
@@ -55,11 +65,21 @@ import {
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { ToolUserError } from '../../utils/errors';
 import { isUniqueViolation } from '../../utils/pg-errors';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import type { ToolContext } from '../registry';
+import { enforceRoleScopeAccess } from '../access-control';
+import { resolveRunInitiator } from '../initiator';
 import { withValidatedArgs } from '../validate-args';
+import { getOrgUrlContext } from '../view-urls';
+import { resolveApprovalChatOrigin } from './approval-delivery';
 import { defineFlatActionTool, flatAction } from './action-tool';
 
 export { ManageEntitySchemaResultSchema, ManageEntitySchemaSchema };
+
+/** `runs.action_key` for an MCP-authored entity-type create held for approval. */
+export const MANAGE_ENTITY_SCHEMA_ACTION_KEY = 'manage_entity_schema';
+
+export type { ManageEntitySchemaProposal };
 
 // ============================================
 // Main Function (Action Router)
@@ -112,9 +132,172 @@ async function manageEntitySchemaImpl(
 		);
 	}
   if (args.schema_type === 'entity_type') {
+    // MCP clients propose entity-type creation; they never apply it inline.
+    // Direct browser/CLI calls carry no MCP transport identity and retain the
+    // existing owner/admin route below.
+    if (args.action === 'create' && ctx.mcpSessionId) {
+      return queueEntityTypeCreateForApproval(args, ctx);
+    }
     return runEntityTypeActions(args, env, ctx);
   }
   return runRelationshipTypeActions(args, env, ctx);
+}
+
+/** Validate the durable proposal shape before the approval registry claims it. */
+export function isManageEntitySchemaProposal(
+  value: unknown
+): value is ManageEntitySchemaProposal {
+  if (!Value.Check(ManageEntitySchemaProposalSchema, value)) return false;
+  const proposal = value as ManageEntitySchemaProposal;
+  return (
+    proposal.schema_type === 'entity_type' &&
+    proposal.action === 'create' &&
+    Value.Check(ManageEntitySchemaSchema, proposal.args) &&
+    proposal.args.schema_type === 'entity_type' &&
+    proposal.args.action === 'create'
+  );
+}
+
+/**
+ * Apply a held MCP entity-type proposal after manage_operations has verified a
+ * human owner/admin. The original proposer remains the row/audit author.
+ */
+export async function applyManageEntitySchemaProposal(
+  proposal: ManageEntitySchemaProposal,
+  ctx: ToolContext,
+  _env: Env,
+  requesterUserId: string | null
+): Promise<ManageEntitySchemaResult> {
+  if (!isManageEntitySchemaProposal(proposal)) {
+    throw new ToolUserError('Invalid manage_entity_schema approval proposal', 400);
+  }
+  return etHandleCreate(proposal.args as ManageEntitySchemaArgs, {
+    ...ctx,
+    userId: requesterUserId,
+  });
+}
+
+async function queueEntityTypeCreateForApproval(
+  args: ManageEntitySchemaArgs,
+  ctx: ToolContext
+): Promise<ManageEntitySchemaResult> {
+  if (!ctx.userId) {
+    throw new ToolUserError(
+      'Entity type proposals require an authenticated workspace member',
+      401
+    );
+  }
+  enforceRoleScopeAccess('write', ctx.memberRole, ctx.scopes, {
+    adminRole: 'Entity type proposals require workspace membership.',
+    writeRole: 'Entity type proposals require workspace membership with write access.',
+    readScope: 'Entity type proposals require an MCP session with read access.',
+    writeScope: 'Entity type proposals require an MCP session with write access.',
+    adminScope: 'Entity type proposals require an MCP session with admin access.',
+  });
+
+  // Reject malformed, reserved, duplicate, or uncompilable proposals before a
+  // durable card is created. Approval repeats the same validation against the
+  // then-current database state.
+  const prepared = await prepareEntityTypeCreate(args, ctx);
+  const proposal: ManageEntitySchemaProposal = {
+    schema_type: 'entity_type',
+    action: 'create',
+    args: { ...args, slug: prepared.slug },
+  };
+  const initiator = resolveRunInitiator(ctx);
+  const label = `create entity type ${prepared.slug}`;
+  const sql = getDb();
+  const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+
+  const { runId, eventId } = await sql.begin(async (tx) => {
+    const inserted = await tx`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, action_input,
+        created_by_user_id, initiator_kind, initiator_ref,
+        approval_status, status, created_at
+      ) VALUES (
+        ${ctx.organizationId}, 'internal', ${MANAGE_ENTITY_SCHEMA_ACTION_KEY},
+        ${tx.json(proposal as unknown as Record<string, unknown>)},
+        ${initiator.createdByUserId},
+        ${initiator.initiatorKind},
+        ${tx.json(initiator.initiatorRef)},
+        'pending', 'pending', current_timestamp
+      )
+      RETURNING id
+    `;
+    const runId = Number((inserted[0] as { id: unknown }).id);
+    const event = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: ctx.organizationId,
+        originId: `run_${runId}_pending`,
+        title: `${label} — pending approval`,
+        content: `MCP client requested: ${label}`,
+        semanticType: 'operation',
+        runId,
+        interactionType: 'approval',
+        interactionStatus: 'pending',
+        interactionInput: proposal as unknown as Record<string, unknown>,
+        metadata: {
+          tool: 'manage_entity_schema',
+          action_key: MANAGE_ENTITY_SCHEMA_ACTION_KEY,
+          schema_type: 'entity_type',
+          action: 'create',
+          slug: prepared.slug,
+          proposal,
+          current: null,
+          initiator: {
+            kind: initiator.initiatorKind,
+            ...initiator.initiatorRef,
+          },
+          status: 'pending_approval',
+          ...currentMcpActivityEventMetadata(ctx),
+        },
+        authorName: ctx.clientId ?? 'MCP client',
+        clientId: ctx.tokenType === 'oauth' ? (ctx.clientId ?? null) : null,
+      },
+      { sql: tx }
+    );
+    return { runId, eventId: Number(event.id) };
+  });
+
+  const approvalUrl = buildResourcePermalink(
+    ownerSlug,
+    { kind: 'run', runId },
+    baseUrl
+  );
+  const chatOrigin = await resolveApprovalChatOrigin(ctx);
+  const actionOrigin = await resolveActionOrigin(ctx);
+  notifyActionApprovalNeeded({
+    orgId: ctx.organizationId,
+    runId,
+    actionKey: MANAGE_ENTITY_SCHEMA_ACTION_KEY,
+    connectionName: label,
+    eventId,
+    approvalUrl,
+    connectionId: chatOrigin.connectionId,
+    channelId: chatOrigin.channelId,
+    teamId: chatOrigin.teamId,
+    requesterUserId: ctx.userId,
+    mcpActivity: currentMcpActivityAttribution(ctx),
+    actionOrigin,
+  }).catch((error) =>
+    logger.error(error, 'Failed to send entity type approval notification')
+  );
+
+  return {
+    schema_type: 'entity_type',
+    action: 'create',
+    status: 'pending_approval',
+    run_id: runId,
+    event_id: eventId,
+    ...(approvalUrl ? { approval_url: approvalUrl } : {}),
+    message: approvalUrl
+      ? `Entity type '${prepared.slug}' is queued for human approval. Call get_approval with run_id ${runId} to show the embedded confirmation, or give the user approval_url.`
+      : `Entity type '${prepared.slug}' is queued for human approval. Call get_approval with run_id ${runId} to show the embedded confirmation.`,
+    proposal,
+    current: null,
+  };
 }
 
 // ============================================
@@ -505,10 +688,16 @@ async function etHandleGet(
   return { schema_type: 'entity_type', action: 'get', entity_type: mapped };
 }
 
-async function etHandleCreate(
+interface PreparedEntityTypeCreate {
+  slug: string;
+  rulesCompiled: string | null;
+}
+
+/** Validate an entity-type create without mutating durable state. */
+async function prepareEntityTypeCreate(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
-): Promise<ManageEntitySchemaResult> {
+): Promise<PreparedEntityTypeCreate> {
   if (!args.slug) throw new ToolUserError('slug is required for create action', 400);
   if (!args.name) throw new ToolUserError('name is required for create action', 400);
   if (!ctx.userId) throw new ToolUserError('Authentication required to create entity types', 401);
@@ -546,13 +735,21 @@ async function etHandleCreate(
   // a derived type are classified ON READ (see etHandleGet), never persisted.
   assertValidMetricsConfig(args.metrics_config);
   assertEventKindsAvoidPlatformVocabulary(args.event_kinds);
+  // Compile during validation so malformed rules never become approval cards;
+  // apply-time validation repeats the check against the current proposal.
+  const rulesCompiled = await compileRulesOrThrow(args.rules_source ?? null);
+  return { slug, rulesCompiled };
+}
+
+async function etHandleCreate(
+  args: ManageEntitySchemaArgs,
+  ctx: ToolContext
+): Promise<ManageEntitySchemaResult> {
+  const { slug, rulesCompiled } = await prepareEntityTypeCreate(args, ctx);
+  const sql = getDb();
   const metadataSchema = args.metadata_schema ? sql.json(args.metadata_schema) : null;
   const eventKinds = args.event_kinds ? sql.json(args.event_kinds) : null;
   const metricsConfig = args.metrics_config ? sql.json(args.metrics_config) : null;
-  // Compile here, at apply time, so the WRITE path never invokes esbuild. A rule
-  // that does not compile is rejected now rather than failing closed on every
-  // write later, when the author is nowhere near the error.
-  const rulesCompiled = await compileRulesOrThrow(args.rules_source ?? null);
 
   let inserted: unknown[];
   try {

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -52,6 +52,12 @@ import {
 	MANAGE_AUTOMATIONS_ACTION_KEY,
 	type ManageAutomationsProposal,
 } from "../../manage_automations";
+import {
+	applyManageEntitySchemaProposal,
+	isManageEntitySchemaProposal,
+	MANAGE_ENTITY_SCHEMA_ACTION_KEY,
+	type ManageEntitySchemaProposal,
+} from "../../manage_entity_schema";
 import { executeOperationInline } from "./execute";
 import { qualifiedOperationKey } from "./shared";
 /**
@@ -291,6 +297,22 @@ function getBuilderApprovalHandlers(): BuilderApprovalHandler[] {
 				),
 			describe: (p) => (p as ManageAutomationsProposal).args.action,
 			detectSoftFailure: detectManageAutomationsApplyFailure,
+		},
+		{
+			actionKey: MANAGE_ENTITY_SCHEMA_ACTION_KEY,
+			nounLabel: "Entity type",
+			isValidProposal: isManageEntitySchemaProposal,
+			apply: (p, ctx, env, owner) =>
+				applyManageEntitySchemaProposal(
+					p as ManageEntitySchemaProposal,
+					ctx,
+					env,
+					owner,
+				),
+			describe: (p) => {
+				const proposal = p as ManageEntitySchemaProposal;
+				return `${proposal.action} ${String(proposal.args.slug)}`;
+			},
 		},
 		{
 			// An agent-authored ask. Unlike the builder families there is no held


### PR DESCRIPTION
## Summary
- Let authenticated organization members with `mcp:write` propose `entitySchema.createType`.
- Queue every MCP create for owner/admin approval, including calls made with `mcp:admin`; no entity type exists before approval.
- Return a durable `run_id`, embedded `get_approval` action, and browser `approval_url`; keep dry-run preview-only and direct browser/CLI behavior unchanged.

## Test plan
- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: focused MCP approval, MCP App resource, approval regression, and metadata suites
- [x] Bug fix: red showed member proposals rejected and admin calls mutating immediately; green is 5/5 entity approval wire tests
- [ ] If bot runtime changed: not applicable

Additional verification:
- `make pre-pr` clean
- MCP Inspector dry-run returned one skipped write and no mutation
- MCP Inspector live call returned pending approval and no entity before approval
- Browser approval URL showed the proposal; owner confirmation completed the run; Inspector query then returned the entity
- Embedded approval callback approve/reject/replay paths covered by wire-level integration tests

## Notes
- No database migration or new endpoint.
- Scope is create-type only; update, delete, relationship types, and configurable approval policy are follow-ups.
- ChatGPT Pro verification requires a publicly reachable preview and is not claimed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity-type creation requests submitted through MCP are now queued for human approval.
  * Approval responses include proposal details, status, run information, and an approval link when available.
  * Approved proposals create the entity type with appropriate attribution.
  * Rejected, duplicate, expired, or invalid proposals are handled safely with clear outcomes.
  * Dry-run requests provide a preview without creating data.

* **Access Control**
  * Entity-type proposals require write access, while direct and relationship-type changes retain their existing permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->