### PR TITLE
fix(connectors): release final X likes parser

### DIFF
--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -2046,7 +2046,7 @@ describe("isReplySubmitLabel", () => {
 
 describe("prepare_reply action contract", () => {
 	test("pins the connector version for catalog upgrades", () => {
-		expect(new XConnector().definition.version).toBe("3.13.6");
+		expect(new XConnector().definition.version).toBe("3.13.7");
 	});
 
 	// This is a deliberate design decision, not an oversight. Publishing is

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -3093,7 +3093,7 @@ export default class XConnector extends ConnectorRuntime {
 		name: "X (Twitter)",
 		description:
 			"Fetches tweets, browser-visible like history, bookmarks, and DMs through the X API v2 or the paired Owletto Chrome extension. Links social actors into the person graph.",
-		version: "3.13.6",
+		version: "3.13.7",
 		faviconDomain: "x.com",
 		authSchema: {
 			methods: [


### PR DESCRIPTION
## Summary

- bump the X connector to 3.13.7 so the final reviewed parser artifact is distinct from the earlier retained 3.13.6 build
- update the connector version contract test

## Why

The organization-local 3.13.6 artifact was deployed before the final cursor-rewrite and empty-boundary fixes landed in #3102. Connector versions are immutable, so the final source needs a patch version instead of overwriting the retained rollback artifact.

## Verification

- `bun test packages/connectors/src/__tests__/x.test.ts` (85 pass)
- connector file compilation and metadata extraction reports `x` version `3.13.7`
- pre-commit Biome and TypeScript checks passed

No API, database schema, or migration changes.