### PR TITLE
fix(server): replace real content id in search_memory example with synthetic one

### DIFF
--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -255,7 +255,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'search_memory',
     description:
-      'Search local saved workspace memory: entities, facts, decisions, preferences, observations, notes, and authorized channel transcripts. Source-backed feeds are never queried implicitly; `coverage` reports local stores searched and visible source feeds with status `not_queried`, which agents can read explicitly through query_sdk client.feeds.readMany. A query such as `memory 4939822` performs an exact permission-checked content read. Pair writes with `save_memory`. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
+      'Search local saved workspace memory: entities, facts, decisions, preferences, observations, notes, and authorized channel transcripts. Source-backed feeds are never queried implicitly; `coverage` reports local stores searched and visible source feeds with status `not_queried`, which agents can read explicitly through query_sdk client.feeds.readMany. A query such as `memory 1234` performs an exact permission-checked content read. Pair writes with `save_memory`. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: SearchSchema,
     // Advertise the narrower public schema: query_embedding (server pre-compute
     // optimization) and agent_id (auth-bound) are server-internal, not client

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -922,7 +922,7 @@ async function searchImpl(
   });
 
   // Preserve compatibility with reviewer prompts and user language such as
-  // "open memory 4939822". The public schema already accepts a query string,
+  // "open memory 1234". The public schema already accepts a query string,
   // so this server-side exact-read fast path fixes existing clients without a
   // metadata rescan. The canonical knowledge reader enforces tenant, connector,
   // entity-policy, and supersede-chain visibility before anything is returned.


### PR DESCRIPTION
## Summary
- The `search_memory` MCP tool description and a `search.ts` comment hardcoded `memory 4939822` — a real production content id — violating the no-live-tenant-identifiers rule and leaking it into MCP metadata that app-directory clients rescan.
- Replaces the example with a synthetic id (`memory 1234`). No behavioral change: the exact-read fast path itself is untouched.

## Test plan
- [x] Intended files staged explicitly (`git diff --name-only origin/main...HEAD` = the 2 files)
- [x] Tests run: `bun test packages/server/src/__tests__/unit/tool-registry-split.test.ts` → 6 pass / 0 fail
- [x] Red→green: `git grep -n 4939822 origin/main -- packages/server/src` → 2 hits; same grep on branch → no matches
- [x] `make pre-pr` clean (build, typecheck, knip, biome, naming, funnel gates)

## Notes
Found while preparing a ChatGPT app-directory resubmission: OpenAI re-pulls tool metadata, so the live id would have been shown to their reviewer against a workspace where it resolves to nothing.