### PR TITLE
fix(chat): verify Google Workspace add-on webhooks

### DIFF
--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1797,7 +1797,12 @@ export class ChatInstanceManager {
     if (!descriptor) {
       throw new Error(`No adapter factory for: ${connection.platform}`);
     }
-    const adapter = await descriptor.createAdapter(connection.config);
+    const webhookUrl = this.publicGatewayUrl
+      ? `${this.publicGatewayUrl}/api/v1/webhooks/${connection.id}`
+      : undefined;
+    const adapter = await descriptor.createAdapter(connection.config, {
+      webhookUrl,
+    });
     return disableSdkMessageHistory(adapter);
   }
 

--- a/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
+++ b/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Chat } from "chat";
 import { InMemoryStateAdapter } from "../../../__tests__/fixtures/in-memory-state-adapter.js";
+import { ChatInstanceManager } from "../../chat-instance-manager.js";
 import { parseConfig } from "../../chat-connection-service.js";
 import { gchatPlatform } from "../gchat.js";
 
@@ -69,6 +70,81 @@ async function waitForDelivery(promise: Promise<void>): Promise<void> {
 }
 
 describe("Google Chat platform compatibility", () => {
+  test("accepts only this project's Workspace Add-on token at the canonical connection webhook", async () => {
+    const endpointUrl =
+      "https://gateway.test/api/v1/webhooks/gchat-addon-test";
+    const manager = new ChatInstanceManager() as any;
+    manager.publicGatewayUrl = "https://gateway.test";
+    const adapter = (await manager.createAdapter({
+      id: "gchat-addon-test",
+      platform: "gchat",
+      config: {
+        platform: "gchat",
+        credentials,
+        googleChatProjectNumber: "123456789",
+        endpointUrl: "https://stale.example.test/wrong-connection",
+      },
+    })) as any;
+    let verifiedAudience: string | string[] | undefined;
+    let tokenEmail =
+      "service-123456789@gcp-sa-gsuiteaddons.iam.gserviceaccount.com";
+    adapter.oauth2Client.verifyIdToken = async ({ audience }: any) => {
+      verifiedAudience = audience;
+      return {
+        getPayload: () => ({
+          iss: "https://accounts.google.com",
+          aud: endpointUrl,
+          email_verified: true,
+          email: tokenEmail,
+        }),
+      };
+    };
+    adapter.verifyProjectNumberToken = async () => false;
+
+    const chat = new Chat({
+      userName: "lobu",
+      adapters: { gchat: adapter },
+      state: new InMemoryStateAdapter(),
+    });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+
+    const response = await chat.webhooks.gchat(
+      new Request(endpointUrl, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer signed-by-google",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(standardDirectMessage()),
+      })
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(verifiedAudience).toBe(endpointUrl);
+    expect(delivered).toEqual(["hello Lobu"]);
+
+    tokenEmail =
+      "service-987654321@gcp-sa-gsuiteaddons.iam.gserviceaccount.com";
+    const wrongProjectResponse = await chat.webhooks.gchat(
+      new Request(endpointUrl, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer signed-by-another-google-project",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(standardDirectMessage("wrong project")),
+      })
+    );
+    expect(wrongProjectResponse.status).toBe(401);
+    expect(delivered).toEqual(["hello Lobu"]);
+  });
+
   test("dispatches Google's standalone MESSAGE payload to the DM handler", async () => {
     const chat = await createTestChat();
     const delivered: string[] = [];

--- a/packages/server/src/gateway/connections/platforms/gchat.ts
+++ b/packages/server/src/gateway/connections/platforms/gchat.ts
@@ -14,7 +14,10 @@ import type {
 } from "@chat-adapter/gchat";
 import type { WebhookOptions } from "chat";
 import { extractWhatsAppStyleRoutingInfo } from "./shared.js";
-import type { ChatPlatformDescriptor } from "./types.js";
+import type {
+  AdapterCreationContext,
+  ChatPlatformDescriptor,
+} from "./types.js";
 
 type JsonObject = Record<string, any>;
 
@@ -160,11 +163,31 @@ export function parseGoogleChatCredentials(
   return parsed as ServiceAccountCredentials;
 }
 
-async function createAdapter(config: JsonObject): Promise<GoogleChatAdapter> {
+async function createAdapter(
+  config: JsonObject,
+  context?: AdapterCreationContext
+): Promise<GoogleChatAdapter> {
   // Preserve the platform registry's existing lazy adapter boundary.
   const { createGoogleChatAdapter } = await import("@chat-adapter/gchat");
   const adapterConfig = { ...config };
   delete adapterConfig.platform;
+
+  // Workspace Add-on webhooks use the manager-owned connection URL as their
+  // JWT audience and sign as the Google-managed identity derived from the
+  // configured project number. Neither value needs a second config field that
+  // can drift from the connection URL or project number.
+  if (context?.webhookUrl) {
+    adapterConfig.endpointUrl = context.webhookUrl;
+  }
+  const projectNumber = adapterConfig.googleChatProjectNumber;
+  if (
+    !adapterConfig.workspaceAddOnServiceAccountEmail &&
+    typeof projectNumber === "string" &&
+    /^\d+$/.test(projectNumber.trim())
+  ) {
+    adapterConfig.workspaceAddOnServiceAccountEmail =
+      `service-${projectNumber.trim()}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`;
+  }
 
   const normalizedConfig = adapterConfig.credentials
     ? {

--- a/packages/server/src/gateway/connections/platforms/types.ts
+++ b/packages/server/src/gateway/connections/platforms/types.ts
@@ -49,6 +49,12 @@ export interface WebhookSecretDeps {
   getStoredConnection(id: string): Promise<StoredConnection | null>;
 }
 
+/** Manager-owned values that are known only once a connection is hydrated. */
+export interface AdapterCreationContext {
+  /** Canonical public URL that receives this connection's webhooks. */
+  webhookUrl?: string;
+}
+
 /**
  * Capability descriptor for one chat platform. `createAdapter` is required
  * (it's the old `ADAPTER_FACTORIES` entry); everything else is optional and
@@ -56,7 +62,7 @@ export interface WebhookSecretDeps {
  */
 export interface ChatPlatformDescriptor {
   /** Lazily construct the `@chat-adapter/*` adapter for a resolved config. */
-  createAdapter(config: any): Promise<any>;
+  createAdapter(config: any, context?: AdapterCreationContext): Promise<any>;
 
   /**
    * Parse platform-specific routing fields out of a messaging-API request


### PR DESCRIPTION
## Summary
- pass each runtime connection’s canonical public webhook URL into the Google Chat adapter
- derive and verify the exact Google-managed Workspace add-on service identity from the configured project number
- override stale manually stored endpoint URLs and reject tokens from a different add-on project

## Test plan
- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: `bun test packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts` (9 passed, 22 assertions) and `make pre-pr` (clean)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

## Red → green

Production Google Chat Workspace add-on request before this change reached the canonical connection endpoint but returned 401:

```text
[chat-sdk:gchat] Project-number JWT verification failed
Error: No pem found for envelope
POST /lobu/api/v1/webhooks/631b0c9e2dd64b04 → 401
```

The focused regression now drives `ChatInstanceManager` → platform adapter → signed-webhook claim validation, accepts the matching `service-123456789@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` identity at the manager-owned endpoint audience, and returns 401 for a different project identity.

## Notes
- Signature verification remains fail-closed; this does not enable the adapter’s verification bypass.
- A live Google-signed retest will run after deployment using the existing private tester app.