### PR TITLE
Support Claude and OpenCode ACP automations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -59,7 +59,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -144,7 +144,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -153,7 +153,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -175,24 +175,14 @@
         "playwright-vanilla",
       ],
     },
-    "packages/device-connectors": {
-      "name": "@lobu/device-connectors",
-      "version": "15.8.0",
-      "dependencies": {
-        "@lobu/connector-sdk": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/node": "^20.10.0",
-        "typescript": "^5.3.3",
-      },
-    },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
       "dependencies": {
+        "@agentclientprotocol/claude-agent-acp": "0.70.0",
         "@agentclientprotocol/codex-acp": "1.6.2",
         "@agentclientprotocol/sdk": "1.4.0",
         "@lobu/connector-sdk": "workspace:*",
@@ -225,7 +215,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -244,9 +234,20 @@
         "typescript": "^5.8.3",
       },
     },
+    "packages/device-connectors": {
+      "name": "@lobu/device-connectors",
+      "version": "15.8.0",
+      "dependencies": {
+        "@lobu/connector-sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "typescript": "^5.3.3",
+      },
+    },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "dependencies": {
         "@hono/node-server": "^2.0.11",
         "@xenova/transformers": "^2.17.2",
@@ -350,7 +351,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -358,7 +359,7 @@
     },
     "packages/plugin-api": {
       "name": "@lobu/plugin-api",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
       },
@@ -383,7 +384,7 @@
     },
     "packages/plugin-host": {
       "name": "@lobu/plugin-host",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "dependencies": {
         "@lobu/plugin-api": "workspace:*",
       },
@@ -452,7 +453,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "15.5.0",
+      "version": "15.8.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -526,6 +527,8 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
+    "@agentclientprotocol/claude-agent-acp": ["@agentclientprotocol/claude-agent-acp@0.70.0", "", { "dependencies": { "@agentclientprotocol/sdk": "1.3.0", "@anthropic-ai/claude-agent-sdk": "0.3.232", "zod": "^3.25.0 || ^4.0.0" }, "bin": { "claude-agent-acp": "dist/index.js" } }, "sha512-Psqj6fhV4pQ8IM480zpJ+xGiMMIqNLxlsTj5Mzn+T8KSURCVNJdl0ktcqLMjgHJC/QnOvDdDkFf3xTW9VIV9aQ=="],
+
     "@agentclientprotocol/codex-acp": ["@agentclientprotocol/codex-acp@1.6.2", "", { "dependencies": { "@agentclientprotocol/sdk": "^1.3.0", "@openai/codex": "^0.148.0", "diff": "^9.0.0", "open": "^11.0.0", "vscode-jsonrpc": "^9.0.1", "zod": "^4.0.0" }, "bin": { "codex-acp": "dist/index.js" } }, "sha512-2eF1mbs1gTqkZJSLYOun/pFDx37sYa7W63HOPezC37b/R8AYms5O1nfQu8lrqFSGDrwDZkASVORymLcqjCNqyA=="],
 
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.4.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg=="],
@@ -533,6 +536,24 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.232", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.232", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.232", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.232", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.232", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.232", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.232", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.232", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.232" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-8od7hJk9fZnF1/oYYiR9PvroGbZRQrpmNgKirjHNGoj5ur5YcAZLohI70XVUAUe3KvjB1msLxtkvmlAT9sqFAg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232", "", { "os": "darwin", "cpu": "x64" }, "sha512-EHZ1Y3aGyZ2mFZ6QLR1bM3/HiIn2cLrPjU+k3/oCIW6omJFodfzf410aWjDPSnMj7CE4d6t7MSjBWekMUbcv0g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232", "", { "os": "linux", "cpu": "arm64" }, "sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232", "", { "os": "linux", "cpu": "arm64" }, "sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232", "", { "os": "linux", "cpu": "x64" }, "sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232", "", { "os": "linux", "cpu": "x64" }, "sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232", "", { "os": "win32", "cpu": "arm64" }, "sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232", "", { "os": "win32", "cpu": "x64" }, "sha512-Hc/9uy1BI9mqKVyB1b/zoUnm3MFgtVNzQY6p5zgaq9DaIjCKDpR4a4L1aDZM4lMqUcWFMZM+u7juOhh+m39NBQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.104.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q=="],
 
@@ -1157,6 +1178,8 @@
     "@lobu/connectors": ["@lobu/connectors@workspace:packages/connectors"],
 
     "@lobu/core": ["@lobu/core@workspace:packages/core"],
+
+    "@lobu/device-connectors": ["@lobu/device-connectors@workspace:packages/device-connectors"],
 
     "@lobu/embeddings": ["@lobu/embeddings@workspace:packages/embeddings"],
 
@@ -3922,6 +3945,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@agentclientprotocol/claude-agent-acp/@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
+
     "@agentclientprotocol/codex-acp/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -4071,6 +4096,8 @@
     "@jimp/plugin-threshold/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@lobu/connector-sdk/tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
 
     "@lobu/core/@sentry/node": ["@sentry/node@10.50.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.50.0", "@sentry/node-core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" } }, "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q=="],
 

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -57,6 +57,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "0.70.0",
     "@agentclientprotocol/codex-acp": "1.6.2",
     "@agentclientprotocol/sdk": "1.4.0",
     "@lobu/connector-sdk": "workspace:*",

--- a/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
+++ b/packages/connector-worker/src/__tests__/advertised-agent-kinds.test.ts
@@ -14,7 +14,10 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import * as agentBinaries from "../daemon/agent-binaries";
-import { resolveRunnableAgentKinds } from "../daemon/agent-binaries";
+import {
+  resolveRunnableAgentKinds,
+  supportsOpenCodeAcp,
+} from "../daemon/agent-binaries";
 
 const tempDirs: string[] = [];
 
