### PR TITLE
fix(auth): reject worker tokens off MCP routes

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-token-headerless-auth.test.ts
@@ -150,13 +150,20 @@ describe('worker-token MCP auth without the direct-auth header', () => {
     });
   });
 
-  it('does not promote a worker token on non-MCP routes', async () => {
-    const response = await post(`/api/${org.slug}/query_sdk`, {
-      body: { sql: 'return lobu.organization.id' },
-      token: workerToken,
-      headers: { 'X-Lobu-Memory-Direct-Auth': '1' },
-    });
-    expect(response.status).toBe(401);
+  it('fast-rejects a worker token on non-MCP routes with or without the direct-auth header', async () => {
+    for (const headers of [undefined, { 'X-Lobu-Memory-Direct-Auth': '1' }]) {
+      const label = headers ? 'with direct-auth header' : 'headerless';
+      const response = await post(`/api/${org.slug}/query_sdk`, {
+        body: { sql: 'return lobu.organization.id' },
+        token: workerToken,
+        headers,
+      });
+      expect(response.status, label).toBe(401);
+      expect(await response.json(), label).toMatchObject({
+        error: 'invalid_token',
+        error_description: 'Worker tokens are only valid on MCP routes',
+      });
+    }
   });
 
   it('a bearer that is not a worker token still falls through to OAuth auth', async () => {

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -306,10 +306,8 @@ export class MultiTenantProvider implements WorkspaceProvider {
     // without that header. Ordinary worker tokens are rejected on both paths;
     // non-worker bearers still fall through to PAT, OAuth, or session auth.
     const directAuthHeader = c.req.header('x-lobu-memory-direct-auth') === '1';
-    const directAuthBearer =
-      authHeader?.startsWith('Bearer ') && isMcpRoute
-        ? authHeader.slice(7)
-        : null;
+    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const directAuthBearer = bearerToken && isMcpRoute ? bearerToken : null;
     const gatewayMcpTokenData =
       directAuthBearer && directAuthHeader && looksLikeWorkerToken(directAuthBearer)
         ? verifyGatewayMcpToken(directAuthBearer)
@@ -460,6 +458,22 @@ export class MultiTenantProvider implements WorkspaceProvider {
         memberRole: directAuthRole,
         authSource: 'pat',
       });
+    }
+
+    // Worker tokens are valid only on MCP routes, so on every other route the
+    // fall-through below is pure waste — an OAuth verify (a DB read) and a
+    // session lookup that cannot succeed. Claiming the bearer on envelope
+    // shape alone is safe: no other credential class can produce that shape,
+    // since PATs carry an `owl_pat_` prefix, and OAuth access tokens and
+    // Better Auth session tokens are base64url, which never emits `:`. A
+    // forged or expired envelope lands on the same 401 the fall-through
+    // would have returned.
+    if (bearerToken && !isMcpRoute && looksLikeWorkerToken(bearerToken)) {
+      return c.json(
+        { error: 'invalid_token', error_description: 'Worker tokens are only valid on MCP routes' },
+        401,
+        { 'WWW-Authenticate': bearerChallenge('invalid_token') }
+      );
     }
 
     // 2) Bearer token auth (PAT or OAuth)


### PR DESCRIPTION
## Summary
- fast-reject recognizable worker-token envelopes on non-MCP routes
- avoid impossible OAuth/session fall-through and DB-pool pressure
- cover both headerless and direct-auth-header requests

## Validation
- red proof: with the source restored, the new assertion received the generic OAuth error instead of the route-specific rejection
- focused integration: 8/8 passed
- full CI-equivalent integration shard 3/3: 168 files, 1435 tests passed
- server TypeScript check passed
- `make review-fix` passed
- `make pre-pr` passed

## Safety
- does not inspect token contents beyond the already-existing worker-token envelope predicate
- PAT, OAuth, and Better Auth token shapes continue through their existing handlers