### PR TITLE
fix(worker-api): ship bundled code to device workers

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1156,11 +1156,17 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId)).not.toBeNull();
   });
 
-  it('admits the daemon-emitted os.shell manifest for a headless device', async () => {
-    const { userId, workerId } = await seedDeviceOwner('headless');
+  it('ships bundled os.shell code to the headless daemon that advertises its manifest', async () => {
+    const { userId, orgId, workerId } = await seedDeviceOwner('headless');
     // The exact manifest the connector-worker daemon sends on poll - not a
     // synthetic fixture - so the test validates what herdr actually declares.
-    const res = await poll(workerId, [HEADLESS_OS_SHELL_MANIFEST], 'headless', { 'os.shell': true });
+    const res = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      { capacityAvailable: 0 },
+    );
     expect(res.status).toBe(200);
 
     // The manifest was admitted and stored on the device row (the headless
@@ -1173,6 +1179,40 @@ describe('device connector manifests', () => {
     `) as unknown as Array<{ connector_manifests: unknown }>;
     const stored = rows[0]?.connector_manifests as Record<string, unknown> | undefined;
     expect(stored?.['os.shell']).toBeDefined();
+
+    const [connection] = (await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId}
+        AND connector_key = 'os.shell'
+        AND deleted_at IS NULL
+      LIMIT 1
+    `) as unknown as Array<{ id: number }>;
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key,
+        connector_version, action_key, action_input, approval_status, status,
+        created_at
+      ) VALUES (
+        ${orgId}, 'action', ${connection.id}, 'os.shell', '0.1.0', 'run',
+        ${sql.json({ command: 'hostname' })}, 'auto', 'pending', NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const claimingPoll = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      { capacityAvailable: 1 },
+    );
+    expect(claimingPoll.status).toBe(200);
+    const body = (await claimingPoll.json()) as Record<string, unknown>;
+    expect(body.run_id).toBe(Number(run.id));
+    expect(body.connector_key).toBe('os.shell');
+    expect(body.execution_backend).toBeUndefined();
+    expect(typeof body.compiled_code).toBe('string');
+    expect((body.compiled_code as string).length).toBeGreaterThan(0);
   });
 
   it('drops a manifest that still declares removed entityLinks rules', async () => {

--- a/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
+++ b/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
@@ -1,7 +1,9 @@
 import { deviceManifestHash, type DeviceConnectorManifest } from '@lobu/connector-sdk';
+import { HEADLESS_OS_SHELL_MANIFEST } from '@lobu/connector-worker/daemon/device-manifests';
 import { describe, expect, test } from 'vitest';
 import {
   classifySelectedConnectorExecution,
+  deviceExecutesConnectorNatively,
   type SelectedConnectorDefinition,
 } from '../connector-execution-backend';
 
@@ -151,5 +153,146 @@ describe('selected connector execution backend', () => {
       backend: 'native_bridge',
       manifestHash: omittedAuthHash,
     });
+  });
+});
+
+describe('device manifests served by connector-worker rather than a bridge', () => {
+  const headless = HEADLESS_OS_SHELL_MANIFEST as unknown as DeviceConnectorManifest;
+  const headlessDefinition: SelectedConnectorDefinition = {
+    key: headless.key,
+    version: headless.version,
+    name: headless.name,
+    requiredCapability: headless.required_capability,
+    runtime: headless.runtime,
+    authSchema: headless.auth_schema,
+    feeds: headless.feeds_schema,
+    actions: headless.actions_schema,
+    optionsSchema: headless.options_schema,
+  };
+  const headlessHash = deviceManifestHash(headless);
+  const headlessSourcePath = `device-manifest://headless/${headless.key}@${headless.version}`;
+
+  function classifyHeadless(overrides: Record<string, unknown> = {}) {
+    return classifySelectedConnectorExecution({
+      artifact: {
+        sourcePath: headlessSourcePath,
+        manifestHash: headlessHash,
+        compiledCode: null,
+        compileConfigHash: null,
+        hasSourceCode: false,
+      },
+      definition: headlessDefinition,
+      connectorKey: headless.key,
+      connectorVersion: headless.version,
+      authorizations: [{
+        connectorKey: headless.key,
+        connectorVersion: headless.version,
+        manifestHash: headlessHash,
+        sourcePath: headlessSourcePath,
+      }],
+      expectedPlatform: 'headless',
+      ...overrides,
+    });
+  }
+
+  test('the shipped headless os.shell manifest declares no bridge execution', () => {
+    expect(headless.runtime).not.toHaveProperty('execution');
+  });
+
+  test('classifies headless os.shell as manifest-backed but not native_bridge', () => {
+    expect(classifyHeadless()).toEqual({ manifestBacked: true });
+  });
+
+  test('stays non-bridge even when the device authorization claims bridge execution', () => {
+    expect(classifyHeadless({
+      authorizations: [{
+        connectorKey: headless.key,
+        connectorVersion: headless.version,
+        manifestHash: headlessHash,
+        sourcePath: headlessSourcePath,
+        runtimeExecution: 'bridge',
+      }],
+    })).toEqual({ manifestBacked: true });
+  });
+});
+
+describe('deviceExecutesConnectorNatively', () => {
+  const base = {
+    isUserScopedWorker: true,
+    hasStoredCompiledCode: false,
+    gatewayHasLocalSource: true,
+    isNativeBridgeRun: false,
+    manifestBacked: false,
+    deviceAdvertisesRequiredCapability: false,
+  };
+
+  test('a native-bridge run needs no bundle', () => {
+    expect(deviceExecutesConnectorNatively({ ...base, isNativeBridgeRun: true })).toBe(true);
+  });
+
+  test('manifest-backed alone does not mean native execution', () => {
+    expect(deviceExecutesConnectorNatively({ ...base, manifestBacked: true })).toBe(false);
+  });
+
+  test('advertising the required capability does not mean native execution', () => {
+    expect(
+      deviceExecutesConnectorNatively({ ...base, deviceAdvertisesRequiredCapability: true })
+    ).toBe(false);
+  });
+
+  test('manifest-backed plus the capability gate still needs the bundle', () => {
+    expect(
+      deviceExecutesConnectorNatively({
+        ...base,
+        manifestBacked: true,
+        deviceAdvertisesRequiredCapability: true,
+      })
+    ).toBe(false);
+  });
+
+  test('keeps a legacy manifest device-executed when the gateway has no code to send', () => {
+    expect(
+      deviceExecutesConnectorNatively({
+        ...base,
+        gatewayHasLocalSource: false,
+        manifestBacked: true,
+      })
+    ).toBe(true);
+  });
+
+  test('keeps a legacy capability-only device-executed when the gateway has no code to send', () => {
+    expect(
+      deviceExecutesConnectorNatively({
+        ...base,
+        gatewayHasLocalSource: false,
+        deviceAdvertisesRequiredCapability: true,
+      })
+    ).toBe(true);
+  });
+
+  test('does not invent native execution without a bridge, manifest, or capability claim', () => {
+    expect(
+      deviceExecutesConnectorNatively({ ...base, gatewayHasLocalSource: false })
+    ).toBe(false);
+  });
+
+  test('stored compiled code always ships inline, even for a bridge run', () => {
+    expect(
+      deviceExecutesConnectorNatively({
+        ...base,
+        isNativeBridgeRun: true,
+        hasStoredCompiledCode: true,
+      })
+    ).toBe(false);
+  });
+
+  test('a fleet worker resolves locally and is never treated as native', () => {
+    expect(
+      deviceExecutesConnectorNatively({
+        ...base,
+        isUserScopedWorker: false,
+        isNativeBridgeRun: true,
+      })
+    ).toBe(false);
   });
 });

