### PR TITLE
chore: bump packages/owletto pointer to 3aa83b4a

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1797,6 +1797,7 @@ describe("LinkedInConnector home_feed", () => {
       rowSelector: string;
       expandRows: {
         rowSelector: string;
+        identity: { selector: string; take: string; attr: string };
         expected: { selector: string; textRegex: string };
         items: { selector: string; idAttr: string };
         open: { selector: string; textRegex: string };
@@ -1819,6 +1820,7 @@ describe("LinkedInConnector home_feed", () => {
           parts: Record<string, unknown>;
         };
         author_control_label: { selector: string; attr: string };
+        post_identity: { selector: string; take: string; attr: string };
         post_url: {
           take: string;
           triggerSelector: string;
@@ -1835,6 +1837,7 @@ describe("LinkedInConnector home_feed", () => {
     };
     expect(cfg.rowSelector).toContain("replaceableComment_urn:li:comment");
     expect(cfg.expandRows.rowSelector).toContain('[componentkey^="expanded"]');
+    expect(cfg.expandRows.identity).toEqual(cfg.fields.post_identity);
     expect(cfg.expandRows.expected.textRegex).toContain("comments?");
     expect(cfg.expandRows.expected.selector).toContain(
       cfg.fields.comment_count_text.selector

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -472,6 +472,14 @@ const HOME_FEED_SCRAPE_CONFIG = {
     // share the FeedType suffix but must never drive another post's controls.
     rowSelector:
       'div[componentkey^="expanded"][componentkey*="FeedType_MAIN_FEED_RELEVANCE"]',
+    // Sorting comments can replace the post row. Preserve the durable activity
+    // identity so the scraper can reacquire that exact row before expanding it.
+    identity: {
+      selector:
+        '[id*="shareId="], [id*="ugcPostId="], [id*="urn:li:activity:"]',
+      take: "attr",
+      attr: "id",
+    },
     expected: {
       // Keep this aligned with the post-level comment count fields below. The
       // count is not always interactive: LinkedIn also renders it as a plain


### PR DESCRIPTION
Bumps `packages/owletto` pointer.

```
Before: 43882e1c
After:  3aa83b4a
```

Picks up: feat(oauth): add explicit workspace consent grants (#974)