### PR TITLE
fix: auto-pause repeatedly failing automations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ DASHSCOPE_API_KEY=
 # Execution timeout in minutes (default: 10)
 TIMEOUT_MINUTES=10
 
+# Hard-pause a schedule after this many consecutive executed scheduled runs
+# fail or time out. A successful window or cadence change resets it (default: 5).
+AUTOMATION_PAUSE_AFTER_CONSECUTIVE_FAILURES=5
+
 # Comma-separated list of additional allowed tools (optional)
 ALLOWED_TOOLS=
 

--- a/db/migrations/20260827211500_automation_schedule_auto_pause.sql
+++ b/db/migrations/20260827211500_automation_schedule_auto_pause.sql
@@ -1,0 +1,39 @@
+-- migrate:up
+-- lobu:no-quiesce
+
+-- Operational cost: not timed against a production-sized automations table.
+-- Both columns are metadata-only additions on supported Postgres versions;
+-- installing the row trigger takes a brief ACCESS EXCLUSIVE metadata lock and
+-- does not scan or rewrite existing rows.
+ALTER TABLE public.automations
+  -- squawk-ignore prefer-bigint-over-int -- bounded circuit-breaker counter (default threshold 5), never an accumulating identifier
+  ADD COLUMN IF NOT EXISTS consecutive_scheduled_failures integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS schedule_auto_paused_at timestamptz;
+
+CREATE OR REPLACE FUNCTION public.automations_enforce_schedule_auto_pause()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.schedule_auto_paused_at IS NOT NULL THEN
+    NEW.next_run_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_automations_enforce_schedule_auto_pause
+  ON public.automations;
+CREATE TRIGGER trg_automations_enforce_schedule_auto_pause
+  BEFORE INSERT OR UPDATE OF next_run_at, schedule_auto_paused_at
+  ON public.automations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.automations_enforce_schedule_auto_pause();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_automations_enforce_schedule_auto_pause
+  ON public.automations;
+DROP FUNCTION IF EXISTS public.automations_enforce_schedule_auto_pause();
+
+ALTER TABLE public.automations
+  DROP COLUMN IF EXISTS schedule_auto_paused_at,
+  DROP COLUMN IF EXISTS consecutive_scheduled_failures;

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -33,6 +33,15 @@ not advance it, so the same period remains visible in `pending_analysis` and can
 be attempted again. Backlog counts and `gaps` therefore include completed periods
 that have not yet materialized as run results.
 
+Repeated execution failures are bounded by a schedule circuit breaker. After
+`AUTOMATION_PAUSE_AFTER_CONSECUTIVE_FAILURES` consecutive scheduled runs fail or
+time out (default five), Lobu keeps the Automation active but stamps
+`schedule_auto_paused_at` and clears `next_run_at`. Event, eval, manual,
+dispatch-only, cancelled, and never-executed runs do not increment the counter.
+A successful scheduled or manual window, or a real schedule/timezone change,
+clears the failure state and resumes the cursor. A scheduled notification sweep
+durably notifies workspace admins and owners once per pause generation.
+
 `pending_analysis.pending_period_count` is the explicit logical-window backlog;
 `unprocessed_count` carries the same missing-period value for existing clients.
 `unprocessed_content_count` separately counts source items not linked to a

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5147,6 +5147,8 @@ export type GetAutomationResponses = {
           }
       >;
       next_run_at?: string | null;
