### PR TITLE
fix(release): keep Mac updater current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,6 +1168,12 @@ jobs:
         # next release.
         run: bun test scripts/__tests__/release-publish-order.test.ts --timeout 30000
 
+      - name: Sparkle appcast ordering
+        # RFC 2822 pubDate values begin with a weekday. A string sort left an
+        # older Wednesday release above newer Monday releases, breaking the
+        # feed's newest-first contract.
+        run: bun test scripts/__tests__/sparkle-appcast-order.test.ts --timeout 30000
+
       - name: Release image audit decision table
         # The scheduled audit (release-image-audit.yml) is the only thing that
         # notices a release which published no image — a run evicted from its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1074,7 +1074,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/setup-submodule
+      - id: submodule
+        uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
@@ -1168,10 +1169,11 @@ jobs:
         # next release.
         run: bun test scripts/__tests__/release-publish-order.test.ts --timeout 30000
 
-      - name: Sparkle appcast ordering
-        # RFC 2822 pubDate values begin with a weekday. A string sort left an
-        # older Wednesday release above newer Monday releases, breaking the
-        # feed's newest-first contract.
+      - name: Sparkle updater freshness
+        # RFC 2822 pubDate values begin with a weekday, so string sorting is
+        # not chronological and breaks the feed's newest-first contract.
+        env:
+          OWLETTO_SUBMODULE_STUBBED: ${{ steps.submodule.outputs.stubbed }}
         run: bun test scripts/__tests__/sparkle-appcast-order.test.ts --timeout 30000
 
       - name: Release image audit decision table

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -210,6 +210,16 @@ jobs:
             exit 1
           fi
 
+          # Device workers are often unattended and long-lived. Sparkle's
+          # default daily cadence left newly released fixes undiscovered until
+          # the following day, so keep the fleet check interval at one hour.
+          update_interval=$(/usr/libexec/PlistBuddy -c "Print :SUScheduledCheckInterval" \
+            packages/owletto/apps/mac/Owletto/Info.plist 2>/dev/null || true)
+          if [ "$update_interval" != "3600" ]; then
+            echo "::error::SUScheduledCheckInterval is '$update_interval', expected 3600 seconds"
+            exit 1
+          fi
+
       - name: Install workspace dependencies for Mac daemon build
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -211,8 +211,8 @@ jobs:
           fi
 
           # Device workers are often unattended and long-lived. Sparkle's
-          # default daily cadence left newly released fixes undiscovered until
-          # the following day, so keep the fleet check interval at one hour.
+          # default daily cadence can delay discovery of new fixes for up to
+          # 24 hours, so keep the fleet check interval at one hour.
           update_interval=$(/usr/libexec/PlistBuddy -c "Print :SUScheduledCheckInterval" \
             packages/owletto/apps/mac/Owletto/Info.plist 2>/dev/null || true)
           if [ "$update_interval" != "3600" ]; then

--- a/scripts/__tests__/sparkle-appcast-order.test.ts
+++ b/scripts/__tests__/sparkle-appcast-order.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { fileURLToPath } from "node:url";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
-import { afterEach, describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const script = join(repoRoot, "scripts/sparkle/update-appcast.py");
@@ -12,6 +12,8 @@ const macInfoPlist = join(
   "packages/owletto/apps/mac/Owletto/Info.plist"
 );
 const temporaryDirectories: string[] = [];
+const owlettoSubmoduleStubbed =
+  process.env.OWLETTO_SUBMODULE_STUBBED === "true";
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -19,7 +21,7 @@ afterEach(() => {
   }
 });
 
