### PR TITLE
refactor(automations): tally polls from vote events

### DIFF
--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -37,13 +37,21 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     } as State,
   };
   let entityState: State = { ...head.metadata };
-  const voteEvents: Array<{
-    id: number;
-    occurredAt: string;
-    platform: string;
-    actorId: string;
-    choice: string;
-  }> = [];
+  let responseEventId = 1_000;
+  const responseEvents = new Map<
+    string,
+    {
+      id: number;
+      metadata: {
+        platform: string;
+        actor_id: string;
+        choice: string;
+        vote_event_id: number;
+        updated_at: string;
+      };
+    }
+  >();
+  const responseSaves: Array<Record<string, unknown>> = [];
   const savedKinds: string[] = [];
 
   const client = {
@@ -53,6 +61,26 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
         return { content: [trigger] };
       },
       save: async (input: Record<string, unknown>) => {
+        if (input.semantic_type === "poll_response_recorded") {
+          const metadata = input.metadata as {
+            platform: string;
+            actor_id: string;
+            choice: string;
+            vote_event_id: number;
+            updated_at: string;
+          };
+          const key = `${metadata.platform}:${metadata.actor_id}`;
+          const previous = responseEvents.get(key);
+          expect(input.supersedes_event_id).toBe(previous?.id);
+          responseEventId += 1;
+          responseEvents.set(key, { id: responseEventId, metadata });
+          responseSaves.push({ ...input, id: responseEventId });
+          return {
+            id: responseEventId,
+            created: true,
+            metadata: input.metadata,
+          };
+        }
         expect(input.supersedes_event_id).toBe(head.id);
         if (closeBeforeNextSave) {
           closeBeforeNextSave = false;
@@ -99,25 +127,30 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     },
     query: async (sql: string) => {
       if (sql.includes("entity_type = 'poll'")) return [{ id: 77 }];
+      if (
+        sql.includes("semantic_type = 'poll_response_recorded'") &&
+        !sql.includes("WITH latest AS")
+      ) {
+        const interaction = trigger.metadata as {
+          interaction: { actor: { platform: string; id: string } };
+        };
+        const actor = interaction.interaction.actor;
+        const response = responseEvents.get(`${actor.platform}:${actor.id}`);
+        return response ? [response] : [];
+      }
       if (sql.includes("WITH latest AS")) {
-        expect(sql).toContain("semantic_type = 'poll_vote_cast'");
-        expect(sql).toContain("origin_type = 'template_interaction'");
-        const latest = new Map<string, (typeof voteEvents)[number]>();
-        for (const event of voteEvents) {
-          if (Date.parse(event.occurredAt) >= Date.parse(closesAt)) continue;
-          const key = `${event.platform}:${event.actorId}`;
-          const previous = latest.get(key);
-          if (
-            !previous ||
-            event.occurredAt > previous.occurredAt ||
-            (event.occurredAt === previous.occurredAt && event.id > previous.id)
-          ) {
-            latest.set(key, event);
-          }
-        }
+        expect(sql).toContain("semantic_type = 'poll_response_recorded'");
         const counts = new Map<string, number>();
-        for (const event of latest.values()) {
-          counts.set(event.choice, (counts.get(event.choice) ?? 0) + 1);
+        for (const response of responseEvents.values()) {
+          if (
+            Date.parse(response.metadata.updated_at) >= Date.parse(closesAt)
+          ) {
+            continue;
+          }
+          counts.set(
+            response.metadata.choice,
+            (counts.get(response.metadata.choice) ?? 0) + 1
+          );
         }
         return [...counts].map(([choice, count]) => ({ choice, count }));
       }
@@ -183,13 +216,6 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
         },
       },
     };
-    voteEvents.push({
-      id: Number(trigger.id),
-      occurredAt: params.occurredAt,
-      platform: "gchat",
-      actorId: params.actorId,
-      choice: params.choice,
-    });
     await run();
   };
 
@@ -218,6 +244,8 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     retryLastVote: run,
     state: () => head.metadata,
     entityState: () => entityState,
+    responses: () => [...responseEvents.values()],
+    responseSaves,
     savedKinds,
   };
 }
@@ -243,6 +271,7 @@ describe("poll vote reaction", () => {
       ],
       response_count: 1,
     });
