### PR TITLE
fix(automations): normalize run-bound poll entity ids

### DIFF
--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -169,10 +169,11 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     actorName: string;
     choice: string;
     occurredAt: string;
+    entityIds?: unknown;
   }) => {
     trigger = {
       id: 200 + runId,
-      entity_ids: [77],
+      entity_ids: params.entityIds ?? [77],
       semantic_type: "poll_vote_cast",
       origin_type: "template_interaction",
       occurred_at: params.occurredAt,
@@ -223,6 +224,29 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
 }
 
 describe("poll vote reaction", () => {
+  test("accepts run-bound PostgreSQL array text for event entity ids", async () => {
+    const poll = harness("2026-08-28T15:00:00.000Z", 1);
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "A",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+      entityIds: "{77,31540}",
+    });
+
+    expect(poll.state()).toMatchObject({
+      status: "closed",
+      close_reason: "quorum",
+      results: [
+        { option: "A", count: 1 },
+        { option: "B", count: 0 },
+        { option: "C", count: 0 },
+      ],
+      response_count: 1,
+    });
+    expect(poll.responses()).toHaveLength(1);
+  });
+
   test("materializes two actors, a vote change, and quorum closure", async () => {
     const poll = harness();
     await poll.vote({

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -66,6 +66,18 @@ function positiveInteger(value: unknown): number | null {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+function positiveIntegerList(value: unknown): number[] {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === "string" && /^\{\d+(,\d+)*\}$/.test(value)
+      ? value.slice(1, -1).split(",")
+      : [];
+  return values.flatMap((item) => {
+    const parsed = positiveInteger(item);
+    return parsed == null ? [] : [parsed];
+  });
+}
+
 function sqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
@@ -133,12 +145,7 @@ async function readTrigger(
   if (id == null) return null;
   return {
     id,
-    entity_ids: Array.isArray(row.entity_ids)
-      ? row.entity_ids.flatMap((value) => {
-          const parsed = positiveInteger(value);
-          return parsed == null ? [] : [parsed];
-        })
-      : [],
+    entity_ids: positiveIntegerList(row.entity_ids),
     origin_type: typeof row.origin_type === "string" ? row.origin_type : null,
     occurred_at: typeof row.occurred_at === "string" ? row.occurred_at : "",
     metadata: objectValue(row.metadata),


### PR DESCRIPTION
## Summary\n- normalize run-bound PostgreSQL array text before resolving poll entities\n- preserve strict positive-integer parsing for SQL construction\n- cover the exact production entity ID array-text shape\n\n## Production reproduction\nGoogle Chat vote event 5749250 reached Automation run 1280304, but the run-bound knowledge read returned entity_ids as PostgreSQL array text. The reducer treated it as empty and safely returned without materializing a poll response.\n\n## Validation\n- focused poll reducer tests: 7 passed\n- make pre-pr: passed\n- diff check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved poll vote processing to accept entity ID lists provided in both standard list and PostgreSQL array formats.
  - Ensured polls continue to close correctly when multiple entity IDs are included.
  - Preserved expected quorum behavior and response generation across supported input formats.

- **Tests**
  - Added coverage validating poll closure and response creation when entity IDs use PostgreSQL-style array values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->