### PR TITLE
feat(device-daemon): run Codex automations over ACP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -193,6 +193,8 @@
         "connector-worker": "./dist/bin.js",
       },
       "dependencies": {
+        "@agentclientprotocol/codex-acp": "1.6.2",
+        "@agentclientprotocol/sdk": "1.4.0",
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
@@ -523,6 +525,10 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@agentclientprotocol/codex-acp": ["@agentclientprotocol/codex-acp@1.6.2", "", { "dependencies": { "@agentclientprotocol/sdk": "^1.3.0", "@openai/codex": "^0.148.0", "diff": "^9.0.0", "open": "^11.0.0", "vscode-jsonrpc": "^9.0.1", "zod": "^4.0.0" }, "bin": { "codex-acp": "dist/index.js" } }, "sha512-2eF1mbs1gTqkZJSLYOun/pFDx37sYa7W63HOPezC37b/R8AYms5O1nfQu8lrqFSGDrwDZkASVORymLcqjCNqyA=="],
+
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.4.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1259,6 +1265,20 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@openai/codex": ["@openai/codex@0.148.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.148.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.148.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.148.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.148.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.148.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.148.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-bh5kH9+BMrFaHGmLeoSansPdfRksvr4UXzjQInns/KRO7r8VJ+6AAW+SqUsE8XcG3+OW/mI4EEy8Gpo9UDXGvQ=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.148.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xgBPFiF1fHUlRS7HE6wGB56LjBJh16kGD7b4TTbwdVBZNB4QDkTok+vdkAGrfpVkfKcwGNhPSKDgCw+KMZOVug=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.148.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-qepQolhJutfOp+e9i7L3xsi8aoWeCUiiRq274WMWqRj50rKTrXxsuAgkAwDbqEfT3G5VynhYZuQvDsW37JgdNQ=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.148.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-51DCd+izzk6n4mMh4w2utWj3lTLhSTnCOEJQfRh0LS9nBDkcYZcK3iSKOST6fByRIlLSXuLO33LlYYA1VPot6A=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.148.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-uDT9s7AfMr9xLuJX3ZLVWHgHkUpCnZ33CZjZEdVQhrYCIErkDHsCW5TG290nNjaKngK0WxGt5uCcxeUHv9MWWA=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.148.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-a8iOwLzs8UdnlWDHjgK3W/YSBBsUImG8X5XLBjengp3XGJRruhiIsQtUDUOYimCmotKPM4aX7Ub6zjl/KPxMQQ=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.148.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-/Jg8eYw0BqTGNUpnrzzWlK2kbu29NWg7t6pnUDEfxqpTUf+mK8r3okXQn60Zjbk9InYZ4d8SwSjrtOa+i5hSPw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -2416,7 +2436,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "diff3": ["diff3@0.0.3", "", {}, "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="],
 
@@ -3816,6 +3836,8 @@
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
+    "vscode-jsonrpc": ["vscode-jsonrpc@9.0.1", "", {}, "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw=="],
+
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
@@ -3899,6 +3921,8 @@
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@agentclientprotocol/codex-acp/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -4059,6 +4083,8 @@
     "@lobu/worker/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@mariozechner/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@mariozechner/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -4450,6 +4476,8 @@
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -4549,6 +4577,8 @@
     "jscpd/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "jstransformer/is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
+
+    "just-bash/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "just-bash/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -4689,6 +4719,8 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
+    "@agentclientprotocol/codex-acp/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -57,6 +57,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@agentclientprotocol/codex-acp": "1.6.2",
+    "@agentclientprotocol/sdk": "1.4.0",
     "@lobu/connector-sdk": "workspace:*",
     "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",

--- a/packages/connector-worker/src/__tests__/codex-acp.test.ts
+++ b/packages/connector-worker/src/__tests__/codex-acp.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parseSessionEntries } from '@lobu/core';
+import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
+import { executeAutomationRun } from '../daemon/automation.js';
+import { type ExecutorClient, WorkerClient } from '../daemon/client.js';
+import { CodexAcpTranscript, runCodexAcpTurn } from '../daemon/codex-acp.js';
+
+function fakeAcpAgent(dir: string): { script: string; trace: string } {
+  const script = path.join(dir, 'fake-acp-agent.mjs');
+  const trace = path.join(dir, 'trace.jsonl');
+  writeFileSync(
+    script,
+    `import fs from 'node:fs';
+import readline from 'node:readline';
+const trace = process.env.FAKE_ACP_TRACE;
+const waiting = new Map();
+const record = (value) => fs.appendFileSync(trace, JSON.stringify(value) + '\\n');
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const response = (id, result) => send({ jsonrpc: '2.0', id, result });
+const update = (sessionId, value) => send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId, update: value } });
+const input = readline.createInterface({ input: process.stdin });
+for await (const line of input) {
+  if (!line.trim()) continue;
+  const message = JSON.parse(line);
+  record(message);
+  if (message.method === 'initialize') {
+    response(message.id, {
+      protocolVersion: 1,
+      agentCapabilities: {
+        mcpCapabilities: { http: true },
+        sessionCapabilities: { resume: {}, close: {} }
+      },
+      agentInfo: { name: 'fake-codex-acp', version: '1' }
+    });
+  } else if (message.method === 'session/new') {
+    response(message.id, {
+      sessionId: 'acp-new-session',
+      modes: { currentModeId: 'read-only', availableModes: [
+        { id: 'read-only', name: 'Read-only' },
+        { id: 'agent', name: 'Agent' }
+      ] },
+      configOptions: [
+        { id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: 'default', options: [{ value: 'gpt-test', name: 'GPT Test' }] },
+        { id: 'reasoning_effort', name: 'Effort', category: 'thought_level', type: 'select', currentValue: 'medium', options: [{ value: 'high', name: 'High' }] }
+      ]
+    });
+  } else if (message.method === 'session/resume') {
+    response(message.id, {
+      modes: { currentModeId: 'agent', availableModes: [{ id: 'agent', name: 'Agent' }] },
+      configOptions: []
+    });
+  } else if (message.method === 'session/set_mode') {
+    response(message.id, {});
+  } else if (message.method === 'session/set_config_option') {
+    response(message.id, { configOptions: [] });
+  } else if (message.method === 'session/prompt') {
+    const sessionId = message.params.sessionId;
+    if (process.env.FAKE_ACP_WAIT_FOR_CANCEL === '1') {
+      waiting.set(sessionId, message.id);
+      continue;
+    }
+    update(sessionId, { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'private chain of thought' }, messageId: 'thought-1' });
+    update(sessionId, { sessionUpdate: 'tool_call', toolCallId: 'tool-1', title: 'Read run context', kind: 'read', status: 'in_progress', rawInput: { run_id: 99 } });
+    update(sessionId, { sessionUpdate: 'tool_call_update', toolCallId: 'tool-1', status: 'completed', rawOutput: { ok: true } });
+    update(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ACP ' }, messageId: 'answer-1' });
+    update(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'finished' }, messageId: 'answer-1' });
+    response(message.id, { stopReason: 'end_turn', usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 } });
+  } else if (message.method === 'session/cancel') {
+    const id = waiting.get(message.params.sessionId);
+    if (id !== undefined) {
+      waiting.delete(message.params.sessionId);
+      response(id, { stopReason: 'cancelled' });
+    }
+  } else if (message.method === 'session/close') {
+    response(message.id, {});
+  }
+}
+`,
+    'utf8'
+  );
+  return { script, trace };
+}
+
+function traceLines(trace: string): Array<Record<string, unknown>> {
+  return readFileSync(trace, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('Codex ACP Automation turn', () => {
+  test('routes the Mac Automation through ACP and uploads its terminal transcript', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-automation-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    const checkpoints: unknown[] = [];
+    const snapshots: Array<{ bearer: string; status: string; jsonl: string }> = [];
+    const client = {
+      id: 'macos:test',
+      async heartbeat(_runId: number, _progress: unknown, session: unknown) {
+        if (session) checkpoints.push(session);
+      },
+      async completeAutomation() {
+        return { ok: true, status: 'completed', run_id: 99 };
+      },
+      async writeAutomationTranscript(
+        _runId: number,
+        bearer: string,
+        status: string,
+        jsonl: string
+      ) {
+        snapshots.push({ bearer, status, jsonl });
+      },
+    } as unknown as ExecutorClient;
+    const job: PollResponse = {
+      run_id: 99,
+      run_type: 'automation',
+      payload: {
+        automation: {
+          id: '42',
+          name: 'ACP Automation',
+          agent_kind: 'codex',
+          prompt: 'Do the work.',
+        },
+        event: { fired_at: new Date().toISOString(), payload: {} },
+        context: {
+          device: { worker_id: 'macos:test' },
+          user: {},
+          agent_session: {
+            conversation_id: 'agent_automation_42_run_99',
+            mcp_url: 'https://lobu.test/mcp/team',
+            token: 'run-scoped-token',
+            expires_at: Date.now() + 60_000,
+          },
+        },
+      },
+    };
+    try {
+      const outcome = await executeAutomationRun(client, job, {
+        requireRunScopedSession: true,
+        timeoutMs: 5_000,
+        codexAcp: {
+          adapterCommand: process.execPath,
+          adapterArgs: [script],
+          adapterEnv: { FAKE_ACP_TRACE: trace },
+          codexPath: '/usr/local/bin/codex',
+        },
+      });
+
+      expect(outcome.error).toBeUndefined();
+      expect(checkpoints).toEqual([
+        { protocol: 'acp', agent_kind: 'codex', session_id: 'acp-new-session' },
+      ]);
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]?.bearer).toBe('run-scoped-token');
+      expect(snapshots[0]?.status).toBe('completed');
+      expect(snapshots[0]?.jsonl).toContain('ACP finished');
+      expect(readFileSync(trace, 'utf8')).toContain('session/new');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('creates a workspace-write session with HTTP MCP, model parity, and a safe transcript', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    const ready: string[] = [];
+    try {
+      const result = await runCodexAcpTurn({
+        adapterCommand: process.execPath,
+        adapterArgs: [script],
+        adapterEnv: { FAKE_ACP_TRACE: trace },
+        codexPath: '/usr/local/bin/codex',
+        cwd: dir,
+        prompt: 'Finish Automation 99',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        model: 'gpt-test',
+        effort: 'high',
+        timeoutMs: 5_000,
+        onSessionReady: async (sessionId) => ready.push(sessionId),
+      });
+
+      expect(result.exitReason).toBe('ok');
+      expect(result.output).toBe('ACP finished');
+      expect(result.sessionId).toBe('acp-new-session');
+      expect(ready).toEqual(['acp-new-session']);
+
+      const calls = traceLines(trace);
+      const created = calls.find((line) => line.method === 'session/new') as {
+        params: { cwd: string; mcpServers: Array<Record<string, unknown>> };
+      };
+      expect(created.params.cwd).toBe(dir);
+      expect(created.params.mcpServers).toEqual([
+        {
+          type: 'http',
+          name: 'lobu-memory',
+          url: 'https://lobu.test/mcp/team',
+          headers: [{ name: 'Authorization', value: 'Bearer run-token' }],
+        },
+      ]);
+      expect(calls).toContainEqual(expect.objectContaining({
+        method: 'session/set_mode',
+        params: { sessionId: 'acp-new-session', modeId: 'agent' },
+      }));
+      expect(calls).toContainEqual(expect.objectContaining({
+        method: 'session/set_config_option',
+        params: { sessionId: 'acp-new-session', configId: 'model', value: 'gpt-test' },
+      }));
+      expect(calls).toContainEqual(expect.objectContaining({
+        method: 'session/set_config_option',
+        params: { sessionId: 'acp-new-session', configId: 'reasoning_effort', value: 'high' },
+      }));
+
+      const parsed = parseSessionEntries(result.transcriptJsonl);
+      expect(parsed.sessionId).toBe('acp-new-session');
+      expect(JSON.stringify(parsed.entries)).not.toContain('private chain of thought');
+      expect(JSON.stringify(parsed.entries)).toContain('Read run context');
+      expect(JSON.stringify(parsed.entries)).toContain('ACP finished');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('resumes the exact persisted session without listing local sessions', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-resume-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    try {
+      const result = await runCodexAcpTurn({
+        adapterCommand: process.execPath,
+        adapterArgs: [script],
+        adapterEnv: { FAKE_ACP_TRACE: trace },
+        codexPath: '/usr/local/bin/codex',
+        cwd: dir,
+        prompt: 'Continue the run',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        resumeSessionId: 'persisted-session-99',
+        timeoutMs: 5_000,
+        onSessionReady: async () => {},
+      });
+
+      expect(result.sessionId).toBe('persisted-session-99');
+      const calls = traceLines(trace);
+      expect(calls.some((line) => line.method === 'session/new')).toBe(false);
+      expect(calls.some((line) => line.method === 'session/list')).toBe(false);
+      expect(calls).toContainEqual(expect.objectContaining({
+        method: 'session/resume',
+        params: expect.objectContaining({ sessionId: 'persisted-session-99' }),
+      }));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('cancels the ACP prompt and tears down the adapter tree on shutdown', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-cancel-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    const controller = new AbortController();
+    try {
+      const running = runCodexAcpTurn({
+        adapterCommand: process.execPath,
+        adapterArgs: [script],
+        adapterEnv: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
+        codexPath: '/usr/local/bin/codex',
+        cwd: dir,
+        prompt: 'Wait until cancelled',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        timeoutMs: 10_000,
+        abortSignal: controller.signal,
+        onSessionReady: async () => {},
+      });
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (existsSync(trace) && readFileSync(trace, 'utf8').includes('session/prompt')) break;
+        await Bun.sleep(20);
+      }
+      controller.abort();
+      const result = await running;
+
+      expect(result.exitReason).toBe('cancelled');
+      expect(traceLines(trace).some((line) => line.method === 'session/cancel')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('classifies an ACP deadline separately from daemon cancellation', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-timeout-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    try {
+      const result = await runCodexAcpTurn({
+        adapterCommand: process.execPath,
+        adapterArgs: [script],
+        adapterEnv: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
+        codexPath: '/usr/local/bin/codex',
+        cwd: dir,
+        prompt: 'Wait until the deadline',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        timeoutMs: 50,
+        onSessionReady: async () => {},
+      });
+
+      expect(result.exitReason).toBe('timeout');
+      expect(result.error).toContain('timed out');
+      expect(traceLines(trace).some((line) => line.method === 'session/cancel')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('each finalize round uploads a byte-exact prefix extension', async () => {
+    const transcript = new CodexAcpTranscript('/workspace');
+    transcript.setSession('acp-multi-round');
+    transcript.appendTurn('first prompt', [
+      { kind: 'assistant', messageId: 'm1', text: 'round one' },
+    ]);
+    const firstUpload = transcript.toJsonl();
+    // The server's snapshot upsert only accepts a continuation that extends the
+    // stored bytes exactly, so the frozen session header must not drift.
+    await Bun.sleep(1_100);
+    transcript.appendTurn('finalize nudge', [
+      { kind: 'assistant', messageId: 'm2', text: 'round two' },
+    ]);
+    const secondUpload = transcript.toJsonl();
+
+    expect(secondUpload.startsWith(firstUpload)).toBe(true);
+    expect(secondUpload).toContain('round two');
+  });
+
+  test('a rejected resume surfaces the adapter error, not a serialization throw', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-resume-fail-'));
+    const script = path.join(dir, 'rejecting-agent.mjs');
+    writeFileSync(
+      script,
+      `import readline from 'node:readline';
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+for await (const line of readline.createInterface({ input: process.stdin })) {
+  if (!line.trim()) continue;
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: message.id, result: {
+      protocolVersion: 1,
+      agentCapabilities: { mcpCapabilities: { http: true }, sessionCapabilities: { resume: {} } },
+      agentInfo: { name: 'rejecting-agent', version: '1' }
+    } });
+  } else if (message.method === 'session/resume') {
+    send({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: 'no such session' } });
+  }
+}
+`,
+      'utf8'
+    );
+    try {
+      const result = await runCodexAcpTurn({
+        adapterCommand: process.execPath,
+        adapterArgs: [script],
+        codexPath: '/usr/local/bin/codex',
+        cwd: dir,
+        prompt: 'Continue a session the agent lost',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        resumeSessionId: 'session-the-agent-forgot',
+        timeoutMs: 5_000,
+        onSessionReady: async () => {},
+      });
+
+      expect(result.exitReason).toBe('crash');
+      expect(result.error).toContain('no such session');
+      expect(result.transcriptJsonl).toBe('');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('WorkerClient uploads with the run token, never the device PAT', async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; authorization: string | null; body: unknown }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: String(input),
+        authorization: headers.get('authorization'),
+        body: JSON.parse(String(init?.body)),
+      });
+      return Response.json({ id: 1 });
+    }) as typeof fetch;
+    try {
+      const client = new WorkerClient({
+        apiUrl: 'https://lobu.test/',
+        workerId: 'macos:test',
+        authToken: 'device-pat-must-not-cross',
+        capabilities: { 'automations.execute': true },
+      });
+      await client.writeAutomationTranscript(
+        99,
+        'run-scoped-token',
+        'completed',
+        '{"type":"session","id":"acp"}\n'
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requests).toEqual([
+      {
+        url: 'https://lobu.test/worker/transcript/snapshot',
+        authorization: 'Bearer run-scoped-token',
+        body: {
+          runId: 99,
+          terminalStatus: 'completed',
+          snapshotJsonl: '{"type":"session","id":"acp"}\n',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -101,9 +101,10 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
     try {
       target = spawnChild(binary, args, {
         env: process.env,
-        stdio: ['ignore', 'inherit', 'inherit'],
+        stdio: ['pipe', 'inherit', 'inherit'],
         windowsHide: true,
       });
+      if (target.stdin) process.stdin.pipe(target.stdin);
     } catch (error) {
       finish(127, null, error instanceof Error ? error.message : String(error));
     }
@@ -317,7 +318,8 @@ export async function terminateChild(proc: ChildProcess): Promise<'SIGTERM' | 'S
 export function spawnSupervisedCli(
   binary: string,
   args: string[],
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  options: { stdin?: 'ignore' | 'pipe' } = {}
 ): SupervisedCli {
   const supervisor = spawn(
     process.execPath,
@@ -325,7 +327,7 @@ export function spawnSupervisedCli(
     {
       detached: SUPPORTS_PROCESS_GROUPS,
       env,
-      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      stdio: [options.stdin ?? 'ignore', 'pipe', 'pipe', 'ipc'],
       windowsHide: true,
     }
   );

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -60,6 +60,10 @@ import {
   handoffToInteractiveSession,
   type InteractiveSession,
 } from './interactive-session.js';
+import {
+  CodexAcpTranscript,
+  runCodexAcpTurn,
+} from './codex-acp.js';
 
 /**
  * The slice of the daemon's `ExecutorConfig` the automation arm reads.
@@ -96,6 +100,13 @@ export interface AutomationExecutorConfig {
    * use to drive a fake binary.
    */
   binaryOverrides?: Partial<Record<AgentKind, string>>;
+  /** Mac-only packaged ACP adapter route for Codex Automations. */
+  codexAcp?: {
+    adapterCommand: string;
+    adapterArgs: string[];
+    adapterEnv?: NodeJS.ProcessEnv;
+    codexPath: string;
+  };
 }
 
 /** Local-CLI run result, mirrored from the Mac app's `ExecutorResult`. */
@@ -106,6 +117,8 @@ export interface ExecutorResult {
   exitSignal: string | null;
   exitReason: WorkerExitReason;
   durationMs: number;
+  /** Present only for a Codex ACP turn; cumulative across finalize rounds. */
+  transcriptJsonl?: string;
 }
 
 const STDOUT_CAP = 4 * 1024 * 1024;
@@ -127,6 +140,8 @@ const DETAIL_TAIL_CHARS = 500;
 const LOCAL_MAX_ROUNDS = 8;
 const EXIT_REPORT_DELIVERY_ATTEMPTS = 3;
 const EXIT_REPORT_RETRY_DELAY_MS = 2000;
+const TRANSCRIPT_DELIVERY_ATTEMPTS = 3;
+const TRANSCRIPT_RETRY_DELAY_MS = 250;
 const TERMINAL_HEARTBEAT_GRACE_MS = 15_000;
 
 /** Sentinel for "binary not on PATH" so it maps to a distinct exit reason. */
@@ -699,6 +714,9 @@ export async function executeAutomationRun(
   // internally; per-run detection is not repeated here.
   const interactiveSession = attachedInteractiveSession(cfg);
   const agentSession = payload.context.agent_session;
+  const codexAcp = spec.kind === 'codex' ? cfg.codexAcp : undefined;
+  let acpSessionId = agentSession?.resume_session_id;
+  const acpTranscript = codexAcp ? new CodexAcpTranscript(process.cwd()) : undefined;
   const selectedSession = isInteractiveSessionEligible(spec.kind, interactiveSession, payload)
     ? interactiveSession
     : undefined;
@@ -809,6 +827,36 @@ export async function executeAutomationRun(
           `[executor] Automation run ${runId}: interactive ${selectedSession.kind} unavailable before delivery; using subprocess`
         );
       }
+      if (codexAcp && agentSession && acpTranscript) {
+        const result = await runCodexAcpTurn({
+          adapterCommand: codexAcp.adapterCommand,
+          adapterArgs: codexAcp.adapterArgs,
+          ...(codexAcp.adapterEnv ? { adapterEnv: codexAcp.adapterEnv } : {}),
+          codexPath: codexAcp.codexPath,
+          cwd: process.cwd(),
+          prompt,
+          mcp: { url: agentSession.mcp_url, bearer: agentSession.token },
+          ...(acpSessionId ? { resumeSessionId: acpSessionId } : {}),
+          ...(payload.automation.execution_config?.model
+            ? { model: payload.automation.execution_config.model }
+            : {}),
+          ...(payload.automation.execution_config?.effort
+            ? { effort: payload.automation.execution_config.effort }
+            : {}),
+          timeoutMs,
+          abortSignal: runAbort.signal,
+          transcript: acpTranscript,
+          onSessionReady: async (sessionId) => {
+            await client.heartbeat(runId, undefined, {
+              protocol: 'acp',
+              agent_kind: 'codex',
+              session_id: sessionId,
+            });
+          },
+        });
+        acpSessionId = result.sessionId;
+        return result;
+      }
       return runCli(
         spec,
         prompt,
@@ -821,8 +869,43 @@ export async function executeAutomationRun(
         cfg.terminalHeartbeatGraceMs
       );
     },
-    deliver: (result, finalizeAttempt) =>
-      deliverExitReport(client, runId, result, finalizeAttempt),
+    deliver: async (result, finalizeAttempt) => {
+      const report = await deliverExitReport(client, runId, result, finalizeAttempt);
+      if (report && report.status !== 'resume' && result.transcriptJsonl && agentSession) {
+        const terminalStatus =
+          report.status === 'completed'
+            ? 'completed'
+            : report.status === 'cancelled' || result.exitReason === 'cancelled'
+              ? 'cancelled'
+              : result.exitReason === 'timeout'
+                ? 'timeout'
+                : 'failed';
+        let transcriptError: unknown;
+        for (let attempt = 0; attempt < TRANSCRIPT_DELIVERY_ATTEMPTS; attempt++) {
+          try {
+            await client.writeAutomationTranscript(
+              runId,
+              agentSession.token,
+              terminalStatus,
+              result.transcriptJsonl
+            );
+            transcriptError = undefined;
+            break;
+          } catch (error) {
+            transcriptError = error;
+            if (attempt + 1 < TRANSCRIPT_DELIVERY_ATTEMPTS) {
+              await sleep(TRANSCRIPT_RETRY_DELAY_MS);
+            }
+          }
+        }
+        if (transcriptError) {
+          log.info(
+            `[executor] Automation run ${runId}: terminal ACP transcript upload failed: ${transcriptError instanceof Error ? transcriptError.message : String(transcriptError)}`
+          );
+        }
+      }
+      return report;
+    },
     reportError: (error, reason) =>
       completeAutomationWithError(client, runId, error, reason),
   };

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -29,7 +29,8 @@ export interface ExecutorClient {
       items_collected_so_far?: number;
       current_page?: number;
       elapsed_ms?: number;
-    }
+    },
+    agentSession?: NonNullable<HeartbeatRequest['agent_session']>
   ): Promise<void>;
   stream(batch: StreamBatch): Promise<void>;
   complete(req: CompleteRequest): Promise<void>;
@@ -57,6 +58,13 @@ export interface ExecutorClient {
   ): Promise<CompleteAutomationResponse>;
   /** MCP endpoint + bearer the automation arm wires into the spawned CLI. */
   readonly mcpWiring?: { url: string; bearer?: string };
+  /** Terminal ACP transcript upload authenticated by the per-run agent token. */
+  writeAutomationTranscript(
+    runId: number,
+    bearer: string,
+    terminalStatus: 'completed' | 'failed' | 'timeout' | 'cancelled',
+    snapshotJsonl: string
+  ): Promise<void>;
 }
 
 // ============================================
@@ -81,6 +89,7 @@ export type {
   DispatchChromeActionResponse,
   EmbedEvent,
   EmitAuthArtifactRequest,
+  HeartbeatRequest,
   OAuthCredentials,
   PollAuthSignalRequest,
   PollAuthSignalResponse,
@@ -98,6 +107,7 @@ import type {
   DispatchChromeActionResponse,
   EmbedEvent,
   EmitAuthArtifactRequest,
+  HeartbeatRequest,
   PollAuthSignalRequest,
   PollAuthSignalResponse,
   PollResponse,
@@ -349,13 +359,40 @@ export class WorkerClient implements ExecutorClient {
       items_collected_so_far?: number;
       current_page?: number;
       elapsed_ms?: number;
-    }
+    },
+    agentSession?: NonNullable<HeartbeatRequest['agent_session']>
   ): Promise<void> {
     await this.requestVoid('/api/workers/heartbeat', {
       run_id: runId,
       worker_id: this.workerId,
       progress,
+      ...(agentSession ? { agent_session: agentSession } : {}),
     });
+  }
+
+  async writeAutomationTranscript(
+    runId: number,
+    bearer: string,
+    terminalStatus: 'completed' | 'failed' | 'timeout' | 'cancelled',
+    snapshotJsonl: string
+  ): Promise<void> {
+    const route = '/worker/transcript/snapshot';
+    const response = await fetch(`${this.apiUrl}${route}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ runId, terminalStatus, snapshotJsonl }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new WorkerHttpError(
+        response.status,
+        route,
+        `${response.statusText} ${body}`.trim()
+      );
+    }
   }
 
   /**

--- a/packages/connector-worker/src/daemon/codex-acp.ts
+++ b/packages/connector-worker/src/daemon/codex-acp.ts
@@ -1,0 +1,442 @@
+import { Readable, Writable } from 'node:stream';
+import * as acp from '@agentclientprotocol/sdk';
+import type {
+  NewSessionResponse,
+  PromptResponse,
+  SessionUpdate,
+  ToolCall,
+  Usage,
+} from '@agentclientprotocol/sdk';
+import {
+  releaseSupervisor,
+  spawnSupervisedCli,
+  terminateChild,
+  waitForTargetExit,
+} from './automation-process.js';
+import type { ExecutorResult } from './automation.js';
+
+const STDERR_CAP = 1024 * 1024;
+const CANCEL_GRACE_MS = 2_000;
+const ADAPTER_EXIT_GRACE_MS = 3_000;
+const TRANSCRIPT_VALUE_CAP = 64 * 1024;
+
+export interface CodexAcpTurnOptions {
+  adapterCommand: string;
+  adapterArgs?: string[];
+  adapterEnv?: NodeJS.ProcessEnv;
+  codexPath: string;
+  cwd: string;
+  prompt: string;
+  mcp: { url: string; bearer: string };
+  resumeSessionId?: string;
+  model?: string;
+  effort?: string;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+  onSessionReady: (sessionId: string) => Promise<void>;
+  transcript?: CodexAcpTranscript;
+}
+
+export interface CodexAcpTurnResult extends ExecutorResult {
+  sessionId: string;
+  transcriptJsonl: string;
+}
+
+type TranscriptEvent =
+  | { kind: 'assistant'; messageId: string; text: string }
+  | { kind: 'tool'; tool: ToolCall }
+  | {
+      kind: 'tool-result';
+      toolCallId: string;
+      failed: boolean;
+      output: unknown;
+    };
+
+function cappedJsonValue(value: unknown): unknown {
+  if (value === undefined) return null;
+  let json: string;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    return '[unserializable ACP value]';
+  }
+  if (json.length <= TRANSCRIPT_VALUE_CAP) return value;
+  return `${json.slice(0, TRANSCRIPT_VALUE_CAP)}…[truncated]`;
+}
+
+function contentText(update: SessionUpdate): string | null {
+  if (
+    (update.sessionUpdate === 'agent_message_chunk' ||
+      update.sessionUpdate === 'agent_thought_chunk' ||
+      update.sessionUpdate === 'user_message_chunk') &&
+    update.content.type === 'text'
+  ) {
+    return update.content.text;
+  }
+  return null;
+}
+
+/** Builds the existing Lobu session JSONL shape from public ACP updates. */
+export class CodexAcpTranscript {
+  private sessionId: string | null = null;
+  private startedAt: string | null = null;
+  private readonly entries: Array<Record<string, unknown>> = [];
+  private parentId: string | null = null;
+  private sequence = 0;
+
+  constructor(private readonly cwd: string) {}
+
+  setSession(sessionId: string): void {
+    if (this.sessionId && this.sessionId !== sessionId) {
+      throw new Error(`ACP transcript session changed from ${this.sessionId} to ${sessionId}`);
+    }
+    this.sessionId = sessionId;
+    this.startedAt ??= new Date().toISOString();
+  }
+
+  appendTurn(prompt: string, events: TranscriptEvent[], usage?: Usage | null): void {
+    this.appendMessage('user', [{ type: 'text', text: prompt }]);
+    let lastAssistantIndex = -1;
+    for (const event of events) {
+      if (event.kind === 'assistant') {
+        this.appendMessage('assistant', [{ type: 'text', text: event.text }]);
+        lastAssistantIndex = this.entries.length - 1;
+        continue;
+      }
+      if (event.kind === 'tool') {
+        this.appendMessage('assistant', [
+          {
+            type: 'tool_use',
+            id: event.tool.toolCallId,
+            name: event.tool.name ?? event.tool.title,
+            input: cappedJsonValue({
+              title: event.tool.title,
+              kind: event.tool.kind,
+              status: event.tool.status,
+              rawInput: event.tool.rawInput,
+            }),
+          },
+        ]);
+        continue;
+      }
+      this.appendMessage('toolResult', [
+        {
+          type: 'tool_result',
+          tool_use_id: event.toolCallId,
+          is_error: event.failed,
+          content: [{ type: 'text', text: JSON.stringify(cappedJsonValue(event.output)) }],
+        },
+      ]);
+    }
+    if (usage && lastAssistantIndex >= 0) {
+      const entry = this.entries[lastAssistantIndex] as {
+        message?: { usage?: { inputTokens: number; outputTokens: number } };
+      };
+      if (entry.message) {
+        entry.message.usage = {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+        };
+      }
+    }
+  }
+
+  /** True once a session id is bound, i.e. `toJsonl` can serialize. */
+  get hasSession(): boolean {
+    return this.sessionId != null;
+  }
+
+  /**
+   * Append-only by construction: the header is frozen at session setup so each
+   * finalize round's upload is a byte-exact prefix extension of the previous
+   * one. The server's snapshot upsert rejects any divergent continuation.
+   */
+  toJsonl(): string {
+    if (!this.sessionId) throw new Error('cannot serialize an ACP transcript before session setup');
+    const session = {
+      type: 'session',
+      version: 3,
+      id: this.sessionId,
+      timestamp: this.startedAt,
+      cwd: this.cwd,
+    };
+    return [session, ...this.entries].map((entry) => JSON.stringify(entry)).join('\n') + '\n';
+  }
+
+  private appendMessage(role: string, content: unknown): void {
+    const id = `acp-${++this.sequence}`;
+    this.entries.push({
+      type: 'message',
+      id,
+      parentId: this.parentId,
+      timestamp: new Date().toISOString(),
+      message: { role, content },
+    });
+    this.parentId = id;
+  }
+}
+
+function collectStderr(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    stream.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (size >= STDERR_CAP) return;
+      const kept = buffer.subarray(0, STDERR_CAP - size);
+      chunks.push(kept);
+      size += kept.length;
+    });
+    const finish = () => resolve(Buffer.concat(chunks).toString('utf8'));
+    stream.once('end', finish);
+    stream.once('close', finish);
+    stream.once('error', finish);
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+/** Run one Automation prompt through Codex's stable ACP v1 adapter. */
+export async function runCodexAcpTurn(
+  options: CodexAcpTurnOptions
+): Promise<CodexAcpTurnResult> {
+  const started = Date.now();
+  const env: NodeJS.ProcessEnv = { ...process.env, ...options.adapterEnv };
+  delete env.WORKER_API_TOKEN;
+  delete env.LOBU_API_TOKEN;
+  delete env.LOBU_MEMORY_URL;
+  env.CODEX_PATH = options.codexPath;
+
+  const supervised = spawnSupervisedCli(
+    options.adapterCommand,
+    options.adapterArgs ?? [],
+    env,
+    { stdin: 'pipe' }
+  );
+  const proc = supervised.supervisor;
+  if (!proc.stdin || !proc.stdout || !proc.stderr) {
+    await terminateChild(proc);
+    throw new Error('Codex ACP supervisor spawned without bidirectional stdio');
+  }
+  const stderrPromise = collectStderr(proc.stderr);
+  const transcript = options.transcript ?? new CodexAcpTranscript(options.cwd);
+  const events: TranscriptEvent[] = [];
+  const tools = new Map<string, ToolCall>();
+  let assistantOutput = '';
+  let connection: acp.ClientConnection | undefined;
+  let sessionId = options.resumeSessionId ?? '';
+  let promptResponse: PromptResponse | undefined;
+  let timedOut = false;
+  let cancelled = false;
+  let workflowError: unknown;
+
+  const app = acp
+    .client({ name: 'lobu-device-daemon' })
+    .onRequest(acp.methods.client.session.requestPermission, ({ params }) => {
+      const rejected =
+        params.options.find((option) => option.kind === 'reject_once') ??
+        params.options.find((option) => option.kind === 'reject_always');
+      return rejected
+        ? { outcome: { outcome: 'selected' as const, optionId: rejected.optionId } }
+        : { outcome: { outcome: 'cancelled' as const } };
+    })
+    .onNotification(acp.methods.client.session.update, ({ params }) => {
+      const update = params.update;
+      if (update.sessionUpdate === 'agent_message_chunk') {
+        const text = contentText(update);
+        if (text == null) return;
+        assistantOutput += text;
+        const messageId = update.messageId ?? `message-${events.length}`;
+        const prior = events.at(-1);
+        if (prior?.kind === 'assistant' && prior.messageId === messageId) prior.text += text;
+        else events.push({ kind: 'assistant', messageId, text });
+      } else if (update.sessionUpdate === 'tool_call') {
+        tools.set(update.toolCallId, update);
+        events.push({ kind: 'tool', tool: update });
+      } else if (
+        update.sessionUpdate === 'tool_call_update' &&
+        (update.status === 'completed' || update.status === 'failed')
+      ) {
+        events.push({
+          kind: 'tool-result',
+          toolCallId: update.toolCallId,
+          failed: update.status === 'failed',
+          output: update.rawOutput ?? update.content ?? tools.get(update.toolCallId)?.rawOutput ?? null,
+        });
+      }
+      // Deliberately do not persist agent_thought_chunk: ACP exposes public
+      // progress and final messages separately from private model reasoning.
+    });
+
+  try {
+    const stream = acp.ndJsonStream(
+      Writable.toWeb(proc.stdin) as WritableStream<Uint8Array>,
+      Readable.toWeb(proc.stdout) as ReadableStream<Uint8Array>
+    );
+    connection = app.connect(stream);
+    const ctx = connection.agent;
+    const initialized = await ctx.request(acp.methods.agent.initialize, {
+      protocolVersion: acp.PROTOCOL_VERSION,
+      clientCapabilities: { session: { configOptions: {} } },
+      clientInfo: { name: 'lobu-device-daemon', version: '1' },
+    });
+    if (initialized.protocolVersion !== acp.PROTOCOL_VERSION) {
+      throw new Error(`Codex ACP negotiated unsupported protocol ${initialized.protocolVersion}`);
+    }
+    if (initialized.agentCapabilities?.mcpCapabilities?.http !== true) {
+      throw new Error('Codex ACP adapter does not support HTTP MCP servers');
+    }
+
+    const mcpServers = [
+      {
+        type: 'http' as const,
+        name: 'lobu-memory',
+        url: options.mcp.url,
+        headers: [{ name: 'Authorization', value: `Bearer ${options.mcp.bearer}` }],
+      },
+    ];
+    if (options.resumeSessionId) {
+      if (initialized.agentCapabilities?.sessionCapabilities?.resume == null) {
+        throw new Error('Codex ACP adapter does not support session/resume');
+      }
+      await ctx.request(acp.methods.agent.session.resume, {
+        sessionId: options.resumeSessionId,
+        cwd: options.cwd,
+        mcpServers,
+      });
+      sessionId = options.resumeSessionId;
+    } else {
+      const created = (await ctx.request(acp.methods.agent.session.new, {
+        cwd: options.cwd,
+        mcpServers,
+      })) as NewSessionResponse;
+      sessionId = created.sessionId;
+    }
+    transcript.setSession(sessionId);
+
+    // Persist the exact id before the prompt can mutate the workspace. A failed
+    // checkpoint aborts the turn instead of creating an unresumable session.
+    await options.onSessionReady(sessionId);
+    await ctx.request(acp.methods.agent.session.setMode, { sessionId, modeId: 'agent' });
+    if (options.model) {
+      await ctx.request(acp.methods.agent.session.setConfigOption, {
+        sessionId,
+        configId: 'model',
+        value: options.model,
+      });
+    }
+    if (options.effort) {
+      await ctx.request(acp.methods.agent.session.setConfigOption, {
+        sessionId,
+        configId: 'reasoning_effort',
+        value: options.effort,
+      });
+    }
+
+    const prompt = ctx.request(acp.methods.agent.session.prompt, {
+      sessionId,
+      prompt: [{ type: 'text', text: options.prompt }],
+    });
+    const control = new Promise<'timeout' | 'cancel'>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), options.timeoutMs);
+      timer.unref?.();
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve('cancel');
+      };
+      if (options.abortSignal?.aborted) onAbort();
+      else options.abortSignal?.addEventListener('abort', onAbort, { once: true });
+      const clearControl = () => {
+        clearTimeout(timer);
+        options.abortSignal?.removeEventListener('abort', onAbort);
+      };
+      prompt.then(clearControl, clearControl);
+    });
+    const outcome = await Promise.race([
+      prompt.then((response) => ({ kind: 'response' as const, response })),
+      control.then((reason) => ({ kind: 'control' as const, reason })),
+      supervised.targetExit.then((target) => ({ kind: 'exit' as const, target })),
+    ]);
+    if (outcome.kind === 'response') {
+      promptResponse = outcome.response;
+      cancelled = outcome.response.stopReason === 'cancelled';
+    } else if (outcome.kind === 'control') {
+      timedOut = outcome.reason === 'timeout';
+      cancelled = outcome.reason === 'cancel';
+      await ctx.notify(acp.methods.agent.session.cancel, { sessionId }).catch(() => {});
+      const cancelledResponse = await Promise.race([
+        prompt.catch(() => undefined),
+        delay(CANCEL_GRACE_MS).then(() => undefined),
+      ]);
+      promptResponse = cancelledResponse;
+    } else {
+      throw new Error(
+        outcome.target.error ??
+          `Codex ACP adapter exited before the prompt completed (status=${outcome.target.exitCode}, signal=${outcome.target.signalCode ?? 'none'})`
+      );
+    }
+
+    if (initialized.agentCapabilities?.sessionCapabilities?.close != null) {
+      await ctx.request(acp.methods.agent.session.close, { sessionId }).catch(() => {});
+    }
+  } catch (error) {
+    workflowError = error;
+  } finally {
+    connection?.close();
+    proc.stdin.end();
+    const graceful = await waitForTargetExit(supervised.targetExit, ADAPTER_EXIT_GRACE_MS);
+    if (graceful.target) await releaseSupervisor(proc);
+    else await terminateChild(proc);
+  }
+
+  const stderr = await Promise.race([
+    stderrPromise,
+    delay(1_000).then(() => ''),
+  ]);
+  const durationMs = Date.now() - started;
+  if (workflowError) {
+    const detail = workflowError instanceof Error ? workflowError.message : String(workflowError);
+    return {
+      output: assistantOutput,
+      error: stderr.trim() ? `${detail}: ${stderr.trim().slice(-500)}` : detail,
+      exitCode: null,
+      exitSignal: null,
+      exitReason: 'crash',
+      durationMs,
+      sessionId,
+      // A rejected resume leaves `sessionId` set but no session bound, and
+      // serializing then would mask the real failure with a second throw.
+      transcriptJsonl: transcript.hasSession ? transcript.toJsonl() : '',
+    };
+  }
+
+  transcript.appendTurn(options.prompt, events, promptResponse?.usage);
+  const exitReason = cancelled
+    ? 'cancelled'
+    : timedOut
+      ? 'timeout'
+      : promptResponse?.stopReason === 'end_turn'
+        ? 'ok'
+        : 'error_message';
+  const error =
+    exitReason === 'timeout'
+      ? `Codex ACP prompt timed out after ${Math.trunc(options.timeoutMs / 1000)}s`
+      : exitReason === 'error_message'
+        ? `Codex ACP stopped with reason ${promptResponse?.stopReason ?? 'unknown'}`
+        : null;
+  return {
+    output: assistantOutput,
+    error,
+    exitCode: exitReason === 'ok' ? 0 : null,
+    exitSignal: cancelled || timedOut ? 'SIGTERM' : null,
+    exitReason,
+    durationMs,
+    sessionId,
+    transcriptJsonl: transcript.toJsonl(),
+  };
+}

--- a/packages/connector-worker/src/daemon/mac-device-daemon.ts
+++ b/packages/connector-worker/src/daemon/mac-device-daemon.ts
@@ -5,7 +5,7 @@ import {
 } from '@lobu/core/contracts/worker/device-automation';
 import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
 import { executeAutomationRun, type AutomationExecutorConfig } from './automation.js';
-import { resolveRunnableAgentKinds } from './agent-binaries.js';
+import { locateBinary, resolveRunnableAgentKinds } from './agent-binaries.js';
 import {
   MutableWorkerAdvertisementProvider,
   WorkerClient,
@@ -24,6 +24,7 @@ const WORKER_PAT_PATTERN = /^owl_pat_[A-Za-z0-9_-]{32}$/;
 const DEFAULT_POLL_INTERVAL_MS = 10000;
 const DEFAULT_MAX_CONCURRENT_JOBS = 1;
 const NATIVE_BRIDGE_SHUTDOWN_TIMEOUT_MS = 5000;
+export const INTERNAL_CODEX_ACP_ARG = '--internal-codex-acp';
 
 export interface MacDeviceDaemonOptions {
   apiUrl?: string;
@@ -220,6 +221,7 @@ export function createMacDeviceDaemon(
   if (validated.noPoll) throw new Error('cannot create a polling daemon with --no-poll');
 
   const runnableAgentKinds = resolveRunnableAgentKinds();
+  const codexPath = runnableAgentKinds.includes('codex') ? locateBinary('codex') : null;
   const defaultAgentKind = selectMacDeviceDaemonAgentKind(
     runnableAgentKinds,
     validated.defaultAgentKind
@@ -245,6 +247,24 @@ export function createMacDeviceDaemon(
     ...(defaultAgentKind ? { defaultAgentKind } : {}),
     requireRunScopedSession: true,
     shutdownSignal: shutdownController.signal,
+    ...(codexPath
+      ? {
+          codexAcp: {
+            // Re-exec this same entrypoint so the adapter is the artifact we
+            // shipped. Run from source (`bun src/...ts`, `node dist/...js`),
+            // argv[1] is the script the runtime needs handed back to it; in the
+            // `bun build --compile` binary argv[1] is the extensionless in-bundle
+            // path (`/$bunfs/root/...`) and execPath is the binary itself, which
+            // already knows its own entry.
+            adapterCommand: process.execPath,
+            adapterArgs:
+              process.argv[1] && /\.[cm]?[jt]s$/.test(process.argv[1])
+                ? [process.argv[1], INTERNAL_CODEX_ACP_ARG]
+                : [INTERNAL_CODEX_ACP_ARG],
+            codexPath,
+          },
+        }
+      : {}),
   };
   const loop = new WorkerPollLoop({
     client,

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -4,6 +4,7 @@ import packageJson from '../package.json' with { type: 'json' };
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
 import {
   MAC_DEVICE_DAEMON_PROTOCOL,
+  INTERNAL_CODEX_ACP_ARG,
   macDeviceDaemonMetadata,
   runMacDeviceDaemon,
   validateMacDeviceDaemonOptions,
@@ -149,7 +150,22 @@ async function main(): Promise<void> {
   await runMacDeviceDaemon(options);
 }
 
-main().catch((error) => {
+async function start(): Promise<void> {
+  if (process.argv[2] === INTERNAL_CODEX_ACP_ARG) {
+    // Dynamic on purpose, and not for bundle size — `bun build --compile` links
+    // this module into the artifact either way. The adapter is a side-effectful
+    // stdio server that binds process stdin/stdout the moment it is evaluated,
+    // so a static import would start a second ACP protocol loop in the daemon
+    // itself and steal the daemon's own stdio. Only the isolated child, which
+    // exists solely to be that server, may evaluate it.
+    // @ts-expect-error codex-acp is an executable-only package with no declarations.
+    await import('@agentclientprotocol/codex-acp');
+    return;
+  }
+  await main();
+}
+
+start().catch((error) => {
   process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`);
   process.exitCode = 1;
 });

--- a/packages/core/src/__tests__/worker-acp-session-protocol.test.ts
+++ b/packages/core/src/__tests__/worker-acp-session-protocol.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { Value } from "@sinclair/typebox/value";
+import {
+  AutomationPollPayloadSchema,
+  HeartbeatRequestSchema,
+} from "../contracts/worker/protocol";
+
+describe("device Automation ACP session protocol", () => {
+  test("accepts a same-device ACP resume id in the poll envelope", () => {
+    expect(
+      AutomationPollPayloadSchema.properties.context.properties.agent_session
+        .properties.resume_session_id
+    ).toBeDefined();
+    expect(
+      Value.Check(AutomationPollPayloadSchema, {
+        automation: { id: "42", agent_kind: "codex" },
+        event: { fired_at: "2026-08-23T10:00:00.000Z" },
+        context: {
+          device: { worker_id: "macos:test" },
+          user: {},
+          agent_session: {
+            conversation_id: "agent_automation_42_run_99",
+            mcp_url: "https://lobu.test/mcp/team",
+            token: "run-token",
+            expires_at: Date.now() + 60_000,
+            resume_session_id: "acp-session-99",
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  test("accepts a run-bound ACP session checkpoint on heartbeat", () => {
+    expect(HeartbeatRequestSchema.properties.agent_session).toBeDefined();
+    expect(
+      Value.Check(HeartbeatRequestSchema, {
+        run_id: 99,
+        worker_id: "macos:test",
+        agent_session: {
+          protocol: "acp",
+          agent_kind: "codex",
+          session_id: "acp-session-99",
+        },
+      })
+    ).toBe(true);
+    expect(
+      Value.Check(HeartbeatRequestSchema, {
+        run_id: 99,
+        worker_id: "macos:test",
+        agent_session: {
+          protocol: "acp-v2",
+          agent_kind: "codex",
+          session_id: "acp-session-99",
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -199,6 +199,10 @@ export const AutomationPollContextSchema = Type.Object({
       mcp_url: Type.String(),
       token: Type.String(),
       expires_at: Type.Number(),
+      /** Exact same-device ACP session to continue; never discovered by listing sessions. */
+      resume_session_id: Type.Optional(
+        Type.String({ minLength: 1, maxLength: 512 })
+      ),
     })
   ),
 });
@@ -477,6 +481,14 @@ export const PollAuthSignalResponseSchema = Type.Object({
 export const HeartbeatRequestSchema = Type.Object({
   run_id: Type.Integer(),
   worker_id: Type.String(),
+  /** Durable checkpoint written before the first prompt in a new ACP session. */
+  agent_session: Type.Optional(
+    Type.Object({
+      protocol: Type.Literal("acp"),
+      agent_kind: Type.Literal("codex"),
+      session_id: Type.String({ minLength: 1, maxLength: 512 }),
+    })
+  ),
   progress: Type.Optional(
     Type.Object({
       items_collected_so_far: Type.Optional(Type.Integer()),

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -56,6 +56,7 @@ async function setupDevicePinnedAutomation(opts: {
   workerId: string;
   platform: string;
   capabilities: Record<string, boolean>;
+  agentKind?: string;
 }): Promise<{
   sql: ReturnType<typeof getTestDb>;
   dbClient: DbClient;
@@ -98,7 +99,7 @@ async function setupDevicePinnedAutomation(opts: {
   await sql`
     UPDATE automations
     SET device_worker_id = ${deviceWorkerId}::uuid,
-        agent_kind = 'opencode'
+        agent_kind = ${opts.agentKind ?? 'opencode'}
     WHERE id = ${automationId}
   `;
 
@@ -216,6 +217,91 @@ describe('headless Automation claim gate (automations.execute)', () => {
       SELECT status FROM runs WHERE id = ${job.run_id}
     `;
     expect(String(run.status)).toBe('running');
+  });
+
+  it('checkpoints a Codex ACP session and returns it only to the same device on reclaim', async () => {
+    const workerId = 'headless-codex-acp';
+    const ctx = await setupDevicePinnedAutomation({
+      workerId,
+      platform: 'headless',
+      capabilities: { 'automations.execute': true },
+      agentKind: 'codex',
+    });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      workerId
+    );
+    await post(`/api/workers/me/automations/${ctx.automationId}/trigger`, { token });
+
+    const pollBody = {
+      worker_id: workerId,
+      capabilities: { 'automations.execute': true },
+      agent_kinds: ['codex'],
+    };
+    const firstPoll = await post('/api/workers/poll', { token, body: pollBody });
+    expect(firstPoll.status).toBe(200);
+    const firstJob = (await firstPoll.json()) as {
+      run_id: number;
+      payload: {
+        context: {
+          agent_session: {
+            token: string;
+            resume_session_id?: string;
+          };
+        };
+      };
+    };
+    expect(firstJob.payload.context.agent_session.resume_session_id).toBeUndefined();
+    expect(verifyWorkerToken(firstJob.payload.context.agent_session.token)?.runId).toBe(
+      firstJob.run_id
+    );
+
+    const heartbeat = await post('/api/workers/heartbeat', {
+      token,
+      body: {
+        run_id: firstJob.run_id,
+        worker_id: workerId,
+        agent_session: {
+          protocol: 'acp',
+          agent_kind: 'codex',
+          session_id: 'codex-acp-session-99',
+        },
+      },
+    });
+    expect(heartbeat.status).toBe(200);
+    const [checkpointed] = await ctx.sql<{
+      run_metadata: { device_agent_session?: Record<string, unknown> } | null;
+    }>`
+      SELECT run_metadata FROM runs WHERE id = ${firstJob.run_id}
+    `;
+    expect(checkpointed.run_metadata?.device_agent_session).toEqual(
+      expect.objectContaining({
+        protocol: 'acp',
+        agent_kind: 'codex',
+        session_id: 'codex-acp-session-99',
+        worker_id: workerId,
+      })
+    );
+
+    // Model a daemon loss before terminal delivery. The durable run keeps its
+    // exact session checkpoint while the ordinary claim fields are released.
+    await ctx.sql`
+      UPDATE runs
+      SET status = 'pending', claimed_by = NULL, claimed_at = NULL,
+          last_heartbeat_at = NULL
+      WHERE id = ${firstJob.run_id}
+    `;
+    const secondPoll = await post('/api/workers/poll', { token, body: pollBody });
+    expect(secondPoll.status).toBe(200);
+    const secondJob = (await secondPoll.json()) as {
+      run_id: number;
+      payload: { context: { agent_session: { resume_session_id?: string } } };
+    };
+    expect(secondJob.run_id).toBe(firstJob.run_id);
+    expect(secondJob.payload.context.agent_session.resume_session_id).toBe(
+      'codex-acp-session-99'
+    );
   });
 
   it('automation without an assigned agent still dispatches instructions-only (no run-scoped session)', async () => {

--- a/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
@@ -24,6 +24,7 @@ import { createTranscriptRoutes } from "../worker-dispatch/transcript-routes.js"
 import { buildApiConversationId } from "../services/api-conversation-id.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
 import { readSnapshotJsonl } from "../services/transcript-snapshot.js";
+import { readAutomationRunThreads } from "../services/automation-run-thread.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
 import {
   ensureDbForGatewayTests,
@@ -115,6 +116,69 @@ async function callRoute(
 }
 
 describe("agent_transcript_snapshot — snapshot route", () => {
+  test("direct Automation run token writes the transcript surfaced in Recent", async () => {
+    const agentId = "agent-automation-acp";
+    const orgId = await seedAgentRow(agentId, {
+      organizationId: "org_automation_acp",
+    });
+    const sql = getDb();
+    const userId = "automation-acp-owner";
+    await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (${userId}, 'Automation ACP owner', 'automation-acp@example.test',
+              false, now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `;
+    const [automation] = await sql<{ id: number }>`
+      WITH next_id AS (SELECT nextval('automations_id_seq')::integer AS id)
+      INSERT INTO automations (
+        id, automation_group_id, organization_id, agent_id, created_by, name, slug
+      )
+      SELECT id, id, ${orgId}, ${agentId}, ${userId}, 'ACP Automation', 'acp-' || id
+      FROM next_id
+      RETURNING id
+    `;
+    const automationId = Number(automation.id);
+    const [run] = await sql<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, automation_id, status, action_input,
+        queue_name, run_at, created_at, completed_at
+      ) VALUES (
+        ${orgId}, 'automation', ${automationId}, 'completed', NULL,
+        'automation', now(), now(), now()
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    const conversationId = `${agentId}_automation_${automationId}_run_${runId}`;
+    const token = mintWorkerToken({
+      organizationId: orgId,
+      agentId,
+      conversationId,
+      runId,
+    });
+    const transcript =
+      `${JSON.stringify({ type: "session", version: 3, id: "acp-session", timestamp: new Date().toISOString(), cwd: "/workspace" })}\n` +
+      `${JSON.stringify({ type: "message", id: "u1", parentId: null, timestamp: new Date().toISOString(), message: { role: "user", content: [{ type: "text", text: "Run the Automation" }] } })}\n` +
+      `${JSON.stringify({ type: "message", id: "a1", parentId: "u1", timestamp: new Date().toISOString(), message: { role: "assistant", content: [{ type: "text", text: "ACP trace is durable" }] } })}\n`;
+
+    const response = await callRoute("POST", "/snapshot", token, {
+      terminalStatus: "completed",
+      snapshotJsonl: transcript,
+      runId,
+    });
+    expect(response.status).toBe(200);
+
+    const recent = await readAutomationRunThreads({
+      agentId,
+      automationId,
+      organizationId: orgId,
+      limit: 10,
+    });
+    expect(recent.runs).toHaveLength(1);
+    expect(JSON.stringify(recent.runs[0]?.messages)).toContain("ACP trace is durable");
+  });
+
   test("happy-path-multi-turn: writes one row per terminal run, hydrates byte-for-byte", async () => {
     const orgId = await seedAgentRow("agent-happy", {
       organizationId: "org_happy",

--- a/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
+++ b/packages/server/src/gateway/__tests__/automation-run-worker-token.test.ts
@@ -37,6 +37,7 @@ describe("Automation run WorkerToken parity", () => {
     expect(claims.agentId).toBe("developer");
     expect(claims.organizationId).toBe("org-team");
     expect(claims.conversationId).toBe(access.conversationId);
+    expect(claims.runId).toBe(456);
     expect(claims.channelId).toBe("api_automation_120");
     expect(claims.platform).toBe("api");
     expect(claims.source).toBe(AUTOMATION_RUN_SOURCE);

--- a/packages/server/src/gateway/services/automation-run-worker-token.ts
+++ b/packages/server/src/gateway/services/automation-run-worker-token.ts
@@ -45,6 +45,7 @@ export function buildAutomationRunWorkerAccess(args: {
       agentId: args.agentId,
       organizationId: args.organizationId,
       platform: "api",
+      runId: args.runId,
       source: AUTOMATION_RUN_SOURCE,
       sessionKey: userId,
     }),

--- a/packages/server/src/gateway/worker-dispatch/transcript-routes.ts
+++ b/packages/server/src/gateway/worker-dispatch/transcript-routes.ts
@@ -53,12 +53,12 @@ function authenticate(c: Context): WorkerTokenData | null {
 /**
  * Verify the `runId` the worker claims belongs to the JWT's (org, agent,
  * conv) tuple. The worker can't lie its way into another conversation's
- * row: the runId is authoritatively set by the gateway's MessageConsumer
- * from the runs-queue claim and threaded into the worker via WorkerConfig.
- * A misbehaving worker that POSTs a forged runId either targets one of its
- * own runs (allowed) or a run owned by a different (org, agent, conv) —
- * this function returns false in the latter case so the route rejects with
- * 403.
+ * row: the runId is authoritatively set by whichever server path minted the
+ * per-run token — the gateway's MessageConsumer from the runs-queue claim,
+ * or `buildAutomationRunWorkerAccess` at device poll. A misbehaving worker
+ * that POSTs a forged runId either targets one of its own runs (allowed) or
+ * a run owned by a different (org, agent, conv) — this function returns
+ * false in the latter case so the route rejects with 403.
  *
  * Codex P1#1 on PR #865 — the previous "latest run for (org, agent, conv)"
  * lookup at write time raced: worker A finishes execute() for run 100,
@@ -83,19 +83,37 @@ async function isRunOwnedByJwtScope(
   // `(action_input #>> '{}')::jsonb ->>` first. New rows (post fix below)
   // always take the 'object' branch; legacy in-flight rows take 'string'.
   const rows = await sql<{ ok: boolean }>`
-    SELECT 1 AS ok FROM public.runs
-    WHERE id = ${runId}
-      AND organization_id = ${organizationId}
-      AND CASE jsonb_typeof(action_input)
-            WHEN 'object' THEN action_input ->> 'agentId'
-            WHEN 'string' THEN (action_input #>> '{}')::jsonb ->> 'agentId'
+    SELECT 1 AS ok
+    FROM public.runs r
+    LEFT JOIN public.automations automation
+      ON automation.id = r.automation_id
+     AND automation.organization_id = r.organization_id
+    WHERE r.id = ${runId}
+      AND r.organization_id = ${organizationId}
+      AND (
+        (
+          CASE jsonb_typeof(r.action_input)
+            WHEN 'object' THEN r.action_input ->> 'agentId'
+            WHEN 'string' THEN (r.action_input #>> '{}')::jsonb ->> 'agentId'
             ELSE NULL
           END = ${agentId}
-      AND CASE jsonb_typeof(action_input)
-            WHEN 'object' THEN action_input ->> 'conversationId'
-            WHEN 'string' THEN (action_input #>> '{}')::jsonb ->> 'conversationId'
+          AND CASE jsonb_typeof(r.action_input)
+            WHEN 'object' THEN r.action_input ->> 'conversationId'
+            WHEN 'string' THEN (r.action_input #>> '{}')::jsonb ->> 'conversationId'
             ELSE NULL
           END = ${conversationId}
+        )
+        -- Device-pinned Automation runs carry no agentId/conversationId in
+        -- action_input: the identity is derived at poll time by
+        -- buildAutomationRunWorkerAccess from (agent, automation, run). Prove
+        -- ownership from the automation's own agent plus the same derived id.
+        OR (
+          r.run_type = 'automation'
+          AND automation.agent_id = ${agentId}
+          AND ${conversationId} =
+            ${agentId} || '_automation_' || r.automation_id::text || '_run_' || r.id::text
+        )
+      )
     LIMIT 1
   `;
   return rows.length > 0;
@@ -194,8 +212,7 @@ export function createTranscriptRoutes(): Hono {
 
     // The JWT must itself be bound to this exact runId. The deployment-
     // lifetime WORKER_TOKEN carries no `runId`, so it can never satisfy
-    // this check — only the per-run JWT that MessageConsumer mints
-    // alongside the runs-queue dispatch can. Without this, a worker
+    // this check — only a per-run JWT can. Without this, a worker
     // bearing a valid same-(org, agent, conv) deployment token could
     // POST under ANY same-scope run's slot, including the next pending
     // run, and overwrite a sibling worker's snapshot. Codex round 2

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1112,7 +1112,13 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       });
     }
     let devicePrompt = automationInstructions;
-    let agentSession: { conversation_id: string; mcp_url: string; token: string; expires_at: number } | undefined;
+    let agentSession: {
+      conversation_id: string;
+      mcp_url: string;
+      token: string;
+      expires_at: number;
+      resume_session_id?: string;
+    } | undefined;
     const requiresRunScopedAgentSession =
       effectivePlatform === 'macos' && authorizedCapabilities.includes('automations.execute');
     if (
@@ -1163,11 +1169,29 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             runId: row.run_id,
             organizationId: row.organization_id,
           });
+          // Hand back the run's own ACP checkpoint only to the device that
+          // wrote it, and only while the run still resolves to the same agent
+          // kind. Sessions are agent-local state, so a different device or a
+          // re-pinned agent kind cannot resume them.
+          const selectedAgentKind = agentKindFromPayload ?? row.automation_agent_kind ?? null;
+          const checkpoint = row.run_metadata?.['device_agent_session'];
+          const stored =
+            checkpoint != null && typeof checkpoint === 'object' && !Array.isArray(checkpoint)
+              ? (checkpoint as Record<string, unknown>)
+              : null;
+          const resumeSessionId =
+            stored?.['protocol'] === 'acp' &&
+            stored['worker_id'] === worker_id &&
+            stored['agent_kind'] === selectedAgentKind &&
+            typeof stored['session_id'] === 'string'
+              ? (stored['session_id'] as string)
+              : undefined;
           agentSession = {
             conversation_id: access.conversationId,
             mcp_url: `${resolvePublicOrigin(c.req.url)}/mcp/${encodeURIComponent(row.organization_slug)}`,
             token: access.token,
             expires_at: access.expiresAt,
+            ...(resumeSessionId ? { resume_session_id: resumeSessionId } : {}),
           };
         } catch (err) {
           if (requiresRunScopedAgentSession) {

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -205,18 +205,34 @@ async function reactivateProfileCascade(
  */
 export async function heartbeat(c: Context<{ Bindings: Env }>) {
 	try {
-		const { run_id, worker_id, progress } =
+		const { run_id, worker_id, progress, agent_session } =
 			await c.req.json<HeartbeatRequest>();
 
 		const denied = await authorizeRunForWorker(c, run_id, worker_id);
 		if (denied) return denied;
 
 		const sql = getDb();
+		// Stamped with the reporting worker so poll can only resume an agent
+		// session on the device that owns it.
+		const agentSessionCheckpoint = agent_session
+			? sql`, run_metadata = jsonb_set(
+              COALESCE(run_metadata, '{}'::jsonb),
+              '{device_agent_session}',
+              ${sql.json({
+								protocol: agent_session.protocol,
+								agent_kind: agent_session.agent_kind,
+								session_id: agent_session.session_id,
+								worker_id,
+								updated_at: new Date().toISOString(),
+							})}::jsonb,
+              true
+            )`
+			: sql``;
 
 		await sql`
       UPDATE runs
       SET last_heartbeat_at = current_timestamp,
-          items_collected = COALESCE(${progress?.items_collected_so_far ?? null}, items_collected)
+          items_collected = COALESCE(${progress?.items_collected_so_far ?? null}, items_collected)${agentSessionCheckpoint}
       WHERE id = ${run_id}
     `;
 


### PR DESCRIPTION
## Summary
- run Mac Codex Automations through the stable ACP adapter with run-scoped HTTP MCP
- checkpoint and exactly resume same-device ACP sessions across daemon reclaims
- materialize terminal ACP traces into the existing transcript snapshot used by Recent

## Validation
- real compiled-daemon Codex ACP new/resume/cancel spike with stub HTTP MCP authorization
- 239 connector-worker tests
- gateway transcript and worker-token tests
- embedded-Postgres Automation claim/resume integration
- standalone macOS daemon package smoke
- make pre-pr

## Scope
No UI, schema migration, new endpoint, live browser streaming, subagent scheduler, or local transcript-file reader.