### PR TITLE
fix(device): authorize WhatsApp activation capability

### DIFF
--- a/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
+++ b/packages/core/src/__tests__/capabilities-prototype-keys.test.ts
@@ -51,6 +51,12 @@ describe("platform allowlist lookups ignore inherited keys", () => {
     ).toContain("automations.execute");
   });
 
+  test("Chrome authorizes the explicit WhatsApp activation capability", () => {
+    expect(
+      authorizeCapabilities("chrome-extension", ["browser.whatsapp"]).authorized
+    ).toEqual(["browser.whatsapp"]);
+  });
+
   test("headless devices authorize shell+files+automation execution but nothing browser-ish", () => {
     // A server/VM device (herdr) advertises the shell/files it actually has
     // plus `automations.execute` (the daemon runs local agent CLIs to complete

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -22,6 +22,7 @@ export const BROWSER_CAPABILITIES = [
   "browser.downloads",
   "browser.notifications",
   "browser.debugger",
+  "browser.whatsapp",
   // browser.cookies intentionally absent in v1 — high-trust, not approved
 ] as const;
 

--- a/packages/server/src/__tests__/unit/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/device-feed-read.test.ts
@@ -118,6 +118,18 @@ describe('WhatsApp Browser manifest compatibility', () => {
     expect(result.manifests[0]?.manifest.key).toBe('whatsapp.local');
   });
 
+  it('accepts whatsapp.local from Chrome with explicit WhatsApp activation', () => {
+    const result = validateDeviceConnectorManifests({
+      platform: 'chrome-extension',
+      capabilities: ['browser.whatsapp'],
+      manifests: [{ ...chromeManifest, required_capability: 'browser.whatsapp' }],
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(result.manifests).toHaveLength(1);
+    expect(result.manifests[0]?.manifest.required_capability).toBe('browser.whatsapp');
+  });
+
   it('rejects a Chrome whatsapp.local manifest with another allowed browser capability', () => {
     const result = validateDeviceConnectorManifests({
       platform: 'chrome-extension',

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -135,10 +135,11 @@ function validateDeviceConnectorManifestsInternal(
       if (
         platform === 'chrome-extension' &&
         isLegacyNativeChromeExtensionConnectorKey(manifest.key) &&
-        manifest.required_capability !== 'browser.scripting'
+        manifest.required_capability !== 'browser.scripting' &&
+        !(manifest.key === 'whatsapp.local' && manifest.required_capability === 'browser.whatsapp')
       ) {
         throw new Error(
-          `chrome-extension connector '${manifest.key}' requires required_capability 'browser.scripting'`
+          `chrome-extension connector '${manifest.key}' has an unsupported required_capability`
         );
       }
       if (!manifest.runtime.platforms.includes(platform)) {
@@ -529,7 +530,8 @@ function connectorKeyAllowedForPlatform(platform: string, key: string): boolean 
     // Compatibility cutover: the extension intentionally keeps the legacy
     // internal key so the existing connection/feed/event identity survives.
     // This is the sole non-chrome namespace admitted for Chrome; validation
-    // above additionally binds it to browser.scripting.
+    // above additionally binds it to browser.scripting or the dedicated
+    // browser.whatsapp activation capability.
     return (
       isChromeNamespaceConnectorKey(key) || isLegacyNativeChromeExtensionConnectorKey(key)
     );


### PR DESCRIPTION
## Summary

- authorize the explicit `browser.whatsapp` capability for Chrome-extension workers
- accept it only for the existing `whatsapp.local` native Chrome manifest while preserving `browser.scripting` compatibility
- cover both the core allowlist and manifest validator contract

## Verification

- `bun test packages/core/src/__tests__/capabilities-prototype-keys.test.ts` (13 passed)
- `cd packages/server && bun test src/__tests__/unit/device-feed-read.test.ts` (28 passed)
- `cd packages/server && bun run test -- run src/__tests__/integration/device-connector-manifests.test.ts` against Owletto `0ea31e4bf8413eadcbdace99c058125889f551d3` (31 passed)
- `make pre-pr`

Unblocks the Owletto pointer bump in #3164.