@@ -62,6 +65,52 @@ describe("resolveRunnableAgentKinds", () => {
     expect(
       resolveRunnableAgentKinds({ codex: path.join(dir, "gone") }, [binDirWith([])])
     ).toEqual([]);
+  });
+});
+
+describe("supportsOpenCodeAcp", () => {
+  test("accepts an installed OpenCode binary only when its ACP entrypoint starts", () => {
+    const dir = binDirWith([]);
+    const supported = path.join(dir, "supported-opencode");
+    writeFileSync(
+      supported,
+      "#!/bin/sh\n[ \"$1\" = acp ] && [ \"$2\" = --pure ] && [ \"$3\" = --help ]\n"
+    );
+    chmodSync(supported, 0o755);
+    const unsupported = path.join(dir, "unsupported-opencode");
+    writeFileSync(unsupported, "#!/bin/sh\nexit 64\n");
+    chmodSync(unsupported, 0o755);
+
+    expect(supportsOpenCodeAcp(supported)).toBe(true);
+    expect(supportsOpenCodeAcp(unsupported)).toBe(false);
+  });
+
+  test("does not expose daemon credentials to the OpenCode capability probe", () => {
+    const dir = binDirWith([]);
+    const binary = path.join(dir, "opencode-env-probe");
+    writeFileSync(
+      binary,
+      "#!/bin/sh\n[ -z \"$WORKER_API_TOKEN\" ] && [ -z \"$LOBU_API_TOKEN\" ] && [ -z \"$LOBU_MEMORY_URL\" ]\n"
+    );
+    chmodSync(binary, 0o755);
+    const previous = {
+      worker: process.env.WORKER_API_TOKEN,
+      api: process.env.LOBU_API_TOKEN,
+      memory: process.env.LOBU_MEMORY_URL,
+    };
+    process.env.WORKER_API_TOKEN = "device-secret";
+    process.env.LOBU_API_TOKEN = "run-secret";
+    process.env.LOBU_MEMORY_URL = "https://lobu.test/mcp";
+    try {
+      expect(supportsOpenCodeAcp(binary)).toBe(true);
+    } finally {
+      if (previous.worker === undefined) delete process.env.WORKER_API_TOKEN;
+      else process.env.WORKER_API_TOKEN = previous.worker;
+      if (previous.api === undefined) delete process.env.LOBU_API_TOKEN;
+      else process.env.LOBU_API_TOKEN = previous.api;
+      if (previous.memory === undefined) delete process.env.LOBU_MEMORY_URL;
+      else process.env.LOBU_MEMORY_URL = previous.memory;
+    }
   });
 });
 

--- a/packages/connector-worker/src/__tests__/automation-acp.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-acp.test.ts
@@ -6,7 +6,7 @@ import { parseSessionEntries } from '@lobu/core';
 import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
 import { executeAutomationRun } from '../daemon/automation.js';
 import { type ExecutorClient, WorkerClient } from '../daemon/client.js';
-import { CodexAcpTranscript, runCodexAcpTurn } from '../daemon/codex-acp.js';
+import { AcpTranscript, runAcpTurn } from '../daemon/automation-acp.js';
 
 function fakeAcpAgent(dir: string): { script: string; trace: string } {
   const script = path.join(dir, 'fake-acp-agent.mjs');
@@ -21,6 +21,10 @@ const record = (value) => fs.appendFileSync(trace, JSON.stringify(value) + '\\n'
 const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
 const response = (id, result) => send({ jsonrpc: '2.0', id, result });
 const update = (sessionId, value) => send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId, update: value } });