-describe("Sparkle appcast ordering", () => {
+describe("Sparkle updater freshness", () => {
   it("orders releases by timestamp rather than weekday text", () => {
     const directory = mkdtempSync(join(tmpdir(), "lobu-appcast-test-"));
     temporaryDirectories.push(directory);
@@ -72,10 +74,13 @@ describe("Sparkle appcast ordering", () => {
     expect(versions).toEqual(["17.0.0", "15.7.0", "14.7.1"]);
   });
 
-  it("checks unattended device workers every hour", () => {
-    const plist = readFileSync(macInfoPlist, "utf8");
-    expect(plist).toMatch(
-      /<key>SUScheduledCheckInterval<\/key>\s*<integer>3600<\/integer>/
-    );
-  });
+  it.skipIf(owlettoSubmoduleStubbed)(
+    "checks unattended device workers every hour",
+    () => {
+      const plist = readFileSync(macInfoPlist, "utf8");
+      expect(plist).toMatch(
+        /<key>SUScheduledCheckInterval<\/key>\s*<integer>3600<\/integer>/
+      );
+    }
+  );
 });

--- a/scripts/__tests__/sparkle-appcast-order.test.ts
+++ b/scripts/__tests__/sparkle-appcast-order.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const script = join(repoRoot, "scripts/sparkle/update-appcast.py");
+const macInfoPlist = join(
+  repoRoot,
+  "packages/owletto/apps/mac/Owletto/Info.plist"
+);
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Sparkle appcast ordering", () => {
+  it("orders releases by timestamp rather than weekday text", () => {
+    const directory = mkdtempSync(join(tmpdir(), "lobu-appcast-test-"));
+    temporaryDirectories.push(directory);
+    const appcast = join(directory, "appcast.xml");
+    writeFileSync(
+      appcast,
+      `<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>Owletto</title>
+    <item>
+      <pubDate>Wed, 29 Jul 2026 18:12:51 GMT</pubDate>
+      <sparkle:version>14.7.1</sparkle:version>
+      <sparkle:shortVersionString>14.7.1</sparkle:shortVersionString>
+    </item>
+    <item>
+      <pubDate>Fri, 21 Aug 2026 19:17:02 GMT</pubDate>
+      <sparkle:version>15.7.0</sparkle:version>
+      <sparkle:shortVersionString>15.7.0</sparkle:shortVersionString>
+    </item>
+  </channel>
+</rss>`
+    );
+
+    const result = spawnSync(
+      "python3",
+      [
+        script,
+        appcast,
+        "--version",
+        "17.0.0",
+        "--build",
+        "17.0.0",
+        "--dmg-url",
+        "https://example.test/Owletto.dmg",
+        "--signature",
+        "test-signature",
+        "--length",
+        "1",
+      ],
+      { encoding: "utf8" }
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const versions = [
+      ...readFileSync(appcast, "utf8").matchAll(
+        /<sparkle:shortVersionString>([^<]+)<\/sparkle:shortVersionString>/g
+      ),
+    ].map((match) => match[1]);
+    expect(versions).toEqual(["17.0.0", "15.7.0", "14.7.1"]);
+  });
+
+  it("checks unattended device workers every hour", () => {
+    const plist = readFileSync(macInfoPlist, "utf8");
+    expect(plist).toMatch(
+      /<key>SUScheduledCheckInterval<\/key>\s*<integer>3600<\/integer>/
+    );
+  });
+});

--- a/scripts/sparkle/update-appcast.py
+++ b/scripts/sparkle/update-appcast.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import argparse
 import sys
 from datetime import datetime, timezone
-from email.utils import format_datetime
+from email.utils import format_datetime, parsedate_to_datetime
 from xml.etree import ElementTree as ET
 
 SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
@@ -79,10 +79,24 @@ def main() -> int:
         },
     )
 
-    # Sort items newest first.
+    # Sort items newest first. RFC 2822 dates start with the weekday, so a raw
+    # string sort puts "Wed" ahead of a newer "Mon" release. Keep the feed's
+    # stated newest-first contract for humans and first-item consumers.
+    def published_at(el: ET.Element) -> datetime:
+        value = el.findtext("pubDate")
+        if not value:
+            return datetime.min.replace(tzinfo=timezone.utc)
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return datetime.min.replace(tzinfo=timezone.utc)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
     items = sorted(
         channel.findall("item"),
-        key=lambda el: el.findtext("pubDate") or "",
+        key=published_at,
         reverse=True,
     )
     for el in channel.findall("item"):


### PR DESCRIPTION
## Summary
- set the Mac app to check for releases hourly instead of Sparkle’s one-day default
- sort appcast entries by parsed RFC 2822 timestamps
- enforce both contracts in release CI with a regression test
- advance Owletto to lobu-ai/owletto#961

## Root cause
The MacBook and Mac mini had both last checked before the 16.1 and 17.0 releases. With Sparkle’s default 24-hour schedule they had not yet looked again. Separately, the appcast helper sorted weekday-prefixed dates as strings, leaving older Wednesday entries above newer Monday releases.

## Verification
- 11 focused Bun tests passed
- `actionlint .github/workflows/ci.yml .github/workflows/mac-release.yml`
- `plutil -lint packages/owletto/apps/mac/Owletto/Info.plist`
- pre-commit Biome and TypeScript checks passed

Paired Owletto PR: https://github.com/lobu-ai/owletto/pull/961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Sparkle appcast ordering so releases consistently appear newest first based on publication time.
  * Added fallback handling for missing or invalid publication dates.

* **Release Validation**
  * Added checks to ensure scheduled update intervals are configured correctly.

* **Tests**
  * Added regression coverage for appcast ordering and macOS update scheduling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->