### PR TITLE
fix(connectors): harden Outlook and Reddit sync

### DIFF
--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -112,6 +112,37 @@ export function connectorSdkMock() {
     }
   }
   class IntegrationConnector extends ConnectorRuntime {}
+  // Connectors create their HTTP client as a class field at construction, so a
+  // throwing stub would break `new XConnector()`. `get`/`post` are faithful
+  // minimal implementations over global fetch (HttpStatusError on non-2xx,
+  // mirroring connector-sdk/src/http-client.ts) so tests can drive a
+  // connector's real request and error paths by stubbing `globalThis.fetch`.
+  // The remaining methods throw only IF actually called — tests that need
+  // them override `connector.http` / `connector.requestJson` first.
+  const createHttpClient = () => ({
+    get: async (url: string) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new HttpStatusError({ status: response.status, body: await response.text() });
+      }
+      return response.json();
+    },
+    json: notUsed('http.json'),
+    request: notUsed('http.request'),
+    raw: notUsed('http.raw'),
+    post: async (url: string, body?: unknown) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new HttpStatusError({ status: response.status, body: await response.text() });
+      }
+      return response.json();
+    },
+  });
+
   return {
     // Sole platform entity-type slug for ACL-gated resources. Inlined (not
     // imported from connector-sdk/src) to keep this mock valid when copied
@@ -192,36 +223,7 @@ export function connectorSdkMock() {
         apiCallCount,
       };
     },
-    // Connectors create their HTTP client as a class field at construction, so a
-    // throwing stub would break `new XConnector()`. `get`/`post` are faithful
-    // minimal implementations over global fetch (HttpStatusError on non-2xx,
-    // mirroring connector-sdk/src/http-client.ts) so tests can drive a
-    // connector's real request and error paths by stubbing `globalThis.fetch`.
-    // The remaining methods throw only IF actually called — tests that need
-    // them override `connector.http` / `connector.requestJson` first.
-    createHttpClient: () => ({
-      get: async (url: string) => {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new HttpStatusError({ status: response.status, body: await response.text() });
-        }
-        return response.json();
-      },
-      json: notUsed('http.json'),
-      request: notUsed('http.request'),
-      raw: notUsed('http.raw'),
-      post: async (url: string, body?: unknown) => {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-        if (!response.ok) {
-          throw new HttpStatusError({ status: response.status, body: await response.text() });
-        }
-        return response.json();
-      },
-    }),
+    createHttpClient,
     // Faithful copy of connector-sdk checkpoint/timestamp-watermark.ts — must
     // honor the checkpoint arg; a passthrough stub leaks via Bun's global mock
     // registry and breaks the SDK's timestamp-watermark.test when connector tests run first.
@@ -236,7 +238,21 @@ export function connectorSdkMock() {
     },
     sleep: async () => {},
     validatePublicUrl: (url: string) => url,
-    requireBearerClient: notUsed('requireBearerClient'),
+    // Mirrors the missing-credential throw of connector-sdk/src/http-client.ts
+    // `requireBearerClient` — connector tests assert this message, so the label
+    // fallback order must stay in step. On the success path it hands back the
+    // mock client above, which is unauthenticated: the token is dropped, so
+    // tests here cannot assert what the SDK would have sent on the wire.
+    requireBearerClient: (
+      credentials: { accessToken?: string } | null,
+      options: { label?: string; errorPrefix?: string } = {}
+    ) => {
+      if (!credentials?.accessToken) {
+        const label = options.label ?? options.errorPrefix ?? 'This connector';
+        throw new Error(`${label} requires OAuth authentication.`);
+      }
+      return createHttpClient();
+    },
     paginateByCursor,
     paginateByOffset,
     ConnectorRuntime,

