### PR TITLE
fix(connector-worker): verify runtime before claiming work

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -124,9 +124,15 @@ describe("lobu daemon", () => {
       undefined as never
     );
 
-    await daemonCommand({ apiUrl: "http://127.0.0.1:9564" });
+    await daemonCommand({
+      apiUrl: "http://127.0.0.1:9564",
+      cliVersion: "17.2.3-test",
+    });
 
-    expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("http://127.0.0.1:9564");
+    expect(start.mock.calls[0]?.[0]).toMatchObject({
+      apiUrl: "http://127.0.0.1:9564",
+      version: "17.2.3-test",
+    });
     expect(load).not.toHaveBeenCalled();
     expect(wizard).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -1,3 +1,5 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   printSelfCheckResult,
   runConnectorRuntimeSelfCheck,
@@ -22,10 +24,20 @@ export async function connectorRunCommand(
  * compile + default `SubprocessExecutor` path. Internal/CI-only — not user
  * facing (no auth, no network), so it's registered hidden in index.ts.
  */
+const HERE = dirname(fileURLToPath(import.meta.url));
+
 export async function connectorRuntimeSelfCheckCommand(options: {
   json?: boolean;
 }): Promise<void> {
-  const result = await runConnectorRuntimeSelfCheck({ surface: "cli" });
+  const result = await runConnectorRuntimeSelfCheck({
+    surface: "cli",
+    connectorSourceCandidates: [
+      // Published CLI: build.cjs vendors connector sources under dist/connectors.
+      resolve(HERE, "../connectors"),
+      // Source/workspace execution.
+      resolve(HERE, "../../../connectors/src"),
+    ],
+  });
   if (options.json) {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   } else {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -29,6 +29,8 @@ import { loginCommand } from "./login.js";
 
 export interface DaemonOptions {
   apiUrl?: string;
+  /** Exact installed CLI version advertised to the gateway. */
+  cliVersion?: string;
   workerId?: string;
   platform?: string;
   capabilities?: string;
@@ -257,6 +259,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
 
   await startDaemonCommand({
     apiUrl: target.gatewayOrigin,
+    version: options.cliVersion,
     platform: sessionLane ? "headless" : requestedPlatform,
     defaultPlatform,
     workerId,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1215,7 +1215,7 @@ Memory:
     )
     .action(async (options) => {
       const { daemonCommand } = await import("./commands/daemon.js");
-      await daemonCommand(options);
+      await daemonCommand({ ...options, cliVersion: version });
     });
 
   program

--- a/packages/connector-worker/integration-tests/subprocess.test.ts
+++ b/packages/connector-worker/integration-tests/subprocess.test.ts
@@ -168,6 +168,26 @@ describe('SubprocessExecutor diagnostic capture', () => {
     }
   });
 
+  test('preserves a missing relative-module diagnostic', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        `
+          import { createRequire } from 'node:module';
+          const require = createRequire(import.meta.url);
+          require('./missing-relative-module.cjs');
+        `,
+        BASE_JOB
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.message).toContain("Cannot find module './missing-relative-module.cjs'");
+    expect(err!.message).not.toContain('Connector requires');
+  });
+
   test('classifies parent-driven SIGKILL as timeout', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 1_000, maxOldSpaceSize: 256 });
     let err: SubprocessError | null = null;

--- a/packages/connector-worker/src/__tests__/runtime-dependency-loader.test.ts
+++ b/packages/connector-worker/src/__tests__/runtime-dependency-loader.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  initialize,
+  isConnectorRuntimeDependency,
+  resolve,
+} from '../executor/runtime-dependency-loader.js';
+
+describe('connector runtime dependency loader', () => {
+  test('classifies the SDK, SDK subpaths, and external runtime packages', () => {
+    expect(isConnectorRuntimeDependency('@lobu/connector-sdk')).toBe(true);
+    expect(
+      isConnectorRuntimeDependency('@lobu/connector-sdk/define-connector')
+    ).toBe(true);
+    expect(isConnectorRuntimeDependency('playwright')).toBe(true);
+    expect(isConnectorRuntimeDependency('sharp/lib/index.js')).toBe(true);
+    expect(isConnectorRuntimeDependency('node:fs')).toBe(false);
+    expect(isConnectorRuntimeDependency('connector-owned-package')).toBe(false);
+  });
+
+  test('rebases runtime packages to the connector-worker installation', async () => {
+    const runtimeAnchorUrl =
+      'file:///runtime/node_modules/@lobu/connector-worker/dist/executor/runtime-dependency-loader.js';
+    initialize({ runtimeAnchorUrl });
+
+    const calls: Array<{
+      specifier: string;
+      context: Record<string, unknown>;
+    }> = [];
+    const nextResolve = async (
+      specifier: string,
+      context: Record<string, unknown>
+    ) => {
+      calls.push({ specifier, context });
+      return { url: `file:///resolved/${encodeURIComponent(specifier)}` };
+    };
+
+    await resolve(
+      '@lobu/connector-sdk/define-connector',
+      { parentURL: 'file:///unrelated/operator-cwd/connector.mjs' },
+      nextResolve
+    );
+    await resolve(
+      'connector-owned-package',
+      { parentURL: 'file:///unrelated/operator-cwd/connector.mjs' },
+      nextResolve
+    );
+
+    expect(calls[0]).toMatchObject({
+      specifier: '@lobu/connector-sdk/define-connector',
+      context: { parentURL: runtimeAnchorUrl },
+    });
+    expect(calls[1]).toMatchObject({
+      specifier: 'connector-owned-package',
+      context: {
+        parentURL: 'file:///unrelated/operator-cwd/connector.mjs',
+      },
+    });
+  });
+});

--- a/packages/connector-worker/src/__tests__/runtime-dependency-loader.test.ts
+++ b/packages/connector-worker/src/__tests__/runtime-dependency-loader.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import {
   initialize,
   isConnectorRuntimeDependency,
@@ -56,4 +58,40 @@ describe('connector runtime dependency loader', () => {
       },
     });
   });
