### PR TITLE
chore: remove personal defaults from shared tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  make pr-fast                                - Optional: broad Linux merge jobs (Daytona sandbox, else local)"
 	@echo "  make pr-full [REMOTE_JOBS='unit …']        - Optional: full Linux CI (Daytona sandbox, else local)"
 	@echo "  make owletto-mac [INSTALL=1] [OPEN=1]      - Build Owletto.app with the Developer ID identity (TCC grants match the notarized release); INSTALL=1 replaces /Applications/Owletto.app, OPEN=1 launches it"
-	@echo "  make owletto-mac-e2e [SKIP_BUILD=1]        - Build/install the signed Owletto.app then probe prod computer_use (permissions + list_windows) via the paired device connection"
+	@echo "  make owletto-mac-e2e ORG=<slug> CONN_ID=<id> [SKIP_BUILD=1] - Build/install the signed Owletto.app then probe prod computer_use (permissions + list_windows) via the paired device connection"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -125,7 +125,7 @@ owletto-mac:
 # paired device connection (permissions + list_windows). SKIP_BUILD=1 reuses the
 # already-installed /Applications/Owletto.app. See scripts/owletto-mac-e2e.sh.
 owletto-mac-e2e:
-	@SKIP_BUILD="$(SKIP_BUILD)" ./scripts/owletto-mac-e2e.sh
+	@SKIP_BUILD="$(SKIP_BUILD)" ORG="$(ORG)" CONN_ID="$(CONN_ID)" ./scripts/owletto-mac-e2e.sh
 
 # Reap task worktrees whose PR is already merged (worktree + branches + dev DB
 # + Lobu context). Dry-run by default — prints what it would remove; pass

--- a/docs/BROWSER_TESTING.md
+++ b/docs/BROWSER_TESTING.md
@@ -48,10 +48,10 @@ Cookie name is `__Secure-better-auth.session_token` whenever the baseURL is `htt
 
 ## Find the Chrome connection
 
-Browser actions dispatch to a paired Chrome extension connection (usually org `buremba`):
+Browser actions dispatch to a paired Chrome extension connection. Pass the organization slug explicitly:
 
 ```bash
-lobu call manage_connections --org buremba --arg action=list --raw
+lobu call manage_connections --org <org-slug> --arg action=list --raw
 ```
 
 Pick the `chrome` connector with `status: active` on the machine whose browser you want to drive. `operations.listAvailable({ connection_id })` reports per-target `readiness` and `execution_targets` — use it to check the device is actually online before a long verification.
@@ -128,7 +128,7 @@ for (const d of ['', '; domain=app.lobu.ai', '; domain=.lobu.ai'])
 For one-off actions, `lobu call manage_operations` is quicker:
 
 ```bash
