### PR TITLE
fix(mac): make Owletto browser login survive non-TTY supervision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1791,6 +1791,9 @@ jobs:
           test "$("$AUTH_CLI" --version)" = "$(bun -p 'require("./packages/cli/package.json").version')"
           "$AUTH_CLI" login --help | grep -q -- '--wait-for-approval'
           "$AUTH_CLI" whoami --help | grep -q -- '--json'
+          codesign --force --options runtime --sign - \
+            --entitlements config/macos/lobu-auth.entitlements "$AUTH_CLI"
+          test "$("$AUTH_CLI" --version)" = "$(bun -p 'require("./packages/cli/package.json").version')"
 
       # The Mac app has no XCTest target, so xcodebuild does not discover the
       # standalone @main tests under apps/mac/Tests — before this step they ran

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1712,7 +1712,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/connector-worker/|packages/core/|scripts/(build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph|verify-mac-device-daemon|with-owletto-mac-daemon)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/cli/|packages/connector-worker/|packages/core/|config/macos/lobu-auth\.entitlements$|scripts/(build-mac-auth-cli|build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph|verify-mac-device-daemon|with-owletto-mac-daemon)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "mac=true" >> "$GITHUB_OUTPUT"
           else
             echo "mac=false" >> "$GITHUB_OUTPUT"
@@ -1735,11 +1735,11 @@ jobs:
   #
   # Runner cost is bounded by the filter job above — the macOS runner is only
   # allocated when something the Mac build actually consumes changes: the
-  # submodule pointer, the device-daemon sources (`packages/connector-worker/`,
-  # `packages/core/`) or its build/verify scripts, the workspace manifest or
-  # lockfile, the release workflow, this workflow, the submodule setup action,
-  # or `.gitmodules`. This workflow is in the filter so a PR editing this job
-  # can't skip it.
+  # submodule pointer, the bundled auth CLI sources/signing inputs, the
+  # device-daemon sources (`packages/connector-worker/`, `packages/core/`) or
+  # its build/verify scripts, the workspace manifest or lockfile, the release
+  # workflow, this workflow, the submodule setup action, or `.gitmodules`. This
+  # workflow is in the filter so a PR editing this job can't skip it.
   mac-build-smoke:
     needs: optional-smoke-filter
     if: needs.optional-smoke-filter.outputs.mac == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1783,6 +1783,15 @@ jobs:
         if: steps.submodule.outputs.stubbed != 'true'
         run: scripts/test-mac-device-daemon-package.sh
 
+      - name: Build and smoke bundled Mac auth helper
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: |
+          AUTH_CLI="$RUNNER_TEMP/lobu-mac-auth"
+          scripts/build-mac-auth-cli.sh "$AUTH_CLI"
+          test "$("$AUTH_CLI" --version)" = "$(bun -p 'require("./packages/cli/package.json").version')"
+          "$AUTH_CLI" login --help | grep -q -- '--wait-for-approval'
+          "$AUTH_CLI" whoami --help | grep -q -- '--json'
+
       # The Mac app has no XCTest target, so xcodebuild does not discover the
       # standalone @main tests under apps/mac/Tests — before this step they ran
       # only when someone pasted a swiftc line out of a file header, which is

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -138,6 +138,7 @@ jobs:
             packages/owletto/apps/mac/Owletto/Info.plist \
             packages/owletto/apps/mac/Owletto/lobu-device-daemon \
             packages/cli/src/mac-auth.ts \
+            config/macos/lobu-auth.entitlements \
             scripts/build-mac-auth-cli.sh \
             scripts/sparkle/update-appcast.py
           do
@@ -400,7 +401,9 @@ jobs:
 
           scripts/verify-mac-device-daemon.sh "$DAEMON"
           test -x "$AUTH_CLI" || { echo "::error::Bundled Lobu auth helper is missing"; exit 1; }
-          codesign "${OPTS[@]}" "$AUTH_CLI"
+          codesign "${OPTS[@]}" \
+            --entitlements config/macos/lobu-auth.entitlements \
+            "$AUTH_CLI"
           codesign "${OPTS[@]}" "$DAEMON"
 
           # XPC services (each has an inner Mach-O + an outer bundle).

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -137,6 +137,8 @@ jobs:
             packages/owletto/apps/mac/Owletto.xcodeproj \
             packages/owletto/apps/mac/Owletto/Info.plist \
             packages/owletto/apps/mac/Owletto/lobu-device-daemon \
