### PR TITLE
fix(linkedin): recover complete comment scraping

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1808,6 +1808,7 @@ describe("LinkedInConnector home_feed", () => {
           optionTextRegex: string;
         };
         more: { selector: string; textRegex: string };
+        maxDurationMs: number;
         outputField: string;
       };
       id: { name: string | string[]; regex: string; group: number };
@@ -1853,6 +1854,7 @@ describe("LinkedInConnector home_feed", () => {
       optionTextRegex: "^Most recent\\b",
     });
     expect(cfg.expandRows.more.textRegex).toContain("replies");
+    expect(cfg.expandRows.maxDurationMs).toBe(55_000);
     expect(cfg.expandRows.outputField).toBe("comment_coverage");
     expect(cfg.id.name).toEqual(["componentkey", "id"]);
     expect(
@@ -1947,7 +1949,8 @@ describe("LinkedInConnector home_feed", () => {
    */
   const syncHomeFeedDom = async (
     body: string,
-    setup?: (dom: JSDOM) => void
+    setup?: (dom: JSDOM) => void,
+    expandRowsOverride?: Record<string, unknown>
   ) => {
     const dom = new JSDOM(`<!doctype html><body>${body}</body>`, {
       url: "https://www.linkedin.com/feed/",
@@ -1996,6 +1999,18 @@ describe("LinkedInConnector home_feed", () => {
               result: await genericScrape({
                 ...(input.scrape_config as Record<string, unknown>),
                 scroll: { max: 0, stall: 0, waitMs: 0 },
+                ...(expandRowsOverride
+                  ? {
+                      expandRows: {
+                        ...((
+                          input.scrape_config as {
+                            expandRows?: Record<string, unknown>;
+                          }
+                        ).expandRows ?? {}),
+                        ...expandRowsOverride,
+                      },
+                    }
+                  : {}),
               }),
             }),
           },
@@ -2035,6 +2050,17 @@ describe("LinkedInConnector home_feed", () => {
       </div>`,
       (dom) => {
         const document = dom.window.document;
+        const bindMore = (row: Element) => {
+          row.querySelector(".more-comments")?.addEventListener("click", () => {
+            const holder = document.createElement("div");
+            holder.innerHTML = comment("8222222222222222224", "Commenter Four");
+            const fourth = holder.firstElementChild;
+            if (fourth) row.append(fourth);
+            row.querySelector(".more-comments")?.remove();
+          });
+        };
+        const initialRow = document.querySelector("[componentkey]");
+        if (initialRow) bindMore(initialRow);
         document
           .querySelector(".comment-sort")
           ?.addEventListener("click", () => {
@@ -2043,21 +2069,19 @@ describe("LinkedInConnector home_feed", () => {
             option.textContent =
               "Most recent See all comments, the most recent comments are first";
             option.addEventListener("click", () => {
-              const sort = document.querySelector(".comment-sort");
-              if (sort) sort.textContent = "Most recent";
+              const current = document.querySelector("[componentkey]");
+              const replacement = current?.cloneNode(true) as
+                | Element
+                | undefined;
+              const sort = replacement?.querySelector(".comment-sort");
+              if (sort && current) {
+                sort.textContent = "Most recent";
+                bindMore(replacement);
+                current.replaceWith(replacement);
+              }
               option.remove();
             });
             document.body.append(option);
-          });
-        document
-          .querySelector(".more-comments")
-          ?.addEventListener("click", () => {
-            const holder = document.createElement("div");
-            holder.innerHTML = comment("8222222222222222224", "Commenter Four");
-            const fourth = holder.firstElementChild;
-            if (fourth)
-              document.querySelector("[componentkey]")?.append(fourth);
-            document.querySelector(".more-comments")?.remove();
           });
       }
     );
@@ -2089,6 +2113,28 @@ describe("LinkedInConnector home_feed", () => {
           <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444443)"><p>Commenter Three • Third rendered fixture comment</p></div>
         </div>`)
     ).rejects.toThrow(/captured 3 of 4 advertised comments/i);
+  });
+
+  test("names the expansion budget when a thread times out mid-expansion", async () => {
+    const activityId = "8555555555555555555";
+    // `more` never resolves the thread, so expansion can only end on its
+    // deadline — the branch that must be reported as a budget timeout rather
+    // than as a stale-extension or wrong-selector failure.
+    await expect(
+      syncHomeFeedDom(
+        `
+        <div componentkey="expandedtimeout_threadFeedType_MAIN_FEED_RELEVANCE">
+          <button aria-label="Open control menu for post by Timed Out Thread Author"></button>
+          <span id="translatable-commentary-urn:li:activity:${activityId}"></span>
+          <p>A timed-out-thread home-feed post with enough useful text to pass the filter</p>
+          <div role="button" class="comment-count">4 comments</div>
+          <div id="replaceableComment_urn:li:comment:(urn:li:activity:${activityId},8666666666666666661)"><p>Commenter One • First rendered fixture comment</p></div>
+          <div role="button" class="more-comments">See 3 more comments</div>
+        </div>`,
+        undefined,
+        { maxDurationMs: 1, waitMs: 5 }
+      )
+    ).rejects.toThrow(/Expansion hit its 55s budget on 1 thread/i);
   });
 
   test("a post does not inherit reactions from a comment rendered above its own counts", async () => {
@@ -3018,7 +3064,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.5");
+    expect(c.definition.version).toBe("3.11.6");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -442,6 +442,7 @@ interface HomeFeedCommentCoverage {
   expected: number;
   collected: number;
   complete: boolean;
+  timedOut?: boolean;
 }
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
@@ -506,6 +507,10 @@ const HOME_FEED_SCRAPE_CONFIG = {
       textRegexFlags: "i",
     },
     maxPasses: 40,
+    // Return explicit incomplete coverage before the extension's 90-second
+    // watchdog. This leaves time for row harvesting and guarantees that a
+    // large thread cannot strand a content script in the user's tab.
+    maxDurationMs: 55_000,
     stall: 2,
     waitMs: 350,
     outputField: "comment_coverage",
@@ -1020,6 +1025,7 @@ interface HomeFeedCommentCoverageSummary {
   collected: number;
   incomplete: number;
   unsupported: number;
+  timedOut: number;
   details: string[];
 }
 
@@ -1058,6 +1064,7 @@ function summarizeHomeFeedCommentCoverage(
   let collected = 0;
   let incomplete = 0;
   let unsupported = 0;
+  let timedOut = 0;
   const details: string[] = [];
   for (const thread of byPost.values()) {
     expected += thread.advertised;
@@ -1074,6 +1081,7 @@ function summarizeHomeFeedCommentCoverage(
       thread.coverage.collected < thread.advertised
     ) {
       incomplete++;
+      if (thread.coverage.timedOut) timedOut++;
       details.push(
         `${thread.advertised}/${thread.coverage.expected}/${thread.coverage.collected}`
       );
@@ -1085,6 +1093,7 @@ function summarizeHomeFeedCommentCoverage(
     collected,
     incomplete,
     unsupported,
+    timedOut,
     details,
   };
 }
@@ -2850,7 +2859,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.5",
+    version: "3.11.6",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -3506,9 +3515,16 @@ export default class LinkedInConnector extends ConnectorRuntime<
 
     const commentCoverage = summarizeHomeFeedCommentCoverage(resolvedRows);
     if (commentCoverage.incomplete > 0) {
-      const runtimeHint = commentCoverage.unsupported
-        ? ` The paired Owletto extension omitted expansion coverage for ${commentCoverage.unsupported} thread${commentCoverage.unsupported === 1 ? "" : "s"}; reload the current extension build.`
-        : "";
+      const hints: string[] = [];
+      if (commentCoverage.unsupported)
+        hints.push(
+          `The paired Owletto extension omitted expansion coverage for ${commentCoverage.unsupported} thread${commentCoverage.unsupported === 1 ? "" : "s"}; reload the current extension build.`
+        );
+      if (commentCoverage.timedOut)
+        hints.push(
+          `Expansion hit its ${HOME_FEED_SCRAPE_CONFIG.expandRows.maxDurationMs / 1000}s budget on ${commentCoverage.timedOut} thread${commentCoverage.timedOut === 1 ? "" : "s"}; retry with fewer scrolls so each thread gets more of the run.`
+        );
+      const runtimeHint = hints.length ? ` ${hints.join(" ")}` : "";
       throw new Error(
         `LinkedIn captured ${commentCoverage.collected} of ${commentCoverage.expected} advertised comments across ${commentCoverage.incomplete} incomplete post thread${commentCoverage.incomplete === 1 ? "" : "s"} (advertised/runtime/collected: ${commentCoverage.details.join(", ")}).${runtimeHint} No partial home-feed batch was persisted.`
       );


### PR DESCRIPTION
## Summary

- Pin Owletto #960 so LinkedIn comment expansion survives DOM row replacement and stops on a bounded deadline
- Give home-feed expansion 55 seconds inside the extension's 90-second watchdog and fail the entire batch with explicit incomplete coverage
- Cover row replacement, complete four-comment collection, and timeout reporting

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; `make pr-full` not run)
- [x] Targeted `bun test examples/personal-agent/__tests__/linkedin.connector.test.ts` — 134 pass, 0 fail
- [x] Bug fix: Owletto red→green regression — before implementation, 107 existing passed and the two new node-replacement/timeout tests failed; after implementation, 109 pass
- [ ] If bot runtime changed: not applicable

## Notes

- Dependency: lobu-ai/owletto#960 (merged as `eaa93abd`)
- No API, database, schema, migration, endpoint, or hosted UI changes
- Production Mac mini E2E follows after merge so the deployed connector and extension exactly match merged code.