### PR TITLE
feat: expose generic webhook automation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Docs: [Agent workspace](https://lobu.ai/guides/agent-prompts/) · [Guardrails](h
 
 Automations are versioned background responsibilities activated manually, on a schedule, by a connector event, or by another Automation's durable output. They read governed sources, persist structured results, and can notify Slack, open a ticket, or start agent work while nobody is in chat.
 
+Collection and activation stay independent: connect a source once, keep its durable history useful to every authorized agent, then choose whether a responsibility should run on a schedule or immediately when a matching event arrives. Polling connectors, authenticated webhooks, and Automation outputs use their appropriate ingestion paths but converge on the same durable Automation run lifecycle. Initial syncs establish a baseline without flooding subscribers; repeated deliveries are deduplicated.
+
 See the [activation and chaining model](docs/AUTOMATIONS.md).
 
 ### Optional execution

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -24,6 +24,24 @@ escape hatch by declaring SQL. Persisted changes go through declared outputs,
 the ClientSDK, reactions, connector actions, and their existing ACL or approval
 rails.
 
+## Scheduling and admission
+
+Feeds and scheduled Automations share cron parsing, due-item materialization,
+the durable `runs` table, dedupe, claiming, status, and observability. They do
+not share one admission clock:
+
+| Work | Due work is admitted by | Why |
+|---|---|---|
+| Scheduled Automation | The per-minute `automation` TaskScheduler tick | Execution is server-dispatched and the tick also reconciles stranded runs. |
+| Connector feed | An eligible idle worker poll | Capability, placement, and worker liveness are known before a run is created, avoiding durable but unclaimable syncs. |
+
+The consolidation boundary is therefore the durable run and event lifecycle,
+not a universal scheduler. Connector events, generic webhook deliveries,
+workspace-output events, and schedules all create the same Automation run shape;
+the periodic Automation tick is the recovery path when immediate event dispatch
+fails. Moving feed admission into the global clock would add a second placement
+queue without removing any existing mechanism.
+
 ## Window recovery and external processors
 
 Scheduled windows have a durable expected-period cursor. It advances by exactly
@@ -113,6 +131,13 @@ declared kind becomes a subscribable event type. A feed's first successful
 non-dry sync establishes its baseline without activation; later inserts of a
 matching kind activate subscribers. Entity-type `eventKinds` describe durable
 workspace semantics and are the catalog for workspace-sourced events.
+
+The generic `webhook` connector exposes `delivery.received`. Its authenticated
+JSON row and matching Automation run commit together, so low-latency webhook
+processing uses the same connector-event lifecycle as a polled feed rather than
+a second webhook scheduler. It defaults to turn/queue so every delivery carries
+its bounded input directly. Choose window/coalesce explicitly for batch-style
+analysis over a configured source.
 
 Sources never activate an Automation. A subscription is the trigger declaration
 that gives an event immediate activation semantics; it is not a second mutable

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -87,13 +87,16 @@ flowchart LR
 
 A connection with connector `webhook` turns any external system that POSTs JSON
 (Sentry, GitHub, Stripe, CI) into a push source: the delivery lands as an
-`events` row. Generic webhook rows are data rather than direct Event-trigger
-activations; process them with a scheduled or manual Automation and a bounded SQL
-source.
+`events` row. Subscribe an Automation to the connector event
+`delivery.received` for immediate processing, optionally filtering on the
+configured `semantic_type`; scheduled and manual Automations can still process
+the same durable rows through bounded SQL sources.
 
 - **Deliver:** `POST <gateway>/lobu/api/v1/webhooks/<connectionId>` with
   `Authorization: Bearer <token>` (or `?token=` when `allowQueryAuth` is on).
-- **Config:** `token` (auto-generated, returned once), `allowQueryAuth`,
+  Public create/apply requires a non-numeric connection slug and a bearer token
+  of at least 32 characters; the slug is the `<connectionId>` in this route.
+- **Config:** caller-supplied `token`, `allowQueryAuth`,
   `dedupeHeader` (the provider's delivery-id header; the default idempotency key
   is `sha256(raw body)`), `semanticType`, `titlePath` (JSON pointer → `title`),
   `searchable` (render `payload_text` for semantic recall).
@@ -102,9 +105,11 @@ source.
   `429` over 120 authenticated deliveries/min per connection. Dedupe is a
   partial unique index on `(organization_id, connector_key, origin_id)`.
 - **Read back:** scheduled or manual Automation SQL sources select
-  `WHERE connector_key = 'webhook:<connectionId>'` and read the verbatim
-  payload from `payload_data`. Object-root JSON is stored directly; array or
-  primitive roots are wrapped as `{"payload": ...}`.
+  the connection by `connection_id` and read the verbatim payload from
+  `payload_data`. The legacy `connector_key = 'webhook:<runtimeConnectionId>'`
+  remains available for compatibility and is required for deliveries ingested
+  before connection-scoped webhook projection shipped. Object-root JSON is
+  stored directly; array or primitive roots are wrapped as `{"payload": ...}`.
 
 ## Reading and writing data (agent-facing)
 

--- a/packages/connectors/src/__tests__/webhook.test.ts
+++ b/packages/connectors/src/__tests__/webhook.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import WebhookConnector from "../webhook";
+
+describe("webhook connector", () => {
+	test("uses the existing adapterless connection lifecycle", () => {
+		const connector = new WebhookConnector();
+		expect(connector.definition.optionsSchema).toMatchObject({
+			"x-lobu-adapterless-platform": "webhook",
+		});
+		expect(connector.definition.optionsSchema).not.toHaveProperty(
+			"x-lobu-chat-platform",
+		);
+	});
+
+	test("declares the durable delivery Automation event", () => {
+		const connector = new WebhookConnector();
+		expect(connector.definition.automationEvents).toContainEqual(
+			expect.objectContaining({
+				key: "delivery.received",
+				defaults: {
+					execution: "turn",
+					activeRun: "queue",
+					output: "silent",
+				},
+			}),
+		);
+	});
+});

--- a/packages/connectors/src/webhook.ts
+++ b/packages/connectors/src/webhook.ts
@@ -9,12 +9,19 @@ export default class WebhookConnector extends IntegrationConnector {
 		kind: "integration",
 		name: "Inbound webhook",
 		description: "Receive authenticated JSON deliveries as Lobu events.",
-		version: "1.0.0",
+		version: "1.0.1",
 		authSchema: { methods: [{ type: "none", label: "Webhook token" }] },
 		optionsSchema: {
 			type: "object",
+			"x-lobu-adapterless-platform": "webhook",
+			required: ["token"],
 			properties: {
-				token: { type: "string", format: "password", title: "Bearer token" },
+				token: {
+					type: "string",
+					format: "password",
+					title: "Bearer token",
+					minLength: 32,
+				},
 				allowQueryAuth: {
 					type: "boolean",
 					title: "Allow query-string authentication",
@@ -25,5 +32,24 @@ export default class WebhookConnector extends IntegrationConnector {
 				searchable: { type: "boolean", title: "Searchable" },
 			},
 		},
+		automationEvents: [
+			{
+				key: "delivery.received",
+				label: "Delivery received",
+				description:
+					"A new authenticated JSON delivery was persisted by this webhook connection.",
+				filterSchema: {
+					type: "object",
+					properties: {
+						semantic_type: { type: "string", title: "Semantic type" },
+					},
+				},
+				defaults: {
+					execution: "turn",
+					activeRun: "queue",
+					output: "silent",
+				},
+			},
+		],
 	};
 }

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -846,7 +846,7 @@ describe("ChatInstanceManager webhook wiring", () => {
 			"../../lobu/gateway.js"
 		);
 		const { manageConnections } = await import(
-			"../../tools/admin/manage_connections/index.js"
+			"../../tools/admin/manage_connections.js"
 		);
 		const { manageAutomations } = await import(
 			"../../tools/admin/manage_automations.js"

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -31,6 +31,7 @@ import {
 	ensureEncryptionKey,
 	resetTestDatabase,
 	seedAgentRow,
+	seedOrgMembership,
 } from "./helpers/db-setup.js";
 const ORG = "org-webhook";
 const AGENT = "agent-webhook";
@@ -834,6 +835,159 @@ describe("ChatInstanceManager webhook wiring", () => {
 		);
 		expect(stored.status).toBe("active");
 		expect(String(stored.config.token).startsWith("secret://")).toBe(true);
+	});
+
+	test("connections.create and manageAutomations reach the public webhook path", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const ownerId = "webhook-create-owner";
+		await seedOrgMembership(ORG, ownerId, "owner");
+		const { manager } = await buildManager();
+		const { __setChatInstanceManagerForTests } = await import(
+			"../../lobu/gateway.js"
+		);
+		const { manageConnections } = await import(
+			"../../tools/admin/manage_connections/index.js"
+		);
+		const { manageAutomations } = await import(
+			"../../tools/admin/manage_automations.js"
+		);
+		const token = "supported-create-webhook-token-0123456789";
+		const toolContext = {
+			organizationId: ORG,
+			userId: ownerId,
+			memberRole: "owner",
+			agentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+			baseUrl: "https://gateway.test/lobu",
+		} as never;
+		__setChatInstanceManagerForTests(manager);
+		try {
+			const missingSlug = await manageConnections(
+				{
+					action: "create",
+					connector_key: "webhook",
+					display_name: "Missing slug webhook",
+					config: { token },
+				},
+				{} as never,
+				toolContext,
+			);
+			expect("error" in missingSlug ? missingSlug.error : "").toMatch(
+				/non-numeric slug/i,
+			);
+
+			const missingToken = await manageConnections(
+				{
+					action: "create",
+					connector_key: "webhook",
+					slug: "missing-token-webhook",
+					display_name: "Missing token webhook",
+				},
+				{} as never,
+				toolContext,
+			);
+			expect("error" in missingToken ? missingToken.error : "").toMatch(/token/i);
+
+			const numericSlug = await manageConnections(
+				{
+					action: "create",
+					connector_key: "webhook",
+					slug: "12345",
+					display_name: "Numeric webhook",
+					config: { token },
+				},
+				{} as never,
+				toolContext,
+			);
+			expect("error" in numericSlug ? numericSlug.error : "").toMatch(
+				/cannot be numeric/i,
+			);
+
+			const created = await manageConnections(
+				{
+					action: "create",
+					connector_key: "webhook",
+					slug: "supported-webhook",
+					display_name: "Supported webhook",
+					config: { token, semanticType: "deployment" },
+				},
+				{} as never,
+				toolContext,
+			);
+			expect("error" in created ? created.error : undefined).toBeUndefined();
+			if (!("connection" in created)) {
+				throw new Error("Webhook connection creation did not return a connection");
+			}
+			const connectionId = Number((created.connection as { id: number }).id);
+			const automation = await manageAutomations(
+				{
+					action: "create",
+					slug: "supported-webhook-automation",
+					name: "Supported webhook Automation",
+					prompt: "Process the incoming deployment.",
+					agent_id: AGENT,
+					triggers: [
+						{
+							kind: "event",
+							source: "connector",
+							connector_key: "webhook",
+							connection_id: connectionId,
+							event_types: ["delivery.received"],
+							match: { semantic_type: "deployment" },
+							execution: "turn",
+							active_run: "queue",
+							output: "silent",
+							skip_if_unchanged: true,
+						},
+					],
+				},
+				{} as never,
+				toolContext,
+			);
+			if (
+				automation.action !== "create" ||
+				!("automation_id" in automation)
+			) {
+				throw new Error("Webhook Automation creation did not complete");
+			}
+
+			const response = await manager.handleIngestWebhook(
+				"supported-webhook",
+				new Request(
+					"http://gateway.test/api/v1/webhooks/supported-webhook",
+					{
+						method: "POST",
+						body: JSON.stringify({ version: "2026.08.31" }),
+						headers: {
+							"content-type": "application/json",
+							authorization: `Bearer ${token}`,
+						},
+					},
+				),
+			);
+			expect(response.status).toBe(202);
+			const rows = await eventRows("supported-webhook");
+			expect(rows).toHaveLength(1);
+			expect(rows[0]).toMatchObject({
+				semantic_type: "deployment",
+				payload_data: { version: "2026.08.31" },
+			});
+			const { getDb } = await import("../../db/client.js");
+			const [runCount] = await getDb()<{ count: number }[]>`
+				SELECT count(*)::integer AS count
+				FROM runs
+				WHERE automation_id = ${Number(automation.automation_id)}
+				  AND run_type = 'automation'
+			`;
+			expect(runCount?.count).toBe(1);
+		} finally {
+			__setChatInstanceManagerForTests(null);
+		}
 	});
 
 	test("handleIngestWebhook round-trips a delivery through the real secret store", async () => {


### PR DESCRIPTION
## Summary

- expose `delivery.received` as the generic webhook connector's Automation event
- keep collection and activation independent: every authenticated delivery persists first, then matching Automations enter the existing durable run lifecycle
- document the production architecture and add a public-path E2E covering connection creation, Automation creation, ingestion, durable event storage, and exactly one Automation run

## Why this is intentionally small

- no new scheduler
- no new queue
- no new database table
- no new public endpoint
- scheduled/manual admission and event admission stay separate; they converge on the existing durable `runs`/event lifecycle
- provider webhook bridges remain excluded from the generic `delivery.received` event

## Release safety

The compatible runtime landed first in #3238 and its production smoke passed before this catalog event was exposed. This avoids mixed-version connector refresh hazards.

## Verification

- Codex review: no blockers after correcting the E2E to query `runs` with `run_type = 'automation'`
- root and server TypeScript checks pass
- 30 focused connector/catalog/signal/connection tests pass
- Phase 1 full CI and production smoke pass
- database-backed public-path E2E will run in canonical GitHub CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Webhook connections now support immediate Automation runs when deliveries arrive.
  - Webhook deliveries can be filtered by semantic type and use configurable execution defaults.
  - Public webhook setup validates connection identifiers and requires bearer tokens of at least 32 characters.
  - Webhook ingestion persists deliveries and creates a single corresponding Automation run.

- **Documentation**
  - Clarified how scheduled and connector-driven Automations collect, activate, deduplicate, and process events.
  - Documented webhook setup, delivery handling, ingestion behavior, and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->