+            packages/cli/src/mac-auth.ts \
+            scripts/build-mac-auth-cli.sh \
             scripts/sparkle/update-appcast.py
           do
             if [ ! -e "$required" ]; then
@@ -372,6 +374,13 @@ jobs:
           fi
           scripts/with-owletto-mac-daemon.sh xcodebuild "${ARGS[@]}"
 
+      - name: Bundle version-pinned Lobu auth helper (signed)
+        if: steps.mode.outputs.signed == 'true'
+        run: |
+          APP="$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
+          scripts/build-mac-auth-cli.sh \
+            "$APP/Contents/Resources/lobu-cli/bin/lobu"
+
       # Re-sign Sparkle's nested helpers — Xcode's archive doesn't apply
       # Developer ID + secure-timestamp to them when Sparkle is integrated
       # via SPM, and notarytool rejects the bundle on that basis. Sign
@@ -386,9 +395,12 @@ jobs:
           APP="$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
           SPARKLE="$APP/Contents/Frameworks/Sparkle.framework/Versions/B"
           DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
+          AUTH_CLI="$APP/Contents/Resources/lobu-cli/bin/lobu"
           OPTS=(--force --options runtime --timestamp --sign "Developer ID Application")
 
           scripts/verify-mac-device-daemon.sh "$DAEMON"
+          test -x "$AUTH_CLI" || { echo "::error::Bundled Lobu auth helper is missing"; exit 1; }
+          codesign "${OPTS[@]}" "$AUTH_CLI"
           codesign "${OPTS[@]}" "$DAEMON"
 
           # XPC services (each has an inner Mach-O + an outer bundle).
@@ -432,7 +444,10 @@ jobs:
           # developer". A real Developer ID + notarization removes that prompt.
           APP="$RUNNER_TEMP/Owletto.xcarchive/Products/Applications/Owletto.app"
           DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
+          AUTH_CLI="$APP/Contents/Resources/lobu-cli/bin/lobu"
+          scripts/build-mac-auth-cli.sh "$AUTH_CLI"
           scripts/verify-mac-device-daemon.sh "$DAEMON"
+          codesign --force --sign - "$AUTH_CLI"
           codesign --force --sign - "$DAEMON"
           codesign --force --deep --sign - "$APP"
 

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -120,6 +120,9 @@ const config: KnipConfig = {
         "src/config/index.ts",
         "src/config/define.ts",
         "src/config/secret.ts",
+        // Standalone native auth helper compiled into Owletto.app by the root
+        // Mac packaging script; it is intentionally outside the npm `bin` map.
+        "src/mac-auth.ts",
         // Build helper invoked as `node scripts/build.cjs`.
         "scripts/build.cjs",
       ],

--- a/config/macos/lobu-auth.entitlements
+++ b/config/macos/lobu-auth.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Bun's JavaScriptCore runtime allocates MAP_JIT executable pages. -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/cli/src/__tests__/login-email.test.ts
+++ b/packages/cli/src/__tests__/login-email.test.ts
@@ -13,7 +13,7 @@ const credentials = await import("../internal/credentials");
  * earlier version checked the void result of the claim call as falsy and
  * returned immediately, so the email sent but no token was ever collected.
  */
