### PR TITLE
fix(linkedin): recall content through person identities

### DIFF
--- a/db/migrations/20260824160000_event_metadata_linkedin_identity_indexes.sql
+++ b/db/migrations/20260824160000_event_metadata_linkedin_identity_indexes.sql
@@ -1,0 +1,51 @@
+-- migrate:up transaction:false
+
+-- LinkedIn attribution stamps the normalized vanity slug and, where Voyager
+-- exposes it, immutable member id onto event metadata. Partial BTREE indexes
+-- let person-scoped recall probe those append-only events without a table scan.
+-- Heal INVALID same-named carcasses inline so an interrupted concurrent build
+-- is repaired on retry before IF NOT EXISTS evaluates the catalog entry.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_events_metadata_linkedin_slug'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_events_metadata_linkedin_slug';
+  END IF;
+END
+$heal$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_metadata_linkedin_slug
+    ON public.events (((metadata ->> 'linkedin_slug'::text)))
+    WHERE (metadata ? 'linkedin_slug'::text);
+
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_events_metadata_linkedin_member_id'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_events_metadata_linkedin_member_id';
+  END IF;
+END
+$heal$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_metadata_linkedin_member_id
+    ON public.events (((metadata ->> 'linkedin_member_id'::text)))
+    WHERE (metadata ? 'linkedin_member_id'::text);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_metadata_linkedin_member_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_metadata_linkedin_slug;

--- a/packages/connectors/src/__tests__/linkedin-identity.test.ts
+++ b/packages/connectors/src/__tests__/linkedin-identity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LINKEDIN_IDENTITY,
+  linkedInIdentityModule,
+  normalizeLinkedInIdentityValue,
+  normalizeLinkedInMemberId,
+  normalizeLinkedInSlug,
+} from '../linkedin-identity';
+
+describe('LinkedIn identity module', () => {
+  it('normalizes profile slugs and rejects non-profile URLs', () => {
+    expect(
+      normalizeLinkedInSlug('https://www.LinkedIn.com/in/Jane-Doe/?trk=x'),
+    ).toBe('jane-doe');
+    expect(
+      normalizeLinkedInSlug('https://www.linkedin.com/company/acme'),
+    ).toBeNull();
+  });
+
+  it('normalizes person member ids and rejects other URNs', () => {
+    expect(normalizeLinkedInMemberId('urn:li:fsd_profile:ACoAAB1234')).toBe(
+      'ACoAAB1234',
+    );
+    expect(normalizeLinkedInMemberId('urn:li:fsd_company:99')).toBeNull();
+  });
+
+  it('owns both namespaces and makes both recallable', () => {
+    expect(
+      normalizeLinkedInIdentityValue(LINKEDIN_IDENTITY.SLUG, 'Jane-Doe'),
+    ).toBe('jane-doe');
+    expect(linkedInIdentityModule.recallNamespaces).toEqual([
+      LINKEDIN_IDENTITY.SLUG,
+      LINKEDIN_IDENTITY.MEMBER_ID,
+    ]);
+  });
+});

