### PR TITLE
fix(server): harden SDK script errors

### DIFF
--- a/packages/core/src/__tests__/connector-query-errors.test.ts
+++ b/packages/core/src/__tests__/connector-query-errors.test.ts
@@ -49,6 +49,9 @@ describe("toToolErrorCode", () => {
   test("accepts known codes, rejects everything else", () => {
     expect(toToolErrorCode("RATE_LIMITED")).toBe("RATE_LIMITED");
     expect(toToolErrorCode("NOPE")).toBeUndefined();
+    expect(toToolErrorCode("constructor")).toBeUndefined();
+    expect(toToolErrorCode("toString")).toBeUndefined();
+    expect(toToolErrorCode("__proto__")).toBeUndefined();
     expect(toToolErrorCode(429)).toBeUndefined();
     expect(toToolErrorCode(null)).toBeUndefined();
     expect(toToolErrorCode(undefined)).toBeUndefined();

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -107,7 +107,7 @@ export function isRetryable(code: ToolErrorCode): boolean {
 /** Parse a `ToolErrorCode` from an unknown value (payload/DB boundary). */
 export function toToolErrorCode(value: unknown): ToolErrorCode | undefined {
   if (typeof value !== "string") return undefined;
-  return Object.prototype.hasOwnProperty.call(TOOL_ERRORS, value)
+  return Object.getOwnPropertyDescriptor(TOOL_ERRORS, value) !== undefined
     ? (value as ToolErrorCode)
     : undefined;
 }

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -107,7 +107,9 @@ export function isRetryable(code: ToolErrorCode): boolean {
 /** Parse a `ToolErrorCode` from an unknown value (payload/DB boundary). */
 export function toToolErrorCode(value: unknown): ToolErrorCode | undefined {
   if (typeof value !== "string") return undefined;
-  return value in TOOL_ERRORS ? (value as ToolErrorCode) : undefined;
+  return Object.prototype.hasOwnProperty.call(TOOL_ERRORS, value)
+    ? (value as ToolErrorCode)
+    : undefined;
 }
 
 /**

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -20,9 +20,15 @@ import { describe, expect, it, vi } from "vitest";
 import { Type } from "@sinclair/typebox";
 import type { ClientSDK } from "../../../sandbox/client-sdk";
 import { METHOD_METADATA } from "../../../sandbox/method-metadata";
-import { runScript } from "../../../sandbox/run-script";
+import { ClientSdkActionError } from "../../../sandbox/namespaces/action-call";
+import {
+  MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+  MAX_SCRIPT_ERROR_STACK_BYTES,
+  runScript,
+} from "../../../sandbox/run-script";
 import { createValidatedSdkMethod } from "../../../sandbox/sdk-preflight";
 import { withValidatedArgs } from "../../../tools/validate-args";
+import { ToolUserError } from "../../../utils/errors";
 
 const StubArgsSchema = Type.Object({ args: Type.Array(Type.Unknown()) });
 
@@ -90,17 +96,387 @@ describe("sandbox runtime", () => {
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("bounds thrown messages and stacks before returning them", async () => {
+    const result = await runScript({
+      source: `export default async () => {
+        const error = new Error("💥".repeat(100_000));
+        error.stack = "stack:" + "x".repeat(100_000);
+        throw error;
+      };`,
+      sdk: stubSDK(),
+      sdkMode: "read",
+    });
+
+    expect(result.success).toBe(false);
+    expect(Buffer.byteLength(result.error?.message ?? "", "utf8")).toBeLessThanOrEqual(
+      MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+    );
+    expect(result.error?.message).toMatch(/… \[truncated\]$/);
+    expect(Buffer.byteLength(result.error?.stack ?? "", "utf8")).toBeLessThanOrEqual(
+      MAX_SCRIPT_ERROR_STACK_BYTES,
+    );
+    expect(result.error?.stack).toMatch(/… \[truncated\]$/);
+  });
+
+  it("classifies a missing default export as a validation error", async () => {
+    const result = await runScript({
+      source: "const value = 1;",
+      sdk: stubSDK(),
+      sdkMode: "read",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({
+      name: "ValidationError",
+      message: "Script must `export default` an async function",
+    });
+  });
+
+  it("normalizes non-string thrown fields without replacing the original error", async () => {
+    const result = await runScript({
+      source: `export default async () => {
+        throw { name: 42, message: { reason: "boom" }, stack: 7 };
+      };`,
+      sdk: stubSDK(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({
+      name: "ScriptError",
+      message: "[object Object]",
+      stack: "7",
+    });
+    expect(result.error?.message).not.toContain("ERR_INVALID_ARG_TYPE");
+  });
+
+  it("handles BigInt, cyclic details, and throwing getters in guest errors", async () => {
+    const [bigIntResult, cyclicResult, getterResult] = await Promise.all([
+      runScript({
+        source: "export default async () => { throw { name: 12n, message: 34n, details: { value: 56n } }; };",
+        sdk: stubSDK(),
+      }),
+      runScript({
+        source: `export default async () => {
+          const error = new Error("cyclic");
+          error.details = {};
+          error.details.self = error.details;
+          throw error;
+        };`,
+        sdk: stubSDK(),
+      }),
+      runScript({
+        source: `export default async () => {
+          const error = { toString: () => "getter fallback" };
+          Object.defineProperty(error, "message", { get: () => { throw new Error("getter"); } });
+          throw error;
+        };`,
+        sdk: stubSDK(),
+      }),
+    ]);
+
+    expect(bigIntResult.error).toMatchObject({ message: "34" });
+    expect(bigIntResult.error).not.toHaveProperty("details");
+    expect(cyclicResult.error).toMatchObject({ message: "cyclic" });
+    expect(cyclicResult.error).not.toHaveProperty("details");
+    expect(getterResult.error).toMatchObject({ message: "getter fallback" });
+  });
+
+  it("does not trust script-forged retry classifications", async () => {
+    const result = await runScript({
+      source: `export default async () => {
+        const error = new Error("rate limit");
+        error.name = "ClientSdkActionError";
+        error.code = "NETWORK";
+        error.retryable = true;
+        error.httpStatus = 503;
+        error.details = { error_code: "UPSTREAM_TIMEOUT" };
+        throw error;
+      };`,
+      sdk: stubSDK(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({
+      name: "ClientSdkActionError",
+      message: "rate limit",
+    });
+    expect(result.error).not.toHaveProperty("code");
+    expect(result.error).not.toHaveProperty("retryable");
+  });
+
+  it("does not transfer a caught host classification to a replacement error", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ToolUserError("knowledge provider unavailable", 503);
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: `export default async (_ctx, client) => {
+        try {
+          await client.entities.list();
+        } catch (caught) {
+          const replacement = new Error((caught as Error).message);
+          replacement.name = (caught as Error).name;
+          (replacement as any).classificationToken = (caught as any).classificationToken;
+          throw replacement;
+        }
+      };`,
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ToolUserError",
+      message: "knowledge provider unavailable",
+    });
+    expect(result.error).not.toHaveProperty("code");
+    expect(result.error).not.toHaveProperty("retryable");
+  });
+
+  it("does not expose classifications through patched WeakMap intrinsics", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ToolUserError("knowledge provider unavailable", 503);
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: `export default async (_ctx, client) => {
+        const replacement = new Error("ordinary later bug");
+        const originalSet = WeakMap.prototype.set;
+        WeakMap.prototype.set = function (key, value) {
+          if (typeof value === "string") {
+            originalSet.call(this, replacement, value);
+          }
+          return originalSet.call(this, key, value);
+        };
+        try { await client.entities.list(); } catch { throw replacement; }
+      };`,
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ScriptError",
+      message: "ordinary later bug",
+    });
+    expect(result.error).not.toHaveProperty("code");
+    expect(result.error).not.toHaveProperty("retryable");
+  });
+
+  it("keeps a caught host classification bound across a later read dispatch", async () => {
+    let calls = 0;
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          calls++;
+          if (calls === 1) {
+            throw new ToolUserError("knowledge provider unavailable", 503);
+          }
+          return [];
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: `export default async (_ctx, client) => {
+        let caught;
+        try { await client.entities.list(); } catch (error) { caught = error; }
+        await client.entities.list();
+        throw caught;
+      };`,
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ToolUserError",
+      message: "knowledge provider unavailable",
+      code: "UPSTREAM_5XX",
+      retryable: true,
+    });
+  });
+
+  it("keeps concurrent same-message failures bound to their own error object", async () => {
+    let calls = 0;
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          calls++;
+          if (calls === 1) {
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            throw new ToolUserError("same failure", 503);
+          }
+          throw new ToolUserError("same failure", 400);
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: `export default async (ctx, client) => {
+        const delayed = client.entities.list().catch((error) => error);
+        await ctx.sleep(5);
+        const immediate = await client.entities.list().catch((error) => error);
+        await delayed;
+        throw immediate;
+      };`,
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ValidationError",
+      message: "same failure",
+      code: "VALIDATION",
+      retryable: false,
+    });
+  });
+
+  it("preserves a structured transient ToolUserError classification", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ToolUserError("knowledge provider unavailable", 503);
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({
+      name: "ToolUserError",
+      code: "UPSTREAM_5XX",
+      retryable: true,
+    });
+  });
+
+  it("maps a local 403 ToolUserError to permission, not invalid credentials", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ToolUserError("workspace access denied", 403);
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ToolUserError",
+      code: "PERMISSION",
+      retryable: false,
+    });
+  });
+
+  it("preserves ClientSdkActionError result codes across the isolate", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ClientSdkActionError("list", "connector failed", {
+            error_code: "NETWORK",
+            retryable: true,
+          });
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ClientSdkActionError",
+      code: "NETWORK",
+      retryable: true,
+      details: { error_code: "NETWORK", retryable: true },
+    });
+  });
+
+  it("rejects inherited object keys as ClientSdkActionError codes", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ClientSdkActionError("list", "connector failed", {
+            error_code: "constructor",
+          });
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ClientSdkActionError",
+      code: "INTERNAL",
+      retryable: false,
+    });
+  });
+
+  it("classifies legacy ClientSdkActionError error_message values", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ClientSdkActionError("list", "connector failed", {
+            status: "failed",
+            error_message: "fetch failed: ENOTFOUND",
+          });
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ClientSdkActionError",
+      code: "NETWORK",
+      retryable: true,
+    });
+  });
+
+  it("classifies an operation timeout result independently of its synthetic 400", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          throw new ClientSdkActionError("list", "operation timed out", {
+            status: "timeout",
+          });
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: "export default async (_ctx, client) => client.entities.list();",
+      sdk,
+    });
+
+    expect(result.error).toMatchObject({
+      name: "ClientSdkActionError",
+      code: "UPSTREAM_TIMEOUT",
+      retryable: true,
+    });
+  });
+
   it("exposes bounded ctx.sleep without exposing unrestricted timers", async () => {
     const stubSdk = { log: () => undefined } as unknown as ClientSDK;
     const started = Date.now();
     const result = await runScript({
       source:
-        "export default async (ctx) => { await ctx.sleep(15); return { timer: typeof setTimeout }; };",
+        "export default async (ctx) => { await ctx.sleep(15); return { timer: typeof setTimeout, hostBridge: typeof __sdk_dispatch }; };",
       sdk: stubSdk,
     });
 
     expect(result.success).toBe(true);
-    expect(result.returnValue).toEqual({ timer: "undefined" });
+    expect(result.returnValue).toEqual({
+      timer: "undefined",
+      hostBridge: "undefined",
+    });
     expect(Date.now() - started).toBeGreaterThanOrEqual(10);
   });
 
@@ -329,11 +705,31 @@ describe("compiled-source memo", () => {
     const second = await runScript({ source: broken, sdk: stub });
 
     expect(first.success).toBe(false);
-    expect(first.error?.name).toBe("CompileError");
+    expect(first.error?.name).toBe("ValidationError");
     expect(second.success).toBe(false);
-    expect(second.error?.name).toBe("CompileError");
+    expect(second.error?.name).toBe("ValidationError");
     // A failed compile leaves no entry, so the retry recompiles.
     expect((await compileCallCount()) - before).toBe(2);
+  });
+
+  it("keeps compiler infrastructure failures internal", async () => {
+    const { compileSource } = await import("../../../utils/compiler-core");
+    vi.mocked(compileSource).mockRejectedValueOnce(
+      Object.assign(new Error("ENOSPC"), {
+        errors: [{ text: "Could not write output file", location: null }],
+      }),
+    );
+
+    const result = await runScript({
+      source: uniqueSource(`compile_enospc_${process.pid}`),
+      sdk: stub,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({
+      name: "CompileError",
+      message: "ENOSPC",
+    });
   });
 });
 

--- a/packages/server/src/__tests__/unit/rest-error-status.test.ts
+++ b/packages/server/src/__tests__/unit/rest-error-status.test.ts
@@ -5,9 +5,47 @@ import {
 	restGetAutomations,
 	restInvokeEventAction,
 	restSearchKnowledge,
+	toRestPublicToolResult,
 } from "../../rest-api";
 
 describe("REST ToolUserError responses", () => {
+	it("projects SDK tool results to the documented public shape", () => {
+		const rich = {
+			success: false,
+			error: {
+				name: "ScriptError",
+				message: "boom",
+				code: "INTERNAL",
+				retryable: false,
+				stack: "internal stack",
+				details: { secret: true },
+			},
+			logs: [{ message: "internal log" }],
+			duration_ms: 12,
+			sdk_call_trace: [{ path: "knowledge.search" }],
+			skipped_calls: 0,
+			side_effect_preview: [],
+			dry_run: false,
+		};
+
+		for (const toolName of ["query_sdk", "run_sdk"]) {
+			const projected = toRestPublicToolResult(toolName, rich) as Record<
+				string,
+				unknown
+			>;
+			expect(projected.error).toEqual({
+				name: "ScriptError",
+				message: "boom",
+				code: "INTERNAL",
+				retryable: false,
+			});
+			expect(projected.logs).toBeUndefined();
+			expect(projected.duration_ms).toBeUndefined();
+			expect(projected.sdk_call_trace).toBeUndefined();
+		}
+		expect(toRestPublicToolResult("manage_operations", rich)).toBe(rich);
+	});
+
 	it("preserves the status thrown by the wrapped tool", async () => {
 		const app = new Hono<{ Bindings: Env }>();
 		app.use("*", async (c, next) => {

--- a/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
+++ b/packages/server/src/__tests__/unit/sdk-mcp-public-result.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { SdkScriptResultSchema, toMcpPublicSdkScriptResult } from "../../tools/sdk_run";
+import { boundScriptErrorText } from "../../sandbox/run-script";
+import {
+	classifySdkScriptError,
+	SdkScriptResultSchema,
+	toMcpPublicSdkScriptResult,
+} from "../../tools/sdk_run";
 import { validateToolResult } from "../../tools/validate-args";
 
 describe("SDK MCP public result", () => {
@@ -155,6 +160,95 @@ describe("SDK MCP public result", () => {
 				}) as Record<string, unknown>
 			).title,
 		).toBeUndefined();
+	});
+
+	test("defensively bounds public error fields", () => {
+		const publicResult = toMcpPublicSdkScriptResult({
+			success: false,
+			skipped_calls: 0,
+			side_effect_preview: [],
+			dry_run: false,
+			error: {
+				name: "N".repeat(2_000),
+				message: "💥".repeat(100_000),
+			},
+		}) as Record<string, unknown>;
+
+		expect(validateToolResult(SdkScriptResultSchema, publicResult)).not.toBeNull();
+		const error = publicResult.error as { name: string; message: string };
+		expect(Buffer.byteLength(error.name, "utf8")).toBeLessThanOrEqual(256);
+		expect(Buffer.byteLength(error.message, "utf8")).toBeLessThanOrEqual(16_384);
+		expect(error.name).toEndWith("… [truncated]");
+		expect(error.message).toEndWith("… [truncated]");
+	});
+
+	test("honors error bounds smaller than the truncation suffix", () => {
+		const bounded = boundScriptErrorText("💥abcdef", 5);
+		expect(Buffer.byteLength(bounded, "utf8")).toBeLessThanOrEqual(5);
+		expect(bounded).toBe("💥a");
+	});
+
+	test("classifies deterministic caller failures as validation errors", () => {
+		expect(
+			classifySdkScriptError({
+				name: "ValidationError",
+				message: "Invalid arguments for client.agents.list: unknown argument(s): limit",
+			}),
+		).toEqual({ code: "VALIDATION", retryable: false });
+		// The compiler block also owns filesystem/module-loading failures, so its
+		// generic name alone is not proof the caller supplied invalid source.
+		expect(
+			classifySdkScriptError({
+				name: "CompileError",
+				message: "ENOSPC while loading compiler infrastructure",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
+		expect(
+			classifySdkScriptError({
+				name: "ScriptError",
+				message: "unexpected application failure",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
+	});
+
+	test("prefers structured classifications and ignores script-controlled markers", () => {
+		expect(
+			classifySdkScriptError({
+				name: "ToolUserError",
+				message: "temporary provider failure",
+				code: "NETWORK",
+			}),
+		).toEqual({ code: "NETWORK", retryable: true });
+		expect(
+			classifySdkScriptError({
+				name: "ToolUserError",
+				message: "provider unavailable",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
+		expect(
+			classifySdkScriptError({
+				name: "ClientSdkActionError",
+				message: "rate limit",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
+		expect(
+			classifySdkScriptError({
+				name: "TimeoutError",
+				message: "script exceeded its wall-clock budget",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
+		expect(
+			classifySdkScriptError({
+				name: "McpScopeRequiredError",
+				message: "mcp:admin is required",
+			}),
+		).toEqual({ code: "PERMISSION", retryable: false });
+		expect(
+			classifySdkScriptError({
+				name: "ScriptError",
+				message: "user text says 429 and rate limit",
+			}),
+		).toEqual({ code: "INTERNAL", retryable: false });
 	});
 
 	test("summarizes change-capable calls a failed live run already dispatched", () => {

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -31,6 +31,7 @@ import {
 } from "./tools/execute";
 import { getContent } from "./tools/get_content";
 import { getAutomation } from "./tools/get_automation";
+import { toMcpPublicSdkScriptResult } from "./tools/sdk_run";
 import {
 	getAllTools,
 	getTool,
@@ -302,6 +303,16 @@ export async function restToolAction(
 	return restToolProxy(c, toolName, fixedActionArgs(action, callerArgs));
 }
 
+/** Match the concise SDK result contract exposed by MCP and OpenAPI. */
+export function toRestPublicToolResult(
+	toolName: string,
+	result: unknown,
+): unknown {
+	return toolName === "run_sdk" || toolName === "query_sdk"
+		? toMcpPublicSdkScriptResult(result)
+		: result;
+}
+
 /**
  * POST /api/:orgSlug/:toolName
  * Generic proxy endpoint for the REST dispatch tool surface.
@@ -325,7 +336,7 @@ export async function restToolProxy(
 		const args: Record<string, unknown> = explicitArgs ?? (await c.req.json());
 		const authCtx = extractAuthContext(c);
 		const result = await executeTool(toolName, args, c.env, authCtx);
-		return c.json(toJsonSafe(result));
+		return c.json(toJsonSafe(toRestPublicToolResult(toolName, result)));
 	} catch (error) {
 		if (error instanceof ToolNotRegisteredError) {
 			// Registry/frontend drift — surface to Sentry so the next "Tool not

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -15,13 +15,22 @@
  * `orgPath` so the host re-walks org swaps without holding refs.
  */
 
+import { randomUUID } from "node:crypto";
 import type { ClientSDK } from "./client-sdk";
+import {
+	classifyToolError,
+	isRetryable,
+	isToolError,
+	toToolErrorCode,
+	type ToolErrorCode,
+} from "@lobu/core";
 import { ClientSdkActionError } from "./namespaces/action-call";
 import { METHOD_METADATA, type MethodAccess } from "./method-metadata";
 import type { ToolAccessLevel } from "../auth/tool-access";
 import { enumerateSDKManifest, type SDKMode } from "./sdk-manifest";
 import { McpScopeRequiredError } from "../tools/access-control";
 import { getSdkPreflight } from "./sdk-preflight";
+import { ToolUserError } from "../utils/errors";
 
 export interface RunLimits {
 	memoryMb?: number;
@@ -148,6 +157,8 @@ interface RunScriptResult {
 	error?: {
 		name: string;
 		message: string;
+		code?: ToolErrorCode;
+		retryable?: boolean;
 		details?: unknown;
 		stack?: string;
 		line?: number;
@@ -171,6 +182,9 @@ export const MAX_SCRIPT_TIMEOUT_MS = 180_000;
 export const MAX_SLEEP_MS = 30_000;
 const MAX_TRACE_ARGS_BYTES = 8192;
 const MAX_ERROR_DETAILS_BYTES = 16_384;
+export const MAX_SCRIPT_ERROR_NAME_BYTES = 256;
+export const MAX_SCRIPT_ERROR_MESSAGE_BYTES = 16_384;
+export const MAX_SCRIPT_ERROR_STACK_BYTES = 32_768;
 const SENSITIVE_TRACE_KEY =
 	/(api[_-]?key|apikey|auth[_-]?data|auth[_-]?values|authorization|cookie|credential|password|private[_-]?key|secret|token)/i;
 
@@ -261,6 +275,25 @@ function byteBoundedPrefix(value: string, maxBytes: number): string {
 	return value.slice(0, lo);
 }
 
+function errorFieldText(value: unknown, fallback: string): string {
+	if (typeof value === "string") return value;
+	if (value == null) return fallback;
+	try {
+		return String(value);
+	} catch {
+		return fallback;
+	}
+}
+
+/** Bound one SDK script error field without cutting a UTF-16 surrogate pair. */
+export function boundScriptErrorText(value: unknown, maxBytes: number): string {
+	const text = errorFieldText(value, "");
+	if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+	const suffixBytes = Buffer.byteLength(PREVIEW_SUFFIX, "utf8");
+	if (maxBytes <= suffixBytes) return byteBoundedPrefix(text, maxBytes);
+	return `${byteBoundedPrefix(text, Math.max(0, maxBytes - suffixBytes))}${PREVIEW_SUFFIX}`;
+}
+
 /**
  * Build the preview for an oversized interactive return value: a UTF-8-safe
  * head of the serialized JSON (a preview the model reads to decide what to
@@ -286,43 +319,131 @@ function buildReturnPreview(
 	};
 }
 
-function classifyRuntimeError(error: {
-	name?: string;
-	message?: string;
-	stack?: string;
-	details?: unknown;
-}): NonNullable<RunScriptResult["error"]> {
-	const message = error.message ?? "Script execution failed";
+type TrustedErrorClassification = {
+	code: ToolErrorCode;
+	retryable: boolean;
+};
+
+function classifyToolUserError(error: ToolUserError): ToolErrorCode {
+	const directCode = toToolErrorCode(error.code);
+	if (directCode) return directCode;
+	if (error.httpStatus === 403) return "PERMISSION";
+	return classifyToolError({ httpStatus: error.httpStatus });
+}
+
+function classifyClientSdkActionResult(
+	result: Readonly<Record<string, unknown>>,
+): ToolErrorCode {
+	const directCode =
+		toToolErrorCode(result.error_code) ?? toToolErrorCode(result.code);
+	if (directCode) return directCode;
+	if (result.status === "timeout" || result.status === "timed_out") {
+		return "UPSTREAM_TIMEOUT";
+	}
+	const httpStatus =
+		typeof result.http_status === "number"
+			? result.http_status
+			: typeof result.httpStatus === "number"
+				? result.httpStatus
+				: undefined;
+	if (httpStatus !== undefined) return classifyToolError({ httpStatus });
+	const failedItem = Array.isArray(result.results)
+		? result.results.find(
+				(item): item is Record<string, unknown> =>
+					item !== null &&
+					typeof item === "object" &&
+					!Array.isArray(item) &&
+					(item as Record<string, unknown>).success === false,
+			)
+		: undefined;
+	const message = [
+		result.error,
+		result.error_message,
+		result.message,
+		result.reason,
+		failedItem?.error,
+		failedItem?.error_message,
+		failedItem?.message,
+		failedItem?.reason,
+	].find(
+		(value): value is string =>
+			typeof value === "string" && value.trim().length > 0,
+	);
+	return classifyToolError({ message });
+}
+
+function trustedRuntimeClassification(
+	error: Record<string, unknown>,
+	trustedClassifications?: ReadonlyMap<string, TrustedErrorClassification>,
+): TrustedErrorClassification | undefined {
+	const token = error.classificationToken;
+	return typeof token === "string"
+		? trustedClassifications?.get(token)
+		: undefined;
+}
+
+function classifyRuntimeError(
+	error: unknown,
+	trustedClassifications?: ReadonlyMap<string, TrustedErrorClassification>,
+): NonNullable<RunScriptResult["error"]> {
+	const record =
+		error !== null && typeof error === "object"
+			? (error as Record<string, unknown>)
+			: {};
+	const rawName = errorFieldText(record.name, "Error");
+	const rawMessage = errorFieldText(record.message, "Script execution failed");
+	const message = boundScriptErrorText(
+		rawMessage,
+		MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+	);
+	const classification = trustedRuntimeClassification(
+		record,
+		trustedClassifications,
+	);
 	// Expected user-input errors (bad SDK args, business-rule failures) must NOT
 	// leak a server-bundle stack to the client — the message already carries the
 	// actionable "Invalid arguments for client.x.y: …" guidance, and the full
 	// stack stays in server logs/observability. An unexpected ScriptError keeps
 	// its stack (a genuine bug the developer needs to trace).
 	const isExpectedUserError =
-		error.name === "ClientSdkActionError" ||
-		error.name === "McpScopeRequiredError" ||
-		error.name === "ToolUserError" ||
-		/^Invalid arguments for /.test(message);
-	if (error.name === "ClientSdkActionError") {
+		rawName === "ClientSdkActionError" ||
+		rawName === "McpScopeRequiredError" ||
+		rawName === "ToolUserError" ||
+		rawMessage === "Script must `export default` an async function" ||
+		/^Invalid arguments for /.test(rawMessage);
+	if (rawName === "ClientSdkActionError") {
 		return {
 			name: "ClientSdkActionError",
 			message,
-			...(error.details === undefined ? {} : { details: error.details }),
+			...classification,
+			...(record.details === undefined
+				? {}
+				: { details: safeErrorDetails(record.details) }),
 		};
 	}
-	if (error.name === "McpScopeRequiredError") {
-		return { name: "McpScopeRequiredError", message };
+	if (rawName === "McpScopeRequiredError") {
+		return { name: "McpScopeRequiredError", message, ...classification };
+	}
+	if (rawName === "ToolUserError") {
+		return {
+			name:
+				classification?.code === "VALIDATION"
+					? "ValidationError"
+					: "ToolUserError",
+			message,
+			...classification,
+		};
 	}
 	if (isExpectedUserError) {
-		return { name: "ValidationError", message };
+		return { name: "ValidationError", message, ...classification };
 	}
 
-	const isTimeout = /script execution timed out|TimeoutError/i.test(message);
-	const isQuota = /QuotaExceeded/.test(message);
-	const isSleepLimit = /SleepLimitExceeded/.test(message);
-	const isInvalidSleep = /InvalidSleepDuration/.test(message);
-	const isOversize = /OutputSizeExceeded/.test(message);
-	const isOom = /memory|allocation|isolate was disposed/i.test(message);
+	const isTimeout = /script execution timed out|TimeoutError/i.test(rawMessage);
+	const isQuota = /QuotaExceeded/.test(rawMessage);
+	const isSleepLimit = /SleepLimitExceeded/.test(rawMessage);
+	const isInvalidSleep = /InvalidSleepDuration/.test(rawMessage);
+	const isOversize = /OutputSizeExceeded/.test(rawMessage);
+	const isOom = /memory|allocation|isolate was disposed/i.test(rawMessage);
 	const name = isTimeout
 		? "TimeoutError"
 		: isQuota
@@ -339,7 +460,15 @@ function classifyRuntimeError(error: {
 	return {
 		name,
 		message,
-		...(error.stack ? { stack: error.stack } : {}),
+		...classification,
+		...(record.stack != null
+			? {
+					stack: boundScriptErrorText(
+						record.stack,
+						MAX_SCRIPT_ERROR_STACK_BYTES,
+					),
+				}
+			: {}),
 	};
 }
 
@@ -520,13 +649,25 @@ async function loadIsolatedVm(): Promise<IsolatedVmRuntime | null> {
 	}
 }
 
-const GUEST_PREAMBLE = `
+function guestPreamble(errorTokenReader: string): string {
+	return `
 const __ctxData = JSON.parse(__ctx_json);
 const ctx = Object.freeze({
   ...__ctxData,
   sleep: async (ms) => __sleep.apply(undefined, [ms], { result: { promise: true, copy: true } }),
 });
-const __manifest = JSON.parse(__sdk_manifest_json);
+const { client, takeErrorToken: ${errorTokenReader} } = (() => {
+const __hostSdkDispatch = __sdk_dispatch;
+try {
+  globalThis.__sdk_dispatch = undefined;
+  delete globalThis.__sdk_dispatch;
+} catch {}
+const __parseJson = JSON.parse.bind(JSON);
+const __trustedErrors = new WeakMap();
+const __rememberTrustedError = WeakMap.prototype.set.bind(__trustedErrors);
+const __readTrustedError = WeakMap.prototype.get.bind(__trustedErrors);
+const __forgetTrustedError = WeakMap.prototype.delete.bind(__trustedErrors);
+const __manifest = __parseJson(__sdk_manifest_json);
 const __namespaceMethods = __manifest.byNamespace;
 const __topLevelKeys = new Set(__manifest.topLevel);
 const __namespaceKeys = new Set(Object.keys(__namespaceMethods));
@@ -550,9 +691,9 @@ function __isReservedKey(k) {
 function __dispatchCall(path, orgPath) {
   return async (...args) => {
     const payload = JSON.stringify({ args, orgPath });
-    const r = await __sdk_dispatch.apply(undefined, [path, payload], { result: { promise: true, copy: true } });
+    const r = await __hostSdkDispatch.apply(undefined, [path, payload], { result: { promise: true, copy: true } });
     if (r === undefined) return undefined;
-    const envelope = JSON.parse(r);
+    const envelope = __parseJson(r);
     if (!envelope || envelope.__lobu_sdk_dispatch !== 1) {
       throw new Error('InvalidSDKDispatchEnvelope');
     }
@@ -560,6 +701,9 @@ function __dispatchCall(path, orgPath) {
       const error = new Error(envelope.error?.message || 'ClientSDK call failed');
       error.name = envelope.error?.name || 'ClientSdkActionError';
       if (envelope.error?.details !== undefined) error.details = envelope.error.details;
+      if (typeof envelope.error?.classificationToken === 'string') {
+		__rememberTrustedError(error, envelope.error.classificationToken);
+      }
       throw error;
     }
     return envelope.has_value ? envelope.value : undefined;
@@ -626,7 +770,15 @@ function __makeClient(orgPath) {
   });
 }
 
-const client = __makeClient([]);
+return {
+  client: __makeClient([]),
+  takeErrorToken(error) {
+    const trusted = __readTrustedError(error);
+    __forgetTrustedError(error);
+	return trusted;
+  },
+};
+})();
 
 let __console_enabled = true;
 function __emitConsole(level, args) {
@@ -645,8 +797,10 @@ const console = {
 const module = { exports: {} };
 const exports = module.exports;
 `;
+}
 
-const GUEST_RUNNER = `
+function guestRunner(errorTokenReader: string): string {
+	return `
 (async () => {
   try {
   const __entry = module.exports.default
@@ -662,19 +816,42 @@ const GUEST_RUNNER = `
       value: __result === undefined ? null : __result,
     });
   } catch (error) {
+	const __safeErrorField = (key, fallback) => {
+	  try {
+		const value = error?.[key];
+		if (typeof value === 'string') return value;
+		if (value == null) return fallback;
+		try { return String(value); } catch { return fallback; }
+	  } catch { return fallback; }
+	};
+	const __safeErrorDetails = () => {
+	  try {
+		if (error?.details === undefined) return undefined;
+		return JSON.parse(JSON.stringify(error.details));
+	  } catch { return undefined; }
+	};
+	const __safeThrownValue = () => {
+	  try { return String(error); } catch { return 'Unknown error'; }
+	};
+	const __details = __safeErrorDetails();
+	const __classificationToken = ${errorTokenReader}(error);
     return JSON.stringify({
       __lobu_script_result: 1,
       ok: false,
       error: {
-        name: error?.name || 'Error',
-        message: error?.message || String(error),
-        stack: error?.stack,
-        ...(error?.details === undefined ? {} : { details: error.details }),
+		name: __safeErrorField('name', 'Error'),
+		message: __safeErrorField('message', __safeThrownValue()),
+		stack: __safeErrorField('stack', undefined),
+		...(__details === undefined ? {} : { details: __details }),
+		...(__classificationToken === undefined
+		  ? {}
+		  : { classificationToken: __classificationToken }),
       },
     });
   }
 })()
 `;
+}
 
 // Read a named export instead of invoking the handler — the module top-level
 // runs (constructing exports), then we serialize the requested export. `__name`
@@ -757,6 +934,18 @@ export async function runScript(
 	 */
 	const startedSideEffects = new Map<string, { access: MethodAccess; count: number }>();
 	const requiredMcpScopes = new Set<"mcp:admin">();
+	const trustedErrorClassifications = new Map<
+		string,
+		TrustedErrorClassification
+	>();
+	const trustErrorClassification = (code: ToolErrorCode): string => {
+		const token = randomUUID();
+		trustedErrorClassifications.set(token, {
+			code,
+			retryable: isRetryable(code),
+		});
+		return token;
+	};
 	let sdkCalls = 0;
 	// Total calls skipped under dry-run, independent of preview retention so a
 	// truncated preview never undercounts the dry-run surface.
@@ -874,12 +1063,16 @@ export async function runScript(
 	}
 
 	let compiled: string;
+	let SourceCompileErrorClass:
+		| typeof import("../utils/compiler-core").SourceCompileError
+		| undefined;
 	try {
 		// Deferred: `compiler-core` pulls in esbuild and resolves the connector
 		// SDK entry at module scope, neither of which a run-free process needs.
-		const { compileSource, computeCodeHash } = await import(
+		const { compileSource, computeCodeHash, SourceCompileError } = await import(
 			"../utils/compiler-core"
 		);
+		SourceCompileErrorClass = SourceCompileError;
 		// Compilation is `mkdtemp` + `writeFile` + a full esbuild bundle + read
 		// back — filesystem I/O and a bundler per call. Measured locally, a cold
 		// `runScript` costs 6–25ms end to end where a memo hit costs ~3ms, so
@@ -932,16 +1125,24 @@ export async function runScript(
 		}
 	} catch (err) {
 		clearTimeout(abortTimer);
-		const e = err as Error & {
-			errors?: Array<{ location?: { line?: number; column?: number } }>;
-		};
-		const loc = e.errors?.[0]?.location;
+		const isSourceCompileFailure =
+			SourceCompileErrorClass !== undefined &&
+			err instanceof SourceCompileErrorClass;
+		const loc = isSourceCompileFailure
+			? err.diagnostics[0]?.location
+			: undefined;
+		const message = boundScriptErrorText(
+			err instanceof Error ? err.message : err,
+			MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+		);
 		return {
 			success: false,
 			logs,
 			error: {
-				name: "CompileError",
-				message: e.message,
+				name: isSourceCompileFailure ? "ValidationError" : "CompileError",
+				message,
+				code: isSourceCompileFailure ? "VALIDATION" : "INTERNAL",
+				retryable: false,
 				line: loc?.line,
 				column: loc?.column,
 			},
@@ -1131,21 +1332,51 @@ export async function runScript(
 						const json = JSON.stringify({
 							__lobu_sdk_dispatch: 1,
 							ok: false,
-							error: {
-								name: error.name,
-								message: error.message,
+								error: {
+									name: error.name,
+									message: error.message,
+									classificationToken:
+										trustErrorClassification("PERMISSION"),
 							},
 						});
 						return guardMessage(json) ? json : terminalEnvelope();
 					}
 					if (error instanceof ClientSdkActionError) {
+						const code = classifyClientSdkActionResult(error.result);
 						const json = JSON.stringify({
 							__lobu_sdk_dispatch: 1,
 							ok: false,
 							error: {
-								name: error.name,
-								message: error.message,
-								details: safeErrorDetails(error.result),
+									name: error.name,
+									message: error.message,
+									details: safeErrorDetails(error.result),
+									classificationToken: trustErrorClassification(code),
+							},
+						});
+						return guardMessage(json) ? json : terminalEnvelope();
+					}
+					if (error instanceof ToolUserError) {
+						const code = classifyToolUserError(error);
+						const json = JSON.stringify({
+							__lobu_sdk_dispatch: 1,
+							ok: false,
+							error: {
+									name: error.name,
+									message: error.message,
+									classificationToken: trustErrorClassification(code),
+							},
+						});
+						return guardMessage(json) ? json : terminalEnvelope();
+					}
+					if (isToolError(error)) {
+						const json = JSON.stringify({
+							__lobu_sdk_dispatch: 1,
+							ok: false,
+							error: {
+									name: error.name,
+									message: error.message,
+									classificationToken:
+										trustErrorClassification(error.code),
 							},
 						});
 						return guardMessage(json) ? json : terminalEnvelope();
@@ -1206,8 +1437,9 @@ export async function runScript(
 			await jail.set("__extract_name", options.extractExport);
 		}
 
+		const errorTokenReader = `__lobu_take_error_token_${randomUUID().replaceAll("-", "")}`;
 		const script = await isolate.compileScript(
-			`${GUEST_PREAMBLE}\n${compiled}\n${options.extractExport ? EXTRACT_RUNNER : GUEST_RUNNER}`,
+			`${guestPreamble(errorTokenReader)}\n${compiled}\n${options.extractExport ? EXTRACT_RUNNER : guestRunner(errorTokenReader)}`,
 		);
 		const returnJson = (await withTimeout(
 			script.run(context, {
@@ -1252,12 +1484,16 @@ export async function runScript(
 							message?: string;
 							stack?: string;
 							details?: unknown;
+							classificationToken?: string;
 					  }
 					| undefined;
 				return {
 					success: false,
 					logs,
-					error: classifyRuntimeError(scriptError ?? {}),
+					error: classifyRuntimeError(
+						scriptError ?? {},
+						trustedErrorClassifications,
+					),
 					durationMs: Date.now() - started,
 					sdkCalls,
 					skippedCalls,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -1,12 +1,22 @@
 import { type Static, Type } from "@sinclair/typebox";
-import { classifyToolError, isRetryable } from "@lobu/core";
+import {
+  isRetryable,
+  toToolErrorCode,
+  type ToolErrorCode,
+} from "@lobu/core";
 import { resolveSdkMaxAccessLevel } from "../auth/tool-access";
 import { buildMcpBearerChallenge } from "../auth/oauth/resource-indicator";
 import { DISCOVERY_SCOPES } from "../auth/oauth/scopes";
 import { isAdminOrOwnerRole } from "./access-control";
 import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
-import { MAX_SCRIPT_TIMEOUT_MS, runScript } from "../sandbox/run-script";
+import {
+  boundScriptErrorText,
+  MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+  MAX_SCRIPT_ERROR_NAME_BYTES,
+  MAX_SCRIPT_TIMEOUT_MS,
+  runScript,
+} from "../sandbox/run-script";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
 import { mcpResourceLinksForSdkReturnValue } from "../mcp-media-resources";
@@ -139,8 +149,8 @@ export const SdkScriptResultSchema = Type.Object({
   error: Type.Optional(
     Type.Object(
       {
-        name: Type.String(),
-        message: Type.String(),
+        name: Type.String({ maxLength: MAX_SCRIPT_ERROR_NAME_BYTES }),
+        message: Type.String({ maxLength: MAX_SCRIPT_ERROR_MESSAGE_BYTES }),
         code: Type.Optional(Type.String()),
         retryable: Type.Optional(Type.Boolean()),
       },
@@ -297,8 +307,14 @@ export function toMcpPublicSdkScriptResult(result: unknown): unknown {
     const error = row.error as Record<string, unknown>;
     if (typeof error.message === "string") {
       out.error = {
-        name: typeof error.name === "string" ? error.name : "Error",
-        message: error.message,
+        name: boundScriptErrorText(
+          typeof error.name === "string" ? error.name : "Error",
+          MAX_SCRIPT_ERROR_NAME_BYTES,
+        ),
+        message: boundScriptErrorText(
+          error.message,
+          MAX_SCRIPT_ERROR_MESSAGE_BYTES,
+        ),
         ...(typeof error.code === "string" ? { code: error.code } : {}),
         ...(typeof error.retryable === "boolean" ? { retryable: error.retryable } : {}),
       };
@@ -339,6 +355,27 @@ export function resolveSandboxDryRun(args: {
 }): boolean {
   const captureSideEffects = args.executionMode === "capture";
   return captureSideEffects || (args.sdkMode === "full" && args.agentDryRun);
+}
+
+export function classifySdkScriptError(error: {
+  name: string;
+  message: string;
+  code?: unknown;
+}): { code: ToolErrorCode; retryable: boolean } {
+  const structuredCode = toToolErrorCode(error.code);
+  if (structuredCode) {
+    return { code: structuredCode, retryable: isRetryable(structuredCode) };
+  }
+
+  let code: ToolErrorCode;
+  if (error.name === "ValidationError") {
+    code = "VALIDATION";
+  } else if (error.name === "McpScopeRequiredError") {
+    code = "PERMISSION";
+  } else {
+    code = "INTERNAL";
+  }
+  return { code, retryable: isRetryable(code) };
 }
 
 /**
@@ -398,8 +435,8 @@ async function runSandbox(
   // is purely advisory.
   const error = result.error
     ? (() => {
-        const code = classifyToolError({ message: result.error?.message });
-        return { ...result.error, code, retryable: isRetryable(code) };
+        const classification = classifySdkScriptError(result.error);
+        return { ...result.error, ...classification };
       })()
     : result.error;
   const title = args.title?.trim() || undefined;

--- a/packages/server/src/utils/__tests__/compiler-core.test.ts
+++ b/packages/server/src/utils/__tests__/compiler-core.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { compileSource } from '../compiler-core';
+import type { Plugin } from 'esbuild';
+import { compileSource, SourceCompileError } from '../compiler-core';
 
 /**
  * #2043 — dependency restrictions must apply only to real module declarations
@@ -35,6 +36,35 @@ async function compileErr(source: string): Promise<string> {
 }
 
 describe('compileSource import validation (#2043)', () => {
+  test('marks source diagnostics but not esbuild output failures', async () => {
+    await expect(compileSource('export default = ;', CONFIG)).rejects.toBeInstanceOf(
+      SourceCompileError
+    );
+
+    const outputFailure = compileSource('export default 1;', {
+      ...CONFIG,
+      buildOptions: { ...CONFIG.buildOptions, outfile: process.cwd() },
+    });
+    await expect(outputFailure).rejects.not.toBeInstanceOf(SourceCompileError);
+  });
+
+  test('does not mark located plugin infrastructure failures as source errors', async () => {
+    const brokenPlugin: Plugin = {
+      name: 'broken-test-plugin',
+      setup(build) {
+        build.onResolve({ filter: /^broken$/ }, () => {
+          throw new Error('plugin infrastructure failed');
+        });
+      },
+    };
+    const pluginFailure = compileSource(`import value from 'broken'; export default value;`, {
+      ...CONFIG,
+      buildOptions: { ...CONFIG.buildOptions, plugins: [brokenPlugin] },
+    });
+
+    await expect(pluginFailure).rejects.not.toBeInstanceOf(SourceCompileError);
+  });
+
   test('rejects a real relative import with a source location', async () => {
     const message = await compileErr(
       `import { sleep } from './scraper-utils.ts';\nexport default sleep;`

--- a/packages/server/src/utils/compiler-core.ts
+++ b/packages/server/src/utils/compiler-core.ts
@@ -19,7 +19,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { EXTERNAL_RUNTIME_DEPS, createNpmSpecifierPlugin } from '@lobu/connector-worker/compile';
 import { type BuildOptions, type Plugin, build } from 'esbuild';
 import logger from './logger';
@@ -31,6 +31,23 @@ const SDK_ENTRY = require.resolve('@lobu/connector-sdk');
 export interface CompileResult {
   compiledCode: string;
   compiledCodeHash: string;
+}
+
+export interface SourceCompileDiagnostic {
+  location?: { file?: string; line?: number; column?: number } | null;
+}
+
+/** A compiler failure tied to a location in the caller's source text. */
+export class SourceCompileError extends Error {
+  readonly name = 'SourceCompileError';
+
+  constructor(
+    message: string,
+    readonly diagnostics: SourceCompileDiagnostic[],
+    cause: Error
+  ) {
+    super(message, { cause });
+  }
 }
 
 interface CompileConfig {
@@ -143,10 +160,26 @@ export async function compileSource(
       }
     } catch (error) {
       if (error instanceof Error) {
-        throw new Error(
+        const message =
           `${config.label} compilation failed: ${error.message}. ` +
-            'If this source imports local project modules, replace them with lobu or npm: imports.'
-        );
+          'If this source imports local project modules, replace them with lobu or npm: imports.';
+        const buildErrors = (error as { errors?: unknown }).errors;
+        const sourceDiagnostics = Array.isArray(buildErrors)
+          ? buildErrors.filter(
+              (diagnostic): diagnostic is SourceCompileDiagnostic =>
+                diagnostic !== null &&
+                typeof diagnostic === 'object' &&
+                typeof (diagnostic as SourceCompileDiagnostic).location?.file === 'string' &&
+                resolve(
+                  process.cwd(),
+                  (diagnostic as SourceCompileDiagnostic).location?.file ?? ''
+                ) === inputPath
+            )
+          : [];
+        if (sourceDiagnostics.length > 0) {
+          throw new SourceCompileError(message, sourceDiagnostics, error);
+        }
+        throw new Error(message, { cause: error });
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- bound SDK script error names/messages/stacks and project only concise SDK results through MCP and REST
- classify deterministic source/argument failures separately from compiler infrastructure failures
- preserve trusted host SDK error codes per exact guest Error identity without accepting guest-forged codes, inherited catalog keys, stale bearer tokens, or concurrent cross-association
- map local 403s, operation timeouts, legacy action failures, and sandbox wall-clock deadlines to the correct retry semantics

## Review

Independent Codex review: **APPROVE** after blocker-driven fixes for provenance, concurrent failures, mutable guest intrinsics, compiler diagnostic ownership, and inherited error-code keys.

## Verification

- `packages/core: bun run build`
- core error taxonomy: **15 tests / 94 assertions**
- server TypeScript: `bun x tsc --noEmit`
- focused compiler, SDK result, REST, wire, and route suites: **59 tests / 292 assertions**
- Node production sandbox runtime: **51 tests**
- `git diff --cached --check`

`make pre-pr` reaches unchanged plugin package builds, then hits the workspace's borrowed `node_modules` symlink portability artifact (TS2742 paths into another worktree). The changed core and server packages typecheck directly; GitHub CI is the canonical clean-workspace run.

## UI

No hosted UI surface changed; `ui-review` is not applicable.