### PR TITLE
fix(mcp): negotiate app sandbox domain

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -343,6 +343,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
 
   it('advertises description, CSP, and the app domain on resources/list', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
+    // Recover from the persisted row rather than the live map, so this asserts
+    // the negotiated flag survives a replica hop in the direction that emits
+    // the field too — not only the direction that withholds it.
+    clearInMemoryMcpSessionsForTests();
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -379,6 +383,53 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toBe('http://localhost');
+  });
+
+  it('omits the app domain for a host that renders Apps without advertising the UI extension', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      advertiseMcpApps: false,
+    });
+    // Exercise the persisted capability across a replica-local session miss:
+    // the compatibility decision must not depend on process affinity.
+    clearInMemoryMcpSessionsForTests();
+
+    const listResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'claude-resources-list',
+        method: 'resources/list',
+      },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+    expect(listResponse.status).toBe(200);
+    const listBody = await listResponse.json();
+    const listed = listBody.result?.resources?.find(
+      (resource: { uri?: string }) => resource.uri === LOBU_INTERACTION_RESOURCE_URI
+    );
+    expect(listed?._meta?.ui?.domain).toBeUndefined();
+    expect(listed?._meta?.ui?.csp).toBeTruthy();
+
+    const readResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'claude-resources-read',
+        method: 'resources/read',
+        params: { uri: LOBU_INTERACTION_RESOURCE_URI },
+      },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+    expect(readResponse.status).toBe(200);
+    const readBody = await readResponse.json();
+    expect(readBody.result?.contents?.[0]?._meta?.ui?.domain).toBeUndefined();
+    expect(readBody.result?.contents?.[0]?._meta?.ui?.csp).toBeTruthy();
   });
 
   it('links direct saves and approval tools to the App resource', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -278,7 +278,7 @@ function mcpAppUiMeta(
   authCtx: SessionAuthContext,
   app: (typeof MCP_APP_RESOURCES)[string]
 ): {
-  domain: string;
+  domain?: string;
   csp: {
     connectDomains: string[];
     resourceDomains: string[];
@@ -293,12 +293,19 @@ function mcpAppUiMeta(
     // request to serve the view from ours: the host derives its own sandbox
     // hostname from it (ChatGPT renders at
     // `<domain>.web-sandbox.oaiusercontent.com`) and owns the resulting
-    // document. Omitted, the view lands on the host's default per-conversation
-    // origin: ChatGPT requires the field for plugin submission, and the derived
+    // document. ChatGPT requires the field for submission, and the derived
     // subdomain is what its fullscreen punch-out needs. The value must be
     // unique per app, so it is the one origin that already identifies this
     // deployment.
-    domain: publicOrigin,
+    //
+    // Only a host that negotiated the UI extension gets it. Claude renders the
+    // same App without advertising the extension, but treats the field as an
+    // unusable iframe origin and leaves the card on a spinner. Omitted, its
+    // view lands on the host's default per-conversation origin — where the card
+    // rendered before this field existed. The negotiated capability is
+    // persisted with the MCP session, so the decision survives cross-replica
+    // recovery without a user-agent or client-name allowlist.
+    ...(authCtx.supportsMcpApps ? { domain: publicOrigin } : {}),
     csp: {
       ...app.csp,
       resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],


### PR DESCRIPTION
## Summary

- emit `_meta.ui.domain` only when the MCP client negotiated the UI extension
- preserve ChatGPT submission metadata while returning Claude to its compatible per-conversation sandbox origin
- cover both branches after persisted-session recovery so behavior is replica-safe

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Tests run: full MCP integration folder (198 passed, 2 skipped) and focused session suites (40 passed)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: not applicable

Red: a non-advertising Claude-style session received `domain: http://localhost`; the new test failed with `expected http://localhost to be undefined`.

Green: `bun run test -- run src/__tests__/integration/mcp/mcp-app-resources.test.ts src/__tests__/integration/mcp/session-refresh-atomicity.test.ts` passed 40/40. Independent Opus pre-review also mutation-tested the unconditional-domain and lost-persisted-capability variants; each failed in the intended branch.

## Notes

Live production reproduction after #3180: ChatGPT required the domain metadata, while Claude completed the Lobu tool call but left its App iframe on a spinner. This follow-up uses capability negotiation rather than user-agent or client-name matching. No resource URI bump is needed because the UI payload is unchanged; existing connections must refresh after rollout before they receive a new handshake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP App session recovery so negotiated app metadata, including content security policy settings, is preserved.
  - Clients that do not support MCP Apps no longer receive an unnecessary sandbox domain.
  - MCP resources now consistently retain security metadata while using the host’s default origin when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->