### PR TITLE
ci(mac-release): pin the bundle id per build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,6 +1191,8 @@ jobs:
         # and a broken guard would surface first at release time. Pin its rules
         # here instead, including the swapped Release/Debug case that a
         # set-of-distinct-values check structurally cannot detect.
+        env:
+          OWLETTO_SUBMODULE_STUBBED: ${{ steps.submodule.outputs.stubbed }}
         run: bun test scripts/__tests__/check-mac-bundle-ids.test.ts --timeout 30000
 
       - name: Merge integrity decision table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1183,6 +1183,16 @@ jobs:
         # disables that alarm, so it is pinned by tests like the tag logic above.
         run: bun test scripts/__tests__/audit-release-images.test.ts --timeout 30000
 
+      - name: Mac bundle-identity gate
+        # The Release bundle id keys the URL scheme, the Keychain service name,
+        # and the Sparkle update path, so drift there stops every installed app
+        # from updating. The gate that pins it lives in mac-release.yml, which
+        # only ever runs on a lobu-v* tag — meaning nothing on a PR executes it
+        # and a broken guard would surface first at release time. Pin its rules
+        # here instead, including the swapped Release/Debug case that a
+        # set-of-distinct-values check structurally cannot detect.
+        run: bun test scripts/__tests__/check-mac-bundle-ids.test.ts --timeout 30000
+
       - name: Merge integrity decision table
         # #2273 was based on another feature branch; squashing that base away
         # left GitHub reporting it MERGED with its fix absent from main, while

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -175,83 +175,18 @@ jobs:
             fi
           done
 
-          # 6. PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj is pinned PER BUILD
-          #    CONFIGURATION. CFBundleIdentifier in Info.plist resolves to
-          #    $(PRODUCT_BUNDLE_IDENTIFIER) at build time, so the real value
-          #    lives in the pbxproj build settings. The URL scheme, Keychain
-          #    service name, and Sparkle update path are all keyed off this —
-          #    a change to the Release identity breaks the upgrade contract for
-          #    every installed app.
+          # 6. PRODUCT_BUNDLE_IDENTIFIER is pinned PER BUILD CONFIGURATION:
+          #    Release must be com.owletto.mac, Debug may additionally be the
+          #    build-scoped com.owletto.mac.debug. The URL scheme, Keychain
+          #    service name, and Sparkle update path are keyed off the Release
+          #    identity, so drift there breaks every installed app's upgrade.
           #