+    expect(poll.responses()).toHaveLength(1);
   });
 
   test("derives two actors, a vote change, and quorum closure from events", async () => {
@@ -281,6 +310,11 @@ describe("poll vote reaction", () => {
       "poll_opened",
       "poll_closed",
     ]);
+    expect(poll.responses()).toHaveLength(2);
+    expect(poll.responseSaves).toHaveLength(3);
+    expect(poll.responseSaves[2]?.supersedes_event_id).toBe(
+      poll.responseSaves[0]?.id
+    );
   });
 
   test("closes at the deadline without counting the late vote", async () => {
@@ -298,6 +332,7 @@ describe("poll vote reaction", () => {
       response_count: 0,
     });
     expect(poll.savedKinds).toEqual(["poll_closed"]);
+    expect(poll.responses()).toHaveLength(0);
   });
 
   test("reconciles an accepted pre-deadline vote processed after closure", async () => {
@@ -385,6 +420,7 @@ describe("poll vote reaction", () => {
 
     expect(poll.entityState()).toEqual(poll.state());
     expect(poll.savedKinds).toEqual(["poll_closed"]);
+    expect(poll.responseSaves).toHaveLength(1);
   });
 
   test("repairs poll entity metadata when a deadline close already exists", async () => {

--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -16,7 +16,6 @@ interface State {
 function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
   let runId = 0;
   let eventId = 100;
-  let responseId = 1_000;
   let closeBeforeNextSave = false;
   let failNextPollEntityUpdate = false;
   let trigger: Record<string, unknown> = {};
@@ -38,11 +37,13 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     } as State,
   };
   let entityState: State = { ...head.metadata };
-  const responses = new Map<
-    string,
-    { id: number; metadata: Record<string, unknown> }
-  >();
-  const createdResponses: Array<Record<string, unknown>> = [];
+  const voteEvents: Array<{
+    id: number;
+    occurredAt: string;
+    platform: string;
+    actorId: string;
+    choice: string;
+  }> = [];
   const savedKinds: string[] = [];
 
   const client = {
@@ -78,18 +79,8 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
       },
     },
     entities: {
-      create: async (input: {
-        metadata?: Record<string, unknown>;
-        [key: string]: unknown;
-      }) => {
-        responseId += 1;
-        const metadata = input.metadata ?? {};
-        createdResponses.push(input);
-        responses.set(`${metadata.platform}:${metadata.actor_id}`, {
-          id: responseId,
-          metadata,
-        });
-        return { entity: { id: responseId } };
+      create: async () => {
+        throw new Error("Reducer must not create response entities");
       },
       update: async (input: {
         entity_id: number;
@@ -103,42 +94,36 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
           if (input.metadata) entityState = input.metadata as unknown as State;
           return;
         }
-        const current = [...responses.entries()].find(
-          ([, response]) => response.id === input.entity_id
-        );
-        if (current && input.metadata) {
-          responses.set(current[0], {
-            id: input.entity_id,
-            metadata: input.metadata,
-          });
-        }
+        throw new Error(`Unexpected entity update: ${input.entity_id}`);
       },
     },
     query: async (sql: string) => {
       if (sql.includes("entity_type = 'poll'")) return [{ id: 77 }];
+      if (sql.includes("WITH latest AS")) {
+        expect(sql).toContain("semantic_type = 'poll_vote_cast'");
+        expect(sql).toContain("origin_type = 'template_interaction'");
+        const latest = new Map<string, (typeof voteEvents)[number]>();
+        for (const event of voteEvents) {
+          if (Date.parse(event.occurredAt) >= Date.parse(closesAt)) continue;
+          const key = `${event.platform}:${event.actorId}`;
+          const previous = latest.get(key);
+          if (
+            !previous ||
+            event.occurredAt > previous.occurredAt ||
+            (event.occurredAt === previous.occurredAt && event.id > previous.id)
+          ) {
+            latest.set(key, event);
+          }
+        }
+        const counts = new Map<string, number>();
+        for (const event of latest.values()) {
+          counts.set(event.choice, (counts.get(event.choice) ?? 0) + 1);
+        }
+        return [...counts].map(([choice, count]) => ({ choice, count }));
+      }
       if (sql.includes("FROM events")) {
         expect(sql).not.toContain("superseded_by");
         return [head];
-      }
-      if (sql.includes("SELECT id FROM entities")) {
-        const actor = [...responses.values()].find(
-          (response) =>
-            sql.includes(
-              `metadata->>'platform' = '${response.metadata.platform}'`
-            ) &&
-            sql.includes(
-              `metadata->>'actor_id' = '${response.metadata.actor_id}'`
-            )
-        );
-        return actor ? [{ id: actor.id }] : [];
-      }
-      if (sql.includes("WITH latest AS")) {
-        const counts = new Map<string, number>();
-        for (const response of responses.values()) {
-          const choice = String(response.metadata.choice);
-          counts.set(choice, (counts.get(choice) ?? 0) + 1);
-        }
-        return [...counts].map(([choice, count]) => ({ choice, count }));
       }
       throw new Error(`Unexpected SQL: ${sql}`);
     },
@@ -198,6 +183,13 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
         },
       },
     };
+    voteEvents.push({
+      id: Number(trigger.id),
+      occurredAt: params.occurredAt,
+      platform: "gchat",
+      actorId: params.actorId,
+      choice: params.choice,
+    });
     await run();
   };
 
