### PR TITLE
fix(server): preserve device auto-wire suppression

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
 import { parsePgTextArray } from '../../db/client';
+import { reconcileDeviceCapabilities } from '../../worker-api/device-reconcile';
+import { TestApiClient } from '../setup/test-mcp-client';
 import {
   deviceManifestHash,
   type DeviceConnectorManifest,
@@ -219,6 +221,14 @@ async function pollClaimingDueFeed(
   return response.json();
 }
 
+async function deviceIdFor(workerId: string): Promise<string> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT id FROM device_workers WHERE worker_id = ${workerId} LIMIT 1
+  `) as unknown as Array<{ id: string }>;
+  return rows[0].id;
+}
+
 async function settleRunsAndFeeds(orgId: string) {
   const sql = getTestDb();
   await sql`
@@ -323,6 +333,222 @@ describe('device connector manifests', () => {
   });
   afterEach(async () => {
     await cleanupTestDatabase();
+  });
+
+  it('durably suppresses an explicitly deleted auto-wired connection until reconnect', async () => {
+    const { orgId, userId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const client = await TestApiClient.for({
+      organizationId: orgId,
+      userId,
+      memberRole: 'owner',
+    });
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    const [wired] = (await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        AND auth_profile_id IS NULL AND app_auth_profile_id IS NULL
+        AND deleted_at IS NULL
+    `) as unknown as Array<{ id: number }>;
+    expect(wired?.id).toBeTruthy();
+
+    const deleted = (await client.connections.delete(Number(wired.id))) as {
+      deleted?: boolean;
+    };
+    expect(deleted.deleted).toBe(true);
+
+    const [tombstone] = (await sql`
+      SELECT deleted_at, config->>'__lobu_device_autowire_suppressed' AS suppressed
+      FROM connections WHERE id = ${wired.id}
+    `) as unknown as Array<{ deleted_at: string | null; suppressed: string | null }>;
+    expect(tombstone.deleted_at).not.toBeNull();
+    expect(tombstone.suppressed).toBe('true');
+
+    await Promise.all(
+      Array.from({ length: 4 }, () => reconcileDeviceCapabilities(userId)),
+    );
+    const liveAfterDelete = await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        AND auth_profile_id IS NULL AND app_auth_profile_id IS NULL
+        AND deleted_at IS NULL
+    `;
+    expect(liveAfterDelete).toHaveLength(0);
+
+    const [reconnected] = await Promise.all([
+      client.connections.connect({
+        connector_key: CONNECTOR_KEY,
+        device_worker_id: await deviceIdFor(workerId),
+      }),
+      reconcileDeviceCapabilities(userId),
+    ]) as [{ connection_id?: number; status?: string }, void];
+    expect(reconnected.connection_id).toBeTruthy();
+    expect(reconnected.status).toBe('active');
+
+    await reconcileDeviceCapabilities(userId);
+    const liveAfterReconnect = await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        AND auth_profile_id IS NULL AND app_auth_profile_id IS NULL
+        AND deleted_at IS NULL
+    `;
+    expect(liveAfterReconnect).toHaveLength(1);
+    expect(Number(liveAfterReconnect[0].id)).toBe(reconnected.connection_id);
+    const healedFeeds = await sql`
+      SELECT status FROM feeds
+      WHERE connection_id = ${reconnected.connection_id}
+        AND feed_key = 'snapshots' AND deleted_at IS NULL
+    `;
+    expect(healedFeeds).toEqual([{ status: 'active' }]);
+  });
+
+  it('suppresses an explicitly deleted auto-wired connection even while it is unpinned', async () => {
+    const { orgId, userId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const client = await TestApiClient.for({
+      organizationId: orgId,
+      userId,
+      memberRole: 'owner',
+    });
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    const [wired] = (await sql`
+      UPDATE connections
+      SET device_worker_id = NULL
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        AND auth_profile_id IS NULL AND app_auth_profile_id IS NULL
+        AND deleted_at IS NULL
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    expect(wired?.id).toBeTruthy();
+
+    const deleted = (await client.connections.delete(Number(wired.id))) as {
+      deleted?: boolean;
+    };
+    expect(deleted.deleted).toBe(true);
+    await Promise.all(
+      Array.from({ length: 4 }, () => reconcileDeviceCapabilities(userId)),
+    );
+
+    const rows = await sql`
+      SELECT id, deleted_at, config->>'__lobu_device_autowire_suppressed' AS suppressed
+      FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(rows[0].suppressed).toBe('true');
+  });
+
+  it('does not let a deleted credential-backed connection suppress auto-wire', async () => {
+    const { orgId, userId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const [profile] = (await sql`
+      INSERT INTO auth_profiles (
+        organization_id, slug, display_name, connector_key, profile_kind, created_by
+      ) VALUES (
+        ${orgId}, ${`profile-${generateSecureToken(4)}`}, 'Manual profile',
+        ${CONNECTOR_KEY}, 'env', ${userId}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const [manual] = (await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        auth_profile_id, created_by, visibility
+      ) VALUES (
+        ${orgId}, ${CONNECTOR_KEY}, ${`manual-${generateSecureToken(4)}`},
+        'Manual connection', 'active', ${profile.id}, ${userId}, 'private'
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const client = await TestApiClient.for({
+      organizationId: orgId,
+      userId,
+      memberRole: 'owner',
+    });
+
+    const deleted = (await client.connections.delete(Number(manual.id))) as {
+      deleted?: boolean;
+    };
+    expect(deleted.deleted).toBe(true);
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+
+    const rows = await sql`
+      SELECT auth_profile_id, deleted_at
+      FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows.some((row) => row.auth_profile_id === null && row.deleted_at === null)).toBe(true);
+  });
+
+  // No definition is installed until the first poll, so `is_device_connector`
+  // is false at delete time and the delete leaves no marker. Once a device
+  // connector IS installed, an auth-none row in the personal org is the
+  // auto-wire identity by construction — `ensureDeviceConnectorWired` matches
+  // and adopts exactly that shape — so there is no separate "manual" case to
+  // exempt.
+  it('does not let an auth-none row deleted before the connector is installed suppress auto-wire', async () => {
+    const { orgId, userId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+    const [manual] = (await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        created_by, visibility, auth_profile_id, app_auth_profile_id, device_worker_id
+      ) VALUES (
+        ${orgId}, ${CONNECTOR_KEY}, ${`manual-none-${generateSecureToken(4)}`},
+        'Manual auth-none connection', 'active', ${userId}, 'private', NULL, NULL, NULL
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const client = await TestApiClient.for({
+      organizationId: orgId,
+      userId,
+      memberRole: 'owner',
+    });
+
+    const deleted = (await client.connections.delete(Number(manual.id))) as {
+      deleted?: boolean;
+    };
+    expect(deleted.deleted).toBe(true);
+    const [manualTombstone] = (await sql`
+      SELECT config->>'__lobu_device_autowire_suppressed' AS suppressed
+      FROM connections WHERE id = ${manual.id}
+    `) as unknown as Array<{ suppressed: string | null }>;
+    expect(manualTombstone.suppressed).toBeNull();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    const live = await sql`
+      SELECT id, device_worker_id
+      FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+        AND auth_profile_id IS NULL AND app_auth_profile_id IS NULL
+        AND deleted_at IS NULL
+    `;
+    expect(live).toHaveLength(1);
+    expect(live[0].device_worker_id).not.toBeNull();
+  });
+
+  it('rejects the reserved auto-wire suppression marker on public config writes', async () => {
+    const { orgId, userId } = await seedDeviceOwner();
+    const client = await TestApiClient.for({
+      organizationId: orgId,
+      userId,
+      memberRole: 'owner',
+    });
+
+    await expect(
+      client.connections.connect({
+        connector_key: CONNECTOR_KEY,
+        config: { __lobu_device_autowire_suppressed: true },
+      }),
+    ).rejects.toThrow(
+      'The device auto-wire suppression marker is reserved for connection deletion.',
+    );
   });
 
   it('installs a metadata-only device connector from poll and claims its feed run without compiled_code', async () => {

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -343,13 +343,97 @@ export function getLockDb(): Sql {
         // Do NOT set lock_timeout here as a startup GUC — Neon/PgBouncer and
         // other poolers reject unsupported startup parameters and the whole
         // reserve() fails with "unsupported startup parameter: lock_timeout".
-        // Callers SET lock_timeout on the reserved session instead
-        // (see withAutomationGroupLock).
+        // withSessionAdvisoryLock SETs lock_timeout on the reserved session
+        // instead.
       },
     });
     logger.info('[DB] PostgreSQL advisory-lock pool created');
   }
   return lockDbSingleton;
+}
+
+type AdvisoryLockKey = {
+  namespace: string;
+  /** Bound as an int4 by default; set `hashValue` to key on an arbitrary string. */
+  value: string | number;
+  hashValue?: boolean;
+};
+
+type SessionAdvisoryLockOptions = {
+  /**
+   * Session GUC bounding the advisory-lock WAIT (not a startup parameter —
+   * poolers reject `lock_timeout` on connect). Expiry surfaces as 55P03.
+   */
+  timeout?: string;
+  /**
+   * Translate a 55P03 raised while ACQUIRING the lock. Scoped to acquisition
+   * on purpose: a 55P03 thrown from inside `fn` is a different contention and
+   * must not be relabelled as a lock-acquisition conflict.
+   */
+  onAcquireTimeout?: (err: unknown) => Error;
+};
+
+/**
+ * Run `fn` while holding a SESSION-level Postgres advisory lock. Acquire and
+ * release happen on ONE reserved connection so the session identity is stable
+ * — any other pool connection serving the unlock would error `you don't own a
+ * lock of type ExclusiveLock`.
+ *
+ * That connection comes from the DEDICATED lock pool (`getLockDb`), never the
+ * main pool. Holders camp on it for the whole critical section while `fn` runs
+ * its reads/transactions on the main pool; if holders camped on the main pool,
+ * N >= DB_POOL_MAX concurrent locked writes would consume every slot and starve
+ * their own handlers — a permanent pool-wide deadlock. With a separate pool the
+ * dependency is one-directional and deadlock-free; excess requests queue FIFO.
+ */
+export async function withSessionAdvisoryLock<T>(
+  key: AdvisoryLockKey,
+  fn: () => Promise<T>,
+  options: SessionAdvisoryLockOptions = {}
+): Promise<T> {
+  const { timeout = '30s', onAcquireTimeout } = options;
+  const reserved = await getLockDb().reserve();
+  const keyValue = key.hashValue
+    ? reserved`hashtext(${String(key.value)})`
+    : reserved`${key.value}`;
+  let acquired = false;
+
+  try {
+    await reserved`SELECT set_config('lock_timeout', ${timeout}, false)`;
+    try {
+      await reserved`SELECT pg_advisory_lock(hashtext(${key.namespace}), ${keyValue})`;
+    } catch (err) {
+      // We do NOT hold the lock here, so the reserved session is clean; the
+      // outer finally just releases it.
+      if (onAcquireTimeout && (err as { code?: string }).code === '55P03') {
+        throw onAcquireTimeout(err);
+      }
+      throw err;
+    }
+    acquired = true;
+    try {
+      return await fn();
+    } finally {
+      await reserved`SELECT pg_advisory_unlock(hashtext(${key.namespace}), ${keyValue})`;
+      acquired = false;
+    }
+  } finally {
+    // A failed unlock leaves the session still owning the lock; returning it to
+    // the pool would leak the lock for the connection's whole lifetime, so kill
+    // the backend instead — Postgres drops session advisory locks on exit.
+    // Deliberately NOT released afterwards: postgres.js only reconnects a
+    // connection it holds in its `closed` queue, and `release()` would move the
+    // dead one into `open` (or hand it straight to a waiting reserve()), so the
+    // next borrower would get a destroyed socket. Skipping release lets the
+    // socket's own close handler requeue it for reconnect.
+    if (acquired) {
+      await reserved`SELECT pg_terminate_backend(pg_backend_pid())`.catch(
+        () => undefined
+      );
+    } else {
+      reserved.release();
+    }
+  }
 }
 
 /**

--- a/packages/server/src/tools/admin/manage_automations.ts
+++ b/packages/server/src/tools/admin/manage_automations.ts
@@ -33,7 +33,7 @@ import {
   type ManageAutomationsResult,
 } from '@lobu/core/contracts/tools/manage-automations';
 import { resolveActingPrincipal, resolveWritePolicyDecision } from '../../authz/entity-policy';
-import { createDbClientFromEnv, getDb, getLockDb } from '../../db/client';
+import { createDbClientFromEnv, getDb, withSessionAdvisoryLock } from '../../db/client';
 import type { Env } from '../../index';
 import {
   currentMcpActivityAttribution,
@@ -279,19 +279,8 @@ async function resolveTargetAutomationGroupId(
  * tx-scoped `pg_advisory_xact_lock`) is required because the guard read and the
  * mutation write happen on different pooled connections and across separate
  * transactions — a tx-scoped lock would release at the guard's implicit commit,
- * before the mutation runs. We acquire + release on ONE reserved connection so
- * the session identity is stable (any pool connection could otherwise serve the
- * unlock and PG would error `you don't own a lock of type ExclusiveLock`).
- *
- * The reserved connection comes from the DEDICATED lock pool (getLockDb), not
- * the main pool. Lock holders camp on a connection for the whole critical
- * section while `fn` runs its reads/transactions on the MAIN pool; if holders
- * camped on the main pool, N >= DB_POOL_MAX concurrent group-locked writes
- * (same group or distinct groups alike) would consume every slot and starve
- * their own handlers — a permanent pool-wide deadlock. With a separate pool
- * the dependency is one-directional and deadlock-free; excess lock requests
- * queue FIFO and progress as holders finish. The lock pool's `lock_timeout`
- * bounds the advisory-lock wait itself (55P03 → coded 409 below).
+ * before the mutation runs. {@link withSessionAdvisoryLock} owns the reserved
+ * lock-pool connection, the `lock_timeout` bound, and the release path.
  *
  * Only the mutating write-gate actions with a resolvable target group are locked;
  * read-only actions and `create` (no pre-existing group) run `fn` directly.
@@ -305,33 +294,20 @@ async function withAutomationGroupLock<T>(
   const groupId = await resolveTargetAutomationGroupId(args, ctx);
   if (groupId == null) return fn();
 
-  const reserved = await getLockDb().reserve();
-  try {
-    // Session GUC (not a startup parameter — poolers reject lock_timeout on
-    // connect). Bounds advisory-lock wait: 55P03 → coded 409 below.
-    await reserved`SELECT set_config('lock_timeout', '30s', false)`;
-    try {
-      await reserved`SELECT pg_advisory_lock(hashtext(${AUTOMATION_GROUP_LOCK_NS}), ${groupId})`;
-    } catch (err) {
+  return withSessionAdvisoryLock(
+    { namespace: AUTOMATION_GROUP_LOCK_NS, value: groupId },
+    fn,
+    {
       // lock_timeout expiry (55P03): another holder kept the group busy past
-      // the bound. We do NOT hold the lock here — surface a clean retryable
+      // the bound. We do NOT hold the lock — surface a clean retryable
       // conflict instead of an unbounded stall.
-      if ((err as { code?: string }).code === '55P03') {
-        throw new ToolUserError(
+      onAcquireTimeout: () =>
+        new ToolUserError(
           'Another change to this Automation group is in progress; retry shortly.',
           409
-        );
-      }
-      throw err;
+        ),
     }
-    try {
-      return await fn();
-    } finally {
-      await reserved`SELECT pg_advisory_unlock(hashtext(${AUTOMATION_GROUP_LOCK_NS}), ${groupId})`;
-    }
-  } finally {
-    reserved.release();
-  }
+  );
 }
 
 /** Maps a manage_automations action to its agent_config write verb, or null for a

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
@@ -7,6 +7,10 @@ import {
 	denyNonHumanActionModesWrite,
 	hasActionModes,
 } from './action-modes-guard';
+import {
+	DEVICE_AUTOWIRE_SUPPRESSION_ERROR,
+	hasDeviceAutowireSuppressionMarker,
+} from '../../../../utils/device-autowire-suppression';
 
 /**
  * Start a managed OAuth grant from any workspace context.
@@ -20,6 +24,9 @@ export async function handleConnectManaged(
 	args: Extract<ConnectionsArgs, { action: 'connect_managed' }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+	if (hasDeviceAutowireSuppressionMarker(args.config)) {
+		return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+	}
 	if (!ctx.isAuthenticated || !ctx.userId) {
 		return { error: 'Lobu login is required before using managed auth.' };
 	}

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -67,6 +67,10 @@ import {
 } from "../../helpers/connect-setup-continuation";
 import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
 import { buildCrossWorkspaceAppInstallResult } from "../../helpers/cross-workspace-app-install";
+import {
+	DEVICE_AUTOWIRE_SUPPRESSION_ERROR,
+	hasDeviceAutowireSuppressionMarker,
+} from "../../../../utils/device-autowire-suppression";
 
 export async function handleConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
@@ -87,6 +91,9 @@ async function handleConnectImpl(
 	ctx: ToolContext,
 	requireManaged: boolean,
 ): Promise<ManageConnectionsResult> {
+  if (hasDeviceAutowireSuppressionMarker(args.config)) {
+    return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+  }
   // A new row has no stored modes to compare against.
   if (hasActionModes(args.config)) {
     const denied = denyNonHumanActionModesWrite(ctx);

--- a/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
@@ -10,6 +10,10 @@ import { getErrorMessage, parseJsonObject } from "@lobu/core";
 import { getDb } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
 import { normalizeAuthValues } from "../../../../utils/auth-profiles";
+import {
+	DEVICE_AUTOWIRE_SUPPRESSION_ERROR,
+	hasDeviceAutowireSuppressionMarker,
+} from "../../../../utils/device-autowire-suppression";
 import logger from "../../../../utils/logger";
 import {
 	actionModesChanged,
@@ -423,6 +427,11 @@ export async function handleUpdateConnectorDefaultConfig(
 	args: Extract<ConnectionsArgs, { action: "update_connector_default_config" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+	// Auto-wire seeds these defaults into the connection rows it creates, so
+	// this is a config-write path for the reserved suppression marker too.
+	if (hasDeviceAutowireSuppressionMarker(args.default_connection_config)) {
+		return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+	}
 	// This is a full replacement, so removal is a modes change too. Compare and
 	// write under one row lock to preserve a concurrent human edit.
 	const sql = getDb();

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -15,6 +15,7 @@ import {
 	parsePgNumberArray,
 	pgBigintArray,
 	pgTextArray,
+	withSessionAdvisoryLock,
 	type DbClient,
 } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
@@ -75,6 +76,14 @@ import {
 	recordChangeEvent,
 	recordLifecycleEvent,
 } from "../../../../utils/insert-event";
+import {
+	DEVICE_AUTOWIRE_SUPPRESSION_ERROR,
+	DEVICE_AUTOWIRE_SUPPRESSION_PATCH,
+	type DeviceAutowireIdentityRow,
+	hasDeviceAutowireSuppressionMarker,
+	IS_DEVICE_CONNECTOR_SQL,
+	isDeviceAutowireIdentity,
+} from "../../../../utils/device-autowire-suppression";
 import logger from "../../../../utils/logger";
 import { syncOAuthConnectionsForAuthProfile } from "../../../../utils/oauth-connection-state";
 import { compileConnectionRowVisibility } from "../../../../authz/connection-visibility";
@@ -642,6 +651,9 @@ export async function handleCreate(
 	args: Extract<ConnectionsArgs, { action: "create" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+  if (hasDeviceAutowireSuppressionMarker(args.config)) {
+    return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+  }
   // Refuse before connector installation or any other create-path side effect.
   if (hasActionModes(args.config)) {
     const denied = denyNonHumanActionModesWrite(ctx);
@@ -1353,6 +1365,9 @@ export async function handleApplyChatConnection(
 	args: Extract<ConnectionsArgs, { action: "apply_chat_connection" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+	if (hasDeviceAutowireSuppressionMarker(args.config)) {
+		return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+	}
 	const { organizationId } = ctx;
 	if (args.agent_id) {
 		const sql = getDb();
@@ -1406,6 +1421,9 @@ export async function handleUpdate(
 	args: Extract<ConnectionsArgs, { action: "update" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+  if (hasDeviceAutowireSuppressionMarker(args.config)) {
+    return { error: DEVICE_AUTOWIRE_SUPPRESSION_ERROR };
+  }
   const sql = getDb();
   const { organizationId } = ctx;
 
@@ -2149,19 +2167,24 @@ export async function handleDelete(
   const sql = getDb();
   const { organizationId } = ctx;
 	const targets = await sql`
-		SELECT credential_mode
-		FROM connections
-		WHERE id = ${args.connection_id}
-			AND organization_id = ${organizationId}
-			AND deleted_at IS NULL
+		SELECT c.credential_mode, c.connector_key, c.auth_profile_id, c.app_auth_profile_id,
+			NULLIF((o.metadata::jsonb)->>'personal_org_for_user_id', '') AS autowire_user_id,
+			${sql.unsafe(IS_DEVICE_CONNECTOR_SQL)} AS is_device_connector
+		FROM connections c
+		JOIN "organization" o ON o.id = c.organization_id
+		WHERE c.id = ${args.connection_id}
+			AND c.organization_id = ${organizationId}
+			AND c.deleted_at IS NULL
 		LIMIT 1
 	`;
 	if (targets.length === 0) {
 		return { error: "Connection not found or already deleted" };
 	}
-	const target = targets[0] as {
+	const target = targets[0] as DeviceAutowireIdentityRow & {
 		credential_mode: string | null;
+		connector_key: string;
 	};
+	const isAutoWiredDeviceConnection = isDeviceAutowireIdentity(target);
 
   // Expire any undecided approval runs for this connection. Deleting a
   // connection makes its pending approvals unreviewable — the card disappears
@@ -2231,6 +2254,7 @@ export async function handleDelete(
 		return expiredRunIds;
   };
 
+  const performDelete = async (): Promise<ManageConnectionsResult> => {
   // Phase 1: fallible EXTERNAL teardown runs FIRST, while the connection is
   // still visible with its approvals pending. A teardown failure (e.g. the chat
   // platform rejects the removal) returns an error BEFORE any approval is
@@ -2272,7 +2296,14 @@ export async function handleDelete(
   const deleted = await sql.begin(async (tx) => {
     const tombstoned = await tx`
       UPDATE connections
-      SET deleted_at = NOW(), status = 'paused', updated_at = NOW()
+      SET deleted_at = NOW(),
+          status = 'paused',
+          config = CASE
+            WHEN ${isAutoWiredDeviceConnection}
+              THEN COALESCE(config, '{}'::jsonb) || ${sql.json(DEVICE_AUTOWIRE_SUPPRESSION_PATCH)}::jsonb
+            ELSE config
+          END,
+          updated_at = NOW()
       WHERE id = ${args.connection_id}
         AND organization_id = ${organizationId}
         AND deleted_at IS NULL
@@ -2368,4 +2399,22 @@ export async function handleDelete(
     connection_id: args.connection_id,
     slug: conn.slug as string,
   };
+  };
+
+  if (!isAutoWiredDeviceConnection) return performDelete();
+
+  // Same `lobu:autowire` key `ensureDeviceConnectorWired` takes per
+  // (owner, connector). Held across the teardown phase AND the atomic tombstone
+  // so a concurrent reconcile cannot wire a replacement in the gap between
+  // them. Cheap to hold on this path: an auto-wired device connection has
+  // `credential_mode` NULL and no `webhook_external_id`, so the teardown phase
+  // early-returns after DB-local checks and never blocks on a provider call.
+  return withSessionAdvisoryLock(
+    {
+      namespace: 'lobu:autowire',
+      value: `${target.autowire_user_id}:${target.connector_key}`,
+      hashValue: true,
+    },
+    performDelete
+  );
 }

--- a/packages/server/src/utils/device-autowire-suppression.ts
+++ b/packages/server/src/utils/device-autowire-suppression.ts
@@ -1,0 +1,80 @@
+import { parseJsonObject } from '@lobu/core';
+
+/** Reserved connection-config key written only by an explicit user delete. */
+export const DEVICE_AUTOWIRE_SUPPRESSION_KEY =
+	'__lobu_device_autowire_suppressed';
+
+export const DEVICE_AUTOWIRE_SUPPRESSION_ERROR =
+	'The device auto-wire suppression marker is reserved for connection deletion.';
+
+/**
+ * SQL fragment (no bound parameters) that resolves TRUE when the `connections`
+ * row aliased `c` belongs to an active device-connector definition: the
+ * definition declares a `required_capability` and its selected version carries
+ * no compiled or source bytes (a device manifest, or a bundled runtime-only
+ * catalog entry). `archiveVanishedDeviceConnectorDefinitions` in
+ * `worker-api/device-reconcile.ts` applies the same artifact test inline (once
+ * to pick candidates, once to re-check under the UPDATE) but keys off `cd`
+ * rather than a `connections` row, so it cannot share this fragment; a change
+ * to the artifact test has to land in all three places.
+ */
+export const IS_DEVICE_CONNECTOR_SQL = /* sql */ `COALESCE((
+  SELECT cd.required_capability IS NOT NULL
+    AND COALESCE((
+      SELECT CASE
+        WHEN cv.organization_id IS NOT NULL
+          THEN cv.source_path LIKE 'device-manifest://%'
+        ELSE cv.source_path IS NOT NULL
+          AND cv.compiled_code IS NULL
+          AND cv.source_code IS NULL
+      END
+      FROM connector_versions cv
+      WHERE cv.connector_key = cd.key
+        AND cv.version = cd.version
+        AND (cv.organization_id = cd.organization_id OR cv.organization_id IS NULL)
+      ORDER BY cv.organization_id NULLS LAST
+      LIMIT 1
+    ), false)
+  FROM connector_definitions cd
+  WHERE cd.organization_id = c.organization_id
+    AND cd.key = c.connector_key
+    AND cd.status = 'active'
+  LIMIT 1
+), false)`;
+
+export type DeviceAutowireIdentityRow = {
+	auth_profile_id: number | string | null;
+	app_auth_profile_id: number | string | null;
+	/** Owner of the personal org this connection lives in, or null for a shared org. */
+	autowire_user_id: string | null;
+	is_device_connector: boolean;
+};
+
+/**
+ * True when the row is exactly what `ensureDeviceConnectorWired` auto-creates:
+ * a credential-free connection to an active device connector inside its owner's
+ * personal org. A device pin is deliberately NOT required — multi-device
+ * auto-wiring leaves the connection unpinned.
+ */
+export function isDeviceAutowireIdentity(
+	row: DeviceAutowireIdentityRow,
+): row is DeviceAutowireIdentityRow & { autowire_user_id: string } {
+	return (
+		row.auth_profile_id == null &&
+		row.app_auth_profile_id == null &&
+		row.autowire_user_id != null &&
+		row.is_device_connector
+	);
+}
+
+/** The marker patch a delete merges into the tombstoned row's config. */
+export const DEVICE_AUTOWIRE_SUPPRESSION_PATCH: Record<string, unknown> = {
+	[DEVICE_AUTOWIRE_SUPPRESSION_KEY]: true,
+};
+
+export function hasDeviceAutowireSuppressionMarker(config: unknown): boolean {
+	return Object.hasOwn(
+		parseJsonObject(config),
+		DEVICE_AUTOWIRE_SUPPRESSION_KEY,
+	);
+}

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -24,6 +24,7 @@ import { extractConnectorMetadata, type ConnectorMetadata } from '../utils/conne
 import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
 import { ensureUniqueConnectionSlug, isConnectionSlugUniqueViolation } from '../utils/connections';
 import { clearDevicePinTombstoneIfPinned } from '../utils/device-pin-tombstones';
+import { DEVICE_AUTOWIRE_SUPPRESSION_KEY } from '../utils/device-autowire-suppression';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import {
@@ -504,6 +505,37 @@ async function ensureDeviceConnectorWired(
       // downgrade metadata or repin after a newer manifest has arrived.
       const currentSource = source ? await lockedManifestWinner(tx) : null;
       if (source && !currentSource) return null;
+
+      // An explicit user delete is durable opt-out for this device connector.
+      // The marker is reserved at every public config-write path and delete
+      // writes it only after proving the connection belongs to this personal
+      // org's active device-connector definition. A device pin is deliberately
+      // not required: multi-device auto-wiring leaves the connection unpinned.
+      // The live-row anti-join makes an explicit reconnect the sole way to
+      // clear the opt-out without mutating the tombstone during heartbeat
+      // reconciliation. `handleDelete` is the only path that soft-deletes a
+      // connection at all, so no system retirement can plant this marker.
+      const suppressed = (await tx`
+        SELECT 1
+        FROM connections
+        WHERE organization_id = ${organizationId}
+          AND connector_key = ${connectorKey}
+          AND auth_profile_id IS NULL
+          AND app_auth_profile_id IS NULL
+          AND deleted_at IS NOT NULL
+          AND config->>${DEVICE_AUTOWIRE_SUPPRESSION_KEY} = 'true'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM connections live
+            WHERE live.organization_id = ${organizationId}
+              AND live.connector_key = ${connectorKey}
+              AND live.auth_profile_id IS NULL
+              AND live.app_auth_profile_id IS NULL
+              AND live.deleted_at IS NULL
+          )
+        LIMIT 1
+      `) as unknown as Array<{ '?column?': number }>;
+      if (suppressed.length > 0) return null;
 
       // 2. Ensure the connector definition + version are installed (idempotent).
       await upsertConnectorDefinitionRecords({


### PR DESCRIPTION
## Summary
- Make explicit deletion of an auto-wired device connection a durable opt-out instead of letting heartbeat reconciliation recreate it.
- Serialize delete and reconcile with the same Postgres advisory key so the behavior is safe across replicas, while explicit reconnect resumes wiring.
- Reserve the suppression marker across caller-controlled config paths and avoid suppressing credential-backed or pre-install auth-none rows.

## Test plan
- [x] Intended nine paths staged explicitly; `make pre-pr` clean before commit and again after rebasing onto fresh `origin/main`.
- [x] Focused and sibling integration coverage: 6 files, 91 tests passed, serialized.
- [x] Bug fix red to green evidence pasted below.

### Red
`device-connector-manifests.test.ts -t "durably suppresses an explicitly deleted auto-wired connection until reconnect"`

Failed before the implementation: expected tombstone marker `"true"`, received `null` (1 failed, 32 skipped).

### Green
`device-connector-manifests.test.ts`, `device-pin-stale-sweep.test.ts`, `device-reconcile-slug-race.test.ts`, `device-reconcile-config-seed.test.ts`, `connection-delete-expires-pending-approvals.test.ts`, and `automations/automations-crud.test.ts`: 6 files passed, 91 tests passed.

## Notes
- Opus `make review-fix` completed and its edits were inspected and retested.
- The shared session-lock helper refactors the existing Automation group lock; its distinct-group pool-starvation regression remains green.
- No schema or public API was added.
