### PR TITLE
fix(automations): preserve device catch-up scheduling

### DIFF
--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -946,7 +946,7 @@ export async function handleCompleteWindow(
       await advanceAutomationScheduleAfterSuccessfulWindow(
         tx,
         automationId,
-        Boolean(lockedRun.device_worker_id),
+        Boolean(assignedDeviceWorkerId),
         timeGranularity
       );
     }


### PR DESCRIPTION
## What changed

Use the device assignment already decoded from the run's durable approved input when advancing a completed schedule window. The previous code read a nonexistent field from the locked run projection, which both failed TypeScript and treated device-pinned catch-up runs as ordinary schedules at runtime.

## Verification

- `bun run --filter '@lobu/server' typecheck`
- `bun run --filter '@lobu/server' test -- run src/__tests__/integration/automations/device-schedule-liveness.test.ts` (3/3)

One runtime line changed. No schema, API, or migration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation schedule advancement by correctly determining whether execution should run on the assigned device worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->