-lobu call manage_operations --org buremba --arg action=execute \
+lobu call manage_operations --org <org-slug> --arg action=execute \
   --arg connection_id=<chrome-connection-id> --arg operation_key=navigate \
   --arg input:='{"url":"https://app.lobu.ai/<path>","wait_for_load":true,"open_in_new_tab":true}' --raw
 ```

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -3,8 +3,6 @@
  * mounted at `POST /api/:orgSlug/:toolName`. Companion to `lobu call --list`
  * (`GET /api/:orgSlug/tools`).
  *
- * Design ref: `/Users/burakemre/.claude/plans/lobu-call-dispatcher.md`.
- *
  * Argument shapes (mutually exclusive):
  *   --input-file <path>     JSON object read from disk
  *   stdin                   JSON object piped on stdin (when stdin is not a TTY)

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -1809,7 +1809,7 @@ const accountTimelineConfigSchema = {
 			type: "string",
 			minLength: 1,
 			description:
-				'Optional X handle (e.g. "buremba"). Defaults to the authenticated account when OAuth is available.',
+				'Optional X handle (e.g. "example_account"). Defaults to the authenticated account when OAuth is available.',
 		},
 		...scrollBudgetProperties,
 		...backendPreferenceProperties,
@@ -1823,7 +1823,7 @@ const bookmarksConfigSchema = {
 			type: "string",
 			minLength: 1,
 			description:
-				'Optional X handle (e.g. "buremba") for DM counterparty resolution when the viewer id is unavailable.',
+				'Optional X handle (e.g. "example_account") for DM counterparty resolution when the viewer id is unavailable.',
 		},
 		account_user_id: {
 			type: "string",

--- a/scripts/lobu/install-connectors.ts
+++ b/scripts/lobu/install-connectors.ts
@@ -7,7 +7,7 @@
  * null-byte limitation in postgres text columns.
  *
  * Usage:
- *   pnpm tsx --env-file=.env scripts/lobu/install-connectors.ts --org buremba --file examples/personal-agent/spotify.connector.ts
+ *   bun --env-file=.env scripts/lobu/install-connectors.ts --org <slug> --file examples/personal-agent/spotify.connector.ts
  */
 
 import { basename, resolve } from 'node:path';
@@ -30,7 +30,7 @@ if (values.help || !values.org || !values.file?.length) {
 Install or refresh connector(s) in an organization.
 
 Usage:
-  pnpm tsx --env-file=.env scripts/lobu/install-connectors.ts --org <slug> --file <path-to-connector.ts>...
+  bun --env-file=.env scripts/lobu/install-connectors.ts --org <slug> --file <path-to-connector.ts>...
 
 Options:
   --org                      Organization slug (required)

--- a/scripts/owletto-mac-e2e.sh
+++ b/scripts/owletto-mac-e2e.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # Build/install Owletto (Developer ID) and probe prod computer_use.
+# Usage: ORG=example-org CONN_ID=123 scripts/owletto-mac-e2e.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ORG="${ORG:-buremba}"
 CONTEXT="${CONTEXT:-lobu}"
-CONN_ID="${CONN_ID:-397}"
+: "${ORG:?Set ORG to the organization slug to test}"
+: "${CONN_ID:?Set CONN_ID to the Owletto connection ID to test}"
+# CONN_ID is interpolated into the `lobu memory exec` script body below, so it
+# must be a bare integer literal rather than arbitrary text.
+[[ "$CONN_ID" =~ ^[0-9]+$ ]] || { echo "error: CONN_ID must be numeric (got '$CONN_ID')" >&2; exit 1; }
 
 cd "$ROOT"
 git -c submodule.recurse=false pull --ff-only origin main

--- a/scripts/sync-owletto-submodule.sh
+++ b/scripts/sync-owletto-submodule.sh
@@ -28,7 +28,7 @@ Refusing to overwrite them. Options:
     for owletto development.
   • Discard owletto-only edits and continue:
     RESET_OWLETTO=1 make owletto-mac
-    RESET_OWLETTO=1 make owletto-mac-e2e
+    RESET_OWLETTO=1 make owletto-mac-e2e ORG=<slug> CONN_ID=<id>
 EOF
     exit 1
   fi

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -111,11 +111,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # `git worktree add` target and the `.env` source.
 #
 # `--path-format=absolute` is load-bearing. Without it, `--git-common-dir`
-# returns a path relative to git's cwd ("../.git"), and `dirname` of that
-# resolves against whatever directory the caller happens to be in — landing
-# the worktree at the wrong path (e.g. /Users/burakemre/Code instead of
-# /Users/burakemre/Code/lobu when run from the main checkout). The absolute
-# form makes the resolution invariant.
+# returns a path relative to git's cwd (".git" from the main checkout), and
+# `dirname` of that resolves against whatever directory the caller happens to
+# be in — landing the worktree under the caller's cwd instead of the repo
+# root. The absolute form makes the resolution invariant.
 repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 worktree_dir="$repo/.claude/worktrees/$name"
 branch="feat/$name"


### PR DESCRIPTION
## Summary

- remove a private filesystem path and live tenant/account examples from shared source and operational docs
- require explicit organization and connection IDs before the Owletto production probe can run
- use the repository-standard Bun command in connector install help

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (not run; `make pre-pr` passed)
- [x] Tests run: `bun test packages/connectors/src/__tests__/x.test.ts` (61 pass)
- [x] Bug fix: red → fix → green outputs pasted below
- [ ] If bot runtime changed: not applicable

Before: `scripts/owletto-mac-e2e.sh` silently selected org `buremba` and connection `397` when variables were absent.

After:

```text
$ env -u ORG CONN_ID=123 bash scripts/owletto-mac-e2e.sh
scripts/owletto-mac-e2e.sh: line 8: ORG: Set ORG to the organization slug to test

$ env -u CONN_ID ORG=example-org bash scripts/owletto-mac-e2e.sh
scripts/owletto-mac-e2e.sh: line 9: CONN_ID: Set CONN_ID to the Owletto connection ID to test

$ env ORG=example-org CONN_ID=not-a-number bash scripts/owletto-mac-e2e.sh
error: CONN_ID must be numeric (got not-a-number)
```

Also passed:

- `make pre-pr`
- pre-commit Biome and root TypeScript checks
- `bash -n scripts/owletto-mac-e2e.sh scripts/task-setup.sh`
- `bun scripts/lobu/install-connectors.ts --help`
- class-wide committed-code grep for personal paths and tenant defaults

## Notes

No API, database, entity schema, connector execution logic, or worker path changed. Historical migrations, changelogs, incident provenance, tenant-owned examples, repository ownership settings, and the exact Owletto deployment-path allowlist are intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated browser testing and end-to-end testing instructions to require explicit organization and connection identifiers.
  * Refreshed connector examples, installation commands, setup guidance, and command help.
  * Removed outdated command documentation references.

* **Chores**
  * Improved end-to-end test invocation by requiring environment-provided values.
  * Added validation to prevent invalid connection identifiers from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->