### PR TITLE
feat(oauth): consolidate authorization review grants

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -231,6 +231,10 @@ jobs:
                       - { name: DATABASE_URL, value: "file:///var/lib/lobu/data/lobu.db" }
                       - { name: NODE_ENV, value: "development" }
                       - { name: CHOKIDAR_USEPOLLING, value: "true" }
+                      # A preview has one backend pod, so it is safe to exercise
+                      # the complete multi-workspace grant path before the
+                      # coordinated production rollout enables it.
+                      - { name: LOBU_OAUTH_MULTI_WORKSPACE_GRANTS, value: "1" }
                       - { name: ENCRYPTION_KEY, valueFrom: { secretKeyRef: { name: preview-encryption, key: key } } }
                       ${LOCK_ENV}
                     ports:
@@ -289,6 +293,68 @@ jobs:
             -n "$PREVIEW_NS" \
             --timeout=600s
 
+      - name: Detect authorization UI changes
+        id: oauth-ui-scope
+        run: |
+          set -euo pipefail
+          changed_files=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[].filename')
+          if grep -Eq '^(packages/owletto$|packages/server/src/auth/oauth/)' <<<"$changed_files"; then
+            echo "capture=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "capture=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Capture authorization UI proof
+        id: oauth-ui-proof
+        if: steps.oauth-ui-scope.outputs.capture == 'true'
+        env:
+          PROOF_BASE_URL: http://127.0.0.1:18788
+          PROOF_OUTPUT_DIR: ${{ runner.temp }}/oauth-authorization-ui
+          PLAYWRIGHT_RUNTIME: ${{ runner.temp }}/oauth-playwright
+        run: |
+          set -euo pipefail
+          mkdir -p "$PROOF_OUTPUT_DIR" "$PLAYWRIGHT_RUNTIME"
+
+          kubectl -n "$PREVIEW_NS" port-forward \
+            service/"$PREVIEW_NAME" 18788:80 \
+            >"$PROOF_OUTPUT_DIR/port-forward.log" 2>&1 &
+          port_forward_pid=$!
+          trap 'kill "$port_forward_pid" 2>/dev/null || true' EXIT
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS "$PROOF_BASE_URL/api/health" >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              cat "$PROOF_OUTPUT_DIR/port-forward.log"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          chrome_path=$(command -v google-chrome-stable || command -v google-chrome)
+          npm install \
+            --prefix "$PLAYWRIGHT_RUNTIME" \
+            --no-package-lock \
+            --no-save \
+            playwright-core@1.60.0
+
+          CHROME_PATH="$chrome_path" node scripts/oauth-authorization-ui-proof.mjs \
+            | tee "$PROOF_OUTPUT_DIR/proof.log"
+
+      - name: Upload authorization UI proof
+        id: oauth-ui-proof-upload
+        if: always() && steps.oauth-ui-scope.outputs.capture == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: oauth-authorization-ui-pr-${{ env.PR_NUMBER }}
+          path: ${{ runner.temp }}/oauth-authorization-ui
+          if-no-files-found: error
+          retention-days: 14
+
       # Deploy and cleanup run in disjoint concurrency groups (so teardown is
       # never cancelled), which opens the reverse window: a close/unlabel that
       # lands mid-deploy no longer cancels this run, and the surviving deploy
@@ -334,6 +400,7 @@ jobs:
           script: |
             const prNumber = context.payload.pull_request?.number ?? Number(process.env.PR_NUMBER);
             const previewUrl = `https://lobu-pr-${prNumber}.${{ vars.TAILNET_DOMAIN }}`;
+            const proofUrl = `${{ steps.oauth-ui-proof-upload.outputs.artifact-url || '' }}`;
 
             // Paginate: listComments defaults to 30 per page, and busy PRs
             // (review bots post here) routinely exceed that - the existing
@@ -357,6 +424,7 @@ jobs:
               `| **URL** | [${previewUrl}](${previewUrl}) |`,
               `| **Namespace** | \`lobu-preview-${prNumber}\` |`,
               "| **Status** | Running |",
+              ...(proofUrl ? [`| **OAuth UI proof** | [Download screenshots](${proofUrl}) |`] : []),
               "",
               "_This preview is deleted when the PR closes or when the `preview` label is removed._",
             ].join("\n");

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -311,7 +311,7 @@ jobs:
         id: oauth-ui-proof
         if: steps.oauth-ui-scope.outputs.capture == 'true'
         env:
-          PROOF_BASE_URL: http://127.0.0.1:18788
+          PROOF_BASE_URL: http://127.0.0.1:8787
           PROOF_OUTPUT_DIR: ${{ runner.temp }}/oauth-authorization-ui
           PLAYWRIGHT_RUNTIME: ${{ runner.temp }}/oauth-playwright
         run: |
@@ -319,7 +319,7 @@ jobs:
           mkdir -p "$PROOF_OUTPUT_DIR" "$PLAYWRIGHT_RUNTIME"
 
           kubectl -n "$PREVIEW_NS" port-forward \
-            service/"$PREVIEW_NAME" 18788:80 \
+            service/"$PREVIEW_NAME" 8787:80 \
             >"$PROOF_OUTPUT_DIR/port-forward.log" 2>&1 &
           port_forward_pid=$!
           trap 'kill "$port_forward_pid" 2>/dev/null || true' EXIT

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -10,6 +10,7 @@
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { createHash } from 'node:crypto';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { createAuthorizationIntent } from '../../../auth/oauth/authorization-intent';
 import { hashToken } from '../../../auth/oauth/utils';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -362,6 +363,19 @@ describe('MCP Authentication', () => {
           code_challenge: 'test-code-challenge',
           code_challenge_method: 'S256',
           resource: `http://localhost/mcp/${publicOrg.slug}`,
+          authorization_intent: createAuthorizationIntent(
+            {
+              client_id: client.client_id,
+              redirect_uri: client.redirect_uris[0],
+              response_type: 'code',
+              scope: 'mcp:read profile:read',
+              state: 'public-org-consent-test',
+              code_challenge: 'test-code-challenge',
+              code_challenge_method: 'S256',
+              resource: `http://localhost/mcp/${publicOrg.slug}`,
+            },
+            'test-jwt-secret-for-testing-only'
+          ),
           approved: true,
         },
         cookie: sessionCookie,

--- a/packages/server/src/__tests__/integration/mcp/bare-oauth-federated-search-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/bare-oauth-federated-search-e2e.test.ts
@@ -9,6 +9,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createAuthorizationIntent } from '../../../auth/oauth/authorization-intent';
 import { hashToken } from '../../../auth/oauth/utils';
 import { parsePgTextArray } from '../../../db/client';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -100,6 +101,18 @@ describe('bare OAuth /mcp federated search end to end', () => {
         organization_id: workspaceA.id,
         organization_ids: [workspaceA.id, workspaceB.id],
         workspace_access: 'selected',
+        authorization_intent: createAuthorizationIntent(
+          {
+            client_id: clientId,
+            redirect_uri: redirectUri,
+            response_type: 'code',
+            scope: 'mcp:read profile:read',
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+            resource,
+          },
+          'test-jwt-secret-for-testing-only'
+        ),
         approved: true,
       },
       cookie: session.cookieHeader,

--- a/packages/server/src/__tests__/integration/oauth/device-code-ownership.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-code-ownership.test.ts
@@ -253,4 +253,42 @@ describe('OAuth device verifier ownership', () => {
     expect(rows).toEqual([{ user_id: verifier.id }]);
     expect(rows[0]?.user_id).not.toBe(attacker.id);
   });
+
+  it('persists a reduction that removes MCP access entirely', async () => {
+    const app = buildApp();
+    const verifier = await createTestUser({ name: 'Scope reducer' });
+    const session = await createTestSession(verifier.id);
+    const client = await createTestOAuthClient({
+      grant_types: [DEVICE_GRANT, 'refresh_token'],
+    });
+    const device = await createTestDeviceCode(client.client_id, {
+      scope: 'mcp:read profile:read',
+    });
+
+    const info = await call(app, 'GET', `/oauth/device/info?user_code=${device.userCode}`, {
+      cookie: session.cookieHeader,
+    });
+    expect(info.status).toBe(200);
+
+    const approved = await call(app, 'POST', '/oauth/device/approve', {
+      cookie: session.cookieHeader,
+      body: {
+        user_code: device.userCode,
+        approved: true,
+        scope: 'profile:read',
+      },
+    });
+    expect(approved.status, await approved.clone().text()).toBe(200);
+
+    const token = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: DEVICE_GRANT,
+        device_code: device.deviceCode,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      },
+    });
+    expect(token.status, await token.clone().text()).toBe(200);
+    expect(await token.json()).toMatchObject({ scope: 'profile:read' });
+  });
 });

--- a/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
@@ -28,6 +28,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createAuthorizationIntent } from '../../../auth/oauth/authorization-intent';
 import { hashToken } from '../../../auth/oauth/utils';
 import type { Env } from '../../../index';
 import { oauthRoutes } from '../../../auth/oauth/routes';