--- a/packages/server/src/utils/connector-execution-backend.ts
+++ b/packages/server/src/utils/connector-execution-backend.ts
@@ -137,6 +137,33 @@ export function classifySelectedConnectorExecution(params: {
   return { manifestBacked, backend: 'native_bridge', manifestHash: params.artifact.manifestHash };
 }
 
+/**
+ * Whether the claiming device implements this connector itself, so the gateway
+ * may omit `compiled_code` from the poll response.
+ *
+ * A native-bridge run always qualifies. Legacy device manifests and
+ * capability-only clients also remain device-executed when the gateway has no
+ * code it could deliver. When bundled or stored code exists, manifest backing
+ * and capability advertisement are authorization signals only; they do not
+ * establish that the device implements the connector.
+ */
+export function deviceExecutesConnectorNatively(params: {
+  isUserScopedWorker: boolean;
+  hasStoredCompiledCode: boolean;
+  gatewayHasLocalSource: boolean;
+  isNativeBridgeRun: boolean;
+  manifestBacked: boolean;
+  deviceAdvertisesRequiredCapability: boolean;
+}): boolean {
+  return (
+    params.isUserScopedWorker &&
+    !params.hasStoredCompiledCode &&
+    (params.isNativeBridgeRun ||
+      (!params.gatewayHasLocalSource &&
+        (params.manifestBacked || params.deviceAdvertisesRequiredCapability)))
+  );
+}
+
 export function parseManifestSourcePath(
   sourcePath: string | null | undefined,
 ): { platform: string; key: string; version: string } | null {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1605,9 +1605,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   //     bundles totalled ~384 MB).
   //   - Device workers and DB-only user-uploaded connectors don't have the
   //     source on disk. When their version has stored TypeScript code, the
-  //     gateway ships `compiled_code` inline. Metadata-only device manifests
-  //     are implemented natively by the device bridge and need no bundle.
-  //     We check the gateway-local
+  //     gateway ships `compiled_code` inline. A metadata-only device manifest
+  //     needs no bundle only when it is an attested native-bridge run, or when
+  //     the gateway has no connector source it could deliver. We check the
+  //     gateway-local
   //     `findBundledConnectorFile` (different filesystem layout from the
   //     worker image — see worker-side resolver in
   //     connector-worker/src/compile-connector.ts) to decide whether the

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -60,7 +60,10 @@ import { stripServerOnlyExecutionConfig } from '../tools/admin/automation-execut
 import { supersedeActionEvent } from '../tools/admin/approval-events';
 import logger from '../utils/logger';
 import { selectedConnectorVersionArtifactSql } from '../utils/connector-execution-placement';
-import { classifySelectedConnectorExecution } from '../utils/connector-execution-backend';
+import {
+  classifySelectedConnectorExecution,
+  deviceExecutesConnectorNatively,
+} from '../utils/connector-execution-backend';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import { isCloudMode } from '../utils/cloud-mode';
 import { normalizeAdvertisedCapabilities, normalizeAgentKinds } from './shared';
@@ -1648,18 +1651,18 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const hasStoredCompiledCode = Boolean(row.compiled_code);
   const workerWillResolveLocally =
     !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
-  // Metadata-only device manifests describe connectors implemented natively by
-  // the device bridge, so there is no TypeScript bundle to deliver. A device
-  // connector that does have compiled code (for example an `os.files` takeout
-  // connector installed from source) runs in connector-worker and needs that
-  // code inline because it is not part of the worker's bundled catalog.
-  const deviceWillExecuteNativeConnector =
-    isUserScopedWorker &&
-    !hasStoredCompiledCode &&
-    (isNativeBridgeRun ||
-      row.connector_manifest_backed ||
-      (row.connector_required_capability != null &&
-        authorizedCapabilities.includes(row.connector_required_capability)));
+  // Only a native-bridge run is implemented by the device itself. Manifest
+  // backing and the capability gate do not establish who executes the code.
+  const deviceWillExecuteNativeConnector = deviceExecutesConnectorNatively({
+    isUserScopedWorker,
+    hasStoredCompiledCode,
+    gatewayHasLocalSource,
+    isNativeBridgeRun,
+    manifestBacked: row.connector_manifest_backed,
+    deviceAdvertisesRequiredCapability:
+      row.connector_required_capability != null &&
+      authorizedCapabilities.includes(row.connector_required_capability),
+  });
   if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteNativeConnector) {
     try {
       compiledCode = await resolveConnectorCode(row.connector_key, {
@@ -1743,10 +1746,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
 
   // Native (nixpkgs) packages the connector declared in `runtime.nix.packages`.
   // The worker provisions these on PATH via nix-shell before executing.
-  const nixPackages = (
-    isNativeBridgeRun || row.connector_manifest_backed
-      ? []
-      : (row.connector_runtime?.nix?.packages ?? [])
+  // A connector executed by connector-worker needs its declared native
+  // dependencies. Device-native bridge and legacy manifest implementations do
+  // not, because the device owns their runtime.
+  const nixPackages = (deviceWillExecuteNativeConnector
+    ? []
+    : (row.connector_runtime?.nix?.packages ?? [])
   ).filter(
     (p): p is string => typeof p === 'string'
   );


### PR DESCRIPTION
## Summary

- ship bundled connector code to device workers when the gateway has a runnable source, even when the connector is manifest-backed or capability-gated
- preserve native execution for explicit bridge artifacts and legacy device manifests when the gateway has no code it can deliver
- use the same execution decision for connector-declared native packages

## Test plan

- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [x] Tests run: targeted server unit and device-manifest integration suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

Red on current `origin/main` after extracting the existing decision into a testable helper:

```text
connector-execution-backend.test.ts: 3 failed | 15 passed
- manifest-backed alone incorrectly reported native execution
- required-capability advertisement incorrectly reported native execution
- both signals together incorrectly reported native execution
```

The reporter branch corrected those three cases but exposed a compatibility regression in the full manifest suite:

```text
device-connector-manifests.test.ts: 7 failed | 30 passed
```

The settled implementation distinguishes deliverable gateway code from legacy device-native manifests:

```text
connector-execution-backend.test.ts + device-connector-manifests.test.ts
2 files passed; 58 tests passed
make pre-pr: clean
```

## Notes

No database migration, API contract, generated client, connector SDK, or public SDK changes.

Fixes #3214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector execution handling for headless devices.
  * Ensured pending connector actions are correctly claimed and returned during device polling.
  * Corrected when compiled connector code and runtime packages are included in poll responses.
  * Added support for accurately distinguishing native device execution from gateway-provided execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->