### PR TITLE
fix(server): return public origin for device credentials

### DIFF
--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -55,6 +55,30 @@ describe('device mint (mint-child-token)', () => {
     await cleanupTestDatabase();
   });
 
+  it('returns the public HTTPS gateway origin behind a reverse proxy', async () => {
+    const personalOrg = await createTestOrganization({ name: 'Personal Public Origin' });
+    const user = await createTestUser({ email: 'public-origin@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await mintApp(user.id).request(
+      'http://app.lobu.ai/api/me/devices/mint-child-token',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-host': 'app.lobu.ai',
+          'x-forwarded-proto': 'https',
+        },
+        body: JSON.stringify({ platform: 'headless', label: 'proxied-device' }),
+      },
+      TEST_ENV
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ gateway_url: 'https://app.lobu.ai' });
+  });
+
   it('mints a headless device bound to the personal org with an owl_pat_ child token', async () => {
     const sql = getTestDb();
     const personalOrg = await createTestOrganization({ name: 'Personal' });

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -13,6 +13,7 @@
 import { isKnownPlatform } from '@lobu/core';
 import type { Context } from 'hono';
 import { createAuth } from '../auth';
+import { resolveBaseUrl } from '../auth/base-url';
 import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { getDb, parsePgTextArray, pgBigintArray } from '../db/client';
@@ -481,7 +482,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       }
     }
 
-    const gatewayUrl = new URL(c.req.url).origin;
+    const gatewayUrl = resolveBaseUrl({ request: c.req.raw });
     if (reused) {
       logger.info(
         { userId, workerId, platform },


### PR DESCRIPTION
## Summary
- Return the externally reachable gateway origin when minting device child credentials behind a reverse proxy.
- Prevent Owletto 16.1 from rejecting a valid child credential because the server stamped its internal HTTP origin.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean.
- [x] Focused integration tests: `device-management-mint.test.ts` and `device-child-token-lifecycle.test.ts` (18 passed).
- [x] Bug fix: red -> fix -> green outputs pasted below.

Red: the proxy regression test received `gateway_url: http://app.lobu.ai` instead of `https://app.lobu.ai` (1 failed, 11 passed).

Green: both device child-token suites passed (18 passed).

## Notes
The mandatory pre-review fixer was attempted with both allowed reviewers. Claude Opus is session-capped until 20:50 Europe/London; Fable requires usage credits. Neither modified the worktree. The posted semantic review remains required before merge.