### PR TITLE
fix(worker): keep transient context out of transcripts

### DIFF
--- a/packages/agent-worker/src/__tests__/provider-session.test.ts
+++ b/packages/agent-worker/src/__tests__/provider-session.test.ts
@@ -7,10 +7,18 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
+import {
+  type BashOperations,
+  SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { buildDynamicOpenAIModel } from "../runtime/model-resolver";
 import { resetSessionForProviderChange } from "../runtime/provider-session";
+import {
+  buildAgentSession,
+  persistBangBashSession,
+} from "../runtime/session-runner";
 
 const temporaryDirectories: string[] = [];
 
@@ -137,5 +145,72 @@ describe("durable provider isolation", () => {
 
     expect(note).toContain("provider metadata was unavailable");
     await expect(stat(session.sessionFile)).rejects.toThrow();
+  });
+
+  test("provider reset followed by !-bash keeps model metadata for the next run", async () => {
+    const previous = await durableSession("anthropic");
+    const summary = await resetSessionForProviderChange({
+      sessionFile: previous.sessionFile,
+      sessionManager: previous.sessionManager,
+      provider: "openai",
+    });
+    expect(summary).toContain("changed from anthropic to openai");
+
+    const sessionManager = SessionManager.create(
+      previous.directory,
+      dirname(previous.sessionFile)
+    );
+    sessionManager.setSessionFile(previous.sessionFile);
+    const { session } = await buildAgentSession({
+      cwd: previous.directory,
+      model: buildDynamicOpenAIModel({
+        rawProvider: "openai",
+        registryProvider: "openai",
+        modelId: "stub-model",
+        providerBaseUrl: "http://127.0.0.1:1/v1",
+      }) as never,
+      sessionManager,
+      customTools: [],
+      providerChangeSummary: summary,
+    });
+    const localOps: BashOperations = {
+      exec: async (...args) => {
+        args[2].onData(Buffer.from("provider-reset-bash\n"));
+        return { exitCode: 0 };
+      },
+    };
+
+    await session.executeBash("echo provider-reset-bash", undefined, {
+      operations: localOps,
+    });
+    await persistBangBashSession(sessionManager, previous.sessionFile);
+    session.dispose();
+
+    const branch = SessionManager.open(previous.sessionFile).getBranch();
+    expect(branch.map((entry) => entry.type)).toEqual([
+      "model_change",
+      "thinking_level_change",
+      "custom_message",
+      "message",
+    ]);
+    expect(
+      branch.find(
+        (entry) =>
+          entry.type === "custom_message" &&
+          entry.customType === "lobu.provider_change"
+      )
+    ).toBeDefined();
+
+    const nextRunManager = SessionManager.open(previous.sessionFile);
+    expect(
+      await resetSessionForProviderChange({
+        sessionFile: previous.sessionFile,
+        sessionManager: nextRunManager,
+        provider: "openai",
+      })
+    ).toBeUndefined();
+    expect(await readFile(previous.sessionFile, "utf-8")).toContain(
+      "provider-reset-bash"
+    );
   });
 });

