### PR TITLE
fix(gateway): verify worker readiness before dispatch

### DIFF
--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -41,6 +41,7 @@ vi.mock("../workspace", () => ({
 // late-built app would silently 404.
 const gwAppSlot = vi.hoisted(() => ({ app: null as unknown }));
 vi.mock("../lobu/gateway", () => ({
+	activateLobuWorkerReadinessWatchdog: vi.fn(),
 	initLobuGateway: vi.fn(async () => gwAppSlot.app),
 	stopLobuGateway: vi.fn(async () => {}),
 	getLobuCoreServices: vi.fn(() => ({})),
@@ -445,8 +446,11 @@ describe("createServerLifecycle (source-level contract)", () => {
 
 	it("starts the embedded connector worker inside the listen callback", () => {
 		const listen = indexOf("httpServer.listen(port, host");
+		const readiness = indexOf("activateLobuWorkerReadinessWatchdog();");
 		const embedded = indexOf("embeddedWorker = startEmbeddedConnectorWorker");
 		const postHooks = indexOf("for (const hook of postListenHooks)");
+		expect(readiness).toBeGreaterThan(listen);
+		expect(readiness).toBeLessThan(postHooks);
 		expect(embedded).toBeGreaterThan(listen);
 		expect(postHooks).toBeGreaterThan(listen);
 		// postListenHooks fire BEFORE the embedded worker so any synchronous

--- a/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
@@ -16,7 +16,8 @@
  * 11. Child-process exit during killWorker (double-exit safety).
  * 12. invalidateGrantSyncCache / clearAllGrantSyncCaches.
  * 13. generateDeploymentName / buildCanonicalConversationKey determinism.
- * 14. backoffSeconds correctness.
+ * 14. Worker startup readiness watchdog.
+ * 15. backoffSeconds correctness.
  */
 
 import {
@@ -591,7 +592,81 @@ describe("maxDeployments concurrency limit", () => {
 });
 
 // ============================================================================
-// 6. WORKSPACE DIR CREATION
+// 6. WORKER STARTUP READINESS
+// ============================================================================
+
+describe("worker startup readiness", () => {
+  test("requires an authenticated worker connection before reporting ready", async () => {
+    const mgr = makeManager({
+      worker: { ...TEST_CONFIG.worker, startupTimeoutSeconds: 0.2 },
+    });
+    let connected = false;
+    mgr.setDeploymentReadinessProbe(() => connected);
+    const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    try {
+      setTimeout(() => {
+        connected = true;
+      }, 10);
+      await mgr.ensureDeployment(
+        "worker-ready",
+        "user-1",
+        "user-1",
+        makePayload(),
+      );
+      expect(await mgr.listDeployments()).toHaveLength(1);
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+  });
+
+  test("recycles a spawned child that never connects so a retry can start fresh", async () => {
+    const mgr = makeManager({
+      worker: { ...TEST_CONFIG.worker, startupTimeoutSeconds: 0.001 },
+    });
+    mgr.setDeploymentReadinessProbe(() => false);
+    const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    try {
+      await expect(
+        mgr.ensureDeployment(
+          "worker-stuck",
+          "user-1",
+          "user-1",
+          makePayload(),
+        ),
+      ).rejects.toThrow("did not connect");
+      expect(await mgr.listDeployments()).toHaveLength(0);
+      expect(mockChildProcesses.at(-1)?.killed).toBe(true);
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+  });
+
+  test("recycles an existing child that remains disconnected on scale-up", async () => {
+    const mgr = makeManager({
+      worker: { ...TEST_CONFIG.worker, startupTimeoutSeconds: 0.001 },
+    });
+    const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    try {
+      await mgr.ensureDeployment(
+        "worker-stale",
+        "user-1",
+        "user-1",
+        makePayload(),
+      );
+      mgr.setDeploymentReadinessProbe(() => false);
+      await expect(mgr.scaleDeployment("worker-stale", 1)).rejects.toThrow(
+        "did not connect",
+      );
+      expect(await mgr.listDeployments()).toHaveLength(0);
+      expect(mockChildProcesses.at(-1)?.killed).toBe(true);
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+  });
+});
+
+// ============================================================================
+// 7. WORKSPACE DIR CREATION
 // ============================================================================
 
 describe("workspace dir creation", () => {

--- a/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
@@ -613,6 +613,7 @@ describe("worker startup readiness", () => {
         "user-1",
         makePayload(),
       );
+      expect(connected).toBe(true);
       expect(await mgr.listDeployments()).toHaveLength(1);
     } finally {
       mkdirSpy.mockRestore();

--- a/packages/server/src/gateway/config/index.ts
+++ b/packages/server/src/gateway/config/index.ts
@@ -25,11 +25,9 @@ const GATEWAY_DEFAULTS = {
   PUBLIC_GATEWAY_URL: "",
   QUEUE_DIRECT_MESSAGE: "direct_message",
   QUEUE_MESSAGE_QUEUE: "message_queue",
-  // A worker normally establishes its local SSE connection in under two
-  // seconds. Bound the cold-start watchdog below the 60s turn-liveness
-  // deadline so a wedged child can be recycled and retried while the original
-  // user turn is still live.
-  WORKER_STARTUP_TIMEOUT_SECONDS: 15,
+  // Leave enough of the default 60s turn-liveness budget for the worst-case
+  // warm path: a stale-worker check, two fresh starts, teardown, and backoff.
+  WORKER_STARTUP_TIMEOUT_SECONDS: 10,
   WORKER_IDLE_CLEANUP_MINUTES: 60,
   MAX_WORKER_DEPLOYMENTS: 100,
   WORKER_STALE_TIMEOUT_MINUTES: 10,

--- a/packages/server/src/gateway/config/index.ts
+++ b/packages/server/src/gateway/config/index.ts
@@ -25,7 +25,11 @@ const GATEWAY_DEFAULTS = {
   PUBLIC_GATEWAY_URL: "",
   QUEUE_DIRECT_MESSAGE: "direct_message",
   QUEUE_MESSAGE_QUEUE: "message_queue",
-  WORKER_STARTUP_TIMEOUT_SECONDS: 90,
+  // A worker normally establishes its local SSE connection in under two
+  // seconds. Bound the cold-start watchdog below the 60s turn-liveness
+  // deadline so a wedged child can be recycled and retried while the original
+  // user turn is still live.
+  WORKER_STARTUP_TIMEOUT_SECONDS: 15,
   WORKER_IDLE_CLEANUP_MINUTES: 60,
   MAX_WORKER_DEPLOYMENTS: 100,
   WORKER_STALE_TIMEOUT_MINUTES: 10,

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -162,7 +162,7 @@ export type ModuleEnvVarsBuilder = (
 ) => Promise<Record<string, string>>;
 
 /** Pod-local probe for the worker's authenticated SSE registration. */
-export type DeploymentReadinessProbe = (deploymentName: string) => boolean;
+type DeploymentReadinessProbe = (deploymentName: string) => boolean;
 
 // Orchestrator configuration
 export interface OrchestratorConfig {
@@ -493,8 +493,8 @@ export class DeploymentManager {
    * accepting the same live-but-never-connected child from `workers`.
    *
    * A missing probe is a deliberate no-op for SDK hosts that construct the
-   * orchestrator without WorkerGateway. The embedded production composition
-   * root wires the probe before platform connections are initialized.
+   * orchestrator without WorkerGateway. The embedded server activates its
+   * probe after the local HTTP listener is live.
    */
   private async requireDeploymentReady(deploymentName: string): Promise<void> {
     const probe = this.readinessProbe;
@@ -502,7 +502,7 @@ export class DeploymentManager {
 
     const timeoutMs = Math.max(
       1,
-      Math.round((this.config.worker.startupTimeoutSeconds ?? 15) * 1000),
+      Math.round((this.config.worker.startupTimeoutSeconds ?? 10) * 1000),
     );
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -161,6 +161,9 @@ export type ModuleEnvVarsBuilder = (
   context?: ProviderCredentialContext
 ) => Promise<Record<string, string>>;
 
+/** Pod-local probe for the worker's authenticated SSE registration. */
+export type DeploymentReadinessProbe = (deploymentName: string) => boolean;
+
 // Orchestrator configuration
 export interface OrchestratorConfig {
   queues: {
@@ -227,6 +230,13 @@ export class DeploymentManager {
    * contribute their packages and domains but no credentials.
    */
   protected leaseRegistry?: CredentialLeaseRegistry;
+  /**
+   * Authenticated worker-connection probe, wired at the composition root once
+   * WorkerGateway exists. A spawned child is not ready merely because spawn()
+   * returned: it must establish its SSE stream before its durable queue can be
+   * consumed.
+   */
+  private readinessProbe?: DeploymentReadinessProbe;
   /**
    * Per-(org, agent) cache of the last-synced `preApprovedTools` patterns,
    * used to diff tool grants/revokes (domains reconcile against Postgres
@@ -471,6 +481,58 @@ export class DeploymentManager {
     this.leaseRegistry = registry;
   }
 
+  setDeploymentReadinessProbe(probe: DeploymentReadinessProbe): void {
+    this.readinessProbe = probe;
+  }
+
+  /**
+   * Wait until a newly spawned/scaled worker has authenticated and registered
+   * its SSE stream. When the watchdog lapses, tear the child down under the
+   * same deployment name before throwing: MessageConsumer's existing retry
+   * loop can then create a genuinely fresh process instead of repeatedly
+   * accepting the same live-but-never-connected child from `workers`.
+   *
+   * A missing probe is a deliberate no-op for SDK hosts that construct the
+   * orchestrator without WorkerGateway. The embedded production composition
+   * root wires the probe before platform connections are initialized.
+   */
+  private async requireDeploymentReady(deploymentName: string): Promise<void> {
+    const probe = this.readinessProbe;
+    if (!probe) return;
+
+    const timeoutMs = Math.max(
+      1,
+      Math.round((this.config.worker.startupTimeoutSeconds ?? 15) * 1000),
+    );
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (probe(deploymentName)) return;
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, Math.min(100, Math.max(1, deadline - Date.now()))),
+      );
+    }
+    if (probe(deploymentName)) return;
+
+    logger.warn(
+      { deploymentName, timeoutMs },
+      "Worker did not establish its authenticated SSE connection before the startup deadline; recycling",
+    );
+    try {
+      await this.deleteWorkerDeployment(deploymentName);
+    } catch (error) {
+      logger.error(
+        { deploymentName, error: getErrorMessage(error) },
+        "Failed to tear down worker after startup-readiness timeout",
+      );
+    }
+    throw new OrchestratorError(
+      ErrorCode.DEPLOYMENT_CREATE_FAILED,
+      `Worker ${deploymentName} did not connect within ${timeoutMs}ms`,
+      { deploymentName, timeoutMs },
+      true,
+    );
+  }
+
   protected getDispatcherHost(): string {
     // Match the systemd-run scope's IPAddressAllow=127.0.0.1 — IPv6 ::1
     // resolution would be blocked under the hardened scope.
@@ -503,12 +565,15 @@ export class DeploymentManager {
       return inFlight;
     }
 
-    const promise = this.spawnDeployment(
-      deploymentName,
-      username,
-      userId,
-      messageData
-    ).finally(() => {
+    const promise = (async () => {
+      await this.spawnDeployment(
+        deploymentName,
+        username,
+        userId,
+        messageData,
+      );
+      await this.requireDeploymentReady(deploymentName);
+    })().finally(() => {
       this.inFlightCreates.delete(deploymentName);
     });
     this.inFlightCreates.set(deploymentName, promise);
@@ -2168,6 +2233,11 @@ export class DeploymentManager {
     if (replicas === 0 && entry) {
       await this.killWorker(entry, deploymentName);
       logger.info(`Stopped embedded worker ${deploymentName}`);
+    } else if (replicas === 1 && entry) {
+      // A live child is not necessarily a usable worker. Every scale-up path
+      // (new message, lock handoff, warm resume) must wait for its authenticated
+      // SSE registration or recycle it so the caller can create a fresh child.
+      await this.requireDeploymentReady(deploymentName);
     } else if (replicas === 1 && !entry) {
       // The worker process is gone (crashed, or exited between a stale
       // listDeployments() snapshot and this call). Throwing here lets the

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -1042,7 +1042,9 @@ export class MessageConsumer {
         logger.info({ traceId, deploymentName }, "Worker is ready");
       },
       {
-        maxRetries: 3,
+        // Three total startup attempts fit inside the 60s turn-liveness
+        // deadline when each readiness probe uses the 15s default timeout.
+        maxRetries: 2,
         baseDelay: 2000,
         strategy: "linear",
         jitter: true,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -1042,13 +1042,13 @@ export class MessageConsumer {
         logger.info({ traceId, deploymentName }, "Worker is ready");
       },
       {
-        // Three total startup attempts fit inside the 60s turn-liveness
-        // deadline when each readiness probe uses the 15s default timeout.
-        maxRetries: 2,
+        // Two orchestration attempts leave room inside the default 60s
+        // turn-liveness budget for stale-worker checks, teardown, and backoff.
+        maxRetries: 1,
         baseDelay: 2000,
         strategy: "linear",
         jitter: true,
-        // Don't burn retries (~14s) on the cross-pod handled-elsewhere signal:
+        // Don't burn the remaining retry on the cross-pod handled-elsewhere signal:
         // the winning replica holds the session-level advisory lock for the
         // whole worker subprocess lifetime, so a retry here can never win.
         // Abort immediately and let the `.catch` above drop silently.
@@ -1056,7 +1056,7 @@ export class MessageConsumer {
           !(error instanceof ConversationOwnedElsewhereError),
         onRetry: (attempt, error) => {
           logger.warn(
-            { traceId, deploymentName, attempt, maxAttempts: 3 },
+            { traceId, deploymentName, attempt, maxAttempts: 2 },
             `Retry attempt failed: ${error.message}`
           );
         },

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -348,7 +348,6 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		logger.info("[Lobu] DATABASE_URL not set — embedded gateway disabled");
 		return null;
 	}
-
 	ensureEmbeddedGatewaySecrets();
 	ensureEmbeddedWorkerLauncher();
 	try {
@@ -421,7 +420,7 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		// here for the same reason as the tracker above — the gateway and the
 		// orchestrator are built separately.
 		//
-		// All three wirings are announced, and their absence is announced louder.
+		// All three integrations are announced, and their absence is announced louder.
 		// Each only takes effect when a worker gateway exists, and all features are
 		// invisible when they silently do not: a missing tracker shows up as a
 		// worker killed mid-turn, and a missing recycle gate shows up as 401s an
@@ -430,21 +429,15 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		// the skip is logged rather than swallowed by the optional chain.
 		const workerGatewayToWire = coreServices.getWorkerGateway();
 		if (workerGatewayToWire) {
-			const workerConnectionManager =
-				workerGatewayToWire.getConnectionManager();
-			orchestrator
-				.getDeploymentManager()
-				.setDeploymentReadinessProbe((deploymentName: string) =>
-					workerConnectionManager.isConnected(deploymentName),
-				);
+			const deploymentManager = orchestrator.getDeploymentManager();
 			workerGatewayToWire.setDeploymentActivityTracker(
-				orchestrator.getDeploymentManager(),
+				deploymentManager,
 			);
 			workerGatewayToWire.setDispatchRecycler(
-				orchestrator.getDeploymentManager(),
+				deploymentManager,
 			);
 			logger.info(
-				"[Lobu] Worker readiness watchdog, idle-clock tracker, and claim-side recycle gate wired into the worker gateway",
+				"[Lobu] Worker idle-clock tracker and claim-side recycle gate wired; readiness watchdog awaiting HTTP listener startup",
 			);
 		} else {
 			logger.warn(
@@ -603,6 +596,26 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		);
 		return null;
 	}
+}
+
+/**
+ * Activate worker connection checks only after the local HTTP listener is live.
+ * The orchestrator consumes persisted turns during gateway initialization; if
+ * this probe were armed then, a boot-recovered worker could not reach its SSE
+ * route yet and would be recycled as though it were wedged.
+ */
+export function activateLobuWorkerReadinessWatchdog(): void {
+	const workerGateway = coreServices?.getWorkerGateway();
+	if (!workerGateway || !orchestrator) return;
+	const workerConnectionManager = workerGateway.getConnectionManager();
+	orchestrator
+		.getDeploymentManager()
+		.setDeploymentReadinessProbe((deploymentName: string) =>
+			workerConnectionManager.isConnected(deploymentName),
+		);
+	logger.info(
+		"[Lobu] Worker readiness watchdog activated after HTTP listener startup",
+	);
 }
 
 /**

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -421,8 +421,8 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		// here for the same reason as the tracker above — the gateway and the
 		// orchestrator are built separately.
 		//
-		// Both wirings are announced, and their absence is announced louder. Each
-		// only takes effect when a worker gateway exists, and both features are
+		// All three wirings are announced, and their absence is announced louder.
+		// Each only takes effect when a worker gateway exists, and all features are
 		// invisible when they silently do not: a missing tracker shows up as a
 		// worker killed mid-turn, and a missing recycle gate shows up as 401s an
 		// hour into a warm conversation. Neither symptom points back here, and
@@ -430,6 +430,13 @@ export async function initLobuGateway(): Promise<Hono | null> {
 		// the skip is logged rather than swallowed by the optional chain.
 		const workerGatewayToWire = coreServices.getWorkerGateway();
 		if (workerGatewayToWire) {
+			const workerConnectionManager =
+				workerGatewayToWire.getConnectionManager();
+			orchestrator
+				.getDeploymentManager()
+				.setDeploymentReadinessProbe((deploymentName: string) =>
+					workerConnectionManager.isConnected(deploymentName),
+				);
 			workerGatewayToWire.setDeploymentActivityTracker(
 				orchestrator.getDeploymentManager(),
 			);
@@ -437,11 +444,11 @@ export async function initLobuGateway(): Promise<Hono | null> {
 				orchestrator.getDeploymentManager(),
 			);
 			logger.info(
-				"[Lobu] Worker idle-clock tracker and claim-side recycle gate wired into the worker gateway",
+				"[Lobu] Worker readiness watchdog, idle-clock tracker, and claim-side recycle gate wired into the worker gateway",
 			);
 		} else {
 			logger.warn(
-				"[Lobu] No worker gateway on this pod — the idle-clock tracker and the claim-side recycle gate are BOTH inactive; warm workers will not be recycled when their connector lease or tooling goes stale",
+				"[Lobu] No worker gateway on this pod — the readiness watchdog, idle-clock tracker, and claim-side recycle gate are ALL inactive; workers can be reported ready before connecting, and warm workers will not be recycled when their connector lease or tooling goes stale",
 			);
 		}
 

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -25,6 +25,7 @@ import { markShuttingDown } from "./lifecycle-state";
 import type { Env } from "./index";
 import { app as mainApp } from "./index";
 import {
+	activateLobuWorkerReadinessWatchdog,
 	getLobuCoreServices,
 	initLobuGateway,
 	stopLobuGateway,
@@ -514,6 +515,7 @@ export function createServerLifecycle(
 					{ host, port, mode },
 					`Lobu running at http://${host}:${port}`,
 				);
+				activateLobuWorkerReadinessWatchdog();
 				for (const hook of postListenHooks) {
 					hook();
 				}


### PR DESCRIPTION
## Summary

- wait for an embedded worker authenticated SSE connection before reporting it ready
- recycle spawned or warm workers that never register so retries start a fresh process
- activate the readiness probe only after the HTTP listener is live
- keep the worst-case warm recovery path inside the 60-second turn-liveness budget

## Why

Google Chat Marketplace review messages were accepted by the webhook but their queued turns were never claimed because a spawned/live child was treated as ready before its worker connection existed. The same failure appeared on non-Google-Chat traffic, confirming a gateway worker lifecycle issue rather than an adapter or model issue.

## Validation

- Codex full pre-review fixer: no unresolved findings
- 74 gateway tests passed, 2 platform-dependent systemd tests skipped
- 24 server lifecycle tests passed
- server TypeScript passed
- commit hooks passed Biome over 596 files and root TypeScript
- make pre-pr passed builds, per-package typechecks, knip, vocabulary, LLM-client, and entity-write-funnel gates

## Operational note

Production verification will require the squash merge SHA to be an ancestor of the deployed revision via scripts/prod-smoke.sh before a live Google Chat DM is used for Marketplace resubmission.