### PR TITLE
fix(connectors): bound os.shell process-group cleanup

### DIFF
--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
+import { kill } from 'node:process';
 import { connectorSdkMock } from './connector-sdk.mock';
 
 mock.module('@lobu/connector-sdk', () => connectorSdkMock());
@@ -69,6 +70,31 @@ describe('os.shell connector', () => {
     expect(result.success).toBe(true);
     const output = result.output as Record<string, unknown>;
     expect(output.exit_code).toBe(0);
+  });
+
+  it('force-kills redirected descendants after the shell leader closes', async () => {
+    const result = await connector.execute(
+      runContext('run', {
+        // Print the detached process-group id, then leave a descendant that
+        // ignores SIGTERM and owns no shell pipes. The shell leader can close
+        // immediately, but the grace timer must still SIGKILL this group.
+        command: `echo $$; bash -c 'trap "" TERM; sleep 10' >/dev/null 2>&1 & wait`,
+        timeout_ms: 300,
+      })
+    );
+    const output = result.output as Record<string, unknown>;
+    const processGroupId = Number(String(output.stdout).trim());
+    expect(output.timed_out).toBe(true);
+    expect(Number.isInteger(processGroupId)).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 3300));
+    let exists = true;
+    try {
+      kill(-processGroupId, 0);
+    } catch (err) {
+      exists = (err as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
+    expect(exists).toBe(false);
   });
 
   it('rejects an unknown action', async () => {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -20,6 +20,12 @@ function runContext(actionKey: string, input: Record<string, unknown>) {
 }
 
 function processIsLive(pid: number): boolean {
+  // pid 0 targets the caller's OWN process group and pid 1 is init; neither is
+  // a descendant, and process.kill reports both as live. An empty stdout parses
+  // to 0, so reject it here rather than reporting a phantom escaped process.
+  if (!Number.isInteger(pid) || pid <= 1) {
+    throw new Error(`processIsLive: ${pid} is not a descendant pid`);
+  }
   try {
     if (process.platform === 'linux') {
       const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
@@ -33,6 +39,15 @@ function processIsLive(pid: number): boolean {
     if (code === 'ENOENT' || code === 'ESRCH') return false;
     throw err;
   }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processIsLive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return !processIsLive(pid);
 }
 
 function forceKillProcessGroup(pid: number): void {
@@ -120,18 +135,23 @@ describe('os.shell connector', () => {
         // Print the descendant pid, then wait on a child that ignores SIGTERM
         // and owns no shell pipes. The grace timer must still SIGKILL it.
         command: `bash -c 'trap "" TERM; sleep 10' >/dev/null 2>&1 & echo $!; wait`,
-        timeout_ms: 300,
+        // Longer than the other timeout cases: this one must actually reach the
+        // echo and print a pid, and `bash -lc` profile sourcing alone can
+        // exceed 300ms on darwin. There is no elapsed-time assertion here.
+        timeout_ms: 1500,
       })
     );
     const output = result.output as Record<string, unknown>;
     const descendantPid = Number(String(output.stdout).trim());
     expect(output.timed_out).toBe(true);
-    expect(Number.isInteger(descendantPid)).toBe(true);
+    expect(descendantPid).toBeGreaterThan(1);
 
     // Some minimal PID 1 implementations reap orphans only when the test
     // process exits. A zombie is already dead; only a live state means the
-    // same-group descendant escaped cleanup.
-    expect(processIsLive(descendantPid)).toBe(false);
+    // same-group descendant escaped cleanup. SIGKILL delivery and reaping are
+    // both asynchronous, so poll rather than sampling once and racing the
+    // kernel on a loaded machine.
+    expect(await waitForProcessExit(descendantPid, 2000)).toBe(true);
   });
 
   it('settles on time when a session-detached child inherits stdio', async () => {
@@ -151,7 +171,7 @@ describe('os.shell connector', () => {
 
       expect(output.timed_out).toBe(true);
       expect(Date.now() - started).toBeLessThan(4000);
-      expect(Number.isInteger(escapedPid)).toBe(true);
+      expect(escapedPid).toBeGreaterThan(1);
       // setsid is explicitly outside process-group cleanup. The connector must
       // return on time even though the escaped session is still alive.
       expect(processGroupExists(escapedPid)).toBe(true);
@@ -177,7 +197,7 @@ describe('os.shell connector', () => {
 
       expect(output.timed_out).toBe(true);
       expect(Date.now() - started).toBeLessThan(4000);
-      expect(Number.isInteger(escapedPid)).toBe(true);
+      expect(escapedPid).toBeGreaterThan(1);
       expect(processGroupExists(escapedPid)).toBe(true);
     } finally {
       if (escapedPid > 0) forceKillProcessGroup(escapedPid);

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -19,6 +19,40 @@ function runContext(actionKey: string, input: Record<string, unknown>) {
   } as never;
 }
 
+function processIsLive(pid: number): boolean {
+  try {
+    if (process.platform === 'linux') {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const state = stat.slice(stat.lastIndexOf(') ') + 2, stat.lastIndexOf(') ') + 3);
+      return state !== 'Z';
+    }
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ESRCH') return false;
+    throw err;
+  }
+}
+
+function forceKillProcessGroup(pid: number): void {
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+  }
+}
+
+function processGroupExists(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw err;
+  }
+}
+
 describe('os.shell connector', () => {
   const connector = new OsShellConnector();
 
@@ -80,7 +114,7 @@ describe('os.shell connector', () => {
     expect((result.output as Record<string, unknown>).stdout).toBe('stdin-through-anchor');
   });
 
-  it('force-kills redirected descendants after the shell leader closes', async () => {
+  it('force-kills SIGTERM-ignoring descendants in the owned process group', async () => {
     const result = await connector.execute(
       runContext('run', {
         // Print the descendant pid, then wait on a child that ignores SIGTERM
@@ -96,22 +130,58 @@ describe('os.shell connector', () => {
 
     // Some minimal PID 1 implementations reap orphans only when the test
     // process exits. A zombie is already dead; only a live state means the
-    // descendant escaped the process-tree timeout.
-    let live = false;
+    // same-group descendant escaped cleanup.
+    expect(processIsLive(descendantPid)).toBe(false);
+  });
+
+  it('settles on time when a session-detached child inherits stdio', async () => {
+    if (process.platform !== 'linux') return;
+
+    let escapedPid = 0;
     try {
-      if (process.platform === 'linux') {
-        const stat = readFileSync(`/proc/${descendantPid}/stat`, 'utf8');
-        const state = stat.slice(stat.lastIndexOf(') ') + 2, stat.lastIndexOf(') ') + 3);
-        live = state !== 'Z';
-      } else {
-        process.kill(descendantPid, 0);
-        live = true;
-      }
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT' && code !== 'ESRCH') throw err;
+      const started = Date.now();
+      const result = await connector.execute(
+        runContext('run', {
+          command: `setsid bash -c 'trap "" TERM; sleep 10' & echo $!; wait`,
+          timeout_ms: 300,
+        })
+      );
+      const output = result.output as Record<string, unknown>;
+      escapedPid = Number(String(output.stdout).trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Number.isInteger(escapedPid)).toBe(true);
+      // setsid is explicitly outside process-group cleanup. The connector must
+      // return on time even though the escaped session is still alive.
+      expect(processGroupExists(escapedPid)).toBe(true);
+    } finally {
+      if (escapedPid > 0) forceKillProcessGroup(escapedPid);
     }
-    expect(live).toBe(false);
+  });
+
+  it('settles on time when a redirected child escapes into a new session', async () => {
+    if (process.platform !== 'linux') return;
+
+    let escapedPid = 0;
+    try {
+      const started = Date.now();
+      const result = await connector.execute(
+        runContext('run', {
+          command: `setsid bash -c 'trap "" TERM; sleep 10' >/dev/null 2>&1 & echo $!; wait`,
+          timeout_ms: 300,
+        })
+      );
+      const output = result.output as Record<string, unknown>;
+      escapedPid = Number(String(output.stdout).trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Number.isInteger(escapedPid)).toBe(true);
+      expect(processGroupExists(escapedPid)).toBe(true);
+    } finally {
+      if (escapedPid > 0) forceKillProcessGroup(escapedPid);
+    }
   });
 
   it('rejects an unknown action', async () => {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
-import { kill } from 'node:process';
+import { readFileSync } from 'node:fs';
 import { connectorSdkMock } from './connector-sdk.mock';
 
 mock.module('@lobu/connector-sdk', () => connectorSdkMock());
@@ -57,7 +57,7 @@ describe('os.shell connector', () => {
     expect(result.success).toBe(false);
     const output = result.output as Record<string, unknown>;
     expect(output.timed_out).toBe(true);
-    expect(Date.now() - started).toBeLessThan(3000);
+    expect(Date.now() - started).toBeLessThan(4000);
   });
 
   it('does not crash when a command exits without consuming stdin', async () => {
@@ -72,29 +72,46 @@ describe('os.shell connector', () => {
     expect(output.exit_code).toBe(0);
   });
 
+  it('passes stdin through the process-group anchor', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'cat', stdin: 'stdin-through-anchor' })
+    );
+    expect(result.success).toBe(true);
+    expect((result.output as Record<string, unknown>).stdout).toBe('stdin-through-anchor');
+  });
+
   it('force-kills redirected descendants after the shell leader closes', async () => {
     const result = await connector.execute(
       runContext('run', {
-        // Print the detached process-group id, then leave a descendant that
-        // ignores SIGTERM and owns no shell pipes. The shell leader can close
-        // immediately, but the grace timer must still SIGKILL this group.
-        command: `echo $$; bash -c 'trap "" TERM; sleep 10' >/dev/null 2>&1 & wait`,
+        // Print the descendant pid, then wait on a child that ignores SIGTERM
+        // and owns no shell pipes. The grace timer must still SIGKILL it.
+        command: `bash -c 'trap "" TERM; sleep 10' >/dev/null 2>&1 & echo $!; wait`,
         timeout_ms: 300,
       })
     );
     const output = result.output as Record<string, unknown>;
-    const processGroupId = Number(String(output.stdout).trim());
+    const descendantPid = Number(String(output.stdout).trim());
     expect(output.timed_out).toBe(true);
-    expect(Number.isInteger(processGroupId)).toBe(true);
+    expect(Number.isInteger(descendantPid)).toBe(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 3300));
-    let exists = true;
+    // Some minimal PID 1 implementations reap orphans only when the test
+    // process exits. A zombie is already dead; only a live state means the
+    // descendant escaped the process-tree timeout.
+    let live = false;
     try {
-      kill(-processGroupId, 0);
+      if (process.platform === 'linux') {
+        const stat = readFileSync(`/proc/${descendantPid}/stat`, 'utf8');
+        const state = stat.slice(stat.lastIndexOf(') ') + 2, stat.lastIndexOf(') ') + 3);
+        live = state !== 'Z';
+      } else {
+        process.kill(descendantPid, 0);
+        live = true;
+      }
     } catch (err) {
-      exists = (err as NodeJS.ErrnoException).code !== 'ESRCH';
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ESRCH') throw err;
     }
-    expect(exists).toBe(false);
+    expect(live).toBe(false);
   });
 
   it('rejects an unknown action', async () => {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -2,8 +2,12 @@
  * os.shell connector - runs commands and returns structured output.
  */
 
-import { describe, expect, it } from 'bun:test';
-import OsShellConnector from '../os_shell.js';
+import { describe, expect, it, mock } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+
+const { default: OsShellConnector } = await import('../os_shell.js');
 
 function runContext(actionKey: string, input: Record<string, unknown>) {
   return {
@@ -40,12 +44,31 @@ describe('os.shell connector', () => {
   });
 
   it('respects timeout_ms and reports timed_out', async () => {
+    const started = Date.now();
     const result = await connector.execute(
-      runContext('run', { command: 'sleep 10', timeout_ms: 300 })
+      runContext('run', {
+        // The background child keeps the shell's output pipes open. Killing
+        // only bash would make this call take the full five seconds.
+        command: 'sleep 5 & wait',
+        timeout_ms: 300,
+      })
     );
     expect(result.success).toBe(false);
     const output = result.output as Record<string, unknown>;
     expect(output.timed_out).toBe(true);
+    expect(Date.now() - started).toBeLessThan(3000);
+  });
+
+  it('does not crash when a command exits without consuming stdin', async () => {
+    const result = await connector.execute(
+      runContext('run', {
+        command: 'exit 0',
+        stdin: 'x'.repeat(1000000),
+      })
+    );
+    expect(result.success).toBe(true);
+    const output = result.output as Record<string, unknown>;
+    expect(output.exit_code).toBe(0);
   });
 
   it('rejects an unknown action', async () => {

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -38,6 +38,13 @@ interface RunOutput {
 const MAX_TIMEOUT_MS = 300000;
 const DEFAULT_TIMEOUT_MS = 60000;
 const SIGTERM_GRACE_MS = 3000;
+// The outer shell remains the live process-group owner until Node's grace
+// timer fires, so its numeric pgid cannot be recycled before SIGKILL. The
+// inner login shell and command still receive SIGTERM normally.
+const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
+bash -lc "$1"
+status=$?
+exit "$status"`;
 // Cap captured output so a chatty command cannot balloon daemon memory.
 // Streams keep draining (the child must not block on a full pipe), but
 // anything past the cap is dropped with a truncation marker.
@@ -59,7 +66,7 @@ function runShellCommand(
 ): Promise<RunOutput> {
   const started = Date.now();
   return new Promise((resolve) => {
-    const child = spawn('bash', ['-lc', command], {
+    const child = spawn('bash', ['-c', SHELL_GROUP_ANCHOR, 'lobu-os-shell', command], {
       cwd: opts.cwd || undefined,
       env: { ...process.env, LC_ALL: 'C' },
       // Give the command its own process group. Killing only the `bash`
@@ -76,16 +83,6 @@ function runShellCommand(
     let timedOut = false;
     let settled = false;
     let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const processGroupExists = (): boolean => {
-      if (child.pid == null) return false;
-      try {
-        process.kill(-child.pid, 0);
-        return true;
-      } catch (err) {
-        return (err as NodeJS.ErrnoException).code !== 'ESRCH';
-      }
-    };
 
     const killProcessGroup = (signal: NodeJS.Signals): void => {
       try {
@@ -108,13 +105,7 @@ function runShellCommand(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      // A redirected descendant can keep running after the shell leader closes,
-      // so preserve the grace timer while that detached process group exists.
-      // If SIGTERM already emptied the group, cancel it to avoid holding the
-      // daemon event loop open for an unnecessary three seconds.
-      if (forceKillTimer && (!timedOut || !processGroupExists())) {
-        clearTimeout(forceKillTimer);
-      }
+      if (forceKillTimer) clearTimeout(forceKillTimer);
       resolve(output);
     };
 
@@ -147,9 +138,7 @@ function runShellCommand(
       timedOut = true;
       killProcessGroup('SIGTERM');
       forceKillTimer = setTimeout(() => {
-        // `close` only proves the shell leader and its owned pipes closed. A
-        // redirected descendant may still exist in the detached group.
-        killProcessGroup('SIGKILL');
+        if (!settled) killProcessGroup('SIGKILL');
       }, SIGTERM_GRACE_MS);
     }, opts.timeoutMs);
 

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -5,7 +5,9 @@
  * devices (servers, VMs, k8s pods). Executes through `bash -lc` and returns
  * structured stdout/stderr/exit_code - the same contract as the macOS
  * os.shell manifest, but for boxes without a UI. Commands run in the device's
- * real environment (host PATH, files), so the action is approval-gated.
+ * real environment (host PATH, files), so the action is approval-gated. The
+ * timeout bounds this call and cleans up its process group; it is not sandbox
+ * containment, and deliberately daemonized/session-detached work may outlive it.
  */
 
 import { spawn } from 'node:child_process';
@@ -70,9 +72,9 @@ function runShellCommand(
       cwd: opts.cwd || undefined,
       env: { ...process.env, LC_ALL: 'C' },
       // Give the command its own process group. Killing only the `bash`
-      // process leaves background descendants alive with stdout/stderr open,
-      // so a timed-out run can otherwise stay pending until those descendants
-      // eventually exit.
+      // process leaves same-group background work alive with stdout/stderr
+      // open. A command can deliberately escape with setsid/daemonization;
+      // this timeout is bounded cleanup, not an OS containment boundary.
       detached: true,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -138,7 +140,24 @@ function runShellCommand(
       timedOut = true;
       killProcessGroup('SIGTERM');
       forceKillTimer = setTimeout(() => {
-        if (!settled) killProcessGroup('SIGKILL');
+        if (settled) return;
+        killProcessGroup('SIGKILL');
+        // A setsid/daemonized descendant can escape the owned group while
+        // retaining inherited pipe descriptors. Destroy our pipe ends and
+        // settle explicitly so such a process cannot extend the caller's
+        // timeout. The escaped process is outside this connector's cleanup
+        // contract and may continue running.
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish({
+          stdout,
+          stderr,
+          exit_code: child.exitCode ?? -1,
+          success: false,
+          timed_out: true,
+          duration_ms: Date.now() - started,
+        });
       }, SIGTERM_GRACE_MS);
     }, opts.timeoutMs);
 
@@ -210,7 +229,8 @@ export default class OsShellConnector extends ConnectorRuntime {
               minimum: 100,
               maximum: 300000,
               default: 60000,
-              description: 'Wall-clock budget in milliseconds. On timeout the process gets SIGTERM (3s grace) then SIGKILL.',
+              description:
+                'Wall-clock budget in milliseconds. On timeout the owned process group gets SIGTERM (3s grace) then SIGKILL. Session-detached or daemonized commands may outlive the call; this is not sandbox containment.',
             },
             stdin: {
               type: 'string',

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -77,6 +77,16 @@ function runShellCommand(
     let settled = false;
     let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
+    const processGroupExists = (): boolean => {
+      if (child.pid == null) return false;
+      try {
+        process.kill(-child.pid, 0);
+        return true;
+      } catch (err) {
+        return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+      }
+    };
+
     const killProcessGroup = (signal: NodeJS.Signals): void => {
       try {
         if (child.pid != null) {
@@ -98,7 +108,13 @@ function runShellCommand(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      if (forceKillTimer) clearTimeout(forceKillTimer);
+      // A redirected descendant can keep running after the shell leader closes,
+      // so preserve the grace timer while that detached process group exists.
+      // If SIGTERM already emptied the group, cancel it to avoid holding the
+      // daemon event loop open for an unnecessary three seconds.
+      if (forceKillTimer && (!timedOut || !processGroupExists())) {
+        clearTimeout(forceKillTimer);
+      }
       resolve(output);
     };
 
@@ -131,7 +147,9 @@ function runShellCommand(
       timedOut = true;
       killProcessGroup('SIGTERM');
       forceKillTimer = setTimeout(() => {
-        if (!settled) killProcessGroup('SIGKILL');
+        // `close` only proves the shell leader and its owned pipes closed. A
+        // redirected descendant may still exist in the detached group.
+        killProcessGroup('SIGKILL');
       }, SIGTERM_GRACE_MS);
     }, opts.timeoutMs);
 

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -62,6 +62,11 @@ function runShellCommand(
     const child = spawn('bash', ['-lc', command], {
       cwd: opts.cwd || undefined,
       env: { ...process.env, LC_ALL: 'C' },
+      // Give the command its own process group. Killing only the `bash`
+      // process leaves background descendants alive with stdout/stderr open,
+      // so a timed-out run can otherwise stay pending until those descendants
+      // eventually exit.
+      detached: true,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdout = '';
@@ -69,9 +74,48 @@ function runShellCommand(
     let stdoutTruncated = false;
     let stderrTruncated = false;
     let timedOut = false;
+    let settled = false;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
-    if (opts.stdin) child.stdin.write(opts.stdin);
-    child.stdin.end();
+    const killProcessGroup = (signal: NodeJS.Signals): void => {
+      try {
+        if (child.pid != null) {
+          process.kill(-child.pid, signal);
+          return;
+        }
+      } catch {
+        // The group may already be gone, or the host may not support negative
+        // process ids. `child.kill` is the safe best-effort fallback.
+      }
+      try {
+        child.kill(signal);
+      } catch {
+        // Exit raced the timeout. `close` still owns final settlement.
+      }
+    };
+
+    const finish = (output: RunOutput): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      resolve(output);
+    };
+
+    // A command is allowed to exit without reading stdin. Node reports that
+    // normal pipe race as EPIPE; without an error listener it becomes an
+    // uncaught exception and takes down the long-lived connector daemon.
+    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EPIPE') {
+        stderr = appendCapped(
+          stderr,
+          `${stderr ? '\n' : ''}stdin error: ${err.message}`,
+          stderrTruncated
+        );
+        if (stderr.includes(TRUNCATED_MARKER)) stderrTruncated = true;
+      }
+    });
+    child.stdin.end(opts.stdin);
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (chunk: string) => {
@@ -85,17 +129,16 @@ function runShellCommand(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
-      setTimeout(() => {
-        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      killProcessGroup('SIGTERM');
+      forceKillTimer = setTimeout(() => {
+        if (!settled) killProcessGroup('SIGKILL');
       }, SIGTERM_GRACE_MS);
     }, opts.timeoutMs);
 
     child.on('close', (code, signal) => {
-      clearTimeout(timer);
       const durationMs = Date.now() - started;
       const exitCode = code ?? (signal ? -1 : 0);
-      resolve({
+      finish({
         stdout,
         stderr,
         exit_code: exitCode,
@@ -106,8 +149,7 @@ function runShellCommand(
     });
 
     child.on('error', (err) => {
-      clearTimeout(timer);
-      resolve({
+      finish({
         stdout,
         stderr: `${stderr}${stderr ? '\n' : ''}spawn error: ${err.message}`,
         exit_code: -1,


### PR DESCRIPTION
## Summary

- tolerate a child that exits before consuming stdin instead of crashing the device daemon on an unhandled `EPIPE`
- run shell commands in an owned process group; on timeout send SIGTERM, keep a live group anchor through the 3s grace, then SIGKILL
- destroy owned stdio and settle at the grace deadline so session-detached work cannot hold the call open
- explicitly document that timeout is bounded process-group cleanup, not sandbox containment; daemonized/`setsid` work may outlive it

## Failures reproduced

- `sleep 5 & wait` with a 300 ms budget returned after 5007 ms on main
- writing 1 MiB to a child that immediately exited crashed Node with an unhandled `EPIPE`
- a redirected SIGTERM-ignoring same-group descendant survived the initial implementation
- a `setsid` child inheriting stdio held the call beyond timeout + grace until the explicit settlement fix

## Verification

- focused os.shell suite: 12/12, independently repeated and approved
- covers ordinary execution, stdin, same-group descendants, SIGTERM-ignore, and inherited/redirected `setsid` escape behavior
- `git diff --check`: pass
- changed files remain limited to `os_shell.ts` and its focused test
- canonical CI owns the full dependency graph because this runner's registry tarballs return HTTP 403

## Contract boundary

This is not an OS sandbox. Commands intentionally detached into another session may continue running; callers that require unescapable containment must provide cgroup/sandbox supervision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command timeout handling, including reliable termination of child processes and descendants.
  * Prevented detached or background processes from extending a timed-out command indefinitely.
  * Improved handling of large or interrupted standard input streams without crashing the service.
  * Ensured command completion and timeout results are reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->