-          #    Release must be exactly com.owletto.mac. Debug is allowed to
-          #    carry the build-scoped com.owletto.mac.debug identity so a
-          #    developer build installs and stores credentials beside the
-          #    Release app instead of colliding with it.
-          #
-          #    Checked per configuration rather than as a set of distinct
-          #    values: a set check cannot tell "Release=mac, Debug=mac.debug"
-          #    apart from the swapped "Release=mac.debug, Debug=mac", and the
-          #    swapped form would ship a release DMG under the debug identity.
-          EXPECTED_RELEASE_BUNDLE_ID="com.owletto.mac"
-          EXPECTED_DEBUG_BUNDLE_ID="com.owletto.mac.debug"
-
-          # Emit "<config name>=<bundle id>" for every XCBuildConfiguration
-          # block that sets one. The setting always precedes the block's
-          # closing `name = <config>;` line.
-          config_ids=$(awk '
-            /isa = XCBuildConfiguration;/ { id = "" }
-            /PRODUCT_BUNDLE_IDENTIFIER = / {
-              line = $0
-              sub(/.*PRODUCT_BUNDLE_IDENTIFIER = /, "", line)
-              sub(/;.*/, "", line)
-              id = line
-            }
-            /^[[:space:]]*name = / {
-              if (id != "") {
-                cfg = $0
-                sub(/.*name = /, "", cfg)
-                sub(/;.*/, "", cfg)
-                print cfg "=" id
-                id = ""
-              }
-            }
-          ' packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj)
-
-          # An empty result means the setting moved, was renamed, or the awk
-          # no longer matches the file's shape — fail loudly instead of
-          # vacuously passing a guard that checked nothing.
-          if [ -z "$config_ids" ]; then
-            echo "::error::no PRODUCT_BUNDLE_IDENTIFIER found per build configuration in project.pbxproj — the bundle id guard is not actually checking anything"
-            exit 1
-          fi
-
-          # The Release configuration is the one that ships; it must exist.
-          if ! grep -q '^Release=' <<<"$config_ids"; then
-            echo "::error::no Release build configuration sets PRODUCT_BUNDLE_IDENTIFIER (got: $(tr '\n' ' ' <<<"$config_ids"))"
-            exit 1
-          fi
-
-          while IFS='=' read -r cfg id; do
-            [ -n "$cfg" ] || continue
-            case "$cfg" in
-              Release)
-                if [ "$id" != "$EXPECTED_RELEASE_BUNDLE_ID" ]; then
-                  echo "::error::Release PRODUCT_BUNDLE_IDENTIFIER is '$id', expected '${EXPECTED_RELEASE_BUNDLE_ID}'. Bundle id drift breaks installed-app upgrades."
-                  exit 1
-                fi
-                ;;
-              Debug)
-                if [ "$id" != "$EXPECTED_RELEASE_BUNDLE_ID" ] && [ "$id" != "$EXPECTED_DEBUG_BUNDLE_ID" ]; then
-                  echo "::error::Debug PRODUCT_BUNDLE_IDENTIFIER is '$id', expected '${EXPECTED_RELEASE_BUNDLE_ID}' or '${EXPECTED_DEBUG_BUNDLE_ID}'."
-                  exit 1
-                fi
-                ;;
-              *)
-                echo "::error::unexpected build configuration '$cfg' sets PRODUCT_BUNDLE_IDENTIFIER='$id'; only Debug and Release are known."
-                exit 1
-                ;;
-            esac
-          done <<<"$config_ids"
+          #    The rule lives in a script rather than inline here so it can be
+          #    tested: a release-only workflow step never executes on a PR, so
+          #    an inline guard is unverifiable until a tag run exercises it.
+          #    See scripts/__tests__/check-mac-bundle-ids.test.ts.
+          node scripts/check-mac-bundle-ids.mjs \
+            packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj
 
           # 7. Sparkle public key must still be in Info.plist. Installed apps
           #    verify update signatures against SUPublicEDKey; if the key is

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -175,27 +175,83 @@ jobs:
             fi
           done
 
-          # 6. PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj must stay
-          #    com.owletto.mac across ALL build configurations. CFBundleIdentifier
-          #    in Info.plist resolves to $(PRODUCT_BUNDLE_IDENTIFIER) at build
-          #    time, so the real value lives in the pbxproj build settings.
-          #    The URL scheme, Keychain service name, and Sparkle update path
-          #    are all keyed off this — a change here breaks the upgrade
-          #    contract for installed apps.
+          # 6. PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj is pinned PER BUILD
+          #    CONFIGURATION. CFBundleIdentifier in Info.plist resolves to
+          #    $(PRODUCT_BUNDLE_IDENTIFIER) at build time, so the real value
+          #    lives in the pbxproj build settings. The URL scheme, Keychain
+          #    service name, and Sparkle update path are all keyed off this —
+          #    a change to the Release identity breaks the upgrade contract for
+          #    every installed app.
           #
