### PR TITLE
fix(server): harden connector relationship claims

### DIFF
--- a/db/migrations/20260829090000_backfill_tombstoned_about_claims.sql
+++ b/db/migrations/20260829090000_backfill_tombstoned_about_claims.sql
@@ -1,0 +1,37 @@
+-- The claims cutover (20260827174500) stamped `about` edges from their legacy
+-- connection/channel metadata only while the owning connection was still live,
+-- retired the LIVE claimless remainder, and excluded every connection-scoped
+-- `about` row from its ordinary manual backfill. A row that was already
+-- tombstoned when its connection went away therefore fell through all three and
+-- carries no `_lobu_claims`. `applyUnmerge` can restore a tombstoned
+-- relationship, so leave each restorable row with an explicit owner rather than
+-- reviving a claimless edge no caller can unlink and no connector can re-assert.
+--
+-- Authorization-bearing rows are excluded for the same reason the cutover
+-- excluded them: a manual claim would let an unmerge restore an access grant
+-- that only the ACL syncs may write. Rows the cutover already stamped are
+-- skipped by the `_lobu_claims` guard, which also makes this re-runnable.
+
+-- migrate:up
+
+UPDATE public.entity_relationships r
+SET metadata = jsonb_set(
+      COALESCE(r.metadata, '{}'::jsonb),
+      ARRAY['_lobu_claims']::text[],
+      '{"manual": {}}'::jsonb,
+      true
+    ),
+    updated_at = current_timestamp
+FROM public.entity_relationship_types rt
+WHERE rt.id = r.relationship_type_id
+  AND rt.slug = 'about'
+  AND rt.purpose IS DISTINCT FROM 'authorization'
+  AND r.deleted_at IS NOT NULL
+  AND NULLIF(r.metadata->>'connection_id', '') IS NOT NULL
+  AND NULLIF(r.metadata->>'channel_key', '') IS NOT NULL
+  AND NOT (COALESCE(r.metadata, '{}'::jsonb) ? '_lobu_claims');
+
+-- migrate:down
+
+-- No-op: removing an ownership claim could let a later unmerge revive a
+-- relationship that no caller or connector can manage safely.

--- a/packages/server/src/__tests__/integration/authz/edge-writes-batch.test.ts
+++ b/packages/server/src/__tests__/integration/authz/edge-writes-batch.test.ts
@@ -77,6 +77,79 @@ describe("upsertEdges", () => {
 		expect(await liveEdges(orgId, typeId)).toHaveLength(1);
 	});
 
