### PR TITLE
fix(cli): make E2E cleanup portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1283,6 +1283,7 @@ jobs:
           bash scripts/lib/__tests__/review-skip.test.sh
           bash scripts/lib/__tests__/review-cache.test.sh
           bash scripts/lib/__tests__/install-bubblewrap.test.sh
+          bash scripts/lib/__tests__/process-cleanup.test.sh
 
       - name: Preview and staging workflow guards
         # The preview deploy's mid-flight teardown decides whether to delete a

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -55,6 +55,8 @@ set -uo pipefail
 WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$WT/scripts/sdk-e2e"          # reuse the deterministic provider + ICU fix
 LOBU_BIN="$WT/packages/cli/bin/lobu.js"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$WT/scripts/lib/process-cleanup.sh"
 GW_PORT="${GW_PORT:-8795}"
 MOCK_PORT="${MOCK_PORT:-11436}"
 MOCK_REPLY="CLI_SMOKE_OK"
@@ -88,8 +90,8 @@ export HOME="$RUN_DIR/home"
 MOCK_PID=""
 cleanup() {
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
-  lsof -nP -iTCP:"$GW_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-  lsof -nP -iTCP:"$MOCK_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  lobu_kill_listening_port "$GW_PORT"
+  lobu_kill_listening_port "$MOCK_PORT"
 }
 trap cleanup EXIT
 

