### PR TITLE
fix(chat): complete live event-card interactions

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -47,7 +47,7 @@ Create no ad-hoc platform card and never use ask_user for a multi-user poll. The
 
 Opening a poll:
 1. Require a non-empty question, 2-5 distinct non-empty options, a positive integer quorum, and a future closes_at. If the user gives a duration, calculate closes_at as an ISO-8601 timestamp.
-2. In one run_sdk call, create a poll entity and then call client.knowledge.save with entity_ids containing only that entity id, semantic_type "poll_opened", payload_type "empty", title equal to the question, a stable idempotency_key "poll-opened:<entity id>", and metadata containing question, options, status "open", quorum, closes_at, results (one { option, count: 0 } row per option), and response_count 0. Return the entity id and saved event id. If retrying after an uncertain result, search for the stable poll slug first instead of creating a duplicate.
+2. In one run_sdk call, create a poll entity, read its numeric id from createResult.entity?.id (stop if the result has no created entity), and then call client.knowledge.save with entity_ids containing only that numeric entity id, semantic_type "poll_opened", payload_type "empty", title equal to the question, a stable idempotency_key "poll-opened:<entity id>", and metadata containing question, options, status "open", quorum, closes_at, results (one { option, count: 0 } row per option), and response_count 0. Return the entity id and saved event id. If retrying after an uncertain result, search for the stable poll slug first instead of creating a duplicate.
 3. Before presenting the event, call schedule_followup with run_at equal to closes_at, idempotency_key "poll-deadline:<entity id>", and prompt: "Close event-backed poll entity <entity id> at its deadline. Follow the event-backed-polls deadline procedure exactly; do nothing if it is already closed."
 4. Call present_event exactly once with the saved event id. That ends the turn because the native card is already the answer.
 
