### PR TITLE
fix(server): reject invalid identity scope keys

### DIFF
--- a/packages/server/src/utils/__tests__/connector-identity-scope.test.ts
+++ b/packages/server/src/utils/__tests__/connector-identity-scope.test.ts
@@ -55,6 +55,31 @@ describe('connector identity scope manifest validation', () => {
     ).toThrow(/erp_customer.*workspace.*organization.*tenant/i);
   });
 
+  it('rejects NUL in identity namespaces and tenant scope paths', () => {
+    expect(() =>
+      validateConnectorMetadata(
+        metadata({
+          customers: feed('customer.created', [
+            identity('erp\0customer', 'metadata.id'),
+          ]),
+        })
+      )
+    ).toThrow(/identity namespace.*must not contain NUL/i);
+
+    expect(() =>
+      validateConnectorMetadata(
+        metadata({
+          customers: feed('customer.created', [
+            identity('erp_customer', 'metadata.id', {
+              scope: 'tenant',
+              scopeKeyPath: 'metadata.tenant\0id',
+            }),
+          ]),
+        })
+      )
+    ).toThrow(/scopeKeyPath.*must not contain NUL/i);
+  });
+
   it('names both declarations when one namespace has conflicting shapes', () => {
     expect(() =>
       validateConnectorMetadata(
@@ -91,5 +116,4 @@ describe('connector identity scope manifest validation', () => {
       )
     ).toThrow(/erp_customer.*customer\.created.*invoice\.created/i);
   });
-
 });

--- a/packages/server/src/utils/connector-identity-scopes.ts
+++ b/packages/server/src/utils/connector-identity-scopes.ts
@@ -54,6 +54,9 @@ export function connectorIdentityScopeDeclarations(
           const namespace =
             typeof identity.namespace === 'string' ? identity.namespace.trim() : '';
           if (!namespace) return;
+          if (namespace.includes('\0')) {
+            throw new Error('Identity namespace must not contain NUL.');
+          }
           const declaration =
             `feed '${feedKey}', event kind '${eventKind}', attribution #${attributionIndex + 1}, ` +
             `identity #${identityIndex + 1}`;
@@ -74,6 +77,11 @@ export function connectorIdentityScopeDeclarations(
             typeof identity.scopeKeyPath === 'string'
               ? identity.scopeKeyPath.trim()
               : null;
+          if (scopeKeyPath?.includes('\0')) {
+            throw new Error(
+              `Identity namespace '${namespace}' in ${declaration} has a scopeKeyPath that must not contain NUL.`
+            );
+          }
           if (scope === 'tenant' && !scopeKeyPath) {
             throw new Error(
               `Identity namespace '${namespace}' in ${declaration} requires a non-empty scopeKeyPath for tenant scope.`


### PR DESCRIPTION
## Summary
- reject NUL bytes in identity namespaces before persistence
- reject NUL bytes in tenant scope key paths before persistence
- cover both invalid manifest forms with a focused regression test

## Test plan
- [x] Intended files staged explicitly; make pre-pr clean
- [x] Tests run: focused connector identity scope suite (5/5) and combined identity matrix (41/41)
- [x] Bug fix: the new regression test failed before the validation change and passed afterward
- [ ] If bot runtime changed: not applicable

## Notes
This is a narrow post-merge hardening follow-up to the tenant-scoped identity foundation. It prevents strings that PostgreSQL cannot represent from reaching connector identity persistence.