### PR TITLE
fix(server): reject structured tenant scope keys

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -670,7 +670,8 @@ export interface EntityIdentitySpec {
   /**
    * Dot path into the event containing the stable upstream tenant key.
    * Required exactly when `scope === 'tenant'`; forbidden for organization
-   * scope. The extracted value is stringified, trimmed, and must be non-empty.
+   * scope. The extracted value must be a string, number, or boolean; it is
+   * stringified, trimmed, and must be non-empty.
    */
   scopeKeyPath?: string;
 }

--- a/packages/server/src/__tests__/integration/connectors/identity-tenant-scope.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/identity-tenant-scope.test.ts
@@ -266,6 +266,35 @@ describe('connector tenant identity scope', () => {
     expect(rows[0].scope_key).toBe('false');
   });
 
+  it('rejects structured tenant keys instead of collapsing them through String()', async () => {
+    const { org, tenantA } = await seed();
+    const sql = getTestDb();
+
+    for (const tenantKey of [{ tenant: 'a' }, ['tenant-a']]) {
+      await expect(
+        applyEventAttributions({
+          connectorKey,
+          feedKey,
+          orgId: org.id,
+          connectionId: tenantA.id,
+          items: [customerEvent('CARI-044', 'Structured Tenant', tenantKey)],
+        })
+      ).rejects.toThrow(
+        /erp_customer.*metadata\.tenant_id.*string, number, or boolean tenant scope key/i
+      );
+    }
+
+    const rows = await sql`
+      SELECT id
+      FROM entity_identities
+      WHERE organization_id = ${org.id}
+        AND namespace = 'erp_customer'
+        AND identifier = 'CARI-044'
+        AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(0);
+  });
+
   it('fails ingestion when a tenant-scoped identity has a missing or empty tenant key', async () => {
     const { org } = await seed();
 

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -487,6 +487,17 @@ function extractLink(item: BatchItem, rule: ResolvedEventAttributionRule): Extra
         );
       }
       const rawScopeKey = getValueAtPath(item, scopeKeyPath);
+      if (
+        rawScopeKey !== null &&
+        rawScopeKey !== undefined &&
+        typeof rawScopeKey !== 'string' &&
+        typeof rawScopeKey !== 'number' &&
+        typeof rawScopeKey !== 'boolean'
+      ) {
+        throw new Error(
+          `Identity namespace '${spec.namespace}' at '${scopeKeyPath}' requires a string, number, or boolean tenant scope key.`
+        );
+      }
       scopeKey =
         rawScopeKey === null || rawScopeKey === undefined ? '' : String(rawScopeKey).trim();
       if (!scopeKey || scopeKey.includes('\u0000')) {


### PR DESCRIPTION
## Summary

- Reject array/object tenant scope values before JavaScript stringification can collapse distinct upstream tenants.
- Preserve the existing scalar contract for strings, numbers, and booleans.
- Document the accepted scalar values for connector authors.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean (local fallback)
- [x] DB-backed tenant-scope integration test: 7/7
- [x] Server and connector-SDK typechecks; `git diff --check`
- [x] Bug fix red → green: before the guard, the new structured-key case failed because the object was accepted and persisted under its stringified value; after the guard, both object and array values fail and no identity row is created
- [x] Codex pre-review fixer completed on the settled diff; its edits were inspected and the DB-backed test rerun locally

## Notes

No schema, migration, or SDK type surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tenant-scoped identity keys now reject object, array, and other unsupported values during ingestion.
  - Clear validation errors are provided when tenant scope keys are not strings, numbers, or booleans.
  - Invalid identity records are prevented from being persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->