--- a/packages/connectors/src/__tests__/microsoft_outlook.test.ts
+++ b/packages/connectors/src/__tests__/microsoft_outlook.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let MicrosoftOutlookConnector: any;
+
+beforeAll(async () => {
+  MicrosoftOutlookConnector = (await import('../microsoft_outlook')).default;
+});
+
+// `folder` is free-form connection config interpolated into the Graph path, and
+// Graph takes an opaque folder id there as well as a well-known name. Reserved
+// characters must survive as one path segment: a raw '/' retargets the request.
+const FOLDER_ID = 'AQMkAGI2/Ly8+Zm9sZGVy=';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function graphMessage(id: string) {
+  return {
+    id,
+    conversationId: `conversation-${id}`,
+    subject: `Subject ${id}`,
+    bodyPreview: `Preview ${id}`,
+    from: { emailAddress: { name: 'Sender', address: 'sender@example.com' } },
+    toRecipients: [{ emailAddress: { name: 'Recipient', address: 'to@example.com' } }],
+    ccRecipients: [],
+    receivedDateTime: '2026-08-20T10:00:00Z',
+    sentDateTime: '2026-08-20T09:59:00Z',
+    hasAttachments: false,
+    importance: 'normal',
+    isRead: true,
+    webLink: `https://outlook.office.com/mail/${id}`,
+  };
+}
+
+function graphEvent(id: string) {
+  return {
+    id,
+    subject: `Event ${id}`,
+    bodyPreview: `Agenda ${id}`,
+    organizer: { emailAddress: { name: 'Organizer', address: 'owner@example.com' } },
+    attendees: [{ emailAddress: { name: 'Guest', address: 'guest@example.com' } }],
+    start: { dateTime: '2026-08-28T10:00:00Z', timeZone: 'UTC' },
+    end: { dateTime: '2026-08-28T11:00:00Z', timeZone: 'UTC' },
+    location: { displayName: 'Room 1' },
+    isAllDay: false,
+    isCancelled: false,
+    webLink: `https://outlook.office.com/calendar/${id}`,
+    createdDateTime: '2026-08-01T10:00:00Z',
+  };
+}
+
+describe('MicrosoftOutlookConnector runtime', () => {
+  test('requires OAuth before issuing a Graph request', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('Graph was called without credentials');
+    }) as typeof fetch;
+
+    const connector = new MicrosoftOutlookConnector();
+
+    await expect(
+      connector.sync({ feedKey: 'messages', config: {}, credentials: null, checkpoint: {} })
+    ).rejects.toThrow('Microsoft Outlook requires OAuth authentication');
+  });
+
+  test('encodes an opaque mail-folder id and follows Graph next links up to max_results', async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      urls.push(url);
+      const page = urls.length === 1
+        ? { value: [graphMessage('one')], '@odata.nextLink': 'https://graph.microsoft.com/v1.0/next-page' }
+        : { value: [graphMessage('two'), graphMessage('three')] };
+      return Response.json(page);
+    }) as typeof fetch;
+
+    const connector = new MicrosoftOutlookConnector();
+    const result = await connector.sync({
+      feedKey: 'messages',
+      config: { folder: FOLDER_ID, max_results: 2, lookback_days: 30 },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    expect(new URL(urls[0]).pathname).toContain(
+      '/mailFolders/AQMkAGI2%2FLy8%2BZm9sZGVy%3D/messages'
+    );
+    expect(urls[1]).toBe('https://graph.microsoft.com/v1.0/next-page');
+    expect(result.events.map((event: { origin_id: string }) => event.origin_id)).toEqual([
+      'outlook_msg_one',
+      'outlook_msg_two',
+    ]);
+    expect(result.events[0]).toMatchObject({
+      origin_type: 'email',
+      author_name: 'Sender',
+      metadata: { from: 'sender@example.com', to: 'Recipient', is_read: true },
+    });
+  });
+
+  test('emits an origin_type the feed declares as an event kind', async () => {
+    globalThis.fetch = (async () => Response.json({ value: [graphEvent('meeting')] })) as typeof fetch;
+
+    const connector = new MicrosoftOutlookConnector();
+    const result = await connector.sync({
+      feedKey: 'calendar',
+      config: { max_results: 10, lookback_days: 7, lookahead_days: 30 },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      origin_id: 'outlook_evt_meeting',
+      origin_type: 'calendar_event',
+      metadata: {
+        organizer: 'owner@example.com',
+        attendee_count: 1,
+        start_time: '2026-08-28T10:00:00Z',
+      },
+    });
+    expect(
+      Object.keys(connector.definition.feeds.calendar.eventKinds)
+    ).toContain(result.events[0].origin_type);
+  });
+});

