### PR TITLE
feat(gchat): prepare Marketplace welcome and help

### DIFF
--- a/packages/connectors/src/__tests__/gchat.test.ts
+++ b/packages/connectors/src/__tests__/gchat.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import GoogleChatConnector from "../gchat";
+
+describe("Google Chat connector definition", () => {
+	test("exposes the project-local help command mapping", () => {
+		const definition = new GoogleChatConnector().definition;
+		const properties = definition.optionsSchema?.properties as
+			| Record<string, Record<string, unknown>>
+			| undefined;
+
+		expect(definition.version).toBe("1.0.1");
+		expect(properties?.helpCommandId).toMatchObject({
+			type: "string",
+			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
+			title: "Help command ID",
+		});
+	});
+});

--- a/packages/connectors/src/gchat.ts
+++ b/packages/connectors/src/gchat.ts
@@ -9,7 +9,7 @@ export default class GoogleChatConnector extends IntegrationConnector {
 		kind: "integration",
 		name: "Google Chat",
 		description: "Connect a Google Chat app to Lobu.",
-		version: "1.0.0",
+		version: "1.0.1",
 		faviconDomain: "chat.google.com",
 		authSchema: { methods: [{ type: "none", label: "Service account" }] },
 		optionsSchema: {
@@ -22,6 +22,13 @@ export default class GoogleChatConnector extends IntegrationConnector {
 					title: "Service account JSON",
 				},
 				googleChatProjectNumber: { type: "string", title: "Project number" },
+				helpCommandId: {
+					type: "string",
+					pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
+					title: "Help command ID",
+					description:
+						"Command ID (1-1000) configured for Lobu help in this Google Cloud project.",
+				},
 				endpointUrl: { type: "string", title: "Endpoint URL" },
 			},
 			required: ["credentials", "googleChatProjectNumber"],

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -9,6 +9,7 @@ import {
   buildAttachmentTranscriptText,
   type InboundAttachmentLike,
   ingestInboundAttachments,
+  isEarlyDispatchableChatCommand,
   isSenderAllowed,
   MessageHandlerBridge,
   parsePreviewLinkCode,
@@ -150,6 +151,18 @@ describe("isSenderAllowed", () => {
     },
   ] as const)("$label → $expected", ({ allow, user, expected }) => {
     expect(isSenderAllowed(allow as string[] | undefined, user)).toBe(expected);
+  });
+});
+
+describe("isEarlyDispatchableChatCommand", () => {
+  test("early dispatch keeps complete commands but excludes reset placeholders", () => {
+    expect(isEarlyDispatchableChatCommand("/link code-123")).toBe(true);
+    expect(isEarlyDispatchableChatCommand("/help")).toBe(true);
+    expect(isEarlyDispatchableChatCommand("/lobu agents")).toBe(true);
+    expect(isEarlyDispatchableChatCommand("/new")).toBe(false);
+    expect(isEarlyDispatchableChatCommand("/lobu clear")).toBe(false);
+    expect(isEarlyDispatchableChatCommand("/HELP")).toBe(false);
+    expect(isEarlyDispatchableChatCommand("help")).toBe(false);
   });
 });
 
