### PR TITLE
fix(linkedin): reuse hydrated feed for live scores

### DIFF
--- a/examples/personal-agent/__tests__/connector-sdk.mock.ts
+++ b/examples/personal-agent/__tests__/connector-sdk.mock.ts
@@ -26,6 +26,7 @@ interface DomScrapeOpts {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
+  existingTabMatch?: string;
 }
 
 // Faithful copies of the SDK's pure pagination generators (no browser stack).
@@ -132,6 +133,9 @@ export function connectorSdkMock() {
         url: opts.url,
         scrape_config: opts.config,
         allowed_origins: opts.allowedOrigins,
+        ...(opts.existingTabMatch
+          ? { existing_tab_match: opts.existingTabMatch }
+          : {}),
       });
       const result = observation?.result;
       const items = opts.parseRows(result?.rows ?? []);

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1691,7 +1691,8 @@ describe("LinkedInConnector home_feed", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].action).toBe("navigate");
     expect(calls[0].input.cs_scrape).toBe(true);
-    expect(calls[0].input.persistent).toBe(false);
+    expect(calls[0].input.persistent).toBe(true);
+    expect(calls[0].input.existing_tab_match).toBe("linkedin.com/feed/");
     expect(calls[0].input.focus).toBe(false);
     expect(calls[0].input.url).toBe("https://www.linkedin.com/feed/");
     expect(
@@ -1952,6 +1953,70 @@ describe("LinkedInConnector home_feed", () => {
     expect(comment.metadata.reposts).toBeUndefined();
   });
 
+  test("scores current obfuscated post counters without reading the Like control", async () => {
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedcurrent_counter_postFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Fixture Current Author"></button>
+        <span id="translatable-commentary-urn:li:activity:8888888888888888888"></span>
+        <p>A current home-feed post with enough useful text to pass the filter</p>
+        <div>
+          <a href="https://www.linkedin.com/">
+            <span>Fixture Reactor and 236 others reacted</span>
+            <span>Fixture Reactor and 236 others</span>
+          </a>
+          <div>
+            <div><p><span>15 comments</span><span>15 comments</span></p></div>
+            <p>•</p>
+            <a href="https://www.linkedin.com/"><p><span>2 reposts</span><span>2 reposts</span></p></a>
+          </div>
+        </div>
+        <hr />
+        <div>
+          <div>
+            <button aria-label="Reaction button state: no reaction">Like</button>
+            <button aria-label="Open reactions menu"></button>
+          </div>
+          <button>Comment</button>
+          <button>Repost</button>
+        </div>
+      </div>`);
+
+    expect(res.events).toHaveLength(1);
+    expect(res.events[0]).toMatchObject({
+      origin_id: "li_home_activity_8888888888888888888",
+      score: 100,
+      metadata: { reactions: 237, comments: 15, reposts: 2 },
+    });
+  });
+
+  test("does not cross-map single-kind current counter groups", async () => {
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedreaction_onlyFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Reaction Only Author"></button>
+        <span id="translatable-commentary-urn:li:activity:9000000000000000001"></span>
+        <p>A reaction-only current post with enough useful text for the filter</p>
+        <div><a href="https://www.linkedin.com/"><span>4 reactions</span><span>4</span></a></div>
+        <hr />
+        <div><div><button aria-label="Reaction button state: no reaction">Like</button><button aria-label="Open reactions menu"></button></div></div>
+      </div>
+      <div componentkey="expandedcomment_onlyFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Comment Only Author"></button>
+        <span id="translatable-commentary-urn:li:activity:9000000000000000002"></span>
+        <p>A comment-only current post with enough useful text for the filter</p>
+        <div><div><div><p><span>1 comment</span><span>1 comment</span></p></div></div></div>
+        <hr />
+        <div><div><button aria-label="Reaction button state: no reaction">Like</button><button aria-label="Open reactions menu"></button></div></div>
+      </div>`);
+
+    expect(res.events).toHaveLength(2);
+    expect(res.events[0].metadata).toMatchObject({ reactions: 4 });
+    expect(res.events[0].metadata.comments).toBeUndefined();
+    expect(res.events[0].metadata.reposts).toBeUndefined();
+    expect(res.events[1].metadata).toMatchObject({ comments: 1 });
+    expect(res.events[1].metadata.reactions).toBeUndefined();
+    expect(res.events[1].metadata.reposts).toBeUndefined();
+  });
+
   test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
     const scrollMaxes: number[] = [];
     const dispatcher = {
@@ -1962,7 +2027,15 @@ describe("LinkedInConnector home_feed", () => {
         return {
           tab_id: 1,
           cs_scrape: true,
-          result: { loggedIn: true, rows: [] },
+          result: {
+            loggedIn: true,
+            rows: [
+              {
+                id: "scroll-budget-fixture",
+                body: "A loaded feed row used only to verify the scroll budget",
+              },
+            ],
+          },
         };
       },
     };
@@ -1982,6 +2055,21 @@ describe("LinkedInConnector home_feed", () => {
     } finally {
       Math.random = realRandom;
     }
+  });
+
+  test("fails health checks when a logged-in feed emits no rows", async () => {
+    const dispatcher = {
+      dispatch: async () => ({ result: { loggedIn: true, rows: [] } }),
+    };
+    const connector = new LinkedInConnector();
+    await expect(
+      connector.sync({
+        feedKey: "home_feed",
+        config: {},
+        checkpoint: {},
+        sessionState: { chrome_dispatcher: dispatcher },
+      })
+    ).rejects.toThrow(/no post rows/i);
   });
 
   test("throws a clear error when not logged into LinkedIn", async () => {
@@ -2455,7 +2543,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.1");
+    expect(c.definition.version).toBe("3.11.2");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -530,22 +530,24 @@ const HOME_FEED_SCRAPE_CONFIG = {
     // menu" button using obfuscated classes, while permalink pages still use a
     // comment social-bar class with an experiment suffix (`--cr`). The semantic
     // sibling branch covers the feed and the prefix class match covers the
-    // permalink shape. Comment and repost counts stay post-only — a comment's
-    // reply count is a different quantity.
+    // permalink shape. Current post cards put their count block immediately
+    // before the divider and action bar; those semantic siblings avoid the
+    // obfuscated classes. Comment and repost counts stay post-only — a
+    // comment's reply count is a different quantity.
     reaction_count_text: {
       selector:
-        ':scope[id^="replaceableComment_"] div:has(> button[aria-label="Open reactions menu"]) > :first-child, :scope[id^="replaceableComment_"] [class*="comments-comment-social-bar__reactions-count"], .social-details-social-counts__reactions-count, .social-details-social-counts__reactions',
+        ':scope:not([id^="replaceableComment_"]) div:has(+ hr + div button[aria-label="Open reactions menu"]):not([id^="replaceableComment_"] *) > a:first-child, :scope[id^="replaceableComment_"] div:has(> button[aria-label="Open reactions menu"]) > :first-child, :scope[id^="replaceableComment_"] [class*="comments-comment-social-bar__reactions-count"], .social-details-social-counts__reactions-count, .social-details-social-counts__reactions',
       take: "text",
     },
     reaction_count_label: {
       selector:
-        ':scope[id^="replaceableComment_"] [aria-label*=" reaction on " i], :scope[id^="replaceableComment_"] [aria-label*=" reactions on " i], .social-details-social-counts [aria-label*="reaction" i], [aria-label$=" reaction" i]:not([id^="replaceableComment_"] *), [aria-label$=" reactions" i]:not([id^="replaceableComment_"] *)',
+        ':scope[id^="replaceableComment_"] [aria-label*=" reaction on " i], :scope[id^="replaceableComment_"] [aria-label*=" reactions on " i], .social-details-social-counts [aria-label*="reaction" i], [aria-label$=" reaction" i]:not([aria-label^="Reaction button state:" i]):not([id^="replaceableComment_"] *), [aria-label$=" reactions" i]:not([aria-label^="Reaction button state:" i]):not([id^="replaceableComment_"] *)',
       take: "attr",
       attr: "aria-label",
     },
     comment_count_text: {
       selector:
-        ".social-details-social-counts__comments, .social-details-social-counts__comments-count",
+        ':scope:not([id^="replaceableComment_"]) div:has(+ hr + div button[aria-label="Open reactions menu"]):not([id^="replaceableComment_"] *) > div:last-child > div:first-child, .social-details-social-counts__comments, .social-details-social-counts__comments-count',
       take: "text",
     },
     comment_count_label: {
@@ -556,7 +558,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
     },
     repost_count_text: {
       selector:
-        ".social-details-social-counts__reposts, .social-details-social-counts__reposts-count",
+        ':scope:not([id^="replaceableComment_"]) div:has(+ hr + div button[aria-label="Open reactions menu"]):not([id^="replaceableComment_"] *) > div:last-child > a:last-child, .social-details-social-counts__reposts, .social-details-social-counts__reposts-count',
       take: "text",
     },
     repost_count_label: {
@@ -892,15 +894,18 @@ function maxHomeFeedCounter(
 }
 
 function homeFeedReactionCount(row: HomeFeedRow): number | undefined {
+  for (const value of [row.reaction_count_text, row.reaction_count_label]) {
+    const others = value?.match(
+      /\band\s+(\d[\d,.]*(?:\s*[kmb])?)\s+others?\s+reacted\b/i
+    );
+    if (others) return parseLinkedInCompactCount(others[1]) + 1;
+  }
+
   const explicitTotal = maxHomeFeedCounter(row.reaction_count_text);
   if (explicitTotal !== undefined) return explicitTotal;
 
   const label = row.reaction_count_label;
   if (!label) return undefined;
-  const others = label.match(
-    /\band\s+(\d[\d,.]*(?:\s*[kmb])?)\s+others?\s+reacted\b/i
-  );
-  if (others) return parseLinkedInCompactCount(others[1]) + 1;
   return maxHomeFeedCounter(label);
 }
 
@@ -2534,7 +2539,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.1",
+    version: "3.11.2",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -3120,8 +3125,9 @@ export default class LinkedInConnector extends ConnectorRuntime<
    * Personalized home feed via the extension's content-script scrape. Network
    * capture can't read it (the CDP debugger stops the feed rendering), so we
    * dispatch a `cs_scrape` against linkedin.com/feed/ with the home-feed
-   * selectors. Each run uses its own scratch tab; the paired Chrome profile
-   * supplies the shared login cookies.
+   * selectors. Prefer an already-loaded feed tab in the paired Chrome profile;
+   * otherwise reuse a site-persistent tab so a slow first hydration is still
+   * available to the next scheduled retry.
    */
   private async syncHomeFeed(
     maxScrolls: number,
@@ -3137,11 +3143,18 @@ export default class LinkedInConnector extends ConnectorRuntime<
       },
       parseRows: (raw) => raw as HomeFeedRow[],
       allowedOrigins: LINKEDIN_ALLOWED_ORIGINS,
+      existingTabMatch: "linkedin.com/feed/",
+      persistent: true,
     });
 
     if (!loggedIn) {
       throw new Error(
         "Not logged into LinkedIn. Sign in to linkedin.com in the paired Chrome profile, then re-run the sync."
+      );
+    }
+    if (rows.length === 0) {
+      throw new Error(
+        "LinkedIn is logged in, but the home feed produced no post rows. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
       );
     }
 


### PR DESCRIPTION
## Summary
- prefer an existing Mac mini LinkedIn feed tab and retain a persistent fallback tab
- extract current obfuscated reaction, comment, and repost groups without confusing the Like control
- fail feed health when a logged-in scrape emits zero post rows

## Verification
- 124 LinkedIn connector tests
- 261 personal-agent tests
- make pre-pr
- live Mac mini scrape used existing tab 1949388839 and captured three rows with reaction/comment/repost counts and media

No API, schema, migration, or endpoint changes.