### PR TITLE
fix(auth): allow packaged Mac child tokens

### DIFF
--- a/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/device-child-token-lifecycle.test.ts
@@ -47,7 +47,7 @@ async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
   `;
 }
 
-type AuthShape = { scopes: string[]; workerId?: string } | null;
+type AuthShape = { scopes: string[]; workerId?: string; resource?: string } | null;
 
 type MintApp = Hono<{
   Bindings: Env;
@@ -198,6 +198,97 @@ describe('device child-token lifecycle', () => {
     `) as unknown as Array<{ token_prefix: string }>;
     expect(live).toHaveLength(1);
     expect(String(rotated.json.access_token)).toContain(live[0].token_prefix);
+  });
+
+  it('requires device scope without an MCP resource audience for macOS minting', async () => {
+    const sql = getTestDb();
+    const userId = await seedUser('child-lifecycle-auth-fences@test.example.com');
+    const workerId = 'mac-auth-fence-device';
+
+    const missingScope = await mint(
+      userId,
+      { scopes: [] },
+      { platform: 'macos', worker_id: workerId }
+    );
+    expect(missingScope.status).toBe(403);
+    expect(missingScope.json).toMatchObject({
+      error: 'insufficient_scope',
+      required: 'device_worker:run',
+    });
+
+    const mcpAudience = await mint(
+      userId,
+      { scopes: ['device_worker:run'], resource: 'https://app.lobu.ai/mcp' },
+      { platform: 'macos', worker_id: workerId }
+    );
+    expect(mcpAudience.status).toBe(403);
+    expect(mcpAudience.json).toMatchObject({
+      error: 'insufficient_scope',
+      required: 'device-bound token without MCP resource',
+    });
+
+    const pats = (await sql`
+      SELECT id FROM personal_access_tokens WHERE user_id = ${userId}
+    `) as unknown as Array<{ id: number }>;
+    expect(pats).toEqual([]);
+    const devices = (await sql`
+      SELECT id FROM device_workers WHERE user_id = ${userId}
+    `) as unknown as Array<{ id: number }>;
+    expect(devices).toEqual([]);
+  });
+
+  it('keeps the old child valid when replacement mint cannot commit', async () => {
+    const sql = getTestDb();
+    const userId = await seedUser('child-lifecycle-rollback@test.example.com');
+    const first = await mint(userId, PARENT_AUTH, {
+      platform: 'macos',
+      worker_id: 'mac-rollback-device',
+      label: 'Mac rollback probe',
+    });
+    expect(first.status).toBe(200);
+    const workerId = first.json.worker_id as string;
+    const childAuth = await verifyPat(first.json.access_token);
+
+    // Force the old-token revocation to fail after the replacement INSERT.
+    // Both writes live in one transaction, so the new PAT must roll back and
+    // the old bearer must remain usable rather than stranding the device.
+    await sql.unsafe(`
+      CREATE OR REPLACE FUNCTION test_fail_device_child_rotation_revoke()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF OLD.revoked_at IS NULL AND NEW.revoked_at IS NOT NULL THEN
+          RAISE EXCEPTION 'forced device child rotation revoke failure';
+        END IF;
+        RETURN NEW;
+      END
+      $$;
+      CREATE TRIGGER test_fail_device_child_rotation_revoke_trg
+      BEFORE UPDATE ON personal_access_tokens
+      FOR EACH ROW EXECUTE FUNCTION test_fail_device_child_rotation_revoke();
+    `);
+    try {
+      const failed = await mint(userId, childAuth, {
+        platform: 'macos',
+        worker_id: workerId,
+      });
+      expect(failed.status).toBe(500);
+    } finally {
+      await sql.unsafe(`
+        DROP TRIGGER IF EXISTS test_fail_device_child_rotation_revoke_trg
+          ON personal_access_tokens;
+        DROP FUNCTION IF EXISTS test_fail_device_child_rotation_revoke();
+      `);
+    }
+
+    expect(await verifyPat(first.json.access_token)).toEqual({
+      scopes: ['device_worker:run'],
+      workerId,
+    });
+    const rows = (await sql`
+      SELECT revoked_at FROM personal_access_tokens
+      WHERE user_id = ${userId} AND worker_id = ${workerId}
+    `) as unknown as Array<{ revoked_at: Date | null }>;
+    expect(rows).toEqual([{ revoked_at: null }]);
   });
 
   it('a LEGACY child (bare scope, worker-bound) is still held to the depth-1 gate', async () => {

--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -1,8 +1,8 @@
 /**
- * POST /api/me/devices/mint-child-token must let a headless device register
- * itself (platform: 'headless') from a device_worker:run bearer, and bind the
- * device + child PAT to the user's personal org - the same contract as the
- * chrome-extension Mac-bridge path, now open to server/VM devices (herdr).
+ * POST /api/me/devices/mint-child-token registers eligible device platforms
+ * from a device_worker:run bearer and binds each device + child PAT to the
+ * user's personal org. The suite covers headless, Chrome, and macOS child-mint
+ * requests plus the shared platform-isolation rules.
  */
 
 import { Hono } from 'hono';
@@ -50,7 +50,7 @@ function mintApp(userId: string): Hono<{ Bindings: Env; Variables: { user: { id:
   return app;
 }
 
-describe('headless device mint (mint-child-token)', () => {
+describe('device mint (mint-child-token)', () => {
   beforeAll(async () => {
     await cleanupTestDatabase();
   });
@@ -421,9 +421,10 @@ describe('headless device mint (mint-child-token)', () => {
     );
   });
 
-  it('rejects a platform that is not eligible for child-token mint', async () => {
-    const user = await createTestUser({ email: 'headless-mint-reject@test.example.com' });
-    const personalOrg = await createTestOrganization({ name: 'Personal Reject' });
+  it('mints the exact requested macos identity without creating a browser session', async () => {
+    const sql = getTestDb();
+    const user = await createTestUser({ email: 'macos-mint@test.example.com' });
+    const personalOrg = await createTestOrganization({ name: 'Test Personal Mac' });
     await markPersonalOrg(personalOrg.id, user.id);
     await addUserToOrganization(user.id, personalOrg.id, 'owner');
 
@@ -432,10 +433,61 @@ describe('headless device mint (mint-child-token)', () => {
       {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ platform: 'macos', label: 'should-fail' }),
+        body: JSON.stringify({
+          platform: 'macos',
+          worker_id: 'mac-test-device',
+          label: 'Test Mac',
+        }),
+      },
+      TEST_ENV
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      worker_id: string;
+      access_token: string;
+      session_token: string | null;
+      platform: string;
+    };
+    expect(body.worker_id).toBe('mac-test-device');
+    expect(body.access_token.startsWith('owl_pat_')).toBe(true);
+    expect(body.session_token).toBeNull();
+    expect(body.platform).toBe('macos');
+
+    const rows = (await sql`
+      SELECT worker_id, platform, organization_id FROM device_workers
+      WHERE user_id = ${user.id}
+    `) as unknown as Array<{
+      worker_id: string;
+      platform: string;
+      organization_id: string;
+    }>;
+    expect(rows).toEqual([
+      {
+        worker_id: 'mac-test-device',
+        platform: 'macos',
+        organization_id: personalOrg.id,
+      },
+    ]);
+  });
+
+  it.each(['ios', 'toString'])('rejects ineligible child-token platform %s', async (platform) => {
+    const user = await createTestUser({ email: `mint-reject-${platform}@test.example.com` });
+    const personalOrg = await createTestOrganization({ name: `Personal Reject ${platform}` });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      '/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform, worker_id: 'must-not-be-created' }),
       },
       TEST_ENV
     );
     expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: `platform '${platform}' is not eligible for child-token mint`,
+    });
   });
 });

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -172,9 +172,8 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
  * re-minting through this endpoint with its stored worker_id (the reuse branch
  * keeps the device identity and revokes the old token). `lobu daemon` does this
  * for itself: on start it re-mints from its cached child PAT once less than a
- * third of that token's life remains. A bearer is still snapshotted for the
- * process lifetime, so a daemon left running past day 90 rotates only on its
- * next start.
+ * third of that token's life remains. The response includes the replacement's
+ * exact expiry so long-running clients can schedule another re-mint before it.
  *
  * Forward-only: legacy children (minted before this shipped) keep their null
  * expiry until they rotate. A retroactive backfill would hard-kill working
@@ -193,12 +192,12 @@ const CHILD_SELF_MINT_ONLY = {
  * POST /api/me/devices/mint-child-token  { platform, label?, worker_id? }
  *
  * Hand-off path for a first-party device grant to authorize a worker without a
- * second OAuth dance: the Mac bridge pairing a sibling device (today: the
- * Owletto Chrome extension), or `lobu daemon` authorizing this host from its
- * stored login. The caller's bearer authenticates the user; we mint a PAT in
- * that user's personal org bound to a worker_id — the one the caller asked for,
- * else a fresh uuid — and return both for the device to use as if it had
- * completed device-authorization on its own.
+ * second OAuth dance. It supports a Mac app authorizing a packaged daemon, a
+ * Mac bridge pairing an Owletto Chrome sibling, or `lobu daemon` authorizing
+ * this host from its stored login. The caller's bearer authenticates the user;
+ * we mint a PAT in that user's personal org bound to a worker_id — the one the
+ * caller asked for, else a fresh uuid — and return both for the device to use
+ * as if it had completed device-authorization on its own.
  *
  * The child token carries the same `device_worker:run` scope the regular Mac
  * OAuth flow ends up with. Its stored worker_id binding stops the mint chain at
@@ -255,11 +254,12 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'platform is required' }, 400);
   }
   // Only known device platforms can mint children — keeps the surface tight.
