### PR TITLE
feat(chat): add event-backed polls

### DIFF
--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
+import reducePollVote from "../poll-vote.reaction";
+
+interface State {
+  question: string;
+  options: string[];
+  status: "open" | "closed";
+  quorum: number;
+  closes_at: string;
+  results: Array<{ option: string; count: number }>;
+  response_count: number;
+  close_reason?: "quorum" | "deadline";
+}
+
+function harness(closesAt = "2026-08-28T15:00:00.000Z") {
+  let runId = 0;
+  let eventId = 100;
+  let responseId = 1_000;
+  let closeBeforeNextSave = false;
+  let trigger: Record<string, unknown> = {};
+  let head = {
+    id: eventId,
+    semantic_type: "poll_opened" as "poll_opened" | "poll_closed",
+    metadata: {
+      question: "Ship which lane?",
+      options: ["A", "B", "C"],
+      status: "open",
+      quorum: 2,
+      closes_at: closesAt,
+      results: [
+        { option: "A", count: 0 },
+        { option: "B", count: 0 },
+        { option: "C", count: 0 },
+      ],
+      response_count: 0,
+    } as State,
+  };
+  const responses = new Map<
+    string,
+    { id: number; metadata: Record<string, unknown> }
+  >();
+  const savedKinds: string[] = [];
+
+  const client = {
+    knowledge: {
+      read: async (input: Record<string, unknown>) => {
+        expect(input).toEqual({ automation_id: 9, run_id: runId, limit: 10 });
+        return { content: [trigger] };
+      },
+      save: async (input: Record<string, unknown>) => {
+        expect(input.supersedes_event_id).toBe(head.id);
+        if (closeBeforeNextSave) {
+          closeBeforeNextSave = false;
+          eventId += 1;
+          head = {
+            id: eventId,
+            semantic_type: "poll_closed",
+            metadata: {
+              ...head.metadata,
+              status: "closed",
+              close_reason: "deadline",
+            },
+          };
+          throw new Error("head was superseded by deadline close");
+        }
+        eventId += 1;
+        head = {
+          id: eventId,
+          semantic_type: input.semantic_type as "poll_opened" | "poll_closed",
+          metadata: input.metadata as unknown as State,
+        };
+        savedKinds.push(head.semantic_type);
+        return { id: eventId, created: true, metadata: input.metadata };
+      },
+    },
+    entities: {
+      create: async (input: { metadata?: Record<string, unknown> }) => {
+        responseId += 1;
+        const metadata = input.metadata ?? {};
+        responses.set(`${metadata.platform}:${metadata.actor_id}`, {
+          id: responseId,
+          metadata,
+        });
+        return { entity: { id: responseId } };
+      },
+      update: async (input: {
+        entity_id: number;
+        metadata?: Record<string, unknown>;
+      }) => {
+        if (input.entity_id === 77) return;
+        const current = [...responses.entries()].find(
+          ([, response]) => response.id === input.entity_id
+        );
+        if (current && input.metadata) {
+          responses.set(current[0], {
+            id: input.entity_id,
+            metadata: input.metadata,
+          });
+        }
+      },
+    },
+    query: async (sql: string) => {
+      if (sql.includes("entity_type = 'poll'")) return [{ id: 77 }];
+      if (sql.includes("FROM events")) return [head];
+      if (sql.includes("SELECT id FROM entities")) {
+        const actor = [...responses.values()].find(
+          (response) =>
+            sql.includes(
+              `metadata->>'platform' = '${response.metadata.platform}'`
+            ) &&
+            sql.includes(
+              `metadata->>'actor_id' = '${response.metadata.actor_id}'`
+            )
+        );
+        return actor ? [{ id: actor.id }] : [];
+      }
+      if (sql.includes("WITH latest AS")) {
+        const counts = new Map<string, number>();
+        for (const response of responses.values()) {
+          const choice = String(response.metadata.choice);
+          counts.set(choice, (counts.get(choice) ?? 0) + 1);
+        }
+        return [...counts].map(([choice, count]) => ({ choice, count }));
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+    log: () => undefined,
+  } as unknown as ReactionClient;
+
+  const vote = async (params: {
+    actorId: string;
+    actorName: string;
+    choice: string;
+    occurredAt: string;
+  }) => {
+    runId += 1;
+    trigger = {
+      id: 200 + runId,
+      entity_ids: [77],
+      semantic_type: "poll_vote_cast",
+      origin_type: "template_interaction",
+      occurred_at: params.occurredAt,
+      metadata: {
+        interaction: {
+          action: "vote",
+          value: params.choice,
+          source_event_id: head.id,
+          actor: {
+            platform: "gchat",
+            id: params.actorId,
+            name: params.actorName,
+          },
+        },
+      },
+    };
+    await reducePollVote(
+      {
+        extracted_data: { summary: "Process the trusted poll interaction." },
+        entities: [],
+        window: {
+          run_id: runId,
+          automation_id: 9,
+          window_start: "2026-08-28T14:00:00.000Z",
+          window_end: "2026-08-28T15:00:00.000Z",
+          granularity: "event",
+          content_analyzed: 1,
+        },
+        automation: {
+          id: 9,
+          slug: "poll-vote-reducer",
+          name: "Poll vote reducer",
+          version: 1,
+        },
+        organization_id: "org-test",
+        organization_slug: "test",
+      } satisfies ReactionContext,
+      client
+    );
+  };
+
+  const close = (reason: "quorum" | "deadline") => {
+    eventId += 1;
+    head = {
+      id: eventId,
+      semantic_type: "poll_closed",
+      metadata: {
+        ...head.metadata,
+        status: "closed",
+        close_reason: reason,
+      },
+    };
+  };
+
+  return {
+    vote,
+    close,
+    raceDeadlineOnNextSave: () => {
+      closeBeforeNextSave = true;
+    },
+    state: () => head.metadata,
+    responses: () => [...responses.values()].map((row) => row.metadata),
+    savedKinds,
+  };
+}
+
+describe("poll vote reaction", () => {
+  test("materializes two actors, a vote change, and quorum closure", async () => {
+    const poll = harness();
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "A",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+    });
+    await poll.vote({
+      actorId: "users/grace",
+      actorName: "Grace",
+      choice: "B",
+      occurredAt: "2026-08-28T14:11:00.000Z",
+    });
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "B",
+      occurredAt: "2026-08-28T14:12:00.000Z",
+    });
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "quorum",
+      results: [
+        { option: "A", count: 0 },
+        { option: "B", count: 2 },
+        { option: "C", count: 0 },
+      ],
+      response_count: 2,
+    });
+    expect(poll.responses()).toHaveLength(2);
+    expect(poll.savedKinds).toEqual([
+      "poll_opened",
+      "poll_opened",
+      "poll_closed",
+    ]);
+  });
+
+  test("closes at the deadline without materializing the late vote", async () => {
+    const poll = harness("2026-08-28T14:05:00.000Z");
+    await poll.vote({
+      actorId: "users/late",
+      actorName: "Late voter",
+      choice: "C",
+      occurredAt: "2026-08-28T14:05:00.000Z",
+    });
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "deadline",
+      response_count: 0,
+    });
+    expect(poll.responses()).toEqual([]);
+    expect(poll.savedKinds).toEqual(["poll_closed"]);
+  });
+
+  test("reconciles an accepted pre-deadline vote processed after closure", async () => {
+    const poll = harness();
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "A",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+    });
+    poll.close("deadline");
+
+    await poll.vote({
+      actorId: "users/grace",
+      actorName: "Grace",
+      choice: "B",
+      occurredAt: "2026-08-28T14:59:59.000Z",
+    });
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "deadline",
+      results: [
+        { option: "A", count: 1 },
+        { option: "B", count: 1 },
+        { option: "C", count: 0 },
+      ],
+      response_count: 2,
+    });
+    expect(poll.savedKinds).toEqual(["poll_opened", "poll_closed"]);
+  });
+
+  test("reconciles when the deadline supersedes the open head during save", async () => {
+    const poll = harness();
+    poll.raceDeadlineOnNextSave();
+
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "A",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+    });
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "deadline",
+      results: [
+        { option: "A", count: 1 },
+        { option: "B", count: 0 },
+        { option: "C", count: 0 },
+      ],
+      response_count: 1,
+    });
+    expect(poll.savedKinds).toEqual(["poll_closed"]);
+  });
+});

--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -13,11 +13,12 @@ interface State {
   close_reason?: "quorum" | "deadline";
 }
 
-function harness(closesAt = "2026-08-28T15:00:00.000Z") {
+function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
   let runId = 0;
   let eventId = 100;
   let responseId = 1_000;
   let closeBeforeNextSave = false;
+  let failNextPollEntityUpdate = false;
   let trigger: Record<string, unknown> = {};
   let head = {
     id: eventId,
@@ -26,7 +27,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
       question: "Ship which lane?",
       options: ["A", "B", "C"],
       status: "open",
-      quorum: 2,
+      quorum,
       closes_at: closesAt,
       results: [
         { option: "A", count: 0 },
@@ -36,6 +37,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
       response_count: 0,
     } as State,
   };
+  let entityState: State = { ...head.metadata };
   const responses = new Map<
     string,
     { id: number; metadata: Record<string, unknown> }
@@ -88,7 +90,14 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
         entity_id: number;
         metadata?: Record<string, unknown>;
       }) => {
-        if (input.entity_id === 77) return;
+        if (input.entity_id === 77) {
+          if (failNextPollEntityUpdate) {
+            failNextPollEntityUpdate = false;
+            throw new Error("poll entity update failed");
+          }
+          if (input.metadata) entityState = input.metadata as unknown as State;
+          return;
+        }
         const current = [...responses.entries()].find(
           ([, response]) => response.id === input.entity_id
         );
@@ -128,32 +137,8 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
     log: () => undefined,
   } as unknown as ReactionClient;
 
-  const vote = async (params: {
-    actorId: string;
-    actorName: string;
-    choice: string;
-    occurredAt: string;
-  }) => {
+  const run = async () => {
     runId += 1;
-    trigger = {
-      id: 200 + runId,
-      entity_ids: [77],
-      semantic_type: "poll_vote_cast",
-      origin_type: "template_interaction",
-      occurred_at: params.occurredAt,
-      metadata: {
-        interaction: {
-          action: "vote",
-          value: params.choice,
-          source_event_id: head.id,
-          actor: {
-            platform: "gchat",
-            id: params.actorId,
-            name: params.actorName,
-          },
-        },
-      },
-    };
     await reducePollVote(
       {
         extracted_data: { summary: "Process the trusted poll interaction." },
@@ -179,6 +164,34 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
     );
   };
 
+  const vote = async (params: {
+    actorId: string;
+    actorName: string;
+    choice: string;
+    occurredAt: string;
+  }) => {
+    trigger = {
+      id: 200 + runId,
+      entity_ids: [77],
+      semantic_type: "poll_vote_cast",
+      origin_type: "template_interaction",
+      occurred_at: params.occurredAt,
+      metadata: {
+        interaction: {
+          action: "vote",
+          value: params.choice,
+          source_event_id: head.id,
+          actor: {
+            platform: "gchat",
+            id: params.actorId,
+            name: params.actorName,
+          },
+        },
+      },
+    };
+    await run();
+  };
+
   const close = (reason: "quorum" | "deadline") => {
     eventId += 1;
     head = {
@@ -198,7 +211,12 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z") {
     raceDeadlineOnNextSave: () => {
       closeBeforeNextSave = true;
     },
+    failNextPollEntityUpdate: () => {
+      failNextPollEntityUpdate = true;
+    },
+    retryLastVote: run,
     state: () => head.metadata,
+    entityState: () => entityState,
     responses: () => [...responses.values()].map((row) => row.metadata),
     savedKinds,
   };
@@ -313,6 +331,65 @@ describe("poll vote reaction", () => {
       ],
       response_count: 1,
     });
+    expect(poll.savedKinds).toEqual(["poll_closed"]);
+  });
+
+  test("repairs poll entity metadata when a closed successor already exists", async () => {
+    const poll = harness("2026-08-28T15:00:00.000Z", 1);
+    poll.failNextPollEntityUpdate();
+
+    await expect(
+      poll.vote({
+        actorId: "users/ada",
+        actorName: "Ada",
+        choice: "A",
+        occurredAt: "2026-08-28T14:10:00.000Z",
+      })
+    ).rejects.toThrow("poll entity update failed");
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "quorum",
+      results: [
+        { option: "A", count: 1 },
+        { option: "B", count: 0 },
+        { option: "C", count: 0 },
+      ],
+    });
+    expect(poll.entityState()).toMatchObject({
+      status: "open",
+      response_count: 0,
+    });
+
+    await poll.retryLastVote();
+
+    expect(poll.entityState()).toEqual(poll.state());
+    expect(poll.savedKinds).toEqual(["poll_closed"]);
+  });
+
+  test("repairs poll entity metadata when a deadline close already exists", async () => {
+    const poll = harness("2026-08-28T14:05:00.000Z");
+    poll.failNextPollEntityUpdate();
+
+    await expect(
+      poll.vote({
+        actorId: "users/late",
+        actorName: "Late voter",
+        choice: "C",
+        occurredAt: "2026-08-28T14:05:00.000Z",
+      })
+    ).rejects.toThrow("poll entity update failed");
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "deadline",
+      response_count: 0,
+    });
+    expect(poll.entityState()).toMatchObject({ status: "open" });
+
+    await poll.retryLastVote();
+
+    expect(poll.entityState()).toEqual(poll.state());
     expect(poll.savedKinds).toEqual(["poll_closed"]);
   });
 });

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -20,6 +20,7 @@ import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
 import type LinkedInConnector from "./linkedin.connector.ts";
 import type MidasConnector from "./midas.connector.ts";
 import type NetWorthReaction from "./net-worth.reaction.ts";
+import type PollVoteReaction from "./poll-vote.reaction.ts";
 import type RevolutTransactionsConnector from "./revolut-transactions.connector.ts";
 import type SpotifyConnector from "./spotify.connector.ts";
 import { takeoutConfig } from "./takeout-dirs.ts";
@@ -38,11 +39,33 @@ const duplicateEntityResolutionRealV3FinalSkill = defineSkill({
     "Review every row in sources.people. Explain likely duplicate groups in analysis_summary and put name-only, alias-only, handle-only, oversized, or otherwise uncertain groups in uncertain_groups with why. Do not call entity tools or emit backlog tasks. After analysis, the deterministic reaction submits only candidate IDs to the server. The person entity type's x-lobu-resolution policy decides which normalized identities auto-merge and which require human review. Without that extension, normalized email and phone matches remain review-only and never auto-merge.\n",
 });
 
