### PR TITLE
fix(feeds): honor pinned connector capabilities

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -24,8 +24,9 @@ conclude "no integration exists" — author a custom connector in the project.
 
 ## The contract
 
-A connector default-exports `defineConnector({ ... })` from
-`@lobu/connector-sdk`. Feed and action keys come from their record keys, and
+A connector default-exports either a `defineConnector({ ... })` spec or a class
+extending `ConnectorRuntime` from `@lobu/connector-sdk`. In the functional
+form below, feed and action keys come from their record keys. In both forms,
 each feed declares its own `sync` and/or `read` handler:
 
 ```ts

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -1,6 +1,6 @@
 # Connector SDK
 
-Connectors are TypeScript modules that sync data from external services into Lobu, read configured feeds directly from their source, and optionally execute write-back actions. Each connector has a `.ts` entry point whose default export is created with `defineConnector({ ... })` from `@lobu/connector-sdk`; the entry point may import sibling modules, which the compiler bundles. This document covers the SDK/runtime contract for bundled built-ins and child-process execution; the project-level authoring flow (`connectorFromFile` + `lobu apply`) is in `docs/connector-authoring.md`.
+Connectors are TypeScript modules that sync data from external services into Lobu, read configured feeds directly from their source, and optionally execute write-back actions. Each connector has a `.ts` entry point whose default export is either a `defineConnector({ ... })` spec or a class extending `ConnectorRuntime` from `@lobu/connector-sdk`; the entry point may import sibling modules, which the compiler bundles. This document covers the SDK/runtime contract for bundled built-ins and child-process execution; the project-level authoring flow (`connectorFromFile` + `lobu apply`) is in `docs/connector-authoring.md`.
 
 ## Quick Start
 

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -117,19 +117,20 @@ async function seedFeed(opts: {
   consecutiveFailures?: number;
   lastError?: string | null;
   deletedAt?: Date | null;
+  pinnedVersion?: string | null;
 }): Promise<void> {
   const sql = getTestDb();
   await sql`
     INSERT INTO feeds (
       organization_id, connection_id, feed_key, status, config,
       last_sync_status, last_sync_at, consecutive_failures, last_error,
-      deleted_at, created_at, updated_at
+      deleted_at, pinned_version, created_at, updated_at
     ) VALUES (
       ${opts.orgId}, ${opts.connectionId}, ${opts.feedKey},
       ${opts.status ?? 'active'}, ${sql.json({ store: opts.store ?? 'events' })},
       ${opts.lastSyncStatus ?? null}, ${opts.lastSyncAt ?? null},
       ${opts.consecutiveFailures ?? 0}, ${opts.lastError ?? null},
-      ${opts.deletedAt ?? null}, NOW(), NOW()
+      ${opts.deletedAt ?? null}, ${opts.pinnedVersion ?? null}, NOW(), NOW()
     )
   `;
 }
@@ -817,6 +818,54 @@ describe('connector-health alerter', () => {
 
     const res = await runConnectorHealthCheck();
     expect(res.details.some((d) => d.connectionId === sourceOnly.id)).toBe(false);
+
+    const [row] = (await sql`
+      SELECT unhealthy_alerted_at FROM connections WHERE id = ${sourceOnly.id}
+    `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
+    expect(row.unhealthy_alerted_at).toBeNull();
+  });
+
+  it('uses the pinned definition when deciding whether a feed can sync', async () => {
+    const sql = getTestDb();
+    const connectorKey = 'health.pinned-source-only';
+    await createTestConnectorDefinition({
+      key: connectorKey,
+      name: 'Pinned Source-only Health Fixture v1',
+      version: '1.0.0',
+      organization_id: orgId,
+      feeds_schema: { history: { key: 'history', operations: ['read'] } },
+    });
+    await sql`
+      UPDATE connector_definitions
+      SET status = 'archived'
+      WHERE organization_id = ${orgId} AND key = ${connectorKey}
+    `;
+    await createTestConnectorDefinition({
+      key: connectorKey,
+      name: 'Pinned Source-only Health Fixture v2',
+      version: '2.0.0',
+      organization_id: orgId,
+      feeds_schema: { history: { key: 'history', operations: ['sync'] } },
+    });
+    const sourceOnly = await seedConnection({
+      orgId,
+      userId,
+      connectorKey,
+      slug: 'pinned-source-only',
+      createdAt: OLD,
+    });
+    await seedFeed({
+      orgId,
+      connectionId: sourceOnly.id,
+      feedKey: 'history',
+      lastSyncStatus: 'failed',
+      lastSyncAt: OLD,
+      consecutiveFailures: cfg.failureThreshold,
+      pinnedVersion: '1.0.0',
+    });
+
+    const res = await runConnectorHealthCheck();
+    expect(res.details.some((detail) => detail.connectionId === sourceOnly.id)).toBe(false);
 
     const [row] = (await sql`
       SELECT unhealthy_alerted_at FROM connections WHERE id = ${sourceOnly.id}

