### PR TITLE
fix(ci): allow AppKit behavior properties in naming gate

### DIFF
--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -45,6 +45,15 @@ const GENERIC_BEHAVIOR_PROBE_FILE = join(
   REPO_ROOT,
   "packages/core/src/guard-probe.json"
 );
+/**
+ * The AppKit exemption is content-shaped, not path-scoped, so a main-repo probe
+ * exercises it. A probe under `packages/owletto` would instead pass vacuously on
+ * a checkout without the submodule, which the guard skips.
+ */
+const APPKIT_BEHAVIOR_PROBE_FILE = join(
+  REPO_ROOT,
+  "packages/core/src/guard-probe.swift"
+);
 const RETIRED_PATH_PROBE_FILE = join(
   REPO_ROOT,
   "packages/core/src/watcher-probe.bin"
@@ -96,6 +105,20 @@ describe("check-exposed-surface-naming", () => {
   it("allows an exact external platform behavior option", () => {
     create(GENERIC_BEHAVIOR_PROBE_FILE, '{"behavior":"smooth"}\n');
     expect(runGuard()).toBe(0);
+  });
+
+  it("allows exact AppKit behavior property and type spellings", () => {
+    create(
+      APPKIT_BEHAVIOR_PROBE_FILE,
+      "panel.collectionBehavior = NSWindow.CollectionBehavior.stationary\n" +
+        "panel.animationBehavior = .none\n"
+    );
+    expect(runGuard()).toBe(0);
+  });
+
+  it("does not exempt an owned AppKit-shaped behavior key", () => {
+    create(GENERIC_BEHAVIOR_PROBE_FILE, '{"collectionBehavior":"owned"}\n');
+    expect(runGuard()).toBe(1);
   });
 
   it("does not turn the generic-option exception into a product-term escape", () => {

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -567,6 +567,11 @@ function scanCanonicalVocabulary(violations: Violation[]): void {
           )
           .replace(/\bbehavior\s*:\s*(?:default|merge)\b/g, "")
           .replace(/\bbehavior\s*=\s*["'`](?:instant|smooth)["'`]/g, "")
+          // AppKit owns these exact NSWindow names, in both their property
+          // (`collectionBehavior`) and type (`NSWindow.CollectionBehavior`)
+          // spellings. Match member access only, so an owned key or prose using
+          // the same words still fails the canonical vocabulary gate.
+          .replace(/\.(?:collectionBehavior|animationBehavior)\b/gi, "")
           .replace(/\bscroll-behavior\b/g, "");
         if (RETIRED_CANONICAL_VOCABULARY.test(canonicalLine)) {
           violations.push({


### PR DESCRIPTION
## Summary

- Exempt exact AppKit member accesses such as `NSWindow.collectionBehavior` and `animationBehavior` from the retired product-vocabulary scan.
- Keep owned keys and prose with the same spelling blocked.
- Add positive and negative subprocess fixtures for the exemption boundary.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] `bun scripts/check-exposed-surface-naming.ts`
- [x] `bun test scripts/__tests__/check-exposed-surface-naming.test.ts --timeout 30000` (18 pass)
- [x] Bug fix red→green: the guard initially reported two violations in `MenuBarPanelController.swift`; after the fix it reports clean while the owned-key fixture still exits nonzero
- [x] Commit hook: Biome and root TypeScript passed

## Notes

This unblocks the forward Owletto pointer PR #3164. It changes only the guard and its regression fixtures; no product/runtime source is changed.