### PR TITLE
fix(gchat): align native command behavior

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   planAutomationActivations,
 } from "../../automations/activation.js";
 import { matchingAutomationTriggers } from "../../automations/event-trigger.js";
+import { normalizeStatefulChatCommand } from "../commands/command-spelling.js";
 import { ConversationStateStore } from "../connections/conversation-state-store.js";
 import {
   buildAttachmentTranscriptText,
@@ -163,6 +164,22 @@ describe("isEarlyDispatchableChatCommand", () => {
     expect(isEarlyDispatchableChatCommand("/lobu clear")).toBe(false);
     expect(isEarlyDispatchableChatCommand("/HELP")).toBe(false);
     expect(isEarlyDispatchableChatCommand("help")).toBe(false);
+  });
+});
+
+describe("normalizeStatefulChatCommand", () => {
+  test.each([
+    ["/new", "new"],
+    ["/lobu new", "new"],
+    ["/clear", "clear"],
+    ["/lobu clear", "clear"],
+  ] as const)("normalizes %s", (input, expected) => {
+    expect(normalizeStatefulChatCommand(input)).toBe(expected);
+  });
+
+  test("does not consume arguments or unrelated commands", () => {
+    expect(normalizeStatefulChatCommand("/lobu clear now")).toBeNull();
+    expect(normalizeStatefulChatCommand("/lobu help")).toBeNull();
   });
 });
 
@@ -973,6 +990,49 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/help");
     expect(enqueueMessage).not.toHaveBeenCalled();
     expect(thread.post).not.toHaveBeenCalled();