--- a/packages/connectors/src/linkedin-identity.ts
+++ b/packages/connectors/src/linkedin-identity.ts
@@ -1,0 +1,80 @@
+/**
+ * LinkedIn connector identity namespaces and normalization.
+ *
+ * Single source of truth for LinkedIn identity matching and event recall. The
+ * connector and server ingestion path both import this module, so the values
+ * written to entity_identities are normalized by the same rules used by the
+ * connector that extracted them.
+ */
+
+import type { ConnectorIdentityModule } from "./connector-identity-module.js";
+
+/** Connector-owned identity namespaces (not SDK-global). */
+export const LINKEDIN_IDENTITY = {
+	/**
+	 * Canonical `/in/<vanity>` profile slug. It is mutable, so it remains an
+	 * equal-weight identity rather than a primary identity. It is recall-indexed
+	 * because the personalized feed exposes no immutable member id for authors.
+	 */
+	SLUG: "linkedin_slug",
+	/** Immutable member id from `urn:li:fsd_profile:<id>`. */
+	MEMBER_ID: "linkedin_member_id",
+} as const;
+
+export type LinkedInIdentityNamespace =
+	(typeof LINKEDIN_IDENTITY)[keyof typeof LINKEDIN_IDENTITY];
+
+/**
+ * Extract a canonical LinkedIn vanity slug from a profile URL or bare slug.
+ */
+export function normalizeLinkedInSlug(
+	raw: string | null | undefined,
+): string | null {
+	if (typeof raw !== "string") return null;
+	const value = raw.trim();
+	if (!value) return null;
+	const match = value.match(/\/in\/([^/?#]+)/i);
+	const slug = (match ? match[1] : value).toLowerCase();
+	if (!/^[a-z0-9\-_%]+$/.test(slug)) return null;
+	return slug;
+}
+
+/**
+ * Extract the immutable member id from a LinkedIn person URN or bare id.
+ */
+export function normalizeLinkedInMemberId(
+	raw: string | null | undefined,
+): string | null {
+	if (typeof raw !== "string") return null;
+	const value = raw.trim();
+	if (!value) return null;
+	if (value.includes(":")) {
+		const match = value.match(
+			/^urn:li:(?:fsd_profile|member):([A-Za-z0-9_-]+)$/,
+		);
+		return match ? match[1] : null;
+	}
+	return /^[A-Za-z0-9_-]+$/.test(value) ? value : null;
+}
+
+/** Normalize a LinkedIn-owned identity namespace. */
+export function normalizeLinkedInIdentityValue(
+	namespace: string,
+	raw: string,
+): string | null | undefined {
+	switch (namespace) {
+		case LINKEDIN_IDENTITY.SLUG:
+			return normalizeLinkedInSlug(raw);
+		case LINKEDIN_IDENTITY.MEMBER_ID:
+			return normalizeLinkedInMemberId(raw);
+		default:
+			return undefined;
+	}
+}
+
+/** The LinkedIn connector's contribution to server identity wiring. */
+export const linkedInIdentityModule: ConnectorIdentityModule = {
+	key: "linkedin",
+	recallNamespaces: [LINKEDIN_IDENTITY.SLUG, LINKEDIN_IDENTITY.MEMBER_ID],
+	normalize: normalizeLinkedInIdentityValue,
+};

--- a/packages/server/src/__tests__/integration/connectors/linkedin-identity-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/linkedin-identity-attribution.test.ts
@@ -1,0 +1,150 @@
+import { LINKEDIN_IDENTITY } from '@lobu/connectors/linkedin-identity';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyEventAttributions,
+  clearEntityLinkRulesCache,
+} from '../../../utils/entity-link-upsert';
+import { entityLinkMatchSql } from '../../../utils/content-search/entity-link';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const connectorKey = 'linkedin';
+const feedKey = 'home_feed';
+
+async function seedOrganization(): Promise<string> {
+  const sql = getTestDb();
+  const organization = await createTestOrganization({
+    name: 'LinkedIn Recall Org',
+  });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, organization.id, 'owner');
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${organization.id}, 'person', 'Person', current_timestamp, current_timestamp)
+  `;
+  await createTestConnectorDefinition({
+    key: connectorKey,
+    name: 'LinkedIn',
+    organization_id: organization.id,
+    feeds_schema: {
+      [feedKey]: {
+        eventKinds: {
+          post: {
+            attributions: [
+              {
+                role: 'authored_by',
+                autoCreate: true,
+                target: {
+                  entityType: 'person',
+                  titlePath: 'metadata.author',
+                  identities: [
+                    {
+                      namespace: LINKEDIN_IDENTITY.MEMBER_ID,
+                      eventPath: 'metadata.author_member_id',
+                    },
+                    {
+                      namespace: LINKEDIN_IDENTITY.SLUG,
+                      eventPath: 'metadata.author_linkedin_slug',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  });
+  clearEntityLinkRulesCache();
+  return organization.id;
+}
+
+describe('LinkedIn person event recall', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('recalls persisted posts through slug-only and member-id identities', async () => {
+    const organizationId = await seedOrganization();
+    const sql = getTestDb();
+    const items: Array<{
+      origin_type: string;
+      metadata: Record<string, unknown>;
+    }> = [
+      {
+        origin_type: 'post',
+        metadata: {
+          author: 'Jane Doe',
+          author_linkedin_slug: 'Jane-Doe',
+        },
+      },
+      {
+        origin_type: 'post',
+        metadata: {
+          author: 'John Doe',
+          author_member_id: 'urn:li:fsd_profile:ACoAAB1234',
+        },
+      },
+    ];
+
+    await applyEventAttributions({
+      connectorKey,
+      feedKey,
+      orgId: organizationId,
+      items,
+    });
+
+    expect(items[0].metadata.linkedin_slug).toBe('jane-doe');
+    expect(items[1].metadata.linkedin_member_id).toBe('ACoAAB1234');
+
+    const inserted = await Promise.all(
+      items.map((item, index) =>
+        insertEvent({
+          entityIds: [],
+          organizationId,
+          originId: `linkedin-post-${index + 1}`,
+          semanticType: 'post',
+          title: `LinkedIn post ${index + 1}`,
+          originType: 'post',
+          connectorKey,
+          metadata: item.metadata,
+        }),
+      ),
+    );
+
+    const people = await sql<{ id: number; name: string }[]>`
+      SELECT e.id, e.name
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${organizationId}
+        AND et.slug = 'person'
+        AND e.deleted_at IS NULL
+      ORDER BY e.name
+    `;
+    expect(people.map((person) => person.name)).toEqual([
+      'Jane Doe',
+      'John Doe',
+    ]);
+
+    const eventIdsFor = async (entityId: number): Promise<number[]> => {
+      const rows = await sql<{ id: number }[]>`
+        SELECT f.id
+        FROM events f
+        WHERE f.organization_id = ${organizationId}
+          AND ${sql.unsafe(entityLinkMatchSql(`${entityId}::bigint`, 'f'))}
+        ORDER BY f.id
+      `;
+      return rows.map((row) => Number(row.id));
+    };
+
+    expect(await eventIdsFor(people[0].id)).toEqual([Number(inserted[0].id)]);
+    expect(await eventIdsFor(people[1].id)).toEqual([Number(inserted[1].id)]);
+  });
+});

--- a/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
@@ -99,6 +99,22 @@ const HEAL_MIGRATIONS = [
         ON notification_targets (event_id)
     `,
 	},