-describe("login --email (user_claimed)", () => {
+describe("login device-code approval", () => {
   afterEach(() => {
     mock.restore();
     openMock.mockClear();

--- a/packages/cli/src/__tests__/login-email.test.ts
+++ b/packages/cli/src/__tests__/login-email.test.ts
@@ -20,9 +20,14 @@ describe("login --email (user_claimed)", () => {
   });
 
   function mockOAuthServer(
-    options: { expiresIn?: number; tokenResult?: "success" | "pending" } = {}
+    options: {
+      expiresIn?: number;
+      interval?: number;
+      tokenResults?: Array<"success" | "pending">;
+    } = {}
   ): { calls: string[] } {
     const calls: string[] = [];
+    const tokenResults = [...(options.tokenResults ?? ["success"])];
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : (input as Request).url;
       calls.push(url);
@@ -52,14 +57,14 @@ describe("login --email (user_claimed)", () => {
           verification_uri_complete:
             "https://lobu.test/oauth/device?user_code=ABCD-1234",
           expires_in: options.expiresIn ?? 600,
-          interval: 1,
+          interval: options.interval ?? 1,
         });
       }
       if (url.endsWith("/oauth/device/email")) {
         return jsonResponse({ status: "pending" }, 202);
       }
       if (url.endsWith("/oauth/token")) {
-        if (options.tokenResult === "pending") {
+        if (tokenResults.shift() === "pending") {
           return jsonResponse({ error: "authorization_pending" }, 400);
         }
         return jsonResponse({
@@ -137,6 +142,66 @@ describe("login --email (user_claimed)", () => {
     );
     expect(calls.some((u) => u.endsWith("/oauth/device/email"))).toBe(false);
     expect(calls.some((u) => u.endsWith("/oauth/token"))).toBe(false);
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+
+  test("keeps polling without a TTY when a supervisor explicitly owns the wait", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://lobu.test/lobu/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "loadCredentials").mockResolvedValue(null);
+    const saveSpy = spyOn(credentials, "saveCredentials").mockResolvedValue();
+    spyOn(process.stdout, "isTTY", "get").mockReturnValue(false);
+    spyOn(process.stdin, "isTTY", "get").mockReturnValue(false);
+    spyOn(console, "log").mockImplementation(() => undefined);
+
+    const originalFetch = globalThis.fetch;
+    const { calls } = mockOAuthServer({
+      interval: 0,
+      tokenResults: ["pending", "success"],
+    });
+    try {
+      await loginCommand({
+        context: "prod",
+        waitForApproval: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.filter((url) => url.endsWith("/oauth/token"))).toHaveLength(2);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("still fails fast for an unsupervised non-interactive login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://lobu.test/lobu/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "loadCredentials").mockResolvedValue(null);
+    const saveSpy = spyOn(credentials, "saveCredentials").mockResolvedValue();
+    spyOn(process.stdout, "isTTY", "get").mockReturnValue(false);
+    spyOn(process.stdin, "isTTY", "get").mockReturnValue(false);
+    spyOn(console, "log").mockImplementation(() => undefined);
+
+    const originalFetch = globalThis.fetch;
+    const { calls } = mockOAuthServer({
+      interval: 0,
+      tokenResults: ["pending", "success"],
+    });
+    try {
+      await loginCommand({ context: "prod" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.filter((url) => url.endsWith("/oauth/token"))).toHaveLength(1);
     expect(saveSpy).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
     process.exitCode = 0;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -32,6 +32,12 @@ interface LoginOptions {
   /** Suppress spinner output; bail out non-interactively if the server rejects polling. */
   quiet?: boolean;
   /**
+   * Keep polling a browser device-code flow without a TTY when an external
+   * process owns cancellation and the user's approval UI. Native apps use
+   * this instead of pretending their piped subprocess is interactive.
+   */
+  waitForApproval?: boolean;
+  /**
    * Headless email "user_claimed" login (auth.md): the server emails this
    * address a one-click approval link instead of showing a code, and we keep
    * polling without a TTY. Lets an agent log in on a user's behalf without a
@@ -214,7 +220,8 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
   // make sense — a backgrounded shell or CI runner has neither stdin to
   // approve from nor stdout to spin on. Require both, plus the absence of
   // `--quiet`, before treating the call as interactive. Email-claim approval
-  // is out of band, so it polls even without a TTY.
+  // and an explicit supervised wait are out of band, so they poll even without
+  // a TTY. The supervisor is responsible for bounding/cancelling the child.
   const isInteractive =
     process.stdout.isTTY === true &&
     process.stdin.isTTY === true &&
@@ -282,17 +289,17 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
       );
 
       if (result.status === "pending") {
-        // Non-interactive callers (CI, backgrounded shells) can't approve a
-        // terminal device code, so a `pending` poll is the terminal answer —
-        // bail instead of looping until expiry. Email-claim is the exception:
-        // approval rides an emailed link, so we keep polling without a TTY.
-        if (!isInteractive && !emailClaim) {
+        // Ordinary non-interactive callers (CI, backgrounded shells) can't
+        // approve a terminal device code, so a `pending` poll is the terminal
+        // answer. Email claims and native apps with an explicit supervisor own
+        // an out-of-band approval path and therefore keep polling without TTYs.
+        if (!isInteractive && !emailClaim && !options.waitForApproval) {
           console.log(
             chalk.red("  Device-code login requires an interactive terminal.")
           );
           console.log(
             chalk.dim(
-              "  Use `--token <pat>`, or `--email <addr>` for headless approval.\n"
+              "  Use `--token <pat>`, `--email <addr>`, or `--wait-for-approval` with an external supervisor.\n"
             )
           );
           process.exitCode = 1;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -435,6 +435,10 @@ Memory:
       "--email <address>",
       "Headless login on a user's behalf: the server emails them an approval link (auth.md user_claimed flow)"
     )
+    .option(
+      "--wait-for-approval",
+      "Keep polling for browser approval when supervised without a TTY"
+    )
     .action(
       async (options: {
         token?: string;
@@ -442,6 +446,7 @@ Memory:
         force?: boolean;
         quiet?: boolean;
         email?: string;
+        waitForApproval?: boolean;
       }) => {
         const { loginCommand } = await import("./commands/login.js");
         await loginCommand({ ...options, cliVersion: version });

--- a/packages/cli/src/mac-auth.ts
+++ b/packages/cli/src/mac-auth.ts
@@ -1,0 +1,83 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
+import { whoamiCommand } from "./commands/whoami.js";
+
+/**
+ * Small, self-contained CLI surface bundled with Owletto.app. The desktop app
+ * needs auth to remain compatible even when a separately installed global CLI
+ * lags behind its Sparkle update. Keep this entrypoint limited to the commands
+ * LobuCLISession invokes; local runtime commands continue to use the user's
+ * full `lobu` installation.
+ */
+export async function runMacAuthCli(
+  argv: readonly string[] = process.argv
+): Promise<void> {
+  const version = process.env.LOBU_MAC_AUTH_CLI_VERSION ?? "0.0.0";
+  const program = new Command()
+    .name("lobu")
+    .description("Owletto's bundled Lobu authentication helper")
+    .version(version);
+
+  program
+    .command("login")
+    .description("Authenticate with Lobu Cloud")
+    .option("-c, --context <name>", "Use a named context")
+    .option("--token <token>", "Use API token directly")
+    .option("-f, --force", "Re-authenticate (revokes existing session)")
+    .option("-q, --quiet", "Suppress spinner output")
+    .option("--email <address>", "Email an out-of-band approval link")
+    .option(
+      "--wait-for-approval",
+      "Keep polling for browser approval when supervised without a TTY"
+    )
+    .action(
+      async (options: {
+        context?: string;
+        token?: string;
+        force?: boolean;
+        quiet?: boolean;
+        email?: string;
+        waitForApproval?: boolean;
+      }) => {
+        await loginCommand({ ...options, cliVersion: version });
+      }
+    );
+
+  program
+    .command("logout")
+    .description("Clear stored credentials")
+    .option("-c, --context <name>", "Use a named context")
+    .action(async (options: { context?: string }) => {
+      await logoutCommand(options);
+    });
+
+  program
+    .command("whoami")
+    .description("Show the current Lobu session")
+    .option("-c, --context <name>", "Use a named context")
+    .option("--json", "Emit machine-readable session JSON")
+    .action(async (options: { context?: string; json?: boolean }) => {
+      await whoamiCommand(options);
+    });
+
+  try {
+    await program.parseAsync([...argv]);
+  } catch (error) {
+    const exitCode =
+      typeof error === "object" &&
+      error !== null &&
+      "exitCode" in error &&
+      typeof (error as { exitCode?: unknown }).exitCode === "number"
+        ? (error as { exitCode: number }).exitCode
+        : 1;
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(chalk.red("\n  Error:"), message);
+    process.exitCode = exitCode;
+  }
+}
+
+if (import.meta.main) {
+  await runMacAuthCli();
+}

--- a/packages/cli/src/mac-auth.ts
+++ b/packages/cli/src/mac-auth.ts
@@ -11,7 +11,7 @@ import { whoamiCommand } from "./commands/whoami.js";
  * LobuCLISession invokes; local runtime commands continue to use the user's
  * full `lobu` installation.
  */
-export async function runMacAuthCli(
+async function runMacAuthCli(
   argv: readonly string[] = process.argv
 ): Promise<void> {
   const version = process.env.LOBU_MAC_AUTH_CLI_VERSION ?? "0.0.0";

--- a/scripts/build-mac-auth-cli.sh
+++ b/scripts/build-mac-auth-cli.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the version-pinned auth helper embedded in Owletto.app.
+#
+# Usage:
+#   scripts/build-mac-auth-cli.sh /path/to/Owletto.app/Contents/Resources/lobu-cli/bin/lobu
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="${1:-}"
+TARGET="${LOBU_MAC_AUTH_TARGET:-bun-darwin-arm64}"
+
+if [ -z "$OUTPUT" ]; then
+  echo "usage: scripts/build-mac-auth-cli.sh <output-path>" >&2
+  exit 2
+fi
+
+VERSION="$(cd "$ROOT" && bun -p 'require("./packages/cli/package.json").version')"
+mkdir -p "$(dirname "$OUTPUT")"
+
+(
+  cd "$ROOT"
+  export LOBU_MAC_AUTH_CLI_VERSION="$VERSION"
+  bun build packages/cli/src/mac-auth.ts \
+    --compile \
+    --target="$TARGET" \
+    '--env=LOBU_MAC_AUTH_CLI_*' \
+    --outfile="$OUTPUT"
+)
+
+chmod 755 "$OUTPUT"

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -66,6 +66,7 @@ APP="$DERIVED/Build/Products/Release/Owletto.app"
 [ -d "$APP" ] || die "build succeeded but $APP is missing"
 AUTH_CLI="$APP/Contents/Resources/lobu-cli/bin/lobu"
 "$ROOT/scripts/build-mac-auth-cli.sh" "$AUTH_CLI"
+AUTH_ENTITLEMENTS="$ROOT/config/macos/lobu-auth.entitlements"
 DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
 "$ROOT/scripts/verify-mac-device-daemon.sh" "$DAEMON" >/dev/null
 
@@ -76,7 +77,7 @@ OPTS=(--force --options runtime --timestamp --sign "$SIGN_ID")
 
 # Xcode treats the daemon as a resource, so seal its Mach-O explicitly before
 # re-signing the umbrella app that records the nested signature.
-codesign "${OPTS[@]}" "$AUTH_CLI"
+codesign "${OPTS[@]}" --entitlements "$AUTH_ENTITLEMENTS" "$AUTH_CLI"
 codesign "${OPTS[@]}" "$DAEMON"
 
 resign_xpc() {

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -64,6 +64,8 @@ echo ">> Building Owletto (Release, $SIGN_ID, version $VERSION)..."
 
 APP="$DERIVED/Build/Products/Release/Owletto.app"
 [ -d "$APP" ] || die "build succeeded but $APP is missing"
+AUTH_CLI="$APP/Contents/Resources/lobu-cli/bin/lobu"
+"$ROOT/scripts/build-mac-auth-cli.sh" "$AUTH_CLI"
 DAEMON="$APP/Contents/Resources/lobu-device-daemon/lobu-device-daemon"
 "$ROOT/scripts/verify-mac-device-daemon.sh" "$DAEMON" >/dev/null
 
@@ -74,6 +76,7 @@ OPTS=(--force --options runtime --timestamp --sign "$SIGN_ID")
 
 # Xcode treats the daemon as a resource, so seal its Mach-O explicitly before
 # re-signing the umbrella app that records the nested signature.
+codesign "${OPTS[@]}" "$AUTH_CLI"
 codesign "${OPTS[@]}" "$DAEMON"
 
 resign_xpc() {

--- a/scripts/lib/__tests__/remote-ci.test.sh
+++ b/scripts/lib/__tests__/remote-ci.test.sh
@@ -250,6 +250,10 @@ optional_filter="$(workflow_job "$workflow" optional-smoke-filter)"
 if grep -q '^    needs:' <<<"$optional_filter"; then
   fail "optional smoke filter still waits for the merge graph"
 fi
+for mac_input in 'packages/cli/' 'config/macos/lobu-auth\.entitlements' 'build-mac-auth-cli'; do
+  grep -Fq "$mac_input" <<<"$optional_filter" ||
+    fail "optional Mac smoke filter omits auth-helper input: $mac_input"
+done
 vitest_job="$(workflow_job "$workflow" server-integration-vitest)"
 grep -q -- '--shard=${{ matrix.shard }}/3' <<<"$vitest_job" ||
   fail "static isolated Vitest shard is missing"


### PR DESCRIPTION
## Summary
- add an explicit `lobu login --wait-for-approval` contract while preserving fail-fast background/CI behavior
- compile a narrow native auth helper into signed and ad-hoc Owletto release artifacts so Sparkle updates do not depend on a matching global CLI version
- update the Owletto pointer to the companion Mac app implementation and add CI/release smoke guards

## Reproduction
Owletto launched `lobu login --force` with piped stdout/stderr and null stdin. The CLI opened the browser, saw `authorization_pending`, then exited after its first poll because both streams were non-TTY. The app only surfaced stderr, while this CLI diagnostic was written to stdout.

## Validation
- red-to-green `packages/cli/src/__tests__/login-email.test.ts` (5 passed)
- Owletto standalone Swift tests (24 passed)
- unsigned Debug Xcode build succeeded
- native auth helper build/version/help smoke succeeded
- Mac mini packaged-helper smoke: remained polling past the former 5-second exit boundary
- `make pre-pr`

## Landing dependency
- [ ] merge lobu-ai/owletto#981 first
- [ ] update this PR to the child squash SHA
- [ ] rerun CI and protected review on the settled parent head