### PR TITLE
fix(sdk): align device-aware method signatures

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -400,7 +400,18 @@ describe("method-metadata", () => {
 					"run_id?: number",
 				],
 			],
-			["connections.update", ["display_name?: string"]],
+			[
+				"connections.update",
+				[
+					"display_name?: string",
+					"device_worker_id?: string | null",
+					"replace_config?: boolean",
+				],
+			],
+			[
+				"automations.create",
+				["device_worker_id?: string | null", "'agy' | null"],
+			],
 			["classifiers.classify", ["classifier_slug: string", "'llm' | 'user'"]],
 			[
 				"classifiers.create",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -561,7 +561,7 @@ export default async (_ctx, client) => {
 		access: "admin",
 		throws: ["EntityNotFound"],
 		signature:
-			"automations.create(input: { slug: string; agent_id: string; prompt?: string; device_worker_id?: string; agent_kind?: 'claude-code' | 'codex' | 'opencode' | 'pi' | 'agy'; ... }): Promise<{ action: 'create'; automation_id: string; version: number; status: string; ... } | { action: 'create'; status: 'pending_approval'; run_id: number; ... }>",
+			"automations.create(input: { slug: string; agent_id: string; prompt?: string; device_worker_id?: string | null; agent_kind?: 'claude-code' | 'codex' | 'opencode' | 'pi' | 'agy' | null; ... }): Promise<{ action: 'create'; automation_id: string; version: number; status: string; ... } | { action: 'create'; status: 'pending_approval'; run_id: number; ... }>",
 		example:
 			"const created = await client.automations.create({ slug: 'pricing', agent_id: 'agt_123', device_worker_id: 'device-worker-uuid', agent_kind: 'opencode', prompt: 'Extract pricing records and notable changes.', outputs: { prices: { entity: 'price', key: ['sku'] }, alerts: { event: 'observation' } }, sources: [{ name: 'content', query: 'SELECT id, content FROM events ORDER BY occurred_at DESC' }] }); const automationId = 'automation_id' in created ? created.automation_id : undefined; // undefined when the create was policy-gated into an approval",
 		usageExample: `// Stand up an Automation that extracts pricing entities from recent events.
@@ -752,10 +752,10 @@ export default async (_ctx, client) => {
 	},
 	"connections.update": {
 		summary:
-			"Update connection config or auth profile. The label field is `display_name` (not `name`).",
+			"Update a connection's config, auth profile, status, slug, or device binding. The label field is `display_name` (not `name`). `config` merges into the stored config by default; pass `replace_config: true` alongside it to store exactly the object you send. `device_worker_id` reassigns which device runs this connection; null moves it back to the server (serverless), which the connector must not require a capability for.",
 		access: "write",
 		signature:
-			"connections.update(input: { connection_id: number; display_name?: string; slug?: string; status?: string; agent_id?: string | null; auth_profile_slug?: string | null; app_auth_profile_slug?: string | null; config?: object; entity_ids?: number[] }): Promise<unknown>",
+			"connections.update(input: { connection_id: number; display_name?: string; slug?: string; status?: string; agent_id?: string | null; auth_profile_slug?: string | null; app_auth_profile_slug?: string | null; config?: object; entity_ids?: number[]; device_worker_id?: string | null; replace_config?: boolean }): Promise<unknown>",
 		example:
 			"await client.connections.update({ connection_id: 42, display_name: 'Team calendar' });",
 	},


### PR DESCRIPTION
## Summary

- expose nullable `device_worker_id` and `replace_config` in `connections.update` sandbox discovery
- align `automations.create` discovery with its nullable device-worker and agent-kind contract
- document merge, replace, pin, and unpin semantics beside the connection update signature

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean
- [x] Targeted tests: `bun test packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts` — 92 pass, 0 fail
- [x] Full sandbox tests: `bun test packages/server/src/__tests__/unit/sandbox/` — 152 pass, 0 fail
- [x] `bun run --cwd packages/server typecheck` and `git diff --check` clean
- [x] Bug fix red→green evidence below
- [ ] If bot runtime changed: not applicable; metadata and tests only

### Red → green

With the contract assertions added on fresh `origin/main`, the combined signature run reported 33 pass / 1 fail:

```text
connections.update signature documents device_worker_id?: string | null
Expected to contain: "device_worker_id?: string | null"
Received: "connections.update(... entity_ids?: number[] }): Promise<unknown>"
```

After aligning metadata, the targeted SDK run reports 92 pass / 0 fail and the full sandbox directory reports 152 pass / 0 fail.

## Notes

The same-class audit found `replace_config` absent from `connections.update` discovery and nullable device fields documented as non-nullable on `automations.create`; both are existing public core contracts and are covered in the focused metadata assertion. The generic runtime wrapper already passes non-alias fields through, so no production namespace code or redundant passthrough test change is needed.