--- a/packages/connectors/src/__tests__/reddit.test.ts
+++ b/packages/connectors/src/__tests__/reddit.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let RedditConnector: any;
+
+beforeAll(async () => {
+  RedditConnector = (await import('../reddit')).default;
+});
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function redditPost(id: string, createdUtc = Date.now() / 1000) {
+  return {
+    kind: 't3',
+    data: {
+      name: `t3_${id}`,
+      id,
+      title: `Post ${id}`,
+      selftext: `Body ${id}`,
+      author: 'author',
+      permalink: `/r/lobu/comments/${id}/post/`,
+      url: `https://reddit.com/r/lobu/comments/${id}/post/`,
+      created_utc: createdUtc,
+      score: 5,
+      ups: 6,
+      num_comments: 2,
+      upvote_ratio: 0.9,
+      is_self: true,
+      domain: 'self.lobu',
+      subreddit: 'lobu',
+    },
+  };
+}
+
+function redditComment(id: string, parentId: string) {
+  return {
+    kind: 't1',
+    data: {
+      name: `t1_${id}`,
+      id,
+      body: `Comment ${id}`,
+      author: 'commenter',
+      permalink: `/r/lobu/comments/post/comment/${id}/`,
+      created_utc: Date.now() / 1000,
+      score: 3,
+      ups: 4,
+      parent_id: parentId,
+      link_id: 't3_post',
+      subreddit: 'lobu',
+    },
+  };
+}
+
+function listing(children: unknown[], after: string | null = null) {
+  return Response.json({ data: { children, after } });
+}
+
+describe('RedditConnector runtime', () => {
+  test('uses chronological all-time search so lookback cutoff cannot skip newer matches', async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(typeof input === 'string' ? input : input.toString());
+      return listing([redditPost('result')]);
+    }) as typeof fetch;
+
+    const connector = new RedditConnector();
+    const result = await connector.sync({
+      feedKey: 'posts',
+      config: { subreddit: 'lobu', search_terms: 'agent memory', lookback_days: 730 },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    const request = new URL(urls[0]);
+    expect(request.pathname).toBe('/r/lobu/search');
+    expect(request.searchParams.get('q')).toBe('agent memory');
+    expect(request.searchParams.get('sort')).toBe('new');
+    expect(request.searchParams.get('t')).toBe('all');
+    expect(result.events[0].origin_id).toBe('reddit_post_t3_result');
+  });
+
+  test('treats subreddit as one encoded path segment', async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(typeof input === 'string' ? input : input.toString());
+      return listing([]);
+    }) as typeof fetch;
+
+    const connector = new RedditConnector();
+    await connector.sync({
+      feedKey: 'posts',
+      config: { subreddit: 'programming/new?limit=1' },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    expect(new URL(urls[0]).pathname).toBe('/r/programming%2Fnew%3Flimit%3D1/new');
+  });
+
+  test('keeps comment parent ids aligned with emitted stable origin ids', async () => {
+    globalThis.fetch = (async () =>
+      listing([
+        redditComment('child', 't1_parent'),
+        redditComment('parent', 't3_post'),
+      ])) as typeof fetch;
+
+    const connector = new RedditConnector();
+    const result = await connector.sync({
+      feedKey: 'comments',
+      config: { subreddit: 'lobu' },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        origin_id: 'reddit_comment_t1_child',
+        origin_parent_id: 'reddit_comment_t1_parent',
+        origin_type: 'comment',
+      }),
+      expect.objectContaining({
+        origin_id: 'reddit_comment_t1_parent',
+        origin_parent_id: 'reddit_post_t3_post',
+        origin_type: 'comment',
+      }),
+    ]);
+  });
+
+  // The first item older than the cutoff ends the whole sync, not just that
+  // item — which is why the listing has to be newest-first. A trailing fresh
+  // item and an unconsumed second page both prove the stop rather than a filter.
+  test('stops the sync at the first item older than the lookback cutoff', async () => {
+    const twoYearsAgo = Date.now() / 1000 - 730 * 24 * 60 * 60;
+    let pages = 0;
+    globalThis.fetch = (async () => {
+      pages++;
+      return pages === 1
+        ? listing(
+            [redditPost('fresh'), redditPost('stale', twoYearsAgo), redditPost('trailing')],
+            't3_next'
+          )
+        : listing([redditPost('secondpage')]);
+    }) as typeof fetch;
+
+    const connector = new RedditConnector();
+    const result = await connector.sync({
+      feedKey: 'posts',
+      config: { subreddit: 'lobu', lookback_days: 30 },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    expect(result.events.map((event: { origin_id: string }) => event.origin_id)).toEqual([
+      'reddit_post_t3_fresh',
+    ]);
+    expect(pages).toBe(1);
+  });
+
+  test('confines a pagination cursor to a single query parameter', async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(typeof input === 'string' ? input : input.toString());
+      return urls.length === 1
+        ? listing([redditPost('first')], 't3_next&limit=1')
+        : listing([redditPost('second')]);
+    }) as typeof fetch;
+
+    const connector = new RedditConnector();
+    const result = await connector.sync({
+      feedKey: 'posts',
+      config: { subreddit: 'lobu' },
+      credentials: { accessToken: 'token' },
+      checkpoint: {},
+    });
+
+    const second = new URL(urls[1]);
+    expect(second.searchParams.get('after')).toBe('t3_next&limit=1');
+    expect(second.searchParams.getAll('limit')).toEqual(['100']);
+    expect(result.events).toHaveLength(2);
+  });
+
+  test('names the subreddit in the error raised for a 404 listing', async () => {
+    globalThis.fetch = (async () => new Response('not found', { status: 404 })) as typeof fetch;
+
+    const connector = new RedditConnector();
+    await expect(
+      connector.sync({
+        feedKey: 'posts',
+        config: { subreddit: 'missing' },
+        credentials: { accessToken: 'token' },
+        checkpoint: {},
+      })
+    ).rejects.toThrow('Subreddit or resource not found');
+  });
+});

