### PR TITLE
docs(server): correct auto-wire tombstone claim

### DIFF
--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -513,8 +513,8 @@ async function ensureDeviceConnectorWired(
       // not required: multi-device auto-wiring leaves the connection unpinned.
       // The live-row anti-join makes an explicit reconnect the sole way to
       // clear the opt-out without mutating the tombstone during heartbeat
-      // reconciliation. `handleDelete` is the only path that soft-deletes a
-      // connection at all, so no system retirement can plant this marker.
+      // reconciliation. Only `handleDelete` writes this reserved marker;
+      // system retirement paths may tombstone rows but never create an opt-out.
       const suppressed = (await tx`
         SELECT 1
         FROM connections


### PR DESCRIPTION
## Summary
- Correct the stale comment introduced in #3189: several system paths soft-delete connection rows, while only explicit `handleDelete` writes the reserved auto-wire suppression marker.
- Keep the reviewed runtime behavior unchanged.

## Test plan
- [x] Intended path staged explicitly; `make pre-pr` clean.
- [x] `device-connector-manifests.test.ts`: 37/37 passed.
- [x] Opus `make review-fix` verified every production connection tombstone and suppression-marker writer; no further edit requested.

## Notes
Follow-up to #3189. The other review suggestion about indentation was checked and not applied: the guards already match the adjacent two-space handler body indentation in `handleCreate` and `handleUpdate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for device connector wiring and autowire-suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->