### PR TITLE
fix(devices): stamp public origin on child tokens

### DIFF
--- a/packages/server/src/__tests__/integration/device-management-mint.test.ts
+++ b/packages/server/src/__tests__/integration/device-management-mint.test.ts
@@ -8,6 +8,7 @@
 import { Hono } from 'hono';
 import { beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../../index';
+import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
 import { mintDeviceChildToken } from '../../worker-api/device-management';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import {
@@ -23,6 +24,29 @@ const TEST_ENV = {
   BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
   RATE_LIMIT_ENABLED: 'false',
 } as unknown as Env;
+
+async function withPublicGatewayUrl<T>(
+  value: string | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  const previous = process.env.PUBLIC_GATEWAY_URL;
+  if (value === undefined) {
+    delete process.env.PUBLIC_GATEWAY_URL;
+  } else {
+    process.env.PUBLIC_GATEWAY_URL = value;
+  }
+  __resetPublicOriginCachesForTests();
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PUBLIC_GATEWAY_URL;
+    } else {
+      process.env.PUBLIC_GATEWAY_URL = previous;
+    }
+    __resetPublicOriginCachesForTests();
+  }
+}
 
 async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
   const sql = getTestDb();
@@ -62,14 +86,16 @@ describe('device mint (mint-child-token)', () => {
     await markPersonalOrg(personalOrg.id, user.id);
     await addUserToOrganization(user.id, personalOrg.id, 'owner');
 
-    const res = await mintApp(user.id).request(
-      '/api/me/devices/mint-child-token',
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ platform: 'headless', label: 'herdr-test' }),
-      },
-      TEST_ENV
+    const res = await withPublicGatewayUrl(undefined, () =>
+      mintApp(user.id).request(
+        '/api/me/devices/mint-child-token',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ platform: 'headless', label: 'herdr-test' }),
+        },
+        TEST_ENV
+      )
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -77,10 +103,12 @@ describe('device mint (mint-child-token)', () => {
       access_token: string;
       platform: string;
       label: string;
+      gateway_url: string;
     };
     expect(body.platform).toBe('headless');
     expect(body.label).toBe('herdr-test');
     expect(body.access_token.startsWith('owl_pat_')).toBe(true);
+    expect(body.gateway_url).toBe('http://localhost');
 
     // The persisted device row is platform- and personal-org-bound.
     const rows = (await sql`
@@ -91,6 +119,29 @@ describe('device mint (mint-child-token)', () => {
     expect(rows[0].platform).toBe('headless');
     expect(rows[0].label).toBe('herdr-test');
     expect(rows[0].organization_id).toBe(personalOrg.id);
+  });
+
+  it('stamps the configured public origin when the request uses an internal ingress URL', async () => {
+    const personalOrg = await createTestOrganization({ name: 'Personal Public Origin' });
+    const user = await createTestUser({ email: 'public-origin-mint@test.example.com' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+
+    const res = await withPublicGatewayUrl('https://app.lobu.ai/lobu', () =>
+      mintApp(user.id).request(
+        'http://app.lobu.ai/api/me/devices/mint-child-token',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ platform: 'macos', label: 'Public origin test' }),
+        },
+        TEST_ENV
+      )
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { gateway_url: string };
+    expect(body.gateway_url).toBe('https://app.lobu.ai');
   });
 
   it('uses a first-party login caller requested worker_id for a new headless device', async () => {

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -28,6 +28,7 @@ import {
 } from '../utils/device-pin-tombstones';
 import { getWorkspaceRole } from '../utils/organization-access';
 import { parseJsonBody } from '../gateway/routes/shared/helpers';
+import { resolvePublicOrigin } from '../utils/public-origin';
 import { buildAutomationUrl, getPublicWebUrl } from '../utils/url-builder';
 
 const DEVICE_WORKER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
@@ -481,7 +482,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       }
     }
 
-    const gatewayUrl = new URL(c.req.url).origin;
+    const gatewayUrl = resolvePublicOrigin(c.req.url);
     if (reused) {
       logger.info(
         { userId, workerId, platform },


### PR DESCRIPTION
## Summary

- Stamp device child credentials with the configured external public origin instead of the internal ingress request origin.
- Preserve request-origin fallback for local and self-hosted deployments.
- Add regression coverage for both paths.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Targeted integration test: `bun run test -- run src/__tests__/integration/device-management-mint.test.ts`
- [x] Bug fix proved red then green: hosted-origin assertion received `http://app.lobu.ai` before the fix and `https://app.lobu.ai` after it
- [x] Full workspace build and strict typechecks completed by `make pre-pr`

## Notes

No API shape, database, ingress, token-scope, or client-origin-validation changes.