--- a/scripts/lib/__tests__/process-cleanup.test.sh
+++ b/scripts/lib/__tests__/process-cleanup.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$ROOT/scripts/lib/process-cleanup.sh"
+
+listener_pid=""
+fake_bin=""
+original_path="$PATH"
+cleanup() {
+  [[ -n "$listener_pid" ]] && kill "$listener_pid" 2>/dev/null || true
+  [[ -n "$fake_bin" ]] && rm -rf "$fake_bin"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sleep 30 &
+listener_pid=$!
+
+# Stub lsof at the function boundary. The implementation must consume its
+# output directly and must not depend on GNU xargs being available.
+lsof() {
+  printf '%s\n' "$listener_pid"
+}
+
+lobu_kill_listening_port 8795
+wait "$listener_pid" 2>/dev/null || true
+if kill -0 "$listener_pid" 2>/dev/null; then
+  fail "listener survived cleanup"
+fi
+listener_pid=""
+
+# No listener is a normal idempotent cleanup case.
+lsof() {
+  return 1
+}
+lobu_kill_listening_port 8795
+
+# The published-artifact smoke's minimal Linux container has fuser but no
+# lsof. Exercise that fallback with a fake fuser on an otherwise-empty PATH.
+unset -f lsof
+sleep 30 &
+listener_pid=$!
+export TEST_LISTENER_PID="$listener_pid"
+fake_bin="$(mktemp -d)"
+printf '%s\n' '#!/bin/sh' 'kill -9 "$TEST_LISTENER_PID"' > "$fake_bin/fuser"
+chmod +x "$fake_bin/fuser"
+PATH="$fake_bin"
+lobu_kill_listening_port 8795
+PATH="$original_path"
+wait "$listener_pid" 2>/dev/null || true
+if kill -0 "$listener_pid" 2>/dev/null; then
+  fail "listener survived fuser cleanup"
+fi
+listener_pid=""
+
+echo "OK process cleanup tests"

--- a/scripts/lib/__tests__/process-cleanup.test.sh
+++ b/scripts/lib/__tests__/process-cleanup.test.sh
@@ -59,4 +59,45 @@ if kill -0 "$listener_pid" 2>/dev/null; then
 fi
 listener_pid=""
 
+grep -Fq '&& exec "$LOBU_BIN" run --port "$GW_PORT"' \
+  "$ROOT/scripts/published-artifact-smoke.sh" || \
+  fail "published smoke does not track the actual lobu run process"
+
+saw_force_kill=false
+kill() {
+  [[ "${1:-}" = "-9" ]] && saw_force_kill=true
+  builtin kill "$@"
+}
+
+ready_fifo="$fake_bin/term-responsive-ready"
+term_marker="$fake_bin/term-responsive-seen"
+mkfifo "$ready_fifo"
+bash -c 'trap '\''printf "TERM\n" > "$2"; exit 0'\'' TERM; printf "ready\n" > "$1"; while :; do sleep 0.05; done' _ "$ready_fifo" "$term_marker" &
+listener_pid=$!
+IFS= read -r ready < "$ready_fifo"
+[[ "$ready" = "ready" ]] || fail "TERM-responsive child did not become ready"
+lobu_terminate_child "$listener_pid"
+if kill -0 "$listener_pid" 2>/dev/null; then
+  fail "TERM-responsive child survived cleanup"
+fi
+[[ -f "$term_marker" ]] || fail "TERM-responsive child did not observe SIGTERM"
+$saw_force_kill && fail "TERM-responsive child received unnecessary SIGKILL"
+listener_pid=""
+
+# Confirm the bounded SIGKILL fallback too. The FIFO handshake guarantees its
+# ignored-SIGTERM disposition is installed before cleanup starts.
+ready_fifo="$fake_bin/term-ignorer-ready"
+mkfifo "$ready_fifo"
+bash -c 'trap "" TERM; printf "ready\n" > "$1"; exec sleep 30' _ "$ready_fifo" &
+listener_pid=$!
+IFS= read -r ready < "$ready_fifo"
+[[ "$ready" = "ready" ]] || fail "TERM-ignoring child did not become ready"
+saw_force_kill=false
+lobu_terminate_child "$listener_pid" 1
+if kill -0 "$listener_pid" 2>/dev/null; then
+  fail "TERM-ignoring child survived forced cleanup"
+fi
+$saw_force_kill || fail "TERM-ignoring child did not receive SIGKILL fallback"
+listener_pid=""
+
 echo "OK process cleanup tests"

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -190,6 +190,7 @@ gate_format_lint() {
   bash scripts/lib/__tests__/review-upstream-guard.test.sh || return 1
   bash scripts/lib/__tests__/review-skip.test.sh || return 1
   bash scripts/lib/__tests__/review-cache.test.sh || return 1
+  bash scripts/lib/__tests__/process-cleanup.test.sh || return 1
   sh scripts/lib/__tests__/kubeconfig-preflight.test.sh || return 1
   cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml || return 1
   bash scripts/lib/__tests__/remote-ci.test.sh || return 1

--- a/scripts/lib/process-cleanup.sh
+++ b/scripts/lib/process-cleanup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared process cleanup helpers for local/E2E scripts.
+
+# Kill every process listening on a TCP port. Use a shell read loop instead of
+# `xargs -r`: `-r` is a GNU extension rejected by the BSD xargs shipped on
+# macOS, which made cleanup report success while leaving the gateway alive.
+lobu_kill_listening_port() {
+  local port="${1:?port is required}"
+  local pid
+
+  if command -v lsof >/dev/null 2>&1; then
+    while IFS= read -r pid; do
+      case "$pid" in
+        "" | *[!0-9]*) continue ;;
+      esac
+      kill -9 "$pid" 2>/dev/null || true
+    done < <(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)
+    return
+  fi
+
+  # Minimal published-artifact containers install psmisc (fuser), not lsof.
+  # Linux fuser supplies the same cleanup guarantee; macOS takes the lsof path.
+  if command -v fuser >/dev/null 2>&1; then
+    fuser -k -9 "$port/tcp" >/dev/null 2>&1 || true
+  fi
+}

--- a/scripts/lib/process-cleanup.sh
+++ b/scripts/lib/process-cleanup.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 # Shared process cleanup helpers for local/E2E scripts.
 
+# Gracefully stop a child job, then force and reap it if it does not exit. The
+# optional poll limit is primarily for focused tests; production callers use
+# the default ten-second grace period.
+lobu_child_job_is_live() {
+  local child_pid="${1:?child pid is required}"
+  local active_pids
+
+  # `jobs` is stronger than kill -0/ps here: it identifies this shell's exact
+  # child job, so a reaped PID cannot alias an unrelated replacement process.
+  # Command-substitution shells inherit EXIT traps; clear it before reading the
+  # copied job table so a caller's cleanup cannot recursively run there.
+  active_pids="$(trap - EXIT; jobs -pr; jobs -ps)"
+  case $'\n'"$active_pids"$'\n' in
+    *$'\n'"$child_pid"$'\n'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+lobu_terminate_child() {
+  local child_pid="${1:?child pid is required}"
+  local max_polls="${2:-100}"
+  local poll
+
+  kill "$child_pid" 2>/dev/null || true
+  for ((poll = 0; poll < max_polls; poll++)); do
+    lobu_child_job_is_live "$child_pid" || break
+    sleep 0.1
+  done
+  if lobu_child_job_is_live "$child_pid"; then
+    kill -9 "$child_pid" 2>/dev/null || true
+  fi
+  wait "$child_pid" 2>/dev/null || true
+}
+
 # Kill every process listening on a TCP port. Use a shell read loop instead of
 # `xargs -r`: `-r` is a GNU extension rejected by the BSD xargs shipped on
 # macOS, which made cleanup report success while leaving the gateway alive.

--- a/scripts/mac-cli-auth-e2e.sh
+++ b/scripts/mac-cli-auth-e2e.sh
@@ -7,6 +7,8 @@ set -uo pipefail
 WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOBU_BIN="$WT/packages/cli/bin/lobu.js"
 HARNESS="$WT/scripts/sdk-e2e"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$WT/scripts/lib/process-cleanup.sh"
 GW_PORT="${GW_PORT:-8798}"
 MOCK_PORT="${MOCK_PORT:-11438}"
 MOCK_REPLY="MAC_CLI_AUTH_E2E_OK"
@@ -24,8 +26,8 @@ export HOME="$RUN_DIR/home"
 MOCK_PID=""
 cleanup() {
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
-  lsof -nP -iTCP:"$GW_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs kill -9 2>/dev/null || true
-  lsof -nP -iTCP:"$MOCK_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs kill -9 2>/dev/null || true
+  lobu_kill_listening_port "$GW_PORT"
+  lobu_kill_listening_port "$MOCK_PORT"
 }
 trap cleanup EXIT
 

--- a/scripts/managed-e2e.sh
+++ b/scripts/managed-e2e.sh
@@ -38,6 +38,8 @@ WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SDK_HARNESS="$WT/scripts/sdk-e2e"
 HARNESS="$WT/scripts/managed-e2e"
 LOBU="node $WT/packages/cli/bin/lobu.js"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$WT/scripts/lib/process-cleanup.sh"
 
 CLOUD_PORT="${CLOUD_PORT:-8901}"
 LOCAL_PORT="${LOCAL_PORT:-8902}"
@@ -75,14 +77,12 @@ kill_pg_orphans() {
   pkill -9 -f "embedded-postgres/darwin-arm64/native/bin/postgres" 2>/dev/null || true
   pkill -9 -f "embedded-postgres/.*/native/bin/postgres" 2>/dev/null || true
 }
-free_port() { lsof -nP -iTCP:"$1" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true; }
-
 cleanup() {
   [ -n "$LOCAL_PID" ] && kill -9 "$LOCAL_PID" 2>/dev/null || true
   [ -n "$CLOUD_PID" ] && kill -9 "$CLOUD_PID" 2>/dev/null || true
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
   [ -n "$DATA_PID" ] && kill -9 "$DATA_PID" 2>/dev/null || true
-  for p in "$CLOUD_PORT" "$LOCAL_PORT" "$MOCK_PORT" "$MOCK_DATA_PORT" "$CLOUD_PG_PORT" "$LOCAL_PG_PORT"; do free_port "$p"; done
+  for p in "$CLOUD_PORT" "$LOCAL_PORT" "$MOCK_PORT" "$MOCK_DATA_PORT" "$CLOUD_PG_PORT" "$LOCAL_PG_PORT"; do lobu_kill_listening_port "$p"; done
   kill_pg_orphans
 }
 trap cleanup EXIT

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -50,6 +50,8 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$REPO_ROOT/scripts/sdk-e2e"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$REPO_ROOT/scripts/lib/process-cleanup.sh"
 LOBU_VERSION="${1:-${LOBU_VERSION:-latest}}"
 GW_PORT="${GW_PORT:-8799}"
 MOCK_PORT="${MOCK_PORT:-11439}"
@@ -65,9 +67,12 @@ fail() { echo "  [FAIL] $*" >&2; FAILS=$((FAILS + 1)); }
 note() { echo ""; echo "== $* =="; }
 
 MOCK_PID=""
+RUN_PID=""
 cleanup() {
-  [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null
-  pkill -f "lobu-artifact-smoke.*run" 2>/dev/null
+  [ -n "$RUN_PID" ] && kill -9 "$RUN_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
+  lobu_kill_listening_port "$GW_PORT"
+  lobu_kill_listening_port "$MOCK_PORT"
   return 0
 }
 trap cleanup EXIT
@@ -193,6 +198,7 @@ if grep -qi "is valid" "$WORK/validate.log"; then pass "lobu validate"; else fai
 note "lobu run (embedded Postgres + pgvector on THIS glibc, as THIS uid)"
 RUN_LOG="$WORK/run.log"
 ( cd "$PROJ" && "$LOBU_BIN" run --port "$GW_PORT" > "$RUN_LOG" 2>&1 ) &
+RUN_PID=$!
 for _ in $(seq 1 180); do
   grep -qiE "Apply complete|auto-apply skipped|Apply halted" "$RUN_LOG" 2>/dev/null && break
   sleep 1

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -69,7 +69,11 @@ note() { echo ""; echo "== $* =="; }
 MOCK_PID=""
 RUN_PID=""
 cleanup() {
-  [ -n "$RUN_PID" ] && kill -9 "$RUN_PID" 2>/dev/null || true
+  if [ -n "$RUN_PID" ]; then
+    # Let `lobu run` forward SIGTERM and stop its embedded Postgres before
+    # forcing and reaping the exact tracked process down.
+    lobu_terminate_child "$RUN_PID"
+  fi
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
   lobu_kill_listening_port "$GW_PORT"
   lobu_kill_listening_port "$MOCK_PORT"
@@ -197,7 +201,7 @@ if grep -qi "is valid" "$WORK/validate.log"; then pass "lobu validate"; else fai
 
 note "lobu run (embedded Postgres + pgvector on THIS glibc, as THIS uid)"
 RUN_LOG="$WORK/run.log"
-( cd "$PROJ" && "$LOBU_BIN" run --port "$GW_PORT" > "$RUN_LOG" 2>&1 ) &
+( cd "$PROJ" && exec "$LOBU_BIN" run --port "$GW_PORT" > "$RUN_LOG" 2>&1 ) &
 RUN_PID=$!
 for _ in $(seq 1 180); do
   grep -qiE "Apply complete|auto-apply skipped|Apply halted" "$RUN_LOG" 2>/dev/null && break

--- a/scripts/sdk-e2e-error.sh
+++ b/scripts/sdk-e2e-error.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$WT/scripts/sdk-e2e"
 LOBU="node $WT/packages/cli/bin/lobu.js"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$WT/scripts/lib/process-cleanup.sh"
 GW_PORT="${GW_PORT:-8795}"
 MOCK_PORT="${MOCK_PORT:-11436}"
 RUN_DIR="$WT/.sdk-e2e-error-run"
@@ -42,8 +44,8 @@ fi
 MOCK_PID=""
 cleanup() {
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
-  lsof -nP -iTCP:"$GW_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-  lsof -nP -iTCP:"$MOCK_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  lobu_kill_listening_port "$GW_PORT"
+  lobu_kill_listening_port "$MOCK_PORT"
 }
 trap cleanup EXIT
 

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$WT/scripts/sdk-e2e"
 LOBU="node $WT/packages/cli/bin/lobu.js"
+# shellcheck source=scripts/lib/process-cleanup.sh
+. "$WT/scripts/lib/process-cleanup.sh"
 GW_PORT="${GW_PORT:-8793}"
 MOCK_PORT="${MOCK_PORT:-11434}"
 MOCK_REPLY="SDK_E2E_OK"
@@ -50,8 +52,8 @@ fi
 MOCK_PID=""
 cleanup() {
   [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
-  lsof -nP -iTCP:"$GW_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-  lsof -nP -iTCP:"$MOCK_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  lobu_kill_listening_port "$GW_PORT"
+  lobu_kill_listening_port "$MOCK_PORT"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

- replace GNU-only `xargs -r` cleanup with one shared Bash helper that works with macOS `lsof` and minimal Linux `fuser`
- wire the helper into CLI, SDK, managed, mac-auth, and published-artifact E2E paths
- launch the published smoke with `exec` so `$!` is the actual CLI process, then terminate that exact child gracefully before bounded SIGKILL fallback
- add dependency-free regressions to CI and the local formatting gate

## Failures reproduced

- BSD `xargs` rejects `-r`, while cleanup suppressed the error and reported success with listeners alive
- a wrapper subshell PID did not guarantee TERM reached `lobu run`
- an unconditional SIGKILL after successful TERM created a PID-reuse signal window and bypassed embedded-Postgres shutdown

## Verification

- focused cleanup regression: 100/100 repeated passes
- explicit-exec PID identity verified independently
- TERM-responsive child observes TERM and never SIGKILL; TERM-ignoring exact child gets bounded fallback
- helper exercised from a real parent EXIT trap
- `bash -n` across helper, test, and all seven consumers: pass
- `git diff --check`: pass
- independent read-only re-review: approved

## Scope

No product/API behavior changes. The existing broad embedded-Postgres `pkill -f` in managed E2E is unchanged and tracked as a separate cleanup-hardening follow-up.