+	{
+		files: ["20260824160000_event_metadata_linkedin_identity_indexes.sql"],
+		index: "idx_events_metadata_linkedin_slug",
+		seedSql: `
+      CREATE INDEX IF NOT EXISTS idx_events_metadata_linkedin_slug
+        ON events (id)
+    `,
+	},
+	{
+		files: ["20260824160000_event_metadata_linkedin_identity_indexes.sql"],
+		index: "idx_events_metadata_linkedin_member_id",
+		seedSql: `
+      CREATE INDEX IF NOT EXISTS idx_events_metadata_linkedin_member_id
+        ON events (id)
+    `,
+	},
 ] as const;
 
 function resolveMigrationsDir(): string {

--- a/packages/server/src/identity/connector-identity-modules.ts
+++ b/packages/server/src/identity/connector-identity-modules.ts
@@ -20,12 +20,14 @@
 
 import type { ConnectorIdentityModule } from '@lobu/connectors/connector-identity-module';
 import { githubIdentityModule } from '@lobu/connectors/github-identity';
+import { linkedInIdentityModule } from '@lobu/connectors/linkedin-identity';
 import { slackIdentityModule } from '@lobu/connectors/slack-identity';
 import { xIdentityModule } from '@lobu/connectors/x-identity';
 
 /** Every connector identity module the server wires in. */
 export const CONNECTOR_IDENTITY_MODULES: readonly ConnectorIdentityModule[] = [
   githubIdentityModule,
+  linkedInIdentityModule,
   slackIdentityModule,
   xIdentityModule,
 ];

--- a/packages/server/src/utils/__tests__/content-search-identity-namespaces.test.ts
+++ b/packages/server/src/utils/__tests__/content-search-identity-namespaces.test.ts
@@ -1,3 +1,4 @@
+import { LINKEDIN_IDENTITY } from '@lobu/connectors/linkedin-identity';
 import { X_IDENTITY } from '@lobu/connectors/x-identity';
 import { describe, expect, it } from 'vitest';
 import {
@@ -13,10 +14,23 @@ describe('content-search identity namespace registry bridge', () => {
     expect(STANDARD_IDENTITY_NAMESPACES).not.toContain(X_IDENTITY.HANDLE);
   });
 
+  it('includes both LinkedIn author identity namespaces', () => {
+    expect(STANDARD_IDENTITY_NAMESPACES).toContain(LINKEDIN_IDENTITY.SLUG);
+    expect(STANDARD_IDENTITY_NAMESPACES).toContain(LINKEDIN_IDENTITY.MEMBER_ID);
+  });
+
   it('emits an indexed x_user_id branch for entity-link matching', () => {
     const sql = entityLinkMatchSql('$1', 'f');
     expect(sql).toContain("ei.namespace = 'x_user_id'");
     expect(sql).toContain("e2.metadata ? 'x_user_id'");
+  });
+
+  it('emits indexed LinkedIn identity branches for entity-link matching', () => {
+    const sql = entityLinkMatchSql('$1', 'f');
+    expect(sql).toContain("ei.namespace = 'linkedin_slug'");
+    expect(sql).toContain("e2.metadata ? 'linkedin_slug'");
+    expect(sql).toContain("ei.namespace = 'linkedin_member_id'");
+    expect(sql).toContain("e2.metadata ? 'linkedin_member_id'");
   });
 
   it('builds scoped unions for indexed namespaces and skips mutable unindexed handles', () => {


### PR DESCRIPTION
## Summary

- add the server-owned LinkedIn identity module to the shared connectors package and register it in the identity registry
- recall persisted LinkedIn events through normalized vanity slug or immutable member id
- add concurrent partial indexes for both LinkedIn event identity fields
- keep the standalone personal-agent example independent of the private workspace package
- exercise producer attribution and real read-time Person-to-event recall against Postgres

## Verification

- 137 focused LinkedIn, identity-registry, and content-search tests pass
- Postgres integration test passes (1 test, 5 assertions)
- LinkedIn, X takeout, and Instagram takeout connectors compile
- server typecheck passes
- `make pre-pr` passes

## Migration

Adds concurrent partial BTREE indexes on `events.metadata` LinkedIn slug and member ID fields. No event rewrite, API change, new table, or new column.

## Scope

This PR makes existing and future LinkedIn posts discoverable through Person identities. Commenter/engager relationship materialization, LinkedIn messages, and other source ingestion remain separate slices.