### PR TITLE
fix(mcp): align app review metadata

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -224,6 +224,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(content?._meta?.ui?.permissions).toEqual({ clipboardWrite: {} });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBe('http://localhost');
+    expect(content?._meta?.['openai/widgetDescription']).toBe(
+      'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.'
+    );
   });
 
   it('serves the stamped external template and registered stable assets', async () => {
@@ -392,6 +395,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toBe('http://localhost');
+    // Same reason as `domain`: ChatGPT reads the component's model-facing
+    // summary off the template it captured at connect time, so the key rides
+    // the listing, not only `resources/read`.
+    expect(resource._meta?.['openai/widgetDescription']).toBe(resource.description);
   });
 
   it('omits the app domain for a host that advertises Apps without OpenAI visibility', async () => {

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -28,6 +28,8 @@ interface QuerySqlResult {
 
 describe('MCP query_sdk / run_sdk tool surface', () => {
   let token: string;
+  let ownerUserId: string;
+  let oauthClientId: string;
   let ownerOrgId: string;
   let ownerSlug: string;
   let publicSlug: string;
@@ -39,8 +41,10 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     ownerOrgId = org.id;
     ownerSlug = org.slug;
     const owner = await createTestUser({ email: 'query-tool@test.example.com' });
+    ownerUserId = owner.id;
     await addUserToOrganization(owner.id, org.id, 'owner');
     const oauthClient = await createTestOAuthClient();
+    oauthClientId = oauthClient.client_id;
     token = (await createTestAccessToken(owner.id, org.id, oauthClient.client_id, { scope: 'mcp:read mcp:write mcp:admin' })).token;
     const publicOrg = await createTestOrganization({
       name: 'Query Tool Public',
@@ -95,6 +99,30 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(byName.has('search')).toBe(false);
     expect(byName.has('query')).toBe(false);
     expect(byName.has('run')).toBe(false);
+  });
+
+  // Authorization is explicitly pinned separately from host-facing safety
+  // hints. This prevents a future annotation refactor from silently hiding an
+  // audited retrieval tool from a read-only client.
+  it('keeps audited-read tools reachable with only mcp:read', async () => {
+    const readOnly = await createTestAccessToken(ownerUserId, ownerOrgId, oauthClientId, {
+      scope: 'mcp:read',
+    });
+    const result = await mcpListTools({ token: readOnly.token, orgSlug: ownerSlug });
+    const names = new Set(result.tools.map((t) => t.name));
+
+    for (const name of [
+      'search_memory',
+      'search_sdk',
+      'query_sdk',
+      'query_sql',
+      'get_approval',
+    ]) {
+      expect(names.has(name), `${name} must list for an mcp:read token`).toBe(true);
+    }
+    // Proves the read-only filter actually ran: write tools are withheld.
+    expect(names.has('run_sdk')).toBe(false);
+    expect(names.has('save_memory')).toBe(false);
   });
 
   it('does not advertise the retired legacy ChatGPT plugin manifest', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -210,7 +210,12 @@ const MCP_APP_RESOURCES: Record<
   string,
   {
     name: string;
-    /** Surfaced on `resources/list` — clients show it in resource browsers. */
+    /**
+     * Surfaced as the resource's typed `description` on `resources/list`, where
+     * clients show it in resource browsers, and as `openai/widgetDescription`
+     * on both the listed and the read template, where ChatGPT gives it to the
+     * model when the component loads instead of narrating the card itself.
+     */
     description: string;
     appDir: string;
     /**
@@ -337,6 +342,24 @@ function mcpAppUiMeta(
   };
 }
 
+/**
+ * Root `_meta` for an MCP App resource. `openai/widgetDescription` sits beside
+ * the nested `ui` block rather than inside it: it is an OpenAI-namespaced key,
+ * and ChatGPT hands it to the model when the component loads so the model stops
+ * re-describing the rendered card in prose. Like `ui.domain`, it has to ride the
+ * listed template as well as the read one because a host captures that copy at
+ * connect time.
+ */
+function mcpAppResourceMeta(
+  authCtx: SessionAuthContext,
+  app: (typeof MCP_APP_RESOURCES)[string]
+) {
+  return {
+    ui: mcpAppUiMeta(authCtx, app),
+    'openai/widgetDescription': app.description,
+  };
+}
+
 function createServerForContext(
   env: Env,
   authCtx: SessionAuthContext,
@@ -420,9 +443,7 @@ function createServerForContext(
         name: meta.name,
         description: meta.description,
         mimeType: MCP_APP_MIME_TYPE,
-        _meta: {
-          ui: mcpAppUiMeta(authCtx, meta),
-        },
+        _meta: mcpAppResourceMeta(authCtx, meta),
       })),
       ...Object.entries(MCP_SKILL_RESOURCES).map(([uri, meta]) => ({
         uri,
@@ -468,9 +489,7 @@ function createServerForContext(
           uri,
           mimeType: MCP_APP_MIME_TYPE,
           text: html,
-          _meta: {
-            ui: mcpAppUiMeta(authCtx, app),
-          },
+          _meta: mcpAppResourceMeta(authCtx, app),
         },
       ],
     };


### PR DESCRIPTION
## Summary
- mark the five externally advertised audited retrieval tools non-read-only because OAuth and PAT calls append private audit/activity state
- keep those tools authorized by `mcp:read` with an explicit regression test
- publish the neutral `openai/widgetDescription` on both listed and read MCP App resources

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (GitHub CI remains the canonical full graph)
- [x] Tests run: `cd packages/server && bun run test -- run src/__tests__/integration/mcp` — 16 files, 201 passed, 2 skipped
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: not applicable

Red before source fix:
- `query-tool.test.ts`: `search_memory.readOnlyHint` expected `false`, received `true`
- `mcp-app-resources.test.ts`: expected the neutral widget description, received `undefined`

Green after source fix:
- focused MCP suites: 46/46 passed
- complete MCP integration folder: 201 passed, 2 skipped
- `make pre-pr`: clean

## Notes
This is one submission-metadata correction: OpenAI stores scanned MCP annotations rather than allowing prose justifications to override them. The audited tools still perform read-only user-facing operations and still require only `mcp:read`; only their host-facing safety label changes because each call appends an audit/activity record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP App resources now expose widget descriptions when listed or read, improving compatibility with supported interfaces.
  * Read-only MCP access now correctly lists audited read tools while excluding write tools.

* **Bug Fixes**
  * Updated MCP safety metadata to accurately indicate that audited read operations record audit activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->