### PR TITLE
fix(server): select active attribution definitions

### DIFF
--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   applyEventAttributions,
   clearEntityLinkRulesCache,
+  loadAttributionRuleByType,
   resolveEventAttributionsForItems,
   resolveSenderIdentity,
 } from '../entity-link-upsert';
@@ -195,6 +196,76 @@ describe('applyEventAttributions', () => {
       WHERE organization_id = ${org.id} AND entity_id = ${entities[0].id}
     `;
     expect(idents).toEqual([{ namespace: 'x_user_id', identifier: '123' }]);
+  });
+
+  it('loads the active connector definition instead of an archived definition', async () => {
+    const { org } = await setupOrg('versioned attribution org');
+    const sql = getTestDb();
+
+    await createTestConnectorDefinition({
+      key: 'x-versioned',
+      name: 'Archived X',
+      version: '1.0.0',
+      organization_id: org.id,
+      feeds_schema: { [FEED_KEY]: { eventKinds: {} } },
+    });
+    await sql`
+      UPDATE connector_definitions
+      SET status = 'archived'
+      WHERE key = 'x-versioned'
+        AND organization_id = ${org.id}
+        AND version = '1.0.0'
+    `;
+    await createTestConnectorDefinition({
+      key: 'x-versioned',
+      name: 'Active X',
+      version: '2.0.0',
+      organization_id: org.id,
+      feeds_schema: {
+        [FEED_KEY]: {
+          eventKinds: {
+            tweet: {
+              attributions: [
+                {
+                  role: 'authored_by',
+                  autoCreate: true,
+                  target: {
+                    entityType: '$member',
+                    titlePath: 'metadata.author_name',
+                    identities: [
+                      { namespace: 'x_user_id', eventPath: 'metadata.author_id', primary: true },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    clearEntityLinkRulesCache();
+
+    const item = {
+      origin_type: 'tweet',
+      metadata: { author_id: '456', author_name: 'Versioned Alice' },
+    };
+    await applyEventAttributions({
+      connectorKey: 'x-versioned',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [item],
+    });
+
+    expect((item.metadata as Record<string, unknown>).x_user_id).toBe('456');
+
+    clearEntityLinkRulesCache();
+    const activeRule = await loadAttributionRuleByType(sql, {
+      connectorKey: 'x-versioned',
+      orgId: org.id,
+      entityType: '$member',
+      role: 'authored_by',
+    });
+    expect(activeRule?.identities[0]?.namespace).toBe('x_user_id');
   });
 
   it('first-writer-wins when two rules stamp the same namespace on one event', async () => {

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -141,6 +141,7 @@ async function loadEventAttributionRules(
       FROM connector_definitions
       WHERE key = ${params.connectorKey}
         AND organization_id = ${params.orgId}
+        AND status = 'active'
       LIMIT 1
     `;
 
@@ -187,6 +188,7 @@ export async function loadAttributionRuleByType(
       FROM connector_definitions
       WHERE key = ${params.connectorKey}
         AND organization_id = ${params.orgId}
+        AND status = 'active'
       LIMIT 1
     `;
     const result: RuleMap = {};


### PR DESCRIPTION
## Summary
- Make feed-sync attribution load only the active organization connector definition.
- Apply the same active-definition rule to webhook actor attribution.
- Add a regression matching production: an archived definition is stored before the active definition.

## Test plan
- [x] Intended files staged explicitly; make pre-pr clean
- [x] Focused DB-backed tests: 24/24 passed
- [x] Bug fix red to green

Red before fix:
- loads the active connector definition instead of an archived definition failed because x_user_id was undefined.

Green after fix:
- entity-link-upsert and entity-write-pool-starvation suites passed, 24/24.
- server typecheck passed.
- make pre-pr passed after rebasing on origin/main.

## Notes
No API, endpoint, connector schema, or database schema changes.