### PR TITLE
fix(automations): expose trigger execution ownership

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4758,6 +4758,40 @@ export type ManageAutomationsResponses = {
         automation_id: string;
         run_id: number;
         status: string;
+        created: boolean;
+        execution:
+          | {
+              lane: "managed_agent";
+              owner: "lobu";
+              agent_id: string;
+              next_action: {
+                kind: "handled_elsewhere";
+              };
+            }
+          | {
+              lane: "device_worker";
+              owner: "device";
+              device_worker_id: string;
+              agent_kind: string | null;
+              next_action: {
+                kind: "handled_elsewhere";
+              };
+            }
+          | {
+              lane: "external_client";
+              owner: "caller";
+              next_action: {
+                kind: "complete_window";
+                read: {
+                  method: "knowledge.read";
+                  input: {
+                    automation_id: number;
+                    run_id: number;
+                  };
+                };
+                then: "automations.completeWindow";
+              };
+            };
       }
     | {
         action: "delete";
@@ -5214,11 +5248,11 @@ export type ReadKnowledgeData = {
      */
     entity_id?: number;
     /**
-     * Persisted Automation ID (`automation_id`) to fetch content for. When provided, uses the Automation's sources and computes its pending window. Returns window_token for complete_window action.
+     * Persisted Automation ID (`automation_id`) to fetch content for. With run_id, uses that run's queued version/window; otherwise computes the Automation's pending window. Returns window_token for complete_window action.
      */
     automation_id?: number;
     /**
-     * Pin to a specific persisted Automation version when reading the prompt/schema. Workers receive this from runs.approved_input.version_id and pass it back so a group edit landing mid-run can't make extraction use a different schema. When omitted, defaults to the Automation's current version.
+     * Pin an interactive or legacy Automation read to a persisted version. When run_id is present, the run's snapshotted version is authoritative and a conflicting value is rejected. Without run_id, omission defaults to the Automation's current version.
      */
     template_version_id?: number;
     /**
@@ -5246,7 +5280,7 @@ export type ReadKnowledgeData = {
      */
     platforms?: Array<string>;
     /**
-     * Automation run ID to filter by (shows only content analyzed in this run)
+     * Run ID. With automation_id, binds the Automation read to that run's queued version, window, and trigger inputs. Without automation_id, filters to content analyzed in this run.
      */
     run_id?: number;
     /**

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4791,6 +4791,25 @@ export type ManageAutomationsResponses = {
                 };
                 then: "automations.completeWindow";
               };
+            }
+          | {
+              lane: "external_client";
+              owner: "caller";
+              next_action: {
+                kind: "resume_claim";
+                method: "automations.claimNextWindow";
+                input: {
+                  automation_id: string;
+                  run_id: number;
+                };
+              };
+            }
+          | {
+              lane: "external_client";
+              owner: "another_caller";
+              next_action: {
+                kind: "handled_elsewhere";
+              };
             };
       }
     | {

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -512,7 +512,7 @@ export const ManageAutomationsSchema = Type.Object(
         }),
         Type.Literal("trigger", {
           description:
-            "Create or reuse an immediate Automation run. The result identifies whether Lobu, a device worker, or this caller owns execution; external callers must follow its knowledge.read then automations.completeWindow next action.",
+            "Create or reuse an immediate Automation run. The result identifies whether Lobu, a device worker, this caller, or another external caller owns execution. Follow the returned next_action: a pending external run uses knowledge.read then automations.completeWindow, while the owner of an existing external lease resumes it with automations.claimNextWindow.",
         }),
         Type.Literal("delete", {
           description:
@@ -1096,6 +1096,23 @@ export const AutomationTriggerExecutionSchema = Type.Union([
       // biome-ignore lint/suspicious/noThenProperty: Public protocol field required by the trigger handoff contract.
       then: Type.Literal("automations.completeWindow"),
     }),
+  }),
+  Type.Object({
+    lane: Type.Literal("external_client"),
+    owner: Type.Literal("caller"),
+    next_action: Type.Object({
+      kind: Type.Literal("resume_claim"),
+      method: Type.Literal("automations.claimNextWindow"),
+      input: Type.Object({
+        automation_id: Type.String(),
+        run_id: Type.Integer(),
+      }),
+    }),
+  }),
+  Type.Object({
+    lane: Type.Literal("external_client"),
+    owner: Type.Literal("another_caller"),
+    next_action: Type.Object({ kind: Type.Literal("handled_elsewhere") }),
   }),
 ]);
 export type AutomationTriggerExecution = Static<

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -511,7 +511,8 @@ export const ManageAutomationsSchema = Type.Object(
             "Atomically claim the oldest completed Automation period and return bounded source context plus a fenced window token.",
         }),
         Type.Literal("trigger", {
-          description: "Manually fire an Automation run.",
+          description:
+            "Create or reuse an immediate Automation run. The result identifies whether Lobu, a device worker, or this caller owns execution; external callers must follow its knowledge.read then automations.completeWindow next action.",
         }),
         Type.Literal("delete", {
           description:
@@ -1066,6 +1067,53 @@ export type AutomationClaimNextWindowResult = Static<
   typeof AutomationClaimNextWindowResultSchema
 >;
 
+export const AutomationTriggerExecutionSchema = Type.Union([
+  Type.Object({
+    lane: Type.Literal("managed_agent"),
+    owner: Type.Literal("lobu"),
+    agent_id: Type.String(),
+    next_action: Type.Object({ kind: Type.Literal("handled_elsewhere") }),
+  }),
+  Type.Object({
+    lane: Type.Literal("device_worker"),
+    owner: Type.Literal("device"),
+    device_worker_id: Type.String(),
+    agent_kind: Type.Union([Type.String(), Type.Null()]),
+    next_action: Type.Object({ kind: Type.Literal("handled_elsewhere") }),
+  }),
+  Type.Object({
+    lane: Type.Literal("external_client"),
+    owner: Type.Literal("caller"),
+    next_action: Type.Object({
+      kind: Type.Literal("complete_window"),
+      read: Type.Object({
+        method: Type.Literal("knowledge.read"),
+        input: Type.Object({
+          automation_id: Type.Integer(),
+          run_id: Type.Integer(),
+        }),
+      }),
+      // biome-ignore lint/suspicious/noThenProperty: Public protocol field required by the trigger handoff contract.
+      then: Type.Literal("automations.completeWindow"),
+    }),
+  }),
+]);
+export type AutomationTriggerExecution = Static<
+  typeof AutomationTriggerExecutionSchema
+>;
+
+export const AutomationTriggerResultSchema = Type.Object({
+  action: Type.Literal("trigger"),
+  automation_id: Type.String(),
+  run_id: Type.Integer(),
+  status: Type.String(),
+  created: Type.Boolean(),
+  execution: AutomationTriggerExecutionSchema,
+});
+export type AutomationTriggerResult = Static<
+  typeof AutomationTriggerResultSchema
+>;
+
 export const ManageAutomationsResultSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
@@ -1100,12 +1148,7 @@ export const ManageAutomationsResultSchema = Type.Union([
     content_linked: Type.Integer(),
   }),
   AutomationClaimNextWindowResultSchema,
-  Type.Object({
-    action: Type.Literal("trigger"),
-    automation_id: Type.String(),
-    run_id: Type.Integer(),
-    status: Type.String(),
-  }),
+  AutomationTriggerResultSchema,
   Type.Object({
     action: Type.Literal("delete"),
     results: Type.Array(ManageAutomationsDeleteResultSchema),

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -1,3 +1,4 @@
+import type { AutomationTriggerResult } from '@lobu/core/contracts/tools/manage-automations';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../../index';
 import { createAutomationRun } from '../../../runs/queue-service';
@@ -88,8 +89,12 @@ describe('external manual Automation execution', () => {
     // materialize and remain pending for the external MCP completion path.
     const triggered = (await workspace.owner.automations.trigger({
       automation_id: created.automation_id,
-    })) as { run_id: number; status: string };
+    })) as AutomationTriggerResult;
     expect(triggered.status).toBe('pending');
+    if (triggered.execution.lane !== 'external_client') {
+      throw new Error(`Expected external_client, got ${triggered.execution.lane}`);
+    }
+    expect(triggered.execution.next_action.then).toBe('automations.completeWindow');
 
     const [queued] = await sql<{
       status: string;
@@ -163,8 +168,7 @@ describe('external manual Automation execution', () => {
     expect(Number(edited.current_version_id)).not.toBe(queuedVersionId);
 
     const read = (await workspace.owner.knowledge.read({
-      automation_id: automationId,
-      run_id: triggered.run_id,
+      ...triggered.execution.next_action.read.input,
       limit: 25,
     })) as {
       window_token?: string;
@@ -277,7 +281,7 @@ describe('external manual Automation execution', () => {
     expect(stillUnclaimed).toEqual({ status: 'pending', claimed_by: null });
 
     const completion = (await workspace.owner.automations.completeWindow({
-      automation_id: created.automation_id,
+      automation_id: triggered.automation_id,
       run_id: triggered.run_id,
       window_token: read.window_token,
       extracted_data: {

--- a/packages/server/src/__tests__/integration/automations/pending-non-event-uniq.test.ts
+++ b/packages/server/src/__tests__/integration/automations/pending-non-event-uniq.test.ts
@@ -16,7 +16,10 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
-import { createAutomationRun } from '../../../runs/queue-service';
+import {
+  createAutomationRun,
+  createAutomationRunInTransaction,
+} from '../../../runs/queue-service';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
 import { TestWorkspace } from '../../setup/test-mcp-client';
@@ -163,14 +166,22 @@ describe('createAutomationRun pending non-event unique index', () => {
 
     // Different dispatch_source + window → different idempotency key; only the
     // partial pending-non-event index conflicts (status=pending, non-event).
-    const manualPromise = createAutomationRun({
-      organizationId: workspace.org.id,
-      automationId,
-      agentId,
-      windowStart: '2026-06-01T00:00:00.000Z',
-      windowEnd: '2026-06-02T00:00:00.000Z',
-      dispatchSource: 'manual',
-    });
+    // Keep the conflicting insert inside a caller-owned transaction. Recovery
+    // must roll the unique violation back to a savepoint before querying the
+    // winning row; otherwise PostgreSQL leaves this outer transaction aborted.
+    const manualPromise = (sql as unknown as DbClient).begin((tx) =>
+      createAutomationRunInTransaction(
+        {
+          organizationId: workspace.org.id,
+          automationId,
+          agentId,
+          windowStart: '2026-06-01T00:00:00.000Z',
+          windowEnd: '2026-06-02T00:00:00.000Z',
+          dispatchSource: 'manual',
+        },
+        tx
+      )
+    );
 
     await waitForLockWait(sql);
     release.resolve();

--- a/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
+++ b/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
@@ -75,6 +75,22 @@ describe("Automation trigger execution contract", () => {
 		expect(retriggered.execution).toEqual(triggered.execution);
 	});
 
+	it.each(["not-a-number", "0", "-1", "1.5", "9007199254740992"])(
+		"rejects invalid Automation ID %s before enqueue",
+		async (automationId) => {
+			const workspace = await TestWorkspace.create({
+				name: "Invalid Trigger ID Org",
+			});
+
+			await expect(
+				workspace.owner.automations.trigger({ automation_id: automationId }),
+			).rejects.toThrow(/automation_id must be a positive integer/);
+			const sql = getTestDb();
+			const runs = await sql`SELECT id FROM runs WHERE run_type = 'automation'`;
+			expect(runs).toHaveLength(0);
+		},
+	);
+
 	it("coalesces concurrent external triggers without poisoning either transaction", async () => {
 		const sql = getTestDb();
 		const workspace = await TestWorkspace.create({

--- a/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
+++ b/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
@@ -1,0 +1,288 @@
+import { inferAutomationGranularityFromSchedule } from "@lobu/connector-sdk";
+import type { AutomationTriggerResult } from "@lobu/core/contracts/tools/manage-automations";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { DbClient } from "../../../db/client";
+import { createAutomationRun } from "../../../runs/queue-service";
+import { computePendingWindow } from "../../../utils/window-utils";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+describe("Automation trigger execution contract", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("directs an agentless manual run through the external completion protocol", async () => {
+		const workspace = await TestWorkspace.create({
+			name: "External Trigger Org",
+		});
+		const entity = await createTestEntity({
+			name: "External Trigger Entity",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: "external-trigger-contract",
+			name: "External Trigger Contract",
+			prompt: "Summarize the current window.",
+			agent_id: null,
+		})) as { automation_id: string };
+
+		const triggered = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+
+		expect(triggered).toEqual({
+			action: "trigger",
+			automation_id: automation.automation_id,
+			run_id: triggered.run_id,
+			status: "pending",
+			created: true,
+			execution: {
+				lane: "external_client",
+				owner: "caller",
+				next_action: {
+					kind: "complete_window",
+					read: {
+						method: "knowledge.read",
+						input: {
+							automation_id: Number(automation.automation_id),
+							run_id: triggered.run_id,
+						},
+					},
+					// biome-ignore lint/suspicious/noThenProperty: Exact public protocol assertion.
+					then: "automations.completeWindow",
+				},
+			},
+		});
+
+		const retargetAgent = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+			agentId: "external-retarget-agent",
+		});
+		await workspace.owner.automations.update({
+			automation_id: automation.automation_id,
+			agent_id: retargetAgent.agentId,
+		});
+		const retriggered = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+		expect(retriggered.run_id).toBe(triggered.run_id);
+		expect(retriggered.created).toBe(false);
+		expect(retriggered.execution).toEqual(triggered.execution);
+	});
+
+	it("coalesces concurrent external triggers without poisoning either transaction", async () => {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({
+			name: "Concurrent Trigger Org",
+		});
+		const entity = await createTestEntity({
+			name: "Concurrent Trigger Entity",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: "concurrent-trigger-contract",
+			name: "Concurrent Trigger Contract",
+			prompt: "Summarize the current window.",
+			agent_id: null,
+		})) as { automation_id: string };
+
+		const results = (await Promise.all([
+			workspace.owner.automations.trigger({
+				automation_id: automation.automation_id,
+			}),
+			workspace.owner.automations.trigger({
+				automation_id: automation.automation_id,
+			}),
+		])) as AutomationTriggerResult[];
+
+		expect(results.map((result) => result.created).sort()).toEqual([false, true]);
+		expect(new Set(results.map((result) => result.run_id)).size).toBe(1);
+		expect(results[0].execution).toEqual(results[1].execution);
+		expect(results[0].execution.lane).toBe("external_client");
+		const runs = await sql`
+      SELECT id FROM runs WHERE automation_id = ${Number(automation.automation_id)}
+    `;
+		expect(runs).toHaveLength(1);
+	});
+
+	it("keeps the persisted device lane when the Automation is retargeted", async () => {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({
+			name: "Device Trigger Org",
+		});
+		const entity = await createTestEntity({
+			name: "Device Trigger Entity",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const [device] = await sql<{ id: string }>`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label, organization_id
+      ) VALUES (
+        ${workspace.users.owner.id}, 'trigger-device-a', 'macos',
+        ${sql.json({})}, 'Device A', ${workspace.org.id}
+      )
+      RETURNING id::text AS id
+    `;
+		const retargetAgent = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+			agentId: "device-retarget-agent",
+		});
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: "device-trigger-contract",
+			name: "Device Trigger Contract",
+			prompt: "Summarize the current window.",
+			agent_id: null,
+			device_worker_id: device.id,
+			agent_kind: "claude-code",
+		})) as { automation_id: string };
+
+		const first = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+		expect(first.execution).toEqual({
+			lane: "device_worker",
+			owner: "device",
+			device_worker_id: device.id,
+			agent_kind: "claude-code",
+			next_action: { kind: "handled_elsewhere" },
+		});
+		expect(first.created).toBe(true);
+
+		// Persisted dual-id snapshots still exist on the claim-next-window path.
+		// Device-first resolution is authoritative for those rows.
+		await sql`
+      UPDATE runs
+      SET approved_input = approved_input
+        || jsonb_build_object('agent_id', ${retargetAgent.agentId}::text)
+      WHERE id = ${first.run_id}
+    `;
+		await workspace.owner.automations.update({
+			automation_id: automation.automation_id,
+			agent_id: retargetAgent.agentId,
+			device_worker_id: null,
+			agent_kind: null,
+		});
+		const retriggered = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+
+		expect(retriggered).toEqual({
+			action: "trigger",
+			automation_id: automation.automation_id,
+			run_id: first.run_id,
+			status: "pending",
+			created: false,
+			execution: {
+				lane: "device_worker",
+				owner: "device",
+				device_worker_id: device.id,
+				agent_kind: "claude-code",
+				next_action: { kind: "handled_elsewhere" },
+			},
+		});
+	});
+
+	it("uses the persisted managed-agent lane for gateway preflight after retargeting", async () => {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({
+			name: "Managed Trigger Org",
+		});
+		const entity = await createTestEntity({
+			name: "Managed Trigger Entity",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const originalAgent = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+			agentId: "trigger-original-agent",
+		});
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: "managed-trigger-contract",
+			name: "Managed Trigger Contract",
+			prompt: "Summarize the current window.",
+			agent_id: originalAgent.agentId,
+		})) as { automation_id: string };
+		const pending = await computePendingWindow(
+			sql as unknown as DbClient,
+			Number(automation.automation_id),
+			inferAutomationGranularityFromSchedule(null),
+		);
+		const queued = await createAutomationRun({
+			organizationId: workspace.org.id,
+			automationId: Number(automation.automation_id),
+			agentId: originalAgent.agentId,
+			windowStart: pending.windowStart.toISOString(),
+			windowEnd: pending.windowEnd.toISOString(),
+			dispatchSource: "manual",
+		});
+		await sql`
+      UPDATE runs
+      SET status = 'running', claimed_by = 'lobu-dispatcher', claimed_at = NOW()
+      WHERE id = ${queued.runId}
+    `;
+		await workspace.owner.automations.update({
+			automation_id: automation.automation_id,
+			agent_id: null,
+		});
+
+		await expect(
+			workspace.owner.automations.trigger({
+				automation_id: automation.automation_id,
+			}),
+		).rejects.toThrow(/Embedded Lobu is not available/);
+		const runs = await sql<{ status: string; approved_input: Record<string, unknown> }>`
+      SELECT status, approved_input
+      FROM runs
+      WHERE automation_id = ${Number(automation.automation_id)}
+    `;
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe("running");
+		expect(runs[0].approved_input.agent_id).toBe(originalAgent.agentId);
+	});
+
+	it("preserves the managed-agent gateway preflight without creating a failed run", async () => {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({
+			name: "Managed Preflight Org",
+		});
+		const entity = await createTestEntity({
+			name: "Managed Preflight Entity",
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		const agent = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+			agentId: "trigger-preflight-agent",
+		});
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: "managed-trigger-preflight",
+			name: "Managed Trigger Preflight",
+			prompt: "Summarize the current window.",
+			agent_id: agent.agentId,
+		})) as { automation_id: string };
+
+		await expect(
+			workspace.owner.automations.trigger({
+				automation_id: automation.automation_id,
+			}),
+		).rejects.toThrow(/Embedded Lobu is not available/);
+		const runs = await sql`
+      SELECT id FROM runs WHERE automation_id = ${Number(automation.automation_id)}
+    `;
+		expect(runs).toHaveLength(0);
+	});
+});

--- a/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
+++ b/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
@@ -1,5 +1,8 @@
 import { inferAutomationGranularityFromSchedule } from "@lobu/connector-sdk";
-import type { AutomationTriggerResult } from "@lobu/core/contracts/tools/manage-automations";
+import type {
+	AutomationClaimNextWindowResult,
+	AutomationTriggerResult,
+} from "@lobu/core/contracts/tools/manage-automations";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { DbClient } from "../../../db/client";
 import { createAutomationRun } from "../../../runs/queue-service";
@@ -12,6 +15,72 @@ describe("Automation trigger execution contract", () => {
 	beforeEach(async () => {
 		await cleanupTestDatabase();
 	});
+
+	async function createExternallyClaimedAutomation(
+		lane: "managed_agent" | "device_worker",
+	) {
+		const sql = getTestDb();
+		const workspace = await TestWorkspace.create({
+			name: `${lane} External Lease Org`,
+		});
+		const entity = await createTestEntity({
+			name: `${lane} External Lease Entity`,
+			organization_id: workspace.org.id,
+			created_by: workspace.users.owner.id,
+		});
+		let executor:
+			| { agent_id: string }
+			| {
+					agent_id: null;
+					device_worker_id: string;
+					agent_kind: "claude-code";
+				};
+		if (lane === "managed_agent") {
+			const agent = await createTestAgent({
+				organizationId: workspace.org.id,
+				ownerUserId: workspace.users.owner.id,
+				agentId: "externally-leased-trigger-agent",
+			});
+			executor = { agent_id: agent.agentId };
+		} else {
+			const [device] = await sql<{ id: string }>`
+        INSERT INTO device_workers (
+          user_id, worker_id, platform, capabilities, label, organization_id
+        ) VALUES (
+          ${workspace.users.owner.id}, 'externally-leased-trigger-device', 'macos',
+          ${sql.json({})}, 'Externally Leased Device', ${workspace.org.id}
+        )
+        RETURNING id::text AS id
+      `;
+			executor = {
+				agent_id: null,
+				device_worker_id: device.id,
+				agent_kind: "claude-code",
+			};
+		}
+		const automation = (await workspace.owner.automations.create({
+			entity_id: entity.id,
+			slug: `${lane}-external-lease`,
+			name: `${lane} External Lease`,
+			prompt: "Summarize the completed window.",
+			triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			...executor,
+		})) as { automation_id: string };
+		const windowStart = new Date();
+		windowStart.setUTCHours(0, 0, 0, 0);
+		windowStart.setUTCDate(windowStart.getUTCDate() - 2);
+		await sql`
+      UPDATE automations
+      SET next_window_start = ${windowStart.toISOString()}::timestamptz,
+          completed_window_coverage = '{}'::tstzmultirange,
+          window_projection_granularity = 'daily'
+      WHERE id = ${Number(automation.automation_id)}
+    `;
+		const claim = (await workspace.owner.automations.claimNextWindow({
+			automation_id: automation.automation_id,
+		})) as AutomationClaimNextWindowResult;
+		return { sql, workspace, automation, claim };
+	}
 
 	it("directs an agentless manual run through the external completion protocol", async () => {
 		const workspace = await TestWorkspace.create({
@@ -74,22 +143,6 @@ describe("Automation trigger execution contract", () => {
 		expect(retriggered.created).toBe(false);
 		expect(retriggered.execution).toEqual(triggered.execution);
 	});
-
-	it.each(["not-a-number", "0", "-1", "1.5", "9007199254740992"])(
-		"rejects invalid Automation ID %s before enqueue",
-		async (automationId) => {
-			const workspace = await TestWorkspace.create({
-				name: "Invalid Trigger ID Org",
-			});
-
-			await expect(
-				workspace.owner.automations.trigger({ automation_id: automationId }),
-			).rejects.toThrow(/automation_id must be a positive integer/);
-			const sql = getTestDb();
-			const runs = await sql`SELECT id FROM runs WHERE run_type = 'automation'`;
-			expect(runs).toHaveLength(0);
-		},
-	);
 
 	it("coalesces concurrent external triggers without poisoning either transaction", async () => {
 		const sql = getTestDb();
@@ -188,6 +241,11 @@ describe("Automation trigger execution contract", () => {
 			device_worker_id: null,
 			agent_kind: null,
 		});
+		await sql`
+      UPDATE runs
+      SET status = 'running', claimed_by = 'trigger-device-a', claimed_at = NOW()
+      WHERE id = ${first.run_id}
+    `;
 		const retriggered = (await workspace.owner.automations.trigger({
 			automation_id: automation.automation_id,
 		})) as AutomationTriggerResult;
@@ -196,7 +254,7 @@ describe("Automation trigger execution contract", () => {
 			action: "trigger",
 			automation_id: automation.automation_id,
 			run_id: first.run_id,
-			status: "pending",
+			status: "running",
 			created: false,
 			execution: {
 				lane: "device_worker",
@@ -208,7 +266,7 @@ describe("Automation trigger execution contract", () => {
 		});
 	});
 
-	it("uses the persisted managed-agent lane for gateway preflight after retargeting", async () => {
+	it("keeps a native managed-agent claim handled elsewhere after retargeting", async () => {
 		const sql = getTestDb();
 		const workspace = await TestWorkspace.create({
 			name: "Managed Trigger Org",
@@ -253,11 +311,22 @@ describe("Automation trigger execution contract", () => {
 			agent_id: null,
 		});
 
-		await expect(
-			workspace.owner.automations.trigger({
-				automation_id: automation.automation_id,
-			}),
-		).rejects.toThrow(/Embedded Lobu is not available/);
+		const retriggered = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+		expect(retriggered).toEqual({
+			action: "trigger",
+			automation_id: automation.automation_id,
+			run_id: queued.runId,
+			status: "running",
+			created: false,
+			execution: {
+				lane: "managed_agent",
+				owner: "lobu",
+				agent_id: originalAgent.agentId,
+				next_action: { kind: "handled_elsewhere" },
+			},
+		});
 		const runs = await sql<{ status: string; approved_input: Record<string, unknown> }>`
       SELECT status, approved_input
       FROM runs
@@ -267,6 +336,120 @@ describe("Automation trigger execution contract", () => {
 		expect(runs[0].status).toBe("running");
 		expect(runs[0].approved_input.agent_id).toBe(originalAgent.agentId);
 	});
+
+	it.each(["managed_agent", "device_worker"] as const)(
+		"uses the durable external claimant for a claimed %s snapshot",
+		async (lane) => {
+			const { sql, workspace, automation, claim } =
+				await createExternallyClaimedAutomation(lane);
+			const [before] = await sql<{
+				status: string;
+				claimed_by: string;
+				expires_at: string;
+			}>`
+        SELECT status, claimed_by, expires_at::text
+        FROM runs
+        WHERE id = ${claim.run_id}
+      `;
+
+			const sameCaller = (await workspace.owner.automations.trigger({
+				automation_id: automation.automation_id,
+			})) as AutomationTriggerResult;
+			expect(sameCaller).toEqual({
+				action: "trigger",
+				automation_id: automation.automation_id,
+				run_id: claim.run_id,
+				status: "running",
+				created: false,
+				execution: {
+					lane: "external_client",
+					owner: "caller",
+					next_action: {
+						kind: "resume_claim",
+						method: "automations.claimNextWindow",
+						input: {
+							automation_id: automation.automation_id,
+							run_id: claim.run_id,
+						},
+					},
+				},
+			});
+
+			const otherCaller = (await workspace.admin.automations.trigger({
+				automation_id: automation.automation_id,
+			})) as AutomationTriggerResult;
+			expect(otherCaller).toEqual({
+				action: "trigger",
+				automation_id: automation.automation_id,
+				run_id: claim.run_id,
+				status: "running",
+				created: false,
+				execution: {
+					lane: "external_client",
+					owner: "another_caller",
+					next_action: { kind: "handled_elsewhere" },
+				},
+			});
+
+			const [after] = await sql<{
+				status: string;
+				claimed_by: string;
+				expires_at: string;
+			}>`
+        SELECT status, claimed_by, expires_at::text
+        FROM runs
+        WHERE id = ${claim.run_id}
+      `;
+			expect(after).toEqual(before);
+		},
+	);
+
+	it.each(["expired", "unrecognized", "malformed_external"] as const)(
+		"fails closed for an %s claimed execution",
+		async (claimState) => {
+			const { sql, workspace, automation, claim } =
+				await createExternallyClaimedAutomation("managed_agent");
+			if (claimState === "expired") {
+				await sql`
+          UPDATE runs
+          SET expires_at = NOW() - INTERVAL '1 second'
+          WHERE id = ${claim.run_id}
+        `;
+			} else if (claimState === "unrecognized") {
+				await sql`
+          UPDATE runs
+          SET claimed_by = 'unrecognized-trigger-claim', expires_at = NULL
+          WHERE id = ${claim.run_id}
+        `;
+			} else {
+				await sql`
+          UPDATE runs
+          SET claimed_by = 'external:{"user_id":"partial"}',
+              expires_at = NOW() + INTERVAL '5 minutes'
+          WHERE id = ${claim.run_id}
+        `;
+			}
+
+			await expect(
+				workspace.owner.automations.trigger({
+					automation_id: automation.automation_id,
+				}),
+			).rejects.toThrow(/no recognized active claimant/);
+			const [after] = await sql<{ status: string; claimed_by: string }>`
+        SELECT status, claimed_by
+        FROM runs
+        WHERE id = ${claim.run_id}
+      `;
+			expect(after.status).toBe("running");
+			if (claimState === "expired") {
+				expect(after.claimed_by).toMatch(/^external:/);
+			} else if (claimState === "unrecognized") {
+				expect(after.claimed_by).toBe("unrecognized-trigger-claim");
+			} else {
+				expect(after.claimed_by).toBe('external:{"user_id":"partial"}');
+			}
+		},
+	);
 
 	it("preserves the managed-agent gateway preflight without creating a failed run", async () => {
 		const sql = getTestDb();

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -405,6 +405,21 @@ describe("sdkSearch", () => {
 		}
 	});
 
+	it("documents the external Automation trigger completion handoff", async () => {
+		const result = await sdkSearch(
+			{ query: "automations.trigger" },
+			stubEnv,
+			adminCtx,
+		);
+		const rendered = result.results[0];
+
+		expect(rendered).toContain("Promise<AutomationTriggerResult>");
+		expect(rendered).toContain("external_client");
+		expect(rendered).toContain("created is false");
+		expect(rendered).toContain("run.execution.next_action.read.input");
+		expect(rendered).toContain("client.automations.completeWindow");
+	});
+
 	it.each([
 		["feeds.get", ["limit?: number", "search_term?: string"]],
 		["feeds.readMany", ["timeout_ms?: number", "search_term?: string"]],

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -416,6 +416,9 @@ describe("sdkSearch", () => {
 		expect(rendered).toContain("Promise<AutomationTriggerResult>");
 		expect(rendered).toContain("external_client");
 		expect(rendered).toContain("created is false");
+		expect(rendered).toContain("resume_claim");
+		expect(rendered).toContain("another_caller");
+		expect(rendered).toContain("client.automations.claimNextWindow");
 		expect(rendered).toContain("run.execution.next_action.read.input");
 		expect(rendered).toContain("client.automations.completeWindow");
 	});

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -24,6 +24,7 @@ import { getLobuServiceToken } from "../lobu/service-token";
 import {
 	claimPendingAutomationRun,
 	createAutomationRun,
+	createAutomationRunInTransaction,
 	type AutomationRunPayload,
 } from "../runs/queue-service";
 import { materializeDueItems } from "../scheduled/due-materializer";
@@ -248,7 +249,8 @@ async function enqueueAutomationRunForRecord(
 	sql: DbClient,
 	automation: DueAutomationRow,
 	dispatchSource: AutomationRunPayload["dispatch_source"],
-	sourceFingerprint?: string
+	sourceFingerprint?: string,
+	tx?: DbClient,
 ): Promise<QueueAutomationRunResult> {
 	if ((automation.status ?? "active") !== "active") {
 		throw new Error(`Automation ${automation.id} is not active.`);
@@ -276,8 +278,7 @@ async function enqueueAutomationRunForRecord(
 		granularity
 	);
 
-	const queued = await createAutomationRun(
-		{
+	const runParams = {
 			organizationId: automation.organization_id,
 			automationId: automation.id,
 			agentId: executor?.kind === "agent" ? executor.agentId : null,
@@ -289,9 +290,10 @@ async function enqueueAutomationRunForRecord(
 			agentKind:
 				executor?.kind === "device" ? executor.agentKind : null,
 			sourceFingerprint,
-		},
-		sql
-	);
+		};
+	const queued = tx
+		? await createAutomationRunInTransaction(runParams, tx)
+		: await createAutomationRun(runParams, sql);
 
 	return queued;
 }
@@ -334,19 +336,50 @@ async function completeSkippedAutomationRun(
 	});
 }
 
-export async function enqueueAutomationRunForAutomation(
+async function enqueueAutomationRunForAutomationWithClient(
 	automationId: number,
 	dispatchSource: AutomationRunPayload["dispatch_source"],
-	db?: DbClient
+	sql: DbClient,
+	tx?: DbClient,
 ): Promise<QueueAutomationRunResult> {
-	const sql = db ?? getDb();
 	const automation = await loadAutomationForAutomation(sql, automationId);
 
 	if (!automation) {
 		throw new ToolUserError(`Automation ${automationId} not found.`, 404);
 	}
 
-	return enqueueAutomationRunForRecord(sql, automation, dispatchSource);
+	return enqueueAutomationRunForRecord(
+		sql,
+		automation,
+		dispatchSource,
+		undefined,
+		tx,
+	);
+}
+
+export async function enqueueAutomationRunForAutomation(
+	automationId: number,
+	dispatchSource: AutomationRunPayload["dispatch_source"],
+	db?: DbClient,
+): Promise<QueueAutomationRunResult> {
+	return enqueueAutomationRunForAutomationWithClient(
+		automationId,
+		dispatchSource,
+		db ?? getDb(),
+	);
+}
+
+export async function enqueueAutomationRunForAutomationInTransaction(
+	automationId: number,
+	dispatchSource: AutomationRunPayload["dispatch_source"],
+	tx: DbClient,
+): Promise<QueueAutomationRunResult> {
+	return enqueueAutomationRunForAutomationWithClient(
+		automationId,
+		dispatchSource,
+		tx,
+		tx,
+	);
 }
 
 async function markAutomationRunFailedIdempotent(
@@ -1500,7 +1533,7 @@ export async function queueAndDispatchAutomationRun(
 	const queued = await enqueueAutomationRunForAutomation(
 		automationId,
 		dispatchSource,
-		sql
+		sql,
 	);
 	const dispatch = await dispatchPendingAutomationRuns({
 		db: sql,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -643,25 +643,30 @@ async function createAutomationRunWithClient(
   return { runId, status, created: true };
 }
 
-export async function createAutomationRun(
-  params: {
-    organizationId: string;
-    automationId: number;
-    agentId?: string | null;
-    windowStart: string;
-    windowEnd: string;
-    dispatchSource: AutomationDispatchSource;
-    deviceWorkerId?: string | null;
-    agentKind?: string | null;
-    sourceFingerprint?: string;
-  },
-  db?: DbClient
+interface CreateAutomationRunParams {
+  organizationId: string;
+  automationId: number;
+  agentId?: string | null;
+  windowStart: string;
+  windowEnd: string;
+  dispatchSource: AutomationDispatchSource;
+  deviceWorkerId?: string | null;
+  agentKind?: string | null;
+  sourceFingerprint?: string;
+}
+
+async function createAutomationRunInternal(
+  params: CreateAutomationRunParams,
+  db: DbClient | undefined,
+  useSavepoint: boolean
 ): Promise<{ runId: number; status: string; created: boolean }> {
   const sql = db ?? getDb();
 
   try {
     if (db) {
-      return await createAutomationRunWithClient(sql, params);
+      return useSavepoint
+        ? await sql.savepoint((tx) => createAutomationRunWithClient(tx, params))
+        : await createAutomationRunWithClient(sql, params);
     }
 
     return await sql.begin(async (tx) => createAutomationRunWithClient(tx, params));
@@ -720,6 +725,21 @@ export async function createAutomationRun(
     logger.error({ error, automationId: params.automationId }, '[queue] Failed to create automation run');
     throw error;
   }
+}
+
+export async function createAutomationRun(
+  params: CreateAutomationRunParams,
+  db?: DbClient
+): Promise<{ runId: number; status: string; created: boolean }> {
+  return createAutomationRunInternal(params, db, false);
+}
+
+/** Create inside a caller-owned transaction without poisoning it on a unique race. */
+export async function createAutomationRunInTransaction(
+  params: CreateAutomationRunParams,
+  tx: DbClient
+): Promise<{ runId: number; status: string; created: boolean }> {
+  return createAutomationRunInternal(params, tx, true);
 }
 
 /** An activation that produced (or joined) a durable run. */

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -305,8 +305,10 @@ export default async (_ctx, client) => {
 	},
 	"knowledge.read": {
 		summary:
-			"Read knowledge events by id (`content_ids`, an array — there is no singular `content_id` arg), or Automation-window context.",
+			"Read knowledge events by id (`content_ids`, an array — there is no singular `content_id` arg), or Automation-window context. Pass automation_id with run_id to bind the read to that queued run's persisted version, window, and trigger inputs.",
 		access: "read",
+		signature:
+			"knowledge.read(input: { content_ids?: number[]; automation_id?: number; run_id?: number; ... }): Promise<unknown>",
 		example: "await client.knowledge.read({ content_ids: [2321593] });",
 	},
 	"knowledge.delete": {
@@ -585,11 +587,24 @@ export default async (_ctx, client) => {
 	},
 	"automations.trigger": {
 		summary:
-			"Trigger an immediate Automation run and dispatch it to its assigned agent.",
+			"Create or reuse an immediate Automation run. The typed result identifies the persisted run's execution lane and owner: Lobu handles managed_agent, the pinned device handles device_worker, and the caller handles external_client by following next_action.read (knowledge.read with automation_id + run_id) and then automations.completeWindow. created is false when an active run was reused.",
 		access: "external",
-		example: "await client.automations.trigger({ automation_id: '42' });",
+		signature:
+			"automations.trigger(input: { automation_id: string }): Promise<AutomationTriggerResult>",
+		example:
+			"const run = await client.automations.trigger({ automation_id: '42' });",
 		usageExample: `export default async (_ctx, client) => {
-  return client.automations.trigger({ automation_id: '42' });
+  const run = await client.automations.trigger({ automation_id: '42' });
+  if (run.execution.lane !== 'external_client') return run;
+
+  const context = await client.knowledge.read(run.execution.next_action.read.input);
+  // Analyze context, then submit the result with the returned run_id and window_token:
+  return client.automations.completeWindow({
+    automation_id: run.automation_id,
+    run_id: run.run_id,
+    window_token: context.window_token,
+    extracted_data: { /* match context.extraction_schema */ },
+  });
 };`,
 	},
 	"automations.delete": {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -587,7 +587,7 @@ export default async (_ctx, client) => {
 	},
 	"automations.trigger": {
 		summary:
-			"Create or reuse an immediate Automation run. The typed result identifies the persisted run's execution lane and owner: Lobu handles managed_agent, the pinned device handles device_worker, and the caller handles external_client by following next_action.read (knowledge.read with automation_id + run_id) and then automations.completeWindow. created is false when an active run was reused.",
+			"Create or reuse an immediate Automation run. The typed result identifies the durable execution owner. Pending runs use their persisted managed_agent, device_worker, or external_client lane. An existing external lease returns owner caller with a resume_claim action when this caller owns it, or owner another_caller with handled_elsewhere. A pending external_client run uses next_action.read (knowledge.read with automation_id + run_id) then automations.completeWindow. created is false when an active run was reused.",
 		access: "external",
 		signature:
 			"automations.trigger(input: { automation_id: string }): Promise<AutomationTriggerResult>",
@@ -596,6 +596,10 @@ export default async (_ctx, client) => {
 		usageExample: `export default async (_ctx, client) => {
   const run = await client.automations.trigger({ automation_id: '42' });
   if (run.execution.lane !== 'external_client') return run;
+  if (run.execution.next_action.kind === 'handled_elsewhere') return run;
+  if (run.execution.next_action.kind === 'resume_claim') {
+    return client.automations.claimNextWindow(run.execution.next_action.input);
+  }
 
   const context = await client.knowledge.read(run.execution.next_action.read.input);
   // Analyze context, then submit the result with the returned run_id and window_token:

--- a/packages/server/src/sandbox/namespaces/automations.ts
+++ b/packages/server/src/sandbox/namespaces/automations.ts
@@ -13,6 +13,7 @@ import type {
 	AutomationExecutionConfig,
 	AutomationSource,
 	AutomationTrigger,
+	AutomationTriggerResult,
 	ListAutomationsArgs,
 	ManageAutomationsResult,
 } from "@lobu/core/contracts/tools/manage-automations";
@@ -141,7 +142,7 @@ export interface AutomationsNamespace {
 	createVersion(input: AutomationCreateVersionInput): Promise<unknown>;
 	completeWindow(input: AutomationCompleteWindowInput): Promise<unknown>;
 	claimNextWindow(input: AutomationClaimNextWindowInput): Promise<AutomationClaimNextWindowResult>;
-	trigger(input: { automation_id: AutomationId }): Promise<unknown>;
+	trigger(input: { automation_id: AutomationId }): Promise<AutomationTriggerResult>;
 	/** Delete one or more Automations. */
 	delete(input: { automation_ids: AutomationId[] }): Promise<unknown>;
 	setReactionScript(input: {

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -66,6 +66,8 @@ export interface KnowledgeReadInput {
 	content_ids?: number[];
 	/** Fetch structured knowledge for an Automation window. */
 	automation_id?: number;
+	/** Bind an Automation read to the queued run's version, window, and trigger inputs. */
+	run_id?: number;
 	since?: string;
 	until?: string;
 	limit?: number;

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -1039,7 +1039,7 @@ const runManageAutomations = defineFlatActionTool<ManageAutomationsArgs, ManageA
     create_version: flatAction((args, ctx, env) => handleCreateVersion(args, env, ctx)),
     complete_window: flatAction((args, ctx, env) => handleCompleteWindow(args, env, ctx)),
     claim_next_window: flatAction((args, ctx, env) => handleClaimNextWindow(args, env, ctx)),
-    trigger: flatAction((args, _ctx, env) => handleTrigger(args, env)),
+    trigger: flatAction((args, ctx, env) => handleTrigger(args, env, ctx)),
     delete: flatAction((args, ctx) => handleDelete(args, ctx)),
     set_reaction_script: flatAction((args, ctx, env) => handleSetReactionScript(args, env, ctx)),
     get_versions: flatAction(handleGetVersions),

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -9,7 +9,10 @@ import type { AutomationClaimNextWindowResult } from '@lobu/core/contracts/tools
 import type { DbClient } from '../../../db/client';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
-import { claimPendingAutomationRun, createAutomationRun } from '../../../runs/queue-service';
+import {
+  claimPendingAutomationRun,
+  createAutomationRunInTransaction,
+} from '../../../runs/queue-service';
 import { classifyRunOutcome } from '../../../runs/run-outcome';
 import { ToolUserError } from '../../../utils/errors';
 import { ensureExpectedAutomationWindowStart } from '../../../utils/window-utils';
@@ -180,7 +183,7 @@ export async function handleClaimNextWindow(
       `;
       const run = pending
         ? { runId: Number(pending.id) }
-        : await createAutomationRun(
+        : await createAutomationRunInTransaction(
             {
               organizationId: automation.organization_id,
               automationId,

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -24,7 +24,7 @@ const DEFAULT_LEASE_SECONDS = 900;
 const MIN_LEASE_SECONDS = 30;
 const MAX_LEASE_SECONDS = 3600;
 
-function claimOwner(ctx: ToolContext): string {
+export function encodeExternalAutomationClaimOwner(ctx: ToolContext): string {
   const identity = {
     user_id: ctx.userId ?? null,
     agent_id: ctx.agentId ?? null,
@@ -38,6 +38,31 @@ function claimOwner(ctx: ToolContext): string {
     );
   }
   return `external:${JSON.stringify(identity)}`;
+}
+
+export function isExternalAutomationClaimOwner(value: string): boolean {
+  if (!value.startsWith('external:')) return false;
+  try {
+    const identity = JSON.parse(value.slice('external:'.length)) as unknown;
+    if (identity == null || typeof identity !== 'object' || Array.isArray(identity)) {
+      return false;
+    }
+    const record = identity as Record<string, unknown>;
+    const keys = ['user_id', 'agent_id', 'client_id', 'mcp_session_id'];
+    if (
+      Object.keys(record).length !== keys.length ||
+      !keys.every(
+        (key) =>
+          Object.hasOwn(record, key) &&
+          (record[key] == null || typeof record[key] === 'string')
+      )
+    ) {
+      return false;
+    }
+    return keys.some((key) => record[key] != null);
+  } catch {
+    return false;
+  }
 }
 
 export async function handleClaimNextWindow(
@@ -72,7 +97,7 @@ export async function handleClaimNextWindow(
   }
 
   const sql = getDb();
-  const owner = claimOwner(ctx);
+  const owner = encodeExternalAutomationClaimOwner(ctx);
   const claimedWindow = await sql.begin(async (tx) => {
     const [automation] = await tx<{
       organization_id: string;

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -34,18 +34,18 @@ import { resolveAutomationExecutor } from "./executors";
 async function loadTriggerExecution(
   sql: DbClient,
   runId: number,
-  automationId: string,
+  automationId: number,
 ): Promise<AutomationTriggerExecution> {
   const [run] = await sql<{ approved_input: unknown }>`
     SELECT approved_input
     FROM runs
     WHERE id = ${runId}
-      AND automation_id = ${Number(automationId)}
+      AND automation_id = ${automationId}
       AND run_type = 'automation'
     LIMIT 1
   `;
   const payload = parseAutomationRunPayload(run?.approved_input);
-  if (!payload || payload.automation_id !== Number(automationId)) {
+  if (!payload || payload.automation_id !== automationId) {
     throw new Error("Automation run is missing a valid dispatch payload.");
   }
   const executor = resolveAutomationExecutor({
@@ -98,11 +98,18 @@ export async function handleTrigger(
   if (!args.automation_id) {
     throw new ToolUserError("automation_id is required for trigger action", 400);
   }
-  const automationId = args.automation_id;
+  const automationIdString = args.automation_id;
+  const automationId = Number(automationIdString);
+  if (!Number.isSafeInteger(automationId) || automationId < 1) {
+    throw new ToolUserError(
+      "automation_id must be a positive integer for trigger action",
+      400,
+    );
+  }
 
   const queued = await sql.begin(async (tx) => {
     const run = await enqueueAutomationRunForAutomationInTransaction(
-      Number(automationId),
+      automationId,
       "manual",
       tx,
     );
@@ -130,7 +137,7 @@ export async function handleTrigger(
 
   return {
     action: "trigger",
-    automation_id: automationId,
+    automation_id: automationIdString,
     run_id: queued.runId,
     status: runInfo?.status ?? queued.status,
     created: queued.created,

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -3,14 +3,16 @@
  *   trigger, set_reaction_script
  */
 
-import { getDb } from "../../../db/client";
+import { getDb, type DbClient } from "../../../db/client";
 import type { Env } from "../../../index";
 import { isLobuGatewayRunning } from "../../../lobu/gateway";
 import { ToolUserError } from "../../../utils/errors";
 import logger from "../../../utils/logger";
 import {
+  dispatchPendingAutomationRuns,
+  enqueueAutomationRunForAutomationInTransaction,
   getAutomationRunInfo,
-  queueAndDispatchAutomationRun,
+  parseAutomationRunPayload,
 } from "../../../automations/automation";
 import {
   compileReactionScript,
@@ -18,12 +20,70 @@ import {
   validateReactionDefaultExport,
 } from "../../../automations/reaction-executor";
 import { assertAutomationInstructions } from "../../../automations/triggers";
-import type { AutomationTrigger } from "@lobu/core/contracts/tools/manage-automations";
+import type {
+  AutomationTrigger,
+  AutomationTriggerExecution,
+  AutomationTriggerResult,
+} from "@lobu/core/contracts/tools/manage-automations";
 import type { ToolContext } from "../../registry";
 import { recordToolConfigChange } from "../helpers/config-audit";
 import { requireExists } from "../helpers/db-helpers";
 import type { ManageAutomationsArgs } from "../manage_automations";
 import { resolveAutomationExecutor } from "./executors";
+
+async function loadTriggerExecution(
+  sql: DbClient,
+  runId: number,
+  automationId: string,
+): Promise<AutomationTriggerExecution> {
+  const [run] = await sql<{ approved_input: unknown }>`
+    SELECT approved_input
+    FROM runs
+    WHERE id = ${runId}
+      AND automation_id = ${Number(automationId)}
+      AND run_type = 'automation'
+    LIMIT 1
+  `;
+  const payload = parseAutomationRunPayload(run?.approved_input);
+  if (!payload || payload.automation_id !== Number(automationId)) {
+    throw new Error("Automation run is missing a valid dispatch payload.");
+  }
+  const executor = resolveAutomationExecutor({
+    agentId: payload.agent_id,
+    deviceWorkerId: payload.device_worker_id,
+    agentKind: payload.agent_kind,
+  });
+  if (executor?.kind === "agent") {
+    return {
+      lane: "managed_agent",
+      owner: "lobu",
+      agent_id: executor.agentId,
+      next_action: { kind: "handled_elsewhere" },
+    };
+  }
+  if (executor?.kind === "device") {
+    return {
+      lane: "device_worker",
+      owner: "device",
+      device_worker_id: executor.deviceWorkerId,
+      agent_kind: executor.agentKind,
+      next_action: { kind: "handled_elsewhere" },
+    };
+  }
+  return {
+    lane: "external_client",
+    owner: "caller",
+    next_action: {
+      kind: "complete_window",
+      read: {
+        method: "knowledge.read",
+        input: { automation_id: payload.automation_id, run_id: runId },
+      },
+      // biome-ignore lint/suspicious/noThenProperty: Public protocol field required by the trigger handoff contract.
+      then: "automations.completeWindow",
+    },
+  };
+}
 
 // ============================================
 // handleTrigger
@@ -32,57 +92,49 @@ import { resolveAutomationExecutor } from "./executors";
 export async function handleTrigger(
   args: ManageAutomationsArgs,
   _env: Env,
-): Promise<{
-  action: "trigger";
-  automation_id: string;
-  run_id: number;
-  status: string;
-}> {
+): Promise<AutomationTriggerResult> {
   const sql = getDb();
 
   if (!args.automation_id) {
     throw new ToolUserError("automation_id is required for trigger action", 400);
   }
+  const automationId = args.automation_id;
 
-  const [automation] = await sql<{
-    agent_id: string | null;
-    device_worker_id: string | null;
-    agent_kind: string | null;
-  }>`
-    SELECT agent_id, device_worker_id::text AS device_worker_id, agent_kind
-    FROM automations
-    WHERE id = ${Number(args.automation_id)}
-    LIMIT 1
-  `;
-  const executor = automation
-    ? resolveAutomationExecutor({
-        agentId: automation.agent_id,
-        deviceWorkerId: automation.device_worker_id,
-        agentKind: automation.agent_kind,
-      })
-    : null;
-  if (executor?.kind === "agent" && !isLobuGatewayRunning()) {
-    throw new Error("Embedded Lobu is not available.");
-  }
+  const queued = await sql.begin(async (tx) => {
+    const run = await enqueueAutomationRunForAutomationInTransaction(
+      Number(automationId),
+      "manual",
+      tx,
+    );
+    const execution = await loadTriggerExecution(
+      tx,
+      run.runId,
+      automationId,
+    );
+    if (execution.lane === "managed_agent" && !isLobuGatewayRunning()) {
+      throw new Error("Embedded Lobu is not available.");
+    }
+    return { ...run, execution };
+  });
+  const dispatch = await dispatchPendingAutomationRuns({
+    db: sql,
+    runIds: [queued.runId],
+  });
+  const runInfo = await getAutomationRunInfo(queued.runId, sql);
 
-  const dispatchResult = await queueAndDispatchAutomationRun(
-    Number(args.automation_id),
-    "manual",
-    sql,
-  );
-
-  if (dispatchResult.dispatch.failed > 0) {
-    const failedRun = await getAutomationRunInfo(dispatchResult.runId, sql);
+  if (dispatch.failed > 0) {
     throw new Error(
-      failedRun?.error_message || "Failed to dispatch Automation run.",
+      runInfo?.error_message || "Failed to dispatch Automation run.",
     );
   }
 
   return {
     action: "trigger",
-    automation_id: args.automation_id,
-    run_id: dispatchResult.runId,
-    status: dispatchResult.status,
+    automation_id: automationId,
+    run_id: queued.runId,
+    status: runInfo?.status ?? queued.status,
+    created: queued.created,
+    execution: queued.execution,
   };
 }
 

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -29,22 +29,47 @@ import type { ToolContext } from "../../registry";
 import { recordToolConfigChange } from "../helpers/config-audit";
 import { requireExists } from "../helpers/db-helpers";
 import type { ManageAutomationsArgs } from "../manage_automations";
+import {
+  encodeExternalAutomationClaimOwner,
+  isExternalAutomationClaimOwner,
+} from "./claim-next-window";
 import { resolveAutomationExecutor } from "./executors";
 
 async function loadTriggerExecution(
   sql: DbClient,
   runId: number,
   automationId: number,
-): Promise<AutomationTriggerExecution> {
-  const [run] = await sql<{ approved_input: unknown }>`
-    SELECT approved_input
-    FROM runs
-    WHERE id = ${runId}
-      AND automation_id = ${automationId}
-      AND run_type = 'automation'
+  automationIdString: string,
+  ctx: ToolContext,
+): Promise<{
+  execution: AutomationTriggerExecution;
+  shouldDispatch: boolean;
+}> {
+  const [run] = await sql<{
+    approved_input: unknown;
+    status: string;
+    claimed_by: string | null;
+    expires_at: string | Date | null;
+    device_claimed_by: string | null;
+  }>`
+    SELECT r.approved_input, r.status, r.claimed_by, r.expires_at,
+           (
+             SELECT dw.worker_id
+             FROM device_workers dw
+             WHERE dw.id::text = r.approved_input->>'device_worker_id'
+             LIMIT 1
+           ) AS device_claimed_by
+    FROM runs r
+    WHERE r.id = ${runId}
+      AND r.automation_id = ${automationId}
+      AND r.run_type = 'automation'
     LIMIT 1
+    FOR UPDATE
   `;
-  const payload = parseAutomationRunPayload(run?.approved_input);
+  if (!run) {
+    throw new Error("Automation run is missing a valid dispatch payload.");
+  }
+  const payload = parseAutomationRunPayload(run.approved_input);
   if (!payload || payload.automation_id !== automationId) {
     throw new Error("Automation run is missing a valid dispatch payload.");
   }
@@ -53,36 +78,100 @@ async function loadTriggerExecution(
     deviceWorkerId: payload.device_worker_id,
     agentKind: payload.agent_kind,
   });
+  let persistedExecution: AutomationTriggerExecution;
   if (executor?.kind === "agent") {
-    return {
+    persistedExecution = {
       lane: "managed_agent",
       owner: "lobu",
       agent_id: executor.agentId,
       next_action: { kind: "handled_elsewhere" },
     };
-  }
-  if (executor?.kind === "device") {
-    return {
+  } else if (executor?.kind === "device") {
+    persistedExecution = {
       lane: "device_worker",
       owner: "device",
       device_worker_id: executor.deviceWorkerId,
       agent_kind: executor.agentKind,
       next_action: { kind: "handled_elsewhere" },
     };
-  }
-  return {
-    lane: "external_client",
-    owner: "caller",
-    next_action: {
-      kind: "complete_window",
-      read: {
-        method: "knowledge.read",
-        input: { automation_id: payload.automation_id, run_id: runId },
+  } else {
+    persistedExecution = {
+      lane: "external_client",
+      owner: "caller",
+      next_action: {
+        kind: "complete_window",
+        read: {
+          method: "knowledge.read",
+          input: { automation_id: payload.automation_id, run_id: runId },
+        },
+        // biome-ignore lint/suspicious/noThenProperty: Public protocol field required by the trigger handoff contract.
+        then: "automations.completeWindow",
       },
-      // biome-ignore lint/suspicious/noThenProperty: Public protocol field required by the trigger handoff contract.
-      then: "automations.completeWindow",
-    },
-  };
+    };
+  }
+
+  if (run.status === "pending") {
+    return { execution: persistedExecution, shouldDispatch: true };
+  }
+  if (run.status !== "claimed" && run.status !== "running") {
+    throw new ToolUserError(
+      `Automation run ${runId} is no longer active.`,
+      409,
+    );
+  }
+
+  const claimedBy = run.claimed_by?.trim();
+  if (!claimedBy) {
+    throw new ToolUserError(
+      `Automation run ${runId} has no recognized active claimant.`,
+      409,
+    );
+  }
+  if (isExternalAutomationClaimOwner(claimedBy)) {
+    const leaseExpiresAt =
+      run.expires_at == null ? Number.NaN : new Date(run.expires_at).getTime();
+    if (!Number.isFinite(leaseExpiresAt) || leaseExpiresAt <= Date.now()) {
+      throw new ToolUserError(
+        `Automation run ${runId} has no recognized active claimant.`,
+        409,
+      );
+    }
+    if (claimedBy === encodeExternalAutomationClaimOwner(ctx)) {
+      return {
+        execution: {
+          lane: "external_client",
+          owner: "caller",
+          next_action: {
+            kind: "resume_claim",
+            method: "automations.claimNextWindow",
+            input: { automation_id: automationIdString, run_id: runId },
+          },
+        },
+        shouldDispatch: false,
+      };
+    }
+    return {
+      execution: {
+        lane: "external_client",
+        owner: "another_caller",
+        next_action: { kind: "handled_elsewhere" },
+      },
+      shouldDispatch: false,
+    };
+  }
+
+  const nativeManagedClaim =
+    executor?.kind === "agent" &&
+    (claimedBy === "lobu-dispatcher" || claimedBy === `lobu:${executor.agentId}`);
+  const nativeDeviceClaim =
+    executor?.kind === "device" && claimedBy === run.device_claimed_by;
+  if (!nativeManagedClaim && !nativeDeviceClaim) {
+    throw new ToolUserError(
+      `Automation run ${runId} has no recognized active claimant.`,
+      409,
+    );
+  }
+  return { execution: persistedExecution, shouldDispatch: false };
 }
 
 // ============================================
@@ -92,6 +181,7 @@ async function loadTriggerExecution(
 export async function handleTrigger(
   args: ManageAutomationsArgs,
   _env: Env,
+  ctx: ToolContext,
 ): Promise<AutomationTriggerResult> {
   const sql = getDb();
 
@@ -100,12 +190,6 @@ export async function handleTrigger(
   }
   const automationIdString = args.automation_id;
   const automationId = Number(automationIdString);
-  if (!Number.isSafeInteger(automationId) || automationId < 1) {
-    throw new ToolUserError(
-      "automation_id must be a positive integer for trigger action",
-      400,
-    );
-  }
 
   const queued = await sql.begin(async (tx) => {
     const run = await enqueueAutomationRunForAutomationInTransaction(
@@ -113,20 +197,28 @@ export async function handleTrigger(
       "manual",
       tx,
     );
-    const execution = await loadTriggerExecution(
+    const loaded = await loadTriggerExecution(
       tx,
       run.runId,
       automationId,
+      automationIdString,
+      ctx,
     );
-    if (execution.lane === "managed_agent" && !isLobuGatewayRunning()) {
+    if (
+      loaded.shouldDispatch &&
+      loaded.execution.lane === "managed_agent" &&
+      !isLobuGatewayRunning()
+    ) {
       throw new Error("Embedded Lobu is not available.");
     }
-    return { ...run, execution };
+    return { ...run, ...loaded };
   });
-  const dispatch = await dispatchPendingAutomationRuns({
-    db: sql,
-    runIds: [queued.runId],
-  });
+  const dispatch = queued.shouldDispatch
+    ? await dispatchPendingAutomationRuns({
+        db: sql,
+        runIds: [queued.runId],
+      })
+    : { failed: 0 };
   const runInfo = await getAutomationRunInfo(queued.runId, sql);
 
   if (dispatch.failed > 0) {


### PR DESCRIPTION
## Summary
- Extend the typed Automation trigger response while preserving action, automation_id, run_id, and status.
- Route pending runs from the persisted approved_input snapshot; route claimed/running runs from the durable claimed_by identity and active lease.
- Return resume_claim to the same external claimant, handled_elsewhere to another external claimant, and fail closed for expired or unrecognized claims.
- Keep native managed-agent and device-worker claims handled elsewhere, and skip dispatch plus managed-gateway preflight for already claimed/running runs.
- Keep enqueue, snapshot resolution, and pending managed-gateway preflight in one transaction; dispatch a pending run only after commit.
- Make transaction-owned run creation recover unique races through an explicit savepoint path while preserving root-pool callers.

## Test plan
- [x] Focused trigger/external-completion/unique-race integration tests
- [x] Sandbox metadata and SDK-search tests
- [x] Server typecheck and generated client contract checks
- [x] make pre-pr

## Notes
Closes #3083

The typed response is extended while retaining all existing fields; no compatibility alias was added. Claim identity, eligibility, lease, token, and completion semantics are unchanged. No approved_input mutation, schema migration, new queue, daemon, scheduler, or UI is included.