### PR TITLE
feat(gchat): add native Lobu command parity

### DIFF
--- a/packages/connectors/src/__tests__/gchat.test.ts
+++ b/packages/connectors/src/__tests__/gchat.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, test } from "bun:test";
 import GoogleChatConnector from "../gchat";
 
 describe("Google Chat connector definition", () => {
-	test("exposes the project-local help command mapping", () => {
+	test("exposes the project-local Lobu command mapping", () => {
 		const definition = new GoogleChatConnector().definition;
 		const properties = definition.optionsSchema?.properties as
 			| Record<string, Record<string, unknown>>
 			| undefined;
 
-		expect(definition.version).toBe("1.0.1");
+		expect(definition.version).toBe("1.0.2");
 		expect(properties?.helpCommandId).toMatchObject({
 			type: "string",
 			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
-			title: "Help command ID",
+			title: "Lobu command ID",
 		});
 	});
 });

--- a/packages/connectors/src/gchat.ts
+++ b/packages/connectors/src/gchat.ts
@@ -9,7 +9,7 @@ export default class GoogleChatConnector extends IntegrationConnector {
 		kind: "integration",
 		name: "Google Chat",
 		description: "Connect a Google Chat app to Lobu.",
-		version: "1.0.1",
+		version: "1.0.2",
 		faviconDomain: "chat.google.com",
 		authSchema: { methods: [{ type: "none", label: "Service account" }] },
 		optionsSchema: {
@@ -25,9 +25,9 @@ export default class GoogleChatConnector extends IntegrationConnector {
 				helpCommandId: {
 					type: "string",
 					pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
-					title: "Help command ID",
+					title: "Lobu command ID",
 					description:
-						"Command ID (1-1000) configured for Lobu help in this Google Cloud project.",
+						"Command ID (1-1000) configured for Lobu's native /lobu wrapper. Existing /help commands stay compatible.",
 				},
 				endpointUrl: { type: "string", title: "Endpoint URL" },
 			},

--- a/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
+++ b/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
@@ -310,6 +310,138 @@ describe("Google Chat platform compatibility", () => {
     expect(deliveredThreadNames).toEqual([commandThread.name]);
   });
 
+  test("dispatches the registered Workspace Add-on /lobu command with its subcommand", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onNewMention(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const messageEvent = standardDirectMessage("/lobu status");
+    messageEvent.message.argumentText = "/lobu status";
+    messageEvent.space.type = "ROOM";
+    messageEvent.space.spaceType = "SPACE";
+    messageEvent.message.space = messageEvent.space;
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: messageEvent.user,
+          eventTime: messageEvent.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: messageEvent.message,
+            space: messageEvent.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["@lobu /lobu status"]);
+  });
+
+  test("preserves Workspace Add-on /lobu arguments when Google only supplies argumentText", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage();
+    delete event.message.text;
+    event.message.argumentText = "/lobu link crm-ABC123";
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/lobu link crm-ABC123"]);
+  });
+
+  test("does not dispatch /lobu for another project-local command ID", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+    });
+    const event = standardDirectMessage("/lobu status");
+
+    const response = await dispatchAndWait(
+      chat,
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "1",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual([]);
+  });
+
+  test("maps a bare registered /lobu command to help", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage("/lobu");
+
+    const response = await chat.webhooks.gchat(
+      webhook({
+        chat: {
+          user: event.user,
+          eventTime: event.eventTime,
+          appCommandPayload: {
+            appCommandMetadata: {
+              appCommandId: "999",
+              appCommandType: "SLASH_COMMAND",
+            },
+            message: event.message,
+            space: event.space,
+          },
+        },
+      }),
+    );
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/help"]);
+  });
+
   test("dispatches a Workspace Add-on slash command without message text", async () => {
     const chat = await createTestChat({ helpCommandId: "999" });
     const delivered: string[] = [];
@@ -422,6 +554,25 @@ describe("Google Chat platform compatibility", () => {
 
     expect(response.status).toBe(200);
     expect(delivered).toEqual(["/help"]);
+  });
+
+  test("dispatches a standalone registered /lobu command with arguments", async () => {
+    const chat = await createTestChat({ helpCommandId: "999" });
+    const delivered: string[] = [];
+    const completion = Promise.withResolvers<void>();
+    chat.onDirectMessage(async (_thread, message) => {
+      delivered.push(message.text);
+      completion.resolve();
+    });
+    const event = standardDirectMessage("/lobu try crm");
+    event.message.argumentText = "/lobu try crm";
+    event.message.slashCommand = { commandId: "999" };
+
+    const response = await chat.webhooks.gchat(webhook(event));
+    await waitForDelivery(completion.promise);
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["/lobu try crm"]);
   });
 
   test("dispatches a standalone annotated slash command without message text", async () => {

--- a/packages/server/src/gateway/connections/platforms/gchat.ts
+++ b/packages/server/src/gateway/connections/platforms/gchat.ts
@@ -117,6 +117,41 @@ function normalizeGoogleChatHelpMessage(
 }
 
 /**
+ * Convert the one registered Google command into Lobu's shared command text.
+ * Google projects own their numeric command IDs, while Lobu intentionally uses
+ * the same `/lobu <subcommand>` wrapper as Slack. Older projects that registered
+ * this ID as `/help` keep their existing mapping.
+ */
+function registeredGoogleChatCommandText(
+  message: JsonObject | undefined,
+): string {
+  const messageText =
+    typeof message?.text === "string" ? message.text.trim() : "";
+  const lobuCommand = messageText.match(/^\/?lobu(?:\s+([\s\S]*))?$/i);
+  if (lobuCommand) {
+    const args = lobuCommand[1]?.trim() || "";
+    return args ? `/lobu ${args}` : "/help";
+  }
+  if (/^\/?help$/i.test(messageText)) return "/help";
+
+  // Google exposes a mention-free copy of the message in argumentText. Use it
+  // when text is absent, and accept both full `/lobu ...` and args-only forms.
+  const argumentText =
+    typeof message?.argumentText === "string"
+      ? message.argumentText.trim()
+      : "";
+  if (argumentText) {
+    const withoutWrapper = argumentText
+      .replace(/^\/?lobu(?:\s+|$)/i, "")
+      .trim();
+    if (!withoutWrapper || /^\/?help$/i.test(withoutWrapper)) return "/help";
+    return `/lobu ${withoutWrapper}`;
+  }
+
+  return "/help";
+}
+
+/**
  * Workspace Events arrive through Pub/Sub with the Chat resource encoded in
  * message.data. Normalize that embedded resource too: the Pub/Sub and direct
  * webhook copies share a message ID, so whichever arrives first wins Chat
@@ -207,7 +242,8 @@ function normalizeWorkspaceAddOnAppCommand(
   // are already explicitly addressed to this app but don't carry a mention,
   // so use its normalized mention form at the adapter boundary. The message
   // bridge removes this prefix again before command dispatch.
-  const text = isDm ? "/help" : `@${botUserName} /help`;
+  const commandText = registeredGoogleChatCommandText(message);
+  const text = isDm ? commandText : `@${botUserName} ${commandText}`;
   const sender = isObject(message?.sender)
     ? message.sender
     : isObject(chat.user)
@@ -357,9 +393,12 @@ function normalizeGoogleChatInteractionEvent(
     helpCommandId !== undefined &&
     standaloneCommandId === helpCommandId
   ) {
+    const commandText = registeredGoogleChatCommandText(rawMessage);
     message = {
       ...message,
-      text: isDirectSpace(space) ? "/help" : `@${botUserName} /help`,
+      text: isDirectSpace(space)
+        ? commandText
+        : `@${botUserName} ${commandText}`,
     };
   }
   const user = isObject(body.user)

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -200,7 +200,7 @@ const GoogleChatConfigSchema = Type.Object({
 		Type.String({
 			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
 			description:
-				"Google Chat command ID (1-1000) mapped to Lobu's native /lobu wrapper; legacy /help registrations remain supported.",
+				"Google Chat command ID (1-1000) mapped to Lobu help for this project.",
 		}),
 	),
 	userName: Type.Optional(

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -200,7 +200,7 @@ const GoogleChatConfigSchema = Type.Object({
 		Type.String({
 			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
 			description:
-				"Google Chat command ID (1-1000) mapped to Lobu help for this project.",
+				"Google Chat command ID (1-1000) mapped to Lobu's native /lobu wrapper; legacy /help registrations remain supported.",
 		}),
 	),
 	userName: Type.Optional(


### PR DESCRIPTION
## Summary
- route the project-local Google Chat slash command through the shared /lobu subcommand dispatcher used by Slack
- preserve command arguments across Workspace Add-on and standalone Google Chat event envelopes
- keep legacy /help registrations compatible and reject command IDs from other projects
- update the Google Chat connector schema label and version

## Validation
- 36 focused Google Chat and connector tests
- strict server and connector typechecks
- make pre-pr
- pre-commit Biome and TypeScript checks

## Deployment test plan
After production deploy, configure Google Chat command ID 1 as /lobu, then verify /lobu help and /lobu status in both a DM and a test space before resubmitting Marketplace review.