### PR TITLE
fix(automations): encode poll response slugs

### DIFF
--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -256,7 +256,7 @@ describe("poll vote reaction", () => {
     expect(poll.responses()).toHaveLength(1);
   });
 
-  test("scopes response identity to the poll and platform actor", async () => {
+  test("scopes response identity with a contract-valid platform actor slug", async () => {
     const poll = harness();
     await poll.vote({
       actorId: "users/ada@example.com",
@@ -270,8 +270,9 @@ describe("poll vote reaction", () => {
       type: "poll-response",
       name: "Ada",
       parent_id: 77,
-      slug: "gchat-users%2Fada%40example.com",
+      slug: "actor-00670063006800610074-00750073006500720073002f0061006400610040006500780061006d0070006c0065002e0063006f006d",
     });
+    expect(poll.createdResponses[0]?.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
   });
 
   test("materializes two actors, a vote change, and quorum closure", async () => {

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -82,6 +82,17 @@ function sqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+function responseSlug(platform: string, actorId: string): string {
+  const hex = (value: string) => {
+    let encoded = "";
+    for (let index = 0; index < value.length; index += 1) {
+      encoded += value.charCodeAt(index).toString(16).padStart(4, "0");
+    }
+    return encoded;
+  };
+  return `actor-${hex(platform)}-${hex(actorId)}`;
+}
+
 function pollState(value: unknown): PollState | null {
   const row = objectValue(value);
   const options = Array.isArray(row.options)
@@ -281,7 +292,7 @@ async function upsertResponse(params: {
     type: "poll-response",
     name: params.actorName,
     parent_id: params.pollEntityId,
-    slug: `${encodeURIComponent(params.platform)}-${encodeURIComponent(params.actorId)}`,
+    slug: responseSlug(params.platform, params.actorId),
     metadata,
   });
 }


### PR DESCRIPTION
## Summary
- encode poll response actor identity as a deterministic lowercase hex slug
- preserve poll-scoped response identity while satisfying the entity slug contract
- add the exact Google Chat actor-id regression

## Validation
- bun test examples/personal-agent/__tests__/poll-vote.reaction.test.ts (8/8)
- make pre-pr
- git diff --check

## Live reproduction
Native Google Chat vote event 5749453 triggered Automation run 1281062, which failed closed because the prior URL-encoded slug did not match `^[a-z0-9]+(-[a-z0-9]+)*$`. This patch makes the same identity contract-valid without changing Google Chat or Owletto runtime code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved poll response identity handling by generating contract-valid actor slugs.
  - Ensured response identifiers consistently use lowercase alphanumeric segments separated by hyphens.
  - Updated response storage behavior to prevent invalid or inconsistent actor identifiers from affecting poll results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->