### PR TITLE
fix(linkedin): resolve copied post links

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -21,6 +21,8 @@ let normalizeLinkedInSlug: any;
 let normalizeLinkedInMemberId: any;
 let LINKEDIN_IDENTITY: any;
 let normalizeLinkedInPostUrl: any;
+let resolveLinkedInShortPostUrl: any;
+let resolveHomeFeedPostUrls: any;
 let isGenericLinkedInFeedUrl: any;
 let isLinkedInAuthWall: any;
 let pickCommentButtonRef: any;
@@ -86,6 +88,8 @@ beforeAll(async () => {
   filterPostsSinceCheckpoint = mod.filterPostsSinceCheckpoint;
   parseCompanyUpdates = mod.parseCompanyUpdates;
   normalizeLinkedInPostUrl = mod.normalizeLinkedInPostUrl;
+  resolveLinkedInShortPostUrl = mod.resolveLinkedInShortPostUrl;
+  resolveHomeFeedPostUrls = mod.resolveHomeFeedPostUrls;
   isGenericLinkedInFeedUrl = mod.isGenericLinkedInFeedUrl;
   isLinkedInAuthWall = mod.isLinkedInAuthWall;
   pickCommentButtonRef = mod.pickCommentButtonRef;
@@ -2033,6 +2037,7 @@ describe("LinkedInConnector home_feed", () => {
               {
                 id: "scroll-budget-fixture",
                 body: "A loaded feed row used only to verify the scroll budget",
+                post_identity: "urn:li:activity:7497353023476916224",
               },
             ],
           },
@@ -2070,6 +2075,32 @@ describe("LinkedInConnector home_feed", () => {
         sessionState: { chrome_dispatcher: dispatcher },
       })
     ).rejects.toThrow(/no post rows/i);
+  });
+
+  test("fails the whole batch when an organic post has no durable identity", async () => {
+    const dispatcher = {
+      dispatch: async () => ({
+        result: {
+          loggedIn: true,
+          rows: [
+            {
+              id: "opaque-component-key",
+              body: "Fixture Author • 1st A real organic post with enough text",
+              post_url: "https://example.com/not-a-linkedin-post",
+            },
+          ],
+        },
+      }),
+    };
+    const connector = new LinkedInConnector();
+    await expect(
+      connector.sync({
+        feedKey: "home_feed",
+        config: {},
+        checkpoint: {},
+        sessionState: { chrome_dispatcher: dispatcher },
+      })
+    ).rejects.toThrow(/No partial home-feed batch was persisted/i);
   });
 
   test("throws a clear error when not logged into LinkedIn", async () => {
@@ -2454,6 +2485,70 @@ describe("prepare_comment helpers", () => {
     expect(normalizeLinkedInPostUrl("")).toBeNull();
   });
 
+  test("resolves a Copy-link short URL to the durable LinkedIn share id", async () => {
+    const calls: Array<{ input: string; init: RequestInit }> = [];
+    const fetchImpl = async (input: URL, init: RequestInit) => {
+      calls.push({ input: input.href, init });
+      return new Response(null, {
+        status: 301,
+        headers: {
+          location:
+            "https://www.linkedin.com/posts/jsduncan98_example-share-7497353023476916224-wb8S/?utm_source=share",
+        },
+      });
+    };
+
+    await expect(
+      resolveLinkedInShortPostUrl("https://lnkd.in/p/eeCQdN3n", fetchImpl)
+    ).resolves.toBe(
+      "https://www.linkedin.com/feed/update/urn:li:share:7497353023476916224"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe("https://lnkd.in/p/eeCQdN3n");
+    expect(calls[0].init.method).toBe("HEAD");
+    expect(calls[0].init.redirect).toBe("manual");
+  });
+
+  test("resolves only LinkedIn post short links and leaves other rows untouched", async () => {
+    let fetchCount = 0;
+    const fetchImpl = async () => {
+      fetchCount += 1;
+      return new Response(null, {
+        status: 301,
+        headers: {
+          location:
+            "https://www.linkedin.com/posts/example_activity-7497353023476916224-x",
+        },
+      });
+    };
+    const rows = [
+      {
+        id: "short",
+        body: "Short URL fixture",
+        post_url: "https://lnkd.in/p/example",
+      },
+      {
+        id: "canonical",
+        body: "Canonical fixture",
+        post_url:
+          "https://www.linkedin.com/feed/update/urn:li:activity:7497353023476916225",
+      },
+      {
+        id: "unsupported",
+        body: "Unsupported fixture",
+        post_url: "https://example.com/post/1",
+      },
+    ];
+
+    const resolved = await resolveHomeFeedPostUrls(rows, fetchImpl);
+    expect(fetchCount).toBe(1);
+    expect(resolved[0].post_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7497353023476916224"
+    );
+    expect(resolved[1]).toBe(rows[1]);
+    expect(resolved[2]).toBe(rows[2]);
+  });
+
   test("isLinkedInAuthWall detects login walls", () => {
     expect(isLinkedInAuthWall("https://www.linkedin.com/login")).toBe(true);
     expect(isLinkedInAuthWall("https://www.linkedin.com/authwall")).toBe(true);
@@ -2543,7 +2638,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.2");
+    expect(c.definition.version).toBe("3.11.3");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2037,7 +2037,7 @@ describe("LinkedInConnector home_feed", () => {
               {
                 id: "scroll-budget-fixture",
                 body: "A loaded feed row used only to verify the scroll budget",
-                post_identity: "urn:li:activity:7497353023476916224",
+                post_identity: "urn:li:activity:1234567890123456789",
               },
             ],
           },
@@ -2101,6 +2101,36 @@ describe("LinkedInConnector home_feed", () => {
         sessionState: { chrome_dispatcher: dispatcher },
       })
     ).rejects.toThrow(/No partial home-feed batch was persisted/i);
+  });
+
+  test("never falls back to an embedded origin when copied-link resolution fails", async () => {
+    const failedFetch = (async () => {
+      throw new Error("temporary redirect failure");
+    }) as typeof fetch;
+    const dispatcher = {
+      dispatch: async () => ({
+        result: {
+          loggedIn: true,
+          rows: [
+            {
+              id: "opaque-component-key",
+              body: "Fixture Author • 1st A real organic post with enough text",
+              post_url: "https://lnkd.in/p/example-token",
+              post_identity: "urn:li:share:1234567890123456789",
+            },
+          ],
+        },
+      }),
+    };
+    const connector = new LinkedInConnector(failedFetch);
+    await expect(
+      connector.sync({
+        feedKey: "home_feed",
+        config: {},
+        checkpoint: {},
+        sessionState: { chrome_dispatcher: dispatcher },
+      })
+    ).rejects.toThrow(/could not resolve.*No home-feed events were persisted/i);
   });
 
   test("throws a clear error when not logged into LinkedIn", async () => {
@@ -2493,18 +2523,18 @@ describe("prepare_comment helpers", () => {
         status: 301,
         headers: {
           location:
-            "https://www.linkedin.com/posts/jsduncan98_example-share-7497353023476916224-wb8S/?utm_source=share",
+            "https://www.linkedin.com/posts/example-user_example-share-1234567890123456789-abcd/?utm_source=share",
         },
       });
     };
 
     await expect(
-      resolveLinkedInShortPostUrl("https://lnkd.in/p/eeCQdN3n", fetchImpl)
+      resolveLinkedInShortPostUrl("https://lnkd.in/p/example-token", fetchImpl)
     ).resolves.toBe(
-      "https://www.linkedin.com/feed/update/urn:li:share:7497353023476916224"
+      "https://www.linkedin.com/feed/update/urn:li:share:1234567890123456789"
     );
     expect(calls).toHaveLength(1);
-    expect(calls[0].input).toBe("https://lnkd.in/p/eeCQdN3n");
+    expect(calls[0].input).toBe("https://lnkd.in/p/example-token");
     expect(calls[0].init.method).toBe("HEAD");
     expect(calls[0].init.redirect).toBe("manual");
   });
@@ -2517,7 +2547,7 @@ describe("prepare_comment helpers", () => {
         status: 301,
         headers: {
           location:
-            "https://www.linkedin.com/posts/example_activity-7497353023476916224-x",
+            "https://www.linkedin.com/posts/example-user_activity-1234567890123456789-abcd",
         },
       });
     };