@@ -226,8 +218,6 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     retryLastVote: run,
     state: () => head.metadata,
     entityState: () => entityState,
-    responses: () => [...responses.values()].map((row) => row.metadata),
-    createdResponses,
     savedKinds,
   };
 }
@@ -253,29 +243,9 @@ describe("poll vote reaction", () => {
       ],
       response_count: 1,
     });
-    expect(poll.responses()).toHaveLength(1);
   });
 
-  test("scopes response identity with a contract-valid platform actor slug", async () => {
-    const poll = harness();
-    await poll.vote({
-      actorId: "users/ada@example.com",
-      actorName: "Ada",
-      choice: "A",
-      occurredAt: "2026-08-28T14:10:00.000Z",
-    });
-
-    expect(poll.createdResponses).toHaveLength(1);
-    expect(poll.createdResponses[0]).toMatchObject({
-      type: "poll-response",
-      name: "Ada",
-      parent_id: 77,
-      slug: "actor-00670063006800610074-00750073006500720073002f0061006400610040006500780061006d0070006c0065002e0063006f006d",
-    });
-    expect(poll.createdResponses[0]?.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
-  });
-
-  test("materializes two actors, a vote change, and quorum closure", async () => {
+  test("derives two actors, a vote change, and quorum closure from events", async () => {
     const poll = harness();
     await poll.vote({
       actorId: "users/ada",
@@ -306,7 +276,6 @@ describe("poll vote reaction", () => {
       ],
       response_count: 2,
     });
-    expect(poll.responses()).toHaveLength(2);
     expect(poll.savedKinds).toEqual([
       "poll_opened",
       "poll_opened",
@@ -314,7 +283,7 @@ describe("poll vote reaction", () => {
     ]);
   });
 
-  test("closes at the deadline without materializing the late vote", async () => {
+  test("closes at the deadline without counting the late vote", async () => {
     const poll = harness("2026-08-28T14:05:00.000Z");
     await poll.vote({
       actorId: "users/late",
@@ -328,7 +297,6 @@ describe("poll vote reaction", () => {
       close_reason: "deadline",
       response_count: 0,
     });
-    expect(poll.responses()).toEqual([]);
     expect(poll.savedKinds).toEqual(["poll_closed"]);
   });
 

--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -13,6 +13,14 @@ interface State {
   close_reason?: "quorum" | "deadline";
 }
 
+interface ResponseMetadata {
+  platform: string;
+  actor_id: string;
+  choice: string;
+  vote_event_id: number;
+  updated_at: string;
+}
+
 function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
   let runId = 0;
   let eventId = 100;
@@ -42,14 +50,13 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
     string,
     {
       id: number;
-      metadata: {
-        platform: string;
-        actor_id: string;
-        choice: string;
-        vote_event_id: number;
-        updated_at: string;
-      };
+      metadata: ResponseMetadata;
     }
+  >();
+  let legacyResponseId = 2_000;
+  const legacyResponses = new Map<
+    string,
+    { id: number; metadata: ResponseMetadata }
   >();
   const responseSaves: Array<Record<string, unknown>> = [];
   const savedKinds: string[] = [];
@@ -62,13 +69,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
       },
       save: async (input: Record<string, unknown>) => {
         if (input.semantic_type === "poll_response_recorded") {
-          const metadata = input.metadata as {
-            platform: string;
-            actor_id: string;
-            choice: string;
-            vote_event_id: number;
-            updated_at: string;
-          };
+          const metadata = input.metadata as ResponseMetadata;
           const key = `${metadata.platform}:${metadata.actor_id}`;
           const previous = responseEvents.get(key);
           expect(input.supersedes_event_id).toBe(previous?.id);
@@ -129,7 +130,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
       if (sql.includes("entity_type = 'poll'")) return [{ id: 77 }];
       if (
         sql.includes("semantic_type = 'poll_response_recorded'") &&
-        !sql.includes("WITH latest AS")
+        !sql.includes("WITH candidates AS")
       ) {
         const interaction = trigger.metadata as {
           interaction: { actor: { platform: string; id: string } };
@@ -138,15 +139,38 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
         const response = responseEvents.get(`${actor.platform}:${actor.id}`);
         return response ? [response] : [];
       }
-      if (sql.includes("WITH latest AS")) {
+      if (sql.includes("WITH candidates AS")) {
+        expect(sql).toContain("entity_type = 'poll-response'");
         expect(sql).toContain("semantic_type = 'poll_response_recorded'");
-        const counts = new Map<string, number>();
-        for (const response of responseEvents.values()) {
+        const latest = new Map<
+          string,
+          { id: number; metadata: ResponseMetadata; sourceOrder: number }
+        >();
+        const consider = (
+          response: { id: number; metadata: ResponseMetadata },
+          sourceOrder: number
+        ) => {
+          const key = `${response.metadata.platform}:${response.metadata.actor_id}`;
+          const previous = latest.get(key);
           if (
-            Date.parse(response.metadata.updated_at) >= Date.parse(closesAt)
+            !previous ||
+            response.metadata.vote_event_id > previous.metadata.vote_event_id ||
+            (response.metadata.vote_event_id ===
+              previous.metadata.vote_event_id &&
+              (response.metadata.updated_at > previous.metadata.updated_at ||
+                (response.metadata.updated_at ===
+                  previous.metadata.updated_at &&
+                  (sourceOrder > previous.sourceOrder ||
+                    (sourceOrder === previous.sourceOrder &&
+                      response.id > previous.id)))))
           ) {
-            continue;
+            latest.set(key, { ...response, sourceOrder });
           }
+        };
+        for (const response of legacyResponses.values()) consider(response, 0);
+        for (const response of responseEvents.values()) consider(response, 1);
+        const counts = new Map<string, number>();
+        for (const response of latest.values()) {
           counts.set(
             response.metadata.choice,
             (counts.get(response.metadata.choice) ?? 0) + 1
@@ -235,6 +259,13 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
   return {
     vote,
     close,
+    seedLegacyResponse: (metadata: ResponseMetadata) => {
+      legacyResponseId += 1;
+      legacyResponses.set(`${metadata.platform}:${metadata.actor_id}`, {
+        id: legacyResponseId,
+        metadata,
+      });
+    },
     raceDeadlineOnNextSave: () => {
       closeBeforeNextSave = true;
     },
@@ -315,6 +346,41 @@ describe("poll vote reaction", () => {
     expect(poll.responseSaves[2]?.supersedes_event_id).toBe(
       poll.responseSaves[0]?.id
     );
+  });
+
+  test("preserves bounded legacy responses during the event cutover", async () => {
+    const poll = harness("2026-08-28T15:00:00.000Z", 3);
+    poll.seedLegacyResponse({
+      platform: "gchat",
+      actor_id: "users/ada",
+      choice: "A",
+      vote_event_id: 150,
+      updated_at: "2026-08-28T14:00:00.000Z",
+    });
+
+    await poll.vote({
+      actorId: "users/grace",
+      actorName: "Grace",
+      choice: "B",
+      occurredAt: "2026-08-28T14:10:00.000Z",
+    });
+    expect(poll.state().results).toEqual([
+      { option: "A", count: 1 },
+      { option: "B", count: 1 },
+      { option: "C", count: 0 },
+    ]);
+
+    await poll.vote({
+      actorId: "users/ada",
+      actorName: "Ada",
+      choice: "C",
+      occurredAt: "2026-08-28T14:11:00.000Z",
+    });
+    expect(poll.state().results).toEqual([
+      { option: "A", count: 0 },
+      { option: "B", count: 1 },
+      { option: "C", count: 1 },
+    ]);
   });
 
   test("closes at the deadline without counting the late vote", async () => {

--- a/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
+++ b/examples/personal-agent/__tests__/poll-vote.reaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
+import { validateAndScopeQuery } from "../../../packages/server/src/utils/execute-data-sources";
 import reducePollVote from "../poll-vote.reaction";
 
 interface State {
@@ -127,6 +128,7 @@ function harness(closesAt = "2026-08-28T15:00:00.000Z", quorum = 2) {
       },
     },
     query: async (sql: string) => {
+      validateAndScopeQuery(sql, "org-test");
       if (sql.includes("entity_type = 'poll'")) return [{ id: 77 }];
       if (
         sql.includes("semantic_type = 'poll_response_recorded'") &&

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -51,10 +51,10 @@ Opening a poll:
 3. Before presenting the event, call schedule_followup with run_at equal to closes_at, idempotency_key "poll-deadline:<entity id>", and prompt: "Close event-backed poll entity <entity id> at its deadline. Follow the event-backed-polls deadline procedure exactly; do nothing if it is already closed."
 4. Call present_event exactly once with the saved event id. That ends the turn because the native card is already the answer.
 
-Votes need no follow-up tool call from the agent. A server-stamped interaction event activates the deterministic poll-vote-reducer Automation; it materializes the latest poll-response per platform actor, supports vote changes, recomputes the tally, closes at quorum, and requests an in-place refresh of the original card.
+Votes need no follow-up tool call from the agent. A server-stamped interaction event activates the deterministic poll-vote-reducer Automation; it derives the latest choice per platform actor from those durable vote events, recomputes the tally, closes at quorum, and requests an in-place refresh of the original card.
 
 Deadline procedure:
-- Use run_sdk. Read the poll entity and query the single current poll_opened or poll_closed event linked to it (superseded_by IS NULL).
+- Use run_sdk. Read the poll entity and query the single current poll_opened or poll_closed event linked to it, ordered newest first. client.query already reads the current event view, so do not add a superseded_by filter.
 - If the current event is poll_opened, copy only the poll schema fields (question, options, quorum, closes_at, results, and response_count) from that event metadata. Never copy delivery, card, _lobu, or any other internal metadata. Set status "closed", close_reason "deadline", and closed_at now. Save poll_closed linked to the poll with supersedes_event_id equal to that current open event and idempotency_key "poll-close:<entity id>"; then update the poll entity to the same state.
 - If the current event is already poll_closed, only reconcile the entity metadata to that event if needed, then stop. Never append a second close event.
 - Do not infer, copy, or accept voter identity from text. Only the chat adapter's trusted interaction envelope may identify a voter.`,
@@ -566,31 +566,6 @@ const poll = defineEntityType({
       },
     },
   },
-});
-
-const pollResponse = defineEntityType({
-  key: "poll-response",
-  name: "Poll response",
-  description:
-    "The latest materialized choice for one trusted platform actor in one poll.",
-  properties: {
-    poll_entity_id: Type.Integer({ minimum: 1 }),
-    platform: Type.String({ minLength: 1, maxLength: 50 }),
-    actor_id: Type.String({ minLength: 1, maxLength: 500 }),
-    actor_name: Type.String({ minLength: 1, maxLength: 500 }),
-    choice: Type.String({ minLength: 1, maxLength: 100 }),
-    vote_event_id: Type.Integer({ minimum: 1 }),
-    updated_at: Type.String({ format: "date-time" }),
-  },
-  required: [
-    "poll_entity_id",
-    "platform",
-    "actor_id",
-    "actor_name",
-    "choice",
-    "vote_event_id",
-    "updated_at",
-  ],
 });
 
 // GBP-equivalent of a transaction amount, using ONLY exact, Revolut-booked
@@ -1539,7 +1514,6 @@ export default defineConfig({
     company,
     task,
     poll,
-    pollResponse,
     channel,
     account,
     netWorthSnapshot,

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -538,6 +538,17 @@ const poll = defineEntityType({
       description:
         "A trusted vote or vote change appended by an interactive surface",
     },
+    poll_response_recorded: {
+      description:
+        "The current derived choice for one trusted platform actor; vote changes supersede it",
+      metadataSchema: Type.Object({
+        platform: Type.String({ minLength: 1, maxLength: 50 }),
+        actor_id: Type.String({ minLength: 1, maxLength: 500 }),
+        choice: Type.String({ minLength: 1, maxLength: 100 }),
+        vote_event_id: Type.Integer({ minimum: 1 }),
+        updated_at: Type.String({ format: "date-time" }),
+      }),
+    },
     poll_closed: {
       description: "A terminal poll result",
       metadataSchema: pollStateSchema,

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -579,6 +579,33 @@ const poll = defineEntityType({
   },
 });
 
+// Temporary bounded cutover source for polls opened before response events
+// were introduced. New interactions never write this entity type.
+const pollResponse = defineEntityType({
+  key: "poll-response",
+  name: "Poll response",
+  description:
+    "The legacy latest materialized choice for one trusted platform actor in one poll.",
+  properties: {
+    poll_entity_id: Type.Integer({ minimum: 1 }),
+    platform: Type.String({ minLength: 1, maxLength: 50 }),
+    actor_id: Type.String({ minLength: 1, maxLength: 500 }),
+    actor_name: Type.String({ minLength: 1, maxLength: 500 }),
+    choice: Type.String({ minLength: 1, maxLength: 100 }),
+    vote_event_id: Type.Integer({ minimum: 1 }),
+    updated_at: Type.String({ format: "date-time" }),
+  },
+  required: [
+    "poll_entity_id",
+    "platform",
+    "actor_id",
+    "actor_name",
+    "choice",
+    "vote_event_id",
+    "updated_at",
+  ],
+});
+
 // GBP-equivalent of a transaction amount, using ONLY exact, Revolut-booked
 // values — never a fuzzy FX-rate lookup:
 //   • native GBP                       → the amount itself
@@ -1525,6 +1552,7 @@ export default defineConfig({
     company,
     task,
     poll,
+    pollResponse,
     channel,
     account,
     netWorthSnapshot,

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -82,17 +82,6 @@ function sqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-function responseSlug(platform: string, actorId: string): string {
-  const hex = (value: string) => {
-    let encoded = "";
-    for (let index = 0; index < value.length; index += 1) {
-      encoded += value.charCodeAt(index).toString(16).padStart(4, "0");
-    }
-    return encoded;
-  };
-  return `actor-${hex(platform)}-${hex(actorId)}`;
-}
-
 function pollState(value: unknown): PollState | null {
   const row = objectValue(value);
   const options = Array.isArray(row.options)
@@ -254,65 +243,26 @@ async function updatePollEntity(
   });
 }
 
-async function upsertResponse(params: {
-  pollEntityId: number;
-  platform: string;
-  actorId: string;
-  actorName: string;
-  choice: string;
-  voteEventId: number;
-  client: ReactionClient;
-}): Promise<void> {
-  const { client } = params;
-  const rows = (await client.query(
-    `SELECT id FROM entities
-     WHERE entity_type = 'poll-response'
-       AND deleted_at IS NULL
-       AND (metadata->>'poll_entity_id')::bigint = ${params.pollEntityId}
-       AND metadata->>'platform' = ${sqlLiteral(params.platform)}
-       AND metadata->>'actor_id' = ${sqlLiteral(params.actorId)}
-     ORDER BY (metadata->>'updated_at') DESC, id DESC
-     LIMIT 1`
-  )) as Array<{ id: number | string }>;
-  const metadata = {
-    poll_entity_id: params.pollEntityId,
-    platform: params.platform,
-    actor_id: params.actorId,
-    actor_name: params.actorName,
-    choice: params.choice,
-    vote_event_id: params.voteEventId,
-    updated_at: new Date().toISOString(),
-  };
-  const existingId = rows[0] ? positiveInteger(rows[0].id) : null;
-  if (existingId != null) {
-    await client.entities.update({ entity_id: existingId, metadata });
-    return;
-  }
-  await client.entities.create({
-    type: "poll-response",
-    name: params.actorName,
-    parent_id: params.pollEntityId,
-    slug: responseSlug(params.platform, params.actorId),
-    metadata,
-  });
-}
-
 async function resultsForPoll(
   entityId: number,
   options: string[],
+  closesAt: string,
   client: ReactionClient
 ): Promise<{ results: PollResult[]; responseCount: number }> {
   const rows = (await client.query(
     `WITH latest AS (
-       SELECT metadata->>'choice' AS choice,
+       SELECT metadata->'interaction'->>'value' AS choice,
               row_number() OVER (
-                PARTITION BY metadata->>'platform', metadata->>'actor_id'
-                ORDER BY (metadata->>'updated_at') DESC, id DESC
+                PARTITION BY metadata->'interaction'->'actor'->>'platform',
+                             metadata->'interaction'->'actor'->>'id'
+                ORDER BY occurred_at DESC, id DESC
               ) AS rank
-       FROM entities
-       WHERE entity_type = 'poll-response'
-         AND deleted_at IS NULL
-         AND (metadata->>'poll_entity_id')::bigint = ${entityId}
+       FROM events
+       WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
+         AND semantic_type = 'poll_vote_cast'
+         AND origin_type = 'template_interaction'
+         AND occurred_at < ${sqlLiteral(closesAt)}::timestamptz
+         AND metadata->'interaction'->>'action' = 'vote'
      )
      SELECT choice, count(*)::int AS count
      FROM latest
@@ -346,10 +296,6 @@ export default async function reducePollVote(
   const choice = typeof interaction.value === "string" ? interaction.value : "";
   const platform = typeof actor.platform === "string" ? actor.platform : "";
   const actorId = typeof actor.id === "string" ? actor.id : "";
-  const actorName =
-    typeof actor.name === "string" && actor.name.trim()
-      ? actor.name.trim().slice(0, 500)
-      : actorId.slice(0, 500);
   if (
     interaction.action !== "vote" ||
     positiveInteger(interaction.source_event_id) == null ||
@@ -376,21 +322,11 @@ export default async function reducePollVote(
     await updatePollEntity(entityId, head.metadata, client);
     return;
   }
-  if (!deadlineReached) {
-    await upsertResponse({
-      pollEntityId: entityId,
-      platform,
-      actorId,
-      actorName,
-      choice,
-      voteEventId: trigger.id,
-      client,
-    });
-  }
 
   const { results, responseCount } = await resultsForPoll(
     entityId,
     head.metadata.options,
+    head.metadata.closes_at,
     client
   );
   const reachedQuorum = results.some(
@@ -436,6 +372,7 @@ export default async function reducePollVote(
     const reconciled = await resultsForPoll(
       entityId,
       winner.metadata.options,
+      winner.metadata.closes_at,
       client
     );
     const terminal: PollState = {

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -319,33 +319,22 @@ async function resultsForPoll(
   // rows are a bounded cutover source for polls opened before this event kind.
   const rows = (await client.query(
     `WITH candidates AS (
-       SELECT metadata->>'platform' AS platform,
-              metadata->>'actor_id' AS actor_id,
-              metadata->>'choice' AS choice,
-              (metadata->>'vote_event_id')::bigint AS vote_event_id,
-              (metadata->>'updated_at')::timestamptz AS updated_at,
-              id,
-              0 AS source_order
+       SELECT metadata
        FROM entities
        WHERE entity_type = 'poll-response'
          AND deleted_at IS NULL
          AND (metadata->>'poll_entity_id')::bigint = ${entityId}
        UNION ALL
-       SELECT metadata->>'platform' AS platform,
-              metadata->>'actor_id' AS actor_id,
-              metadata->>'choice' AS choice,
-              (metadata->>'vote_event_id')::bigint AS vote_event_id,
-              (metadata->>'updated_at')::timestamptz AS updated_at,
-              id,
-              1 AS source_order
+       SELECT metadata
        FROM events
        WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
          AND semantic_type = 'poll_response_recorded'
      ), latest AS (
-       SELECT choice,
+       SELECT metadata->>'choice' AS choice,
               row_number() OVER (
-                PARTITION BY platform, actor_id
-                ORDER BY vote_event_id DESC, updated_at DESC, source_order DESC, id DESC
+                PARTITION BY metadata->>'platform', metadata->>'actor_id'
+                ORDER BY (metadata->>'vote_event_id')::bigint DESC,
+                         (metadata->>'updated_at')::timestamptz DESC
               ) AS rank
        FROM candidates
      )

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -243,26 +243,92 @@ async function updatePollEntity(
   });
 }
 
+async function currentResponseEvent(
+  entityId: number,
+  platform: string,
+  actorId: string,
+  client: ReactionClient
+): Promise<{ id: number; voteEventId: number } | null> {
+  const rows = (await client.query(
+    `SELECT id, metadata
+     FROM events
+     WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
+       AND semantic_type = 'poll_response_recorded'
+       AND metadata->>'platform' = ${sqlLiteral(platform)}
+       AND metadata->>'actor_id' = ${sqlLiteral(actorId)}
+     ORDER BY id DESC
+     LIMIT 2`
+  )) as Array<{ id: number | string; metadata: unknown }>;
+  if (rows.length > 1) {
+    throw new Error("Ambiguous current poll response projection");
+  }
+  if (!rows[0]) return null;
+  const id = positiveInteger(rows[0].id);
+  const voteEventId = positiveInteger(
+    objectValue(rows[0].metadata).vote_event_id
+  );
+  if (id == null || voteEventId == null) {
+    throw new Error("Invalid current poll response projection");
+  }
+  return { id, voteEventId };
+}
+
+async function upsertResponseEvent(params: {
+  ctx: ReactionContext;
+  pollEntityId: number;
+  platform: string;
+  actorId: string;
+  choice: string;
+  trigger: TriggerEvent;
+  client: ReactionClient;
+}): Promise<void> {
+  const current = await currentResponseEvent(
+    params.pollEntityId,
+    params.platform,
+    params.actorId,
+    params.client
+  );
+  if (current && current.voteEventId >= params.trigger.id) return;
+  await params.client.knowledge.save({
+    entity_ids: [params.pollEntityId],
+    content: `Current poll response from vote event ${params.trigger.id}.`,
+    semantic_type: "poll_response_recorded",
+    payload_type: "empty",
+    metadata: {
+      platform: params.platform,
+      actor_id: params.actorId,
+      choice: params.choice,
+      vote_event_id: params.trigger.id,
+      updated_at: params.trigger.occurred_at,
+    },
+    ...(current ? { supersedes_event_id: current.id } : {}),
+    idempotency_key: `poll-response:${params.pollEntityId}:vote:${params.trigger.id}`,
+    automation_source: {
+      automation_id: params.ctx.window.automation_id,
+      run_id: params.ctx.window.run_id,
+    },
+  });
+}
+
 async function resultsForPoll(
   entityId: number,
   options: string[],
   closesAt: string,
   client: ReactionClient
 ): Promise<{ results: PollResult[]; responseCount: number }> {
+  // client.query reads the governed current-event view, so this scan is bounded
+  // to one live projection per actor rather than the append-only vote history.
   const rows = (await client.query(
     `WITH latest AS (
-       SELECT metadata->'interaction'->>'value' AS choice,
+       SELECT metadata->>'choice' AS choice,
               row_number() OVER (
-                PARTITION BY metadata->'interaction'->'actor'->>'platform',
-                             metadata->'interaction'->'actor'->>'id'
-                ORDER BY occurred_at DESC, id DESC
+                PARTITION BY metadata->>'platform', metadata->>'actor_id'
+                ORDER BY (metadata->>'updated_at') DESC, id DESC
               ) AS rank
        FROM events
        WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
-         AND semantic_type = 'poll_vote_cast'
-         AND origin_type = 'template_interaction'
-         AND occurred_at < ${sqlLiteral(closesAt)}::timestamptz
-         AND metadata->'interaction'->>'action' = 'vote'
+         AND semantic_type = 'poll_response_recorded'
+         AND (metadata->>'updated_at')::timestamptz < ${sqlLiteral(closesAt)}::timestamptz
      )
      SELECT choice, count(*)::int AS count
      FROM latest
@@ -321,6 +387,17 @@ export default async function reducePollVote(
   if (alreadyClosed && deadlineReached) {
     await updatePollEntity(entityId, head.metadata, client);
     return;
+  }
+  if (!deadlineReached) {
+    await upsertResponseEvent({
+      ctx,
+      pollEntityId: entityId,
+      platform,
+      actorId,
+      choice,
+      trigger,
+      client,
+    });
   }
 
   const { results, responseCount } = await resultsForPoll(

--- a/examples/personal-agent/poll-vote.reaction.ts
+++ b/examples/personal-agent/poll-vote.reaction.ts
@@ -313,22 +313,41 @@ async function upsertResponseEvent(params: {
 async function resultsForPoll(
   entityId: number,
   options: string[],
-  closesAt: string,
   client: ReactionClient
 ): Promise<{ results: PollResult[]; responseCount: number }> {
-  // client.query reads the governed current-event view, so this scan is bounded
-  // to one live projection per actor rather than the append-only vote history.
+  // The event view contains one current projection per actor. Legacy entity
+  // rows are a bounded cutover source for polls opened before this event kind.
   const rows = (await client.query(
-    `WITH latest AS (
-       SELECT metadata->>'choice' AS choice,
-              row_number() OVER (
-                PARTITION BY metadata->>'platform', metadata->>'actor_id'
-                ORDER BY (metadata->>'updated_at') DESC, id DESC
-              ) AS rank
+    `WITH candidates AS (
+       SELECT metadata->>'platform' AS platform,
+              metadata->>'actor_id' AS actor_id,
+              metadata->>'choice' AS choice,
+              (metadata->>'vote_event_id')::bigint AS vote_event_id,
+              (metadata->>'updated_at')::timestamptz AS updated_at,
+              id,
+              0 AS source_order
+       FROM entities
+       WHERE entity_type = 'poll-response'
+         AND deleted_at IS NULL
+         AND (metadata->>'poll_entity_id')::bigint = ${entityId}
+       UNION ALL
+       SELECT metadata->>'platform' AS platform,
+              metadata->>'actor_id' AS actor_id,
+              metadata->>'choice' AS choice,
+              (metadata->>'vote_event_id')::bigint AS vote_event_id,
+              (metadata->>'updated_at')::timestamptz AS updated_at,
+              id,
+              1 AS source_order
        FROM events
        WHERE entity_ids @> ARRAY[${entityId}]::bigint[]
          AND semantic_type = 'poll_response_recorded'
-         AND (metadata->>'updated_at')::timestamptz < ${sqlLiteral(closesAt)}::timestamptz
+     ), latest AS (
+       SELECT choice,
+              row_number() OVER (
+                PARTITION BY platform, actor_id
+                ORDER BY vote_event_id DESC, updated_at DESC, source_order DESC, id DESC
+              ) AS rank
+       FROM candidates
      )
      SELECT choice, count(*)::int AS count
      FROM latest
@@ -403,7 +422,6 @@ export default async function reducePollVote(
   const { results, responseCount } = await resultsForPoll(
     entityId,
     head.metadata.options,
-    head.metadata.closes_at,
     client
   );
   const reachedQuorum = results.some(
@@ -449,7 +467,6 @@ export default async function reducePollVote(
     const reconciled = await resultsForPoll(
       entityId,
       winner.metadata.options,
-      winner.metadata.closes_at,
       client
     );
     const terminal: PollState = {


### PR DESCRIPTION
## Summary
- derive latest-per-actor poll tallies directly from canonical `poll_vote_cast` events
- remove the duplicate `poll-response` entity projection and schema from the example
- keep late votes excluded by the poll deadline and preserve vote-change semantics
- correct the deadline skill to rely on the governed current-event view without a nonexistent `superseded_by` column

## Why
Live Google Chat proved the interaction events are complete and trusted. The projection added avoidable identity/foreign-key failure modes while duplicating data already present in durable events. A production read of the exact live poll returns `Maple: 1` from the event-only aggregation.

## Validation
- bun test examples/personal-agent/__tests__/poll-vote.reaction.test.ts (7/7)
- node packages/cli/bin/lobu.js validate (from examples/personal-agent)
- make pre-pr
- production read-only event aggregation against poll entity 35937

## Scope
Three example files only; 55 insertions, 176 deletions. No Google Chat transport, Owletto, or Chrome-extension code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Poll votes are now recorded as durable events.
  - Poll results combine legacy responses with vote events and show the latest choice per actor.
  - Poll response events include vote identity and relevant metadata.

- **Bug Fixes**
  - Prevented stale votes from replacing newer responses through deterministic latest-response selection.
  - Improved handling of superseded responses and poll event state.
  - Preserved bounded legacy responses during the transition to event-based voting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->