### PR TITLE
fix(runtime): preserve serialized durable delivery

### DIFF
--- a/packages/agent-worker/src/__tests__/message-batcher.test.ts
+++ b/packages/agent-worker/src/__tests__/message-batcher.test.ts
@@ -244,6 +244,43 @@ describe("MessageBatcher — error resilience", () => {
     // After any error path, isProcessing must be false
     expect(batcher.isCurrentlyProcessing()).toBe(false);
   });
+
+  test("messages queued during a failed batch are still processed", async () => {
+    const processed: string[] = [];
+    let releaseFirst: (() => void) | null = null;
+    let signalFirstStarted: (() => void) | null = null;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+
+    const batcher = new MessageBatcher({
+      batchWindowMs: 10,
+      onBatchReady: async (messages) => {
+        const id = messages[0]?.payload.messageId;
+        if (id === "fails") {
+          signalFirstStarted?.();
+          await new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+          throw new Error("turn failed");
+        }
+        if (id) processed.push(id);
+      },
+    });
+
+    const failedBatch = batcher.addMessage(makeMsg("fails", "first", 1));
+    await firstStarted;
+    await batcher.addMessage(makeMsg("must-survive", "second", 2));
+    releaseFirst?.();
+    await failedBatch.catch(() => undefined);
+
+    const deadline = Date.now() + 500;
+    while (processed.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(processed).toEqual(["must-survive"]);
+  });
 });
 
 describe("MessageBatcher — addPriorityMessage (`!`-bash)", () => {

--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -853,6 +853,48 @@ describe("live steering classification", () => {
     expect(processSingleMessage).toHaveBeenNthCalledWith(2, second, ["second"]);
   });
 
+  test("continues an unattempted batch suffix exactly once after an earlier item fails", async () => {
+    const client = makeClient();
+    const attempts: string[] = [];
+    (client as any).processSingleMessage = mock(async (message: any) => {
+      const messageId = message.payload.messageId as string;
+      attempts.push(messageId);
+      if (messageId === "first-fails") throw new Error("turn failed");
+    });
+
+    const batcher = (client as any).messageBatcher;
+    batcher.batchWindowMs = 5;
+    await batcher.addMessage({
+      payload: { ...payload, messageId: "warmup" },
+      timestamp: 0,
+    });
+    await batcher.addMessage({
+      payload: {
+        ...payload,
+        messageId: "first-fails",
+        userId: "first-user",
+      },
+      timestamp: 1,
+    });
+    await batcher.addMessage({
+      payload: {
+        ...payload,
+        messageId: "suffix-must-run",
+        userId: "second-user",
+      },
+      timestamp: 2,
+    });
+
+    const deadline = Date.now() + 500;
+    while (!attempts.includes("suffix-must-run") && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(attempts).toEqual(["warmup", "first-fails", "suffix-must-run"]);
+    batcher.stop();
+  });
+
   test("keeps queue-policy Automation events as one turn per delivery", async () => {
     const client = makeClient();
     const processSingleMessage = mock(async () => undefined);

--- a/packages/agent-worker/src/gateway/message-batcher.ts
+++ b/packages/agent-worker/src/gateway/message-batcher.ts
@@ -146,10 +146,15 @@ export class MessageBatcher {
       if (this.onBatchReady) {
         await this.onBatchReady(messagesToProcess);
       }
+    } finally {
+      this.isProcessing = false;
 
-      // If more messages arrived during processing, start new batch.
-      // `batchTimer` is always null here — it was cleared at the top of
-      // processBatch() and addMessage() can't set it while isProcessing.
+      // Always schedule messages that arrived during this batch, including
+      // when onBatchReady failed. The queue job was already acknowledged on
+      // SSE receipt, so leaving these messages only in memory until a third
+      // message happened to arrive stranded a durable user turn indefinitely.
+      // `batchTimer` is null here: processBatch cleared it before setting
+      // isProcessing, and addMessage never starts one while a batch is active.
       if (this.messageQueue.length > 0) {
         logger.info(
           `Starting new batch window for ${this.messageQueue.length} queued messages`
@@ -160,8 +165,6 @@ export class MessageBatcher {
           });
         }, this.batchWindowMs);
       }
-    } finally {
-      this.isProcessing = false;
     }
   }
 

--- a/packages/agent-worker/src/gateway/message-batcher.ts
+++ b/packages/agent-worker/src/gateway/message-batcher.ts
@@ -124,6 +124,29 @@ export class MessageBatcher {
     }
   }
 
+  /**
+   * Restore the never-attempted suffix of a batch whose callback failed.
+   * These IDs were reserved before the original batch was captured, so this
+   * deliberately bypasses claimMessageId(). Prepend them ahead of messages
+   * that arrived while the failed callback was running to preserve delivery
+   * order without replaying the already-attempted prefix.
+   */
+  requeueClaimedMessages(messages: QueuedMessage[]): void {
+    if (messages.length === 0) return;
+    this.messageQueue = [...messages, ...this.messageQueue];
+
+    // Production calls this from onBatchReady while isProcessing is true, and
+    // processBatch() schedules the restored suffix in its finally block. Keep
+    // the method safe for direct callers too.
+    if (!this.isProcessing && !this.batchTimer) {
+      this.batchTimer = setTimeout(() => {
+        void this.processBatch().catch((error) => {
+          logger.error("Error during requeued batch processing:", error);
+        });
+      }, this.batchWindowMs);
+    }
+  }
+
   private async processBatch(): Promise<void> {
     if (this.batchTimer) {
       clearTimeout(this.batchTimer);

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -802,9 +802,7 @@ export class GatewayClient {
     // into one prompt under the first message's token; preserve arrival order
     // and execute each subject with its own token instead.
     if (new Set(messages.map((message) => message.payload.userId)).size > 1) {
-      for (const message of messages) {
-        await this.processSingleMessage(message, [message.payload.messageId]);
-      }
+      await this.processMessagesIndividually(messages);
       return;
     }
 
@@ -829,9 +827,7 @@ export class GatewayClient {
         (message) => message.payload.platformMetadata?.bangBash !== undefined
       )
     ) {
-      for (const message of messages) {
-        await this.processSingleMessage(message, [message.payload.messageId]);
-      }
+      await this.processMessagesIndividually(messages);
       return;
     }
 
@@ -874,6 +870,25 @@ export class GatewayClient {
       .map((m) => m.payload.messageId)
       .filter(Boolean);
     await this.processSingleMessage(batchedMessage, processedIds);
+  }
+
+  private async processMessagesIndividually(
+    messages: QueuedMessage[]
+  ): Promise<void> {
+    for (let index = 0; index < messages.length; index += 1) {
+      const message = messages[index];
+      if (!message) continue;
+      try {
+        await this.processSingleMessage(message, [message.payload.messageId]);
+      } catch (error) {
+        // The failing item was attempted and processSingleMessage already
+        // reported its terminal error. Only restore the untouched suffix: all
+        // of its IDs were reserved before batching, so routing it back through
+        // claimMessageId would incorrectly discard it as duplicate delivery.
+        this.messageBatcher.requeueClaimedMessages(messages.slice(index + 1));
+        throw error;
+      }
+    }
   }
 
   private async processSingleMessage(

--- a/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
+++ b/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
@@ -82,3 +82,96 @@ describe("RunsQueue construction", () => {
     }
   });
 });
+
+describe("RunsQueue worker registration", () => {
+  test("re-registering a queue preserves its single active handler", async () => {
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+    const queue = new RunsQueue();
+    if (previousDatabaseUrl !== undefined) {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+
+    const claimed = [
+      {
+        runId: 1,
+        payload: { turn: 1 },
+        attempts: 0,
+        maxAttempts: 3,
+        retryDelaySeconds: null,
+      },
+      {
+        runId: 2,
+        payload: { turn: 2 },
+        attempts: 0,
+        maxAttempts: 3,
+        retryDelaySeconds: null,
+      },
+    ];
+    let releaseFirst: (() => void) | null = null;
+    let signalFirstStarted: (() => void) | null = null;
+    let signalSecondStarted: (() => void) | null = null;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      signalSecondStarted = resolve;
+    });
+    let activeHandlers = 0;
+    let maxActiveHandlers = 0;
+
+    // Keep this a unit test: drive the production worker loop with deterministic
+    // claims while replacing only the database-facing seams.
+    (queue as any).isConnected = true;
+    (queue as any).ensureChannelListened = async () => undefined;
+    (queue as any).claimOne = async () => claimed.shift() ?? null;
+    (queue as any).heartbeatClaim = async () => undefined;
+    (queue as any).markCompleted = async () => undefined;
+
+    const firstHandler = async () => {
+      activeHandlers += 1;
+      maxActiveHandlers = Math.max(maxActiveHandlers, activeHandlers);
+      signalFirstStarted?.();
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      activeHandlers -= 1;
+    };
+    const replacementHandler = async () => {
+      activeHandlers += 1;
+      maxActiveHandlers = Math.max(maxActiveHandlers, activeHandlers);
+      signalSecondStarted?.();
+      activeHandlers -= 1;
+    };
+
+    try {
+      await queue.work("same-conversation", firstHandler);
+      await firstStarted;
+
+      // Worker SSE reconnects call work() again for the same deployment. The
+      // replacement may update future delivery behavior, but it must not start
+      // a second claim loop alongside the turn already in flight.
+      await queue.work("same-conversation", replacementHandler);
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(maxActiveHandlers).toBe(1);
+
+      releaseFirst?.();
+      await Promise.race([
+        secondStarted,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("second turn was not processed")), 500)
+        ),
+      ]);
+      expect(maxActiveHandlers).toBe(1);
+    } finally {
+      releaseFirst?.();
+      for (const worker of (queue as any).workers.values()) {
+        worker.stopped = true;
+        worker.wakeup();
+      }
+      (queue as any).workers.clear();
+    }
+  });
+});

