### PR TITLE
feat(core): share device agent display labels

### DIFF
--- a/packages/core/src/__tests__/device-automation.test.ts
+++ b/packages/core/src/__tests__/device-automation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AutomationPollPayload } from "../contracts/worker/protocol.js";
 import {
+  AGENT_KIND_LABELS,
   AGENT_KINDS,
   DEVICE_AGENT_SPECS,
   DEVICE_AGENT_SPECS_BY_KIND,
@@ -65,6 +66,17 @@ describe("AgentSpec table", () => {
     for (const kind of AGENT_KINDS) {
       expect(DEVICE_AGENT_SPECS_BY_KIND.get(kind)?.kind).toBe(kind);
     }
+  });
+
+  test("every kind has a stable user-facing label", () => {
+    expect(AGENT_KIND_LABELS).toEqual({
+      "claude-code": "Claude Code",
+      codex: "Codex",
+      opencode: "OpenCode",
+      pi: "Pi",
+      agy: "Antigravity (agy)",
+    });
+    expect(Object.keys(AGENT_KIND_LABELS)).toEqual(AGENT_KINDS);
   });
 });
 

--- a/packages/core/src/contracts/worker/device-automation.ts
+++ b/packages/core/src/contracts/worker/device-automation.ts
@@ -33,6 +33,19 @@ export const AGENT_KINDS: readonly AgentKind[] = [
   "agy",
 ];
 
+/**
+ * Display copy for each kind. Keyed by `AgentKind` so a new CLI cannot ship
+ * without a label, and in `AGENT_KINDS` order so a selector can iterate it
+ * directly. These strings are user-facing: editing one edits what a picker shows.
+ */
+export const AGENT_KIND_LABELS: Readonly<Record<AgentKind, string>> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  opencode: "OpenCode",
+  pi: "Pi",
+  agy: "Antigravity (agy)",
+};
+
 /** How a CLI takes its prompt. `claude`/`agy` behind a flag; others positional. */
 export type PromptDelivery =
   | { kind: "flag"; flag: string }


### PR DESCRIPTION
## Summary
- export stable user-facing labels for every device agent kind
- enforce label completeness, copy, and iteration order in core tests

## Why
Owletto Activity chat now imports this shared contract when rendering the device/agent selector. This lands before the pure Owletto pointer update so the parent build has the required API.

## Validation
- `bun test packages/core/src/__tests__/device-automation.test.ts` (18 pass)
- `bunx tsc --build packages/core/tsconfig.json --force`
- `make review-fix`
- `make pre-pr`