-          #    Assert the set of distinct values is exactly {com.owletto.mac},
-          #    not "some occurrence equals com.owletto.mac". A simple grep
-          #    would still pass if one config drifted while another stale
-          #    occurrence stayed correct.
-          EXPECTED_BUNDLE_ID="com.owletto.mac"
-          distinct_ids=$(grep -E 'PRODUCT_BUNDLE_IDENTIFIER = ' \
-            packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj \
-            | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);.*/\1/' \
-            | sort -u)
-          if [ "$distinct_ids" != "$EXPECTED_BUNDLE_ID" ]; then
-            echo "::error::PRODUCT_BUNDLE_IDENTIFIER must be exactly '${EXPECTED_BUNDLE_ID}' across all configs (got: $distinct_ids). Bundle id drift breaks installed-app upgrades."
+          #    Release must be exactly com.owletto.mac. Debug is allowed to
+          #    carry the build-scoped com.owletto.mac.debug identity so a
+          #    developer build installs and stores credentials beside the
+          #    Release app instead of colliding with it.
+          #
+          #    Checked per configuration rather than as a set of distinct
+          #    values: a set check cannot tell "Release=mac, Debug=mac.debug"
+          #    apart from the swapped "Release=mac.debug, Debug=mac", and the
+          #    swapped form would ship a release DMG under the debug identity.
+          EXPECTED_RELEASE_BUNDLE_ID="com.owletto.mac"
+          EXPECTED_DEBUG_BUNDLE_ID="com.owletto.mac.debug"
+
+          # Emit "<config name>=<bundle id>" for every XCBuildConfiguration
+          # block that sets one. The setting always precedes the block's
+          # closing `name = <config>;` line.
+          config_ids=$(awk '
+            /isa = XCBuildConfiguration;/ { id = "" }
+            /PRODUCT_BUNDLE_IDENTIFIER = / {
+              line = $0
+              sub(/.*PRODUCT_BUNDLE_IDENTIFIER = /, "", line)
+              sub(/;.*/, "", line)
+              id = line
+            }
+            /^[[:space:]]*name = / {
+              if (id != "") {
+                cfg = $0
+                sub(/.*name = /, "", cfg)
+                sub(/;.*/, "", cfg)
+                print cfg "=" id
+                id = ""
+              }
+            }
+          ' packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj)
+
+          # An empty result means the setting moved, was renamed, or the awk
+          # no longer matches the file's shape — fail loudly instead of
+          # vacuously passing a guard that checked nothing.
+          if [ -z "$config_ids" ]; then
+            echo "::error::no PRODUCT_BUNDLE_IDENTIFIER found per build configuration in project.pbxproj — the bundle id guard is not actually checking anything"
             exit 1
           fi
+
+          # The Release configuration is the one that ships; it must exist.
+          if ! grep -q '^Release=' <<<"$config_ids"; then
+            echo "::error::no Release build configuration sets PRODUCT_BUNDLE_IDENTIFIER (got: $(tr '\n' ' ' <<<"$config_ids"))"
+            exit 1
+          fi
+
+          while IFS='=' read -r cfg id; do
+            [ -n "$cfg" ] || continue
+            case "$cfg" in
+              Release)
+                if [ "$id" != "$EXPECTED_RELEASE_BUNDLE_ID" ]; then
+                  echo "::error::Release PRODUCT_BUNDLE_IDENTIFIER is '$id', expected '${EXPECTED_RELEASE_BUNDLE_ID}'. Bundle id drift breaks installed-app upgrades."
+                  exit 1
+                fi
+                ;;
+              Debug)
+                if [ "$id" != "$EXPECTED_RELEASE_BUNDLE_ID" ] && [ "$id" != "$EXPECTED_DEBUG_BUNDLE_ID" ]; then
+                  echo "::error::Debug PRODUCT_BUNDLE_IDENTIFIER is '$id', expected '${EXPECTED_RELEASE_BUNDLE_ID}' or '${EXPECTED_DEBUG_BUNDLE_ID}'."
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "::error::unexpected build configuration '$cfg' sets PRODUCT_BUNDLE_IDENTIFIER='$id'; only Debug and Release are known."
+                exit 1
+                ;;
+            esac
+          done <<<"$config_ids"
 
           # 7. Sparkle public key must still be in Info.plist. Installed apps
           #    verify update signatures against SUPublicEDKey; if the key is

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -177,15 +177,20 @@ jobs:
 
           # 6. PRODUCT_BUNDLE_IDENTIFIER is pinned PER BUILD CONFIGURATION:
           #    Release must be com.owletto.mac, Debug may additionally be the
-          #    build-scoped com.owletto.mac.debug. The URL scheme, Keychain
-          #    service name, and Sparkle update path are keyed off the Release
-          #    identity, so drift there breaks every installed app's upgrade.
+          #    build-scoped com.owletto.mac.debug. The bundle id is the app's
+          #    identity to macOS, so a release shipped under a different id
+          #    installs a second copy beside the existing app rather than
+          #    upgrading it, stranding every install with no update path.
           #
           #    The rule lives in a script rather than inline here so it can be
           #    tested: a release-only workflow step never executes on a PR, so
           #    an inline guard is unverifiable until a tag run exercises it.
           #    See scripts/__tests__/check-mac-bundle-ids.test.ts.
-          node scripts/check-mac-bundle-ids.mjs \
+          # `bun`, not `node`: this job pins bun via setup-bun and never runs
+          # actions/setup-node, so `node` would be whatever the macos-15 image
+          # happens to preinstall. Every other `node scripts/*.mjs` call in
+          # this repo is on an ubuntu runner where node is guaranteed.
+          bun scripts/check-mac-bundle-ids.mjs \
             packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj
 
           # 7. Sparkle public key must still be in Info.plist. Installed apps

