### PR TITLE
fix(mcp): scope app sandbox domain per session

### DIFF
--- a/db/migrations/20260826210000_mcp_sessions_app_sandbox_domain.sql
+++ b/db/migrations/20260826210000_mcp_sessions_app_sandbox_domain.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+ALTER TABLE mcp_sessions
+  ADD COLUMN IF NOT EXISTS supports_app_sandbox_domain boolean;
+
+COMMENT ON COLUMN mcp_sessions.supports_app_sandbox_domain IS
+  'Whether this MCP session advertised the OpenAI visibility capability used to gate App sandbox-domain metadata; NULL marks rows written before this capability was persisted';
+
+-- migrate:down
+ALTER TABLE mcp_sessions
+  DROP COLUMN IF EXISTS supports_app_sandbox_domain;

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -99,11 +99,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       sessionToken?: string;
       agentId?: string;
       advertiseMcpApps?: boolean;
+      advertiseOpenAIVisibility?: boolean;
       headers?: Record<string, string>;
     } = {}
   ): Promise<string> {
     const sessionToken = options.sessionToken ?? token;
     const advertiseMcpApps = options.advertiseMcpApps ?? true;
+    const advertiseOpenAIVisibility = options.advertiseOpenAIVisibility ?? true;
     const initResponse = await post(path, {
       body: {
         jsonrpc: '2.0',
@@ -118,6 +120,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
                     mimeTypes: ['text/html;profile=mcp-app'],
                   },
                 },
+                ...(advertiseOpenAIVisibility
+                  ? {
+                      experimental: {
+                        'openai/visibility': { enabled: true },
+                      },
+                    }
+                  : {}),
               }
             : {},
           clientInfo: {
@@ -385,18 +394,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(resource._meta?.ui?.domain).toBe('http://localhost');
   });
 
-  it('omits the app domain for a host that renders Apps without advertising the UI extension', async () => {
+  it('omits the app domain for a host that advertises Apps without OpenAI visibility', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
-      advertiseMcpApps: false,
+      advertiseOpenAIVisibility: false,
     });
-    // Exercise the persisted capability across a replica-local session miss:
-    // the compatibility decision must not depend on process affinity.
-    clearInMemoryMcpSessionsForTests();
-
-    const listResponse = await post(`/mcp/${org.slug}`, {
+    const liveListResponse = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
-        id: 'claude-resources-list',
+        id: 'non-openai-resources-list',
         method: 'resources/list',
       },
       headers: {
@@ -405,18 +410,41 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       },
       token,
     });
-    expect(listResponse.status).toBe(200);
-    const listBody = await listResponse.json();
-    const listed = listBody.result?.resources?.find(
+    expect(liveListResponse.status).toBe(200);
+    const liveListBody = await liveListResponse.json();
+    const liveResource = liveListBody.result?.resources?.find(
       (resource: { uri?: string }) => resource.uri === LOBU_INTERACTION_RESOURCE_URI
     );
-    expect(listed?._meta?.ui?.domain).toBeUndefined();
-    expect(listed?._meta?.ui?.csp).toBeTruthy();
+    expect(liveResource?._meta?.ui?.domain).toBeUndefined();
+    expect(liveResource?._meta?.ui?.csp).toBeTruthy();
+
+    // Exercise persisted session-capability recovery across a replica-local
+    // miss: the compatibility decision must not depend on process affinity.
+    clearInMemoryMcpSessionsForTests();
+
+    const toolsResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'non-openai-tools-list',
+        method: 'tools/list',
+      },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+    const toolsBody = await toolsResponse.json();
+    expect(
+      toolsBody.result?.tools?.some(
+        (tool: { name?: string }) => tool.name === 'resolve_approval'
+      )
+    ).toBe(true);
 
     const readResponse = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
-        id: 'claude-resources-read',
+        id: 'non-openai-resources-read',
         method: 'resources/read',
         params: { uri: LOBU_INTERACTION_RESOURCE_URI },
       },