+record({ environment: {
+  OPENCODE_DISABLE_PROJECT_CONFIG: process.env.OPENCODE_DISABLE_PROJECT_CONFIG,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME
+} });
 const input = readline.createInterface({ input: process.stdin });
 for await (const line of input) {
   if (!line.trim()) continue;
@@ -92,7 +96,51 @@ function traceLines(trace: string): Array<Record<string, unknown>> {
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
-describe('Codex ACP Automation turn', () => {
+function permissionAcpAgent(dir: string): { script: string; trace: string } {
+  const script = path.join(dir, 'permission-acp-agent.mjs');
+  const trace = path.join(dir, 'permission-trace.jsonl');
+  writeFileSync(
+    script,
+    `import fs from 'node:fs';
+import readline from 'node:readline';
+const trace = process.env.FAKE_ACP_TRACE;
+const send = (value) => process.stdout.write(JSON.stringify({ jsonrpc: '2.0', ...value }) + '\\n');
+let promptId;
+for await (const line of readline.createInterface({ input: process.stdin })) {
+  if (!line.trim()) continue;
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    send({ id: message.id, result: {
+      protocolVersion: 1,
+      agentCapabilities: { mcpCapabilities: { http: true }, sessionCapabilities: { close: {} } },
+      agentInfo: { name: 'permission-agent', version: '1' }
+    } });
+  } else if (message.method === 'session/new') {
+    send({ id: message.id, result: { sessionId: 'permission-session' } });
+  } else if (message.method === 'session/prompt') {
+    promptId = message.id;
+    send({ id: 700, method: 'session/request_permission', params: {
+      sessionId: 'permission-session',
+      toolCall: { toolCallId: 'tool-1', title: 'Run command' },
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+      ]
+    } });
+  } else if (message.id === 700) {
+    fs.writeFileSync(trace, JSON.stringify(message.result));
+    send({ id: promptId, result: { stopReason: 'end_turn' } });
+  } else if (message.method === 'session/close') {
+    send({ id: message.id, result: {} });
+  }
+}
+`,
+    'utf8'
+  );
+  return { script, trace };
+}
+
+describe('Automation ACP turn', () => {
   test('routes the Mac Automation through ACP and uploads its terminal transcript', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-automation-'));
     const { script, trace } = fakeAcpAgent(dir);
@@ -142,11 +190,14 @@ describe('Codex ACP Automation turn', () => {
       const outcome = await executeAutomationRun(client, job, {
         requireRunScopedSession: true,
         timeoutMs: 5_000,
-        codexAcp: {
-          adapterCommand: process.execPath,
-          adapterArgs: [script],
-          adapterEnv: { FAKE_ACP_TRACE: trace },
-          codexPath: '/usr/local/bin/codex',
+        acpAdapters: {
+          codex: {
+            command: process.execPath,
+            args: [script],
+            env: { FAKE_ACP_TRACE: trace },
+            defaultMode: 'agent',
+            effortConfigId: 'reasoning_effort',
+          },
         },
       });
 
@@ -164,16 +215,134 @@ describe('Codex ACP Automation turn', () => {
     }
   }, 15_000);
 
+  for (const agentKind of ['claude-code', 'opencode'] as const) {
+    test(`checkpoints and uploads a ${agentKind} ACP Automation`, async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), `lobu-${agentKind}-acp-automation-`));
+      const { script, trace } = fakeAcpAgent(dir);
+      const checkpoints: unknown[] = [];
+      const snapshots: string[] = [];
+      const client = {
+        id: 'macos:test',
+        async heartbeat(_runId: number, _progress: unknown, session: unknown) {
+          if (session) checkpoints.push(session);
+        },
+        async completeAutomation() {
+          return { ok: true, status: 'completed', run_id: 99 };
+        },
+        async writeAutomationTranscript(
+          _runId: number,
+          _bearer: string,
+          _status: string,
+          jsonl: string
+        ) {
+          snapshots.push(jsonl);
+        },
+      } as unknown as ExecutorClient;
+      const job = {
+        run_id: 99,
+        run_type: 'automation',
+        payload: {
+          automation: {
+            id: '42',
+            agent_kind: agentKind,
+            prompt: 'Do the work.',
+            execution_config: {
+              effort: 'high',
+              ...(agentKind === 'claude-code'
+                ? { max_budget_usd: 1, model: 'claude-test', permission_mode: 'acceptEdits' }
+                : {}),
+            },
+          },
+          event: { fired_at: new Date().toISOString(), payload: {} },
+          context: {
+            device: { worker_id: 'macos:test' },
+            user: {},
+            agent_session: {
+              conversation_id: 'agent_automation_42_run_99',
+              mcp_url: 'https://lobu.test/mcp/team',
+              token: 'run-scoped-token',
+              expires_at: Date.now() + 60_000,
+            },
+          },
+        },
+      } as PollResponse;
+      try {
+        await executeAutomationRun(client, job, {
+          requireRunScopedSession: true,
+          timeoutMs: 5_000,
+          acpAdapters: {
+            [agentKind]: {
+              command: process.execPath,
+              args: [script],
+              env: { FAKE_ACP_TRACE: trace },
+              effortConfigId: 'effort',
+              ...(agentKind === 'claude-code'
+                ? {
+                    mcpServerName: 'lobu',
+                    sessionMeta: {
+                      claudeCode: { options: { settingSources: [] } },
+                    },
+                  }
+                : {}),
+            },
+          },
+        });
+
+        expect(checkpoints).toEqual([
+          { protocol: 'acp', agent_kind: agentKind, session_id: 'acp-new-session' },
+        ]);
+        expect(snapshots).toHaveLength(1);
+        expect(snapshots[0]).toContain('ACP finished');
+        const calls = traceLines(trace);
+        expect(calls).toContainEqual(
+          expect.objectContaining({
+            method: 'session/set_config_option',
+            params: { sessionId: 'acp-new-session', configId: 'effort', value: 'high' },
+          })
+        );
+        if (agentKind === 'claude-code') {
+          const modelIndex = calls.findIndex(
+            (call) =>
+              call.method === 'session/set_config_option' &&
+              (call.params as { configId?: string } | undefined)?.configId === 'model'
+          );
+          const modeIndex = calls.findIndex((call) => call.method === 'session/set_mode');
+          expect(modelIndex).toBeGreaterThanOrEqual(0);
+          expect(modelIndex).toBeLessThan(modeIndex);
+          expect(calls).toContainEqual(
+            expect.objectContaining({
+              method: 'session/set_mode',
+              params: { sessionId: 'acp-new-session', modeId: 'acceptEdits' },
+            })
+          );
+          const created = calls.find((line) => line.method === 'session/new') as {
+            params: { _meta: { claudeCode: { options: Record<string, unknown> } } };
+          };
+          expect(created.params._meta.claudeCode.options).toMatchObject({
+            maxBudgetUsd: 1,
+            settingSources: [],
+          });
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }, 15_000);
+  }
+
   test('creates a workspace-write session with HTTP MCP, model parity, and a safe transcript', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-'));
     const { script, trace } = fakeAcpAgent(dir);
     const ready: string[] = [];
     try {
-      const result = await runCodexAcpTurn({
-        adapterCommand: process.execPath,
-        adapterArgs: [script],
-        adapterEnv: { FAKE_ACP_TRACE: trace },
-        codexPath: '/usr/local/bin/codex',
+      const result = await runAcpTurn({
+        agentKind: 'codex',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          env: { FAKE_ACP_TRACE: trace },
+          defaultMode: 'agent',
+          effortConfigId: 'reasoning_effort',
+        },
         cwd: dir,
         prompt: 'Finish Automation 99',
         mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
@@ -224,15 +393,95 @@ describe('Codex ACP Automation turn', () => {
     }
   }, 15_000);
 
+  test('isolates OpenCode project/global settings while preserving its explicit adapter env', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'lobu-opencode-acp-isolation-'));
+    const { script, trace } = fakeAcpAgent(dir);
+    try {
+      const result = await runAcpTurn({
+        agentKind: 'opencode',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          env: {
+            FAKE_ACP_TRACE: trace,
+            OPENCODE_DISABLE_PROJECT_CONFIG: '1',
+          },
+          effortConfigId: 'effort',
+          isolateXdgConfig: true,
+          mcpServerName: 'lobu',
+        },
+        cwd: dir,
+        prompt: 'Finish Automation 99',
+        mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+        timeoutMs: 5_000,
+        onSessionReady: async () => {},
+      });
+
+      expect(result.exitReason).toBe('ok');
+      const environment = traceLines(trace)[0] as {
+        environment: {
+          OPENCODE_DISABLE_PROJECT_CONFIG?: string;
+          XDG_CONFIG_HOME?: string;
+        };
+      };
+      expect(environment.environment.OPENCODE_DISABLE_PROJECT_CONFIG).toBe('1');
+      expect(environment.environment.XDG_CONFIG_HOME).toContain('lobu-acp-config-');
+      expect(existsSync(environment.environment.XDG_CONFIG_HOME!)).toBe(false);
+      const created = traceLines(trace).find((line) => line.method === 'session/new') as {
+        params: { mcpServers: Array<Record<string, unknown>> };
+      };
+      expect(created.params.mcpServers[0]?.name).toBe('lobu');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  for (const policy of [
+    { agentKind: 'opencode', autoApprovePermissions: true, optionId: 'allow' },
+    { agentKind: 'claude-code', autoApprovePermissions: false, optionId: 'reject' },
+  ] as const) {
+    test(`${policy.agentKind} ${policy.optionId}s ACP permission requests`, async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), `lobu-${policy.agentKind}-permission-`));
+      const { script, trace } = permissionAcpAgent(dir);
+      try {
+        const result = await runAcpTurn({
+          agentKind: policy.agentKind,
+          adapter: {
+            command: process.execPath,
+            args: [script],
+            env: { FAKE_ACP_TRACE: trace },
+            autoApprovePermissions: policy.autoApprovePermissions,
+          },
+          cwd: dir,
+          prompt: 'Use a tool',
+          mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
+          timeoutMs: 5_000,
+          onSessionReady: async () => {},
+        });
+
+        expect(result.exitReason).toBe('ok');
+        expect(JSON.parse(readFileSync(trace, 'utf8'))).toEqual({
+          outcome: { outcome: 'selected', optionId: policy.optionId },
+        });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }, 15_000);
+  }
+
   test('resumes the exact persisted session without listing local sessions', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-resume-'));
     const { script, trace } = fakeAcpAgent(dir);
     try {
-      const result = await runCodexAcpTurn({
-        adapterCommand: process.execPath,
-        adapterArgs: [script],
-        adapterEnv: { FAKE_ACP_TRACE: trace },
-        codexPath: '/usr/local/bin/codex',
+      const result = await runAcpTurn({
+        agentKind: 'codex',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          env: { FAKE_ACP_TRACE: trace },
+          defaultMode: 'agent',
+          effortConfigId: 'reasoning_effort',
+        },
         cwd: dir,
         prompt: 'Continue the run',
         mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
@@ -259,11 +508,15 @@ describe('Codex ACP Automation turn', () => {
     const { script, trace } = fakeAcpAgent(dir);
     const controller = new AbortController();
     try {
-      const running = runCodexAcpTurn({
-        adapterCommand: process.execPath,
-        adapterArgs: [script],
-        adapterEnv: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
-        codexPath: '/usr/local/bin/codex',
+      const running = runAcpTurn({
+        agentKind: 'codex',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          env: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
+          defaultMode: 'agent',
+          effortConfigId: 'reasoning_effort',
+        },
         cwd: dir,
         prompt: 'Wait until cancelled',
         mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
@@ -289,11 +542,15 @@ describe('Codex ACP Automation turn', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'lobu-codex-acp-timeout-'));
     const { script, trace } = fakeAcpAgent(dir);
     try {
-      const result = await runCodexAcpTurn({
-        adapterCommand: process.execPath,
-        adapterArgs: [script],
-        adapterEnv: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
-        codexPath: '/usr/local/bin/codex',
+      const result = await runAcpTurn({
+        agentKind: 'codex',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          env: { FAKE_ACP_TRACE: trace, FAKE_ACP_WAIT_FOR_CANCEL: '1' },
+          defaultMode: 'agent',
+          effortConfigId: 'reasoning_effort',
+        },
         cwd: dir,
         prompt: 'Wait until the deadline',
         mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },
@@ -310,7 +567,7 @@ describe('Codex ACP Automation turn', () => {
   }, 15_000);
 
   test('each finalize round uploads a byte-exact prefix extension', async () => {
-    const transcript = new CodexAcpTranscript('/workspace');
+    const transcript = new AcpTranscript('/workspace');
     transcript.setSession('acp-multi-round');
     transcript.appendTurn('first prompt', [
       { kind: 'assistant', messageId: 'm1', text: 'round one' },
@@ -352,10 +609,14 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
       'utf8'
     );
     try {
-      const result = await runCodexAcpTurn({
-        adapterCommand: process.execPath,
-        adapterArgs: [script],
-        codexPath: '/usr/local/bin/codex',
+      const result = await runAcpTurn({
+        agentKind: 'codex',
+        adapter: {
+          command: process.execPath,
+          args: [script],
+          defaultMode: 'agent',
+          effortConfigId: 'reasoning_effort',
+        },
         cwd: dir,
         prompt: 'Continue a session the agent lost',
         mcp: { url: 'https://lobu.test/mcp/team', bearer: 'run-token' },

--- a/packages/connector-worker/src/daemon/agent-binaries.ts
+++ b/packages/connector-worker/src/daemon/agent-binaries.ts
@@ -12,6 +12,7 @@
  * which is exactly the outcome the gateway gate exists to prevent.
  */
 
+import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -47,6 +48,29 @@ export function locateBinary(name: string, dirs?: string[]): string | null {
     if (existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+/**
+ * OpenCode must expose its ACP entrypoint before the device advertises it. An
+ * older binary can exist and still lack `acp`; claiming its runs would then
+ * fail only after the gateway assigned one.
+ */
+export function supportsOpenCodeAcp(binaryPath: string): boolean {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCODE_DISABLE_AUTOUPDATE: '1',
+    OPENCODE_DISABLE_PROJECT_CONFIG: '1',
+  };
+  delete env.WORKER_API_TOKEN;
+  delete env.LOBU_API_TOKEN;
+  delete env.LOBU_MEMORY_URL;
+  const result = spawnSync(binaryPath, ['acp', '--pure', '--help'], {
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5_000,
+  });
+  return result.status === 0;
 }
 
 /**

--- a/packages/connector-worker/src/daemon/automation-acp.ts
+++ b/packages/connector-worker/src/daemon/automation-acp.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 import * as acp from '@agentclientprotocol/sdk';
 import type {
@@ -7,6 +10,7 @@ import type {
   ToolCall,
   Usage,
 } from '@agentclientprotocol/sdk';
+import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
 import {
   releaseSupervisor,
   spawnSupervisedCli,
@@ -20,24 +24,47 @@ const CANCEL_GRACE_MS = 2_000;
 const ADAPTER_EXIT_GRACE_MS = 3_000;
 const TRANSCRIPT_VALUE_CAP = 64 * 1024;
 
-export interface CodexAcpTurnOptions {
-  adapterCommand: string;
-  adapterArgs?: string[];
-  adapterEnv?: NodeJS.ProcessEnv;
-  codexPath: string;
+export type AcpAgentKind = Extract<AgentKind, 'claude-code' | 'codex' | 'opencode'>;
+
+/** Configuration for one installed or packaged ACP agent entrypoint. */
+export interface AutomationAcpAdapter {
+  command: string;
+  args?: string[];
+  env?: NodeJS.ProcessEnv;
+  /** Mode applied before each prompt (Codex uses `agent`). */
+  defaultMode?: string;
+  /** ACP config-option id for effort; providers do not use one common id. */
+  effortConfigId?: string;
+  /** Preserve OpenCode's existing unattended `--auto` permission semantics. */
+  autoApprovePermissions?: boolean;
+  /** Hide ambient global/project configuration while keeping provider auth data. */
+  isolateXdgConfig?: boolean;
+  /** Provider extension metadata forwarded on both session/new and session/resume. */
+  sessionMeta?: Record<string, unknown>;
+  /** ACP MCP server name; controls provider-visible tool prefixes. */
+  mcpServerName?: string;
+}
+
+export type AutomationAcpAdapters = Partial<Record<AcpAgentKind, AutomationAcpAdapter>>;
+
+export interface AcpTurnOptions {
+  agentKind: AcpAgentKind;
+  adapter: AutomationAcpAdapter;
   cwd: string;
   prompt: string;
   mcp: { url: string; bearer: string };
   resumeSessionId?: string;
+  mode?: string;
   model?: string;
   effort?: string;
+  sessionMeta?: Record<string, unknown>;
   timeoutMs: number;
   abortSignal?: AbortSignal;
   onSessionReady: (sessionId: string) => Promise<void>;
-  transcript?: CodexAcpTranscript;
+  transcript?: AcpTranscript;
 }
 
-export interface CodexAcpTurnResult extends ExecutorResult {
+export interface AcpTurnResult extends ExecutorResult {
   sessionId: string;
   transcriptJsonl: string;
 }
@@ -77,7 +104,7 @@ function contentText(update: SessionUpdate): string | null {
 }
 
 /** Builds the existing Lobu session JSONL shape from public ACP updates. */
-export class CodexAcpTranscript {
+export class AcpTranscript {
   private sessionId: string | null = null;
   private startedAt: string | null = null;
   private readonly entries: Array<Record<string, unknown>> = [];
@@ -201,30 +228,41 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-/** Run one Automation prompt through Codex's stable ACP v1 adapter. */
-export async function runCodexAcpTurn(
-  options: CodexAcpTurnOptions
-): Promise<CodexAcpTurnResult> {
+/** Run one Automation prompt through a provider's stable ACP v1 entrypoint. */
+export async function runAcpTurn(
+  options: AcpTurnOptions
+): Promise<AcpTurnResult> {
   const started = Date.now();
-  const env: NodeJS.ProcessEnv = { ...process.env, ...options.adapterEnv };
+  const env: NodeJS.ProcessEnv = { ...process.env, ...options.adapter.env };
   delete env.WORKER_API_TOKEN;
   delete env.LOBU_API_TOKEN;
   delete env.LOBU_MEMORY_URL;
-  env.CODEX_PATH = options.codexPath;
+  let isolatedConfigDir: string | undefined;
+  if (options.adapter.isolateXdgConfig) {
+    isolatedConfigDir = mkdtempSync(path.join(tmpdir(), 'lobu-acp-config-'));
+    env.XDG_CONFIG_HOME = isolatedConfigDir;
+  }
 
-  const supervised = spawnSupervisedCli(
-    options.adapterCommand,
-    options.adapterArgs ?? [],
-    env,
-    { stdin: 'pipe' }
-  );
+  let supervised: ReturnType<typeof spawnSupervisedCli>;
+  try {
+    supervised = spawnSupervisedCli(
+      options.adapter.command,
+      options.adapter.args ?? [],
+      env,
+      { stdin: 'pipe' }
+    );
+  } catch (error) {
+    if (isolatedConfigDir) rmSync(isolatedConfigDir, { recursive: true, force: true });
+    throw error;
+  }
   const proc = supervised.supervisor;
   if (!proc.stdin || !proc.stdout || !proc.stderr) {
     await terminateChild(proc);
-    throw new Error('Codex ACP supervisor spawned without bidirectional stdio');
+    if (isolatedConfigDir) rmSync(isolatedConfigDir, { recursive: true, force: true });
+    throw new Error(`${options.agentKind} ACP supervisor spawned without bidirectional stdio`);
   }
   const stderrPromise = collectStderr(proc.stderr);
-  const transcript = options.transcript ?? new CodexAcpTranscript(options.cwd);
+  const transcript = options.transcript ?? new AcpTranscript(options.cwd);
   const events: TranscriptEvent[] = [];
   const tools = new Map<string, ToolCall>();
   let assistantOutput = '';
@@ -238,11 +276,13 @@ export async function runCodexAcpTurn(
   const app = acp
     .client({ name: 'lobu-device-daemon' })
     .onRequest(acp.methods.client.session.requestPermission, ({ params }) => {
-      const rejected =
-        params.options.find((option) => option.kind === 'reject_once') ??
-        params.options.find((option) => option.kind === 'reject_always');
-      return rejected
-        ? { outcome: { outcome: 'selected' as const, optionId: rejected.optionId } }
+      const selected = options.adapter.autoApprovePermissions
+        ? params.options.find((option) => option.kind === 'allow_always') ??
+          params.options.find((option) => option.kind === 'allow_once')
+        : params.options.find((option) => option.kind === 'reject_once') ??
+          params.options.find((option) => option.kind === 'reject_always');
+      return selected
+        ? { outcome: { outcome: 'selected' as const, optionId: selected.optionId } }
         : { outcome: { outcome: 'cancelled' as const } };
     })
     .onNotification(acp.methods.client.session.update, ({ params }) => {
@@ -286,34 +326,39 @@ export async function runCodexAcpTurn(
       clientInfo: { name: 'lobu-device-daemon', version: '1' },
     });
     if (initialized.protocolVersion !== acp.PROTOCOL_VERSION) {
-      throw new Error(`Codex ACP negotiated unsupported protocol ${initialized.protocolVersion}`);
+      throw new Error(
+        `${options.agentKind} ACP negotiated unsupported protocol ${initialized.protocolVersion}`
+      );
     }
     if (initialized.agentCapabilities?.mcpCapabilities?.http !== true) {
-      throw new Error('Codex ACP adapter does not support HTTP MCP servers');
+      throw new Error(`${options.agentKind} ACP adapter does not support HTTP MCP servers`);
     }
 
+    const sessionMeta = options.sessionMeta ?? options.adapter.sessionMeta;
     const mcpServers = [
       {
         type: 'http' as const,
-        name: 'lobu-memory',
+        name: options.adapter.mcpServerName ?? 'lobu-memory',
         url: options.mcp.url,
         headers: [{ name: 'Authorization', value: `Bearer ${options.mcp.bearer}` }],
       },
     ];
     if (options.resumeSessionId) {
       if (initialized.agentCapabilities?.sessionCapabilities?.resume == null) {
-        throw new Error('Codex ACP adapter does not support session/resume');
+        throw new Error(`${options.agentKind} ACP adapter does not support session/resume`);
       }
       await ctx.request(acp.methods.agent.session.resume, {
         sessionId: options.resumeSessionId,
         cwd: options.cwd,
         mcpServers,
+        ...(sessionMeta ? { _meta: sessionMeta } : {}),
       });
       sessionId = options.resumeSessionId;
     } else {
       const created = (await ctx.request(acp.methods.agent.session.new, {
         cwd: options.cwd,
         mcpServers,
+        ...(sessionMeta ? { _meta: sessionMeta } : {}),
       })) as NewSessionResponse;
       sessionId = created.sessionId;
     }
@@ -322,7 +367,6 @@ export async function runCodexAcpTurn(
     // Persist the exact id before the prompt can mutate the workspace. A failed
     // checkpoint aborts the turn instead of creating an unresumable session.
     await options.onSessionReady(sessionId);
-    await ctx.request(acp.methods.agent.session.setMode, { sessionId, modeId: 'agent' });
     if (options.model) {
       await ctx.request(acp.methods.agent.session.setConfigOption, {
         sessionId,
@@ -330,10 +374,14 @@ export async function runCodexAcpTurn(
         value: options.model,
       });
     }
-    if (options.effort) {
+    const mode = options.mode ?? options.adapter.defaultMode;
+    if (mode) {
+      await ctx.request(acp.methods.agent.session.setMode, { sessionId, modeId: mode });
+    }
+    if (options.effort && options.adapter.effortConfigId) {
       await ctx.request(acp.methods.agent.session.setConfigOption, {
         sessionId,
-        configId: 'reasoning_effort',
+        configId: options.adapter.effortConfigId,
         value: options.effort,
       });
     }
@@ -376,8 +424,8 @@ export async function runCodexAcpTurn(
       promptResponse = cancelledResponse;
     } else {
       throw new Error(
-        outcome.target.error ??
-          `Codex ACP adapter exited before the prompt completed (status=${outcome.target.exitCode}, signal=${outcome.target.signalCode ?? 'none'})`
+        outcome.target.error ?? `${options.agentKind} ACP adapter exited before the prompt completed ` +
+          `(status=${outcome.target.exitCode}, signal=${outcome.target.signalCode ?? 'none'})`
       );
     }
 
@@ -392,6 +440,7 @@ export async function runCodexAcpTurn(
     const graceful = await waitForTargetExit(supervised.targetExit, ADAPTER_EXIT_GRACE_MS);
     if (graceful.target) await releaseSupervisor(proc);
     else await terminateChild(proc);
+    if (isolatedConfigDir) rmSync(isolatedConfigDir, { recursive: true, force: true });
   }
 
   const stderr = await Promise.race([
@@ -425,9 +474,9 @@ export async function runCodexAcpTurn(
         : 'error_message';
   const error =
     exitReason === 'timeout'
-      ? `Codex ACP prompt timed out after ${Math.trunc(options.timeoutMs / 1000)}s`
+      ? `${options.agentKind} ACP prompt timed out after ${Math.trunc(options.timeoutMs / 1000)}s`
       : exitReason === 'error_message'
-        ? `Codex ACP stopped with reason ${promptResponse?.stopReason ?? 'unknown'}`
+        ? `${options.agentKind} ACP stopped with reason ${promptResponse?.stopReason ?? 'unknown'}`
         : null;
   return {
     output: assistantOutput,

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -61,9 +61,11 @@ import {
   type InteractiveSession,
 } from './interactive-session.js';
 import {
-  CodexAcpTranscript,
-  runCodexAcpTurn,
-} from './codex-acp.js';
+  AcpTranscript,
+  type AcpAgentKind,
+  type AutomationAcpAdapters,
+  runAcpTurn,
+} from './automation-acp.js';
 
 /**
  * The slice of the daemon's `ExecutorConfig` the automation arm reads.
@@ -100,13 +102,8 @@ export interface AutomationExecutorConfig {
    * use to drive a fake binary.
    */
   binaryOverrides?: Partial<Record<AgentKind, string>>;
-  /** Mac-only packaged ACP adapter route for Codex Automations. */
-  codexAcp?: {
-    adapterCommand: string;
-    adapterArgs: string[];
-    adapterEnv?: NodeJS.ProcessEnv;
-    codexPath: string;
-  };
+  /** Maintained ACP entrypoints keyed by the local agent kind they drive. */
+  acpAdapters?: AutomationAcpAdapters;
 }
 
 /** Local-CLI run result, mirrored from the Mac app's `ExecutorResult`. */
@@ -117,7 +114,7 @@ export interface ExecutorResult {
   exitSignal: string | null;
   exitReason: WorkerExitReason;
   durationMs: number;
-  /** Present only for a Codex ACP turn; cumulative across finalize rounds. */
+  /** Present for an ACP turn; cumulative across finalize rounds. */
   transcriptJsonl?: string;
 }
 
@@ -341,6 +338,31 @@ export interface AutomationRunAccess {
   wiring: { url: string; bearer?: string } | undefined;
   /** Extra env for the child process (LOBU_API_TOKEN / LOBU_MEMORY_URL). */
   env: Record<string, string>;
+}
+
+function claudeSessionMeta(
+  base: Record<string, unknown> | undefined,
+  maxBudgetUsd: number | undefined
+): Record<string, unknown> | undefined {
+  if (!base && !(maxBudgetUsd != null && maxBudgetUsd > 0)) return undefined;
+  const claudeCode =
+    base?.claudeCode != null && typeof base.claudeCode === 'object'
+      ? (base.claudeCode as Record<string, unknown>)
+      : {};
+  const options =
+    claudeCode.options != null && typeof claudeCode.options === 'object'
+      ? (claudeCode.options as Record<string, unknown>)
+      : {};
+  return {
+    ...base,
+    claudeCode: {
+      ...claudeCode,
+      options: {
+        ...options,
+        ...(maxBudgetUsd != null && maxBudgetUsd > 0 ? { maxBudgetUsd } : {}),
+      },
+    },
+  };
 }
 
 /**
@@ -714,9 +736,9 @@ export async function executeAutomationRun(
   // internally; per-run detection is not repeated here.
   const interactiveSession = attachedInteractiveSession(cfg);
   const agentSession = payload.context.agent_session;
-  const codexAcp = spec.kind === 'codex' ? cfg.codexAcp : undefined;
+  const acpAdapter = cfg.acpAdapters?.[spec.kind as AcpAgentKind];
   let acpSessionId = agentSession?.resume_session_id;
-  const acpTranscript = codexAcp ? new CodexAcpTranscript(process.cwd()) : undefined;
+  const acpTranscript = acpAdapter ? new AcpTranscript(process.cwd()) : undefined;
   const selectedSession = isInteractiveSessionEligible(spec.kind, interactiveSession, payload)
     ? interactiveSession
     : undefined;
@@ -827,29 +849,36 @@ export async function executeAutomationRun(
           `[executor] Automation run ${runId}: interactive ${selectedSession.kind} unavailable before delivery; using subprocess`
         );
       }
-      if (codexAcp && agentSession && acpTranscript) {
-        const result = await runCodexAcpTurn({
-          adapterCommand: codexAcp.adapterCommand,
-          adapterArgs: codexAcp.adapterArgs,
-          ...(codexAcp.adapterEnv ? { adapterEnv: codexAcp.adapterEnv } : {}),
-          codexPath: codexAcp.codexPath,
+      if (acpAdapter && agentSession && acpTranscript) {
+        const executionConfig = payload.automation.execution_config;
+        const sessionMeta =
+          spec.kind === 'claude-code'
+            ? claudeSessionMeta(acpAdapter.sessionMeta, executionConfig?.max_budget_usd)
+            : acpAdapter.sessionMeta;
+        const result = await runAcpTurn({
+          agentKind: spec.kind as AcpAgentKind,
+          adapter: acpAdapter,
           cwd: process.cwd(),
           prompt,
           mcp: { url: agentSession.mcp_url, bearer: agentSession.token },
           ...(acpSessionId ? { resumeSessionId: acpSessionId } : {}),
-          ...(payload.automation.execution_config?.model
-            ? { model: payload.automation.execution_config.model }
+          ...(spec.kind === 'claude-code' && executionConfig?.permission_mode
+            ? { mode: executionConfig.permission_mode }
             : {}),
-          ...(payload.automation.execution_config?.effort
-            ? { effort: payload.automation.execution_config.effort }
+          ...(executionConfig?.model
+            ? { model: executionConfig.model }
             : {}),
+          ...(executionConfig?.effort
+            ? { effort: executionConfig.effort }
+            : {}),
+          ...(sessionMeta ? { sessionMeta } : {}),
           timeoutMs,
           abortSignal: runAbort.signal,
           transcript: acpTranscript,
           onSessionReady: async (sessionId) => {
             await client.heartbeat(runId, undefined, {
               protocol: 'acp',
-              agent_kind: 'codex',
+              agent_kind: spec.kind as AcpAgentKind,
               session_id: sessionId,
             });
           },

--- a/packages/connector-worker/src/daemon/mac-device-daemon.ts
+++ b/packages/connector-worker/src/daemon/mac-device-daemon.ts
@@ -5,7 +5,12 @@ import {
 } from '@lobu/core/contracts/worker/device-automation';
 import type { PollResponse } from '@lobu/core/contracts/worker/protocol';
 import { executeAutomationRun, type AutomationExecutorConfig } from './automation.js';
-import { locateBinary, resolveRunnableAgentKinds } from './agent-binaries.js';
+import type { AutomationAcpAdapters } from './automation-acp.js';
+import {
+  locateBinary,
+  resolveRunnableAgentKinds,
+  supportsOpenCodeAcp,
+} from './agent-binaries.js';
 import {
   MutableWorkerAdvertisementProvider,
   WorkerClient,
@@ -24,7 +29,7 @@ const WORKER_PAT_PATTERN = /^owl_pat_[A-Za-z0-9_-]{32}$/;
 const DEFAULT_POLL_INTERVAL_MS = 10000;
 const DEFAULT_MAX_CONCURRENT_JOBS = 1;
 const NATIVE_BRIDGE_SHUTDOWN_TIMEOUT_MS = 5000;
-export const INTERNAL_CODEX_ACP_ARG = '--internal-codex-acp';
+export const INTERNAL_ACP_ADAPTER_ARG = '--internal-acp-adapter';
 
 export interface MacDeviceDaemonOptions {
   apiUrl?: string;
@@ -60,6 +65,13 @@ export function macDeviceDaemonMetadata(version: string): MacDeviceDaemonMetadat
 function defaultWorkerId(): string {
   const shortHostname = hostname().split('.')[0] || hostname();
   return `${MAC_DEVICE_PLATFORM}:${shortHostname}`;
+}
+
+function packagedAcpAdapterArgs(agentKind: 'claude-code' | 'codex'): string[] {
+  const args = [INTERNAL_ACP_ADAPTER_ARG, agentKind];
+  return process.argv[1] && /\.[cm]?[jt]s$/.test(process.argv[1])
+    ? [process.argv[1], ...args]
+    : args;
 }
 
 function validateNumber(value: number | undefined, name: string): number | undefined {
@@ -220,8 +232,19 @@ export function createMacDeviceDaemon(
   const validated = validateMacDeviceDaemonOptions(options);
   if (validated.noPoll) throw new Error('cannot create a polling daemon with --no-poll');
 
-  const runnableAgentKinds = resolveRunnableAgentKinds();
-  const codexPath = runnableAgentKinds.includes('codex') ? locateBinary('codex') : null;
+  const discoveredAgentKinds = resolveRunnableAgentKinds();
+  const codexPath = discoveredAgentKinds.includes('codex') ? locateBinary('codex') : null;
+  const claudePath = discoveredAgentKinds.includes('claude-code') ? locateBinary('claude') : null;
+  const discoveredOpenCodePath = discoveredAgentKinds.includes('opencode')
+    ? locateBinary('opencode')
+    : null;
+  const openCodePath =
+    discoveredOpenCodePath && supportsOpenCodeAcp(discoveredOpenCodePath)
+      ? discoveredOpenCodePath
+      : null;
+  const runnableAgentKinds = discoveredAgentKinds.filter(
+    (kind) => kind !== 'opencode' || openCodePath !== null
+  );
   const defaultAgentKind = selectMacDeviceDaemonAgentKind(
     runnableAgentKinds,
     validated.defaultAgentKind
@@ -241,30 +264,57 @@ export function createMacDeviceDaemon(
       ? { advertisementProvider: dependencies.advertisementProvider }
       : {}),
   });
+  const acpAdapters: AutomationAcpAdapters = {};
+  if (codexPath) {
+    acpAdapters.codex = {
+      command: process.execPath,
+      args: packagedAcpAdapterArgs('codex'),
+      env: { CODEX_PATH: codexPath },
+      defaultMode: 'agent',
+      effortConfigId: 'reasoning_effort',
+    };
+  }
+  if (claudePath) {
+    acpAdapters['claude-code'] = {
+      command: process.execPath,
+      args: packagedAcpAdapterArgs('claude-code'),
+      env: {
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+        CLAUDE_CODE_EXECUTABLE: claudePath,
+      },
+      effortConfigId: 'effort',
+      mcpServerName: 'lobu',
+      sessionMeta: {
+        claudeCode: {
+          options: {
+            allowedTools: ['mcp__lobu__query_sdk', 'mcp__lobu__run_sdk'],
+            settingSources: [],
+          },
+        },
+      },
+    };
+  }
+  if (openCodePath) {
+    acpAdapters.opencode = {
+      command: openCodePath,
+      args: ['acp', '--pure'],
+      env: {
+        OPENCODE_DISABLE_AUTOUPDATE: '1',
+        OPENCODE_DISABLE_PROJECT_CONFIG: '1',
+      },
+      autoApprovePermissions: true,
+      effortConfigId: 'effort',
+      isolateXdgConfig: true,
+      mcpServerName: 'lobu',
+    };
+  }
   const automationConfig: AutomationExecutorConfig = {
     heartbeatIntervalMs: 30000,
     timeoutMs: 600000,
     ...(defaultAgentKind ? { defaultAgentKind } : {}),
     requireRunScopedSession: true,
     shutdownSignal: shutdownController.signal,
-    ...(codexPath
-      ? {
-          codexAcp: {
-            // Re-exec this same entrypoint so the adapter is the artifact we
-            // shipped. Run from source (`bun src/...ts`, `node dist/...js`),
-            // argv[1] is the script the runtime needs handed back to it; in the
-            // `bun build --compile` binary argv[1] is the extensionless in-bundle
-            // path (`/$bunfs/root/...`) and execPath is the binary itself, which
-            // already knows its own entry.
-            adapterCommand: process.execPath,
-            adapterArgs:
-              process.argv[1] && /\.[cm]?[jt]s$/.test(process.argv[1])
-                ? [process.argv[1], INTERNAL_CODEX_ACP_ARG]
-                : [INTERNAL_CODEX_ACP_ARG],
-            codexPath,
-          },
-        }
-      : {}),
+    acpAdapters,
   };
   const loop = new WorkerPollLoop({
     client,

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -4,7 +4,7 @@ import packageJson from '../package.json' with { type: 'json' };
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
 import {
   MAC_DEVICE_DAEMON_PROTOCOL,
-  INTERNAL_CODEX_ACP_ARG,
+  INTERNAL_ACP_ADAPTER_ARG,
   macDeviceDaemonMetadata,
   runMacDeviceDaemon,
   validateMacDeviceDaemonOptions,
@@ -151,16 +151,24 @@ async function main(): Promise<void> {
 }
 
 async function start(): Promise<void> {
-  if (process.argv[2] === INTERNAL_CODEX_ACP_ARG) {
+  if (process.argv[2] === INTERNAL_ACP_ADAPTER_ARG) {
     // Dynamic on purpose, and not for bundle size — `bun build --compile` links
     // this module into the artifact either way. The adapter is a side-effectful
     // stdio server that binds process stdin/stdout the moment it is evaluated,
     // so a static import would start a second ACP protocol loop in the daemon
     // itself and steal the daemon's own stdio. Only the isolated child, which
     // exists solely to be that server, may evaluate it.
-    // @ts-expect-error codex-acp is an executable-only package with no declarations.
-    await import('@agentclientprotocol/codex-acp');
-    return;
+    const agentKind = process.argv[3];
+    if (agentKind === 'codex') {
+      // @ts-expect-error codex-acp is an executable-only package with no declarations.
+      await import('@agentclientprotocol/codex-acp');
+      return;
+    }
+    if (agentKind === 'claude-code') {
+      await import('@agentclientprotocol/claude-agent-acp/dist/index.js');
+      return;
+    }
+    throw new Error(`unknown internal ACP adapter '${agentKind ?? ''}'`);
   }
   await main();
 }

--- a/packages/core/src/__tests__/worker-acp-session-protocol.test.ts
+++ b/packages/core/src/__tests__/worker-acp-session-protocol.test.ts
@@ -30,19 +30,21 @@ describe("device Automation ACP session protocol", () => {
     ).toBe(true);
   });
 
-  test("accepts a run-bound ACP session checkpoint on heartbeat", () => {
+  test("accepts a run-bound ACP session checkpoint for every ACP-backed agent", () => {
     expect(HeartbeatRequestSchema.properties.agent_session).toBeDefined();
-    expect(
-      Value.Check(HeartbeatRequestSchema, {
-        run_id: 99,
-        worker_id: "macos:test",
-        agent_session: {
-          protocol: "acp",
-          agent_kind: "codex",
-          session_id: "acp-session-99",
-        },
-      })
-    ).toBe(true);
+    for (const agentKind of ["codex", "claude-code", "opencode"]) {
+      expect(
+        Value.Check(HeartbeatRequestSchema, {
+          run_id: 99,
+          worker_id: "macos:test",
+          agent_session: {
+            protocol: "acp",
+            agent_kind: agentKind,
+            session_id: "acp-session-99",
+          },
+        })
+      ).toBe(true);
+    }
     expect(
       Value.Check(HeartbeatRequestSchema, {
         run_id: 99,

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -485,7 +485,11 @@ export const HeartbeatRequestSchema = Type.Object({
   agent_session: Type.Optional(
     Type.Object({
       protocol: Type.Literal("acp"),
-      agent_kind: Type.Literal("codex"),
+      agent_kind: Type.Union([
+        Type.Literal("claude-code"),
+        Type.Literal("codex"),
+        Type.Literal("opencode"),
+      ]),
       session_id: Type.String({ minLength: 1, maxLength: 512 }),
     })
   ),

--- a/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/headless-automation-claim-gate.test.ts
@@ -219,13 +219,16 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(String(run.status)).toBe('running');
   });
 
-  it('checkpoints a Codex ACP session and returns it only to the same device on reclaim', async () => {
-    const workerId = 'headless-codex-acp';
+  async function assertSameDeviceAcpReclaim(
+    agentKind: 'claude-code' | 'codex' | 'opencode'
+  ): Promise<void> {
+    const workerId = `headless-${agentKind}-acp`;
+    const sessionId = `${agentKind}-acp-session-99`;
     const ctx = await setupDevicePinnedAutomation({
       workerId,
       platform: 'headless',
       capabilities: { 'automations.execute': true },
-      agentKind: 'codex',
+      agentKind,
     });
     const { token } = await createWorkerBoundPat(
       ctx.workspace.users.owner.id,
@@ -237,7 +240,7 @@ describe('headless Automation claim gate (automations.execute)', () => {
     const pollBody = {
       worker_id: workerId,
       capabilities: { 'automations.execute': true },
-      agent_kinds: ['codex'],
+      agent_kinds: [agentKind],
     };
     const firstPoll = await post('/api/workers/poll', { token, body: pollBody });
     expect(firstPoll.status).toBe(200);
@@ -264,8 +267,8 @@ describe('headless Automation claim gate (automations.execute)', () => {
         worker_id: workerId,
         agent_session: {
           protocol: 'acp',
-          agent_kind: 'codex',
-          session_id: 'codex-acp-session-99',
+          agent_kind: agentKind,
+          session_id: sessionId,
         },
       },
     });
@@ -278,8 +281,8 @@ describe('headless Automation claim gate (automations.execute)', () => {
     expect(checkpointed.run_metadata?.device_agent_session).toEqual(
       expect.objectContaining({
         protocol: 'acp',
-        agent_kind: 'codex',
-        session_id: 'codex-acp-session-99',
+        agent_kind: agentKind,
+        session_id: sessionId,
         worker_id: workerId,
       })
     );
@@ -300,9 +303,14 @@ describe('headless Automation claim gate (automations.execute)', () => {
     };
     expect(secondJob.run_id).toBe(firstJob.run_id);
     expect(secondJob.payload.context.agent_session.resume_session_id).toBe(
-      'codex-acp-session-99'
+      sessionId
     );
-  });
+  }
+
+  it.each(['claude-code', 'codex', 'opencode'] as const)(
+    'checkpoints a %s ACP session and returns it only to the same device on reclaim',
+    assertSameDeviceAcpReclaim
+  );
 
   it('automation without an assigned agent still dispatches instructions-only (no run-scoped session)', async () => {
     const ctx = await setupDevicePinnedAutomation({


### PR DESCRIPTION
Summary
- generalize the Mac daemon ACP runner across Codex, Claude Code, and OpenCode
- package the maintained Claude adapter and drive native OpenCode ACP in isolated pure mode
- checkpoint and resume exact sessions for all ACP-backed agents, then upload public assistant/tool transcripts for the existing Recent-runs UI
- withhold incompatible OpenCode installs and strip daemon credentials from probes and agent children

Verification
- 245 connector-worker tests passed
- ACP checkpoint/reclaim integration passed for Claude Code, Codex, and OpenCode
- Recent-run transcript API and UI mapping tests passed
- compiled Codex and Claude adapters plus OpenCode 1.18.21 negotiated HTTP MCP, created resumable sessions, and exited cleanly
- make pre-pr passed

Known gap
- no paid live provider prompt was sent in the final pass; Claude was quota-blocked, while protocol/session behavior was exercised against the real packaged adapters