### PR TITLE
feat(lobu-team): manage engineering task dogfood runner

### DIFF
--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -9,7 +9,56 @@ describe("Lobu Team configuration", () => {
       "lobu-team-lunch-open",
       "lobu-team-lunch-finalize",
       "product-activity-digest",
+      "engineering-task-runner-dogfood-35364",
     ]);
+  });
+
+  test("owns the engineering task schema and runner configuration", () => {
+    const task = config.entities?.find(
+      (entity) => entity.key === "engineering-task"
+    );
+    expect(task).toMatchObject({
+      name: "Engineering Task",
+      eventKinds: {
+        "engineering-task.checkpoint": expect.any(Object),
+        "engineering-task.decision": expect.any(Object),
+        "engineering-task.verification_completed": expect.any(Object),
+        "engineering-task.review_completed": expect.any(Object),
+      },
+    });
+
+    const target = config.relationships?.find(
+      (relationship) => relationship.key === "targets_repository"
+    );
+    expect(target?.rules).toEqual([
+      {
+        source: expect.objectContaining({ key: "engineering-task" }),
+        target: "$resource",
+      },
+    ]);
+
+    const runner = config.automations?.find(
+      (automation) =>
+        automation.slug === "engineering-task-runner-dogfood-35364"
+    );
+    expect(runner).toMatchObject({
+      agent: "developer",
+      triggers: [],
+      deviceWorkerId: "66af4f1d-13c5-4d2d-b848-5b6b5dde7b63",
+      agentKind: "opencode",
+      tags: ["engineering-task", "dogfood"],
+    });
+    expect(runner?.prompt).toContain("entity_id: 35364");
+    expect(runner?.prompt).toContain("Never edit a shared checkout");
+    expect(runner?.prompt).toContain("engineering-task.checkpoint");
+
+    expect(config.agents.find((agent) => agent.id === "developer")).toEqual({
+      kind: "agent",
+      id: "developer",
+      name: "Developer",
+      description:
+        "A software development agent for Lobu repositories that works in the team Vercel sandbox, runs checks, creates pull requests, reviews previews, and coordinates approved merges.",
+    });
   });
 
   test("uses one hosted Slack declaration for the whole team", () => {

--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -48,6 +48,9 @@ describe("Lobu Team configuration", () => {
       agentKind: "opencode",
       tags: ["engineering-task", "dogfood"],
     });
+    expect(runner?.sources?.task_history).toContain(
+      "entity_ids @> ARRAY[35364]::bigint[]"
+    );
     expect(runner?.prompt).toContain("entity_id: 35364");
     expect(runner?.prompt).toContain("Never edit a shared checkout");
     expect(runner?.prompt).toContain("engineering-task.checkpoint");

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -7,6 +7,7 @@ import {
   defineConfig,
   defineConnection,
   defineEntityType,
+  defineRelationshipType,
   defineSkill,
   reactionFromFile,
   secret,
@@ -117,6 +118,69 @@ const lunchRun = defineEntityType({
   },
 });
 
+const engineeringTask = defineEntityType({
+  key: "engineering-task",
+  name: "Engineering Task",
+  description:
+    "A durable unit of engineering work coordinated by Lobu agents and linked to code changes.",
+  properties: {
+    branch: Type.Optional(Type.String()),
+    source: Type.Optional(Type.String()),
+    status: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: [
+          "open",
+          "implementing",
+          "review",
+          "verification",
+          "merged",
+          "done",
+          "blocked",
+        ],
+      })
+    ),
+    github_pr: Type.Optional(Type.Integer()),
+    repository: Type.Optional(Type.String()),
+    github_issue: Type.Optional(Type.Integer()),
+    verification_level: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["none", "tests", "e2e", "ui", "production"],
+      })
+    ),
+    verification_status: Type.Optional(
+      Type.Unsafe({
+        type: "string",
+        enum: ["pending", "passed", "failed"],
+      })
+    ),
+    verification_required: Type.Optional(Type.Boolean()),
+  },
+  eventKinds: {
+    "engineering-task.checkpoint": {
+      description:
+        "Durable implementation checkpoint with status, branch, PR, tests, verification, and blockers",
+    },
+    "engineering-task.decision": {
+      description: "Durable engineering decision and rationale",
+    },
+    "engineering-task.verification_completed": {
+      description: "Completed test or environment verification evidence",
+    },
+    "engineering-task.review_completed": {
+      description: "Completed code review outcome and remaining findings",
+    },
+  },
+});
+
+const targetsRepository = defineRelationshipType({
+  key: "targets_repository",
+  name: "Targets Repository",
+  description: "Engineering task targets a code repository resource.",
+  rules: [{ source: engineeringTask, target: "$resource" }],
+});
+
 // The office's Deliveroo connection. Feedless — it exposes only on-demand
 // actions (search_restaurants / read_menu) that the lobu-team-lunch-finalize reaction
 // drives through the paired Owletto Chrome extension. `restaurants_url` is the