+  });
+
+  test("Google Chat /lobu clear clears the scoped history without an agent turn", async () => {
+    const { bridge, conversationState, enqueueMessage } = makePreviewHarness({
+      platform: "gchat",
+      previewMode: false,
+    });
+    const thread = makeThread(undefined);
+    await conversationState.appendHistory(CONN_ID, CHANNEL_ID, THREAD_ID, {
+      role: "user",
+      content: "remember this",
+      timestamp: Date.now(),
+    });
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "/lobu clear" }),
+      "dm",
+    );
+
+    expect(
+      await conversationState.getEntries(CONN_ID, CHANNEL_ID, THREAD_ID),
+    ).toEqual([]);
+    expect(thread.post).toHaveBeenCalledWith({ text: "Chat history cleared." });
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("Google Chat /lobu new reaches the worker as a real session reset", async () => {
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "gchat",
+      previewMode: false,
+    });
+
+    await bridge.handleMessage(
+      makeThread(undefined),
+      makeMessage({ text: "/lobu new" }),
+      "dm",
+    );
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    expect(payload.messageText).toBe("Starting new session.");
+    expect(payload.platformMetadata?.sessionReset).toBe(true);
   });
 
   test("linked chat → routes to the Automation's agent, no notice", async () => {

--- a/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
+++ b/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { CommandRegistry } from "@lobu/core";
+import { registerBuiltInCommands } from "../built-in-commands.js";
+
+async function helpFor(platform: string): Promise<string> {
+  const registry = new CommandRegistry();
+  registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+  const replies: string[] = [];
+  await registry.tryHandle("help", {
+    userId: "user-1",
+    channelId: "channel-1",
+    isGroup: false,
+    platform,
+    args: "",
+    reply: async (text: string) => {
+      replies.push(text);
+    },
+  });
+  return replies.join("\n");
+}
+
+describe("built-in command help", () => {
+  test.each(["slack", "gchat"])(
+    "uses the native /lobu wrapper on %s",
+    async (platform) => {
+      const help = await helpFor(platform);
+      expect(help).toContain("/lobu help - Show available commands");
+      expect(help).toContain("/lobu new - Save context to memory");
+      expect(help).toContain("/lobu clear - Clear chat history");
+      expect(help).not.toContain("\n/help -");
+    },
+  );
+
+  test("keeps bare commands on platforms without the wrapper", async () => {
+    const help = await helpFor("telegram");
+    expect(help).toContain("/help - Show available commands");
+    expect(help).not.toContain("/lobu help");
+  });
+});

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -12,6 +12,7 @@ import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.j
 import {
   resolveEffectiveModelRef,
 } from "../auth/settings/model-selection.js";
+import { formatChatCommand } from "./command-spelling.js";
 
 interface BuiltInCommandDeps {
   agentSettingsStore: AgentSettingsStore;
@@ -47,7 +48,10 @@ export function registerBuiltInCommands(
     description: "Show available commands",
     handler: async (ctx: CommandContext) => {
       const commands = registry.getAll();
-      const lines = commands.map((c) => `/${c.name} - ${c.description}`);
+      const lines = commands.map(
+        (command) =>
+          `${formatChatCommand(ctx.platform, command.name)} - ${command.description}`,
+      );
       await ctx.reply(
 				`Available commands:\n${lines.join("\n")}\n\nYou can also just send a message to start a conversation with the agent.`,
       );
@@ -84,9 +88,8 @@ export function registerBuiltInCommands(
   });
 
   // Public preview: bind this chat to one of the demo agents in the preview
-  // connection's org. `/lobu try <agentId>` (no code, no CLI); `/lobu try` /
-  // `/lobu agents` with no arg lists them. Re-running with another agent
-  // rebinds. (Reached as the `try` / `agents` subcommand on Slack.)
+  // connection's org. Re-running with another agent rebinds; wrapped-command
+  // platforms reach these handlers as the `try` / `agents` subcommands.
   const replyDemoMenu = async (ctx: CommandContext, prefix?: string) => {
     if (!ctx.connectionId) {
 			await ctx.reply(
@@ -154,18 +157,17 @@ export function registerBuiltInCommands(
     },
   });
 
-  // Slack Preview: redeem a `/lobu link <code>` minted by `lobu run` and bind
-  // this channel/DM to that agent. Re-running it with a different code rebinds.
-  // (Slack only delivers the natively-registered `/lobu` slash command, so this
-  // is reached as the `link` subcommand — not a bare `/link`.)
+  // Redeem a link code minted by `lobu run` and bind this channel/DM to that
+  // agent. Wrapped-command platforms reach this as the `link` subcommand;
+  // re-running it with a different code rebinds.
   registry.register({
     name: "link",
-    // `/help` renders this on every platform, so it stays code-only; the
+    // The help command renders this on every platform, so it stays code-only; the
     // Slack-only `<agentId>` shortcut is surfaced by `agentIdHint` below.
     description: "Link this chat to a Lobu agent with a `<code>` from `lobu run`",
     handler: async (ctx: CommandContext) => {
       const arg = ctx.args.trim();
-      const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";
+      const cmd = formatChatCommand(ctx.platform, "link");
       // The codeless `<agentId>` shortcut needs a workspace-scoped Slack
       // identity, which only Slack sign-in and the install claim write — so it
       // never applies on other platforms. Don't promise it there.
@@ -248,7 +250,7 @@ export function registerBuiltInCommands(
               return;
             }
             await ctx.reply(
-							`No agent \`${arg}\` you can manage in your orgs. Either run \`lobu apply\` to register it, or paste a fresh \`/lobu link <code>\` from \`lobu run\`.`,
+						`No agent \`${arg}\` you can manage in your orgs. Either run \`lobu apply\` to register it, or paste a fresh \`${formatChatCommand(ctx.platform, "link")} <code>\` from \`lobu run\`.`,
             );
             return;
           }

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -42,12 +42,10 @@ export class CommandDispatcher {
     if (!match?.[1]) return false;
     let commandName = match[1];
     let commandArgs = match[2]?.trim() || "";
-    // Slack registers a single `/lobu` wrapper, so its subcommands arrive as
-    // `/lobu link <code>`. Slack only dispatches that as a native slash command
-    // in channels — in an "Agents & AI Apps" DM it is delivered as plain
-    // message text instead (no slash-command UI). Unwrap the wrapper here so
-    // `/lobu link <code>` typed or pasted from `lobu run` in a DM dispatches the
-    // `link` subcommand, matching the native slash-command path.
+    // Slack and Google Chat register a single `/lobu` wrapper, so subcommands
+    // arrive as `/lobu link <code>`. Slack also delivers this as plain message
+    // text in an "Agents & AI Apps" DM (no slash-command UI). Unwrap at the
+    // shared boundary so native and pasted command paths dispatch identically.
     if (commandName.toLowerCase() === "lobu" && commandArgs) {
       const sub = commandArgs.match(/^(\S+)(?:\s+(.*))?$/);
       if (sub?.[1]) {

--- a/packages/server/src/gateway/commands/command-spelling.ts
+++ b/packages/server/src/gateway/commands/command-spelling.ts
@@ -1,0 +1,17 @@
+const LOBU_WRAPPER_PLATFORMS = new Set(["slack", "gchat"]);
+
+/** Render the advertised command spelling for the target platform. */
+export function formatChatCommand(platform: string, name: string): string {
+  return LOBU_WRAPPER_PLATFORMS.has(platform) ? `/lobu ${name}` : `/${name}`;
+}
+
+/** Stateful commands are handled by the message bridge, before dispatch. */
+export function normalizeStatefulChatCommand(
+  text: string,
+): "new" | "clear" | null {
+  const match = text
+    .trim()
+    .toLowerCase()
+    .match(/^\/(?:lobu\s+)?(new|clear)$/);
+  return match?.[1] === "new" || match?.[1] === "clear" ? match[1] : null;
+}

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -18,6 +18,7 @@ import {
 } from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
+import { normalizeStatefulChatCommand } from "../commands/command-spelling.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
 import type { ModelProviderModule } from "../modules/module-system.js";
 import type { CoreServices } from "../platform.js";
@@ -1056,15 +1057,15 @@ export class MessageHandlerBridge {
     // A bare `!` / `!!` with no command falls through as ordinary text.
     const bangBash = parseBangBashCommand(messageText);
 
-    // Intercept /new and /clear before slash dispatch. A `!`-bash message is a
-    // control action, not model input: it skips /new, /clear, and slash dispatch
-    // entirely and enqueues as its own worker turn.
+    // Intercept bare and `/lobu`-wrapped new/clear commands before slash
+    // dispatch. A `!`-bash message is a control action, not model input: it skips
+    // stateful commands and slash dispatch, then enqueues as its own worker turn.
     let sessionReset = false;
-    const trimmedLower = messageText.trim().toLowerCase();
-    if (!bangBash && trimmedLower === "/new") {
+    const statefulCommand = normalizeStatefulChatCommand(messageText);
+    if (!bangBash && statefulCommand === "new") {
       messageText = "Starting new session.";
       sessionReset = true;
-    } else if (!bangBash && trimmedLower === "/clear") {
+    } else if (!bangBash && statefulCommand === "clear") {
       await this.conversationState()?.clearHistory(
         this.connection.id,
         channelId,

--- a/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
+++ b/packages/server/src/gateway/connections/platforms/__tests__/gchat.test.ts
@@ -80,6 +80,10 @@ async function dispatchAndWait(chat: Chat, request: Request) {
 }
 
 describe("Google Chat platform compatibility", () => {
+  test("welcome points users to the registered /lobu wrapper", () => {
+    expect(GOOGLE_CHAT_WELCOME_TEXT).toContain("/lobu help");
+  });
+
   test("accepts only this project's Workspace Add-on token at the canonical connection webhook", async () => {
     const endpointUrl =
       "https://gateway.test/api/v1/webhooks/gchat-addon-test";

--- a/packages/server/src/gateway/connections/platforms/gchat.ts
+++ b/packages/server/src/gateway/connections/platforms/gchat.ts
@@ -25,7 +25,7 @@ export const GOOGLE_CHAT_WELCOME_TEXT = [
   "Welcome 👋",
   "",
   "In a direct message, just ask. In a space, mention this app when you want a response.",
-  "Use `/help` at any time to see commands and setup options.",
+  "Use `/lobu help` at any time to see commands and setup options.",
 ].join("\n");
 
 function isObject(value: unknown): value is JsonObject {

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -200,7 +200,7 @@ const GoogleChatConfigSchema = Type.Object({
 		Type.String({
 			pattern: "^(?:[1-9][0-9]{0,2}|1000)$",
 			description:
-				"Google Chat command ID (1-1000) mapped to Lobu help for this project.",
+				"Google Chat command ID (1-1000) mapped to this project's registered /lobu command (or legacy /help command).",
 		}),
 	),
 	userName: Type.Optional(

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -14,6 +14,7 @@ import { getConfiguredPublicOrigin } from "../utils/public-origin";
 import { requireOrgUser } from "../utils/require-org-user";
 import { MANAGED_CHAT_PLATFORMS_SET } from "./managed-platforms";
 import { AutomationSubscriptionService } from "../gateway/channels/automation-subscription-service";
+import { formatChatCommand } from "../gateway/commands/command-spelling";
 
 // Slack Preview lets people trying Lobu locally talk to their agent through the
 // hosted "Lobu Developer" Slack workspace before they have their own bot token.
@@ -44,17 +45,16 @@ const PREVIEW_JOIN_DEFAULTS: Record<string, string> = {
 
 type SurfaceType = "dm" | "channel";
 
-// Slash-command spellings differ by platform: Slack only delivers the
-// natively-registered `/lobu`, so its subcommands are `/lobu try` etc.; other
-// platforms register each command directly (`/try`, `/agents`, `/link`).
+// Slack and Google Chat expose a native `/lobu` wrapper; other chat platforms
+// use bare command spellings.
 function tryCommand(platform: string): string {
-	return platform === "slack" ? "/lobu try" : "/try";
+	return formatChatCommand(platform, "try");
 }
 function listCommand(platform: string): string {
-	return platform === "slack" ? "/lobu agents" : "/agents";
+	return formatChatCommand(platform, "agents");
 }
 function linkCommand(platform: string): string {
-	return platform === "slack" ? "/lobu link" : "/link";
+	return formatChatCommand(platform, "link");
 }
 
 interface ClaimPayload {
@@ -110,7 +110,7 @@ function previewJoinUrl(platform: string): string {
 
 /** The slash command to send to the hosted bot to redeem a code. */
 function previewLinkCommand(platform: string, code: string): string {
-	return platform === "slack" ? `/lobu link ${code}` : `/link ${code}`;
+	return `${formatChatCommand(platform, "link")} ${code}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- advertise Google Chat and Slack built-in commands through the native `/lobu` wrapper
- make `/lobu new` and `/lobu clear` exercise the real stateful command path
- document the Google Chat command ID contract and keep preview spelling platform-aware

## Validation
- 124 focused server tests pass
- server TypeScript check passes
- `make pre-pr` passes
- live OpenAPI generation produced no relevant client diff; `[client-regen-not-needed]` is intentional
- independent Codex review-fix completed with no unresolved findings