--- a/packages/server/src/__tests__/integration/mcp/session-refresh-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/session-refresh-atomicity.test.ts
@@ -49,6 +49,7 @@ describe('mcp session refresh is update-only', () => {
       isAuthenticated: true,
       scopedToOrg: false,
       supportsMcpApps: true,
+      supportsAppSandboxDomain: true,
       lastAccessedAt: Date.now(),
       expiresAt: Date.now() + 3_600_000,
     };
@@ -63,6 +64,41 @@ describe('mcp session refresh is update-only', () => {
     const row = await store.getSession(session.sessionId);
     expect(row).not.toBeNull();
     expect(row?.supportsMcpApps).toBe(true);
+    expect(row?.supportsAppSandboxDomain).toBe(true);
+  });
+
+  it('preserves MCP Apps domain metadata for a row written by the previous binary', async () => {
+    await getTestDb()`
+      INSERT INTO mcp_sessions (
+        session_id,
+        user_id,
+        client_id,
+        organization_id,
+        member_role,
+        requested_agent_id,
+        is_authenticated,
+        scoped_to_org,
+        supports_mcp_apps,
+        last_accessed_at,
+        expires_at
+      ) VALUES (
+        ${session.sessionId},
+        ${session.userId},
+        ${session.clientId},
+        ${session.organizationId},
+        ${session.memberRole},
+        ${session.requestedAgentId},
+        ${session.isAuthenticated},
+        ${session.scopedToOrg},
+        ${session.supportsMcpApps},
+        ${new Date(session.lastAccessedAt)},
+        ${new Date(session.expiresAt)}
+      )
+    `;
+
+    const row = await store.getSession(session.sessionId);
+    expect(row?.supportsMcpApps).toBe(true);
+    expect(row?.supportsAppSandboxDomain).toBe(true);
   });
 
   it('does NOT resurrect a row deleted by a concurrent revoke', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -96,6 +96,7 @@ const mcpSessionStore = new McpSessionStore();
 type SessionAuthContext = AuthContext & {
   instructions?: string;
   supportsMcpApps?: boolean;
+  supportsAppSandboxDomain?: boolean;
 };
 
 export function hostConversationIdFromMeta(value: unknown): string | null {
@@ -283,6 +284,20 @@ function supportsMcpApps(capabilities: Record<string, unknown> | null | undefine
   return Array.isArray(mimeTypes) && mimeTypes.includes(MCP_APP_MIME_TYPE);
 }
 
+function supportsAppSandboxDomain(
+  capabilities: Record<string, unknown> | null | undefined
+): boolean {
+  if (!supportsMcpApps(capabilities)) return false;
+  const experimental = capabilities?.experimental;
+  if (!experimental || typeof experimental !== 'object') return false;
+  const visibility = (experimental as Record<string, unknown>)['openai/visibility'];
+  return (
+    !!visibility &&
+    typeof visibility === 'object' &&
+    (visibility as Record<string, unknown>).enabled === true
+  );
+}
+
 function mcpAppUiMeta(
   authCtx: SessionAuthContext,
   app: (typeof MCP_APP_RESOURCES)[string]
@@ -307,14 +322,12 @@ function mcpAppUiMeta(
     // unique per app, so it is the one origin that already identifies this
     // deployment.
     //
-    // Only a host that negotiated the UI extension gets it. Claude renders the
-    // same App without advertising the extension, but treats the field as an
-    // unusable iframe origin and leaves the card on a spinner. Omitted, its
-    // view lands on the host's default per-conversation origin — where the card
-    // rendered before this field existed. The negotiated capability is
-    // persisted with the MCP session, so the decision survives cross-replica
-    // recovery without a user-agent or client-name allowlist.
-    ...(authCtx.supportsMcpApps ? { domain: publicOrigin } : {}),
+    // Some hosts negotiate the MCP Apps UI extension without advertising the
+    // OpenAI visibility capability. Such hosts can treat this field as an
+    // unusable iframe origin and leave the card on a spinner. Omitted, the view
+    // lands on the host's default per-conversation origin. Keying on the
+    // negotiated capability avoids a user-agent or client-name allowlist.
+    ...(authCtx.supportsAppSandboxDomain ? { domain: publicOrigin } : {}),
     csp: {
       ...app.csp,
       resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],
@@ -778,6 +791,7 @@ function buildPersistedSession(
     isAuthenticated: authCtx.isAuthenticated,
     scopedToOrg: authCtx.scopedToOrg,
     supportsMcpApps: authCtx.supportsMcpApps ?? false,
+    supportsAppSandboxDomain: authCtx.supportsAppSandboxDomain ?? false,
     lastAccessedAt,
     expiresAt: lastAccessedAt + SESSION_MAX_AGE_MS,
   };
@@ -900,6 +914,7 @@ async function recoverSessionAuthContext(
   }
   authCtx.requestedAgentId = persisted.requestedAgentId ?? authCtx.requestedAgentId;
   authCtx.supportsMcpApps = persisted.supportsMcpApps;
+  authCtx.supportsAppSandboxDomain = persisted.supportsAppSandboxDomain;
   authCtx.instructions = authCtx.organizationId
     ? ((await buildWorkspaceInstructions(authCtx.organizationId)) ?? undefined)
     : undefined;
@@ -1488,6 +1503,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     await hydrateScopedMemberRole(c.env, authCtx);
     await recordMcpClientActivity(c.env, authCtx, req, initialize);
     authCtx.supportsMcpApps = supportsMcpApps(initialize?.capabilities);
+    authCtx.supportsAppSandboxDomain = supportsAppSandboxDomain(initialize?.capabilities);
     const { transport, server } = createSessionTransport(
       c.env,
       authCtx,

--- a/packages/server/src/mcp-session-store.ts
+++ b/packages/server/src/mcp-session-store.ts
@@ -10,6 +10,7 @@ export interface PersistedMcpSession {
   isAuthenticated: boolean;
   scopedToOrg: boolean;
   supportsMcpApps: boolean;
+  supportsAppSandboxDomain: boolean;
   lastAccessedAt: number;
   expiresAt: number;
 }
@@ -47,6 +48,7 @@ export class McpSessionStore {
         is_authenticated,
         scoped_to_org,
         supports_mcp_apps,
+        supports_app_sandbox_domain,
         last_accessed_at,
         expires_at
       ) VALUES (
@@ -59,6 +61,7 @@ export class McpSessionStore {
         ${session.isAuthenticated},
         ${session.scopedToOrg},
         ${session.supportsMcpApps},
+        ${session.supportsAppSandboxDomain},
         ${new Date(session.lastAccessedAt)},
         ${new Date(session.expiresAt)}
       )
@@ -71,6 +74,7 @@ export class McpSessionStore {
         is_authenticated = EXCLUDED.is_authenticated,
         scoped_to_org = EXCLUDED.scoped_to_org,
         supports_mcp_apps = EXCLUDED.supports_mcp_apps,
+        supports_app_sandbox_domain = EXCLUDED.supports_app_sandbox_domain,
         last_accessed_at = EXCLUDED.last_accessed_at,
         expires_at = EXCLUDED.expires_at
     `;
@@ -99,6 +103,7 @@ export class McpSessionStore {
         is_authenticated = ${session.isAuthenticated},
         scoped_to_org = ${session.scopedToOrg},
         supports_mcp_apps = ${session.supportsMcpApps},
+        supports_app_sandbox_domain = ${session.supportsAppSandboxDomain},
         last_accessed_at = ${new Date(session.lastAccessedAt)},
         expires_at = ${new Date(session.expiresAt)}
       WHERE session_id = ${session.sessionId}
@@ -119,6 +124,7 @@ export class McpSessionStore {
     if (rows.length === 0) return null;
 
     const row = rows[0] as Record<string, unknown>;
+    const supportsMcpApps = fromBool(row.supports_mcp_apps);
     return {
       sessionId: String(row.session_id),
       userId: typeof row.user_id === 'string' ? row.user_id : null,
@@ -128,7 +134,11 @@ export class McpSessionStore {
       requestedAgentId: typeof row.requested_agent_id === 'string' ? row.requested_agent_id : null,
       isAuthenticated: fromBool(row.is_authenticated),
       scopedToOrg: fromBool(row.scoped_to_org),
-      supportsMcpApps: fromBool(row.supports_mcp_apps),
+      supportsMcpApps,
+      supportsAppSandboxDomain:
+        row.supports_app_sandbox_domain == null
+          ? supportsMcpApps
+          : fromBool(row.supports_app_sandbox_domain),
       lastAccessedAt: fromDate(row.last_accessed_at) ?? Date.now(),
       expiresAt: fromDate(row.expires_at) ?? Date.now(),
     };


### PR DESCRIPTION
## Summary
- Gate `_meta.ui.domain` on the session's advertised OpenAI visibility capability while keeping MCP Apps support independent.
- Persist the one-bit compatibility decision on `mcp_sessions` so replica recovery returns identical metadata.
- Keep the new column nullable only as a legacy-writer marker; new sessions store explicit booleans, while legacy rows preserve their prior MCP Apps behavior.
- Cover OpenAI-positive, Claude-shaped negative, replica-recovery, and previous-binary session paths.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean.
- [x] `cd packages/server && bun run test -- run src/__tests__/integration/mcp/mcp-app-resources.test.ts src/__tests__/integration/mcp/session-refresh-atomicity.test.ts` — 41/41 tests passed.
- [x] `bun run db:lint db/migrations/20260826210000_mcp_sessions_app_sandbox_domain.sql` — 0 issues.
- [x] Bug fix red→green evidence:
  - Red: after #3181 deployed, a fresh Claude session still left the Lobu MCP App card spinning. Live initialization metadata showed both Claude and ChatGPT advertise the MCP Apps UI extension, while only ChatGPT advertised `experimental.openai/visibility.enabled`.
  - Red: the first required review showed that `NOT NULL DEFAULT false` made rows written before the new capability indistinguishable from explicit non-OpenAI sessions during recovery.
  - Green: integration coverage proves the domain is present for the OpenAI-capability session, absent for the Claude-shaped session live and after DB recovery, and preserved for a legacy row written without the new column. App-only tools remain available.

## Notes
This deliberately avoids a client-name allowlist and avoids OAuth-client-wide state, which could race when the same OAuth client has concurrent host sessions. The nullable database value does not escape the store: callers still receive an effective boolean. Owletto is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-aware MCP App sandbox domain support.
  * Sandbox domain metadata is now shown only to clients that advertise support.
  * Existing sessions continue to work with safe default behavior after upgrades.

* **Bug Fixes**
  * Preserved sandbox-domain capabilities during session refresh and recovery.
  * Improved compatibility for sessions created by earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->