### PR TITLE
fix(linkedin): ignore feed helper rows

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2137,6 +2137,23 @@ describe("LinkedInConnector home_feed", () => {
     ).rejects.toThrow(/Expansion hit its 55s budget on 1 thread/i);
   });
 
+  test("ignores FeedType helper rows nested inside a real post", async () => {
+    const activityId = "8777777777777777777";
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedhelper_rowFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Real Post Author"></button>
+        <span id="translatable-commentary-urn:li:activity:${activityId}"></span>
+        <p>A real home-feed post with enough useful text to pass the filter</p>
+        <div componentkey="commentsSectionContainerhelper_rowFeedType_MAIN_FEED_RELEVANCE">
+          <p>Helper Row Person • This nested comment-section helper has author-like text but is not a post</p>
+        </div>
+      </div>`);
+
+    expect(res.events.map((event: any) => event.origin_id)).toEqual([
+      `li_home_activity_${activityId}`,
+    ]);
+  });
+
   test("a post does not inherit reactions from a comment rendered above its own counts", async () => {
     // Ordering matters: `querySelector` returns the first match in DOCUMENT
     // order across the whole selector list, not the first branch that matches.
@@ -3064,7 +3081,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.6");
+    expect(c.definition.version).toBe("3.11.7");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -464,7 +464,7 @@ const HOME_FEED_SCRAPE_CONFIG = {
     pathRegex: "/(login|authwall|uas/login|checkpoint|signup)\\b",
   },
   rowSelector:
-    'div[componentkey*="FeedType_MAIN_FEED_RELEVANCE"], [id^="replaceableComment_urn:li:comment:"]',
+    'div[componentkey^="expanded"][componentkey*="FeedType_MAIN_FEED_RELEVANCE"], [id^="replaceableComment_urn:li:comment:"]',
   expandRows: {
     // Only actual post containers start with `expanded`; helper/component rows
     // share the FeedType suffix but must never drive another post's controls.
@@ -2859,7 +2859,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.6",
+    version: "3.11.7",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com


### PR DESCRIPTION
## Summary

- Restrict LinkedIn home-feed post harvesting to real `expanded…` post roots
- Keep native comment rows as independent records
- Add a live-DOM-shaped regression for nested `commentsSectionContainer…FeedType` helpers

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; `make pr-full` not run)
- [x] Targeted `bun test examples/personal-agent/__tests__/linkedin.connector.test.ts` — 135 pass, 0 fail
- [x] Bug fix red→green: before the selector change, the new fixture failed with `1 post row without a durable identity`; after it, only the real durable post is emitted
- [ ] If bot runtime changed: not applicable

## Notes

- Production 3.11.6 E2E run 1153007 exposed this selector bug after terminating cleanly in 61 seconds
- No extension, API, database, schema, migration, endpoint, or hosted UI changes
- `make review-fix` was attempted but the external reviewer session limit was exhausted; it made no changes.