### PR TITLE
fix(worker): route os.shell through daemon builtin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1718,7 +1718,7 @@ jobs:
             echo "mac=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
           fi
-          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|scripts/test-headless-shell-package\.sh$|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
             echo "connector=true" >> "$GITHUB_OUTPUT"
           else
             echo "connector=false" >> "$GITHUB_OUTPUT"
@@ -1909,6 +1909,9 @@ jobs:
       - name: Build workspace packages (CLI + deps)
         if: steps.dist-cache.outputs.cache-hit != 'true'
         run: make build-packages
+
+      - name: Published worker tarball shell smoke (including restart)
+        run: ./scripts/test-headless-shell-package.sh
 
       - name: CLI runtime self-check (host)
         run: node packages/cli/bin/lobu.js connector runtime-self-check --json

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lobu:connectors:install": "bun run scripts/lobu/install-connectors.ts",
     "lobu:connectors:dry-run": "bun run scripts/lobu/dry-run-connector.ts",
     "build:mac-device-daemon": "./scripts/build-mac-device-daemon.sh",
-    "test:mac-device-daemon": "./scripts/test-mac-device-daemon-package.sh"
+    "test:mac-device-daemon": "./scripts/test-mac-device-daemon-package.sh",
+    "test:headless-shell-package": "./scripts/test-headless-shell-package.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -162,9 +162,9 @@ export interface ConnectorAgentToolingEnv {
 
 export interface ConnectorRuntimeInfo {
   /** Platforms this connector can run on. */
-  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-  /** Native bridge-owned execution. Absent means the normal worker runtime. */
-  execution?: 'bridge';
+  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'>;
+  /** Device-owned execution. Absent means the normal compiled worker runtime. */
+  execution?: 'bridge' | 'daemon_builtin';
   /**
    * Permission/auth scopes forwarded verbatim to the native platform adapter.
    * Optional — omit when the platform adapter needs no fine-grained scope list.

--- a/packages/connector-sdk/src/device-manifest.ts
+++ b/packages/connector-sdk/src/device-manifest.ts
@@ -2,6 +2,9 @@ import { createHash } from 'node:crypto';
 
 export type DeviceManifestSchema = Record<string, unknown>;
 
+/** Execution owner declared by a device-manifest wire artifact. */
+export type DeviceManifestExecution = 'bridge' | 'daemon_builtin';
+
 export interface DeviceConnectorManifest {
   key: string;
   version: string;
@@ -11,7 +14,7 @@ export interface DeviceConnectorManifest {
   required_capability: string;
   runtime: {
     platforms: string[];
-    execution?: 'bridge';
+    execution?: DeviceManifestExecution;
     scopes?: string[];
     nix?: { packages?: string[] } | null;
   };

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { executeRun } from '../daemon/executor.js';
+
+function stubClient() {
+  const completions: Array<Record<string, unknown>> = [];
+  return {
+    client: {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        completions.push(input);
+      },
+    },
+    completions,
+  };
+}
+
+describe('daemon-builtin os.shell', () => {
+  test('executes without compiled connector code or connector SDK resolution', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 464,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        connector_version: '0.2.0',
+        connector_manifest_hash: 'test-manifest-hash',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {
+          command: "printf 'lobu-shell-ok\\n'",
+          cwd: process.cwd(),
+        },
+      },
+      {},
+      { heartbeatIntervalMs: 5_000 }
+    );
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      run_id: 464,
+      worker_id: 'headless:test',
+      status: 'success',
+      action_output: {
+        stdout: 'lobu-shell-ok\n',
+        stderr: '',
+        exit_code: 0,
+        success: true,
+        timed_out: false,
+      },
+    });
+  });
+
+  test('fails closed when the declared built-in is not registered', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 465,
+        run_type: 'action',
+        connector_key: 'missing.builtin',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {},
+      },
+      {}
+    );
+
+    expect(result.error).toStartWith('operation_backend_unavailable:');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+
+  test('rejects a contradictory compiled payload', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 466,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        execution_backend: 'daemon_builtin',
+        compiled_code: 'must not execute',
+        action_key: 'run',
+        action_input: { command: 'exit 0' },
+      },
+      {}
+    );
+
+    expect(result.error).toContain('must not contain compiled_code');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+});

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -1,0 +1,44 @@
+import { runShellBuiltin } from './os-shell.js';
+
+export type DaemonBuiltinErrorCode =
+  | 'invalid_operation_input'
+  | 'operation_backend_unavailable'
+  | 'operation_execution_failed';
+
+export type DaemonBuiltinResult =
+  | { ok: true; output: Record<string, unknown> }
+  | { ok: false; code: DaemonBuiltinErrorCode; error: string };
+
+export async function executeDaemonBuiltin(params: {
+  connectorKey: string;
+  actionKey: string;
+  input: Record<string, unknown>;
+}): Promise<DaemonBuiltinResult> {
+  if (params.connectorKey !== 'os.shell' || params.actionKey !== 'run') {
+    return {
+      ok: false,
+      code: 'operation_backend_unavailable',
+      error: `No daemon built-in is registered for '${params.connectorKey}/${params.actionKey}'`,
+    };
+  }
+
+  try {
+    const output = await runShellBuiltin(params.input);
+    if (!output.success) {
+      return {
+        ok: false,
+        code: 'operation_execution_failed',
+        error: output.timed_out
+          ? `Shell command timed out after ${output.duration_ms}ms`
+          : `Shell command exited with code ${output.exit_code}`,
+      };
+    }
+    return { ok: true, output: { ...output } };
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'invalid_operation_input',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -1,0 +1,134 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
+
+export interface ShellRunOutput {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  success: boolean;
+  timed_out: boolean;
+  duration_ms: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_TIMEOUT_MS = 300_000;
+const TERMINATION_GRACE_MS = 3_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const TRUNCATED_MARKER = '\n... (output truncated)';
+
+function appendCapped(current: string, chunk: string): string {
+  if (current.endsWith(TRUNCATED_MARKER)) return current;
+  const next = current + chunk;
+  if (Buffer.byteLength(next, 'utf8') <= MAX_OUTPUT_BYTES) return next;
+  return Buffer.from(next, 'utf8').subarray(0, MAX_OUTPUT_BYTES).toString('utf8') + TRUNCATED_MARKER;
+}
+
+function readTimeout(value: unknown): number {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(value) || Number(value) < 100 || Number(value) > MAX_TIMEOUT_MS) {
+    throw new Error(`timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`);
+  }
+  return Number(value);
+}
+
+export async function runShellBuiltin(input: Record<string, unknown>): Promise<ShellRunOutput> {
+  const command = typeof input.command === 'string' ? input.command.trim() : '';
+  if (!command) throw new Error('command is required');
+  if (command.length > 20_000) throw new Error('command must contain at most 20000 characters');
+
+  const cwdValue = input.cwd;
+  const cwd = cwdValue === undefined ? homedir() : String(cwdValue);
+  if (!isAbsolute(cwd) || !existsSync(cwd)) {
+    throw new Error(`cwd must be an existing absolute path (got '${cwd}')`);
+  }
+  const timeoutMs = readTimeout(input.timeout_ms);
+  const stdin = input.stdin;
+  if (stdin !== undefined && typeof stdin !== 'string') throw new Error('stdin must be a string');
+  if (typeof stdin === 'string' && stdin.length > 1_000_000) {
+    throw new Error('stdin must contain at most 1000000 characters');
+  }
+
+  const startedAt = Date.now();
+  return await new Promise<ShellRunOutput>((resolve) => {
+    const child = spawn('bash', ['-lc', command], {
+      cwd,
+      env: { ...process.env, LC_ALL: 'C' },
+      detached: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
+      try {
+        if (child.pid != null) {
+          process.kill(-child.pid, signal);
+          return;
+        }
+      } catch {
+        // The process group may have already exited or the platform may not
+        // support negative process ids. Fall back to the direct child.
+      }
+      try {
+        child.kill(signal);
+      } catch {
+        // Exit raced cleanup; close/error still owns settlement.
+      }
+    };
+
+    const finish = (exitCode: number): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      resolve({
+        stdout,
+        stderr,
+        exit_code: exitCode,
+        success: !timedOut && exitCode === 0,
+        timed_out: timedOut,
+        duration_ms: Date.now() - startedAt,
+      });
+    };
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout = appendCapped(stdout, chunk);
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr = appendCapped(stderr, chunk);
+    });
+    child.stdin.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EPIPE') stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
+    });
+    child.stdin.end(stdin);
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      killOwnedProcessGroup('SIGTERM');
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        killOwnedProcessGroup('SIGKILL');
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish(child.exitCode ?? -1);
+      }, TERMINATION_GRACE_MS);
+    }, timeoutMs);
+
+    child.on('close', (code, signal) => {
+      finish(code ?? (signal ? -1 : 0));
+    });
+    child.on('error', (error) => {
+      stderr = appendCapped(stderr, `spawn error: ${error.message}`);
+      finish(-1);
+    });
+  });
+}

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -2,22 +2,23 @@
  * Device manifests the connector-worker daemon declares on poll, keyed by
  * platform. A headless device (server/VM/pod) advertises the os.shell
  * connector so an org can create a connection pinned to it and run shell