@@ -501,16 +501,20 @@ const poll = defineEntityType({
         type: "card",
         children: [
           {
-            type: "text",
-            content: "Open until {{closes_at}} · quorum {{quorum}}",
+            type: "context",
+            children: [
+              { type: "text", content: "Open until " },
+              { type: "data", path: "closes_at" },
+              { type: "text", content: " · quorum " },
+              { type: "data", path: "quorum" },
+            ],
           },
           {
-            type: "each",
-            items: "results",
-            as: "result",
-            render: {
-              type: "text",
-              content: "{{result.option}} — {{result.count}} vote(s)",
+            type: "table",
+            props: {
+              title: "Results",
+              data: "{{results}}",
+              columns: ["option", "count"],
             },
           },
           {
@@ -540,19 +544,23 @@ const poll = defineEntityType({
       jsonTemplate: {
         type: "card",
         children: [
-          { type: "text", content: "Closed · {{close_reason}}" },
           {
-            type: "each",
-            items: "results",
-            as: "result",
-            render: {
-              type: "text",
-              content: "{{result.option}} — {{result.count}} vote(s)",
-            },
+            type: "context",
+            children: [
+              { type: "text", content: "Closed · " },
+              { type: "data", path: "close_reason" },
+              { type: "text", content: " · " },
+              { type: "data", path: "response_count" },
+              { type: "text", content: " participant(s)" },
+            ],
           },
           {
-            type: "text",
-            content: "{{response_count}} participant(s)",
+            type: "table",
+            props: {
+              title: "Results",
+              data: "{{results}}",
+              columns: ["option", "count"],
+            },
           },
         ],
       },

--- a/packages/server/src/__tests__/integration/events/template-event-actions.test.ts
+++ b/packages/server/src/__tests__/integration/events/template-event-actions.test.ts
@@ -137,7 +137,7 @@ describe("template event actions", () => {
 						connectionId: "91",
 						channelKey: "gchat:spaces/AAA",
 						messageId: "spaces/AAA/messages/poll-1",
-						threadId: "gchat:spaces/AAA:threads/thread-1",
+						threadId: "gchat:spaces/AAA:dm",
 					},
 				],
 			},
@@ -249,7 +249,7 @@ describe("template event actions", () => {
 				source: {
 					connectionId: "91",
 					messageId: "spaces/AAA/messages/poll-1",
-					threadId: "gchat:spaces/AAA:threads/thread-1",
+					threadId: "gchat:spaces/AAA:dm",
 				},
 				...overrides,
 			} as never);
@@ -258,6 +258,18 @@ describe("template event actions", () => {
 		expect(first).toMatchObject({ created: true, eventType: "poll_vote_cast" });
 		const replay = await invoke();
 		expect(replay).toEqual({ ...first, created: false });
+		await expect(
+			invoke({
+				source: {
+					connectionId: "91",
+					messageId: "spaces/AAA/messages/poll-1",
+					// Google Chat stores a direct-message delivery under the stable
+					// DM conversation id, but its card callback re-encodes the exact
+					// message as a message-bound thread id.
+					threadId: "gchat:spaces/AAA:c3BhY2VzL0FBQS9tZXNzYWdlcy9wb2xsLTE",
+				},
+			}),
+		).resolves.toEqual({ ...first, created: false });
 
 		const votes = await sql<{
 			id: number;
@@ -326,6 +338,31 @@ describe("template event actions", () => {
 				},
 			}),
 		).rejects.toThrow(/does not belong to this chat delivery/i);
+		await expect(
+			invoke({
+				interactionId: "wrong-message",
+				source: {
+					connectionId: "91",
+					messageId: "spaces/AAA/messages/another-card",
+				},
+			}),
+		).rejects.toThrow(/does not belong to this chat delivery/i);
+		await expect(
+			invoke({
+				interactionId: "wrong-thread",
+				surface: "slack",
+				actor: {
+					platform: "slack",
+					platformUserId: "UADA",
+					name: "Ada",
+				},
+				source: {
+					connectionId: "91",
+					messageId: "spaces/AAA/messages/poll-1",
+					threadId: "slack:C999:1712345678.000001",
+				},
+			}),
+		).rejects.toThrow(/does not belong to this chat delivery/i);
 
 		const otherWorkspace = await TestWorkspace.create({
 			name: "Other Template Action Org",
@@ -370,7 +407,7 @@ describe("template event actions", () => {
 		});
 		expect(editMessageContent).toHaveBeenCalledTimes(1);
 		expect(editMessageContent).toHaveBeenCalledWith("91", {
-			threadId: "gchat:spaces/AAA:threads/thread-1",
+			threadId: "gchat:spaces/AAA:dm",
 			messageId: "spaces/AAA/messages/poll-1",
 			content: expect.objectContaining({ card: expect.anything() }),
 		});
@@ -403,7 +440,7 @@ describe("template event actions", () => {
 					connectionId: "91",
 					channelKey: "gchat:spaces/AAA",
 					messageId: "spaces/AAA/messages/poll-1",
-					threadId: "gchat:spaces/AAA:threads/thread-1",
+					threadId: "gchat:spaces/AAA:dm",
 				},
 			]);
 		});
@@ -423,7 +460,7 @@ describe("template event actions", () => {
 				source: {
 					connectionId: "91",
 					messageId: "spaces/AAA/messages/poll-1",
-					threadId: "gchat:spaces/AAA:threads/thread-1",
+					threadId: "gchat:spaces/AAA:dm",
 				},
 			}),
 		).resolves.toMatchObject({

--- a/packages/server/src/gateway/connections/__tests__/chat-instance-manager-message-mutations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-instance-manager-message-mutations.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ChatInstanceManager } from "../chat-instance-manager.js";
+
+describe("ChatInstanceManager message mutations", () => {
+  test("resolves the registered adapter for every message mutation", async () => {
+    const editMessage = mock(async () => undefined);
+    const addReaction = mock(async () => undefined);
+    const removeReaction = mock(async () => undefined);
+    const deleteMessage = mock(async () => undefined);
+    const getAdapter = mock((platform: string) =>
+      platform === "gchat"
+        ? { addReaction, deleteMessage, editMessage, removeReaction }
+        : undefined,
+    );
+    const manager = new ChatInstanceManager() as any;
+    manager.ensureConnectionRunning = mock(async () => undefined);
+    manager.instances.set("gchat-1", {
+      connection: { id: "gchat-1", platform: "gchat" },
+      chat: { getAdapter },
+    });
+
+    await manager.editMessageContent("gchat-1", {
+      threadId: "gchat:spaces/AAA:dm",
+      messageId: "spaces/AAA/messages/poll-1",
+      content: { markdown: "Closed" },
+    });
+
+    expect(editMessage).toHaveBeenCalledWith(
+      "gchat:spaces/AAA:dm",
+      "spaces/AAA/messages/poll-1",
+      { markdown: "Closed" },
+    );
+
+    await manager.reactToMessage("gchat-1", {
+      threadId: "gchat:spaces/AAA:dm",
+      messageId: "spaces/AAA/messages/poll-1",
+      emoji: "✅",
+    });
+    await manager.reactToMessage("gchat-1", {
+      threadId: "gchat:spaces/AAA:dm",
+      messageId: "spaces/AAA/messages/poll-1",
+      emoji: "✅",
+      remove: true,
+    });
+    await manager.deleteMessage("gchat-1", {
+      threadId: "gchat:spaces/AAA:dm",
+      messageId: "spaces/AAA/messages/poll-1",
+    });
+    expect(addReaction).toHaveBeenCalledWith(
+      "gchat:spaces/AAA:dm",
+      "spaces/AAA/messages/poll-1",
+      "✅",
+    );
+    expect(removeReaction).toHaveBeenCalledWith(
+      "gchat:spaces/AAA:dm",
+      "spaces/AAA/messages/poll-1",
+      "✅",
+    );
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "gchat:spaces/AAA:dm",
+      "spaces/AAA/messages/poll-1",
+    );
+    expect(getAdapter).toHaveBeenCalledTimes(4);
+    expect(getAdapter).toHaveBeenCalledWith("gchat");
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -15,7 +15,7 @@
 import { randomUUID } from "node:crypto";
 import type { AgentConnectionStore, StoredConnection } from "@lobu/core";
 import { createLogger, getErrorMessage, isSecretRef } from "@lobu/core";
-import { type AdapterPostableMessage, Chat } from "chat";
+import { type Adapter, type AdapterPostableMessage, Chat } from "chat";
 import { verifyAtlassianWebhookAuthorization } from "../../connect/atlassian-webhook-auth.js";
 import { resolveConnectionWebhookConfig } from "../../connect/webhook-registration.js";
 import { getDb } from "../../db/client.js";
@@ -1109,6 +1109,19 @@ export class ChatInstanceManager {
     return instance;
   }
 
+  private requireRunningAdapter(connectionId: string): Adapter {
+    const instance = this.requireRunningInstance(connectionId);
+    const adapter = instance.chat.getAdapter(
+      instance.connection.platform,
+    ) as Adapter | undefined;
+    if (!adapter) {
+      throw new Error(
+				`No active ${instance.connection.platform} adapter for connection ${connectionId}`,
+      );
+    }
+    return adapter;
+  }
+
   /** Add or remove an emoji reaction on a specific message. */
   async reactToMessage(
     connectionId: string,
@@ -1120,8 +1133,7 @@ export class ChatInstanceManager {
 		},
   ): Promise<void> {
     await this.ensureConnectionRunning(connectionId);
-    const instance = this.requireRunningInstance(connectionId);
-    const adapter = instance.chat?.adapter;
+    const adapter = this.requireRunningAdapter(connectionId);
     if (opts.remove) {
       await adapter.removeReaction(opts.threadId, opts.messageId, opts.emoji);
     } else {
@@ -1150,14 +1162,10 @@ export class ChatInstanceManager {
 			content: AdapterPostableMessage;
 		},
 	): Promise<void> {
-    await this.ensureConnectionRunning(connectionId);
-    const instance = this.requireRunningInstance(connectionId);
-		await instance.chat?.adapter.editMessage(
-			opts.threadId,
-			opts.messageId,
-			opts.content,
-		);
-  }
+		await this.ensureConnectionRunning(connectionId);
+		const adapter = this.requireRunningAdapter(connectionId);
+		await adapter.editMessage(opts.threadId, opts.messageId, opts.content);
+	}
 
   /** Delete a message the bot previously sent. */
   async deleteMessage(
@@ -1165,8 +1173,8 @@ export class ChatInstanceManager {
 		opts: { threadId: string; messageId: string },
   ): Promise<void> {
     await this.ensureConnectionRunning(connectionId);
-    const instance = this.requireRunningInstance(connectionId);
-    await instance.chat?.adapter.deleteMessage(opts.threadId, opts.messageId);
+    const adapter = this.requireRunningAdapter(connectionId);
+    await adapter.deleteMessage(opts.threadId, opts.messageId);
   }
 
   /**

--- a/packages/server/src/interactions/template-event-actions.ts
+++ b/packages/server/src/interactions/template-event-actions.ts
@@ -108,6 +108,7 @@ function deliveryMatches(
 	metadata: Record<string, unknown>,
 	source: Required<Pick<TemplateActionSource, "connectionId" | "messageId">> &
 		Pick<TemplateActionSource, "threadId">,
+	platform: string,
 ): boolean {
 	if (!Array.isArray(metadata.delivery)) return false;
 	return metadata.delivery.some((raw) => {
@@ -118,8 +119,18 @@ function deliveryMatches(
 		) {
 			return false;
 		}
+		// Google Chat identifies the exact message with a full space-scoped
+		// resource name, but a DM click re-encodes its thread from the stable DM
+		// route to a message-bound route. Other adapters retain the thread check:
+		// identifiers such as Slack's `ts` are only conversation-scoped.
+		const isSpaceScopedGoogleChatMessage =
+			platform === "gchat" &&
+			typeof source.messageId === "string" &&
+			/^spaces\/[^/]+\/messages\/[^/]+$/.test(source.messageId);
 		return (
-			!source.threadId || stringOrNull(delivery.threadId) === source.threadId
+			isSpaceScopedGoogleChatMessage ||
+			!source.threadId ||
+			stringOrNull(delivery.threadId) === source.threadId
 		);
 	});
 }
@@ -202,11 +213,15 @@ export async function invokeTemplateEventAction(
 			);
 		}
 		if (
-			!deliveryMatches(record(sourceEvent.metadata), {
-				connectionId: source.connectionId,
-				messageId: source.messageId,
-				threadId: source.threadId,
-			})
+			!deliveryMatches(
+				record(sourceEvent.metadata),
+				{
+					connectionId: source.connectionId,
+					messageId: source.messageId,
+					threadId: source.threadId,
+				},
+				params.surface,
+			)
 		) {
 			throw new ToolUserError(
 				"This action does not belong to this chat delivery.",


### PR DESCRIPTION
## Summary
- render poll metadata and result tables through the shared JSON-template DSL without literal placeholders
- accept Google Chat DM callback thread re-encoding only when the exact connection and space-scoped message still match
- route edit/reaction/delete mutations through the Chat SDK registered adapter

## Live production reproduction
- native Google Chat poll card rendered and its button callback reached the webhook
- callback was rejected because Google re-encoded the stored DM thread for the same message
- subsequent card refresh failed because the manager read a nonexistent `chat.adapter` property

## Validation
- 37 Google Chat and message-mutation unit tests
- 2 DB-backed template-event integration tests
- 6 poll reducer tests
- TypeScript and personal-agent config validation
- `make pre-pr`
- `git diff --check`

Scope is five files. No Owletto or Chrome-extension source changes.