+
+  test.skipIf(!existsSync('/sys') && !existsSync('/System'))(
+    'boots from a read-only cwd with a CommonJS runtime dependency',
+    () => {
+      const readOnlyCwd = existsSync('/sys') ? '/sys' : '/System';
+      const selfCheckUrl = new URL(
+        '../../dist/self-check/index.js',
+        import.meta.url
+      ).href;
+      const probe = `
+        const timeout = setTimeout(() => process.exit(9), 20_000);
+        const { assertConnectorRuntimeLoadable } = await import(${JSON.stringify(
+          selfCheckUrl
+        )});
+        await assertConnectorRuntimeLoadable();
+        clearTimeout(timeout);
+      `;
+      const env = { ...process.env };
+      delete env.NODE_PATH;
+      const result = spawnSync(
+        'node',
+        ['--input-type=module', '--eval', probe],
+        {
+          cwd: readOnlyCwd,
+          env,
+          encoding: 'utf-8',
+          timeout: 30_000,
+        }
+      );
+
+      expect(
+        result.status,
+        `read-only cwd readiness probe failed:\n${result.stdout}${result.stderr}`
+      ).toBe(0);
+    }
+  );
 });

--- a/packages/connector-worker/src/__tests__/runtime-timeout.test.ts
+++ b/packages/connector-worker/src/__tests__/runtime-timeout.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const SLOW_CONNECTOR = `
 export class SlowConnector {
@@ -11,9 +15,23 @@ export class SlowConnector {
 }
 `;
 
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 5_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for probe state');
+    await Bun.sleep(25);
+  }
+}
+
 describe('executeCompiledConnector timeout', () => {
   it('kills the connector subprocess at the caller deadline', async () => {
     const startedAt = Date.now();
+    const isolatedTempRoot = await mkdtemp(
+      join(tmpdir(), 'lobu-runtime-timeout-test-')
+    );
     const runtimeUrl = new URL('../executor/runtime.ts', import.meta.url).href;
     // Several worker tests use Bun's process-global mock.module on this seam.
     // Exercise the real runtime in a clean process so test order cannot replace
@@ -36,18 +54,85 @@ describe('executeCompiledConnector timeout', () => {
         process.exit(error?.exitReason === 'timeout' ? 0 : 1);
       }
     `;
-    const child = Bun.spawn([process.execPath, '--eval', probe], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const [exitCode, stderr] = await Promise.all([
-      child.exited,
-      new Response(child.stderr).text(),
-    ]);
+    try {
+      const child = Bun.spawn([process.execPath, '--eval', probe], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: {
+          ...process.env,
+          TMPDIR: isolatedTempRoot,
+          TMP: isolatedTempRoot,
+          TEMP: isolatedTempRoot,
+        },
+      });
+      const [exitCode, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ]);
 
-    if (exitCode !== 0) {
-      throw new Error(`timeout probe exited ${exitCode}: ${stderr}`);
+      if (exitCode !== 0) {
+        throw new Error(`timeout probe exited ${exitCode}: ${stderr}`);
+      }
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      expect(await readdir(isolatedTempRoot)).toEqual([]);
+    } finally {
+      await rm(isolatedTempRoot, { recursive: true, force: true });
     }
-    expect(Date.now() - startedAt).toBeLessThan(5_000);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'removes the runtime directory when the parent is killed',
+    async () => {
+      const isolatedTempRoot = await mkdtemp(
+        join(tmpdir(), 'lobu-runtime-parent-death-test-')
+      );
+      const runtimeUrl = new URL(
+        '../../dist/executor/runtime.js',
+        import.meta.url
+      ).href;
+      const probe = `
+        const { executeCompiledConnector } = await import(${JSON.stringify(
+          runtimeUrl
+        )});
+        await executeCompiledConnector({
+          compiledCode: ${JSON.stringify(SLOW_CONNECTOR)},
+          job: {
+            mode: 'query', query: 'SELECT 1', config: {}, credentials: null,
+            sessionState: null, env: {}
+          },
+          timeoutMs: 60_000
+        });
+      `;
+      const env = {
+        ...process.env,
+        TMPDIR: isolatedTempRoot,
+        TMP: isolatedTempRoot,
+        TEMP: isolatedTempRoot,
+      };
+      delete env.NODE_PATH;
+      const parent = Bun.spawn(
+        ['node', '--input-type=module', '--eval', probe],
+        { stdout: 'pipe', stderr: 'pipe', env }
+      );
+
+      try {
+        await waitFor(async () => {
+          const entries = await readdir(isolatedTempRoot);
+          return entries.some((entry) =>
+            existsSync(join(isolatedTempRoot, entry, 'connector.mjs'))
+          );
+        });
+        parent.kill('SIGKILL');
+        await parent.exited;
+        await waitFor(async () => (await readdir(isolatedTempRoot)).length === 0);
+      } finally {
+        try {
+          parent.kill('SIGKILL');
+        } catch {
+          // Already exited.
+        }
+        await rm(isolatedTempRoot, { recursive: true, force: true });
+      }
+    }
+  );
 });

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -10,6 +10,7 @@ import { hostname } from 'node:os';
 import { isKnownPlatform } from '@lobu/core';
 import { assertExternalDepsResolvable } from '../compile/index.js';
 import { buildConnectorWorkerEnv } from '../env.js';
+import { assertConnectorRuntimeLoadable } from '../self-check/index.js';
 import { DEVICE_MANIFESTS_BY_PLATFORM } from './device-manifests.js';
 import { startDaemon, type WorkerDaemon } from './index.js';
 import { log, setDebug } from './log.js';
@@ -153,8 +154,10 @@ export async function startDaemonCommand(
   const workerId = resolveDaemonWorkerId(opts, platform, shortHostname, detected);
   const label = opts.label ?? (platform ? shortHostname : undefined);
 
-  // Crash loud at boot if the runtime image is missing a connector dep.
+  // Crash loud before the first poll if the installed runtime cannot resolve
+  // or execute the same connector graph this worker is about to advertise.
   assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
+  await assertConnectorRuntimeLoadable();
   log.info(`[cli] Starting worker daemon (ID: ${workerId}, API: ${opts.apiUrl})`);
   const env = buildConnectorWorkerEnv();
   const maxConcurrentJobs = process.env.WORKER_MAX_CONCURRENT_JOBS

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -12,7 +12,10 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { EventEnvelope, SyncResult } from '@lobu/connector-sdk';
 import { extractHttpStatus } from './http-status.js';
-import { registerConnectorRuntimeDependencyLoader } from './runtime-dependency-loader.js';
+import {
+  isConnectorRuntimeDependency,
+  registerConnectorRuntimeDependencyLoader,
+} from './runtime-dependency-loader.js';
 import type { ExecutorJob, ExecutorResult } from './interface.js';
 
 const EVENT_CHUNK_SIZE = 100;
@@ -499,7 +502,9 @@ async function main() {
     if (started) return;
     started = true;
 
-    // Keep temp module under cwd so bare imports (e.g. lobu) resolve via local node_modules.
+    // Keep the temp module under cwd so the runtime never writes into an
+    // installed package. The dependency loader below rebases runtime-provided
+    // bare imports to connector-worker's own package graph.
     // Use a cryptographically random suffix (not pid+Date.now()) so a co-tenant
     // can't pre-create or guess the path. Combined with the `wx` open flag below
     // this prevents both symlink-swap (pointing tmpFile at another file the
@@ -546,11 +551,12 @@ async function main() {
       if (error.code === 'ERR_MODULE_NOT_FOUND') {
         const pkgMatch = error.message.match(/Cannot find package '([^']+)'/);
         const pkg = pkgMatch?.[1] ?? 'unknown';
-        error.message =
-          `Connector requires '${pkg}' but it's not installed in the runtime image. ` +
-          `'${pkg}' is declared as an external dependency in EXTERNAL_RUNTIME_DEPS ` +
-          `(packages/connector-worker/src/runtime-deps.ts). ` +
-          `Add it to packages/connector-worker/package.json and rebuild the runtime image.`;
+        error.message = isConnectorRuntimeDependency(pkg)
+          ? `Connector runtime is missing required package '${pkg}'. ` +
+            `It must resolve from @lobu/connector-worker's installed dependency graph; ` +
+            `reinstall the matching runtime artifact before advertising connector capabilities.`
+          : `Connector requires '${pkg}' but it is not installed in the runtime image. ` +
+            `Add the connector's declared package to the runtime image and rebuild it.`;
       }
       await sendIPC({
         type: 'error',

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { EventEnvelope, SyncResult } from '@lobu/connector-sdk';
 import { extractHttpStatus } from './http-status.js';
+import { registerConnectorRuntimeDependencyLoader } from './runtime-dependency-loader.js';
 import type { ExecutorJob, ExecutorResult } from './interface.js';
 
 const EVENT_CHUNK_SIZE = 100;
@@ -520,6 +521,11 @@ async function main() {
       //   process memory referenced by the bundle) unreadable by other
       //   local users on shared hosts. Umask cannot widen this.
       await writeFile(tmpFile, compiledCode, { encoding: 'utf-8', flag: 'wx', mode: 0o600 });
+
+      // Rebase runtime-provided bare imports (SDK, native deps, Playwright)
+      // to connector-worker's installation before loading code staged under
+      // an arbitrary operator cwd.
+      registerConnectorRuntimeDependencyLoader();
 
       // Import the compiled module
       const mod = await import(pathToFileURL(tmpFile).href);

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -6,7 +6,7 @@
  * authenticate() using the V1 SDK shapes directly — no magic-key adapter.
  */
 
-import { randomBytes } from 'node:crypto';
+import { rmSync } from 'node:fs';
 import { rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -15,14 +15,19 @@ import { extractHttpStatus } from './http-status.js';
 import {
   isConnectorRuntimeDependency,
   registerConnectorRuntimeDependencyLoader,
+  stageConnectorRuntimeDependencies,
 } from './runtime-dependency-loader.js';
 import type { ExecutorJob, ExecutorResult } from './interface.js';
 
 const EVENT_CHUNK_SIZE = 100;
+const INTERNAL_RUNTIME_TEMP_DIR_ENV = 'LOBU_INTERNAL_RUNTIME_TEMP_DIR';
+let activeRuntimeTempDir = process.env[INTERNAL_RUNTIME_TEMP_DIR_ENV] ?? null;
+delete process.env[INTERNAL_RUNTIME_TEMP_DIR_ENV];
 
 interface ChildMessage {
   compiledCode: string;
   job: ExecutorJob;
+  runtimeTempDir: string;
 }
 
 /**
@@ -451,10 +456,27 @@ function installUncaughtHandlers(): void {
  * or a Playwright session) — leaving zombie subprocesses behind that nothing
  * cleans up until OOM. Exit promptly on parent disconnect so the OS reaps us.
  */
+function cleanupActiveRuntimeTempDir(): void {
+  if (!activeRuntimeTempDir) return;
+  try {
+    rmSync(activeRuntimeTempDir, { recursive: true, force: true });
+  } catch {
+    // The parent normally owns cleanup. If it died and the host refuses
+    // removal (for example, a transient Windows file lock), exit promptly
+    // rather than keeping unowned connector code running indefinitely.
+  }
+  activeRuntimeTempDir = null;
+}
+
 function installParentDeathHandlers(): void {
+  // Also covers connector-authored process.exit() and uncaught-handler exits.
+  process.on('exit', cleanupActiveRuntimeTempDir);
   // Best-effort: don't bother flushing IPC, the channel is already gone.
   // Exit code 143 = 128 + SIGTERM, conventional for "killed externally".
-  process.on('disconnect', () => process.exit(143));
+  process.on('disconnect', () => {
+    cleanupActiveRuntimeTempDir();
+    process.exit(143);
+  });
 }
 
 async function main() {
@@ -502,21 +524,23 @@ async function main() {
     if (started) return;
     started = true;
 
-    // Keep the temp module under cwd so the runtime never writes into an
-    // installed package. The dependency loader below rebases runtime-provided
-    // bare imports to connector-worker's own package graph.
-    // Use a cryptographically random suffix (not pid+Date.now()) so a co-tenant
-    // can't pre-create or guess the path. Combined with the `wx` open flag below
-    // this prevents both symlink-swap (pointing tmpFile at another file the
-    // worker can write) and pre-creation of a malicious .mjs that the worker
-    // would otherwise overwrite then import.
-    const tmpFile = join(
-      process.cwd(),
-      `.connector-child-${process.pid}-${randomBytes(16).toString('hex')}.mjs`
-    );
+    let tempDir: string | null = null;
 
     try {
-      const { compiledCode, job } = msg as ChildMessage;
+      const { compiledCode, job, runtimeTempDir } = msg as ChildMessage;
+
+      if (typeof runtimeTempDir !== 'string' || runtimeTempDir.length === 0) {
+        throw new Error('Connector subprocess received no runtime temp directory.');
+      }
+      if (runtimeTempDir !== activeRuntimeTempDir) {
+        throw new Error('Connector subprocess runtime temp directory mismatch.');
+      }
+      // The parent creates and owns this private writable directory so it can
+      // clean up even when a timeout SIGKILL prevents this child's finally.
+      // The staged facade supports ESM and createRequire()/CommonJS bundles.
+      tempDir = runtimeTempDir;
+      const tmpFile = join(tempDir, 'connector.mjs');
+      await stageConnectorRuntimeDependencies(tempDir);
 
       // Write compiled code to temp file for dynamic import.
       // - `flag: 'wx'` fails if the file already exists (no symlink follow,
@@ -548,15 +572,29 @@ async function main() {
       // Send result back to parent (wait for IPC flush before exiting)
       await sendIPC({ type: 'result', result });
     } catch (error: any) {
-      if (error.code === 'ERR_MODULE_NOT_FOUND') {
-        const pkgMatch = error.message.match(/Cannot find package '([^']+)'/);
-        const pkg = pkgMatch?.[1] ?? 'unknown';
-        error.message = isConnectorRuntimeDependency(pkg)
-          ? `Connector runtime is missing required package '${pkg}'. ` +
-            `It must resolve from @lobu/connector-worker's installed dependency graph; ` +
-            `reinstall the matching runtime artifact before advertising connector capabilities.`
-          : `Connector requires '${pkg}' but it is not installed in the runtime image. ` +
-            `Add the connector's declared package to the runtime image and rebuild it.`;
+      if (
+        error.code === 'ERR_MODULE_NOT_FOUND' ||
+        error.code === 'MODULE_NOT_FOUND'
+      ) {
+        const pkgMatch = error.message.match(
+          /Cannot find (?:package|module) '([^']+)'/
+        );
+        const pkg = pkgMatch?.[1];
+        const isBareSpecifier =
+          pkg &&
+          !pkg.startsWith('.') &&
+          !pkg.startsWith('/') &&
+          !pkg.startsWith('\\') &&
+          !pkg.startsWith('#') &&
+          !/^[A-Za-z]:[\\/]/.test(pkg);
+        if (pkg && isBareSpecifier) {
+          error.message = isConnectorRuntimeDependency(pkg)
+            ? `Connector runtime is missing required package '${pkg}'. ` +
+              `It must resolve from @lobu/connector-worker's installed dependency graph; ` +
+              `reinstall the matching runtime artifact before advertising connector capabilities.`
+            : `Connector requires '${pkg}' but it is not installed in the runtime image. ` +
+              `Add the connector's declared package to the runtime image and rebuild it.`;
+        }
       }
       await sendIPC({
         type: 'error',
@@ -570,9 +608,12 @@ async function main() {
         },
       });
     } finally {
-      // Clean up temp file
+      // Clean up the compiled module and its private dependency facade.
       try {
-        await rm(tmpFile, { force: true });
+        if (tempDir) {
+          await rm(tempDir, { recursive: true, force: true });
+          activeRuntimeTempDir = null;
+        }
       } catch {
         // Ignore cleanup errors
       }

--- a/packages/connector-worker/src/executor/runtime-dependency-loader.ts
+++ b/packages/connector-worker/src/executor/runtime-dependency-loader.ts
@@ -1,0 +1,94 @@
+/**
+ * Runtime dependency resolver for compiled connector modules.
+ *
+ * Compiled connectors are staged under the daemon's current working directory
+ * so the runtime never writes into an installed package. Bare imports in those
+ * modules must nevertheless resolve from the connector-worker installation,
+ * not from whatever directory the operator happened to launch `lobu daemon`
+ * in. Node's module loader supports that exact rebase without copying or
+ * bundling a second SDK graph.
+ */
+
+import { register } from 'node:module';
+import { EXTERNAL_RUNTIME_DEPS } from '../runtime-deps.js';
+
+const RUNTIME_DEPENDENCY_ROOTS = [
+  '@lobu/connector-sdk',
+  ...EXTERNAL_RUNTIME_DEPS,
+] as const;
+
+type ResolveContext = {
+  parentURL?: string;
+  [key: string]: unknown;
+};
+
+type ResolveResult = {
+  url: string;
+  format?: string | null;
+  shortCircuit?: boolean;
+  [key: string]: unknown;
+};
+
+type NextResolve = (
+  specifier: string,
+  context: ResolveContext
+) => Promise<ResolveResult>;
+
+let runtimeAnchorUrl: string | undefined;
+let registered = false;
+
+function isRuntimeDependency(specifier: string): boolean {
+  return RUNTIME_DEPENDENCY_ROOTS.some(
+    (root) => specifier === root || specifier.startsWith(`${root}/`)
+  );
+}
+
+/** Receive the connector-worker module URL in the isolated loader thread. */
+export function initialize(data: unknown): void {
+  const anchor =
+    data && typeof data === 'object'
+      ? (data as { runtimeAnchorUrl?: unknown }).runtimeAnchorUrl
+      : undefined;
+  if (typeof anchor !== 'string' || anchor.length === 0) {
+    throw new Error('connector runtime dependency loader received no anchor URL');
+  }
+  runtimeAnchorUrl = anchor;
+}
+
+/**
+ * Resolve runtime-provided connector dependencies as though the import
+ * originated inside connector-worker. Delegating to Node's next resolver keeps
+ * package export conditions (including import-only SDK subpaths) intact.
+ */
+export async function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: NextResolve
+): Promise<ResolveResult> {
+  if (!runtimeAnchorUrl || !isRuntimeDependency(specifier)) {
+    return nextResolve(specifier, context);
+  }
+  return nextResolve(specifier, {
+    ...context,
+    parentURL: runtimeAnchorUrl,
+  });
+}
+
+/**
+ * Install the resolver once in this process before importing a compiled
+ * connector. Bun's source-mode resolver already runs from the workspace graph;
+ * the loader is for the Node runtime used by published packages and images.
+ */
+export function registerConnectorRuntimeDependencyLoader(): void {
+  if (
+    registered ||
+    typeof (process.versions as { bun?: string }).bun === 'string'
+  ) {
+    return;
+  }
+  register(import.meta.url, {
+    parentURL: import.meta.url,
+    data: { runtimeAnchorUrl: import.meta.url },
+  });
+  registered = true;
+}

--- a/packages/connector-worker/src/executor/runtime-dependency-loader.ts
+++ b/packages/connector-worker/src/executor/runtime-dependency-loader.ts
@@ -37,7 +37,7 @@ type NextResolve = (
 let runtimeAnchorUrl: string | undefined;
 let registered = false;
 
-function isRuntimeDependency(specifier: string): boolean {
+export function isConnectorRuntimeDependency(specifier: string): boolean {
   return RUNTIME_DEPENDENCY_ROOTS.some(
     (root) => specifier === root || specifier.startsWith(`${root}/`)
   );
@@ -65,7 +65,7 @@ export async function resolve(
   context: ResolveContext,
   nextResolve: NextResolve
 ): Promise<ResolveResult> {
-  if (!runtimeAnchorUrl || !isRuntimeDependency(specifier)) {
+  if (!runtimeAnchorUrl || !isConnectorRuntimeDependency(specifier)) {
     return nextResolve(specifier, context);
   }
   return nextResolve(specifier, {

--- a/packages/connector-worker/src/executor/runtime-dependency-loader.ts
+++ b/packages/connector-worker/src/executor/runtime-dependency-loader.ts
@@ -1,15 +1,17 @@
 /**
  * Runtime dependency resolver for compiled connector modules.
  *
- * Compiled connectors are staged under the daemon's current working directory
- * so the runtime never writes into an installed package. Bare imports in those
- * modules must nevertheless resolve from the connector-worker installation,
- * not from whatever directory the operator happened to launch `lobu daemon`
- * in. Node's module loader supports that exact rebase without copying or
- * bundling a second SDK graph.
+ * Compiled connectors are staged in private OS temp directories so the runtime
+ * never writes into an installed package or requires a writable launch cwd.
+ * Bare imports in those modules must nevertheless resolve from the
+ * connector-worker installation. The ESM hook and staged node_modules facade
+ * provide that rebase for both ESM imports and CommonJS require().
  */
 
-import { register } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, symlink } from 'node:fs/promises';
+import { createRequire, register } from 'node:module';
+import { basename, dirname, join } from 'node:path';
 import { EXTERNAL_RUNTIME_DEPS } from '../runtime-deps.js';
 
 const RUNTIME_DEPENDENCY_ROOTS = [
@@ -36,11 +38,84 @@ type NextResolve = (
 
 let runtimeAnchorUrl: string | undefined;
 let registered = false;
+const runtimeRequire = createRequire(import.meta.url);
+const packageRootCache = new Map<string, string | null>();
 
 export function isConnectorRuntimeDependency(specifier: string): boolean {
   return RUNTIME_DEPENDENCY_ROOTS.some(
     (root) => specifier === root || specifier.startsWith(`${root}/`)
   );
+}
+
+/**
+ * Find the installed package root for a runtime-provided bare specifier.
+ * Accepting both the declared package name and a direct node_modules child
+ * covers workspace symlinks as well as npm aliases such as patched Playwright
+ * packages whose package.json name differs from the requested specifier.
+ */
+function resolveRuntimePackageRoot(pkgName: string): string | null {
+  let entry: string;
+  try {
+    entry = runtimeRequire.resolve(pkgName);
+  } catch {
+    return null;
+  }
+
+  let dir = dirname(entry);
+  for (let depth = 0; depth < 30; depth++) {
+    const packageJsonPath = join(dir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const parent = dirname(dir);
+      const underNodeModules =
+        basename(parent) === 'node_modules' ||
+        (basename(parent).startsWith('@') &&
+          basename(dirname(parent)) === 'node_modules');
+      if (underNodeModules) return dir;
+
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+          name?: string;
+        };
+        if (pkg.name === pkgName) return dir;
+      } catch {
+        // Invalid package metadata cannot identify this directory as the root.
+      }
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Stage a private node_modules facade beside a compiled connector module.
+ * Node's ESM loader hook does not affect createRequire()/CommonJS resolution,
+ * so both current and previously persisted bundles need these package links.
+ */
+export async function stageConnectorRuntimeDependencies(
+  tempDir: string
+): Promise<void> {
+  for (const pkgName of RUNTIME_DEPENDENCY_ROOTS) {
+    if (!packageRootCache.has(pkgName)) {
+      packageRootCache.set(pkgName, resolveRuntimePackageRoot(pkgName));
+    }
+    const root = packageRootCache.get(pkgName);
+    if (!root) {
+      throw new Error(
+        `Connector runtime is missing required package '${pkgName}'. ` +
+          `It must resolve from @lobu/connector-worker's installed dependency graph; ` +
+          `reinstall the matching runtime artifact before advertising connector capabilities.`
+      );
+    }
+
+    const linkPath = join(tempDir, 'node_modules', pkgName);
+    await mkdir(dirname(linkPath), { recursive: true });
+    // Junctions avoid elevated symlink privileges on Windows and are ignored
+    // as a special type on POSIX, where the target remains an absolute link.
+    await symlink(root, linkPath, 'junction');
+  }
 }
 
 /** Receive the connector-worker module URL in the isolated loader thread. */

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -8,7 +8,9 @@
 
 import { type ChildProcess, fork, spawn, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { EventEnvelope } from '@lobu/connector-sdk';
@@ -133,6 +135,7 @@ const SYSTEM_ENV_KEYS = [
   'NODE_PATH',
   'PLAYWRIGHT_BROWSERS_PATH',
 ];
+const INTERNAL_RUNTIME_TEMP_DIR_ENV = 'LOBU_INTERNAL_RUNTIME_TEMP_DIR';
 function pickSystemEnv(): Record<string, string | undefined> {
   const env: Record<string, string | undefined> = {};
   for (const key of SYSTEM_ENV_KEYS) {
@@ -152,6 +155,29 @@ const DEFAULT_OPTIONS: SubprocessExecutorOptions = {
   timeoutMs: 600000,
   maxOldSpaceSize: 512,
 };
+
+async function removeRuntimeTempDir(tempDir: string): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4) {
+        // Cleanup must never replace the connector's real result/error. This
+        // warning makes a persistent Windows file lock or host FS failure
+        // visible while preserving the execution outcome.
+        console.warn(
+          `[SubprocessExecutor] Failed to remove runtime temp directory ${tempDir}:`,
+          error
+        );
+        return;
+      }
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, 25 * (attempt + 1))
+      );
+    }
+  }
+}
 
 export class SubprocessExecutor implements SyncExecutor {
   private options: SubprocessExecutorOptions;
@@ -174,6 +200,10 @@ export class SubprocessExecutor implements SyncExecutor {
           `connector on a backend that provisions native dependencies.`
       );
     }
+    // The parent owns this directory so a timeout/crash SIGKILL cannot bypass
+    // cleanup in the child. The child also removes it on graceful completion;
+    // both paths use forceful recursive cleanup so the race is harmless.
+    const runtimeTempDir = await mkdtemp(join(tmpdir(), 'lobu-connector-child-'));
     return new Promise<ExecutorResult>((resolve, reject) => {
       let childRunnerPath = join(__dirname, 'child-runner.js');
       const childRunnerTsPath = join(__dirname, 'child-runner.ts');
@@ -207,7 +237,13 @@ export class SubprocessExecutor implements SyncExecutor {
       // Node subprocess execution is process isolation, not a security sandbox.
       // Node --experimental-permission flags intentionally NOT enabled — the
       // connector runtime isn't compatible. Revisit if that changes.
-      const env = { ...pickSystemEnv(), ...job.env } as NodeJS.ProcessEnv;
+      const env = {
+        ...pickSystemEnv(),
+        ...job.env,
+        // Set last: connector-controlled job.env must never redirect the
+        // child disconnect handler into deleting an arbitrary path.
+        [INTERNAL_RUNTIME_TEMP_DIR_ENV]: runtimeTempDir,
+      } as NodeJS.ProcessEnv;
       let child: ChildProcess;
       if (nixPackages.length > 0) {
         // Wrap in nix-shell so the connector's declared native tools are on
@@ -554,6 +590,7 @@ export class SubprocessExecutor implements SyncExecutor {
         {
           compiledCode,
           job,
+          runtimeTempDir,
         },
         (err) => {
           if (err) {
@@ -579,6 +616,6 @@ export class SubprocessExecutor implements SyncExecutor {
           }
         }
       );
-    });
+    }).finally(() => removeRuntimeTempDir(runtimeTempDir));
   }
 }

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -15,10 +15,10 @@
  * gateway, or OAuth, and passes under `docker run --network=none`.
  */
 
-import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import { extname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -26,7 +26,10 @@ import {
 	EXTERNAL_RUNTIME_DEPS,
 } from "../compile/index.js";
 import type { ExecutorJob } from "../executor/interface.js";
-import { registerConnectorRuntimeDependencyLoader } from "../executor/runtime-dependency-loader.js";
+import {
+	registerConnectorRuntimeDependencyLoader,
+	stageConnectorRuntimeDependencies,
+} from "../executor/runtime-dependency-loader.js";
 import { executeCompiledConnector } from "../executor/runtime.js";
 
 /**
@@ -37,6 +40,8 @@ import { executeCompiledConnector } from "../executor/runtime.js";
  */
 const SYNTHETIC_CONNECTOR_SOURCE = `
 import { ConnectorRuntime } from '@lobu/connector-sdk';
+const sharp = require('sharp');
+void sharp;
 
 export default class SelfCheckNoopConnector extends ConnectorRuntime {
   definition = {
@@ -123,29 +128,27 @@ const errMsg = (err: unknown): string =>
 	err instanceof Error ? err.message : String(err);
 
 /**
- * Write `content` to a temp file UNDER cwd, run `fn`, then remove it. Under cwd
- * (not the OS tmpdir) so the bundle's bare `@lobu/connector-sdk` import — left
- * externalized by the compiler — resolves via the runtime's `node_modules`,
- * the same reason `child-runner.ts` stages its module under cwd.
+ * Write `content` inside a private OS temp directory, stage the runtime package
+ * facade used by both ESM and CommonJS resolution, run `fn`, then remove the
+ * directory. This keeps startup independent of whether cwd is writable.
  */
-async function withCwdTempFile<T>(
+async function withRuntimeTempFile<T>(
 	ext: string,
 	content: string,
 	fn: (filePath: string) => Promise<T>,
 ): Promise<T> {
-	const filePath = join(
-		process.cwd(),
-		`.lobu-self-check-${process.pid}-${randomBytes(8).toString("hex")}${ext}`,
-	);
-	await writeFile(filePath, content, {
-		encoding: "utf-8",
-		flag: "wx",
-		mode: 0o600,
-	});
+	const tempDir = await mkdtemp(join(tmpdir(), "lobu-self-check-"));
+	const filePath = join(tempDir, `connector${ext}`);
 	try {
+		await stageConnectorRuntimeDependencies(tempDir);
+		await writeFile(filePath, content, {
+			encoding: "utf-8",
+			flag: "wx",
+			mode: 0o600,
+		});
 		return await fn(filePath);
 	} finally {
-		await rm(filePath, { force: true });
+		await rm(tempDir, { recursive: true, force: true });
 	}
 }
 
@@ -214,7 +217,7 @@ async function instantiateConnector(
 	compile: (filePath: string) => Promise<string>,
 ): Promise<DiscoveredConnector | null> {
 	const compiled = await compile(sourcePath);
-	return withCwdTempFile(".mjs", compiled, async (tmpFile) => {
+	return withRuntimeTempFile(".mjs", compiled, async (tmpFile) => {
 		const mod = (await import(pathToFileURL(tmpFile).href)) as Record<
 			string,
 			unknown
@@ -250,7 +253,7 @@ async function runSyntheticConnector(
 	compile: (filePath: string) => Promise<string>,
 ): Promise<void> {
 	// esbuild needs a file entry, so stage the inline source in a temp `.ts`.
-	const compiled = await withCwdTempFile(
+	const compiled = await withRuntimeTempFile(
 		".ts",
 		SYNTHETIC_CONNECTOR_SOURCE,
 		compile,

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -26,6 +26,7 @@ import {
 	EXTERNAL_RUNTIME_DEPS,
 } from "../compile/index.js";
 import type { ExecutorJob } from "../executor/interface.js";
+import { registerConnectorRuntimeDependencyLoader } from "../executor/runtime-dependency-loader.js";
 import { executeCompiledConnector } from "../executor/runtime.js";
 
 /**
@@ -288,6 +289,18 @@ async function runSyntheticConnector(
 }
 
 /**
+ * Fast boot gate for a worker that is about to advertise connector
+ * capabilities. It compiles and executes the synthetic connector through the
+ * real subprocess path, so a runtime that cannot load the SDK fails before its
+ * first poll can claim production work.
+ */
+export async function assertConnectorRuntimeLoadable(): Promise<void> {
+	registerConnectorRuntimeDependencyLoader();
+	const { compileConnectorFromFile } = createConnectorCompiler({ cacheMax: 1 });
+	await runSyntheticConnector(compileConnectorFromFile);
+}
+
+/**
  * Run the shared connector-runtime parity self-check. Each assertion is
  * recorded as a `{ ok }` entry rather than thrown; the top-level `ok` is the
  * AND of all of them.
@@ -295,6 +308,7 @@ async function runSyntheticConnector(
 export async function runConnectorRuntimeSelfCheck(
 	opts?: SelfCheckOptions,
 ): Promise<SelfCheckResult> {
+	registerConnectorRuntimeDependencyLoader();
 	const checks: SelfCheckEntry[] = [];
 	const require_ = createRequire(import.meta.url);
 
@@ -335,18 +349,12 @@ export async function runConnectorRuntimeSelfCheck(
 		() => import(pathToFileURL(sdkRequire().resolve("@lobu/core")).href),
 	);
 
-	// External runtime deps (native binaries + Playwright) must be installed
-	// wherever compiled connectors execute. `child-runner` stages the bundle UNDER cwd, so the
-	// bundle's bare imports of these externalized deps resolve from cwd's
-	// node_modules — not connector-worker's. Anchor the probe the same way (a
-	// require rooted at a cwd module path; the file need not exist for `.resolve`)
-	// so the check fails exactly where a real connector would, instead of falsely
-	// passing off connector-worker's hoisted dev tree.
-	const cwdRequire = createRequire(
-		pathToFileURL(join(process.cwd(), "self-check-resolver.mjs")).href,
-	);
+	// External runtime deps (native binaries + Playwright) are provided by the
+	// connector-worker package. Compiled modules may live under an unrelated cwd,
+	// but the registered loader deliberately resolves these imports from this
+	// package graph; probe the same anchor here.
 	for (const dep of EXTERNAL_RUNTIME_DEPS) {
-		await check(`resolve:${dep}`, () => cwdRequire.resolve(dep));
+		await check(`resolve:${dep}`, () => require_.resolve(dep));
 	}
 
 	const candidates =

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -108,6 +108,17 @@ pass "installed, bin present"
 RESOLVED="$("$LOBU_BIN" --version 2>&1 | tr -d '[:space:]')"
 if [ -n "$RESOLVED" ]; then pass "lobu --version -> $RESOLVED"; else fail "lobu --version produced nothing"; fi
 
+# Run from a directory that is deliberately outside the npm install tree. A
+# compiled connector must load the SDK from connector-worker's package graph,
+# not from an operator cwd that happens to contain a compatible node_modules.
+RUNTIME_CHECK_LOG="$WORK/connector-runtime-self-check.log"
+if (cd "$HOME" && "$LOBU_BIN" connector runtime-self-check --json >"$RUNTIME_CHECK_LOG" 2>&1); then
+  pass "connector runtime self-check from unrelated cwd"
+else
+  fail "connector runtime self-check from unrelated cwd"
+  tail -40 "$RUNTIME_CHECK_LOG" >&2
+fi
+
 # The worker bundle is the artifact that actually has to load under node.
 WORKER_BUNDLE="$INSTALL_DIR/node_modules/@lobu/worker/dist/index.bundle.mjs"
 if [ -f "$WORKER_BUNDLE" ]; then


### PR DESCRIPTION
## Summary

- resolve compiled connector SDK/native dependencies from the installed `@lobu/connector-worker` package graph instead of the operator's current working directory
- run a synthetic compile + subprocess execution before the daemon's first poll, so a broken runtime never advertises readiness or claims work
- advertise the exact installed CLI version instead of the hard-coded `1.0.0`
- point the CLI parity check at its packaged connector sources and run the published artifact smoke from an unrelated clean directory
- stage compiled modules in private OS temp directories with an adjacent runtime dependency facade that supports both ESM imports and CommonJS `require()`
- clean staged modules from both the child and parent paths, including timeout and parent-death exits

## Production evidence

- connection 464 is online and advertises `os.shell`, but `printf lobu-shell-ok` fails before Bash with `@lobu/connector-sdk` missing
- the same worker reports `app_version=1.0.0`, so current provenance cannot distinguish the installed artifact
- the original compiled child module was written under `process.cwd()`; Node therefore searched that unrelated directory's ancestors for bare imports
- Codex reproduced daemon boot failure from read-only `/sys` and CommonJS `require('sharp')` bypassing the ESM-only loader

## Test plan

- [x] Regression coverage: CLI daemon test asserts the package version reaches worker registration
- [x] Packaging gate: published `@lobu/cli` self-check runs outside its npm install tree
- [x] Boot gate exercises the real compiler + default `SubprocessExecutor` before polling
- [x] Read-only cwd regression runs from `/sys` with `NODE_PATH` removed and loads CommonJS `sharp`
- [x] Timeout and parent-death regressions assert the private runtime directory is removed
- [x] Codex Sol Ultra review: 93% bug-free confidence, zero bugs/blockers, final delta PASS
- [ ] GitHub CI (canonical full graph)

## Scope / safety

No database, public API, SDK contract, or approval-policy changes. Compiled code is written mode 0600 inside an OS-created private directory. The runtime package facade is restricted to the SDK plus the existing runtime-provided dependency allow-list, and both parent and child own cleanup paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved connector runtime compatibility when launched from different directories and environments.
  * Added startup validation to detect runtime dependency and loading issues before connector execution.
  * Improved support for SDK and external runtime dependencies, including native packages.
  * Connector execution now uses isolated temporary storage with more reliable cleanup.
  * Missing connector modules now produce clearer error messages.
  * Gateway connections now receive the installed CLI version for improved compatibility and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->