### PR TITLE
fix(server): allow agent chat from workspace subdomains

### DIFF
--- a/packages/server/src/__tests__/unit/cors-origin.test.ts
+++ b/packages/server/src/__tests__/unit/cors-origin.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { app, getOwnedOwlettoExtensionIds, isAllowedCorsOrigin } from '../../index';
+import type { Env } from '@lobu/connector-sdk';
+import { Hono } from 'hono';
+import { createGatewayApp } from '../../gateway/cli/gateway';
+import { app } from '../../index';
+import { buildWrapperApp } from '../../server-lifecycle';
+import {
+  getOwnedOwlettoExtensionIds,
+  isAllowedCorsOrigin,
+} from '../../utils/cors-origin';
 import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
 
 // The Hono CORS middleware in packages/server/src/index.ts must accept
@@ -15,16 +23,20 @@ import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
 const REQUEST_URL = 'http://10.0.0.1/api/workers/poll';
 
 const ORIGINAL_PUBLIC_GATEWAY_URL = process.env.PUBLIC_GATEWAY_URL;
+const ORIGINAL_AUTH_COOKIE_DOMAIN = process.env.AUTH_COOKIE_DOMAIN;
+const ORIGINAL_ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
 
-function makeEnv(overrides: Record<string, string | undefined> = {}) {
+function makeEnv(overrides: Record<string, string | undefined> = {}): Env {
   return {
     ENVIRONMENT: 'test',
     ...overrides,
-  } as unknown as Parameters<typeof isAllowedCorsOrigin>[1];
+  } as Env;
 }
 
 beforeEach(() => {
   process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+  process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+  delete process.env.ALLOWED_ORIGINS;
   __resetPublicOriginCachesForTests();
 });
 
@@ -33,6 +45,16 @@ afterEach(() => {
     delete process.env.PUBLIC_GATEWAY_URL;
   } else {
     process.env.PUBLIC_GATEWAY_URL = ORIGINAL_PUBLIC_GATEWAY_URL;
+  }
+  if (ORIGINAL_AUTH_COOKIE_DOMAIN === undefined) {
+    delete process.env.AUTH_COOKIE_DOMAIN;
+  } else {
+    process.env.AUTH_COOKIE_DOMAIN = ORIGINAL_AUTH_COOKIE_DOMAIN;
+  }
+  if (ORIGINAL_ALLOWED_ORIGINS === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = ORIGINAL_ALLOWED_ORIGINS;
   }
   __resetPublicOriginCachesForTests();
 });