--- a/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
+++ b/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
@@ -6,7 +6,7 @@
  * gated on `DATABASE_URL`.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   backoffSeconds,
   classifyQueue,
@@ -151,7 +151,7 @@ describe("RunsQueue worker registration", () => {
       await firstStarted;
 
       // Worker SSE reconnects call work() again for the same deployment. The
-      // replacement may update future delivery behavior, but it must not start
+      // replacement may update future delivery handling, but it must not start
       // a second claim loop alongside the turn already in flight.
       await queue.work("same-conversation", replacementHandler);
       await new Promise((resolve) => setTimeout(resolve, 75));
@@ -167,6 +167,91 @@ describe("RunsQueue worker registration", () => {
       expect(maxActiveHandlers).toBe(1);
     } finally {
       releaseFirst?.();
+      for (const worker of (queue as any).workers.values()) {
+        worker.stopped = true;
+        worker.wakeup();
+      }
+      (queue as any).workers.clear();
+    }
+  });
+
+  test("stop fences and releases a claim that resolves during shutdown", async () => {
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+    const queue = new RunsQueue();
+    if (previousDatabaseUrl !== undefined) {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+
+    let signalClaimStarted: (() => void) | null = null;
+    let releaseClaimAttempt: (() => void) | null = null;
+    const claimStarted = new Promise<void>((resolve) => {
+      signalClaimStarted = resolve;
+    });
+    const claimMayFinish = new Promise<void>((resolve) => {
+      releaseClaimAttempt = resolve;
+    });
+    const claimedRows = new Set<number>();
+    const handler = mock(async () => undefined);
+    let signalReleasedAfterShutdown: (() => void) | null = null;
+    const releasedAfterShutdown = new Promise<void>((resolve) => {
+      signalReleasedAfterShutdown = resolve;
+    });
+    const releaseClaim = mock(async (runId: number) => {
+      claimedRows.delete(runId);
+      signalReleasedAfterShutdown?.();
+    });
+
+    (queue as any).isConnected = true;
+    // Exercise the hard-timeout path without waiting 30 seconds: stop returns
+    // while claimOne is still held, so its later continuation owns the release.
+    (queue as any).shutdownDrainMs = 0;
+    (queue as any).ensureChannelListened = async () => undefined;
+    (queue as any).claimOne = async () => {
+      signalClaimStarted?.();
+      await claimMayFinish;
+      claimedRows.add(41);
+      return {
+        runId: 41,
+        payload: { turn: 1 },
+        attempts: 0,
+        maxAttempts: 3,
+        retryDelaySeconds: null,
+      };
+    };
+    (queue as any).releaseClaim = releaseClaim;
+    (queue as any).releaseAllClaims = async () => {
+      const count = claimedRows.size;
+      claimedRows.clear();
+      return count;
+    };
+    (queue as any).heartbeatClaim = async () => undefined;
+    (queue as any).markCompleted = async () => undefined;
+
+    try {
+      await queue.work("shutdown-race", handler);
+      await claimStarted;
+      expect((queue as any).workers.get("shutdown-race").claiming).toBe(1);
+
+      await queue.stop();
+      releaseClaimAttempt?.();
+      await Promise.race([
+        releasedAfterShutdown,
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("late claim was not released")),
+            500,
+          )
+        ),
+      ]);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(releaseClaim).toHaveBeenCalledWith(41);
+      expect(claimedRows.size).toBe(0);
+    } finally {
+      releaseClaimAttempt?.();
       for (const worker of (queue as any).workers.values()) {
         worker.stopped = true;
         worker.wakeup();

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -102,6 +102,7 @@ interface QueueWorker {
   concurrency: number;
   paused: boolean;
   stopped: boolean;
+  claiming: number;
   active: number;
   wakeup: () => void;
   pendingWakeup: boolean;
@@ -129,6 +130,7 @@ export class RunsQueue implements IMessageQueue {
   private isConnected = false;
   /** Set true on stop(); send/work check this and refuse new work. */
   private shuttingDown = false;
+  private readonly shutdownDrainMs = SHUTDOWN_DRAIN_MS;
 
   isShuttingDown(): boolean {
     return this.shuttingDown;
@@ -225,9 +227,9 @@ export class RunsQueue implements IMessageQueue {
     }
 
     const drainStart = Date.now();
-    while (Date.now() - drainStart < SHUTDOWN_DRAIN_MS) {
+    while (Date.now() - drainStart < this.shutdownDrainMs) {
       const inFlight = Array.from(this.workers.values()).reduce(
-        (sum, w) => sum + w.active,
+        (sum, w) => sum + w.claiming + w.active,
         0,
       );
       if (inFlight === 0) break;
@@ -239,18 +241,10 @@ export class RunsQueue implements IMessageQueue {
     // sweeper. Filter by our per-process claim identity so a sibling pod's
     // in-flight claims aren't released out from under it.
     try {
-      const sql = getDb();
-      const result = await sql`
-        UPDATE public.runs
-        SET status = 'pending',
-            claimed_at = NULL,
-            claimed_by = NULL
-        WHERE claimed_by = ${this.claimedBy}
-          AND status = 'claimed'
-      `;
-      if (result.count > 0) {
+      const released = await this.releaseAllClaims();
+      if (released > 0) {
         logger.info(
-          `Released ${result.count} claimed run(s) on shutdown`,
+          `Released ${released} claimed run(s) on shutdown`,
         );
       }
     } catch (err) {
@@ -469,6 +463,7 @@ export class RunsQueue implements IMessageQueue {
       concurrency: DEFAULT_WORKER_CONCURRENCY,
       paused: options?.startPaused ?? false,
       stopped: false,
+      claiming: 0,
       active: 0,
       pendingWakeup: false,
       wakeup: () => {
@@ -513,7 +508,25 @@ export class RunsQueue implements IMessageQueue {
           continue;
         }
         try {
-          const claimed = await this.claimOne(worker);
+          let claimed: Awaited<ReturnType<RunsQueue["claimOne"]>> = null;
+          worker.claiming += 1;
+          try {
+            claimed = await this.claimOne(worker);
+            if (claimed && (worker.stopped || this.shuttingDown)) {
+              await this.releaseClaim(claimed.runId);
+              claimed = null;
+            }
+          } finally {
+            worker.claiming -= 1;
+          }
+
+          // stop() can begin after claimOne's promise settles but before this
+          // continuation runs. Recheck before crossing the handler boundary;
+          // there is no await between this fence and active++/runHandler().
+          if (worker.stopped || this.shuttingDown) {
+            if (claimed) await this.releaseClaim(claimed.runId);
+            continue;
+          }
           if (!claimed) {
             await this.sleep(intervals.runsPollIntervalMs, worker, () => {
               resolveWake = null;
@@ -717,6 +730,34 @@ export class RunsQueue implements IMessageQueue {
     } catch (err) {
       logger.warn({ runId, err }, "runs-queue heartbeat failed");
     }
+  }
+
+  /** Release one row acquired after shutdown began. Ownership fencing keeps a
+   *  stale continuation from releasing a row since reclaimed by another pod. */
+  private async releaseClaim(runId: number): Promise<void> {
+    const sql = getDb();
+    await sql`
+      UPDATE public.runs
+      SET status = 'pending',
+          claimed_at = NULL,
+          claimed_by = NULL
+      WHERE id = ${runId}
+        AND status = 'claimed'
+        AND claimed_by = ${this.claimedBy}
+    `;
+  }
+
+  private async releaseAllClaims(): Promise<number> {
+    const sql = getDb();
+    const result = await sql`
+      UPDATE public.runs
+      SET status = 'pending',
+          claimed_at = NULL,
+          claimed_by = NULL
+      WHERE claimed_by = ${this.claimedBy}
+        AND status = 'claimed'
+    `;
+    return result.count;
   }
 
   private async markCompleted(runId: number): Promise<void> {

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -443,13 +443,21 @@ export class RunsQueue implements IMessageQueue {
       throw new Error("RunsQueue is shutting down; refusing new work");
     }
 
-    // Replace any existing worker for this queue.
+    // Re-register in place. Worker SSE reconnects call work() again for the
+    // same deployment queue; replacing the QueueWorker used to stop its poll
+    // loop but left an already-running handler alive, then immediately started
+    // a second loop with active=0. That let the next conversation turn run
+    // concurrently and out of order with the first. Updating the single
+    // worker preserves its active count and serialization boundary while
+    // swapping the handler used by future claims.
     const existing = this.workers.get(queueName);
     if (existing) {
-      existing.stopped = true;
-      this.removeFromChannelIndex(existing);
+      existing.handler = handler as JobHandler<unknown>;
+      existing.concurrency = DEFAULT_WORKER_CONCURRENCY;
+      existing.paused = options?.startPaused ?? false;
       existing.wakeup();
-      this.workers.delete(queueName);
+      await this.ensureChannelListened(notifyChannelFor(queueName));
+      return;
     }
 
     const runType = classifyQueue(queueName);
@@ -784,14 +792,6 @@ export class RunsQueue implements IMessageQueue {
       attempt,
       delaySeconds: delay,
     });
-  }
-
-  private removeFromChannelIndex(worker: QueueWorker): void {
-    const channel = notifyChannelFor(worker.queueName);
-    const set = this.subscribersByChannel.get(channel);
-    if (!set) return;
-    set.delete(worker);
-    if (set.size === 0) this.subscribersByChannel.delete(channel);
   }
 
   /**


### PR DESCRIPTION
## Summary

- re-register an existing RunsQueue worker in place so SSE reconnects preserve one poll loop and active counter
- always schedule messages arriving during an active batch, including after callback failure
- when sequential processing fails, restore only the never-attempted already-claimed suffix ahead of concurrent arrivals—without replaying attempted items
- track in-flight claims during shutdown, fence handler entry, and owner-fenced-release any claim that completes after shutdown

## Failures reproduced

- same-queue reconnect produced max handler concurrency 2
- a message arriving during a failed batch remained stranded in memory
- a captured multi-item batch dropped items 2…N after item 1 failed; replay was rejected by dedupe
- `stop()` could return while `claimOne()` was unresolved, then run that handler after shutdown

## Verification

- agent focused tests: 61/61
- server expanded router/recycle/RunsQueue tests: 57/57
- naming gate: 18/18
- root, agent-worker, and server typechecks: pass
- Biome: 604 files clean
- `git diff --check`: pass
- independent adversarial re-review: approved exact suffix order/once and late-claim release fencing

## Environment limitations

Embedded Postgres refuses uid 0 in this runner; canonical CI owns DB-backed integration. Full local dependency installation is blocked by registry/private-submodule access.