+const eventBackedPollsSkill = defineSkill({
+  name: "event-backed-polls",
+  content: `Use this workflow whenever the user asks for a poll, vote, or ballot.
+
+Create no ad-hoc platform card and never use ask_user for a multi-user poll. The durable poll event is the source of truth and its declared json_template supplies the native buttons on every supported surface.
+
+Opening a poll:
+1. Require a non-empty question, 2-5 distinct non-empty options, a positive integer quorum, and a future closes_at. If the user gives a duration, calculate closes_at as an ISO-8601 timestamp.
+2. In one run_sdk call, create a poll entity and then call client.knowledge.save with entity_ids containing only that entity id, semantic_type "poll_opened", payload_type "empty", title equal to the question, a stable idempotency_key "poll-opened:<entity id>", and metadata containing question, options, status "open", quorum, closes_at, results (one { option, count: 0 } row per option), and response_count 0. Return the entity id and saved event id. If retrying after an uncertain result, search for the stable poll slug first instead of creating a duplicate.
+3. Before presenting the event, call schedule_followup with run_at equal to closes_at, idempotency_key "poll-deadline:<entity id>", and prompt: "Close event-backed poll entity <entity id> at its deadline. Follow the event-backed-polls deadline procedure exactly; do nothing if it is already closed."
+4. Call present_event exactly once with the saved event id. That ends the turn because the native card is already the answer.
+
+Votes need no follow-up tool call from the agent. A server-stamped interaction event activates the deterministic poll-vote-reducer Automation; it materializes the latest poll-response per platform actor, supports vote changes, recomputes the tally, closes at quorum, and requests an in-place refresh of the original card.
+
+Deadline procedure:
+- Use run_sdk. Read the poll entity and query the single current poll_opened or poll_closed event linked to it (superseded_by IS NULL).
+- If the current event is poll_opened, copy only the poll schema fields (question, options, quorum, closes_at, results, and response_count) from that event metadata. Never copy delivery, card, _lobu, or any other internal metadata. Set status "closed", close_reason "deadline", and closed_at now. Save poll_closed linked to the poll with supersedes_event_id equal to that current open event and idempotency_key "poll-close:<entity id>"; then update the poll entity to the same state.
+- If the current event is already poll_closed, only reconcile the entity metadata to that event if needed, then stop. Never append a second close event.
+- Do not infer, copy, or accept voter identity from text. Only the chat adapter's trusted interaction envelope may identify a voter.`,
+});
+
 const personalAgent = defineAgent({
   id: "personal-agent",
   skills: [
     hourlyTaskCollaboratorSkill,
     duplicateEntityResolutionRealV3FinalSkill,
+    eventBackedPollsSkill,
   ],
   dir: ".",
   name: "personal-agent",
@@ -418,6 +441,148 @@ const task = defineEntityType({
         "Stable machine key for one distinct action within the source event",
     },
   },
+});
+
+const pollStateProperties = {
+  question: Type.String({ minLength: 1, maxLength: 500 }),
+  options: Type.Array(Type.String({ minLength: 1, maxLength: 100 }), {
+    minItems: 2,
+    maxItems: 5,
+    uniqueItems: true,
+  }),
+  status: Type.Unsafe({ type: "string", enum: ["open", "closed"] }),
+  quorum: Type.Integer({ minimum: 1, maximum: 10_000 }),
+  closes_at: Type.String({ format: "date-time" }),
+  results: Type.Array(
+    Type.Object(
+      {
+        option: Type.String({ minLength: 1, maxLength: 100 }),
+        count: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false }
+    ),
+    { minItems: 2, maxItems: 5 }
+  ),
+  response_count: Type.Integer({ minimum: 0 }),
+  close_reason: Type.Optional(
+    Type.Unsafe({ type: "string", enum: ["quorum", "deadline"] })
+  ),
+  closed_at: Type.Optional(Type.String({ format: "date-time" })),
+};
+
+const pollStateSchema = {
+  type: "object",
+  properties: pollStateProperties,
+  required: [
+    "question",
+    "options",
+    "status",
+    "quorum",
+    "closes_at",
+    "results",
+    "response_count",
+  ],
+  additionalProperties: false,
+};
+
+const poll = defineEntityType({
+  key: "poll",
+  name: "Poll",
+  description:
+    "A durable multi-user ballot whose native controls append trusted interaction events.",
+  metadata: { icon: "list-checks", color: "#6366F1" },
+  properties: pollStateProperties,
+  required: pollStateSchema.required,
+  eventKinds: {
+    poll_opened: {
+      description: "An open event-backed poll",
+      metadataSchema: pollStateSchema,
+      jsonTemplate: {
+        type: "card",
+        children: [
+          {
+            type: "text",
+            content: "Open until {{closes_at}} · quorum {{quorum}}",
+          },
+          {
+            type: "each",
+            items: "results",
+            as: "result",
+            render: {
+              type: "text",
+              content: "{{result.option}} — {{result.count}} vote(s)",
+            },
+          },
+          {
+            type: "each",
+            items: "options",
+            as: "option",
+            render: {
+              type: "button",
+              props: {
+                label: "{{option}}",
+                value: "{{option}}",
+                onClick: "@vote",
+              },
+            },
+          },
+        ],
+      },
+      interactions: { vote: { emits: "poll_vote_cast" } },
+    },
+    poll_vote_cast: {
+      description:
+        "A trusted vote or vote change appended by an interactive surface",
+    },
+    poll_closed: {
+      description: "A terminal poll result",
+      metadataSchema: pollStateSchema,
+      jsonTemplate: {
+        type: "card",
+        children: [
+          { type: "text", content: "Closed · {{close_reason}}" },
+          {
+            type: "each",
+            items: "results",
+            as: "result",
+            render: {
+              type: "text",
+              content: "{{result.option}} — {{result.count}} vote(s)",
+            },
+          },
+          {
+            type: "text",
+            content: "{{response_count}} participant(s)",
+          },
+        ],
+      },
+    },
+  },
+});
+
+const pollResponse = defineEntityType({
+  key: "poll-response",
+  name: "Poll response",
+  description:
+    "The latest materialized choice for one trusted platform actor in one poll.",
+  properties: {
+    poll_entity_id: Type.Integer({ minimum: 1 }),
+    platform: Type.String({ minLength: 1, maxLength: 50 }),
+    actor_id: Type.String({ minLength: 1, maxLength: 500 }),
+    actor_name: Type.String({ minLength: 1, maxLength: 500 }),
+    choice: Type.String({ minLength: 1, maxLength: 100 }),
+    vote_event_id: Type.Integer({ minimum: 1 }),
+    updated_at: Type.String({ format: "date-time" }),
+  },
+  required: [
+    "poll_entity_id",
+    "platform",
+    "actor_id",
+    "actor_name",
+    "choice",
+    "vote_event_id",
+    "updated_at",
+  ],
 });
 
 // GBP-equivalent of a transaction amount, using ONLY exact, Revolut-booked
@@ -1304,6 +1469,31 @@ const duplicateEntityResolution = defineAutomation({
   skills: ["duplicate-entity-resolution-real-v3-final"],
 });
 