@@ -118,14 +140,132 @@ describe('isAllowedCorsOrigin — regression coverage for pre-existing branches'
   });
 
   test('still accepts wildcard subdomains of the public origin', () => {
-    // PUBLIC_GATEWAY_URL is app.lobu.ai → only `.app.lobu.ai` subdomains match
-    // without AUTH_COOKIE_DOMAIN. The sibling-zone case is exercised
-    // separately in the existing subdomain-zone tests.
     expect(isAllowedCorsOrigin('https://acme.app.lobu.ai', makeEnv(), REQUEST_URL)).toBe(true);
+  });
+
+  test('accepts sibling workspace subdomains in the configured cookie zone', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'https://umit-unal.lobu.ai',
+        makeEnv({ AUTH_COOKIE_DOMAIN: '.lobu.ai' }),
+        REQUEST_URL
+      )
+    ).toBe(true);
+  });
+
+  test('accepts trimmed exact ALLOWED_ORIGINS entries for standalone clients', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'https://console.example.com',
+        makeEnv({ ALLOWED_ORIGINS: ' https://console.example.com , malformed ' }),
+        REQUEST_URL,
+        { allowConfiguredOrigins: true }
+      )
+    ).toBe(true);
+  });
+
+  test('does not widen the main-app policy with Agent API standalone origins', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'https://console.example.com',
+        makeEnv({ ALLOWED_ORIGINS: 'https://console.example.com' }),
+        REQUEST_URL
+      )
+    ).toBe(false);
   });
 
   test('still rejects an arbitrary third-party origin', () => {
     expect(isAllowedCorsOrigin('https://evil.com', makeEnv(), REQUEST_URL)).toBe(false);
+  });
+
+  test('rejects a cookie-zone lookalike hostname', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'https://umit-unal.lobu.ai.evil.example',
+        makeEnv({ AUTH_COOKIE_DOMAIN: '.lobu.ai' }),
+        REQUEST_URL
+      )
+    ).toBe(false);
+  });
+});
+
+describe('embedded /lobu Agent API CORS boundary', () => {
+  function buildAgentGateway() {
+    const rawGateway = createGatewayApp({
+      secretProxy: null,
+      workerGateway: null,
+      mcpProxy: null,
+    });
+    const lobuApp = new Hono();
+    lobuApp.route('/', rawGateway);
+    return buildWrapperApp(makeEnv(), lobuApp, new Hono());
+  }
+
+  // The gateway's CORS callback resolves its zone from process.env (see
+  // gateway.ts), which `beforeEach` pins to `.lobu.ai`; the env handed to
+  // `fetch` only feeds the wrapper's injection middleware.
+  function preflight(origin: string) {
+    return buildAgentGateway().fetch(
+      new Request('https://app.lobu.ai/lobu/api/v1/agents/example/messages', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type',
+        },
+      }),
+      makeEnv()
+    );
+  }
+
+  test('allows credentialed message preflight from a workspace subdomain', async () => {
+    const response = await preflight('https://umit-unal.lobu.ai');
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://umit-unal.lobu.ai'
+    );
+    expect(response.headers.get('access-control-allow-credentials')).toBe('true');
+  });
+
+  test('preserves canonical app and localhost browser clients', async () => {
+    const canonical = await preflight('https://app.lobu.ai');
+    const localhost = await preflight('http://localhost:5173');
+
+    expect(canonical.headers.get('access-control-allow-origin')).toBe(
+      'https://app.lobu.ai'
+    );
+    expect(localhost.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:5173'
+    );
+  });
+
+  test('requires an explicitly configured zone for sibling workspace hosts', async () => {
+    delete process.env.AUTH_COOKIE_DOMAIN;
+    __resetPublicOriginCachesForTests();
+
+    const response = await preflight('https://umit-unal.lobu.ai');
+
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  test('preserves exact standalone Agent API origins', async () => {
+    delete process.env.AUTH_COOKIE_DOMAIN;
+    process.env.ALLOWED_ORIGINS = ' https://console.example.com ';
+    __resetPublicOriginCachesForTests();
+
+    const response = await preflight('https://console.example.com');
+
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://console.example.com'
+    );
+  });
+
+  test('does not allow an unrelated site to call the Agent API', async () => {
+    const response = await preflight('https://evil.example');
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
   });
 });
 

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -7,6 +7,8 @@ import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { isAllowedCorsOrigin } from "../../utils/cors-origin.js";
+import { getConfiguredPublicOrigin } from "../../utils/public-origin.js";
 import {
   pairAdminGrant,
   takePendingTool,
@@ -152,9 +154,21 @@ export function createGatewayApp(
   app.use(
     "*",
     cors({
-      origin: process.env.ALLOWED_ORIGINS
-        ? process.env.ALLOWED_ORIGINS.split(",")
-        : [],
+      // Same browser-origin boundary as the main app (packages/server/src/index.ts)
+      // so a workspace host like `acme.lobu.ai` can call the Agent API mounted at
+      // /lobu, plus the operator's exact ALLOWED_ORIGINS for standalone clients.
+      // Reads process.env, not c.env: standalone `lobu run` has no env-injecting
+      // wrapper, so c.env only carries the Node adapter's fields there.
+      origin: (origin, c) => {
+        if (!origin) {
+          return getConfiguredPublicOrigin() ?? new URL(c.req.url).origin;
+        }
+        return isAllowedCorsOrigin(origin, process.env, c.req.url, {
+          allowConfiguredOrigins: true,
+        })
+          ? origin
+          : undefined;
+      },
       credentials: true,
 		}),
   );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -119,6 +119,10 @@ import {
 import { getSchedulerHealth } from "./scheduled/scheduler-health";
 import { isCloudMode } from "./utils/cloud-mode";
 import { entityLinkMatchSql } from "./utils/content-search";
+import {
+	getOwnedOwlettoExtensionIds,
+	isAllowedCorsOrigin,
+} from "./utils/cors-origin";
 import { isValidFrameAncestor } from "./utils/csp";
 import { errorMessage } from "./utils/errors";
 import logger from "./utils/logger";
@@ -142,92 +146,6 @@ import { joinPublicOrganization } from "./workspace/join-public";
 import { invalidateOrgSlugCache } from "./workspace/multi-tenant";
 
 export type { Env };
-
-const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
-
-// Owned Owletto for Chrome extension IDs. Identity for CSP frame-ancestors
-// AND CORS — both have to agree that an extension is "us", otherwise either
-// iframe embedding or fetch-from-SW breaks. There are two distinct IDs and
-// both are production facts, so both are pinned here:
-//   - DEV/UNPACKED: derived from the manifest `key` field (see
-//     lobu-ai/owletto:apps/chrome/manifest.json). This is the ID our local
-//     harness and any unpacked build loads as.
-//   - PUBLISHED: assigned by the Chrome Web Store, which overrides the
-//     manifest `key` with its own signing key, so the store build runs under
-//     a different ID (see lobu-ai/owletto:store-assets/STORE-LISTING.md and
-//     apps/mac/Owletto/OwlettoApp.swift). The store ID was previously missing
-//     from this list, so app.lobu.ai's frame-ancestors blocked the published
-//     sidepanel iframe even though local dev worked.
-const OWLETTO_EXTENSION_IDS = [
-	"amnnhclgmbldmfcfamonoggjhfidemmm", // dev/unpacked (manifest `key`)
-	"jhgcecbdpnoehfnhpdfihlchjddapepi", // Chrome Web Store (published)
-] as const;
-
-const CHROME_EXTENSION_ID_RE = /^[a-p]{32}$/;
-
-/**
- * Owned Owletto extension IDs (the pinned dev + published IDs, plus anything
- * pinned via the LOBU_OWLETTO_EXTENSION_IDS env so an ad-hoc build with a
- * different manifest key can be allowed alongside them). Same source for both
- * the CSP frame-ancestors directive on HTML responses and the CORS
- * allowlist that lets the service worker fetch /api/workers/poll.
- */
-export function getOwnedOwlettoExtensionIds(env: Env): string[] {
-	const extra = (env.LOBU_OWLETTO_EXTENSION_IDS ?? "")
-		.split(",")
-		.map((s) => s.trim())
-		.filter((s) => CHROME_EXTENSION_ID_RE.test(s));
-	return [...OWLETTO_EXTENSION_IDS, ...extra];
-}
-
-export function isAllowedCorsOrigin(
-	origin: string,
-	env: Env,
-	requestUrl: string,
-): boolean {
-	let parsed: URL;
-	try {
-		parsed = new URL(origin);
-	} catch {
-		return false;
-	}
-
-	// The Owletto extension's service worker fetches /api/workers/poll as
-	// origin chrome-extension://<id>. Match against the same owned-IDs list
-	// the CSP block uses so the two trust boundaries can't drift.
-	if (parsed.protocol === "chrome-extension:") {
-		const owned = new Set(getOwnedOwlettoExtensionIds(env));
-		return owned.has(parsed.hostname);
-	}
-
-	if (LOCALHOST_HOSTNAMES.has(parsed.hostname.toLowerCase())) {
-		return true;
-	}
-
-	// Behind a TLS-terminating proxy, c.req.url is http://, so the configured
-	// public origin is the source of truth for the canonical (https) origin.
-	const canonicalOrigin =
-		getConfiguredPublicOrigin() ?? new URL(requestUrl).origin;
-
-	if (parsed.origin === canonicalOrigin) return true;
-
-	// Allow wildcard subdomains of the canonical origin (e.g. acme.lobu.com)
-	// and — when AUTH_COOKIE_DOMAIN is configured — sibling subdomains under the
-	// cookie zone so browsers on `acme.lobu.ai` can call `app.lobu.ai`.
-	const parsedHost = parsed.hostname.toLowerCase();
-	const baseDomain = new URL(canonicalOrigin).hostname.toLowerCase();
-	if (parsedHost.endsWith(`.${baseDomain}`)) return true;
-
-	const subdomainZone = getSubdomainZone(canonicalOrigin);
-	if (
-		subdomainZone &&
-		(parsedHost === subdomainZone || parsedHost.endsWith(`.${subdomainZone}`))
-	) {
-		return true;
-	}
-
-	return false;
-}
 
 const STATIC_TEXT_CONTENT_TYPES: Record<string, string> = {
 	".css": "text/css; charset=utf-8",

--- a/packages/server/src/utils/cors-origin.ts
+++ b/packages/server/src/utils/cors-origin.ts
@@ -1,0 +1,127 @@
+import { getConfiguredPublicOrigin, getSubdomainZone } from "./public-origin";
+
+/** Env bindings this boundary reads. `Env` and `process.env` both satisfy it. */
+type CorsEnv = Record<string, string | undefined>;
+
+const LOCALHOST_HOSTNAMES = new Set([
+	"localhost",
+	"127.0.0.1",
+	"::1",
+	"[::1]",
+]);
+
+// Owned Owletto for Chrome extension IDs. Identity for CSP frame-ancestors
+// AND CORS — both have to agree that an extension is "us", otherwise either
+// iframe embedding or fetch-from-SW breaks. There are two distinct IDs and
+// both are production facts, so both are pinned here:
+//   - DEV/UNPACKED: derived from the manifest `key` field (see
+//     lobu-ai/owletto:apps/chrome/manifest.json). This is the ID our local
+//     harness and any unpacked build loads as.
+//   - PUBLISHED: assigned by the Chrome Web Store, which overrides the
+//     manifest `key` with its own signing key, so the store build runs under
+//     a different ID (see lobu-ai/owletto:store-assets/STORE-LISTING.md and
+//     apps/mac/Owletto/OwlettoApp.swift). The store ID was previously missing
+//     from this list, so app.lobu.ai's frame-ancestors blocked the published
+//     sidepanel iframe even though local dev worked.
+const OWLETTO_EXTENSION_IDS = [
+	"amnnhclgmbldmfcfamonoggjhfidemmm", // dev/unpacked (manifest `key`)
+	"jhgcecbdpnoehfnhpdfihlchjddapepi", // Chrome Web Store (published)
+] as const;
+
+const CHROME_EXTENSION_ID_RE = /^[a-p]{32}$/;
+
+/**
+ * Owned Owletto extension IDs (the pinned dev + published IDs, plus anything
+ * pinned via LOBU_OWLETTO_EXTENSION_IDS for an ad-hoc signed build). This is
+ * shared by CSP and both CORS middleware instances so those boundaries cannot
+ * drift apart.
+ */
+export function getOwnedOwlettoExtensionIds(env: CorsEnv): string[] {
+	const extra = (env.LOBU_OWLETTO_EXTENSION_IDS ?? "")
+		.split(",")
+		.map((value) => value.trim())
+		.filter((value) => CHROME_EXTENSION_ID_RE.test(value));
+	return [...OWLETTO_EXTENSION_IDS, ...extra];
+}
+
+function getExplicitAllowedOrigins(raw: string | undefined): Set<string> {
+	const origins = new Set<string>();
+	for (const value of raw?.split(",") ?? []) {
+		const candidate = value.trim();
+		if (!candidate) continue;
+		try {
+			const parsed = new URL(candidate);
+			// `file:`/`data:`/`chrome-extension:` entries all serialize to the
+			// opaque origin "null"; storing that would match any other opaque
+			// origin, so drop them rather than collapse distinct origins into one.
+			if (parsed.origin !== "null") origins.add(parsed.origin);
+		} catch {
+			// Ignore malformed operator entries instead of widening CORS.
+		}
+	}
+	return origins;
+}
+
+/**
+ * Shared browser-origin trust boundary for both the main app and the embedded
+ * Agent API mounted at `/lobu`.
+ *
+ * CORS is transport permission, not tenant authorization. Approved requests
+ * still pass through Better Auth plus the Agent API's ownership/membership
+ * checks. The configured cookie zone is the authority for sibling workspace
+ * hosts; never infer a registrable domain from the request hostname.
+ */
+export function isAllowedCorsOrigin(
+	origin: string,
+	env: CorsEnv,
+	requestUrl: string,
+	options: { allowConfiguredOrigins?: boolean } = {},
+): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(origin);
+	} catch {
+		return false;
+	}
+
+	// The Owletto extension's service worker fetches /api/workers/poll as
+	// origin chrome-extension://<id>. Match against the same owned-IDs list
+	// the CSP block uses so the two trust boundaries can't drift.
+	if (parsed.protocol === "chrome-extension:") {
+		const owned = new Set(getOwnedOwlettoExtensionIds(env));
+		return owned.has(parsed.hostname);
+	}
+
+	if (LOCALHOST_HOSTNAMES.has(parsed.hostname.toLowerCase())) {
+		return true;
+	}
+
+	if (
+		options.allowConfiguredOrigins &&
+		getExplicitAllowedOrigins(env.ALLOWED_ORIGINS).has(parsed.origin)
+	) {
+		return true;
+	}
+
+	// Behind a TLS-terminating proxy, requestUrl may be http://. The configured
+	// public origin remains the source of truth for the canonical https origin.
+	const canonicalOrigin =
+		getConfiguredPublicOrigin() ?? new URL(requestUrl).origin;
+	if (parsed.origin === canonicalOrigin) return true;
+
+	// Allow wildcard subdomains of the canonical origin (e.g. acme.lobu.com)
+	// and — when AUTH_COOKIE_DOMAIN is configured — sibling subdomains under the
+	// cookie zone so browsers on `acme.lobu.ai` can call `app.lobu.ai`.
+	const parsedHost = parsed.hostname.toLowerCase();
+	const baseDomain = new URL(canonicalOrigin).hostname.toLowerCase();
+	if (parsedHost.endsWith(`.${baseDomain}`)) return true;
+
+	const subdomainZone = getSubdomainZone(
+		canonicalOrigin,
+		env.AUTH_COOKIE_DOMAIN,
+	);
+	return !!(
+		subdomainZone &&
+		(parsedHost === subdomainZone || parsedHost.endsWith(`.${subdomainZone}`))
+	);
+}


### PR DESCRIPTION
## What changed
- share the existing first-party CORS trust boundary with the embedded Agent API mounted at /lobu
- allow explicitly configured standalone browser origins only on the Agent gateway, without widening main-app routes
- advance Owletto to merged PR #954, which keeps first-party Agent session URLs on the active workspace origin

## Root cause
The workspace created the Agent session same-origin, but the response advertised canonical app.lobu.ai message and SSE URLs. The follow-up POST from an org subdomain therefore crossed origins and hit a separate static CORS allowlist on the raw Agent gateway. Its preflight returned no Access-Control-Allow-Origin header, so auth, tenancy checks, and run creation were never reached.

## End-to-end behavior
- org subdomains in the explicitly configured AUTH_COOKIE_DOMAIN zone are trusted and rebased same-origin
- app.lobu.ai/{org} remains same-origin
- localhost/127.0.0.1 aliases remain supported
- standalone Lobu browser clients retain exact ALLOWED_ORIGINS support
- non-browser CLI requests remain unaffected
- unrelated and lookalike hosts are rejected

## Validation
- mounted production-mode /lobu preflight: affected origin returned exact ACAO plus credentials; unrelated origin returned no ACAO
- server CORS suite: 21 passed
- server lifecycle suite: 24 passed
- public-origin suite: 26 passed
- Owletto full suite after rebase: 197 files / 1843 tests passed
- Owletto production build and browser bundle check passed
- make pre-pr passed all 5 gates

## Review status
The mandatory local pre-review fixer was invoked once but its Claude session failed externally with HTTP 403 Unable to verify organization membership. It returned no finding. No review gate is being represented as passed.