### PR TITLE
fix(server): preserve transcription event identity

### DIFF
--- a/packages/server/src/__tests__/integration/events/transcription-event-identity.test.ts
+++ b/packages/server/src/__tests__/integration/events/transcription-event-identity.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Issue #3067 reproducer: transcription enriches one connector event version.
+ *
+ * Source identity is (connection_id, origin_id), and a transcript is the next
+ * version of that same source item. It must never select another connection's
+ * colliding origin or fork the chain under a synthetic origin.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as lobuGateway from '../../../lobu/gateway';
+import { transcribeOne } from '../../../utils/inline-attachments';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestOrganization,
+} from '../../setup/test-fixtures';
+
+const ORIGIN_ID = 'provider-message-42';
+const previousEmbeddingsServiceUrl = process.env.EMBEDDINGS_SERVICE_URL;
+const previousEmbeddingsModel = process.env.EMBEDDINGS_MODEL;
+
+function transcriptionJob(
+  eventId: number,
+  connectionId: number,
+  title: string | null = null
+): Parameters<typeof transcribeOne>[0] {
+  return {
+    originId: ORIGIN_ID,
+    baseEventId: eventId,
+    connectionId,
+    artifactId: `artifact-${eventId}`,
+    mimeType: 'audio/opus',
+    title,
+  };
+}
+
+async function currentHeads(organizationId: string) {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, origin_id, payload_text, connector_key, connection_id,
+           feed_key, feed_id, run_id, origin_parent_id
+    FROM events e
+    WHERE organization_id = ${organizationId}
+      AND NOT EXISTS (
+        SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
+      )
+    ORDER BY connection_id, id
+  `) as Array<{
+    id: number | string;
+    origin_id: string;
+    payload_text: string | null;
+    connector_key: string | null;
+    connection_id: number | string | null;
+    feed_key: string | null;
+    feed_id: number | string | null;
+    run_id: number | string | null;
+    origin_parent_id: string | null;
+  }>;
+}
+
+async function createFeed(
+  organizationId: string,
+  connectionId: number,
+  feedKey: string
+): Promise<number> {
+  const [row] = await getTestDb()`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, status, created_at, updated_at
+    ) VALUES (
+      ${organizationId}, ${connectionId}, ${feedKey}, 'active', NOW(), NOW()
+    )
+    RETURNING id
+  `;
+  return Number(row!.id);
+}
+
+async function createRun(organizationId: string): Promise<number> {
+  const [row] = await getTestDb()`
+    INSERT INTO runs (
+      organization_id, run_type, status, approval_status, action_key, created_at
+    ) VALUES (
+      ${organizationId}, 'action', 'pending', 'pending', 'transcribe-test', NOW()
+    )
+    RETURNING id
+  `;
+  return Number(row!.id);
+}
+
+describe('inline attachment transcription event identity (issue #3067)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.EMBEDDINGS_SERVICE_URL;
+    delete process.env.EMBEDDINGS_MODEL;
+    vi.spyOn(lobuGateway, 'getLobuCoreServices').mockReturnValue({
+      getArtifactStore: () => ({
+        read: async () => ({ bytes: Buffer.from('synthetic audio') }),
+      }),
+      getTranscriptionService: () => ({
+        transcribe: async () => ({
+          text: 'transcribed voice note',
+          provider: 'test-stt',
+        }),
+      }),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (previousEmbeddingsServiceUrl === undefined) {
+      delete process.env.EMBEDDINGS_SERVICE_URL;
+    } else {
+      process.env.EMBEDDINGS_SERVICE_URL = previousEmbeddingsServiceUrl;
+    }
+    if (previousEmbeddingsModel === undefined) {
+      delete process.env.EMBEDDINGS_MODEL;
+    } else {
+      process.env.EMBEDDINGS_MODEL = previousEmbeddingsModel;
+    }
+  });
+
+  it('never selects a colliding origin from another connection', async () => {
+    const org = await createTestOrganization();
+    const firstConnection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+    const secondConnection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+
+    const first = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: ORIGIN_ID,
+      title: 'First account voice note',
+      content: '[voice note from first account]',
+      semanticType: 'message',
+      connectorKey: 'whatsapp.local',
+      connectionId: Number(firstConnection.id),
+    });
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: ORIGIN_ID,
+      title: 'Second account voice note',
+      content: '[voice note from second account]',
+      semanticType: 'message',
+      connectorKey: 'whatsapp.local',
+      connectionId: Number(secondConnection.id),
+    });
+
+    await transcribeOne(
+      transcriptionJob(Number(first.id), Number(firstConnection.id)),
+      org.id,
+      'test-agent'
+    );
+
+    const heads = await currentHeads(org.id);
+    expect(heads).toHaveLength(2);
+    expect(heads).toEqual([
+      expect.objectContaining({
+        origin_id: ORIGIN_ID,
+        payload_text: 'transcribed voice note',
+        connection_id: Number(firstConnection.id),
+      }),
+      expect.objectContaining({
+        origin_id: ORIGIN_ID,
+        payload_text: '[voice note from second account]',
+        connection_id: Number(secondConnection.id),
+      }),
+    ]);
+  });
+
+  it('keeps transcription and resync in one same-origin lineage', async () => {
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+    const connectionId = Number(connection.id);
+    const feedId = await createFeed(org.id, connectionId, 'messages');
+    const runId = await createRun(org.id);
+    const baseParams = {
+      entityIds: [],
+      organizationId: org.id,
+      originId: ORIGIN_ID,
+      title: 'Voice note',
+      content: '[voice note]',
+      semanticType: 'message' as const,
+      originType: 'message',
+      connectorKey: 'whatsapp.local',
+      connectionId,
+      feedKey: 'messages',
+      feedId,
+      runId,
+      parentOriginId: 'conversation-7',
+    };
+    const base = await insertEvent(baseParams, { onConflictUpdate: true });
+
+    await transcribeOne(transcriptionJob(Number(base.id), connectionId), org.id, 'test-agent');
+    const afterTranscript = await currentHeads(org.id);
+    expect(afterTranscript).toHaveLength(1);
+    expect(afterTranscript[0]).toMatchObject({
+      origin_id: ORIGIN_ID,
+      payload_text: 'transcribed voice note',
+      connector_key: 'whatsapp.local',
+      connection_id: connectionId,
+      feed_key: 'messages',
+      feed_id: feedId,
+      run_id: runId,
+      origin_parent_id: 'conversation-7',
+    });
+
+    const resync = await insertEvent(baseParams, { onConflictUpdate: true });
+    expect(resync.change).toBe('superseded');
+    await transcribeOne(
+      transcriptionJob(Number(resync.id), connectionId),
+      org.id,
+      'test-agent'
+    );
+
+    const heads = await currentHeads(org.id);
+    expect(heads).toHaveLength(1);
+    expect(heads[0]).toMatchObject({
+      origin_id: ORIGIN_ID,
+      payload_text: 'transcribed voice note',
+      connector_key: 'whatsapp.local',
+      connection_id: connectionId,
+      feed_key: 'messages',
+      feed_id: feedId,
+      run_id: runId,
+      origin_parent_id: 'conversation-7',
+    });
+
+    const chain = await getTestDb()`
+      SELECT origin_id, supersedes_event_id, superseded_by
+      FROM events
+      WHERE organization_id = ${org.id}
+        AND connection_id = ${connectionId}
+      ORDER BY id
+    `;
+    expect(chain).toHaveLength(4);
+    expect(chain.every((row) => row.origin_id === ORIGIN_ID)).toBe(true);
+    expect(chain.filter((row) => row.superseded_by == null)).toHaveLength(1);
+  });
+
+  it('serializes duplicate transcription completion for the same event version', async () => {
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+    const connectionId = Number(connection.id);
+    const base = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId: ORIGIN_ID,
+        title: 'Concurrent voice note',
+        content: '[voice note]',
+        semanticType: 'message',
+        connectorKey: 'whatsapp.local',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+    const job = transcriptionJob(Number(base.id), connectionId);
+
+    await Promise.all([
+      transcribeOne(job, org.id, 'test-agent'),
+      transcribeOne(job, org.id, 'test-agent'),
+    ]);
+
+    const heads = await currentHeads(org.id);
+    expect(heads).toHaveLength(1);
+    expect(heads[0]).toMatchObject({
+      origin_id: ORIGIN_ID,
+      payload_text: 'transcribed voice note',
+      connection_id: connectionId,
+    });
+    const [count] = await getTestDb()`
+      SELECT count(*)::int AS count
+      FROM events
+      WHERE organization_id = ${org.id}
+        AND connection_id = ${connectionId}
+        AND origin_id = ${ORIGIN_ID}
+    `;
+    expect(count!.count).toBe(2);
+  });
+
+  it('drops a stale transcript when a normal resync replaces its exact base', async () => {
+    let transcriptionStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      transcriptionStarted = resolve;
+    });
+    let finishTranscription!: () => void;
+    const mayFinish = new Promise<void>((resolve) => {
+      finishTranscription = resolve;
+    });
+    vi.mocked(lobuGateway.getLobuCoreServices).mockReturnValue({
+      getArtifactStore: () => ({
+        read: async () => ({ bytes: Buffer.from('old synthetic audio') }),
+      }),
+      getTranscriptionService: () => ({
+        transcribe: async () => {
+          transcriptionStarted();
+          await mayFinish;
+          return { text: 'stale transcript', provider: 'test-stt' };
+        },
+      }),
+    } as never);
+
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+    const connectionId = Number(connection.id);
+    const baseParams = {
+      entityIds: [],
+      organizationId: org.id,
+      originId: ORIGIN_ID,
+      title: 'Voice note',
+      content: '[old voice note]',
+      semanticType: 'message' as const,
+      connectorKey: 'whatsapp.local',
+      connectionId,
+    };
+    const base = await insertEvent(baseParams, { onConflictUpdate: true });
+
+    const transcribing = transcribeOne(
+      transcriptionJob(Number(base.id), connectionId),
+      org.id,
+      'test-agent'
+    );
+    await started;
+    const resync = await insertEvent(
+      { ...baseParams, content: '[new voice note]' },
+      { onConflictUpdate: true }
+    );
+    expect(resync.change).toBe('superseded');
+    finishTranscription();
+    await transcribing;
+
+    const heads = await currentHeads(org.id);
+    expect(heads).toHaveLength(1);
+    expect(heads[0]).toMatchObject({
+      origin_id: ORIGIN_ID,
+      payload_text: '[new voice note]',
+      connection_id: connectionId,
+    });
+    const [count] = await getTestDb()`
+      SELECT count(*)::int AS count
+      FROM events
+      WHERE organization_id = ${org.id}
+        AND connection_id = ${connectionId}
+        AND origin_id = ${ORIGIN_ID}
+    `;
+    expect(count!.count).toBe(2);
+  });
+
+  it('stamps the transcript vector through the canonical insertEvent path', async () => {
+    const embeddingModel = 'test/transcription-768d';
+    const embedding = new Array<number>(768).fill(0);
+    embedding[17] = 1;
+    process.env.EMBEDDINGS_SERVICE_URL = 'http://embeddings.test';
+    process.env.EMBEDDINGS_MODEL = embeddingModel;
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          embeddings: [embedding],
+          dimensions: 768,
+          model: embeddingModel,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const org = await createTestOrganization();
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp.local',
+    });
+    const connectionId = Number(connection.id);
+    const base = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: ORIGIN_ID,
+      title: 'Embedded voice note',
+      content: '[voice note]',
+      semanticType: 'message',
+      connectorKey: 'whatsapp.local',
+      connectionId,
+    });
+
+    await transcribeOne(
+      transcriptionJob(Number(base.id), connectionId, 'Embedded voice note'),
+      org.id,
+      'test-agent'
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchMock.mock.calls[0]![1]!.body))).toEqual({
+      texts: ['Embedded voice note transcribed voice note'],
+      model: embeddingModel,
+    });
+    const [vectorRow] = await getTestDb()`
+      SELECT ee.embedding_model
+      FROM event_embeddings ee
+      JOIN events e ON e.id = ee.event_id
+      WHERE e.organization_id = ${org.id}
+        AND e.connection_id = ${connectionId}
+        AND e.origin_id = ${ORIGIN_ID}
+        AND e.superseded_by IS NULL
+    `;
+    expect(vectorRow).toEqual({ embedding_model: embeddingModel });
+  });
+});

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -27,7 +27,15 @@ import {
   type ArtifactStore,
 } from "../gateway/files/artifact-store";
 import { resolvePublicGatewayUrl } from "./public-origin";
-import { insertEvent } from "./insert-event";
+import {
+  insertEvent,
+  lockEventDedupIdentity,
+} from "./insert-event";
+import {
+  generateEmbeddings,
+  getConfiguredEmbeddingModel,
+} from "./embeddings";
+import { getEnvFromProcess } from "./env";
 import logger from "./logger";
 
 /**
@@ -79,11 +87,20 @@ interface StreamItemLike {
 }
 
 /** Per-item record of audio attachments that the gateway should transcribe. */
-interface AudioTranscriptionPending {
-  originId: string;
+interface AudioTranscriptionCandidate {
   artifactId: string;
-  filename: string;
   mimeType: string;
+}
+
+interface AudioTranscriptionJob extends AudioTranscriptionCandidate {
+  /** Connection-scoped source identity of the persisted event. */
+  originId: string;
+  /** Exact stored version whose audio bytes produced this job. */
+  baseEventId: number;
+  /** Source identity is scoped to a connection, never only an organization. */
+  connectionId: number;
+  /** Persisted title included in the canonical event embedding text. */
+  title: string | null;
 }
 
 function publicGatewayUrl(): string {
@@ -104,7 +121,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
   bindingForItem?: (item: T) => string | undefined
 ): Promise<{
   items: T[];
-  pendingTranscriptions: AudioTranscriptionPending[];
+  pendingTranscriptions: AudioTranscriptionCandidate[];
   publishedArtifactIds: string[];
 }> {
   const coreServices = getLobuCoreServices();
@@ -114,7 +131,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
   }
 
   const baseUrl = publicGatewayUrl();
-  const pendingTranscriptions: AudioTranscriptionPending[] = [];
+  const pendingTranscriptions: AudioTranscriptionCandidate[] = [];
   const publishedArtifactIds: string[] = [];
   const out: T[] = [];
 
@@ -193,9 +210,7 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
 
       if (kind === "audio") {
         pendingTranscriptions.push({
-          originId: item.id,
           artifactId: published.artifactId,
-          filename: published.filename,
           mimeType: published.contentType,
         });
       }
@@ -266,7 +281,7 @@ function inferKindFromMime(mime: string): string {
  */
 export function triggerAudioTranscriptions(
   organizationId: string,
-  pending: AudioTranscriptionPending[]
+  pending: AudioTranscriptionJob[]
 ): void {
   if (pending.length === 0) return;
 
@@ -335,8 +350,8 @@ async function pickTranscriptionAgent(
   return null;
 }
 
-async function transcribeOne(
-  job: AudioTranscriptionPending,
+export async function transcribeOne(
+  job: AudioTranscriptionJob,
   organizationId: string,
   agentId: string
 ): Promise<void> {
@@ -371,58 +386,89 @@ async function transcribeOne(
   const transcript = result.text.trim();
   if (!transcript) return;
 
+  let embedding: number[] | undefined;
+  let embeddingModel: string | undefined;
+  const env = getEnvFromProcess();
+  if (env.EMBEDDINGS_SERVICE_URL?.trim()) {
+    try {
+      embeddingModel = getConfiguredEmbeddingModel();
+      const embeddingText = [job.title, transcript].filter(Boolean).join(" ").trim();
+      [embedding] = await generateEmbeddings([embeddingText], env, embeddingModel);
+    } catch (err) {
+      embedding = undefined;
+      embeddingModel = undefined;
+      logger.warn(
+        { origin_id: job.originId, err: String(err) },
+        "[inline-attachments] transcript embedding failed — backfill will retry"
+      );
+    }
+  }
+
   const sql = getDb();
-  const baseRows = (await sql`
-    SELECT id, entity_ids, title, payload_type, payload_data, attachments,
-           author_name, source_url, occurred_at, metadata, semantic_type,
-           origin_type, score
-    FROM events
-    WHERE organization_id = ${organizationId}
-      AND origin_id = ${job.originId}
-      AND NOT EXISTS (
-        SELECT 1 FROM events newer WHERE newer.supersedes_event_id = events.id
-      )
-    ORDER BY created_at DESC, id DESC
-    LIMIT 1
-  `) as Array<{
-    id: number;
-    entity_ids: number[] | null;
-    title: string | null;
-    payload_type: string;
-    payload_data: Record<string, unknown> | null;
-    attachments: unknown[] | null;
-    author_name: string | null;
-    source_url: string | null;
-    occurred_at: string | null;
-    metadata: Record<string, unknown> | null;
-    semantic_type: string;
-    origin_type: string | null;
-    score: number | null;
-  }>;
-  const base = baseRows[0];
-  if (!base) return;
+  await sql.begin(async (tx) => {
+    // Use the same per-source lock as normal connector resync. The exact event
+    // id ties this transcript to the bytes that produced it: if a newer resync
+    // already replaced that version, its own transcription job owns the new
+    // head and this stale result is discarded.
+    await lockEventDedupIdentity(tx, job.connectionId, job.originId);
+    const baseRows = (await tx`
+      SELECT e.id, e.entity_ids, e.title, e.payload_type, e.payload_data,
+             e.attachments, e.author_name, e.source_url, e.occurred_at,
+             e.metadata, e.semantic_type, e.origin_type, e.score
+      FROM events e
+      WHERE e.id = ${job.baseEventId}
+        AND e.organization_id = ${organizationId}
+        AND e.connection_id = ${job.connectionId}
+        AND e.origin_id = ${job.originId}
+        AND NOT EXISTS (
+          SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
+        )
+      FOR UPDATE
+    `) as Array<{
+      id: number;
+      entity_ids: number[] | null;
+      title: string | null;
+      payload_type: string;
+      payload_data: Record<string, unknown> | null;
+      attachments: unknown[] | null;
+      author_name: string | null;
+      source_url: string | null;
+      occurred_at: string | null;
+      metadata: Record<string, unknown> | null;
+      semantic_type: string;
+      origin_type: string | null;
+      score: number | null;
+    }>;
+    const base = baseRows[0];
+    if (!base) return;
 
-  const meta = { ...(base.metadata ?? {}), transcript_provider: result.provider };
+    const meta = { ...(base.metadata ?? {}), transcript_provider: result.provider };
 
-  // Tombstone-style supersede: insert a new event that points at the current
-  // row. The `current_event_records` view (and findCurrentEventByOrigin) will
-  // surface this one going forward; the original stays in history.
-  await insertEvent({
-    entityIds: base.entity_ids ?? [],
-    organizationId,
-    originId: `${job.originId}#transcript`,
-    title: base.title,
-    payloadType: (base.payload_type as never) || "text",
-    content: transcript,
-    payloadData: base.payload_data ?? {},
-    attachments: base.attachments ?? [],
-    authorName: base.author_name,
-    sourceUrl: base.source_url,
-    occurredAt: base.occurred_at,
-    semanticType: base.semantic_type,
-    originType: base.origin_type,
-    metadata: meta,
-    score: base.score,
-    supersedesEventId: base.id,
+    // Content enrichment is the next stored version of the same source item.
+    // Keeping origin_id stable lets the next connector resync find this head;
+    // insertEvent inherits connector/feed/run/parent lineage from the base.
+    await insertEvent(
+      {
+        entityIds: base.entity_ids ?? [],
+        organizationId,
+        originId: job.originId,
+        title: base.title,
+        payloadType: (base.payload_type as never) || "text",
+        content: transcript,
+        payloadData: base.payload_data ?? {},
+        attachments: base.attachments ?? [],
+        authorName: base.author_name,
+        sourceUrl: base.source_url,
+        occurredAt: base.occurred_at,
+        semanticType: base.semantic_type,
+        originType: base.origin_type,
+        metadata: meta,
+        score: base.score,
+        embedding,
+        embeddingModel,
+        supersedesEventId: base.id,
+      },
+      { sql: tx }
+    );
   });
 }

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -73,6 +73,18 @@ export function eventDedupLockKey(connectionId: number, originId: string): numbe
   return hash | 0;
 }
 
