### PR TITLE
test(auth): clear cache across DB pool handoff

### DIFF
--- a/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { clearAuthCacheForTests } from '../../../auth';
 import { closeDbSingleton, type DbClient } from '../../../db/client';
 import type { Env } from '../../../index';
 import { createAutomationRun } from '../../../runs/queue-service';
@@ -317,6 +318,7 @@ describe('Automation window claim and recovery', () => {
   it('loads claimed source context with a one-connection database pool', async () => {
     const previousPoolMax = process.env.DB_POOL_MAX;
     await closeDbSingleton();
+    clearAuthCacheForTests();
     process.env.DB_POOL_MAX = '1';
     try {
       const claimed = (await manageAutomations(
@@ -331,6 +333,7 @@ describe('Automation window claim and recovery', () => {
       expect(claimed.context.window_start).toBe(dayStart(1).toISOString());
     } finally {
       await closeDbSingleton();
+      clearAuthCacheForTests();
       if (previousPoolMax === undefined) delete process.env.DB_POOL_MAX;
       else process.env.DB_POOL_MAX = previousPoolMax;
     }


### PR DESCRIPTION
Fix the deterministic integration-shard timeout on current main.

`window-claim-recovery.test.ts` intentionally closes and recreates the shared PostgreSQL singleton to exercise `DB_POOL_MAX=1`. Better Auth caches an adapter bound to that singleton for 60 seconds, so later auth tests could reuse a closed pool and hang until their 30-second timeout. Clear the Better Auth test cache at both pool handoff points.

Verification:
- full Vitest shard 1/3: 168 files passed, 1310 tests passed, 2 skipped
- `make pre-pr`

No production behavior changes.