+const pollVoteReducer = defineAutomation({
+  agent: personalAgent,
+  slug: "poll-vote-reducer",
+  name: "Poll vote reducer",
+  description:
+    "Materializes trusted interactive votes, vote changes, tallies, quorum closure, and card refreshes.",
+  triggers: [
+    {
+      kind: "event",
+      source: "workspace",
+      entity_type: "poll",
+      event_types: ["poll_vote_cast"],
+      execution: "window",
+      active_run: "queue",
+    },
+  ],
+  prompt:
+    'Return only {"summary":"Process the trusted poll interaction."}. Do not copy actor identity or mutate poll state; the deterministic reaction owns all writes.',
+  reactionsGuidance:
+    "The reaction reads the exact run-bound event and accepts only template_interaction provenance with a server-stamped actor.",
+  reaction: reactionFromFile<typeof PollVoteReaction>(
+    "./poll-vote.reaction.ts"
+  ),
+});
+
 export default defineConfig({
   // Source of truth for buremba definitions. Deletes org-owned entity /
   // relationship types and automations absent from this config (including
@@ -1340,6 +1530,8 @@ export default defineConfig({
     person,
     company,
     task,
+    poll,
+    pollResponse,
     channel,
     account,
     netWorthSnapshot,
@@ -1362,6 +1554,7 @@ export default defineConfig({
     hourlyTaskCollaborator,
     duplicateEntityResolution,
     midasNetWorth,
+    pollVoteReducer,
   ],
   authProfiles: [gmailAccountAuth, gmailAppAuth],
   connections: [

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -1,0 +1,442 @@
+import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
+
+export const input = {
+  type: "object",
+  properties: { summary: { type: "string" } },
+  required: ["summary"],
+} as const;
+
+interface PollResult {
+  option: string;
+  count: number;
+}
+
+interface PollState {
+  question: string;
+  options: string[];
+  status: "open" | "closed";
+  quorum: number;
+  closes_at: string;
+  results: PollResult[];
+  response_count: number;
+  close_reason?: "quorum" | "deadline";
+  closed_at?: string;
+}
+
+interface TriggerEvent {
+  id: number;
+  entity_ids: number[];
+  origin_type: string | null;
+  occurred_at: string;
+  metadata: Record<string, unknown>;
+}
+
+interface EventHead {
+  id: number;
+  semantic_type: "poll_opened" | "poll_closed";
+  metadata: PollState;
+}
+
+function sameResults(left: PollResult[], right: PollResult[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (result, index) =>
+        result.option === right[index]?.option &&
+        result.count === right[index]?.count
+    )
+  );
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function positiveInteger(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function pollState(value: unknown): PollState | null {
+  const row = objectValue(value);
+  const options = Array.isArray(row.options)
+    ? row.options.filter(
+        (option): option is string => typeof option === "string"
+      )
+    : [];
+  const closesAt = typeof row.closes_at === "string" ? row.closes_at : "";
+  const closesAtMs = Date.parse(closesAt);
+  const quorum = positiveInteger(row.quorum);
+  if (
+    typeof row.question !== "string" ||
+    options.length < 2 ||
+    quorum == null ||
+    !Number.isFinite(closesAtMs) ||
+    (row.status !== "open" && row.status !== "closed")
+  ) {
+    return null;
+  }
+  return {
+    question: row.question,
+    options,
+    status: row.status,
+    quorum,
+    closes_at: closesAt,
+    results: Array.isArray(row.results)
+      ? row.results.flatMap((entry) => {
+          const result = objectValue(entry);
+          return typeof result.option === "string" &&
+            Number.isFinite(Number(result.count))
+            ? [{ option: result.option, count: Number(result.count) }]
+            : [];
+        })
+      : options.map((option) => ({ option, count: 0 })),
+    response_count: Math.max(0, Number(row.response_count) || 0),
+    ...(row.close_reason === "quorum" || row.close_reason === "deadline"
+      ? { close_reason: row.close_reason }
+      : {}),
+    ...(typeof row.closed_at === "string" ? { closed_at: row.closed_at } : {}),
+  };
+}
+
+async function readTrigger(
+  ctx: ReactionContext,
+  client: ReactionClient
+): Promise<TriggerEvent | null> {
+  const page = objectValue(
+    await client.knowledge.read({
+      automation_id: ctx.window.automation_id,
+      run_id: ctx.window.run_id,
+      limit: 10,
+    })
+  );
+  const content = Array.isArray(page.content) ? page.content : [];
+  const matches = content.filter(
+    (item) => objectValue(item).semantic_type === "poll_vote_cast"
+  );
+  if (matches.length !== 1) return null;
+  const row = objectValue(matches[0]);
+  const id = positiveInteger(row.id);
+  if (id == null) return null;
+  return {
+    id,
+    entity_ids: Array.isArray(row.entity_ids)
+      ? row.entity_ids.flatMap((value) => {
+          const parsed = positiveInteger(value);
+          return parsed == null ? [] : [parsed];
+        })
+      : [],
+    origin_type: typeof row.origin_type === "string" ? row.origin_type : null,
+    occurred_at: typeof row.occurred_at === "string" ? row.occurred_at : "",
+    metadata: objectValue(row.metadata),
+  };
+}
+
+async function pollEntityId(
+  trigger: TriggerEvent,
+  client: ReactionClient
+): Promise<number | null> {
+  if (trigger.entity_ids.length === 0) return null;
+  const rows = (await client.query(
+    `SELECT id FROM entities
+     WHERE entity_type = 'poll'
+       AND id IN (${trigger.entity_ids.join(",")})
+       AND deleted_at IS NULL
+     ORDER BY id
+     LIMIT 2`
+  )) as Array<{ id: number | string }>;
+  return rows.length === 1 ? positiveInteger(rows[0].id) : null;
+}
+
+async function currentHead(
+  entityId: number,
+  client: ReactionClient
+): Promise<EventHead | null> {
+  const rows = (await client.query(
+    `SELECT id, semantic_type, metadata
+     FROM events
+     WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
+       AND semantic_type IN ('poll_opened', 'poll_closed')
+       AND superseded_by IS NULL
+     ORDER BY id DESC
+     LIMIT 2`
+  )) as Array<{
+    id: number | string;
+    semantic_type: string;
+    metadata: unknown;
+  }>;
+  if (rows.length !== 1) return null;
+  const id = positiveInteger(rows[0].id);
+  const state = pollState(rows[0].metadata);
+  if (
+    id == null ||
+    state == null ||
+    (rows[0].semantic_type !== "poll_opened" &&
+      rows[0].semantic_type !== "poll_closed") ||
+    (rows[0].semantic_type === "poll_opened" && state.status !== "open") ||
+    (rows[0].semantic_type === "poll_closed" && state.status !== "closed")
+  ) {
+    return null;
+  }
+  return { id, semantic_type: rows[0].semantic_type, metadata: state };
+}
+
+async function saveSuccessor(params: {
+  ctx: ReactionContext;
+  client: ReactionClient;
+  entityId: number;
+  headId: number;
+  triggerId: number;
+  state: PollState;
+  alreadyClosed: boolean;
+}): Promise<void> {
+  const closed = params.state.status === "closed";
+  await params.client.knowledge.save({
+    entity_ids: [params.entityId],
+    content: closed
+      ? `Poll closed by ${params.state.close_reason}.`
+      : `Poll tally updated after vote event ${params.triggerId}.`,
+    title: closed ? `${params.state.question} — closed` : params.state.question,
+    semantic_type: closed ? "poll_closed" : "poll_opened",
+    payload_type: "empty",
+    metadata: params.state as unknown as Record<string, unknown>,
+    supersedes_event_id: params.headId,
+    idempotency_key: params.alreadyClosed
+      ? `poll-finalize:${params.entityId}:vote:${params.triggerId}`
+      : closed
+        ? `poll-close:${params.entityId}`
+        : `poll-state:${params.entityId}:vote:${params.triggerId}`,
+    automation_source: {
+      automation_id: params.ctx.window.automation_id,
+      run_id: params.ctx.window.run_id,
+    },
+  });
+}
+
+async function upsertResponse(params: {
+  pollEntityId: number;
+  platform: string;
+  actorId: string;
+  actorName: string;
+  choice: string;
+  voteEventId: number;
+  client: ReactionClient;
+}): Promise<void> {
+  const { client } = params;
+  const rows = (await client.query(
+    `SELECT id FROM entities
+     WHERE entity_type = 'poll-response'
+       AND deleted_at IS NULL
+       AND (metadata->>'poll_entity_id')::bigint = ${params.pollEntityId}
+       AND metadata->>'platform' = ${sqlLiteral(params.platform)}
+       AND metadata->>'actor_id' = ${sqlLiteral(params.actorId)}
+     ORDER BY (metadata->>'updated_at') DESC, id DESC
+     LIMIT 1`
+  )) as Array<{ id: number | string }>;
+  const metadata = {
+    poll_entity_id: params.pollEntityId,
+    platform: params.platform,
+    actor_id: params.actorId,
+    actor_name: params.actorName,
+    choice: params.choice,
+    vote_event_id: params.voteEventId,
+    updated_at: new Date().toISOString(),
+  };
+  const existingId = rows[0] ? positiveInteger(rows[0].id) : null;
+  if (existingId != null) {
+    await client.entities.update({ entity_id: existingId, metadata });
+    return;
+  }
+  await client.entities.create({
+    type: "poll-response",
+    name: params.actorName,
+    metadata,
+  });
+}
+
+async function resultsForPoll(
+  entityId: number,
+  options: string[],
+  client: ReactionClient
+): Promise<{ results: PollResult[]; responseCount: number }> {
+  const rows = (await client.query(
+    `WITH latest AS (
+       SELECT metadata->>'choice' AS choice,
+              row_number() OVER (
+                PARTITION BY metadata->>'platform', metadata->>'actor_id'
+                ORDER BY (metadata->>'updated_at') DESC, id DESC
+              ) AS rank
+       FROM entities
+       WHERE entity_type = 'poll-response'
+         AND deleted_at IS NULL
+         AND (metadata->>'poll_entity_id')::bigint = ${entityId}
+     )
+     SELECT choice, count(*)::int AS count
+     FROM latest
+     WHERE rank = 1
+     GROUP BY choice
+     ORDER BY choice
+     LIMIT 100`
+  )) as Array<{ choice: string; count: number | string }>;
+  const counts = new Map(
+    rows.map((row) => [row.choice, Math.max(0, Number(row.count) || 0)])
+  );
+  const results = options.map((option) => ({
+    option,
+    count: counts.get(option) ?? 0,
+  }));
+  return {
+    results,
+    responseCount: results.reduce((sum, result) => sum + result.count, 0),
+  };
+}
+
+export default async function reducePollVote(
+  ctx: ReactionContext,
+  client: ReactionClient
+): Promise<void> {
+  const trigger = await readTrigger(ctx, client);
+  if (!trigger || trigger.origin_type !== "template_interaction") return;
+
+  const interaction = objectValue(trigger.metadata.interaction);
+  const actor = objectValue(interaction.actor);
+  const choice = typeof interaction.value === "string" ? interaction.value : "";
+  const platform = typeof actor.platform === "string" ? actor.platform : "";
+  const actorId = typeof actor.id === "string" ? actor.id : "";
+  const actorName =
+    typeof actor.name === "string" && actor.name.trim()
+      ? actor.name.trim().slice(0, 500)
+      : actorId.slice(0, 500);
+  if (
+    interaction.action !== "vote" ||
+    positiveInteger(interaction.source_event_id) == null ||
+    !choice ||
+    !platform ||
+    !actorId ||
+    platform.length > 50 ||
+    actorId.length > 500
+  ) {
+    return;
+  }
+
+  const entityId = await pollEntityId(trigger, client);
+  if (entityId == null) return;
+  const head = await currentHead(entityId, client);
+  if (!head) return;
+  if (!head.metadata.options.includes(choice)) return;
+
+  const voteAt = Date.parse(trigger.occurred_at);
+  const closesAt = Date.parse(head.metadata.closes_at);
+  const deadlineReached = !Number.isFinite(voteAt) || voteAt >= closesAt;
+  const alreadyClosed = head.semantic_type === "poll_closed";
+  if (alreadyClosed && deadlineReached) return;
+  if (!deadlineReached) {
+    await upsertResponse({
+      pollEntityId: entityId,
+      platform,
+      actorId,
+      actorName,
+      choice,
+      voteEventId: trigger.id,
+      client,
+    });
+  }
+
+  const { results, responseCount } = await resultsForPoll(
+    entityId,
+    head.metadata.options,
+    client
+  );
+  const reachedQuorum = results.some(
+    (result) => result.count >= head.metadata.quorum
+  );
+  const closed = alreadyClosed || deadlineReached || reachedQuorum;
+  const next: PollState = {
+    ...head.metadata,
+    status: closed ? "closed" : "open",
+    results,
+    response_count: responseCount,
+    ...(closed && !alreadyClosed
+      ? {
+          close_reason: deadlineReached ? "deadline" : "quorum",
+          closed_at: new Date().toISOString(),
+        }
+      : {}),
+  };
+  if (
+    alreadyClosed &&
+    next.response_count === head.metadata.response_count &&
+    sameResults(next.results, head.metadata.results)
+  ) {
+    return;
+  }
+  try {
+    await saveSuccessor({
+      ctx,
+      client,
+      entityId,
+      headId: head.id,
+      triggerId: trigger.id,
+      state: next,
+      alreadyClosed,
+    });
+  } catch (error) {
+    // A deadline wake-up may close the head after this accepted pre-deadline
+    // vote was materialized. Reconcile that durable response into a terminal
+    // successor instead of silently losing it from the displayed tally.
+    const winner = await currentHead(entityId, client);
+    if (winner?.semantic_type !== "poll_closed" || deadlineReached) throw error;
+    const reconciled = await resultsForPoll(
+      entityId,
+      winner.metadata.options,
+      client
+    );
+    const terminal: PollState = {
+      ...winner.metadata,
+      results: reconciled.results,
+      response_count: reconciled.responseCount,
+    };
+    if (
+      terminal.response_count !== winner.metadata.response_count ||
+      !sameResults(terminal.results, winner.metadata.results)
+    ) {
+      await saveSuccessor({
+        ctx,
+        client,
+        entityId,
+        headId: winner.id,
+        triggerId: trigger.id,
+        state: terminal,
+        alreadyClosed: true,
+      });
+    }
+    await client.entities.update({
+      entity_id: entityId,
+      metadata: terminal as unknown as Record<string, unknown>,
+    });
+    return;
+  }
+  await client.entities.update({
+    entity_id: entityId,
+    metadata: next as unknown as Record<string, unknown>,
+  });
+  client.log("Poll vote reduced", {
+    poll_entity_id: entityId,
+    vote_event_id: trigger.id,
+    status: next.status,
+    response_count: next.response_count,
+  });
+}

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -226,6 +226,17 @@ async function saveSuccessor(params: {
   });
 }
 
+async function updatePollEntity(
+  entityId: number,
+  state: PollState,
+  client: ReactionClient
+): Promise<void> {
+  await client.entities.update({
+    entity_id: entityId,
+    metadata: state as unknown as Record<string, unknown>,
+  });
+}
+
 async function upsertResponse(params: {
   pollEntityId: number;
   platform: string;
@@ -342,7 +353,10 @@ export default async function reducePollVote(
   const closesAt = Date.parse(head.metadata.closes_at);
   const deadlineReached = !Number.isFinite(voteAt) || voteAt >= closesAt;
   const alreadyClosed = head.semantic_type === "poll_closed";
-  if (alreadyClosed && deadlineReached) return;
+  if (alreadyClosed && deadlineReached) {
+    await updatePollEntity(entityId, head.metadata, client);
+    return;
+  }
   if (!deadlineReached) {
     await upsertResponse({
       pollEntityId: entityId,
@@ -381,6 +395,7 @@ export default async function reducePollVote(
     next.response_count === head.metadata.response_count &&
     sameResults(next.results, head.metadata.results)
   ) {
+    await updatePollEntity(entityId, next, client);
     return;
   }
   try {
@@ -423,16 +438,10 @@ export default async function reducePollVote(
         alreadyClosed: true,
       });
     }
-    await client.entities.update({
-      entity_id: entityId,
-      metadata: terminal as unknown as Record<string, unknown>,
-    });
+    await updatePollEntity(entityId, terminal, client);
     return;
   }
-  await client.entities.update({
-    entity_id: entityId,
-    metadata: next as unknown as Record<string, unknown>,
-  });
+  await updatePollEntity(entityId, next, client);
   client.log("Poll vote reduced", {
     poll_entity_id: entityId,
     vote_event_id: trigger.id,

--- a/packages/agent-worker/src/__tests__/custom-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/custom-tools.test.ts
@@ -57,6 +57,8 @@ describe("createLobuCustomTools", () => {
       "list_conversations",
       "read_conversation",
       "send_message",
+      "present_event",
+      "schedule_followup",
       "react",
       "edit_message",
       "delete_message",

--- a/packages/agent-worker/src/__tests__/plugin-composition.test.ts
+++ b/packages/agent-worker/src/__tests__/plugin-composition.test.ts
@@ -57,6 +57,8 @@ describe("runtime plugin composition", () => {
       "list_conversations",
       "read_conversation",
       "send_message",
+      "present_event",
+      "schedule_followup",
       "react",
       "edit_message",
       "delete_message",

--- a/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
+++ b/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
@@ -5,9 +5,10 @@ describe("ReactionClient knowledge.read input", () => {
   it("accepts the content_ids (array) shape save_memory's exact_read hint advertises", () => {
     // Compile-time contract: read_knowledge takes `content_ids: number[]` —
     // excess-property checking here would fail if the published type regressed
-    // to the singular `content_id` the live bug advertised.
+    // to the singular `content_id` the live bug advertised. Reaction scripts
+    // also bind Automation reads to the exact queued run.
     const call = (client: ReactionClient) =>
-      client.knowledge.read({ content_ids: [42] });
+      client.knowledge.read({ content_ids: [42], run_id: 7 });
     expect(typeof call).toBe("function");
   });
 });

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -57,6 +57,8 @@ export interface KnowledgeReadInput {
   /** Fetch specific content events by id (read_knowledge takes an array). */
   content_ids?: number[];
   automation_id?: number;
+  /** Bind the read to the exact queued Automation run and trigger snapshot. */
+  run_id?: number;
   since?: string;
   until?: string;
   limit?: number;

--- a/packages/core/src/__tests__/agent-policy-harden.test.ts
+++ b/packages/core/src/__tests__/agent-policy-harden.test.ts
@@ -113,6 +113,15 @@ describe("getCustomToolDescription", () => {
     expect(desc).toContain("user's next turn");
   });
 
+  test("registers the event presentation and scoped follow-up tools", () => {
+    expect(getCustomToolDescription("present_event")).toContain(
+      "declared json_template"
+    );
+    expect(getCustomToolDescription("schedule_followup")).toContain(
+      "current conversation"
+    );
+  });
+
   test("falls back to the tool name for unknown tools", () => {
     expect(getCustomToolDescription("UnknownTool")).toBe("UnknownTool");
   });

--- a/packages/core/src/agent-policy.ts
+++ b/packages/core/src/agent-policy.ts
@@ -41,6 +41,14 @@ export const CUSTOM_TOOL_METADATA: Record<string, CustomToolMetadata> = {
     description:
       "Post a message to one of your conversations. Pass a conversation handle (from list_conversations) to post to the channel, or a thread handle (returned by a previous send_message) to reply in that thread. This is how an automated/scheduled run speaks in its channel.",
   },
+  present_event: {
+    description:
+      "Render an existing Lobu event in the current conversation through its declared json_template. Use the event id returned by knowledge.save; do not hand-author platform card JSON or action ids.",
+  },
+  schedule_followup: {
+    description:
+      "Schedule one durable future wake-up for yourself in the current conversation. The server fixes the agent and destination from the signed turn; provide a stable idempotency key so retries do not duplicate the wake-up.",
+  },
   react: {
     description:
       'Add (or remove) an emoji reaction on a message. Pass a conversation handle (from list_conversations/read_conversation) or a thread handle (from a previous send_message) plus the message id to react to — you can react to a message you only READ, using the id read_conversation surfaces. Use to acknowledge or triage a message without posting text (e.g. "eyes" while working, "white_check_mark" when done). Set remove=true to take a reaction back.',

--- a/packages/plugin-conversations/src/__tests__/plugin.test.ts
+++ b/packages/plugin-conversations/src/__tests__/plugin.test.ts
@@ -5,6 +5,8 @@ const BASE_TOOLS = [
   "list_conversations",
   "read_conversation",
   "send_message",
+  "present_event",
+  "schedule_followup",
   "react",
   "edit_message",
   "delete_message",

--- a/packages/plugin-conversations/src/index.ts
+++ b/packages/plugin-conversations/src/index.ts
@@ -204,17 +204,85 @@ export async function sendMessage(
       ? ` To reply in this message's thread later, send to target="${data!.thread}".`
       : "";
 
-    // The post landed in the conversation this run is already replying to, so
-    // the user has read it. Tell the gateway to drop the terminal reply (it
-    // would arrive as a second message), and tell the model so it does not
-    // spend its final answer narrating what it just said.
+    // The post landed in the conversation this run is already replying to.
+    // Tell the gateway to drop the terminal reply (it would arrive as a second
+    // message), and tell the model so it does not narrate the in-band post.
     if (data!.deliveredInBand) {
       hooks?.onDeliveredInBand?.();
       return textResult(
-        `Message sent.${threadNote} This posted into the conversation you are already replying to, so the user has now seen it — your reply for this turn is DONE. Do not repeat or summarize it in your final answer, and do not send it again.`
+        `Message sent.${threadNote} This in-band post is your reply for the turn. Do not repeat or summarize it in your final answer, and do not send it again.`
       );
     }
     return textResult(`Message sent.${threadNote}`);
+  });
+}
+
+/**
+ * Present an existing Lobu event in the conversation that triggered this turn.
+ * The server owns rendering and routing; the model supplies only the durable
+ * event id returned by knowledge.save.
+ */
+export async function presentEvent(
+  gateway: GatewayParams,
+  args: { event_id: number },
+  hooks?: { onDeliveredInBand?: () => void }
+): Promise<TextResult> {
+  return withErrorHandling("present_event", async () => {
+    if (!Number.isSafeInteger(args.event_id) || args.event_id < 1) {
+      return textResult("Error: event_id must be a positive integer.");
+    }
+    const { data, error } = await gatewayFetch<{
+      messageId: string | null;
+      deliveredInBand: boolean;
+    }>(
+      gateway,
+      "/internal/conversations/present-event",
+      {
+        method: "POST",
+        body: JSON.stringify({ eventId: args.event_id }),
+      },
+      "Failed to present event"
+    );
+    if (error) return error;
+    if (data?.deliveredInBand) hooks?.onDeliveredInBand?.();
+    return textResult(
+      "Event rendered and posted in the conversation you are already replying to. That in-band post is your reply for this turn. Do not repeat or summarize it in your final answer."
+    );
+  });
+}
+
+/** Schedule one durable wake-up back into the conversation driving this turn. */
+export async function scheduleFollowup(
+  gateway: GatewayParams,
+  args: { run_at: string; prompt: string; idempotency_key: string }
+): Promise<TextResult> {
+  return withErrorHandling("schedule_followup", async () => {
+    if (
+      !args.run_at?.trim() ||
+      !args.prompt?.trim() ||
+      !args.idempotency_key?.trim()
+    ) {
+      return textResult(
+        "Error: run_at, prompt, and idempotency_key are required."
+      );
+    }
+    const { error } = await gatewayFetch<{ scheduled: boolean }>(
+      gateway,
+      "/internal/conversations/schedule-followup",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          runAt: args.run_at,
+          prompt: args.prompt,
+          idempotencyKey: args.idempotency_key,
+        }),
+      },
+      "Failed to schedule follow-up"
+    );
+    if (error) return error;
+    return textResult(
+      `Follow-up scheduled for ${args.run_at}. It will wake you in this conversation.`
+    );
   });
 }
 
@@ -324,6 +392,38 @@ export function createConversationTools(params: ConversationPluginParams) {
         sendMessage(gateway, args, {
           onDeliveredInBand: params.onInBandReplyDelivered,
         }),
+    }),
+    defineGatewayTool({
+      name: "present_event",
+      parameters: Type.Object({
+        event_id: Type.Integer({
+          minimum: 1,
+          description: "Durable Lobu event id returned by knowledge.save",
+        }),
+      }),
+      run: (args) =>
+        presentEvent(gateway, args, {
+          onDeliveredInBand: params.onInBandReplyDelivered,
+        }),
+    }),
+    defineGatewayTool({
+      name: "schedule_followup",
+      parameters: Type.Object({
+        run_at: Type.String({
+          description: "Future ISO-8601 timestamp for the one-shot wake-up",
+        }),
+        prompt: Type.String({
+          minLength: 1,
+          maxLength: 2000,
+          description: "Instruction you should execute when the wake-up fires",
+        }),
+        idempotency_key: Type.String({
+          minLength: 1,
+          maxLength: 200,
+          description: "Stable key that makes retries return the same schedule",
+        }),
+      }),
+      run: (args) => scheduleFollowup(gateway, args),
     }),
     defineGatewayTool({
       name: "react",

--- a/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
+++ b/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
@@ -451,6 +451,7 @@ describe("Google Chat declared event action adapter", () => {
 				platform: "gchat",
 				channelId: SPACE_NAME,
 				channelKey: `gchat:${SPACE_NAME}`,
+				conversationId: `gchat:${SPACE_NAME}:${threadId}`,
 				threadId,
 			}),
 			presentStoredEventToConversation({
@@ -460,6 +461,7 @@ describe("Google Chat declared event action adapter", () => {
 				platform: "gchat",
 				channelId: SPACE_NAME,
 				channelKey: `gchat:${SPACE_NAME}`,
+				conversationId: `gchat:${SPACE_NAME}:${threadId}`,
 				threadId,
 			}),
 		]);
@@ -475,8 +477,21 @@ describe("Google Chat declared event action adapter", () => {
 				eventId: source.id,
 				connectionId: CONNECTION_ID,
 				platform: "gchat",
+				channelId: SPACE_NAME,
+				channelKey: `gchat:${SPACE_NAME}`,
+				conversationId: `gchat:${SPACE_NAME}:thread-two`,
+				threadId: "thread-two",
+			}),
+		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
+		expect(
+			await presentStoredEventToConversation({
+				organizationId: workspace.org.id,
+				eventId: source.id,
+				connectionId: CONNECTION_ID,
+				platform: "gchat",
 				channelId: `${SPACE_NAME}/secondary`,
 				channelKey: `gchat:${SPACE_NAME}/secondary`,
+				conversationId: `gchat:${SPACE_NAME}/secondary:${threadId}`,
 				threadId,
 			}),
 		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
@@ -488,15 +503,16 @@ describe("Google Chat declared event action adapter", () => {
 				platform: "gchat",
 				channelId: SPACE_NAME,
 				channelKey: `gchat:${SPACE_NAME}`,
+				conversationId: `gchat:${SPACE_NAME}:${threadId}`,
 				threadId,
 			}),
 		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
-		expect(postToConversation).toHaveBeenCalledTimes(2);
+		expect(postToConversation).toHaveBeenCalledTimes(3);
 		expect(
 			(await sql<{ metadata: { delivery: unknown[] } }>`
 				SELECT metadata FROM events WHERE id = ${source.id}
 			`)[0]?.metadata.delivery,
-		).toHaveLength(2);
+		).toHaveLength(3);
 		const reduceVote = async (voteEventId: number) => {
 			const [vote] = await sql<{
 				metadata: {
@@ -681,7 +697,7 @@ describe("Google Chat declared event action adapter", () => {
 			close_reason: "quorum",
 		});
 
-		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(3));
 		const responses = await sql<{
 			metadata: { actor_id: string; choice: string };
 		}>`
@@ -735,7 +751,7 @@ describe("Google Chat declared event action adapter", () => {
 				  AND semantic_type = 'poll_vote_cast'
 			`,
 		).toHaveLength(3);
-		expect(editMessageContent).toHaveBeenCalledTimes(2);
+		expect(editMessageContent).toHaveBeenCalledTimes(3);
 		expect(JSON.stringify(postMessage.mock.calls)).toContain(
 			"This interaction is closed or has been replaced.",
 		);
@@ -919,7 +935,7 @@ describe("Google Chat declared event action adapter", () => {
 				{ pollId: deadlinePoll.poll_id, closed: true },
 			].sort((a, b) => a.pollId.localeCompare(b.pollId)),
 		);
-		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(3));
 		const [deadlineClosed] = await sql<{ metadata: typeof deadlinePoll }>`
 			SELECT metadata FROM entities
 			WHERE organization_id = ${workspace.org.id}

--- a/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
+++ b/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
@@ -25,7 +25,10 @@ import {
 } from "../../../interactions/template-event-actions.js";
 import { __setChatInstanceManagerForTests } from "../../../lobu/gateway.js";
 import { runtimeConnectionIdToSlug } from "../../../lobu/stores/connections-projection.js";
-import { presentStoredEventToConversation } from "../../../notifications/service.js";
+import {
+	presentStoredEventToConversation,
+	refreshInteractiveEventCardTask,
+} from "../../../notifications/service.js";
 import { registerScheduledJobsTicker } from "../../../scheduled/scheduled-jobs-service.js";
 import { manageSchedules } from "../../../tools/admin/manage_schedules.js";
 import type { ToolContext } from "../../../tools/registry.js";
@@ -425,10 +428,20 @@ describe("Google Chat declared event action adapter", () => {
 			workspace.org.id,
 		);
 		const editMessageContent = vi.fn(async () => undefined);
-		const postToConversation = vi.fn(async () => ({
-			messageId: MESSAGE_NAME,
-			threadId,
-		}));
+		const postToConversation = vi.fn(
+			async (
+				_connectionId: string,
+				request: { channelId: string; threadId?: string },
+			) => ({
+				messageId:
+					request.channelId !== SPACE_NAME
+						? `${request.channelId}/messages/poll-card`
+						: request.threadId === "thread-two"
+							? `${SPACE_NAME}/messages/poll-card-thread-two`
+							: MESSAGE_NAME,
+				threadId: request.threadId ?? threadId,
+			}),
+		);
 		__setChatInstanceManagerForTests({
 			postToConversation,
 			editMessageContent,
@@ -482,7 +495,10 @@ describe("Google Chat declared event action adapter", () => {
 				conversationId: `gchat:${SPACE_NAME}:thread-two`,
 				threadId: "thread-two",
 			}),
-		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
+		).toMatchObject({
+			ok: true,
+			messageId: `${SPACE_NAME}/messages/poll-card-thread-two`,
+		});
 		expect(
 			await presentStoredEventToConversation({
 				organizationId: workspace.org.id,
@@ -494,7 +510,10 @@ describe("Google Chat declared event action adapter", () => {
 				conversationId: `gchat:${SPACE_NAME}/secondary:${threadId}`,
 				threadId,
 			}),
-		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
+		).toMatchObject({
+			ok: true,
+			messageId: `${SPACE_NAME}/secondary/messages/poll-card`,
+		});
 		expect(
 			await presentStoredEventToConversation({
 				organizationId: workspace.org.id,
@@ -580,7 +599,7 @@ describe("Google Chat declared event action adapter", () => {
 				responses: [response],
 			});
 			if (reachedQuorum) {
-				await agentApi.knowledge.save({
+				const successor = await agentApi.knowledge.save({
 					entity_ids: [board.id, poll.id],
 					content: `Poll closed after ${winningChoice} reached quorum 2.`,
 					title: `${question} — closed`,
@@ -589,6 +608,10 @@ describe("Google Chat declared event action adapter", () => {
 					metadata: pollOutput,
 					supersedes_event_id: source.id,
 					idempotency_key: `poll-close:${pollId}`,
+				});
+				await refreshInteractiveEventCardTask({
+					organizationId: workspace.org.id,
+					replacementEventId: Number(successor.id),
 				});
 			}
 			return pollOutput;
@@ -893,7 +916,7 @@ describe("Google Chat declared event action adapter", () => {
 					metadata: closed,
 				});
 			}
-			await agentApi.knowledge.save({
+			const successor = await agentApi.knowledge.save({
 				entity_ids: [board.id, params.entityId],
 				content: `Poll closed by ${closed.close_reason}.`,
 				title: `${params.state.question} — closed`,
@@ -902,6 +925,10 @@ describe("Google Chat declared event action adapter", () => {
 				metadata: closed,
 				supersedes_event_id: params.sourceEventId,
 				idempotency_key: `poll-close:${params.state.poll_id}`,
+			});
+			await refreshInteractiveEventCardTask({
+				organizationId: workspace.org.id,
+				replacementEventId: Number(successor.id),
 			});
 			return true;
 		};
@@ -935,7 +962,7 @@ describe("Google Chat declared event action adapter", () => {
 				{ pollId: deadlinePoll.poll_id, closed: true },
 			].sort((a, b) => a.pollId.localeCompare(b.pollId)),
 		);
-		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(3));
+		expect(editMessageContent).toHaveBeenCalledTimes(4);
 		const [deadlineClosed] = await sql<{ metadata: typeof deadlinePoll }>`
 			SELECT metadata FROM entities
 			WHERE organization_id = ${workspace.org.id}

--- a/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
+++ b/packages/server/src/__tests__/integration/events/gchat-template-event-action.test.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../interactions/template-event-actions.js";
 import { __setChatInstanceManagerForTests } from "../../../lobu/gateway.js";
 import { runtimeConnectionIdToSlug } from "../../../lobu/stores/connections-projection.js";
-import { resolveNotificationKindCard } from "../../../notifications/service.js";
+import { presentStoredEventToConversation } from "../../../notifications/service.js";
 import { registerScheduledJobsTicker } from "../../../scheduled/scheduled-jobs-service.js";
 import { manageSchedules } from "../../../tools/admin/manage_schedules.js";
 import type { ToolContext } from "../../../tools/registry.js";
@@ -424,41 +424,79 @@ describe("Google Chat declared event action adapter", () => {
 		const { chat, postMessage, threadId } = await createGoogleChatHarness(
 			workspace.org.id,
 		);
+		const editMessageContent = vi.fn(async () => undefined);
+		const postToConversation = vi.fn(async () => ({
+			messageId: MESSAGE_NAME,
+			threadId,
+		}));
+		__setChatInstanceManagerForTests({
+			postToConversation,
+			editMessageContent,
+		});
 		const source = await insertEvent({
 			entityIds: [board.id, poll.id],
 			organizationId: workspace.org.id,
 			originId: `poll-opened:${pollId}`,
 			title: question,
 			payloadType: "empty",
-			payloadData: initialPoll,
 			semanticType: "poll_opened",
-			metadata: {
-				notification_type: "generic",
-				delivery: [
-					{
-						connectionId: CONNECTION_ID,
-						messageId: MESSAGE_NAME,
-						threadId,
-					},
-				],
-			},
+			metadata: initialPoll,
 		});
 		const actionId = templateEventActionId(source.id, "vote");
-		const rendered = await resolveNotificationKindCard(
-			{
+		const presentations = await Promise.all([
+			presentStoredEventToConversation({
 				organizationId: workspace.org.id,
-				type: "agent_message",
-				title: question,
-				semanticType: "poll_opened",
-				entityIds: [board.id, poll.id],
-				payloadData: initialPoll,
-			},
-			source.id,
-		);
-		expect(JSON.stringify(rendered)).toContain(actionId);
-
-		const editMessageContent = vi.fn(async () => undefined);
-		__setChatInstanceManagerForTests({ editMessageContent });
+				eventId: source.id,
+				connectionId: CONNECTION_ID,
+				platform: "gchat",
+				channelId: SPACE_NAME,
+				channelKey: `gchat:${SPACE_NAME}`,
+				threadId,
+			}),
+			presentStoredEventToConversation({
+				organizationId: workspace.org.id,
+				eventId: source.id,
+				connectionId: CONNECTION_ID,
+				platform: "gchat",
+				channelId: SPACE_NAME,
+				channelKey: `gchat:${SPACE_NAME}`,
+				threadId,
+			}),
+		]);
+		expect(presentations).toEqual([
+			expect.objectContaining({ ok: true, messageId: MESSAGE_NAME }),
+			expect.objectContaining({ ok: true, messageId: MESSAGE_NAME }),
+		]);
+		expect(JSON.stringify(postToConversation.mock.calls)).toContain(actionId);
+		expect(postToConversation).toHaveBeenCalledTimes(1);
+		expect(
+			await presentStoredEventToConversation({
+				organizationId: workspace.org.id,
+				eventId: source.id,
+				connectionId: CONNECTION_ID,
+				platform: "gchat",
+				channelId: `${SPACE_NAME}/secondary`,
+				channelKey: `gchat:${SPACE_NAME}/secondary`,
+				threadId,
+			}),
+		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
+		expect(
+			await presentStoredEventToConversation({
+				organizationId: workspace.org.id,
+				eventId: source.id,
+				connectionId: CONNECTION_ID,
+				platform: "gchat",
+				channelId: SPACE_NAME,
+				channelKey: `gchat:${SPACE_NAME}`,
+				threadId,
+			}),
+		).toMatchObject({ ok: true, messageId: MESSAGE_NAME });
+		expect(postToConversation).toHaveBeenCalledTimes(2);
+		expect(
+			(await sql<{ metadata: { delivery: unknown[] } }>`
+				SELECT metadata FROM events WHERE id = ${source.id}
+			`)[0]?.metadata.delivery,
+		).toHaveLength(2);
 		const reduceVote = async (voteEventId: number) => {
 			const [vote] = await sql<{
 				metadata: {
@@ -643,7 +681,7 @@ describe("Google Chat declared event action adapter", () => {
 			close_reason: "quorum",
 		});
 
-		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(1));
+		await vi.waitFor(() => expect(editMessageContent).toHaveBeenCalledTimes(2));
 		const responses = await sql<{
 			metadata: { actor_id: string; choice: string };
 		}>`
@@ -697,7 +735,7 @@ describe("Google Chat declared event action adapter", () => {
 				  AND semantic_type = 'poll_vote_cast'
 			`,
 		).toHaveLength(3);
-		expect(editMessageContent).toHaveBeenCalledTimes(1);
+		expect(editMessageContent).toHaveBeenCalledTimes(2);
 		expect(JSON.stringify(postMessage.mock.calls)).toContain(
 			"This interaction is closed or has been replaced.",
 		);

--- a/packages/server/src/__tests__/integration/events/template-event-actions.test.ts
+++ b/packages/server/src/__tests__/integration/events/template-event-actions.test.ts
@@ -7,13 +7,18 @@ import {
 	it,
 	vi,
 } from "vitest";
-import { invokeTemplateEventAction } from "../../../interactions/template-event-actions";
+import {
+	invokeTemplateEventAction,
+	templateEventActionId,
+} from "../../../interactions/template-event-actions";
 import {
 	assertTemplateActionCapability,
 	MAX_TEMPLATE_ACTION_SOURCE_EVENTS,
 	TEMPLATE_ACTION_CAPABILITY_META_KEY,
 } from "../../../interactions/template-action-capability";
 import { __setChatInstanceManagerForTests } from "../../../lobu/gateway";
+import { refreshInteractiveEventCardTask } from "../../../notifications/service";
+import { INTERACTIVE_EVENT_CARD_REFRESH_TASK } from "../../../scheduled/task-definitions";
 import { getContent } from "../../../tools/get_content";
 import { getMcpResultMeta } from "../../../tools/mcp-result-meta";
 import type { ToolContext } from "../../../tools/registry";
@@ -344,9 +349,26 @@ describe("template event actions", () => {
 			supersedes_event_id: source.id,
 			idempotency_key: "poll-close:poll-1",
 		});
-		await vi.waitFor(() =>
-			expect(editMessageContent).toHaveBeenCalledTimes(1),
-		);
+		const [closedReplacement] = await sql<{ id: number }>`
+      SELECT id FROM events
+      WHERE organization_id = ${workspace.org.id}
+        AND supersedes_event_id = ${source.id}
+      LIMIT 1
+		`;
+		if (!closedReplacement) throw new Error("Expected poll replacement");
+		expect(
+			await sql`
+        SELECT id FROM runs
+        WHERE organization_id = ${workspace.org.id}
+          AND action_key = ${INTERACTIVE_EVENT_CARD_REFRESH_TASK}
+          AND (action_input->'payload'->>'replacementEventId')::bigint = ${closedReplacement.id}
+      `,
+		).toHaveLength(1);
+		await refreshInteractiveEventCardTask({
+			organizationId: workspace.org.id,
+			replacementEventId: Number(closedReplacement.id),
+		});
+		expect(editMessageContent).toHaveBeenCalledTimes(1);
 		expect(editMessageContent).toHaveBeenCalledWith("91", {
 			threadId: "gchat:spaces/AAA:threads/thread-1",
 			messageId: "spaces/AAA/messages/poll-1",
@@ -416,7 +438,108 @@ describe("template event actions", () => {
         SELECT id FROM events
         WHERE organization_id = ${workspace.org.id}
           AND semantic_type = 'poll_vote_cast'
-      `,
+			`,
 		).toHaveLength(1);
+
+		// A slow old refresh and a newly queued successor must converge on the
+		// newest controls. The task lock spans the physical edit, while each waiter
+		// resolves the head only after acquiring it.
+		const raceSource = await insertEvent({
+			entityIds: [poll.id],
+			organizationId: workspace.org.id,
+			originId: "poll-opened-refresh-race",
+			title: "Race-safe poll",
+			payloadType: "empty",
+			semanticType: "poll_opened",
+			metadata: {
+				poll_id: "poll-refresh-race",
+				delivery: [
+					{
+						connectionId: "93",
+						messageId: "spaces/AAA/messages/poll-race",
+						threadId: "gchat:spaces/AAA:threads/thread-race",
+					},
+				],
+			},
+		});
+		const firstSuccessor = await api.knowledge.save({
+			entity_ids: [poll.id],
+			semantic_type: "poll_opened",
+			title: "Race-safe poll · one vote",
+			payload_type: "empty",
+			metadata: { poll_id: "poll-refresh-race", response_count: 1 },
+			supersedes_event_id: raceSource.id,
+			idempotency_key: "poll-refresh-race:one",
+		});
+		let releaseFirstEdit = () => {};
+		const firstEditRelease = new Promise<void>((resolve) => {
+			releaseFirstEdit = resolve;
+		});
+		let markFirstEditStarted = () => {};
+		const firstEditStarted = new Promise<void>((resolve) => {
+			markFirstEditStarted = resolve;
+		});
+		const racingEdit = vi.fn(async () => {
+			if (racingEdit.mock.calls.length === 1) {
+				markFirstEditStarted();
+				await firstEditRelease;
+			}
+		});
+		__setChatInstanceManagerForTests({ editMessageContent: racingEdit });
+		const slowOldRefresh = refreshInteractiveEventCardTask({
+			organizationId: workspace.org.id,
+			replacementEventId: Number(firstSuccessor.id),
+		});
+		await firstEditStarted;
+		const newestSuccessor = await api.knowledge.save({
+			entity_ids: [poll.id],
+			semantic_type: "poll_opened",
+			title: "Race-safe poll · two votes",
+			payload_type: "empty",
+			metadata: { poll_id: "poll-refresh-race", response_count: 2 },
+			supersedes_event_id: Number(firstSuccessor.id),
+			idempotency_key: "poll-refresh-race:two",
+		});
+		const newestRefresh = refreshInteractiveEventCardTask({
+			organizationId: workspace.org.id,
+			replacementEventId: Number(newestSuccessor.id),
+		});
+		releaseFirstEdit();
+		await Promise.all([slowOldRefresh, newestRefresh]);
+		expect(racingEdit).toHaveBeenCalledTimes(2);
+		expect(JSON.stringify(racingEdit.mock.calls.at(-1))).toContain(
+			templateEventActionId(Number(newestSuccessor.id), "vote"),
+		);
+		await expect(
+			invokeTemplateEventAction({
+				organizationId: workspace.org.id,
+				sourceEventId: Number(newestSuccessor.id),
+				action: "vote",
+				value: "A",
+				interactionId: "google-refresh-race-vote",
+				surface: "gchat",
+				actor: {
+					platform: "gchat",
+					platformUserId: "users/grace",
+					name: "Grace",
+				},
+				source: {
+					connectionId: "93",
+					messageId: "spaces/AAA/messages/poll-race",
+					threadId: "gchat:spaces/AAA:threads/thread-race",
+				},
+			}),
+		).resolves.toMatchObject({ created: true, eventType: "poll_vote_cast" });
+		__setChatInstanceManagerForTests({
+			editMessageContent: vi.fn(async () => {
+				throw new Error("transient edit failure");
+			}),
+		});
+		await expect(
+			refreshInteractiveEventCardTask({
+				organizationId: workspace.org.id,
+				replacementEventId: Number(newestSuccessor.id),
+			}),
+		).rejects.toThrow("transient edit failure");
 	});
 });

--- a/packages/server/src/__tests__/unit/template-card.test.ts
+++ b/packages/server/src/__tests__/unit/template-card.test.ts
@@ -572,6 +572,34 @@ describe("template-declared controls", () => {
 		]);
 	});
 
+	it("binds one declared event button per dynamic option", () => {
+		const card = buildKindCard({
+			jsonTemplate: {
+				type: "card",
+				children: [
+					{
+						type: "each",
+						items: "options",
+						as: "option",
+						render: bound({
+							label: "{{option}}",
+							value: "{{option}}",
+							onClick: "@vote",
+						}),
+					},
+				],
+			},
+			data: { options: ["Alpha", "Beta", "Gamma"] },
+			interactions: { vote: { emits: "poll_vote_cast" } },
+			sourceEventId: 42,
+		});
+		expect(buttons(card)).toMatchObject([
+			{ id: "event-action:42:vote", label: "Alpha", value: "Alpha" },
+			{ id: "event-action:42:vote", label: "Beta", value: "Beta" },
+			{ id: "event-action:42:vote", label: "Gamma", value: "Gamma" },
+		]);
+	});
+
 	it("keeps a valueless declared button valueless on chat", () => {
 		const card = buildKindCard({
 			jsonTemplate: bound({ label: "Refresh", onClick: "@refresh" }),

--- a/packages/server/src/gateway/__tests__/routes/conversations-event-tools.test.ts
+++ b/packages/server/src/gateway/__tests__/routes/conversations-event-tools.test.ts
@@ -90,6 +90,7 @@ describe("active-conversation event tools", () => {
       platform: "gchat",
       channelId: "gchat:spaces/AAAA",
       channelKey: "gchat:spaces/AAAA",
+      conversationId: "gchat:spaces/AAAA:dm",
       threadId: "dm",
     });
   });
@@ -174,6 +175,21 @@ describe("active-conversation event tools", () => {
       }
     );
     expect(response.status).toBe(400);
+    expect(manageSchedules).not.toHaveBeenCalled();
+  });
+
+  test("rejects a follow-up on a platform without scheduled chat delivery", async () => {
+    const response = await post(
+      router,
+      "/conversations/schedule-followup",
+      token({ platform: "discord", channelId: "channel-1" }, "discord:channel-1"),
+      {
+        runAt: new Date(Date.now() + 60_000).toISOString(),
+        prompt: "follow up here",
+        idempotencyKey: "unsupported-platform",
+      }
+    );
+    expect(response.status).toBe(422);
     expect(manageSchedules).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/gateway/__tests__/routes/conversations-event-tools.test.ts
+++ b/packages/server/src/gateway/__tests__/routes/conversations-event-tools.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
+import { createConversationsRoutes } from "../../routes/internal/conversations.js";
+
+const presentStoredEventToConversation = mock(async () => ({
+  ok: true as const,
+  messageId: "spaces/AAAA/messages/card-1",
+  threadId: "gchat:spaces/AAAA:dm",
+  fallbackText: "Poll",
+}));
+const manageSchedules = mock(async () => ({
+  schedule: { id: "schedule-1" },
+}));
+
+mock.module("../../../notifications/service.js", () => ({
+  presentStoredEventToConversation,
+}));
+mock.module("../../../tools/admin/manage_schedules.js", () => ({
+  manageSchedules,
+}));
+
+const ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function token(
+  overrides: Record<string, unknown> = {},
+  conversationId = "gchat:spaces/AAAA:dm"
+) {
+  return generateWorkerToken(
+    "users/owner",
+    conversationId,
+    "personal-agent-deploy",
+    {
+      channelId: "spaces/AAAA",
+      platform: "gchat",
+      agentId: "personal-agent",
+      organizationId: "org-event-tools-test",
+      connectionId: "567",
+      ...overrides,
+    }
+  );
+}
+
+function post(
+  router: ReturnType<typeof createConversationsRoutes>,
+  path: string,
+  workerToken: string,
+  body: Record<string, unknown>
+) {
+  return router.request(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${workerToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("active-conversation event tools", () => {
+  let originalKey: string | undefined;
+  let router: ReturnType<typeof createConversationsRoutes>;
+
+  beforeEach(() => {
+    originalKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
+    presentStoredEventToConversation.mockClear();
+    manageSchedules.mockClear();
+    router = createConversationsRoutes();
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = originalKey;
+  });
+
+  test("presents only the event id into the signed source conversation", async () => {
+    const response = await post(
+      router,
+      "/conversations/present-event",
+      token({ channelId: "gchat:spaces/AAAA" }),
+      { eventId: 42 }
+    );
+
+    expect(response.status).toBe(200);
+    expect(presentStoredEventToConversation).toHaveBeenCalledWith({
+      organizationId: "org-event-tools-test",
+      eventId: 42,
+      connectionId: "567",
+      platform: "gchat",
+      channelId: "gchat:spaces/AAAA",
+      channelKey: "gchat:spaces/AAAA",
+      threadId: "dm",
+    });
+  });
+
+  test("rejects presentation without signed chat coordinates", async () => {
+    const response = await post(
+      router,
+      "/conversations/present-event",
+      token({ connectionId: undefined }),
+      { eventId: 42 }
+    );
+    expect(response.status).toBe(403);
+    expect(presentStoredEventToConversation).not.toHaveBeenCalled();
+  });
+
+  test("schedules only the signed agent in the signed conversation", async () => {
+    const runAt = new Date(Date.now() + 60_000).toISOString();
+    const response = await post(
+      router,
+      "/conversations/schedule-followup",
+      token(),
+      {
+        runAt,
+        prompt: "Close event-backed poll entity 77.",
+        idempotencyKey: "poll-deadline:77",
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const [args, , context] = manageSchedules.mock.calls[0];
+    expect(args).toMatchObject({
+      action: "create",
+      run_at: runAt,
+      payload: {
+        type: "wake_agent",
+        agent_id: "personal-agent",
+        prompt: "Close event-backed poll entity 77.",
+      },
+    });
+    expect(args.idempotency_key).toMatch(/^conversation-followup:[0-9a-f]{64}$/);
+    expect(context).toMatchObject({
+      organizationId: "org-event-tools-test",
+      userId: null,
+      agentId: "personal-agent",
+      sourceContext: {
+        platform: "gchat",
+        connectionId: "567",
+        channelId: "spaces/AAAA",
+        conversationId: "gchat:spaces/AAAA:dm",
+        userId: "users/owner",
+      },
+    });
+
+    const second = await post(
+      router,
+      "/conversations/schedule-followup",
+      token({}, "gchat:spaces/AAAA:thread-two"),
+      {
+        runAt,
+        prompt: "Close event-backed poll entity 77.",
+        idempotencyKey: "poll-deadline:77",
+      }
+    );
+    expect(second.status).toBe(200);
+    expect(manageSchedules.mock.calls[1][0].idempotency_key).not.toBe(
+      args.idempotency_key
+    );
+    expect(manageSchedules.mock.calls[1][0].source_thread_id).toBe(
+      "gchat:spaces/AAAA:thread-two"
+    );
+  });
+
+  test("rejects a past follow-up without touching the scheduler", async () => {
+    const response = await post(
+      router,
+      "/conversations/schedule-followup",
+      token(),
+      {
+        runAt: "2020-01-01T00:00:00.000Z",
+        prompt: "too late",
+        idempotencyKey: "past",
+      }
+    );
+    expect(response.status).toBe(400);
+    expect(manageSchedules).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/gateway/routes/internal/conversations.ts
+++ b/packages/server/src/gateway/routes/internal/conversations.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { createLogger } from "@lobu/core";
 import { Hono, type Context } from "hono";
 import {
@@ -11,7 +12,11 @@ import {
   conversationRefsMatch,
   parseConversationRef,
 } from "../../conversations/conversation-ref.js";
+import { stripPlatformPrefix } from "../../channels/bound-channels.js";
 import { getChatInstanceManager } from "../../../lobu/gateway.js";
+import { presentStoredEventToConversation } from "../../../notifications/service.js";
+import { manageSchedules } from "../../../tools/admin/manage_schedules.js";
+import type { ToolContext } from "../../../tools/registry.js";
 import {
   captureChannelMessage,
   readChannelTranscript,
@@ -271,6 +276,206 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
       });
     } catch (error) {
       logger.error(`send conversation failed: ${String(error)}`);
+      return errorResponse(c, "Internal server error", 500);
+    }
+  });
+
+  // POST /conversations/present-event { eventId }
+  //
+  // Unlike send_message, this route accepts no destination or authored card.
+  // It renders a tenant-owned durable event through its declared json_template
+  // and posts it back into the signed source conversation. That keeps event
+  // actions portable across web/Slack/Google Chat without teaching the model
+  // platform card JSON or internal action-id formats.
+  router.post("/conversations/present-event", authenticateWorker, async (c) => {
+    try {
+      const worker = getVerifiedWorker(c);
+      if (
+        !worker.agentId ||
+        !worker.organizationId ||
+        !worker.connectionId ||
+        !worker.platform ||
+        !worker.channelId
+      ) {
+        return errorResponse(
+          c,
+          "This turn is not attached to an active chat conversation",
+          403
+        );
+      }
+      const body = (await c.req.json().catch(() => null)) as {
+        eventId?: unknown;
+      } | null;
+      const eventId = Number(body?.eventId);
+      if (!Number.isSafeInteger(eventId) || eventId < 1) {
+        return errorResponse(c, "eventId must be a positive integer", 400);
+      }
+
+      const captured = await captureSideEffect(c, "conversations.present-event", {
+        eventId,
+        conversationId: worker.conversationId,
+      });
+      if (captured) return captured;
+
+      const presentation = await presentStoredEventToConversation({
+        organizationId: worker.organizationId,
+        eventId,
+        connectionId: worker.connectionId,
+        platform: worker.platform,
+        channelId: worker.channelId,
+        channelKey: `${worker.platform}:${stripPlatformPrefix(
+          worker.platform,
+          worker.channelId
+        )}`,
+        threadId:
+          worker.responseThreadId ??
+          parseConversationRef(worker.conversationId)?.threadId,
+      });
+      if (!presentation.ok) {
+        if (presentation.reason === "not_found") {
+          return errorResponse(c, "Event not found or already replaced", 404);
+        }
+        if (presentation.reason === "not_renderable") {
+          return errorResponse(
+            c,
+            "Event has no renderable declared json_template",
+            422
+          );
+        }
+        return errorResponse(c, "Chat instance manager unavailable", 503);
+      }
+
+      captureChannelMessage({
+        organizationId: worker.organizationId,
+        connectionId: worker.connectionId,
+        platform: worker.platform,
+        channelId: worker.channelId,
+        threadId: presentation.threadId,
+        platformMessageId: presentation.messageId,
+        authorId: worker.agentId,
+        authorName: worker.agentId,
+        teamId: worker.teamId ?? null,
+        isBot: true,
+        text: presentation.fallbackText,
+        occurredAt: new Date(),
+      });
+
+      return c.json({
+        messageId: presentation.messageId,
+        deliveredInBand: true,
+      });
+    } catch (error) {
+      logger.error(`present event failed: ${String(error)}`);
+      return errorResponse(c, "Internal server error", 500);
+    }
+  });
+
+  // POST /conversations/schedule-followup { runAt, prompt, idempotencyKey }
+  //
+  // This is the user-level, conversation-scoped subset of manage_schedules:
+  // one shot, same signed agent, same signed conversation. The model cannot
+  // choose another destination/agent, create a cron, or fan out a notification.
+  router.post("/conversations/schedule-followup", authenticateWorker, async (c) => {
+    try {
+      const worker = getVerifiedWorker(c);
+      if (
+        !worker.agentId ||
+        !worker.organizationId ||
+        !worker.connectionId ||
+        !worker.platform ||
+        !worker.channelId ||
+        !worker.conversationId
+      ) {
+        return errorResponse(
+          c,
+          "This turn is not attached to an active chat conversation",
+          403
+        );
+      }
+      const body = (await c.req.json().catch(() => null)) as {
+        runAt?: unknown;
+        prompt?: unknown;
+        idempotencyKey?: unknown;
+      } | null;
+      const runAt = typeof body?.runAt === "string" ? body.runAt.trim() : "";
+      const prompt = typeof body?.prompt === "string" ? body.prompt.trim() : "";
+      const idempotencyKey =
+        typeof body?.idempotencyKey === "string"
+          ? body.idempotencyKey.trim()
+          : "";
+      const runAtDate = new Date(runAt);
+      if (!runAt || Number.isNaN(runAtDate.getTime())) {
+        return errorResponse(c, "runAt must be an ISO timestamp", 400);
+      }
+      if (runAtDate.getTime() <= Date.now()) {
+        return errorResponse(c, "runAt must be in the future", 400);
+      }
+      if (!prompt || prompt.length > 2_000) {
+        return errorResponse(c, "prompt must be 1-2000 characters", 400);
+      }
+      if (!idempotencyKey || idempotencyKey.length > 200) {
+        return errorResponse(c, "idempotencyKey must be 1-200 characters", 400);
+      }
+
+      const captured = await captureSideEffect(
+        c,
+        "conversations.schedule-followup",
+        { runAt, prompt, idempotencyKey }
+      );
+      if (captured) return captured;
+
+      // scheduled_jobs idempotency is organization-wide. Scope the caller's
+      // stable key to the signed agent and conversation so another chat cannot
+      // replay an unrelated schedule that happens to use the same key.
+      const scopedIdempotencyKey = `conversation-followup:${createHash("sha256")
+        .update(`${worker.agentId}\0${worker.conversationId}\0${idempotencyKey}`)
+        .digest("hex")}`;
+      const schedule = await manageSchedules(
+        {
+          action: "create",
+          description: `Follow up in ${worker.platform} conversation`,
+          run_at: runAt,
+          idempotency_key: scopedIdempotencyKey,
+          source_thread_id: worker.conversationId,
+          payload: {
+            type: "wake_agent",
+            agent_id: worker.agentId,
+            prompt,
+          },
+        },
+        {} as never,
+        {
+          organizationId: worker.organizationId,
+          // Chat platform user ids are not Lobu user-row ids. Keep durable
+          // creator attribution on the signed agent and retain the platform
+          // principal only inside the trusted delivery context.
+          userId: null,
+          memberRole: null,
+          agentId: worker.agentId,
+          sourceContext: {
+            platform: worker.platform,
+            connectionId: worker.connectionId,
+            channelId: worker.channelId,
+            conversationId: worker.conversationId,
+            teamId: worker.teamId,
+            userId: worker.userId,
+          },
+          isAuthenticated: true,
+          clientId: "lobu-worker",
+          scopes: null,
+          tokenType: "session",
+          scopedToOrg: true,
+          allowCrossOrg: false,
+          grantedOrganizationIds: null,
+          directSearchFederation: false,
+        } satisfies ToolContext
+      );
+      if (schedule.error) {
+        return errorResponse(c, schedule.error, 422);
+      }
+      return c.json({ scheduled: true, schedule: schedule.schedule });
+    } catch (error) {
+      logger.error(`schedule followup failed: ${String(error)}`);
       return errorResponse(c, "Internal server error", 500);
     }
   });

--- a/packages/server/src/gateway/routes/internal/conversations.ts
+++ b/packages/server/src/gateway/routes/internal/conversations.ts
@@ -15,6 +15,7 @@ import {
 import { stripPlatformPrefix } from "../../channels/bound-channels.js";
 import { getChatInstanceManager } from "../../../lobu/gateway.js";
 import { presentStoredEventToConversation } from "../../../notifications/service.js";
+import { isDeliverableChatPlatform } from "../../../scheduled/scheduled-jobs-service.js";
 import { manageSchedules } from "../../../tools/admin/manage_schedules.js";
 import type { ToolContext } from "../../../tools/registry.js";
 import {
@@ -327,6 +328,7 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
           worker.platform,
           worker.channelId
         )}`,
+        conversationId: worker.conversationId,
         threadId:
           worker.responseThreadId ??
           parseConversationRef(worker.conversationId)?.threadId,
@@ -390,6 +392,13 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
           c,
           "This turn is not attached to an active chat conversation",
           403
+        );
+      }
+      if (!isDeliverableChatPlatform(worker.platform)) {
+        return errorResponse(
+          c,
+          "Scheduled follow-ups are not supported on this chat platform",
+          422
         );
       }
       const body = (await c.req.json().catch(() => null)) as {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -416,6 +416,8 @@ interface NotificationDeliveryRecord {
 	connectionId: string;
 	/** Platform-prefixed channel id, or `dm` for the owner-routed tier. */
 	channelKey: string;
+	/** Trusted flat conversation id; present for conversation-scoped delivery. */
+	conversationId?: string;
 	messageId: string;
 	threadId: string;
 }
@@ -503,6 +505,7 @@ interface StoredEventPresentationParams {
 	platform: string;
 	channelId: string;
 	channelKey: string;
+	conversationId: string;
 	threadId?: string;
 }
 
@@ -564,7 +567,8 @@ async function presentStoredEventToConversationLocked(
 	const existingDelivery = deliveryRecords(metadata).find(
 		(delivery) =>
 			delivery.connectionId === params.connectionId &&
-			delivery.channelKey === params.channelKey,
+			delivery.channelKey === params.channelKey &&
+			delivery.conversationId === params.conversationId,
 	);
 	if (existingDelivery) {
 		return {
@@ -623,6 +627,7 @@ async function presentStoredEventToConversationLocked(
 			{
 				connectionId: params.connectionId,
 				channelKey: params.channelKey,
+				conversationId: params.conversationId,
 				messageId: sent.messageId,
 				threadId: sent.threadId,
 			},
@@ -676,6 +681,7 @@ function deliveryRecords(
 			const row = jsonRecord(entry);
 			const connectionId = row.connectionId;
 			const channelKey = row.channelKey;
+			const conversationId = row.conversationId;
 			const messageId = row.messageId;
 			const threadId = row.threadId;
 			return typeof connectionId === "string" &&
@@ -685,6 +691,7 @@ function deliveryRecords(
 				? [{
 						connectionId,
 						...(typeof channelKey === "string" ? { channelKey } : {}),
+						...(typeof conversationId === "string" ? { conversationId } : {}),
 						messageId,
 						threadId,
 					}]

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -471,12 +471,18 @@ async function persistDeliveryMetadata(
 			delivery: addressable,
 			...(card ? { card } : {}),
 		};
-		await db`
+		const updated = await db<{ id: number }>`
       UPDATE events
       SET metadata = coalesce(metadata, '{}'::jsonb)
         || ${db.json(deliveryMetadata)}::jsonb
       WHERE id = ${eventId}
+      RETURNING id
     `;
+		if (options?.required && updated.length === 0) {
+			throw new Error(
+				`Event ${eventId} vanished before delivery metadata persisted`,
+			);
+		}
 	} catch (err) {
 		if (options?.required) throw err;
 		logger.warn(
@@ -519,9 +525,8 @@ interface StoredEventPresentationParams {
  * supplies a template, executable handler, action id, actor id, or platform
  * destination. The destination coordinates are signed worker-token claims.
  *
- * Persisting the platform message pointer on the SAME event gives a later
- * superseding event the routing data used by
- * `queueInteractiveEventCardRefresh` for an in-place refresh attempt.
+ * Persisting the platform message pointer on the SAME event gives the durable
+ * interactive-card refresh task the routing data used for in-place updates.
  */
 export async function presentStoredEventToConversation(
 	params: StoredEventPresentationParams,
@@ -827,139 +832,172 @@ export function queueApprovalNotificationCardRefresh(
 	);
 }
 
-/** Replace persisted chat copies only when the superseded event was interactive. */
-async function refreshInteractiveEventCard(
-	organizationId: string,
-	replacementEventId: number,
-	supersededEventId: number,
-): Promise<void> {
-	const manager = getChatInstanceManager();
-	if (!manager) return;
-	const [row] = await getDb()<{
-		title: string | null;
-		entity_ids: unknown;
-		semantic_type: string;
-		payload_text: string | null;
-		payload_data: unknown;
-		metadata: unknown;
-		source_entity_ids: unknown;
-		source_semantic_type: string;
-		source_metadata: unknown;
-	}>`
-    SELECT replacement.title, replacement.entity_ids,
-           replacement.semantic_type, replacement.payload_text,
-           replacement.payload_data, replacement.metadata,
-           source.entity_ids AS source_entity_ids,
-           source.semantic_type AS source_semantic_type,
-           source.metadata AS source_metadata
-    FROM events replacement
-    JOIN events source
-      ON source.id = ${supersededEventId}
-     AND source.organization_id = replacement.organization_id
-    WHERE replacement.id = ${replacementEventId}
-      AND replacement.organization_id = ${organizationId}
-    LIMIT 1
-  `;
-	if (!row) return;
-	const sourceMetadata = jsonRecord(row.source_metadata);
-	const deliveries = deliveryRecords(sourceMetadata);
-	if (deliveries.length === 0) return;
-	const sourceKind = await resolveEventKindDefinition(
-		row.source_semantic_type,
-		organizationId,
-		parsePgNumberArray(row.source_entity_ids),
-	);
-	if (!sourceKind?.interactions || Object.keys(sourceKind.interactions).length === 0) {
-		return;
-	}
-
-	const entityIds = parsePgNumberArray(row.entity_ids);
-	const kind = await resolveEventKindDefinition(
-		row.semantic_type,
-		organizationId,
-		entityIds,
-	);
-	if (!kind) return;
-	const metadata = jsonRecord(row.metadata);
-	const data =
-		typeof metadata.notification_type === "string"
-			? jsonRecord(row.payload_data)
-			: metadata;
-	const card = buildKindCard({
-		metadataSchema: kind.metadataSchema,
-		jsonTemplate: kind.jsonTemplate,
-		data,
-		title: row.title ?? row.semantic_type,
-		body: row.payload_text ?? undefined,
-		url: toAbsolutePermalink(
-			typeof metadata.resource_url === "string"
-				? metadata.resource_url
-				: typeof sourceMetadata.resource_url === "string"
-					? sourceMetadata.resource_url
-					: undefined,
-		),
-		sourceEventId: replacementEventId,
-		interactions: kind.interactions,
-	});
-	if (!card) return;
-	const content: AdapterPostableMessage = {
-		card,
-		fallbackText: row.payload_text
-			? `${row.title ?? row.semantic_type}\n\n${row.payload_text}`
-			: row.title ?? row.semantic_type,
-	};
-	const successfulDeliveries = (
-		await Promise.all(
-			deliveries.map(async (delivery) => {
-				try {
-					await manager.editMessageContent(delivery.connectionId, {
-						threadId: delivery.threadId,
-						messageId: delivery.messageId,
-						content,
-					});
-					return delivery;
-				} catch (err) {
-					logger.warn(
-						{ err, replacementEventId, connectionId: delivery.connectionId },
-						"[Notifications] Failed to refresh interactive event card",
-					);
-					return null;
-				}
-			}),
-		)
-	).filter(
-		(delivery): delivery is PersistedNotificationDeliveryRecord =>
-			delivery !== null,
-	);
-	// Carry the delivery pointer to the replacement only while it is still
-	// interactive: that record exists to let the NEXT supersede find these chat
-	// copies. Once a kind stops declaring interactions the chain has nothing
-	// left to refresh, so stamping it would be dead metadata.
-	if (kind.interactions && Object.keys(kind.interactions).length > 0) {
-		await persistDeliveryMetadata(
-			replacementEventId,
-			successfulDeliveries,
-			card,
-		);
-	}
+export interface InteractiveEventCardRefreshTaskPayload {
+	organizationId: string;
+	replacementEventId: number;
 }
 
-/** Best-effort post-commit refresh, mirroring approval-card settlement. */
-export function queueInteractiveEventCardRefresh(
-	organizationId: string,
-	replacementEventId: number,
-	supersededEventId: number,
-): void {
-	void refreshInteractiveEventCard(
-		organizationId,
-		replacementEventId,
-		supersededEventId,
-	).catch((err) =>
-		logger.warn(
-			{ err, organizationId, replacementEventId, supersededEventId },
-			"[Notifications] Failed to refresh interactive event card",
-		),
-	);
+/**
+ * Refresh every persisted copy of an interactive event at the newest live
+ * successor in its chain.
+ *
+ * Tasks commit atomically with successor events. The advisory lock serializes
+ * old/new tasks across pods, and each task resolves the live head only after it
+ * acquires that lock. An older delayed task can therefore repeat the newest
+ * edit, but cannot move a card back to stale controls. Gateway, edit, and
+ * metadata failures throw so the shared runs queue retries them.
+ */
+export async function refreshInteractiveEventCardTask(
+	payload: InteractiveEventCardRefreshTaskPayload,
+): Promise<void> {
+	if (
+		typeof payload.organizationId !== "string" ||
+		payload.organizationId === "" ||
+		!Number.isSafeInteger(payload.replacementEventId) ||
+		payload.replacementEventId <= 0
+	) {
+		throw new Error("Invalid interactive event card refresh task payload");
+	}
+	const manager = getChatInstanceManager();
+	if (!manager) throw new Error("Chat gateway is unavailable");
+	await getDb().begin(async (sql) => {
+		const [root] = await sql<{ id: number }>`
+      WITH RECURSIVE ancestry AS (
+        SELECT id, supersedes_event_id
+        FROM events
+        WHERE id = ${payload.replacementEventId}
+          AND organization_id = ${payload.organizationId}
+        UNION ALL
+        SELECT parent.id, parent.supersedes_event_id
+        FROM events parent
+        JOIN ancestry child ON child.supersedes_event_id = parent.id
+        WHERE parent.organization_id = ${payload.organizationId}
+      )
+      SELECT id FROM ancestry
+      WHERE supersedes_event_id IS NULL
+      LIMIT 1
+    `;
+		if (!root) return;
+		await sql`
+      SELECT pg_advisory_xact_lock(
+        hashtextextended(${`interactive-event-card:${payload.organizationId}:${root.id}`}, 0)
+      )
+    `;
+		const chain = await sql<{
+			id: number;
+			title: string | null;
+			entity_ids: unknown;
+			semantic_type: string;
+			payload_text: string | null;
+			payload_data: unknown;
+			metadata: unknown;
+			supersedes_event_id: number | null;
+		}>`
+      WITH RECURSIVE event_chain AS (
+        SELECT id, supersedes_event_id, title, entity_ids,
+               semantic_type, payload_text, payload_data, metadata, 0 AS depth
+        FROM events
+        WHERE id = ${root.id}
+          AND organization_id = ${payload.organizationId}
+        UNION ALL
+        SELECT successor.id, successor.supersedes_event_id, successor.title,
+               successor.entity_ids, successor.semantic_type,
+               successor.payload_text, successor.payload_data,
+               successor.metadata, event_chain.depth + 1
+        FROM events successor
+        JOIN event_chain ON successor.supersedes_event_id = event_chain.id
+        WHERE successor.organization_id = ${payload.organizationId}
+      )
+      SELECT id, supersedes_event_id, title, entity_ids,
+             semantic_type, payload_text, payload_data, metadata
+      FROM event_chain
+      ORDER BY depth
+  `;
+		const row = chain.at(-1);
+		if (!row) return;
+		const deliveredSource = chain.find(
+			(event) => deliveryRecords(jsonRecord(event.metadata)).length > 0,
+		);
+		if (!deliveredSource) return;
+		const sourceMetadata = jsonRecord(deliveredSource.metadata);
+		const deliveries = [
+			...new Map(
+				chain.flatMap((event) =>
+					deliveryRecords(jsonRecord(event.metadata)).map((delivery) => [
+						`${delivery.connectionId}\u0000${delivery.threadId}\u0000${delivery.messageId}`,
+						delivery,
+					] as const),
+				),
+			).values(),
+		];
+		if (deliveries.length === 0) return;
+		const sourceKind = await resolveEventKindDefinition(
+			deliveredSource.semantic_type,
+			payload.organizationId,
+			parsePgNumberArray(deliveredSource.entity_ids),
+		);
+		if (
+			!sourceKind?.interactions ||
+			Object.keys(sourceKind.interactions).length === 0
+		) {
+			return;
+		}
+
+		const entityIds = parsePgNumberArray(row.entity_ids);
+		const kind = await resolveEventKindDefinition(
+			row.semantic_type,
+			payload.organizationId,
+			entityIds,
+		);
+		if (!kind) {
+			throw new Error(`Event kind ${row.semantic_type} is unavailable`);
+		}
+		const metadata = jsonRecord(row.metadata);
+		const data =
+			typeof metadata.notification_type === "string"
+				? jsonRecord(row.payload_data)
+				: metadata;
+		const card = buildKindCard({
+			metadataSchema: kind.metadataSchema,
+			jsonTemplate: kind.jsonTemplate,
+			data,
+			title: row.title ?? row.semantic_type,
+			body: row.payload_text ?? undefined,
+			url: toAbsolutePermalink(
+				typeof metadata.resource_url === "string"
+					? metadata.resource_url
+					: typeof sourceMetadata.resource_url === "string"
+						? sourceMetadata.resource_url
+						: undefined,
+			),
+			sourceEventId: row.id,
+			interactions: kind.interactions,
+		});
+		if (!card) throw new Error(`Event ${row.id} is not renderable`);
+		const content: AdapterPostableMessage = {
+			card,
+			fallbackText: row.payload_text
+				? `${row.title ?? row.semantic_type}\n\n${row.payload_text}`
+				: row.title ?? row.semantic_type,
+		};
+		await Promise.all(
+			deliveries.map((delivery) =>
+				manager.editMessageContent(delivery.connectionId, {
+					threadId: delivery.threadId,
+					messageId: delivery.messageId,
+					content,
+				}),
+			),
+		);
+		// Carry the delivery pointer to an interactive successor for observability
+		// and presentation retries. A terminal successor has no future refresh hop.
+		if (kind.interactions && Object.keys(kind.interactions).length > 0) {
+			await persistDeliveryMetadata(row.id, deliveries, card, {
+				db: sql,
+				required: true,
+			});
+		}
+	});
 }
 
 /**

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -4,7 +4,13 @@ import {
 	type CardElement,
 } from "chat";
 import { loadConfiguredAutomationDeliveryTarget } from "../automations/delivery-target";
-import { getDb, parsePgNumberArray, pgBigintArray, pgTextArray } from "../db/client";
+import {
+	type DbClient,
+	getDb,
+	parsePgNumberArray,
+	pgBigintArray,
+	pgTextArray,
+} from "../db/client";
 import { resolveBoundChannelRows } from "../gateway/channels/bound-channels";
 import { getChatInstanceManager, isLobuGatewayRunning } from "../lobu/gateway";
 import type { McpActivityAttribution } from "../lobu/stores/mcp-client-conversations";
@@ -436,38 +442,200 @@ type PersistedNotificationDeliveryRecord = Omit<
  * returns, and the durable notification write must not block on a best-effort
  * chat post.
  *
- * Best-effort: losing the record costs a later in-place edit, not the
- * notification itself.
+ * Best-effort by default: losing the record costs a later in-place edit, not
+ * the notification itself. `present_event` opts into required persistence
+ * because the pointer drives in-place refresh and deduplicates later calls.
  */
 async function persistDeliveryMetadata(
 	eventId: number,
 	deliveries: PersistedNotificationDeliveryRecord[],
 	card?: CardElement,
+	options?: { db?: DbClient; required?: boolean },
 ): Promise<void> {
 	// A record exists to be addressed later, and `editMessage(threadId, messageId)`
 	// cannot address an empty id — an adapter that returned no message id has
 	// given us nothing to point at. Dropping it here rather than at each caller
 	// keeps the one rule in the one place that writes the record.
 	const addressable = deliveries.filter((entry) => entry.messageId !== "");
-	if (addressable.length === 0) return;
+	if (addressable.length === 0) {
+		if (options?.required) {
+			throw new Error("Delivery did not return an addressable message id");
+		}
+		return;
+	}
+	const db = options?.db ?? getDb();
 	try {
-		const sql = getDb();
 		const deliveryMetadata = {
 			delivery: addressable,
 			...(card ? { card } : {}),
 		};
-		await sql`
+		await db`
       UPDATE events
       SET metadata = coalesce(metadata, '{}'::jsonb)
-        || ${sql.json(deliveryMetadata)}::jsonb
+        || ${db.json(deliveryMetadata)}::jsonb
       WHERE id = ${eventId}
     `;
 	} catch (err) {
+		if (options?.required) throw err;
 		logger.warn(
 			{ err, eventId },
 			"[Notifications] Failed to record delivery targets",
 		);
 	}
+}
+
+type StoredEventPresentationResult =
+	| {
+			ok: true;
+			messageId: string;
+			threadId: string;
+			fallbackText: string;
+	  }
+	| {
+			ok: false;
+			reason: "not_found" | "not_renderable" | "gateway_unavailable";
+	  };
+
+interface StoredEventPresentationParams {
+	organizationId: string;
+	eventId: number;
+	connectionId: string;
+	platform: string;
+	channelId: string;
+	channelKey: string;
+	threadId?: string;
+}
+
+/**
+ * Render one already-persisted event into the conversation that invoked the
+ * current agent turn.
+ *
+ * The event is the authority: the worker supplies only its id, while the
+ * server re-reads the tenant-scoped row, resolves the linked entity kind, and
+ * derives the native card from that kind's json_template. The worker never
+ * supplies a template, executable handler, action id, actor id, or platform
+ * destination. The destination coordinates are signed worker-token claims.
+ *
+ * Persisting the platform message pointer on the SAME event gives a later
+ * superseding event the routing data used by
+ * `queueInteractiveEventCardRefresh` for an in-place refresh attempt.
+ */
+export async function presentStoredEventToConversation(
+	params: StoredEventPresentationParams,
+): Promise<StoredEventPresentationResult> {
+	return getDb().begin((sql) =>
+		presentStoredEventToConversationLocked(params, sql),
+	);
+}
+
+async function presentStoredEventToConversationLocked(
+	params: StoredEventPresentationParams,
+	sql: DbClient,
+): Promise<StoredEventPresentationResult> {
+	const [row] = await sql<{
+		title: string | null;
+		entity_ids: unknown;
+		semantic_type: string;
+		payload_text: string | null;
+		payload_data: unknown;
+		metadata: unknown;
+		source_url: string | null;
+		superseded_by: number | null;
+	}>`
+    SELECT title, entity_ids, semantic_type, payload_text, payload_data,
+           metadata, source_url, superseded_by
+    FROM events
+    WHERE id = ${params.eventId}
+      AND organization_id = ${params.organizationId}
+    LIMIT 1
+    FOR UPDATE
+  `;
+	if (!row || row.superseded_by !== null) {
+		return { ok: false, reason: "not_found" };
+	}
+
+	const metadata = jsonRecord(row.metadata);
+	const fallbackText = row.payload_text
+		? `${row.title ?? row.semantic_type}\n\n${row.payload_text}`
+		: row.title ?? row.semantic_type;
+	// The row lock serializes concurrent retries across replicas. A completed
+	// presentation already has everything a retry needs, so replay it before
+	// resolving a template that may have changed since the original post.
+	const existingDelivery = deliveryRecords(metadata).find(
+		(delivery) =>
+			delivery.connectionId === params.connectionId &&
+			delivery.channelKey === params.channelKey,
+	);
+	if (existingDelivery) {
+		return {
+			ok: true,
+			messageId: existingDelivery.messageId,
+			threadId: existingDelivery.threadId,
+			fallbackText,
+		};
+	}
+
+	const kind = await resolveEventKindDefinition(
+		row.semantic_type,
+		params.organizationId,
+		parsePgNumberArray(row.entity_ids),
+	);
+	// `present_event` is deliberately narrower than the ordinary Activity view:
+	// only an explicitly authored portable template may become an unsolicited
+	// native chat card. A schema-derived fallback is useful in the web UI, but it
+	// is not an authored chat presentation contract.
+	if (!kind?.jsonTemplate) return { ok: false, reason: "not_renderable" };
+
+	const data =
+		typeof metadata.notification_type === "string"
+			? jsonRecord(row.payload_data)
+			: metadata;
+	const card = buildKindCard({
+		metadataSchema: kind.metadataSchema,
+		jsonTemplate: kind.jsonTemplate,
+		data,
+		title: row.title ?? row.semantic_type,
+		body: row.payload_text ?? undefined,
+		url: toAbsolutePermalink(
+			typeof metadata.resource_url === "string"
+				? metadata.resource_url
+				: row.source_url ?? undefined,
+		),
+		sourceEventId: params.eventId,
+		interactions: kind.interactions,
+	});
+	if (!card) return { ok: false, reason: "not_renderable" };
+
+	const manager = getChatInstanceManager();
+	if (!manager) return { ok: false, reason: "gateway_unavailable" };
+	const sent = await manager.postToConversation(params.connectionId, {
+		platform: params.platform,
+		channelKey: params.channelKey,
+		channelId: params.channelId,
+		threadId: params.threadId,
+		content: { card, fallbackText },
+		subscribe: true,
+	});
+	await persistDeliveryMetadata(
+		params.eventId,
+		[
+			...deliveryRecords(metadata),
+			{
+				connectionId: params.connectionId,
+				channelKey: params.channelKey,
+				messageId: sent.messageId,
+				threadId: sent.threadId,
+			},
+		],
+		card,
+		{ db: sql, required: true },
+	);
+	return {
+		ok: true,
+		messageId: sent.messageId,
+		threadId: sent.threadId,
+		fallbackText,
+	};
 }
 
 async function recordDeliveryError(

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -31,7 +31,10 @@ import {
   validateDeliveryAuthorization,
 } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
-import { WORKSPACE_EVENT_ACTIVATION_TASK } from './task-definitions';
+import {
+  INTERACTIVE_EVENT_CARD_REFRESH_TASK,
+  WORKSPACE_EVENT_ACTIVATION_TASK,
+} from './task-definitions';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
 import { runMemberClaimDriftCheck } from './member-claim-drift';
 import { runReapStaleDeviceWorkers } from './reap-stale-device-workers';
@@ -39,7 +42,11 @@ import { runReapExpiredPendingSlackInstalls } from './reap-expired-pending-insta
 import { runExpirePendingApprovals } from './expire-pending-approvals';
 import { runScoreEvalRuns } from './score-eval-runs';
 import { getDb, pgTextArray } from '../db/client';
-import { createNotificationForUsers } from '../notifications/service';
+import {
+  createNotificationForUsers,
+  refreshInteractiveEventCardTask,
+  type InteractiveEventCardRefreshTaskPayload,
+} from '../notifications/service';
 import {
   createThreadForAgent,
   enqueueAgentMessage,
@@ -455,6 +462,12 @@ function registerMaintenanceTasks(
     ) {
       logger.info(result, '[task] activate-workspace-event completed');
     }
+  });
+
+  scheduler.register(INTERACTIVE_EVENT_CARD_REFRESH_TASK, async (ctx) => {
+    await refreshInteractiveEventCardTask(
+      ctx.payload as InteractiveEventCardRefreshTaskPayload,
+    );
   });
 
   // scheduled_jobs ticker: scans the table every minute, spawns due rows

--- a/packages/server/src/scheduled/task-definitions.ts
+++ b/packages/server/src/scheduled/task-definitions.ts
@@ -7,7 +7,12 @@
  * so adding another transactional task is an explicit platform change.
  */
 export const WORKSPACE_EVENT_ACTIVATION_TASK = 'activate-workspace-event';
+export const INTERACTIVE_EVENT_CARD_REFRESH_TASK =
+  'refresh-interactive-event-card';
 
 export function isTransactionalTaskName(name: string): boolean {
-  return name === WORKSPACE_EVENT_ACTIVATION_TASK;
+  return (
+    name === WORKSPACE_EVENT_ACTIVATION_TASK ||
+    name === INTERACTIVE_EVENT_CARD_REFRESH_TASK
+  );
 }

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -15,7 +15,8 @@ import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
 import { type DbClient, getDb, parsePgNumberArray } from '../db/client';
 import type { Env } from '../index';
-import { queueInteractiveEventCardRefresh } from '../notifications/service';
+import { INTERACTIVE_EVENT_CARD_REFRESH_TASK } from '../scheduled/task-definitions';
+import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
 import { autoLinkEvent } from '../utils/auto-linker';
 import { ToolUserError } from '../utils/errors';
 import { validateSaveContentSemanticType } from '../utils/event-kind-validation';
@@ -25,7 +26,7 @@ import {
   deleteMaterializedArtifacts,
   materializeInlineAttachments,
 } from '../utils/inline-attachments';
-import { insertEvent } from '../utils/insert-event';
+import { insertEvent, type InsertedEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import {
   assertCanAuthorGuidance,
@@ -632,6 +633,48 @@ async function saveContentImpl(
       // bytes live.
     }
 
+    const insertOptions = args.supersedes_event_id
+      ? {
+          afterPersist: async (event: InsertedEvent, tx: DbClient) => {
+            if (event.change !== 'superseded') return;
+            const [presented] = await tx<{ presented: boolean }>`
+              WITH RECURSIVE ancestry AS (
+                SELECT id, supersedes_event_id, metadata
+                FROM events
+                WHERE id = ${args.supersedes_event_id}
+                  AND organization_id = ${ctx.organizationId}
+                UNION ALL
+                SELECT parent.id, parent.supersedes_event_id, parent.metadata
+                FROM events parent
+                JOIN ancestry child ON child.supersedes_event_id = parent.id
+                WHERE parent.organization_id = ${ctx.organizationId}
+              )
+              SELECT EXISTS (
+                SELECT 1 FROM ancestry
+                WHERE jsonb_array_length(
+                  CASE WHEN jsonb_typeof(metadata->'delivery') = 'array'
+                    THEN metadata->'delivery' ELSE '[]'::jsonb END
+                ) > 0
+              ) AS presented
+            `;
+            if (!presented?.presented) return;
+            await enqueueTasksInTransaction(tx, [
+              {
+                name: INTERACTIVE_EVENT_CARD_REFRESH_TASK,
+                payload: {
+                  organizationId: ctx.organizationId,
+                  replacementEventId: Number(event.id),
+                },
+                opts: {
+                  idempotencyKey: `interactive-event-card-refresh:${event.id}`,
+                  maxAttempts: 5,
+                  organizationId: ctx.organizationId,
+                },
+              },
+            ]);
+          },
+        }
+      : undefined;
     try {
       row = await insertEvent({
         entityIds: finalEntityIds,
@@ -655,7 +698,7 @@ async function saveContentImpl(
         createdBy: ctx.userId,
         clientId: ctx.clientId,
         supersedesEventId: args.supersedes_event_id ?? null,
-      });
+      }, insertOptions);
     } catch (error) {
       // No row of ours references these artifacts on any branch below — the
       // idempotency loser returns the winner's event, and everything else
@@ -708,14 +751,6 @@ async function saveContentImpl(
     }).catch((err) => {
       logger.warn({ err, eventId: row.id }, 'autoLinkEvent failed');
     });
-  }
-
-  if (inserted && args.supersedes_event_id) {
-    queueInteractiveEventCardRefresh(
-      ctx.organizationId,
-      Number(row.id),
-      args.supersedes_event_id
-    );
   }
 
   logger.info(


### PR DESCRIPTION
## Summary\n- render an existing durable event into the signed active conversation through its declared portable json_template\n- add a scoped one-shot follow-up tool and an example-owned deterministic poll reducer with trusted actor identity, vote changes, quorum/deadline closure, and in-place card refresh\n- cover dynamic template buttons, signed-route confinement, concurrent presentation dedupe, reducer races, and the full Google Chat interaction lifecycle\n\n## Test plan\n- [x] Intended 14 files staged explicitly; 🔎 [1/5] Build workspace packages (fresh dist)...
📦 Building TypeScript packages by dependency layer...
🔹 foundations (6 parallel builds)
   📦 Building packages/core...
   📦 Building packages/plugin-api...
   📦 Building packages/pgvector-embedded...
   📦 Building packages/client...
   📦 Building packages/embeddings...
   📦 Building packages/promptfoo-provider...
🔹 contracts (3 parallel builds)
   📦 Building packages/plugin-host...
   📦 Building packages/plugin-toolkit...
   📦 Building packages/connector-sdk...
🔹 device-connectors (1 parallel build)
   📦 Building packages/device-connectors...
generated artifact is current: /Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/device-connectors/generated/macos-device-connector-manifests.json
🔹 plugins (4 parallel builds)
   📦 Building packages/plugin-memory...
   📦 Building packages/plugin-conversations...
   📦 Building packages/plugin-media...
   📦 Building packages/plugin-mcp...
🔹 runtimes (2 parallel builds)
   📦 Building packages/agent-worker...
   📦 Building packages/connector-worker...

[build-worker-bundle] ok — 15 external(s), all declared: @hono/node-server, @mariozechner/pi-ai, @mariozechner/pi-coding-agent, @opentelemetry/api, @opentelemetry/exporter-trace-otlp-grpc, @opentelemetry/resources, @opentelemetry/sdk-trace-node, @opentelemetry/semantic-conventions, @sentry/node, @sinclair/typebox, form-data, hono, just-bash, winston, zod
🔹 applications (2 parallel builds)
   📦 Building packages/server...
   📦 Building packages/owletto...
No runtime @lobu/core barrel imports in SPA source.
    connector-worker inputs: 28 module stem(s), 0 duplicated across src+dist

=== bundle ready: dist/server-main.bundle.mjs (5.78 MB)
    warnings: 0, errors: 0
    connector-worker inputs: 0 module stem(s), 0 duplicated across src+dist

=== bundle ready: dist/server.bundle.mjs (0.00 MB)
    warnings: 0, errors: 0

=== copied connectors: /Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/server/dist/connectors
vite v6.4.2 building for production...
transforming...
{"level":"debug","time":1787935854561,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/connector-identity-module.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935854582,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/db-egress-guard.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935854883,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/github-automation-events.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935854899,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/github-identity.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935855771,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/linkedin-identity.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
✓ 2089 modules transformed.
rendering chunks...
computing gzip size...
../../../dist-mcp-apps/interaction/index.html        0.35 kB │ gzip:   0.25 kB
../../../dist-mcp-apps/interaction/assets/app.css   39.16 kB │ gzip:   7.92 kB
../../../dist-mcp-apps/interaction/assets/app.js   979.57 kB │ gzip: 272.20 kB
✓ built in 1.82s
Versioned stable MCP App asset URLs from their content digests.
MCP App bundle check passed (465 external HTML bytes; 810 canonical resources/read JSON bytes; classic content-versioned app.js/app.css).
vite v6.4.2 building for production...
transforming...
{"level":"debug","time":1787935856716,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/slack-automation-events.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935856732,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/slack-identity.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}
{"level":"debug","time":1787935857433,"pid":14337,"hostname":"Buraks-MacBook-Pro.local","file_path":"/Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/connectors/src/x-identity.ts","msg":"Skipping catalog entry: file exports no ConnectorRuntime"}

=== catalog manifests: 22 connectors, 2 skills, 6 Automations -> /Users/burakemre/Code/lobu/.claude/worktrees/gchat-live-event-card/packages/server/dist/catalogs (3180ms)
✓ 1945 modules transformed.
rendering chunks...
computing gzip size...
dist-mcp-review/mcp-app-harness.html                   0.49 kB │ gzip:   0.30 kB
dist-mcp-review/assets/mcp-app-harness-i9JAc7n9.css  126.50 kB │ gzip:  20.23 kB
dist-mcp-review/assets/mcp-app-harness-2PzPHytS.js   667.78 kB │ gzip: 200.06 kB
✓ built in 1.37s
vite v6.4.2 building for production...
transforming...
✓ 5991 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                          3.21 kB │ gzip:   1.09 kB
dist/assets/memory-browse-page-BnuhLJ6X.css             15.87 kB │ gzip:   2.67 kB
dist/assets/index-BgILb7Pp.css                         127.57 kB │ gzip:  20.44 kB
dist/assets/index-DtqBFgK5.js                            0.04 kB │ gzip:   0.06 kB
dist/assets/_-DtqBFgK5.js                                0.04 kB │ gzip:   0.06 kB
dist/assets/index-rrnUF981.js                            0.04 kB │ gzip:   0.06 kB
dist/assets/_threadId-DtqBFgK5.js                        0.04 kB │ gzip:   0.06 kB
dist/assets/index-Cj_5Vcw9.js                            0.07 kB │ gzip:   0.08 kB
dist/assets/auth-methods-B94pvDWu.js                     0.08 kB │ gzip:   0.09 kB
dist/assets/automations-CpxrLeQQ.js                      0.10 kB │ gzip:   0.11 kB
dist/assets/agents-CpxrLeQQ.js                           0.10 kB │ gzip:   0.11 kB
dist/assets/deployments-BZ7xmr3z.js                      0.10 kB │ gzip:   0.11 kB
dist/assets/connect-dt2GDqmt.js                          0.10 kB │ gzip:   0.11 kB
dist/assets/guardrails-CWDgdwih.js                       0.10 kB │ gzip:   0.11 kB
dist/assets/agent-thread-storage-U6htL3ad.js             0.17 kB │ gzip:   0.15 kB
dist/assets/pending-seed-CPbfgnLX.js                     0.18 kB │ gzip:   0.16 kB
dist/assets/create._connectorKey-CoYW6C9g.js             0.19 kB │ gzip:   0.16 kB
dist/assets/index-BHtL3-Kv.js                            0.19 kB │ gzip:   0.17 kB
dist/assets/connection-label-BobuYiAG.js                 0.20 kB │ gzip:   0.15 kB
dist/assets/index-BpCz_Vl2.js                            0.21 kB │ gzip:   0.18 kB
dist/assets/claim-B-rQeZJk.js                            0.23 kB │ gzip:   0.19 kB
dist/assets/runs-layout-skeleton-Yzv9XL2c.js             0.25 kB │ gzip:   0.22 kB
dist/assets/use-visible-entity-types-6QF7R7SB.js         0.26 kB │ gzip:   0.22 kB
dist/assets/connectors-CFt3JFZ-.js                       0.27 kB │ gzip:   0.19 kB
dist/assets/skills-zFkvXgr6.js                           0.29 kB │ gzip:   0.23 kB
dist/assets/_agentId-D0dqF8gY.js                         0.36 kB │ gzip:   0.26 kB
dist/assets/models-CdbaztDZ.js                           0.37 kB │ gzip:   0.27 kB
dist/assets/logout-BxEFM8RD.js                           0.38 kB │ gzip:   0.29 kB
dist/assets/create--9v6B8nn.js                           0.39 kB │ gzip:   0.27 kB
dist/assets/index-zYA8r0p8.js                            0.39 kB │ gzip:   0.27 kB
dist/assets/index-6gZLwRbm.js                            0.40 kB │ gzip:   0.27 kB
dist/assets/settings-BiXc1_sn.js                         0.41 kB │ gzip:   0.29 kB
dist/assets/identity-yM9CvXiF.js                         0.41 kB │ gzip:   0.29 kB
dist/assets/_name-Bs8aBtBH.js                            0.41 kB │ gzip:   0.28 kB
dist/assets/connect._clientId-uzeENlXB.js                0.41 kB │ gzip:   0.28 kB
dist/assets/callback-DILTOZJZ.js                         0.43 kB │ gzip:   0.30 kB
dist/assets/index-BXXeFgsV.js                            0.44 kB │ gzip:   0.28 kB
dist/assets/create-C9jgqkY6.js                           0.44 kB │ gzip:   0.28 kB
dist/assets/_skillKey-DMAbKyer.js                        0.46 kB │ gzip:   0.29 kB
dist/assets/full-page-spinner-BBkQDZ1y.js                0.47 kB │ gzip:   0.34 kB
dist/assets/skill-editor-D_W3QlRz.js                     0.62 kB │ gzip:   0.31 kB
dist/assets/device-rows-C_oiTcMY.js                      0.67 kB │ gzip:   0.42 kB
dist/assets/index-gGGD6Ivw.js                            0.68 kB │ gzip:   0.41 kB
dist/assets/index-B9Xh2_Ze.js                            0.72 kB │ gzip:   0.43 kB
dist/assets/index-BkLGkSIq.js                            0.74 kB │ gzip:   0.44 kB
dist/assets/events-C3F787qx.js                           0.74 kB │ gzip:   0.45 kB
dist/assets/switch-DhW-o6M-.js                           0.76 kB │ gzip:   0.44 kB
dist/assets/_slug-CzAg8WOd.js                            0.81 kB │ gzip:   0.51 kB
dist/assets/card-CBAKtI66.js                             0.91 kB │ gzip:   0.41 kB
dist/assets/permissions-CnuWraWg.js                      0.98 kB │ gzip:   0.52 kB
dist/assets/connection-picker-DikXjZTz.js                1.02 kB │ gzip:   0.56 kB
dist/assets/create-BeDIekqV.js                           1.03 kB │ gzip:   0.56 kB
dist/assets/client-rows-EJSKR6z1.js                      1.12 kB │ gzip:   0.57 kB
dist/assets/clients-ZifxxXml.js                          1.14 kB │ gzip:   0.62 kB
dist/assets/page-section-B_ZR5GWy.js                     1.21 kB │ gzip:   0.55 kB
dist/assets/table-DbUEUcjw.js                            1.23 kB │ gzip:   0.48 kB
dist/assets/new-CvF8-e96.js                              1.28 kB │ gzip:   0.75 kB
dist/assets/member-scope-gate-CvkM2swU.js                1.45 kB │ gzip:   0.80 kB
dist/assets/index-Vcq4gwWv.js                            1.49 kB │ gzip:   0.79 kB
dist/assets/agent-loading-shells-DnPej7Sr.js             1.74 kB │ gzip:   0.67 kB
dist/assets/_-C4_QjQGg.js                                1.82 kB │ gzip:   0.97 kB
dist/assets/runs-C0Drp5N9.js                             1.84 kB │ gzip:   0.88 kB
dist/assets/agent-subpage-shell-B8Hdh2Jx.js              1.87 kB │ gzip:   0.68 kB
dist/assets/accept-invitation-C38bLf-f.js                1.95 kB │ gzip:   0.98 kB
dist/assets/index-UlxK6A-S.js                            2.17 kB │ gzip:   1.04 kB
dist/assets/proposal-review-shell-B_V2bTZF.js            2.54 kB │ gzip:   1.15 kB
dist/assets/new-BZLMmrm4.js                              2.65 kB │ gzip:   1.27 kB
dist/assets/settings-1zJmXb65.js                         2.74 kB │ gzip:   0.90 kB
dist/assets/model-selector-C72ObTD-.js                   2.91 kB │ gzip:   1.18 kB
dist/assets/_agentId-N2HuNNkb.js                         2.97 kB │ gzip:   1.32 kB
dist/assets/_automationId-CMYsawWi.js                    2.99 kB │ gzip:   1.29 kB
dist/assets/reset-password-a7UhYQMx.js                   3.21 kB │ gzip:   1.29 kB
dist/assets/app._appId-Dp2WEPPI.js                       3.50 kB │ gzip:   1.45 kB
dist/assets/new-D6hoiiKq.js                              3.62 kB │ gzip:   1.73 kB
dist/assets/agents-workbench-bi_ofnu_.js                 4.31 kB │ gzip:   1.86 kB
dist/assets/deployments-body-KzP-WAH_.js                 4.48 kB │ gzip:   1.67 kB
dist/assets/agent-connect-pages-DDUTVf3D.js              5.04 kB │ gzip:   1.99 kB
dist/assets/index-DOULwQaK.js                            5.45 kB │ gzip:   1.98 kB
dist/assets/_deploymentId-B1E9STec.js                    5.49 kB │ gzip:   1.82 kB
dist/assets/device-automation-DgkSQfs6.js                5.85 kB │ gzip:   2.41 kB
dist/assets/device._deviceId-DM3JWfTQ.js                 6.79 kB │ gzip:   2.57 kB
dist/assets/agent-client-setup-list-Dq4gEHDd.js          6.84 kB │ gzip:   2.25 kB
dist/assets/connection-D94rZ5g_.js                       6.87 kB │ gzip:   2.48 kB
dist/assets/_conversationId-BPKgVRYU.js                  6.89 kB │ gzip:   3.18 kB
dist/assets/connected._clientId-BNcdeRXH.js              6.92 kB │ gzip:   2.54 kB
dist/assets/oauth-workspace-access-SlC_GGMp.js           6.97 kB │ gzip:   2.40 kB
dist/assets/connector-scope-lists-h4sSMCgi.js            7.92 kB │ gzip:   2.73 kB
dist/assets/entity-page-D4qFuuu-.js                      8.30 kB │ gzip:   2.91 kB
dist/assets/consent-BmdccVMo.js                          8.49 kB │ gzip:   3.20 kB
dist/assets/index-C37uAba-.js                            8.63 kB │ gzip:   3.09 kB
dist/assets/_owner-B4IxFG3I.js                           8.73 kB │ gzip:   2.99 kB
dist/assets/agent-skill-context-DKOskDdN.js              9.39 kB │ gzip:   3.96 kB
dist/assets/runs-panel-Bbfjf67S.js                       9.56 kB │ gzip:   3.01 kB
dist/assets/index-PFahwaax.js                            9.80 kB │ gzip:   3.53 kB
dist/assets/agent-skills-route-Oih2KHxk.js              10.34 kB │ gzip:   3.39 kB
dist/assets/agent-editor-form-Ddnh5G7j.js               10.77 kB │ gzip:   3.97 kB
dist/assets/automation-detail-content-CIdbqDwW.js       10.78 kB │ gzip:   4.30 kB
dist/assets/device-BO44qIPr.js                          11.57 kB │ gzip:   3.75 kB
dist/assets/organization-CZ5oiVWZ.js                    13.18 kB │ gzip:   4.13 kB
dist/assets/_connectorKey._connectionId-D_6k_iLs.js     16.56 kB │ gzip:   5.57 kB
dist/assets/agent-guardrails-route-DwGrOCK-.js          16.58 kB │ gzip:   5.35 kB
dist/assets/login-Cq-6471t.js                           18.82 kB │ gzip:   5.01 kB
dist/assets/agent-permissions-matrix-BqURlLmj.js        19.46 kB │ gzip:   5.44 kB
dist/assets/cronstrue-BtXld-IB.js                       22.04 kB │ gzip:   6.19 kB
dist/assets/json-diff-ujKr38JL.js                       22.19 kB │ gzip:   8.33 kB
dist/assets/entity-type-page-DUEIHSaW.js                26.40 kB │ gzip:   7.54 kB
dist/assets/index-BA3bZLrF.js                           28.12 kB │ gzip:   9.41 kB
dist/assets/core.esm-BzAsEHC0.js                        39.00 kB │ gzip:  13.08 kB
dist/assets/_connectorKey.index-BsKCr-1S.js             43.64 kB │ gzip:  11.12 kB
dist/assets/events-feed-B0p_U01L.js                     44.19 kB │ gzip:  11.79 kB
dist/assets/calendar-Csdn5V1r.js                        49.48 kB │ gzip:  15.31 kB
dist/assets/activity-route-view-B6HqbD7F.js             57.61 kB │ gzip:  18.78 kB
dist/assets/create-automation-form-jITgPF4Q.js          58.17 kB │ gzip:  17.12 kB
dist/assets/index-BVc7gj0m.js                          149.81 kB │ gzip:  49.07 kB
dist/assets/code-editor-BBOebLix.js                    190.06 kB │ gzip:  68.90 kB
dist/assets/agent-thread-NScth5W2.js                   200.36 kB │ gzip:  56.84 kB
dist/assets/index-OUb5Mlez.js                          322.68 kB │ gzip: 105.49 kB
dist/assets/use-mention-search-D8Wen-Vf.js             342.23 kB │ gzip: 106.98 kB
dist/assets/renderer-WaDRU486.js                     1,118.26 kB │ gzip: 366.11 kB
dist/assets/memory-browse-page-CJJ_XZSz.js           1,690.08 kB │ gzip: 518.97 kB
dist/assets/index-B4HejnZd.js                        1,830.40 kB │ gzip: 454.62 kB
✓ built in 11.41s
Browser bundle check passed (largest entry index-B4HejnZd.js 1.83MB).
🔹 distribution (1 parallel build)
   📦 Building packages/cli...
✅ Package build completed successfully!
🔎 [2/5] Strict typecheck (per-package; root is covered by the commit hook)...
   typecheck packages/server...
   typecheck packages/connector-worker...
   typecheck packages/connector-sdk...
   typecheck packages/device-connectors...
   typecheck packages/plugin-api...
   typecheck packages/plugin-host...
   typecheck packages/plugin-toolkit...
   typecheck packages/plugin-memory...
   typecheck packages/plugin-conversations...
   typecheck packages/plugin-media...
   typecheck packages/plugin-mcp...
   typecheck packages/embeddings...
   typecheck packages/cli...
🔎 [3/5] Dead-code gate (knip --include files)...
Configuration hints (2)
🔎 [4/5] Exposed surface naming (Automation is canonical)...
check-exposed-surface-naming: clean — Automation is canonical across live tracked files.
🔎 [5/5] Gateway LLM + entity-write funnel gates...
✓ gateway-llm gate: 734 packages/server/src files contain no unsuppressed one-off LLM client
✓ entity-write funnel gate: 1068 runtime package source files scanned; 0 pinned bypasses, zero entity writes outside packages/server/src/utils/entity-management.ts
   funnel-checker unchanged; fixture suite skipped (CI still runs it)
✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',
   not just the working tree — a fix that isn't committed won't reach CI. clean\n- [x] Focused unit tests: core policy, conversation plugin, connector SDK contract, template cards, signed conversation routes, and poll reducer\n- [x] Database-backed Google Chat event-action lifecycle integration\n- [x] Server, plugin-conversations, and connector-sdk typechecks\n- [x]  for \n\n## Notes\n- No Owletto, Chrome-extension, LinkedIn, or platform-specific renderer code changed.\n- Visible production Google Chat render/click proof follows protected landing and exact-SHA rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive polls with native poll cards, vote tracking, deadlines, quorum-based closure, and protection against late or duplicate votes.
  - Added tools for presenting saved events directly in conversations.
  - Added scheduled follow-ups with conversation context, thread preservation, and duplicate-scheduling protection.
  - Improved support for dynamic event controls and trusted voter identity handling.

- **Bug Fixes**
  - Improved event delivery tracking and prevented duplicate event presentations.
  - Added stronger handling for concurrent poll updates and deadline-related vote processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->