--- a/packages/connectors/src/microsoft_outlook.ts
+++ b/packages/connectors/src/microsoft_outlook.ts
@@ -257,6 +257,7 @@ export default class MicrosoftOutlookConnector extends ConnectorRuntime {
     const folder = (config.folder as string) ?? 'inbox';
     const maxResults = (config.max_results as number) ?? 50;
     const lookbackDays = (config.lookback_days as number) ?? 30;
+    const encodedFolder = encodeURIComponent(folder);
 
     const since = new Date();
     since.setDate(since.getDate() - lookbackDays);
@@ -264,7 +265,7 @@ export default class MicrosoftOutlookConnector extends ConnectorRuntime {
 
     const events: EventEnvelope[] = [];
     const firstUrl =
-      `${this.API_BASE}/me/mailFolders/${folder}/messages` +
+      `${this.API_BASE}/me/mailFolders/${encodedFolder}/messages` +
       `?$top=${Math.min(maxResults, this.PAGE_SIZE)}` +
       '&$orderby=receivedDateTime desc' +
       `&$filter=receivedDateTime ge ${sinceFilter}` +

--- a/packages/connectors/src/reddit.ts
+++ b/packages/connectors/src/reddit.ts
@@ -458,7 +458,8 @@ export default class RedditConnector extends ConnectorRuntime {
   }): string {
     const { baseUrl, subreddit, searchTerms, username, contentType, after, isOAuth } = params;
     const jsonSuffix = isOAuth ? '' : '.json';
-    const afterParam = after ? `&after=${after}` : '';
+    const afterParam = after ? `&after=${encodeURIComponent(after)}` : '';
+    const subredditPath = subreddit ? encodeURIComponent(subreddit) : undefined;
 
     if (contentType === 'overview') {
       if (!username) {
@@ -469,29 +470,33 @@ export default class RedditConnector extends ConnectorRuntime {
 
     if (contentType === 'comment') {
       // Comments from a subreddit
-      if (subreddit) {
-        return `${baseUrl}/r/${subreddit}/comments${jsonSuffix}?limit=100${afterParam}`;
+      if (subredditPath) {
+        return `${baseUrl}/r/${subredditPath}/comments${jsonSuffix}?limit=100${afterParam}`;
       }
       // Comments aren't searchable via Reddit search API, fall back to r/all
       return `${baseUrl}/r/all/comments${jsonSuffix}?limit=100${afterParam}`;
     }
 
-    // Posts mode
+    // Posts mode. The sync loop stops at the first item older than the lookback
+    // cutoff, so a listing has to come back newest-first: under `sort=relevance`
+    // one old-but-relevant hit ends the sync and hides the newer matches behind
+    // it. `t=all` because lookback_days allows up to 730.
     if (searchTerms) {
       const query = encodeURIComponent(searchTerms);
-      if (subreddit) {
-        return `${baseUrl}/r/${subreddit}/search${jsonSuffix}?q=${query}&restrict_sr=on&sort=relevance&t=year&limit=100${afterParam}`;
+      if (subredditPath) {
+        return `${baseUrl}/r/${subredditPath}/search${jsonSuffix}?q=${query}&restrict_sr=on&sort=new&t=all&limit=100${afterParam}`;
       }
-      return `${baseUrl}/search${jsonSuffix}?q=${query}&sort=relevance&t=year&limit=100${afterParam}`;
+      return `${baseUrl}/search${jsonSuffix}?q=${query}&sort=new&t=all&limit=100${afterParam}`;
     }
 
-    // Subreddit listing
-    if (subreddit) {
-      return `${baseUrl}/r/${subreddit}/new${jsonSuffix}?t=year&limit=100${afterParam}`;
+    // Subreddit listing. `/new` is already chronological and takes no time
+    // window, so a `t=` here would either be ignored or cap the lookback.
+    if (subredditPath) {
+      return `${baseUrl}/r/${subredditPath}/new${jsonSuffix}?limit=100${afterParam}`;
     }
 
     // Fallback to r/all
-    return `${baseUrl}/r/all/new${jsonSuffix}?t=year&limit=100${afterParam}`;
+    return `${baseUrl}/r/all/new${jsonSuffix}?limit=100${afterParam}`;
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n\n- percent-encode free-form Outlook folder ids before placing them in a Graph path\n- make Reddit lookback sync chronological, encode user-controlled path/cursor values, and stop safely at the cutoff\n- add direct runtime coverage for Outlook and Reddit using the shared connector SDK test mock\n\n## Test plan\n\n- [x] Intended files staged explicitly; make pre-pr clean\n- [x] packages/connectors tests: 405 passed, 0 failed\n- [x] package typecheck and git diff --check clean\n- [x] semantic fixer completed; production mutations were killed by the new tests\n\nRed to green:\n- Outlook initially requested a slash-containing folder as multiple path segments; now it emits one percent-encoded segment.\n- Reddit initially used relevance/year search and accepted raw cursor/path input; now tests require new/all ordering, encoded values, and one-page cutoff termination.\n\n## Notes\n\nNo live Reddit or Microsoft account was accessed. Provider acceptance remains CI/mocked-request evidence rather than a live credential smoke.