@@ -2531,7 +2561,7 @@ describe("prepare_comment helpers", () => {
         id: "canonical",
         body: "Canonical fixture",
         post_url:
-          "https://www.linkedin.com/feed/update/urn:li:activity:7497353023476916225",
+          "https://www.linkedin.com/feed/update/urn:li:activity:1234567890123456790",
       },
       {
         id: "unsupported",
@@ -2543,7 +2573,7 @@ describe("prepare_comment helpers", () => {
     const resolved = await resolveHomeFeedPostUrls(rows, fetchImpl);
     expect(fetchCount).toBe(1);
     expect(resolved[0].post_url).toBe(
-      "https://www.linkedin.com/feed/update/urn:li:activity:7497353023476916224"
+      "https://www.linkedin.com/feed/update/urn:li:activity:1234567890123456789"
     );
     expect(resolved[1]).toBe(rows[1]);
     expect(resolved[2]).toBe(rows[2]);

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -1283,6 +1283,20 @@ export function normalizeLinkedInPostUrl(input: string): string | null {
   }
 }
 
+function isLinkedInShortPostUrl(input: string | undefined): boolean {
+  if (!input) return false;
+  try {
+    const url = new URL(input);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "lnkd.in" &&
+      url.pathname.startsWith("/p/")
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Resolve LinkedIn's Copy-link short URL to its durable post URN URL. */
 export async function resolveLinkedInShortPostUrl(
   input: string,
@@ -1294,13 +1308,7 @@ export async function resolveLinkedInShortPostUrl(
   } catch {
     return null;
   }
-  if (
-    shortUrl.protocol !== "https:" ||
-    shortUrl.hostname !== "lnkd.in" ||
-    !shortUrl.pathname.startsWith("/p/")
-  ) {
-    return null;
-  }
+  if (!isLinkedInShortPostUrl(shortUrl.href)) return null;
 
   try {
     const response = await fetchImpl(shortUrl, {
@@ -1341,6 +1349,16 @@ function unresolvedHomeFeedPostCount(rows: HomeFeedRow[]): number {
     if (!homeFeedPostIdentityKey(row, context)) count += 1;
   }
   return count;
+}
+
+function unresolvedHomeFeedShortUrlCount(rows: HomeFeedRow[]): number {
+  return rows.filter(
+    (row) =>
+      Boolean(row?.id && row.body) &&
+      !parseHomeFeedCommentIdentity(row.id) &&
+      !isHomeFeedNoise(row.body ?? "") &&
+      isLinkedInShortPostUrl(row.post_url)
+  ).length;
 }
 
 /** True when navigate landed on login / authwall rather than the post. */
@@ -2594,6 +2612,13 @@ export default class LinkedInConnector extends ConnectorRuntime<
   LinkedInCheckpoint,
   LinkedInConfig
 > {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(fetchImpl: typeof fetch = fetch) {
+    super();
+    this.fetchImpl = fetchImpl;
+  }
+
   readonly definition: ConnectorDefinition = {
     key: "linkedin",
     name: "LinkedIn",
@@ -3218,7 +3243,14 @@ export default class LinkedInConnector extends ConnectorRuntime<
       );
     }
 
-    const resolvedRows = await resolveHomeFeedPostUrls(rows);
+    const resolvedRows = await resolveHomeFeedPostUrls(rows, this.fetchImpl);
+    const unresolvedShortUrlCount =
+      unresolvedHomeFeedShortUrlCount(resolvedRows);
+    if (unresolvedShortUrlCount > 0) {
+      throw new Error(
+        `LinkedIn could not resolve ${unresolvedShortUrlCount} copied post short URL${unresolvedShortUrlCount === 1 ? "" : "s"} to a durable identity. No home-feed events were persisted.`
+      );
+    }
     const unresolvedPostCount = unresolvedHomeFeedPostCount(resolvedRows);
     if (unresolvedPostCount > 0) {
       throw new Error(

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -1283,6 +1283,66 @@ export function normalizeLinkedInPostUrl(input: string): string | null {
   }
 }
 
+/** Resolve LinkedIn's Copy-link short URL to its durable post URN URL. */
+export async function resolveLinkedInShortPostUrl(
+  input: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<string | null> {
+  let shortUrl: URL;
+  try {
+    shortUrl = new URL(input);
+  } catch {
+    return null;
+  }
+  if (
+    shortUrl.protocol !== "https:" ||
+    shortUrl.hostname !== "lnkd.in" ||
+    !shortUrl.pathname.startsWith("/p/")
+  ) {
+    return null;
+  }
+
+  try {
+    const response = await fetchImpl(shortUrl, {
+      method: "HEAD",
+      redirect: "manual",
+      signal: AbortSignal.timeout(5_000),
+    });
+    const location = response.headers.get("location");
+    if (!location) return normalizeLinkedInPostUrl(response.url);
+    return normalizeLinkedInPostUrl(new URL(location, shortUrl).href);
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveHomeFeedPostUrls(
+  rows: HomeFeedRow[],
+  fetchImpl: typeof fetch = fetch
+): Promise<HomeFeedRow[]> {
+  return Promise.all(
+    rows.map(async (row) => {
+      const postUrl = row.post_url?.trim();
+      if (!postUrl || normalizeLinkedInPostUrl(postUrl)) return row;
+      const resolved = await resolveLinkedInShortPostUrl(postUrl, fetchImpl);
+      return resolved ? { ...row, post_url: resolved } : row;
+    })
+  );
+}
+
+function unresolvedHomeFeedPostCount(rows: HomeFeedRow[]): number {
+  let count = 0;
+  for (const row of rows) {
+    if (!row?.id || !row.body) continue;
+    if (parseHomeFeedCommentIdentity(row.id) || isHomeFeedNoise(row.body)) {
+      continue;
+    }
+    const context = buildHomeFeedRowContext(row);
+    if (!homeFeedPostIdentityKey(row, context)) count += 1;
+  }
+  return count;
+}
+
 /** True when navigate landed on login / authwall rather than the post. */
 export function isLinkedInAuthWall(url: string | null | undefined): boolean {
   if (!url) return false;
@@ -2539,7 +2599,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.2",
+    version: "3.11.3",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -3158,13 +3218,21 @@ export default class LinkedInConnector extends ConnectorRuntime<
       );
     }
 
-    const events = buildHomeFeedEvents(rows, new Date());
+    const resolvedRows = await resolveHomeFeedPostUrls(rows);
+    const unresolvedPostCount = unresolvedHomeFeedPostCount(resolvedRows);
+    if (unresolvedPostCount > 0) {
+      throw new Error(
+        `LinkedIn scraped ${unresolvedPostCount} post row${unresolvedPostCount === 1 ? "" : "s"} without a durable activity/share/ugcPost identity. No partial home-feed batch was persisted.`
+      );
+    }
+
+    const events = buildHomeFeedEvents(resolvedRows, new Date());
 
     // Capability gate: author/engager slugs need the `objectAll` scrape take. An
     // older extension can't produce it, so identity degrades to name-only.
     // Surface it in metadata (rather than failing) so a stale extension is
     // observable — events still flow, just without slugs.
-    const objectAllSupported = homeFeedObjectAllSupported(rows);
+    const objectAllSupported = homeFeedObjectAllSupported(resolvedRows);
 
     return {
       events,


### PR DESCRIPTION
LinkedIn home-feed Copy link currently returns lnkd.in/p short URLs on the live Mac mini DOM. Resolve those public redirects to durable activity/share/ugcPost identities before event mapping, and fail the whole batch if any organic post still lacks a durable identity so partial timelines are never persisted.

Verified:
- bun test examples/personal-agent (265 pass)
- make pre-pr
- live resolver against the current Shannon Duncan and Saaras Mehan short URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving LinkedIn short post links into canonical post URLs.
  * Improved home-feed processing to recognize durable post identities before syncing.

* **Bug Fixes**
  * Home-feed synchronization now fails as a complete batch when a post lacks a durable identity, preventing partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->