--- a/scripts/__tests__/check-mac-bundle-ids.test.ts
+++ b/scripts/__tests__/check-mac-bundle-ids.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+// @ts-expect-error — plain .mjs gate, no type declarations by design.
+import {
+  checkBundleIds,
+  parseBundleIdsByConfiguration,
+} from "../check-mac-bundle-ids.mjs";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const PBXPROJ = join(
+  REPO_ROOT,
+  "packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj"
+);
+
+/** A minimal pbxproj shaped like the real one: settings, then the block's name. */
+function pbxproj(configs: Array<{ name: string; bundleId?: string }>) {
+  return configs
+    .map(
+      ({ name, bundleId }, index) => `
+\t\tBA000000000000000000000${index + 1} /* ${name} */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tCODE_SIGN_STYLE = Automatic;${
+        bundleId ? `\n\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = ${bundleId};` : ""
+      }
+\t\t\t};
+\t\t\tname = ${name};
+\t\t};`
+    )
+    .join("\n");
+}
+
+describe("check-mac-bundle-ids", () => {
+  it("accepts the real checked-in pbxproj", () => {
+    expect(checkBundleIds(readFileSync(PBXPROJ, "utf8"))).toEqual([]);
+  });
+
+  // Guard the guard: if this ever returns nothing, every `toEqual([])` above
+  // and below passes vacuously.
+  it("actually finds an identity in the real pbxproj", () => {
+    const found = parseBundleIdsByConfiguration(readFileSync(PBXPROJ, "utf8"));
+    expect(found.length).toBeGreaterThan(0);
+    expect(
+      found.some(
+        (e: { configuration: string }) => e.configuration === "Release"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts Release pinned with a build-scoped Debug identity", () => {
+    const source = pbxproj([
+      { name: "Debug", bundleId: "com.owletto.mac.debug" },
+      { name: "Release", bundleId: "com.owletto.mac" },
+    ]);
+    expect(parseBundleIdsByConfiguration(source)).toEqual([
+      { configuration: "Debug", bundleId: "com.owletto.mac.debug" },
+      { configuration: "Release", bundleId: "com.owletto.mac" },
+    ]);
+    expect(checkBundleIds(source)).toEqual([]);
+  });
+
+  it("accepts both configurations on the release identity", () => {
+    expect(
+      checkBundleIds(
+        pbxproj([
+          { name: "Debug", bundleId: "com.owletto.mac" },
+          { name: "Release", bundleId: "com.owletto.mac" },
+        ])
+      )
+    ).toEqual([]);
+  });
+
+  // The case a set-of-distinct-values check structurally cannot catch: both
+  // identities are present, so the set is right, but they are on the wrong
+  // configurations and the release DMG would ship as the debug app.
+  it("rejects swapped Release and Debug identities", () => {
+    const problems = checkBundleIds(
+      pbxproj([
+        { name: "Debug", bundleId: "com.owletto.mac" },
+        { name: "Release", bundleId: "com.owletto.mac.debug" },
+      ])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain(
+      "Release PRODUCT_BUNDLE_IDENTIFIER is 'com.owletto.mac.debug'"
+    );
+  });
+
+  it("rejects an unrelated Release identity", () => {
+    const problems = checkBundleIds(
+      pbxproj([{ name: "Release", bundleId: "com.example.other" }])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("breaks installed-app upgrades");
+  });
+
+  it("rejects an unexpected Debug identity", () => {
+    const problems = checkBundleIds(
+      pbxproj([
+        { name: "Debug", bundleId: "com.owletto.mac.staging" },
+        { name: "Release", bundleId: "com.owletto.mac" },
+      ])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain(
+      "Debug PRODUCT_BUNDLE_IDENTIFIER is 'com.owletto.mac.staging'"
+    );
+  });
+
+  it("rejects a new configuration name rather than ignoring it", () => {
+    const problems = checkBundleIds(
+      pbxproj([
+        { name: "Release", bundleId: "com.owletto.mac" },
+        { name: "Beta", bundleId: "com.owletto.mac.beta" },
+      ])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("unexpected build configuration 'Beta'");
+  });
+
+  it("fails closed when the setting is absent rather than passing vacuously", () => {
+    const problems = checkBundleIds(
+      pbxproj([{ name: "Debug" }, { name: "Release" }])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("not actually checking anything");
+  });
+
+  it("fails closed when no Release configuration sets an identity", () => {
+    const problems = checkBundleIds(
+      pbxproj([{ name: "Debug", bundleId: "com.owletto.mac" }])
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("no Release build configuration");
+  });
+
+  // A block that sets no identity must not inherit the previous block's. The
+  // `isa = XCBuildConfiguration` reset is what prevents that, and it only has
+  // work to do when the preceding block never reached a `name` line to consume
+  // its identity — so the fixture below is hand-built with a nameless block
+  // rather than produced by pbxproj(), which always emits a name.
+  it("does not leak an identity from a block that never named itself", () => {
+    const source = [
+      "\t\tBA0000000000000000000001 /* Release */ = {",
+      "\t\t\tisa = XCBuildConfiguration;",
+      "\t\t\tbuildSettings = {",
+      "\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = com.owletto.mac.debug;",
+      "\t\t\t};",
+      "\t\t};",
+      "\t\tBA0000000000000000000002 /* Debug */ = {",
+      "\t\t\tisa = XCBuildConfiguration;",
+      "\t\t\tbuildSettings = {",
+      "\t\t\t\tCODE_SIGN_STYLE = Automatic;",
+      "\t\t\t};",
+      "\t\t\tname = Debug;",
+      "\t\t};",
+    ].join("\n");
+    expect(parseBundleIdsByConfiguration(source)).toEqual([]);
+  });
+
+  it("does not carry an identity across configuration blocks", () => {
+    expect(
+      parseBundleIdsByConfiguration(
+        pbxproj([
+          { name: "Release", bundleId: "com.owletto.mac" },
+          { name: "Debug" },
+        ])
+      )
+    ).toEqual([{ configuration: "Release", bundleId: "com.owletto.mac" }]);
+  });
+});

--- a/scripts/__tests__/check-mac-bundle-ids.test.ts
+++ b/scripts/__tests__/check-mac-bundle-ids.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "bun:test";
 
 // @ts-expect-error — plain .mjs gate, no type declarations by design.
 import {
@@ -13,6 +13,8 @@ const PBXPROJ = join(
   REPO_ROOT,
   "packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj"
 );
+const owlettoSubmoduleStubbed =
+  process.env.OWLETTO_SUBMODULE_STUBBED === "true";
 
 /** A minimal pbxproj shaped like the real one: settings, then the block's name. */
 function pbxproj(configs: Array<{ name: string; bundleId?: string }>) {
@@ -33,21 +35,29 @@ function pbxproj(configs: Array<{ name: string; bundleId?: string }>) {
 }
 
 describe("check-mac-bundle-ids", () => {
-  it("accepts the real checked-in pbxproj", () => {
-    expect(checkBundleIds(readFileSync(PBXPROJ, "utf8"))).toEqual([]);
-  });
+  it.skipIf(owlettoSubmoduleStubbed)(
+    "accepts the real checked-in pbxproj",
+    () => {
+      expect(checkBundleIds(readFileSync(PBXPROJ, "utf8"))).toEqual([]);
+    }
+  );
 
   // Guard the guard: if this ever returns nothing, every `toEqual([])` above
   // and below passes vacuously.
-  it("actually finds an identity in the real pbxproj", () => {
-    const found = parseBundleIdsByConfiguration(readFileSync(PBXPROJ, "utf8"));
-    expect(found.length).toBeGreaterThan(0);
-    expect(
-      found.some(
-        (e: { configuration: string }) => e.configuration === "Release"
-      )
-    ).toBe(true);
-  });
+  it.skipIf(owlettoSubmoduleStubbed)(
+    "actually finds an identity in the real pbxproj",
+    () => {
+      const found = parseBundleIdsByConfiguration(
+        readFileSync(PBXPROJ, "utf8")
+      );
+      expect(found.length).toBeGreaterThan(0);
+      expect(
+        found.some(
+          (e: { configuration: string }) => e.configuration === "Release"
+        )
+      ).toBe(true);
+    }
+  );
 
   it("accepts Release pinned with a build-scoped Debug identity", () => {
     const source = pbxproj([

--- a/scripts/check-mac-bundle-ids.mjs
+++ b/scripts/check-mac-bundle-ids.mjs
@@ -4,17 +4,25 @@
  *
  * `PRODUCT_BUNDLE_IDENTIFIER` in `project.pbxproj` is the real bundle id:
  * `CFBundleIdentifier` in Info.plist resolves to `$(PRODUCT_BUNDLE_IDENTIFIER)`
- * at build time. The URL scheme, the Keychain service name, and the Sparkle
- * update path are all keyed off it, so the Release identity is part of the
- * upgrade contract for every installed app — change it and existing installs
- * stop updating and lose their stored secrets.
+ * at build time.
+ *
+ * The bundle id IS the app's identity to macOS. LaunchServices keys on it, code
+ * signing is scoped to it, and Sparkle replaces the bundle it is embedded in —
+ * so shipping a release under a different id does not upgrade the installed
+ * app, it installs a second copy beside it and strands the original with no
+ * update path. That is the whole reason the Release value is pinned here.
+ *
+ * (It is NOT what keys the URL scheme or the Keychain: Info.plist registers the
+ * static scheme `owletto` and the bundle id appears only as CFBundleURLName,
+ * and KeychainTokenStore hardcodes the service `ai.lobu.mac`. Isolating the
+ * Debug build's stored secrets is a separate, context-keyed mechanism.)
  *
  * The identity is pinned PER BUILD CONFIGURATION rather than globally:
  *
  *   Release  must be exactly `com.owletto.mac`.
  *   Debug    may be `com.owletto.mac` or the build-scoped
- *            `com.owletto.mac.debug`, so a developer build installs and stores
- *            credentials beside the Release app instead of colliding with it.
+ *            `com.owletto.mac.debug`, so a developer build is a distinct app to
+ *            macOS and installs beside the Release app instead of replacing it.
  *
  * Why per-configuration and not "the set of distinct values must be
  * {com.owletto.mac, com.owletto.mac.debug}": a set cannot tell

--- a/scripts/check-mac-bundle-ids.mjs
+++ b/scripts/check-mac-bundle-ids.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Mac bundle-identity gate.
+ *
+ * `PRODUCT_BUNDLE_IDENTIFIER` in `project.pbxproj` is the real bundle id:
+ * `CFBundleIdentifier` in Info.plist resolves to `$(PRODUCT_BUNDLE_IDENTIFIER)`
+ * at build time. The URL scheme, the Keychain service name, and the Sparkle
+ * update path are all keyed off it, so the Release identity is part of the
+ * upgrade contract for every installed app — change it and existing installs
+ * stop updating and lose their stored secrets.
+ *
+ * The identity is pinned PER BUILD CONFIGURATION rather than globally:
+ *
+ *   Release  must be exactly `com.owletto.mac`.
+ *   Debug    may be `com.owletto.mac` or the build-scoped
+ *            `com.owletto.mac.debug`, so a developer build installs and stores
+ *            credentials beside the Release app instead of colliding with it.
+ *
+ * Why per-configuration and not "the set of distinct values must be
+ * {com.owletto.mac, com.owletto.mac.debug}": a set cannot tell
+ * `Release=mac, Debug=mac.debug` apart from the swapped
+ * `Release=mac.debug, Debug=mac`, and the swapped form ships a release DMG
+ * under the debug identity — precisely the break this gate exists to stop.
+ *
+ * Degenerate shapes fail closed rather than passing vacuously: a pbxproj the
+ * parser finds no identity in (the setting moved or was renamed), and one with
+ * no Release configuration at all, are each an error.
+ */
+
+import { readFileSync } from "node:fs";
+
+const EXPECTED_RELEASE_BUNDLE_ID = "com.owletto.mac";
+const EXPECTED_DEBUG_BUNDLE_ID = "com.owletto.mac.debug";
+const DEFAULT_PBXPROJ =
+  "packages/owletto/apps/mac/Owletto.xcodeproj/project.pbxproj";
+
+/**
+ * Pair each XCBuildConfiguration block's `PRODUCT_BUNDLE_IDENTIFIER` with the
+ * block's own `name`. pbxproj emits `buildSettings` before the closing
+ * `name = <config>;`, so the identity is always in hand by the time the name
+ * is read; `isa = XCBuildConfiguration` resets it so a block that sets no
+ * identity cannot inherit the previous block's.
+ */
+export function parseBundleIdsByConfiguration(source) {
+  const found = [];
+  let bundleId = null;
+  for (const line of source.split("\n")) {
+    if (line.includes("isa = XCBuildConfiguration;")) {
+      bundleId = null;
+      continue;
+    }
+    const setting = line.match(/PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/);
+    if (setting) {
+      bundleId = setting[1].trim().replace(/^"|"$/g, "");
+      continue;
+    }
+    const name = line.match(/^\s*name = ([^;]+);/);
+    if (name && bundleId !== null) {
+      found.push({
+        configuration: name[1].trim().replace(/^"|"$/g, ""),
+        bundleId,
+      });
+      bundleId = null;
+    }
+  }
+  return found;
+}
+
+/** Returns the list of violations; empty means the pbxproj satisfies the contract. */
+export function checkBundleIds(source) {
+  const found = parseBundleIdsByConfiguration(source);
+  if (found.length === 0) {
+    return [
+      "no PRODUCT_BUNDLE_IDENTIFIER found per build configuration — the bundle id gate is not actually checking anything (setting moved or renamed?)",
+    ];
+  }
+  if (!found.some((entry) => entry.configuration === "Release")) {
+    const seen = found.map((e) => `${e.configuration}=${e.bundleId}`).join(" ");
+    return [
+      `no Release build configuration sets PRODUCT_BUNDLE_IDENTIFIER (got: ${seen})`,
+    ];
+  }
+
+  const problems = [];
+  for (const { configuration, bundleId } of found) {
+    if (configuration === "Release") {
+      if (bundleId !== EXPECTED_RELEASE_BUNDLE_ID) {
+        problems.push(
+          `Release PRODUCT_BUNDLE_IDENTIFIER is '${bundleId}', expected '${EXPECTED_RELEASE_BUNDLE_ID}'. Bundle id drift breaks installed-app upgrades.`
+        );
+      }
+    } else if (configuration === "Debug") {
+      if (
+        bundleId !== EXPECTED_RELEASE_BUNDLE_ID &&
+        bundleId !== EXPECTED_DEBUG_BUNDLE_ID
+      ) {
+        problems.push(
+          `Debug PRODUCT_BUNDLE_IDENTIFIER is '${bundleId}', expected '${EXPECTED_RELEASE_BUNDLE_ID}' or '${EXPECTED_DEBUG_BUNDLE_ID}'.`
+        );
+      }
+    } else {
+      problems.push(
+        `unexpected build configuration '${configuration}' sets PRODUCT_BUNDLE_IDENTIFIER='${bundleId}'; only Debug and Release are known.`
+      );
+    }
+  }
+  return problems;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const path = process.argv[2] ?? DEFAULT_PBXPROJ;
+  let source;
+  try {
+    source = readFileSync(path, "utf8");
+  } catch (error) {
+    console.error(`::error::cannot read ${path}: ${error.message}`);
+    process.exit(1);
+  }
+  const problems = checkBundleIds(source);
+  for (const problem of problems) console.error(`::error::${problem}`);
+  if (problems.length > 0) process.exit(1);
+  console.log(
+    `bundle id gate: ${path} pins Release to ${EXPECTED_RELEASE_BUNDLE_ID}`
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the release workflow's global bundle-ID set check with a build-configuration-aware gate.
- Require Release to remain exactly `com.owletto.mac`.
- Permit Debug to remain backward-compatible as `com.owletto.mac` or move to the isolated `com.owletto.mac.debug` identity.
- Fail closed for missing Release identities, unknown configurations, swapped identities, or parser drift.
- Run the same guard in ordinary CI, while keeping fork CI meaningful when the private Owletto submodule is intentionally stubbed: fixture/adversarial coverage still runs and only the two real-pbxproj assertions skip.

This is the prerequisite for Owletto #965. It preserves the current release identity and upgrade path while allowing Debug builds to coexist without replacing the installed Release app.

## Validation
- `make pre-pr` — passed
- real checked-in project guard suite — 12 passed
- stubbed-submodule mode — 10 passed, 2 expected real-project skips
- fresh Release/Debug fixtures cover correct, swapped, missing, unexpected, and parser-degenerate identities
- `git diff --check` — passed
- UI review — not applicable; the PR does not move `packages/owletto` or change a hosted UI surface
- current exact-head GitHub CI is running on `750276bd21035bac2ab5e21586586bf37b28892b`

## Release safety
No tag or release is created by this PR. The actual release job will still require the non-stubbed Owletto checkout and will run this same fail-closed gate before building.