@@ -222,6 +223,18 @@ describe('Stage 1 — login token carries connections:token', () => {
         code_challenge: challenge,
         code_challenge_method: 'S256',
         resource: `${ORIGIN}/mcp/${org.slug}`,
+        authorization_intent: createAuthorizationIntent(
+          {
+            client_id: client.client_id,
+            redirect_uri: redirectUri,
+            response_type: 'code',
+            scope: fullScope,
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+            resource: `${ORIGIN}/mcp/${org.slug}`,
+          },
+          TEST_ENV.JWT_SECRET as string
+        ),
         approved: true,
       },
       headers: { Cookie: session.cookieHeader },

--- a/packages/server/src/__tests__/integration/oauth/progressive-admin-consent.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/progressive-admin-consent.test.ts
@@ -19,6 +19,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../../index';
+import { createAuthorizationIntent } from '../../../auth/oauth/authorization-intent';
 import { OAuthProvider } from '../../../auth/oauth/provider';
 import { oauthRoutes } from '../../../auth/oauth/routes';
 import { hashToken } from '../../../auth/oauth/utils';
@@ -46,6 +47,21 @@ const TEST_ENV = {
 // an Origin matching the app's own base URL. The test app is served at
 // http://localhost, so send that as Origin.
 const ORIGIN = 'http://localhost';
+
+function signAuthorizationRequest(params: {
+  client_id: string;
+  redirect_uri: string;
+  scope: string;
+  code_challenge: string;
+  code_challenge_method: 'S256';
+  state?: string;
+  resource?: string;
+}): string {
+  return createAuthorizationIntent(
+    { ...params, response_type: 'code' },
+    TEST_ENV.JWT_SECRET as string
+  );
+}
 
 function buildApp(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
@@ -96,6 +112,14 @@ async function authorizeCodeGrant(params: {
       code_challenge: challenge,
       code_challenge_method: 'S256',
       resource: params.resource,
+      authorization_intent: signAuthorizationRequest({
+        client_id: params.clientId,
+        redirect_uri: params.redirectUri,
+        scope: params.scope,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        resource: params.resource,
+      }),
       ...(params.organizationId ? { organization_id: params.organizationId } : {}),
       ...(params.organizationIds ? { organization_ids: params.organizationIds } : {}),
       ...(params.workspaceAccess ? { workspace_access: params.workspaceAccess } : {}),
@@ -226,6 +250,13 @@ describe('Progressive mcp:admin consent', () => {
         scope: 'connections:token device_worker:run',
         code_challenge: challenge,
         code_challenge_method: 'S256',
+        authorization_intent: signAuthorizationRequest({
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          scope: 'connections:token device_worker:run',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+        }),
         approved: true,
       },
       headers: { Cookie: session.cookieHeader },
@@ -240,12 +271,42 @@ describe('Progressive mcp:admin consent', () => {
         scope: '',
         code_challenge: challenge,
         code_challenge_method: 'S256',
+        authorization_intent: signAuthorizationRequest({
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          scope: 'mcp:read',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+        }),
         approved: true,
       },
       headers: { Cookie: session.cookieHeader },
     });
     expect(empty.status).toBe(400);
     expect(await empty.json()).toMatchObject({ error: 'invalid_scope' });
+
+    const elevated = await call(app, 'POST', '/oauth/authorize/consent', {
+      body: {
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        scope: 'mcp:read mcp:write mcp:admin',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        resource,
+        authorization_intent: signAuthorizationRequest({
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          scope: 'mcp:read',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+          resource,
+        }),
+        approved: true,
+      },
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(elevated.status).toBe(400);
+    expect(await elevated.json()).toMatchObject({ error: 'invalid_scope' });
 
     // Codes minted before the consent-path fix must be narrowed again at
     // exchange time so a rolling deploy cannot preserve a private scope.
@@ -459,6 +520,14 @@ describe('Progressive mcp:admin consent', () => {
       organization_id: primary.id,
       organization_ids: [primary.id, secondary.id],
       workspace_access: 'selected' as const,
+      authorization_intent: signAuthorizationRequest({
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        scope: 'mcp:read',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        resource: `${ORIGIN}/mcp`,
+      }),
       approved: true,
     };
 
@@ -539,15 +608,63 @@ describe('Progressive mcp:admin consent', () => {
       resource: `${ORIGIN}/mcp`,
     });
     const disabledUi = await call(app, 'GET', `/oauth/authorize?${authorizeQuery}`);
-    expect(new URL(disabledUi.headers.get('location')!).searchParams.has('workspace_grants')).toBe(
-      false,
-    );
+    const disabledLocation = disabledUi.headers.get('location');
+    expect(disabledLocation).toBeTruthy();
+    if (!disabledLocation) throw new Error('Expected consent redirect');
+    expect(new URL(disabledLocation).searchParams.has('workspace_grants')).toBe(false);
     const enabledUi = await call(app, 'GET', `/oauth/authorize?${authorizeQuery}`, {
       env: { LOBU_OAUTH_MULTI_WORKSPACE_GRANTS: '1' },
     });
-    expect(new URL(enabledUi.headers.get('location')!).searchParams.get('workspace_grants')).toBe(
-      '1',
-    );
+    const enabledLocation = enabledUi.headers.get('location');
+    expect(enabledLocation).toBeTruthy();
+    if (!enabledLocation) throw new Error('Expected consent redirect');
+    const enabledSearch = new URL(enabledLocation).searchParams;
+    expect(enabledSearch.get('workspace_grants')).toBe('1');
+    expect(enabledSearch.get('authorization_intent')).toBeTruthy();
+
+    const displayedConsentBody = {
+      client_id: enabledSearch.get('client_id'),
+      redirect_uri: enabledSearch.get('redirect_uri'),
+      scope: enabledSearch.get('scope'),
+      state: enabledSearch.get('state'),
+      code_challenge: enabledSearch.get('code_challenge'),
+      code_challenge_method: enabledSearch.get('code_challenge_method'),
+      resource: enabledSearch.get('resource'),
+      client_name: enabledSearch.get('client_name'),
+      authorization_intent: enabledSearch.get('authorization_intent'),
+      organization_id: primary.id,
+      organization_ids: [primary.id],
+      workspace_access: 'selected',
+      approved: true,
+    };
+    const changedDisplay = await call(app, 'POST', '/oauth/authorize/consent', {
+      body: { ...displayedConsentBody, resource: `${ORIGIN}/mcp/not-the-displayed-request` },
+      headers: { Cookie: session.cookieHeader },
+      env: { LOBU_OAUTH_MULTI_WORKSPACE_GRANTS: '1' },
+    });
+    expect(changedDisplay.status).toBe(400);
+    expect(await changedDisplay.json()).toMatchObject({
+      error: 'invalid_request',
+      error_description: 'The displayed authorization request was changed',
+    });
+
+    const changedIdentity = await call(app, 'POST', '/oauth/authorize/consent', {
+      body: { ...displayedConsentBody, client_name: 'Trusted Finance App' },
+      headers: { Cookie: session.cookieHeader },
+      env: { LOBU_OAUTH_MULTI_WORKSPACE_GRANTS: '1' },
+    });
+    expect(changedIdentity.status).toBe(400);
+    expect(await changedIdentity.json()).toMatchObject({
+      error: 'invalid_request',
+      error_description: 'The displayed application identity was changed',
+    });
+
+    const submittedFromGet = await call(app, 'POST', '/oauth/authorize/consent', {
+      body: displayedConsentBody,
+      headers: { Cookie: session.cookieHeader },
+      env: { LOBU_OAUTH_MULTI_WORKSPACE_GRANTS: '1' },
+    });
+    expect(submittedFromGet.status).toBe(200);
   });
 
   it('rejects an empty workspace selection without issuing an authorization code', async () => {
@@ -582,6 +699,14 @@ describe('Progressive mcp:admin consent', () => {
         organization_id: organization.id,
         organization_ids: [],
         workspace_access: 'selected',
+        authorization_intent: signAuthorizationRequest({
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          scope: 'mcp:read',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+          resource: `${ORIGIN}/mcp`,
+        }),
         approved: true,
       },
       headers: { Cookie: session.cookieHeader },
@@ -743,6 +868,14 @@ describe('Progressive mcp:admin consent', () => {
         organization_id: owned.id,
         organization_ids: [owned.id, foreign.id],
         workspace_access: 'selected',
+        authorization_intent: signAuthorizationRequest({
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          scope: 'mcp:read',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+          resource: `${ORIGIN}/mcp`,
+        }),
         approved: true,
       },
       headers: { Cookie: session.cookieHeader },

--- a/packages/server/src/__tests__/unit/oauth-authorization-intent.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-authorization-intent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  createAuthorizationIntent,
+  verifyAuthorizationIntent,
+} from '../../auth/oauth/authorization-intent';
+
+const SECRET = 'test-authorization-intent-secret';
+const NOW = 1_700_000_000;
+const PARAMS = {
+  client_id: 'client-1',
+  redirect_uri: 'https://client.example/callback',
+  response_type: 'code' as const,
+  scope: 'mcp:read mcp:write',
+  state: 'state-1',
+  code_challenge: 'challenge-1',
+  code_challenge_method: 'S256' as const,
+  resource: 'https://lobu.example/mcp/acme',
+};
+
+describe('OAuth authorization intent', () => {
+  it('round-trips the validated authorization request', () => {
+    const token = createAuthorizationIntent(PARAMS, SECRET, NOW);
+    expect(verifyAuthorizationIntent(token, SECRET, NOW + 30)).toEqual(PARAMS);
+  });
+
+  it('rejects tampering and a different signing secret', () => {
+    const token = createAuthorizationIntent(PARAMS, SECRET, NOW);
+    const [payload, signature] = token.split('.');
+    const tamperedPayload = Buffer.from(
+      JSON.stringify({
+        ...PARAMS,
+        scope: 'mcp:read mcp:write mcp:admin',
+        version: 1,
+        issued_at: NOW,
+        expires_at: NOW + 600,
+      })
+    ).toString('base64url');
+    expect(verifyAuthorizationIntent(`${tamperedPayload}.${signature}`, SECRET, NOW)).toBeNull();
+    expect(verifyAuthorizationIntent(`${payload}.${signature}`, 'different-secret', NOW)).toBeNull();
+  });
+
+  it('rejects expired and malformed intents', () => {
+    const token = createAuthorizationIntent(PARAMS, SECRET, NOW);
+    expect(verifyAuthorizationIntent(token, SECRET, NOW + 601)).toBeNull();
+    expect(verifyAuthorizationIntent('not-an-intent', SECRET, NOW)).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
@@ -5,7 +5,8 @@ import {
   filterScopeByRole,
   isOAuthScopeGrantWithinRequest,
   NON_PUBLIC_OAUTH_SCOPES,
-  filterToDiscoveryScopes,
+  AVAILABLE_SCOPES,
+  filterRequestedScopes,
   normalizeOAuthScopeRequest,
   stripNonPublicOAuthScopes,
 } from '../../auth/oauth/scopes';
@@ -152,32 +153,52 @@ describe('filterScopeByRole', () => {
   });
 });
 
-describe('filterToDiscoveryScopes', () => {
+describe('filterRequestedScopes', () => {
   // The /oauth/authorize endpoint takes a STRANGER's scope string. Slack,
   // Claude Desktop and Cursor all append standard OIDC scopes that Lobu has
   // never issued. Rejecting the whole request over one of them breaks the
   // integration; narrowing it just grants less.
   it('keeps grantable scopes and ignores OIDC scopes Lobu does not issue', () => {
-    expect(filterToDiscoveryScopes('openid email profile offline_access mcp:read')).toBe(
+    expect(filterRequestedScopes('openid email profile offline_access mcp:read', DISCOVERY_SCOPES)).toBe(
       'mcp:read'
     );
   });
 
   it('drops non-public scopes without needing stripNonPublicOAuthScopes first', () => {
-    expect(filterToDiscoveryScopes('mcp:read device_worker:run connections:token')).toBe(
+    expect(filterRequestedScopes('mcp:read device_worker:run connections:token', DISCOVERY_SCOPES)).toBe(
       'mcp:read'
     );
   });
 
   it('returns null only when nothing requested is grantable', () => {
-    expect(filterToDiscoveryScopes('openid offline_access')).toBeNull();
-    expect(filterToDiscoveryScopes('')).toBeNull();
+    expect(filterRequestedScopes('openid offline_access', DISCOVERY_SCOPES)).toBeNull();
+    expect(filterRequestedScopes('', DISCOVERY_SCOPES)).toBeNull();
   });
 
   // The contrast that motivates the split: the strict form is still correct
   // for scope strings we generate ourselves (consent form, device flow).
   it('is deliberately more permissive than the strict normalizer', () => {
     expect(normalizeOAuthScopeRequest('openid mcp:read', DISCOVERY_SCOPES)).toBeNull();
-    expect(filterToDiscoveryScopes('openid mcp:read')).toBe('mcp:read');
+    expect(filterRequestedScopes('openid mcp:read', DISCOVERY_SCOPES)).toBe('mcp:read');
+  });
+});
+
+describe('filterRequestedScopes on the device flow', () => {
+  // Device-code registration is open (DCR), so this scope string comes from a
+  // stranger too — but the device flow may legitimately grant the non-public
+  // scopes when a client asks for them explicitly, gated by the user's
+  // device-code consent. So it filters against AVAILABLE_SCOPES, not
+  // DISCOVERY_SCOPES.
+  it('keeps explicitly requested non-public scopes that the authorize path drops', () => {
+    expect(filterRequestedScopes('mcp:read connections:token', AVAILABLE_SCOPES)).toBe(
+      'mcp:read connections:token'
+    );
+    expect(filterRequestedScopes('mcp:read connections:token', DISCOVERY_SCOPES)).toBe('mcp:read');
+  });
+
+  it('still ignores OIDC scopes rather than failing the device authorization', () => {
+    expect(filterRequestedScopes('openid offline_access mcp:read', AVAILABLE_SCOPES)).toBe(
+      'mcp:read'
+    );
   });
 });

--- a/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
@@ -5,6 +5,7 @@ import {
   filterScopeByRole,
   isOAuthScopeGrantWithinRequest,
   NON_PUBLIC_OAUTH_SCOPES,
+  filterToDiscoveryScopes,
   normalizeOAuthScopeRequest,
   stripNonPublicOAuthScopes,
 } from '../../auth/oauth/scopes';
@@ -148,5 +149,35 @@ describe('filterScopeByRole', () => {
     );
     expect((owner as string).split(' ')).toContain('connections:token');
     expect((owner as string).split(' ')).toContain('mcp:admin');
+  });
+});
+
+describe('filterToDiscoveryScopes', () => {
+  // The /oauth/authorize endpoint takes a STRANGER's scope string. Slack,
+  // Claude Desktop and Cursor all append standard OIDC scopes that Lobu has
+  // never issued. Rejecting the whole request over one of them breaks the
+  // integration; narrowing it just grants less.
+  it('keeps grantable scopes and ignores OIDC scopes Lobu does not issue', () => {
+    expect(filterToDiscoveryScopes('openid email profile offline_access mcp:read')).toBe(
+      'mcp:read'
+    );
+  });
+
+  it('drops non-public scopes without needing stripNonPublicOAuthScopes first', () => {
+    expect(filterToDiscoveryScopes('mcp:read device_worker:run connections:token')).toBe(
+      'mcp:read'
+    );
+  });
+
+  it('returns null only when nothing requested is grantable', () => {
+    expect(filterToDiscoveryScopes('openid offline_access')).toBeNull();
+    expect(filterToDiscoveryScopes('')).toBeNull();
+  });
+
+  // The contrast that motivates the split: the strict form is still correct
+  // for scope strings we generate ourselves (consent form, device flow).
+  it('is deliberately more permissive than the strict normalizer', () => {
+    expect(normalizeOAuthScopeRequest('openid mcp:read', DISCOVERY_SCOPES)).toBeNull();
+    expect(filterToDiscoveryScopes('openid mcp:read')).toBe('mcp:read');
   });
 });

--- a/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  canonicalizeOAuthScopeGrant,
   DISCOVERY_SCOPES,
   filterScopeByRole,
+  isOAuthScopeGrantWithinRequest,
   NON_PUBLIC_OAUTH_SCOPES,
+  normalizeOAuthScopeRequest,
   stripNonPublicOAuthScopes,
 } from '../../auth/oauth/scopes';
 
@@ -33,6 +36,34 @@ describe('stripNonPublicOAuthScopes', () => {
   it('passes public scopes through unchanged', () => {
     expect(stripNonPublicOAuthScopes('mcp:read mcp:write profile:read')).toBe(
       'mcp:read mcp:write profile:read'
+    );
+  });
+});
+
+describe('OAuth scope grant normalization', () => {
+  it('rejects unknown requested scopes at the OAuth boundary', () => {
+    expect(normalizeOAuthScopeRequest('mcp:read invented:scope')).toBeNull();
+    expect(normalizeOAuthScopeRequest('mcp:read profile:read')).toBe(
+      'mcp:read profile:read'
+    );
+  });
+
+  it('treats MCP access as a hierarchy when reducing consent', () => {
+    expect(isOAuthScopeGrantWithinRequest('mcp:read mcp:write', 'mcp:read')).toBe(true);
+    expect(isOAuthScopeGrantWithinRequest('mcp:write', 'mcp:read')).toBe(true);
+    expect(isOAuthScopeGrantWithinRequest('mcp:read', 'mcp:write')).toBe(false);
+    expect(isOAuthScopeGrantWithinRequest('mcp:admin profile:read', 'mcp:write')).toBe(true);
+    expect(
+      isOAuthScopeGrantWithinRequest('mcp:admin', 'mcp:read connections:token')
+    ).toBe(false);
+  });
+
+  it('persists the hierarchy explicitly', () => {
+    expect(canonicalizeOAuthScopeGrant('mcp:write profile:read')).toBe(
+      'mcp:read mcp:write profile:read'
+    );
+    expect(canonicalizeOAuthScopeGrant('mcp:admin connections:token')).toBe(
+      'mcp:read mcp:write mcp:admin connections:token'
     );
   });
 });

--- a/packages/server/src/auth/oauth/authorization-intent.ts
+++ b/packages/server/src/auth/oauth/authorization-intent.ts
@@ -1,0 +1,100 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { AuthorizationParams } from './types';
+
+const INTENT_VERSION = 1;
+const INTENT_LIFETIME_SECONDS = 10 * 60;
+const SIGNING_CONTEXT = 'lobu:oauth-authorization-intent:v1:';
+
+type AuthorizationIntentClaims = AuthorizationParams & {
+  version: typeof INTENT_VERSION;
+  issued_at: number;
+  expires_at: number;
+};
+
+function sign(encodedClaims: string, secret: string): string {
+  return createHmac('sha256', secret)
+    .update(`${SIGNING_CONTEXT}${encodedClaims}`)
+    .digest('base64url');
+}
+
+/**
+ * Bind the consent screen to the request that passed the authorization
+ * endpoint's client, redirect, PKCE, scope, and resource validation.
+ *
+ * The token is intentionally self-contained so it verifies on every replica.
+ * Authorization codes remain the one-time protocol artifact; this short-lived
+ * intent prevents the browser from widening or retargeting the validated
+ * request before a code is minted.
+ */
+export function createAuthorizationIntent(
+  params: AuthorizationParams,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): string {
+  if (!secret) throw new Error('OAuth authorization intent signing secret is required');
+  const claims: AuthorizationIntentClaims = {
+    ...params,
+    version: INTENT_VERSION,
+    issued_at: nowSeconds,
+    expires_at: nowSeconds + INTENT_LIFETIME_SECONDS,
+  };
+  const encodedClaims = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  return `${encodedClaims}.${sign(encodedClaims, secret)}`;
+}
+
+export function verifyAuthorizationIntent(
+  token: string | undefined,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): AuthorizationParams | null {
+  if (!token || !secret) return null;
+  const parts = token.split('.');
+  if (parts.length !== 2) return null;
+  const [encodedClaims, presentedSignature] = parts;
+  if (!encodedClaims || !presentedSignature) return null;
+
+  const expectedSignature = sign(encodedClaims, secret);
+  const presented = Buffer.from(presentedSignature);
+  const expected = Buffer.from(expectedSignature);
+  if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) return null;
+
+  let claims: AuthorizationIntentClaims;
+  try {
+    claims = JSON.parse(Buffer.from(encodedClaims, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+
+  if (
+    claims.version !== INTENT_VERSION ||
+    !Number.isInteger(claims.issued_at) ||
+    !Number.isInteger(claims.expires_at) ||
+    claims.issued_at > nowSeconds + 60 ||
+    claims.expires_at < nowSeconds ||
+    claims.response_type !== 'code' ||
+    claims.code_challenge_method !== 'S256' ||
+    typeof claims.client_id !== 'string' ||
+    !claims.client_id ||
+    typeof claims.redirect_uri !== 'string' ||
+    !claims.redirect_uri ||
+    typeof claims.code_challenge !== 'string' ||
+    !claims.code_challenge ||
+    typeof claims.scope !== 'string' ||
+    !claims.scope
+  ) {
+    return null;
+  }
+  if (claims.state !== undefined && typeof claims.state !== 'string') return null;
+  if (claims.resource !== undefined && typeof claims.resource !== 'string') return null;
+
+  return {
+    client_id: claims.client_id,
+    redirect_uri: claims.redirect_uri,
+    response_type: 'code',
+    scope: claims.scope,
+    state: claims.state,
+    code_challenge: claims.code_challenge,
+    code_challenge_method: 'S256',
+    resource: claims.resource,
+  };
+}

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -26,7 +26,7 @@ import {
   canonicalizeOAuthScopeGrant,
   DEFAULT_SCOPES_STRING,
   DISCOVERY_SCOPES,
-  filterToDiscoveryScopes,
+  filterRequestedScopes,
   filterScopeByRole,
   isOAuthScopeGrantWithinRequest,
   NON_PUBLIC_OAUTH_SCOPES,
@@ -719,7 +719,8 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     );
   }
 
-  params.scope = filterToDiscoveryScopes(params.scope || DEFAULT_SCOPES_STRING) ?? undefined;
+  params.scope =
+    filterRequestedScopes(params.scope || DEFAULT_SCOPES_STRING, DISCOVERY_SCOPES) ?? undefined;
   if (!params.scope) {
     return c.json(
       createOAuthError('invalid_scope', 'No requested scopes are available to OAuth clients'),
@@ -1108,7 +1109,13 @@ oauthRoutes.post('/oauth/device_authorization', async (c) => {
     return c.json(createOAuthError('invalid_scope', 'Requested scope must not be empty'), 400);
   }
 
-  const normalizedDeviceScope = normalizeOAuthScopeRequest(
+  // Same tolerance as /oauth/authorize, and for the same reason: device-code
+  // registration is open (DCR), so this scope string comes from a stranger
+  // too. AVAILABLE_SCOPES rather than DISCOVERY_SCOPES — the device flow may
+  // legitimately grant `device_worker:run`/`connections:token` when a client
+  // asks for them explicitly, and the user's device-code consent is the
+  // boundary that makes that safe.
+  const normalizedDeviceScope = filterRequestedScopes(
     body.scope || DEFAULT_SCOPES_STRING,
     AVAILABLE_SCOPES
   );

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -26,6 +26,7 @@ import {
   canonicalizeOAuthScopeGrant,
   DEFAULT_SCOPES_STRING,
   DISCOVERY_SCOPES,
+  filterToDiscoveryScopes,
   filterScopeByRole,
   isOAuthScopeGrantWithinRequest,
   NON_PUBLIC_OAUTH_SCOPES,
@@ -718,10 +719,7 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     );
   }
 
-  params.scope = normalizeOAuthScopeRequest(
-    stripNonPublicOAuthScopes(params.scope || DEFAULT_SCOPES_STRING),
-    DISCOVERY_SCOPES
-  ) ?? undefined;
+  params.scope = filterToDiscoveryScopes(params.scope || DEFAULT_SCOPES_STRING) ?? undefined;
   if (!params.scope) {
     return c.json(
       createOAuthError('invalid_scope', 'No requested scopes are available to OAuth clients'),

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -14,12 +14,22 @@ import { resolveBaseUrl, safeOrigin, safeParseUrl } from '../base-url';
 import { createAuth } from '../index';
 import { requireAuth } from '../middleware';
 import { findExistingPersonalOrg } from '../personal-org-provisioning';
+import {
+  createAuthorizationIntent,
+  verifyAuthorizationIntent,
+} from './authorization-intent';
 import { buildAuthMd } from './auth-md';
 import { OAuthProvider } from './provider';
 import { canonicalizeMcpResource, publicMcpRequestUrl } from './resource-indicator';
 import {
+  AVAILABLE_SCOPES,
+  canonicalizeOAuthScopeGrant,
   DEFAULT_SCOPES_STRING,
+  DISCOVERY_SCOPES,
   filterScopeByRole,
+  isOAuthScopeGrantWithinRequest,
+  NON_PUBLIC_OAUTH_SCOPES,
+  normalizeOAuthScopeRequest,
   stripNonPublicOAuthScopes,
 } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
@@ -36,6 +46,11 @@ import { resolveSession } from '../resolve-session';
 
 const oauthRoutes = new Hono<{ Bindings: Env }>();
 const INVALID_DEVICE_CODE_MESSAGE = 'Invalid or expired user code';
+
+function getAuthorizationIntentSecret(env: Env): string | null {
+  const secret = env.JWT_SECRET || env.BETTER_AUTH_SECRET;
+  return typeof secret === 'string' && secret.length > 0 ? secret : null;
+}
 
 /**
  * Parse a request body that may be application/x-www-form-urlencoded or JSON.
@@ -370,6 +385,100 @@ async function resolveOrganizationForGrant(params: {
   };
 }
 
+type ResolvedMcpGrant = {
+  organizationId: string;
+  grantedOrganizationIds: string[];
+  scope: string;
+};
+
+/**
+ * Resolve the ordinary MCP grant once for both authorization-code and device
+ * flows. Protocol handlers own only their request verification and completion;
+ * workspace membership, primary selection, role filtering, and the immutable
+ * workspace snapshot stay identical here.
+ */
+async function resolveMcpGrant(params: {
+  sql: ReturnType<typeof createDbClientFromEnv>;
+  userId: string;
+  resource: string | null | undefined;
+  scope: string;
+  organizationId: string | undefined;
+  organizationIds: string[] | undefined;
+  workspaceAccess: WorkspaceAccessMode | undefined;
+  multiWorkspaceGrantsEnabled: boolean;
+  forceSelectionForMultiOrg: boolean;
+}): Promise<
+  | { grant: ResolvedMcpGrant }
+  | { error: ReturnType<typeof createOAuthError>; status: number }
+  | { orgSelectionRequired: true; organizations: { id: unknown; name: unknown; slug: unknown }[] }
+> {
+  const resourceOrgSlug = getOrgSlugFromResource(params.resource);
+  const submittedGrant =
+    isBareMcpResource(params.resource) &&
+    (params.workspaceAccess !== undefined || params.organizationIds !== undefined)
+      ? await resolveSubmittedWorkspaceGrant({
+          sql: params.sql,
+          userId: params.userId,
+          organizationIds: params.organizationIds,
+          anchorOrganizationId: params.organizationId,
+          workspaceAccess: params.workspaceAccess,
+          multiWorkspaceGrantsEnabled: params.multiWorkspaceGrantsEnabled,
+        })
+      : null;
+  if (submittedGrant && 'error' in submittedGrant) return submittedGrant;
+
+  const validSubmittedGrant = submittedGrant && !('error' in submittedGrant) ? submittedGrant : null;
+  const orgResult =
+    validSubmittedGrant ??
+    (await resolveOrganizationForGrant({
+      sql: params.sql,
+      userId: params.userId,
+      resourceOrgSlug,
+      explicitOrgId: params.organizationId,
+      forceSelectionForMultiOrg: params.forceSelectionForMultiOrg,
+    }));
+  if ('error' in orgResult || 'orgSelectionRequired' in orgResult) return orgResult;
+
+  const grantedOrganizationIds = validSubmittedGrant?.grantedOrganizationIds ?? [
+    orgResult.organizationId,
+  ];
+  const liveGrantedWorkspaces =
+    validSubmittedGrant?.liveGrantedWorkspaces ??
+    (resourceOrgSlug === null
+      ? await listLiveGrantedMemberWorkspaces({
+          sql: params.sql,
+          userId: params.userId,
+          grantedOrganizationIds,
+        })
+      : []);
+  const grantRole =
+    resourceOrgSlug !== null
+      ? orgResult.memberRole
+      : liveGrantedWorkspaces.some(
+            (workspace) => workspace.role === 'owner' || workspace.role === 'admin'
+          )
+        ? 'admin'
+        : 'member';
+  const filteredScope = filterScopeByRole(params.scope, grantRole);
+  if (filteredScope === null) {
+    return {
+      error: createOAuthError(
+        'invalid_scope',
+        'Your role is not authorized for any of the requested scopes'
+      ),
+      status: 400,
+    };
+  }
+
+  return {
+    grant: {
+      organizationId: orgResult.organizationId,
+      grantedOrganizationIds,
+      scope: filteredScope,
+    },
+  };
+}
+
 /**
  * Helper to get OAuth provider
  */
@@ -609,7 +718,10 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     );
   }
 
-  params.scope = stripNonPublicOAuthScopes(params.scope || DEFAULT_SCOPES_STRING);
+  params.scope = normalizeOAuthScopeRequest(
+    stripNonPublicOAuthScopes(params.scope || DEFAULT_SCOPES_STRING),
+    DISCOVERY_SCOPES
+  ) ?? undefined;
   if (!params.scope) {
     return c.json(
       createOAuthError('invalid_scope', 'No requested scopes are available to OAuth clients'),
@@ -698,6 +810,11 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
   // authorization-code consent.
   const webUrl = getBaseUrl(c);
   const consentUrl = new URL('/oauth/consent', webUrl);
+  const intentSecret = getAuthorizationIntentSecret(c.env);
+  if (!intentSecret) {
+    return c.json(createOAuthError('server_error', 'Authorization is unavailable'), 500);
+  }
+  const authorizationIntent = createAuthorizationIntent(params, intentSecret);
 
   consentUrl.searchParams.set('client_id', params.client_id);
   consentUrl.searchParams.set('redirect_uri', params.redirect_uri);
@@ -718,6 +835,7 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     consentUrl.searchParams.set('workspace_grants', '1');
   }
   consentUrl.searchParams.set('client_name', client.client_name || client.client_id);
+  consentUrl.searchParams.set('authorization_intent', authorizationIntent);
 
   return c.redirect(consentUrl.toString());
 });
@@ -753,14 +871,57 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
     organization_id?: string;
     organization_ids?: string[];
     workspace_access?: WorkspaceAccessMode;
+    authorization_intent?: string;
+    client_name?: string;
     approved: boolean;
   };
 
   try {
-    body = await c.req.json();
+    const parsedBody: unknown = await c.req.json();
+    if (!parsedBody || typeof parsedBody !== 'object' || Array.isArray(parsedBody)) {
+      return c.json(createOAuthError('invalid_request', 'Invalid JSON body'), 400);
+    }
+    body = parsedBody as typeof body;
   } catch {
     return c.json(createOAuthError('invalid_request', 'Invalid JSON body'), 400);
   }
+
+  const intentSecret = getAuthorizationIntentSecret(c.env);
+  const authorizationRequest = intentSecret
+    ? verifyAuthorizationIntent(body.authorization_intent, intentSecret)
+    : null;
+  if (!authorizationRequest) {
+    return c.json(
+      createOAuthError('invalid_request', 'The authorization request is invalid or expired'),
+      400
+    );
+  }
+
+  const optionalParam = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.length > 0 ? value : undefined;
+  const immutableRequestMatches =
+    body.client_id === authorizationRequest.client_id &&
+    body.redirect_uri === authorizationRequest.redirect_uri &&
+    optionalParam(body.state) === optionalParam(authorizationRequest.state) &&
+    body.code_challenge === authorizationRequest.code_challenge &&
+    body.code_challenge_method === authorizationRequest.code_challenge_method &&
+    optionalParam(body.resource) === optionalParam(authorizationRequest.resource);
+  if (!immutableRequestMatches) {
+    return c.json(
+      createOAuthError('invalid_request', 'The displayed authorization request was changed'),
+      400
+    );
+  }
+
+  // The duplicated browser fields now match the signed request the user saw.
+  // Keep the signed values authoritative for downstream canonicalization; the
+  // browser may vary only the reduced scope and workspace choices.
+  body.client_id = authorizationRequest.client_id;
+  body.redirect_uri = authorizationRequest.redirect_uri;
+  body.state = authorizationRequest.state;
+  body.code_challenge = authorizationRequest.code_challenge;
+  body.code_challenge_method = authorizationRequest.code_challenge_method;
+  body.resource = authorizationRequest.resource;
 
   // A denial remains possible even when the client supplied malformed grant
   // details. Approval, however, must never let the scope parser turn an
@@ -770,13 +931,23 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
   }
 
   if (body.approved) {
-    body.scope = stripNonPublicOAuthScopes(body.scope);
-    if (!body.scope) {
+    const normalizedScope = normalizeOAuthScopeRequest(
+      stripNonPublicOAuthScopes(body.scope),
+      DISCOVERY_SCOPES
+    );
+    if (!normalizedScope) {
       return c.json(
-        createOAuthError('invalid_scope', 'No requested scopes are available to OAuth clients'),
+        createOAuthError('invalid_scope', 'The requested scope is empty or unsupported'),
         400
       );
     }
+    if (!isOAuthScopeGrantWithinRequest(authorizationRequest.scope, normalizedScope)) {
+      return c.json(
+        createOAuthError('invalid_scope', 'Approved scopes exceed the authorization request'),
+        400
+      );
+    }
+    body.scope = canonicalizeOAuthScopeGrant(normalizedScope);
   }
 
   // Keep the remaining client-requested public scopes after the device-only
@@ -794,6 +965,23 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
       );
     }
     body.resource = resource;
+  }
+
+  // Validate the registered redirect again for both approval and denial. The
+  // signed intent proves what GET validated; this also catches a client that
+  // was removed or changed while the consent page was open.
+  const clientResult = await provider.getClientForAuthorization(body.client_id, body.redirect_uri);
+  if ('error' in clientResult) {
+    return c.json(clientResult, 400);
+  }
+  if (
+    body.client_name !== undefined &&
+    body.client_name !== (clientResult.client_name || clientResult.client_id)
+  ) {
+    return c.json(
+      createOAuthError('invalid_request', 'The displayed application identity was changed'),
+      400
+    );
   }
 
   // User denied consent
@@ -823,13 +1011,6 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
     );
   }
 
-  // Validate client again
-  const clientResult = await provider.getClientForAuthorization(body.client_id, body.redirect_uri);
-
-  if ('error' in clientResult) {
-    return c.json(clientResult, 400);
-  }
-
   // Create authorization code
   const params: AuthorizationParams = {
     client_id: body.client_id,
@@ -848,83 +1029,33 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
 
     if (consentHasMcpScopes) {
       const sql = createDbClientFromEnv(c.env);
-      const resourceOrgSlug = getOrgSlugFromResource(body.resource);
-      const submittedGrant =
-        isBareMcpResource(body.resource) &&
-        (body.workspace_access !== undefined || body.organization_ids !== undefined)
-          ? await resolveSubmittedWorkspaceGrant({
-              sql,
-              userId: user.id,
-              organizationIds: body.organization_ids,
-              anchorOrganizationId: body.organization_id,
-              workspaceAccess: body.workspace_access,
-              multiWorkspaceGrantsEnabled: isMultiWorkspaceGrantIssuanceEnabled(c.env),
-            })
-          : null;
-      if (submittedGrant && 'error' in submittedGrant) {
-        return c.json(submittedGrant.error, submittedGrant.status as 400);
+      const grantResult = await resolveMcpGrant({
+        sql,
+        userId: user.id,
+        resource: body.resource,
+        scope: body.scope,
+        organizationId: body.organization_id,
+        organizationIds: body.organization_ids,
+        workspaceAccess: body.workspace_access,
+        multiWorkspaceGrantsEnabled: isMultiWorkspaceGrantIssuanceEnabled(c.env),
+        forceSelectionForMultiOrg: isBareMcpResource(body.resource),
+      });
+      if ('error' in grantResult) {
+        return c.json(grantResult.error, grantResult.status as 400);
       }
-      const validSubmittedGrant =
-        submittedGrant && !('error' in submittedGrant) ? submittedGrant : null;
-      const orgResult =
-        validSubmittedGrant ??
-        (await resolveOrganizationForGrant({
-          sql,
-          userId: user.id,
-          resourceOrgSlug,
-          explicitOrgId: body.organization_id,
-          forceSelectionForMultiOrg: isBareMcpResource(body.resource),
-        }));
-      if ('error' in orgResult) {
-        return c.json(orgResult.error, orgResult.status as 400);
-      }
-      if ('orgSelectionRequired' in orgResult) {
+      if ('orgSelectionRequired' in grantResult) {
         return c.json(
           {
             error: 'org_selection_required',
             error_description: 'Please select an organization for this session',
-            organizations: orgResult.organizations,
+            organizations: grantResult.organizations,
           },
           400
         );
       }
-      organizationId = orgResult.organizationId;
-      grantedOrganizationIds = validSubmittedGrant?.grantedOrganizationIds ?? [
-        orgResult.organizationId,
-      ];
-      const liveGrantedWorkspaces =
-        validSubmittedGrant?.liveGrantedWorkspaces ??
-        (resourceOrgSlug === null
-          ? await listLiveGrantedMemberWorkspaces({
-              sql,
-              userId: user.id,
-              grantedOrganizationIds,
-            })
-          : []);
-      // A scoped resource is governed by its one bound workspace. For /mcp,
-      // the resolved org is only the session default; target workspace role
-      // checks remain authoritative at runtime.
-      const grantRole =
-        resourceOrgSlug !== null
-          ? orgResult.memberRole
-          : liveGrantedWorkspaces.some(
-                (workspace) => workspace.role === 'owner' || workspace.role === 'admin'
-              )
-            ? 'admin'
-            : 'member';
-      const filtered = filterScopeByRole(body.scope, grantRole);
-      if (filtered === null) {
-        return c.json(
-          createOAuthError(
-            'invalid_scope',
-            'Your role is not authorized for any of the requested scopes'
-          ),
-          400
-        );
-      }
-      // Grant exactly the resource-aware filtered request. Runtime target-role
-      // gates stay separate from the token's transport capability.
-      params.scope = filtered;
+      organizationId = grantResult.grant.organizationId;
+      grantedOrganizationIds = grantResult.grant.grantedOrganizationIds;
+      params.scope = grantResult.grant.scope;
     }
 
     const code = await provider.createAuthorizationCode(
@@ -979,6 +1110,14 @@ oauthRoutes.post('/oauth/device_authorization', async (c) => {
     return c.json(createOAuthError('invalid_scope', 'Requested scope must not be empty'), 400);
   }
 
+  const normalizedDeviceScope = normalizeOAuthScopeRequest(
+    body.scope || DEFAULT_SCOPES_STRING,
+    AVAILABLE_SCOPES
+  );
+  if (!normalizedDeviceScope) {
+    return c.json(createOAuthError('invalid_scope', 'The requested scope is unsupported'), 400);
+  }
+  body.scope = canonicalizeOAuthScopeGrant(normalizedDeviceScope);
   const deviceScopes = getRequestedScopes(body.scope);
   const isDeviceWorkerGrant = deviceScopes.includes('device_worker:run');
   const deviceHasMcpScopes = deviceScopes.some((scope) => scope.startsWith('mcp:'));
@@ -1184,6 +1323,7 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
   let body: {
     user_code: string;
     approved: boolean;
+    scope?: string;
     organization_id?: string;
     organization_ids?: string[];
     workspace_access?: WorkspaceAccessMode;
@@ -1213,8 +1353,32 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
     return c.json(createOAuthError('invalid_grant', INVALID_DEVICE_CODE_MESSAGE), 400);
   }
 
-  const deviceHasMcpScopes = hasMcpScopes(deviceCode.scope);
-  const requestedScopes = (deviceCode.scope ?? '').split(/\s+/).filter(Boolean);
+  const requestedScope = deviceCode.scope || DEFAULT_SCOPES_STRING;
+  let approvedScope = requestedScope;
+  if (body.scope !== undefined) {
+    const normalizedScope = normalizeOAuthScopeRequest(body.scope, AVAILABLE_SCOPES);
+    if (!normalizedScope || !isOAuthScopeGrantWithinRequest(requestedScope, normalizedScope)) {
+      return c.json(
+        createOAuthError('invalid_scope', 'Approved scopes exceed or do not match the request'),
+        400
+      );
+    }
+    const requestedSet = new Set(getRequestedScopes(requestedScope));
+    const approvedSet = new Set(getRequestedScopes(normalizedScope));
+    if (
+      NON_PUBLIC_OAUTH_SCOPES.some(
+        (scope) => requestedSet.has(scope) && !approvedSet.has(scope)
+      )
+    ) {
+      return c.json(
+        createOAuthError('invalid_scope', 'Device capabilities cannot be changed during approval'),
+        400
+      );
+    }
+    approvedScope = canonicalizeOAuthScopeGrant(normalizedScope);
+  }
+  const deviceHasMcpScopes = hasMcpScopes(approvedScope);
+  const requestedScopes = getRequestedScopes(approvedScope);
   // `device_worker:run` tokens drive personal devices — the Owletto Mac app,
   // the Chrome extension, and the local `lobu run` worker. Device data
   // (WhatsApp, Photos, browser context, …) always belongs in the user's
@@ -1238,7 +1402,9 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
   }
   let organizationId: string | null = null;
   let grantedOrganizationIds: string[] = [];
-  let scopeOverride: string | null | undefined;
+  // Always persist the user's reduction, including the valid case where they
+  // remove MCP access entirely and retain only a non-MCP scope.
+  let scopeOverride: string | null = approvedScope;
 
   if (isDeviceWorkerGrant) {
     const sql = createDbClientFromEnv(c.env);
@@ -1306,7 +1472,7 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
     )
       ? 'admin'
       : memberRole;
-    scopeOverride = filterScopeByRole(deviceCode.scope, grantRole);
+    scopeOverride = filterScopeByRole(approvedScope, grantRole);
     if (scopeOverride === null) {
       return c.json(
         createOAuthError(
@@ -1318,79 +1484,35 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
     }
   } else if (deviceHasMcpScopes) {
     const sql = createDbClientFromEnv(c.env);
-    const resourceOrgSlug = getOrgSlugFromResource(deviceCode.resource);
-    const submittedGrant =
-      isBareMcpResource(deviceCode.resource) &&
-      (body.workspace_access !== undefined || body.organization_ids !== undefined)
-        ? await resolveSubmittedWorkspaceGrant({
-            sql,
-            userId: user.id,
-            organizationIds: body.organization_ids,
-            anchorOrganizationId: body.organization_id,
-            workspaceAccess: body.workspace_access,
-            multiWorkspaceGrantsEnabled: isMultiWorkspaceGrantIssuanceEnabled(c.env),
-          })
-        : null;
-    if (submittedGrant && 'error' in submittedGrant) {
-      return c.json(submittedGrant.error, submittedGrant.status as 400);
+    const grantResult = await resolveMcpGrant({
+      sql,
+      userId: user.id,
+      resource: deviceCode.resource,
+      scope: approvedScope,
+      organizationId: body.organization_id,
+      organizationIds: body.organization_ids,
+      workspaceAccess: body.workspace_access,
+      multiWorkspaceGrantsEnabled: isMultiWorkspaceGrantIssuanceEnabled(c.env),
+      // Device pairing must not silently default a multi-org user's device to
+      // an unrelated workspace — require an explicit pick.
+      forceSelectionForMultiOrg: true,
+    });
+    if ('error' in grantResult) {
+      return c.json(grantResult.error, grantResult.status as 400);
     }
-    const validSubmittedGrant =
-      submittedGrant && !('error' in submittedGrant) ? submittedGrant : null;
-    const orgResult =
-      validSubmittedGrant ??
-      (await resolveOrganizationForGrant({
-        sql,
-        userId: user.id,
-        resourceOrgSlug,
-        explicitOrgId: body.organization_id,
-        // Device pairing must not silently default a multi-org user's device to
-        // their personal org — require an explicit pick.
-        forceSelectionForMultiOrg: true,
-      }));
-    if ('error' in orgResult) {
-      return c.json(orgResult.error, orgResult.status as 400);
-    }
-    if ('orgSelectionRequired' in orgResult) {
+    if ('orgSelectionRequired' in grantResult) {
       return c.json(
         {
           error: 'org_selection_required',
           error_description: 'Please select an organization for this session',
-          organizations: orgResult.organizations,
+          organizations: grantResult.organizations,
         },
         400
       );
     }
-    organizationId = orgResult.organizationId;
-    grantedOrganizationIds = validSubmittedGrant?.grantedOrganizationIds ?? [
-      orgResult.organizationId,
-    ];
-    const liveGrantedWorkspaces =
-      validSubmittedGrant?.liveGrantedWorkspaces ??
-      (resourceOrgSlug === null
-        ? await listLiveGrantedMemberWorkspaces({
-            sql,
-            userId: user.id,
-            grantedOrganizationIds,
-          })
-        : []);
-    const grantRole =
-      resourceOrgSlug !== null
-        ? orgResult.memberRole
-        : liveGrantedWorkspaces.some(
-              (workspace) => workspace.role === 'owner' || workspace.role === 'admin'
-            )
-          ? 'admin'
-          : 'member';
-    scopeOverride = filterScopeByRole(deviceCode.scope, grantRole);
-    if (scopeOverride === null) {
-      return c.json(
-        createOAuthError(
-          'invalid_scope',
-          'Your role is not authorized for any of the requested scopes'
-        ),
-        400
-      );
-    }
+    organizationId = grantResult.grant.organizationId;
+    grantedOrganizationIds = grantResult.grant.grantedOrganizationIds;
+    scopeOverride = grantResult.grant.scope;
     // NOTE: `connections:token` is NOT auto-appended here. Device-code
     // registration is open (DCR), so auto-granting it to any device client
     // would silently widen its token beyond what it requested — the same

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -90,6 +90,75 @@ export const CONNECTIONS_TOKEN_SCOPE = 'connections:token';
 /** Default scopes as a space-separated string (for OAuth params) */
 export const DEFAULT_SCOPES_STRING = DEFAULT_SCOPES.join(' ');
 
+const MCP_SCOPE_RANK = new Map<string, number>([
+  ['mcp:read', 0],
+  ['mcp:write', 1],
+  ['mcp:admin', 2],
+]);
+
+/**
+ * Normalize a requested scope string and reject unknown values at the OAuth
+ * boundary. Unknown scopes used to survive storage and disappear only when a
+ * token was used, which made consent promise access the token did not carry.
+ */
+export function normalizeOAuthScopeRequest(
+  scope: string | undefined | null,
+  allowedScopes: readonly string[] = AVAILABLE_SCOPES
+): string | null {
+  const normalized = normalizeScopeList(scope);
+  if (normalized.length === 0) return null;
+  const allowed = new Set(allowedScopes);
+  if (normalized.some((value) => !allowed.has(value))) return null;
+  return normalized.join(' ');
+}
+
+/**
+ * True when a consent-time scope choice is no more powerful than the original
+ * request. MCP scopes are hierarchical: admin includes write and read, while
+ * write includes read. Non-MCP capabilities must be exact requested members.
+ */
+export function isOAuthScopeGrantWithinRequest(
+  requestedScope: string | undefined | null,
+  grantedScope: string | undefined | null
+): boolean {
+  const requested = normalizeScopeList(requestedScope);
+  const granted = normalizeScopeList(grantedScope);
+  if (requested.length === 0 || granted.length === 0) return false;
+
+  const available = new Set<string>(AVAILABLE_SCOPES);
+  if (requested.some((scope) => !available.has(scope))) return false;
+  if (granted.some((scope) => !available.has(scope))) return false;
+
+  const highestMcpRank = (scopes: readonly string[]) => {
+    let rank = -1;
+    for (const scope of scopes) {
+      const candidate = MCP_SCOPE_RANK.get(scope);
+      if (candidate !== undefined && candidate > rank) rank = candidate;
+    }
+    return rank;
+  };
+
+  if (highestMcpRank(granted) > highestMcpRank(requested)) return false;
+  const requestedSet = new Set(requested);
+  return granted.every((scope) => MCP_SCOPE_RANK.has(scope) || requestedSet.has(scope));
+}
+
+/** Persist MCP grants in the same explicit hierarchy the UI displays. */
+export function canonicalizeOAuthScopeGrant(scope: string): string {
+  const normalized = normalizeScopeList(scope);
+  const highestMcpRank = normalized.reduce((rank, value) => {
+    const candidate = MCP_SCOPE_RANK.get(value);
+    return candidate === undefined ? rank : Math.max(rank, candidate);
+  }, -1);
+  const mcpScopes = [
+    ...(highestMcpRank >= 0 ? ['mcp:read'] : []),
+    ...(highestMcpRank >= 1 ? ['mcp:write'] : []),
+    ...(highestMcpRank >= 2 ? ['mcp:admin'] : []),
+  ];
+  const nonMcpScopes = normalized.filter((value) => !MCP_SCOPE_RANK.has(value));
+  return [...mcpScopes, ...nonMcpScopes].join(' ');
+}
+
 /**
  * Drop device-flow-only scopes from an authorization-code request.
  *

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -176,25 +176,32 @@ export function stripNonPublicOAuthScopes(scope: string | undefined | null): str
 }
 
 /**
- * Narrow a THIRD-PARTY client's requested scope to what auth-code clients may
- * receive, dropping anything else.
+ * Narrow an UNTRUSTED client's requested scope to what it may receive,
+ * dropping anything else. The tolerant counterpart to
+ * {@link normalizeOAuthScopeRequest}, and deliberately the same shape so the
+ * choice between them is the only difference at a call site.
  *
  * Unknown scopes are IGNORED, not rejected. RFC 6749 §3.3 permits either, but
- * the clients on the other end of this endpoint — Slack, Claude Desktop,
- * Cursor — routinely append `openid`, `email`, `profile` or `offline_access`
- * to whatever discovery advertises. Failing the whole authorization over one
- * unrecognized value breaks the integration outright, where narrowing it just
- * grants less. Rejecting is right for scope strings WE produce (the consent
- * form, the device flow); it is wrong for a stranger's request.
+ * the clients on these endpoints are strangers: registration is open (DCR),
+ * and Slack, Claude Desktop and Cursor all append standard OIDC scopes
+ * (`openid`, `email`, `profile`, `offline_access`) that Lobu has never issued.
+ * Failing a whole authorization over one unrecognized value breaks the
+ * integration outright, where narrowing it just grants less. Dropping a scope
+ * is never a privilege risk — the user still consents to what remains.
  *
- * Returns null only when nothing requested is grantable at all, which is a
- * genuine `invalid_scope`. Supersedes stripNonPublicOAuthScopes here:
- * DISCOVERY_SCOPES already excludes the non-public ones.
+ * Reject instead for scope strings WE generate (the consent form), where an
+ * unknown value is a real error rather than someone else's dialect.
+ *
+ * Returns null only when nothing requested is grantable, a genuine
+ * `invalid_scope`.
  */
-export function filterToDiscoveryScopes(scope: string | undefined | null): string | null {
+export function filterRequestedScopes(
+  scope: string | undefined | null,
+  allowedScopes: readonly string[] = AVAILABLE_SCOPES
+): string | null {
   const requested = normalizeScopeList(scope);
   if (requested.length === 0) return null;
-  const allowed = new Set<string>(DISCOVERY_SCOPES);
+  const allowed = new Set<string>(allowedScopes);
   const kept = requested.filter((value) => allowed.has(value));
   return kept.length > 0 ? kept.join(' ') : null;
 }

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -176,6 +176,30 @@ export function stripNonPublicOAuthScopes(scope: string | undefined | null): str
 }
 
 /**
+ * Narrow a THIRD-PARTY client's requested scope to what auth-code clients may
+ * receive, dropping anything else.
+ *
+ * Unknown scopes are IGNORED, not rejected. RFC 6749 §3.3 permits either, but
+ * the clients on the other end of this endpoint — Slack, Claude Desktop,
+ * Cursor — routinely append `openid`, `email`, `profile` or `offline_access`
+ * to whatever discovery advertises. Failing the whole authorization over one
+ * unrecognized value breaks the integration outright, where narrowing it just
+ * grants less. Rejecting is right for scope strings WE produce (the consent
+ * form, the device flow); it is wrong for a stranger's request.
+ *
+ * Returns null only when nothing requested is grantable at all, which is a
+ * genuine `invalid_scope`. Supersedes stripNonPublicOAuthScopes here:
+ * DISCOVERY_SCOPES already excludes the non-public ones.
+ */
+export function filterToDiscoveryScopes(scope: string | undefined | null): string | null {
+  const requested = normalizeScopeList(scope);
+  if (requested.length === 0) return null;
+  const allowed = new Set<string>(DISCOVERY_SCOPES);
+  const kept = requested.filter((value) => allowed.has(value));
+  return kept.length > 0 ? kept.join(' ') : null;
+}
+
+/**
  * Strip `mcp:admin` from a requested scope string when the user is not an
  * owner/admin of the target org. The runtime tool-access checks reject
  * admin-tier actions for non-admins anyway, so filtering at consent makes

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -157,15 +157,14 @@ try {
 
   await page.goto(authorizeUrl.toString(), { waitUntil: "domcontentloaded" });
   await page.getByRole("heading", { name: "Authorize application" }).waitFor();
-  await page.getByText("1 of 3 workspaces selected.").waitFor();
+  await page.getByText("0 of 3 workspaces selected.").waitFor();
+  await page.getByRole("button", { name: "Select all 3" }).click();
+  await page.getByText("3 of 3 workspaces selected.").waitFor();
+  await page.getByLabel("Read only").check();
   await page.screenshot({
     path: join(outputDir, "oauth-consent-review.png"),
     fullPage: true,
   });
-
-  await page.getByRole("button", { name: "Select all 3" }).click();
-  await page.getByText("3 of 3 workspaces selected.").waitFor();
-  await page.getByLabel("Read only").check();
   await page.getByRole("button", { name: "Approve" }).click();
   await page.waitForURL((url) => url.pathname === "/oauth-proof/callback");
 
@@ -233,18 +232,18 @@ try {
   });
   await page.getByRole("heading", { name: "Authorize application" }).waitFor();
   await page.getByText("Device capabilities").waitFor();
-  await page.getByText("1 of 3 workspaces selected.").waitFor();
-  await page.screenshot({
-    path: join(outputDir, "oauth-device-review.png"),
-    fullPage: true,
-  });
-
+  await page.getByText("0 of 3 workspaces selected.").waitFor();
   await page.getByRole("button", { name: "Select all 3" }).click();
+  await page.getByText("3 of 3 workspaces selected.").waitFor();
   await page
     .getByLabel(
       "I initiated this request and confirmed that the device code matches."
     )
     .click();
+  await page.screenshot({
+    path: join(outputDir, "oauth-device-review.png"),
+    fullPage: true,
+  });
   await page.getByRole("button", { name: "Approve" }).click();
   await page.getByRole("heading", { name: "Access Authorized" }).waitFor();
 

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -246,7 +246,7 @@ try {
     fullPage: true,
   });
   await page.getByRole("button", { name: "Approve" }).click();
-  await page.getByRole("heading", { name: "Access Authorized" }).waitFor();
+  await page.getByText("Access Authorized", { exact: true }).waitFor();
 
   const deviceTokens = await postForm("/oauth/token", {
     grant_type: "urn:ietf:params:oauth:grant-type:device_code",

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -125,7 +125,7 @@ try {
 		results.workspaces_created.push({ id: organization?.id, name, slug });
 	}
 
-	const redirectUri = "http://localhost:18788/oauth-proof/callback";
+	const redirectUri = "http://localhost:8787/oauth-proof/callback";
 	const consentClient = await postJson("/oauth/register", {
 		client_name: "Lobu MCP Client",
 		redirect_uris: [redirectUri],

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -1,0 +1,292 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const runtime = process.env.PLAYWRIGHT_RUNTIME;
+const chromePath = process.env.CHROME_PATH;
+const baseUrl = process.env.PROOF_BASE_URL;
+const outputDir = process.env.PROOF_OUTPUT_DIR;
+
+if (!runtime || !chromePath || !baseUrl || !outputDir) {
+	throw new Error(
+		"PLAYWRIGHT_RUNTIME, CHROME_PATH, PROOF_BASE_URL, and PROOF_OUTPUT_DIR are required",
+	);
+}
+
+const { chromium } = require(join(runtime, "node_modules", "playwright-core"));
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+async function jsonResponse(response, operation) {
+	const body = await response.json().catch(() => null);
+	if (!response.ok) {
+		throw new Error(
+			`${operation} failed (${response.status}): ${JSON.stringify(body)}`,
+		);
+	}
+	return body;
+}
+
+async function postJson(path, body) {
+	return jsonResponse(
+		await fetch(new URL(path, baseUrl), {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}),
+		`POST ${path}`,
+	);
+}
+
+async function postForm(path, body) {
+	return jsonResponse(
+		await fetch(new URL(path, baseUrl), {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams(body),
+		}),
+		`POST ${path}`,
+	);
+}
+
+async function browserPost(page, path, body, headers = {}) {
+	const result = await page.evaluate(
+		async ({ path, body, headers }) => {
+			const response = await fetch(path, {
+				method: "POST",
+				credentials: "include",
+				headers: { "Content-Type": "application/json", ...headers },
+				body: JSON.stringify(body),
+			});
+			return {
+				ok: response.ok,
+				status: response.status,
+				body: await response.json().catch(() => null),
+			};
+		},
+		{ path, body, headers },
+	);
+	if (!result.ok) {
+		throw new Error(
+			`POST ${path} failed (${result.status}): ${JSON.stringify(result.body)}`,
+		);
+	}
+	return result.body;
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const browser = await chromium.launch({
+	executablePath: chromePath,
+	headless: true,
+	args: ["--no-sandbox", "--disable-dev-shm-usage"],
+});
+
+const page = await browser.newPage({
+	viewport: { width: 1440, height: 1400 },
+	colorScheme: "light",
+	deviceScaleFactor: 1,
+});
+
+const results = {
+	base_url: baseUrl,
+	workspaces_created: [],
+	consent: {},
+	device: {},
+};
+
+try {
+	await page.goto(new URL("/api/health", baseUrl).toString());
+	const localInit = await browserPost(
+		page,
+		"/api/local-init",
+		{},
+		{ "X-Lobu-Client": "oauth-authorization-ui-proof" },
+	);
+	assert(localInit?.user?.id, "Local preview bootstrap did not return a user");
+	assert(
+		localInit?.organization?.id,
+		"Local preview bootstrap did not return a workspace",
+	);
+
+	for (const [name, slug] of [
+		["Engineering", "oauth-proof-engineering"],
+		["Customer operations", "oauth-proof-customer-operations"],
+	]) {
+		const organization = await browserPost(
+			page,
+			"/api/auth/organization/create",
+			{ name, slug },
+		);
+		results.workspaces_created.push({ id: organization?.id, name, slug });
+	}
+
+	const redirectUri = "http://localhost:18788/oauth-proof/callback";
+	const consentClient = await postJson("/oauth/register", {
+		client_name: "Lobu MCP Client",
+		redirect_uris: [redirectUri],
+		grant_types: ["authorization_code", "refresh_token"],
+		token_endpoint_auth_method: "none",
+	});
+	assert(
+		consentClient?.client_id,
+		"Consent client registration returned no client_id",
+	);
+
+	const verifier = randomBytes(32).toString("base64url");
+	const challenge = createHash("sha256").update(verifier).digest("base64url");
+	const state = randomBytes(12).toString("base64url");
+	const authorizeUrl = new URL("/oauth/authorize", baseUrl);
+	authorizeUrl.searchParams.set("client_id", consentClient.client_id);
+	authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+	authorizeUrl.searchParams.set("response_type", "code");
+	authorizeUrl.searchParams.set(
+		"scope",
+		"mcp:read mcp:write mcp:admin profile:read",
+	);
+	authorizeUrl.searchParams.set("state", state);
+	authorizeUrl.searchParams.set("code_challenge", challenge);
+	authorizeUrl.searchParams.set("code_challenge_method", "S256");
+	authorizeUrl.searchParams.set(
+		"resource",
+		new URL("/mcp", baseUrl).toString(),
+	);
+
+	await page.goto(authorizeUrl.toString(), { waitUntil: "domcontentloaded" });
+	await page.getByRole("heading", { name: "Authorize application" }).waitFor();
+	await page.getByText("1 of 3 workspaces selected.").waitFor();
+	await page.screenshot({
+		path: join(outputDir, "oauth-consent-review.png"),
+		fullPage: true,
+	});
+
+	await page.getByRole("button", { name: "Select all 3" }).click();
+	await page.getByText("3 of 3 workspaces selected.").waitFor();
+	await page.getByLabel("Read only").check();
+	await page.getByRole("button", { name: "Approve" }).click();
+	await page.waitForURL((url) => url.pathname === "/oauth-proof/callback");
+
+	const callbackUrl = new URL(page.url());
+	const code = callbackUrl.searchParams.get("code");
+	assert(code, "Consent approval did not redirect with an authorization code");
+	assert(
+		callbackUrl.searchParams.get("state") === state,
+		"Consent redirect changed OAuth state",
+	);
+	const consentTokens = await postForm("/oauth/token", {
+		grant_type: "authorization_code",
+		code,
+		redirect_uri: redirectUri,
+		client_id: consentClient.client_id,
+		code_verifier: verifier,
+	});
+	const consentScope = String(consentTokens.scope || "")
+		.split(/\s+/)
+		.filter(Boolean);
+	assert(
+		consentScope.includes("mcp:read"),
+		"Downscoped consent token lost mcp:read",
+	);
+	assert(
+		!consentScope.includes("mcp:write"),
+		"Downscoped consent token retained mcp:write",
+	);
+	assert(
+		!consentScope.includes("mcp:admin"),
+		"Downscoped consent token retained mcp:admin",
+	);
+	results.consent = {
+		screenshot: "oauth-consent-review.png",
+		requested_access: "admin",
+		approved_access: "read",
+		workspace_access: "all_current",
+		token_scope: consentScope,
+	};
+
+	const deviceClient = await postJson("/oauth/register", {
+		client_name: "Lobu CLI",
+		grant_types: [
+			"urn:ietf:params:oauth:grant-type:device_code",
+			"refresh_token",
+		],
+		token_endpoint_auth_method: "none",
+	});
+	assert(
+		deviceClient?.client_id,
+		"Device client registration returned no client_id",
+	);
+	const deviceAuthorization = await postJson("/oauth/device_authorization", {
+		client_id: deviceClient.client_id,
+		scope:
+			"device_worker:run mcp:read mcp:write mcp:admin profile:read connections:token",
+	});
+	assert(
+		deviceAuthorization?.verification_uri_complete,
+		"Device authorization returned no link",
+	);
+
+	await page.goto(deviceAuthorization.verification_uri_complete, {
+		waitUntil: "domcontentloaded",
+	});
+	await page.getByRole("heading", { name: "Authorize application" }).waitFor();
+	await page.getByText("Device capabilities").waitFor();
+	await page.getByText("1 of 3 workspaces selected.").waitFor();
+	await page.screenshot({
+		path: join(outputDir, "oauth-device-review.png"),
+		fullPage: true,
+	});
+
+	await page.getByRole("button", { name: "Select all 3" }).click();
+	await page
+		.getByLabel(
+			"I initiated this request and confirmed that the device code matches.",
+		)
+		.click();
+	await page.getByRole("button", { name: "Approve" }).click();
+	await page.getByRole("heading", { name: "Access Authorized" }).waitFor();
+
+	const deviceTokens = await postForm("/oauth/token", {
+		grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		device_code: deviceAuthorization.device_code,
+		client_id: deviceClient.client_id,
+	});
+	const deviceScope = String(deviceTokens.scope || "")
+		.split(/\s+/)
+		.filter(Boolean);
+	assert(
+		deviceScope.includes("device_worker:run"),
+		"Device token lost device_worker:run",
+	);
+	assert(
+		deviceScope.includes("mcp:admin"),
+		"Device token lost approved mcp:admin",
+	);
+	results.device = {
+		screenshot: "oauth-device-review.png",
+		approved_access: "admin",
+		workspace_access: "all_current",
+		sensitive_capabilities_acknowledged: true,
+		token_scope: deviceScope,
+	};
+
+	await writeFile(
+		join(outputDir, "results.json"),
+		`${JSON.stringify(results, null, 2)}\n`,
+	);
+	console.log(JSON.stringify(results, null, 2));
+} catch (error) {
+	await page
+		.screenshot({ path: join(outputDir, "failure.png"), fullPage: true })
+		.catch(() => {});
+	await writeFile(
+		join(outputDir, "failure.txt"),
+		`${error instanceof Error ? error.stack : String(error)}\n`,
+	);
+	throw error;
+} finally {
+	await browser.close();
+}

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -10,283 +10,284 @@ const baseUrl = process.env.PROOF_BASE_URL;
 const outputDir = process.env.PROOF_OUTPUT_DIR;
 
 if (!runtime || !chromePath || !baseUrl || !outputDir) {
-	throw new Error(
-		"PLAYWRIGHT_RUNTIME, CHROME_PATH, PROOF_BASE_URL, and PROOF_OUTPUT_DIR are required",
-	);
+  throw new Error(
+    "PLAYWRIGHT_RUNTIME, CHROME_PATH, PROOF_BASE_URL, and PROOF_OUTPUT_DIR are required"
+  );
 }
 
 const { chromium } = require(join(runtime, "node_modules", "playwright-core"));
 
 function assert(condition, message) {
-	if (!condition) throw new Error(message);
+  if (!condition) throw new Error(message);
 }
 
 async function jsonResponse(response, operation) {
-	const body = await response.json().catch(() => null);
-	if (!response.ok) {
-		throw new Error(
-			`${operation} failed (${response.status}): ${JSON.stringify(body)}`,
-		);
-	}
-	return body;
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(
+      `${operation} failed (${response.status}): ${JSON.stringify(body)}`
+    );
+  }
+  return body;
 }
 
 async function postJson(path, body) {
-	return jsonResponse(
-		await fetch(new URL(path, baseUrl), {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(body),
-		}),
-		`POST ${path}`,
-	);
+  return jsonResponse(
+    await fetch(new URL(path, baseUrl), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    `POST ${path}`
+  );
 }
 
 async function postForm(path, body) {
-	return jsonResponse(
-		await fetch(new URL(path, baseUrl), {
-			method: "POST",
-			headers: { "Content-Type": "application/x-www-form-urlencoded" },
-			body: new URLSearchParams(body),
-		}),
-		`POST ${path}`,
-	);
+  return jsonResponse(
+    await fetch(new URL(path, baseUrl), {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(body),
+    }),
+    `POST ${path}`
+  );
 }
 
 async function browserPost(page, path, body, headers = {}) {
-	const result = await page.evaluate(
-		async ({ path, body, headers }) => {
-			const response = await fetch(path, {
-				method: "POST",
-				credentials: "include",
-				headers: { "Content-Type": "application/json", ...headers },
-				body: JSON.stringify(body),
-			});
-			return {
-				ok: response.ok,
-				status: response.status,
-				body: await response.json().catch(() => null),
-			};
-		},
-		{ path, body, headers },
-	);
-	if (!result.ok) {
-		throw new Error(
-			`POST ${path} failed (${result.status}): ${JSON.stringify(result.body)}`,
-		);
-	}
-	return result.body;
+  const result = await page.evaluate(
+    async ({ path, body, headers }) => {
+      const response = await fetch(path, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: JSON.stringify(body),
+      });
+      return {
+        ok: response.ok,
+        status: response.status,
+        body: await response.json().catch(() => null),
+      };
+    },
+    { path, body, headers }
+  );
+  if (!result.ok) {
+    throw new Error(
+      `POST ${path} failed (${result.status}): ${JSON.stringify(result.body)}`
+    );
+  }
+  return result.body;
 }
 
 await mkdir(outputDir, { recursive: true });
 
 const browser = await chromium.launch({
-	executablePath: chromePath,
-	headless: true,
-	args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  executablePath: chromePath,
+  headless: true,
+  args: ["--no-sandbox", "--disable-dev-shm-usage"],
 });
 
 const page = await browser.newPage({
-	viewport: { width: 1440, height: 1400 },
-	colorScheme: "light",
-	deviceScaleFactor: 1,
+  viewport: { width: 1440, height: 1400 },
+  colorScheme: "light",
+  deviceScaleFactor: 1,
 });
 
 const results = {
-	base_url: baseUrl,
-	workspaces_created: [],
-	consent: {},
-	device: {},
+  base_url: baseUrl,
+  workspaces_created: [],
+  consent: {},
+  device: {},
 };
 
 try {
-	await page.goto(new URL("/api/health", baseUrl).toString());
-	const localInit = await browserPost(
-		page,
-		"/api/local-init",
-		{},
-		{ "X-Lobu-Client": "oauth-authorization-ui-proof" },
-	);
-	assert(localInit?.user?.id, "Local preview bootstrap did not return a user");
-	assert(
-		localInit?.organization?.id,
-		"Local preview bootstrap did not return a workspace",
-	);
+  await page.goto(new URL("/api/health", baseUrl).toString());
+  const localInit = await browserPost(
+    page,
+    "/api/local-init",
+    {},
+    { "X-Lobu-Client": "oauth-authorization-ui-proof" }
+  );
+  assert(localInit?.user?.id, "Local preview bootstrap did not return a user");
+  assert(
+    localInit?.organization?.id,
+    "Local preview bootstrap did not return a workspace"
+  );
 
-	for (const [name, slug] of [
-		["Engineering", "oauth-proof-engineering"],
-		["Customer operations", "oauth-proof-customer-operations"],
-	]) {
-		const organization = await browserPost(
-			page,
-			"/api/auth/organization/create",
-			{ name, slug },
-		);
-		results.workspaces_created.push({ id: organization?.id, name, slug });
-	}
+  for (const [name, slug] of [
+    ["Engineering", "oauth-proof-engineering"],
+    ["Customer operations", "oauth-proof-customer-operations"],
+  ]) {
+    const organization = await browserPost(
+      page,
+      "/api/auth/organization/create",
+      { name, slug }
+    );
+    results.workspaces_created.push({ id: organization?.id, name, slug });
+  }
 
-	const redirectUri = "http://localhost:8787/oauth-proof/callback";
-	const consentClient = await postJson("/oauth/register", {
-		client_name: "Lobu MCP Client",
-		redirect_uris: [redirectUri],
-		grant_types: ["authorization_code", "refresh_token"],
-		token_endpoint_auth_method: "none",
-	});
-	assert(
-		consentClient?.client_id,
-		"Consent client registration returned no client_id",
-	);
+  const redirectUri = "http://localhost:8787/oauth-proof/callback";
+  const consentClient = await postJson("/oauth/register", {
+    client_name: "Lobu MCP Client",
+    redirect_uris: [redirectUri],
+    grant_types: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_method: "none",
+  });
+  assert(
+    consentClient?.client_id,
+    "Consent client registration returned no client_id"
+  );
 
-	const verifier = randomBytes(32).toString("base64url");
-	const challenge = createHash("sha256").update(verifier).digest("base64url");
-	const state = randomBytes(12).toString("base64url");
-	const authorizeUrl = new URL("/oauth/authorize", baseUrl);
-	authorizeUrl.searchParams.set("client_id", consentClient.client_id);
-	authorizeUrl.searchParams.set("redirect_uri", redirectUri);
-	authorizeUrl.searchParams.set("response_type", "code");
-	authorizeUrl.searchParams.set(
-		"scope",
-		"mcp:read mcp:write mcp:admin profile:read",
-	);
-	authorizeUrl.searchParams.set("state", state);
-	authorizeUrl.searchParams.set("code_challenge", challenge);
-	authorizeUrl.searchParams.set("code_challenge_method", "S256");
-	authorizeUrl.searchParams.set(
-		"resource",
-		new URL("/mcp", baseUrl).toString(),
-	);
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const state = randomBytes(12).toString("base64url");
+  const authorizeUrl = new URL("/oauth/authorize", baseUrl);
+  authorizeUrl.searchParams.set("client_id", consentClient.client_id);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set(
+    "scope",
+    "mcp:read mcp:write mcp:admin profile:read"
+  );
+  authorizeUrl.searchParams.set("state", state);
+  authorizeUrl.searchParams.set("code_challenge", challenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  const resourceUrl = new URL("/mcp", baseUrl);
+  resourceUrl.hostname = "localhost";
+  authorizeUrl.searchParams.set("resource", resourceUrl.toString());
 
-	await page.goto(authorizeUrl.toString(), { waitUntil: "domcontentloaded" });
-	await page.getByRole("heading", { name: "Authorize application" }).waitFor();
-	await page.getByText("1 of 3 workspaces selected.").waitFor();
-	await page.screenshot({
-		path: join(outputDir, "oauth-consent-review.png"),
-		fullPage: true,
-	});
+  await page.goto(authorizeUrl.toString(), { waitUntil: "domcontentloaded" });
+  await page.getByRole("heading", { name: "Authorize application" }).waitFor();
+  await page.getByText("1 of 3 workspaces selected.").waitFor();
+  await page.screenshot({
+    path: join(outputDir, "oauth-consent-review.png"),
+    fullPage: true,
+  });
 
-	await page.getByRole("button", { name: "Select all 3" }).click();
-	await page.getByText("3 of 3 workspaces selected.").waitFor();
-	await page.getByLabel("Read only").check();
-	await page.getByRole("button", { name: "Approve" }).click();
-	await page.waitForURL((url) => url.pathname === "/oauth-proof/callback");
+  await page.getByRole("button", { name: "Select all 3" }).click();
+  await page.getByText("3 of 3 workspaces selected.").waitFor();
+  await page.getByLabel("Read only").check();
+  await page.getByRole("button", { name: "Approve" }).click();
+  await page.waitForURL((url) => url.pathname === "/oauth-proof/callback");
 
-	const callbackUrl = new URL(page.url());
-	const code = callbackUrl.searchParams.get("code");
-	assert(code, "Consent approval did not redirect with an authorization code");
-	assert(
-		callbackUrl.searchParams.get("state") === state,
-		"Consent redirect changed OAuth state",
-	);
-	const consentTokens = await postForm("/oauth/token", {
-		grant_type: "authorization_code",
-		code,
-		redirect_uri: redirectUri,
-		client_id: consentClient.client_id,
-		code_verifier: verifier,
-	});
-	const consentScope = String(consentTokens.scope || "")
-		.split(/\s+/)
-		.filter(Boolean);
-	assert(
-		consentScope.includes("mcp:read"),
-		"Downscoped consent token lost mcp:read",
-	);
-	assert(
-		!consentScope.includes("mcp:write"),
-		"Downscoped consent token retained mcp:write",
-	);
-	assert(
-		!consentScope.includes("mcp:admin"),
-		"Downscoped consent token retained mcp:admin",
-	);
-	results.consent = {
-		screenshot: "oauth-consent-review.png",
-		requested_access: "admin",
-		approved_access: "read",
-		workspace_access: "all_current",
-		token_scope: consentScope,
-	};
+  const callbackUrl = new URL(page.url());
+  const code = callbackUrl.searchParams.get("code");
+  assert(code, "Consent approval did not redirect with an authorization code");
+  assert(
+    callbackUrl.searchParams.get("state") === state,
+    "Consent redirect changed OAuth state"
+  );
+  const consentTokens = await postForm("/oauth/token", {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: consentClient.client_id,
+    code_verifier: verifier,
+  });
+  const consentScope = String(consentTokens.scope || "")
+    .split(/\s+/)
+    .filter(Boolean);
+  assert(
+    consentScope.includes("mcp:read"),
+    "Downscoped consent token lost mcp:read"
+  );
+  assert(
+    !consentScope.includes("mcp:write"),
+    "Downscoped consent token retained mcp:write"
+  );
+  assert(
+    !consentScope.includes("mcp:admin"),
+    "Downscoped consent token retained mcp:admin"
+  );
+  results.consent = {
+    screenshot: "oauth-consent-review.png",
+    requested_access: "admin",
+    approved_access: "read",
+    workspace_access: "all_current",
+    token_scope: consentScope,
+  };
 
-	const deviceClient = await postJson("/oauth/register", {
-		client_name: "Lobu CLI",
-		grant_types: [
-			"urn:ietf:params:oauth:grant-type:device_code",
-			"refresh_token",
-		],
-		token_endpoint_auth_method: "none",
-	});
-	assert(
-		deviceClient?.client_id,
-		"Device client registration returned no client_id",
-	);
-	const deviceAuthorization = await postJson("/oauth/device_authorization", {
-		client_id: deviceClient.client_id,
-		scope:
-			"device_worker:run mcp:read mcp:write mcp:admin profile:read connections:token",
-	});
-	assert(
-		deviceAuthorization?.verification_uri_complete,
-		"Device authorization returned no link",
-	);
+  const deviceClient = await postJson("/oauth/register", {
+    client_name: "Lobu CLI",
+    grant_types: [
+      "urn:ietf:params:oauth:grant-type:device_code",
+      "refresh_token",
+    ],
+    token_endpoint_auth_method: "none",
+  });
+  assert(
+    deviceClient?.client_id,
+    "Device client registration returned no client_id"
+  );
+  const deviceAuthorization = await postJson("/oauth/device_authorization", {
+    client_id: deviceClient.client_id,
+    scope:
+      "device_worker:run mcp:read mcp:write mcp:admin profile:read connections:token",
+  });
+  assert(
+    deviceAuthorization?.verification_uri_complete,
+    "Device authorization returned no link"
+  );
 
-	await page.goto(deviceAuthorization.verification_uri_complete, {
-		waitUntil: "domcontentloaded",
-	});
-	await page.getByRole("heading", { name: "Authorize application" }).waitFor();
-	await page.getByText("Device capabilities").waitFor();
-	await page.getByText("1 of 3 workspaces selected.").waitFor();
-	await page.screenshot({
-		path: join(outputDir, "oauth-device-review.png"),
-		fullPage: true,
-	});
+  await page.goto(deviceAuthorization.verification_uri_complete, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.getByRole("heading", { name: "Authorize application" }).waitFor();
+  await page.getByText("Device capabilities").waitFor();
+  await page.getByText("1 of 3 workspaces selected.").waitFor();
+  await page.screenshot({
+    path: join(outputDir, "oauth-device-review.png"),
+    fullPage: true,
+  });
 
-	await page.getByRole("button", { name: "Select all 3" }).click();
-	await page
-		.getByLabel(
-			"I initiated this request and confirmed that the device code matches.",
-		)
-		.click();
-	await page.getByRole("button", { name: "Approve" }).click();
-	await page.getByRole("heading", { name: "Access Authorized" }).waitFor();
+  await page.getByRole("button", { name: "Select all 3" }).click();
+  await page
+    .getByLabel(
+      "I initiated this request and confirmed that the device code matches."
+    )
+    .click();
+  await page.getByRole("button", { name: "Approve" }).click();
+  await page.getByRole("heading", { name: "Access Authorized" }).waitFor();
 
-	const deviceTokens = await postForm("/oauth/token", {
-		grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-		device_code: deviceAuthorization.device_code,
-		client_id: deviceClient.client_id,
-	});
-	const deviceScope = String(deviceTokens.scope || "")
-		.split(/\s+/)
-		.filter(Boolean);
-	assert(
-		deviceScope.includes("device_worker:run"),
-		"Device token lost device_worker:run",
-	);
-	assert(
-		deviceScope.includes("mcp:admin"),
-		"Device token lost approved mcp:admin",
-	);
-	results.device = {
-		screenshot: "oauth-device-review.png",
-		approved_access: "admin",
-		workspace_access: "all_current",
-		sensitive_capabilities_acknowledged: true,
-		token_scope: deviceScope,
-	};
+  const deviceTokens = await postForm("/oauth/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: deviceAuthorization.device_code,
+    client_id: deviceClient.client_id,
+  });
+  const deviceScope = String(deviceTokens.scope || "")
+    .split(/\s+/)
+    .filter(Boolean);
+  assert(
+    deviceScope.includes("device_worker:run"),
+    "Device token lost device_worker:run"
+  );
+  assert(
+    deviceScope.includes("mcp:admin"),
+    "Device token lost approved mcp:admin"
+  );
+  results.device = {
+    screenshot: "oauth-device-review.png",
+    approved_access: "admin",
+    workspace_access: "all_current",
+    sensitive_capabilities_acknowledged: true,
+    token_scope: deviceScope,
+  };
 
-	await writeFile(
-		join(outputDir, "results.json"),
-		`${JSON.stringify(results, null, 2)}\n`,
-	);
-	console.log(JSON.stringify(results, null, 2));
+  await writeFile(
+    join(outputDir, "results.json"),
+    `${JSON.stringify(results, null, 2)}\n`
+  );
+  console.log(JSON.stringify(results, null, 2));
 } catch (error) {
-	await page
-		.screenshot({ path: join(outputDir, "failure.png"), fullPage: true })
-		.catch(() => {});
-	await writeFile(
-		join(outputDir, "failure.txt"),
-		`${error instanceof Error ? error.stack : String(error)}\n`,
-	);
-	throw error;
+  await page
+    .screenshot({ path: join(outputDir, "failure.png"), fullPage: true })
+    .catch(() => {
+      // Preserve the original proof failure when a diagnostic screenshot fails.
+    });
+  await writeFile(
+    join(outputDir, "failure.txt"),
+    `${error instanceof Error ? error.stack : String(error)}\n`
+  );
+  throw error;
 } finally {
-	await browser.close();
+  await browser.close();
 }

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -181,6 +181,7 @@ try {
     redirect_uri: redirectUri,
     client_id: consentClient.client_id,
     code_verifier: verifier,
+    resource: resourceUrl.toString(),
   });
   const consentScope = String(consentTokens.scope || "")
     .split(/\s+/)

--- a/scripts/oauth-authorization-ui-proof.mjs
+++ b/scripts/oauth-authorization-ui-proof.mjs
@@ -233,7 +233,7 @@ try {
   });
   await page.getByRole("heading", { name: "Authorize application" }).waitFor();
   await page.getByText("Device capabilities").waitFor();
-  await page.getByText("0 of 3 workspaces selected.").waitFor();
+  await page.getByText("1 of 3 workspaces selected.").waitFor();
   await page.getByRole("button", { name: "Select all 3" }).click();
   await page.getByText("3 of 3 workspaces selected.").waitFor();
   await page


### PR DESCRIPTION
## Summary

- bind OAuth consent POSTs to a short-lived signed authorization intent
- reject display/request mismatches for resource, client, redirect, state, and PKCE
- treat MCP Read → Write → Admin as one hierarchy and allow explicit downscoping
- persist device-flow scope reductions, including profile-only approval
- reuse one MCP workspace/role grant resolver across authorization-code and device flows
- point the Owletto submodule at the paired unified authorization UI

Owletto UI: https://github.com/lobu-ai/owletto/pull/982

## Verification

- 20 focused backend tests pass
- server TypeScript passes
- 33 paired Owletto authorization tests pass
- changed files lint without new errors
- production UI proof bundle builds
- independent Codex review completed with no remaining blocking or major issues

## Rollout

Merge/deploy Owletto PR #982 first, then this strict backend. An already-open pre-intent consent page may need authorization restarted after the backend deploy.

## Environment limitations

The local runner could not execute Postgres integration suites because embedded Postgres refuses root and the container blocks switching to an unprivileged identity. The repository-wide pre-PR build also hit the existing cross-worktree node_modules TS2742 portability issue in untouched plugin packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tamper-resistant OAuth authorization validation to protect consent requests.
  - Added support for multi-workspace OAuth grants.
  - Added scope reduction during device authorization approval.
  - Improved MCP permission hierarchy and scope validation.

- **Bug Fixes**
  - Prevented approved permissions from exceeding requested scopes.
  - Rejected modified application, redirect, or consent details.

- **Tests**
  - Expanded coverage for OAuth consent, scope handling, device approval, and authorization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->