### PR TITLE
fix(automations): scope poll responses by poll actor

### DIFF
--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -42,6 +42,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     string,
     { id: number; metadata: Record<string, unknown> }
   >();
+  const createdResponses: Array<Record<string, unknown>> = [];
   const savedKinds: string[] = [];
 
   const client = {
@@ -77,9 +78,13 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
       },
     },
     entities: {
-      create: async (input: { metadata?: Record<string, unknown> }) => {
+      create: async (input: {
+        metadata?: Record<string, unknown>;
+        [key: string]: unknown;
+      }) => {
         responseId += 1;
         const metadata = input.metadata ?? {};
+        createdResponses.push(input);
         responses.set(`${metadata.platform}:${metadata.actor_id}`, {
           id: responseId,
           metadata,
@@ -222,6 +227,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     state: () => head.metadata,
     entityState: () => entityState,
     responses: () => [...responses.values()].map((row) => row.metadata),
+    createdResponses,
     savedKinds,
   };
 }
@@ -248,6 +254,24 @@ describe("poll vote reaction", () => {
       response_count: 1,
     });
     expect(poll.responses()).toHaveLength(1);
+  });
+
+  test("scopes response identity to the poll and platform actor", async () => {
+    const poll = harness();
+    await poll.vote({
+      actorId: "users/ada@example.com",
+      actorName: "Ada",
+      choice: "A",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+    });
+
+    expect(poll.createdResponses).toHaveLength(1);
+    expect(poll.createdResponses[0]).toMatchObject({
+      type: "poll-response",
+      name: "Ada",
+      parent_id: 77,
+      slug: "gchat-users%2Fada%40example.com",
+    });
   });
 
   test("materializes two actors, a vote change, and quorum closure", async () => {

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -280,6 +280,8 @@ async function upsertResponse(params: {
   await client.entities.create({
     type: "poll-response",
     name: params.actorName,
+    parent_id: params.pollEntityId,
+    slug: `${encodeURIComponent(params.platform)}-${encodeURIComponent(params.actorId)}`,
     metadata,
   });
 }


### PR DESCRIPTION
## Summary
- parent each poll-response under its poll entity
- use the platform and actor id as the deterministic response slug
- cover the production cross-poll display-name collision

## Why
A Google Chat vote reached the reducer, but poll-response creation retried three times with `Entity already exists with this name/domain` because previous polls had already created a root response with the same voter display name.

## Validation
- `bun test examples/personal-agent/__tests__/poll-vote.reaction.test.ts` (8/8)
- `make pre-pr`
- `git diff --check`

No Owletto or Chrome-extension production files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Poll responses now retain their association with the originating poll.
  * Response identities are scoped to the platform and actor, preventing collisions across polls or platforms.
  * Added coverage to verify poll-response details, including type, name, parent poll, and encoded identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->