### PR TITLE
fix(linkedin): fail unusable home feed scrapes

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2133,6 +2133,32 @@ describe("LinkedInConnector home_feed", () => {
     ).rejects.toThrow(/could not resolve.*No home-feed events were persisted/i);
   });
 
+  test("fails health checks when every scraped row is unusable", async () => {
+    const dispatcher = {
+      dispatch: async () => ({
+        result: {
+          loggedIn: true,
+          rows: [
+            {
+              id: "opaque_component_key",
+              body: "Promoted Try LinkedIn Ads for more leads today",
+              post_identity: "urn:li:activity:7111111111111111111",
+            },
+          ],
+        },
+      }),
+    };
+    const connector = new LinkedInConnector();
+    await expect(
+      connector.sync({
+        feedKey: "home_feed",
+        config: {},
+        checkpoint: {},
+        sessionState: { chrome_dispatcher: dispatcher },
+      })
+    ).rejects.toThrow(/none had a durable post identity or usable content/i);
+  });
+
   test("throws a clear error when not logged into LinkedIn", async () => {
     const dispatcher = {
       dispatch: async () => ({ result: { loggedIn: false, rows: [] } }),

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2156,7 +2156,7 @@ describe("LinkedInConnector home_feed", () => {
         checkpoint: {},
         sessionState: { chrome_dispatcher: dispatcher },
       })
-    ).rejects.toThrow(/none had a durable post identity or usable content/i);
+    ).rejects.toThrow(/usable content with a durable identity/i);
   });
 
   test("throws a clear error when not logged into LinkedIn", async () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -3259,6 +3259,11 @@ export default class LinkedInConnector extends ConnectorRuntime<
     }
 
     const events = buildHomeFeedEvents(resolvedRows, new Date());
+    if (events.length === 0) {
+      throw new Error(
+        "LinkedIn is logged in and returned feed rows, but none had a durable post identity or usable content. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
+      );
+    }
 
     // Capability gate: author/engager slugs need the `objectAll` scrape take. An
     // older extension can't produce it, so identity degrades to name-only.

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -3261,7 +3261,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     const events = buildHomeFeedEvents(resolvedRows, new Date());
     if (events.length === 0) {
       throw new Error(
-        "LinkedIn is logged in and returned feed rows, but none had a durable post identity or usable content. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
+        "LinkedIn is logged in and returned feed rows, but no row combined usable content with a durable identity. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
       );
     }
 


### PR DESCRIPTION
## Summary
- fail the LinkedIn home-feed health check when raw rows normalize to zero durable events
- keep the scroll-budget fixture realistic with a durable post identity
- cover all-unusable rows as a regression

## Validation
- bun test v1.3.5 (1e86cebd) (125 passed)
- bun test v1.3.5 (1e86cebd) (263 passed)
- pre-commit Biome and TypeScript checks passed