### PR TITLE
fix(linkedin): score visible comment reactions

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1609,6 +1609,7 @@ describe("LinkedInConnector home_feed", () => {
               <span aria-label="View Fixture Commenter One’s profile"></span>
             </a>
             <p>Fixture Commenter One • This first visible comment is long enough to pass the noise filter</p>
+            <button class="comments-comment-social-bar__reactions-count--cr">2 reactions</button>
             <img src="https://media.licdn.com/dms/image/sync/v2/fixture-comment-one" alt="First fixture diagram" />
           </div>
           <div id="replaceableComment_urn:li:comment:(urn:li:activity:1111111111111111111,3333333333333333333)">
@@ -1751,6 +1752,12 @@ describe("LinkedInConnector home_feed", () => {
     expect(cfg.fields.reaction_count_text.selector).toContain(
       "social-details-social-counts"
     );
+    expect(cfg.fields.reaction_count_text.selector).toContain(
+      "comments-comment-social-bar__reactions-count"
+    );
+    expect(cfg.fields.reaction_count_text.selector).toContain(
+      'button[aria-label="Open reactions menu"]'
+    );
     expect(cfg.fields.comment_count_label.attr).toBe("aria-label");
     expect(cfg.fields.repost_count_label.attr).toBe("aria-label");
 
@@ -1765,6 +1772,8 @@ describe("LinkedInConnector home_feed", () => {
       origin_parent_id: "li_home_activity_1111111111111111111",
       origin_type: "comment",
       author_name: "Fixture Commenter One",
+      score: 2,
+      metadata: { reactions: 2 },
       attachments: [
         {
           kind: "image",
@@ -1778,6 +1787,9 @@ describe("LinkedInConnector home_feed", () => {
       origin_parent_id: "li_home_activity_1111111111111111111",
       origin_type: "comment",
       author_name: "Fixture Commenter Two",
+      // This row has no comment social bar, so it reports no reaction count and
+      // scores 0 rather than defaulting to some non-zero engagement.
+      score: 0,
       attachments: [
         {
           kind: "image",
@@ -1786,9 +1798,158 @@ describe("LinkedInConnector home_feed", () => {
         },
       ],
     });
+    expect(
+      (res.events[2].metadata as Record<string, unknown>).reactions
+    ).toBeUndefined();
     expect(res.metadata.backend).toBe("extension-cs-scrape");
     // These mock rows carry no links field, so support is assumed.
     expect(res.metadata.object_all_supported).toBe(true);
+  });
+
+  /**
+   * Drive a real `genericScrape` over `body` with the connector's own home-feed
+   * config, so selector scoping is exercised end to end rather than asserted
+   * as a string.
+   */
+  const syncHomeFeedDom = async (body: string) => {
+    const dom = new JSDOM(`<!doctype html><body>${body}</body>`, {
+      url: "https://www.linkedin.com/feed/",
+    });
+    Object.defineProperty(dom.window.HTMLElement.prototype, "innerText", {
+      configurable: true,
+      get() {
+        return this.textContent ?? "";
+      },
+    });
+    dom.window.scrollTo = () => undefined;
+    dom.window.document.documentElement.scrollTo = () => undefined;
+    const savedGlobals = new Map(
+      ["document", "window", "location"].map((name) => [
+        name,
+        Object.getOwnPropertyDescriptor(globalThis, name),
+      ])
+    );
+    Object.defineProperties(globalThis, {
+      document: {
+        configurable: true,
+        value: dom.window.document,
+        writable: true,
+      },
+      window: { configurable: true, value: dom.window, writable: true },
+      location: {
+        configurable: true,
+        value: dom.window.location,
+        writable: true,
+      },
+    });
+    try {
+      return await new LinkedInConnector().sync({
+        feedKey: "home_feed",
+        config: { max_scrolls: 1 },
+        checkpoint: {},
+        sessionState: {
+          chrome_dispatcher: {
+            dispatch: async (
+              _action: string,
+              input: Record<string, unknown>
+            ) => ({
+              tab_id: 1,
+              cs_scrape: true,
+              result: await genericScrape({
+                ...(input.scrape_config as Record<string, unknown>),
+                scroll: { max: 0, stall: 0, waitMs: 0 },
+              }),
+            }),
+          },
+        },
+      });
+    } finally {
+      dom.window.close();
+      for (const [name, descriptor] of savedGlobals) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete (globalThis as Record<string, unknown>)[name];
+      }
+    }
+  };
+
+  test("a post does not inherit reactions from a comment rendered above its own counts", async () => {
+    // Ordering matters: `querySelector` returns the first match in DOCUMENT
+    // order across the whole selector list, not the first branch that matches.
+    // Put the comment's social bar BEFORE the post's social-details block, the
+    // layout in which an unscoped comment branch would hijack the post's count.
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedparent_orderingFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Fixture Post Author"></button>
+        <span id="translatable-commentary-urn:li:activity:4444444444444444444"></span>
+        <p>A home-feed post with enough useful text to pass the noise filter</p>
+        <div componentkey="commentsSectionContainerordering_token">
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:4444444444444444444,5555555555555555555)">
+            <a href="https://www.linkedin.com/in/fixture-commenter-three/">
+              <span aria-hidden="true">Fixture Commenter Three</span>
+              <span aria-label="View Fixture Commenter Three’s profile"></span>
+            </a>
+            <p>Fixture Commenter Three • A visible comment long enough to pass the noise filter</p>
+            <button class="comments-comment-social-bar__reactions-count--cr">7 reactions</button>
+          </div>
+        </div>
+        <div class="social-details-social-counts">
+          <span class="social-details-social-counts__reactions-count">99</span>
+        </div>
+      </div>`);
+
+    const post = res.events.find((event: any) => event.origin_type === "post");
+    const comment = res.events.find(
+      (event: any) => event.origin_type === "comment"
+    );
+    // The post keeps its own 99 reactions; the comment keeps its own 7.
+    expect(post.metadata.reactions).toBe(99);
+    expect(comment.metadata.reactions).toBe(7);
+  });
+
+  test("a label-only post card does not inherit a nested comment's aria-label counts", async () => {
+    // The label branches are the shape with no social-details text node to win
+    // on document order, so an unscoped label selector leaks the comment's
+    // numbers into the post for reactions, comments, and reposts alike.
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedparent_orderingFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Fixture Label Author"></button>
+        <span id="translatable-commentary-urn:li:activity:6666666666666666666"></span>
+        <p>A label-only home-feed post with text long enough to pass the filter</p>
+        <div componentkey="commentsSectionContainerordering_token">
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:6666666666666666666,7777777777777777777)">
+            <a href="https://www.linkedin.com/in/fixture-commenter-four/">
+              <span aria-hidden="true">Fixture Commenter Four</span>
+              <span aria-label="View Fixture Commenter Four’s profile"></span>
+            </a>
+            <p>Fixture Commenter Four • Another visible comment long enough to pass the filter</p>
+            <svg aria-label="Reaction button state: no reaction"></svg>
+            <div>
+              <div><span>3 reactions</span><span>3</span></div>
+              <button aria-label="Open reactions menu"></button>
+            </div>
+            <button aria-label="2 comments">2</button>
+            <button aria-label="1 repost">1</button>
+          </div>
+        </div>
+        <span aria-label="140 reactions"></span>
+        <span aria-label="65 comments"></span>
+        <span aria-label="49 reposts"></span>
+      </div>`);
+
+    const post = res.events.find((event: any) => event.origin_type === "post");
+    const comment = res.events.find(
+      (event: any) => event.origin_type === "comment"
+    );
+    expect(post.metadata).toMatchObject({
+      reactions: 140,
+      comments: 65,
+      reposts: 49,
+    });
+    // The comment scores from its own reactions only; reply and repost counts
+    // stay post-only quantities.
+    expect(comment.metadata.reactions).toBe(3);
+    expect(comment.metadata.comments).toBeUndefined();
+    expect(comment.metadata.reposts).toBeUndefined();
   });
 
   test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
@@ -2294,7 +2455,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.0");
+    expect(c.definition.version).toBe("3.11.1");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -518,14 +518,28 @@ const HOME_FEED_SCRAPE_CONFIG = {
     // Engagement comes only from LinkedIn's dedicated social-count controls.
     // Keep both visible text and accessible-label variants because the current
     // feed uses both shapes across post types and experiments.
+    //
+    // Row scoping matters here: a post row CONTAINS its visible comment rows,
+    // and `querySelector` returns the first match in DOCUMENT order across the
+    // whole comma list, not the first branch that matches. So every branch that
+    // is not already anchored to `.social-details-social-counts` (the post's own
+    // block) carries `:not([id^="replaceableComment_"] *)`, which excludes
+    // elements inside a nested comment. The reaction fields then add a leading
+    // `:scope[id^="replaceableComment_"]` branch so a comment row reads its OWN
+    // reactions: the current feed puts the count beside an "Open reactions
+    // menu" button using obfuscated classes, while permalink pages still use a
+    // comment social-bar class with an experiment suffix (`--cr`). The semantic
+    // sibling branch covers the feed and the prefix class match covers the
+    // permalink shape. Comment and repost counts stay post-only — a comment's
+    // reply count is a different quantity.
     reaction_count_text: {
       selector:
-        ".social-details-social-counts__reactions-count, .social-details-social-counts__reactions",
+        ':scope[id^="replaceableComment_"] div:has(> button[aria-label="Open reactions menu"]) > :first-child, :scope[id^="replaceableComment_"] [class*="comments-comment-social-bar__reactions-count"], .social-details-social-counts__reactions-count, .social-details-social-counts__reactions',
       take: "text",
     },
     reaction_count_label: {
       selector:
-        '.social-details-social-counts [aria-label*="reaction" i], [aria-label$=" reaction" i], [aria-label$=" reactions" i]',
+        ':scope[id^="replaceableComment_"] [aria-label*=" reaction on " i], :scope[id^="replaceableComment_"] [aria-label*=" reactions on " i], .social-details-social-counts [aria-label*="reaction" i], [aria-label$=" reaction" i]:not([id^="replaceableComment_"] *), [aria-label$=" reactions" i]:not([id^="replaceableComment_"] *)',
       take: "attr",
       attr: "aria-label",
     },
@@ -536,7 +550,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
     },
     comment_count_label: {
       selector:
-        '.social-details-social-counts [aria-label*="comment" i], [aria-label$=" comments" i]',
+        '.social-details-social-counts [aria-label*="comment" i], [aria-label$=" comments" i]:not([id^="replaceableComment_"] *)',
       take: "attr",
       attr: "aria-label",
     },
@@ -547,7 +561,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
     },
     repost_count_label: {
       selector:
-        '.social-details-social-counts [aria-label*="repost" i], [aria-label$=" repost" i], [aria-label$=" reposts" i]',
+        '.social-details-social-counts [aria-label*="repost" i], [aria-label$=" repost" i]:not([id^="replaceableComment_"] *), [aria-label$=" reposts" i]:not([id^="replaceableComment_"] *)',
       take: "attr",
       attr: "aria-label",
     },
@@ -2520,7 +2534,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.0",
+    version: "3.11.1",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com


### PR DESCRIPTION
## Summary
- Capture visible reaction totals on LinkedIn native comment rows in both current home-feed and permalink DOM shapes.
- Keep post counters scoped to the post so nested comment reactions, replies, and repost-like labels cannot leak into the parent score.
- Bump the connector to 3.11.1 for a deployable definition.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback)
- [x] Tests run: `bun test examples/personal-agent/__tests__/linkedin.connector.test.ts` (121 pass) and `bun test examples/personal-agent/__tests__` (259 pass)
- [x] Bug fix: red→fix→green outputs pasted below

Red: the regression fixture exposed that the comment reaction selector missed LinkedIn’s suffixed permalink class; production event 5727213 consequently stored score 0 despite visible text `2 reactions`. Live Mac mini DOM inspection then showed the home feed also uses obfuscated count classes and the old broad label branch selected `Reaction button state: no reaction`.

Green: selector regression coverage passes for permalink, current home-feed, and nested post/comment ordering; live Mac mini selector validation returned `2 reactions2` from the target comment row while avoiding the Like-control label.

## Notes
- Production deploy and persisted re-sync verification will follow merge so the active connection remains on reviewed code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LinkedIn engagement data extraction for comments and nested comment threads.
  * Prevented post-level reaction and engagement counts from being incorrectly assigned to comments.
  * Added support for comment reactions and improved handling when reaction data is unavailable.
  * Updated the LinkedIn connector version to 3.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->