### PR TITLE
fix(automations): make reactions crash-safe through TaskScheduler

### DIFF
--- a/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-contract.test.ts
@@ -34,6 +34,7 @@ import {
 	sweepStaleAutomationRuns,
 } from "../../../automations/automation";
 import { advanceAutomationSchedule } from "../../../automations/schedule-cursor";
+import { runAutomationReactionTask } from "../../../automations/reaction-task";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	createTestAgent,
@@ -794,6 +795,7 @@ describe("automation contract", () => {
 				run_id: number;
 				content_linked: number;
 				reaction_status: string;
+				reaction_task_run_id?: number;
 			};
 
       // Zero content linked, yet the reaction fired for the completed run.
@@ -802,7 +804,21 @@ describe("automation contract", () => {
 			// suite covers executor health), so assert "attempted", never
 			// 'skipped' — the pre-fix outcome this test exists to prevent.
 			expect(completion.content_linked).toBe(0);
-			expect(completion.reaction_status).not.toBe("skipped");
+			expect(completion.reaction_status).toBe("queued");
+
+			// The reaction is now a durable task committed with the window rather
+			// than an inline call, so drive it the way the scheduler would before
+			// asserting on its log. Crash safety itself is pinned in
+			// reaction-crash-safety.test.ts.
+			await runAutomationReactionTask(
+				{
+					organizationId: workspace.org.id,
+					automationId,
+					sourceRunId: completion.run_id,
+				},
+				{} as Env,
+				Number(completion.reaction_task_run_id)
+			);
 
 			const reactionRows = await sql`
         SELECT reaction_type, tool_name FROM automation_reactions

--- a/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
+++ b/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Automation reactions must survive a crash between the window commit and the
+ * script running.
+ *
+ * The reaction used to execute INLINE, after `complete_window`'s transaction had
+ * already committed. A process death in that gap lost it permanently: the run
+ * was durably `completed`, and `complete_window` short-circuits on an
+ * already-completed run, so no replay path would ever fire it again. These
+ * tests pin the durable handoff that replaces it — the task row commits WITH the
+ * window — plus the rehydration and retry classification the inline loop used to own.
+ */
+
+import { inferAutomationGranularityFromSchedule } from "@lobu/connector-sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	automationReactionIdempotencyKey,
+	type AutomationReactionTaskPayload,
+} from "../../../automations/reaction-enqueue";
+import { runAutomationReactionTask } from "../../../automations/reaction-task";
+import type { Env } from "../../../index";
+import { createAutomationRun } from "../../../runs/queue-service";
+import {
+	AUTOMATION_REACTION_TASK,
+	AUTOMATION_REACTION_TASK_QUEUE,
+} from "../../../scheduled/task-definitions";
+import { computePendingWindow } from "../../../utils/window-utils";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
+import { TestApiClient, TestWorkspace } from "../../setup/test-mcp-client";
+
+const DEVICE_WORKER_ID = "77777777-7777-7777-7777-777777777777";
+
+/** A reaction-bearing Automation with one claimed, running window ready to complete. */
+async function seedRunnableWindow(reactionScript: string) {
+	const sql = getTestDb();
+	const workspace = await TestWorkspace.create({ name: "Reaction Durability Org" });
+	const entity = await createTestEntity({
+		name: "Reaction Entity",
+		organization_id: workspace.org.id,
+		created_by: workspace.users.owner.id,
+	});
+	const agent = await createTestAgent({
+		organizationId: workspace.org.id,
+		ownerUserId: workspace.users.owner.id,
+		agentId: "reaction-agent",
+		name: "Reaction Agent",
+	});
+	const automation = (await workspace.owner.automations.create({
+		entity_id: entity.id,
+		slug: "reaction-automation",
+		name: "Reaction Automation",
+		prompt: "Summarize content for the bound entities.",
+		triggers: [
+			{
+				kind: "schedule",
+				cron: "0 9 * * *",
+				execution: "window",
+				active_run: "coalesce",
+				skip_if_unchanged: false,
+			},
+		],
+		agent_id: agent.agentId,
+	})) as { automation_id: string };
+	const automationId = Number(automation.automation_id);
+
+	await sql`
+    UPDATE automations SET next_run_at = NOW() - INTERVAL '10 minutes'
+    WHERE id = ${automationId}
+  `;
+
+	const api = await TestApiClient.for({
+		organizationId: workspace.org.id,
+		userId: workspace.users.owner.id,
+		memberRole: "owner",
+	});
+	await api.automations.setReactionScript({
+		automation_id: String(automationId),
+		reaction_script: reactionScript,
+	});
+
+	const granularity = inferAutomationGranularityFromSchedule("0 9 * * *");
+	const { windowStart, windowEnd } = await computePendingWindow(
+		sql as never,
+		automationId,
+		granularity,
+	);
+	const queued = await createAutomationRun({
+		organizationId: workspace.org.id,
+		automationId,
+		agentId: agent.agentId,
+		windowStart: windowStart.toISOString(),
+		windowEnd: windowEnd.toISOString(),
+		dispatchSource: "scheduled",
+		deviceWorkerId: DEVICE_WORKER_ID,
+		agentKind: "claude-code",
+	});
+	await sql`
+    UPDATE runs
+    SET status = 'running', claimed_at = NOW(), claimed_by = 'reaction-durability-test'
+    WHERE id = ${queued.runId}
+  `;
+
+	return { sql, workspace, api, automationId, runId: queued.runId };
+}
+
+async function issueWindowToken(
+	api: Awaited<ReturnType<typeof seedRunnableWindow>>["api"],
+	automationId: number,
+) {
+	const content = (await api.knowledge.read({ automation_id: automationId })) as {
+		window_token: string;
+	};
+	return content.window_token;
+}
+
+async function completeWindow(
+	api: Awaited<ReturnType<typeof seedRunnableWindow>>["api"],
+	automationId: number,
+	runId: number,
+	extracted: Record<string, unknown> = { summary: "Reaction durability run." },
+	windowToken?: string,
+) {
+	const token = windowToken ?? (await issueWindowToken(api, automationId));
+	return (await api.automations.completeWindow({
+		automation_id: String(automationId),
+		run_id: runId,
+		window_token: token,
+		extracted_data: extracted,
+		run_metadata: { source: "device_worker", run_id: runId },
+	})) as {
+		run_id: number;
+		reaction_status: string;
+		reaction_task_run_id?: number;
+	};
+}
+
+/** The durable reaction task rows for a source run, newest first. */
+function reactionTasks(sql: ReturnType<typeof getTestDb>, runId: number) {
+	return sql`
+    SELECT id, status, action_key, action_input, max_attempts, organization_id,
+           automation_id, parent_run_id, queue_name,
+           run_metadata->>'reaction_script_compiled' AS reaction_script_compiled
+    FROM runs
+    WHERE run_type = 'task'
+      AND action_key = ${AUTOMATION_REACTION_TASK}
+      AND idempotency_key = ${automationReactionIdempotencyKey(runId)}
+    ORDER BY id DESC
+  `;
+}
+
+describe("automation reaction crash safety", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("commits a durable reaction task with the window instead of running it inline", async () => {
+		const { sql, automationId, runId, api } = await seedRunnableWindow(
+			"export default async function reaction() { return; }",
+		);
+
+		const completion = await completeWindow(api, automationId, runId);
+
+		// The handoff is committed, not executed: the caller is told it is queued
+		// and the script has demonstrably not run yet.
+		expect(completion.reaction_status).toBe("queued");
+		const logged = await sql`
+      SELECT id FROM automation_reactions WHERE source_run_id = ${runId}
+    `;
+		expect(logged.length).toBe(0);
+
+		// This row is what survives a crash. Before the fix nothing existed here,
+		// so a process death after commit lost the reaction permanently.
+		const tasks = await reactionTasks(sql, runId);
+		expect(tasks.length).toBe(1);
+		expect(completion.reaction_task_run_id).toBe(Number(tasks[0].id));
+		expect(String(tasks[0].status)).toBe("pending");
+		// A dedicated lane keeps old rolling-deploy pods, which only work the
+		// shared `task` queue, from claiming and exhausting an unknown handler.
+		expect(String(tasks[0].queue_name)).toBe(AUTOMATION_REACTION_TASK_QUEUE);
+		expect(Number(tasks[0].automation_id)).toBe(automationId);
+		expect(Number(tasks[0].parent_run_id)).toBe(runId);
+		// Retry budget matches the inline loop it replaced.
+		expect(Number(tasks[0].max_attempts)).toBe(3);
+		expect(String(tasks[0].reaction_script_compiled)).toContain("reaction");
+
+		// It committed atomically with the completed run.
+		const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+		expect(String(run.status)).toBe("completed");
+	});
+
+	it("rehydrates the window context from the source run and runs the script", async () => {
+		// The script writes what it received into knowledge, so the assertion is on
+		// the context the sandbox actually saw — not on a serialized bundle.
+		const { sql, automationId, runId, api, workspace } = await seedRunnableWindow(
+			`export default async function reaction(ctx, client) {
+        await client.knowledge.save({
+          semantic_type: 'note',
+          title: 'reaction-echo',
+          content: JSON.stringify({
+            run_id: ctx.window.run_id,
+            automation_id: ctx.window.automation_id,
+            granularity: ctx.window.granularity,
+            summary: ctx.extracted_data.summary,
+            automation_slug: ctx.automation.slug,
+          }),
+        });
+      }`,
+		);
+
+		await completeWindow(api, automationId, runId, { summary: "Churn rose 4%." });
+
+		const [task] = await reactionTasks(sql, runId);
+		const payload = (task.action_input as { payload: AutomationReactionTaskPayload })
+			.payload;
+		expect(payload).toEqual({
+			organizationId: workspace.org.id,
+			automationId,
+			sourceRunId: runId,
+		});
+
+		const outcome = await runAutomationReactionTask(
+			payload,
+			{} as Env,
+			Number(task.id),
+			2,
+		);
+		expect(outcome.status).toBe("success");
+
+		const [echo] = await sql`
+      SELECT payload_text FROM events
+      WHERE organization_id = ${workspace.org.id} AND title = 'reaction-echo'
+      ORDER BY id DESC LIMIT 1
+    `;
+		expect(echo).toBeDefined();
+		const seen = JSON.parse(String(echo.payload_text));
+		expect(seen.run_id).toBe(runId);
+		expect(seen.automation_id).toBe(automationId);
+		expect(seen.summary).toBe("Churn rose 4%.");
+		expect(seen.automation_slug).toBe("reaction-automation");
+		expect(seen.granularity).toBeTruthy();
+
+		// The run is logged where get_automation already surfaces it.
+		const logged = await sql`
+      SELECT reaction_type, tool_args
+      FROM automation_reactions WHERE source_run_id = ${runId}
+    `;
+		expect(logged.length).toBe(1);
+		expect(String(logged[0].reaction_type)).toBe("script_execution");
+		expect(logged[0].tool_args).toEqual({ attempt: 2 });
+	});
+
+	it("does not queue a second reaction when the completion is replayed", async () => {
+		const { sql, automationId, runId, api } = await seedRunnableWindow(
+			"export default async function reaction() { return; }",
+		);
+
+		const token = await issueWindowToken(api, automationId);
+		await completeWindow(api, automationId, runId, undefined, token);
+		const first = await reactionTasks(sql, runId);
+		expect(first.length).toBe(1);
+
+		// Drive the task to completion, which CLOSES the scheduler's in-flight
+		// idempotency window — the point at which a naive re-enqueue would insert a
+		// duplicate rather than conflict.
+		await sql`UPDATE runs SET status = 'completed' WHERE id = ${first[0].id}`;
+
+		const replay = await completeWindow(api, automationId, runId, undefined, token);
+		expect(replay.reaction_status).toBe("skipped");
+
+		const after = await reactionTasks(sql, runId);
+		expect(after.length).toBe(1);
+		expect(Number(after[0].id)).toBe(Number(first[0].id));
+	});
+
+	it("settles without retrying when the script fails deterministically", async () => {
+		// A compile failure is non-transient: retrying re-burns the executor budget
+		// for no chance of recovery, so the handler must NOT ask for another attempt.
+		const { sql, automationId, runId, api, workspace } = await seedRunnableWindow(
+			"export default async function reaction() { return; }",
+		);
+		await sql`
+      UPDATE automations
+      SET reaction_script_compiled = 'this is not valid javascript ((('
+      WHERE id = ${automationId}
+    `;
+		await completeWindow(api, automationId, runId);
+		const [task] = await reactionTasks(sql, runId);
+
+		const outcome = await runAutomationReactionTask(
+			{ organizationId: workspace.org.id, automationId, sourceRunId: runId },
+			{} as Env,
+			Number(task.id),
+		);
+
+		expect(outcome.status).toBe("failed");
+		// The failure is durably recorded rather than silently swallowed.
+		const logged = await sql`
+      SELECT tool_result FROM automation_reactions WHERE source_run_id = ${runId}
+    `;
+		expect(logged.length).toBe(1);
+		expect((logged[0].tool_result as { success: boolean }).success).toBe(false);
+	});
+
+	it.each([
+		[
+			"edited",
+			`export default async function replacement(ctx, client) {
+        await client.knowledge.save({
+          semantic_type: 'note',
+          title: 'replacement-reaction',
+          content: 'wrong script',
+        });
+      }`,
+		],
+		["cleared", null],
+	])("runs the completion-time script when the live script is %s", async (_state, liveScript) => {
+		const { sql, automationId, runId, api, workspace } = await seedRunnableWindow(
+			`export default async function completionSnapshot(ctx, client) {
+        await client.knowledge.save({
+          semantic_type: 'note',
+          title: 'completion-reaction',
+          content: 'completion-time script',
+        });
+      }`,
+		);
+		await completeWindow(api, automationId, runId);
+		const [task] = await reactionTasks(sql, runId);
+
+		await sql`
+      UPDATE automations
+      SET reaction_script_compiled = ${liveScript}
+      WHERE id = ${automationId}
+    `;
+
+		const outcome = await runAutomationReactionTask(
+			{ organizationId: workspace.org.id, automationId, sourceRunId: runId },
+			{} as Env,
+			Number(task.id),
+		);
+		expect(outcome.status).toBe("success");
+
+		const events = await sql`
+      SELECT title FROM events
+      WHERE organization_id = ${workspace.org.id}
+        AND title IN ('completion-reaction', 'replacement-reaction')
+      ORDER BY id
+    `;
+		expect(events.map((event) => String(event.title))).toEqual(["completion-reaction"]);
+	});
+
+	it("skips a task whose source run is no longer completable", async () => {
+		const { sql, automationId, runId, api, workspace } = await seedRunnableWindow(
+			"export default async function reaction() { return; }",
+		);
+		await completeWindow(api, automationId, runId);
+		const [task] = await reactionTasks(sql, runId);
+
+		// A task that outlived its run must settle, never retry against state that
+		// will never appear.
+		const missing = await runAutomationReactionTask(
+			{ organizationId: workspace.org.id, automationId, sourceRunId: runId + 9999 },
+			{} as Env,
+			Number(task.id),
+		);
+		expect(missing).toEqual({ status: "skipped", reason: "source run not found" });
+
+		await sql`UPDATE runs SET status = 'failed' WHERE id = ${runId}`;
+		const notCompleted = await runAutomationReactionTask(
+			{ organizationId: workspace.org.id, automationId, sourceRunId: runId },
+			{} as Env,
+			Number(task.id),
+		);
+		// Asserted on the REASON, not just the status: every skip in this test
+		// would otherwise pass for the wrong cause.
+		expect(notCompleted).toEqual({
+			status: "skipped",
+			reason: "source run is failed",
+		});
+
+		// Cross-org payloads resolve nothing rather than leaking another org's run.
+		const otherOrg = await TestWorkspace.create({ name: "Other Org" });
+		const crossOrg = await runAutomationReactionTask(
+			{ organizationId: otherOrg.org.id, automationId, sourceRunId: runId },
+			{} as Env,
+			Number(task.id),
+		);
+		expect(crossOrg).toEqual({
+			status: "skipped",
+			reason: "source run not found",
+		});
+	});
+
+	it("queues nothing when the Automation has no reaction script", async () => {
+		const { sql, automationId, runId, api } = await seedRunnableWindow(
+			"export default async function reaction() { return; }",
+		);
+		await sql`
+      UPDATE automations SET reaction_script_compiled = NULL, reaction_script = NULL
+      WHERE id = ${automationId}
+    `;
+
+		const completion = await completeWindow(api, automationId, runId);
+
+		expect(completion.reaction_status).toBe("skipped");
+		const tasks = await reactionTasks(sql, runId);
+		expect(tasks.length).toBe(0);
+	});
+});

--- a/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { clearAuthCacheForTests } from '../../../auth';
 import { closeDbSingleton, type DbClient } from '../../../db/client';
 import type { Env } from '../../../index';
+import { runAutomationReactionTask } from '../../../automations/reaction-task';
 import { createAutomationRun } from '../../../runs/queue-service';
 import { manageAutomations } from '../../../tools/admin/manage_automations';
 import { handleClaimNextWindow } from '../../../tools/admin/manage_automations/claim-next-window';
@@ -771,6 +772,7 @@ describe('Automation window claim and recovery', () => {
     };
     const first = (await api.automations.completeWindow(completionInput)) as {
       completed_now: boolean;
+      reaction_task_run_id?: number;
     };
     expect(first.completed_now).toBe(true);
     const outputCountAfterFirst = await sql<{ count: number }>`
@@ -783,6 +785,20 @@ describe('Automation window claim and recovery', () => {
       SELECT COUNT(*)::int AS count FROM automation_reactions
       WHERE source_run_id = ${empty.run_id}
     `;
+
+    // The reaction is a durable task now, so drive it the way the scheduler
+    // would; the invariant under test is unchanged — a replayed completion must
+    // not produce a second execution.
+    await runAutomationReactionTask(
+      { organizationId: orgId, automationId, sourceRunId: empty.run_id },
+      {} as Env,
+      Number(first.reaction_task_run_id)
+    );
+    const reactionCountAfterTask = await sql<{ count: number }>`
+      SELECT COUNT(*)::int AS count FROM automation_reactions
+      WHERE source_run_id = ${empty.run_id}
+    `;
+    expect(Number(reactionCountAfterTask[0].count)).toBe(1);
 
     const replay = (await api.automations.completeWindow(completionInput)) as {
       completed_now: boolean;
@@ -799,8 +815,11 @@ describe('Automation window claim and recovery', () => {
       WHERE source_run_id = ${empty.run_id}
     `;
     expect(Number(outputCountAfterFirst[0].count)).toBe(1);
-    expect(Number(reactionCountAfterFirst[0].count)).toBe(1);
+    // Zero BEFORE the task runs: completion commits the handoff, it no longer
+    // executes the script inline.
+    expect(Number(reactionCountAfterFirst[0].count)).toBe(0);
     expect(outputCountAfterReplay).toEqual(outputCountAfterFirst);
-    expect(reactionCountAfterReplay).toEqual(reactionCountAfterFirst);
+    // Still exactly one execution after the replay — the replay queued nothing.
+    expect(Number(reactionCountAfterReplay[0].count)).toBe(1);
   });
 });

--- a/packages/server/src/__tests__/unit/automations/reaction-retry-classification.test.ts
+++ b/packages/server/src/__tests__/unit/automations/reaction-retry-classification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { reactionErrorIsNonTransient } from '../../../tools/admin/manage_automations/complete-window';
+import { reactionErrorIsNonTransient } from '../../../automations/reaction-task';
 
 describe('reactionErrorIsNonTransient', () => {
   it('classifies deterministic sandbox failures as non-retryable', () => {

--- a/packages/server/src/automations/reaction-enqueue.ts
+++ b/packages/server/src/automations/reaction-enqueue.ts
@@ -1,0 +1,96 @@
+/**
+ * Transactional handoff for the Automation reaction script.
+ *
+ * The reaction used to run INLINE, after `complete_window`'s transaction had
+ * already committed the window, its output events, and the schedule cursor. A
+ * process death in that gap lost the reaction permanently: the run was durably
+ * `completed`, so no replay path would ever fire it again (`complete_window`
+ * short-circuits on an already-completed run and returns `completed_now:false`).
+ * Enqueueing the handoff INSIDE the same transaction moves it across the
+ * existing durability boundary — the reaction row and the window commit or roll
+ * back together, and a crash before the handler claims it leaves a `pending`
+ * task the scheduler picks up.
+ *
+ * Kept dependency-light and separate from `./reaction-task` (the RUNTIME) for
+ * the reason `workspace-event-enqueue.ts` documents: the queueing end of a seam
+ * must not drag in the consuming end. `complete-window.ts` imports only this
+ * module, so committing a handoff never pulls in the sandbox executor.
+ *
+ * Exactly one task per source run, without needing a durable claim: the enqueue
+ * is gated on the run's `running|claimed -> completed` transition, which the
+ * completion UPDATE allows only once. The idempotency key is belt-and-braces
+ * for two completions racing inside their own transactions — note the
+ * scheduler's partial unique index only covers in-flight statuses, so the key
+ * alone would NOT stop a re-enqueue after the task finished.
+ */
+
+import type { DbClient } from '../db/client';
+import { AUTOMATION_REACTION_TASK } from '../scheduled/task-definitions';
+import { enqueueTasksInTransaction } from '../scheduled/task-scheduler';
+
+/**
+ * Everything the handler needs to REHYDRATE the reaction context from durable
+ * state. Deliberately not a serialized context bundle: the extracted data,
+ * window bounds and entity links all live on the source run and the Automation,
+ * so a bundle would be a second copy that can only go stale between commit and
+ * execution.
+ */
+export interface AutomationReactionTaskPayload {
+  organizationId: string;
+  automationId: number;
+  sourceRunId: number;
+}
+
+/** Stable per-source-run key. Exported so tests and the handler agree on it. */
+export function automationReactionIdempotencyKey(sourceRunId: number): string {
+  return `${AUTOMATION_REACTION_TASK}:${sourceRunId}`;
+}
+
+/**
+ * Queue the reaction handoff on `tx`. Call INSIDE the window transaction, only
+ * when the run actually transitioned to completed and the Automation has a
+ * compiled reaction script.
+ *
+ * `maxAttempts` is 3 to preserve the inline loop's budget exactly — the
+ * executor burns a 60s wall-clock timeout per attempt, and the handler still
+ * classifies non-transient failures so those stop after one.
+ */
+export async function enqueueAutomationReaction(
+  tx: DbClient,
+  payload: AutomationReactionTaskPayload,
+  compiledScript: string
+): Promise<number> {
+  const idempotencyKey = automationReactionIdempotencyKey(payload.sourceRunId);
+  const taskRunIds = await enqueueTasksInTransaction(tx, [
+    {
+      name: AUTOMATION_REACTION_TASK,
+      payload,
+      opts: {
+        idempotencyKey,
+        maxAttempts: 3,
+        organizationId: payload.organizationId,
+        automationId: payload.automationId,
+        parentRunId: payload.sourceRunId,
+      },
+    },
+  ]);
+  const taskRunId = taskRunIds.get(idempotencyKey);
+  if (taskRunId === undefined) {
+    throw new Error(
+      `Failed to resolve queued reaction task for source run ${payload.sourceRunId}`
+    );
+  }
+  // Keep #3205's three-field payload while preserving the old inline path's
+  // completion-time script. The task row is committed by this same transaction,
+  // so a later script edit or clear cannot change an already-queued effect.
+  await tx`
+    UPDATE public.runs
+    SET run_metadata = COALESCE(run_metadata, '{}'::jsonb) || ${tx.json({
+      reaction_script_compiled: compiledScript,
+    })}::jsonb
+    WHERE id = ${taskRunId}
+      AND run_type = 'task'
+      AND action_key = ${AUTOMATION_REACTION_TASK}
+  `;
+  return taskRunId;
+}

--- a/packages/server/src/automations/reaction-task.ts
+++ b/packages/server/src/automations/reaction-task.ts
@@ -1,0 +1,229 @@
+/**
+ * Runtime for the durable Automation reaction handoff queued by
+ * `./reaction-enqueue`.
+ *
+ * Rehydrates the reaction context from the source run rather than from a
+ * serialized bundle: `runs.action_output` holds the cleaned `extracted_data`,
+ * `runs.approved_input` the window bounds and granularity, and
+ * `runs.run_metadata.content_analyzed` the linked-content count — all written
+ * by the same transaction that queued this task, so the context the script sees
+ * is exactly the one the inline path built.
+ *
+ * Delivery is at-least-once and external effects are NOT exactly-once. That is
+ * unchanged from the inline path, which already re-ran the whole script on a
+ * transient failure; what is new is that a crash mid-reaction now redelivers
+ * instead of dropping the reaction on the floor. Reaction scripts performing
+ * external writes should use connector idempotency keys.
+ *
+ * Retry budget and failure classification are carried over verbatim from the
+ * inline loop: three attempts total, and a deterministic failure
+ * (`reactionErrorIsNonTransient`) stops immediately rather than re-burning the
+ * executor's 60s wall-clock budget twice more for no chance of recovery. The
+ * handler signals those two outcomes differently to the scheduler — a transient
+ * failure THROWS so the scheduler retries with its own backoff; a non-transient
+ * one returns normally so the task settles, with the failure recorded on the
+ * `automation_reactions` log where `get_automation` already surfaces it.
+ */
+
+import type { Env, ReactionContext } from '@lobu/connector-sdk';
+import { getDb, pgBigintArray } from '../db/client';
+import { AUTOMATION_REACTION_TASK } from '../scheduled/task-definitions';
+import { trackAutomationReaction } from '../utils/automation-reactions';
+import { getErrorMessage } from '@lobu/core';
+import logger from '../utils/logger';
+import { executeReaction } from './reaction-executor';
+import type { AutomationReactionTaskPayload } from './reaction-enqueue';
+
+/**
+ * Deterministic reaction-script failure classes that a retry can never fix.
+ * The sandbox prefixes these errors (`run-script.ts` classifyRuntimeError +
+ * terminateRun): a timed-out, quota-exhausted, oversize, or compile-failed
+ * reaction burns its full wall-clock budget on EVERY attempt, so retrying
+ * multiplies the stall (a 60s TimeoutError retried 3x costs ~182s) with zero
+ * recovery probability. Everything else — provider/network 5xx, transient SDK
+ * failures — stays retryable.
+ *
+ * Moved here from `complete-window.ts` with the retry loop it guards.
+ */
+export function reactionErrorIsNonTransient(error: string | undefined): boolean {
+  if (!error) return false;
+  return (
+    /^(TimeoutError|CompileError|QuotaExceeded|OutputSizeExceeded|InvalidSleepDuration|SleepLimitExceeded|OutOfMemory|ValidationError|ClientSdkActionError|McpScopeRequiredError):/.test(
+      error
+    ) ||
+    /^ScriptError: (?:Script must `export default` an async function|NamespaceNotAvailable:|CrossOrgAccessDenied:|InvalidSDKDispatchEnvelope|Unknown SDK method:)/.test(
+      error
+    )
+  );
+}
+
+/** Outcome reported back to the scheduler log; failures are also tracked durably. */
+export type AutomationReactionTaskOutcome =
+  | { status: 'success' }
+  | { status: 'failed'; error: string | undefined }
+  | { status: 'skipped'; reason: string };
+
+interface SourceRunRow {
+  status: string;
+  action_output: unknown;
+  approved_input: unknown;
+  run_metadata: unknown;
+}
+
+interface AutomationRow {
+  entity_ids: number[] | null;
+  /** COALESCEd in SQL, so never null. */
+  name: string;
+  slug: string;
+  organization_slug: string;
+  automation_version: number | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Execute one queued reaction. Throws only on a TRANSIENT failure, which is the
+ * scheduler's signal to retry; every other outcome settles the task.
+ */
+export async function runAutomationReactionTask(
+  payload: AutomationReactionTaskPayload,
+  env: Env,
+  taskRunId: number,
+  attempt = 1
+): Promise<AutomationReactionTaskOutcome> {
+  const { organizationId, automationId, sourceRunId } = payload;
+  const sql = getDb();
+
+  // Re-read the source run under its org + automation. A task that outlived its
+  // run (superseded, or an org torn down between commit and claim) must settle
+  // rather than retry against state that will never appear.
+  const [run] = await sql<SourceRunRow>`
+    SELECT status, action_output, approved_input, run_metadata
+    FROM runs
+    WHERE id = ${sourceRunId}
+      AND organization_id = ${organizationId}
+      AND automation_id = ${automationId}
+    LIMIT 1
+  `;
+  if (!run) return { status: 'skipped', reason: 'source run not found' };
+  if (run.status !== 'completed') {
+    return { status: 'skipped', reason: `source run is ${run.status}` };
+  }
+
+  const [task] = await sql<{ reaction_script_compiled: string | null }>`
+    SELECT run_metadata->>'reaction_script_compiled' AS reaction_script_compiled
+    FROM runs
+    WHERE id = ${taskRunId}
+      AND run_type = 'task'
+      AND action_key = ${AUTOMATION_REACTION_TASK}
+      AND organization_id = ${organizationId}
+      AND automation_id = ${automationId}
+      AND parent_run_id = ${sourceRunId}
+    LIMIT 1
+  `;
+  if (!task?.reaction_script_compiled) {
+    return { status: 'skipped', reason: 'reaction script snapshot not found' };
+  }
+
+  const [automation] = await sql<AutomationRow>`
+    SELECT w.entity_ids,
+           COALESCE(wv.name, 'automation-' || w.id) AS name,
+           COALESCE(w.slug, 'automation-' || w.id) AS slug,
+           o.slug AS organization_slug,
+           wv.version AS automation_version
+    FROM automations w
+    JOIN organization o ON o.id = w.organization_id
+    LEFT JOIN automation_versions wv ON w.current_version_id = wv.id
+    WHERE w.id = ${automationId}
+      AND w.organization_id = ${organizationId}
+  `;
+  if (!automation) return { status: 'skipped', reason: 'automation not found' };
+
+  const entityIds = Array.isArray(automation.entity_ids)
+    ? automation.entity_ids.map(Number)
+    : [];
+  const entityRows =
+    entityIds.length > 0
+      ? await sql<{
+          id: number;
+          name: string;
+          entity_type: string;
+          metadata: Record<string, unknown> | null;
+        }>`
+          SELECT e.id, e.name, et.slug AS entity_type, e.metadata
+          FROM entities e
+          JOIN entity_types et ON et.id = e.entity_type_id
+          WHERE e.id = ANY(${pgBigintArray(entityIds)}::bigint[])
+        `
+      : [];
+
+  const approvedInput = asRecord(run.approved_input);
+  const runMetadata = asRecord(run.run_metadata);
+  const context: ReactionContext = {
+    extracted_data: asRecord(run.action_output),
+    entities: entityRows.map((e) => ({
+      id: Number(e.id),
+      name: e.name,
+      entity_type: e.entity_type,
+      metadata: e.metadata ?? {},
+    })),
+    window: {
+      run_id: sourceRunId,
+      automation_id: automationId,
+      window_start: String(approvedInput.window_start ?? ''),
+      window_end: String(approvedInput.window_end ?? ''),
+      granularity: String(approvedInput.granularity ?? ''),
+      content_analyzed: Number(runMetadata.content_analyzed ?? 0),
+    },
+    automation: {
+      id: automationId,
+      slug: automation.slug,
+      name: automation.name,
+      version: Number(automation.automation_version ?? 1),
+    },
+    organization_id: organizationId,
+    organization_slug: automation.organization_slug,
+  };
+
+  const execResult = await executeReaction({
+    compiledScript: task.reaction_script_compiled,
+    context,
+    env: env as Record<string, string | undefined>,
+  });
+
+  await trackAutomationReaction({
+    organizationId,
+    automationId,
+    sourceRunId,
+    reactionType: 'script_execution',
+    toolName: 'reaction_executor',
+    toolArgs: { attempt },
+    toolResult: { success: execResult.success, error: execResult.error },
+  });
+
+  if (execResult.success) {
+    logger.info(
+      { automation_id: automationId, run_id: sourceRunId },
+      'Reaction script executed successfully (task)'
+    );
+    return { status: 'success' };
+  }
+
+  if (reactionErrorIsNonTransient(execResult.error)) {
+    logger.warn(
+      { automation_id: automationId, run_id: sourceRunId, error: execResult.error },
+      'Reaction script failed on a non-transient error; not retrying'
+    );
+    return { status: 'failed', error: execResult.error };
+  }
+
+  // Transient: hand the retry decision to the scheduler, which owns the attempt
+  // count and backoff. Throwing is the only way to signal that.
+  throw new Error(
+    `Reaction script failed transiently for run ${sourceRunId}: ${getErrorMessage(execResult.error)}`
+  );
+}

--- a/packages/server/src/scheduled/__tests__/task-scheduler.test.ts
+++ b/packages/server/src/scheduled/__tests__/task-scheduler.test.ts
@@ -25,6 +25,10 @@ import {
   enqueueTasksInTransaction,
   TaskScheduler,
 } from "../task-scheduler";
+import {
+  AUTOMATION_REACTION_TASK,
+  AUTOMATION_REACTION_TASK_QUEUE,
+} from "../task-definitions";
 
 interface SentRecord {
   queueName: string;
@@ -122,6 +126,16 @@ describe("TaskScheduler.spawn", () => {
     expect(delayMs).toBeGreaterThan(55_000);
     expect(delayMs).toBeLessThanOrEqual(60_000);
   });
+
+  test("uses a rollout-safe dedicated lane for Automation reactions", async () => {
+    const queue = new FakeQueue();
+    const scheduler = new TaskScheduler(queue);
+    scheduler.register(AUTOMATION_REACTION_TASK, async () => {});
+
+    await scheduler.spawn(AUTOMATION_REACTION_TASK, { sourceRunId: 42 });
+
+    expect(queue.sent[0]?.queueName).toBe(AUTOMATION_REACTION_TASK_QUEUE);
+  });
 });
 
 describe("enqueueTasksInTransaction", () => {
@@ -177,17 +191,36 @@ describe("TaskScheduler.start (cron seeding)", () => {
     await scheduler.start();
     expect(queue.sent).toHaveLength(1);
   });
+
+  test("registers the Automation reaction lane only when its handler exists", async () => {
+    const withoutReactionQueue = new FakeQueue();
+    await new TaskScheduler(withoutReactionQueue).start();
+    expect(
+      withoutReactionQueue.workers.has(AUTOMATION_REACTION_TASK_QUEUE),
+    ).toBe(false);
+
+    const withReactionQueue = new FakeQueue();
+    const scheduler = new TaskScheduler(withReactionQueue);
+    scheduler.register(AUTOMATION_REACTION_TASK, async () => {});
+    await scheduler.start();
+
+    expect(withReactionQueue.workers.has(AUTOMATION_REACTION_TASK_QUEUE)).toBe(
+      true,
+    );
+  });
 });
 
 describe("TaskScheduler.dispatch", () => {
-  test("routes to the registered handler with payload + run id", async () => {
+  test("routes payload, run id, and one-based attempt to the handler", async () => {
     const queue = new FakeQueue();
     const scheduler = new TaskScheduler(queue);
     let received: unknown = null;
     let receivedRunId: number | null = null;
+    let receivedAttempt: number | null = null;
     scheduler.register("foo", async (ctx) => {
       received = ctx.payload;
       receivedRunId = ctx.taskRunId;
+      receivedAttempt = ctx.attempt;
     });
     await scheduler.start();
 
@@ -197,11 +230,13 @@ describe("TaskScheduler.dispatch", () => {
       id: "42",
       data: { name: "foo", payload: { x: 1 } },
       name: "task",
+      attempt: 1,
     };
     await handler(job);
 
     expect(received).toEqual({ x: 1 });
     expect(receivedRunId).toBe(42);
+    expect(receivedAttempt).toBe(2);
   });
 
   test("seeds next cron tick BEFORE running the handler", async () => {

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -19,6 +19,8 @@ import { cleanupExpiredMcpAppResultSnapshots } from '../mcp-app-result-snapshots
 import logger from '../utils/logger';
 import { runAutomationTick } from '../automations/automation';
 import { runAutomationAutoPauseNotificationSweep } from '../automations/auto-pause-notifications';
+import type { AutomationReactionTaskPayload } from '../automations/reaction-enqueue';
+import { runAutomationReactionTask } from '../automations/reaction-task';
 import { checkStalledExecutions } from './check-stalled-executions';
 import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { retryPendingFeedAutoPausedSignals } from '../automations/platform-events';
@@ -32,6 +34,7 @@ import {
 } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
 import {
+  AUTOMATION_REACTION_TASK,
   INTERACTIVE_EVENT_CARD_REFRESH_TASK,
   WORKSPACE_EVENT_ACTIVATION_TASK,
 } from './task-definitions';
@@ -468,6 +471,27 @@ function registerMaintenanceTasks(
     await refreshInteractiveEventCardTask(
       ctx.payload as InteractiveEventCardRefreshTaskPayload,
     );
+  });
+
+  // The Automation reaction script. Queued inside `complete_window`'s window
+  // transaction, so the handoff survives a crash that would previously have
+  // lost the reaction outright. The handler throws only on a TRANSIENT script
+  // failure — that is what asks this scheduler for another attempt; a
+  // deterministic failure settles the task and is recorded on
+  // `automation_reactions` instead of re-burning the 60s executor budget.
+  scheduler.register(AUTOMATION_REACTION_TASK, async (ctx) => {
+    const outcome = await runAutomationReactionTask(
+      ctx.payload as AutomationReactionTaskPayload,
+      env,
+      ctx.taskRunId,
+      ctx.attempt,
+    );
+    if (outcome.status !== 'success') {
+      logger.info(
+        { ...outcome, payload: ctx.payload },
+        '[task] automation-reaction settled',
+      );
+    }
   });
 
   // scheduled_jobs ticker: scans the table every minute, spawns due rows

--- a/packages/server/src/scheduled/task-definitions.ts
+++ b/packages/server/src/scheduled/task-definitions.ts
@@ -9,10 +9,26 @@
 export const WORKSPACE_EVENT_ACTIVATION_TASK = 'activate-workspace-event';
 export const INTERACTIVE_EVENT_CARD_REFRESH_TASK =
   'refresh-interactive-event-card';
+export const AUTOMATION_REACTION_TASK = 'automation-reaction';
+export const AUTOMATION_REACTION_TASK_QUEUE =
+  `task:${AUTOMATION_REACTION_TASK}`;
+
+/**
+ * New task handlers that can be enqueued before every old pod has drained need
+ * their own queue lane. An old pod works the shared `task` lane and would
+ * otherwise claim an unknown task name, consuming its genuine-failure budget
+ * during a rolling deploy. Existing task names stay on the shared lane.
+ */
+export function taskQueueName(name: string): string {
+  return name === AUTOMATION_REACTION_TASK
+    ? AUTOMATION_REACTION_TASK_QUEUE
+    : 'task';
+}
 
 export function isTransactionalTaskName(name: string): boolean {
   return (
     name === WORKSPACE_EVENT_ACTIVATION_TASK ||
-    name === INTERACTIVE_EVENT_CARD_REFRESH_TASK
+    name === INTERACTIVE_EVENT_CARD_REFRESH_TASK ||
+    name === AUTOMATION_REACTION_TASK
   );
 }

--- a/packages/server/src/scheduled/task-scheduler.ts
+++ b/packages/server/src/scheduled/task-scheduler.ts
@@ -12,7 +12,8 @@
  *
  * The TaskScheduler collapses all of that into a single concept: every
  * platform-side scheduled or lazy job is a *task* with a registered handler.
- * Tasks live as rows in `public.runs` (run_type='task', queue_name='task'),
+ * Tasks live as rows in `public.runs` (run_type='task', queue_name='task' or a
+ * rollout-safe `task:<name>` lane),
  * which gives us — for free — claim semantics, retry/backoff, heartbeats,
  * idempotency-key dedup, observability via the existing runs/operations
  * dashboards, and LISTEN/NOTIFY wakeups via the existing runs-queue.
@@ -46,7 +47,10 @@ import { incrementCounter } from '../gateway/metrics/prometheus';
 import { notifyChannelFor } from '../gateway/infrastructure/queue/runs-queue';
 import type { IMessageQueue, QueueJob } from '../gateway/infrastructure/queue/types';
 import { nextRunAt } from '../utils/cron';
-import { isTransactionalTaskName } from './task-definitions';
+import {
+  isTransactionalTaskName,
+  taskQueueName,
+} from './task-definitions';
 
 const logger = createLogger('task-scheduler');
 
@@ -57,6 +61,8 @@ interface TaskContext<P = unknown> {
   payload: P;
   /** runs.id — useful for correlating logs. */
   taskRunId: number;
+  /** One-based delivery attempt for this task run. */
+  attempt: number;
 }
 
 type TaskHandler<P = unknown> = (ctx: TaskContext<P>) => Promise<void>;
@@ -97,6 +103,8 @@ interface TransactionalTask<P = unknown> {
     maxAttempts?: number;
     priority?: number;
     organizationId?: string;
+    automationId?: number;
+    parentRunId?: number;
   };
 }
 
@@ -106,16 +114,16 @@ interface TransactionalTask<P = unknown> {
  * nested transaction and acquires no domain/Automation locks. Postgres holds the
  * NOTIFY until the caller commits; the queue poller remains the fallback if
  * notification delivery fails. Domain writers persist a bounded set of rows in
- * one transaction, so the whole batch takes one INSERT and one NOTIFY rather
- * than a database round-trip per row. Transactional handoffs deliberately have
- * no expiry: if every worker is unavailable, the durable row must remain until
- * it is claimed.
+ * one transaction, so the whole batch takes one INSERT and one NOTIFY per queue
+ * lane rather than a database round-trip per row. Transactional handoffs
+ * deliberately have no expiry: if every worker is unavailable, the durable row
+ * must remain until it is claimed.
  */
 export async function enqueueTasksInTransaction<P>(
   tx: DbClient,
   tasks: TransactionalTask<P>[],
-): Promise<void> {
-  if (tasks.length === 0) return;
+): Promise<Map<string, number>> {
+  if (tasks.length === 0) return new Map();
   const unknownTask = tasks.find((task) => !isTransactionalTaskName(task.name));
   if (unknownTask) {
     throw new Error(
@@ -124,43 +132,54 @@ export async function enqueueTasksInTransaction<P>(
   }
   const requested = tasks.map(({ name, payload, opts }) => ({
     name,
+    queue_name: taskQueueName(name),
     data: { name, payload } satisfies TaskJobData,
     idempotency_key: opts.idempotencyKey,
     max_attempts: opts.maxAttempts ?? 5,
     priority: opts.priority ?? 0,
     organization_id: opts.organizationId ?? null,
+    automation_id: opts.automationId ?? null,
+    parent_run_id: opts.parentRunId ?? null,
   }));
   await tx`
     INSERT INTO public.runs (
       run_type, queue_name, action_key, action_input, idempotency_key,
       max_attempts, attempts, status, run_at, priority, expires_at,
-      organization_id
+      organization_id, automation_id, parent_run_id
     )
     SELECT
-      'task', ${TASK_QUEUE_NAME}, task.name, task.data, task.idempotency_key,
+      'task', task.queue_name, task.name, task.data, task.idempotency_key,
       task.max_attempts, 0, 'pending', now(), task.priority, NULL,
-      task.organization_id
+      task.organization_id, task.automation_id, task.parent_run_id
     FROM jsonb_to_recordset(${tx.json(requested)}::jsonb) AS task(
       name text,
+      queue_name text,
       data jsonb,
       idempotency_key text,
       max_attempts integer,
       priority integer,
-      organization_id text
+      organization_id text,
+      automation_id bigint,
+      parent_run_id bigint
     )
     ON CONFLICT (idempotency_key)
       WHERE idempotency_key IS NOT NULL
         AND status IN ('pending', 'claimed', 'running')
     DO NOTHING
   `;
-  const keys = requested.map((task) => task.idempotency_key);
-  const resolved = await tx<{ idempotency_key: string }>`
-    SELECT r.idempotency_key
+  const resolved = await tx<{
+    id: number | string;
+    idempotency_key: string;
+  }>`
+    SELECT r.id, r.idempotency_key
     FROM public.runs r
-    JOIN jsonb_array_elements_text(${tx.json(keys)}::jsonb) requested(key)
-      ON requested.key = r.idempotency_key
+    JOIN jsonb_to_recordset(${tx.json(requested)}::jsonb) requested(
+      idempotency_key text,
+      queue_name text
+    )
+      ON requested.idempotency_key = r.idempotency_key
+     AND requested.queue_name = r.queue_name
     WHERE r.run_type = 'task'
-      AND r.queue_name = ${TASK_QUEUE_NAME}
       AND r.status IN ('pending', 'claimed', 'running')
   `;
   const resolvedKeys = new Set(resolved.map((row) => row.idempotency_key));
@@ -172,7 +191,12 @@ export async function enqueueTasksInTransaction<P>(
       `Failed to enqueue transactional task "${missingTask.name}"`,
     );
   }
-  await tx`SELECT pg_notify(${notifyChannelFor(TASK_QUEUE_NAME)}, ${TASK_QUEUE_NAME})`;
+  for (const queueName of new Set(requested.map((task) => task.queue_name))) {
+    await tx`SELECT pg_notify(${notifyChannelFor(queueName)}, ${queueName})`;
+  }
+  return new Map(
+    resolved.map((row) => [row.idempotency_key, Number(row.id)]),
+  );
 }
 
 interface TaskRegistration {
@@ -224,7 +248,7 @@ export class TaskScheduler {
     const delayMs = opts?.runAt
       ? Math.max(0, opts.runAt.getTime() - Date.now())
       : 0;
-    return this.queue.send(TASK_QUEUE_NAME, data, {
+    return this.queue.send(taskQueueName(name), data, {
       singletonKey: opts?.idempotencyKey,
       delayMs,
       retryLimit: opts?.maxAttempts,
@@ -256,7 +280,13 @@ export class TaskScheduler {
       }
     }
 
-    await this.queue.work<TaskJobData>(TASK_QUEUE_NAME, (job) => this.dispatch(job));
+    const queueNames = new Set([
+      TASK_QUEUE_NAME,
+      ...[...this.handlers.keys()].map(taskQueueName),
+    ]);
+    for (const queueName of queueNames) {
+      await this.queue.work<TaskJobData>(queueName, (job) => this.dispatch(job));
+    }
 
     const periodic = [...this.handlers.values()].filter((r) => r.cron).length;
     logger.info(
@@ -339,6 +369,7 @@ export class TaskScheduler {
       await reg.handler({
         payload: data.payload,
         taskRunId: Number(job.id),
+        attempt: (job.attempt ?? 0) + 1,
       });
       // Label is `task`, NOT `job`: Prometheus reserves `job` for the scrape
       // target and overwrites any same-named metric label, which silently
@@ -376,7 +407,7 @@ export class TaskScheduler {
       payload: {},
       __scheduledTick: tick.toISOString(),
     };
-    await this.queue.send(TASK_QUEUE_NAME, data, {
+    await this.queue.send(taskQueueName(reg.name), data, {
       singletonKey: cronSeedKey(reg.name, tick),
       delayMs,
       actionKey: reg.name,

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -2,7 +2,8 @@
  * complete_window action handler for manage_automations.
  *
  * Validates token, writes the run result + content links, processes classifications,
- * marks run completed, advances schedule, and runs reaction script.
+ * marks run completed, advances schedule, and queues the reaction script as a
+ * durable task inside the same transaction (see automations/reaction-enqueue).
  */
 
 import Ajv from 'ajv';
@@ -32,14 +33,13 @@ import { isUniqueViolation } from '../../../utils/pg-errors';
 import { persistAutomationEventOutput } from '../../../utils/persist-automation-event-output';
 import { validateStableKeyComponents } from '../../../utils/stable-keys';
 import { deriveAutomationExtractionSchema } from '../../../utils/automation-extraction-schema';
-import { trackAutomationReaction } from '../../../utils/automation-reactions';
 import {
   getFieldsToStrip,
   processAutomationClassifications,
   stripFields,
 } from '../../../automations/classifier-extraction';
 import { advanceAutomationScheduleAfterSuccessfulWindow } from '../../../automations/schedule-cursor';
-import { executeReaction } from '../../../automations/reaction-executor';
+import { enqueueAutomationReaction } from '../../../automations/reaction-enqueue';
 import { getNextNumericId } from '../helpers/db-helpers';
 import type { Outputs } from '../../../types/automations';
 import type { ToolContext } from '../../registry';
@@ -58,27 +58,6 @@ import {
  *  be read, and an unbounded id list on a wide window is neither useful nor
  *  cheap to store. Mirrors the capping rationale in worker-api/run-lifecycle. */
 const CAPTURE_PREVIEW_CONTENT_CAP = 200;
-
-/**
- * Deterministic reaction-script failure classes that a retry can never fix.
- * The sandbox prefixes these errors (`run-script.ts` classifyRuntimeError +
- * terminateRun): a timed-out, quota-exhausted, oversize, or compile-failed
- * reaction burns its full wall-clock budget on EVERY attempt, so retrying
- * multiplies the stall (a 60s TimeoutError retried 3x costs ~182s) with zero
- * recovery probability. Everything else — provider/network 5xx, transient SDK
- * failures — stays retryable.
- */
-export function reactionErrorIsNonTransient(error: string | undefined): boolean {
-  if (!error) return false;
-  return (
-    /^(TimeoutError|CompileError|QuotaExceeded|OutputSizeExceeded|InvalidSleepDuration|SleepLimitExceeded|OutOfMemory|ValidationError|ClientSdkActionError|McpScopeRequiredError):/.test(
-      error
-    ) ||
-    /^ScriptError: (?:Script must `export default` an async function|NamespaceNotAvailable:|CrossOrgAccessDenied:|InvalidSDKDispatchEnvelope|Unknown SDK method:)/.test(
-      error
-    )
-  );
-}
 
 function assertCompleteWindowPageChain(
   tokens: Array<{
@@ -189,8 +168,13 @@ export async function handleCompleteWindow(
   content_linked: number;
   /** Internal reaction gate; false on idempotent replays. */
   completed_now: boolean;
-  reaction_status: 'success' | 'failed' | 'skipped';
-  reaction_error?: string;
+  /** `queued` = the reaction handoff committed with the window and the
+   *  scheduler owns it from here; `skipped` = this Automation has no compiled
+   *  reaction script, or the completion was an idempotent replay / capture. The
+   *  script's own success or failure is recorded on `automation_reactions`. */
+  reaction_status: 'queued' | 'skipped';
+  /** Durable task run that owns the queued reaction. */
+  reaction_task_run_id?: number;
   /** Set only on an eval replay (`executionMode = 'capture'`): the extraction
    *  was recorded on the eval run's `dry_run_preview` and nothing was written. */
   captured?: true;
@@ -668,8 +652,15 @@ export async function handleCompleteWindow(
       }
     }
 
-    const [lockedAutomation] = await tx<{ schedule: string | null }>`
-      SELECT schedule FROM automations
+    // `reaction_script_compiled` is read under the same row lock as the
+    // schedule so the decision to queue a reaction is made from the state this
+    // transaction commits against, not from a post-commit re-read that could
+    // observe a script cleared in between.
+    const [lockedAutomation] = await tx<{
+      schedule: string | null;
+      reaction_script_compiled: string | null;
+    }>`
+      SELECT schedule, reaction_script_compiled FROM automations
       WHERE id = ${automationId} AND organization_id = ${automationOrgId}
       FOR UPDATE
     `;
@@ -691,6 +682,9 @@ export async function handleCompleteWindow(
       throw new ToolUserError(`Automation run ${runId} not found.`, 404);
     }
     if (lockedRun.status === 'completed') {
+      // Idempotent replay. The reaction was queued by whichever transaction won
+      // the completion transition; re-queueing here would double-fire it,
+      // because the scheduler's idempotency index only covers in-flight rows.
       return {
         action: 'complete_window' as const,
         automation_id: String(automationId),
@@ -699,6 +693,8 @@ export async function handleCompleteWindow(
         window_end,
         content_linked: 0,
         completed_now: false,
+        queues_reaction: false,
+        reaction_task_run_id: undefined,
       };
     }
     if (lockedRun.expires_at != null) {
@@ -951,6 +947,25 @@ export async function handleCompleteWindow(
       );
     }
 
+    // Reaction handoff, committed WITH the window. Reaching here means the
+    // completion UPDATE matched, i.e. this transaction owns the single
+    // `running|claimed -> completed` transition for the run — so the enqueue
+    // happens exactly once per run without needing a durable claim of its own.
+    const reactionScriptSnapshot = lockedAutomation.reaction_script_compiled;
+    const queuesReaction = Boolean(reactionScriptSnapshot);
+    let reactionTaskRunId: number | undefined;
+    if (reactionScriptSnapshot) {
+      reactionTaskRunId = await enqueueAutomationReaction(
+        tx,
+        {
+          organizationId: automationOrgId,
+          automationId: Number(automationId),
+          sourceRunId: runId,
+        },
+        reactionScriptSnapshot
+      );
+    }
+
     logger.info(
       `[manage_automations] Completed run ${runId} for automation ${automationId} ` +
         `(${window_start} - ${window_end}), linked ${batchContentIds.length} content items`
@@ -964,6 +979,8 @@ export async function handleCompleteWindow(
       window_end,
       content_linked: batchContentIds.length,
       completed_now: true,
+      queues_reaction: queuesReaction,
+      reaction_task_run_id: reactionTaskRunId,
     };
   });
 
@@ -982,152 +999,13 @@ export async function handleCompleteWindow(
       );
   }
 
-  // Execute the reaction script inline in the isolated reaction sandbox.
-  // Fire on linked content OR on a freshly created window: device-run and
-  // other self-sourcing automations link no server-side content — their signal
-  // is the extracted_data itself, and the reaction script decides what to do
-  // with it. Idempotent replays (no new window, nothing linked) still skip,
-  // so a retried completion can't double-fire a reaction.
-  let reactionStatus: 'success' | 'failed' | 'skipped' = 'skipped';
-  let reactionError: string | undefined;
-
-  // Fetch automation metadata once — used for both reaction script and auto-notify
-  const automationMetaSql = getDb();
-  const automationMetaRows = await automationMetaSql`
-    SELECT w.reaction_script_compiled, w.entity_ids,
-           w.organization_id, w.current_version_id,
-           w.name, o.slug AS organization_slug,
-           wv.version as automation_version
-    FROM automations w
-    JOIN organization o ON o.id = w.organization_id
-    LEFT JOIN automation_versions wv ON w.current_version_id = wv.id
-    WHERE w.id = ${result.automation_id}
-  `;
-
-  try {
-    const sql = automationMetaSql;
-    const scriptRows = automationMetaRows;
-    if (
-      result.completed_now &&
-      scriptRows.length > 0 &&
-      scriptRows[0].reaction_script_compiled
-    ) {
-      const row = scriptRows[0];
-      const orgId = row.organization_id as string;
-
-      // Fetch all entities
-      const eIds = Array.isArray(row.entity_ids) ? row.entity_ids.map(Number) : [];
-      const entityRows =
-        eIds.length > 0
-          ? await sql`
-              SELECT e.id, e.name, et.slug AS entity_type, e.metadata
-              FROM entities e
-              JOIN entity_types et ON et.id = e.entity_type_id
-              WHERE e.id = ANY(${`{${eIds.join(',')}}`}::bigint[])
-            `
-          : [];
-
-      // Fetch automation name from version, slug from template (pre-consolidation)
-      const automationMeta = await sql`
-        SELECT w.id, COALESCE(wv.name, 'automation-' || w.id) as name,
-               COALESCE(w.slug, 'automation-' || w.id) as slug
-        FROM automations w
-        LEFT JOIN automation_versions wv ON w.current_version_id = wv.id
-        WHERE w.id = ${result.automation_id}
-      `;
-
-      const reactionContext = {
-        extracted_data: cleanedExtractedData,
-        entities: entityRows.map((e: any) => ({
-          id: Number(e.id),
-          name: e.name as string,
-          entity_type: e.entity_type as string,
-          metadata: (e.metadata ?? {}) as Record<string, unknown>,
-        })),
-        window: {
-          run_id: result.run_id,
-          automation_id: Number(result.automation_id),
-          window_start: result.window_start,
-          window_end: result.window_end,
-          granularity: timeGranularity,
-          content_analyzed: batchContentIds.length,
-        },
-        automation: {
-          id: Number(result.automation_id),
-          slug: (automationMeta[0]?.slug ?? `automation-${result.automation_id}`) as string,
-          name: (automationMeta[0]?.name ?? `automation-${result.automation_id}`) as string,
-          version: Number(row.automation_version ?? 1),
-        },
-        organization_id: orgId,
-        organization_slug: String(row.organization_slug),
-      };
-
-      const MAX_ATTEMPTS = 3;
-      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        const execResult = await executeReaction({
-          compiledScript: row.reaction_script_compiled as string,
-          context: reactionContext,
-          env: env as Record<string, string | undefined>,
-        });
-
-        await trackAutomationReaction({
-          organizationId: orgId,
-          automationId: Number(result.automation_id),
-          sourceRunId: result.run_id,
-          reactionType: 'script_execution',
-          toolName: 'reaction_executor',
-          toolArgs: { attempt },
-          toolResult: { success: execResult.success, error: execResult.error },
-        });
-
-        if (execResult.success) {
-          reactionStatus = 'success';
-          logger.info(
-            {
-              automation_id: result.automation_id,
-              run_id: result.run_id,
-              attempt,
-            },
-            'Reaction script executed successfully (inline)'
-          );
-          break;
-        }
-
-        // Deterministic script failures are NOT transient: retrying a timed-out
-        // or quota-exhausted reaction re-burns the same 60s budget 3x and
-        // stalls complete_window by ~3 minutes for zero chance of recovery
-        // (run-script's error names are stable — TimeoutError, CompileError,
-        // QuotaExceeded, OutputSizeExceeded, ValidationError, …). Only the transient
-        // remainder (provider/network 5xx and similar) gets the retry loop.
-        const isNonTransient = reactionErrorIsNonTransient(execResult.error);
-        if (isNonTransient || attempt === MAX_ATTEMPTS) {
-          reactionStatus = 'failed';
-          reactionError = execResult.error;
-          logger[isNonTransient ? 'warn' : 'error'](
-            { automation_id: result.automation_id, attempt, error: execResult.error },
-            isNonTransient
-              ? 'Reaction script failed on a non-transient error; not retrying'
-              : 'Reaction script failed after all retries'
-          );
-          break;
-        }
-
-        logger.warn(
-          { automation_id: result.automation_id, attempt, error: execResult.error },
-          'Reaction script failed, retrying...'
-        );
-        await new Promise((r) => setTimeout(r, 1000));
-      }
-    }
-  } catch (err) {
-    reactionStatus = 'failed';
-    reactionError = getErrorMessage(err);
-    logger.warn({ err }, '[manage_automations] Failed to execute reaction script');
-  }
-
+  // `queued` means the handoff committed inside the window transaction above,
+  // NOT that the script ran: `automations/reaction-task.ts` executes it and
+  // records the outcome on the `automation_reactions` log that `get_automation`
+  // already surfaces. The task run id lets callers follow the durable handoff.
+  const { queues_reaction: queuesReaction, ...completion } = result;
   return {
-    ...result,
-    reaction_status: reactionStatus,
-    reaction_error: reactionError,
+    ...completion,
+    reaction_status: queuesReaction ? ('queued' as const) : ('skipped' as const),
   };
 }


### PR DESCRIPTION
## Summary

- Enqueues the Automation reaction inside the existing `complete_window` transaction, so the completed window and durable reaction handoff commit or roll back together.
- Rehydrates reaction context from the source run and Automation instead of serializing a second context bundle.
- Snapshots only the compiled reaction script in the linked task run metadata at completion time, so later Automation edits or clearing cannot change or discard an already-queued reaction.
- Reuses TaskScheduler retry/recovery with the existing three-attempt budget and deterministic-failure classification.
- Returns `reaction_status: "queued"` plus `reaction_task_run_id`; callers no longer wait for inline reaction execution.

## Safety and rollout

- Stable key: `automation-reaction:<sourceRunId>`.
- Payload remains exactly `{ organizationId, automationId, sourceRunId }`.
- Task rows carry the existing `automation_id` and `parent_run_id` causal links.
- A dedicated existing `task:<name>` lane prevents old rolling-deploy pods from claiming a task whose handler they do not know.
- Delivery is durable at-least-once. External reaction effects must use connector idempotency keys.
- The dedicated lane processes one reaction per pod at a time. This trades immediate concurrency for a durable backlog; adding a concurrency framework is outside #3205.

## Consolidation and review

The branch is rebased onto current `main` and collapsed to one commit. Claude Opus review-fix removed duplicate SQL, redundant row fields/fallbacks, duplicated imports, and stale narrative comments; it also strengthened skip-reason assertions. Claude was unavailable for the final exact-head gate, so the user-authorized Codex fallback reviewed it. That review found that rereading the live Automation script could change or drop an already-queued side effect; the task-run snapshot above fixes the issue without a migration, new table, payload expansion, serialized context bundle, or new queue framework.

## Validation

- Automation completion/reaction integration: 61/61 passed, including edit-after-enqueue and clear-after-enqueue regression cases.
- Scheduler/retry tests: 18/18 passed.
- Server typecheck, root Biome/TypeScript checks, and `make pre-pr` passed.
- Fresh GitHub CI passed on exact head `e731c7cdeb3fde6245cf5744d3ff863a13bcd571` (run 33256406817), including all unit, frontend, integration, migration, CodeQL, and policy gates.
- UI review: not applicable; `packages/owletto` is unchanged.

Closes #3205.