--- a/packages/server/src/__tests__/integration/connectors/source-feed-surfaces.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/source-feed-surfaces.test.ts
@@ -86,6 +86,13 @@ describe('explicit feed source reads', () => {
       VALUES ('postgres', '1.0.1', NULL, NULL, NOW())
       ON CONFLICT DO NOTHING
     `;
+    await db`
+      INSERT INTO connector_definitions
+        (key, name, version, feeds_schema, auth_schema, organization_id, status, created_at, updated_at)
+      VALUES ('postgres', 'PostgreSQL', '1.0.0',
+        ${db.json({ query: { key: 'query', operations: ['sync'] } })},
+        ${db.json({})}, ${orgId}, 'archived', NOW(), NOW())
+    `;
 
     const createConnection = async (slug: string, visibility: 'org' | 'private') => {
       const [row] = await db`
@@ -98,13 +105,20 @@ describe('explicit feed source reads', () => {
     };
     const publicConnectionId = await createConnection('explicit-public', 'org');
     const privateConnectionId = await createConnection('explicit-private', 'private');
+    const pinnedConnectionId = await createConnection('explicit-pinned', 'org');
 
-    const createFeed = async (connectionId: number, feedKey: string) => {
+    const createFeed = async (
+      connectionId: number,
+      feedKey: string,
+      pinnedVersion?: string,
+    ) => {
       const [row] = await db`
         INSERT INTO feeds
-          (organization_id, connection_id, feed_key, display_name, status, config, created_at, updated_at)
+          (organization_id, connection_id, feed_key, display_name, status, config,
+            pinned_version, created_at, updated_at)
         VALUES (${orgId}, ${connectionId}, ${feedKey}, ${feedKey}, 'active',
-          ${db.json({ query: SOURCE_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+          ${db.json({ query: SOURCE_SQL, primary_key: 'id', cursor_column: 'id' })},
+          ${pinnedVersion ?? null}, NOW(), NOW())
         RETURNING id
       `;
       return Number((row as { id: number }).id);
@@ -112,13 +126,14 @@ describe('explicit feed source reads', () => {
     publicFeedId = await createFeed(publicConnectionId, 'query');
     privateFeedId = await createFeed(privateConnectionId, 'query');
     collectedFeedId = await createFeed(publicConnectionId, 'collected');
+    await createFeed(pinnedConnectionId, 'query', '1.0.0');
   }, 120_000);
 
   afterAll(async () => {
     await getTestDb()`DROP TABLE IF EXISTS vfsurf_ext`;
   });
 
-  it('search stays local and reports source feeds as not queried under the visibility fence', async () => {
+  it('search stays local and applies visibility plus pinned-capability fences', async () => {
     const owner = await gatherLocalRecall(ownerScope(), recallContext());
     expect(owner.coverage).toMatchObject({
       source_queried: false,
@@ -128,7 +143,6 @@ describe('explicit feed source reads', () => {
       [publicFeedId, privateFeedId].sort()
     );
     expect(owner.coverage?.source_feeds.every((feed) => feed.status === 'not_queried')).toBe(true);
-
     const member = await gatherLocalRecall(memberScope(), recallContext());
     expect(member.coverage?.source_feeds.map((feed) => feed.feed_id)).toEqual([publicFeedId]);
   });

--- a/packages/server/src/__tests__/integration/connectors/source-feed-surfaces.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/source-feed-surfaces.test.ts
@@ -143,6 +143,7 @@ describe('explicit feed source reads', () => {
       [publicFeedId, privateFeedId].sort()
     );
     expect(owner.coverage?.source_feeds.every((feed) => feed.status === 'not_queried')).toBe(true);
+
     const member = await gatherLocalRecall(memberScope(), recallContext());
     expect(member.coverage?.source_feeds.map((feed) => feed.feed_id)).toEqual([publicFeedId]);
   });

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -322,8 +322,8 @@ describe("list_feeds health filter and true total", () => {
 				entity_ids, pinned_version, created_at, updated_at
 			) VALUES (
 				${orgId}, ${conn.id}, 'pinned-read-only', 'active',
-				'0 * * * *', current_timestamp - interval '2 hours', 'success',
-				current_timestamp - interval '3 hours', 0, ARRAY[]::bigint[],
+				'0 * * * *', current_timestamp - interval '2 hours', 'failed',
+				current_timestamp - interval '3 hours', 3, ARRAY[]::bigint[],
 				'0.9.0', NOW(), NOW()
 			)
 		`;
@@ -344,6 +344,7 @@ describe("list_feeds health filter and true total", () => {
 		expect(byKey.get("scheduled-active")?.attention).toBe("healthy");
 		expect(byKey.get("no-schedule-old")?.attention).toBe("healthy");
 		expect(byKey.get("pinned-read-only")?.operations).toEqual(["read"]);
+		expect(byKey.get("pinned-read-only")?.attention).toBe("healthy");
 
 		const healthy = await runList({
 			connection_id: conn.id,

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -272,6 +272,28 @@ describe("list_feeds health filter and true total", () => {
 		});
 		const sql = getTestDb();
 		await sql`
+			INSERT INTO connector_definitions (
+				key, name, version, feeds_schema, auth_schema, organization_id,
+				status, created_at, updated_at
+			) VALUES (
+				'hackernews', 'Hacker News', '0.9.0',
+				${sql.json({ "pinned-read-only": { operations: ["read"] } })},
+				${sql.json({})}, ${orgId}, 'archived', NOW(), NOW()
+			)
+		`;
+		await sql`
+			UPDATE connector_definitions
+			SET feeds_schema = jsonb_set(
+				feeds_schema,
+				'{pinned-read-only}',
+				${sql.json({ operations: ["sync"] })}::jsonb,
+				true
+			)
+			WHERE organization_id = ${orgId}
+				AND key = 'hackernews'
+				AND status = 'active'
+		`;
+		await sql`
 			INSERT INTO feeds (
 					organization_id, connection_id, feed_key, status, schedule,
 				next_run_at, last_sync_status, last_sync_at, consecutive_failures,
@@ -294,6 +316,18 @@ describe("list_feeds health filter and true total", () => {
 				)
 		`;
 		await sql`
+			INSERT INTO feeds (
+				organization_id, connection_id, feed_key, status, schedule,
+				next_run_at, last_sync_status, last_sync_at, consecutive_failures,
+				entity_ids, pinned_version, created_at, updated_at
+			) VALUES (
+				${orgId}, ${conn.id}, 'pinned-read-only', 'active',
+				'0 * * * *', current_timestamp - interval '2 hours', 'success',
+				current_timestamp - interval '3 hours', 0, ARRAY[]::bigint[],
+				'0.9.0', NOW(), NOW()
+			)
+		`;
+		await sql`
 			INSERT INTO runs (
 				organization_id, run_type, feed_id, status, approval_status, created_at
 			)
@@ -309,6 +343,7 @@ describe("list_feeds health filter and true total", () => {
 		expect(byKey.get("scheduled-overdue")?.attention).toBe("overdue");
 		expect(byKey.get("scheduled-active")?.attention).toBe("healthy");
 		expect(byKey.get("no-schedule-old")?.attention).toBe("healthy");
+		expect(byKey.get("pinned-read-only")?.operations).toEqual(["read"]);
 
 		const healthy = await runList({
 			connection_id: conn.id,
@@ -316,6 +351,7 @@ describe("list_feeds health filter and true total", () => {
 		});
 		expect(healthy.feeds.map((feed) => feed.feed_key).sort()).toEqual([
 			"no-schedule-old",
+			"pinned-read-only",
 			"scheduled-active",
 		]);
 

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -259,9 +259,10 @@ interface FeedHealthRow {
   connection_created_at: Date | string;
   connection_status: string | null;
   credential_mode: string | null;
-  /** Whether the installed definition declares a sync operation that Lobu
-   *  can create without user-supplied instance config. NULL means no active
-   *  definition was found, preserving the fail-closed zero-feed alert. */
+  /** Whether the selected definition declares a sync operation that Lobu can
+   *  create without user-supplied instance config. A zero-feed row necessarily
+   *  selects the active definition. NULL means no selectable definition was
+   *  found, preserving the fail-closed zero-feed alert. */
   connector_has_auto_syncable_feeds: boolean | null;
   auth_profile_status: string | null;
   /** Device pinned but silent for longer than `cfg.deviceOfflineHours`, or its
@@ -349,16 +350,25 @@ async function loadConnectionHealthRows(
         COALESCE(definition.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
           AS feed_operations,
         EXISTS (
-        SELECT 1
-        FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)
-        WHERE COALESCE(declared.config -> 'operations', '[]'::jsonb) @> '["sync"]'::jsonb
-          AND COALESCE((declared.config ->> 'userManaged')::boolean, false) = false
-      ) AS has_auto_syncable_feeds
+          SELECT 1
+          FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)
+          WHERE COALESCE(declared.config -> 'operations', '[]'::jsonb) @> '["sync"]'::jsonb
+            AND COALESCE((declared.config ->> 'userManaged')::boolean, false) = false
+        ) AS has_auto_syncable_feeds
       FROM connector_definitions definition
       WHERE definition.key = c.connector_key
-        AND definition.status = 'active'
         AND definition.organization_id = c.organization_id
-      ORDER BY definition.updated_at DESC
+        AND (
+          (f.pinned_version IS NULL AND definition.status = 'active')
+          OR (
+            f.pinned_version IS NOT NULL
+            AND (definition.version = f.pinned_version OR definition.status = 'active')
+          )
+        )
+      ORDER BY (definition.version = f.pinned_version) DESC,
+               (definition.status = 'active') DESC,
+               definition.updated_at DESC,
+               definition.id DESC
       LIMIT 1
     ) cd ON TRUE
     LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -243,8 +243,8 @@ async function handleListFeeds(
     where = sql`${where} AND f.status = 'active' AND c.status <> 'paused'`;
     const overdue = sql`
       COALESCE(f.schedule, '') <> ''
-      AND EXISTS (
-        SELECT 1
+      AND COALESCE((
+        SELECT health_cd.feeds_schema -> f.feed_key -> 'operations'
         FROM connector_definitions health_cd
         WHERE health_cd.key = c.connector_key
           AND health_cd.organization_id = f.organization_id
@@ -258,9 +258,12 @@ async function handleListFeeds(
               AND (health_cd.version = f.pinned_version OR health_cd.status = 'active')
             )
           )
-          AND COALESCE(health_cd.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
-            @> '["sync"]'::jsonb
-      )
+        ORDER BY (health_cd.version = f.pinned_version) DESC,
+                 (health_cd.status = 'active') DESC,
+                 health_cd.updated_at DESC,
+                 health_cd.id DESC
+        LIMIT 1
+      ), '[]'::jsonb) @> '["sync"]'::jsonb
       AND f.next_run_at IS NOT NULL
       AND f.next_run_at < now() - interval '1 hour'
       AND NOT EXISTS (

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -241,9 +241,8 @@ async function handleListFeeds(
   // intentionally separate from this sync-health filter.
   if (args.health) {
     where = sql`${where} AND f.status = 'active' AND c.status <> 'paused'`;
-    const overdue = sql`
-      COALESCE(f.schedule, '') <> ''
-      AND COALESCE((
+    const selectedOperations = sql`
+      COALESCE((
         SELECT health_cd.feeds_schema -> f.feed_key -> 'operations'
         FROM connector_definitions health_cd
         WHERE health_cd.key = c.connector_key
@@ -263,7 +262,15 @@ async function handleListFeeds(
                  health_cd.updated_at DESC,
                  health_cd.id DESC
         LIMIT 1
-      ), '[]'::jsonb) @> '["sync"]'::jsonb
+      ), '[]'::jsonb)
+    `;
+    const sourceOnly = sql`
+      ${selectedOperations} @> '["read"]'::jsonb
+      AND NOT (${selectedOperations} @> '["sync"]'::jsonb)
+    `;
+    const overdue = sql`
+      ${selectedOperations} @> '["sync"]'::jsonb
+      AND COALESCE(f.schedule, '') <> ''
       AND f.next_run_at IS NOT NULL
       AND f.next_run_at < now() - interval '1 hour'
       AND NOT EXISTS (
@@ -273,16 +280,24 @@ async function handleListFeeds(
       )
     `;
     if (args.health === 'failing') {
-      where = sql`${where} AND (
-        f.last_sync_status = 'failed'
-        OR COALESCE(f.consecutive_failures, 0) > 0
-        OR (${overdue})
-      )`;
+      where = sql`${where}
+        AND NOT (${sourceOnly})
+        AND (
+          f.last_sync_status = 'failed'
+          OR COALESCE(f.consecutive_failures, 0) > 0
+          OR (${overdue})
+        )
+      `;
     } else {
       where = sql`${where}
-        AND f.last_sync_status IS DISTINCT FROM 'failed'
-        AND COALESCE(f.consecutive_failures, 0) = 0
-        AND NOT (${overdue})
+        AND (
+          (${sourceOnly})
+          OR (
+            f.last_sync_status IS DISTINCT FROM 'failed'
+            AND COALESCE(f.consecutive_failures, 0) = 0
+            AND NOT (${overdue})
+          )
+        )
       `;
     }
   }

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -694,8 +694,8 @@ async function discoverSourceFeeds(gate: AuthzScope) {
        AND f.status = 'active'
        AND c.deleted_at IS NULL
        AND c.status = 'active'
-       AND EXISTS (
-         SELECT 1
+       AND COALESCE((
+         SELECT definition.feeds_schema -> f.feed_key -> 'operations'
          FROM connector_definitions definition
          WHERE definition.key = c.connector_key
            AND definition.organization_id = f.organization_id
@@ -709,9 +709,12 @@ async function discoverSourceFeeds(gate: AuthzScope) {
                AND (definition.version = f.pinned_version OR definition.status = 'active')
              )
            )
-           AND COALESCE(definition.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
-             @> '["read"]'::jsonb
-       )
+         ORDER BY (definition.version = f.pinned_version) DESC,
+                  (definition.status = 'active') DESC,
+                  definition.updated_at DESC,
+                  definition.id DESC
+         LIMIT 1
+       ), '[]'::jsonb) @> '["read"]'::jsonb
        ${vis}
      ORDER BY f.id
      LIMIT ${MAX_SOURCE_FEEDS_IN_COVERAGE + 1}`,


### PR DESCRIPTION
## Summary

- select the feed-pinned connector definition before the active fallback when deriving read/sync capabilities
- keep source coverage, overdue filtering, and connector-health alerts aligned to the same selected definition
- clarify that connector entry points may use either defineConnector or ConnectorRuntime

## Validation

- 37 database-backed integration tests pass across connector health, source-feed surfaces, and list_feeds health filtering
- server typecheck passes
- make pre-pr passes all five repository gates
- git diff --check is clean

## Safety

- no migration, schema change, secret, or generated-client change
- focused follow-up to #3132; pinned read-only feeds can no longer inherit sync/read classification from a newer active definition