### PR TITLE
fix(mcp): render approval changes clearly

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/entity-schema-create-approval.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/entity-schema-create-approval.test.ts
@@ -152,14 +152,17 @@ describe("MCP entitySchema.createType approval", () => {
 	async function propose(
 		slug: string,
 		token = ownerAdminToken,
+		name = slug,
+		extra: Record<string, unknown> = {},
 	): Promise<PendingCreate> {
+		const input = { ...extra, slug, name };
 		const result = await mcpToolsCall<{
 			success: boolean;
 			return_value: PendingCreate;
 		}>(
 			"run_sdk",
 			{
-				script: `export default async (_ctx, client) => client.entitySchema.createType({ slug: ${JSON.stringify(slug)}, name: ${JSON.stringify(slug)} });`,
+				script: `export default async (_ctx, client) => client.entitySchema.createType(${JSON.stringify(input)});`,
 			},
 			{ token, orgSlug: org.slug },
 		);
@@ -193,6 +196,7 @@ describe("MCP entitySchema.createType approval", () => {
 		);
 		const capability = viewResponse.result?._meta?.["lobu/approval-capability"];
 		expect(typeof capability).toBe("string");
+		const view = viewResponse.result?.structuredContent;
 
 		const response = await mcpRequest<any>(
 			"tools/call",
@@ -206,7 +210,7 @@ describe("MCP entitySchema.createType approval", () => {
 			},
 			{ token, orgSlug: org.slug },
 		);
-		return { response, capability };
+		return { response, capability, view };
 	}
 
 	it("keeps a direct human owner create immediate", async () => {
@@ -427,7 +431,11 @@ describe("MCP entitySchema.createType approval", () => {
 
 	it("requires policy approval and applies only after embedded human approval", async () => {
 		await setCreatePolicy("approval");
-		const pending = await propose("member-proposed-type");
+		const pending = await propose(
+			"member-proposed-type",
+			ownerAdminToken,
+			"ChatGPT schema E2E",
+		);
 		expect(pending).toMatchObject({
 			schema_type: "entity_type",
 			action: "create",
@@ -441,7 +449,7 @@ describe("MCP entitySchema.createType approval", () => {
 				policy_action: "create_type",
 				schema_type: "entity_type",
 				action: "create",
-				args: { slug: "member-proposed-type", name: "member-proposed-type" },
+				args: { slug: "member-proposed-type", name: "ChatGPT schema E2E" },
 			},
 			current: null,
 		});
@@ -478,6 +486,47 @@ describe("MCP entitySchema.createType approval", () => {
 			interaction_type: "approval",
 			interaction_status: "pending",
 		});
+
+		const reviewView = await mcpRequest<any>(
+			"tools/call",
+			{
+				name: "get_approval",
+				arguments: { run_id: pending.run_id },
+			},
+			{ token: ownerWriteToken, orgSlug: org.slug },
+		);
+		expect(reviewView.result?.isError).not.toBe(true);
+		const reviewBlocks = reviewView.result?.structuredContent?.blocks ?? [];
+		expect(reviewBlocks.find((block: { type?: string }) => block.type === "diff")).toEqual({
+			type: "diff",
+			fields: [
+				{ label: "Resource", after: "Entity type" },
+				{ label: "Name", after: "ChatGPT schema E2E" },
+				{
+					label: "Slug",
+					after: "member-proposed-type",
+					format: "code",
+				},
+				{ label: "Metadata schema", after: "Any metadata (no schema)" },
+				{ label: "Storage", after: "Stored" },
+				{ label: "Event kinds", after: "None declared" },
+				{ label: "Metrics", after: "None declared" },
+				{ label: "Write rules", after: "None" },
+			],
+		});
+		expect(reviewBlocks.some((block: { type?: string }) => block.type === "code")).toBe(false);
+		expect(JSON.stringify(reviewBlocks)).not.toMatch(
+			/owner_resolved|policy_action|precondition|resource_class/,
+		);
+		expect(reviewView.result?.structuredContent?.title).toBe(
+			"Create entity type: ChatGPT schema E2E",
+		);
+		expect(reviewView.result?.structuredContent?.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "review", label: "Review in Lobu" }),
+			]),
+		);
+
 		const unauthorized = await resolveInApp(
 			pending.run_id,
 			"approve",
@@ -527,6 +576,34 @@ describe("MCP entitySchema.createType approval", () => {
 				AND metadata->>'op' = 'created'
 		`;
 		expect(configEvents).toHaveLength(1);
+	});
+
+	it("renders an explicit metadata schema exactly with code typography", async () => {
+		await setCreatePolicy("approval");
+		const metadataSchema = {
+			type: "object",
+			properties: {
+				status: { type: "string", enum: ["active", "archived"] },
+			},
+			required: ["status"],
+		};
+		const pending = await propose(
+			"typed-proposed-type",
+			ownerAdminToken,
+			"Typed proposed type",
+			{ metadata_schema: metadataSchema },
+		);
+		const { response, view } = await resolveInApp(pending.run_id, "reject");
+		const schemaField = view.blocks[0].fields.find(
+			(field: { label: string }) => field.label === "Metadata schema",
+		);
+		expect(schemaField).toMatchObject({
+			label: "Metadata schema",
+			format: "code",
+		});
+		expect(JSON.parse(schemaField.after)).toEqual(metadataSchema);
+		expect(response.result?.isError).not.toBe(true);
+		expect(await entityTypeExists("typed-proposed-type")).toBe(false);
 	});
 
 	it("rejects a policy-held mutation without applying and refuses replay", async () => {
@@ -745,6 +822,51 @@ describe("MCP entitySchema.createType approval", () => {
 		);
 		expect(proposed.success).toBe(true);
 		expect(proposed.return_value.status).toBe("pending_approval");
+		const [interaction] = await getDb()<
+			[
+				{
+					interaction_input: Record<string, unknown>;
+					current: Record<string, unknown>;
+				},
+			]
+		>`
+			SELECT interaction_input, metadata->'current' AS current
+			FROM events
+			WHERE run_id = ${proposed.return_value.run_id}
+				AND interaction_type = 'approval'
+				AND interaction_status = 'pending'
+		`;
+		expect(interaction.interaction_input).toMatchObject({
+			name: "Approved old name",
+			slug: "stale-update-type",
+		});
+		expect(interaction.current).toMatchObject({
+			name: "Original",
+			slug: "stale-update-type",
+		});
+
+		const reviewView = await mcpRequest<any>(
+			"tools/call",
+			{
+				name: "get_approval",
+				arguments: { run_id: proposed.return_value.run_id },
+			},
+			{ token: ownerWriteToken, orgSlug: org.slug },
+		);
+		const reviewFields = reviewView.result?.structuredContent?.blocks?.find(
+			(block: { type?: string }) => block.type === "diff",
+		)?.fields;
+		expect(reviewFields).toEqual([
+			{ label: "Resource", after: "Entity type" },
+			{ label: "Name", before: "Original", after: "Approved old name" },
+			{
+				label: "Slug",
+				before: "stale-update-type",
+				after: "stale-update-type",
+				format: "code",
+			},
+		]);
+
 		await getDb()`
 			UPDATE entity_types
 			SET name = 'Newer human name',
@@ -809,10 +931,25 @@ describe("MCP entitySchema.createType approval", () => {
 			await getDb()`SELECT id FROM entity_relationship_types
 			WHERE organization_id = ${org.id} AND slug = 'governed-rel' AND deleted_at IS NULL`,
 		).toHaveLength(0);
-		const { response } = await resolveInApp(
+		const { response, view } = await resolveInApp(
 			proposed.return_value.run_id,
 			"approve",
 		);
+		expect(view.blocks[0]).toEqual({
+			type: "diff",
+			fields: [
+				{ label: "Resource", after: "Relationship type" },
+				{ label: "Name", after: "Governed relation" },
+				{ label: "Slug", after: "governed-rel", format: "code" },
+				{
+					label: "Metadata schema",
+					after: "Any relationship metadata (no schema)",
+				},
+				{ label: "Direction", after: "Directional" },
+				{ label: "Inverse type", after: "None" },
+				{ label: "Status", after: "Active" },
+			],
+		});
 		expect(response.result?.isError).not.toBe(true);
 		expect(
 			await getDb()`SELECT id FROM entity_relationship_types

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -1324,7 +1324,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         }),
         expect.objectContaining({
           id: 'review',
-          label: 'Open in Lobu',
+          label: 'Review in Lobu',
           href: expect.stringMatching(/^https?:\/\//),
         }),
       ])
@@ -1678,6 +1678,16 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(serialized).toContain('[redacted]');
     expect(view.blocks).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          type: 'diff',
+          fields: expect.arrayContaining([
+            expect.objectContaining({ label: expect.stringMatching(/^Field 0 /) }),
+          ]),
+        }),
+      ])
+    );
+    expect(view.blocks).toEqual(
+      expect.arrayContaining([
         expect.objectContaining({ label: 'Source', value: 'Direct request' }),
       ])
     );
@@ -1708,6 +1718,117 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(field.before?.length ?? 0).toBeLessThanOrEqual(20_000);
       expect(field.after.length).toBeLessThanOrEqual(20_000);
     }
+  });
+
+  it('keeps explicit null distinct from an empty string in approval diffs', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connector_key, action_key
+      ) VALUES (
+        ${org.id}, 'action', 'pending', 'pending', 'github', 'update_issue'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_null_approval_${runId}`,
+      title: 'Update issue — pending approval',
+      content: 'Review this issue update.',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      interactionInput: { cleared: null, emptied: '' },
+      metadata: {
+        proposal: { cleared: null, emptied: '' },
+        current: { cleared: 'before', emptied: 'before' },
+      },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 214,
+        method: 'tools/call',
+        params: {
+          name: 'get_approval',
+          arguments: { run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    expect(body.result?.structuredContent?.blocks?.[0]?.fields).toEqual([
+      { label: 'Cleared', before: 'before', after: 'null' },
+      { label: 'Emptied', before: 'before', after: '' },
+    ]);
+    expect(body.result?.content?.[0]?.text).toContain('before → null');
+    expect(body.result?.content?.[0]?.text).toContain('before → —');
+  });
+
+  it('keeps user-authored envelope-shaped fields in an ordinary approval proposal', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (organization_id, run_type, status, approval_status)
+      VALUES (${org.id}, 'internal', 'pending', 'pending')
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_user_args_approval_${runId}`,
+      title: 'Create entity — pending approval',
+      content: 'Review this entity proposal.',
+      semanticType: 'operation',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      interactionInput: { action: 'create' },
+      metadata: {
+        tool: 'entity_change',
+        proposal: {
+          args: { mode: 'careful' },
+          title: 'Visible sibling field',
+          schema_type: 'Visible user field',
+          version: 'Visible user version',
+        },
+      },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 215,
+        method: 'tools/call',
+        params: {
+          name: 'get_approval',
+          arguments: { run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    const ordinaryFields = body.result?.structuredContent?.blocks?.[0]?.fields;
+    expect(ordinaryFields).toHaveLength(4);
+    expect(ordinaryFields).toEqual(
+      expect.arrayContaining([
+        {
+          label: 'Args',
+          after: '{\n  "mode": "careful"\n}',
+          format: 'code',
+        },
+        { label: 'Title', after: 'Visible sibling field' },
+        { label: 'Schema type', after: 'Visible user field' },
+        { label: 'Version', after: 'Visible user version' },
+      ]),
+    );
   });
 
   it('does not render an approval from another member private connection', async () => {

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -310,6 +310,94 @@ function entitySchemaPolicyAction(args: ManageEntitySchemaArgs): WriteAction | n
   return 'update_relationship_type';
 }
 
+function entitySchemaApprovalLabel(proposal: ManageEntitySchemaProposal): string {
+  const action = proposal.action === 'add_rule'
+    ? 'add'
+    : proposal.action === 'remove_rule'
+      ? 'remove'
+      : proposal.action.replaceAll('_', ' ');
+  const subject = proposal.action === 'add_rule' || proposal.action === 'remove_rule'
+    ? 'relationship rule'
+    : proposal.schema_type.replace('_', ' ');
+  const target =
+    proposal.args.name ??
+    proposal.current?.name ??
+    proposal.args.slug ??
+    proposal.current?.slug ??
+    proposal.args.rule_id;
+  const title = `${action.charAt(0).toUpperCase()}${action.slice(1)} ${subject}`;
+  return target == null || String(target).trim() === '' ? title : `${title}: ${String(target)}`;
+}
+
+function entitySchemaApprovalFields(
+  proposal: ManageEntitySchemaProposal
+): Array<{ key: string; value: unknown }> {
+  const resource =
+    proposal.action === 'add_rule' || proposal.action === 'remove_rule'
+      ? 'Relationship rule'
+      : proposal.schema_type === 'entity_type'
+        ? 'Entity type'
+        : 'Relationship type';
+  const entries = Object.entries(proposal.args).filter(
+    ([key, value]) => key !== 'action' && key !== 'schema_type' && value !== undefined
+  );
+  const byKey = new Map(entries);
+  const ordered: Array<[string, unknown]> = [['resource', resource]];
+  const take = (key: string): void => {
+    if (!byKey.has(key)) return;
+    ordered.push([key, byKey.get(key)]);
+    byKey.delete(key);
+  };
+
+  for (const key of ['name', 'slug', 'description', 'icon', 'color']) {
+    take(key);
+  }
+
+  if (proposal.action === 'create' && proposal.schema_type === 'entity_type') {
+    ordered.push([
+      'metadata_schema',
+      byKey.get('metadata_schema') ?? 'Any metadata (no schema)',
+    ]);
+    byKey.delete('metadata_schema');
+    const backing = byKey.get('backing');
+    const backingConnection =
+      backing && typeof backing === 'object' && !Array.isArray(backing)
+        ? (backing as Record<string, unknown>).connection
+        : null;
+    ordered.push([
+      'storage',
+      backing && typeof backing === 'object'
+        ? backingConnection
+          ? `Derived view via ${String(backingConnection)}`
+          : 'Derived view'
+        : 'Stored',
+    ]);
+    if (backing && typeof backing === 'object') ordered.push(['backing', backing]);
+    byKey.delete('backing');
+    ordered.push(['event_kinds', byKey.get('event_kinds') ?? 'None declared']);
+    byKey.delete('event_kinds');
+    ordered.push(['metrics', byKey.get('metrics_config') ?? 'None declared']);
+    byKey.delete('metrics_config');
+    ordered.push(['write_rules', byKey.get('rules_source') ?? 'None']);
+    byKey.delete('rules_source');
+  } else if (proposal.action === 'create' && proposal.schema_type === 'relationship_type') {
+    ordered.push([
+      'metadata_schema',
+      byKey.get('metadata_schema') ?? 'Any relationship metadata (no schema)',
+    ]);
+    byKey.delete('metadata_schema');
+    ordered.push(['direction', byKey.get('is_symmetric') === true ? 'Symmetric' : 'Directional']);
+    byKey.delete('is_symmetric');
+    ordered.push(['inverse_type', byKey.get('inverse_type_slug') ?? 'None']);
+    byKey.delete('inverse_type_slug');
+    ordered.push(['status', byKey.get('status') ?? 'Active']);
+    byKey.delete('status');
+  }
+
+  ordered.push(...byKey.entries());
+  return ordered.map(([key, value]) => ({ key, value }));
+}
+
 function timestamp(value: unknown): string | null {
   if (value == null) return null;
   // PROD_PG_VALUE_OPTIONS returns untyped timestamptz values as strings. Keep
@@ -617,8 +705,7 @@ async function governEntitySchemaMutation(
         result: await applyPreparedEntitySchemaMutation(proposal, ctx, tx),
       };
     }
-    const label =
-      `${proposal.action} ${proposal.schema_type.replace('_', ' ')} ${String(proposal.args.slug ?? proposal.args.rule_id ?? '')}`.trim();
+    const label = entitySchemaApprovalLabel(proposal);
     const inserted = await tx`
       INSERT INTO runs (
         organization_id, run_type, action_key, action_input,
@@ -648,7 +735,7 @@ async function governEntitySchemaMutation(
         runId,
         interactionType: 'approval',
         interactionStatus: 'pending',
-        interactionInput: proposal as unknown as Record<string, unknown>,
+        interactionInput: proposal.args,
         metadata: {
           tool: 'manage_entity_schema',
           action_key: MANAGE_ENTITY_SCHEMA_ACTION_KEY,
@@ -657,7 +744,8 @@ async function governEntitySchemaMutation(
           policy_action: proposal.policy_action,
           slug: proposal.args.slug ?? null,
           proposal,
-          current: null,
+          review_fields: entitySchemaApprovalFields(proposal),
+          current: proposal.current,
           initiator: {
             kind: initiator.initiatorKind,
             ...initiator.initiatorRef,

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -63,6 +63,7 @@ const DiffBlockSchema = Type.Object({
       label: Type.String({ minLength: 1, maxLength: TEXT_LABEL_MAX_LENGTH }),
       before: Type.Optional(Type.String({ maxLength: TEXT_VALUE_MAX_LENGTH })),
       after: Type.String({ maxLength: TEXT_VALUE_MAX_LENGTH }),
+      format: Type.Optional(Type.Literal('code')),
     }),
     { maxItems: DIFF_FIELD_MAX_ITEMS }
   ),
@@ -183,7 +184,18 @@ const DIFF_ROUTING_KEYS = new Set([
   'id',
   'owner_user_id',
   'reason',
-  'automation_id',
+]);
+
+const DIFF_ENVELOPE_ROUTING_KEYS = new Set([
+  'owner_agent_id',
+  'owner_resolved',
+  'policy_action',
+  'policy_principal_id',
+  'policy_principal_kind',
+  'precondition',
+  'resource_class',
+  'schema_type',
+  'version',
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -275,7 +287,8 @@ function sanitizeFormInitialValues(value: Record<string, unknown>): Record<strin
 }
 
 function displayValue(value: unknown, maxLength: number, key?: string): string {
-  if (value === undefined || value === null) return '';
+  if (value === undefined) return '';
+  if (value === null) return 'null';
   const redacted = redactForDisplay(value, key);
   let rendered: string;
   if (typeof redacted === 'string') {
@@ -290,6 +303,30 @@ function displayValue(value: unknown, maxLength: number, key?: string): string {
   return truncate(rendered, maxLength);
 }
 
+function displayFieldLabel(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+  if (!words) return 'Field';
+  return truncate(`${words.charAt(0).toUpperCase()}${words.slice(1)}`, TEXT_LABEL_MAX_LENGTH);
+}
+
+function displayFieldFormat(key: string, value: unknown): 'code' | undefined {
+  if (
+    Array.isArray(value) ||
+    isRecord(value) ||
+    key === 'slug' ||
+    key.endsWith('_slug') ||
+    key === 'rule_id' ||
+    key === 'rules_source' ||
+    (key === 'write_rules' && value !== 'None')
+  ) {
+    return 'code';
+  }
+  return undefined;
+}
+
 function approvalBlocks(row: {
   content: string | null;
   interaction_input_schema: Record<string, unknown> | null;
@@ -299,21 +336,47 @@ function approvalBlocks(row: {
 }): LobuViewBlock[] {
   const metadata = row.metadata ?? {};
   const proposal = isRecord(metadata.proposal) ? metadata.proposal : null;
-  const current = isRecord(metadata.current) ? metadata.current : null;
+  // Only platform producers with this durable shape store execution envelopes
+  // in `proposal`. An ordinary proposal may legitimately contain user fields
+  // named `args`, `schema_type`, or `version` and must keep them visible.
+  const hasArgumentEnvelope =
+    metadata.tool === 'manage_automations' || metadata.tool === 'manage_entity_schema';
+  const proposalArgs =
+    hasArgumentEnvelope && proposal && isRecord(proposal.args) ? proposal.args : null;
+  const proposalCurrent =
+    metadata.tool === 'manage_entity_schema' && proposal && isRecord(proposal.current)
+      ? proposal.current
+      : null;
+  const current = isRecord(metadata.current) ? metadata.current : proposalCurrent;
   const fields = isRecord(metadata.fields) ? metadata.fields : null;
-  const proposed = fields ?? proposal;
+  const reviewFields = Array.isArray(metadata.review_fields)
+    ? metadata.review_fields.flatMap((item) => {
+        if (!isRecord(item) || typeof item.key !== 'string' || item.value === undefined) return [];
+        return [[item.key, item.value] as [string, unknown]];
+      })
+    : null;
+  // Durable proposals may be execution envelopes. Prefer producer-authored
+  // review fields, then their public args; routing and policy state belongs in
+  // the run/audit record, not in a human confirmation card.
+  const proposed = fields ?? proposalArgs ?? proposal ?? row.interaction_input;
   const blocks: LobuViewBlock[] = [];
 
-  if (proposed) {
-    const diffFields = Object.entries(proposed)
-      .filter(([key, value]) => !DIFF_ROUTING_KEYS.has(key) && value !== undefined)
+  if (reviewFields || proposed) {
+    const diffFields = (reviewFields ?? Object.entries(proposed ?? {}))
+      .filter(
+        ([key, value]) =>
+          !DIFF_ROUTING_KEYS.has(key) &&
+          !(hasArgumentEnvelope && DIFF_ENVELOPE_ROUTING_KEYS.has(key)) &&
+          value !== undefined
+      )
       .slice(0, DIFF_FIELD_MAX_ITEMS)
       .map(([key, value]) => ({
-        label: truncate(key || 'field', TEXT_LABEL_MAX_LENGTH),
+        label: displayFieldLabel(key),
         ...(current && current[key] !== undefined
           ? { before: displayValue(current[key], TEXT_VALUE_MAX_LENGTH, key) }
           : {}),
         after: displayValue(value, TEXT_VALUE_MAX_LENGTH, key),
+        ...(displayFieldFormat(key, value) ? { format: 'code' as const } : {}),
       }));
     if (diffFields.length > 0) blocks.push({ type: 'diff', fields: diffFields });
   }
@@ -332,7 +395,11 @@ function approvalBlocks(row: {
           }
         : {}),
     });
-  } else if (row.interaction_input && Object.keys(row.interaction_input).length > 0) {
+  } else if (
+    blocks.length === 0 &&
+    row.interaction_input &&
+    Object.keys(row.interaction_input).length > 0
+  ) {
     blocks.push({
       type: 'code',
       value: displayValue(row.interaction_input, CODE_VALUE_MAX_LENGTH),
@@ -625,7 +692,7 @@ async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Pro
     }
     actions.push({
       id: 'review',
-      label: 'Open in Lobu',
+      label: 'Review in Lobu',
       variant: appCanResolve ? 'outline' : 'primary',
       icon: 'external',
       terminal: false,


### PR DESCRIPTION
## Summary
- render entity-schema approvals from user-facing review fields instead of the internal execution envelope
- give create, update, relationship-type, and rule approvals human-readable titles and ordered fields
- persist the current schema preimage so update cards show meaningful before/after values
- preserve explicit null versus empty values and legitimate user-authored envelope-shaped fields
- pin the merged Owletto presentation update from lobu-ai/owletto#950

## Test plan
- [x] Pre-review fixer completed; all edits inspected
- [x] Entity-schema approval integration suite: 19 passed
- [x] MCP App resource integration suite: 30 passed
- [x] Owletto focused presentation tests: 15 passed
- [x] Owletto exact-head Codex review: no findings
- [x] Changed-file Biome checks clean
- [x] Full make pre-pr clean

## Notes
This is the presentation fix found during the production approval-flow audit. It adds no database or SDK contract changes. Owletto PR #950 is merged, and this head pins its reachable squash commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval reviews now show clearer labels for entity types, relationship types, and relationship rules.
  - Review cards display organized before-and-after changes, including names, slugs, metadata schemas, and relationship details.
  - Structured metadata can be displayed with code formatting for easier review.

- **Bug Fixes**
  - Large approval proposals now produce bounded, readable change summaries.
  - Reviews preserve distinctions between empty and null values.
  - User-provided proposal fields are displayed accurately without exposing internal-only details.
  - Updated the review action label to **“Review in Lobu.”**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->