### PR TITLE
fix(automations): expire abandoned manual runs

### DIFF
--- a/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
@@ -2040,7 +2040,7 @@ describe("automation contract", () => {
 			expect(String(run.status)).toBe("pending");
 		});
 
-		it("does not expire a stale manually triggered pending run", async () => {
+		it("expires a stale manually triggered pending run without advancing its schedule", async () => {
 			const { sql, automationId } = await createAutomatedAutomation();
 			await materializeDueAutomationRuns({} as Env);
 			await sql`
@@ -2057,12 +2057,12 @@ describe("automation contract", () => {
       `;
 
 			const { timedOut } = await sweepStaleAutomationRuns(sql);
-			expect(timedOut).toBe(0);
+			expect(timedOut).toBe(1);
 			const [run] = await sql`
         SELECT status FROM runs
         WHERE automation_id = ${automationId} AND run_type = 'automation'
       `;
-			expect(String(run.status)).toBe("pending");
+			expect(String(run.status)).toBe("timeout");
 			const [automation] =
 				await sql`SELECT next_run_at FROM automations WHERE id = ${automationId}`;
 			expect(new Date(automation.next_run_at as string).getTime()).toBeLessThan(

--- a/packages/server/src/__tests__/integration/automations/manual-run-expiry.test.ts
+++ b/packages/server/src/__tests__/integration/automations/manual-run-expiry.test.ts
@@ -1,0 +1,208 @@
+import type { AutomationTriggerResult } from '@lobu/core/contracts/tools/manage-automations';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  materializeDueAutomationRuns,
+  sweepStaleAutomationRuns,
+} from '../../../automations/automation';
+import type { Env } from '../../../index';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+async function createAgentlessAutomation(opts: { slug: string }) {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({
+    name: `Manual Run Expiry ${opts.slug}`,
+  });
+  const entity = await createTestEntity({
+    name: `Manual Run Entity ${opts.slug}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const created = (await workspace.owner.automations.create({
+    entity_id: entity.id,
+    slug: opts.slug,
+    name: `Manual Run Automation ${opts.slug}`,
+    prompt: 'Summarize the bounded window.',
+    agent_id: null,
+  })) as { automation_id: string };
+
+  return {
+    sql,
+    workspace,
+    automationId: Number(created.automation_id),
+  };
+}
+
+async function triggerManual(
+  workspace: Awaited<ReturnType<typeof TestWorkspace.create>>,
+  automationId: number
+) {
+  return (await workspace.owner.automations.trigger({
+    automation_id: automationId,
+  })) as AutomationTriggerResult;
+}
+
+describe('abandoned manual Automation run expiry', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('terminalizes one stale agentless manual run across concurrent sweepers and frees a fresh manual trigger', async () => {
+    const { sql, workspace, automationId } = await createAgentlessAutomation({
+      slug: 'manual-expiry-retrigger',
+    });
+    const abandoned = await triggerManual(workspace, automationId);
+    expect(abandoned.status).toBe('pending');
+    if (abandoned.execution.lane !== 'external_client') {
+      throw new Error(`Expected external_client, got ${abandoned.execution.lane}`);
+    }
+
+    await sql`
+      UPDATE runs
+      SET created_at = NOW() - INTERVAL '3 hours'
+      WHERE id = ${abandoned.run_id}
+    `;
+
+    const [sweepA, sweepB] = await Promise.all([
+      sweepStaleAutomationRuns(sql),
+      sweepStaleAutomationRuns(sql),
+    ]);
+    expect(sweepA.timedOut + sweepB.timedOut).toBe(1);
+
+    const [expired] = await sql<{
+      status: string;
+      outcome: string | null;
+      claimed_by: string | null;
+      completed_at: string | null;
+      error_message: string | null;
+    }>`
+      SELECT status, outcome, claimed_by, completed_at, error_message
+      FROM runs
+      WHERE id = ${abandoned.run_id}
+    `;
+    expect(expired).toMatchObject({
+      status: 'timeout',
+      outcome: 'infra_error',
+      claimed_by: null,
+    });
+    expect(expired.completed_at).not.toBeNull();
+    expect(expired.error_message).toMatch(/pending.*2 hours.*without being claimed/i);
+
+    const replacement = await triggerManual(workspace, automationId);
+    expect(replacement.run_id).not.toBe(abandoned.run_id);
+    expect(replacement.status).toBe('pending');
+
+    expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(0);
+    const [fresh] = await sql<{ status: string; claimed_by: string | null }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${replacement.run_id}
+    `;
+    expect(fresh).toEqual({ status: 'pending', claimed_by: null });
+  });
+
+  it('preserves the schedule cursor and frees a due scheduled activation after manual timeout', async () => {
+    const { sql, workspace, automationId } = await createAgentlessAutomation({
+      slug: 'manual-expiry-schedule',
+    });
+    const abandoned = await triggerManual(workspace, automationId);
+    const agent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId: workspace.users.owner.id,
+      agentId: 'manual-expiry-schedule-agent',
+      name: 'Manual Expiry Schedule Agent',
+    });
+    await workspace.owner.automations.update({
+      automation_id: automationId,
+      agent_id: agent.agentId,
+      triggers: [
+        {
+          kind: 'schedule',
+          cron: '0 * * * *',
+          execution: 'window',
+          active_run: 'coalesce',
+          skip_if_unchanged: false,
+        },
+      ],
+    });
+    const dueAt = new Date(Date.now() - 10 * 60 * 1000);
+    await sql`
+      UPDATE automations
+      SET next_run_at = ${dueAt}::timestamptz
+      WHERE id = ${automationId}
+    `;
+    await sql`
+      UPDATE runs
+      SET created_at = NOW() - INTERVAL '3 hours'
+      WHERE id = ${abandoned.run_id}
+    `;
+
+    expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(1);
+    const [afterTimeout] = await sql<{ next_run_at: string }>`
+      SELECT next_run_at FROM automations WHERE id = ${automationId}
+    `;
+    expect(new Date(afterTimeout.next_run_at).getTime()).toBe(dueAt.getTime());
+
+    const materialized = await materializeDueAutomationRuns({} as Env);
+    expect(materialized.runsCreated).toBe(1);
+    const [scheduled] = await sql<{
+      id: number;
+      status: string;
+      dispatch_source: string | null;
+    }>`
+      SELECT id, status, approved_input->>'dispatch_source' AS dispatch_source
+      FROM runs
+      WHERE automation_id = ${automationId}
+        AND id <> ${abandoned.run_id}
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    expect(scheduled).toMatchObject({
+      status: 'pending',
+      dispatch_source: 'scheduled',
+    });
+  });
+
+  it('does not apply pending-run age to freshly claimed or running external work', async () => {
+    const claimedSetup = await createAgentlessAutomation({
+      slug: 'manual-expiry-claimed',
+    });
+    const claimed = await triggerManual(
+      claimedSetup.workspace,
+      claimedSetup.automationId
+    );
+    const runningSetup = await createAgentlessAutomation({
+      slug: 'manual-expiry-running',
+    });
+    const running = await triggerManual(
+      runningSetup.workspace,
+      runningSetup.automationId
+    );
+
+    await claimedSetup.sql`
+      UPDATE runs
+      SET status = 'claimed',
+          claimed_by = 'mcp:manual-expiry-client',
+          claimed_at = NOW() - INTERVAL '30 minutes',
+          last_heartbeat_at = NOW() - INTERVAL '30 minutes',
+          created_at = NOW() - INTERVAL '3 hours'
+      WHERE id = ${claimed.run_id}
+    `;
+    await claimedSetup.sql`
+      UPDATE runs
+      SET status = 'running',
+          claimed_by = 'mcp:manual-expiry-client',
+          claimed_at = NOW() - INTERVAL '30 minutes',
+          last_heartbeat_at = NOW() - INTERVAL '30 seconds',
+          created_at = NOW() - INTERVAL '3 hours'
+      WHERE id = ${running.run_id}
+    `;
+
+    expect((await sweepStaleAutomationRuns(claimedSetup.sql)).timedOut).toBe(0);
+    const rows = await claimedSetup.sql<{ id: number; status: string }>`
+      SELECT id, status FROM runs
+      WHERE id IN (${claimed.run_id}, ${running.run_id})
+      ORDER BY id
+    `;
+    expect(rows.map((row) => row.status).sort()).toEqual(['claimed', 'running']);
+  });
+});

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -609,10 +609,14 @@ export async function sweepStaleAutomationRuns(
  * the same transaction prevents the next Automation scheduler tick from immediately
  * recreating the missed run.
  *
- * Manual runs are intentionally excluded: a manual caller owns retry policy.
- * Scheduled device runs remain durable past the TTL while their exact snapshot
- * owner exists. If that row is deleted, only the stale orphan times out; its
- * schedule cursor stays due so current ownership retries the same window.
+ * Unclaimed manual runs use the same coarse TTL: an external caller can vanish
+ * after triggering but before claiming, and that abandoned pending row must not
+ * wedge later manual or scheduled activation. Their timeout never advances a
+ * schedule cursor; claimed/running work remains governed by the heartbeat and
+ * coarse execution paths below. Scheduled device runs remain durable past the
+ * TTL while their exact snapshot owner exists. If that row is deleted, only the
+ * stale orphan times out; its schedule cursor stays due so current ownership
+ * retries the same window.
  */
 async function finalizeStalePendingAutomationRuns(
 	sql: DbClient,
@@ -635,7 +639,6 @@ async function finalizeStalePendingAutomationRuns(
       WHERE r.run_type = 'automation'
         AND r.status = 'pending'
         AND r.created_at < current_timestamp - ${staleInterval}::interval
-        AND COALESCE(r.approved_input->>'dispatch_source', 'scheduled') <> 'manual'
         -- Snapshot ownership stays durable after retarget; only a missing exact row is orphaned.
         AND NOT (
           COALESCE(r.approved_input->>'dispatch_source', 'scheduled') = 'scheduled'

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -612,11 +612,11 @@ export async function sweepStaleAutomationRuns(
  * Unclaimed manual runs use the same coarse TTL: an external caller can vanish
  * after triggering but before claiming, and that abandoned pending row must not
  * wedge later manual or scheduled activation. Their timeout never advances a
- * schedule cursor; claimed/running work remains governed by the heartbeat and
- * coarse execution paths below. Scheduled device runs remain durable past the
- * TTL while their exact snapshot owner exists. If that row is deleted, only the
- * stale orphan times out; its schedule cursor stays due so current ownership
- * retries the same window.
+ * schedule cursor; claimed/running work remains governed by the separate
+ * heartbeat and coarse execution paths. Scheduled device runs remain durable
+ * past the TTL while their exact snapshot owner exists. If that row is deleted,
+ * only the stale orphan times out; its schedule cursor stays due so current
+ * ownership retries the same window.
  */
 async function finalizeStalePendingAutomationRuns(
 	sql: DbClient,


### PR DESCRIPTION
## Summary

- Expire unclaimed manual Automation runs through the existing coarse-TTL sweeper so an abandoned external client cannot wedge future activation.
- Preserve the schedule cursor for manual timeouts and retain the existing heartbeat/coarse-timeout behavior for claimed and running work.
- Cover manual retriggering, later scheduled activation, fresh pending work, claimed/running work, and concurrent replica sweeps.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean.
- [x] Targeted integration tests: 4 files, 44 tests passed.
- [x] Bug fix: red-to-green evidence below.
- [ ] If bot runtime changed: not applicable.

### Red

Against unchanged source, `manual-run-expiry.test.ts` produced 2 failures and 1 pass. Both stale agentless manual cases observed `timedOut = 0` where the contract requires exactly one timeout.

### Green

- `manual-run-expiry.test.ts`: 3 passed.
- Co-run with `automation-contract.test.ts`, `external-manual-run.test.ts`, and `pending-non-event-uniq.test.ts`: 4 files, 44 tests passed.
- `make pre-pr`: clean.

## Notes

`make review-fix` was attempted with both permitted reviewers and made no edits. Opus is session-quota blocked until its reset; Fable requires usage credits. The posted independent-review gate remains pending and will not be bypassed.

Closes #3082