+      consecutive_scheduled_failures?: number;
+      schedule_auto_paused_at?: string | null;
       agent_id?: string | null;
       delivery_target?: {
         /**

--- a/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/automation-health-surfacing.test.ts
@@ -141,6 +141,44 @@ describe("automation health surfacing (#2033)", () => {
     expect(row?.health).toBe("healthy");
   });
 
+  it("3.1 (integration): list and detail surface a durable schedule auto-pause", async () => {
+    const { automationId, ctx } = await createScheduledAutomation();
+    const sql = getTestDb();
+    await sql`
+      UPDATE automations
+      SET consecutive_scheduled_failures = 5,
+          schedule_auto_paused_at = date_trunc('milliseconds', current_timestamp)
+      WHERE id = ${automationId}
+    `;
+
+    const result = await manageAutomations({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.automations.find(
+      (automation) =>
+        String((automation as { automation_id?: unknown }).automation_id) ===
+        String(automationId),
+    ) as Record<string, unknown> | undefined;
+    expect(row?.next_run_at).toBeNull();
+    expect(Number(row?.consecutive_scheduled_failures)).toBe(5);
+    expect(row?.schedule_auto_paused_at).not.toBeNull();
+    expect(row?.health).toBe("degraded");
+    expect((row?.health_reasons as string[] | undefined)?.[0]).toBe(
+      "schedule auto-paused after 5 consecutive execution failures",
+    );
+
+    const detail = await getAutomation(
+      { automation_id: String(automationId) },
+      {} as Env,
+      ctx,
+    );
+    expect(detail.automation?.next_run_at).toBeNull();
+    expect(detail.automation?.consecutive_scheduled_failures).toBe(5);
+    expect(detail.automation?.schedule_auto_paused_at).not.toBeNull();
+    expect(detail.automation?.health_reasons?.[0]).toBe(
+      "schedule auto-paused after 5 consecutive execution failures",
+    );
+  });
+
   it("3.1 (integration): a failed latest run degrades an on-schedule automation", async () => {
     const { automationId, ctx } = await createScheduledAutomation();
     const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/automations/auto-pause-notifications.test.ts
+++ b/packages/server/src/__tests__/integration/automations/auto-pause-notifications.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	automationAutoPauseNotificationKey,
+	runAutomationAutoPauseNotificationSweep,
+} from "../../../automations/auto-pause-notifications";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+async function createScheduledAutomation(name: string) {
+	const workspace = await TestWorkspace.create({ name: `${name} workspace` });
+	const entity = await createTestEntity({
+		name: `${name} entity`,
+		organization_id: workspace.org.id,
+		created_by: workspace.users.owner.id,
+	});
+	const agent = await createTestAgent({
+		organizationId: workspace.org.id,
+		ownerUserId: workspace.users.owner.id,
+		agentId: `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-agent`,
+		name: `${name} agent`,
+	});
+	const created = (await workspace.owner.automations.create({
+		entity_id: entity.id,
+		slug: `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-automation`,
+		name,
+		prompt: "Run the scheduled task.",
+		triggers: [{ kind: "schedule", cron: "0 * * * *" }],
+		agent_id: agent.agentId,
+	})) as { automation_id: string };
+	return {
+		workspace,
+		automationId: Number(created.automation_id),
+	};
+}
+
+describe("Automation schedule auto-pause notifications", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("delivers once per pause generation to every admin/owner", async () => {
+		const { workspace, automationId } =
+			await createScheduledAutomation("Notification pause");
+		const sql = getTestDb();
+		const firstPause = new Date("2026-08-27T12:00:00.000Z");
+		await sql`
+			UPDATE automations
+			SET consecutive_scheduled_failures = 5,
+				schedule_auto_paused_at = ${firstPause}::timestamptz
+			WHERE id = ${automationId}
+		`;
+
+		expect(await runAutomationAutoPauseNotificationSweep()).toEqual({
+			scanned: 1,
+			attempted: 1,
+			created: 1,
+			errors: 0,
+		});
+		expect(await runAutomationAutoPauseNotificationSweep()).toEqual({
+			scanned: 0,
+			attempted: 0,
+			created: 0,
+			errors: 0,
+		});
+
+		const firstKey = automationAutoPauseNotificationKey(
+			automationId,
+			firstPause,
+		);
+		const firstEvents = await sql`
+			SELECT
+				e.id,
+				e.title,
+				e.metadata,
+				to_jsonb(array_agg(t.user_id ORDER BY t.user_id)) AS target_user_ids
+			FROM events e
+			JOIN notification_targets t ON t.event_id = e.id
+			WHERE e.organization_id = ${workspace.org.id}
+			  AND e.metadata->>'_lobu_idempotency_key' = ${firstKey}
+			GROUP BY e.id, e.title, e.metadata
+		`;
+		expect(firstEvents).toHaveLength(1);
+		expect(firstEvents[0]?.title).toBe(
+			'Automation "Notification pause" was auto-paused',
+		);
+		expect(firstEvents[0]?.target_user_ids).toEqual(
+			[workspace.users.admin.id, workspace.users.owner.id].sort(),
+		);
+		expect(firstEvents[0]?.metadata).toMatchObject({
+			notification_type: "generic",
+			resource_type: "automation",
+			resource_id: String(automationId),
+		});
+
+		const secondPause = new Date("2026-08-27T13:00:00.000Z");
+		await sql`
+			UPDATE automations
+			SET schedule_auto_paused_at = NULL,
+				consecutive_scheduled_failures = 0,
+				next_run_at = current_timestamp + interval '1 hour'
+			WHERE id = ${automationId}
+		`;
+		await sql`
+			UPDATE automations
+			SET consecutive_scheduled_failures = 5,
+				schedule_auto_paused_at = ${secondPause}::timestamptz
+			WHERE id = ${automationId}
+		`;
+		expect((await runAutomationAutoPauseNotificationSweep()).created).toBe(1);
+
+		const notificationCount = await sql`
+			SELECT id FROM events
+			WHERE organization_id = ${workspace.org.id}
+			  AND metadata->>'resource_type' = 'automation'
+			  AND metadata->>'resource_id' = ${String(automationId)}
+			  AND metadata ? '_lobu_idempotency_key'
+		`;
+		expect(notificationCount).toHaveLength(2);
+	});
+
+	it("does not let an organization without admins occupy the bounded window", async () => {
+		const undeliverable = await createScheduledAutomation("No admin pause");
+		const deliverable = await createScheduledAutomation("Deliverable pause");
+		const sql = getTestDb();
+		await sql`
+			UPDATE "member" SET role = 'member'
+			WHERE "organizationId" = ${undeliverable.workspace.org.id}
+		`;
+		await sql`
+			UPDATE automations
+			SET consecutive_scheduled_failures = 5,
+				schedule_auto_paused_at = CASE id
+					WHEN ${undeliverable.automationId} THEN '2026-08-27T11:00:00.000Z'::timestamptz
+					ELSE '2026-08-27T12:00:00.000Z'::timestamptz
+				END
+			WHERE id IN (${undeliverable.automationId}, ${deliverable.automationId})
+		`;
+
+		const result = await runAutomationAutoPauseNotificationSweep({ limit: 1 });
+		expect(result).toEqual({
+			scanned: 1,
+			attempted: 1,
+			created: 1,
+			errors: 0,
+		});
+		const [event] = await sql`
+			SELECT organization_id, metadata->>'resource_id' AS resource_id
+			FROM events
+			WHERE metadata ? '_lobu_idempotency_key'
+			  AND metadata->>'resource_type' = 'automation'
+		`;
+		expect(event.organization_id).toBe(deliverable.workspace.org.id);
+		expect(event.resource_id).toBe(String(deliverable.automationId));
+	});
+});

--- a/packages/server/src/__tests__/integration/automations/auto-pause-notifications.test.ts
+++ b/packages/server/src/__tests__/integration/automations/auto-pause-notifications.test.ts
@@ -84,7 +84,9 @@ describe("Automation schedule auto-pause notifications", () => {
 		expect(firstEvents[0]?.title).toBe(
 			'Automation "Notification pause" was auto-paused',
 		);
-		expect(firstEvents[0]?.target_user_ids).toEqual(
+		expect(
+			[...(firstEvents[0]?.target_user_ids as string[])].sort(),
+		).toEqual(
 			[workspace.users.admin.id, workspace.users.owner.id].sort(),
 		);
 		expect(firstEvents[0]?.metadata).toMatchObject({

--- a/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
@@ -440,7 +440,7 @@ describe("automation contract", () => {
 		);
 	});
 
-	it("links the exact signed content IDs without re-running automation sources", async () => {
+	it("links exact signed content IDs and a successful manual window resumes an auto-pause", async () => {
 		const { sql, workspace, api, entityId, automationId } =
 			await createAutomatedAutomation();
 
@@ -460,6 +460,12 @@ describe("automation contract", () => {
 			windowEnd,
 			dispatchSource: "manual",
 		});
+		await sql`
+      UPDATE automations
+      SET consecutive_scheduled_failures = 5,
+          schedule_auto_paused_at = date_trunc('milliseconds', current_timestamp)
+      WHERE id = ${automationId}
+    `;
 		const windowToken = await generateWindowToken(
 			{
 				automation_id: automationId,
@@ -494,6 +500,13 @@ describe("automation contract", () => {
 		expect(completion.content_linked).toBe(1);
 		expect(Number(completedRun.content_analyzed)).toBe(1);
 		expect(links.map((row) => Number(row.event_id))).toEqual([event.id]);
+		const [recovered] = await sql`
+      SELECT consecutive_scheduled_failures, schedule_auto_paused_at, next_run_at
+      FROM automations WHERE id = ${automationId}
+    `;
+		expect(Number(recovered.consecutive_scheduled_failures)).toBe(0);
+		expect(recovered.schedule_auto_paused_at).toBeNull();
+		expect(recovered.next_run_at).not.toBeNull();
 	});
 
 	// #798 — device-pinned automation execution end-to-end:
@@ -1045,7 +1058,7 @@ describe("automation contract", () => {
 				agentId: agent.agentId,
 				windowStart: windowStart.toISOString(),
 				windowEnd: windowEnd.toISOString(),
-				dispatchSource: "scheduled",
+				dispatchSource: "event",
 				deviceWorkerId: "77777777-7777-7777-7777-777777777777",
 				agentKind: "claude-code",
 			});
@@ -1058,6 +1071,11 @@ describe("automation contract", () => {
               '{trigger_execution}', '"turn"'::jsonb
             )
         WHERE id = ${queued.runId}
+      `;
+			await sql`
+        UPDATE automations
+        SET consecutive_scheduled_failures = 3
+        WHERE id = ${automationId}
       `;
 
 			// Token-auth workers are trusted at the HTTP authorization layer, so the
@@ -1119,6 +1137,11 @@ describe("automation contract", () => {
 			expect(String(run.exit_reason)).toBe("ok");
 			expect(String(run.model_used)).toBe("device-cli:claude-code");
 			expect(Number(run.execution_time_ms)).toBe(40);
+			const [automation] = await sql`
+        SELECT consecutive_scheduled_failures
+        FROM automations WHERE id = ${automationId}
+      `;
+			expect(Number(automation.consecutive_scheduled_failures)).toBe(3);
 
 
 			// A duplicate report is a no-op ack, not a second completion.
@@ -1389,8 +1412,12 @@ describe("automation contract", () => {
 			);
 
 			const [afterFirst] =
-				await sql`SELECT next_run_at FROM automations WHERE id = ${automationId}`;
+				await sql`
+          SELECT next_run_at, consecutive_scheduled_failures
+          FROM automations WHERE id = ${automationId}
+        `;
 			const advancedOnce = new Date(afterFirst.next_run_at as string).getTime();
+			expect(Number(afterFirst.consecutive_scheduled_failures)).toBe(1);
 
 			// Second report acks the terminal state; no extra side effects.
 			const second = await post(
@@ -1408,10 +1435,14 @@ describe("automation contract", () => {
 			expect(secondJson.idempotent).toBe(true);
 
 			const [afterSecond] =
-				await sql`SELECT next_run_at FROM automations WHERE id = ${automationId}`;
+				await sql`
+          SELECT next_run_at, consecutive_scheduled_failures
+          FROM automations WHERE id = ${automationId}
+        `;
 			expect(new Date(afterSecond.next_run_at as string).getTime()).toBe(
 				advancedOnce
 			);
+			expect(Number(afterSecond.consecutive_scheduled_failures)).toBe(1);
 
 		});
 

--- a/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
@@ -187,6 +187,86 @@ describe('automation CRUD', () => {
     expect(versionReset.last_completed_window_start).toBeNull();
   });
 
+  it('resets an auto-pause only for a real cadence change', async () => {
+    const sql = getTestDb();
+    const created = (await owner.automations.create({
+      entity_id: entityId,
+      slug: 'schedule-auto-pause-reset-contract',
+      prompt: 'Track the scheduled period.',
+      triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+      agent_id: agentId,
+    })) as { automation_id: string };
+    const pauseAt = new Date('2026-08-27T12:00:00.000Z');
+    await sql`
+      UPDATE automations
+      SET consecutive_scheduled_failures = 5,
+          schedule_auto_paused_at = ${pauseAt}::timestamptz
+      WHERE id = ${created.automation_id}
+    `;
+
+    // Resending byte-identical triggers may still re-anchor the legacy cursor,
+    // but it is not operator recovery and must not clear the circuit breaker.
+    await owner.automations.update({
+      automation_id: created.automation_id,
+      triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+    });
+    let [state] = await sql`
+      SELECT next_run_at, consecutive_scheduled_failures, schedule_auto_paused_at
+      FROM automations WHERE id = ${created.automation_id}
+    `;
+    expect(state.next_run_at).toBeNull();
+    expect(Number(state.consecutive_scheduled_failures)).toBe(5);
+    expect(new Date(state.schedule_auto_paused_at as string).toISOString()).toBe(
+      pauseAt.toISOString(),
+    );
+
+    // A prompt-only version is definition history, not schedule recovery.
+    await owner.automations.createVersion({
+      automation_id: created.automation_id,
+      prompt: 'Track the scheduled period with clearer instructions.',
+    });
+    [state] = await sql`
+      SELECT next_run_at, consecutive_scheduled_failures, schedule_auto_paused_at
+      FROM automations WHERE id = ${created.automation_id}
+    `;
+    expect(state.next_run_at).toBeNull();
+    expect(Number(state.consecutive_scheduled_failures)).toBe(5);
+    expect(new Date(state.schedule_auto_paused_at as string).toISOString()).toBe(
+      pauseAt.toISOString(),
+    );
+
+    await owner.automations.update({
+      automation_id: created.automation_id,
+      triggers: [{ kind: 'schedule', cron: '0 10 * * *' }],
+    });
+    [state] = await sql`
+      SELECT next_run_at, consecutive_scheduled_failures, schedule_auto_paused_at
+      FROM automations WHERE id = ${created.automation_id}
+    `;
+    expect(state.next_run_at).not.toBeNull();
+    expect(Number(state.consecutive_scheduled_failures)).toBe(0);
+    expect(state.schedule_auto_paused_at).toBeNull();
+
+    await sql`
+      UPDATE automations
+      SET consecutive_scheduled_failures = 5,
+          schedule_auto_paused_at = ${pauseAt}::timestamptz
+      WHERE id = ${created.automation_id}
+    `;
+    await owner.automations.createVersion({
+      automation_id: created.automation_id,
+      prompt: 'Track the rescheduled period.',
+      triggers: [{ kind: 'schedule', cron: '0 11 * * *' }],
+    });
+    [state] = await sql`
+      SELECT next_run_at, consecutive_scheduled_failures, schedule_auto_paused_at
+      FROM automations WHERE id = ${created.automation_id}
+    `;
+    expect(state.next_run_at).not.toBeNull();
+    expect(Number(state.consecutive_scheduled_failures)).toBe(0);
+    expect(state.schedule_auto_paused_at).toBeNull();
+  });
+
   it('creates an automation and its reaction contract atomically', async () => {
     const sql = getTestDb();
     const reaction = `export const input = { type: "object", properties: { merge_proposals: { type: "array" } }, required: ["merge_proposals"] }; export default async function () {}`;

--- a/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
@@ -69,7 +69,13 @@ async function setupDeviceAutomation() {
 		userId,
 		memberRole: "owner",
 	});
-	return { sql, api, automationId, deviceId: device.id };
+	return {
+		sql,
+		api,
+		automationId,
+		deviceId: device.id,
+		organizationId: workspace.org.id,
+	};
 }
 
 async function cursor(sql: ReturnType<typeof getTestDb>, automationId: number) {
@@ -225,6 +231,49 @@ describe("device-pinned scheduled Automation liveness (#2538)", () => {
 			WHERE id = ${deviceId}::uuid
 		`;
 		expect((await materializeDueAutomationRuns({} as Env)).runsCreated).toBe(1);
+	});
+
+	it("counts stale running executions but not claims that never started", async () => {
+		const { sql, automationId, organizationId } =
+			await setupDeviceAutomation();
+
+		const insertStale = async (status: "claimed" | "running") => {
+			await sql`
+				INSERT INTO runs (
+					organization_id, run_type, automation_id, status,
+					claimed_at, claimed_by, created_at, approved_input
+				) VALUES (
+					${organizationId}, 'automation', ${automationId}, ${status},
+					current_timestamp - interval '3 hours', 'stale-device-worker',
+					current_timestamp - interval '3 hours',
+					${sql.json({ dispatch_source: "scheduled" })}
+				)
+			`;
+		};
+
+		await insertStale("claimed");
+		expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(1);
+		let [automation] = await sql`
+			SELECT consecutive_scheduled_failures, schedule_auto_paused_at
+			FROM automations WHERE id = ${automationId}
+		`;
+		expect(Number(automation.consecutive_scheduled_failures)).toBe(0);
+		expect(automation.schedule_auto_paused_at).toBeNull();
+
+		for (let attempt = 1; attempt <= 5; attempt += 1) {
+			await insertStale("running");
+			expect((await sweepStaleAutomationRuns(sql)).timedOut).toBe(1);
+		}
+
+		[automation] = await sql`
+			SELECT status, next_run_at, consecutive_scheduled_failures,
+			       schedule_auto_paused_at
+			FROM automations WHERE id = ${automationId}
+		`;
+		expect(automation.status).toBe("active");
+		expect(automation.next_run_at).toBeNull();
+		expect(Number(automation.consecutive_scheduled_failures)).toBe(5);
+		expect(automation.schedule_auto_paused_at).not.toBeNull();
 	});
 
 	it("completes every missed period oldest-first, then advances to the next cron", async () => {

--- a/packages/server/src/__tests__/integration/automations/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/automations/failed-run-advances-schedule.test.ts
@@ -18,7 +18,7 @@ async function createDueAutomationWithDispatchedRun(opts: {
   slug: string;
   messageId: string;
   nudgeCount?: number;
-  dispatchSource?: "scheduled" | "event";
+  dispatchSource?: "scheduled" | "event" | "manual";
   skipIfUnchanged?: boolean;
 }) {
   const sql = getTestDb();
@@ -337,6 +337,74 @@ describe("provider quota reset parsing", () => {
 });
 
 describe("a terminally failed Automation run advances next_run_at", () => {
+  it("auto-pauses after five consecutive scheduled execution failures", async () => {
+    const { sql, automationId, organizationId } =
+      await createDueAutomationWithDispatchedRun({
+        slug: "auto-pause-repeated-failures",
+        messageId: "msg-repeated-failure-1",
+      });
+
+    for (let attempt = 1; attempt <= 5; attempt += 1) {
+      const messageId = `msg-repeated-failure-${attempt}`;
+      if (attempt > 1) {
+        await sql`
+          UPDATE automations
+          SET next_run_at = current_timestamp - interval '1 minute'
+          WHERE id = ${automationId}
+        `;
+        await sql`
+          INSERT INTO runs (
+            organization_id, run_type, automation_id, status,
+            dispatched_message_id, approved_input
+          ) VALUES (
+            ${organizationId}, 'automation', ${automationId}, 'running',
+            ${messageId},
+            ${sql.json({ finalize_nudge_count: 99, dispatch_source: "scheduled" })}
+          )
+        `;
+      }
+
+      await resolveAutomationRunsByMessageIds([messageId], {
+        ok: false,
+        error: `executor timed out on attempt ${attempt}`,
+      });
+    }
+
+    const [automation] = await sql`
+      SELECT status, next_run_at, consecutive_scheduled_failures,
+             schedule_auto_paused_at
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(automation.status).toBe("active");
+    expect(automation.next_run_at).toBeNull();
+    expect(Number(automation.consecutive_scheduled_failures)).toBe(5);
+    expect(automation.schedule_auto_paused_at).not.toBeNull();
+  });
+
+  it("does not double-count a duplicate terminal report", async () => {
+    const { sql, automationId } = await createDueAutomationWithDispatchedRun({
+      slug: "dedupe-failure-count",
+      messageId: "msg-dedupe-failure-count",
+    });
+
+    await Promise.all([
+      resolveAutomationRunsByMessageIds(["msg-dedupe-failure-count"], {
+        ok: false,
+        error: "executor timed out",
+      }),
+      resolveAutomationRunsByMessageIds(["msg-dedupe-failure-count"], {
+        ok: false,
+        error: "executor timed out",
+      }),
+    ]);
+
+    const [automation] = await sql`
+      SELECT consecutive_scheduled_failures
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(Number(automation.consecutive_scheduled_failures)).toBe(1);
+  });
+
   it("advances the cursor when the agent turn returns an error", async () => {
     const { automationId, runId, staleCursor } =
       await createDueAutomationWithDispatchedRun({
@@ -480,6 +548,53 @@ describe("a terminally failed Automation run advances next_run_at", () => {
 
     const after = await cursorOf(automationId);
     expect(after.getTime()).toBe(staleCursor.getTime());
+    const [automation] = await sql`
+      SELECT consecutive_scheduled_failures
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(Number(automation.consecutive_scheduled_failures)).toBe(0);
+  });
+
+  it("does not count a failed manual run", async () => {
+    const { sql, automationId } = await createDueAutomationWithDispatchedRun({
+      slug: "no-count-on-manual",
+      messageId: "msg-manual-dispatch",
+      dispatchSource: "manual",
+    });
+
+    await resolveAutomationRunsByMessageIds(["msg-manual-dispatch"], {
+      ok: false,
+      error: "manual executor failed",
+    });
+
+    const [automation] = await sql`
+      SELECT consecutive_scheduled_failures, schedule_auto_paused_at
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(Number(automation.consecutive_scheduled_failures)).toBe(0);
+    expect(automation.schedule_auto_paused_at).toBeNull();
+  });
+
+  it("does not count an eval replay failure", async () => {
+    const { sql, automationId, runId } =
+      await createDueAutomationWithDispatchedRun({
+        slug: "no-count-on-eval",
+        messageId: "msg-eval-failure",
+      });
+    await sql`
+      UPDATE runs SET run_type = 'automation_eval' WHERE id = ${runId}
+    `;
+
+    await resolveAutomationRunsByMessageIds(["msg-eval-failure"], {
+      ok: false,
+      error: "eval executor failed",
+    });
+
+    const [automation] = await sql`
+      SELECT consecutive_scheduled_failures
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(Number(automation.consecutive_scheduled_failures)).toBe(0);
   });
 
   it("parks a scheduled Automation after a quota-exhausted event dispatch", async () => {

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -271,6 +271,49 @@ describe('migration invariants', () => {
 			expect(feed.next_run_at).toBeNull();
 		});
 
+		it('schedule-auto-paused Automations cannot retain or resurrect a cursor', async () => {
+			const org = await createTestOrganization({
+				name: 'Automation Pause Invariant Org',
+			});
+			const user = await createTestUser({
+				email: 'automation-pause-invariant@example.com',
+			});
+			await addUserToOrganization(user.id, org.id, 'owner');
+			const sql = getTestDb();
+			const [automation] = await sql`
+				INSERT INTO automations (
+					organization_id, created_by, automation_group_id, name, slug,
+					status, version, schedule, next_run_at,
+					consecutive_scheduled_failures, schedule_auto_paused_at
+				) VALUES (
+					${org.id}, ${user.id}, 0, 'Paused Automation Invariant',
+					'paused-automation-invariant', 'active', 1, '0 * * * *',
+					current_timestamp + interval '1 hour', 5, current_timestamp
+				)
+				RETURNING id, next_run_at
+			`;
+			expect(automation.next_run_at).toBeNull();
+
+			const [stillPaused] = await sql`
+				UPDATE automations
+				SET next_run_at = current_timestamp + interval '2 hours'
+				WHERE id = ${automation.id}
+				RETURNING next_run_at
+			`;
+			expect(stillPaused.next_run_at).toBeNull();
+
+			const [resumed] = await sql`
+				UPDATE automations
+				SET schedule_auto_paused_at = NULL,
+					consecutive_scheduled_failures = 0,
+					next_run_at = current_timestamp + interval '1 hour'
+				WHERE id = ${automation.id}
+				RETURNING next_run_at, consecutive_scheduled_failures
+			`;
+			expect(resumed.next_run_at).not.toBeNull();
+			expect(Number(resumed.consecutive_scheduled_failures)).toBe(0);
+		});
+
     it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
       const sql = getTestDb();
       // Dropped: idx_events_source_embedding (redundant btree(event_id) before

--- a/packages/server/src/__tests__/unit/automation-health.test.ts
+++ b/packages/server/src/__tests__/unit/automation-health.test.ts
@@ -4,6 +4,24 @@ import { computeAutomationHealth } from "../../automations/automation-health";
 const NOW = 1_700_000_000_000;
 
 describe("computeAutomationHealth", () => {
+	it("puts the durable schedule auto-pause reason first", () => {
+		const result = computeAutomationHealth(
+			{
+				status: "active",
+				nextRunAt: null,
+				consecutiveScheduledFailures: 5,
+				scheduleAutoPausedAt: new Date(NOW - 60_000).toISOString(),
+				latestRunStatus: "failed",
+				latestRunError: "executor timed out",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.reasons[0]).toBe(
+			"schedule auto-paused after 5 consecutive execution failures",
+		);
+	});
+
 	it("degrades an active automation whose latest run failed", () => {
 		const result = computeAutomationHealth(
 			{

--- a/packages/server/src/automations/auto-pause-notifications.ts
+++ b/packages/server/src/automations/auto-pause-notifications.ts
@@ -1,0 +1,108 @@
+import { getDb } from "../db/client";
+import { emit } from "../events/emitter";
+import { createNotificationForUsers } from "../notifications/service";
+import logger from "../utils/logger";
+import { buildAutomationUrl } from "../utils/url-builder";
+
+interface PausedAutomationNotificationRow {
+	id: number;
+	name: string | null;
+	organization_id: string;
+	organization_slug: string;
+	consecutive_scheduled_failures: number;
+	schedule_auto_paused_at: Date | string;
+	admin_user_ids: string[];
+}
+
+export function automationAutoPauseNotificationKey(
+	automationId: number,
+	pausedAt: Date | string,
+): string {
+	return `automation:schedule-auto-paused:${automationId}:${new Date(pausedAt).getTime()}`;
+}
+
+/**
+ * Deliver durable admin notifications for newly auto-paused Automations.
+ *
+ * The notification event is the completion marker. A failed insert remains
+ * absent and is retried next tick; concurrent ticks collapse on the existing
+ * events idempotency index. Rows without an admin/owner are excluded from the
+ * bounded window so they cannot starve later, deliverable pauses.
+ */
+export async function runAutomationAutoPauseNotificationSweep(
+	opts: { limit?: number } = {},
+): Promise<{
+	scanned: number;
+	attempted: number;
+	created: number;
+	errors: number;
+}> {
+	const sql = getDb();
+	const limit = Math.min(200, Math.max(1, Math.floor(opts.limit ?? 50)));
+	const rows = await sql<PausedAutomationNotificationRow>`
+    SELECT
+      a.id,
+      a.name,
+      a.organization_id,
+      o.slug AS organization_slug,
+      a.consecutive_scheduled_failures,
+      a.schedule_auto_paused_at,
+      to_jsonb(array_agg(DISTINCT m."userId" ORDER BY m."userId")) AS admin_user_ids
+    FROM automations a
+    JOIN "organization" o ON o.id = a.organization_id
+    JOIN "member" m
+      ON m."organizationId" = a.organization_id
+     AND m.role IN ('admin', 'owner')
+    WHERE a.schedule_auto_paused_at IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM events e
+        WHERE e.organization_id = a.organization_id
+          AND e.metadata ? '_lobu_idempotency_key'
+          AND e.metadata->>'_lobu_idempotency_key' =
+            'automation:schedule-auto-paused:' || a.id::text || ':' ||
+            floor(extract(epoch FROM a.schedule_auto_paused_at) * 1000)::bigint::text
+      )
+    GROUP BY a.id, a.name, a.organization_id, o.slug,
+             a.consecutive_scheduled_failures, a.schedule_auto_paused_at
+    ORDER BY a.schedule_auto_paused_at ASC, a.id ASC
+    LIMIT ${limit}
+  `;
+
+	let attempted = 0;
+	let created = 0;
+	let errors = 0;
+	for (const row of rows) {
+		attempted++;
+		try {
+			const result = await createNotificationForUsers(row.admin_user_ids, {
+				organizationId: row.organization_id,
+				type: "generic",
+				title: `Automation "${row.name ?? row.id}" was auto-paused`,
+				body:
+					`Lobu paused this schedule after ${row.consecutive_scheduled_failures} ` +
+					"consecutive execution failures. Review the latest run, then complete " +
+					"a successful manual run or change the cadence to resume it.",
+				resourceType: "automation",
+				resourceId: String(row.id),
+				resourceUrl: buildAutomationUrl(row.organization_slug, row.id),
+				idempotencyKey: automationAutoPauseNotificationKey(
+					row.id,
+					row.schedule_auto_paused_at,
+				),
+			});
+			if (result.created) created++;
+			emit(row.organization_id, {
+				keys: ["notifications", "notifications-unread-count"],
+			});
+		} catch (error) {
+			errors++;
+			logger.warn(
+				{ error, automationId: row.id },
+				"[automations] Failed to deliver schedule auto-pause notification",
+			);
+		}
+	}
+
+	return { scanned: rows.length, attempted, created, errors };
+}

--- a/packages/server/src/automations/automation-health.ts
+++ b/packages/server/src/automations/automation-health.ts
@@ -57,6 +57,10 @@ export interface AutomationHealthInput {
   status: string | null | undefined;
   /** `automations.next_run_at` — the scheduler cursor. */
   nextRunAt: string | Date | null | undefined;
+  /** Consecutive terminal failures from executed scheduled runs. */
+  consecutiveScheduledFailures?: number | null;
+  /** Durable circuit-breaker stamp; non-null means the schedule is hard-paused. */
+  scheduleAutoPausedAt?: string | Date | null;
   /** Latest run status (from buildLatestAutomationRunJoinSql). */
   latestRunStatus?: string | null;
   /** Latest run `created_at`, used to age a stuck pending run. */
@@ -131,6 +135,13 @@ export function computeAutomationHealth(
   }
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
+
+  if (input.scheduleAutoPausedAt != null) {
+    const failures = Math.max(0, Number(input.consecutiveScheduledFailures ?? 0));
+    reasons.push(
+      `schedule auto-paused after ${failures} consecutive execution failures`
+    );
+  }
 
   const hasEventTrigger = (input.triggers ?? []).some(
     (trigger) => trigger.kind === 'event'

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -45,6 +45,7 @@ import {
 	advanceAutomationSchedule,
 	advanceAutomationScheduleAfterSuccessfulWindow,
 } from "./schedule-cursor";
+import { recordScheduledExecutionFailure } from "./scheduled-failure-policy";
 import {
 	resolveAutomationRunsByMessageIds,
 } from "./run-completion";
@@ -570,20 +571,33 @@ export async function sweepStaleAutomationRuns(
 		sql,
 		coarseStaleInterval
 	);
-	const executingTimedOut = await markStaleRunsAsTimeout(sql, {
-		// Both lanes: this is a pure status UPDATE with no schedule-cursor or
-		// live result side effect, so terminating a crashed eval cannot touch the
-		// Automation it replays. Without it a `running` eval never reaches a
-		// terminal state and its same-lane claim guard wedges the eval lane.
-		// `finalizeStalePendingAutomationRuns` above stays automation-only on
-		// purpose — it advances `next_run_at`, which an eval must never do.
-		runTypes: AUTOMATION_RUN_TYPES,
-		heartbeatSemantics: "beat-after-claim",
-		heartbeatStaleInterval,
-		coarseStaleInterval,
-		heartbeatErrorMessage: `Automation run heartbeat went silent for over ${heartbeatStaleInterval} — the executor crashed or was abandoned`,
-		coarseErrorMessage: `Automation run exceeded ${coarseStaleInterval} without reaching terminal state`,
+	const executingTimedOutRows = await sql.begin(async (tx) => {
+		const rows = await markStaleRunsAsTimeout(tx, {
+			// Both lanes are terminalized, but only a real Automation that reached
+			// `running` may count toward the schedule circuit breaker. A claimed
+			// row is a dispatch failure; an eval is a replay of live state.
+			runTypes: AUTOMATION_RUN_TYPES,
+			heartbeatSemantics: "beat-after-claim",
+			heartbeatStaleInterval,
+			coarseStaleInterval,
+			heartbeatErrorMessage: `Automation run heartbeat went silent for over ${heartbeatStaleInterval} — the executor crashed or was abandoned`,
+			coarseErrorMessage: `Automation run exceeded ${coarseStaleInterval} without reaching terminal state`,
+		});
+		for (const row of rows) {
+			if (
+				row.previous_status === "running" &&
+				row.run_type === AUTOMATION_RUN_TYPE
+			) {
+				await recordScheduledExecutionFailure(
+					tx,
+					row.automation_id,
+					row.dispatch_source,
+				);
+			}
+		}
+		return rows;
 	});
+	const executingTimedOut = executingTimedOutRows.length;
 	const timedOut = pendingTimedOut + executingTimedOut;
 	if (timedOut > 0) {
 		logger.warn(

--- a/packages/server/src/automations/run-completion.ts
+++ b/packages/server/src/automations/run-completion.ts
@@ -8,6 +8,7 @@ import {
 	advanceScheduleAfterTerminalFailure,
 	providerQuotaResetNotBefore,
 } from "./schedule-cursor";
+import { recordScheduledExecutionFailure } from "./scheduled-failure-policy";
 import {
 	AUTOMATION_EVAL_RUN_TYPE,
 	AUTOMATION_RUN_TYPE,
@@ -177,6 +178,11 @@ async function markAutomationRunFailed(
 		// failing eval (a quota 429, a scoring rerun) would advance — or park for
 		// a day — the live Automation's cron cursor it is merely replaying.
 		if (failed.run_type === AUTOMATION_RUN_TYPE) {
+			await recordScheduledExecutionFailure(
+				tx,
+				failed.automation_id == null ? null : Number(failed.automation_id),
+				failed.dispatch_source,
+			);
 			await advanceScheduleAfterTerminalFailure(
 				tx,
 				failed.automation_id == null ? null : Number(failed.automation_id),

--- a/packages/server/src/automations/schedule-cursor.ts
+++ b/packages/server/src/automations/schedule-cursor.ts
@@ -6,6 +6,7 @@ import { AgentErrorCode, PROVIDER_BALANCE_EXHAUSTED } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
+import { resetScheduledFailureState } from "./scheduled-failure-policy";
 
 const PROVIDER_RESET_GRACE_MS = 60_000;
 const PROVIDER_RETRY_GRACE_MS = 1_000;
@@ -329,13 +330,15 @@ export async function advanceAutomationSchedule(
 ): Promise<void> {
 	if (automationId == null) return;
 	const rows = await sql`
-    SELECT schedule, timezone
+    SELECT schedule, timezone, schedule_auto_paused_at
     FROM automations
     WHERE id = ${automationId}
     LIMIT 1
   `;
 	const schedule = (rows[0]?.schedule as string | null) ?? null;
 	const timezone = (rows[0]?.timezone as string | null) ?? null;
+	const autoPausedAt = rows[0]?.schedule_auto_paused_at ?? null;
+	if (autoPausedAt != null) return;
 	if (!schedule) return;
 
 	// `nextRunAt` returns an ISO string, not a Date.
@@ -353,6 +356,7 @@ export async function advanceAutomationSchedule(
       SET next_run_at = NULL,
           updated_at = NOW()
       WHERE id = ${automationId}
+        AND schedule_auto_paused_at IS NULL
     `;
 		return;
 	}
@@ -370,6 +374,7 @@ export async function advanceAutomationSchedule(
     SET next_run_at = GREATEST(next_run_at, ${target}::timestamptz),
         updated_at = NOW()
     WHERE id = ${automationId}
+      AND schedule_auto_paused_at IS NULL
   `;
 }
 
@@ -383,6 +388,7 @@ export async function advanceAutomationScheduleAfterSuccessfulWindow(
 	devicePinned: boolean,
 	granularity: AutomationTimeGranularity
 ): Promise<void> {
+	await resetScheduledFailureState(sql, automationId);
 	if (devicePinned) {
 		const boundary = alignToAutomationWindowStart(new Date(), granularity);
 		const result = await sql`
@@ -390,6 +396,7 @@ export async function advanceAutomationScheduleAfterSuccessfulWindow(
       SET next_run_at = LEAST(next_run_at, current_timestamp),
           updated_at = current_timestamp
       WHERE id = ${automationId}
+        AND schedule_auto_paused_at IS NULL
         AND next_window_start < ${boundary.toISOString()}::timestamptz
     `;
 		if (Number(result.count ?? 0) > 0) return;

--- a/packages/server/src/automations/scheduled-failure-policy.ts
+++ b/packages/server/src/automations/scheduled-failure-policy.ts
@@ -1,0 +1,78 @@
+import type { DbClient } from "../db/client";
+
+const DEFAULT_PAUSE_AFTER_CONSECUTIVE_FAILURES = 5;
+
+function scheduledFailurePauseThreshold(): number {
+	const raw = process.env.AUTOMATION_PAUSE_AFTER_CONSECUTIVE_FAILURES;
+	if (raw === undefined) return DEFAULT_PAUSE_AFTER_CONSECUTIVE_FAILURES;
+	const parsed = Number(raw);
+	return Number.isInteger(parsed) && parsed > 0
+		? parsed
+		: DEFAULT_PAUSE_AFTER_CONSECUTIVE_FAILURES;
+}
+
+function isScheduledDispatch(
+	dispatchSource: string | null | undefined,
+): boolean {
+	// Older scheduled runs predate the explicit dispatch_source stamp. Manual
+	// and event runs have always carried their source when they need different
+	// cursor semantics, so NULL remains the backwards-compatible schedule lane.
+	return dispatchSource == null || dispatchSource === "scheduled";
+}
+
+/**
+ * Count one terminal failure from a real, executed scheduled Automation run.
+ *
+ * The UPDATE is the counter lock: concurrent distinct failures serialize on
+ * the Automation row, while a duplicate terminal report never reaches this
+ * helper because every caller first wins a status-guarded run transition.
+ * Once the threshold winner stamps the pause, later in-flight failures leave
+ * both the stable count and pause timestamp untouched.
+ */
+export async function recordScheduledExecutionFailure(
+	sql: DbClient,
+	automationId: number | null | undefined,
+	dispatchSource: string | null | undefined,
+): Promise<void> {
+	if (automationId == null || !isScheduledDispatch(dispatchSource)) {
+		return;
+	}
+
+	const threshold = scheduledFailurePauseThreshold();
+	await sql`
+    UPDATE automations
+    SET consecutive_scheduled_failures = consecutive_scheduled_failures + 1,
+        schedule_auto_paused_at = CASE
+          WHEN consecutive_scheduled_failures + 1 >= ${threshold}
+            THEN date_trunc('milliseconds', current_timestamp)
+          ELSE NULL
+        END,
+        next_run_at = CASE
+          WHEN consecutive_scheduled_failures + 1 >= ${threshold}
+            THEN NULL
+          ELSE next_run_at
+        END,
+        updated_at = current_timestamp
+    WHERE id = ${automationId}
+      AND status = 'active'
+      AND schedule IS NOT NULL
+      AND schedule_auto_paused_at IS NULL
+  `;
+}
+
+/** Clear the circuit breaker after a successful non-event window. */
+export async function resetScheduledFailureState(
+	sql: DbClient,
+	automationId: number,
+): Promise<void> {
+	await sql`
+    UPDATE automations
+    SET consecutive_scheduled_failures = 0,
+        schedule_auto_paused_at = NULL
+    WHERE id = ${automationId}
+      AND (
+        consecutive_scheduled_failures <> 0
+        OR schedule_auto_paused_at IS NOT NULL
+      )
+  `;
+}

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -18,6 +18,7 @@ import { cleanupExpiredMcpSessions } from '../mcp-handler';
 import { cleanupExpiredMcpAppResultSnapshots } from '../mcp-app-result-snapshots';
 import logger from '../utils/logger';
 import { runAutomationTick } from '../automations/automation';
+import { runAutomationAutoPauseNotificationSweep } from '../automations/auto-pause-notifications';
 import { checkStalledExecutions } from './check-stalled-executions';
 import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { retryPendingFeedAutoPausedSignals } from '../automations/platform-events';
@@ -274,6 +275,20 @@ function registerMaintenanceTasks(
       }
     },
     { cron: '*/15 * * * *' }
+  );
+
+  scheduler.register(
+    'automation-auto-pause-notifications',
+    async () => {
+      const result = await runAutomationAutoPauseNotificationSweep();
+      if (result.attempted > 0 || result.errors > 0) {
+        logger.info(
+          { ...result },
+          '[task] automation-auto-pause-notifications swept'
+        );
+      }
+    },
+    { cron: '*/5 * * * *' },
   );
 
   // Read-only detector for members whose trusted $member claim is missing or

--- a/packages/server/src/scheduled/stale-run-sweeper.ts
+++ b/packages/server/src/scheduled/stale-run-sweeper.ts
@@ -17,9 +17,10 @@
  *
  * `buildStaleRunWhereSql` returns the WHERE fragment so the connector reaper
  * can keep its atomic timeout-plus-retry CTE (the UPDATE must stay inside
- * that single statement); `markStaleRunsAsTimeout` runs the plain UPDATE for
- * callers without a retry lane. The fragments are inlined via `sql.unsafe`,
- * so every input is validated against a strict literal pattern first.
+ * that single statement); `markStaleRunsAsTimeout` returns the transitioned
+ * rows so Automation callers can apply lane-specific terminal policy in the
+ * same transaction. The fragments are inlined via `sql.unsafe`, so every
+ * input is validated against a strict literal pattern first.
  */
 
 import { PG_INTERVAL_PATTERN } from "../config/intervals";
@@ -165,9 +166,18 @@ export function buildStaleRunWhereSql(spec: StaleRunSweepSpec): string {
 
 /**
  * Mark every stale in-progress run matched by the spec as `timeout` in one
- * UPDATE, stamping the path-appropriate error message. Returns the number of
- * rows transitioned.
+ * statement, stamping the path-appropriate error message. The locked CTE
+ * retains each row's prior status so callers can distinguish work that was
+ * actually running from a claim that never reached execution.
  */
+export interface TimedOutStaleRun {
+	id: number;
+	automation_id: number | null;
+	run_type: string;
+	previous_status: string;
+	dispatch_source: string | null;
+}
+
 export async function markStaleRunsAsTimeout(
 	sql: DbClient,
 	spec: StaleRunSweepSpec & {
@@ -176,22 +186,37 @@ export async function markStaleRunsAsTimeout(
 		/** error_message for rows reaped via the coarse TTL backstop. */
 		coarseErrorMessage: string;
 	},
-): Promise<number> {
+): Promise<TimedOutStaleRun[]> {
 	const result = await sql.unsafe(
-		`UPDATE runs
+		`WITH stale AS MATERIALIZED (
+       SELECT id,
+              status AS previous_status,
+              automation_id,
+              run_type,
+              approved_input->>'dispatch_source' AS dispatch_source,
+              CASE
+                WHEN ${hasHeartbeatSql(spec.heartbeatSemantics)} THEN $1
+                ELSE $2
+              END AS timeout_error
+       FROM runs
+       WHERE ${buildStaleRunWhereSql(spec)}
+       FOR UPDATE SKIP LOCKED
+     )
+     UPDATE runs AS r
      SET status = 'timeout',
          outcome = $3,
          completed_at = current_timestamp,
-         error_message = CASE
-           WHEN ${hasHeartbeatSql(spec.heartbeatSemantics)} THEN $1
-           ELSE $2
-         END
-     WHERE ${buildStaleRunWhereSql(spec)}`,
+         error_message = stale.timeout_error
+     FROM stale
+     WHERE r.id = stale.id
+       AND r.status = stale.previous_status
+     RETURNING r.id, r.automation_id, r.run_type,
+               stale.previous_status, stale.dispatch_source`,
 		[
 			spec.heartbeatErrorMessage,
 			spec.coarseErrorMessage,
 			classifyRunOutcome({ status: "timeout" }),
 		],
 	);
-	return Number(result.count ?? 0);
+	return result as unknown as TimedOutStaleRun[];
 }

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -670,6 +670,10 @@ export async function handleUpdate(
   const touchesCadence = args.triggers !== undefined;
   const effectiveSchedule = touchesCadence ? triggerWrite.schedule : currentRow.schedule;
   const effectiveTimezone = touchesCadence ? triggerWrite.timezone : currentRow.timezone;
+  const cadenceChanged =
+    touchesCadence &&
+    (effectiveSchedule !== currentRow.schedule ||
+      effectiveTimezone !== currentRow.timezone);
   const projectionNow = new Date();
   const currentGranularity = inferAutomationGranularityFromSchedule(currentRow.schedule);
   const effectiveGranularity = inferAutomationGranularityFromSchedule(effectiveSchedule);
@@ -689,6 +693,8 @@ export async function handleUpdate(
       timezone = CASE WHEN ${touchesCadence} THEN ${triggerWrite.timezone ?? null} ELSE timezone END,
       triggers = CASE WHEN ${has('triggers')} THEN ${toJsonParam(sql, patch.triggers)} ELSE triggers END,
       next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
+      consecutive_scheduled_failures = CASE WHEN ${cadenceChanged} THEN 0 ELSE consecutive_scheduled_failures END,
+      schedule_auto_paused_at = CASE WHEN ${cadenceChanged} THEN NULL ELSE schedule_auto_paused_at END,
       next_window_start = CASE WHEN ${resetsWindowProjection} THEN ${resetWindowStart.toISOString()}::timestamptz ELSE next_window_start END,
       completed_window_coverage = CASE WHEN ${resetsWindowProjection} THEN '{}'::tstzmultirange ELSE completed_window_coverage END,
       window_projection_granularity = CASE WHEN ${resetsWindowProjection} THEN ${effectiveGranularity} ELSE window_projection_granularity END,

--- a/packages/server/src/tools/admin/manage_automations/list.ts
+++ b/packages/server/src/tools/admin/manage_automations/list.ts
@@ -58,6 +58,8 @@ export async function handleList(
       i.updated_at,
       i.triggers,
       i.next_run_at,
+      i.consecutive_scheduled_failures,
+      i.schedule_auto_paused_at,
       i.last_event_activation_at AS health_last_event_activation_at,
       i.agent_id,
       i.device_worker_id,
@@ -253,6 +255,9 @@ export async function handleList(
 		const automationHealth = computeAutomationHealth({
 			status: automation.status,
 			nextRunAt: automation.next_run_at,
+			consecutiveScheduledFailures:
+				automation.consecutive_scheduled_failures,
+			scheduleAutoPausedAt: automation.schedule_auto_paused_at,
 			latestRunStatus: automation.automation_run_status,
 			latestRunCreatedAt: automation.automation_run_created_at,
 			latestRunError: (rest as Record<string, unknown>).automation_run_error as

--- a/packages/server/src/tools/admin/manage_automations/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_automations/version-actions.ts
@@ -348,6 +348,12 @@ export async function handleCreateVersion(
       const effectiveTimezone = touchesCadence
         ? timezoneValue
         : ((automationRows[0].timezone as string | null) ?? null);
+      const cadenceChanged =
+        touchesCadence &&
+        (effectiveSchedule !==
+          ((automationRows[0].schedule as string | null) ?? null) ||
+          effectiveTimezone !==
+            ((automationRows[0].timezone as string | null) ?? null));
       const projectionNow = new Date();
       const previousGranularity = inferAutomationGranularityFromSchedule(
         (automationRows[0].schedule as string | null) ?? null
@@ -385,6 +391,8 @@ export async function handleCreateVersion(
           timezone = CASE WHEN ${touchesCadence} THEN ${timezoneValue} ELSE timezone END,
           triggers = CASE WHEN ${touchesCadence} THEN ${tx.json(triggerWrite.triggers)} ELSE triggers END,
           next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
+          consecutive_scheduled_failures = CASE WHEN ${cadenceChanged} THEN 0 ELSE consecutive_scheduled_failures END,
+          schedule_auto_paused_at = CASE WHEN ${cadenceChanged} THEN NULL ELSE schedule_auto_paused_at END,
           next_window_start = CASE WHEN ${resetsWindowProjection} THEN ${resetWindowStart.toISOString()}::timestamptz ELSE next_window_start END,
           completed_window_coverage = CASE WHEN ${resetsWindowProjection} THEN '{}'::tstzmultirange ELSE completed_window_coverage END,
           window_projection_granularity = CASE WHEN ${resetsWindowProjection} THEN ${effectiveGranularity} ELSE window_projection_granularity END,

--- a/packages/server/src/tools/get_automation.ts
+++ b/packages/server/src/tools/get_automation.ts
@@ -227,6 +227,8 @@ interface AutomationQueryRow {
   schedule: string | null;
   triggers: AutomationTrigger[] | null;
   next_run_at: string | null;
+  consecutive_scheduled_failures: number;
+  schedule_auto_paused_at: string | null;
   last_event_activation_at: string | null;
   agent_id: string | null;
   delivery_target: {
@@ -565,6 +567,8 @@ async function getAutomationImpl(
         i.schedule,
         i.triggers,
         i.next_run_at,
+        i.consecutive_scheduled_failures,
+        i.schedule_auto_paused_at,
         i.last_event_activation_at,
         i.agent_id,
         i.delivery_target,
@@ -798,6 +802,9 @@ async function getAutomationImpl(
     const automationHealth = computeAutomationHealth({
       status: automationRow.status,
       nextRunAt: automationRow.next_run_at,
+      consecutiveScheduledFailures:
+        automationRow.consecutive_scheduled_failures,
+      scheduleAutoPausedAt: automationRow.schedule_auto_paused_at,
       latestRunStatus: automationRow.automation_run_status,
       latestRunCreatedAt: automationRow.automation_run_created_at,
       latestRunError: automationRunError,
@@ -814,6 +821,9 @@ async function getAutomationImpl(
       status: automationRow.status as 'active' | 'archived',
       triggers: automationRow.triggers ?? [],
       next_run_at: automationRow.next_run_at,
+      consecutive_scheduled_failures:
+        automationRow.consecutive_scheduled_failures,
+      schedule_auto_paused_at: automationRow.schedule_auto_paused_at,
       agent_id: automationRow.agent_id,
       delivery_target: automationRow.delivery_target ?? null,
       device_worker_id: automationRow.device_worker_id ?? null,

--- a/packages/server/src/types/automations.ts
+++ b/packages/server/src/types/automations.ts
@@ -132,6 +132,10 @@ export const AutomationMetadataSchema = Type.Object({
   status: Type.Union([Type.Literal('active'), Type.Literal('archived')]),
   triggers: Type.Optional(Type.Array(AutomationTriggerSchema)),
   next_run_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  consecutive_scheduled_failures: Type.Optional(Type.Integer({ minimum: 0 })),
+  schedule_auto_paused_at: Type.Optional(
+    Type.Union([Type.String(), Type.Null()])
+  ),
   agent_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   delivery_target: Type.Optional(
     Type.Union([AutomationDeliveryTargetSchema, Type.Null()])

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -464,6 +464,8 @@ export const QUERYABLE_SCHEMA = {
         'timezone',
         'triggers',
         'next_run_at',
+        'consecutive_scheduled_failures',
+        'schedule_auto_paused_at',
         'agent_id',
         'model_config',
         'execution_config',

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -75,6 +75,7 @@ import {
 	advanceScheduleAfterTerminalFailure,
 	deviceProviderQuotaResetNotBefore,
 } from "../automations/schedule-cursor";
+import { recordScheduledExecutionFailure } from "../automations/scheduled-failure-policy";
 import { authorizeRunForWorker } from "./shared";
 import { classifyRunOutcome } from "../runs/run-outcome";
 
@@ -1382,6 +1383,13 @@ export async function completeAutomationRun(c: Context<{ Bindings: Env }>) {
         SET last_fired_at = NOW(), updated_at = NOW()
         WHERE id = ${automationId}
       `;
+			await recordScheduledExecutionFailure(
+				tx,
+				automationId,
+				typeof approved.dispatch_source === "string"
+					? approved.dispatch_source
+					: null,
+			);
 			await advanceScheduleAfterTerminalFailure(
 				tx,
 				automationId,


### PR DESCRIPTION
## Summary
- Stop scheduled Automations from retrying forever after five consecutive executed failures while keeping the Automation active and visibly degraded.
- Reset the durable failure streak on a successful non-event run or a real schedule/timezone change.
- Surface the auto-pause through Automation health and a deduplicated durable owner/admin notification.

## Test plan
- [ ] Intended files staged explicitly, then make pr-full clean (full Linux CI graph; make pre-pr only as local fallback)
- [x] Tests run: 7 focused integration files (160 tests), automation-health unit tests (13), generated client tests (7), migration lint, and make pre-pr
- [ ] Bug fix: red-to-green outputs pasted below
- [ ] If bot runtime changed: ran ./scripts/test-bot.sh or relevant eval

Embedded runtime E2E used an authenticated disposable local agent and schedule. Five real worker-completion HTTP failures left the first four scheduled and auto-paused the fifth; a duplicate fifth report was idempotent. The authenticated API reported degraded health, the notification sweep created the durable attention item, and a cadence update cleared the pause and rescheduled the Automation.

## Notes
- The configurable threshold is AUTOMATION_PAUSE_AFTER_CONSECUTIVE_FAILURES, defaulting to 5.
- Event/manual/eval/dispatch/claim/cancel paths do not count toward the streak.
- No Owletto changes.

Closes #2953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled Automations now automatically pause after five consecutive failed or timed-out scheduled runs by default.
  * Paused Automations show degraded health, failure counts, and pause timestamps.
  * Workspace admins and owners receive notifications when an Automation is paused.
  * Successful runs or genuine schedule and timezone changes restore scheduling.
* **Documentation**
  * Added configuration and behavior details for automatic schedule pausing.
* **Bug Fixes**
  * Prevented paused schedules from retaining or unexpectedly restoring their next run time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->