@@ -938,6 +951,30 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
+  test("adapter-normalized help dispatches before preview onboarding", async () => {
+    const tryHandleSlashText = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "gchat",
+      linkedAutomation: null,
+      commandDispatcher: {
+        tryHandleSlashText,
+        tryHandle: mock(async () => false),
+      },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "/help" }),
+      "dm",
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/help");
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).not.toHaveBeenCalled();
+  });
+
   test("linked chat → routes to the Automation's agent, no notice", async () => {
     const { bridge, enqueueMessage } = makePreviewHarness({
       linkedAutomation: { agentId: "linked-agent" },
@@ -1289,6 +1326,103 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     expect(resolveForConnection).not.toHaveBeenCalled();
     // Linked + filter-rejected must not spam the "link your agent" notice.
     expect(thread.post).not.toHaveBeenCalled();
+  });
+
+  test("adapter-normalized help bypasses a rejected linked Automation filter", async () => {
+    const tryHandleSlashText = mock(async () => true);
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "gchat",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID, mention_only: true },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const { bridge, enqueueMessage, resolveForConnection } = makePreviewHarness({
+      platform: "gchat",
+      agentId: undefined,
+      previewMode: false,
+      commandDispatcher: {
+        tryHandleSlashText,
+        tryHandle: mock(async () => false),
+      },
+      fallbackSubscription: {
+        agentId: "filtered-agent",
+        organizationId: "org-filtered",
+      },
+      automations: [
+        {
+          automationId: 74,
+          organizationId: "org-filtered",
+          agentId: "filtered-agent",
+          deviceWorkerId: null,
+          agentKind: null,
+          model: null,
+          instructions: "Only respond to mentions.",
+          trigger,
+        },
+      ],
+    });
+
+    await bridge.handleMessage(
+      makeThread(undefined),
+      makeMessage({ text: "/help", isMention: false }),
+      "subscribed",
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/help");
+    expect(resolveForConnection).not.toHaveBeenCalled();
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("adapter-normalized help bypasses record-only capture for a matched Automation", async () => {
+    const tryHandleSlashText = mock(async () => true);
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "gchat",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "gchat",
+      previewMode: false,
+      settings: { recordChannelMessages: true },
+      commandDispatcher: {
+        tryHandleSlashText,
+        tryHandle: mock(async () => false),
+      },
+      automations: [
+        {
+          automationId: 75,
+          organizationId: "org-connection",
+          agentId: "recording-agent",
+          deviceWorkerId: null,
+          agentKind: null,
+          model: null,
+          instructions: "Capture ordinary messages and respond to commands.",
+          trigger,
+        },
+      ],
+    });
+
+    await bridge.handleMessage(
+      makeThread(undefined),
+      makeMessage({ text: "/help", isMention: false }),
+      "subscribed",
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/help");
+    expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
   test("recordChannelMessages skips agent turns for Automation-routed subscribed messages", async () => {

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -410,6 +410,15 @@ export function isSenderAllowed(
   return allowFrom.includes(userId);
 }
 
+export function isEarlyDispatchableChatCommand(text: string): boolean {
+  const tokens = text.trim().split(/\s+/);
+  const firstToken = tokens[0];
+  if (!firstToken?.startsWith("/")) return false;
+  const first = firstToken.replace(/^\/+/, "");
+  const command = first === "lobu" ? tokens[1] : first;
+  return ["help", "status", "try", "agents", "link"].includes(command ?? "");
+}
+
 /**
  * Register Chat SDK event handlers for a connection.
  *
@@ -801,6 +810,34 @@ export class MessageHandlerBridge {
         }
       : fallbackResolved;
     if (!resolved) {
+      // App-level commands still work when no Automation matches. Keep this
+      // early path to commands whose complete implementation lives in the
+      // dispatcher: /new and /clear have real state handling later in the
+      // resolved path and must not be falsely acknowledged here.
+      const unroutedCommandText = this.stripBotMention(
+        typeof message.text === "string" ? message.text : ""
+      );
+      if (
+        this.commandDispatcher &&
+        isEarlyDispatchableChatCommand(unroutedCommandText)
+      ) {
+        const handled = await this.commandDispatcher.tryHandleSlashText(
+          unroutedCommandText,
+          {
+            platform,
+            userId,
+            channelId,
+            teamId,
+            isGroup,
+            conversationId,
+            connectionId: this.connection.id,
+            organizationId: this.connection.organizationId,
+            reply: createChatReply((content) => thread.post(content)),
+          }
+        );
+        if (handled) return;
+      }
+
       // Linked channel but trigger filters rejected this message (e.g.
       // mention_only on a non-mention). The planner is the authority for
       // activation; do not fall through to the "unlinked" notice or the notice
@@ -822,31 +859,6 @@ export class MessageHandlerBridge {
         return;
       }
 
-      // An unrouted chat still has to honor commands: the unlinked notice
-      // below tells the user to paste `/link <code>` (or `/lobu link <code>`)
-      // into this same chat. Slack delivers those natively via the
-      // `onSlashCommand` ingress, but every other platform delivers them as
-      // plain message text — which used to die in this dead end before the
-      // dispatcher ever saw it (#2230).
-      if (this.commandDispatcher) {
-        const handled = await this.commandDispatcher.tryHandleSlashText(
-          this.stripBotMention(
-            typeof message.text === "string" ? message.text : ""
-          ),
-          {
-            platform,
-            userId,
-            channelId,
-            teamId,
-            isGroup,
-            conversationId,
-            connectionId: this.connection.id,
-            organizationId: this.connection.organizationId,
-            reply: createChatReply((content) => thread.post(content)),
-          }
-        );
-        if (handled) return;
-      }
       if (
         !isPreview &&
         (await this.postUnlinkedChatNotice(thread, channelId, teamId))
@@ -972,7 +984,12 @@ export class MessageHandlerBridge {
     if (
       source === "subscribed" &&
       message.isMention !== true &&
-      connection.settings?.recordChannelMessages === true
+      connection.settings?.recordChannelMessages === true &&
+      !isEarlyDispatchableChatCommand(
+        this.stripBotMention(
+          typeof message.text === "string" ? message.text : ""
+        ),
+      )
     ) {
       return;
     }

--- a/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
+++ b/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Chat } from "chat";
 import { InMemoryStateAdapter } from "../../../__tests__/fixtures/in-memory-state-adapter.js";
-import { ChatInstanceManager } from "../../chat-instance-manager.js";
 import { parseConfig } from "../../chat-connection-service.js";
-import { gchatPlatform } from "../gchat.js";
+import { ChatInstanceManager } from "../../chat-instance-manager.js";
+import { GOOGLE_CHAT_WELCOME_TEXT, gchatPlatform } from "../gchat.js";
 
 const credentials = JSON.stringify({
   client_email: "lobu-chat@example.iam.gserviceaccount.com",
@@ -38,11 +38,12 @@ function standardDirectMessage(text = "hello Lobu"): any {
   };
 }
 
-async function createTestChat() {
+async function createTestChat(config: { helpCommandId?: string } = {}) {
   const adapter = await gchatPlatform.createAdapter({
     credentials,
     disableSignatureVerification: true,
     userName: "lobu",
+    ...config,
   });
   const chat = new Chat({
     userName: "lobu",
@@ -67,6 +68,15 @@ async function waitForDelivery(promise: Promise<void>): Promise<void> {
       throw new Error("Timed out waiting for Google Chat event delivery");
     }),
   ]);
+}
+
+async function dispatchAndWait(chat: Chat, request: Request) {
+  const tasks: Promise<unknown>[] = [];
+  const response = await chat.webhooks.gchat(request, {
+    waitUntil: (task) => tasks.push(task),
+  });
+  await Promise.all(tasks);
+  return response;
 }
 
 describe("Google Chat platform compatibility", () => {
@@ -161,7 +171,349 @@ describe("Google Chat platform compatibility", () => {
     expect(delivered).toEqual(["hello Lobu"]);
   });
 
-  test("dispatches a standalone space mention to the mention handler", async () => {
+  test("canonicalizes plain and mixed-case help at the adapter boundary", async () => {
+    const chat = await createTestChat();
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      if (delivered.length === 2) completion.resolve();
+    });
+    const plainEvent = standardDirectMessage(" Help ");
+    const slashEvent = standardDirectMessage("/HeLp");
+    slashEvent.message.name = "spaces/AAAA-test/messages/message-2";
+    slashEvent.message.createTime = "2026-08-24T12:00:01Z";
+    slashEvent.eventTime = slashEvent.message.createTime;
+
+    const plainResponse = await chat.webhooks.gchat(webhook(plainEvent));
+    const slashResponse = await chat.webhooks.gchat(webhook(slashEvent));
+    await waitForDelivery(completion.promise);
+
+    expect(plainResponse.status).toBe(200);
+    expect(slashResponse.status).toBe(200);
+    expect(delivered).toEqual(["/help", "/help"]);
+  });
+
+  test("canonicalizes Workspace Add-on message help at the adapter boundary", async () => {
+    const chat = await createTestChat();
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage("/HELP");
+
+    const response = await dispatchAndWait(
+      chat,
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          messagePayload: {
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
+  test("returns the Marketplace welcome when added to a DM or space", async () => {
+    const chat = await createTestChat();
+    const messageEvent = standardDirectMessage();
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        type: "ADDED_TO_SPACE",
+        eventTime: messageEvent.eventTime,
+        space: messageEvent.space,
+        user: messageEvent.user,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ text: GOOGLE_CHAT_WELCOME_TEXT });
+  });
+
+  test("wraps the Marketplace welcome for a Workspace Add-on event", async () => {
+    const chat = await createTestChat();
+    const messageEvent = standardDirectMessage();
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: messageEvent.user,
+          eventTime: messageEvent.eventTime,
+          addedToSpacePayload: { space: messageEvent.space },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      hostAppDataAction: {
+        chatDataAction: {
+          createMessageAction: {
+            message: { text: GOOGLE_CHAT_WELCOME_TEXT },
+          },
+        },
+      },
+    });
+  });
+
+  test("dispatches the registered Workspace Add-on /help command", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const deliveredThreadNames: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onNewMention(async (thread, message) => {
+      delivered.push(message.text);
+      deliveredThreadNames.push(
+        (chat.getAdapter("gchat") as any).decodeThreadId(thread.id).threadName,
+      );
+      completion.resolve();
+    });
+    const messageEvent = standardDirectMessage("/help");
+    messageEvent.space.type = "ROOM";
+    messageEvent.space.spaceType = "SPACE";
+    messageEvent.message.space = messageEvent.space;
+    const commandThread = { name: "spaces/AAAA-test/threads/thread-help" };
+    delete messageEvent.message.thread;
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: messageEvent.user,
+          eventTime: messageEvent.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: messageEvent.message,
+            space: messageEvent.space,
+            thread: commandThread,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+    expect(delivered).toEqual(["@lobu /help"]);
+    expect(deliveredThreadNames).toEqual([commandThread.name]);
+  });
+
+  test("dispatches a Workspace Add-on slash command without message text", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onNewMention(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+    event.space.type = "ROOM";
+    event.space.spaceType = "SPACE";
+    event.message.space = event.space;
+    delete event.message.text;
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["@lobu /help"]);
+  });
+
+  test("dispatches a Workspace Add-on quick command without a message", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "QUICK_COMMAND",
+            },
+            space: event.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
+  test("dispatches a standalone quick command without a message", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        type: "APP_COMMAND",
+        eventTime: event.eventTime,
+        appCommandMetadata: {
+          appCommandId: "999",
+          appCommandType: "QUICK_COMMAND",
+        },
+        space: event.space,
+        user: event.user,
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
+  test("dispatches a standalone slash command without message text", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+    delete event.message.text;
+    event.message.slashCommand = { commandId: "999" };
+
+    const response = await chat.webhooks.gchat(webhook(event));
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
+  test("dispatches a standalone annotated slash command without message text", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+    delete event.message.text;
+    event.message.annotations = [
+      {
+        type: "SLASH_COMMAND",
+        slashCommand: { commandId: "999" },
+      },
+    ];
+
+    const response = await chat.webhooks.gchat(webhook(event));
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
+  test("ignores a no-text command whose ID is not mapped to help", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+    });
+    const event = standardDirectMessage();
+    delete event.message.text;
+
+    const response = await dispatchAndWait(
+      chat,
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "1",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual([]);
+  });
+
+  test("does not reinterpret another project's command ID 1 as help", async () => {
+    const chat = await createTestChat();
+    const delivered: string[] = [];
+    chat.onNewMention(async (_thread, message) => {
+      delivered.push(message.text);
+    });
+    const messageEvent = standardDirectMessage("/about");
+    messageEvent.space.type = "ROOM";
+    messageEvent.space.spaceType = "SPACE";
+    messageEvent.message.space = messageEvent.space;
+
+    const response = await dispatchAndWait(
+      chat,
+      webhook({
+        chat: {
+          user: messageEvent.user,
+          eventTime: messageEvent.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "1",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: messageEvent.message,
+            space: messageEvent.space,
+          },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+    expect(delivered).toEqual([]);
+  });
+
+  test("canonicalizes mentioned space help at the adapter boundary", async () => {
     const chat = await createTestChat();
     const delivered: string[] = [];
     const completion = Promise.withResolvers<void>();
@@ -189,7 +541,115 @@ describe("Google Chat platform compatibility", () => {
     await waitForDelivery(completion.promise);
 
     expect(response.status).toBe(200);
-    expect(delivered).toEqual(["@lobu help"]);
+    expect(delivered).toEqual(["@lobu /help"]);
+  });
+
+  test("canonicalizes Pub/Sub space help before duplicate webhook delivery", async () => {
+    const chat = await createTestChat();
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onNewMention(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage("@Lobu help");
+    event.space.type = "ROOM";
+    event.space.spaceType = "SPACE";
+    event.message.annotations = [
+      {
+        type: "USER_MENTION",
+        startIndex: 0,
+        length: 5,
+        userMention: {
+          user: { name: "users/lobu", displayName: "Lobu", type: "BOT" },
+          type: "MENTION",
+        },
+      },
+    ];
+    event.message.thread = { name: "spaces/AAAA-test/threads/thread-1" };
+
+    const pubSubResponse = await chat.webhooks.gchat(
+      webhook({
+        message: {
+          data: Buffer.from(
+            JSON.stringify({ message: event.message }),
+          ).toString("base64"),
+          attributes: {
+            "ce-type": "google.workspace.chat.message.v1.created",
+            "ce-subject": "//chat.googleapis.com/spaces/AAAA-test",
+            "ce-time": event.eventTime,
+          },
+        },
+        subscription: "projects/test/subscriptions/gchat-test",
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    // Google can also deliver the same resource through the direct webhook.
+    // The Pub/Sub-first copy must already be canonical because Chat SDK drops
+    // this second copy by message ID.
+    const webhookResponse = await dispatchAndWait(chat, webhook(event));
+
+    expect(pubSubResponse.status).toBe(200);
+    expect(webhookResponse.status).toBe(200);
+    expect(delivered).toEqual(["@lobu /help"]);
+  });
+
+  test("does not canonicalize unmentioned space help from Pub/Sub", async () => {
+    const chat = await createTestChat();
+    const delivered: string[] = [];
+    const subscribed = Promise.withResolvers<void>();
+    chat.onNewMention(async (thread) => {
+      await thread.subscribe();
+      subscribed.resolve();
+    });
+    chat.onSubscribedMessage(async (_thread, message) => {
+      delivered.push(message.text);
+    });
+    const event = standardDirectMessage("@Lobu subscribe");
+    event.space.type = "ROOM";
+    event.space.spaceType = "SPACE";
+    event.message.annotations = [
+      {
+        type: "USER_MENTION",
+        startIndex: 0,
+        length: 5,
+        userMention: {
+          user: { name: "users/lobu", displayName: "Lobu", type: "BOT" },
+          type: "MENTION",
+        },
+      },
+    ];
+    event.message.thread = { name: "spaces/AAAA-test/threads/thread-1" };
+    await chat.webhooks.gchat(webhook(event));
+    await waitForDelivery(subscribed.promise);
+
+    const ordinaryMessage = {
+      ...event.message,
+      name: "spaces/AAAA-test/messages/message-ordinary-help",
+      text: "help",
+      annotations: [],
+      createTime: "2026-08-24T12:00:01Z",
+    };
+    const response = await dispatchAndWait(
+      chat,
+      webhook({
+        message: {
+          data: Buffer.from(
+            JSON.stringify({ message: ordinaryMessage }),
+          ).toString("base64"),
+          attributes: {
+            "ce-type": "google.workspace.chat.message.v1.created",
+            "ce-subject": "//chat.googleapis.com/spaces/AAAA-test",
+            "ce-time": ordinaryMessage.createTime,
+          },
+        },
+        subscription: "projects/test/subscriptions/gchat-test",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["help"]);
   });
 
   test("dispatches standalone CARD_CLICKED action metadata", async () => {
@@ -288,4 +748,35 @@ describe("Google Chat platform compatibility", () => {
       googleChatProjectNumber: "123456789",
     });
   });
+
+  test.each(["1", "999", "1000"])(
+    "keeps Google Chat help command ID %s",
+    (helpCommandId) => {
+      expect(
+        parseConfig("gchat", {
+          useApplicationDefaultCredentials: true,
+          googleChatProjectNumber: "123456789",
+          helpCommandId,
+        }),
+      ).toEqual({
+        platform: "gchat",
+        useApplicationDefaultCredentials: true,
+        googleChatProjectNumber: "123456789",
+        helpCommandId,
+      });
+    },
+  );
+
+  test.each(["help", "0", "01", "1001"])(
+    "rejects invalid Google Chat help command ID %s",
+    (helpCommandId) => {
+      expect(() =>
+        parseConfig("gchat", {
+          useApplicationDefaultCredentials: true,
+          googleChatProjectNumber: "123456789",
+          helpCommandId,
+        }),
+      ).toThrow(/helpCommandId/);
+    },
+  );
 });

--- a/packages/server/src/gateway/connections/platforms/gchat.ts
+++ b/packages/server/src/gateway/connections/platforms/gchat.ts
@@ -21,8 +21,21 @@ import type {
 
 type JsonObject = Record<string, any>;
 
+export const GOOGLE_CHAT_WELCOME_TEXT = [
+  "Welcome 👋",
+  "",
+  "In a direct message, just ask. In a space, mention this app when you want a response.",
+  "Use `/help` at any time to see commands and setup options.",
+].join("\n");
+
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function commandId(value: unknown): string | undefined {
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : undefined;
 }
 
 function actionParameters(value: unknown): Record<string, string> | undefined {
@@ -45,9 +58,236 @@ function actionParameters(value: unknown): Record<string, string> | undefined {
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-/** Translate standalone Chat API events into Chat SDK's Add-on envelope. */
-function normalizeGoogleChatInteractionEvent(body: unknown): unknown {
-  if (!isObject(body) || isObject(body.chat)) return body;
+/**
+ * Canonicalize the Marketplace help command before Chat SDK parses the event.
+ * Google can deliver it as plain message text or slash-form text, and users can
+ * vary casing. Keeping this translation here prevents the shared message
+ * pipeline from needing Google-specific command rules.
+ */
+function isDirectSpace(space: unknown): boolean {
+  return (
+    isObject(space) &&
+    (space.type === "DM" || space.spaceType === "DIRECT_MESSAGE")
+  );
+}
+
+function normalizeGoogleChatHelpMessage(
+  message: JsonObject,
+  allowBareHelp: boolean,
+): JsonObject {
+  const text = typeof message.text === "string" ? message.text : undefined;
+  if (!text) return message;
+
+  if (allowBareHelp && /^\/?help$/i.test(text.trim())) {
+    return { ...message, text: "/help" };
+  }
+
+  const annotations = Array.isArray(message.annotations)
+    ? message.annotations
+    : [];
+  for (const annotation of annotations) {
+    if (
+      !isObject(annotation) ||
+      annotation.type !== "USER_MENTION" ||
+      !isObject(annotation.userMention) ||
+      !isObject(annotation.userMention.user) ||
+      annotation.userMention.user.type !== "BOT" ||
+      typeof annotation.startIndex !== "number" ||
+      typeof annotation.length !== "number"
+    ) {
+      continue;
+    }
+
+    const mentionStart = annotation.startIndex;
+    const mentionEnd = mentionStart + annotation.length;
+    if (
+      text.slice(0, mentionStart).trim().length === 0 &&
+      /^\/?help$/i.test(text.slice(mentionEnd).trim())
+    ) {
+      // Preserve the original mention span so the pinned adapter can normalize
+      // it from its annotation without invalidating the recorded offsets.
+      return {
+        ...message,
+        text: `${text.slice(0, mentionEnd)} /help`,
+      };
+    }
+  }
+
+  return message;
+}
+
+/**
+ * Workspace Events arrive through Pub/Sub with the Chat resource encoded in
+ * message.data. Normalize that embedded resource too: the Pub/Sub and direct
+ * webhook copies share a message ID, so whichever arrives first wins Chat
+ * SDK's deduplication.
+ */
+function normalizePubSubHelpMessage(body: JsonObject): JsonObject {
+  const pushMessage = isObject(body.message) ? body.message : undefined;
+  if (
+    !pushMessage ||
+    typeof pushMessage.data !== "string" ||
+    typeof body.subscription !== "string"
+  ) {
+    return body;
+  }
+
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(pushMessage.data, "base64").toString("utf8"),
+    );
+    if (!isObject(decoded) || !isObject(decoded.message)) return body;
+
+    const message = normalizeGoogleChatHelpMessage(
+      decoded.message,
+      isDirectSpace(decoded.message.space),
+    );
+    if (message === decoded.message) return body;
+
+    return {
+      ...body,
+      message: {
+        ...pushMessage,
+        data: Buffer.from(
+          JSON.stringify({ ...decoded, message }),
+          "utf8",
+        ).toString("base64"),
+      },
+    };
+  } catch {
+    // Leave malformed envelopes untouched so the adapter keeps ownership of
+    // validation and its existing retry/acknowledgement semantics.
+    return body;
+  }
+}
+
+function normalizeWorkspaceAddOnAppCommand(
+  body: JsonObject,
+  botUserName: string,
+  helpCommandId?: string,
+): JsonObject {
+  const chat = isObject(body.chat) ? body.chat : undefined;
+  const payload = isObject(chat?.appCommandPayload)
+    ? chat.appCommandPayload
+    : undefined;
+  const metadata = isObject(payload?.appCommandMetadata)
+    ? payload.appCommandMetadata
+    : undefined;
+  const message = isObject(payload?.message) ? payload.message : undefined;
+  const space = isObject(payload?.space) ? payload.space : undefined;
+  if (!(chat && payload && metadata && space)) return body;
+
+  const commandType = metadata.appCommandType;
+  // Workspace Add-ons deliver registered commands as appCommandPayload, which
+  // the current @chat-adapter/gchat release does not parse. Command IDs are
+  // local to each Google Cloud project, so the connection owns the mapping.
+  // Keep the text fallback for legacy payloads where Google supplies it.
+  const messageText = typeof message?.text === "string" ? message.text : "";
+  const invokedCommandId = commandId(metadata.appCommandId);
+  const matchesConfiguredId =
+    helpCommandId !== undefined &&
+    invokedCommandId === helpCommandId;
+  if (
+    (commandType !== "SLASH_COMMAND" && commandType !== "QUICK_COMMAND") ||
+    (!matchesConfiguredId && !/^\/?help$/i.test(messageText.trim()))
+  ) {
+    return body;
+  }
+
+  const eventTime =
+    typeof message?.createTime === "string"
+      ? message.createTime
+      : typeof chat.eventTime === "string"
+        ? chat.eventTime
+        : undefined;
+  if (!eventTime) return body;
+
+  const isDm = isDirectSpace(space);
+  // Chat SDK routes group messages only when the bot is mentioned. Commands
+  // are already explicitly addressed to this app but don't carry a mention,
+  // so use its normalized mention form at the adapter boundary. The message
+  // bridge removes this prefix again before command dispatch.
+  const text = isDm ? "/help" : `@${botUserName} /help`;
+  const sender = isObject(message?.sender)
+    ? message.sender
+    : isObject(chat.user)
+      ? chat.user
+      : undefined;
+  const thread = isObject(message?.thread)
+    ? message.thread
+    : isObject(payload.thread)
+      ? payload.thread
+      : undefined;
+  const messageName =
+    typeof message?.name === "string"
+      ? message.name
+      : `${space.name}/messages/app-command-${Buffer.from(
+          JSON.stringify([
+            invokedCommandId,
+            commandType,
+            eventTime,
+            typeof sender?.name === "string" ? sender.name : "unknown",
+          ]),
+          "utf8",
+        ).toString("base64url")}`;
+
+  return {
+    ...body,
+    chat: {
+      ...chat,
+      messagePayload: {
+        space,
+        message: {
+          ...(message ? normalizeGoogleChatHelpMessage(message, isDm) : {}),
+          name: messageName,
+          createTime: eventTime,
+          text,
+          ...(sender ? { sender } : {}),
+          space,
+          ...(thread ? { thread } : {}),
+        },
+      },
+    },
+  };
+}
+
+/** Translate Google interaction events into the envelope Chat SDK parses. */
+function normalizeGoogleChatInteractionEvent(
+  body: unknown,
+  botUserName: string,
+  helpCommandId?: string,
+): unknown {
+  if (!isObject(body)) return body;
+  const normalizedPubSub = normalizePubSubHelpMessage(body);
+  if (normalizedPubSub !== body) return normalizedPubSub;
+  if (isObject(body.chat)) {
+    const normalizedCommand = normalizeWorkspaceAddOnAppCommand(
+      body,
+      botUserName,
+      helpCommandId,
+    );
+    const chat = isObject(normalizedCommand.chat)
+      ? normalizedCommand.chat
+      : undefined;
+    const payload = isObject(chat?.messagePayload)
+      ? chat.messagePayload
+      : undefined;
+    const message = isObject(payload?.message) ? payload.message : undefined;
+    if (!(chat && payload && message)) return normalizedCommand;
+    return {
+      ...normalizedCommand,
+      chat: {
+        ...chat,
+        messagePayload: {
+          ...payload,
+          message: normalizeGoogleChatHelpMessage(
+            message,
+            isDirectSpace(payload.space),
+          ),
+        },
+      },
+    };
+  }
 
   const eventType =
     typeof body.type === "string"
@@ -57,12 +297,71 @@ function normalizeGoogleChatInteractionEvent(body: unknown): unknown {
         : undefined;
   if (!eventType) return body;
 
-  const message = isObject(body.message) ? body.message : undefined;
+  if (eventType === "APP_COMMAND") {
+    const metadata = isObject(body.appCommandMetadata)
+      ? body.appCommandMetadata
+      : undefined;
+    const space = isObject(body.space) ? body.space : undefined;
+    if (!(metadata && space)) return body;
+    const user = isObject(body.user) ? body.user : undefined;
+    const message = isObject(body.message) ? body.message : undefined;
+    const thread = isObject(body.thread) ? body.thread : undefined;
+    return normalizeWorkspaceAddOnAppCommand(
+      {
+        ...body,
+        chat: {
+          ...(user ? { user } : {}),
+          ...(typeof body.eventTime === "string"
+            ? { eventTime: body.eventTime }
+            : {}),
+          appCommandPayload: {
+            appCommandMetadata: metadata,
+            space,
+            ...(message ? { message } : {}),
+            ...(thread ? { thread } : {}),
+          },
+        },
+      },
+      botUserName,
+      helpCommandId,
+    );
+  }
+
+  const rawMessage = isObject(body.message) ? body.message : undefined;
   const space = isObject(body.space)
     ? body.space
-    : isObject(message?.space)
-      ? message.space
+    : isObject(rawMessage?.space)
+      ? rawMessage.space
       : undefined;
+  let message = rawMessage
+    ? normalizeGoogleChatHelpMessage(rawMessage, isDirectSpace(space))
+    : undefined;
+  const annotationCommandId = Array.isArray(rawMessage?.annotations)
+    ? rawMessage.annotations
+        .map((annotation: unknown) =>
+          isObject(annotation) &&
+          annotation.type === "SLASH_COMMAND" &&
+          isObject(annotation.slashCommand)
+            ? commandId(annotation.slashCommand.commandId)
+            : undefined,
+        )
+        .find((value: string | undefined) => value !== undefined)
+    : undefined;
+  const standaloneCommandId = isObject(rawMessage?.slashCommand)
+    ? commandId(rawMessage.slashCommand.commandId)
+    : annotationCommandId;
+  if (
+    eventType === "MESSAGE" &&
+    message &&
+    space &&
+    helpCommandId !== undefined &&
+    standaloneCommandId === helpCommandId
+  ) {
+    message = {
+      ...message,
+      text: isDirectSpace(space) ? "/help" : `@${botUserName} /help`,
+    };
+  }
   const user = isObject(body.user)
     ? body.user
     : isObject(message?.sender)
@@ -120,22 +419,51 @@ function normalizeGoogleChatInteractionEvent(body: unknown): unknown {
   };
 }
 
-async function normalizeWebhookRequest(request: Request): Promise<Request> {
+async function normalizeWebhookRequest(
+  request: Request,
+  botUserName: string,
+  helpCommandId?: string,
+): Promise<{
+  request: Request;
+  addedToSpaceEnvelope: "standalone" | "workspaceAddOn" | null;
+}> {
   const rawBody = await request.text();
   let body: unknown;
+  let addedToSpaceEnvelope: "standalone" | "workspaceAddOn" | null = null;
   try {
-    body = normalizeGoogleChatInteractionEvent(JSON.parse(rawBody));
+    const originalBody: unknown = JSON.parse(rawBody);
+    const workspaceAddOnAddedToSpace =
+      isObject(originalBody) &&
+      isObject(originalBody.chat) &&
+      isObject(originalBody.chat.addedToSpacePayload);
+    body = normalizeGoogleChatInteractionEvent(
+      originalBody,
+      botUserName,
+      helpCommandId,
+    );
+    const addedToSpace =
+      isObject(body) &&
+      isObject(body.chat) &&
+      isObject(body.chat.addedToSpacePayload);
+    if (addedToSpace) {
+      addedToSpaceEnvelope = workspaceAddOnAddedToSpace
+        ? "workspaceAddOn"
+        : "standalone";
+    }
   } catch {
     body = rawBody;
   }
   const headers = new Headers(request.headers);
   headers.delete("content-length");
-  return new Request(request.url, {
-    method: request.method,
-    headers,
-    body: typeof body === "string" ? body : JSON.stringify(body),
-    signal: request.signal,
-  });
+  return {
+    request: new Request(request.url, {
+      method: request.method,
+      headers,
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      signal: request.signal,
+    }),
+    addedToSpaceEnvelope,
+  };
 }
 
 export function parseGoogleChatCredentials(
@@ -171,6 +499,13 @@ async function createAdapter(
   const { createGoogleChatAdapter } = await import("@chat-adapter/gchat");
   const adapterConfig = { ...config };
   delete adapterConfig.platform;
+  const helpCommandId =
+    typeof adapterConfig.helpCommandId === "string"
+      ? adapterConfig.helpCommandId.trim()
+      : undefined;
+  // Lobu consumes this project-local mapping at its compatibility boundary;
+  // it is not a @chat-adapter/gchat configuration option.
+  delete adapterConfig.helpCommandId;
 
   // Workspace Add-on webhooks use the manager-owned connection URL as their
   // JWT audience and sign as the Google-managed identity derived from the
@@ -200,13 +535,37 @@ async function createAdapter(
     normalizedConfig as GoogleChatAdapterConfig
   );
   const handleWebhook = adapter.handleWebhook.bind(adapter);
-  adapter.handleWebhook = (
+  adapter.handleWebhook = async (
     request: Request,
     options?: WebhookOptions
-  ): Promise<Response> =>
-    normalizeWebhookRequest(request).then((normalized) =>
-      handleWebhook(normalized, options)
+  ): Promise<Response> => {
+    const normalized = await normalizeWebhookRequest(
+      request,
+      adapter.userName || "lobu",
+      helpCommandId,
     );
+    const response = await handleWebhook(normalized.request, options);
+    if (normalized.addedToSpaceEnvelope && response.ok) {
+      // Marketplace review requires an unprompted welcome when a DM starts or
+      // the app is added to a space. Keep the adapter's subscription side
+      // effect above, then replace its empty success body with the synchronous
+      // Google Chat response so the welcome cannot depend on agent/model
+      // availability.
+      if (normalized.addedToSpaceEnvelope === "workspaceAddOn") {
+        return Response.json({
+          hostAppDataAction: {
+            chatDataAction: {
+              createMessageAction: {
+                message: { text: GOOGLE_CHAT_WELCOME_TEXT },
+              },
+            },
+          },
+        });
+      }
+      return Response.json({ text: GOOGLE_CHAT_WELCOME_TEXT });
+    }
+    return response;
+  };
   return adapter;
 }
 

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -29,7 +29,7 @@ export type TeamsAdapterConfig = NonNullable<
 > & { platform: "teams" };
 export type GoogleChatAdapterConfig = NonNullable<
   Parameters<typeof createGoogleChatAdapter>[0]
-> & { platform: "gchat" };
+> & { platform: "gchat"; helpCommandId?: string };
 
 /**
  * `rest` is the always-on HTTP Agent API

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -196,6 +196,13 @@ const GoogleChatConfigSchema = Type.Object({
 				"Expected audience for Pub/Sub push JWT verification. Defaults to GOOGLE_CHAT_PUBSUB_AUDIENCE env var.",
 		}),
 	),
+	helpCommandId: Type.Optional(
+		Type.String({
+			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
+			description:
+				"Google Chat command ID (1-1000) mapped to Lobu help for this project.",
+		}),
+	),
 	userName: Type.Optional(
 		Type.String({ description: "Override bot username." }),
 	),


### PR DESCRIPTION
## Summary
- Handle Google Chat Marketplace welcome events across standalone Chat apps and Google Workspace add-on envelopes.
- Normalize native `/help` and quick-command events without turning unrelated group messages or project commands into help.
- Add a validated per-connection `helpCommandId`, expose it in the connector definition, and route preview help before onboarding/menu handling.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local macOS fallback; GitHub CI runs the Linux graph)
- [x] Focused tests: 105 passed across connector definition, Google Chat adapter, and bridge suites
- [x] `packages/server` strict TypeScript check passed
- [ ] Live Google Chat command and welcome test after deployment

## Notes
- `[client-regen-not-needed]`: the changed runtime platform config schema is not an emitted OpenAPI client surface.
- Marketplace developer identity/address and Google publication review remain operational launch steps, not repository changes.