+	it("locks overlapping batches in one global pair order", async () => {
+		const sql = getTestDb();
+		const pairs = [
+			{ fromEntityId: a, toEntityId: b },
+			{ fromEntityId: a, toEntityId: c },
+		];
+		await upsertEdges({
+			db: sql,
+			organizationId: orgId,
+			relationshipTypeId: typeId,
+			pairs,
+			source: "feed",
+			claimKey: "config:seed-writer",
+			onConflict: "ignore",
+		});
+		await sql.unsafe(`
+			CREATE OR REPLACE FUNCTION test_pause_edge_batch_update()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				PERFORM pg_sleep(0.5);
+				RETURN NEW;
+			END
+			$$
+		`);
+		await sql.unsafe(`
+			CREATE TRIGGER test_pause_edge_batch_update
+			BEFORE UPDATE ON entity_relationships
+			FOR EACH ROW
+			EXECUTE FUNCTION test_pause_edge_batch_update()
+		`);
+
+		try {
+			await Promise.all([
+				upsertEdges({
+					db: sql,
+					organizationId: orgId,
+					relationshipTypeId: typeId,
+					pairs,
+					source: "feed",
+					claimKey: "config:ordered-writer-a",
+					onConflict: "ignore",
+				}),
+				upsertEdges({
+					db: sql,
+					organizationId: orgId,
+					relationshipTypeId: typeId,
+					pairs: [...pairs].reverse(),
+					source: "feed",
+					claimKey: "config:ordered-writer-b",
+					onConflict: "ignore",
+				}),
+			]);
+		} finally {
+			await sql.unsafe(`
+				DROP TRIGGER IF EXISTS test_pause_edge_batch_update
+				ON entity_relationships
+			`);
+			await sql.unsafe(`DROP FUNCTION IF EXISTS test_pause_edge_batch_update()`);
+		}
+
+		const rows = await liveEdges(orgId, typeId);
+		expect(rows).toHaveLength(2);
+		for (const row of rows) {
+			expect(row.metadata?.[RELATIONSHIP_CLAIMS_METADATA_KEY]).toEqual({
+				"config:seed-writer": {},
+				"config:ordered-writer-a": {},
+				"config:ordered-writer-b": {},
+			});
+		}
+	});
+
 	it("writes a batch and reports what it created", async () => {
 		const result = await upsertEdges({
 			db: getTestDb(),

--- a/packages/server/src/__tests__/integration/connectors/connector-declared-edges.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-declared-edges.test.ts
@@ -68,6 +68,10 @@ describe('connector-declared relationships', () => {
                     titlePath: 'metadata.customer_name',
                     identities: [
                       { namespace: 'crm_customer_id', eventPath: 'metadata.customer_id' },
+                      {
+                        namespace: 'email',
+                        eventPath: 'metadata.customer_email',
+                      },
                     ],
                   },
                 },
@@ -181,6 +185,137 @@ describe('connector-declared relationships', () => {
       `connection:${connection.id}:feed:${originId}`,
       'manual',
     ]);
+
+    // A temporarily ambiguous endpoint is not evidence that the source item
+    // withdrew its previous assertion. Preserve the existing connector claim
+    // until every referenced attribution resolves again.
+    const conflictingCustomer = (await workspace.owner.entities.create({
+      type: 'customer',
+      name: 'Rival GmbH',
+    })) as { entity: { id: number } };
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      VALUES (
+        ${workspace.org.id},
+        ${conflictingCustomer.entity.id},
+        'email',
+        'rival@example.com'
+      )
+    `;
+    const ambiguous = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 has an ambiguous customer identity',
+            metadata: {
+              invoice_id: 'inv-1001',
+              invoice_number: 'INV-1001',
+              customer_id: 'cust-42',
+              customer_email: 'rival@example.com',
+              customer_name: 'Acme Ltd',
+            },
+          },
+        ],
+      },
+    });
+    expect(ambiguous.status).toBe(200);
+    const [afterAmbiguousResolution] = await sql`
+      SELECT metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(afterAmbiguousResolution.metadata._lobu_claims).toHaveProperty(
+      `connection:${connection.id}:feed:${originId}`
+    );
+
+    // A present but malformed identity is also an unresolved read, not proof
+    // that the source withdrew the endpoint.
+    const malformed = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 carries an invalid customer email',
+            metadata: {
+              invoice_id: 'inv-1001',
+              invoice_number: 'INV-1001',
+              customer_email: 'not-an-email',
+              customer_name: 'Acme Ltd',
+            },
+          },
+        ],
+      },
+    });
+    expect(malformed.status).toBe(200);
+    const [afterMalformedIdentity] = await sql`
+      SELECT metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(afterMalformedIdentity.metadata._lobu_claims).toHaveProperty(
+      `connection:${connection.id}:feed:${originId}`
+    );
+
+    // An endpoint the item stops mentioning at all IS a withdrawal, and stays
+    // distinct from the unresolved case above: the connector claim is retracted
+    // while the co-owning manual claim keeps the graph fact live.
+    const withdrawn = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 no longer names a customer',
+            metadata: { invoice_id: 'inv-1001', invoice_number: 'INV-1001' },
+          },
+        ],
+      },
+    });
+    expect(withdrawn.status).toBe(200);
+    const [afterWithdrawal] = await sql`
+      SELECT deleted_at, metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(afterWithdrawal.deleted_at).toBeNull();
+    expect(afterWithdrawal.metadata._lobu_claims).toEqual({ manual: {} });
+
+    // Restore the connector claim for the rest of the lifecycle below.
+    const reasserted = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: originId,
+            origin_type: 'invoice',
+            title: 'Invoice INV-1001',
+            payload_text: 'Invoice INV-1001 belongs to Acme Ltd',
+            metadata: {
+              invoice_id: 'inv-1001',
+              invoice_number: 'INV-1001',
+              customer_id: 'cust-42',
+              customer_name: 'Acme Ltd',
+            },
+          },
+        ],
+      },
+    });
+    expect(reasserted.status).toBe(200);
+    const [afterReassertion] = await sql`
+      SELECT metadata FROM entity_relationships WHERE id = ${edges[0].id}
+    `;
+    expect(Object.keys(afterReassertion.metadata._lobu_claims).sort()).toEqual([
+      `connection:${connection.id}:feed:${originId}`,
+      'manual',
+    ]);
+
     await workspace.owner.entities.manage({
       action: 'update_link',
       relationship_id: Number(edges[0].id),

--- a/packages/server/src/__tests__/integration/migrations/relationship-claims-cutover-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/relationship-claims-cutover-migration.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../../setup/test-fixtures';
 
 const MIGRATION = '20260827174500_index_live_relationship_claims.sql';
+const TOMBSTONED_ABOUT_BACKFILL =
+  '20260829090000_backfill_tombstoned_about_claims.sql';
 
 function resolveMigrationsDir(): string {
   let dir = __dirname;
@@ -123,10 +125,33 @@ describe('relationship claims cutover migration', () => {
          'manual', current_timestamp, current_timestamp)
       RETURNING id
     `;
+    const [tombstonedOrphanAbout] = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationships
+        (organization_id, from_entity_id, to_entity_id, relationship_type_id,
+         metadata, source, deleted_at, created_at, updated_at)
+      VALUES (
+        ${org.id}, ${from.id}, ${to.id}, ${aboutTypeId},
+        ${sql.json({ connection_id: '999999998', channel_key: 'T01:C03' })},
+        'manual', current_timestamp, current_timestamp, current_timestamp
+      )
+      RETURNING id
+    `;
 
     const up = loadMigrationUp(resolveMigrationsDir(), MIGRATION);
     await executeMigrationSection((statement) => sql.unsafe(statement), up);
     await executeMigrationSection((statement) => sql.unsafe(statement), up);
+    const tombstonedAboutBackfill = loadMigrationUp(
+      resolveMigrationsDir(),
+      TOMBSTONED_ABOUT_BACKFILL
+    );
+    await executeMigrationSection(
+      (statement) => sql.unsafe(statement),
+      tombstonedAboutBackfill
+    );
+    await executeMigrationSection(
+      (statement) => sql.unsafe(statement),
+      tombstonedAboutBackfill
+    );
 
     const [ordinaryAfter] = await sql`
       SELECT deleted_at, metadata FROM entity_relationships WHERE id = ${ordinary.id}
@@ -174,6 +199,19 @@ describe('relationship claims cutover migration', () => {
     expect(orphanedAboutAfter.metadata).toEqual({
       connection_id: '999999999',
       channel_key: 'T01:C02',
+      _lobu_claims: { manual: {} },
+    });
+
+    const [tombstonedOrphanAboutAfter] = await sql`
+      SELECT deleted_at, metadata
+      FROM entity_relationships
+      WHERE id = ${tombstonedOrphanAbout.id}
+    `;
+    expect(tombstonedOrphanAboutAfter.deleted_at).not.toBeNull();
+    expect(tombstonedOrphanAboutAfter.metadata).toEqual({
+      connection_id: '999999998',
+      channel_key: 'T01:C03',
+      _lobu_claims: { manual: {} },
     });
 
     const [index] = await sql<{ indisvalid: boolean }[]>`

--- a/packages/server/src/__tests__/integration/relationships/relationship-claims.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/relationship-claims.test.ts
@@ -54,6 +54,37 @@ async function seedClaimGraph() {
   return { sql, workspace, connection, invoice, customer, desired };
 }
 
+async function withPausedRelationshipUpdates(run: () => Promise<unknown>): Promise<void> {
+  const sql = getTestDb();
+  await sql.unsafe(`
+    CREATE OR REPLACE FUNCTION test_pause_relationship_claim_update()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      PERFORM pg_sleep(0.5);
+      RETURN NEW;
+    END
+    $$
+  `);
+  await sql.unsafe(`
+    CREATE TRIGGER test_pause_relationship_claim_update
+    BEFORE UPDATE ON entity_relationships
+    FOR EACH ROW
+    EXECUTE FUNCTION test_pause_relationship_claim_update()
+  `);
+
+  try {
+    await run();
+  } finally {
+    await sql.unsafe(`
+      DROP TRIGGER IF EXISTS test_pause_relationship_claim_update
+      ON entity_relationships
+    `);
+    await sql.unsafe(`DROP FUNCTION IF EXISTS test_pause_relationship_claim_update()`);
+  }
+}
+
 describe('relationship source claims', () => {
   beforeEach(async () => {
     await cleanupTestDatabase();
@@ -167,6 +198,147 @@ describe('relationship source claims', () => {
         `connection:${connection.id}:feed:invoice:ordered-b`,
       ]);
     }
+  });
+
+  it('locks desired and departing claims in one order during concurrent moves', async () => {
+    const { sql, workspace, connection, desired } = await seedClaimGraph();
+    const secondCustomer = (await workspace.owner.entities.create({
+      type: 'customer',
+      name: 'Move Race Customer',
+    })) as { entity: { id: number } };
+    const secondEdge = {
+      ...desired[0],
+      toEntityId: secondCustomer.entity.id,
+    };
+
+    await sql.begin((tx) =>
+      reconcileConnectorRelationshipClaims(tx, {
+        organizationId: workspace.org.id,
+        connectionId: connection.id,
+        originId: 'invoice:move-a',
+        desired: [secondEdge],
+      })
+    );
+    await sql.begin((tx) =>
+      reconcileConnectorRelationshipClaims(tx, {
+        organizationId: workspace.org.id,
+        connectionId: connection.id,
+        originId: 'invoice:move-b',
+        desired,
+      })
+    );
+
+    await withPausedRelationshipUpdates(() =>
+      Promise.all([
+        sql.begin((tx) =>
+          reconcileConnectorRelationshipClaims(tx, {
+            organizationId: workspace.org.id,
+            connectionId: connection.id,
+            originId: 'invoice:move-a',
+            desired,
+          })
+        ),
+        sql.begin((tx) =>
+          reconcileConnectorRelationshipClaims(tx, {
+            organizationId: workspace.org.id,
+            connectionId: connection.id,
+            originId: 'invoice:move-b',
+            desired: [secondEdge],
+          })
+        ),
+      ])
+    );
+
+    const rows = await sql`
+      SELECT to_entity_id, metadata
+      FROM entity_relationships
+      WHERE organization_id = ${workspace.org.id}
+        AND deleted_at IS NULL
+      ORDER BY to_entity_id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].metadata[RELATIONSHIP_CLAIMS_METADATA_KEY]).toEqual({
+      [`connection:${connection.id}:feed:invoice:move-a`]: {},
+    });
+    expect(rows[1].metadata[RELATIONSHIP_CLAIMS_METADATA_KEY]).toEqual({
+      [`connection:${connection.id}:feed:invoice:move-b`]: {},
+    });
+  });
+
+  it('uses the same existing-row lock order in batch and claim writers', async () => {
+    const { sql, workspace, connection, desired } = await seedClaimGraph();
+    const secondCustomer = (await workspace.owner.entities.create({
+      type: 'customer',
+      name: 'Cross Writer Customer',
+    })) as { entity: { id: number } };
+    const secondEdge = {
+      ...desired[0],
+      toEntityId: secondCustomer.entity.id,
+    };
+    const [type] = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE organization_id = ${workspace.org.id} AND slug = 'invoice_customer'
+    `;
+
+    // Create the lexicographically later triple first so row-id and triple order
+    // disagree. The two writers must still prelock both existing rows by id.
+    await sql.begin((tx) =>
+      reconcileConnectorRelationshipClaims(tx, {
+        organizationId: workspace.org.id,
+        connectionId: connection.id,
+        originId: 'invoice:cross-writer',
+        desired: [secondEdge],
+      })
+    );
+    await upsertEdges({
+      db: sql,
+      organizationId: workspace.org.id,
+      relationshipTypeId: Number(type.id),
+      pairs: [desired[0]],
+      source: 'feed',
+      claimKey: 'config:cross-writer-seed',
+      onConflict: 'ignore',
+    });
+
+    await withPausedRelationshipUpdates(() =>
+      Promise.all([
+        upsertEdges({
+          db: sql,
+          organizationId: workspace.org.id,
+          relationshipTypeId: Number(type.id),
+          pairs: [desired[0], secondEdge],
+          source: 'feed',
+          claimKey: 'config:cross-writer-batch',
+          onConflict: 'ignore',
+        }),
+        sql.begin((tx) =>
+          reconcileConnectorRelationshipClaims(tx, {
+            organizationId: workspace.org.id,
+            connectionId: connection.id,
+            originId: 'invoice:cross-writer',
+            desired,
+          })
+        ),
+      ])
+    );
+
+    const rows = await sql`
+      SELECT to_entity_id, metadata
+      FROM entity_relationships
+      WHERE organization_id = ${workspace.org.id}
+        AND relationship_type_id = ${type.id}
+        AND deleted_at IS NULL
+      ORDER BY to_entity_id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].metadata[RELATIONSHIP_CLAIMS_METADATA_KEY]).toEqual({
+      'config:cross-writer-seed': {},
+      'config:cross-writer-batch': {},
+      [`connection:${connection.id}:feed:invoice:cross-writer`]: {},
+    });
+    expect(rows[1].metadata[RELATIONSHIP_CLAIMS_METADATA_KEY]).toEqual({
+      'config:cross-writer-batch': {},
+    });
   });
 
   it('fails closed on an unclaimed pre-cutover row instead of silently adopting it', async () => {

--- a/packages/server/src/utils/edge-writes.ts
+++ b/packages/server/src/utils/edge-writes.ts
@@ -99,6 +99,13 @@ export async function upsertEdges(params: UpsertEdgesParams): Promise<number[]> 
     pairs.push(pair);
   }
   if (pairs.length === 0) return [];
+  // `unnest` feeds the INSERT in array order. Keep new-triple conflicts in one
+  // deterministic order; existing rows are prelocked by id in the statement
+  // below, matching the relationship reconcilers and entity merge/unmerge.
+  pairs.sort(
+    (left, right) =>
+      left.fromEntityId - right.fromEntityId || left.toEntityId - right.toEntityId
+  );
 
   const froms = pairs.map((p) => p.fromEntityId);
   const tos = pairs.map((p) => p.toEntityId);
@@ -141,18 +148,41 @@ export async function upsertEdges(params: UpsertEdgesParams): Promise<number[]> 
             ) ? ${params.claimKey}
           )`;
 
+  // The non-negative count predicate is an execution barrier, not validation:
+  // it forces the materialized lock CTE to finish before the INSERT can begin.
   const written = await db<{ id: number; inserted: boolean }>`
+    WITH input(from_entity_id, to_entity_id) AS (
+      SELECT *
+      FROM unnest(
+        ${pgBigintArray(froms)}::bigint[],
+        ${pgBigintArray(tos)}::bigint[]
+      )
+    ),
+    locked AS MATERIALIZED (
+      SELECT r.id
+      FROM input i
+      JOIN entity_relationships r
+        ON r.from_entity_id = i.from_entity_id
+       AND r.to_entity_id = i.to_entity_id
+       AND r.relationship_type_id = ${relationshipTypeId}
+      WHERE r.organization_id = ${organizationId}
+        AND r.deleted_at IS NULL
+      ORDER BY r.id
+      FOR UPDATE OF r
+    )
     INSERT INTO entity_relationships (
       organization_id, from_entity_id, to_entity_id, relationship_type_id,
       metadata, confidence, source, created_by, updated_by, created_at, updated_at
     )
     SELECT
-      ${organizationId}, v.f, v.t, ${relationshipTypeId},
+      ${organizationId}, v.from_entity_id, v.to_entity_id, ${relationshipTypeId},
       ${db.json(metadata)},
       ${params.confidence ?? null}, ${source},
       ${params.createdBy ?? null}, ${params.createdBy ?? null},
       current_timestamp, current_timestamp
-    FROM unnest(${pgBigintArray(froms)}::bigint[], ${pgBigintArray(tos)}::bigint[]) AS v(f, t)
+    FROM input v
+    CROSS JOIN (SELECT count(*) FROM locked) AS lock_barrier
+    WHERE lock_barrier.count >= 0
     ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
       WHERE deleted_at IS NULL
     ${conflictAction}

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -111,12 +111,40 @@ interface EventAttributionPlan {
 interface AttributionResolution {
   entityIdsByItem: Map<number, number[]>;
   namedEntityIdsByItem: Map<number, Map<string, number>>;
+  unresolvedNamedAttributionsByItem: Map<number, Set<string>>;
 }
 
 interface AppliedEventAttributions {
   /** Entity id per attribution `name`, keyed by the caller's item index. */
   namedEntityIdsByItem: Map<number, Map<string, number>>;
+  /** Named rules that were applicable but did not resolve for this item. */
+  unresolvedNamedAttributionsByItem: Map<number, Set<string>>;
   relationshipsByKind: Record<string, ConnectorRelationshipDeclaration[]>;
+}
+
+/**
+ * Named rules the item supplied at least one raw identifier for, yet which
+ * produced no entity — invalid normalization, an ambiguous merge candidate, an
+ * entity that vanished between lookup and lock, or a `createWhen`/`autoCreate`
+ * miss. An endpoint the source item never mentioned is a withdrawal instead.
+ */
+function collectUnresolvedNamedAttributions(
+  suppliedNamesByItem: ReadonlyMap<number, ReadonlySet<string>>,
+  namedEntityIdsByItem: Map<number, Map<string, number>>
+): Map<number, Set<string>> {
+  const unresolved = new Map<number, Set<string>>();
+  for (const [index, suppliedNames] of suppliedNamesByItem) {
+    for (const name of suppliedNames) {
+      if (namedEntityIdsByItem.get(index)?.has(name)) continue;
+      let unresolvedNames = unresolved.get(index);
+      if (!unresolvedNames) {
+        unresolvedNames = new Set();
+        unresolved.set(index, unresolvedNames);
+      }
+      unresolvedNames.add(name);
+    }
+  }
+  return unresolved;
 }
 
 function resolveEventAttributions(
@@ -917,6 +945,7 @@ export async function applyEventAttributions(
   scrubIdentityScopeProjections(params.items);
   const empty: AppliedEventAttributions = {
     namedEntityIdsByItem: new Map(),
+    unresolvedNamedAttributionsByItem: new Map(),
     relationshipsByKind: {},
   };
   if (!params.feedKey || params.items.length === 0) return empty;
@@ -948,6 +977,7 @@ export async function applyEventAttributions(
   );
   return {
     namedEntityIdsByItem: resolved.namedEntityIdsByItem,
+    unresolvedNamedAttributionsByItem: resolved.unresolvedNamedAttributionsByItem,
     relationshipsByKind: plan.relationshipsByKind,
   };
 }
@@ -1021,7 +1051,11 @@ async function resolveLinksByKind(
   const namedEntityIdsByItem = new Map<number, Map<string, number>>();
   scrubIdentityScopeProjections(params.items);
   if (Object.keys(params.rulesByKind).length === 0 || params.items.length === 0) {
-    return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
+    return {
+      entityIdsByItem: resolvedByItem,
+      namedEntityIdsByItem,
+      unresolvedNamedAttributionsByItem: new Map(),
+    };
   }
 
   // entities.created_by is NOT NULL; resolve an org owner/admin once per batch
@@ -1031,6 +1065,7 @@ async function resolveLinksByKind(
   // rule -> per-item extracted link, carrying the source item + index (the
   // caller recovers the resolved entity per item; metadata is stamped onto the
   // item post-resolution).
+  const suppliedNamesByItem = new Map<number, Set<string>>();
   const byRule = new Map<
     ResolvedEventAttributionRule,
     Array<{ index: number; item: BatchItem; link: ExtractedLink }>
@@ -1041,6 +1076,20 @@ async function resolveLinksByKind(
     const rules = params.rulesByKind[kind];
     if (!rules) return;
     for (const rule of rules) {
+      if (
+        rule.name &&
+        rule.identities.some((identity) => {
+          const raw = getValueAtPath(item, identity.eventPath);
+          return raw !== undefined && raw !== null && raw !== '';
+        })
+      ) {
+        let names = suppliedNamesByItem.get(index);
+        if (!names) {
+          names = new Set();
+          suppliedNamesByItem.set(index, names);
+        }
+        names.add(rule.name);
+      }
       const link = extractLink(item, rule);
       if (!link) continue;
       // Metadata stamping is deferred to post-resolution (below) — only
@@ -1057,7 +1106,14 @@ async function resolveLinksByKind(
   // The reserved projections were scrubbed before extraction and are rebuilt
   // below only from identities that actually attach to an entity.
   if (byRule.size === 0) {
-    return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
+    return {
+      entityIdsByItem: resolvedByItem,
+      namedEntityIdsByItem,
+      unresolvedNamedAttributionsByItem: collectUnresolvedNamedAttributions(
+        suppliedNamesByItem,
+        namedEntityIdsByItem
+      ),
+    };
   }
 
   // Resolve first, then lock every existing entity in one ascending-id pass.
@@ -1336,7 +1392,14 @@ async function resolveLinksByKind(
     }
   }
 
-  return { entityIdsByItem: resolvedByItem, namedEntityIdsByItem };
+  return {
+    entityIdsByItem: resolvedByItem,
+    namedEntityIdsByItem,
+    unresolvedNamedAttributionsByItem: collectUnresolvedNamedAttributions(
+      suppliedNamesByItem,
+      namedEntityIdsByItem
+    ),
+  };
 }
 
 interface SenderIdentityParams {

--- a/packages/server/src/utils/relationship-claims.ts
+++ b/packages/server/src/utils/relationship-claims.ts
@@ -548,6 +548,52 @@ export async function reconcileConnectorRelationshipClaims(
       left.toEntityId - right.toEntityId ||
       left.relationshipTypeId - right.relationshipTypeId
   );
+
+  // A move asserts the new triple before retracting the old one. Lock both the
+  // desired existing rows and every row this source currently owns in one
+  // ascending-id pass, so two sources swapping edges cannot each hold their
+  // destination while waiting to retract the other's source row.
+  //
+  // The two candidate sets are collected separately so each keeps its own index
+  // (`idx_entity_relationships_live_triple` and `idx_entity_relationships_live_claims`).
+  // ORing them in a single predicate turns this into a scan of the org's whole
+  // live edge set, once per ingested item.
+  const desiredFroms = orderedEdges.map((edge) => edge.fromEntityId);
+  const desiredTos = orderedEdges.map((edge) => edge.toEntityId);
+  const desiredTypeIds = orderedEdges.map((edge) => edge.relationshipTypeId);
+  await tx`
+    WITH desired(from_entity_id, to_entity_id, relationship_type_id) AS (
+      SELECT *
+      FROM unnest(
+        ${pgBigintArray(desiredFroms)}::bigint[],
+        ${pgBigintArray(desiredTos)}::bigint[],
+        ${pgBigintArray(desiredTypeIds)}::bigint[]
+      )
+    ),
+    candidates AS (
+      SELECT r.id
+      FROM desired d
+      JOIN entity_relationships r
+        ON r.from_entity_id = d.from_entity_id
+       AND r.to_entity_id = d.to_entity_id
+       AND r.relationship_type_id = d.relationship_type_id
+      WHERE r.organization_id = ${params.organizationId}
+        AND r.deleted_at IS NULL
+      UNION
+      SELECT r.id
+      FROM entity_relationships r
+      WHERE r.organization_id = ${params.organizationId}
+        AND r.deleted_at IS NULL
+        AND r.metadata ? ${RELATIONSHIP_CLAIMS_METADATA_KEY}
+        AND (r.metadata -> ${RELATIONSHIP_CLAIMS_METADATA_KEY}) ? ${claimKey}
+    )
+    SELECT r.id
+    FROM entity_relationships r
+    WHERE r.id IN (SELECT id FROM candidates)
+    ORDER BY r.id
+    FOR UPDATE OF r
+  `;
+
   for (const edge of orderedEdges) {
     const asserted = await mergeRelationshipClaim(tx, {
       organizationId: params.organizationId,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -556,9 +556,11 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 							// (connection_id, origin_id) across replicas.
 							sql: isDry ? db : undefined,
 							afterPersist: async (persisted, tx) => {
-								// Keyed by `origin_type`, like attribution rules. Declarations
-								// whose named entities were not resolved are omitted below; an
-								// empty desired set means this source no longer asserts the edge.
+								// Keyed by `origin_type`, like attribution rules. A declaration
+								// naming an endpoint the item never mentioned is omitted below,
+								// and an empty desired set means this source no longer asserts
+								// the edge. An endpoint the item DID mention but that failed to
+								// resolve is handled separately — see below.
 								const relationshipDeclarations = itemOriginType
 									? (appliedAttributions.relationshipsByKind[itemOriginType] ??
 										[])
@@ -575,19 +577,48 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 									const named =
 										appliedAttributions.namedEntityIdsByItem.get(itemIndex) ??
 										new Map<string, number>();
-									await reconcileConnectorRelationshipClaims(tx, {
-										organizationId: run.organization_id,
-										connectionId: run.connection_id,
-										originId: persisted.origin_id,
-										desired: relationshipDeclarations.flatMap((declaration) => {
-											const fromEntityId = named.get(declaration.from);
-											const toEntityId = named.get(declaration.to);
-											return fromEntityId === undefined ||
-												toEntityId === undefined
-												? []
-												: [{ declaration, fromEntityId, toEntityId }];
-										}),
-									});
+									const unresolved =
+										appliedAttributions.unresolvedNamedAttributionsByItem.get(
+											itemIndex
+										) ?? new Set<string>();
+									const hasUnresolvedRelationshipEndpoint =
+										relationshipDeclarations.some(
+											(declaration) =>
+												unresolved.has(declaration.from) ||
+												unresolved.has(declaration.to)
+										);
+									// A named endpoint that the item asserted but that resolved to
+									// nothing (ambiguous merge candidate, create declined) is a
+									// transient read failure, not a withdrawal. Reconciliation is
+									// all-or-nothing per source item because the claim key covers the
+									// item's whole edge set: partially reconciling would retract the
+									// unreadable edge. Hold every edge until the next sync reads the
+									// item completely.
+									if (hasUnresolvedRelationshipEndpoint) {
+										logger.warn(
+											{
+												organizationId: run.organization_id,
+												connectionId: run.connection_id,
+												originId: persisted.origin_id,
+												unresolvedAttributions: [...unresolved],
+											},
+											"Connector relationship reconciliation skipped because an endpoint attribution did not resolve"
+										);
+									} else {
+										await reconcileConnectorRelationshipClaims(tx, {
+											organizationId: run.organization_id,
+											connectionId: run.connection_id,
+											originId: persisted.origin_id,
+											desired: relationshipDeclarations.flatMap((declaration) => {
+												const fromEntityId = named.get(declaration.from);
+												const toEntityId = named.get(declaration.to);
+												return fromEntityId === undefined ||
+													toEntityId === undefined
+													? []
+													: [{ declaration, fromEntityId, toEntityId }];
+											}),
+										});
+									}
 								}
 								const drafts = item.automation_signals ?? [];
 								if (drafts.length > 0) {


### PR DESCRIPTION
## Summary

- Preserve a connector item's existing relationship claims when a supplied named endpoint is temporarily ambiguous or malformed; genuine endpoint omission remains a withdrawal.
- Give generic batch writes and connector claim reconciliation one stored-row lock order, preventing reverse-order and cross-writer deadlocks.
- Backfill explicit ownership onto restorable tombstoned legacy `about` rows so an unmerge cannot revive a claimless edge.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean (local fallback)
- [x] DB-backed focused matrix: 8 files, 44/44 tests
- [x] Server typecheck, raw-array SQL binding gate, `git diff --check`, and Squawk migration lint
- [x] Bug fix red → green:
  - ambiguous named attribution previously retracted a live connector claim
  - reverse-order batch writes and concurrent claim moves reproduced PostgreSQL `40P01` deadlocks
  - tombstoned legacy `about` rows remained claimless after the cutover migration
- [x] Codex pre-review fixer completed on the settled diff; its edits were inspected and the DB-backed matrix rerun locally

## Notes

No UI surface changed. Claude Opus found the original post-merge correctness cases; Claude later exhausted its session during the fixer, so the repository-supported Codex reviewer completed the mandatory fixer pass.