- * commands (executed by the bundled os.shell connector via bash -lc).
+ * commands through the daemon's built-in shell backend.
  */
 
 /**
  * os.shell manifest for headless platforms. Mirrors the macOS manifest's
  * run action (packages/owletto/apps/mac/.../os_shell.json) but targets
- * linux, where the connector-worker daemon (not a native bridge) serves it.
+ * headless workers, where the connector-worker daemon (not a native bridge or
+ * dynamically compiled connector) serves it.
  */
 export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
   key: 'os.shell',
-  version: '0.1.0',
+  version: '0.2.0',
   name: 'Shell',
   description:
     'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
   required_capability: 'os.shell',
-  runtime: { platforms: ['headless'] },
+  runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
   auth_schema: { methods: [{ type: 'none' }] },
   feeds_schema: {},
   actions_schema: {

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -12,6 +12,7 @@ import { batchGenerateEmbeddings } from '../embeddings.js';
 import { executeCompiledConnector } from '../executor/runtime.js';
 import { SubprocessExecutor } from '../executor/subprocess.js';
 import { executeAutomationRun } from './automation.js';
+import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
@@ -145,6 +146,16 @@ export async function executeRun(
       await reportTerminalFailure(client, job, message, 'error_message');
     } catch (error) {
       log.info('[executor] Failed to reject native bridge run:', error);
+    }
+    return { itemsCollected: 0, error: message };
+  }
+  if (job.execution_backend === 'daemon_builtin' && job.run_type !== 'action') {
+    const message =
+      'operation_backend_unavailable: daemon_builtin currently supports action runs only';
+    try {
+      await reportTerminalFailure(client, job, message, 'error_message');
+    } catch (error) {
+      log.info('[executor] Failed to reject invalid daemon built-in run:', error);
     }
     return { itemsCollected: 0, error: message };
   }
@@ -459,6 +470,10 @@ async function executeActionRun(
     throw new Error('Invalid action run: missing run_id, connector_key, or action_key');
   }
 
+  if (job.execution_backend === 'daemon_builtin') {
+    return await executeDaemonBuiltinActionRun(client, job, cfg);
+  }
+
   const codeResult = await resolveJobCode(job);
   if (!codeResult.ok) {
     const errorMessage = `Action run ${run_id} (${connector_key}): ${codeResult.error}`;
@@ -553,6 +568,64 @@ async function executeActionRun(
     });
 
     return { itemsCollected: 0, error: errorMessage };