--- a/packages/agent-worker/src/__tests__/run-context-block.test.ts
+++ b/packages/agent-worker/src/__tests__/run-context-block.test.ts
@@ -104,10 +104,6 @@ describe("buildRunContextBlock", () => {
     // synthetic "Channel: api_<userId>" name orient nobody — there is no other
     // channel they could have meant. The block is only useful where a run could
     // have come from one of several places (Slack channel, Telegram thread).
-    // It also LEAKS: pi records whatever string is passed to session.prompt()
-    // into the transcript, so an injected block replays into the UI as if the
-    // user had typed it. Suppressing it here is what keeps the web transcript
-    // equal to what the user actually wrote.
     expect(
       buildRunContextBlock({
         platform: "api",

--- a/packages/agent-worker/src/__tests__/transient-turn-context-e2e.test.ts
+++ b/packages/agent-worker/src/__tests__/transient-turn-context-e2e.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Provider-only turn context must reach every model iteration without becoming
+ * part of the durable user transcript. This boots a real Pi AgentSession,
+ * drives text, tool-loop, image, and context-cleared turns through an
+ * OpenAI-compatible stub, and then reads the session.jsonl Pi wrote. A
+ * request-only assertion would miss the persistence leak that made private
+ * workspace attention render as if the user typed it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { titleFromSessionJsonl } from "@lobu/core";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import {
+  AuthStorage,
+  ModelRegistry,
+  SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { buildDynamicOpenAIModel } from "../runtime/model-resolver";
+import { buildAgentSession } from "../runtime/session-runner";
+
+const STUB_BASE_URL = "http://127.0.0.1:1/v1";
+const USER_PROMPT = "hi";
+const IMAGE_PROMPT = "what is in this image?";
+const NEXT_PROMPT = "thanks";
+const TEST_IMAGE = {
+  type: "image" as const,
+  data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAHnOcQAAAAABJRU5ErkJggg==",
+  mimeType: "image/png",
+};
+const PRIVATE_CONTEXT = [
+  "## Workspace attention (recent)",
+  "- Private signal the model needs for this turn.",
+].join("\n");
+
+function completionStream(options?: { callTool?: boolean }): string {
+  const base = {
+    id: "chatcmpl_turn_context",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "stub-model",
+  };
+  const events = options?.callTool
+    ? [
+        {
+          ...base,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_context_1",
+                    type: "function",
+                    function: { name: "echo_context", arguments: "{}" },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          ...base,
+          choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+        },
+      ]
+    : [
+        {
+          ...base,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "ok" },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          ...base,
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        },
+      ];
+
+  return `${events.map((event) => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+let tempDir: string;
+let realFetch: typeof globalThis.fetch;
+let requestBodies: Array<Record<string, unknown>>;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "transient-turn-context-"));
+  requestBodies = [];
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (!url.startsWith(STUB_BASE_URL)) {
+      return realFetch(input as never, init);
+    }
+    requestBodies.push(JSON.parse(String(init?.body ?? "{}")));
+    return new Response(
+      completionStream({ callTool: requestBodies.length === 1 }),
+      {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }
+    );
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("transient turn context (real Pi session E2E)", () => {
+  test("reaches active provider iterations but never durable user messages", async () => {
+    const sessionFile = join(tempDir, ".lobu", "session.jsonl");
+    const sessionManager = SessionManager.create(tempDir, dirname(sessionFile));
+    sessionManager.setSessionFile(sessionFile);
+
+    const authStorage = AuthStorage.inMemory();
+    authStorage.setRuntimeApiKey("openai", "stub-key");
+    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const echoTool: AgentTool = {
+      name: "echo_context",
+      label: "echo_context",
+      description: "Return a deterministic result for the context test",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "tool-ok" }],
+        details: {},
+      }),
+    };
+
+    let transientContext = PRIVATE_CONTEXT;
+    const sessionOptions = {
+      cwd: tempDir,
+      model: buildDynamicOpenAIModel({
+        rawProvider: "openai",
+        registryProvider: "openai",
+        modelId: "stub-model",
+        providerBaseUrl: STUB_BASE_URL,
+      }) as never,
+      tools: [echoTool.name],
+      customTools: [echoTool],
+      authStorage,
+      modelRegistry,
+      getTransientTurnContext: () => transientContext,
+      sessionManager,
+    };
+    const { session } = await buildAgentSession(
+      sessionOptions as Parameters<typeof buildAgentSession>[0]
+    );
+
+    try {
+      await session.prompt(USER_PROMPT);
+      await session.prompt(IMAGE_PROMPT, { images: [TEST_IMAGE] });
+      transientContext = "";
+      await session.prompt(NEXT_PROMPT);
+    } finally {
+      session.dispose();
+    }
+
+    expect(requestBodies).toHaveLength(4);
+    for (const body of requestBodies.slice(0, 2)) {
+      const messages = body.messages as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const user = messages.find((message) => message.role === "user");
+      expect(contentText(user?.content)).toBe(
+        `${PRIVATE_CONTEXT}\n\n${USER_PROMPT}`
+      );
+    }
+    const imageRequestMessages = requestBodies[2]?.messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const imageRequestUser = imageRequestMessages.findLast(
+      (message) => message.role === "user"
+    );
+    expect(contentText(imageRequestUser?.content)).toBe(
+      `${PRIVATE_CONTEXT}\n\n${IMAGE_PROMPT}`
+    );
+    expect(imageRequestUser?.content).toContainEqual({
+      type: "image_url",
+      image_url: {
+        url: `data:${TEST_IMAGE.mimeType};base64,${TEST_IMAGE.data}`,
+      },
+    });
+
+    const nextRequestMessages = requestBodies[3]?.messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const nextRequestUser = nextRequestMessages.findLast(
+      (message) => message.role === "user"
+    );
+    expect(contentText(nextRequestUser?.content)).toBe(NEXT_PROMPT);
+
+    const jsonl = readFileSync(sessionFile, "utf-8");
+    const entries = jsonl
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const userEntries = entries.filter(
+      (entry) =>
+        entry.type === "message" &&
+        (entry.message as { role?: string } | undefined)?.role === "user"
+    );
+    expect(
+      userEntries.map((entry) =>
+        contentText((entry.message as { content?: unknown }).content)
+      )
+    ).toEqual([USER_PROMPT, IMAGE_PROMPT, NEXT_PROMPT]);
+    expect(
+      (userEntries[1]?.message as { content?: unknown }).content
+    ).toContainEqual(TEST_IMAGE);
+    expect(jsonl).not.toContain(PRIVATE_CONTEXT);
+    expect(titleFromSessionJsonl(jsonl, "fallback")).toBe(USER_PROMPT);
+  });
+});

--- a/packages/agent-worker/src/runtime/pi-resources.ts
+++ b/packages/agent-worker/src/runtime/pi-resources.ts
@@ -46,6 +46,7 @@
 import {
   type BeforeAgentStartEvent,
   type BeforeAgentStartEventResult,
+  type ContextEvent,
   createExtensionRuntime,
   createSyntheticSourceInfo,
   type Extension,
@@ -57,6 +58,7 @@ import type { LobuSystemPromptRenderer } from "./system-prompt.js";
 
 /** Identifies our synthetic extension in pi's diagnostics and error reports. */
 const SYSTEM_PROMPT_EXTENSION_PATH = "<lobu:system-prompt>";
+const TRANSIENT_TURN_CONTEXT_EXTENSION_PATH = "<lobu:transient-turn-context>";
 
 /**
  * The extension that installs Lobu's system prompt on every turn.
@@ -100,16 +102,84 @@ function createSystemPromptExtension(
   };
 }
 
+/**
+ * Inject Lobu's per-run context into the provider view without changing the
+ * AgentSession messages that Pi persists.
+ *
+ * Pi emits `context` before every LLM request (including later tool-loop
+ * iterations) with a deep copy of the session messages. Prefixing the latest
+ * user message in that copy gives the model the same ordering it had when the
+ * worker concatenated the strings, while leaving persisted user entries in
+ * session.jsonl and transcript snapshots equal to what the user authored.
+ */
+function createTransientTurnContextExtension(
+  getTransientTurnContext: () => string | undefined
+): Extension {
+  const handler: ExtensionHandler<
+    ContextEvent,
+    { messages?: ContextEvent["messages"] }
+  > = (event) => {
+    const transientContext = getTransientTurnContext()?.trim();
+    if (!transientContext) return;
+
+    let latestUserIndex = -1;
+    for (let index = event.messages.length - 1; index >= 0; index -= 1) {
+      if (event.messages[index]?.role === "user") {
+        latestUserIndex = index;
+        break;
+      }
+    }
+    if (latestUserIndex < 0) return;
+
+    const userMessage = event.messages[latestUserIndex];
+    if (!userMessage || userMessage.role !== "user") return;
+
+    const content =
+      typeof userMessage.content === "string"
+        ? `${transientContext}\n\n${userMessage.content}`
+        : [
+            { type: "text" as const, text: `${transientContext}\n\n` },
+            ...userMessage.content,
+          ];
+    const messages = [...event.messages];
+    messages[latestUserIndex] = { ...userMessage, content };
+    return { messages };
+  };
+
+  return {
+    path: TRANSIENT_TURN_CONTEXT_EXTENSION_PATH,
+    resolvedPath: TRANSIENT_TURN_CONTEXT_EXTENSION_PATH,
+    sourceInfo: createSyntheticSourceInfo(
+      TRANSIENT_TURN_CONTEXT_EXTENSION_PATH,
+      { source: "lobu" }
+    ),
+    handlers: new Map([["context", [handler as never]]]),
+    tools: new Map(),
+    messageRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  };
+}
+
 export function createLobuResourceLoader(
-  renderSystemPrompt?: LobuSystemPromptRenderer
+  renderSystemPrompt?: LobuSystemPromptRenderer,
+  getTransientTurnContext?: () => string | undefined
 ): ResourceLoader {
   // Built once, not per call: `AgentSession._buildRuntime` reads this result and
   // writes extension flag values onto `runtime`, which a fresh object per call
   // would silently discard.
+  const loadedExtensions: Extension[] = [];
+  if (renderSystemPrompt) {
+    loadedExtensions.push(createSystemPromptExtension(renderSystemPrompt));
+  }
+  if (getTransientTurnContext) {
+    loadedExtensions.push(
+      createTransientTurnContextExtension(getTransientTurnContext)
+    );
+  }
   const extensions: LoadExtensionsResult = {
-    extensions: renderSystemPrompt
-      ? [createSystemPromptExtension(renderSystemPrompt)]
-      : [],
+    extensions: loadedExtensions,
     errors: [],
     runtime: createExtensionRuntime(),
   };

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -131,11 +131,17 @@ type BuildAgentSessionOptions = Omit<
    * Production must always pass it.
    */
   renderSystemPrompt?: LobuSystemPromptRenderer;
+  /**
+   * Returns Lobu-owned context for the active turn. The resource loader injects
+   * it into Pi's provider-only context copy, never the persisted user message.
+   */
+  getTransientTurnContext?: () => string | undefined;
 };
 
 export async function buildAgentSession({
   builtinOverrides,
   renderSystemPrompt,
+  getTransientTurnContext,
   ...options
 }: BuildAgentSessionOptions): Promise<CreateAgentSessionResult> {
   // Pi's defaults persist under ~/.pi and discover resources/config from cwd.
@@ -150,7 +156,10 @@ export async function buildAgentSession({
     AuthStorage.inMemory();
   const modelRegistry =
     options.modelRegistry ?? ModelRegistry.inMemory(authStorage);
-  const resourceLoader = createLobuResourceLoader(renderSystemPrompt);
+  const resourceLoader = createLobuResourceLoader(
+    renderSystemPrompt,
+    getTransientTurnContext
+  );
 
   const result = await createAgentSession({
     ...options,
@@ -406,10 +415,11 @@ export function resolveAgentIdentity(
  * Per-run conversation context: where this turn is happening, who triggered it,
  * and (when available) a link back to the conversation.
  *
- * This is DELIBERATELY injected into the per-turn USER prompt, never the system
- * prompt. It varies every turn/channel, so putting it in the cached system
- * prefix would bust the prompt cache on every message. As the tail of the user
- * turn it appends after all cached content and costs nothing in cache terms.
+ * This is DELIBERATELY injected into Pi's provider-only view of the current
+ * user turn, never the system prompt or durable transcript. It varies every
+ * turn/channel, so putting it in the cached system prefix would bust the prompt
+ * cache on every message. It stays in the uncached current turn and costs
+ * nothing in cache terms.
  *
  * Only fields actually present are rendered — an empty/unknown field is omitted
  * rather than shown as "unknown". Returns "" when nothing is known, so the
@@ -427,13 +437,9 @@ export function buildRunContextBlock(input: {
   // The web chat gets no block. This context exists to disambiguate WHICH
   // conversation a run came from when several are possible (a Slack channel, a
   // Telegram thread); on `api` there is only ever the chat the user is looking
-  // at, so "Platform: api" / "Channel: api_<userId>" is pure noise. It is also
-  // the one surface where the block is visibly harmful: pi records whatever
-  // string is handed to `session.prompt()` into the transcript, so the injected
-  // scaffolding replays into the UI attributed to the user. Suppressing it at
-  // the source keeps the web transcript equal to what the user actually typed —
-  // stripping it back out downstream can't work, because by then injected text
-  // and identical user-typed text are indistinguishable.
+  // at, so "Platform: api" / "Channel: api_<userId>" is pure noise. The
+  // provider-only context boundary below now protects every surface from
+  // transcript leakage; this suppression remains solely a relevance choice.
   if (input.platform === "api") return "";
 
   const md =
@@ -1031,6 +1037,16 @@ export async function runAISession(
   // for a normal session (has an assistant). Must run on the FINAL manager,
   // after any provider-change reopen above.
   await normalizeHydratedSessionFile(sessionManager, sessionFile);
+  if (sessionSummary) {
+    // Provider isolation is a durable conversation event, unlike per-run
+    // attention/recall/channel context. Pi custom messages participate in LLM
+    // context but remain hidden from the normal transcript surface.
+    sessionManager.appendCustomMessageEntry(
+      "lobu.provider_change",
+      sessionSummary,
+      false
+    );
+  }
   const settingsManager = SettingsManager.inMemory();
 
   const toolsPolicy = buildToolPolicy({
@@ -1271,6 +1287,7 @@ user references earlier discussion or you need prior context.`);
   let deltaTimer: Timer | null = null;
   let session: Awaited<ReturnType<typeof buildAgentSession>>["session"] | null =
     null;
+  let activeTransientTurnContext = "";
   // Fire the plugin `agent_end` hook with the live session messages. No-op
   // when the session never came up (the catch path before construction). An
   // `error` makes it a failure; its absence makes it a success.
@@ -1309,6 +1326,7 @@ user references earlier discussion or you need prior context.`);
       cwd: workspaceDir,
       model,
       renderSystemPrompt,
+      getTransientTurnContext: () => activeTransientTurnContext,
       // pi's createAgentSession() uses `tools` only to derive active tool
       // names and rebuilds the base tools internally (bash via getShellEnv()
       // = {...process.env}, no env strip, no embedded BashOperations).
@@ -1391,7 +1409,11 @@ user references earlier discussion or you need prior context.`);
 
     const runPromptTurn = async (
       promptText: string,
-      options?: { images?: ImageContent[]; silent?: boolean }
+      options?: {
+        images?: ImageContent[];
+        silent?: boolean;
+        transientContext?: string;
+      }
     ): Promise<void> => {
       const currentSession = session;
       if (!currentSession) {
@@ -1416,6 +1438,7 @@ user references earlier discussion or you need prior context.`);
       });
 
       suppressProgressOutput = options?.silent === true;
+      activeTransientTurnContext = options?.transientContext?.trim() ?? "";
 
       try {
         onSteerReady((prompt) => {
@@ -1444,6 +1467,7 @@ user references earlier discussion or you need prior context.`);
         }
         await turnDone;
       } finally {
+        activeTransientTurnContext = "";
         suppressProgressOutput = false;
         if (resolveTurnDone && currentTurnNonce === turnNonce) {
           resolveTurnDone = null;
@@ -1781,7 +1805,8 @@ user references earlier discussion or you need prior context.`);
     // the user turn the model tended to echo it back into its reply. (Full
     // pre-resolution of refs into injected data is a possible future follow-up.)
     // Per-run conversation context (channel, trigger, link). Injected into the
-    // user turn — NOT the cached system prompt — because it varies per turn.
+    // provider's user-turn view — NOT the cached system prompt or persisted
+    // user message — because it varies per turn.
     const runContext = buildRunContextBlock({
       platform,
       channelId,
@@ -1794,7 +1819,20 @@ user references earlier discussion or you need prior context.`);
       webOrigin: context.webOrigin,
     });
 
-    const effectivePromptText = `${configNotice}${sessionSummary ? `${sessionSummary}\n\n` : ""}${ephemeralContext ? `${ephemeralContext}\n\n` : ""}${prependContexts ? `${prependContexts}\n\n` : ""}${runContext ? `${runContext}\n\n` : ""}${userPrompt}`;
+    const transientTurnContext = [
+      configNotice,
+      ephemeralContext,
+      prependContexts,
+      runContext,
+    ]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join("\n\n");
+    // Token forecasting must account for the provider's complete view even
+    // though only userPrompt is durable in the transcript.
+    const modelPromptText = transientTurnContext
+      ? `${transientTurnContext}\n\n${userPrompt}`
+      : userPrompt;
 
     // Load image attachments for vision-capable models
     const images = await loadImageAttachments();
@@ -1807,14 +1845,17 @@ user references earlier discussion or you need prior context.`);
       sessionManager,
       settingsManager,
       memoryFlushConfig,
-      incomingPromptText: effectivePromptText,
+      incomingPromptText: modelPromptText,
       incomingImageCount: images.length,
       runSilentPrompt: async (prompt) => {
         await runPromptTurn(prompt, { silent: true });
       },
     });
 
-    await runPromptTurn(effectivePromptText, { images });
+    await runPromptTurn(userPrompt, {
+      images,
+      transientContext: transientTurnContext,
+    });
 
     const sessionError = progressProcessor.consumeFatalErrorMessage();
     if (sessionError) {

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -136,12 +136,18 @@ type BuildAgentSessionOptions = Omit<
    * it into Pi's provider-only context copy, never the persisted user message.
    */
   getTransientTurnContext?: () => string | undefined;
+  /**
+   * Durable provider-isolation note for a session Pi is about to initialize.
+   * It must be appended only after Pi records the new session's model_change.
+   */
+  providerChangeSummary?: string;
 };
 
 export async function buildAgentSession({
   builtinOverrides,
   renderSystemPrompt,
   getTransientTurnContext,
+  providerChangeSummary,
   ...options
 }: BuildAgentSessionOptions): Promise<CreateAgentSessionResult> {
   // Pi's defaults persist under ~/.pi and discover resources/config from cwd.
@@ -171,6 +177,17 @@ export async function buildAgentSession({
     resourceLoader,
   });
   const { session } = result;
+
+  if (providerChangeSummary) {
+    await session.sendCustomMessage(
+      {
+        customType: "lobu.provider_change",
+        content: providerChangeSummary,
+        display: false,
+      },
+      { triggerTurn: false }
+    );
+  }
 
   const lobuBuiltins = new Map<string, AgentTool<any>>();
   for (const tool of builtinOverrides ?? []) {
@@ -1037,16 +1054,6 @@ export async function runAISession(
   // for a normal session (has an assistant). Must run on the FINAL manager,
   // after any provider-change reopen above.
   await normalizeHydratedSessionFile(sessionManager, sessionFile);
-  if (sessionSummary) {
-    // Provider isolation is a durable conversation event, unlike per-run
-    // attention/recall/channel context. Pi custom messages participate in LLM
-    // context but remain hidden from the normal transcript surface.
-    sessionManager.appendCustomMessageEntry(
-      "lobu.provider_change",
-      sessionSummary,
-      false
-    );
-  }
   const settingsManager = SettingsManager.inMemory();
 
   const toolsPolicy = buildToolPolicy({
@@ -1358,6 +1365,10 @@ user references earlier discussion or you need prior context.`);
       // tools are bounded identically to the built-ins.
       customTools: wrapToolsWithTurnGuard(customTools, turnController),
       sessionManager,
+      // Provider isolation is a durable conversation event, unlike per-run
+      // attention/recall/channel context. buildAgentSession adds the hidden Pi
+      // custom message only AFTER Pi records this new session's model_change.
+      providerChangeSummary: sessionSummary,
       settingsManager,
       authStorage,
       modelRegistry,


### PR DESCRIPTION
## Summary

- Keep workspace attention, memory recall, config notices, and channel/run context in Pi's provider-only turn view instead of persisting them as user-authored transcript text.
- Preserve provider-change notices as durable hidden custom messages.
- Add a real Pi session regression covering tool loops, image prompts, context clearing, JSONL persistence, and conversation titles.

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: full agent-worker suite (`836 pass`, `12 platform skips`, `0 fail`), focused worker/core suites (`50 pass`), worker typecheck, formatting, lint, and `make pre-pr`
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot runtime changed: ran the real Pi provider/session E2E and the complete agent-worker suite

Red before the fix:

```text
expected provider user content: "## Workspace attention (recent)\n...\n\nhi"
received: "hi"
0 pass, 1 fail
```

Green after the fix:

```text
transient turn context (real Pi session E2E): pass
full worker suite: 836 pass, 12 skip, 0 fail
make pre-pr: clean
```

## Notes

- Independent Codex pre-review found no merge-blocking defect and strengthened the E2E coverage.
- No Owletto source change is required: the UI was correctly rendering a persisted `role=user` message; this fixes the worker persistence boundary that created the bad message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-only context for agent turns, including tool loops and image requests, without adding it to the visible conversation history.
  * Context is omitted automatically when cleared.
  * Token forecasting now accounts for transient context.

* **Bug Fixes**
  * Prevented internal turn context from appearing in persisted user prompts and transcripts.

* **Tests**
  * Added end-to-end coverage for text, tool, image, and context-cleared turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->