@@ -160,6 +224,44 @@ const lunchFinalize = defineAutomation({
   // No inline schema: the reaction reads the run's outcome straight off the
   // `lunch-run` entity this prompt updates (status "done" + restaurant), so the
   // handoff contract is the entity, not an Automation-authored payload.
+});
+
+// This declaration owns only the existing agent's metadata. Model, tools,
+// skills, and sandbox settings remain unmanaged because they are omitted.
+const developer = defineAgent({
+  id: "developer",
+  name: "Developer",
+  description:
+    "A software development agent for Lobu repositories that works in the team Vercel sandbox, runs checks, creates pull requests, reviews previews, and coordinates approved merges.",
+});
+
+// Dogfood task 35364 is deliberately project-owned. The worker and local coding
+// agent are selected here, not embedded in Lobu's shared runtime. Change
+// `agentKind` to another daemon-supported CLI when switching agents.
+const engineeringTaskRunner = defineAutomation({
+  agent: "developer",
+  slug: "engineering-task-runner-dogfood-35364",
+  name: "Engineering Task Runner Dogfood 35364",
+  triggers: [],
+  tags: ["engineering-task", "dogfood"],
+  deviceWorkerId: "66af4f1d-13c5-4d2d-b848-5b6b5dde7b63",
+  agentKind: "opencode",
+  sources: {
+    task_history: `SELECT id, semantic_type, occurred_at, payload_text, metadata
+      FROM events
+      WHERE 35364 = ANY(entity_ids)
+      ORDER BY occurred_at DESC
+      LIMIT 100`,
+  },
+  prompt: `Continue engineering task 35364.
+
+Before editing, read the task with client.entities.get({ entity_id: 35364 }) and its durable history with client.knowledge.read({ entity_id: 35364, limit: 100 }). The task metadata repository is authoritative.
+
+Never edit a shared checkout. Work only in a workspace owned by task 35364. If no isolated task workspace is available, another writer is active, or a required environment change needs approval, stop without editing and save a blocked checkpoint.
+
+Before completing the Automation run, append engineering-task.checkpoint linked to entity 35364 with the current status, workspace, branch, PR, tests, verification, and blockers. Persist important rationale as engineering-task.decision, test evidence as engineering-task.verification_completed, and review results as engineering-task.review_completed. Update the task metadata when its current status, branch, PR, or verification state changes.
+
+Use the existing GitHub connector and approval flow. Never bypass an approval or merge without the required review and verification evidence.`,
 });
 
 const productOps = defineAgent({
@@ -373,14 +475,20 @@ export default defineConfig({
   orgName: "Lobu Team",
   orgDescription: "Lobu Team agents and internal operations",
   organizationId: "UdNAH1bb3csC842vhOgxAHVcfX4tYU5A",
-  agents: [foodOrdering, productOps],
+  agents: [foodOrdering, developer, productOps],
   authProfiles: [productActivityDbAuth, productionLogsAuth],
-  entities: [lunchRun],
+  entities: [lunchRun, engineeringTask],
+  relationships: [targetsRepository],
   connections: [
     deliverooConn,
     productActivityDb,
     productionLogs,
     lobuTeamSlack,
   ],
-  automations: [lunchOpen, lunchFinalize, productActivityDigest],
+  automations: [
+    lunchOpen,
+    lunchFinalize,
+    productActivityDigest,
+    engineeringTaskRunner,
+  ],
 });

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -226,8 +226,9 @@ const lunchFinalize = defineAutomation({
   // handoff contract is the entity, not an Automation-authored payload.
 });
 
-// This declaration owns only the existing agent's metadata. Model, tools,
-// skills, and sandbox settings remain unmanaged because they are omitted.
+// This declaration owns only the existing agent's metadata. `lobu apply`
+// diffs a settings field only when the config declares it, so the live model,
+// tools, and skills stay unmanaged here.
 const developer = defineAgent({
   id: "developer",
   name: "Developer",
@@ -249,7 +250,7 @@ const engineeringTaskRunner = defineAutomation({
   sources: {
     task_history: `SELECT id, semantic_type, occurred_at, payload_text, metadata
       FROM events
-      WHERE 35364 = ANY(entity_ids)
+      WHERE entity_ids @> ARRAY[35364]::bigint[]
       ORDER BY occurred_at DESC
       LIMIT 100`,
   },


### PR DESCRIPTION
This replaces the closed over-scoped PR with an example-only change.

What changed:
- declares the engineering-task schema and durable checkpoint event kinds in examples/lobu-team
- declares targets_repository from engineering-task to $resource
- manages the existing developer agent metadata and task 35364 Automation, including the Mac mini worker and interchangeable agent_kind
- adds config regression coverage

Live verification:
- cross-workspace admin mutation through client.org("lobu-team") succeeded
- Automation 133 is still attached to task 35364 and is now version 2
- the task-only history source and targets_repository rule were read back successfully
- a fresh cloud apply dry-run reports engineering-task, targets_repository, developer, and the runner as no-ops

Checks:
- bun test examples/lobu-team: 22 pass
- lobu validate: pass
- bun run check: pass
- bun run typecheck: pass
- make pre-pr: pass

Known gap:
- the config Automation API cannot declare entity_id, so a deleted/recreated runner would be global even though updates preserve the existing attachment. That needs a separate public API design slice.
- the full Lobu Team config has unrelated existing drift, so it was not applied wholesale.