### PR TITLE
fix(mcp): declare ChatGPT app widget domain

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -180,14 +180,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(await initSession(`/mcp/${org.slug}`)).toBeTruthy();
   });
 
-  it('serves the external v43 interaction bundle over resources/read', async () => {
+  it('serves the external v44 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v43.html' },
+        params: { uri: 'ui://lobu/interaction/v44.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -196,7 +196,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v43.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v44.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-external-stub');
     // Absolute, not `./assets/…` behind a `<base>`: Claude serves the app
@@ -214,7 +214,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     expect(content?._meta?.ui?.permissions).toEqual({ clipboardWrite: {} });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
-    expect(content?._meta?.ui?.domain).toBeUndefined();
+    expect(content?._meta?.ui?.domain).toBe('http://localhost');
   });
 
   it('serves the stamped external template and registered stable assets', async () => {
@@ -320,7 +320,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // error, so a typo or a foreign `ui://` id cannot silently render Lobu's.
     for (const uri of [
       'ui://lobu/interaction/vNext.html',
-      'ui://lobu/interaction/v43.htm',
+      'ui://lobu/interaction/v44.htm',
       'ui://lobu/interaction',
       'ui://lobu/dashboard/v1.html',
       'ui://other/interaction/v1.html',
@@ -341,7 +341,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
+  it('advertises description, CSP, and the app domain on resources/list', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
@@ -356,7 +356,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v43.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v44.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -367,8 +367,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // description is a typed resource field surfaced in client browsers.
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
-    // CSP rides the current nested _meta.ui shape. ui.domain is intentionally
-    // absent because it means a dedicated sandbox origin, not the MCP server.
+    // CSP and the sandbox `domain` ride the nested _meta.ui shape. `domain` is
+    // this deployment's own origin; the host derives its sandbox hostname from
+    // it, and it has to be on the *listed* template because that is the copy a
+    // host captures at connect time.
     expect(resource.mimeType).toBe('text/html;profile=mcp-app');
     expect(resource._meta?.ui?.csp).toEqual({
       connectDomains: [],
@@ -376,7 +378,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       frameDomains: [],
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
-    expect(resource._meta?.ui?.domain).toBeUndefined();
+    expect(resource._meta?.ui?.domain).toBe('http://localhost');
   });
 
   it('links direct saves and approval tools to the App resource', async () => {
@@ -404,10 +406,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v43.html',
+            resourceUri: 'ui://lobu/interaction/v44.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v43.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v44.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -422,10 +424,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v43.html',
+            resourceUri: 'ui://lobu/interaction/v44.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v43.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v44.html',
           'openai/widgetAccessible': true,
         }),
       })
@@ -511,7 +513,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v43.html',
+        resourceUri: 'ui://lobu/interaction/v44.html',
         visibility: ['model', 'app'],
       })
     );
@@ -581,7 +583,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).not.toContain('payload_data');
     expect(body.result?.content?.[0]?.text).not.toContain('payload_template');
     expect(body.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v43.html'
+      'ui://lobu/interaction/v44.html'
     );
   });
 
@@ -1337,7 +1339,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(capability.length).toBeGreaterThan(40);
     expect(renderBody.result?._meta?.['lobu/member-role']).toBe('owner');
     expect(renderBody.result?._meta?.['openai/outputTemplate']).toBe(
-      'ui://lobu/interaction/v43.html'
+      'ui://lobu/interaction/v44.html'
     );
     expect(JSON.stringify(view)).not.toContain(capability);
     expect(renderBody.result?.content?.[0]?.text).not.toContain(capability);

--- a/packages/server/src/mcp-app-resource-uris.ts
+++ b/packages/server/src/mcp-app-resource-uris.ts
@@ -35,7 +35,7 @@
  * correct answer to "give me the Lobu interaction shell", and it makes a bump
  * mean what the comment above claims it means: a cache eviction, not an outage.
  */
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v43.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v44.html';
 
 /**
  * Any interaction-shell id, current or superseded. The `.html` suffix is

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -278,6 +278,7 @@ function mcpAppUiMeta(
   authCtx: SessionAuthContext,
   app: (typeof MCP_APP_RESOURCES)[string]
 ): {
+  domain: string;
   csp: {
     connectDomains: string[];
     resourceDomains: string[];
@@ -288,6 +289,16 @@ function mcpAppUiMeta(
 } {
   const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
   return {
+    // `_meta.ui.domain` is the view's dedicated sandbox origin, and it is not a
+    // request to serve the view from ours: the host derives its own sandbox
+    // hostname from it (ChatGPT renders at
+    // `<domain>.web-sandbox.oaiusercontent.com`) and owns the resulting
+    // document. Omitted, the view lands on the host's default per-conversation
+    // origin: ChatGPT requires the field for plugin submission, and the derived
+    // subdomain is what its fullscreen punch-out needs. The value must be
+    // unique per app, so it is the one origin that already identifies this
+    // deployment.
+    domain: publicOrigin,
     csp: {
       ...app.csp,
       resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],


### PR DESCRIPTION
## Summary

- advertise the canonical public origin as nested MCP Apps ui.domain metadata
- bump the interaction resource URI from v43 to v44 so hosts do not reuse cached domain-less metadata
- keep all prior interaction URIs readable for existing client sessions

## Test plan

- [x] Intended files staged explicitly; make pre-pr clean
- [x] Targeted MCP App resource suite: 36/36 passed
- [x] MCP authentication suite: 50 passed, 2 skipped
- [x] Tool metadata audit: 8/8 tools have explicit hints and output schemas
- [x] Opus review-fix: typecheck, format check, MCP App resources 36/36, MCP media resources 6/6
- [x] Bug fix red-to-green:
  - before: resources/list and resources/read returned ui.domain as undefined (2 focused failures after asserting the required origin)
  - after: both return the canonical origin and the focused suite passes 36/36

## Notes

After rollout, verify the v44 resource in ChatGPT and a representative MCP App card in Claude before rescanning the OpenAI submission draft.