### PR TITLE
feat(linkedin): collect complete comment threads

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1827,6 +1827,7 @@ describe("LinkedInConnector home_feed", () => {
         post_media: { selector: string; take: string };
         comment_media: { selector: string; take: string };
         reaction_count_text: { selector: string; take: string };
+        comment_count_text: { selector: string; take: string };
         comment_count_label: { selector: string; attr: string };
         repost_count_label: { selector: string; attr: string };
       };
@@ -1834,6 +1835,12 @@ describe("LinkedInConnector home_feed", () => {
     expect(cfg.rowSelector).toContain("replaceableComment_urn:li:comment");
     expect(cfg.expandRows.rowSelector).toContain('[componentkey^="expanded"]');
     expect(cfg.expandRows.expected.textRegex).toContain("comments?");
+    expect(cfg.expandRows.expected.selector).toContain(
+      cfg.fields.comment_count_text.selector
+    );
+    expect(cfg.expandRows.expected.selector).toContain(
+      cfg.fields.comment_count_label.selector
+    );
     expect(cfg.expandRows.items).toEqual({
       selector: '[id^="replaceableComment_urn:li:comment:"]',
       idAttr: "id",
@@ -2144,7 +2151,7 @@ describe("LinkedInConnector home_feed", () => {
           </div>
         </div>
         <span aria-label="140 reactions"></span>
-        <div role="button" aria-label="65 comments"></div>
+        <span aria-label="65 comments"></span>
         <span aria-label="49 reposts"></span>
         ${Array.from(
           { length: 64 },
@@ -2163,6 +2170,11 @@ describe("LinkedInConnector home_feed", () => {
       reactions: 140,
       comments: 65,
       reposts: 49,
+    });
+    expect(res.metadata).toMatchObject({
+      comment_threads_complete: true,
+      comments_expected: 65,
+      comments_collected: 65,
     });
     // The comment scores from its own reactions only; reply and repost counts
     // stay post-only quantities.
@@ -2183,7 +2195,7 @@ describe("LinkedInConnector home_feed", () => {
             <span>Fixture Reactor and 236 others</span>
           </a>
           <div>
-            <div role="button"><p><span>15 comments</span><span>15 comments</span></p></div>
+            <div><p><span>15 comments</span><span>15 comments</span></p></div>
             <p>•</p>
             <a href="https://www.linkedin.com/"><p><span>2 reposts</span><span>2 reposts</span></p></a>
           </div>
@@ -2228,7 +2240,7 @@ describe("LinkedInConnector home_feed", () => {
         <button aria-label="Open control menu for post by Comment Only Author"></button>
         <span id="translatable-commentary-urn:li:activity:9000000000000000002"></span>
         <p>A comment-only current post with enough useful text for the filter</p>
-        <div><div><div role="button"><p><span>1 comment</span><span>1 comment</span></p></div></div></div>
+        <div><div><div><p><span>1 comment</span><span>1 comment</span></p></div></div></div>
         <hr />
         <div><div><button aria-label="Reaction button state: no reaction">Like</button><button aria-label="Open reactions menu"></button></div></div>
         <div id="replaceableComment_urn:li:comment:(urn:li:activity:9000000000000000002,9000000000000000003)">

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -470,6 +470,68 @@ describe("buildHomeFeedEvents", () => {
     });
   });
 
+  test("links a nested reply to both its parent comment and the original post", () => {
+    const activityId = "3111111111111111111";
+    const parentCommentId = "3222222222222222222";
+    const replyId = "3333333333333333333";
+    const events = buildHomeFeedEvents(
+      [
+        {
+          id: "reply_parent_post",
+          body: "Feed post Parent Post Author • 1st A parent post with enough text to keep",
+          author_control_label:
+            "Open control menu for post by Parent Post Author",
+          post_identity: `urn:li:activity:${activityId}`,
+          links: [
+            {
+              href: "https://www.linkedin.com/in/parent-post-author/",
+              name: "View Parent Post Author’s profile",
+            },
+          ],
+        },
+        {
+          id: `replaceableComment_urn:li:comment:(urn:li:activity:${activityId},${parentCommentId})`,
+          body: "Parent comment body",
+          author: "Parent Commenter",
+          links: [
+            {
+              href: "https://www.linkedin.com/in/parent-commenter/",
+              name: "View Parent Commenter’s profile",
+            },
+          ],
+        },
+        {
+          id: `replaceableComment_urn:li:comment:(urn:li:activity:${activityId},${replyId})`,
+          parent_comment_identity: `replaceableComment_urn:li:comment:(urn:li:activity:${activityId},${parentCommentId})`,
+          body: "Nested reply body",
+          author: "Reply Author",
+          links: [
+            {
+              href: "https://www.linkedin.com/in/reply-author/",
+              name: "View Reply Author’s profile",
+            },
+          ],
+        },
+      ],
+      new Date("2026-08-24T12:00:00.000Z")
+    );
+
+    const reply = events.find(
+      (event: any) => event.origin_id === `li_comment_${replyId}`
+    );
+    expect(reply).toMatchObject({
+      origin_parent_id: `li_comment_${parentCommentId}`,
+      metadata: {
+        parent_post_origin_id: `li_home_activity_${activityId}`,
+        parent_comment_origin_id: `li_comment_${parentCommentId}`,
+        parent_comment_id: parentCommentId,
+        parent_comment_author: "Parent Commenter",
+        parent_comment_author_linkedin_slug: "parent-commenter",
+        is_reply: true,
+      },
+    });
+  });
+
   test("keeps content media while rejecting avatars, duplicates, and unsafe URLs", () => {
     const [event] = buildHomeFeedEvents(
       [
@@ -1609,13 +1671,13 @@ describe("LinkedInConnector home_feed", () => {
     ]);
   });
 
-  test("declares visible comments with commenter and post-author attributions", () => {
+  test("declares complete comments with commenter and post-author attributions", () => {
     const comment = new LinkedInConnector().definition.feeds.home_feed
       .eventKinds.comment;
     expect(comment).toBeDefined();
     expect(
       comment.attributions.map((rule: { name: string }) => rule.name)
-    ).toEqual(["commenter", "post_author"]);
+    ).toEqual(["commenter", "post_author", "parent_comment_author"]);
   });
 
   test("syncHomeFeed dispatches cs_scrape and maps rows to events", async () => {
@@ -1632,7 +1694,7 @@ describe("LinkedInConnector home_feed", () => {
         <p>A home-feed post with enough useful text to pass the noise filter</p>
         <div class="social-details-social-counts">
           <span class="social-details-social-counts__reactions-count">12</span>
-          <button aria-label="3 comments"></button>
+          <button aria-label="2 comments"></button>
           <button aria-label="2 reposts"></button>
         </div>
         <div componentkey="commentsSectionContainerparent_token">
@@ -1733,6 +1795,21 @@ describe("LinkedInConnector home_feed", () => {
     ).toBe(4);
     const cfg = calls[0].input.scrape_config as {
       rowSelector: string;
+      expandRows: {
+        rowSelector: string;
+        expected: { selector: string; textRegex: string };
+        items: { selector: string; idAttr: string };
+        open: { selector: string; textRegex: string };
+        sort: {
+          triggerSelector: string;
+          triggerTextRegex: string;
+          selectedTextRegex: string;
+          optionSelector: string;
+          optionTextRegex: string;
+        };
+        more: { selector: string; textRegex: string };
+        outputField: string;
+      };
       id: { name: string | string[]; regex: string; group: number };
       fields: {
         links: {
@@ -1755,6 +1832,21 @@ describe("LinkedInConnector home_feed", () => {
       };
     };
     expect(cfg.rowSelector).toContain("replaceableComment_urn:li:comment");
+    expect(cfg.expandRows.rowSelector).toContain('[componentkey^="expanded"]');
+    expect(cfg.expandRows.expected.textRegex).toContain("comments?");
+    expect(cfg.expandRows.items).toEqual({
+      selector: '[id^="replaceableComment_urn:li:comment:"]',
+      idAttr: "id",
+    });
+    expect(cfg.expandRows.open.textRegex).toContain("comments?");
+    expect(cfg.expandRows.sort).toMatchObject({
+      triggerTextRegex: "^Most relevant$|^Most recent$",
+      selectedTextRegex: "^Most recent$",
+      optionSelector: '[role="menuitem"]',
+      optionTextRegex: "^Most recent\\b",
+    });
+    expect(cfg.expandRows.more.textRegex).toContain("replies");
+    expect(cfg.expandRows.outputField).toBe("comment_coverage");
     expect(cfg.id.name).toEqual(["componentkey", "id"]);
     expect(
       "expandedparent_tokenFeedType_MAIN_FEED_RELEVANCE".match(
@@ -1798,8 +1890,8 @@ describe("LinkedInConnector home_feed", () => {
     expect(res.events).toHaveLength(3);
     expect(res.events[0]).toMatchObject({
       origin_id: "li_home_activity_1111111111111111111",
-      score: 24,
-      metadata: { reactions: 12, comments: 3, reposts: 2 },
+      score: 22,
+      metadata: { reactions: 12, comments: 2, reposts: 2 },
     });
     expect(res.events[1]).toMatchObject({
       origin_id: "li_comment_2222222222222222222",
@@ -1836,6 +1928,7 @@ describe("LinkedInConnector home_feed", () => {
       (res.events[2].metadata as Record<string, unknown>).reactions
     ).toBeUndefined();
     expect(res.metadata.backend).toBe("extension-cs-scrape");
+    expect(res.metadata.comment_threads_complete).toBe(true);
     // These mock rows carry no links field, so support is assumed.
     expect(res.metadata.object_all_supported).toBe(true);
   });
@@ -1845,7 +1938,10 @@ describe("LinkedInConnector home_feed", () => {
    * config, so selector scoping is exercised end to end rather than asserted
    * as a string.
    */
-  const syncHomeFeedDom = async (body: string) => {
+  const syncHomeFeedDom = async (
+    body: string,
+    setup?: (dom: JSDOM) => void
+  ) => {
     const dom = new JSDOM(`<!doctype html><body>${body}</body>`, {
       url: "https://www.linkedin.com/feed/",
     });
@@ -1876,6 +1972,7 @@ describe("LinkedInConnector home_feed", () => {
         writable: true,
       },
     });
+    setup?.(dom);
     try {
       return await new LinkedInConnector().sync({
         feedKey: "home_feed",
@@ -1905,6 +2002,87 @@ describe("LinkedInConnector home_feed", () => {
       }
     }
   };
+
+  test("expands a 4-comment thread from 3 rendered comments and emits all durable comments", async () => {
+    const activityId = "8111111111111111111";
+    const comment = (id: string, name: string) => `
+      <div id="replaceableComment_urn:li:comment:(urn:li:activity:${activityId},${id})">
+        <a href="https://www.linkedin.com/in/${name.toLowerCase().replace(/ /g, "-")}/">
+          <span aria-hidden="true">${name}</span>
+          <span aria-label="View ${name}’s profile"></span>
+        </a>
+        <p>${name} • A complete fixture comment with enough text for collection</p>
+      </div>`;
+    const res = await syncHomeFeedDom(
+      `
+      <div componentkey="expandedcomplete_threadFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Complete Thread Author"></button>
+        <span id="translatable-commentary-urn:li:activity:${activityId}"></span>
+        <p>A complete-thread home-feed post with enough useful text to pass the filter</p>
+        <div role="button" class="comment-count">4 comments</div>
+        <div role="button" class="comment-sort">Most relevant</div>
+        ${comment("8222222222222222221", "Commenter One")}
+        ${comment("8222222222222222222", "Commenter Two")}
+        ${comment("8222222222222222223", "Commenter Three")}
+        <div role="button" class="more-comments">See 1 more comment</div>
+      </div>`,
+      (dom) => {
+        const document = dom.window.document;
+        document
+          .querySelector(".comment-sort")
+          ?.addEventListener("click", () => {
+            const option = document.createElement("div");
+            option.setAttribute("role", "menuitem");
+            option.textContent =
+              "Most recent See all comments, the most recent comments are first";
+            option.addEventListener("click", () => {
+              const sort = document.querySelector(".comment-sort");
+              if (sort) sort.textContent = "Most recent";
+              option.remove();
+            });
+            document.body.append(option);
+          });
+        document
+          .querySelector(".more-comments")
+          ?.addEventListener("click", () => {
+            const holder = document.createElement("div");
+            holder.innerHTML = comment("8222222222222222224", "Commenter Four");
+            const fourth = holder.firstElementChild;
+            if (fourth)
+              document.querySelector("[componentkey]")?.append(fourth);
+            document.querySelector(".more-comments")?.remove();
+          });
+      }
+    );
+
+    expect(res.events.map((event: any) => event.origin_id)).toEqual([
+      `li_home_activity_${activityId}`,
+      "li_comment_8222222222222222221",
+      "li_comment_8222222222222222222",
+      "li_comment_8222222222222222223",
+      "li_comment_8222222222222222224",
+    ]);
+    expect(res.metadata).toMatchObject({
+      comment_threads_complete: true,
+      comments_expected: 4,
+      comments_collected: 4,
+    });
+  });
+
+  test("fails the batch when an advertised comment thread remains incomplete", async () => {
+    await expect(
+      syncHomeFeedDom(`
+        <div componentkey="expandedincomplete_threadFeedType_MAIN_FEED_RELEVANCE">
+          <button aria-label="Open control menu for post by Incomplete Thread Author"></button>
+          <span id="translatable-commentary-urn:li:activity:8333333333333333333"></span>
+          <p>An incomplete-thread home-feed post with enough useful text to pass the filter</p>
+          <div role="button" class="comment-count">4 comments</div>
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444441)"><p>Commenter One • First rendered fixture comment</p></div>
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444442)"><p>Commenter Two • Second rendered fixture comment</p></div>
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444443)"><p>Commenter Three • Third rendered fixture comment</p></div>
+        </div>`)
+    ).rejects.toThrow(/captured 3 of 4 advertised comments/i);
+  });
 
   test("a post does not inherit reactions from a comment rendered above its own counts", async () => {
     // Ordering matters: `querySelector` returns the first match in DOCUMENT
@@ -1966,8 +2144,15 @@ describe("LinkedInConnector home_feed", () => {
           </div>
         </div>
         <span aria-label="140 reactions"></span>
-        <span aria-label="65 comments"></span>
+        <div role="button" aria-label="65 comments"></div>
         <span aria-label="49 reposts"></span>
+        ${Array.from(
+          { length: 64 },
+          (_, index) => `
+            <div id="replaceableComment_urn:li:comment:(urn:li:activity:6666666666666666666,${8800000000000000000n + BigInt(index)})">
+              <p>Additional complete fixture comment ${index + 1} with enough text to collect</p>
+            </div>`
+        ).join("")}
       </div>`);
 
     const post = res.events.find((event: any) => event.origin_type === "post");
@@ -1998,7 +2183,7 @@ describe("LinkedInConnector home_feed", () => {
             <span>Fixture Reactor and 236 others</span>
           </a>
           <div>
-            <div><p><span>15 comments</span><span>15 comments</span></p></div>
+            <div role="button"><p><span>15 comments</span><span>15 comments</span></p></div>
             <p>•</p>
             <a href="https://www.linkedin.com/"><p><span>2 reposts</span><span>2 reposts</span></p></a>
           </div>
@@ -2012,10 +2197,17 @@ describe("LinkedInConnector home_feed", () => {
           <button>Comment</button>
           <button>Repost</button>
         </div>
+        ${Array.from(
+          { length: 15 },
+          (_, index) => `
+            <div id="replaceableComment_urn:li:comment:(urn:li:activity:8888888888888888888,${8900000000000000000n + BigInt(index)})">
+              <p>Complete counter fixture comment ${index + 1} with enough text to collect</p>
+            </div>`
+        ).join("")}
       </div>`);
 
-    expect(res.events).toHaveLength(1);
-    expect(res.events[0]).toMatchObject({
+    const post = res.events.find((event: any) => event.origin_type === "post");
+    expect(post).toMatchObject({
       origin_id: "li_home_activity_8888888888888888888",
       score: 100,
       metadata: { reactions: 237, comments: 15, reposts: 2 },
@@ -2036,18 +2228,24 @@ describe("LinkedInConnector home_feed", () => {
         <button aria-label="Open control menu for post by Comment Only Author"></button>
         <span id="translatable-commentary-urn:li:activity:9000000000000000002"></span>
         <p>A comment-only current post with enough useful text for the filter</p>
-        <div><div><div><p><span>1 comment</span><span>1 comment</span></p></div></div></div>
+        <div><div><div role="button"><p><span>1 comment</span><span>1 comment</span></p></div></div></div>
         <hr />
         <div><div><button aria-label="Reaction button state: no reaction">Like</button><button aria-label="Open reactions menu"></button></div></div>
+        <div id="replaceableComment_urn:li:comment:(urn:li:activity:9000000000000000002,9000000000000000003)">
+          <p>A complete single-kind fixture comment with enough text to collect</p>
+        </div>
       </div>`);
 
-    expect(res.events).toHaveLength(2);
-    expect(res.events[0].metadata).toMatchObject({ reactions: 4 });
-    expect(res.events[0].metadata.comments).toBeUndefined();
-    expect(res.events[0].metadata.reposts).toBeUndefined();
-    expect(res.events[1].metadata).toMatchObject({ comments: 1 });
-    expect(res.events[1].metadata.reactions).toBeUndefined();
-    expect(res.events[1].metadata.reposts).toBeUndefined();
+    const posts = res.events.filter(
+      (event: any) => event.origin_type === "post"
+    );
+    expect(posts).toHaveLength(2);
+    expect(posts[0].metadata).toMatchObject({ reactions: 4 });
+    expect(posts[0].metadata.comments).toBeUndefined();
+    expect(posts[0].metadata.reposts).toBeUndefined();
+    expect(posts[1].metadata).toMatchObject({ comments: 1 });
+    expect(posts[1].metadata.reactions).toBeUndefined();
+    expect(posts[1].metadata.reposts).toBeUndefined();
   });
 
   test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
@@ -2808,7 +3006,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.4");
+    expect(c.definition.version).toBe("3.11.5");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -442,12 +442,15 @@ interface HomeFeedCommentCoverage {
   expected: number;
   collected: number;
   complete: boolean;
-  clicks: number;
-  capped: boolean;
 }
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
 const LINKEDIN_ALLOWED_ORIGINS = ["linkedin.com", "*.linkedin.com"];
+
+const HOME_FEED_COMMENT_COUNT_TEXT_SELECTOR =
+  ':scope:not([id^="replaceableComment_"]) div:has(+ hr + div button[aria-label="Open reactions menu"]):not([id^="replaceableComment_"] *) > div:last-child > div:first-child, .social-details-social-counts__comments, .social-details-social-counts__comments-count';
+const HOME_FEED_COMMENT_COUNT_LABEL_SELECTOR =
+  '.social-details-social-counts [aria-label*="comment" i], [aria-label$=" comment" i]:not([id^="replaceableComment_"] *), [aria-label$=" comments" i]:not([id^="replaceableComment_"] *)';
 
 /**
  * Selectors for the virtualized linkedin.com/feed/ DOM. Home-feed posts are
@@ -467,7 +470,10 @@ const HOME_FEED_SCRAPE_CONFIG = {
     rowSelector:
       'div[componentkey^="expanded"][componentkey*="FeedType_MAIN_FEED_RELEVANCE"]',
     expected: {
-      selector: '[role="button"], button, a',
+      // Keep this aligned with the post-level comment count fields below. The
+      // count is not always interactive: LinkedIn also renders it as a plain
+      // counter wrapper or an aria-labelled span.
+      selector: `${HOME_FEED_COMMENT_COUNT_TEXT_SELECTOR}, ${HOME_FEED_COMMENT_COUNT_LABEL_SELECTOR}, [role="button"], button, a`,
       textRegex: "^\\d[\\d,.]*(?:\\s*[kmb])?\\s+comments?",
       textRegexFlags: "i",
       regex: "(\\d[\\d,.]*(?:\\s*[kmb])?)\\s+comments?",
@@ -630,13 +636,11 @@ const HOME_FEED_SCRAPE_CONFIG = {
       attr: "aria-label",
     },
     comment_count_text: {
-      selector:
-        ':scope:not([id^="replaceableComment_"]) div:has(+ hr + div button[aria-label="Open reactions menu"]):not([id^="replaceableComment_"] *) > div:last-child > div:first-child, .social-details-social-counts__comments, .social-details-social-counts__comments-count',
+      selector: HOME_FEED_COMMENT_COUNT_TEXT_SELECTOR,
       take: "text",
     },
     comment_count_label: {
-      selector:
-        '.social-details-social-counts [aria-label*="comment" i], [aria-label$=" comments" i]:not([id^="replaceableComment_"] *)',
+      selector: HOME_FEED_COMMENT_COUNT_LABEL_SELECTOR,
       take: "attr",
       attr: "aria-label",
     },

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -26,7 +26,7 @@
  * themselves — Lobu never submits the comment.
  *
  * Closed-loop (optional): `verify_staged_comment` re-opens the post and scrapes
- * visible comments to check whether the human actually posted the draft.
+ * comments to check whether the human actually posted the draft.
  * Staging ≠ verified posted.
  */
 
@@ -350,6 +350,27 @@ const LINKEDIN_HOME_COMMENT_ATTRIBUTIONS: EventAttributionRule[] = [
       },
     },
   },
+  {
+    name: "parent_comment_author",
+    role: "in_reply_to",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.parent_comment_author",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.parent_comment_author_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.parent_comment_author_profile_url",
+        mergeStrategy: "prefer_non_empty",
+      },
+    },
+  },
 ];
 
 // ── Home-feed content-script scrape contract ────────────────────
@@ -411,6 +432,18 @@ interface HomeFeedRow {
   comment_count_label?: string;
   repost_count_text?: string;
   repost_count_label?: string;
+  /** Explicit browser-runtime proof that the post's thread was fully expanded. */
+  comment_coverage?: HomeFeedCommentCoverage;
+  /** Durable identity of an enclosing comment when this row is a nested reply. */
+  parent_comment_identity?: string;
+}
+
+interface HomeFeedCommentCoverage {
+  expected: number;
+  collected: number;
+  complete: boolean;
+  clicks: number;
+  capped: boolean;
 }
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
@@ -428,6 +461,49 @@ const HOME_FEED_SCRAPE_CONFIG = {
   },
   rowSelector:
     'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"], [id^="replaceableComment_urn:li:comment:"]',
+  expandRows: {
+    // Only actual post containers start with `expanded`; helper/component rows
+    // share the FeedType suffix but must never drive another post's controls.
+    rowSelector:
+      'div[componentkey^="expanded"][componentkey*="FeedType_MAIN_FEED_RELEVANCE"]',
+    expected: {
+      selector: '[role="button"], button, a',
+      textRegex: "^\\d[\\d,.]*(?:\\s*[kmb])?\\s+comments?",
+      textRegexFlags: "i",
+      regex: "(\\d[\\d,.]*(?:\\s*[kmb])?)\\s+comments?",
+      regexFlags: "i",
+    },
+    items: {
+      selector: '[id^="replaceableComment_urn:li:comment:"]',
+      idAttr: "id",
+    },
+    open: {
+      selector: '[role="button"], button, a',
+      textRegex: "^\\d[\\d,.]*(?:\\s*[kmb])?\\s+comments?",
+      textRegexFlags: "i",
+    },
+    sort: {
+      triggerSelector: '[role="button"], button',
+      triggerTextRegex: "^Most relevant$|^Most recent$",
+      triggerTextRegexFlags: "i",
+      selectedTextRegex: "^Most recent$",
+      selectedTextRegexFlags: "i",
+      optionSelector: '[role="menuitem"]',
+      optionTextRegex: "^Most recent\\b",
+      optionTextRegexFlags: "i",
+      maxWaitMs: 1500,
+    },
+    more: {
+      selector: '[role="button"], button, a',
+      textRegex:
+        "^(?:(?:See|Load|View)\\s+\\d[\\d,.]*\\s+(?:more\\s+)?comments?|(?:See|Load|View)\\s+(?:more|previous)\\s+(?:comments?|replies)|\\d[\\d,.]*\\s+replies)\\b",
+      textRegexFlags: "i",
+    },
+    maxPasses: 40,
+    stall: 2,
+    waitMs: 350,
+    outputField: "comment_coverage",
+  },
   id: {
     source: "attr",
     // Posts identify themselves with componentkey; native comments use their
@@ -514,6 +590,14 @@ const HOME_FEED_SCRAPE_CONFIG = {
         url: { take: "attr", attr: "src" },
         alt_text: { take: "attr", attr: "alt" },
       },
+    },
+    parent_comment_identity: {
+      // Replies are nested beneath their parent comment on the current feed.
+      // Starting the closest lookup at parentElement keeps top-level comments
+      // empty while recording the enclosing durable comment id for replies.
+      closestSelector: '[id^="replaceableComment_urn:li:comment:"]',
+      take: "attr",
+      attr: "id",
     },
     // Engagement comes only from LinkedIn's dedicated social-count controls.
     // Keep both visible text and accessible-label variants because the current
@@ -926,6 +1010,81 @@ export function parseHomeFeedEngagement(row: HomeFeedRow): HomeFeedEngagement {
   };
 }
 
+interface HomeFeedCommentCoverageSummary {
+  threads: number;
+  expected: number;
+  collected: number;
+  incomplete: number;
+  unsupported: number;
+  details: string[];
+}
+
+/**
+ * Prove completeness from the browser runtime's per-post expansion result.
+ * The independently parsed LinkedIn counter is authoritative: a stale runtime
+ * that omits coverage, or an expansion selector that reads a different count,
+ * fails closed instead of silently persisting a visible-only comment subset.
+ */
+function summarizeHomeFeedCommentCoverage(
+  rows: HomeFeedRow[]
+): HomeFeedCommentCoverageSummary {
+  const byPost = new Map<
+    string,
+    { advertised: number; coverage?: HomeFeedCommentCoverage }
+  >();
+  for (const row of rows) {
+    if (!row?.id || parseHomeFeedCommentIdentity(row.id)) continue;
+    const advertised = parseHomeFeedEngagement(row).comments ?? 0;
+    const expected = Math.max(advertised, row.comment_coverage?.expected ?? 0);
+    if (expected <= 0) continue;
+    const context = buildHomeFeedRowContext(row);
+    if (isHomeFeedRowNoise(row, context)) continue;
+    const identityKey = homeFeedPostIdentityKey(row, context);
+    if (!identityKey) continue;
+    const existing = byPost.get(identityKey);
+    if (!existing || (!existing.coverage && row.comment_coverage)) {
+      byPost.set(identityKey, {
+        advertised: expected,
+        ...(row.comment_coverage ? { coverage: row.comment_coverage } : {}),
+      });
+    }
+  }
+
+  let expected = 0;
+  let collected = 0;
+  let incomplete = 0;
+  let unsupported = 0;
+  const details: string[] = [];
+  for (const thread of byPost.values()) {
+    expected += thread.advertised;
+    if (!thread.coverage) {
+      unsupported++;
+      incomplete++;
+      details.push(`${thread.advertised}/unknown/unknown`);
+      continue;
+    }
+    collected += Math.min(thread.coverage.collected, thread.advertised);
+    if (
+      !thread.coverage.complete ||
+      thread.coverage.expected !== thread.advertised ||
+      thread.coverage.collected < thread.advertised
+    ) {
+      incomplete++;
+      details.push(
+        `${thread.advertised}/${thread.coverage.expected}/${thread.coverage.collected}`
+      );
+    }
+  }
+  return {
+    threads: byPost.size,
+    expected,
+    collected,
+    incomplete,
+    unsupported,
+    details,
+  };
+}
+
 function homeFeedEngagementMetadata(
   counts: HomeFeedEngagement
 ): Record<string, number> {
@@ -1084,11 +1243,20 @@ export function buildHomeFeedEvents(
     body: string;
     context: HomeFeedRowContext;
     nativeIdentity?: HomeFeedCommentIdentity;
+    parentCommentIdentity?: HomeFeedCommentIdentity;
   }> = [];
   const postContextsByIdentity = new Map<string, HomeFeedRowContext>();
+  const commentContextsById = new Map<string, HomeFeedRowContext>();
   for (const row of rows) {
     if (!row?.id || !row.body) continue;
     const nativeIdentity = parseHomeFeedCommentIdentity(row.id);
+    const enclosingCommentIdentity = parseHomeFeedCommentIdentity(
+      row.parent_comment_identity
+    );
+    const parentCommentIdentity =
+      enclosingCommentIdentity?.commentId !== nativeIdentity?.commentId
+        ? enclosingCommentIdentity
+        : undefined;
     const context = buildHomeFeedRowContext(row);
     if (!nativeIdentity && isHomeFeedRowNoise(row, context)) {
       continue;
@@ -1098,22 +1266,37 @@ export function buildHomeFeedEvents(
       body: row.body,
       context,
       ...(nativeIdentity ? { nativeIdentity } : {}),
+      ...(parentCommentIdentity ? { parentCommentIdentity } : {}),
     });
-    if (!nativeIdentity) {
+    if (nativeIdentity) {
+      commentContextsById.set(nativeIdentity.commentId, context);
+    } else {
       const identityKey = homeFeedPostIdentityKey(row, context);
       if (identityKey && !postContextsByIdentity.has(identityKey)) {
         postContextsByIdentity.set(identityKey, context);
       }
     }
   }
-  for (const { row, body, context, nativeIdentity } of prepared) {
+  for (const {
+    row,
+    body,
+    context,
+    nativeIdentity,
+    parentCommentIdentity,
+  } of prepared) {
     if (nativeIdentity) {
       const originId = `li_comment_${nativeIdentity.commentId}`;
       if (seenOrigins.has(originId)) continue;
       seenOrigins.add(originId);
       const parentIdentityKey = `${nativeIdentity.parentNamespace}:${nativeIdentity.parentId}`;
       const parentOriginId = homeFeedPostOriginId(parentIdentityKey);
+      const immediateParentOriginId = parentCommentIdentity
+        ? `li_comment_${parentCommentIdentity.commentId}`
+        : parentOriginId;
       const parent = postContextsByIdentity.get(parentIdentityKey);
+      const parentComment = parentCommentIdentity
+        ? commentContextsById.get(parentCommentIdentity.commentId)
+        : undefined;
       const sourceUrl =
         parent?.postUrl ??
         normalizeLinkedInPostUrl(
@@ -1129,6 +1312,19 @@ export function buildHomeFeedEvents(
         parent_activity_id: nativeIdentity.parentId,
         parent_activity_namespace: nativeIdentity.parentNamespace,
       };
+      if (parentCommentIdentity) {
+        commentMetadata.parent_comment_origin_id = immediateParentOriginId;
+        commentMetadata.parent_comment_id = parentCommentIdentity.commentId;
+        commentMetadata.is_reply = true;
+        if (parentComment) {
+          commentMetadata.parent_comment_author = parentComment.author;
+          if (parentComment.authorSlug) {
+            commentMetadata.parent_comment_author_linkedin_slug =
+              parentComment.authorSlug;
+            commentMetadata.parent_comment_author_profile_url = `https://www.linkedin.com/in/${parentComment.authorSlug}`;
+          }
+        }
+      }
       if (parent) {
         commentMetadata.parent_author = parent.author;
         if (parent.authorSlug) {
@@ -1138,7 +1334,7 @@ export function buildHomeFeedEvents(
       }
       events.push({
         origin_id: originId,
-        origin_parent_id: parentOriginId,
+        origin_parent_id: immediateParentOriginId,
         payload_text: body,
         attachments: normalizeHomeFeedMedia(row.comment_media),
         author_name: context.author,
@@ -2650,7 +2846,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.4",
+    version: "3.11.5",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -2706,7 +2902,8 @@ export default class LinkedInConnector extends ConnectorRuntime<
             },
           },
           comment: {
-            description: "A visible comment on a personalized feed post",
+            description:
+              "A complete comment or reply on a personalized feed post",
             attributions: LINKEDIN_HOME_COMMENT_ATTRIBUTIONS,
             metadataSchema: {
               type: "object",
@@ -2722,6 +2919,12 @@ export default class LinkedInConnector extends ConnectorRuntime<
                 comment_id: { type: "string" },
                 parent_activity_id: { type: "string" },
                 parent_activity_namespace: { type: "string" },
+                parent_comment_origin_id: { type: "string" },
+                parent_comment_id: { type: "string" },
+                parent_comment_author: { type: "string" },
+                parent_comment_author_linkedin_slug: { type: "string" },
+                parent_comment_author_profile_url: { type: "string" },
+                is_reply: { type: "boolean" },
                 reactions: { type: "number" },
                 comments: { type: "number" },
                 reposts: { type: "number" },
@@ -3297,6 +3500,16 @@ export default class LinkedInConnector extends ConnectorRuntime<
       );
     }
 
+    const commentCoverage = summarizeHomeFeedCommentCoverage(resolvedRows);
+    if (commentCoverage.incomplete > 0) {
+      const runtimeHint = commentCoverage.unsupported
+        ? ` The paired Owletto extension omitted expansion coverage for ${commentCoverage.unsupported} thread${commentCoverage.unsupported === 1 ? "" : "s"}; reload the current extension build.`
+        : "";
+      throw new Error(
+        `LinkedIn captured ${commentCoverage.collected} of ${commentCoverage.expected} advertised comments across ${commentCoverage.incomplete} incomplete post thread${commentCoverage.incomplete === 1 ? "" : "s"} (advertised/runtime/collected: ${commentCoverage.details.join(", ")}).${runtimeHint} No partial home-feed batch was persisted.`
+      );
+    }
+
     const events = buildHomeFeedEvents(resolvedRows, new Date());
     if (events.length === 0) {
       throw new Error(
@@ -3321,6 +3534,10 @@ export default class LinkedInConnector extends ConnectorRuntime<
         scrolls_this_run: maxScrolls,
         backend: "extension-cs-scrape",
         object_all_supported: objectAllSupported,
+        comment_threads_complete: true,
+        comment_threads_checked: commentCoverage.threads,
+        comments_expected: commentCoverage.expected,
+        comments_collected: commentCoverage.collected,
       },
     };
   }


### PR DESCRIPTION
Expands every harvested LinkedIn post thread to Most recent, exhausts comment and reply controls, and fails the batch when advertised completeness cannot be proven. Emits durable reply-parent origins and attributes commenters, post authors, and parent-comment authors into the people graph.\n\nOwletto runtime: https://github.com/lobu-ai/owletto/pull/958\n\nVerification: 133 LinkedIn tests; 107 Owletto Chrome tests; Owletto production build; make pre-pr.