+  } finally {
+    clearInterval(heartbeatInterval);
+  }
+}
+
+async function executeDaemonBuiltinActionRun(
+  client: ExecutorClient,
+  job: PollResponse,
+  cfg: ExecutorConfig
+): Promise<{ itemsCollected: number; error?: string }> {
+  const { run_id, connector_key, action_key, action_input } = job;
+  if (!run_id || !connector_key || !action_key) {
+    throw new Error('Invalid daemon built-in action: missing run_id, connector_key, or action_key');
+  }
+  if (job.compiled_code) {
+    const message =
+      'operation_backend_unavailable: daemon_builtin payload must not contain compiled_code';
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: message,
+    });
+    return { itemsCollected: 0, error: message };
+  }
+
+  const heartbeatInterval = setInterval(async () => {
+    try {
+      await client.heartbeat(run_id);
+    } catch (error) {
+      log.debug('[executor] Daemon built-in heartbeat failed:', error);
+    }
+  }, cfg.heartbeatIntervalMs);
+
+  try {
+    const result = await executeDaemonBuiltin({
+      connectorKey: connector_key,
+      actionKey: action_key,
+      input: (action_input ?? {}) as Record<string, unknown>,
+    });
+    if (!result.ok) {
+      const message = `${result.code}: ${result.error}`;
+      await client.completeAction({
+        run_id,
+        worker_id: client.id,
+        status: 'failed',
+        error_message: message,
+      });
+      return { itemsCollected: 0, error: message };
+    }
+
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'success',
+      action_output: result.output,
+    });
+    return { itemsCollected: 0 };
   } finally {
     clearInterval(heartbeatInterval);
   }

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -11,6 +11,7 @@ import { rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { EventEnvelope, SyncResult } from '@lobu/connector-sdk';
+import { EXTERNAL_RUNTIME_DEPS } from '../runtime-deps.js';
 import { extractHttpStatus } from './http-status.js';
 import type { ExecutorJob, ExecutorResult } from './interface.js';
 
@@ -540,11 +541,20 @@ async function main() {
       if (error.code === 'ERR_MODULE_NOT_FOUND') {
         const pkgMatch = error.message.match(/Cannot find package '([^']+)'/);
         const pkg = pkgMatch?.[1] ?? 'unknown';
-        error.message =
-          `Connector requires '${pkg}' but it's not installed in the runtime image. ` +
-          `'${pkg}' is declared as an external dependency in EXTERNAL_RUNTIME_DEPS ` +
-          `(packages/connector-worker/src/runtime-deps.ts). ` +
-          `Add it to packages/connector-worker/package.json and rebuild the runtime image.`;
+        if (pkg === '@lobu/connector-sdk') {
+          error.message =
+            "The compiled-connector runtime cannot resolve '@lobu/connector-sdk'. " +
+            'The worker package declares it as a required workspace dependency; rebuild and redeploy ' +
+            'the packaged worker instead of modifying node_modules on the host.';
+        } else if ((EXTERNAL_RUNTIME_DEPS as readonly string[]).includes(pkg)) {
+          error.message =
+            `Connector requires '${pkg}' but it is not installed in the runtime image. ` +
+            `'${pkg}' is declared in EXTERNAL_RUNTIME_DEPS; rebuild the packaged runtime.`;
+        } else {
+          error.message =
+            `Compiled connector could not resolve '${pkg}'. ` +
+            'The artifact/runtime dependency contract is incompatible; rebuild the connector artifact and worker image.';
+        }
       }
       await sendIPC({
         type: 'error',

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -25,6 +25,7 @@ import {
 	createConnectorCompiler,
 	EXTERNAL_RUNTIME_DEPS,
 } from "../compile/index.js";
+import { executeDaemonBuiltin } from "../daemon/builtins/index.js";
 import type { ExecutorJob } from "../executor/interface.js";
 import { executeCompiledConnector } from "../executor/runtime.js";
 
@@ -395,6 +396,26 @@ export async function runConnectorRuntimeSelfCheck(
 	await check("synthetic-connector-subprocess-execute", async () => {
 		await runSyntheticConnector(compileConnectorFromFile);
 		return "compiled + executed via default SubprocessExecutor; emitted >=1 event.";
+	});
+
+	// Recovery/control primitives must remain executable even when the dynamic
+	// connector compiler or its npm resolution graph is unhealthy. This call is
+	// intentionally direct and therefore proves the packaged dist contains the
+	// daemon-owned os.shell backend.
+	await check("daemon-builtin:os.shell/run", async () => {
+		const result = await executeDaemonBuiltin({
+			connectorKey: "os.shell",
+			actionKey: "run",
+			input: { command: "printf 'lobu-shell-self-check\\n'", cwd: process.cwd() },
+		});
+		if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+		if (result.output.stdout !== "lobu-shell-self-check\n") {
+			throw new Error(`Unexpected stdout: ${JSON.stringify(result.output.stdout)}.`);
+		}
+		if (result.output.stderr !== "" || result.output.exit_code !== 0) {
+			throw new Error(`Unexpected shell result: ${JSON.stringify(result.output)}.`);
+		}
+		return "executed from packaged worker code without connector compilation.";
 	});
 
 	return {

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -101,7 +101,11 @@ export const OAuthCredentialsSchema = Type.Object({
 // ── poll ────────────────────────────────────────────────────────────────────
 
 /** Server-selected execution path for an exact pinned connector artifact. */
-export const ExecutionBackendSchema = Type.Literal("native_bridge");
+export const ExecutionBackendSchema = Type.Union([
+  Type.Literal("compiled_connector"),
+  Type.Literal("daemon_builtin"),
+  Type.Literal("native_bridge"),
+]);
 
 /** `POST /api/workers/poll` request body. */
 export const PollRequestSchema = Type.Object({

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -15,6 +15,7 @@ import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { createAuthProfile } from "../../utils/auth-profiles";
+import { deviceManifestHash, type DeviceConnectorManifest } from "../../worker-api/device-manifests";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestConnection,
@@ -107,6 +108,62 @@ describe("connections.test device availability", () => {
 		expect(result.device_online).toBe(false);
 		expect(result.retryable).toBe(true);
 		expect(String(result.message)).toMatch(/offline/i);
+	});
+
+	it("reports an online legacy headless shell as backend unavailable", async () => {
+		const sql = getTestDb();
+		const key = "os.shell";
+		const version = "0.1.0";
+		await createTestConnectorDefinition({
+			key,
+			name: "Shell",
+			version,
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "none" }] },
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET runtime = ${sql.json({ platforms: ["headless"] })},
+			    required_capability = 'os.shell'
+			WHERE organization_id = ${orgId} AND key = ${key}
+		`;
+		const manifest = {
+			key,
+			version,
+			name: "Shell",
+			required_capability: "os.shell",
+			runtime: { platforms: ["headless"] },
+			auth_schema: { methods: [{ type: "none" }] },
+			feeds_schema: {},
+			actions_schema: { run: { key: "run", name: "Run" } },
+		};
+		const manifestHash = deviceManifestHash(manifest as DeviceConnectorManifest);
+		const [device] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, connector_manifests,
+				label, organization_id, last_seen_at
+			) VALUES (
+				${userId}, ${`headless-${Date.now()}`}, 'headless', ${sql.json(["os.shell"])},
+				${sql.json({
+					[key]: { manifest, manifest_hash: manifestHash, received_at: new Date().toISOString() },
+				})},
+				'Legacy Headless', ${orgId}, NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: key,
+			created_by: userId,
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${device.id}::uuid WHERE id = ${conn.id}`;
+
+		const result = await test(conn.id);
+		expect(result.status).toBe("warning");
+		expect(result.device_online).toBe(true);
+		expect(result.error_code).toBe("UPSTREAM_UNAVAILABLE");
+		expect(String(result.message)).toMatch(/does not declare a supported execution backend/i);
 	});
 
 	it("does not let valid OAuth credentials mask an offline selected device", async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1193,7 +1193,7 @@ describe('device connector manifests', () => {
         connector_version, action_key, action_input, approval_status, status,
         created_at
       ) VALUES (
-        ${orgId}, 'action', ${connection.id}, 'os.shell', '0.1.0', 'run',
+        ${orgId}, 'action', ${connection.id}, 'os.shell', '0.2.0', 'run',
         ${sql.json({ command: 'hostname' })}, 'auto', 'pending', NOW()
       )
       RETURNING id
@@ -1210,9 +1210,8 @@ describe('device connector manifests', () => {
     const body = (await claimingPoll.json()) as Record<string, unknown>;
     expect(body.run_id).toBe(Number(run.id));
     expect(body.connector_key).toBe('os.shell');
-    expect(body.execution_backend).toBeUndefined();
-    expect(typeof body.compiled_code).toBe('string');
-    expect((body.compiled_code as string).length).toBeGreaterThan(0);
+    expect(body.execution_backend).toBe('daemon_builtin');
+    expect(body.compiled_code).toBeUndefined();
   });
 
   it('drops a manifest that still declares removed entityLinks rules', async () => {

--- a/packages/server/src/__tests__/unit/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/device-feed-read.test.ts
@@ -96,6 +96,39 @@ describe('device manifest feed operations', () => {
   });
 });
 
+describe('headless device manifest backend contract', () => {
+  const manifest = {
+    key: 'os.shell',
+    version: '0.2.0',
+    name: 'Shell',
+    required_capability: 'os.shell',
+    runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
+    feeds_schema: {},
+    actions_schema: { run: { key: 'run', name: 'Run' } },
+  };
+
+  it('accepts the explicit daemon built-in backend', () => {
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [manifest],
+    }).accepted).toBe(true);
+  });
+
+  it('rejects legacy or unknown headless execution before advertisement', () => {
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [{ ...manifest, runtime: { platforms: ['headless'] } }],
+    }).accepted).toBe(false);
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [{ ...manifest, runtime: { platforms: ['headless'], execution: 'mystery' } }],
+    }).accepted).toBe(false);
+  });
+});
+
 describe('WhatsApp Browser manifest capability', () => {
   const chromeManifest = {
     key: 'whatsapp.local',
@@ -173,6 +206,24 @@ describe('device connector readiness', () => {
     expect(classifyDeviceConnectorReadiness(source(['device-1'], ['device-1'])).state).toBe(
       'ready'
     );
+  });
+
+  it('does not report a legacy headless manifest ready without an explicit backend', () => {
+    const headless = {
+      ...source(['device-1'], ['device-1']),
+      sourcePath: 'device-manifest://headless/os.shell@0.1.0',
+      metadata: { name: 'Shell', runtime: { platforms: ['headless'] } },
+    } as DeviceConnectorSource;
+    expect(classifyDeviceConnectorReadiness(headless).state).toBe('backend_unavailable');
+    expect(
+      classifyDeviceConnectorReadiness({
+        ...headless,
+        metadata: {
+          name: 'Shell',
+          runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
+        },
+      }).state
+    ).toBe('ready');
   });
 
   it('derives offline when the selected manifest has no online advertiser', () => {

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -103,6 +103,7 @@ interface FeedHealthSemanticsInput {
   device_connector_readiness?:
     | "ready"
     | "setup_required"
+    | "backend_unavailable"
     | "device_offline"
     | null;
 }
@@ -153,7 +154,11 @@ function deviceOffline(input: FeedHealthSemanticsInput): boolean {
 }
 
 function setupRequired(input: FeedHealthSemanticsInput): boolean {
-  return !pinnedDeviceOffline(input) && input.device_connector_readiness === "setup_required";
+  return (
+    !pinnedDeviceOffline(input) &&
+    (input.device_connector_readiness === "setup_required" ||
+      input.device_connector_readiness === "backend_unavailable")
+  );
 }
 
 /** The most recent attempt failed, or a failure episode is underway. */

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -10,6 +10,11 @@ import {
   describeDeviceLastSeen,
 } from '../../../../utils/device-liveness';
 import {
+  describeDeviceConnectorBackendUnavailable,
+  findDeviceConnectorReadiness,
+  loadDeviceConnectorReadiness,
+} from '../../../../worker-api/device-connector-readiness';
+import {
   getAuthProfileById,
   getBrowserSessionReadiness,
   normalizeAuthValues,
@@ -182,13 +187,15 @@ export async function handleTest(
            c.status,
            c.device_worker_id,
            dw.label AS device_label,
+           dw.user_id AS device_owner_user_id,
            dw.last_seen_at AS device_last_seen_at,
            COALESCE(dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}), false) AS device_online,
-           cd.auth_schema
+           cd.auth_schema,
+           cd.version AS connector_version
     FROM connections c
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     LEFT JOIN LATERAL (
-      SELECT auth_schema
+      SELECT auth_schema, version
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -204,6 +211,29 @@ export async function handleTest(
   }
 
   const conn = rows[0] as any;
+  if (conn.device_worker_id && conn.device_owner_user_id && conn.connector_version) {
+    const readiness = findDeviceConnectorReadiness(
+      await loadDeviceConnectorReadiness({
+        sql,
+        targets: [{
+          ownerUserId: conn.device_owner_user_id,
+          connectorKey: conn.connector_key,
+          connectorVersion: conn.connector_version,
+          deviceWorkerId: conn.device_worker_id,
+        }],
+      }),
+      {
+        ownerUserId: conn.device_owner_user_id,
+        connectorKey: conn.connector_key,
+        connectorVersion: conn.connector_version,
+        deviceWorkerId: conn.device_worker_id,
+      }
+    );
+    if (readiness?.state === 'backend_unavailable') {
+      conn.device_backend_unavailable_reason =
+        describeDeviceConnectorBackendUnavailable(readiness);
+    }
+  }
   const withDeviceHealth = (result: ConnectionTestResult): ConnectionTestResult =>
     applySelectedDeviceHealth(conn, result);
 
@@ -379,6 +409,15 @@ export async function handleTest(
   // mask an offline device behind a generic "requires no auth profile" ok.
   if (conn.device_worker_id) {
     const deviceName = conn.device_label || 'paired device';
+    if (conn.device_backend_unavailable_reason) {
+      return {
+        action: 'test',
+        status: 'warning',
+        message: conn.device_backend_unavailable_reason,
+        device_online: true,
+        ...testErrorFields('UPSTREAM_UNAVAILABLE'),
+      };
+    }
     return conn.device_online
       ? {
           action: 'test',
@@ -433,10 +472,20 @@ function applySelectedDeviceHealth(
     device_online?: unknown;
     device_label?: unknown;
     device_last_seen_at?: Date | string | null;
+    device_backend_unavailable_reason?: unknown;
   },
   result: ConnectionTestResult
 ): ConnectionTestResult {
   if (!conn.device_worker_id) return result;
+  if (typeof conn.device_backend_unavailable_reason === 'string') {
+    return {
+      ...result,
+      status: result.status === 'error' ? 'error' : 'warning',
+      message: `${result.message}; ${conn.device_backend_unavailable_reason}`,
+      device_online: true,
+      ...(result.error_code ? {} : testErrorFields('UPSTREAM_UNAVAILABLE')),
+    };
+  }
   if (conn.device_online === true) {
     return { ...result, device_online: true };
   }

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -83,6 +83,7 @@ import {
   runStatusLiteral,
 } from '../../utils/run-statuses';
 import {
+  describeDeviceConnectorBackendUnavailable,
   describeDeviceConnectorSetupRequired,
   findDeviceConnectorReadiness,
   loadDeviceConnectorReadiness,
@@ -513,6 +514,8 @@ async function handleListFeeds(
       attention: semantics.attention,
       ...(connectorReadiness?.state === 'setup_required'
         ? { attention_reason: describeDeviceConnectorSetupRequired(connectorReadiness) }
+        : connectorReadiness?.state === 'backend_unavailable'
+          ? { attention_reason: describeDeviceConnectorBackendUnavailable(connectorReadiness) }
         : {}),
     };
   });

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -29,6 +29,7 @@ import {
 import { buildConnectionsUrl } from "../../../../utils/url-builder";
 import {
 	describeDeviceConnectorSetupRequired,
+	describeDeviceConnectorBackendUnavailable,
 	findDeviceConnectorReadiness,
 	loadDeviceConnectorReadiness,
 	type DeviceConnectorReadiness,
@@ -119,6 +120,14 @@ function executionTargetFromRow(
 			reason: describeDeviceConnectorSetupRequired(deviceReadiness),
 		};
 	}
+	if (deviceReadiness?.state === "backend_unavailable") {
+		return {
+			...base,
+			status: "backend_unavailable",
+			executable: false,
+			reason: describeDeviceConnectorBackendUnavailable(deviceReadiness),
+		};
+	}
 	if (deviceReadiness?.state === "ready") {
 		return {
 			...base,
@@ -197,6 +206,9 @@ function operationReadinessReason(
 	}
 	if (readiness === "setup_required") {
 		return "Connector setup is incomplete on every otherwise-available device.";
+	}
+	if (readiness === "backend_unavailable") {
+		return "Every otherwise-available device is missing the connector's declared execution backend.";
 	}
 	if (readiness === "scope_upgrade_required") {
 		return "This operation needs OAuth scopes the connection has not granted. Reauthorize to grant them.";
@@ -416,7 +428,11 @@ function buildOperationNextAction(args: {
 	}
 	return {
 		action:
-			readiness === "device_offline" ? "bring_device_online" : "open_setup",
+			readiness === "device_offline"
+				? "bring_device_online"
+				: readiness === "backend_unavailable"
+					? "update_device_daemon"
+					: "open_setup",
 		manual: true,
 		...(viewUrl ? { view_url: viewUrl } : {}),
 	};

--- a/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
+++ b/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
@@ -103,10 +103,13 @@ describe('selected connector execution backend', () => {
     })).toEqual({ manifestBacked: false });
   });
 
-  test('active exact non-bridge definition wins over retained bridge authorization', () => {
+  test('active exact unsupported definition wins over retained bridge authorization', () => {
     expect(classify({
       definition: { ...definition, runtime: { platforms: ['macos'], execution: 'compiled' } },
-    })).toEqual({ manifestBacked: true, inconsistency: 'active exact definition is not bridge execution' });
+    })).toEqual({
+      manifestBacked: true,
+      inconsistency: 'active exact definition declares an unsupported execution backend',
+    });
   });
 
   test('rejects a bridge artifact that is not authorized by the claiming device', () => {
@@ -162,6 +165,8 @@ describe('device manifests served by connector-worker rather than a bridge', () 
     key: headless.key,
     version: headless.version,
     name: headless.name,
+    description: headless.description,
+    faviconDomain: headless.favicon_domain,
     requiredCapability: headless.required_capability,
     runtime: headless.runtime,
     authSchema: headless.auth_schema,
@@ -189,21 +194,26 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         connectorVersion: headless.version,
         manifestHash: headlessHash,
         sourcePath: headlessSourcePath,
+        runtimeExecution: 'daemon_builtin',
       }],
       expectedPlatform: 'headless',
       ...overrides,
     });
   }
 
-  test('the shipped headless os.shell manifest declares no bridge execution', () => {
-    expect(headless.runtime).not.toHaveProperty('execution');
+  test('the shipped headless os.shell manifest declares daemon-owned execution', () => {
+    expect(headless.runtime.execution).toBe('daemon_builtin');
   });
 
-  test('classifies headless os.shell as manifest-backed but not native_bridge', () => {
-    expect(classifyHeadless()).toEqual({ manifestBacked: true });
+  test('classifies headless os.shell as an attested daemon built-in', () => {
+    expect(classifyHeadless()).toEqual({
+      manifestBacked: true,
+      backend: 'daemon_builtin',
+      manifestHash: headlessHash,
+    });
   });
 
-  test('stays non-bridge even when the device authorization claims bridge execution', () => {
+  test('rejects an authorization that claims a different backend', () => {
     expect(classifyHeadless({
       authorizations: [{
         connectorKey: headless.key,
@@ -212,7 +222,7 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         sourcePath: headlessSourcePath,
         runtimeExecution: 'bridge',
       }],
-    })).toEqual({ manifestBacked: true });
+    }).inconsistency).toContain('different execution backend');
   });
 });
 
@@ -221,13 +231,13 @@ describe('deviceExecutesConnectorNatively', () => {
     isUserScopedWorker: true,
     hasStoredCompiledCode: false,
     gatewayHasLocalSource: true,
-    isNativeBridgeRun: false,
+    isDeviceOwnedRun: false,
     manifestBacked: false,
     deviceAdvertisesRequiredCapability: false,
   };
 
   test('a native-bridge run needs no bundle', () => {
-    expect(deviceExecutesConnectorNatively({ ...base, isNativeBridgeRun: true })).toBe(true);
+    expect(deviceExecutesConnectorNatively({ ...base, isDeviceOwnedRun: true })).toBe(true);
   });
 
   test('manifest-backed alone does not mean native execution', () => {
@@ -280,7 +290,7 @@ describe('deviceExecutesConnectorNatively', () => {
     expect(
       deviceExecutesConnectorNatively({
         ...base,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
         hasStoredCompiledCode: true,
       })
     ).toBe(false);
@@ -291,7 +301,7 @@ describe('deviceExecutesConnectorNatively', () => {
       deviceExecutesConnectorNatively({
         ...base,
         isUserScopedWorker: false,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
       })
     ).toBe(false);
   });

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -31,8 +31,10 @@ export interface ConnectorMetadata {
   openapiConfig?: Record<string, unknown> | null;
   requiredCapability?: string | null;
   runtime?: {
-    platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-    execution?: 'bridge';
+    platforms: Array<
+      'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'
+    >;
+    execution?: 'bridge' | 'daemon_builtin';
     scopes?: string[];
   } | null;
   /**

--- a/packages/server/src/utils/connector-execution-backend.ts
+++ b/packages/server/src/utils/connector-execution-backend.ts
@@ -1,6 +1,7 @@
 import { deviceManifestHash, type DeviceConnectorManifest } from '@lobu/connector-sdk';
+import type { ExecutionBackend } from '@lobu/core/contracts/worker/protocol';
 
-export type SelectedConnectorExecutionBackend = 'native_bridge';
+export type SelectedConnectorExecutionBackend = ExecutionBackend;
 
 export interface SelectedConnectorArtifact {
   sourcePath: string | null | undefined;
@@ -41,9 +42,10 @@ export interface SelectedConnectorExecution {
 }
 
 /**
- * Classify the exact artifact selected by the poll query. A bridge marker is
- * emitted only when the selected artifact is hash-attested by this device and
- * its canonical definition is bridge-owned. The artifact source path is part
+ * Classify the exact artifact selected by the poll query. A device-owned
+ * backend marker is emitted only when the selected artifact is hash-attested
+ * by this device and its canonical definition declares that backend. The
+ * artifact source path is part
  * of the authorization, so an organization override cannot silently replace a
  * shared bridge artifact with compiled code or another device's manifest.
  */
@@ -57,7 +59,11 @@ export function classifySelectedConnectorExecution(params: {
 }): SelectedConnectorExecution {
   const manifestBacked = isManifestArtifact(params.artifact);
   const definitionRuntime = asRecord(params.definition?.runtime);
-  const definitionBridge = definitionRuntime?.execution === 'bridge';
+  const definitionExecution = definitionRuntime?.execution;
+  const definitionDeviceExecution =
+    definitionExecution === 'bridge' || definitionExecution === 'daemon_builtin'
+      ? definitionExecution
+      : undefined;
   const definitionExecutionDeclared =
     definitionRuntime !== null && Object.hasOwn(definitionRuntime, 'execution');
   const authorization = params.authorizations.find(
@@ -67,34 +73,37 @@ export function classifySelectedConnectorExecution(params: {
       entry.manifestHash === params.artifact.manifestHash &&
       entry.sourcePath === params.artifact.sourcePath,
   );
-  const authorizedBridge = authorization?.runtimeExecution === 'bridge';
+  const authorizedDeviceExecution = authorization?.runtimeExecution;
   // An active exact definition is authoritative. Retained authorization may
   // only select a historical pinned version when no exact definition exists.
   // Legacy metadata-only definitions remain ordinary manifest-backed device
-  // work; an explicit non-bridge execution value is a contradictory artifact
+  // work; an explicit unsupported execution value is a contradictory artifact
   // selection and must terminalize the already-claimed run.
-  if (params.definition && !definitionBridge) {
+  if (params.definition && !definitionDeviceExecution) {
     return manifestBacked && definitionExecutionDeclared
       ? {
           manifestBacked,
-          inconsistency: 'active exact definition is not bridge execution',
+          inconsistency: 'active exact definition declares an unsupported execution backend',
         }
       : { manifestBacked };
   }
-  const bridgeCandidate = definitionBridge || authorizedBridge;
+  const deviceExecution = definitionDeviceExecution ?? authorizedDeviceExecution;
 
-  if (!bridgeCandidate) return { manifestBacked };
+  if (!deviceExecution) return { manifestBacked };
   if (!params.definition && !authorization) {
-    return { manifestBacked, inconsistency: 'bridge artifact has no canonical definition or manifest authorization' };
+    return { manifestBacked, inconsistency: 'device-owned artifact has no canonical definition or manifest authorization' };
   }
   if (!manifestBacked) {
-    return { manifestBacked, inconsistency: 'bridge-marked definition selected a non-manifest artifact' };
+    return { manifestBacked, inconsistency: 'device-owned definition selected a non-manifest artifact' };
   }
   if (params.artifact.compiledCode || params.artifact.compileConfigHash || params.artifact.hasSourceCode) {
-    return { manifestBacked, inconsistency: 'bridge-marked artifact contains compiled or source code' };
+    return { manifestBacked, inconsistency: 'device-owned artifact contains compiled or source code' };
   }
   if (!authorization) {
-    return { manifestBacked, inconsistency: 'selected bridge artifact is not authorized by the claiming device' };
+    return { manifestBacked, inconsistency: 'selected device-owned artifact is not authorized by the claiming device' };
+  }
+  if (authorization.runtimeExecution !== deviceExecution) {
+    return { manifestBacked, inconsistency: 'claiming device advertised a different execution backend' };
   }
   const parsedSource = parseManifestSourcePath(params.artifact.sourcePath);
   if (!parsedSource) {
@@ -123,7 +132,7 @@ export function classifySelectedConnectorExecution(params: {
   // historical pinned version, the validated device manifest is the canonical
   // definition retained by the authorization and the same hash check has
   // already happened during manifest reconciliation.
-  if (params.definition && definitionBridge) {
+  if (params.definition && definitionDeviceExecution) {
     const hashes = definitionManifestHashes(params.definition, definitionRuntime!);
     if (
       !hashes.has(params.artifact.manifestHash) &&
@@ -134,7 +143,11 @@ export function classifySelectedConnectorExecution(params: {
     }
   }
 
-  return { manifestBacked, backend: 'native_bridge', manifestHash: params.artifact.manifestHash };
+  return {
+    manifestBacked,
+    backend: deviceExecution === 'bridge' ? 'native_bridge' : 'daemon_builtin',
+    manifestHash: params.artifact.manifestHash,
+  };
 }
 
 /**
@@ -151,14 +164,14 @@ export function deviceExecutesConnectorNatively(params: {
   isUserScopedWorker: boolean;
   hasStoredCompiledCode: boolean;
   gatewayHasLocalSource: boolean;
-  isNativeBridgeRun: boolean;
+  isDeviceOwnedRun: boolean;
   manifestBacked: boolean;
   deviceAdvertisesRequiredCapability: boolean;
 }): boolean {
   return (
     params.isUserScopedWorker &&
     !params.hasStoredCompiledCode &&
-    (params.isNativeBridgeRun ||
+    (params.isDeviceOwnedRun ||
       (!params.gatewayHasLocalSource &&
         (params.manifestBacked || params.deviceAdvertisesRequiredCapability)))
   );

--- a/packages/server/src/worker-api/device-connector-readiness.ts
+++ b/packages/server/src/worker-api/device-connector-readiness.ts
@@ -15,6 +15,7 @@ import {
 export type DeviceConnectorReadinessState =
   | 'ready'
   | 'setup_required'
+  | 'backend_unavailable'
   | 'device_offline';
 
 export interface DeviceConnectorReadiness {
@@ -51,9 +52,10 @@ export function classifyDeviceConnectorReadiness(
   source: DeviceConnectorSource,
   deviceWorkerId?: string | null
 ): DeviceConnectorReadiness {
+  const backendReady = deviceManifestBackendReady(source);
   if (deviceWorkerId) {
     if (source.onlineAdvertiserDeviceIds.includes(deviceWorkerId)) {
-      return { state: 'ready', source };
+      return { state: backendReady ? 'ready' : 'backend_unavailable', source };
     }
     if (source.onlineManifestDeviceIds.includes(deviceWorkerId)) {
       return { state: 'setup_required', source };
@@ -61,12 +63,24 @@ export function classifyDeviceConnectorReadiness(
     return { state: 'device_offline', source };
   }
   if (source.onlineAdvertiserDeviceIds.length > 0) {
-    return { state: 'ready', source };
+    return { state: backendReady ? 'ready' : 'backend_unavailable', source };
   }
   if (source.onlineManifestDeviceIds.length > 0) {
     return { state: 'setup_required', source };
   }
   return { state: 'device_offline', source };
+}
+
+/**
+ * Headless manifests execute inside connector-worker, so an online heartbeat
+ * is not sufficient proof. New headless artifacts must name the daemon-owned
+ * backend; legacy metadata-only artifacts are inventory, not executable
+ * readiness. Other platforms retain their compatibility policy while their
+ * bridge/extension clients migrate independently.
+ */
+function deviceManifestBackendReady(source: DeviceConnectorSource): boolean {
+  if (!source.sourcePath?.startsWith('device-manifest://headless/')) return true;
+  return source.metadata.runtime?.execution === 'daemon_builtin';
 }
 
 /** Load each owner's manifest inventory once, then index the requested targets. */
@@ -152,5 +166,14 @@ export function describeDeviceConnectorSetupRequired(
     `${readiness.source.metadata.name} is available on an online device, but setup is incomplete: ` +
     `'${readiness.source.requiredCapability}' has not been granted. ` +
     'Open the paired device app, finish setup, then retry.'
+  );
+}
+
+export function describeDeviceConnectorBackendUnavailable(
+  readiness: DeviceConnectorReadiness,
+): string {
+  return (
+    `${readiness.source.metadata.name} is advertised by an online device, but its exact ` +
+    'manifest does not declare a supported execution backend. Update/restart the device daemon.'
   );
 }

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -153,6 +153,16 @@ function validateDeviceConnectorManifestsInternal(
       if (!manifest.runtime.platforms.includes(platform)) {
         throw new Error(`runtime.platforms must include '${platform}'`);
       }
+      if (
+        manifest.runtime.execution !== undefined &&
+        manifest.runtime.execution !== 'bridge' &&
+        manifest.runtime.execution !== 'daemon_builtin'
+      ) {
+        throw new Error(`unsupported runtime.execution '${String(manifest.runtime.execution)}'`);
+      }
+      if (platform === 'headless' && manifest.runtime.execution !== 'daemon_builtin') {
+        throw new Error("headless device manifests must declare runtime.execution='daemon_builtin'");
+      }
       const capAuth = authorizeCapabilities(platform, [manifest.required_capability]);
       if (!capAuth.authorized.includes(manifest.required_capability)) {
         throw new Error(`required_capability '${manifest.required_capability}' is not allowed for '${platform}'`);

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1185,7 +1185,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     });
     logger.error(
       { run_id: row.run_id, connector_key: row.connector_key, connector_version: row.connector_version },
-      '[poll] rejected inconsistent native bridge artifact'
+      '[poll] rejected inconsistent device-owned artifact'
     );
     return c.json({
       next_poll_seconds: 1,
@@ -1195,6 +1195,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     });
   }
   const isNativeBridgeRun = selectedExecution.backend === 'native_bridge';
+  const isDeviceOwnedRun =
+    isNativeBridgeRun || selectedExecution.backend === 'daemon_builtin';
 
   // Device chat reuses the ordinary messages/chat_message row. The poll
   // response is only an execution envelope: ownership/routing remain on the
@@ -1652,18 +1654,24 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const hasStoredCompiledCode = Boolean(row.compiled_code);
   const workerWillResolveLocally =
     !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
-  // Only a native-bridge run is implemented by the device itself. Manifest
+  // Only an explicitly selected device-owned backend is implemented by the
+  // device itself. Manifest
   // backing and the capability gate do not establish who executes the code.
   const deviceWillExecuteNativeConnector = deviceExecutesConnectorNatively({
     isUserScopedWorker,
     hasStoredCompiledCode,
     gatewayHasLocalSource,
-    isNativeBridgeRun,
+    isDeviceOwnedRun,
     manifestBacked: row.connector_manifest_backed,
     deviceAdvertisesRequiredCapability:
       row.connector_required_capability != null &&
       authorizedCapabilities.includes(row.connector_required_capability),
   });
+  const responseExecutionBackend =
+    selectedExecution.backend ??
+    (row.connector_key && !deviceWillExecuteNativeConnector
+      ? ('compiled_connector' as const)
+      : undefined);
   if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteNativeConnector) {
     try {
       compiledCode = await resolveConnectorCode(row.connector_key, {
@@ -1702,7 +1710,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   //    profile still can't leak secrets to an arbitrary capability-matched device.
   const connectionIsDevicePinned = row.connection_device_worker_id != null;
   const deliverConnectionAuth =
-    !isNativeBridgeRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
+    !isDeviceOwnedRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
   // `user_data_dir` and `cdp_url` for device-bound browser profiles flow to
   // the worker via `sessionState.user_data_dir` / `sessionState.cdp_url`
   // (set inside resolveExecutionAuth). No need to thread them as separate
@@ -1774,10 +1782,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     run_type: row.run_type,
     connector_key: row.connector_key,
     connector_version: row.connector_version ?? undefined,
-    ...(isNativeBridgeRun
+    ...(responseExecutionBackend
       ? {
-          execution_backend: 'native_bridge' as const,
-          connector_manifest_hash: selectedExecution.manifestHash,
+          execution_backend: responseExecutionBackend,
+          ...(selectedExecution.manifestHash
+            ? { connector_manifest_hash: selectedExecution.manifestHash }
+            : {}),
         }
       : {}),
     nix_packages: nixPackages.length > 0 ? nixPackages : undefined,

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -319,6 +319,7 @@ gate_connector_parity_smoke() {
   gate_require_docker || return 77
   docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke .
   docker run --rm --network=none lobu-worker:parity-smoke bun src/bin.ts self-check --json
+  ./scripts/test-headless-shell-package.sh || return 1
   node packages/cli/bin/lobu.js connector runtime-self-check --json || return 1
 }
 

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Prove the published connector-worker tarball contains a working daemon-owned
+# os.shell backend, then boot that exact artifact twice against the worker HTTP
+# contract. The direct import deliberately runs before dependencies are made
+# available, so it fails if the built-in grows a runtime dependency on
+# @lobu/connector-sdk or the dynamic compiler. The daemon phase covers poll,
+# manifest advertisement, execution, completion, shutdown, and restart.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_root="$repo_root/packages/connector-worker"
+test -f "$package_root/dist/daemon/builtins/index.js" || {
+  echo "connector-worker dist is missing; build packages before this smoke" >&2
+  exit 1
+}
+
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir"' EXIT
+
+npm pack "$package_root" --pack-destination "$smoke_dir" --silent >/dev/null
+archives=("$smoke_dir"/*.tgz)
+test "${#archives[@]}" -eq 1 || {
+  echo "expected one connector-worker tarball, found ${#archives[@]}" >&2
+  exit 1
+}
+tar -xzf "${archives[0]}" -C "$smoke_dir"
+
+PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const entry = resolve(process.env.PACKAGE_ROOT, 'dist/daemon/builtins/index.js');
+const { executeDaemonBuiltin } = await import(pathToFileURL(entry).href);
+const result = await executeDaemonBuiltin({
+  connectorKey: 'os.shell',
+  actionKey: 'run',
+  input: { command: "printf 'lobu-shell-ok\\n'", cwd: process.cwd() },
+});
+if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+const output = result.output;
+if (
+  output.stdout !== 'lobu-shell-ok\n' ||
+  output.stderr !== '' ||
+  output.exit_code !== 0 ||
+  output.success !== true ||
+  output.timed_out !== false
+) {
+  throw new Error(`unexpected shell result: ${JSON.stringify(output)}`);
+}
+process.stdout.write('packaged os.shell dependency-isolation check: ok\n');
+NODE
+
+# The full daemon has ordinary package dependencies. Reuse the repository's
+# already-installed dependency graph without copying it into the artifact; ESM
+# resolution still starts from the extracted package and the direct check above
+# has already proven the built-in itself is dependency-isolated.
+ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
+
+PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+
+const packageRoot = process.env.PACKAGE_ROOT;
+const entry = resolve(packageRoot, 'dist/bin.js');
+const token = 'owl_pat_packaged_shell_smoke';
+let activeAttempt = null;
+
+function json(response, status, body) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+}
+
+const server = createServer(async (request, response) => {
+  try {
+    if (request.url === '/api/health' && request.method === 'GET') {
+      json(response, 200, { ok: true });
+      return;
+    }
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      json(response, 401, { error: 'bad smoke-test authorization' });
+      return;
+    }
+    if (request.url === '/api/workers/poll' && request.method === 'POST') {
+      const body = await readJson(request);
+      const manifest = body.connector_manifests?.find((item) => item.key === 'os.shell');
+      if (
+        body.worker_id !== 'headless:package-smoke' ||
+        body.platform !== 'headless' ||
+        body.capabilities?.['os.shell'] !== true ||
+        body.capacity_available !== 1 ||
+        manifest?.version !== '0.2.0' ||
+        manifest?.runtime?.execution !== 'daemon_builtin'
+      ) {
+        json(response, 400, { error: 'invalid worker advertisement', body });
+        return;
+      }
+      if (activeAttempt && !activeAttempt.claimed) {
+        activeAttempt.claimed = true;
+        json(response, 200, {
+          run_id: activeAttempt.runId,
+          run_type: 'action',
+          connector_key: 'os.shell',
+          connector_version: '0.2.0',
+          connector_manifest_hash: 'package-smoke-manifest',
+          execution_backend: 'daemon_builtin',
+          action_key: 'run',
+          action_input: {
+            command: "printf 'lobu-shell-ok\\n'",
+            cwd: process.cwd(),
+          },
+        });
+        return;
+      }
+      json(response, 200, { next_poll_seconds: 0.05 });
+      return;
+    }
+    if (request.url === '/api/workers/complete-action' && request.method === 'POST') {
+      const body = await readJson(request);
+      if (!activeAttempt || body.run_id !== activeAttempt.runId) {
+        json(response, 409, { error: 'unexpected completion', body });
+        return;
+      }
+      const output = body.action_output;
+      if (
+        body.worker_id !== 'headless:package-smoke' ||
+        body.status !== 'success' ||
+        output?.stdout !== 'lobu-shell-ok\n' ||
+        output?.stderr !== '' ||
+        output?.exit_code !== 0 ||
+        output?.success !== true ||
+        output?.timed_out !== false
+      ) {
+        activeAttempt.reject(new Error(`unexpected completion: ${JSON.stringify(body)}`));
+      } else {
+        activeAttempt.resolve();
+      }
+      json(response, 200, {});
+      return;
+    }
+    if (request.url === '/api/workers/heartbeat' && request.method === 'POST') {
+      json(response, 200, {});
+      return;
+    }
+    json(response, 404, { error: `unexpected route ${request.method} ${request.url}` });
+  } catch (error) {
+    json(response, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+await new Promise((resolveListen, rejectListen) => {
+  server.once('error', rejectListen);
+  server.listen(0, '127.0.0.1', resolveListen);
+});
+const address = server.address();
+if (!address || typeof address === 'string') throw new Error('mock worker API did not bind TCP');
+const apiUrl = `http://127.0.0.1:${address.port}`;
+
+async function runAttempt(attempt) {
+  const runId = 463 + attempt;
+  let resolveCompletion;
+  let rejectCompletion;
+  const completion = new Promise((resolveDone, rejectDone) => {
+    resolveCompletion = resolveDone;
+    rejectCompletion = rejectDone;
+  });
+  activeAttempt = {
+    runId,
+    claimed: false,
+    resolve: resolveCompletion,
+    reject: rejectCompletion,
+  };
+  const child = spawn(
+    process.execPath,
+    [
+      entry,
+      'daemon',
+      '--api-url', apiUrl,
+      '--platform', 'headless',
+      '--worker-id', 'headless:package-smoke',
+      '--capabilities', 'os.shell',
+      '--version', 'package-smoke',
+    ],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        WORKER_API_TOKEN: token,
+        WORKER_MAX_CONCURRENT_JOBS: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let logs = '';
+  child.stdout.on('data', (chunk) => { logs += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { logs += chunk.toString(); });
+  const exitResult = new Promise((resolveExit) => {
+    child.once('exit', (code, signal) => resolveExit({ code, signal }));
+  });
+  const earlyExit = exitResult.then(({ code, signal }) => {
+    throw new Error(`packaged daemon exited before completion (${code ?? signal})\n${logs}`);
+  });
+  let timeoutHandle;
+  const timeout = new Promise((_, rejectTimeout) => {
+    timeoutHandle = setTimeout(
+      () => rejectTimeout(new Error(`packaged daemon timed out\n${logs}`)),
+      15_000,
+    );
+  });
+
+  try {
+    await Promise.race([completion, earlyExit, timeout]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+  child.kill('SIGTERM');
+  const exit = await exitResult;
+  if (exit.code !== 0) {
+    throw new Error(`packaged daemon shutdown failed (${exit.code ?? exit.signal})\n${logs}`);
+  }
+  process.stdout.write(`packaged queue os.shell attempt ${attempt}: ok\n`);
+}
+
+try {
+  await runAttempt(1);
+  await runAttempt(2);
+} finally {
+  activeAttempt = null;
+  await new Promise((resolveClose) => server.close(resolveClose));
+}
+NODE


### PR DESCRIPTION
## Summary

- route headless `os.shell/run` through an explicit `daemon_builtin` execution backend
- fail closed when a headless manifest does not declare a supported backend, and surface that state through operation availability and connection tests
- add worker startup/self-check coverage plus a packaged-tarball queue smoke that runs the exact command twice across daemon restart
- keep native-bridge and compiled-connector execution explicit and separate

## Root cause

The first bad boundary was backend selection after device claim. The headless `device-manifest://headless/os.shell@0.1.0` artifact had no execution owner, so the gateway treated it as a portable compiled connector. The compiler leaves `@lobu/connector-sdk` as a bare runtime import; the packaged daemon then loaded a temporary ESM module whose deployment graph could not resolve that workspace package. The action failed before Bash.

This is a combined routing-contract and packaged-runtime/deployment-skew incident. The P0 removes dynamic compilation and npm resolution from the shell recovery primitive. Version `0.2.0` also prevents reuse of the incompatible metadata/artifact identity.

## Verification

Passed locally:

- root Biome and TypeScript pre-commit gates
- strict typecheck for server, connector-worker, connector-sdk, device-connectors, plugin packages, embeddings, and CLI
- knip, exposed-surface naming, gateway LLM, entity-write funnel, and package-content checks
- 65 focused server/backend/readiness tests
- 6 connector-sdk manifest tests
- new daemon-builtin worker tests
- worker runtime self-check, including `daemon-builtin:os.shell/run`
- `./scripts/test-headless-shell-package.sh`:
  - imports the built-in directly from the extracted npm tarball with no workspace dependencies
  - starts the packed daemon against the worker HTTP queue
  - verifies the advertised `daemon_builtin` manifest
  - claims and completes `printf 'lobu-shell-ok\\n'`
  - shuts down, restarts, and repeats successfully

Environment-only local limitations:

- the private Owletto submodule is unavailable to this runner, so the aggregate build stopped only at `packages/owletto` after public affected packages built
- Postgres and Docker are unavailable locally; canonical CI owns the DB integration and worker-image gates
- the broad worker suite recorded 242 passes and 17 unrelated Unix-socket fixture failures because this container cannot bind their `/tmp/*.sock` sockets

## Rollout / rollback

Roll out the server before the worker. A new server degrades a legacy headless manifest instead of advertising it ready; a new worker then advertises `os.shell@0.2.0` and executes it in-process. Roll back by reverting this commit and redeploying the prior server/worker pair together. No device, connection, event, run, or historical row is deleted or rebound.

## Scope

This PR intentionally does not redesign device identity, archive connections 547/566, change connection 464, or add Herdr sessions. Those remain separate follow-ups after live shell recovery.

## Checklist

- [x] Intended files staged explicitly
- [x] Packaged artifact and restart path tested
- [x] No production restart or data mutation performed
