### PR TITLE
feat: prepare generic webhook event activation

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -116,6 +116,31 @@ describe("validateConnectionAgainstConnector — chat capability", () => {
     ).not.toThrow();
   });
 
+  test("accepts an explicitly declared adapterless BYO connection", () => {
+    expect(() =>
+      validateConnectionAgainstConnector(
+        {
+          slug: "alerts",
+          connector: "webhook",
+          credentialMode: "byo",
+          config: { token: "webhook-token-at-least-32-characters" },
+          feeds: [],
+          sourceFile: "lobu.config.ts",
+        },
+        new Map(),
+        {
+          ...chatSchemas,
+          optionsSchema: {
+            type: "object",
+            "x-lobu-adapterless-platform": "webhook",
+            properties: { token: { type: "string", minLength: 32 } },
+            required: ["token"],
+          },
+        }
+      )
+    ).not.toThrow();
+  });
+
   test("rejects a chat connection that omits credentialMode", () => {
     expect(() =>
       validateConnectionAgainstConnector(

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -671,23 +671,25 @@ export function validateConnectionAgainstConnector(
   authProfiles: ReadonlyMap<string, DesiredAuthProfile>,
   schemas: ResolvedConnectorSchemas | null
 ): void {
-  const declaredChatPlatform = schemas?.optionsSchema?.["x-lobu-chat-platform"];
-  const isChatConnector =
-    typeof declaredChatPlatform === "string" &&
-    declaredChatPlatform === connection.connector;
-  if (schemas && connection.credentialMode === "byo" && !isChatConnector) {
+  const declaredConnectionPlatform =
+    schemas?.optionsSchema?.["x-lobu-chat-platform"] ??
+    schemas?.optionsSchema?.["x-lobu-adapterless-platform"];
+  const isByoConnection =
+    typeof declaredConnectionPlatform === "string" &&
+    declaredConnectionPlatform === connection.connector;
+  if (schemas && connection.credentialMode === "byo" && !isByoConnection) {
     throw new ValidationError(
-      `${connection.sourceFile}: connection "${connection.slug}" uses credentialMode "byo", but connector "${connection.connector}" does not declare the chat capability`
+      `${connection.sourceFile}: connection "${connection.slug}" uses credentialMode "byo", but connector "${connection.connector}" does not declare the chat capability or an adapterless connection platform`
     );
   }
-  if (schemas && isChatConnector && connection.credentialMode !== "byo") {
+  if (schemas && isByoConnection && connection.credentialMode !== "byo") {
     if (connection.config?.managedBy) {
       throw new ValidationError(
-        `${connection.sourceFile}: managed chat connection "${connection.slug}" is owned by the OAuth/install flow and cannot be declared in config`
+        `${connection.sourceFile}: managed connection "${connection.slug}" is owned by the OAuth/install flow and cannot be declared in config`
       );
     }
     throw new ValidationError(
-      `${connection.sourceFile}: chat connection "${connection.slug}" must declare credentialMode "byo" (hosted connections use "hosted" and are not persisted)`
+      `${connection.sourceFile}: connection "${connection.slug}" must declare credentialMode "byo" (hosted connections use "hosted" and are not persisted)`
     );
   }
   // Validate against `{}` when config is omitted too — that surfaces missing

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -855,8 +855,8 @@ function mapConnection(
       `connection "${connection.slug}" cannot combine credentialMode "byo" with managedBy`
     );
   }
-  // A BYO chat connection (a chat connector whose credential is supplied in
-  // `config`, not the hosted bot — hosted is filtered out before this) applies
+  // A BYO connection (chat or adapterless, with its credential supplied in
+  // `config`; hosted chat is filtered out before this) applies
   // through the secret-aware `apply_chat_connection` path. Resolve `secret()` /
   // `$VAR` refs in its config to the REAL value: the chat-write path stores the
   // incoming plaintext as the secret (server-side `normalizeConfigForStorage`
@@ -865,10 +865,11 @@ function mapConnection(
   // auth-profile credentials; the config row never holds cleartext at rest, and
   // the secret name is collected so the apply secrets gate fails loud if unset.
   // `credentialMode` is explicit so connector definitions remain the only
-  // registry of chat capability (`x-lobu-chat-platform`). Validation against
-  // that marker happens after connector definitions are installed/refetched.
-  const isByoChat = connection.credentialMode === "byo";
-  const resolvedConfig = isByoChat
+  // registry of connection capability (`x-lobu-chat-platform` or
+  // `x-lobu-adapterless-platform`). Validation against that marker happens
+  // after connector definitions are installed/refetched.
+  const isByoConnection = connection.credentialMode === "byo";
+  const resolvedConfig = isByoConnection
     ? Object.fromEntries(
         Object.entries(connection.config ?? {}).map(([k, v]) => [
           k,
@@ -893,10 +894,9 @@ function mapConnection(
     ...(authSlug ? { authProfileSlug: authSlug } : {}),
     ...(appAuthSlug ? { appAuthProfileSlug: appAuthSlug } : {}),
     ...(config ? { config } : {}),
-    // Mark BYO chat so apply routes it through `apply_chat_connection` (which
-    // persists a non-null `credential_mode` the gateway needs to treat the row
-    // as chat). Data connectors leave it undefined.
-    ...(isByoChat ? { credentialMode: "byo" as const } : {}),
+    // Mark BYO chat/adapterless connections so apply routes them through the
+    // secret-aware connection path. Feed/data connectors leave it undefined.
+    ...(isByoConnection ? { credentialMode: "byo" as const } : {}),
     ...(connection.deviceWorkerId
       ? { deviceWorkerId: connection.deviceWorkerId }
       : {}),

--- a/packages/server/src/__tests__/unit/connectors/connection-facets.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/connection-facets.test.ts
@@ -38,15 +38,20 @@ describe('deriveConnectionFacets', () => {
     ).toEqual({ data: true, chat: false, actions: false, audience: false });
   });
 
-  it('data lights from live feeds even when the connector declares none', () => {
+  it('a generic webhook is data, not chat, without a feed row', () => {
     const f = deriveConnectionFacets({
       connectorKey: 'webhook',
       isChat: false,
-      feedCount: 2,
+      feedCount: 0,
       connectorHasFeeds: false,
       hasOperations: false,
     });
-    expect(f.data).toBe(true);
+    expect(f).toEqual({
+      data: true,
+      chat: false,
+      actions: false,
+      audience: false,
+    });
   });
 
   it('GitHub lights data + actions + audience but not chat', () => {

--- a/packages/server/src/__tests__/unit/webhook-automation-signal.test.ts
+++ b/packages/server/src/__tests__/unit/webhook-automation-signal.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { buildWebhookAutomationSignal } from "../../gateway/connections/webhook-ingest";
+
+describe("generic webhook Automation signal", () => {
+	test("carries exact durable identity and only trusted routing metadata", () => {
+		const signal = buildWebhookAutomationSignal({
+			connectionId: 7,
+			eventId: 42,
+			originId: "provider-delivery-42",
+			semanticType: "alert",
+			title: "Production alert",
+			payload: {
+				severity: "critical",
+				attempt: 3,
+				semantic_type: "sender-controlled",
+				nested: { ignored: true },
+			},
+			occurredAt: new Date("2026-08-30T12:00:00.000Z"),
+		});
+
+		expect(signal).toMatchObject({
+			connector_key: "webhook",
+			connection_id: 7,
+			resource_type: "alert",
+			resource_ref: "provider-delivery-42",
+			event_type: "delivery.received",
+			delivery_id: "webhook:event:42",
+			label: "Production alert",
+			occurred_at: "2026-08-30T12:00:00.000Z",
+			attributes: { semantic_type: "alert" },
+		});
+		expect(signal.input_text).toContain("severity: critical");
+		expect(signal.attributes).toEqual({ semantic_type: "alert" });
+	});
+
+	test("bounds deeply nested payloads without recursive stack overflow", () => {
+		const payload: Record<string, unknown> = {};
+		let cursor = payload;
+		for (let depth = 0; depth < 10_000; depth += 1) {
+			const child: Record<string, unknown> = {};
+			cursor.child = child;
+			cursor = child;
+		}
+
+		const signal = buildWebhookAutomationSignal({
+			connectionId: 7,
+			eventId: 43,
+			originId: "deep-delivery",
+			semanticType: "content",
+			payload,
+			occurredAt: new Date("2026-08-30T12:00:00.000Z"),
+		});
+
+		expect(signal.input_text).toContain("[nested value]");
+		expect(signal.input_text.length).toBeLessThanOrEqual(8 * 1024);
+	});
+
+	test("bounds traversal of a request-sized wide array", () => {
+		const signal = buildWebhookAutomationSignal({
+			connectionId: 7,
+			eventId: 44,
+			originId: "wide-delivery",
+			semanticType: "content",
+			payload: { values: Array.from({ length: 100_000 }, () => 0) },
+			occurredAt: new Date("2026-08-30T12:00:00.000Z"),
+		});
+
+		expect(signal.input_text).toStartWith("values.0: 0");
+		expect(signal.input_text.length).toBeLessThanOrEqual(8 * 1024);
+	});
+});

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -145,6 +145,66 @@ async function eventRows(connectionId = "whk1"): Promise<any[]> {
   `;
 }
 
+async function seedWebhookEventAutomation({
+	connectionId,
+	semanticType = "alert",
+}: {
+	connectionId: number;
+	semanticType?: string;
+}): Promise<number> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const creatorId = "webhook-automation-owner";
+	await sql`
+		INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+		VALUES (${creatorId}, 'Webhook owner', 'webhook-owner@test.example', true, now(), now())
+		ON CONFLICT (id) DO NOTHING
+	`;
+	return sql.begin(async (tx) => {
+		const [automation] = await tx<{ id: number }>`
+			WITH next_id AS (SELECT nextval('automations_id_seq')::integer AS id)
+			INSERT INTO automations (
+				id, automation_group_id, organization_id, agent_id, created_by,
+				name, slug, status, triggers
+			)
+			SELECT id, id, ${ORG}, ${AGENT}, ${creatorId},
+			       'Webhook alert processor', 'webhook-alert-' || id, 'active',
+			       ${tx.json([
+					{
+						kind: "event",
+						source: "connector",
+						connector_key: "webhook",
+						connection_id: connectionId,
+						event_types: ["delivery.received"],
+						match: { semantic_type: semanticType },
+						execution: "turn",
+						active_run: "queue",
+						output: "silent",
+						skip_if_unchanged: true,
+					},
+				])}::jsonb
+			FROM next_id
+			RETURNING id
+		`;
+		const [version] = await tx<{ id: number }>`
+			INSERT INTO automation_versions (
+				automation_id, version, name, prompt, version_sources,
+				change_notes, created_by
+			) VALUES (
+				${automation.id}, 1, 'Webhook alert processor',
+				'Process the incoming alert.', '[]'::jsonb,
+				'Test webhook activation', ${creatorId}
+			)
+			RETURNING id
+		`;
+		await tx`
+			UPDATE automations SET current_version_id = ${version.id}
+			WHERE id = ${automation.id}
+		`;
+		return Number(automation.id);
+	});
+}
+
 describe("handleWebhookIngest auth", () => {
 	test("accepts Authorization: Bearer and persists the event", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
@@ -812,6 +872,138 @@ describe("ChatInstanceManager webhook wiring", () => {
 		expect(rows[0].organization_id).toBe(ORG);
 	});
 
+	test("persists, activates, scopes, and deduplicates a generic delivery", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const { orgContext } = await import("../../lobu/stores/org-context.js");
+		const { runtimeConnectionIdToSlug } = await import(
+			"../../lobu/stores/connections-projection.js"
+		);
+		const { getDb } = await import("../../db/client.js");
+		const { manager } = await buildManager();
+
+		const created = await orgContext.run({ organizationId: ORG }, () =>
+			manager.addConnection("webhook", AGENT, {
+				platform: "webhook",
+				semanticType: "alert",
+				titlePath: "/title",
+			}),
+		);
+		const token = created.config.token as string;
+		const sql = getDb();
+		const [connection] = await sql<{ id: number }>`
+			SELECT id FROM connections
+			WHERE organization_id = ${ORG}
+			  AND connector_key = 'webhook'
+			  AND slug = ${runtimeConnectionIdToSlug(created.id)}
+			LIMIT 1
+		`;
+		if (!connection) throw new Error("Webhook connection projection was not created");
+
+		const automationId = await seedWebhookEventAutomation({
+			connectionId: Number(connection.id),
+		});
+
+		const makeRequest = () =>
+			new Request(`http://gateway.test/api/v1/webhooks/${created.id}`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Database unavailable", severity: "critical" }),
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${token}`,
+				},
+			});
+		const concurrent = await Promise.all(
+			Array.from({ length: 6 }, () =>
+				manager.handleIngestWebhook(created.id, makeRequest()),
+			),
+		);
+		expect(concurrent.every((response) => response.status === 202)).toBe(true);
+		const concurrentBodies = (await Promise.all(
+			concurrent.map((response) => response.json()),
+		)) as Array<{ id: number; duplicate?: boolean }>;
+		expect(new Set(concurrentBodies.map((body) => body.id)).size).toBe(1);
+		expect(concurrentBodies.some((body) => body.duplicate === true)).toBe(true);
+		const firstBody = concurrentBodies[0];
+		if (!firstBody) throw new Error("Webhook delivery returned no response body");
+
+		const runs = await sql<{
+			approved_input: Record<string, unknown>;
+			status: string;
+		}>`
+			SELECT approved_input, status FROM runs
+			WHERE automation_id = ${automationId}
+			  AND run_type = 'automation'
+			ORDER BY id
+		`;
+		expect(runs).toHaveLength(1);
+		expect(runs[0]?.approved_input).toMatchObject({
+			dispatch_source: "event",
+			trigger_execution: "turn",
+			delivery_ids: [`webhook:event:${firstBody.id}`],
+			trigger_signal: {
+				connector_key: "webhook",
+				connection_id: Number(connection.id),
+				event_type: "delivery.received",
+				attributes: {
+					semantic_type: "alert",
+				},
+			},
+		});
+		const [event] = await sql<{ connection_id: number }>`
+			SELECT connection_id FROM events WHERE id = ${firstBody.id}
+		`;
+		expect(Number(event?.connection_id)).toBe(Number(connection.id));
+
+		const other = await orgContext.run({ organizationId: ORG }, () =>
+			manager.addConnection("webhook", AGENT, {
+				platform: "webhook",
+				semanticType: "alert",
+			}),
+		);
+		const otherResponse = await manager.handleIngestWebhook(
+			other.id,
+			new Request(`http://gateway.test/api/v1/webhooks/${other.id}`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Different connection" }),
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${String(other.config.token)}`,
+				},
+			}),
+		);
+		expect(otherResponse.status).toBe(202);
+
+		const { normalizeAutomationSources } = await import(
+			"../../automations/source-refs.js"
+		);
+		const { executeDataSources } = await import(
+			"../../utils/execute-data-sources.js"
+		);
+		const [source] = await normalizeAutomationSources(sql, ORG, [
+			{ name: "incoming", query: `@connection:${connection.id}` },
+		]);
+		const readback = await executeDataSources(
+			[{ name: source.name, query: source.query }],
+			{ organizationId: ORG },
+			sql,
+		);
+		expect(readback.incoming).toHaveLength(1);
+		expect(readback.incoming?.[0]).toMatchObject({
+			id: firstBody.id,
+			connection_id: Number(connection.id),
+			payload_data: {
+				title: "Database unavailable",
+				severity: "critical",
+			},
+		});
+
+		const [{ count }] = await sql<{ count: number }>`
+			SELECT count(*)::int AS count FROM runs
+			WHERE automation_id = ${automationId} AND run_type = 'automation'
+		`;
+		expect(count).toBe(1);
+	});
+
 	test("a stopped webhook connection refuses deliveries with 404", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const { orgContext } = await import("../../lobu/stores/org-context.js");
@@ -1025,7 +1217,11 @@ describe("connector-connection webhook bridge (connections table)", () => {
 	 */
 	async function seedRegisteredConnectorConnection(
 		secretStore: any,
-		overrides: { status?: string; secret?: string | null } = {},
+		overrides: {
+			status?: string;
+			secret?: string | null;
+			connectorKey?: string;
+		} = {},
 	): Promise<string> {
 		const { getDb } = await import("../../db/client.js");
 		const { orgContext } = await import("../../lobu/stores/org-context.js");
@@ -1034,9 +1230,10 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		const secretValue =
 			overrides.secret === null ? null : (overrides.secret ?? SIG_SECRET);
 		// Insert first to get the generated id, then persist the secret + stamp.
+		const connectorKey = overrides.connectorKey ?? "github";
 		const inserted = (await getDb()`
 			INSERT INTO connections (organization_id, connector_key, slug, status, config)
-			VALUES (${ORG}, ${"github"}, ${`github-${Date.now()}-${Math.random()}`},
+			VALUES (${ORG}, ${connectorKey}, ${`${connectorKey}-${Date.now()}-${Math.random()}`},
 				${overrides.status ?? "active"}, ${getDb().json({})})
 			RETURNING id
 		`) as Array<{ id: number }>;
@@ -1209,6 +1406,69 @@ describe("connector-connection webhook bridge (connections table)", () => {
 		expect(new Date(String(feed.next_run_at)).getTime()).toBeLessThanOrEqual(
 			Date.now() + 1000,
 		);
+	});
+
+	test("a raw provider bridge does not emit the generic webhook Automation event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const { manager, secretStore } = await buildManager();
+		const { orgContext } = await import("../../lobu/stores/org-context.js");
+		const { createConnectionWebhookRoutes } = await import(
+			"../routes/public/connections.js"
+		);
+		const { getDb } = await import("../../db/client.js");
+		const id = await seedRegisteredConnectorConnection(secretStore, {
+			connectorKey: "linear",
+		});
+		// Simulate a pre-guard legacy generic webhook with the same numeric runtime
+		// id. Provider IDs own numeric URLs, so this row must not shadow the signed
+		// connector delivery and turn it into generic bearer-token auth.
+		await orgContext.run({ organizationId: ORG }, () =>
+			manager.addConnection(
+				"webhook",
+				AGENT,
+				{
+					platform: "webhook",
+					token: "legacy-numeric-webhook-token-0123456789",
+				},
+				undefined,
+				undefined,
+				id,
+			),
+		);
+		const automationId = await seedWebhookEventAutomation({
+			connectionId: Number(id),
+			semanticType: "issue",
+		});
+		const app = createConnectionWebhookRoutes(manager);
+		const raw = JSON.stringify({ action: "create", issue: { id: "LIN-1" } });
+		const response = await app.fetch(
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
+				method: "POST",
+				body: raw,
+				headers: {
+					"content-type": "application/json",
+					"x-github-delivery": "linear-bridge-1",
+					"x-hub-signature-256": sign(raw, { prefix: "sha256=" }),
+				},
+			}),
+		);
+
+		expect(response.status).toBe(202);
+		const rows = await eventRows(id);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			connector_key: `webhook:${id}`,
+			origin_id: "linear-bridge-1",
+			semantic_type: "issue",
+		});
+		expect(rows[0].connection_id).toBeNull();
+		const [{ count }] = await getDb()<{ count: number }>`
+			SELECT count(*)::int AS count
+			FROM runs
+			WHERE automation_id = ${automationId}
+			  AND run_type = 'automation'
+		`;
+		expect(count).toBe(0);
 	});
 
 	test("an authenticated Jira delivery lands as a structured event on the Atlassian Rovo feed", async () => {

--- a/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
@@ -15,15 +15,23 @@ import {
 describe("parseConfig", () => {
 	test("webhook string booleans are accepted and unknown keys stripped", () => {
 		const parsed = parseConfig("webhook", {
-			token: "t1",
+			token: "webhook-token-at-least-32-characters",
 			searchable: "true",
 			junkKey: "should-not-persist",
 		}) as Record<string, unknown>;
 		expect(parsed).toEqual({
 			platform: "webhook",
-			token: "t1",
+			token: "webhook-token-at-least-32-characters",
 			searchable: "true",
 		});
+	});
+
+	test("webhook config rejects missing, empty, and weak bearer tokens", () => {
+		expect(() => parseConfig("webhook", {})).toThrow(/token/);
+		expect(() => parseConfig("webhook", { token: "" })).toThrow(/token/);
+		expect(() => parseConfig("webhook", { token: "too-short" })).toThrow(
+			/token/,
+		);
 	});
 
 	test("telegram config keeps declared keys and drops extras", () => {

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -328,6 +328,11 @@ export async function upsertByoChatConnection(
 	created: boolean;
 	changed: boolean;
 }> {
+	if (input.platform === "webhook" && /^\d+$/.test(input.stableId)) {
+		throw new Error(
+			"Webhook connection slugs cannot be numeric because numeric webhook URLs are reserved for provider connector IDs",
+		);
+	}
 	if (input.stableId.startsWith(SLACK_INSTALLATION_ID_PREFIX)) {
 		throw new Error(
 			`Stable ID ${input.stableId} is reserved for managed Slack installations`,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1289,24 +1289,12 @@ export class ChatInstanceManager {
     request: Request,
 		peerAddress?: string | null,
   ): Promise<Response> {
-    // A stopped row is deliberately off — refuse deliveries exactly like a
-    // stopped chat connection (whose instance would not be running). Error
-    // status stays accepting: webhook connections have no startup that can
-    // fail, and a stray error row should not silently drop deliveries.
-    const stored = await this.connectionStore.getConnection(connectionId);
-		if (
-			!stored ||
-			stored.platform !== "webhook" ||
-			stored.status === "stopped"
-		) {
-      // A chat-connection miss may still be a CONNECTOR connection (a data
-      // connector row in `connections`, credential_mode NULL) that registered a
-      // provider webhook at connect time. Resolve that row, build a synthetic
-      // webhook config from
-      // its stored scheme + secret, and run the SAME ingest handler — so HMAC
-      // verification, size cap, rate limits, and dedupe all apply unchanged.
-			const bridged =
-				await this.resolveConnectorWebhookConnection(connectionId);
+		// Numeric webhook URLs are the canonical provider-connector namespace.
+		// Resolve it first so a legacy generic webhook whose stable id is numeric
+		// cannot shadow an unrelated provider connection across organizations.
+		const bridged = /^\d+$/.test(connectionId)
+			? await this.resolveConnectorWebhookConnection(connectionId)
+			: null;
       if (bridged) {
         return orgContext.run({ organizationId: bridged.stored.organizationId! }, () =>
           handleWebhookIngest(
@@ -1380,6 +1368,17 @@ export class ChatInstanceManager {
 					),
         );
       }
+
+    // A stopped row is deliberately off — refuse deliveries exactly like a
+    // stopped chat connection (whose instance would not be running). Error
+    // status stays accepting: webhook connections have no startup that can
+    // fail, and a stray error row should not silently drop deliveries.
+    const stored = await this.connectionStore.getConnection(connectionId);
+		if (
+			!stored ||
+			stored.platform !== "webhook" ||
+			stored.status === "stopped"
+		) {
       return new Response(JSON.stringify({ error: "Connection not found" }), {
         status: 404,
         headers: { "content-type": "application/json" },
@@ -1391,7 +1390,8 @@ export class ChatInstanceManager {
         stored,
         request,
         this.services.getSecretStore(),
-				peerAddress,
+        peerAddress,
+        { activateGenericAutomationEvent: true },
       );
     }
     return orgContext.run({ organizationId: stored.organizationId }, () =>
@@ -1399,8 +1399,9 @@ export class ChatInstanceManager {
         stored,
         request,
         this.services.getSecretStore(),
-				peerAddress,
-			),
+        peerAddress,
+        { activateGenericAutomationEvent: true },
+      ),
     );
   }
 

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -5,9 +5,10 @@
  * no mention/DM handlers, no thread semantics. It is a push-source primitive —
  * any external system (Sentry, GitHub, Stripe, healthchecks) POSTs JSON to
  * `POST /api/v1/webhooks/:connectionId` and the payload is persisted as an
- * `events` row (`connector_key = 'webhook:<connectionId>'`). Automations consume
- * those rows through their existing checkpointed SQL sources; reaction latency
- * is bounded by the automation cadence, not by this handler.
+ * `events` row (`connector_key = 'webhook:<connectionId>'`). The durable insert
+ * atomically queues matching `webhook / delivery.received` Automations through
+ * the ordinary connector-event path; scheduled/manual Automations may also read
+ * the rows later through checkpointed SQL sources.
  *
  * Request pipeline (persist BEFORE ack — a 202 issued before the insert
  * commits would lose the delivery on pod crash, and providers won't retry a
@@ -32,8 +33,15 @@
  */
 
 import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import type { ConnectorTriggerSignal } from "@lobu/connector-sdk";
 import type { StoredConnection } from "@lobu/core";
+import {
+	activateAutomationSignal,
+	type AutomationActivationResult,
+	dispatchAutomationRunsBestEffort,
+} from "../../automations/activation.js";
 import { type DbClient, getDb } from "../../db/client.js";
+import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection.js";
 import { constantTimeEqual } from "../../utils/constant-time-equal.js";
 import { insertEvent } from "../../utils/insert-event.js";
 import logger from "../../utils/logger.js";
@@ -240,6 +248,10 @@ function resolveJsonPointer(root: unknown, pointer: string): unknown {
  * full in `payload_data` — this is only the searchable text projection. */
 export const WEBHOOK_PAYLOAD_TEXT_MAX_CHARS = 8 * 1024;
 
+/** Bound path construction and traversal for adversarially deep/sparse JSON. */
+const WEBHOOK_PAYLOAD_TEXT_MAX_DEPTH = 64;
+const WEBHOOK_PAYLOAD_TEXT_MAX_NODES = 10_000;
+
 /**
  * Render the parsed payload into a flat text document for `events.payload_text`.
  * Without this the column is null, so the embed-backfill (which skips rows with
@@ -258,8 +270,58 @@ export function renderPayloadText(payload: unknown): string {
 		lines.push(clipped);
 		budget -= clipped.length + 1; // + newline
 	};
-	const walk = (node: unknown, path: string): void => {
-		if (budget <= 0) return;
+	type NodeFrame = {
+		kind: "node";
+		node: unknown;
+		path: string;
+		depth: number;
+	};
+	type ChildrenFrame = {
+		kind: "children";
+		iterator: Iterator<[string, unknown]>;
+		path: string;
+		depth: number;
+	};
+	type Frame = NodeFrame | ChildrenFrame;
+	function* children(node: object): Generator<[string, unknown]> {
+		if (Array.isArray(node)) {
+			for (let i = 0; i < node.length; i += 1) {
+				yield [String(i), node[i]];
+			}
+			return;
+		}
+		const record = node as Record<string, unknown>;
+		for (const key in record) {
+			if (Object.hasOwn(record, key)) yield [key, record[key]];
+		}
+	}
+	const stack: Frame[] = [
+		{ kind: "node", node: payload, path: "", depth: 0 },
+	];
+	let visited = 0;
+	while (
+		stack.length > 0 &&
+		budget > 0 &&
+		visited < WEBHOOK_PAYLOAD_TEXT_MAX_NODES
+	) {
+		const frame = stack.pop();
+		if (!frame) break;
+		if (frame.kind === "children") {
+			const next = frame.iterator.next();
+			if (!next.done) {
+				stack.push(frame);
+				const [key, value] = next.value;
+				stack.push({
+					kind: "node",
+					node: value,
+					path: frame.path ? `${frame.path}.${key}` : key,
+					depth: frame.depth + 1,
+				});
+			}
+			continue;
+		}
+		visited += 1;
+		const { node, path, depth } = frame;
 		if (
 			node === null ||
 			typeof node === "string" ||
@@ -267,20 +329,61 @@ export function renderPayloadText(payload: unknown): string {
 			typeof node === "boolean"
 		) {
 			push(path ? `${path}: ${String(node)}` : String(node));
-			return;
+			continue;
 		}
-		if (Array.isArray(node)) {
-			node.forEach((item, i) => walk(item, path ? `${path}.${i}` : String(i)));
-			return;
+		if (depth >= WEBHOOK_PAYLOAD_TEXT_MAX_DEPTH) {
+			push(path ? `${path}: [nested value]` : "[nested value]");
+			continue;
 		}
 		if (typeof node === "object") {
-			for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-				walk(value, path ? `${path}.${key}` : key);
-			}
+			stack.push({
+				kind: "children",
+				iterator: children(node),
+				path,
+				depth,
+			});
 		}
-	};
-	walk(payload, "");
+	}
 	return lines.join("\n");
+}
+
+/** Stable connector event exposed by the built-in webhook catalog. */
+export const WEBHOOK_DELIVERY_RECEIVED_EVENT = "delivery.received";
+
+/**
+ * Normalize an authenticated webhook delivery into the same connector signal
+ * consumed by feed syncs and chat transports. The durable event remains the
+ * source of truth; this bounded envelope only decides which Automations wake.
+ */
+export function buildWebhookAutomationSignal(args: {
+	connectionId: number;
+	eventId: number;
+	originId: string;
+	semanticType: string;
+	title?: string | null;
+	payload: Record<string, unknown>;
+	occurredAt: Date;
+}): ConnectorTriggerSignal {
+	const fallbackLabel = `Webhook delivery: ${args.semanticType}`;
+	const inputText = renderPayloadText(args.payload);
+	return {
+		connector_key: "webhook",
+		connection_id: args.connectionId,
+		resource_type:
+			args.semanticType.length <= 100 ? args.semanticType : undefined,
+		...(args.originId.length <= 500
+			? { resource_ref: args.originId }
+			: {}),
+		event_type: WEBHOOK_DELIVERY_RECEIVED_EVENT,
+		// events.id is globally bounded and avoids sender-controlled btree keys.
+		delivery_id: `webhook:event:${args.eventId}`,
+		label: (args.title?.trim() || fallbackLabel).slice(0, 300),
+		input_text: inputText || fallbackLabel,
+		occurred_at: args.occurredAt.toISOString(),
+		// Only trusted, connection-configured routing metadata belongs in every
+		// fan-out run. The complete sender payload remains on the durable event.
+		attributes: { semantic_type: args.semanticType.slice(0, 1_000) },
+	};
 }
 
 function extractTitle(
@@ -336,6 +439,13 @@ export interface WebhookActorAttribution {
 export interface WebhookIngestOverrides {
 	title?: string | null;
 	sourceUrl?: string | null;
+	/**
+	 * The caller verified this is a real generic `webhook` connection, rather
+	 * than a synthetic webhook envelope for a connector/app installation.
+	 * Fail-closed so provider bridges cannot activate an unrelated generic
+	 * webhook connection whose generated slug happens to collide.
+	 */
+	activateGenericAutomationEvent?: boolean;
 	/** Provider-specific bearer verification (Atlassian OAuth webhook JWTs). */
 	verifyBearerToken?: (token: string) => Promise<boolean>;
 	/**
@@ -570,23 +680,46 @@ export async function handleWebhookIngest(
 	const eventContent = isSearchableEnabled(config) ? renderPayloadText(parsed) : null;
 
 	try {
-		const landedId = await getDb().begin(async (tx) => {
+		const landed = await getDb().begin(async (tx) => {
+			let automationConnectionId: number | null = null;
+			if (overrides?.activateGenericAutomationEvent) {
+				const [projected] = await tx<{ id: number }>`
+					SELECT id
+					FROM connections
+					WHERE organization_id = ${organizationId}
+					  AND slug = ${runtimeConnectionIdToSlug(stored.id)}
+					  AND connector_key = 'webhook'
+					  AND deleted_at IS NULL
+					LIMIT 1
+				`;
+				if (!projected) {
+					throw new Error(
+						`Generic webhook connection ${stored.id} has no active projection`,
+					);
+				}
+				automationConnectionId = Number(projected.id);
+			}
+
 			// Insert FIRST (empty entity_ids). A concurrent duplicate trips the
 			// delivery-unique index → 23505 → this tx rolls back, so the loser never
 			// reaches actor resolution. Only the winner continues.
+			const occurredAt = new Date();
 			const inserted = await insertEvent(
 				{
 					entityIds: [],
 					organizationId,
 					originId,
 					connectorKey,
+					...(automationConnectionId != null
+						? { connectionId: automationConnectionId }
+						: {}),
 					semanticType,
 					payloadType: "json_template",
 					payloadData,
 					content: eventContent,
 					title: eventTitle,
 					sourceUrl: overrides?.sourceUrl ?? null,
-					occurredAt: new Date(),
+					occurredAt,
 					metadata: eventMetadata,
 				},
 				{ sql: tx as unknown as ReturnType<typeof getDb> },
@@ -638,13 +771,39 @@ export async function handleWebhookIngest(
 					WHERE id = ${inserted.id}
 				`;
 			}
-			return inserted.id;
+
+			// Persisted event + matching Automation runs commit together. Connector
+			// scheduling stays independent: this is the same durable event seam used
+			// by polled feeds, so no webhook-specific scheduler or subscription row
+			// is introduced. Only the generic-webhook route opts in; provider bridges
+			// keep interpreting their own event vocabulary.
+			let activationRuns: AutomationActivationResult[] = [];
+			if (automationConnectionId != null) {
+				activationRuns = await activateAutomationSignal({
+					organizationId,
+					signal: buildWebhookAutomationSignal({
+						connectionId: automationConnectionId,
+						eventId: inserted.id,
+						originId,
+						semanticType,
+						title: eventTitle,
+						payload: payloadData,
+						occurredAt,
+					}),
+					db: tx,
+				});
+			}
+			return { eventId: inserted.id, activationRuns };
 		});
+		// The committed run rows are authoritative. Wake dispatch for low latency,
+		// but never hold the sender's acknowledgement open on agent/session HTTP.
+		// The periodic Automation tick recovers a pending run if this pod exits.
+		void dispatchAutomationRunsBestEffort(landed.activationRuns);
 		logger.info(
-			{ connectionId: stored.id, eventId: landedId, dedupeSource },
+			{ connectionId: stored.id, eventId: landed.eventId, dedupeSource },
 			"[webhook-ingest] delivery persisted",
 		);
-		return json(202, { ok: true, id: landedId });
+		return json(202, { ok: true, id: landed.eventId });
 	} catch (error) {
 		if (isUniqueViolation(error)) {
 			// Lost the concurrent race: the winner's row exists; ack as a duplicate.

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -218,12 +218,11 @@ const boolOrString = (description: string) =>
 
 export const WebhookConfigSchema = Type.Object({
 	platform: Type.Literal("webhook"),
-	token: Type.Optional(
-		Type.String({
-			description:
-				"Bearer token authenticating inbound deliveries. Auto-generated when omitted; stored as a secret:// ref.",
-		}),
-	),
+	token: Type.String({
+		minLength: 32,
+		description:
+			"Bearer token authenticating inbound deliveries. Required on public create/apply surfaces; stored as a secret:// ref.",
+	}),
 	allowQueryAuth: Type.Optional(
 		boolOrString(
 			"Allow `?token=` auth for senders that cannot set headers (e.g. Sentry's legacy WebHooks plugin). Default false.",

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -751,13 +751,19 @@ export async function handleCreate(
 		authSchema: connector.auth_schema,
 	});
 
-	const chatPlatform =
+	const connectionPlatform =
 		connector.options_schema &&
 		typeof connector.options_schema === "object" &&
-		(connector.options_schema as Record<string, unknown>)[
+		((connector.options_schema as Record<string, unknown>)[
 			"x-lobu-chat-platform"
-		];
-	if (chatPlatform === args.connector_key) {
+		] ??
+			(connector.options_schema as Record<string, unknown>)[
+				"x-lobu-adapterless-platform"
+			]);
+	if (connectionPlatform === args.connector_key) {
+		if (args.connector_key === "webhook" && !args.slug) {
+			return { error: "Webhook connections require a non-numeric slug." };
+		}
 		try {
 			const stableId = args.slug || randomUUID().replace(/-/g, "").slice(0, 16);
 			const created = await upsertByoChatConnection({

--- a/packages/server/src/tools/admin/manage_connections/handlers/facets.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/facets.ts
@@ -40,7 +40,11 @@ export function deriveConnectionFacets(input: {
   hasOperations: boolean;
 }): ConnectionFacets {
   return {
-    data: input.feedCount > 0 || input.connectorHasFeeds,
+    // Generic webhooks ingest directly into events without a feed row.
+    data:
+      input.connectorKey === 'webhook' ||
+      input.feedCount > 0 ||
+      input.connectorHasFeeds,
     chat: input.isChat,
     actions: input.hasOperations,
     audience: AUDIENCE_CONNECTOR_KEYS.has(input.connectorKey),


### PR DESCRIPTION
## Summary

- route generic webhook deliveries through the existing durable event + Automation run lifecycle
- preserve provider-specific signed webhook handling and make numeric provider routes win over legacy generic IDs
- add bounded payload-to-input rendering, exact connection scoping, transactional activation, and delivery deduplication
- extend the existing BYO connection path to recognize adapterless connector schemas, without adding a scheduler, queue, table, or API surface

## Release composition

This is phase 1 (runtime compatibility) only. It intentionally does **not** publish the webhook adapterless marker or `delivery.received` catalog entry. That connector metadata and the public authoring E2E ship in phase 2 only after this runtime is fully deployed, preventing old pods from observing metadata they cannot serve.

## Verification

- `bun run typecheck`
- 165 focused unit/CLI tests passed
- gateway database E2E scenarios are included for CI: persist → activate → readback → concurrent dedupe, provider exclusion, and numeric route collision
- Codex blocker review completed; release-composition finding addressed by moving the entire webhook connector definition and public creation test to phase 2

Local database integration is unavailable because the embedded Postgres harness refuses the root user in this sandbox; GitHub CI is the canonical DB-backed run.