### PR TITLE
fix(cli): isolate Mac debug bootstrap context

### DIFF
--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -277,7 +277,7 @@ describe("lobu run backend bundle resolution", () => {
 });
 
 describe("shouldAutoApplyLocalProject", () => {
-  test("applies for an embedded run once the local context is ready", () => {
+  test("applies for an embedded run once the selected context is ready", () => {
     expect(
       shouldAutoApplyLocalProject({
         mode: "embedded",
@@ -287,7 +287,7 @@ describe("shouldAutoApplyLocalProject", () => {
     ).toBe(true);
   });
 
-  test("skips when sign-in did not establish the local context", () => {
+  test("skips when sign-in did not establish the selected context", () => {
     // The guard that stops `lobu run` applying a local project to whatever
     // cloud/prod context happened to be active.
     expect(
@@ -622,6 +622,43 @@ describe("lobu run local sign-in diagnostics", () => {
         hasLobuConfig: true,
       })
     ).toBeNull();
+  });
+
+  test("isolates an explicit process context without changing the global default", async () => {
+    const previousContext = process.env.LOBU_CONTEXT;
+    process.env.LOBU_CONTEXT = "__owletto_debug_v2__5:local";
+    const calls: string[] = [];
+    try {
+      const result = await announceLocalSignIn("http://127.0.0.1:8788", true, {
+        ...dependencies(),
+        addContextImpl: async (name, url) => {
+          calls.push(`context:${name}:${url}`);
+        },
+        saveCredentialsImpl: async (_credentials, name) => {
+          calls.push(`credentials:${name}`);
+        },
+        setActiveOrgImpl: async (slug, name) => {
+          calls.push(`org:${slug}:${name}`);
+        },
+        getCurrentContextNameImpl: async () => {
+          calls.push("read-current");
+          return "local";
+        },
+        setCurrentContextImpl: async (name) => {
+          calls.push(`set-current:${name}`);
+        },
+      });
+
+      expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
+      expect(calls).toEqual([
+        "context:__owletto_debug_v2__5:local:http://127.0.0.1:8788",
+        "credentials:__owletto_debug_v2__5:local",
+        "org:local-install:__owletto_debug_v2__5:local",
+      ]);
+    } finally {
+      if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
+      else process.env.LOBU_CONTEXT = previousContext;
+    }
   });
 
   test("warns only when an embedded project will skip auto-apply", () => {

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -338,6 +338,7 @@ describe("lobu run local sign-in diagnostics", () => {
     addContextImpl: async () => undefined,
     saveCredentialsImpl: async () => undefined,
     setActiveOrgImpl: async () => undefined,
+    inspectContextImpl: async () => undefined,
     getCurrentContextNameImpl: async () => "local",
     setCurrentContextImpl: async () => undefined,
   });
@@ -626,7 +627,9 @@ describe("lobu run local sign-in diagnostics", () => {
 
   test("isolates an explicit process context without changing the global default", async () => {
     const previousContext = process.env.LOBU_CONTEXT;
+    const previousApiUrl = process.env.LOBU_API_URL;
     process.env.LOBU_CONTEXT = "__owletto_debug_v2__5:local";
+    process.env.LOBU_API_URL = "http://localhost:8788";
     const calls: string[] = [];
     try {
       const result = await announceLocalSignIn("http://127.0.0.1:8788", true, {
@@ -658,6 +661,46 @@ describe("lobu run local sign-in diagnostics", () => {
     } finally {
       if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
       else process.env.LOBU_CONTEXT = previousContext;
+      if (previousApiUrl === undefined) delete process.env.LOBU_API_URL;
+      else process.env.LOBU_API_URL = previousApiUrl;
+    }
+  });
+
+  test("refuses to overwrite an explicit remote context", async () => {
+    const previousContext = process.env.LOBU_CONTEXT;
+    const previousApiUrl = process.env.LOBU_API_URL;
+    process.env.LOBU_CONTEXT = "production";
+    delete process.env.LOBU_API_URL;
+    const calls: string[] = [];
+    try {
+      const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
+        ...dependencies(),
+        inspectContextImpl: async () => ({
+          url: "https://app.lobu.ai/api/v1",
+          lifecycle: "external",
+        }),
+        addContextImpl: async () => {
+          calls.push("context");
+        },
+        saveCredentialsImpl: async () => {
+          calls.push("credentials");
+        },
+        setActiveOrgImpl: async () => {
+          calls.push("org");
+        },
+      });
+
+      expect(result).toEqual({
+        ready: false,
+        stage: "context_setup",
+        detail: 'could not register or persist the "production" context',
+      });
+      expect(calls).toEqual([]);
+    } finally {
+      if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
+      else process.env.LOBU_CONTEXT = previousContext;
+      if (previousApiUrl === undefined) delete process.env.LOBU_API_URL;
+      else process.env.LOBU_API_URL = previousApiUrl;
     }
   });
 

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -712,6 +712,52 @@ describe("lobu run local sign-in diagnostics", () => {
     }
   });
 
+  test.each([
+    {
+      name: "legacy lifecycle-less local context",
+      contextName: "local",
+      configured: { url: "http://localhost:8788" },
+    },
+    {
+      name: "managed context with an API base path",
+      contextName: "__owletto_debug_v2__5:local",
+      configured: {
+        url: "http://localhost:8788/api/v1",
+        lifecycle: "managed" as const,
+      },
+    },
+  ])("refreshes credentials for a $name", async ({
+    contextName,
+    configured,
+  }) => {
+    const previousContext = process.env.LOBU_CONTEXT;
+    const previousApiUrl = process.env.LOBU_API_URL;
+    process.env.LOBU_CONTEXT = contextName;
+    process.env.LOBU_API_URL = "http://127.0.0.1:8788";
+    const calls: string[] = [];
+
+    try {
+      const result = await announceLocalSignIn("http://127.0.0.1:8788", true, {
+        ...dependencies(),
+        inspectContextImpl: async () => configured,
+        addContextImpl: async (name, url, server) => {
+          calls.push(`context:${name}:${url}:${server?.lifecycle}`);
+        },
+        saveCredentialsImpl: async (_credentials, name) => {
+          calls.push(`credentials:${name}`);
+        },
+      });
+
+      expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
+      expect(calls).toContain(`credentials:${contextName}`);
+    } finally {
+      if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
+      else process.env.LOBU_CONTEXT = previousContext;
+      if (previousApiUrl === undefined) delete process.env.LOBU_API_URL;
+      else process.env.LOBU_API_URL = previousApiUrl;
+    }
+  });
+
   test("refuses to overwrite an explicit remote context", async () => {
     const previousContext = process.env.LOBU_CONTEXT;
     const previousApiUrl = process.env.LOBU_API_URL;

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -634,8 +634,8 @@ describe("lobu run local sign-in diagnostics", () => {
     try {
       const result = await announceLocalSignIn("http://127.0.0.1:8788", true, {
         ...dependencies(),
-        addContextImpl: async (name, url) => {
-          calls.push(`context:${name}:${url}`);
+        addContextImpl: async (name, url, server) => {
+          calls.push(`context:${name}:${url}:${server?.lifecycle}`);
         },
         saveCredentialsImpl: async (_credentials, name) => {
           calls.push(`credentials:${name}`);
@@ -654,10 +654,56 @@ describe("lobu run local sign-in diagnostics", () => {
 
       expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
       expect(calls).toEqual([
-        "context:__owletto_debug_v2__5:local:http://127.0.0.1:8788",
+        "context:__owletto_debug_v2__5:local:http://127.0.0.1:8788:managed",
         "credentials:__owletto_debug_v2__5:local",
         "org:local-install:__owletto_debug_v2__5:local",
       ]);
+    } finally {
+      if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
+      else process.env.LOBU_CONTEXT = previousContext;
+      if (previousApiUrl === undefined) delete process.env.LOBU_API_URL;
+      else process.env.LOBU_API_URL = previousApiUrl;
+    }
+  });
+
+  test("keeps a new explicit runner context ready across restarts", async () => {
+    const previousContext = process.env.LOBU_CONTEXT;
+    const previousApiUrl = process.env.LOBU_API_URL;
+    process.env.LOBU_CONTEXT = "__owletto_debug_v2__5:local";
+    process.env.LOBU_API_URL = "http://localhost:8788";
+    let storedContext:
+      | { url: string; lifecycle?: "managed" | "external" }
+      | undefined;
+    const testDependencies = {
+      ...dependencies(),
+      inspectContextImpl: async () => storedContext,
+      addContextImpl: async (
+        _name: string,
+        url: string,
+        server?: { lifecycle?: "managed" | "external" }
+      ) => {
+        storedContext = { url, lifecycle: server?.lifecycle };
+      },
+    };
+
+    try {
+      const first = await announceLocalSignIn(
+        "http://127.0.0.1:8788",
+        true,
+        testDependencies
+      );
+      const second = await announceLocalSignIn(
+        "http://127.0.0.1:8788",
+        true,
+        testDependencies
+      );
+
+      expect(first).toEqual({ ready: true, localOrgSlug: "local-install" });
+      expect(second).toEqual({ ready: true, localOrgSlug: "local-install" });
+      expect(storedContext).toEqual({
+        url: "http://127.0.0.1:8788",
+        lifecycle: "managed",
+      });
     } finally {
       if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
       else process.env.LOBU_CONTEXT = previousContext;

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -758,36 +758,67 @@ describe("lobu run local sign-in diagnostics", () => {
     }
   });
 
-  test("refuses to overwrite an explicit remote context", async () => {
+  // The Mac runner exports LOBU_CONTEXT straight from the CLI's ambient
+  // `currentContext` and only pins LOBU_API_URL on Debug builds, so both of
+  // these are what a shipped Release app actually produces for a user whose
+  // selected context is a cloud entry. Refusing to repurpose that name is
+  // correct; abandoning local sign-in because of it is not — the fallback has
+  // to leave the user with a credentialed `local` context, a deep link, and
+  // auto-apply, exactly as a bare `lobu run` does.
+  test.each([
+    {
+      name: "an explicit remote context",
+      contextName: "production",
+      configured: {
+        url: "https://app.lobu.ai/api/v1",
+        lifecycle: "external" as const,
+      },
+    },
+    {
+      name: "an unknown context with no pinned endpoint",
+      contextName: "lobu",
+      configured: undefined,
+    },
+  ])("falls back to local rather than repurposing $name", async ({
+    contextName,
+    configured,
+  }) => {
     const previousContext = process.env.LOBU_CONTEXT;
     const previousApiUrl = process.env.LOBU_API_URL;
-    process.env.LOBU_CONTEXT = "production";
+    process.env.LOBU_CONTEXT = contextName;
     delete process.env.LOBU_API_URL;
     const calls: string[] = [];
     try {
       const result = await announceLocalSignIn("http://127.0.0.1:8787", true, {
         ...dependencies(),
-        inspectContextImpl: async () => ({
-          url: "https://app.lobu.ai/api/v1",
-          lifecycle: "external",
-        }),
-        addContextImpl: async () => {
-          calls.push("context");
+        inspectContextImpl: async () => configured,
+        addContextImpl: async (name, url, server) => {
+          calls.push(`context:${name}:${url}:${server?.lifecycle}`);
         },
-        saveCredentialsImpl: async () => {
-          calls.push("credentials");
+        saveCredentialsImpl: async (_credentials, name) => {
+          calls.push(`credentials:${name}`);
         },
-        setActiveOrgImpl: async () => {
-          calls.push("org");
+        setActiveOrgImpl: async (_slug, name) => {
+          calls.push(`org:${name}`);
+        },
+        setCurrentContextImpl: async (name) => {
+          calls.push(`current:${name}`);
         },
       });
 
-      expect(result).toEqual({
-        ready: false,
-        stage: "context_setup",
-        detail: 'could not register or persist the "production" context',
-      });
-      expect(calls).toEqual([]);
+      expect(result).toEqual({ ready: true, localOrgSlug: "local-install" });
+      // Registered as the plain `local` slot — no `managed` lifecycle, since
+      // this runner was never handed a name it owns.
+      expect(calls).toEqual([
+        "context:local:http://127.0.0.1:8787:undefined",
+        "credentials:local",
+        "org:local",
+      ]);
+      // The rejected name is never written...
+      expect(calls.some((call) => call.includes(contextName))).toBe(false);
+      // ...and an explicit LOBU_CONTEXT still pins this process only: the
+      // user's global default must not be retargeted behind their back.
+      expect(calls.some((call) => call.startsWith("current:"))).toBe(false);
     } finally {
       if (previousContext === undefined) delete process.env.LOBU_CONTEXT;
       else process.env.LOBU_CONTEXT = previousContext;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -686,7 +686,6 @@ function matchingLoopbackEndpoints(leftRaw: string, rightRaw: string): boolean {
         scheme,
         host: "loopback",
         port: url.port || (scheme === "https:" ? "443" : "80"),
-        path: url.pathname.replace(/\/+$/, "") || "/",
       };
     } catch {
       return null;
@@ -700,8 +699,7 @@ function matchingLoopbackEndpoints(leftRaw: string, rightRaw: string): boolean {
     right !== null &&
     left.scheme === right.scheme &&
     left.host === right.host &&
-    left.port === right.port &&
-    left.path === right.path
+    left.port === right.port
   );
 }
 
@@ -836,8 +834,11 @@ export async function announceLocalSignIn(
     if (requestedContextName) {
       const configured = await dependencies.inspectContextImpl(contextName);
       if (configured) {
+        const hasRunnerOwnedLifecycle =
+          configured.lifecycle === "managed" ||
+          (contextName === "local" && configured.lifecycle === undefined);
         if (
-          configured.lifecycle !== "managed" ||
+          !hasRunnerOwnedLifecycle ||
           !matchingLoopbackEndpoints(configured.url, gatewayUrl)
         ) {
           throw new Error("explicit context is not owned by this local runner");

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -57,7 +57,11 @@ export type LocalSignInResult =
 export interface LocalSignInDependencies {
   waitForReachable: (url: string) => Promise<boolean>;
   fetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
-  addContextImpl: (name: string, url: string) => Promise<unknown>;
+  addContextImpl: (
+    name: string,
+    url: string,
+    server?: { lifecycle?: "managed" | "external" }
+  ) => Promise<unknown>;
   saveCredentialsImpl: (
     credentials: Credentials,
     contextName: string
@@ -849,7 +853,11 @@ export async function announceLocalSignIn(
         }
       }
     }
-    await dependencies.addContextImpl(contextName, gatewayUrl);
+    await dependencies.addContextImpl(
+      contextName,
+      gatewayUrl,
+      requestedContextName ? { lifecycle: "managed" } : undefined
+    );
     const creds: Credentials = {
       accessToken: cliToken,
       ...(deviceToken ? { localWorkerToken: deviceToken } : {}),

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -682,9 +682,10 @@ function matchingLoopbackEndpoints(leftRaw: string, rightRaw: string): boolean {
       ) {
         return null;
       }
+      // No `host` in the shape: the guard above already established both
+      // sides are loopback, so comparing them would be vacuously true.
       return {
         scheme,
-        host: "loopback",
         port: url.port || (scheme === "https:" ? "443" : "80"),
       };
     } catch {
@@ -698,9 +699,33 @@ function matchingLoopbackEndpoints(leftRaw: string, rightRaw: string): boolean {
     left !== null &&
     right !== null &&
     left.scheme === right.scheme &&
-    left.host === right.host &&
     left.port === right.port
   );
+}
+
+// Whether `contextName` names a credential slot this local runner may write.
+// Two ways to qualify: an already-configured context whose lifecycle marks it
+// runner-managed and whose URL is this same loopback endpoint, or a brand-new
+// name whose spawning process pinned the identical endpoint via LOBU_API_URL
+// (how Owletto Debug claims its build-scoped slot on first boot). A bare
+// LOBU_CONTEXT must never repurpose a cloud or user-managed name.
+async function isRunnerOwnedContext(
+  dependencies: LocalSignInDependencies,
+  contextName: string,
+  gatewayUrl: string
+): Promise<boolean> {
+  const configured = await dependencies.inspectContextImpl(contextName);
+  if (configured) {
+    const hasRunnerOwnedLifecycle =
+      configured.lifecycle === "managed" ||
+      (contextName === "local" && configured.lifecycle === undefined);
+    return (
+      hasRunnerOwnedLifecycle &&
+      matchingLoopbackEndpoints(configured.url, gatewayUrl)
+    );
+  }
+  const pinnedUrl = process.env.LOBU_API_URL?.trim();
+  return !!pinnedUrl && matchingLoopbackEndpoints(pinnedUrl, gatewayUrl);
 }
 
 export async function announceLocalSignIn(
@@ -829,35 +854,32 @@ export async function announceLocalSignIn(
   }
 
   const requestedContextName = process.env.LOBU_CONTEXT?.trim();
-  const contextName = requestedContextName || "local";
+  // An explicit LOBU_CONTEXT is honored only when it names a slot this runner
+  // owns. Refusing an unowned name must NOT abort the bootstrap, though: the
+  // Mac runner derives LOBU_CONTEXT from the CLI's ambient `currentContext`
+  // (owletto apps/mac/Owletto/LocalLobuRunner.swift), and only pins
+  // LOBU_API_URL on Debug builds — so a Release user whose selected context is
+  // a cloud entry would otherwise lose the local context, its credentials, the
+  // deep link, and auto-apply outright. Fall back to the pre-existing `local`
+  // bootstrap instead, which is exactly what a bare `lobu run` does.
+  // Assigned inside the try so a throwing context probe still reports the
+  // slot the failure is about.
+  let contextName = "local";
   try {
-    if (requestedContextName) {
-      const configured = await dependencies.inspectContextImpl(contextName);
-      if (configured) {
-        const hasRunnerOwnedLifecycle =
-          configured.lifecycle === "managed" ||
-          (contextName === "local" && configured.lifecycle === undefined);
-        if (
-          !hasRunnerOwnedLifecycle ||
-          !matchingLoopbackEndpoints(configured.url, gatewayUrl)
-        ) {
-          throw new Error("explicit context is not owned by this local runner");
-        }
-      } else {
-        // Owletto Debug deliberately uses a new build-scoped credential
-        // context on first boot. Only allow that new slot when the spawning
-        // process also pins the same loopback endpoint explicitly; a bare
-        // LOBU_CONTEXT must never repurpose a cloud or user-managed name.
-        const pinnedUrl = process.env.LOBU_API_URL?.trim();
-        if (!pinnedUrl || !matchingLoopbackEndpoints(pinnedUrl, gatewayUrl)) {
-          throw new Error("new explicit context is not pinned to this runner");
-        }
-      }
-    }
+    const pinnedContextName =
+      requestedContextName &&
+      (await isRunnerOwnedContext(
+        dependencies,
+        requestedContextName,
+        gatewayUrl
+      ))
+        ? requestedContextName
+        : undefined;
+    contextName = pinnedContextName ?? "local";
     await dependencies.addContextImpl(
       contextName,
       gatewayUrl,
-      requestedContextName ? { lifecycle: "managed" } : undefined
+      pinnedContextName ? { lifecycle: "managed" } : undefined
     );
     const creds: Credentials = {
       accessToken: cliToken,

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -428,8 +428,8 @@ export async function devCommand(
   // /api/local-init and print a deep-link URL. The SPA hook accepts
   // ?lobu_token=<session> and exchanges it for a cookie, so the user can
   // click the URL straight from their terminal and land logged in. Also
-  // persists the session as the `local` CLI context so `lobu chat -c local`
-  // works without a separate `lobu login`.
+  // persists the session in the selected CLI context so later commands work
+  // without a separate `lobu login`.
   void announceLocalSignIn(gatewayUrl, mode === "embedded").then(
     async (localSignIn) => {
       const localContextReady = localSignIn.ready;
@@ -444,9 +444,9 @@ export async function devCommand(
       if (signInWarning) {
         console.warn(chalk.yellow(`  ${signInWarning}`));
       }
-      // Once the `local` context is confirmed registered + active, push the
+      // Once the selected context is registered and credentialed, push the
       // project's lobu.config.ts into the embedded DB so the scaffolded agent is
-      // usable via `lobu chat -c local …` with no separate `lobu apply`.
+      // usable with no separate `lobu apply`.
       // Gated (see shouldAutoApplyLocalProject) AND pinned to the local URL so
       // a failed sign-in can never apply this local project to whatever
       // cloud/prod context happened to be active.
@@ -496,8 +496,7 @@ export async function devCommand(
 /**
  * Whether `lobu run` should auto-apply the project. True only when:
  *  - the backend is embedded (never auto-mutate an external/prod DB), AND
- *  - the `local` context was registered + made active (so the apply targets the
- *    embedded server, not whatever cloud context was active before), AND
+ *  - local sign-in registered and credentialed the selected context, AND
  *  - the project actually has a `lobu.config.ts` to apply.
  */
 export function shouldAutoApplyLocalProject(opts: {
@@ -513,8 +512,8 @@ export function shouldAutoApplyLocalProject(opts: {
 /**
  * After `lobu run` boots an embedded backend, push the project's `lobu.config.ts`
  * into the local DB so the agent the user just scaffolded is immediately usable
- * (`lobu chat -c local …`) without a separate `lobu apply`. Uses the `local`
- * context that `announceLocalSignIn` just registered.
+ * without a separate `lobu apply`. The apply is pinned to the embedded URL and
+ * bootstrap org rather than relying on the globally active context.
  *
  * Best-effort: a project with nothing to apply, or a transient failure, must
  * never crash the running server. The apply graph (esbuild + connector-worker
@@ -538,7 +537,7 @@ export async function autoApplyLocalProject(
     const applyCommand =
       applyImpl ?? (await import("./_lib/apply/apply-cmd.js")).applyCommand;
     // Pin the apply to the embedded server's URL. `resolveApiTarget` matches
-    // the `local` context by URL — and refuses to send any other context's
+    // a stored context by URL — and refuses to send any other context's
     // credentials to a different URL — so this can only ever target the local
     // server, never a cloud/prod org. Also pin the ORG to the embedded server's
     // bootstrap org (from /api/local-init) so a `defineConfig({ org })` naming a
@@ -632,8 +631,8 @@ export function resolveBackendBundle(
 
 /**
  * After the embedded server is reachable, hit POST /api/local-init for
- * a fresh session token, register a `local` CLI context pointing at the
- * gateway, persist the session as that context's bearer credential, and
+ * a fresh session token, register a CLI context pointing at the gateway,
+ * persist the session as that context's bearer credential, and
  * print a deep-link URL the user can click to land logged into the SPA.
  *
  * Best-effort: a failure here (server not ready, /local-init refused because
@@ -777,8 +776,9 @@ export async function announceLocalSignIn(
     };
   }
 
+  const requestedContextName = process.env.LOBU_CONTEXT?.trim();
+  const contextName = requestedContextName || "local";
   try {
-    const contextName = "local";
     await dependencies.addContextImpl(contextName, gatewayUrl);
     const creds: Credentials = {
       accessToken: cliToken,
@@ -789,7 +789,7 @@ export async function announceLocalSignIn(
     };
     await dependencies.saveCredentialsImpl(creds, contextName);
     // Bind the bootstrap org slug returned by /api/local-init to the
-    // context. Without this, `lobu apply -c local` errors with
+    // context. Without this, an apply targeting the context errors with
     // "No organization selected" until the user manually runs
     // `lobu org set <slug>`. The server is the source of truth — it
     // auto-provisioned this org for the install operator.
@@ -798,22 +798,21 @@ export async function announceLocalSignIn(
         .setActiveOrgImpl(orgSlug, contextName)
         .catch(() => undefined);
     }
-    // Auto-switch the active context so plain `lobu apply` / `lobu chat`
-    // from any shell hit this loopback server instead of whatever cloud
-    // context was active. Announce on stderr when we actually flip so the
-    // user isn't surprised — `lobu run` on a fresh box silently lands on
-    // `local`; `lobu run` from a shell previously on `lobu` cloud prints
-    // the switch.
-    try {
-      const current = await dependencies.getCurrentContextNameImpl();
-      if (current !== contextName) {
-        await dependencies.setCurrentContextImpl(contextName);
-        process.stderr.write(
-          `Switched active context to "${contextName}" (lobu run)\n`
-        );
+    // A normal interactive `lobu run` switches the global default to `local`.
+    // An explicit LOBU_CONTEXT pins this process and must not retarget CLI
+    // commands running without that override.
+    if (!requestedContextName) {
+      try {
+        const current = await dependencies.getCurrentContextNameImpl();
+        if (current !== contextName) {
+          await dependencies.setCurrentContextImpl(contextName);
+          process.stderr.write(
+            `Switched active context to "${contextName}" (lobu run)\n`
+          );
+        }
+      } catch {
+        // Best-effort — failing to switch shouldn't kill the run banner.
       }
-    } catch {
-      // Best-effort — failing to switch shouldn't kill the run banner.
     }
 
     const url = new URL(gatewayUrl);
@@ -828,8 +827,8 @@ export async function announceLocalSignIn(
         chalk.cyan(`lobu chat -c ${contextName} "hello"`)
     );
     console.log();
-    // The `local` context is registered, credentialed, and active — safe to
-    // auto-apply the project against it. Return the bootstrap org slug so the
+    // The selected context is registered and credentialed, so the URL-pinned
+    // auto-apply is safe. Return the bootstrap org slug so the
     // auto-apply can target the local org explicitly (a config `org:` for a
     // cloud org must not redirect the local apply — that 404s silently).
     return { ready: true, localOrgSlug: orgSlug };
@@ -837,7 +836,7 @@ export async function announceLocalSignIn(
     return {
       ready: false,
       stage: "context_setup",
-      detail: 'could not register or persist the "local" context',
+      detail: `could not register or persist the "${contextName}" context`,
     };
   }
 }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -15,6 +15,7 @@ import {
   addContext,
   getCurrentContextName,
   getServerConfig,
+  loadContextConfig,
   setActiveOrg,
   setCurrentContext,
 } from "../internal/context.js";
@@ -62,6 +63,9 @@ export interface LocalSignInDependencies {
     contextName: string
   ) => Promise<unknown>;
   setActiveOrgImpl: (slug: string, contextName: string) => Promise<unknown>;
+  inspectContextImpl: (
+    contextName: string
+  ) => Promise<{ url: string; lifecycle?: "managed" | "external" } | undefined>;
   getCurrentContextNameImpl: () => Promise<string>;
   setCurrentContextImpl: (contextName: string) => Promise<unknown>;
 }
@@ -647,9 +651,55 @@ const defaultLocalSignInDependencies: LocalSignInDependencies = {
   addContextImpl: addContext,
   saveCredentialsImpl: saveCredentials,
   setActiveOrgImpl: setActiveOrg,
+  inspectContextImpl: async (contextName) => {
+    const config = await loadContextConfig();
+    const context = config.contexts[contextName];
+    return context
+      ? { url: context.url, lifecycle: context.lifecycle }
+      : undefined;
+  },
   getCurrentContextNameImpl: getCurrentContextName,
   setCurrentContextImpl: setCurrentContext,
 };
+
+function matchingLoopbackEndpoints(leftRaw: string, rightRaw: string): boolean {
+  const normalize = (raw: string) => {
+    try {
+      const url = new URL(raw);
+      const scheme = url.protocol.toLowerCase();
+      const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+      if (
+        (scheme !== "http:" && scheme !== "https:") ||
+        !["localhost", "127.0.0.1", "::1"].includes(host) ||
+        url.username ||
+        url.password ||
+        url.search ||
+        url.hash
+      ) {
+        return null;
+      }
+      return {
+        scheme,
+        host: "loopback",
+        port: url.port || (scheme === "https:" ? "443" : "80"),
+        path: url.pathname.replace(/\/+$/, "") || "/",
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  const left = normalize(leftRaw);
+  const right = normalize(rightRaw);
+  return (
+    left !== null &&
+    right !== null &&
+    left.scheme === right.scheme &&
+    left.host === right.host &&
+    left.port === right.port &&
+    left.path === right.path
+  );
+}
 
 export async function announceLocalSignIn(
   gatewayUrl: string,
@@ -779,6 +829,26 @@ export async function announceLocalSignIn(
   const requestedContextName = process.env.LOBU_CONTEXT?.trim();
   const contextName = requestedContextName || "local";
   try {
+    if (requestedContextName) {
+      const configured = await dependencies.inspectContextImpl(contextName);
+      if (configured) {
+        if (
+          configured.lifecycle !== "managed" ||
+          !matchingLoopbackEndpoints(configured.url, gatewayUrl)
+        ) {
+          throw new Error("explicit context is not owned by this local runner");
+        }
+      } else {
+        // Owletto Debug deliberately uses a new build-scoped credential
+        // context on first boot. Only allow that new slot when the spawning
+        // process also pins the same loopback endpoint explicitly; a bare
+        // LOBU_CONTEXT must never repurpose a cloud or user-managed name.
+        const pinnedUrl = process.env.LOBU_API_URL?.trim();
+        if (!pinnedUrl || !matchingLoopbackEndpoints(pinnedUrl, gatewayUrl)) {
+          throw new Error("new explicit context is not pinned to this runner");
+        }
+      }
+    }
     await dependencies.addContextImpl(contextName, gatewayUrl);
     const creds: Credentials = {
       accessToken: cliToken,

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -313,6 +313,60 @@ describe("context management", () => {
     });
   });
 
+  test("addContext preserves omitted lifecycle metadata when refreshing a context", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        currentContext: "release",
+        contexts: {
+          release: { url: "https://app.lobu.ai/api/v1" },
+          debug: {
+            url: "http://localhost:8787",
+            activeOrg: "local-install",
+            memoryUrl: "http://localhost:8787/api/v1",
+            lifecycle: "managed",
+            cwd: "/tmp/lobu-debug",
+          },
+        },
+      })
+    );
+
+    await addContext("debug", "http://127.0.0.1:8788");
+
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string);
+    expect(saved.currentContext).toBe("release");
+    expect(saved.contexts.debug).toEqual({
+      url: "http://127.0.0.1:8788",
+      lifecycle: "managed",
+      cwd: "/tmp/lobu-debug",
+    });
+  });
+
+  test("changing a managed context to external removes its managed cwd", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        contexts: {
+          local: {
+            url: "http://localhost:8787",
+            lifecycle: "managed",
+            cwd: "/tmp/lobu-local",
+          },
+        },
+      })
+    );
+
+    await addContext("local", "http://localhost:8787", {
+      lifecycle: "external",
+    });
+
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string);
+    expect(saved.contexts.local).toEqual({
+      url: "http://localhost:8787",
+      lifecycle: "external",
+    });
+  });
+
   test("addContext rejects cwd on a non-managed context", async () => {
     readFileSpy.mockResolvedValue(JSON.stringify({ contexts: {} }));
 

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -212,8 +212,13 @@ export async function addContext(
   }
 
   const config = await loadContextConfig();
+  const previous = config.contexts[trimmedName];
+  // Re-registering a running named context must not erase lifecycle ownership.
+  // Org and memory targeting are still reset by the refreshed registration.
   const entry: LobuContextEntry = {
     url: normalizeAndValidateApiUrl(url),
+    ...(previous?.lifecycle ? { lifecycle: previous.lifecycle } : {}),
+    ...(previous?.cwd ? { cwd: previous.cwd } : {}),
   };
   const lifecycle = normalizeLifecycle(server?.lifecycle);
   const cwd = server?.cwd?.trim();
@@ -224,6 +229,7 @@ export async function addContext(
     throw new Error("`cwd` can only be set on managed contexts.");
   }
   if (lifecycle) entry.lifecycle = lifecycle;
+  if (entry.lifecycle !== "managed") delete entry.cwd;
   if (cwd) entry.cwd = cwd;
 
   config.contexts[trimmedName] = entry;


### PR DESCRIPTION
Summary:
- honor an explicit LOBU_CONTEXT when an embedded server bootstraps its local session
- keep that process-scoped context isolated instead of changing the global CLI default
- preserve Mac-managed lifecycle and working-directory metadata when refreshing the context
- keep normal interactive lobu run behavior on the existing local context

This is the core-side prerequisite for Owletto PR #957 and must land before it.

Validation:
- 64 focused CLI context/dev tests passed (187 assertions)
- make pre-pr passed
- pre-commit Biome and TypeScript checks passed
- Codex pre-review fixer completed; its changes were inspected