-  // Today: chrome-extension (Mac bridge pairs the extension) and headless
-  // (a server/VM registers itself via a CLI session, then runs the worker
-  // daemon with the minted PAT). The Mac app calling for itself would just
-  // use its existing OAuth token; macos/ios don't need this path.
-  if ((platform !== 'chrome-extension' && platform !== 'headless') || !isKnownPlatform(platform)) {
+  // Eligible identities are macos (packaged daemon), chrome-extension (Mac
+  // bridge pairing), and headless (server/VM daemon). iOS remains ineligible.
+  if (
+    (platform !== 'macos' && platform !== 'chrome-extension' && platform !== 'headless') ||
+    !isKnownPlatform(platform)
+  ) {
     return c.json({ error: `platform '${platform}' is not eligible for child-token mint` }, 400);
   }
   const label = body.label?.toString().trim() || null;


### PR DESCRIPTION
## Summary

- Allow the known `macos` device platform to mint an exact worker-bound child PAT through the existing device route.
- Preserve all existing scope, resource, depth-1, worker, platform, personal-org, and rollback fences.
- Correct the server lifecycle documentation so clients retain the returned expiry and rotate before it.

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted DB-backed device mint and child-token lifecycle suites, 17/17 green; strict server typecheck green; `make pre-pr` green
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Red: current Lobu `main` rejected `platform=macos` with HTTP 400; the exact incompatibility was reproduced by the formal review on Owletto PR #948.

Green: `device-management-mint.test.ts` 11/11 and `device-child-token-lifecycle.test.ts` 6/6 pass against the real handler and embedded Postgres. The regressions prove macOS eligibility, rejection of iOS/prototype-key platforms, scope/resource fencing with zero side effects, exact same-platform self-rotation, cross-platform/depth-1 rejection, and transactional rollback that leaves the old PAT valid.

## Notes

Server-contract prerequisite for Owletto PR #948 and part of #3103. This PR intentionally contains no Owletto pointer or client change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minting device child tokens on macOS.
  * Enabled macOS token minting without a session token when the required device scope is present.
  * Added platform-specific validation for supported device hand-offs.

* **Bug Fixes**
  * Prevented token records from being created for ineligible platforms or invalid credentials.
  * Preserved existing child tokens when replacement minting fails during revocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->