### PR TITLE
Fix LinkedIn home-feed module classification

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2132,6 +2132,51 @@ describe("LinkedInConnector home_feed", () => {
     ).rejects.toThrow(/No partial home-feed batch was persisted/i);
   });
 
+  test("ignores current feed modules without weakening organic-post identity checks", async () => {
+    const dispatcher = {
+      dispatch: async () => ({
+        result: {
+          loggedIn: true,
+          rows: [
+            {
+              id: "market-like-a-pro-module",
+              body: "Feed post Market like a pro Transform every high-performing post into a campaign that converts Learn how",
+              author_control_label: "",
+              post_url: "",
+            },
+            {
+              id: "jobs-recommended-module",
+              body: "Feed post Jobs recommended for you Staff / Senior Staff Engineer, AI Agent Engineering Equinix London (Hybrid) Show more",
+              author_control_label: "",
+              post_url: "",
+            },
+            {
+              id: "organic-post",
+              body: "Feed post Fixture Author • 1st A real organic post with enough text",
+              author_control_label:
+                "Open control menu for post by Fixture Author",
+              post_url:
+                "https://www.linkedin.com/feed/update/urn:li:activity:1234567890123456789",
+            },
+          ],
+        },
+      }),
+    };
+    const connector = new LinkedInConnector();
+
+    const result = await connector.sync({
+      feedKey: "home_feed",
+      config: {},
+      checkpoint: {},
+      sessionState: { chrome_dispatcher: dispatcher },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].origin_id).toBe(
+      "li_home_activity_1234567890123456789"
+    );
+  });
+
   test("persists the durable post identity resolved from a copied short URL", async () => {
     const fetchImpl = async () =>
       new Response(null, {
@@ -2763,7 +2808,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.3");
+    expect(c.definition.version).toBe("3.11.4");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -789,21 +789,27 @@ function resolveMemberSlug(
  * the home feed has no structured "is this an ad" field over the content-script
  * scrape.
  */
-export function isHomeFeedNoise(body: string): boolean {
+export function isHomeFeedNoise(
+  body: string,
+  signals: {
+    authorControlLabel?: string;
+    hasDurableIdentity?: boolean;
+  } = {}
+): boolean {
   if (!body || body.trim().length < 30) return true;
   if (/\bPromoted\b/i.test(body.slice(0, 130))) return true;
   if (/\bSuggested\b/i.test(body.slice(0, 30))) return true;
-  // Platform self-promo cards only when there is no real member header
-  // (no connection-degree " • " and no expanded "Author" badge). A genuine
-  // post that *discusses* LinkedIn Ads must not be dropped.
+  // Current feed modules use the same outer componentkey shape and "Feed post"
+  // prefix as posts, but have neither a post control nor an author/time header.
+  // Real member/company cards expose at least one of those signals. Keeping the
+  // header fallback makes a broken control-menu selector fail the durable-id
+  // health check instead of silently dropping genuine posts.
   const text = body.replace(/^feed post\s+/i, "").trim();
   const hasMemberHeader = text.includes(" • ") || /^\S.+\s+Author\b/.test(text);
-  if (!hasMemberHeader) {
-    if (/\b(?:Try )?LinkedIn Ads\b/i.test(body)) return true;
-    if (/\bGet more leads with boosting\b/i.test(body)) return true;
-    if (/\bBoost your best content on LinkedIn\b/i.test(body)) return true;
-  }
-  return false;
+  const hasPostControl = Boolean(
+    parseAuthorControlLabel(signals.authorControlLabel)
+  );
+  return !hasMemberHeader && !hasPostControl && !signals.hasDurableIdentity;
 }
 
 interface HomeFeedEngagement {
@@ -1044,6 +1050,16 @@ function buildHomeFeedRowContext(row: HomeFeedRow): HomeFeedRowContext {
   };
 }
 
+function isHomeFeedRowNoise(
+  row: HomeFeedRow,
+  context: HomeFeedRowContext
+): boolean {
+  return isHomeFeedNoise(row.body ?? "", {
+    authorControlLabel: row.author_control_label,
+    hasDurableIdentity: Boolean(homeFeedPostIdentityKey(row, context)),
+  });
+}
+
 /**
  * Map cs_scrape home-feed rows to event envelopes. The permalink recovered
  * from LinkedIn's Copy-link action is the canonical post identity; an embedded
@@ -1073,8 +1089,10 @@ export function buildHomeFeedEvents(
   for (const row of rows) {
     if (!row?.id || !row.body) continue;
     const nativeIdentity = parseHomeFeedCommentIdentity(row.id);
-    if (!nativeIdentity && isHomeFeedNoise(row.body)) continue;
     const context = buildHomeFeedRowContext(row);
+    if (!nativeIdentity && isHomeFeedRowNoise(row, context)) {
+      continue;
+    }
     prepared.push({
       row,
       body: row.body,
@@ -1342,23 +1360,28 @@ function unresolvedHomeFeedPostCount(rows: HomeFeedRow[]): number {
   let count = 0;
   for (const row of rows) {
     if (!row?.id || !row.body) continue;
-    if (parseHomeFeedCommentIdentity(row.id) || isHomeFeedNoise(row.body)) {
+    const context = buildHomeFeedRowContext(row);
+    if (
+      parseHomeFeedCommentIdentity(row.id) ||
+      isHomeFeedRowNoise(row, context)
+    ) {
       continue;
     }
-    const context = buildHomeFeedRowContext(row);
     if (!homeFeedPostIdentityKey(row, context)) count += 1;
   }
   return count;
 }
 
 function unresolvedHomeFeedShortUrlCount(rows: HomeFeedRow[]): number {
-  return rows.filter(
-    (row) =>
-      Boolean(row?.id && row.body) &&
-      !parseHomeFeedCommentIdentity(row.id) &&
-      !isHomeFeedNoise(row.body ?? "") &&
-      isLinkedInShortPostUrl(row.post_url)
-  ).length;
+  return rows.filter((row) => {
+    if (!row?.id || !row.body || parseHomeFeedCommentIdentity(row.id)) {
+      return false;
+    }
+    const context = buildHomeFeedRowContext(row);
+    return (
+      !isHomeFeedRowNoise(row, context) && isLinkedInShortPostUrl(row.post_url)
+    );
+  }).length;
 }
 
 /** True when navigate landed on login / authwall rather than the post. */
@@ -2627,7 +2650,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.3",
+    version: "3.11.4",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com


### PR DESCRIPTION
Fixes the live LinkedIn home-feed sync failure where identity-less recommendation modules were counted as broken posts.

Real posts remain fail-closed when durable identity extraction breaks. A row is treated as a module only when it has no author/time header, no post control, and no durable identity.

Verified:
- live Mac mini scrape captured canonical links for real posts and exposed the two module shapes
- 130/130 LinkedIn connector tests
- make pre-pr
- pre-commit Biome and TypeScript checks