### PR TITLE
fix(sdk): document nullable entity schema lookups

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -335,6 +335,25 @@ describe("method-metadata", () => {
 		);
 	});
 
+	it("documents the nullable payload of both entitySchema getters", () => {
+		// Unlike entities.get, agents.get and conversations.get — which throw 404
+		// when the row is missing — these two report "not found" as a null payload
+		// field. The wrapper itself is always truthy, so `if (await getType(slug))`
+		// silently reports every missing type as present.
+		const nullable: Array<[string, string, string]> = [
+			["entitySchema.getType", "entity_type", "'company'"],
+			["entitySchema.getRelType", "relationship_type", "'works-at'"],
+		];
+		for (const [path, field, slug] of nullable) {
+			const meta = METHOD_METADATA[path];
+			expect(meta.summary, path).toContain(`nullable \`${field}\` field`);
+			expect(meta.summary, path).toContain("do not truth-test the wrapper");
+			expect(meta.example ?? "", path).toContain(`const { ${field} }`);
+			expect(meta.example ?? "", path).toContain(`${path}(${slug})`);
+			expect(meta.example ?? "", path).toContain("null when absent");
+		}
+	});
+
 	it("documents the exact positional signature AND the accepted object form for every positional-id method", () => {
 		// #2046: these methods take a positional id at runtime but were described
 		// like named-object methods, so discovery and runtime disagreed. Every one

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -208,11 +208,13 @@ export default async (_ctx, client) => {
 			"entitySchema.listTypes(input?: { list_scope?: 'accessible' | 'organization' }): Promise<unknown>",
 	},
 	"entitySchema.getType": {
-		summary: "Get an entity type by slug.",
+		summary:
+			"Get an entity type by slug. A missing type resolves rather than throwing: check the nullable `entity_type` field to determine whether the type exists — do not truth-test the wrapper, which is always present.",
 		access: "read",
 		signature:
 			"entitySchema.getType(slug: string): Promise<unknown> // or entitySchema.getType({ slug })",
-		example: "const t = await client.entitySchema.getType('company');",
+		example:
+			"const { entity_type } = await client.entitySchema.getType('company'); // null when absent",
 	},
 	"entitySchema.createType": {
 		summary:
@@ -246,11 +248,13 @@ export default async (_ctx, client) => {
 			"entitySchema.listRelTypes(input?: { list_scope?: 'accessible' | 'organization' }): Promise<unknown>",
 	},
 	"entitySchema.getRelType": {
-		summary: "Get a relationship type by slug.",
+		summary:
+			"Get a relationship type by slug. A missing type resolves rather than throwing: check the nullable `relationship_type` field to determine whether the type exists — do not truth-test the wrapper, which is always present.",
 		access: "read",
 		signature:
 			"entitySchema.getRelType(slug: string): Promise<unknown> // or entitySchema.getRelType({ slug })",
-		example: "const t = await client.entitySchema.getRelType('works-at');",
+		example:
+			"const { relationship_type } = await client.entitySchema.getRelType('works-at'); // null when absent",
 	},
 	"entitySchema.createRelType": {
 		summary: "Create a relationship type.",


### PR DESCRIPTION
## Summary
- make `search_sdk` explicitly document that entity-schema getters return a response wrapper with a nullable payload
- provide copy-pasteable destructuring examples for entity and relationship type lookups
- cover both discovery entries with a regression test

## Why
The production ChatGPT E2E correctly returned `{ entity_type: null }` after cleanup, but a one-off wrapper truth-tested the outer result and briefly reported the missing type as present. Runtime semantics and generated types were already correct; this fixes the model-facing discovery guidance at the layer that caused the misuse.

## Validation
- `bun test src/__tests__/unit/sandbox/method-metadata.test.ts src/__tests__/unit/sandbox/sdk-search.test.ts` (85 passed)
- `make review-fix`
- `make pre-pr`
- pre-commit Biome and TypeScript checks