### PR TITLE
fix(linkedin): allow short-link resolution

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.config.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import config from "../lobu.config";
+
+describe("LinkedIn worker network configuration", () => {
+  test("allows only the exact LinkedIn post-shortener host", () => {
+    const agent = config.agents?.find(
+      (candidate) => candidate.id === "personal-agent"
+    );
+    expect(agent?.network?.allowed).toContain("lnkd.in");
+    expect(agent?.network?.allowed).not.toContain(".lnkd.in");
+  });
+});

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -61,6 +61,7 @@ const personalAgent = defineAgent({
       "github.com",
       ".github.com",
       ".githubusercontent.com",
+      "lnkd.in",
       "registry.npmjs.org",
       ".npmjs.org",
     ],


### PR DESCRIPTION
Allow the exact lnkd.in host in the personal agent worker egress policy so LinkedIn v3.11.3 can resolve Copy-link redirects to durable post IDs in production. No wildcard or subdomain access is added.

Verified:
- focused config test
- make pre-pr
- pre-commit Biome and TypeScript gates