### PR TITLE
fix(linkedin): settle asynchronous comments

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1855,6 +1855,7 @@ describe("LinkedInConnector home_feed", () => {
     });
     expect(cfg.expandRows.more.textRegex).toContain("replies");
     expect(cfg.expandRows.maxDurationMs).toBe(55_000);
+    expect(cfg.expandRows.stall).toBe(12);
     expect(cfg.expandRows.outputField).toBe("comment_coverage");
     expect(cfg.id.name).toEqual(["componentkey", "id"]);
     expect(
@@ -3081,7 +3082,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.7");
+    expect(c.definition.version).toBe("3.11.8");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -511,7 +511,10 @@ const HOME_FEED_SCRAPE_CONFIG = {
     // watchdog. This leaves time for row harvesting and guarantees that a
     // large thread cannot strand a content script in the user's tab.
     maxDurationMs: 55_000,
-    stall: 2,
+    // LinkedIn removes its controls before the requested comments finish
+    // rendering. Allow a short control-free settling window; the shared
+    // maxDurationMs budget still caps the whole expansion pass.
+    stall: 12,
     waitMs: 350,
     outputField: "comment_coverage",
   },
@@ -2859,7 +2862,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.7",
+    version: "3.11.8",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com


### PR DESCRIPTION
LinkedIn removes expansion controls before requested comments finish rendering. This pins Owletto #966 and gives home-feed rows a 4.2-second bounded settling window while retaining the existing 55-second global deadline. Connector version becomes 3.11.8.

No API, schema, endpoint, or migration changes.

Verification:
- bun test examples/personal-agent/__tests__/linkedin.connector.test.ts (135/135)
- Owletto bun run test apps/chrome/tools.test.js (111/111)
- Owletto bun run test (1879/1879)
- Owletto bun run build
- make pre-pr
- git diff --check