### PR TITLE
feat(server): materialize connector-declared edges

### DIFF
--- a/db/migrations/20260827174500_index_live_relationship_claims.sql
+++ b/db/migrations/20260827174500_index_live_relationship_claims.sql
@@ -1,0 +1,18 @@
+-- migrate:up transaction:false
+-- lobu:no-quiesce
+
+-- Additive partial expression index used to find an exact source claim on live
+-- relationships. Operational cost is one concurrent scan of
+-- entity_relationships; writes remain available. This was not benchmarked on a
+-- prod-sized copy, so verify indisvalid after deploy if the 60s migration
+-- statement_timeout interrupts the build.
+-- No ownership backfill is performed: existing ordinary relationships must be
+-- classified and moved to a manual/source claim explicitly before cutover.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entity_relationships_live_claims
+  ON public.entity_relationships
+  USING gin ((metadata -> '_lobu_claims'))
+  WHERE deleted_at IS NULL AND metadata ? '_lobu_claims';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_entity_relationships_live_claims;

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -44,7 +44,11 @@ flowchart LR
   G --> H["Downstream workspace-triggered Automations (chaining)"]
 ```
 
-1. **Ingest.** A connector feed sync lands rows in `events`. Generic webhook
+1. **Ingest.** A connector feed sync lands rows in `events`. Named event
+   attributions may also materialize connector-declared entity relationships in
+   the same event transaction; each relationship claim is owned by the event's
+   `(connection_id, origin_id)`, so resync and connection deletion retract only
+   the source facts they own. Generic webhook
    deliveries also land there; chat messages instead persist in
    `channel_messages` and are normalized into connector turn signals. Connector
    event ingestion dedupes by `(connection_id, origin_id)`; a row whose current

--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -131,6 +131,38 @@ timeout, and one failure does not discard successful results from the others.
   `automationEvents` keys that differ from your feed `eventKinds`, attach matching
   `automation_signals` to each emitted `EventEnvelope`, or those triggers never
   fire (the picker advertises them but ingestion never emits them).
+- **Entity relationships.** Give the event kind's attribution rules stable
+  `name` values, then reference those names from `relationships`:
+
+  ```ts
+  eventKinds: {
+    invoice: {
+      attributions: [
+        {
+          name: "invoice",
+          role: "belongs_to",
+          target: { entityType: "invoice", identities: [/* ... */] },
+        },
+        {
+          name: "customer",
+          role: "about",
+          target: { entityType: "customer", identities: [/* ... */] },
+        },
+      ],
+      relationships: [
+        { type: "invoice_customer", from: "invoice", to: "customer" },
+      ],
+    },
+  }
+  ```
+
+  Install preflight requires the relationship type to be active in the target
+  organization and rejects authorization-bearing types. On ingestion, Lobu
+  resolves the named attributions and reconciles the event's complete edge set
+  atomically with its event row. Ownership follows `(connection_id, origin_id)`,
+  so resync changes retract only that source item's claim; another source or a
+  manual claim can retain the same graph fact. Deleting the connection retracts
+  its remaining claims.
 - **No real credentials in code.** Secrets flow through `ctx.credentials` /
   `ctx.config`; workers never receive durable stored credentials.
 

--- a/packages/server/src/__tests__/integration/connectors/connector-declared-edges.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-declared-edges.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Connector-declared relationship E2E.
+ *
+ * Drives the real connector definition -> attribution -> worker stream ->
+ * event/relationship transaction used by CRM and ERP feeds.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { post } from '../../setup/test-helpers';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+} from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const CONNECTOR_KEY = 'erp-crm-relationships';
+const FEED_KEY = 'invoices';
+
+describe('connector-declared relationships', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('materializes a source-owned invoice -> customer edge through worker ingestion', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'ERP CRM Relationship E2E' });
+    await workspace.owner.entity_schema.createType({ slug: 'invoice', name: 'Invoice' });
+    await workspace.owner.entity_schema.createType({ slug: 'customer', name: 'Customer' });
+    await workspace.owner.entity_schema.createRelType({
+      slug: 'invoice_customer',
+      name: 'Invoice Customer',
+    });
+    await workspace.owner.entity_schema.addRule({
+      slug: 'invoice_customer',
+      source_entity_type_slug: 'invoice',
+      target_entity_type_slug: 'customer',
+    });
+    await createTestConnectorDefinition({
+      key: CONNECTOR_KEY,
+      name: 'ERP CRM Relationships',
+      organization_id: workspace.org.id,
+      feeds_schema: {
+        [FEED_KEY]: {
+          eventKinds: {
+            invoice: {
+              attributions: [
+                {
+                  name: 'invoice',
+                  role: 'belongs_to',
+                  autoCreate: true,
+                  target: {
+                    entityType: 'invoice',
+                    titlePath: 'metadata.invoice_number',
+                    identities: [
+                      { namespace: 'erp_invoice_id', eventPath: 'metadata.invoice_id' },
+                    ],
+                  },
+                },
+                {
+                  name: 'customer',
+                  role: 'about',
+                  autoCreate: true,
+                  target: {
+                    entityType: 'customer',
+                    titlePath: 'metadata.customer_name',
+                    identities: [
+                      { namespace: 'crm_customer_id', eventPath: 'metadata.customer_id' },
+                    ],
+                  },
+                },
+              ],
+              relationships: [
+                { type: 'invoice_customer', from: 'invoice', to: 'customer' },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const connection = await createTestConnection({
+      organization_id: workspace.org.id,
+      connector_key: CONNECTOR_KEY,
+      created_by: workspace.users.owner.id,
+      createDefaultFeed: false,
+    });
+    const [feed] = await sql`
+      INSERT INTO feeds (
+        organization_id, connection_id, feed_key, status, created_at, updated_at
+      ) VALUES (
+        ${workspace.org.id}, ${connection.id}, ${FEED_KEY}, 'active', NOW(), NOW()
+      )
+      RETURNING id
+    `;
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, feed_id, connection_id, connector_key,
+        connector_version, status, approval_status, created_at
+      ) VALUES (
+        ${workspace.org.id}, 'sync', ${feed.id}, ${connection.id}, ${CONNECTOR_KEY},
+        '1.0.0', 'running', 'auto', NOW()
+      )
+      RETURNING id
+    `;
+
+    const originId = 'invoice:inv-1001';
+    const response = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 belongs to Acme Ltd',
+            metadata: {
+              invoice_id: 'inv-1001',
+              invoice_number: 'INV-1001',
+              customer_id: 'cust-42',
+              customer_name: 'Acme Ltd',
+            },
+          },
+        ],
+      },
+    });
+    expect(response.status).toBe(200);
+
+    const edges = await sql`
+      SELECT r.id, r.from_entity_id, r.to_entity_id,
+             fe.name AS from_name, te.name AS to_name, rt.slug AS type, r.metadata
+      FROM entity_relationships r
+      JOIN entities fe ON fe.id = r.from_entity_id
+      JOIN entities te ON te.id = r.to_entity_id
+      JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+      WHERE r.organization_id = ${workspace.org.id}
+        AND r.deleted_at IS NULL
+        AND rt.slug = 'invoice_customer'
+    `;
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      from_name: 'INV-1001',
+      to_name: 'Acme Ltd',
+      type: 'invoice_customer',
+      metadata: {
+        _lobu_claims: {
+          [`feed:${connection.id}:${originId}`]: {
+            rules: ['invoice_customer:invoice->customer'],
+          },
+        },
+      },
+    });
+
+    // A manual assertion co-owns the same graph fact instead of creating a
+    // duplicate row. Its claim is independent of the connector event claim.
+    const manualAssertion = (await workspace.owner.entities.link({
+      from_entity_id: Number(edges[0].from_entity_id),
+      to_entity_id: Number(edges[0].to_entity_id),
+      relationship_type_slug: 'invoice_customer',
+    })) as { relationship: { metadata: Record<string, unknown> | null } };
+    expect(manualAssertion.relationship.metadata).toBeNull();
+    const [coOwned] = await sql`
+      SELECT metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(Object.keys(coOwned.metadata._lobu_claims).sort()).toEqual([
+      `feed:${connection.id}:${originId}`,
+      'manual',
+    ]);
+    await workspace.owner.entities.manage({
+      action: 'update_link',
+      relationship_id: Number(edges[0].id),
+      metadata: { reviewed: true },
+    });
+    const [afterManualUpdate] = await sql`
+      SELECT metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(afterManualUpdate.metadata).toMatchObject({
+      reviewed: true,
+      _lobu_claims: {
+        manual: {},
+        [`feed:${connection.id}:${originId}`]: expect.any(Object),
+      },
+    });
+
+    // Resyncing the same durable source item to a different customer moves only
+    // its connector claim. The old relationship stays live because manual still
+    // asserts it; the new relationship is connector-owned.
+    const moved = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 now belongs to Beta GmbH',
+            metadata: {
+              invoice_id: 'inv-1001',
+              invoice_number: 'INV-1001',
+              customer_id: 'cust-84',
+              customer_name: 'Beta GmbH',
+            },
+          },
+        ],
+      },
+    });
+    expect(moved.status).toBe(200);
+
+    const liveAfterMove = await sql`
+      SELECT r.id, r.from_entity_id, r.to_entity_id, te.name AS to_name, r.metadata
+      FROM entity_relationships r
+      JOIN entities te ON te.id = r.to_entity_id
+      JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+      WHERE r.organization_id = ${workspace.org.id}
+        AND r.deleted_at IS NULL
+        AND rt.slug = 'invoice_customer'
+      ORDER BY te.name
+    `;
+    expect(liveAfterMove).toHaveLength(2);
+    const oldManual = liveAfterMove.find((row) => row.to_name === 'Acme Ltd');
+    const newSource = liveAfterMove.find((row) => row.to_name === 'Beta GmbH');
+    expect(oldManual?.metadata).toEqual({ reviewed: true, _lobu_claims: { manual: {} } });
+    expect(Object.keys(newSource?.metadata._lobu_claims ?? {})).toEqual([
+      `feed:${connection.id}:${originId}`,
+    ]);
+
+    await expect(
+      workspace.owner.entities.manage({
+        action: 'unlink',
+        relationship_id: Number(newSource?.id),
+      })
+    ).rejects.toThrow(/source-managed/i);
+
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: Number(oldManual?.id),
+    });
+    const [oldAfterUnlink] = await sql`
+      SELECT deleted_at FROM entity_relationships WHERE id = ${oldManual?.id}
+    `;
+    expect(oldAfterUnlink.deleted_at).not.toBeNull();
+
+    // Connection deletion retracts its remaining claims in the same durable
+    // lifecycle transaction, so no connector-owned graph fact is orphaned.
+    const deleted = (await workspace.owner.connections.delete(connection.id)) as {
+      deleted?: boolean;
+    };
+    expect(deleted.deleted).toBe(true);
+    const [remaining] = await sql`
+      SELECT count(*)::int AS count
+      FROM entity_relationships r
+      JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+      WHERE r.organization_id = ${workspace.org.id}
+        AND r.deleted_at IS NULL
+        AND rt.slug = 'invoice_customer'
+    `;
+    expect(Number(remaining.count)).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/integration/relationships/edge-source-vocabulary.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/edge-source-vocabulary.test.ts
@@ -46,10 +46,10 @@ describe('relationship source vocabulary', () => {
       await sql`
         UPDATE entity_relationships
         SET source = ${source},
-            metadata = ${sql.json({
+            metadata = COALESCE(metadata, '{}'::jsonb) || ${sql.json({
               connection_id: 'test-connection',
               channel_key: prefix,
-            })}
+            })}::jsonb
         WHERE id = ${linked.relationship.id}
       `;
     }

--- a/packages/server/src/__tests__/integration/relationships/relationship-claims.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/relationship-claims.test.ts
@@ -1,0 +1,143 @@
+/** Atomic source-claim invariants for shared relationship triples. */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  reconcileConnectorRelationshipClaims,
+  RELATIONSHIP_CLAIMS_METADATA_KEY,
+} from '../../../utils/relationship-claims';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestConnection } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+async function seedClaimGraph() {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({ name: 'Relationship Claim Races' });
+  await workspace.owner.entity_schema.createType({ slug: 'invoice', name: 'Invoice' });
+  await workspace.owner.entity_schema.createType({ slug: 'customer', name: 'Customer' });
+  await workspace.owner.entity_schema.createRelType({
+    slug: 'invoice_customer',
+    name: 'Invoice Customer',
+  });
+  const invoice = (await workspace.owner.entities.create({
+    type: 'invoice',
+    name: 'INV-RACE',
+  })) as { entity: { id: number } };
+  const customer = (await workspace.owner.entities.create({
+    type: 'customer',
+    name: 'Race Customer',
+  })) as { entity: { id: number } };
+  const connection = await createTestConnection({
+    organization_id: workspace.org.id,
+    connector_key: 'claim-race',
+    created_by: workspace.users.owner.id,
+    createDefaultFeed: false,
+  });
+  const desired = [
+    {
+      declaration: {
+        type: 'invoice_customer',
+        from: 'invoice',
+        to: 'customer',
+      },
+      fromEntityId: invoice.entity.id,
+      toEntityId: customer.entity.id,
+    },
+  ];
+  return { sql, workspace, connection, invoice, customer, desired };
+}
+
+describe('relationship source claims', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('atomically keeps two concurrent source claims on one live triple', async () => {
+    const { sql, workspace, connection, desired } = await seedClaimGraph();
+    const [index] = await sql`
+      SELECT i.indisvalid
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE c.relname = 'idx_entity_relationships_live_claims'
+    `;
+    expect(index?.indisvalid).toBe(true);
+
+    await Promise.all([
+      sql.begin((tx) =>
+        reconcileConnectorRelationshipClaims(tx, {
+          organizationId: workspace.org.id,
+          connectionId: connection.id,
+          originId: 'invoice:source-a',
+          desired,
+        })
+      ),
+      sql.begin((tx) =>
+        reconcileConnectorRelationshipClaims(tx, {
+          organizationId: workspace.org.id,
+          connectionId: connection.id,
+          originId: 'invoice:source-b',
+          desired,
+        })
+      ),
+    ]);
+
+    const rows = await sql`
+      SELECT id, metadata
+      FROM entity_relationships
+      WHERE organization_id = ${workspace.org.id} AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+    expect(Object.keys(rows[0].metadata[RELATIONSHIP_CLAIMS_METADATA_KEY]).sort()).toEqual([
+      `feed:${connection.id}:invoice:source-a`,
+      `feed:${connection.id}:invoice:source-b`,
+    ]);
+
+    await sql.begin((tx) =>
+      reconcileConnectorRelationshipClaims(tx, {
+        organizationId: workspace.org.id,
+        connectionId: connection.id,
+        originId: 'invoice:source-a',
+        desired: [],
+      })
+    );
+    const [retained] = await sql`
+      SELECT deleted_at, metadata FROM entity_relationships WHERE id = ${rows[0].id}
+    `;
+    expect(retained.deleted_at).toBeNull();
+    expect(Object.keys(retained.metadata[RELATIONSHIP_CLAIMS_METADATA_KEY])).toEqual([
+      `feed:${connection.id}:invoice:source-b`,
+    ]);
+  });
+
+  it('fails closed on an unclaimed pre-cutover row instead of silently adopting it', async () => {
+    const { sql, workspace, connection, invoice, customer, desired } = await seedClaimGraph();
+    const [type] = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE organization_id = ${workspace.org.id} AND slug = 'invoice_customer'
+    `;
+    await sql`
+      INSERT INTO entity_relationships (
+        organization_id, from_entity_id, to_entity_id, relationship_type_id,
+        metadata, source, created_at, updated_at
+      ) VALUES (
+        ${workspace.org.id}, ${invoice.entity.id}, ${customer.entity.id}, ${type.id},
+        ${sql.json({ migrated: false })}, 'api', NOW(), NOW()
+      )
+    `;
+
+    await expect(
+      sql.begin((tx) =>
+        reconcileConnectorRelationshipClaims(tx, {
+          organizationId: workspace.org.id,
+          connectionId: connection.id,
+          originId: 'invoice:needs-migration',
+          desired,
+        })
+      )
+    ).rejects.toThrow(/_lobu_claims.*migrate/i);
+
+    const [unchanged] = await sql`
+      SELECT metadata FROM entity_relationships WHERE organization_id = ${workspace.org.id}
+    `;
+    expect(unchanged.metadata).toEqual({ migrated: false });
+  });
+});

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -16,6 +16,7 @@ import type { StoredConnection } from "@lobu/core";
 import { createLogger } from "@lobu/core";
 import { type DbClient, tsTime } from "../../db/client";
 import { deleteConnectionAclRow } from "../../authz/acl-observability";