+/** Serialize writes for one connection-scoped source identity in a transaction. */
+export async function lockEventDedupIdentity(
+  sql: DbClient,
+  connectionId: number,
+  originId: string
+): Promise<void> {
+  const lockKey = eventDedupLockKey(connectionId, originId);
+  await sql`
+    SELECT pg_advisory_xact_lock(${EVENT_DEDUP_LOCK_NAMESPACE}, ${lockKey})
+  `;
+}
+
 // ============================================
 // Types
 // ============================================
@@ -964,12 +976,10 @@ export async function insertEvent(
   // transaction-scoped advisory lock keyed on (connection_id, origin_id) so
   // these serialize. Only engage when we own the connection (no caller-supplied
   // tx, which already runs in its own atomic scope) and have both keys.
-  if (options?.onConflictUpdate && !options.sql && params.connectionId && params.originId) {
-    const lockKey = eventDedupLockKey(params.connectionId, params.originId);
+  const dedupConnectionId = params.connectionId;
+  if (options?.onConflictUpdate && !options.sql && dedupConnectionId && params.originId) {
     return sql.begin(async (tx) => {
-      await tx`
-        SELECT pg_advisory_xact_lock(${EVENT_DEDUP_LOCK_NAMESPACE}, ${lockKey})
-      `;
+      await lockEventDedupIdentity(tx, dedupConnectionId, params.originId);
       return runInsert(tx);
     }) as Promise<InsertedEvent>;
   }

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -367,9 +367,9 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		// entity attribution writes. The dry path passes a tx that is rolled back.
 		const ingestBatch = async (db: DbClient) => {
 			// Audio attachments are queued only after their event insert commits.
-			let pendingTranscriptions: Awaited<
-				ReturnType<typeof materializeInlineAttachments>
-			>["pendingTranscriptions"] = [];
+			let pendingTranscriptions: Parameters<
+				typeof triggerAudioTranscriptions
+			>[1] = [];
 
 			// Resolve or create entities declared via eventKinds[kind].attributions
 			// before inserting events. One query per (entityType, matchField) per
@@ -469,7 +469,9 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 					continue;
 				}
 
-				let itemPendingTranscriptions: typeof pendingTranscriptions = [];
+				let itemPendingTranscriptions: Awaited<
+					ReturnType<typeof materializeInlineAttachments>
+				>["pendingTranscriptions"] = [];
 				if (!isDry) {
 					// ESCAPES THE TX: publish only after validation, immediately before
 					// the event insert. The finally block deletes this item's artifacts
@@ -587,7 +589,23 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 				// exactly as `unchanged` does — the ones just published are unreferenced.
 				if (inserted.change !== "unchanged" && inserted.change !== "state_updated") {
 					artifactCommitted = true;
-					pendingTranscriptions.push(...itemPendingTranscriptions);
+					const transcriptionConnectionId = run.connection_id;
+					if (transcriptionConnectionId != null) {
+						pendingTranscriptions.push(
+							...itemPendingTranscriptions.map((job) => ({
+								...job,
+								originId: inserted.origin_id,
+								baseEventId: inserted.id,
+								connectionId: transcriptionConnectionId,
+								title: inserted.title,
+							}))
+						);
+					} else if (itemPendingTranscriptions.length > 0) {
+						logger.warn(
+							{ run_id: batch.run_id },
+							"[stream] Audio transcription skipped — source connection missing"
+						);
+					}
 				}
 				// ESCAPES THE TX: this dispatches real Automation runs to the worker
 				// fleet. The activation ROWS roll back with the tx, but a dispatched


### PR DESCRIPTION
## Summary
- scope inline-audio transcription to the exact persisted event version and connection, sharing the canonical connection-scoped origin lock with normal resyncs
- append the transcript as a same-origin successor while preserving connector, connection, feed, run, and parent lineage
- persist the canonical title-plus-transcript embedding at enrichment time when embeddings are configured, with existing backfill behavior retained on embedding failure

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean after review-fix
- [x] Focused and surrounding tests: 6 files, 40 tests passed
- [x] Server TypeScript typecheck passed
- [x] Bug fix red -> green evidence:
  - before the fix, two connections sharing one `origin_id` caused transcription to replace the other connection event
  - before the fix, transcription wrote an `#transcript` origin, so normal resync could create another live root
  - after the fix, connection isolation, same-origin resync lineage, duplicate concurrent completion, stale-result races, and write-time embedding all pass

## Notes
No DB, API, or SDK surface changes.

Closes #3067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription event handling during resynchronization and duplicate completion scenarios.
  * Prevented stale transcription results from being applied after a resync.
  * Preserved original event identity and metadata through transcription workflows.
  * Improved reliability of concurrent event updates and duplicate detection.
  * Added embedding generation for eligible transcription results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->