### PR TITLE
fix(connector-worker): stop terminal interactive handoffs

### DIFF
--- a/packages/connector-worker/src/__tests__/interactive-automation.test.ts
+++ b/packages/connector-worker/src/__tests__/interactive-automation.test.ts
@@ -3,6 +3,7 @@ import type { AutomationPollPayload, PollResponse } from '@lobu/core/contracts/w
 import { executeAutomationRun, isInteractiveSessionEligible } from '../daemon/automation.js';
 import { executeRun } from '../daemon/executor.js';
 import { executeRun } from '../daemon/executor.js';
+import { WorkerHttpError } from '../daemon/client.js';
 import * as interactive from '../daemon/interactive-session.js';
 import { resolveDaemonWorkerId } from '../daemon/start.js';
 
@@ -226,6 +227,128 @@ describe('interactive-session routing', () => {
     expect(reports[0]?.error).toBe(
       'daemon shut down before parent Claude completed the Automation'
     );
+  });
+
+  test('a terminal heartbeat cancels an active interactive handoff without reporting a stale failure', async () => {
+    const session: interactive.ParentClaudeSession = {
+      kind: 'claude-code',
+      pid: process.pid,
+      sessionId: 'parent-session',
+      socketPath: '/private/unused-parent.sock',
+      messagingToken: 'messaging-token',
+      registryPath: '/private/unused-session.json',
+    };
+    const handoff = spyOn(interactive, 'handoffToInteractiveSession').mockImplementation(
+      async (opts) => ({
+        kind: 'handed-off',
+        certainty: 'possible',
+        helperPath: '/private/helper',
+        completion: new Promise((resolve) => {
+          // Resolving as `timeout` keeps an unforwarded signal a visible
+          // assertion failure instead of a hung test.
+          const fallback = setTimeout(
+            () =>
+              resolve({
+                kind: 'timeout',
+                durationMs: 50,
+                error: 'terminal signal was not forwarded to the active handoff',
+              }),
+            50
+          );
+          opts.terminalSignal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(fallback);
+              resolve({
+                kind: 'terminal',
+                durationMs: 7,
+                error: 'automation run became terminal before the interactive session completed it',
+              });
+            },
+            { once: true }
+          );
+        }),
+      })
+    );
+    const reports: Array<Record<string, unknown>> = [];
+    const client = {
+      id: 'worker-test',
+      mcpWiring: undefined,
+      async heartbeat() {
+        throw new WorkerHttpError(409, '/heartbeat', 'run is no longer active');
+      },
+      async completeAutomation(_runId: number, request: Record<string, unknown>) {
+        reports.push(request);
+        return { ok: true, status: 'completed' };
+      },
+    };
+
+    await executeAutomationRun(
+      client as never,
+      { run_id: 96, run_type: 'automation', payload: payload() } satisfies PollResponse,
+      interactive.attachInteractiveSession({ heartbeatIntervalMs: 5 }, session)
+    );
+
+    expect(handoff).toHaveBeenCalledTimes(1);
+    expect(handoff.mock.calls[0]?.[0]?.terminalSignal?.aborted).toBe(true);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.finalize_attempt).toBe(0);
+    expect(reports[0]?.exit_reason).toBe('ok');
+    expect(reports[0]?.exit_code).toBeNull();
+    expect(reports[0]?.exit_signal).toBeNull();
+    expect(reports[0]?.error).toBeUndefined();
+  });
+
+  test('a resume granted before the terminal latch never re-injects an interactive prompt', async () => {
+    const session: interactive.ParentClaudeSession = {
+      kind: 'claude-code',
+      pid: process.pid,
+      sessionId: 'parent-session',
+      socketPath: '/private/unused-parent.sock',
+      messagingToken: 'messaging-token',
+      registryPath: '/private/unused-session.json',
+    };
+    const handoff = spyOn(interactive, 'handoffToInteractiveSession').mockResolvedValue({
+      kind: 'handed-off',
+      certainty: 'possible',
+      helperPath: '/private/helper',
+      completion: Promise.resolve({
+        kind: 'completed',
+        durationMs: 5,
+        output: 'first attempt',
+      }),
+    });
+    let heartbeatConflict = false;
+    const reports: Array<Record<string, unknown>> = [];
+    const client = {
+      id: 'worker-test',
+      mcpWiring: undefined,
+      async heartbeat() {
+        if (!heartbeatConflict) return;
+        throw new WorkerHttpError(409, '/heartbeat', 'run is no longer active');
+      },
+      async completeAutomation(_runId: number, request: Record<string, unknown>) {
+        reports.push(request);
+        heartbeatConflict = true;
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        return { ok: true, status: 'resume', attempt: 1, nudge: 'finalize' };
+      },
+    };
+
+    const outcome = await executeAutomationRun(
+      client as never,
+      { run_id: 97, run_type: 'automation', payload: payload() } satisfies PollResponse,
+      interactive.attachInteractiveSession({ heartbeatIntervalMs: 5 }, session)
+    );
+
+    expect(handoff).toHaveBeenCalledTimes(1);
+    expect(reports).toHaveLength(1);
+    // The one report is the first round's real completion, and the granted
+    // resume is dropped rather than driving a second prompt into the session.
+    expect(reports[0]?.output).toBe('first attempt');
+    expect(reports[0]?.exit_reason).toBe('ok');
+    expect(reports[0]?.finalize_attempt).toBe(0);
+    expect(outcome.error).toBeUndefined();
   });
 
   test('Codex handoff preserves completion and finalize-resume semantics without subprocess fallback', async () => {

--- a/packages/connector-worker/src/__tests__/interactive-session.test.ts
+++ b/packages/connector-worker/src/__tests__/interactive-session.test.ts
@@ -780,6 +780,34 @@ describe('handoffToInteractiveSession', () => {
     expect(existsSync(helperDir)).toBe(false);
   });
 
+  test('a terminal heartbeat completes only its active handoff and removes the helper', async () => {
+    const fixture = await parentFixture();
+    const terminal = new AbortController();
+    const delivery = await handoffToInteractiveSession({
+      session: fixture.session,
+      runId: 85,
+      prompt: 'Do work',
+      token: 'secret',
+      memoryUrl: 'https://gateway.test/mcp/test',
+      // Long enough that only the terminal latch can settle this handoff — a
+      // short timeout would let the deadline win the race and pass for the
+      // wrong reason.
+      timeoutMs: 10_000,
+      disconnectCheckIntervalMs: 10_000,
+      terminalSignal: terminal.signal,
+    });
+
+    expect(delivery.kind).toBe('handed-off');
+    if (delivery.kind !== 'handed-off') throw new Error(delivery.reason);
+    const helperDir = path.dirname(delivery.helperPath);
+    terminal.abort();
+    expect(await delivery.completion).toMatchObject({
+      kind: 'terminal',
+      error: 'automation run became terminal before the interactive session completed it',
+    });
+    expect(existsSync(helperDir)).toBe(false);
+  });
+
   test('daemon shutdown destroys a half-open helper connection before cleanup', async () => {
     const fixture = await parentFixture();
     const shutdown = new AbortController();

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -114,6 +114,7 @@ export function monitorDeviceAgentRun(
   label: string,
 ) {
   const abortController = new AbortController();
+  const terminalController = new AbortController();
   let shutdownRequested = false;
   const onShutdown = () => {
     shutdownRequested = true;
@@ -129,6 +130,7 @@ export function monitorDeviceAgentRun(
           log.info(
             `[executor] ${label} run ${runId} is no longer active; stopping the local CLI`,
           );
+          terminalController.abort();
           abortController.abort();
           clearInterval(heartbeat);
         }
@@ -140,6 +142,7 @@ export function monitorDeviceAgentRun(
 
   return {
     abortController,
+    terminalSignal: terminalController.signal,
     shutdownRequested: () => shutdownRequested,
     stop: () => {
       clearInterval(heartbeat);
@@ -824,6 +827,7 @@ export async function executeAutomationRun(
           token: agentSession.token,
           memoryUrl: agentSession.mcp_url,
           timeoutMs,
+          terminalSignal: monitor.terminalSignal,
           ...(selectedSession.kind === 'codex' && cfg.binaryOverrides?.codex
             ? { codexCommand: cfg.binaryOverrides.codex }
             : {}),
@@ -840,6 +844,21 @@ export async function executeAutomationRun(
               output: completion.output,
               error: null,
               exitCode: 0,
+              exitSignal: null,
+              exitReason: 'ok',
+              durationMs: completion.durationMs,
+            };
+          }
+          if (completion.kind === 'terminal') {
+            // Heartbeat 409 proves the server owns this run's terminal outcome.
+            // A follow-up exit report can only stamp first-report device
+            // provenance on a completed run or ack idempotently; it cannot
+            // overwrite that outcome. Report the intentional local stop as clean
+            // rather than inventing a timeout the session never hit.
+            return {
+              output: '',
+              error: null,
+              exitCode: null,
               exitSignal: null,
               exitReason: 'ok',
               durationMs: completion.durationMs,

--- a/packages/connector-worker/src/daemon/interactive-session.ts
+++ b/packages/connector-worker/src/daemon/interactive-session.ts
@@ -70,7 +70,11 @@ export function attachedInteractiveSession(target: object): InteractiveSession |
 
 export type InteractiveSessionCompletion =
   | { kind: 'completed'; durationMs: number; output: string }
-  | { kind: 'timeout' | 'disconnected' | 'shutdown'; durationMs: number; error: string };
+  | {
+      kind: 'timeout' | 'disconnected' | 'shutdown' | 'terminal';
+      durationMs: number;
+      error: string;
+    };
 
 export type InteractiveSessionDelivery =
   | { kind: 'not-delivered'; reason: string }
@@ -89,6 +93,7 @@ export interface InteractiveSessionHandoffOptions {
   memoryUrl: string;
   timeoutMs: number;
   shutdownSignal?: AbortSignal;
+  terminalSignal?: AbortSignal;
   cliLaunch?: { command: string; args: string[] };
   /** Exact installed Codex command; injected by tests or a binary override. */
   codexCommand?: string;
@@ -733,6 +738,7 @@ export async function handoffToInteractiveSession(
   let timeout: NodeJS.Timeout | undefined;
   let disconnectCheck: NodeJS.Timeout | undefined;
   let onShutdown: (() => void) | undefined;
+  let onTerminal: (() => void) | undefined;
   const nonce = randomBytes(32).toString('hex');
   const helperSockets = new Set<net.Socket>();
 
@@ -839,6 +845,9 @@ export async function handoffToInteractiveSession(
     if (opts.shutdownSignal && onShutdown) {
       opts.shutdownSignal.removeEventListener('abort', onShutdown);
     }
+    if (opts.terminalSignal && onTerminal) {
+      opts.terminalSignal.removeEventListener('abort', onTerminal);
+    }
     process.removeListener('exit', cleanup);
     for (const socket of helperSockets) socket.destroy();
     helperSockets.clear();
@@ -943,6 +952,17 @@ export async function handoffToInteractiveSession(
       };
       if (opts.shutdownSignal.aborted) onShutdown();
       else opts.shutdownSignal.addEventListener('abort', onShutdown, { once: true });
+    }
+    if (opts.terminalSignal) {
+      onTerminal = () => {
+        settle({
+          kind: 'terminal',
+          durationMs: Date.now() - started,
+          error: 'automation run became terminal before the interactive session completed it',
+        });
+      };
+      if (opts.terminalSignal.aborted) onTerminal();
+      else opts.terminalSignal.addEventListener('abort', onTerminal, { once: true });
     }
   }
 


### PR DESCRIPTION
## Summary

- distinguish a terminal heartbeat conflict from daemon shutdown while monitoring a device-local agent run
- forward that terminal signal into an active interactive Claude/Codex/OpenCode handoff so it settles immediately and removes its helper
- treat the server-owned terminal outcome as an intentional local stop and prevent a late resume from injecting another prompt

## Test plan

- [x] Intended four files staged explicitly; `make pre-pr` clean
- [x] Focused co-run: 71 pass, 0 fail across interactive session, interactive automation, automation-arm unit, and automation-arm E2E suites
- [x] Full connector-worker suite during Opus fixer review: 256 pass, 0 fail across 30 files; package typecheck clean
- [x] Bug fix red -> green evidence:
  - Red: the terminal-signal handoff test settled as `timeout`, and the arm reported `exit_reason: timeout` (1 pass, 2 fail)
  - Green: active handoff cancellation, helper cleanup, and no-reinjection race all pass (3 pass, 0 fail)
- [x] `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus make review-fix` completed; every edit inspected

## Notes

No UI or public contract change. `make ui-review` should classify this connector-worker-only diff as not applicable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive automation runs now complete cleanly when the underlying run becomes inactive.
  * Prevented stale failure information and late resume requests from affecting terminal runs.
  * Improved cleanup of temporary interactive-session resources after terminal completion.
* **Tests**
  * Added coverage for terminal heartbeat handling, handoff cancellation, final result reporting, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->