### PR TITLE
fix(server): contain escaped browser callback parameters

### DIFF
--- a/packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts
+++ b/packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts
@@ -45,6 +45,34 @@ describe("browser ingestion sanitizer", () => {
 		expect(sanitizeBrowserText("https://example.test/?keep=1&amp;code=secret")).toBe(
 			"https://example.test/?keep=1&amp;code=REDACTED",
 		);
+		// An escaped separator must not smuggle a sensitive parameter past
+		// redaction, whatever spelling the page used for `&`.
+		for (const separator of [
+			"&AMP;",
+			"&Amp;",
+			"&amp;amp;",
+			"&AMP;AMP;",
+			"&#38;",
+			"&#038;",
+			"&#x26;",
+			"&#X26;",
+			"&#x0026;",
+			"&amp;#38;",
+		]) {
+			expect(sanitizeBrowserText(`https://example.test/?keep=1${separator}code=secret`)).toBe(
+				`https://example.test/?keep=1${separator}code=REDACTED`,
+			);
+		}
+		expect(sanitizeBrowserText("https://example.test/?keep=1&AMP;CODE=secret")).toBe(
+			"https://example.test/?keep=1&AMP;CODE=REDACTED",
+		);
+		// Keys that merely begin with "amp" are ordinary parameters, not separators.
+		expect(sanitizeBrowserText("https://example.test/?keep=1&amplitude=7")).toBe(
+			"https://example.test/?keep=1&amplitude=7",
+		);
+		expect(sanitizeBrowserText("https://example.test/?q=research&amp;lang=en")).toBe(
+			"https://example.test/?q=research&amp;lang=en",
+		);
 		expect(sanitizeBrowserText("code%3Dencoded-query-secret")).toBe("REDACTED");
 		expect(sanitizeBrowserText("https://example.test/?next=code%3Dnested-secret")).toBe(
 			"https://example.test/?next=REDACTED",

--- a/packages/server/src/utils/browser-ingestion-sanitizer.ts
+++ b/packages/server/src/utils/browser-ingestion-sanitizer.ts
@@ -26,6 +26,23 @@ const MAX_ENCODED_CALLBACK_PROBE_DEPTH = 8;
 const MAX_NESTED_BROWSER_DEPTH = 16;
 const MAX_BROWSER_CONTAINERS = 10_000;
 const BROWSER_TEXT_TOKEN_RE = /[^\s<>'"`]+/g;
+/**
+ * A parameter separator captured out of untrusted page content, where a literal
+ * `&` may instead arrive HTML-escaped — including repeatedly, when a URL has
+ * been escaped more than once — or as a numeric character reference. Matching
+ * only `&amp;` lets `code=` ride in behind any other spelling and skip
+ * redaction, so every form is accepted here and the patterns using it are
+ * case-insensitive.
+ *
+ * The entity run is wrapped in an atomic group (`(?=(x))\N`, since JS has no
+ * possessive quantifier) so a long chain of escapes that ultimately fails to
+ * reach `=` is rejected at once. Plain `(?:...)*` backtracks into every shorter
+ * prefix of the run, which is quadratic on hostile input like `&amp;amp;…!`.
+ * Each pattern below passes the group number its own capture takes.
+ */
+function paramSeparator(group: number): string {
+	return `&(?=((?:amp;|#0*38;|#[xX]0*26;)*))\\${group}`;
+}
 const URL_FIELD_KEYS = new Set([
 	"url",
 	"urls",
@@ -102,11 +119,12 @@ function encodeNestedValue(value: string): string {
 }
 
 function containsSensitiveParameter(value: string): boolean {
+	// Group 1 is the atomic separator's lookahead capture; key and value follow.
 	for (const match of value.matchAll(
-		/(?:^|[?#]|&(?:amp;)?)([^=&?#\s]+)=([^&#\s<>'"`]*)/g,
+		new RegExp(`(?:^|[?#]|${paramSeparator(1)})([^=&?#\\s]+)=([^&#\\s<>'"\`]*)`, "gi"),
 	)) {
-		if (!SENSITIVE_KEYS.has(decodeParamKey(match[1] ?? ""))) continue;
-		const decodedValue = decodeValue(match[2] ?? "");
+		if (!SENSITIVE_KEYS.has(decodeParamKey(match[2] ?? ""))) continue;
+		const decodedValue = decodeValue(match[3] ?? "");
 		if (decodedValue && decodedValue !== BROWSER_REDACTED_MARKER) return true;
 	}
 	return false;
@@ -147,9 +165,10 @@ function redactParameterPart(part: string, depth: number): string {
 }
 
 function redactUrlPart(url: string, depth: number): string {
+	// Group 1 is the whole separator; group 2 is its atomic lookahead capture.
 	return url.replace(
-		/(^|[?#]|&(?:amp;)?)([^=&?#\s]+)=([^&#\s<>'"`]+)/g,
-		(_match, separator: string, key: string, value: string) =>
+		new RegExp(`(^|[?#]|${paramSeparator(2)})([^=&?#\\s]+)=([^&#\\s<>'"\`]+)`, "gi"),
+		(_match, separator: string, _entities: string, key: string, value: string) =>
 			`${separator}${redactParameterPart(`${key}=${value}`, depth)}`,
 	);
 }


### PR DESCRIPTION
## Summary

- Treat mixed-case, repeated, decimal, and hexadecimal HTML encodings of an ampersand as browser callback parameter separators.
- Redact sensitive callback values behind those separators while preserving benign amp-prefixed parameters byte-for-byte.
- Bound hostile entity runs with an atomic-match pattern so the broader containment does not introduce regex backtracking growth.

## Test plan

- [ ] Intended files staged explicitly, then make pr-full clean (full Linux CI graph; make pre-pr only as local fallback)
- [x] Tests run: targeted Bun sanitizer/context suites and the Vitest browser-ingestion containment integration suite
- [x] Bug fix: red -> fix -> green outputs pasted below
- [ ] If bot runtime changed: ran ./scripts/test-bot.sh or relevant eval

Red on fresh origin/main:

    expected https://example.test/?keep=1&AMP;code=REDACTED
    got      https://example.test/?keep=1&AMP;code=secret
    exit 1

Green after the fix:

    bun test packages/server/src/__tests__/unit/browser-ingestion-sanitizer.test.ts
    6 pass, 0 fail, 58 assertions

    cd packages/server && bun run test -- run src/__tests__/integration/events/browser-ingestion-containment.test.ts
    1 file passed, 7 tests passed

    bun test packages/server/src/__tests__/unit/browser-action-context.test.ts
    3 pass, 0 fail, 11 assertions

    make pre-pr
    all 5 gates clean

A 20,000-entity hostile-shape preservation probe completed in 8.88 ms and remained byte-identical.

## Notes

The required Opus review-fix pass expanded the original mixed-case fix to cover same-class double-escaped and numeric-entity bypasses and hardened the matcher against quadratic backtracking. Its edits were inspected before the suites and pre-PR gate were rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL sanitization to redact sensitive parameters when separators use HTML-escaped or numeric ampersand forms.
  * Preserved benign parameters, including language settings and keys that merely begin with similar text.
  * Added coverage for mixed-case and repeatedly escaped URL separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->