+import { retractConnectionRelationshipClaims } from "../../utils/relationship-claims";
 
 const logger = createLogger("connections-projection");
 
@@ -314,6 +315,10 @@ export async function upsertChatConnectionProjection(
         for (const retired of supersededEnterprise as Array<{
           id: string;
         }>) {
+          await retractConnectionRelationshipClaims(sql, {
+            organizationId: orgId,
+            connectionId: retired.id,
+          });
           await deleteConnectionAclRow(sql, {
             organizationId: orgId,
             connectionId: retired.id,
@@ -478,6 +483,10 @@ export async function softDeleteChatConnectionProjection(
       RETURNING id::text AS id
     `) as Array<{ id: string }>;
     for (const row of tombstoned) {
+      await retractConnectionRelationshipClaims(sql, {
+        organizationId: orgId,
+        connectionId: row.id,
+      });
       await deleteConnectionAclRow(sql, {
         organizationId: orgId,
         connectionId: row.id,
@@ -490,6 +499,10 @@ export async function softDeleteChatConnectionProjection(
       RETURNING id::text AS id, organization_id
     `) as Array<{ id: string; organization_id: string }>;
     for (const row of tombstoned) {
+      await retractConnectionRelationshipClaims(sql, {
+        organizationId: row.organization_id,
+        connectionId: row.id,
+      });
       await deleteConnectionAclRow(sql, {
         organizationId: row.organization_id,
         connectionId: row.id,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -140,6 +140,7 @@ import {
 } from "../../helpers/connect-setup-continuation";
 import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
 import { supersedeActionEvent } from "../../approval-events";
+import { retractConnectionRelationshipClaims } from "../../../../utils/relationship-claims";
 
 // These Atlassian MCP config keys select a separately-consented Jira OAuth
 // grant. A member must not bind an admin's Jira authorization to a connection.
@@ -2310,6 +2311,11 @@ export async function handleDelete(
       RETURNING id, slug, display_name, connector_key
     `;
     if (tombstoned.length === 0) return null; // concurrently deleted
+
+		await retractConnectionRelationshipClaims(tx, {
+			organizationId,
+			connectionId: args.connection_id,
+		});
 
 		const expiredApprovalRunIds = await expirePendingApprovalsBeforeDelete(tx);
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -88,7 +88,6 @@ import {
 	ACL_MANAGED_TYPE_SQL,
 	assertNotAclManagedEdge,
 	canonicalizeSymmetricEdge,
-	checkDuplicateEdge,
 	validateConfidence,
 	validateNoSelfReference,
 	validateReconciledEdgeUpdate,
@@ -96,6 +95,13 @@ import {
 	validateSource,
 	validateTypeRule,
 } from "../../utils/relationship-validation";
+import {
+	assertManualRelationshipClaim,
+	assertManualRelationshipMutationAllowed,
+	assertNoReservedRelationshipMetadata,
+	relationshipMetadataWithoutClaims,
+	retractManualRelationshipClaim,
+} from "../../utils/relationship-claims";
 import {
 	exceedsValidationLimits,
 	isEmptyObject,
@@ -1687,7 +1693,7 @@ const RELATIONSHIP_SELECT = `
   fet.slug as from_entity_type,
   te.name as to_entity_name,
   tet.slug as to_entity_type,
-  r.metadata,
+  NULLIF(r.metadata - '_lobu_claims', '{}'::jsonb) AS metadata,
   r.confidence,
   r.source,
   r.created_by,
@@ -1852,63 +1858,39 @@ async function handleLink(
 		// validateScopeRule already required `from` to be in caller's org.
 	}
 
-	await checkDuplicateEdge(fromId, toId, typeId, sql);
-
 	validateConfidence(args.confidence);
 	validateSource(args.source);
+	assertNoReservedRelationshipMetadata(args.metadata);
 	const source = args.source ?? "api";
 	const confidence =
 		args.confidence ?? (source === "ui" || source === "api" ? 1.0 : null);
 
 	const created = await sql.begin(async (tx) => {
-		await lockOrganizationForSemanticEvent(tx, ctx.organizationId);
-		const inserted = await tx`
-    INSERT INTO entity_relationships (
-      organization_id, from_entity_id, to_entity_id, relationship_type_id,
-      metadata, confidence, source, created_by, updated_by,
-      created_at, updated_at
-    ) VALUES (
-      ${ctx.organizationId},
-      ${fromId},
-      ${toId},
-      ${typeId},
-			${args.metadata ? tx.json(args.metadata) : null},
-      ${confidence},
-      ${source},
-      ${ctx.userId},
-      ${ctx.userId},
-      current_timestamp,
-      current_timestamp
-    )
-    RETURNING id
-  `;
-		const relationshipId = Number((inserted[0] as { id: unknown }).id);
+		const asserted = await assertManualRelationshipClaim(tx, {
+			organizationId: ctx.organizationId,
+			fromEntityId: fromId,
+			toEntityId: toId,
+			relationshipTypeId: typeId,
+			relationshipTypeSlug: args.relationship_type_slug!,
+			metadata: args.metadata ?? null,
+			confidence,
+			source,
+			createdBy: ctx.userId,
+			clientId: ctx.clientId,
+		});
+		if (!asserted.claimAdded) {
+			throw new ToolUserError(
+				`An active relationship of this type already exists between entities ${fromId} and ${toId}`,
+				409,
+			);
+		}
+		const relationshipId = asserted.id;
 
 		const createdRows = await tx.unsafe<RelationshipRow>(
     `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
 			[relationshipId],
   );
 
-		await insertEdgeChangeEventInTransaction(
-			{
-				organizationId: ctx.organizationId,
-				relationshipId,
-				fromEntityId: fromId,
-				toEntityId: toId,
-				relationshipTypeId: typeId,
-				relationshipTypeSlug: args.relationship_type_slug ?? null,
-				op: "link",
-				changes: [
-					{ field: "exists", old: false, new: true },
-					{ field: "metadata", old: null, new: args.metadata ?? null },
-					{ field: "confidence", old: null, new: confidence },
-					{ field: "source", old: null, new: source },
-				],
-				createdBy: ctx.userId,
-				clientId: ctx.clientId,
-			},
-			tx,
-		);
 		return createdRows[0];
 	});
 
@@ -1924,45 +1906,21 @@ async function handleUnlink(
 
   const sql = getDb();
 
-	await sql.begin(async (tx) => {
-		await lockOrganizationForSemanticEvent(tx, ctx.organizationId);
-		const edge = await lockEdgeForMutation(
-			tx,
-			args.relationship_id!,
-			ctx.organizationId,
-			"unlink",
-		);
-		await tx`
-      UPDATE entity_relationships
-      SET deleted_at = current_timestamp, updated_at = current_timestamp, updated_by = ${ctx.userId}
-      WHERE id = ${args.relationship_id} AND deleted_at IS NULL
-    `;
-		await insertEdgeChangeEventInTransaction(
-			{
-				organizationId: ctx.organizationId,
-				relationshipId: Number(edge.id),
-				fromEntityId: Number(edge.from_entity_id),
-				toEntityId: Number(edge.to_entity_id),
-				relationshipTypeId: Number(edge.relationship_type_id),
-				relationshipTypeSlug: edge.relationship_type_slug,
-				op: "unlink",
-				changes: [
-					{ field: "exists", old: true, new: false },
-					{ field: "metadata", old: edge.metadata, new: null },
-					{ field: "confidence", old: edge.confidence, new: null },
-					{ field: "source", old: edge.source, new: null },
-				],
-				createdBy: ctx.userId,
-				clientId: ctx.clientId,
-			},
-			tx,
-		);
-	});
+	const result = await sql.begin((tx) =>
+		retractManualRelationshipClaim(tx, {
+			organizationId: ctx.organizationId,
+			relationshipId: args.relationship_id!,
+			updatedBy: ctx.userId,
+			clientId: ctx.clientId,
+		}),
+	);
 
 	return {
 		action: "unlink",
 		success: true,
-		message: `Relationship ${args.relationship_id} deleted`,
+		message: result.relationshipRemoved
+			? `Relationship ${args.relationship_id} deleted`
+			: `Manual claim removed from relationship ${args.relationship_id}; source claims still retain it`,
 	};
 }
 
@@ -1983,11 +1941,15 @@ async function handleUpdateLink(
 			ctx.organizationId,
 			"update_link",
 		);
+		assertManualRelationshipMutationAllowed(edge, "updated");
 		validateConfidence(args.confidence);
 		validateSource(args.source);
 		const hasMetadata = args.metadata !== undefined;
+		assertNoReservedRelationshipMetadata(args.metadata);
+		const visibleMetadataBefore = relationshipMetadataWithoutClaims(edge.metadata);
 		const metadataChanged =
-			hasMetadata && stableJson(edge.metadata ?? null) !== stableJson(args.metadata ?? null);
+			hasMetadata &&
+			stableJson(visibleMetadataBefore) !== stableJson(args.metadata ?? null);
 		// Check the locked pre-image so concurrent updates cannot move a reconciled
 		// edge out of the scope that retires it.
 		validateReconciledEdgeUpdate(edge.source, args.source, metadataChanged);
@@ -1999,7 +1961,11 @@ async function handleUpdateLink(
 		}>`
       UPDATE entity_relationships SET
         metadata = CASE
-          WHEN ${hasMetadata} THEN ${metadataJson}
+					WHEN ${hasMetadata} THEN
+						COALESCE(${metadataJson}, '{}'::jsonb)
+						|| jsonb_build_object(
+							'_lobu_claims', metadata -> '_lobu_claims'
+						)
           ELSE metadata
         END,
         confidence = COALESCE(${args.confidence ?? null}, confidence),
@@ -2015,7 +1981,11 @@ async function handleUpdateLink(
 		);
 		const after = updatedRows[0];
 		const changes = [
-			{ field: "metadata", old: edge.metadata, new: after.metadata },
+			{
+				field: "metadata",
+				old: visibleMetadataBefore,
+				new: relationshipMetadataWithoutClaims(after.metadata),
+			},
 			{ field: "confidence", old: edge.confidence, new: after.confidence },
 			{ field: "source", old: edge.source, new: after.source },
 		].filter(

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -41,6 +41,7 @@ import {
 } from './entity-management';
 import logger from './logger';
 import { getValueAtPath } from './object-path';
+import type { ConnectorRelationshipDeclaration } from './relationship-claims';
 import { TtlCache } from './ttl-cache';
 
 interface BatchItem {
@@ -50,6 +51,7 @@ interface BatchItem {
 }
 
 type ResolvedEventAttributionRule = {
+  name?: string;
   role: EventAttributionRule['role'];
   entityType: string;
   autoCreate?: boolean;
@@ -65,7 +67,22 @@ interface RuleMap {
 
 type EventKindAttributionDefinition = {
   attributions?: EventAttributionRule[];
+  relationships?: ConnectorRelationshipDeclaration[];
 };
+
+interface EventAttributionPlan {
+  rulesByKind: RuleMap;
+  relationshipsByKind: Record<string, ConnectorRelationshipDeclaration[]>;
+}
+
+interface AttributionResolution {
+  entityIdsByItem: Map<number, number[]>;
+  namedEntityIdsByItem: Map<number, Map<string, number>>;
+}
+
+export interface AppliedEventAttributions extends AttributionResolution {
+  relationshipsByKind: Record<string, ConnectorRelationshipDeclaration[]>;
+}
 
 function resolveEventAttributions(
   def: EventKindAttributionDefinition | undefined
@@ -77,6 +94,7 @@ function resolveEventAttributions(
     }
     return [
       {
+        name: rule.name,
         role: rule.role,
         entityType: rule.target.entityType,
         autoCreate: rule.autoCreate,
@@ -91,7 +109,8 @@ function resolveEventAttributions(
 
 const RULES_CACHE_TTL_MS = 60_000;
 // Per-pod caches — no cross-replica sharing.
-const rulesCache = new TtlCache<RuleMap>(RULES_CACHE_TTL_MS);
+const plansCache = new TtlCache<EventAttributionPlan>(RULES_CACHE_TTL_MS);
+const rulesByTypeCache = new TtlCache<RuleMap>(RULES_CACHE_TTL_MS);
 const creatorCache = new TtlCache<string | null>(RULES_CACHE_TTL_MS);
 
 /**
@@ -126,16 +145,16 @@ function randomSlug(entityType: string): string {
   return `${prefix}-${randomBytes(5).toString('hex')}`;
 }
 
-async function loadEventAttributionRules(
+async function loadEventAttributionPlan(
   sql: DbClient,
   params: {
     connectorKey: string;
     feedKey: string;
     orgId: string;
   }
-): Promise<RuleMap> {
+): Promise<EventAttributionPlan> {
   const cacheKey = `${params.orgId}:${params.connectorKey}:${params.feedKey}`;
-  return rulesCache.getOrSet(cacheKey, async () => {
+  return plansCache.getOrSet(cacheKey, async () => {
     const rows = await sql`
       SELECT feeds_schema
       FROM connector_definitions
@@ -145,17 +164,21 @@ async function loadEventAttributionRules(
       LIMIT 1
     `;
 
-    const result: RuleMap = {};
+    const rulesByKind: RuleMap = {};
+    const relationshipsByKind: Record<string, ConnectorRelationshipDeclaration[]> = {};
     const feedsSchema = rows[0]?.feeds_schema as Record<string, any> | null | undefined;
     const feedDef = feedsSchema?.[params.feedKey];
     const eventKinds = feedDef?.eventKinds as Record<string, EventKindAttributionDefinition> | undefined;
     if (eventKinds) {
       for (const [kind, def] of Object.entries(eventKinds)) {
         const resolved = resolveEventAttributions(def);
-        if (resolved.length > 0) result[kind] = resolved;
+        if (resolved.length > 0) rulesByKind[kind] = resolved;
+        if (Array.isArray(def.relationships) && def.relationships.length > 0) {
+          relationshipsByKind[kind] = def.relationships;
+        }
       }
     }
-    return result;
+    return { rulesByKind, relationshipsByKind };
   });
 }
 
@@ -182,7 +205,7 @@ export async function loadAttributionRuleByType(
 ): Promise<ResolvedEventAttributionRule | null> {
   const roleKey = params.role ?? '__any__';
   const cacheKey = `${params.orgId}:${params.connectorKey}:__bytype__:${params.entityType}:${roleKey}`;
-  const map = await rulesCache.getOrSet(cacheKey, async () => {
+  const map = await rulesByTypeCache.getOrSet(cacheKey, async () => {
     const rows = await sql`
       SELECT feeds_schema
       FROM connector_definitions
@@ -217,7 +240,8 @@ export async function loadAttributionRuleByType(
 }
 
 export function clearEntityLinkRulesCache(): void {
-  rulesCache.clear();
+  plansCache.clear();
+  rulesByTypeCache.clear();
   creatorCache.clear();
 }
 
@@ -823,32 +847,40 @@ export async function applyEventAttributions(
   // handle opens a transaction here. The sync dry-run path threads its rolled-
   // back tx so auto-created entities disappear with their events.
   sql?: DbClient
-): Promise<void> {
-  if (!params.feedKey || params.items.length === 0) return;
+): Promise<AppliedEventAttributions> {
+  const empty: AppliedEventAttributions = {
+    entityIdsByItem: new Map(),
+    namedEntityIdsByItem: new Map(),
+    relationshipsByKind: {},
+  };
+  if (!params.feedKey || params.items.length === 0) return empty;
 
   // Resolved BEFORE the rule load: the sync dry-run path supplies its
   // rolled-back transaction, and reading rules on the pool while that is open is
   // the starvation this file exists to avoid (#2818).
   const db = sql ?? getDb();
 
-  const rulesByKind = await loadEventAttributionRules(db, {
+  const plan = await loadEventAttributionPlan(db, {
     connectorKey: params.connectorKey,
     feedKey: params.feedKey,
     orgId: params.orgId,
   });
-  if (Object.keys(rulesByKind).length === 0) return;
-  await withEntityWriteTransaction(db, (tx) =>
+  if (Object.keys(plan.rulesByKind).length === 0) {
+    return { ...empty, relationshipsByKind: plan.relationshipsByKind };
+  }
+  const resolved = await withEntityWriteTransaction(db, (tx) =>
     resolveLinksByKind(
       {
         connectorKey: params.connectorKey,
         connectionId: params.connectionId,
         orgId: params.orgId,
         items: params.items,
-        rulesByKind,
+        rulesByKind: plan.rulesByKind,
       },
       tx
     )
   );
+  return { ...resolved, relationshipsByKind: plan.relationshipsByKind };
 }
 
 /**
@@ -880,7 +912,7 @@ export async function resolveEventAttributionsForItems(
 ): Promise<Map<number, number[]>> {
   if (params.items.length === 0) return new Map();
   const db = sql ?? getDb();
-  return withEntityWriteTransaction(db, (tx) =>
+  const resolved = await withEntityWriteTransaction(db, (tx) =>
     resolveLinksByKind(
       {
         connectorKey: params.connectorKey,
@@ -892,6 +924,7 @@ export async function resolveEventAttributionsForItems(
       tx
     )
   );
+  return resolved.entityIdsByItem;
 }
 
 /**
@@ -912,10 +945,11 @@ async function resolveLinksByKind(
   // A real transaction handle for ALL match/insert/update writes. Public entry
   // points either join the caller's tx or open one before reaching this core.
   sql: DbClient
-): Promise<Map<number, number[]>> {
+): Promise<AttributionResolution> {
   const resolvedByItem = new Map<number, number[]>();
+  const namedEntityIdsByItem = new Map<number, Map<string, number>>();
   if (Object.keys(params.rulesByKind).length === 0 || params.items.length === 0) {
-    return resolvedByItem;
+    return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
   }
 
   // entities.created_by is NOT NULL; resolve an org owner/admin once per batch
@@ -948,7 +982,9 @@ async function resolveLinksByKind(
       bucket.push({ index, item, link });
     }
   });
-  if (byRule.size === 0) return resolvedByItem;
+  if (byRule.size === 0) {
+    return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
+  }
 
   // Resolve first, then lock every existing entity in one ascending-id pass.
   // Without a global lock order, two connector batches containing the same
@@ -984,13 +1020,30 @@ async function resolveLinksByKind(
     }
   }
 
-  const recordResolved = (index: number, entityId: number): void => {
+  const recordResolved = (
+    index: number,
+    entityId: number,
+    rule: ResolvedEventAttributionRule
+  ): void => {
     const existing = resolvedByItem.get(index);
     if (existing) {
       if (!existing.includes(entityId)) existing.push(entityId);
     } else {
       resolvedByItem.set(index, [entityId]);
     }
+    if (!rule.name) return;
+    let named = namedEntityIdsByItem.get(index);
+    if (!named) {
+      named = new Map();
+      namedEntityIdsByItem.set(index, named);
+    }
+    const previous = named.get(rule.name);
+    if (previous !== undefined && previous !== entityId) {
+      throw new Error(
+        `Attribution name '${rule.name}' resolved to more than one entity for item ${index}`
+      );
+    }
+    named.set(rule.name, entityId);
   };
 
   for (const [rule, entries] of byRule) {
@@ -1123,7 +1176,7 @@ async function resolveLinksByKind(
         isCreate,
       });
 
-      recordResolved(index, entityId);
+      recordResolved(index, entityId, rule);
 
       // Cache the mapping for the rest of the batch — only for attached
       // identifiers, so an identifier that stayed on another entity (ON CONFLICT
@@ -1173,7 +1226,7 @@ async function resolveLinksByKind(
     }
   }
 
-  return resolvedByItem;
+  return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
 }
 
 interface SenderIdentityParams {

--- a/packages/server/src/utils/relationship-claims.ts
+++ b/packages/server/src/utils/relationship-claims.ts
@@ -1,0 +1,530 @@
+/**
+ * Source ownership for ordinary entity relationships.
+ *
+ * A live edge is one graph fact with one or more independent claims. Connector
+ * claims are keyed by the same durable source identity as connector events:
+ * (connection_id, origin_id). Reconciliation removes only that exact claim;
+ * the edge is tombstoned only after its final claim disappears.
+ */
+
+import { type DbClient, pgTextArray } from '../db/client';
+import { ToolUserError } from './errors';
+import { insertEdgeChangeEventInTransaction } from './insert-event';
+import {
+  assertNotAclManagedEdge,
+  canonicalizeSymmetricEdge,
+  validateNoSelfReference,
+  validateTypeRule,
+} from './relationship-validation';
+
+export const RELATIONSHIP_CLAIMS_METADATA_KEY = '_lobu_claims';
+export const MANUAL_RELATIONSHIP_CLAIM_KEY = 'manual';
+
+export interface ConnectorRelationshipDeclaration {
+  type: string;
+  from: string;
+  to: string;
+}
+
+export interface DesiredConnectorRelationship {
+  declaration: ConnectorRelationshipDeclaration;
+  fromEntityId: number;
+  toEntityId: number;
+}
+
+interface ConnectorRelationshipClaim extends Record<string, unknown> {
+  rules: string[];
+}
+
+interface RelationshipTypeRow {
+  id: number | string;
+  slug: string;
+  is_symmetric: boolean;
+  purpose: string | null;
+}
+
+interface ClaimedRelationshipRow {
+  id: number | string;
+  from_entity_id: number | string;
+  to_entity_id: number | string;
+  relationship_type_id: number | string;
+  relationship_type_slug: string | null;
+  relationship_type_purpose?: string | null;
+  metadata: unknown;
+  confidence: number | null;
+  source: string | null;
+  inserted?: boolean;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function connectorRelationshipClaimKey(
+  connectionId: number | string,
+  originId: string
+): string {
+  return `feed:${connectionId}:${originId}`;
+}
+
+function connectorRelationshipClaimPrefix(connectionId: number | string): string {
+  return `feed:${connectionId}:`;
+}
+
+export function relationshipMetadataWithoutClaims(value: unknown): Record<string, unknown> | null {
+  const metadata = record(value);
+  if (!metadata) return null;
+  const { [RELATIONSHIP_CLAIMS_METADATA_KEY]: _claims, ...visible } = metadata;
+  return Object.keys(visible).length > 0 ? visible : null;
+}
+
+function claimsFromMetadata(value: unknown): Record<string, unknown> | null {
+  const metadata = record(value);
+  return record(metadata?.[RELATIONSHIP_CLAIMS_METADATA_KEY]);
+}
+
+export function assertManualRelationshipMutationAllowed(
+  row: { id: number | string; metadata: unknown },
+  action: string
+): void {
+  const claims = claimsFromMetadata(row.metadata);
+  if (!claims) throw migrationRequired(row);
+  if (!Object.hasOwn(claims, MANUAL_RELATIONSHIP_CLAIM_KEY)) {
+    throw new ToolUserError(
+      `Relationship ${row.id} is source-managed and cannot be ${action} manually. ` +
+        'Change or remove it through the connector that owns its remaining claims.',
+      409
+    );
+  }
+}
+
+export function assertNoReservedRelationshipMetadata(metadata: unknown): void {
+  if (record(metadata) && Object.hasOwn(metadata as object, RELATIONSHIP_CLAIMS_METADATA_KEY)) {
+    throw new ToolUserError(
+      `Metadata key '${RELATIONSHIP_CLAIMS_METADATA_KEY}' is reserved for relationship ownership.`,
+      400
+    );
+  }
+}
+
+function migrationRequired(row: { id: number | string }): ToolUserError {
+  return new ToolUserError(
+    `Relationship ${row.id} has no ${RELATIONSHIP_CLAIMS_METADATA_KEY} ownership metadata. ` +
+      'Migrate the relationship to a manual or source claim before connector ingestion.',
+    409
+  );
+}
+
+async function lockOrganization(tx: DbClient, organizationId: string): Promise<void> {
+  const rows = await tx`
+    SELECT 1 FROM organization
+    WHERE id = ${organizationId}
+    FOR KEY SHARE
+  `;
+  if (rows.length === 0) throw new ToolUserError('Organization not found', 404);
+}
+
+async function lockLiveConnection(
+  tx: DbClient,
+  organizationId: string,
+  connectionId: number
+): Promise<void> {
+  const rows = await tx`
+    SELECT 1 FROM connections
+    WHERE id = ${connectionId}
+      AND organization_id = ${organizationId}
+      AND deleted_at IS NULL
+    FOR SHARE
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(`Connection ${connectionId} is not active`, 409);
+  }
+}
+
+async function assertRelationshipClaim(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    fromEntityId: number;
+    toEntityId: number;
+    relationshipTypeId: number;
+    relationshipTypeSlug: string;
+    claimKey: string;
+    claim: Record<string, unknown>;
+    source: string;
+    confidence?: number | null;
+    createdBy?: string | null;
+    clientId?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }
+): Promise<{ id: number; inserted: boolean; claimAdded: boolean }> {
+  const initialMetadata = {
+    ...(params.metadata ?? {}),
+    [RELATIONSHIP_CLAIMS_METADATA_KEY]: { [params.claimKey]: params.claim },
+  };
+  const written = await tx<ClaimedRelationshipRow>`
+    INSERT INTO entity_relationships (
+      organization_id, from_entity_id, to_entity_id, relationship_type_id,
+      metadata, confidence, source, created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      ${params.organizationId}, ${params.fromEntityId}, ${params.toEntityId},
+      ${params.relationshipTypeId}, ${tx.json(initialMetadata)},
+      ${params.confidence ?? null}, ${params.source}, ${params.createdBy ?? null},
+      ${params.createdBy ?? null}, current_timestamp, current_timestamp
+    )
+    ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
+      WHERE deleted_at IS NULL
+    DO UPDATE SET
+      metadata = jsonb_set(
+        COALESCE(entity_relationships.metadata, '{}'::jsonb),
+        '{_lobu_claims}',
+        (entity_relationships.metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY})
+          || jsonb_build_object(${params.claimKey}::text, ${tx.json(params.claim)}::jsonb),
+        true
+      ),
+      updated_at = current_timestamp
+    WHERE entity_relationships.metadata ? ${RELATIONSHIP_CLAIMS_METADATA_KEY}
+      AND entity_relationships.metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY} -> ${params.claimKey}
+          IS DISTINCT FROM ${tx.json(params.claim)}::jsonb
+    RETURNING id, from_entity_id, to_entity_id, relationship_type_id,
+              metadata, confidence, source, (xmax = 0) AS inserted
+  `;
+
+  let row = written[0];
+  if (!row) {
+    const existing = await tx<ClaimedRelationshipRow>`
+      SELECT id, from_entity_id, to_entity_id, relationship_type_id,
+             metadata, confidence, source
+      FROM entity_relationships
+      WHERE organization_id = ${params.organizationId}
+        AND from_entity_id = ${params.fromEntityId}
+        AND to_entity_id = ${params.toEntityId}
+        AND relationship_type_id = ${params.relationshipTypeId}
+        AND deleted_at IS NULL
+      LIMIT 1
+      FOR UPDATE
+    `;
+    row = existing[0];
+    if (!row) throw new Error('Relationship claim upsert returned no live relationship');
+    const claims = claimsFromMetadata(row.metadata);
+    if (!claims) throw migrationRequired(row);
+    if (!Object.hasOwn(claims, params.claimKey)) {
+      throw new Error(`Relationship ${row.id} did not persist claim '${params.claimKey}'`);
+    }
+    return { id: Number(row.id), inserted: false, claimAdded: false };
+  }
+
+  const inserted = row.inserted === true;
+  if (inserted) {
+    await insertEdgeChangeEventInTransaction(
+      {
+        organizationId: params.organizationId,
+        relationshipId: Number(row.id),
+        fromEntityId: params.fromEntityId,
+        toEntityId: params.toEntityId,
+        relationshipTypeId: params.relationshipTypeId,
+        relationshipTypeSlug: params.relationshipTypeSlug,
+        op: 'link',
+        changes: [
+          { field: 'exists', old: false, new: true },
+          { field: 'metadata', old: null, new: params.metadata ?? null },
+          { field: 'confidence', old: null, new: params.confidence ?? null },
+          { field: 'source', old: null, new: params.source },
+        ],
+        createdBy: params.createdBy ?? null,
+        clientId: params.clientId ?? null,
+      },
+      tx
+    );
+  }
+  return { id: Number(row.id), inserted, claimAdded: true };
+}
+
+/** Add the caller-owned claim to a manual relationship assertion. */
+export async function assertManualRelationshipClaim(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    fromEntityId: number;
+    toEntityId: number;
+    relationshipTypeId: number;
+    relationshipTypeSlug: string;
+    source: string;
+    confidence?: number | null;
+    createdBy?: string | null;
+    clientId?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }
+): Promise<{ id: number; inserted: boolean; claimAdded: boolean }> {
+  await lockOrganization(tx, params.organizationId);
+  return assertRelationshipClaim(tx, {
+    ...params,
+    claimKey: MANUAL_RELATIONSHIP_CLAIM_KEY,
+    claim: {},
+  });
+}
+
+async function retractLockedRelationshipClaim(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    claimKey: string;
+    row: ClaimedRelationshipRow;
+    updatedBy?: string | null;
+    clientId?: string | null;
+  }
+): Promise<{ relationshipRemoved: boolean }> {
+  const claims = claimsFromMetadata(params.row.metadata);
+  if (!claims) throw migrationRequired(params.row);
+  if (!Object.hasOwn(claims, params.claimKey)) {
+    throw new Error(`Relationship ${params.row.id} does not carry claim '${params.claimKey}'`);
+  }
+  const relationshipId = Number(params.row.id);
+  const remainingClaims = Object.keys(claims).filter((key) => key !== params.claimKey);
+  if (remainingClaims.length > 0) {
+    await tx`
+      UPDATE entity_relationships
+      SET metadata = jsonb_set(
+            metadata,
+            '{_lobu_claims}',
+            (metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY}) - ${params.claimKey},
+            true
+          ),
+          updated_by = COALESCE(${params.updatedBy ?? null}, updated_by),
+          updated_at = current_timestamp
+      WHERE id = ${relationshipId} AND deleted_at IS NULL
+    `;
+    return { relationshipRemoved: false };
+  }
+
+  await tx`
+    UPDATE entity_relationships
+    SET deleted_at = current_timestamp,
+        updated_by = COALESCE(${params.updatedBy ?? null}, updated_by),
+        updated_at = current_timestamp
+    WHERE id = ${relationshipId} AND deleted_at IS NULL
+  `;
+  await insertEdgeChangeEventInTransaction(
+    {
+      organizationId: params.organizationId,
+      relationshipId,
+      fromEntityId: Number(params.row.from_entity_id),
+      toEntityId: Number(params.row.to_entity_id),
+      relationshipTypeId: Number(params.row.relationship_type_id),
+      relationshipTypeSlug: params.row.relationship_type_slug,
+      op: 'unlink',
+      changes: [
+        { field: 'exists', old: true, new: false },
+        {
+          field: 'metadata',
+          old: relationshipMetadataWithoutClaims(params.row.metadata),
+          new: null,
+        },
+        { field: 'confidence', old: params.row.confidence, new: null },
+        { field: 'source', old: params.row.source, new: null },
+      ],
+      createdBy: params.updatedBy ?? null,
+      clientId: params.clientId ?? null,
+    },
+    tx
+  );
+  return { relationshipRemoved: true };
+}
+
+/** Remove only the manual claim; retain a source-claimed edge. */
+export async function retractManualRelationshipClaim(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    relationshipId: number;
+    updatedBy?: string | null;
+    clientId?: string | null;
+  }
+): Promise<{ relationshipRemoved: boolean }> {
+  await lockOrganization(tx, params.organizationId);
+  const rows = await tx<ClaimedRelationshipRow>`
+    SELECT r.id, r.from_entity_id, r.to_entity_id, r.relationship_type_id,
+           rt.slug AS relationship_type_slug, rt.purpose AS relationship_type_purpose,
+           r.metadata, r.confidence, r.source
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.id = ${params.relationshipId}
+      AND r.organization_id = ${params.organizationId}
+      AND r.deleted_at IS NULL
+    LIMIT 1
+    FOR UPDATE OF r
+  `;
+  const row = rows[0];
+  if (!row) throw new ToolUserError(`Relationship ${params.relationshipId} not found`, 404);
+  assertNotAclManagedEdge(
+    { slug: row.relationship_type_slug, purpose: row.relationship_type_purpose },
+    'unlink'
+  );
+  assertManualRelationshipMutationAllowed(row, 'unlinked');
+  return retractLockedRelationshipClaim(tx, {
+    organizationId: params.organizationId,
+    claimKey: MANUAL_RELATIONSHIP_CLAIM_KEY,
+    row,
+    updatedBy: params.updatedBy,
+    clientId: params.clientId,
+  });
+}
+
+async function retractRelationshipClaimExcept(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    claimKey: string;
+    keepRelationshipIds: ReadonlySet<number>;
+  }
+): Promise<void> {
+  const rows = await tx<ClaimedRelationshipRow>`
+    SELECT r.id, r.from_entity_id, r.to_entity_id, r.relationship_type_id,
+           rt.slug AS relationship_type_slug, r.metadata, r.confidence, r.source
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${params.organizationId}
+      AND r.deleted_at IS NULL
+      AND r.metadata ? ${RELATIONSHIP_CLAIMS_METADATA_KEY}
+      AND (r.metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY}) ? ${params.claimKey}
+    ORDER BY r.id
+    FOR UPDATE OF r
+  `;
+
+  for (const row of rows) {
+    if (params.keepRelationshipIds.has(Number(row.id))) continue;
+    await retractLockedRelationshipClaim(tx, {
+      organizationId: params.organizationId,
+      claimKey: params.claimKey,
+      row,
+    });
+  }
+}
+
+/** Reconcile one connector event's complete declared relationship set. */
+export async function reconcileConnectorRelationshipClaims(
+  tx: DbClient,
+  params: {
+    organizationId: string;
+    connectionId: number;
+    originId: string;
+    desired: DesiredConnectorRelationship[];
+  }
+): Promise<void> {
+  await lockOrganization(tx, params.organizationId);
+  await lockLiveConnection(tx, params.organizationId, params.connectionId);
+
+  const typeSlugs = [...new Set(params.desired.map((edge) => edge.declaration.type))];
+  const typeRows =
+    typeSlugs.length === 0
+      ? []
+      : await tx<RelationshipTypeRow>`
+          SELECT id, slug, is_symmetric, purpose
+          FROM entity_relationship_types
+          WHERE organization_id = ${params.organizationId}
+            AND slug = ANY(${pgTextArray(typeSlugs)}::text[])
+            AND status = 'active'
+            AND deleted_at IS NULL
+        `;
+  const typeBySlug = new Map(typeRows.map((row) => [row.slug, row]));
+  for (const slug of typeSlugs) {
+    const type = typeBySlug.get(slug);
+    if (!type) {
+      throw new ToolUserError(`Connector relationship type '${slug}' is not active`, 409);
+    }
+    assertNotAclManagedEdge(type, 'connector relationship materialization');
+  }
+
+  const aggregated = new Map<
+    string,
+    {
+      fromEntityId: number;
+      toEntityId: number;
+      relationshipTypeId: number;
+      relationshipTypeSlug: string;
+      rules: Set<string>;
+    }
+  >();
+  for (const desired of params.desired) {
+    const type = typeBySlug.get(desired.declaration.type)!;
+    validateNoSelfReference(desired.fromEntityId, desired.toEntityId);
+    await validateTypeRule(
+      Number(type.id),
+      desired.fromEntityId,
+      desired.toEntityId,
+      tx
+    );
+    const endpoints = type.is_symmetric
+      ? canonicalizeSymmetricEdge(desired.fromEntityId, desired.toEntityId)
+      : { from: desired.fromEntityId, to: desired.toEntityId };
+    const key = `${endpoints.from}:${endpoints.to}:${type.id}`;
+    const declarationKey = `${desired.declaration.type}:${desired.declaration.from}->${desired.declaration.to}`;
+    const current = aggregated.get(key);
+    if (current) {
+      current.rules.add(declarationKey);
+    } else {
+      aggregated.set(key, {
+        fromEntityId: endpoints.from,
+        toEntityId: endpoints.to,
+        relationshipTypeId: Number(type.id),
+        relationshipTypeSlug: type.slug,
+        rules: new Set([declarationKey]),
+      });
+    }
+  }
+
+  const claimKey = connectorRelationshipClaimKey(params.connectionId, params.originId);
+  const keepRelationshipIds = new Set<number>();
+  for (const edge of aggregated.values()) {
+    const claim: ConnectorRelationshipClaim = {
+      rules: [...edge.rules].sort(),
+    };
+    const asserted = await assertRelationshipClaim(tx, {
+      organizationId: params.organizationId,
+      fromEntityId: edge.fromEntityId,
+      toEntityId: edge.toEntityId,
+      relationshipTypeId: edge.relationshipTypeId,
+      relationshipTypeSlug: edge.relationshipTypeSlug,
+      claimKey,
+      claim,
+      source: 'feed',
+    });
+    keepRelationshipIds.add(asserted.id);
+  }
+
+  await retractRelationshipClaimExcept(tx, {
+    organizationId: params.organizationId,
+    claimKey,
+    keepRelationshipIds,
+  });
+}
+
+/** Remove every connector-event claim owned by a connection. */
+export async function retractConnectionRelationshipClaims(
+  tx: DbClient,
+  params: { organizationId: string; connectionId: number | string }
+): Promise<void> {
+  await lockOrganization(tx, params.organizationId);
+  const prefix = connectorRelationshipClaimPrefix(params.connectionId);
+  const keys = await tx<{ claim_key: string }>`
+    SELECT DISTINCT claim.key AS claim_key
+    FROM entity_relationships r
+    CROSS JOIN LATERAL jsonb_object_keys(
+      COALESCE(r.metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY}, '{}'::jsonb)
+    ) AS claim(key)
+    WHERE r.organization_id = ${params.organizationId}
+      AND r.deleted_at IS NULL
+      AND left(claim.key, length(${prefix})) = ${prefix}
+    ORDER BY claim.key
+  `;
+
+  for (const row of keys) {
+    await retractRelationshipClaimExcept(tx, {
+      organizationId: params.organizationId,
+      claimKey: row.claim_key,
+      keepRelationshipIds: new Set(),
+    });
+  }
+}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -59,6 +59,7 @@ import {
 } from "../utils/inline-attachments";
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
+import { reconcileConnectorRelationshipClaims } from "../utils/relationship-claims";
 import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import {
 	isBrowserConnectorKey,
@@ -378,7 +379,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			// Runs on a dry run too, against `db`: it creates entity rows, and those
 			// roll back with everything else. Running it is what makes the inserts
 			// below realistic — events carry the entity ids it resolves.
-			await applyEventAttributions(
+			const appliedAttributions = await applyEventAttributions(
 				{
 					connectorKey: run.connector_key,
 					connectionId: run.connection_id,
@@ -418,7 +419,8 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 				);
 			}
 
-			for (let item of batch.items) {
+			for (const [itemIndex, batchItem] of batch.items.entries()) {
+				let item = batchItem;
 				const sourceOriginId = browserSourceOriginIds.get(item);
 				let publishedArtifactIds: string[] = [];
 				let artifactCommitted = false;
@@ -532,6 +534,32 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 						// (connection_id, origin_id) across replicas.
 						sql: isDry ? db : undefined,
 						afterPersist: async (persisted, tx) => {
+							const relationshipDeclarations =
+								appliedAttributions.relationshipsByKind[
+									itemOriginType ?? itemSemanticType
+								] ?? [];
+							if (relationshipDeclarations.length > 0) {
+								if (run.connection_id == null) {
+									throw new Error(
+										"Connector-declared relationships require a source connection",
+									);
+								}
+								const named =
+									appliedAttributions.namedEntityIdsByItem.get(itemIndex) ??
+									new Map<string, number>();
+								await reconcileConnectorRelationshipClaims(tx, {
+									organizationId: run.organization_id,
+									connectionId: run.connection_id,
+									originId: persisted.origin_id,
+									desired: relationshipDeclarations.flatMap((declaration) => {
+										const fromEntityId = named.get(declaration.from);
+										const toEntityId = named.get(declaration.to);
+										return fromEntityId === undefined || toEntityId === undefined
+											? []
+											: [{ declaration, fromEntityId, toEntityId }];
+									}),
+								});
+							}
 							const drafts = item.automation_signals ?? [];
 							if (drafts.length > 0) {
 								for (const [draftIndex, draft] of drafts.entries()) {


### PR DESCRIPTION
Addresses #2857 with the simplified clean-cutover runtime agreed in review.

## Summary
- materialize connector-declared relationships from named event attributions in the event transaction
- track independent manual and per-source connector claims so shared graph facts survive partial retraction
- clean connector claims on connection removal and hide ownership metadata from the public relationship surface
- use a clean cutover: unclaimed collisions fail with an explicit migration-required error; no legacy backfill

## Intentional scope
- no public connector API change
- connector claim identity is feed:<connectionId>:<originId>; rule declarations remain claim metadata
- no legacy baseline claim or compatibility path; existing unclaimed data must be migrated manually
- declaration removal is reconciled when each origin is emitted again, or when its connection is removed; this PR does not add a connector-definition apply sweep
- no whole-feed absence inference

## Validation
- make pre-pr
- server typecheck and migration lint
- connector ingestion E2E and relationship concurrency/cutover tests
- edge history, source vocabulary, and connection deletion atomicity regression suites
- GitHub CI: 26 successful, 0 failing on 31b4eb503

The protected Claude semantic-review process is currently account-rate-limited; the gate remains fail-closed and has not been bypassed.