### PR TITLE
fix(shell): route headless os.shell through daemon executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1719,7 +1719,7 @@ jobs:
             echo "mac=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
           fi
-          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|scripts/test-headless-shell-package\.sh$|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|scripts/publish-packages\.mjs$|scripts/test-headless-shell-package\.sh$|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
             echo "connector=true" >> "$GITHUB_OUTPUT"
           else
             echo "connector=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1719,7 +1719,7 @@ jobs:
             echo "mac=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
           fi
-          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(docker/|packages/connector-worker/|packages/connector-sdk/|packages/connectors/|packages/core/|packages/embeddings/|packages/cli/|scripts/test-headless-shell-package\.sh$|package\.json$|bun\.lock$|\.github/workflows/ci\.yml$|\.github/workflows/build-images\.yml$)' >/dev/null; then
             echo "connector=true" >> "$GITHUB_OUTPUT"
           else
             echo "connector=false" >> "$GITHUB_OUTPUT"
@@ -1910,6 +1910,9 @@ jobs:
       - name: Build workspace packages (CLI + deps)
         if: steps.dist-cache.outputs.cache-hit != 'true'
         run: make build-packages
+
+      - name: Published worker tarball shell smoke (including restart)
+        run: ./scripts/test-headless-shell-package.sh
 
       - name: CLI runtime self-check (host)
         run: node packages/cli/bin/lobu.js connector runtime-self-check --json

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -88,6 +88,14 @@ Skills are executable, security-sensitive input:
 - Network policy is declared on the agent (`network.allowed` / `network.denied` → `settings.networkConfig`), not on skills; gateway egress controls apply on top.
 - Destructive MCP tool calls require in-thread approval unless pre-approved via `defineAgent({ tools: { preApproved } })` in `lobu.config.ts`.
 
+### Approved device shell
+
+`os.shell` runs as the device user with that user's HOME and filesystem access.
+Its child environment omits control-plane variables, but this is not a same-user
+credential or filesystem boundary: an approved shell can read files available to
+the device user, including device configuration. Human/agent approval is the
+trust boundary; automatic mode is opt-in and remains approval-gated by default.
+
 ## What changed from earlier docs
 
 Previous versions of this page described Kubernetes pod isolation, NetworkPolicies, gVisor, Kata, and per-pod PVCs. None of that is shipped any more — the gateway now spawns local worker subprocesses instead of orchestrating per-worker containers. On Linux hosts with an enabled, usable systemd user manager, the worker spawn path applies loopback-only IP rules and cgroup limits through `systemd-run --scope`; it does not apply capability drops or other exec-context hardening. The rest were paying isolation costs for a multi-tenant deployment Lobu doesn't ship.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lobu:connectors:install": "bun run scripts/lobu/install-connectors.ts",
     "lobu:connectors:dry-run": "bun run scripts/lobu/dry-run-connector.ts",
     "build:mac-device-daemon": "./scripts/build-mac-device-daemon.sh",
-    "test:mac-device-daemon": "./scripts/test-mac-device-daemon-package.sh"
+    "test:mac-device-daemon": "./scripts/test-mac-device-daemon-package.sh",
+    "test:headless-shell-package": "./scripts/test-headless-shell-package.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -162,9 +162,9 @@ export interface ConnectorAgentToolingEnv {
 
 export interface ConnectorRuntimeInfo {
   /** Platforms this connector can run on. */
-  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-  /** Native bridge-owned execution. Absent means the normal worker runtime. */
-  execution?: 'bridge';
+  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'>;
+  /** Device-owned execution. Absent means the normal compiled worker runtime. */
+  execution?: 'bridge' | 'daemon_builtin';
   /**
    * Permission/auth scopes forwarded verbatim to the native platform adapter.
    * Optional — omit when the platform adapter needs no fine-grained scope list.

--- a/packages/connector-sdk/src/device-manifest.ts
+++ b/packages/connector-sdk/src/device-manifest.ts
@@ -2,6 +2,9 @@ import { createHash } from 'node:crypto';
 
 export type DeviceManifestSchema = Record<string, unknown>;
 
+/** Execution owner declared by a device-manifest wire artifact. */
+export type DeviceManifestExecution = 'bridge' | 'daemon_builtin';
+
 export interface DeviceConnectorManifest {
   key: string;
   version: string;
@@ -11,7 +14,7 @@ export interface DeviceConnectorManifest {
   required_capability: string;
   runtime: {
     platforms: string[];
-    execution?: 'bridge';
+    execution?: DeviceManifestExecution;
     scopes?: string[];
     nix?: { packages?: string[] } | null;
   };

--- a/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts
@@ -624,6 +624,7 @@ describe('automation arm e2e', () => {
 describe('automation arm drain deadline', () => {
   const hangBinary = path.join(tmp, 'pi-orphan-pipe');
   const bothPipesBinary = path.join(tmp, 'pi-orphan-both');
+  const trailingOutputBinary = path.join(tmp, 'pi-trailing-output');
 
   beforeAll(() => {
     writeFileSync(
@@ -633,6 +634,12 @@ describe('automation arm drain deadline', () => {
       `#!/usr/bin/env node\nconst { spawn } = require('node:child_process');\nspawn(${JSON.stringify(heartbeatConflictGrandchildBinary)}, [], { detached: true, env: process.env, stdio: ['ignore', 'inherit', 'inherit'] });\nprocess.on('SIGTERM', () => {});\nconsole.log('PARTIAL_OUTPUT');\nsetTimeout(() => {}, 20_000);\n`
     );
     chmodSync(bothPipesBinary, 0o755);
+
+    writeFileSync(
+      trailingOutputBinary,
+      `#!/usr/bin/env node\nconst { spawn } = require('node:child_process');\nconst child = spawn(process.execPath, ['-e', "setTimeout(() => process.stdout.write('TRAILING_OUTPUT'), 100); setTimeout(() => {}, 20_000)"], { detached: true, stdio: ['ignore', 'inherit', 'inherit'] });\nchild.unref();\nconsole.log('INITIAL_OUTPUT');\n`
+    );
+    chmodSync(trailingOutputBinary, 0o755);
 
     writeFileSync(
       hangBinary,
@@ -663,6 +670,18 @@ describe('automation arm drain deadline', () => {
     expect(completions[0].body.output).toContain('PARTIAL_OUTPUT');
     // Well under the 15s the grandchild holds the pipe: the deadline fired.
     expect(elapsedMs).toBeLessThan(12_000);
+  }, 30_000);
+
+  test('captures output written after the target exits before the drain bound', async () => {
+    completions = [];
+    script = [{ status: 'completed' }];
+    const trailing = cfg();
+    trailing.binaryOverrides = { pi: trailingOutputBinary };
+
+    await executeAutomationRun(client(), automationJob(), trailing);
+
+    expect(completions[0].body.output).toContain('INITIAL_OUTPUT');
+    expect(completions[0].body.output).toContain('TRAILING_OUTPUT');
   }, 30_000);
 
   /**

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../daemon/automation.js';
 import {
   signalOwnedPosixProcessGroup,
+  spawnSupervisedCli,
+  releaseSupervisor,
   terminateWindowsProcessTree,
   waitForTargetExitAfterTermination,
 } from '../daemon/automation-process.js';
@@ -39,6 +41,31 @@ function okResult(): ExecutorResult {
 }
 
 describe('POSIX process-group ownership', () => {
+  test('passes the supplied target environment without serializing it in argv', async () => {
+    const supplied = 'target-env-secret';
+    const supervised = spawnSupervisedCli(
+      process.execPath,
+      ['-e', "process.stdout.write(JSON.stringify({ argv: process.argv, value: process.env.TARGET_ENV }))"],
+      { TARGET_ENV: supplied, PATH: process.env.PATH },
+      { stdin: 'ignore' },
+    );
+    let stdout = '';
+    supervised.supervisor.stdout?.setEncoding('utf8');
+    supervised.supervisor.stdout?.on('data', (chunk) => { stdout += chunk; });
+    try {
+      await waitForTargetExitAfterTermination(supervised.targetExit, 2_000);
+      await releaseSupervisor(supervised.supervisor);
+      const result = JSON.parse(stdout) as { argv: string[]; value: string };
+      expect(result.value).toBe(supplied);
+      expect(result.argv).not.toContain(supplied);
+      expect(result.argv.join(' ')).not.toContain('lobu-target-env');
+    } finally {
+      if (supervised.supervisor.exitCode === null && supervised.supervisor.signalCode === null) {
+        supervised.supervisor.kill('SIGKILL');
+      }
+    }
+  });
+
   test('shutdown abort terminates the supervised CLI and reports cancellation', async () => {
     if (process.platform === 'win32') return;
     const dir = mkdtempSync(path.join(tmpdir(), 'lobu-shutdown-cli-'));

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -161,6 +161,29 @@ describe('daemon-builtin os.shell', () => {
     expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
   });
 
+  test('ignores poisoned Bash function state while enforcing timeout reaping', async () => {
+    const previousBashFunction = process.env['BASH_FUNC_sleep%%'];
+    const previousBashEnv = process.env.BASH_ENV;
+    process.env['BASH_FUNC_sleep%%'] = '() { :; }';
+    process.env.BASH_ENV = '/tmp/does-not-exist-lobu-shell-test';
+    try {
+      const started = Date.now();
+      const result = await runShellBuiltin({
+        command: 'trap "" TERM; sleep 30',
+        cwd: process.cwd(),
+        timeout_ms: 100,
+      });
+      expect(result.success).toBe(false);
+      expect(result.timed_out).toBe(true);
+      expect(Date.now() - started).toBeLessThan(4_000);
+    } finally {
+      if (previousBashFunction === undefined) delete process.env['BASH_FUNC_sleep%%'];
+      else process.env['BASH_FUNC_sleep%%'] = previousBashFunction;
+      if (previousBashEnv === undefined) delete process.env.BASH_ENV;
+      else process.env.BASH_ENV = previousBashEnv;
+    }
+  });
+
   test('daemon abort kills a long-lived child and grandchild process tree', async () => {
     const shutdown = new AbortController();
     const started = Date.now();

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -123,7 +123,7 @@ describe('daemon-builtin os.shell', () => {
     try {
       const started = Date.now();
       const output = await runShellBuiltin({
-        command: `setsid bash -c 'trap "" TERM; sleep 10' & echo $!; wait`,
+        command: `setsid bash -c 'trap "" TERM; (sleep 0.1; printf detached-trailing-output >&2) & sleep 10' & echo $!; wait`,
         cwd: process.cwd(),
         timeout_ms: 300,
       });
@@ -131,6 +131,7 @@ describe('daemon-builtin os.shell', () => {
 
       expect(output.timed_out).toBe(true);
       expect(Date.now() - started).toBeLessThan(5_500);
+      expect(output.stderr).toContain('detached-trailing-output');
       expect(Number.isInteger(escapedPid)).toBe(true);
       // A deliberately new session is outside the supervisor's owned group;
       // the test owns this exact PID/group and cleans it up below.

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { executeRun } from '../daemon/executor.js';
+import { runShellBuiltin } from '../daemon/builtins/os-shell.js';
 
 function stubClient() {
   const completions: Array<Record<string, unknown>> = [];
@@ -16,6 +17,44 @@ function stubClient() {
 }
 
 describe('daemon-builtin os.shell', () => {
+  test('uses a minimal child environment and does not leak worker or control-plane secrets', async () => {
+    const sentinels = {
+      WORKER_API_TOKEN: process.env.WORKER_API_TOKEN,
+      LOBU_API_TOKEN: process.env.LOBU_API_TOKEN,
+      LOBU_MEMORY_URL: process.env.LOBU_MEMORY_URL,
+      DATABASE_URL: process.env.DATABASE_URL,
+      LOBU_ENCRYPTION_KEY: process.env.LOBU_ENCRYPTION_KEY,
+      AUTH_SECRET: process.env.AUTH_SECRET,
+      PROVIDER_API_KEY: process.env.PROVIDER_API_KEY,
+    };
+    Object.assign(process.env, {
+      WORKER_API_TOKEN: 'worker-secret',
+      LOBU_API_TOKEN: 'api-secret',
+      LOBU_MEMORY_URL: 'https://memory.invalid',
+      DATABASE_URL: 'postgres://secret',
+      LOBU_ENCRYPTION_KEY: 'encryption-secret',
+      AUTH_SECRET: 'auth-secret',
+      PROVIDER_API_KEY: 'provider-secret',
+    });
+    try {
+      const result = await runShellBuiltin({
+        command: 'printf "PATH=%s\\nHOME=%s\\nTMPDIR=%s\\n" "$PATH" "$HOME" "$TMPDIR"; env',
+        cwd: process.cwd(),
+      });
+      expect(result.success).toBe(true);
+      expect(result.stdout).toMatch(/PATH=.+/);
+      expect(result.stdout).toMatch(/HOME=.+/);
+      expect(result.stdout).toMatch(/TMPDIR=.+/);
+      for (const name of Object.keys(sentinels)) expect(result.stdout).not.toContain(`${name}=`);
+      expect(result.stdout).toContain('LC_ALL=C');
+    } finally {
+      for (const [name, value] of Object.entries(sentinels)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  });
+
   test('executes without compiled connector code or connector SDK resolution', async () => {
     const { client, completions } = stubClient();
     const result = await executeRun(
@@ -120,5 +159,20 @@ describe('daemon-builtin os.shell', () => {
     expect(Date.now() - started).toBeLessThan(4_000);
     expect(completions[0]?.status).toBe('failed');
     expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
+  });
+
+  test('daemon abort kills a long-lived child and grandchild process tree', async () => {
+    const shutdown = new AbortController();
+    const started = Date.now();
+    const pending = runShellBuiltin({
+      command: 'sleep 30 & child=$!; sleep 30 & grandchild=$!; wait "$child" "$grandchild"',
+      cwd: process.cwd(),
+      timeout_ms: 300_000,
+    }, shutdown.signal);
+    setTimeout(() => shutdown.abort(), 100);
+    const result = await pending;
+    expect(result.success).toBe(false);
+    expect(result.timed_out).toBe(false);
+    expect(Date.now() - started).toBeLessThan(4_000);
   });
 });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -91,4 +91,34 @@ describe('daemon-builtin os.shell', () => {
     expect(result.error).toContain('must not contain compiled_code');
     expect(completions[0]).toMatchObject({ status: 'failed' });
   });
+
+  test('bounds timeout while killing descendants in the owned process group', async () => {
+    const { client, completions } = stubClient();
+    const started = Date.now();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 467,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        connector_version: '0.2.0',
+        connector_manifest_hash: 'test-manifest-hash',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {
+          command: 'sleep 5 & wait',
+          cwd: process.cwd(),
+          timeout_ms: 300,
+        },
+      },
+      {},
+      { heartbeatIntervalMs: 5_000 }
+    );
+
+    expect(result.itemsCollected).toBe(0);
+    expect(result.error).toStartWith('operation_execution_failed:');
+    expect(Date.now() - started).toBeLessThan(4_000);
+    expect(completions[0]?.status).toBe('failed');
+    expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
+  });
 });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -116,7 +116,7 @@ describe('daemon-builtin os.shell', () => {
     }
   });
 
-  test('kills a session-detached descendant before settlement', async () => {
+  test('bounds settlement without claiming ownership of a detached session', async () => {
     if (process.platform !== 'linux') return;
 
     let escapedPid = 0;
@@ -132,7 +132,9 @@ describe('daemon-builtin os.shell', () => {
       expect(output.timed_out).toBe(true);
       expect(Date.now() - started).toBeLessThan(5_500);
       expect(Number.isInteger(escapedPid)).toBe(true);
-      expect(processGroupExists(escapedPid)).toBe(false);
+      // A deliberately new session is outside the supervisor's owned group;
+      // the test owns this exact PID/group and cleans it up below.
+      expect(processGroupExists(escapedPid)).toBe(true);
     } finally {
       if (escapedPid > 0) forceKill(escapedPid, true);
     }
@@ -301,6 +303,32 @@ describe('daemon-builtin os.shell', () => {
     expect(payloads).toHaveLength(2);
     expect(payloads[0]).toEqual(payloads[1]);
     expect(payloads[0]).toMatchObject({ status: 'success', action_output: { stdout: 'success' } });
+  });
+
+  test('retries one immutable failed payload after terminal delivery loss', async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    let attempts = 0;
+    const client = {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        payloads.push(structuredClone(input));
+        attempts += 1;
+        if (attempts === 1) throw new Error('response lost');
+      },
+    };
+    await expect(executeRun(client as never, {
+      run_id: 470,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: 'printf err >&2; exit 7', cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 })).resolves.toMatchObject({ itemsCollected: 0, error: expect.stringContaining('exited with code 7') });
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual(payloads[1]);
+    expect(payloads[0]).toMatchObject({ status: 'failed', action_output: { stderr: 'err', exit_code: 7 } });
   });
 
   test('ignores poisoned Bash function state while enforcing timeout reaping', async () => {

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -151,6 +151,20 @@ describe('daemon-builtin os.shell', () => {
     expect(output.exit_code).toBe(0);
   });
 
+  test('drains output emitted as the supervisor closes', async () => {
+    const output = await runShellBuiltin({
+      command: `node -e 'process.stdout.write("stdout-at-close"); process.stderr.write("stderr-at-close"); process.exit(0)'`,
+      cwd: process.cwd(),
+    });
+
+    expect(output).toMatchObject({
+      success: true,
+      stdout: 'stdout-at-close',
+      stderr: 'stderr-at-close',
+      exit_code: 0,
+    });
+  });
+
   test('executes without compiled connector code or connector SDK resolution', async () => {
     const { client, completions } = stubClient();
     const result = await executeRun(

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -361,12 +361,20 @@ describe('daemon-builtin os.shell', () => {
     const pending = runShellBuiltin({
       command: 'sleep 30 & child=$!; sleep 30 & grandchild=$!; wait "$child" "$grandchild"',
       cwd: process.cwd(),
-      timeout_ms: 300_000,
+      timeout_ms: 170_000,
     }, shutdown.signal);
     setTimeout(() => shutdown.abort(), 100);
     const result = await pending;
     expect(result.success).toBe(false);
     expect(result.timed_out).toBe(false);
     expect(Date.now() - started).toBeLessThan(4_000);
+  });
+
+  test('rejects a timeout that exceeds the caller truth budget', async () => {
+    await expect(runShellBuiltin({
+      command: 'printf nope',
+      cwd: process.cwd(),
+      timeout_ms: 170_001,
+    })).rejects.toThrow('between 100 and 170000');
   });
 });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -361,7 +361,7 @@ describe('daemon-builtin os.shell', () => {
     const pending = runShellBuiltin({
       command: 'sleep 30 & child=$!; sleep 30 & grandchild=$!; wait "$child" "$grandchild"',
       cwd: process.cwd(),
-      timeout_ms: 170_000,
+      timeout_ms: 150_000,
     }, shutdown.signal);
     setTimeout(() => shutdown.abort(), 100);
     const result = await pending;
@@ -374,7 +374,7 @@ describe('daemon-builtin os.shell', () => {
     await expect(runShellBuiltin({
       command: 'printf nope',
       cwd: process.cwd(),
-      timeout_ms: 170_001,
-    })).rejects.toThrow('between 100 and 170000');
+      timeout_ms: 150_001,
+    })).rejects.toThrow('between 100 and 150000');
   });
 });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { executeRun } from '../daemon/executor.js';
+
+function stubClient() {
+  const completions: Array<Record<string, unknown>> = [];
+  return {
+    client: {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        completions.push(input);
+      },
+    },
+    completions,
+  };
+}
+
+describe('daemon-builtin os.shell', () => {
+  test('executes without compiled connector code or connector SDK resolution', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 464,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        connector_version: '0.2.0',
+        connector_manifest_hash: 'test-manifest-hash',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {
+          command: "printf 'lobu-shell-ok\\n'",
+          cwd: process.cwd(),
+        },
+      },
+      {},
+      { heartbeatIntervalMs: 5_000 }
+    );
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      run_id: 464,
+      worker_id: 'headless:test',
+      status: 'success',
+      action_output: {
+        stdout: 'lobu-shell-ok\n',
+        stderr: '',
+        exit_code: 0,
+        success: true,
+        timed_out: false,
+      },
+    });
+  });
+
+  test('fails closed when the declared built-in is not registered', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 465,
+        run_type: 'action',
+        connector_key: 'missing.builtin',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {},
+      },
+      {}
+    );
+
+    expect(result.error).toStartWith('operation_backend_unavailable:');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+
+  test('rejects a contradictory compiled payload', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 466,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        execution_backend: 'daemon_builtin',
+        compiled_code: 'must not execute',
+        action_key: 'run',
+        action_input: { command: 'exit 0' },
+      },
+      {}
+    );
+
+    expect(result.error).toContain('must not contain compiled_code');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+});

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,6 +1,50 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { executeRun } from '../daemon/executor.js';
 import { runShellBuiltin } from '../daemon/builtins/os-shell.js';
+
+function processIsLive(pid: number): boolean {
+  try {
+    if (process.platform === 'linux') {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const state = stat.slice(stat.lastIndexOf(') ') + 2, stat.lastIndexOf(') ') + 3);
+      return state !== 'Z';
+    }
+    process.kill(pid, 0);
+    if (process.platform === 'darwin') {
+      const state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+        encoding: 'utf8',
+      }).trim();
+      return !state.startsWith('Z');
+    }
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function forceKill(pid: number, group = false): void {
+  try {
+    process.kill(group ? -pid : pid, 'SIGKILL');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+  }
+}
+
+function processGroupExists(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw error;
+  }
+}
 
 function stubClient() {
   const completions: Array<Record<string, unknown>> = [];
@@ -53,6 +97,60 @@ describe('daemon-builtin os.shell', () => {
         else process.env[name] = value;
       }
     }
+  });
+
+  test('force-kills SIGTERM-ignoring descendants in its process group', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'lobu-shell-test-'));
+    const readyPath = join(testDir, 'ready');
+    let descendantPid = 0;
+    try {
+      const output = await runShellBuiltin({
+        command: `node -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); fs.writeFileSync("${readyPath}", String(process.pid)); setTimeout(() => {}, 10000)' >/dev/null 2>&1 & while [ ! -s ${JSON.stringify(readyPath)} ]; do sleep 0.01; done; cat ${JSON.stringify(readyPath)}; wait`,
+        cwd: process.cwd(),
+        timeout_ms: 300,
+      });
+      descendantPid = Number(output.stdout.trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Number.isInteger(descendantPid)).toBe(true);
+      expect(processIsLive(descendantPid)).toBe(false);
+    } finally {
+      if (descendantPid > 0 && processIsLive(descendantPid)) forceKill(descendantPid);
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('settles after its grace period when a session-detached child keeps stdio open', async () => {
+    if (process.platform !== 'linux') return;
+
+    let escapedPid = 0;
+    try {
+      const started = Date.now();
+      const output = await runShellBuiltin({
+        command: `setsid bash -c 'trap "" TERM; sleep 10' & echo $!; wait`,
+        cwd: process.cwd(),
+        timeout_ms: 300,
+      });
+      escapedPid = Number(output.stdout.trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Date.now() - started).toBeLessThan(5_500);
+      expect(Number.isInteger(escapedPid)).toBe(true);
+      expect(processGroupExists(escapedPid)).toBe(true);
+    } finally {
+      if (escapedPid > 0) forceKill(escapedPid, true);
+    }
+  });
+
+  test('does not reject when the command exits before consuming stdin', async () => {
+    const output = await runShellBuiltin({
+      command: 'exit 0',
+      cwd: process.cwd(),
+      stdin: 'x'.repeat(1_000_000),
+    });
+
+    expect(output.success).toBe(true);
+    expect(output.exit_code).toBe(0);
   });
 
   test('executes without compiled connector code or connector SDK resolution', async () => {
@@ -145,7 +243,7 @@ describe('daemon-builtin os.shell', () => {
         execution_backend: 'daemon_builtin',
         action_key: 'run',
         action_input: {
-          command: 'sleep 5 & wait',
+          command: 'sleep 10 & wait',
           cwd: process.cwd(),
           timeout_ms: 300,
         },
@@ -156,7 +254,7 @@ describe('daemon-builtin os.shell', () => {
 
     expect(result.itemsCollected).toBe(0);
     expect(result.error).toStartWith('operation_execution_failed:');
-    expect(Date.now() - started).toBeLessThan(4_000);
+    expect(Date.now() - started).toBeLessThan(5_500);
     expect(completions[0]?.status).toBe('failed');
     expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
   });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'bun:test';
-import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,10 +14,8 @@ function processIsLive(pid: number): boolean {
     }
     process.kill(pid, 0);
     if (process.platform === 'darwin') {
-      const state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
-        encoding: 'utf8',
-      }).trim();
-      return !state.startsWith('Z');
+      process.kill(pid, 0);
+      return true;
     }
     return true;
   } catch (error) {
@@ -61,7 +58,7 @@ function stubClient() {
 }
 
 describe('daemon-builtin os.shell', () => {
-  test('uses a minimal child environment and does not leak worker or control-plane secrets', async () => {
+  test('uses a minimal child environment and does not inherit control-plane env', async () => {
     const sentinels = {
       WORKER_API_TOKEN: process.env.WORKER_API_TOKEN,
       LOBU_API_TOKEN: process.env.LOBU_API_TOKEN,
@@ -101,12 +98,11 @@ describe('daemon-builtin os.shell', () => {
 
   test('force-kills SIGTERM-ignoring descendants in its process group', async () => {
     const testDir = mkdtempSync(join(tmpdir(), 'lobu-shell-test-'));
-    const readyPath = join(testDir, 'ready');
     let descendantPid = 0;
     try {
       const output = await runShellBuiltin({
-        command: `node -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); fs.writeFileSync("${readyPath}", String(process.pid)); setTimeout(() => {}, 10000)' >/dev/null 2>&1 & while [ ! -s ${JSON.stringify(readyPath)} ]; do sleep 0.01; done; cat ${JSON.stringify(readyPath)}; wait`,
-        cwd: process.cwd(),
+        command: `node -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); fs.writeFileSync("./ready", String(process.pid)); setTimeout(() => {}, 10000)' >/dev/null 2>&1 & while [ ! -s ./ready ]; do sleep 0.01; done; cat ./ready; wait`,
+        cwd: testDir,
         timeout_ms: 300,
       });
       descendantPid = Number(output.stdout.trim());
@@ -120,7 +116,7 @@ describe('daemon-builtin os.shell', () => {
     }
   });
 
-  test('settles after its grace period when a session-detached child keeps stdio open', async () => {
+  test('kills a session-detached descendant before settlement', async () => {
     if (process.platform !== 'linux') return;
 
     let escapedPid = 0;
@@ -136,7 +132,7 @@ describe('daemon-builtin os.shell', () => {
       expect(output.timed_out).toBe(true);
       expect(Date.now() - started).toBeLessThan(5_500);
       expect(Number.isInteger(escapedPid)).toBe(true);
-      expect(processGroupExists(escapedPid)).toBe(true);
+      expect(processGroupExists(escapedPid)).toBe(false);
     } finally {
       if (escapedPid > 0) forceKill(escapedPid, true);
     }
@@ -257,6 +253,54 @@ describe('daemon-builtin os.shell', () => {
     expect(Date.now() - started).toBeLessThan(5_500);
     expect(completions[0]?.status).toBe('failed');
     expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
+    expect(completions[0]?.action_output).toMatchObject({
+      stdout: '', stderr: '', timed_out: true, success: false,
+    });
+  });
+
+  test('preserves structured output for nonzero builtin results', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(client as never, {
+      run_id: 468,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: "printf out; printf err >&2; exit 7", cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 });
+    expect(result.error).toContain('operation_execution_failed: Shell command exited with code 7');
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      status: 'failed',
+      action_output: { stdout: 'out', stderr: 'err', exit_code: 7, timed_out: false, success: false },
+    });
+  });
+
+  test('retries one immutable success payload after terminal delivery loss', async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    let attempts = 0;
+    const client = {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        payloads.push(structuredClone(input));
+        attempts += 1;
+        if (attempts === 1) throw new Error('response lost');
+      },
+    };
+    await expect(executeRun(client as never, {
+      run_id: 469,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: 'printf success', cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 })).resolves.toEqual({ itemsCollected: 0 });
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual(payloads[1]);
+    expect(payloads[0]).toMatchObject({ status: 'success', action_output: { stdout: 'success' } });
   });
 
   test('ignores poisoned Bash function state while enforcing timeout reaping', async () => {
@@ -267,12 +311,13 @@ describe('daemon-builtin os.shell', () => {
     try {
       const started = Date.now();
       const result = await runShellBuiltin({
-        command: 'trap "" TERM; sleep 30',
+        command: 'trap "" TERM; sleep 30 & descendant=$!; echo "$descendant"; wait',
         cwd: process.cwd(),
         timeout_ms: 100,
       });
       expect(result.success).toBe(false);
       expect(result.timed_out).toBe(true);
+      if (process.platform !== 'darwin') expect(processIsLive(Number(result.stdout.trim()))).toBe(false);
       expect(Date.now() - started).toBeLessThan(4_000);
     } finally {
       if (previousBashFunction === undefined) delete process.env['BASH_FUNC_sleep%%'];

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -84,25 +84,13 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
       }
     }, treeTermGraceMs);
   };
-  const stopAfterSourceError = () => {
-    if (process.platform === 'win32') {
-      try { target?.kill('SIGTERM'); } catch {}
-      setTimeout(() => {
-        try { target?.kill('SIGKILL'); } catch {}
-      }, treeTermGraceMs);
-      return;
-    }
-    try { process.kill(-process.pid, 'SIGTERM'); } catch { try { target?.kill('SIGTERM'); } catch {} }
-    setTimeout(() => {
-      try { process.kill(-process.pid, 'SIGKILL'); } catch { try { target?.kill('SIGKILL'); } catch {} }
-    }, treeTermGraceMs);
-  };
   process.on('SIGTERM', () => {});
   process.once('disconnect', stopAfterParentLoss);
-  process.stdin.once('error', () => {
-    finish(1, null, 'source stream error');
-    stopAfterSourceError();
-  });
+  // A broken parent pipe is parent loss for ownership purposes. Do not report
+  // the target's normal exit first: the gateway may release the run while the
+  // delayed whole-tree SIGKILL is still pending, orphaning TERM-ignoring
+  // descendants.
+  process.stdin.once('error', stopAfterParentLoss);
   process.on('message', (message: unknown) => {
     if (
       typeof message !== 'object' ||

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -25,7 +25,13 @@ const PROCESS_REAP_GRACE_MS = 5000;
  * negative-pid group signals.
  */
 function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
-  const [binary, ...args] = process.argv.slice(1);
+  const supervisorArgs = process.argv.slice(1);
+  const targetEnvIndex = supervisorArgs.indexOf('--lobu-target-env');
+  const targetEnv = targetEnvIndex >= 0
+    ? JSON.parse(supervisorArgs[targetEnvIndex + 1] ?? '{}') as NodeJS.ProcessEnv
+    : process.env;
+  if (targetEnvIndex >= 0) supervisorArgs.splice(targetEnvIndex, 2);
+  const [binary, ...args] = supervisorArgs;
   let targetFinished = false;
   let parentLost = false;
   let target: ChildProcess | undefined;
@@ -100,7 +106,7 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
   } else {
     try {
       target = spawnChild(binary, args, {
-        env: process.env,
+        env: targetEnv,
         stdio: ['pipe', 'inherit', 'inherit'],
         windowsHide: true,
       });
@@ -218,7 +224,7 @@ export function signalOwnedPosixProcessGroup(
     sendSignal(-owner.pid, signal);
     return true;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH' || (err as NodeJS.ErrnoException).code === 'EPERM') return false;
     throw err;
   }
 }
@@ -319,14 +325,15 @@ export function spawnSupervisedCli(
   binary: string,
   args: string[],
   env: NodeJS.ProcessEnv,
-  options: { stdin?: 'ignore' | 'pipe' } = {}
+  options: { stdin?: 'ignore' | 'pipe'; cwd?: string } = {}
 ): SupervisedCli {
   const supervisor = spawn(
     process.execPath,
-    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
+    ['-e', CLI_SUPERVISOR_SOURCE, '--', '--lobu-target-env', JSON.stringify(env), binary, ...args],
     {
       detached: SUPPORTS_PROCESS_GROUPS,
       env,
+      cwd: options.cwd,
       stdio: [options.stdin ?? 'ignore', 'pipe', 'pipe', 'ipc'],
       windowsHide: true,
     }

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -84,8 +84,25 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
       }
     }, treeTermGraceMs);
   };
+  const stopAfterSourceError = () => {
+    if (process.platform === 'win32') {
+      try { target?.kill('SIGTERM'); } catch {}
+      setTimeout(() => {
+        try { target?.kill('SIGKILL'); } catch {}
+      }, treeTermGraceMs);
+      return;
+    }
+    try { process.kill(-process.pid, 'SIGTERM'); } catch { try { target?.kill('SIGTERM'); } catch {} }
+    setTimeout(() => {
+      try { process.kill(-process.pid, 'SIGKILL'); } catch { try { target?.kill('SIGKILL'); } catch {} }
+    }, treeTermGraceMs);
+  };
   process.on('SIGTERM', () => {});
   process.once('disconnect', stopAfterParentLoss);
+  process.stdin.once('error', () => {
+    finish(1, null, 'source stream error');
+    stopAfterSourceError();
+  });
   process.on('message', (message: unknown) => {
     if (
       typeof message !== 'object' ||

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -26,11 +26,6 @@ const PROCESS_REAP_GRACE_MS = 5000;
  */
 function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
   const supervisorArgs = process.argv.slice(1);
-  const targetEnvIndex = supervisorArgs.indexOf('--lobu-target-env');
-  const targetEnv = targetEnvIndex >= 0
-    ? JSON.parse(supervisorArgs[targetEnvIndex + 1] ?? '{}') as NodeJS.ProcessEnv
-    : process.env;
-  if (targetEnvIndex >= 0) supervisorArgs.splice(targetEnvIndex, 2);
   const [binary, ...args] = supervisorArgs;
   let targetFinished = false;
   let parentLost = false;
@@ -106,11 +101,14 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
   } else {
     try {
       target = spawnChild(binary, args, {
-        env: targetEnv,
+        env: process.env,
         stdio: ['pipe', 'inherit', 'inherit'],
         windowsHide: true,
       });
-      if (target.stdin) process.stdin.pipe(target.stdin);
+      if (target.stdin) {
+        target.stdin.on('error', () => {});
+        process.stdin.pipe(target.stdin);
+      }
     } catch (error) {
       finish(127, null, error instanceof Error ? error.message : String(error));
     }
@@ -328,8 +326,12 @@ export function spawnSupervisedCli(
   options: { stdin?: 'ignore' | 'pipe'; cwd?: string } = {}
 ): SupervisedCli {
   const supervisor = spawn(
-    process.execPath,
-    ['-e', CLI_SUPERVISOR_SOURCE, '--', '--lobu-target-env', JSON.stringify(env), binary, ...args],
+    // Bun's node:child_process compatibility layer merges env with the
+    // parent environment. Use the installed Node runtime there so the
+    // spawn-options contract remains an actual replacement environment; the
+    // packaged/runtime path uses its own executable unchanged.
+    process.versions.bun ? 'node' : process.execPath,
+    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
     {
       detached: SUPPORTS_PROCESS_GROUPS,
       env,

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -186,6 +186,7 @@ const EXIT_REPORT_RETRY_DELAY_MS = 2000;
 const TRANSCRIPT_DELIVERY_ATTEMPTS = 3;
 const TRANSCRIPT_RETRY_DELAY_MS = 250;
 const TERMINAL_HEARTBEAT_GRACE_MS = 15_000;
+const POST_TARGET_DRAIN_MS = 2_000;
 
 /** Sentinel for "binary not on PATH" so it maps to a distinct exit reason. */
 class ExecutableNotFoundError extends Error {
@@ -208,8 +209,13 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** Drain a child stream to a byte-capped buffer; stop at EOF. */
-function drain(stream: Readable, capBytes: number): Promise<{ data: Buffer; truncated: boolean }> {
-  return new Promise((resolve) => {
+function drain(stream: Readable, capBytes: number): {
+  pending: Promise<{ data: Buffer; truncated: boolean }>;
+  snapshot: () => { data: Buffer; truncated: boolean };
+} {
+  let settled = false;
+  let result: { data: Buffer; truncated: boolean } = { data: Buffer.alloc(0), truncated: false };
+  const pending = new Promise<{ data: Buffer; truncated: boolean }>((resolve) => {
     const chunks: Buffer[] = [];
     let total = 0;
     let truncated = false;
@@ -227,13 +233,20 @@ function drain(stream: Readable, capBytes: number): Promise<{ data: Buffer; trun
       } else {
         truncated = true;
       }
+      result = { data: Buffer.concat(chunks), truncated };
     });
-    const settle = () => resolve({ data: Buffer.concat(chunks), truncated });
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      result = { data: Buffer.concat(chunks), truncated };
+      resolve(result);
+    };
     stream.on('end', settle);
     stream.on('error', settle);
     // `close` covers the forced-destroy path below, which emits neither.
     stream.on('close', settle);
   });
+  return { pending, snapshot: () => result };
 }
 
 /**
@@ -277,20 +290,21 @@ function openCodeTerminalRetryDiagnostic(output: string): string | null {
  * Past the deadline, force-close the pipe and take what was flushed.
  */
 async function awaitDrain(
-  pending: Promise<{ data: Buffer; truncated: boolean }>,
+  drainState: ReturnType<typeof drain>,
   stream: Readable,
   deadlineMs: number
 ): Promise<{ data: Buffer; truncated: boolean }> {
   const expired = Symbol('drain-deadline');
   const outcome = await Promise.race([
-    pending,
+    drainState.pending,
     new Promise<typeof expired>((resolve) => {
       setTimeout(() => resolve(expired), deadlineMs).unref?.();
     }),
   ]);
   if (outcome !== expired) return outcome;
+  const flushed = drainState.snapshot();
   stream.destroy();
-  return pending;
+  return flushed;
 }
 
 /** Assemble argv from the spec + execution config, mirroring `SpecExecutor`. */
@@ -498,8 +512,8 @@ export async function runCli(
       throw new Error('automation supervisor spawned without stdio pipes');
     }
 
-    const stdoutPromise = drain(stdout, STDOUT_CAP);
-    const stderrPromise = drain(stderr, STDERR_CAP);
+    const stdoutDrain = drain(stdout, STDOUT_CAP);
+    const stderrDrain = drain(stderr, STDERR_CAP);
 
     // OpenCode can sleep for the provider's full account reset window and
     // otherwise emits no headless progress. Observe its error-level diagnostic
@@ -594,24 +608,18 @@ export async function runCli(
       supervisorSettled = true;
     }
 
-    // A SIGKILLed child gets a short flush window; a clean exit gets a long one.
-    const drainDeadlineMs =
-      cancelled ||
-      killedSignal === 'SIGKILL' ||
-      cleanupSignal === 'SIGKILL' ||
-      diagnosticSignal === 'SIGKILL'
-        ? 2000
-        : 60_000;
+    // Every post-target pipe drain has the same small bound. A detached
+    // descriptor holder must not extend settlement after the target is gone.
+    const drainDeadlineMs = POST_TARGET_DRAIN_MS;
     // Both pipes must race the SAME clock. Awaiting them in sequence gave
     // stderr a fresh deadline only after stdout's had expired, so a grandchild
-    // holding both ends cost 2x the deadline (measured: 120s for a child that
-    // had already exited cleanly), not the one window the constant describes.
+    // holding both ends costs 2x the deadline, not the one window above.
     const [
       { data: stdoutData, truncated: stdoutTruncated },
       { data: stderrData },
     ] = await Promise.all([
-      awaitDrain(stdoutPromise, stdout, drainDeadlineMs),
-      awaitDrain(stderrPromise, stderr, drainDeadlineMs),
+      awaitDrain(stdoutDrain, stdout, drainDeadlineMs),
+      awaitDrain(stderrDrain, stderr, drainDeadlineMs),
     ]);
 
     const label = spec.binaryName;

--- a/packages/connector-worker/src/daemon/automation.ts
+++ b/packages/connector-worker/src/daemon/automation.ts
@@ -215,10 +215,13 @@ function drain(stream: Readable, capBytes: number): {
 } {
   let settled = false;
   let result: { data: Buffer; truncated: boolean } = { data: Buffer.alloc(0), truncated: false };
+  // Declared out here so snapshot() can concatenate on demand. Concatenating
+  // per chunk instead made a chatty CLI quadratic -- and past the cap it kept
+  // re-copying the full capped buffer for every further chunk, forever.
+  const chunks: Buffer[] = [];
+  let truncated = false;
   const pending = new Promise<{ data: Buffer; truncated: boolean }>((resolve) => {
-    const chunks: Buffer[] = [];
     let total = 0;
-    let truncated = false;
     stream.on('data', (chunk: Buffer) => {
       if (total < capBytes) {
         const room = capBytes - total;
@@ -233,7 +236,6 @@ function drain(stream: Readable, capBytes: number): {
       } else {
         truncated = true;
       }
-      result = { data: Buffer.concat(chunks), truncated };
     });
     const settle = () => {
       if (settled) return;
@@ -246,7 +248,10 @@ function drain(stream: Readable, capBytes: number): {
     // `close` covers the forced-destroy path below, which emits neither.
     stream.on('close', settle);
   });
-  return { pending, snapshot: () => result };
+  return {
+    pending,
+    snapshot: () => (settled ? result : { data: Buffer.concat(chunks), truncated }),
+  };
 }
 
 /**

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -7,7 +7,7 @@ export type DaemonBuiltinErrorCode =
 
 export type DaemonBuiltinResult =
   | { ok: true; output: Record<string, unknown> }
-  | { ok: false; code: DaemonBuiltinErrorCode; error: string };
+  | { ok: false; code: DaemonBuiltinErrorCode; error: string; output?: Record<string, unknown> };
 
 export async function executeDaemonBuiltin(params: {
   connectorKey: string;
@@ -32,6 +32,7 @@ export async function executeDaemonBuiltin(params: {
         error: output.timed_out
           ? `Shell command timed out after ${output.duration_ms}ms`
           : `Shell command exited with code ${output.exit_code}`,
+        output: { ...output },
       };
     }
     return { ok: true, output: { ...output } };

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -13,6 +13,7 @@ export async function executeDaemonBuiltin(params: {
   connectorKey: string;
   actionKey: string;
   input: Record<string, unknown>;
+  shutdownSignal?: AbortSignal;
 }): Promise<DaemonBuiltinResult> {
   if (params.connectorKey !== 'os.shell' || params.actionKey !== 'run') {
     return {
@@ -23,7 +24,7 @@ export async function executeDaemonBuiltin(params: {
   }
 
   try {
-    const output = await runShellBuiltin(params.input);
+    const output = await runShellBuiltin(params.input, params.shutdownSignal);
     if (!output.success) {
       return {
         ok: false,

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -1,0 +1,44 @@
+import { runShellBuiltin } from './os-shell.js';
+
+export type DaemonBuiltinErrorCode =
+  | 'invalid_operation_input'
+  | 'operation_backend_unavailable'
+  | 'operation_execution_failed';
+
+export type DaemonBuiltinResult =
+  | { ok: true; output: Record<string, unknown> }
+  | { ok: false; code: DaemonBuiltinErrorCode; error: string };
+
+export async function executeDaemonBuiltin(params: {
+  connectorKey: string;
+  actionKey: string;
+  input: Record<string, unknown>;
+}): Promise<DaemonBuiltinResult> {
+  if (params.connectorKey !== 'os.shell' || params.actionKey !== 'run') {
+    return {
+      ok: false,
+      code: 'operation_backend_unavailable',
+      error: `No daemon built-in is registered for '${params.connectorKey}/${params.actionKey}'`,
+    };
+  }
+
+  try {
+    const output = await runShellBuiltin(params.input);
+    if (!output.success) {
+      return {
+        ok: false,
+        code: 'operation_execution_failed',
+        error: output.timed_out
+          ? `Shell command timed out after ${output.duration_ms}ms`
+          : `Shell command exited with code ${output.exit_code}`,
+      };
+    }
+    return { ok: true, output: { ...output } };
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'invalid_operation_input',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -27,6 +27,7 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 // bounded network/server grace.
 const MAX_TIMEOUT_MS = 150_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
+const OUTPUT_DRAIN_GRACE_MS = 2_000;
 const TRUNCATED_MARKER = '\n... (output truncated)';
 function appendCapped(current: string, chunk: string): string {
   if (current.endsWith(TRUNCATED_MARKER)) return current;
@@ -106,7 +107,7 @@ export async function runShellBuiltin(
     };
 
     const abortHandler = () => {
-      if (!settled) void terminateChild(child).finally(() => finish(child.exitCode ?? -1));
+      if (!settled) void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
     };
     // Let the finish closure initialize before handling an already-aborted
     // signal; this path is common during daemon shutdown.
@@ -118,7 +119,9 @@ export async function runShellBuiltin(
       finishing = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       shutdownSignal?.removeEventListener('abort', abortHandler);
-      await Promise.all([stdoutClosed, stderrClosed]);
+      if (!child.stdout?.destroyed && !child.stderr?.destroyed) {
+        await Promise.all([stdoutClosed, stderrClosed]);
+      }
       if (settled) return;
       settled = true;
       resolve({
@@ -129,6 +132,16 @@ export async function runShellBuiltin(
         timed_out: timedOut,
         duration_ms: Date.now() - startedAt,
       });
+    };
+
+    const finishAfterOutputDrain = async (exitCode: number): Promise<void> => {
+      await Promise.race([
+        Promise.all([stdoutClosed, stderrClosed]),
+        new Promise((resolve) => setTimeout(resolve, OUTPUT_DRAIN_GRACE_MS).unref()),
+      ]);
+      if (!settled) child.stdout?.destroy();
+      if (!settled) child.stderr?.destroy();
+      await finish(exitCode);
     };
 
     child.stdout?.setEncoding('utf8');
@@ -146,17 +159,17 @@ export async function runShellBuiltin(
 
     timeoutTimer = setTimeout(() => {
       timedOut = true;
-      void terminateChild(child).finally(() => finish(child.exitCode ?? -1));
+      void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
     }, timeoutMs);
 
     supervised.targetExit.then((target) => {
       if (process.platform !== 'win32') killOwnedProcessGroup('SIGKILL');
       else void terminateChild(child);
-      void releaseSupervisor(child).finally(() => finish(target.exitCode ?? -1));
+      void releaseSupervisor(child).finally(() => finishAfterOutputDrain(target.exitCode ?? -1));
     });
     child.on('error', (error) => {
       stderr = appendCapped(stderr, `spawn error: ${error.message}`);
-      finish(-1);
+      void finishAfterOutputDrain(-1);
     });
   });
 }

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -22,7 +22,9 @@ export interface ShellRunOutput {
 // their creator; never signal a detached numeric PGID after ownership ends.
 
 const DEFAULT_TIMEOUT_MS = 60_000;
-const MAX_TIMEOUT_MS = 300_000;
+// Leave 10s inside run_sdk's 180s ceiling for process-group cleanup and the
+// completion request/response grace period.
+const MAX_TIMEOUT_MS = 170_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 const TRUNCATED_MARKER = '\n... (output truncated)';
 function appendCapped(current: string, chunk: string): string {

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -84,7 +84,17 @@ export async function runShellBuiltin(
     let stderr = '';
     let timedOut = false;
     let settled = false;
+    let finishing = false;
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const waitForClose = (stream: NodeJS.ReadableStream | null | undefined): Promise<void> => {
+      if (!stream || (stream as NodeJS.ReadableStream & { destroyed?: boolean }).destroyed) {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => stream.once('close', resolve));
+    };
+    const stdoutClosed = waitForClose(child.stdout);
+    const stderrClosed = waitForClose(child.stderr);
 
     const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
       try {
@@ -98,14 +108,19 @@ export async function runShellBuiltin(
     const abortHandler = () => {
       if (!settled) void terminateChild(child).finally(() => finish(child.exitCode ?? -1));
     };
-    if (shutdownSignal?.aborted) abortHandler();
+    // Let the finish closure initialize before handling an already-aborted
+    // signal; this path is common during daemon shutdown.
+    if (shutdownSignal?.aborted) queueMicrotask(abortHandler);
     else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
 
-    const finish = (exitCode: number): void => {
-      if (settled) return;
-      settled = true;
+    const finish = async (exitCode: number): Promise<void> => {
+      if (settled || finishing) return;
+      finishing = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       shutdownSignal?.removeEventListener('abort', abortHandler);
+      await Promise.all([stdoutClosed, stderrClosed]);
+      if (settled) return;
+      settled = true;
       resolve({
         stdout,
         stderr,

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -1,7 +1,12 @@
-import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute } from 'node:path';
+import {
+  releaseSupervisor,
+  signalOwnedPosixProcessGroup,
+  spawnSupervisedCli,
+  terminateChild,
+} from '../automation-process.js';
 
 export interface ShellRunOutput {
   stdout: string;
@@ -14,17 +19,8 @@ export interface ShellRunOutput {
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 300_000;
-const TERMINATION_GRACE_MS = 3_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 const TRUNCATED_MARKER = '\n... (output truncated)';
-// Keep the outer process group alive through the grace period so its numeric
-// pgid cannot be recycled before SIGKILL. The inner shell starts cleanly and
-// still receives the command's normal signals.
-const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
-bash --noprofile --norc -lc "$1"
-status=$?
-exit "$status"`;
-
 function appendCapped(current: string, chunk: string): string {
   if (current.endsWith(TRUNCATED_MARKER)) return current;
   const next = current + chunk;
@@ -73,46 +69,27 @@ export async function runShellBuiltin(
 
   const startedAt = Date.now();
   return await new Promise<ShellRunOutput>((resolve) => {
-    const child = spawn('bash', ['-c', SHELL_GROUP_ANCHOR, 'lobu-os-shell', command], {
-      cwd,
-      env: shellEnvironment(),
-      detached: true,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const supervised = spawnSupervisedCli(
+      'bash', ['--noprofile', '--norc', '-c', command], shellEnvironment(), { stdin: 'pipe', cwd },
+    );
+    const child = supervised.supervisor;
     let stdout = '';
     let stderr = '';
     let timedOut = false;
     let settled = false;
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
     const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
       try {
         if (child.pid != null) {
-          process.kill(-child.pid, signal);
-          return;
+          if (signalOwnedPosixProcessGroup(child, signal)) return;
         }
-      } catch {
-        // The process group may have already exited or the platform may not
-        // support negative process ids. Fall back to the direct child.
-      }
-      try {
-        child.kill(signal);
-      } catch {
-        // Exit raced cleanup; close/error still owns settlement.
-      }
+      } catch {}
+      try { child.kill(signal); } catch {}
     };
 
     const abortHandler = () => {
-      killOwnedProcessGroup('SIGTERM');
-      forceKillTimer = setTimeout(() => {
-        if (settled) return;
-        killOwnedProcessGroup('SIGKILL');
-        child.stdin.destroy();
-        child.stdout.destroy();
-        child.stderr.destroy();
-        finish(child.exitCode ?? -1);
-      }, TERMINATION_GRACE_MS);
+      if (!settled) void terminateChild(child).finally(() => finish(child.exitCode ?? -1));
     };
     if (shutdownSignal?.aborted) abortHandler();
     else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
@@ -121,7 +98,6 @@ export async function runShellBuiltin(
       if (settled) return;
       settled = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
-      if (forceKillTimer) clearTimeout(forceKillTimer);
       shutdownSignal?.removeEventListener('abort', abortHandler);
       resolve({
         stdout,
@@ -133,34 +109,28 @@ export async function runShellBuiltin(
       });
     };
 
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
       stdout = appendCapped(stdout, chunk);
     });
-    child.stderr.on('data', (chunk: string) => {
+    child.stderr?.on('data', (chunk: string) => {
       stderr = appendCapped(stderr, chunk);
     });
-    child.stdin.on('error', (error: NodeJS.ErrnoException) => {
+    child.stdin?.on('error', (error: NodeJS.ErrnoException) => {
       if (error.code !== 'EPIPE') stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
     });
-    child.stdin.end(stdin);
+    child.stdin?.end(stdin);
 
     timeoutTimer = setTimeout(() => {
       timedOut = true;
-      killOwnedProcessGroup('SIGTERM');
-      forceKillTimer = setTimeout(() => {
-        if (settled) return;
-        killOwnedProcessGroup('SIGKILL');
-        child.stdin.destroy();
-        child.stdout.destroy();
-        child.stderr.destroy();
-        finish(child.exitCode ?? -1);
-      }, TERMINATION_GRACE_MS);
+      void terminateChild(child).finally(() => finish(child.exitCode ?? -1));
     }, timeoutMs);
 
-    child.on('close', (code, signal) => {
-      finish(code ?? (signal ? -1 : 0));
+    supervised.targetExit.then((target) => {
+      if (process.platform !== 'win32') killOwnedProcessGroup('SIGKILL');
+      else void terminateChild(child);
+      void releaseSupervisor(child).finally(() => finish(target.exitCode ?? -1));
     });
     child.on('error', (error) => {
       stderr = appendCapped(stderr, `spawn error: ${error.message}`);

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -1,0 +1,134 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
+
+export interface ShellRunOutput {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  success: boolean;
+  timed_out: boolean;
+  duration_ms: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_TIMEOUT_MS = 300_000;
+const TERMINATION_GRACE_MS = 3_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const TRUNCATED_MARKER = '\n... (output truncated)';
+
+function appendCapped(current: string, chunk: string): string {
+  if (current.endsWith(TRUNCATED_MARKER)) return current;
+  const next = current + chunk;
+  if (Buffer.byteLength(next, 'utf8') <= MAX_OUTPUT_BYTES) return next;
+  return Buffer.from(next, 'utf8').subarray(0, MAX_OUTPUT_BYTES).toString('utf8') + TRUNCATED_MARKER;
+}
+
+function readTimeout(value: unknown): number {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(value) || Number(value) < 100 || Number(value) > MAX_TIMEOUT_MS) {
+    throw new Error(`timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`);
+  }
+  return Number(value);
+}
+
+export async function runShellBuiltin(input: Record<string, unknown>): Promise<ShellRunOutput> {
+  const command = typeof input.command === 'string' ? input.command.trim() : '';
+  if (!command) throw new Error('command is required');
+  if (command.length > 20_000) throw new Error('command must contain at most 20000 characters');
+
+  const cwdValue = input.cwd;
+  const cwd = cwdValue === undefined ? homedir() : String(cwdValue);
+  if (!isAbsolute(cwd) || !existsSync(cwd)) {
+    throw new Error(`cwd must be an existing absolute path (got '${cwd}')`);
+  }
+  const timeoutMs = readTimeout(input.timeout_ms);
+  const stdin = input.stdin;
+  if (stdin !== undefined && typeof stdin !== 'string') throw new Error('stdin must be a string');
+  if (typeof stdin === 'string' && stdin.length > 1_000_000) {
+    throw new Error('stdin must contain at most 1000000 characters');
+  }
+
+  const startedAt = Date.now();
+  return await new Promise<ShellRunOutput>((resolve) => {
+    const child = spawn('bash', ['-lc', command], {
+      cwd,
+      env: { ...process.env, LC_ALL: 'C' },
+      detached: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
+      try {
+        if (child.pid != null) {
+          process.kill(-child.pid, signal);
+          return;
+        }
+      } catch {
+        // The process group may have already exited or the platform may not
+        // support negative process ids. Fall back to the direct child.
+      }
+      try {
+        child.kill(signal);
+      } catch {
+        // Exit raced cleanup; close/error still owns settlement.
+      }
+    };
+
+    const finish = (exitCode: number): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      resolve({
+        stdout,
+        stderr,
+        exit_code: exitCode,
+        success: !timedOut && exitCode === 0,
+        timed_out: timedOut,
+        duration_ms: Date.now() - startedAt,
+      });
+    };
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout = appendCapped(stdout, chunk);
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr = appendCapped(stderr, chunk);
+    });
+    child.stdin.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EPIPE') stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
+    });
+    child.stdin.end(stdin);
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      killOwnedProcessGroup('SIGTERM');
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        killOwnedProcessGroup('SIGKILL');
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish(child.exitCode ?? -1);
+      }, TERMINATION_GRACE_MS);
+    }, timeoutMs);
+
+    child.on('close', (code, signal) => {
+      finish(code ?? (signal ? -1 : 0));
+    });
+    child.on('error', (error) => {
+      stderr = appendCapped(stderr, `spawn error: ${error.message}`);
+      finish(-1);
+    });
+  });
+}

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -114,15 +114,13 @@ export async function runShellBuiltin(
     if (shutdownSignal?.aborted) queueMicrotask(abortHandler);
     else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
 
-    const finish = async (exitCode: number): Promise<void> => {
+    // Synchronous by construction: the only caller drains and destroys both
+    // pipes before calling this, so there is nothing left to await here.
+    const finish = (exitCode: number): void => {
       if (settled || finishing) return;
       finishing = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       shutdownSignal?.removeEventListener('abort', abortHandler);
-      if (!child.stdout?.destroyed && !child.stderr?.destroyed) {
-        await Promise.all([stdoutClosed, stderrClosed]);
-      }
-      if (settled) return;
       settled = true;
       resolve({
         stdout,
@@ -141,7 +139,7 @@ export async function runShellBuiltin(
       ]);
       if (!settled) child.stdout?.destroy();
       if (!settled) child.stderr?.destroy();
-      await finish(exitCode);
+      finish(exitCode);
     };
 
     child.stdout?.setEncoding('utf8');

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -22,9 +22,10 @@ export interface ShellRunOutput {
 // their creator; never signal a detached numeric PGID after ownership ends.
 
 const DEFAULT_TIMEOUT_MS = 60_000;
-// Leave 10s inside run_sdk's 180s ceiling for process-group cleanup and the
-// completion request/response grace period.
-const MAX_TIMEOUT_MS = 170_000;
+// The requested command budget must leave room inside run_sdk's 180s ceiling
+// for 3s TERM grace, up to 5s reaping, up to 15s terminal delivery, and
+// bounded network/server grace.
+const MAX_TIMEOUT_MS = 150_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 const TRUNCATED_MARKER = '\n... (output truncated)';
 function appendCapped(current: string, chunk: string): string {

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -17,6 +17,10 @@ export interface ShellRunOutput {
   duration_ms: number;
 }
 
+// The owned process group is cleaned up automatically. Deliberately detached
+// new sessions are outside that ownership contract and must be cleaned up by
+// their creator; never signal a detached numeric PGID after ownership ends.
+
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 300_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -40,7 +40,21 @@ function readTimeout(value: unknown): number {
   return Number(value);
 }
 
-export async function runShellBuiltin(input: Record<string, unknown>): Promise<ShellRunOutput> {
+function shellEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: process.env.HOME ?? homedir(),
+    TMPDIR: process.env.TMPDIR ?? '/tmp',
+    LANG: 'C',
+    LC_ALL: 'C',
+  };
+  return env;
+}
+
+export async function runShellBuiltin(
+  input: Record<string, unknown>,
+  shutdownSignal?: AbortSignal
+): Promise<ShellRunOutput> {
   const command = typeof input.command === 'string' ? input.command.trim() : '';
   if (!command) throw new Error('command is required');
   if (command.length > 20_000) throw new Error('command must contain at most 20000 characters');
@@ -61,7 +75,7 @@ export async function runShellBuiltin(input: Record<string, unknown>): Promise<S
   return await new Promise<ShellRunOutput>((resolve) => {
     const child = spawn('bash', ['-c', SHELL_GROUP_ANCHOR, 'lobu-os-shell', command], {
       cwd,
-      env: { ...process.env, LC_ALL: 'C' },
+      env: shellEnvironment(),
       detached: true,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -89,11 +103,26 @@ export async function runShellBuiltin(input: Record<string, unknown>): Promise<S
       }
     };
 
+    const abortHandler = () => {
+      killOwnedProcessGroup('SIGTERM');
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        killOwnedProcessGroup('SIGKILL');
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish(child.exitCode ?? -1);
+      }, TERMINATION_GRACE_MS);
+    };
+    if (shutdownSignal?.aborted) abortHandler();
+    else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
+
     const finish = (exitCode: number): void => {
       if (settled) return;
       settled = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       if (forceKillTimer) clearTimeout(forceKillTimer);
+      shutdownSignal?.removeEventListener('abort', abortHandler);
       resolve({
         stdout,
         stderr,

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -52,7 +52,7 @@ export async function runShellBuiltin(input: Record<string, unknown>): Promise<S
 
   const startedAt = Date.now();
   return await new Promise<ShellRunOutput>((resolve) => {
-    const child = spawn('bash', ['-lc', command], {
+    const child = spawn('bash', ['--noprofile', '--norc', '-lc', command], {
       cwd,
       env: { ...process.env, LC_ALL: 'C' },
       detached: true,

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -17,6 +17,13 @@ const MAX_TIMEOUT_MS = 300_000;
 const TERMINATION_GRACE_MS = 3_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 const TRUNCATED_MARKER = '\n... (output truncated)';
+// Keep the outer process group alive through the grace period so its numeric
+// pgid cannot be recycled before SIGKILL. The inner shell starts cleanly and
+// still receives the command's normal signals.
+const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
+bash --noprofile --norc -lc "$1"
+status=$?
+exit "$status"`;
 
 function appendCapped(current: string, chunk: string): string {
   if (current.endsWith(TRUNCATED_MARKER)) return current;
@@ -52,7 +59,7 @@ export async function runShellBuiltin(input: Record<string, unknown>): Promise<S
 
   const startedAt = Date.now();
   return await new Promise<ShellRunOutput>((resolve) => {
-    const child = spawn('bash', ['--noprofile', '--norc', '-lc', command], {
+    const child = spawn('bash', ['-c', SHELL_GROUP_ANCHOR, 'lobu-os-shell', command], {
       cwd,
       env: { ...process.env, LC_ALL: 'C' },
       detached: true,

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -439,7 +439,10 @@ export class WorkerClient implements ExecutorClient {
       '/api/workers/complete-action',
       req
     );
-    if (response?.success === true || response?.success === false && response?.reason === 'already_finalized') {
+    if (
+      response?.success === true ||
+      (response?.success === false && response?.reason === 'already_finalized')
+    ) {
       return;
     }
     throw new WorkerDecodeError('Invalid /api/workers/complete-action response');

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -435,10 +435,14 @@ export class WorkerClient implements ExecutorClient {
    * Report action run completion
    */
   async completeAction(req: CompleteActionRequest): Promise<void> {
-    await this.requestVoid(
+    const response = await this.requestJson<{ success?: unknown; reason?: unknown }>(
       '/api/workers/complete-action',
       req
     );
+    if (response?.success === true || response?.success === false && response?.reason === 'already_finalized') {
+      return;
+    }
+    throw new WorkerDecodeError('Invalid /api/workers/complete-action response');
   }
 
   /**

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -228,6 +228,7 @@ export class WorkerClient implements ExecutorClient {
   private fixedAgentKinds?: AgentKind[];
   private advertisementProvider?: WorkerAdvertisementProvider;
   private agentKindsCache: { kinds: AgentKind[]; at: number } | null = null;
+  private backendCapacity: Record<string, number>;
 
   constructor(config: {
     apiUrl: string;
@@ -247,6 +248,8 @@ export class WorkerClient implements ExecutorClient {
     agentKinds?: AgentKind[];
     /** Mutable device capability/manifest snapshot, updated by the native bridge. */
     advertisementProvider?: WorkerAdvertisementProvider;
+    /** Static readiness/capacity per execution backend. */
+    backendCapacity?: Record<string, number>;
   }) {
     this.apiUrl = trimTrailingSlashes(config.apiUrl);
     this.workerId = config.workerId;
@@ -259,6 +262,7 @@ export class WorkerClient implements ExecutorClient {
     this.binaryOverrides = config.binaryOverrides;
     this.fixedAgentKinds = config.agentKinds;
     this.advertisementProvider = config.advertisementProvider;
+    this.backendCapacity = { ...(config.backendCapacity ?? {}) };
   }
 
   /**
@@ -341,6 +345,16 @@ export class WorkerClient implements ExecutorClient {
       ...(capacityAvailable === undefined
         ? {}
         : { capacity_available: capacityAvailable }),
+      ...(Object.keys(this.backendCapacity).length > 0
+        ? {
+            backend_capacity: Object.fromEntries(
+              Object.entries(this.backendCapacity).map(([backend, capacity]) => [
+                backend,
+                Math.min(capacity, capacityAvailable ?? capacity),
+              ])
+            ),
+          }
+        : {}),
       // app_version belongs to the device registration fields, so omit both for
       // fleet workers rather than sending empty values. A device worker also
       // advertises the agent kinds its automation arm can run.

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -39,7 +39,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
             maxLength: 20000,
           },
           cwd: { type: 'string' },
-          timeout_ms: { type: 'integer', minimum: 100, maximum: 170000, default: 60000 },
+          timeout_ms: { type: 'integer', minimum: 100, maximum: 150000, default: 60000 },
           stdin: { type: 'string', maxLength: 1000000 },
         },
         additionalProperties: false,

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -39,7 +39,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
             maxLength: 20000,
           },
           cwd: { type: 'string' },
-          timeout_ms: { type: 'integer', minimum: 100, maximum: 300000, default: 60000 },
+          timeout_ms: { type: 'integer', minimum: 100, maximum: 170000, default: 60000 },
           stdin: { type: 'string', maxLength: 1000000 },
         },
         additionalProperties: false,

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -2,22 +2,23 @@
  * Device manifests the connector-worker daemon declares on poll, keyed by
  * platform. A headless device (server/VM/pod) advertises the os.shell
  * connector so an org can create a connection pinned to it and run shell
- * commands (executed by the bundled os.shell connector via bash -lc).
+ * commands through the daemon's built-in shell backend.
  */
 
 /**
  * os.shell manifest for headless platforms. Mirrors the macOS manifest's
  * run action (packages/owletto/apps/mac/.../os_shell.json) but targets
- * linux, where the connector-worker daemon (not a native bridge) serves it.
+ * headless workers, where the connector-worker daemon (not a native bridge or
+ * dynamically compiled connector) serves it.
  */
 export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
   key: 'os.shell',
-  version: '0.1.0',
+  version: '0.2.0',
   name: 'Shell',
   description:
     'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
   required_capability: 'os.shell',
-  runtime: { platforms: ['headless'] },
+  runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
   auth_schema: { methods: [{ type: 'none' }] },
   feeds_schema: {},
   actions_schema: {

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -7,10 +7,6 @@
 
 import type { Env, EventEnvelope } from '@lobu/connector-sdk';
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
-import { compileConnectorFromFile, findBundledConnectorFile } from '../compile-connector.js';
-import { batchGenerateEmbeddings } from '../embeddings.js';
-import { executeCompiledConnector } from '../executor/runtime.js';
-import { SubprocessExecutor } from '../executor/subprocess.js';
 import { executeAutomationRun } from './automation.js';
 import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
@@ -42,6 +38,7 @@ import { reportTerminalFailure } from './terminal-failure.js';
 type JobCodeResult = { ok: true; code: string } | { ok: false; error: string };
 
 async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
+  const { compileConnectorFromFile, findBundledConnectorFile } = await import('../compile-connector.js');
   if (job.compiled_code) return { ok: true, code: job.compiled_code };
   if (!job.connector_key) {
     return { ok: false, error: 'No compiled_code and no connector_key — gateway sent neither.' };
@@ -252,6 +249,10 @@ async function executeSyncRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
+    import('../executor/subprocess.js'),
+    import('../executor/runtime.js'),
+  ]);
   const subprocessExecutor = new SubprocessExecutor({
     timeoutMs: cfg.timeoutMs,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
@@ -500,10 +501,6 @@ async function executeActionRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
-  const subprocessExecutor = new SubprocessExecutor({
-    timeoutMs: cfg.timeoutMs,
-    maxOldSpaceSize: cfg.maxOldSpaceSize,
-  });
   const { run_id, connector_key, action_key, action_input, credentials } = job;
 
   if (!run_id || !connector_key || !action_key) {
@@ -513,6 +510,15 @@ async function executeActionRun(
   if (job.execution_backend === 'daemon_builtin') {
     return await executeDaemonBuiltinActionRun(client, job, cfg);
   }
+
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
+    import('../executor/subprocess.js'),
+    import('../executor/runtime.js'),
+  ]);
+  const subprocessExecutor = new SubprocessExecutor({
+    timeoutMs: cfg.timeoutMs,
+    maxOldSpaceSize: cfg.maxOldSpaceSize,
+  });
 
   const codeResult = await resolveJobCode(job);
   if (!codeResult.ok) {
@@ -694,6 +700,10 @@ async function executeAuthRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
+    import('../executor/subprocess.js'),
+    import('../executor/runtime.js'),
+  ]);
   // Interactive auth runs wait on human input (QR scans, OTP entry, OAuth
   // redirects) — a fixed subprocess timeout would kill the pairing mid-flow.
   // Terminate via the UI cancel signal instead.
@@ -921,6 +931,7 @@ async function executeEmbedBackfillRun(
     }> = [];
     let batchError: string | undefined;
     try {
+      const { batchGenerateEmbeddings } = await import('../embeddings.js');
       const { embeddings, model } = await batchGenerateEmbeddings(pending.map((p) => p.text));
       for (let i = 0; i < pending.length; i++) {
         const embedding = embeddings[i];
@@ -1062,6 +1073,7 @@ async function processEventChunk(
   }
 
   try {
+    const { batchGenerateEmbeddings } = await import('../embeddings.js');
     const { embeddings, model } = await batchGenerateEmbeddings(texts);
     for (let j = 0; j < targets.length; j++) {
       const embedding = embeddings[j];

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -129,7 +129,11 @@ async function completeActionOnce(
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     try {
-      await withTerminalDeliveryTimeout(client.completeAction(payload), remaining);
+      const attemptsLeft = 2 - attempt;
+      await withTerminalDeliveryTimeout(
+        client.completeAction(payload),
+        Math.max(1, Math.floor(remaining / attemptsLeft)),
+      );
       return;
     } catch (error) {
       if (error instanceof WorkerDecodeError) throw error;
@@ -642,7 +646,7 @@ async function executeDaemonBuiltinActionRun(
   if (job.compiled_code) {
     const message =
       'operation_backend_unavailable: daemon_builtin payload must not contain compiled_code';
-    await client.completeAction({
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'failed',

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -12,6 +12,7 @@ import { batchGenerateEmbeddings } from '../embeddings.js';
 import { executeCompiledConnector } from '../executor/runtime.js';
 import { SubprocessExecutor } from '../executor/subprocess.js';
 import { executeAutomationRun } from './automation.js';
+import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
@@ -145,6 +146,16 @@ export async function executeRun(
       await reportTerminalFailure(client, job, message, 'error_message');
     } catch (error) {
       log.info('[executor] Failed to reject native bridge run:', error);
+    }
+    return { itemsCollected: 0, error: message };
+  }
+  if (job.execution_backend === 'daemon_builtin' && job.run_type !== 'action') {
+    const message =
+      'operation_backend_unavailable: daemon_builtin currently supports action runs only';
+    try {
+      await reportTerminalFailure(client, job, message, 'error_message');
+    } catch (error) {
+      log.info('[executor] Failed to reject invalid daemon built-in run:', error);
     }
     return { itemsCollected: 0, error: message };
   }
@@ -459,6 +470,10 @@ async function executeActionRun(
     throw new Error('Invalid action run: missing run_id, connector_key, or action_key');
   }
 
+  if (job.execution_backend === 'daemon_builtin') {
+    return await executeDaemonBuiltinActionRun(client, job, cfg);
+  }
+
   const codeResult = await resolveJobCode(job);
   if (!codeResult.ok) {
     const errorMessage = `Action run ${run_id} (${connector_key}): ${codeResult.error}`;
@@ -553,6 +568,64 @@ async function executeActionRun(
     });
 
     return { itemsCollected: 0, error: errorMessage };
+  } finally {
+    clearInterval(heartbeatInterval);
+  }
+}
+
+async function executeDaemonBuiltinActionRun(
+  client: ExecutorClient,
+  job: PollResponse,
+  cfg: ExecutorConfig
+): Promise<{ itemsCollected: number; error?: string }> {
+  const { run_id, connector_key, action_key, action_input } = job;
+  if (!run_id || !connector_key || !action_key) {
+    throw new Error('Invalid daemon built-in action: missing run_id, connector_key, or action_key');
+  }
+  if (job.compiled_code) {
+    const message =
+      'operation_backend_unavailable: daemon_builtin payload must not contain compiled_code';
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: message,
+    });
+    return { itemsCollected: 0, error: message };
+  }
+
+  const heartbeatInterval = setInterval(async () => {
+    try {
+      await client.heartbeat(run_id);
+    } catch (error) {
+      log.debug('[executor] Daemon built-in heartbeat failed:', error);
+    }
+  }, cfg.heartbeatIntervalMs);
+
+  try {
+    const result = await executeDaemonBuiltin({
+      connectorKey: connector_key,
+      actionKey: action_key,
+      input: (action_input ?? {}) as Record<string, unknown>,
+    });
+    if (!result.ok) {
+      const message = `${result.code}: ${result.error}`;
+      await client.completeAction({
+        run_id,
+        worker_id: client.id,
+        status: 'failed',
+        error_message: message,
+      });
+      return { itemsCollected: 0, error: message };
+    }
+
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'success',
+      action_output: result.output,
+    });
+    return { itemsCollected: 0 };
   } finally {
     clearInterval(heartbeatInterval);
   }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -938,6 +938,9 @@ async function executeEmbedBackfillRun(
     }> = [];
     let batchError: string | undefined;
     try {
+      // Dynamic: the headless shell package ships without the embeddings
+      // provider stack, so a static import would pull it into every daemon
+      // bundle. Loaded only when a feed actually has text to embed.
       const { batchGenerateEmbeddings } = await import('../embeddings.js');
       const { embeddings, model } = await batchGenerateEmbeddings(pending.map((p) => p.text));
       for (let i = 0; i < pending.length; i++) {
@@ -1080,6 +1083,8 @@ async function processEventChunk(
   }
 
   try {
+    // Dynamic for the same reason as above: keeps the embeddings provider
+    // stack out of the headless shell bundle.
     const { batchGenerateEmbeddings } = await import('../embeddings.js');
     const { embeddings, model } = await batchGenerateEmbeddings(texts);
     for (let j = 0; j < targets.length; j++) {

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -38,8 +38,9 @@ import { reportTerminalFailure } from './terminal-failure.js';
 type JobCodeResult = { ok: true; code: string } | { ok: false; error: string };
 
 async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
-  const { compileConnectorFromFile, findBundledConnectorFile } = await import('../compile-connector.js');
   if (job.compiled_code) return { ok: true, code: job.compiled_code };
+  // Inline compiled jobs must not load the optional compiler/SDK graph.
+  const { compileConnectorFromFile, findBundledConnectorFile } = await import('../compile-connector.js');
   if (!job.connector_key) {
     return { ok: false, error: 'No compiled_code and no connector_key — gateway sent neither.' };
   }
@@ -59,6 +60,17 @@ async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, error: `esbuild failed for '${job.connector_key}' (${localPath}): ${msg}` };
   }
+}
+
+async function loadCompiledRuntime() {
+  // These are the only production imports retained for source-backed jobs:
+  // the published-package isolation smoke runs inline and daemon_builtin jobs
+  // with compiler/SDK source artifacts absent, while source-backed jobs still
+  // need the compiler and subprocess runtime together.
+  return Promise.all([
+    import('../executor/subprocess.js'),
+    import('../executor/runtime.js'),
+  ]);
 }
 
 export interface ExecutorConfig {
@@ -249,10 +261,7 @@ async function executeSyncRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
-  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
-    import('../executor/subprocess.js'),
-    import('../executor/runtime.js'),
-  ]);
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
   const subprocessExecutor = new SubprocessExecutor({
     timeoutMs: cfg.timeoutMs,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
@@ -511,10 +520,7 @@ async function executeActionRun(
     return await executeDaemonBuiltinActionRun(client, job, cfg);
   }
 
-  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
-    import('../executor/subprocess.js'),
-    import('../executor/runtime.js'),
-  ]);
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
   const subprocessExecutor = new SubprocessExecutor({
     timeoutMs: cfg.timeoutMs,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
@@ -700,10 +706,7 @@ async function executeAuthRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
-  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await Promise.all([
-    import('../executor/subprocess.js'),
-    import('../executor/runtime.js'),
-  ]);
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
   // Interactive auth runs wait on human input (QR scans, OTP entry, OAuth
   // redirects) — a fixed subprocess timeout would kill the pairing mid-flow.
   // Terminate via the UI cancel signal instead.

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -93,6 +93,21 @@ const DEFAULT_CONFIG: ExecutorConfig = {
 
 const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
 
+async function withTerminalDeliveryTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /** Retry one immutable terminal payload without changing its outcome. */
 async function completeActionOnce(
   client: ExecutorClient,
@@ -104,10 +119,7 @@ async function completeActionOnce(
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     try {
-      await Promise.race([
-        client.completeAction(payload),
-        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('terminal completion deadline exceeded')), remaining)),
-      ]);
+      await withTerminalDeliveryTimeout(client.completeAction(payload), remaining);
       return;
     } catch (error) {
       lastError = error;

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -14,6 +14,7 @@ import { SubprocessExecutor } from '../executor/subprocess.js';
 import { executeAutomationRun } from './automation.js';
 import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
+import { WorkerDecodeError } from './client.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
 import { log } from './log.js';
@@ -122,7 +123,9 @@ async function completeActionOnce(
       await withTerminalDeliveryTimeout(client.completeAction(payload), remaining);
       return;
     } catch (error) {
+      if (error instanceof WorkerDecodeError) throw error;
       lastError = error;
+      if (error instanceof Error && error.message === 'terminal completion deadline exceeded') break;
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -91,6 +91,31 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   maxOldSpaceSize: 1024,
 };
 
+const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+
+/** Retry one immutable terminal payload without changing its outcome. */
+async function completeActionOnce(
+  client: ExecutorClient,
+  payload: Parameters<ExecutorClient['completeAction']>[0],
+): Promise<void> {
+  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    try {
+      await Promise.race([
+        client.completeAction(payload),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('terminal completion deadline exceeded')), remaining)),
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 /**
  * Fold the gateway's authoritative DB egress config into the worker's env.
  *
@@ -478,7 +503,7 @@ async function executeActionRun(
   if (!codeResult.ok) {
     const errorMessage = `Action run ${run_id} (${connector_key}): ${codeResult.error}`;
     log.info('[executor]', errorMessage);
-    await client.completeAction({
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'failed',
@@ -504,6 +529,7 @@ async function executeActionRun(
       log.debug('[executor] Action heartbeat failed:', err);
     }
   }, cfg.heartbeatIntervalMs);
+  let terminalPayloadStarted = false;
 
   try {
     const result = await executeCompiledConnector({
@@ -547,7 +573,8 @@ async function executeActionRun(
     }
     const actionOutput = result.output;
 
-    await client.completeAction({
+    terminalPayloadStarted = true;
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'success',
@@ -560,7 +587,10 @@ async function executeActionRun(
     const errorMessage = error instanceof Error ? error.message : String(error);
     log.info(`[executor] Action run ${run_id} failed:`, errorMessage);
 
-    await client.completeAction({
+    if (terminalPayloadStarted) {
+      return { itemsCollected: 0, error: errorMessage };
+    }
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'failed',
@@ -611,22 +641,29 @@ async function executeDaemonBuiltinActionRun(
     });
     if (!result.ok) {
       const message = `${result.code}: ${result.error}`;
-      await client.completeAction({
+      await completeActionOnce(client, {
         run_id,
         worker_id: client.id,
         status: 'failed',
         error_message: message,
+        ...(result.output ? { action_output: result.output } : {}),
       });
       return { itemsCollected: 0, error: message };
     }
 
-    await client.completeAction({
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'success',
       action_output: result.output,
     });
     return { itemsCollected: 0 };
+  } catch (error) {
+    // Delivery uncertainty is not an execution failure. The immutable payload
+    // was retried above; never send a contradictory terminal result here.
+    const message = error instanceof Error ? error.message : String(error);
+    log.info(`[executor] Daemon built-in terminal delivery uncertain for ${run_id}:`, message);
+    return { itemsCollected: 0, error: message };
   } finally {
     clearInterval(heartbeatInterval);
   }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -607,6 +607,7 @@ async function executeDaemonBuiltinActionRun(
       connectorKey: connector_key,
       actionKey: action_key,
       input: (action_input ?? {}) as Record<string, unknown>,
+      shutdownSignal: cfg.shutdownSignal,
     });
     if (!result.ok) {
       const message = `${result.code}: ${result.error}`;

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -21,10 +21,7 @@ export {
 } from './native-bridge/protocol.js';
 export { NativeBridgeClient } from './native-bridge/client.js';
 export type { ExecutorConfig } from './executor.js';
-export async function executeRun(...args: Parameters<typeof import('./executor.js')['executeRun']>) {
-  const { executeRun: run } = await import('./executor.js');
-  return run(...args);
-}
+export { executeRun } from './executor.js';
 export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
 export {

--- a/packages/connector-worker/src/daemon/index.ts
+++ b/packages/connector-worker/src/daemon/index.ts
@@ -21,7 +21,10 @@ export {
 } from './native-bridge/protocol.js';
 export { NativeBridgeClient } from './native-bridge/client.js';
 export type { ExecutorConfig } from './executor.js';
-export { executeRun } from './executor.js';
+export async function executeRun(...args: Parameters<typeof import('./executor.js')['executeRun']>) {
+  const { executeRun: run } = await import('./executor.js');
+  return run(...args);
+}
 export type { DaemonConfig } from './worker.js';
 export { startDaemon, WorkerDaemon } from './worker.js';
 export {

--- a/packages/connector-worker/src/daemon/native-bridge/executor.ts
+++ b/packages/connector-worker/src/daemon/native-bridge/executor.ts
@@ -7,6 +7,7 @@ import { NativeBridgeClient, type NativeBridgeRunResult } from './client.js';
 const FEED_READ_ACTION = '__lobu_feed_read';
 const NATIVE_BRIDGE_HEARTBEAT_INTERVAL_MS = 30_000;
 export const NATIVE_BRIDGE_EXECUTION_TIMEOUT_MS = 600_000;
+const TERMINAL_DELIVERY_BUDGET_MS = 15_000;
 
 export async function executeNativeBridgeRun(
   client: WorkerClient,
@@ -24,6 +25,7 @@ export async function executeNativeBridgeRun(
   let terminalDelivered = false;
   let terminalReporter: (() => Promise<void>) | undefined;
   let terminalAttempts = 0;
+  const terminalDeadline = Date.now() + TERMINAL_DELIVERY_BUDGET_MS;
   let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
 
   const deliverTerminal = async (reporter: () => Promise<void>): Promise<void> => {
@@ -31,9 +33,27 @@ export async function executeNativeBridgeRun(
     terminalReporter ??= reporter;
     let lastError: unknown;
     while (terminalAttempts < 2) {
+      const remaining = terminalDeadline - Date.now();
+      if (remaining <= 0) break;
       terminalAttempts += 1;
       try {
-        await terminalReporter();
+        const attemptsLeft = 3 - terminalAttempts;
+        const attemptBudget = Math.max(1, Math.floor(remaining / attemptsLeft));
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            terminalReporter(),
+            new Promise<never>((_, reject) => {
+              timer = setTimeout(
+                () => reject(new Error('native bridge terminal delivery timed out')),
+                attemptBudget,
+              );
+              timer.unref?.();
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
         terminalDelivered = true;
         return;
       } catch (error) {

--- a/packages/connector-worker/src/daemon/native-bridge/executor.ts
+++ b/packages/connector-worker/src/daemon/native-bridge/executor.ts
@@ -25,12 +25,13 @@ export async function executeNativeBridgeRun(
   let terminalDelivered = false;
   let terminalReporter: (() => Promise<void>) | undefined;
   let terminalAttempts = 0;
-  const terminalDeadline = Date.now() + TERMINAL_DELIVERY_BUDGET_MS;
+  let terminalDeadline: number | undefined;
   let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
 
   const deliverTerminal = async (reporter: () => Promise<void>): Promise<void> => {
     if (terminalDelivered) return;
     terminalReporter ??= reporter;
+    terminalDeadline ??= Date.now() + TERMINAL_DELIVERY_BUDGET_MS;
     let lastError: unknown;
     while (terminalAttempts < 2) {
       const remaining = terminalDeadline - Date.now();

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -143,10 +143,9 @@ export async function startDaemonCommand(
   const workerCapabilities: Record<string, boolean> = platform
     ? Object.fromEntries(capabilities.map((name) => [name, true]))
     : { db_egress_hardening: true };
-  const backendCapacity: Record<string, number> = platform === 'headless'
-    ? { daemon_builtin: 1, compiled_connector: 0 }
-    : platform
-      ? { compiled_connector: 1 }
+  const backendCapacity: Record<string, number> =
+    platform === 'headless'
+      ? { daemon_builtin: 1, compiled_connector: 0 }
       : { compiled_connector: 1 };
   // Auto-discover device identity from the host when not passed: a device
   // worker defaults to `<platform>:<short-hostname>` and a hostname label. An

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -145,6 +145,11 @@ export async function startDaemonCommand(
   const workerCapabilities: Record<string, boolean> = platform
     ? Object.fromEntries(capabilities.map((name) => [name, true]))
     : { db_egress_hardening: true };
+  const backendCapacity: Record<string, number> = platform === 'headless'
+    ? { daemon_builtin: 1, compiled_connector: 0 }
+    : platform
+      ? { compiled_connector: 1 }
+      : { compiled_connector: 1 };
   // Auto-discover device identity from the host when not passed: a device
   // worker defaults to `<platform>:<short-hostname>` and a hostname label. An
   // interactive daemon instead derives its id from the exact inherited
@@ -187,6 +192,7 @@ export async function startDaemonCommand(
     ...(label ? { label } : {}),
     ...(platform ? { manifests: DEVICE_MANIFESTS_BY_PLATFORM[platform] ?? [] } : {}),
     ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
+    backendCapacity,
     ...(opts.workerCredentialMaintenance
       ? { workerCredentialMaintenance: opts.workerCredentialMaintenance }
       : {}),

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -154,10 +154,13 @@ export async function startDaemonCommand(
   const workerId = resolveDaemonWorkerId(opts, platform, shortHostname, detected);
   const label = opts.label ?? (platform ? shortHostname : undefined);
 
-  // Crash loud before the first poll if the installed runtime cannot resolve
-  // or execute the same connector graph this worker is about to advertise.
-  assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
-  await assertConnectorRuntimeLoadable();
+  // Recovery daemons own their built-in control plane. They must still boot and
+  // advertise os.shell when the optional connector SDK/compiler graph is broken;
+  // compiled connector capacity remains closed by the poll/executor backend gate.
+  if (platform !== 'headless') {
+    assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
+    await assertConnectorRuntimeLoadable();
+  }
   log.info(`[cli] Starting worker daemon (ID: ${workerId}, API: ${opts.apiUrl})`);
   const env = buildConnectorWorkerEnv();
   const maxConcurrentJobs = process.env.WORKER_MAX_CONCURRENT_JOBS

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -8,11 +8,9 @@ import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { hostname } from 'node:os';
 import { isKnownPlatform } from '@lobu/core';
-import { assertExternalDepsResolvable } from '../compile/index.js';
 import { buildConnectorWorkerEnv } from '../env.js';
-import { assertConnectorRuntimeLoadable } from '../self-check/index.js';
 import { DEVICE_MANIFESTS_BY_PLATFORM } from './device-manifests.js';
-import { startDaemon, type WorkerDaemon } from './index.js';
+import { startDaemon, type WorkerDaemon } from './worker.js';
 import { log, setDebug } from './log.js';
 import {
   attachInteractiveSession,
@@ -163,6 +161,10 @@ export async function startDaemonCommand(
   // advertise os.shell when the optional connector SDK/compiler graph is broken;
   // compiled connector capacity remains closed by the poll/executor backend gate.
   if (platform !== 'headless') {
+    const [{ assertExternalDepsResolvable }, { assertConnectorRuntimeLoadable }] = await Promise.all([
+      import('../compile/index.js'),
+      import('../self-check/index.js'),
+    ]);
     assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
     await assertConnectorRuntimeLoadable();
   }

--- a/packages/connector-worker/src/daemon/terminal-failure.ts
+++ b/packages/connector-worker/src/daemon/terminal-failure.ts
@@ -1,5 +1,36 @@
 import type { PollResponse, ExecutorClient } from './client.js';
 
+const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+
+async function completeActionWithBoundedRetry(
+  client: ExecutorClient,
+  payload: Parameters<ExecutorClient['completeAction']>[0],
+): Promise<void> {
+  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const budget = Math.max(1, Math.floor(remaining / (2 - attempt)));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        client.completeAction(payload),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), budget);
+          timer.unref?.();
+        }),
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 export async function reportTerminalFailure(
   client: ExecutorClient,
   job: PollResponse,
@@ -8,7 +39,7 @@ export async function reportTerminalFailure(
 ): Promise<void> {
   if (job.run_id == null) return;
   if (job.run_type === 'action') {
-    await client.completeAction({
+    await completeActionWithBoundedRetry(client, {
       run_id: job.run_id,
       worker_id: client.id,
       status: 'failed',

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -32,6 +32,8 @@ export interface DaemonConfig {
   /** Fixed advertisement for an exact interactive session. */
   agentKinds?: AgentKind[];
   workerCredentialMaintenance?: (activate: (workerApiToken: string) => void) => Promise<void>;
+  /** Backend capacities advertised to the gateway. */
+  backendCapacity?: Record<string, number>;
 }
 
 const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
@@ -65,6 +67,7 @@ export class WorkerDaemon {
       // binaries, or the device advertises a kind it then fails to launch.
       binaryOverrides: daemonConfig.executor?.binaryOverrides,
       agentKinds: daemonConfig.agentKinds,
+      backendCapacity: daemonConfig.backendCapacity,
     });
 
     this.env = env;

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -68,15 +68,11 @@ export class WorkerDaemon {
     });
 
     this.env = env;
-    this.shutdownController = interactiveSession
-      ? new AbortController()
-      : undefined;
+    this.shutdownController = new AbortController();
     const executor = {
       timeoutMs: DEFAULT_EXECUTOR_TIMEOUT_MS,
       ...(daemonConfig.executor ?? {}),
-      ...(this.shutdownController
-        ? { shutdownSignal: this.shutdownController.signal }
-        : {}),
+      shutdownSignal: this.shutdownController.signal,
     };
     if (interactiveSession) attachInteractiveSession(executor, interactiveSession);
     this.config = {

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -25,6 +25,7 @@ import {
 	createConnectorCompiler,
 	EXTERNAL_RUNTIME_DEPS,
 } from "../compile/index.js";
+import { executeDaemonBuiltin } from "../daemon/builtins/index.js";
 import type { ExecutorJob } from "../executor/interface.js";
 import {
 	registerConnectorRuntimeDependencyLoader,
@@ -406,6 +407,26 @@ export async function runConnectorRuntimeSelfCheck(
 	await check("synthetic-connector-subprocess-execute", async () => {
 		await runSyntheticConnector(compileConnectorFromFile);
 		return "compiled + executed via default SubprocessExecutor; emitted >=1 event.";
+	});
+
+	// Recovery/control primitives must remain executable even when the dynamic
+	// connector compiler or its npm resolution graph is unhealthy. This call is
+	// intentionally direct and therefore proves the packaged dist contains the
+	// daemon-owned os.shell backend.
+	await check("daemon-builtin:os.shell/run", async () => {
+		const result = await executeDaemonBuiltin({
+			connectorKey: "os.shell",
+			actionKey: "run",
+			input: { command: "printf 'lobu-shell-self-check\\n'", cwd: process.cwd() },
+		});
+		if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+		if (result.output.stdout !== "lobu-shell-self-check\n") {
+			throw new Error(`Unexpected stdout: ${JSON.stringify(result.output.stdout)}.`);
+		}
+		if (result.output.stderr !== "" || result.output.exit_code !== 0) {
+			throw new Error(`Unexpected shell result: ${JSON.stringify(result.output)}.`);
+		}
+		return "executed from packaged worker code without connector compilation.";
 	});
 
 	return {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -177,7 +177,7 @@ describe('os.shell connector', () => {
       escapedPid = Number(String(output.stdout).trim());
 
       expect(output.timed_out).toBe(true);
-      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Date.now() - started).toBeLessThan(5500);
       expect(escapedPid).toBeGreaterThan(1);
       // setsid is explicitly outside process-group cleanup. The connector must
       // return on time even though the escaped session is still alive.
@@ -203,7 +203,7 @@ describe('os.shell connector', () => {
       escapedPid = Number(String(output.stdout).trim());
 
       expect(output.timed_out).toBe(true);
-      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Date.now() - started).toBeLessThan(5500);
       expect(escapedPid).toBeGreaterThan(1);
       expect(processGroupExists(escapedPid)).toBe(true);
     } finally {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -35,10 +35,22 @@ function processIsLive(pid: number): boolean {
     }
     process.kill(pid, 0);
     if (process.platform === 'darwin') {
-      const state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
-        encoding: 'utf8',
-      }).trim();
-      return !state.startsWith('Z');
+      // A zombie still answers kill(pid, 0), so ask `ps` for the real state.
+      // Between that signal probe and this call the pid can be reaped, and
+      // `ps` then exits 1 with no stdout -- which execFileSync raises as an
+      // error carrying a `status`, not an ESRCH/ENOENT `code`, so the handler
+      // below would rethrow it and fail the test. A pid `ps` cannot find is
+      // not an error here: it is the definition of not live.
+      let state: string;
+      try {
+        state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        return false;
+      }
+      return state !== '' && !state.startsWith('Z');
     }
     return true;
   } catch (err) {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -78,6 +78,15 @@ function processGroupExists(pid: number): boolean {
 describe('os.shell connector', () => {
   const connector = new OsShellConnector();
 
+  it('rejects timeout values beyond the published execution budget', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'printf nope', timeout_ms: 170001 })
+    );
+    expect(result).toEqual({
+      success: false,
+      error: 'timeout_ms must be an integer between 100 and 170000',
+    });
+  });
   it('runs a command and returns stdout with exit 0', async () => {
     const result = await connector.execute(
       runContext('run', { command: 'echo hello-from-shell' })

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -80,11 +80,11 @@ describe('os.shell connector', () => {
 
   it('rejects timeout values beyond the published execution budget', async () => {
     const result = await connector.execute(
-      runContext('run', { command: 'printf nope', timeout_ms: 170001 })
+      runContext('run', { command: 'printf nope', timeout_ms: 150001 })
     );
     expect(result).toEqual({
       success: false,
-      error: 'timeout_ms must be an integer between 100 and 170000',
+      error: 'timeout_ms must be an integer between 100 and 150000',
     });
   });
   it('runs a command and returns stdout with exit 0', async () => {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { connectorSdkMock } from './connector-sdk.mock';
 
@@ -33,6 +34,12 @@ function processIsLive(pid: number): boolean {
       return state !== 'Z';
     }
     process.kill(pid, 0);
+    if (process.platform === 'darwin') {
+      const state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+        encoding: 'utf8',
+      }).trim();
+      return !state.startsWith('Z');
+    }
     return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -44,7 +44,7 @@ const SIGTERM_GRACE_MS = 3000;
 // timer fires, so its numeric pgid cannot be recycled before SIGKILL. The
 // inner login shell and command still receive SIGTERM normally.
 const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
-bash -lc "$1"
+bash --noprofile --norc -lc "$1"
 status=$?
 exit "$status"`;
 // Cap captured output so a chatty command cannot balloon daemon memory.

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -46,7 +46,11 @@ const SIGTERM_GRACE_MS = 3000;
 // The outer shell remains the live process-group owner until Node's grace
 // timer fires, so its numeric pgid cannot be recycled before SIGKILL. The
 // inner login shell and command still receive SIGTERM normally.
-const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
+//
+// The trap must outlive the grace timer, so derive it rather than restating
+// it: a hardcoded sleep silently reopens the recycle window the moment
+// SIGTERM_GRACE_MS is raised past it, and nothing would fail to say so.
+const SHELL_GROUP_ANCHOR = `trap 'sleep ${(SIGTERM_GRACE_MS + 1000) / 1000}' TERM
 bash --noprofile --norc -lc "$1"
 status=$?
 exit "$status"`;

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -37,7 +37,9 @@ interface RunOutput {
   duration_ms: number;
 }
 
-const MAX_TIMEOUT_MS = 300000;
+// Keep execution inside run_sdk's 180s outer ceiling after cleanup and
+// terminal-delivery grace.
+const MAX_TIMEOUT_MS = 170000;
 const DEFAULT_TIMEOUT_MS = 60000;
 const SIGTERM_GRACE_MS = 3000;
 // The outer shell remains the live process-group owner until Node's grace
@@ -227,7 +229,7 @@ export default class OsShellConnector extends ConnectorRuntime {
             timeout_ms: {
               type: 'integer',
               minimum: 100,
-              maximum: 300000,
+              maximum: 170000,
               default: 60000,
               description:
                 'Wall-clock budget in milliseconds. On timeout the owned process group gets SIGTERM (3s grace) then SIGKILL. Session-detached or daemonized commands may outlive the call; this is not sandbox containment.',
@@ -265,10 +267,17 @@ export default class OsShellConnector extends ConnectorRuntime {
     if (!command) {
       return { success: false, error: 'command is required' };
     }
-    const timeoutMs = Math.min(
-      typeof input.timeout_ms === 'number' ? input.timeout_ms : DEFAULT_TIMEOUT_MS,
-      MAX_TIMEOUT_MS
-    );
+    const timeoutMs = input.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    if (
+      !Number.isInteger(timeoutMs) ||
+      timeoutMs < 100 ||
+      timeoutMs > MAX_TIMEOUT_MS
+    ) {
+      return {
+        success: false,
+        error: `timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`,
+      };
+    }
     // cwd must be an existing absolute path (the declared contract); default
     // to the device home. Reject rather than let bash guess at a relative cwd.
     let cwd: string | undefined;

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -37,9 +37,10 @@ interface RunOutput {
   duration_ms: number;
 }
 
-// Keep execution inside run_sdk's 180s outer ceiling after cleanup and
-// terminal-delivery grace.
-const MAX_TIMEOUT_MS = 170000;
+// Keep the requested command budget truthful: run_sdk's 180s outer ceiling
+// must also cover 3s TERM grace, up to 5s reaping, up to 15s terminal
+// delivery, and bounded network/server grace.
+const MAX_TIMEOUT_MS = 150000;
 const DEFAULT_TIMEOUT_MS = 60000;
 const SIGTERM_GRACE_MS = 3000;
 // The outer shell remains the live process-group owner until Node's grace
@@ -229,7 +230,7 @@ export default class OsShellConnector extends ConnectorRuntime {
             timeout_ms: {
               type: 'integer',
               minimum: 100,
-              maximum: 170000,
+              maximum: 150000,
               default: 60000,
               description:
                 'Wall-clock budget in milliseconds. On timeout the owned process group gets SIGTERM (3s grace) then SIGKILL. Session-detached or daemonized commands may outlive the call; this is not sandbox containment.',

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -115,6 +115,10 @@ export const PollRequestSchema = Type.Object({
   capacity_available: Type.Optional(
     Type.Integer({ minimum: 0, maximum: 1024 })
   ),
+  /** Per-execution-backend capacity. Zero means the backend is not ready. */
+  backend_capacity: Type.Optional(
+    Type.Record(Type.String(), Type.Integer({ minimum: 0, maximum: 1024 }))
+  ),
   platform: Type.Optional(Type.String()),
   app_version: Type.Optional(Type.String()),
   /**

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -101,7 +101,11 @@ export const OAuthCredentialsSchema = Type.Object({
 // ── poll ────────────────────────────────────────────────────────────────────
 
 /** Server-selected execution path for an exact pinned connector artifact. */
-export const ExecutionBackendSchema = Type.Literal("native_bridge");
+export const ExecutionBackendSchema = Type.Union([
+  Type.Literal("compiled_connector"),
+  Type.Literal("daemon_builtin"),
+  Type.Literal("native_bridge"),
+]);
 
 /** `POST /api/workers/poll` request body. */
 export const PollRequestSchema = Type.Object({

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -15,6 +15,7 @@ import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { createAuthProfile } from "../../utils/auth-profiles";
+import { deviceManifestHash, type DeviceConnectorManifest } from "../../worker-api/device-manifests";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestConnection,
@@ -107,6 +108,62 @@ describe("connections.test device availability", () => {
 		expect(result.device_online).toBe(false);
 		expect(result.retryable).toBe(true);
 		expect(String(result.message)).toMatch(/offline/i);
+	});
+
+	it("reports an online legacy headless shell as backend unavailable", async () => {
+		const sql = getTestDb();
+		const key = "os.shell";
+		const version = "0.1.0";
+		await createTestConnectorDefinition({
+			key,
+			name: "Shell",
+			version,
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "none" }] },
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET runtime = ${sql.json({ platforms: ["headless"] })},
+			    required_capability = 'os.shell'
+			WHERE organization_id = ${orgId} AND key = ${key}
+		`;
+		const manifest = {
+			key,
+			version,
+			name: "Shell",
+			required_capability: "os.shell",
+			runtime: { platforms: ["headless"] },
+			auth_schema: { methods: [{ type: "none" }] },
+			feeds_schema: {},
+			actions_schema: { run: { key: "run", name: "Run" } },
+		};
+		const manifestHash = deviceManifestHash(manifest as DeviceConnectorManifest);
+		const [device] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, connector_manifests,
+				label, organization_id, last_seen_at
+			) VALUES (
+				${userId}, ${`headless-${Date.now()}`}, 'headless', ${sql.json(["os.shell"])},
+				${sql.json({
+					[key]: { manifest, manifest_hash: manifestHash, received_at: new Date().toISOString() },
+				})},
+				'Legacy Headless', ${orgId}, NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: key,
+			created_by: userId,
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${device.id}::uuid WHERE id = ${conn.id}`;
+
+		const result = await test(conn.id);
+		expect(result.status).toBe("warning");
+		expect(result.device_online).toBe(true);
+		expect(result.error_code).toBe("UPSTREAM_UNAVAILABLE");
+		expect(String(result.message)).toMatch(/does not declare a supported execution backend/i);
 	});
 
 	it("does not let valid OAuth credentials mask an offline selected device", async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -181,7 +181,7 @@ async function readDefinition(orgId: string, key = CONNECTOR_KEY) {
 
 async function poll(
   workerId: string,
-  connectorManifests: unknown[],
+  connectorManifests: unknown[] | undefined,
   platform = 'macos',
   capabilities: Record<string, boolean> = { screentime: true },
   options: { capacityAvailable?: number; agentKinds?: string[] } = {},
@@ -192,8 +192,8 @@ async function poll(
     app_version: '9.9.0',
     label: 'Test Device',
     capabilities,
-    connector_manifests: connectorManifests,
   };
+  if (connectorManifests !== undefined) body.connector_manifests = connectorManifests;
   if (options.capacityAvailable !== undefined) {
     body.capacity_available = options.capacityAvailable;
   }
@@ -1197,6 +1197,15 @@ describe('device connector manifests', () => {
       RETURNING id
     `) as unknown as Array<{ id: number }>;
 
+    const downgraded = { ...HEADLESS_OS_SHELL_MANIFEST, version: '0.1.0', runtime: { platforms: ['headless'] } };
+    expect((await poll(workerId, [downgraded], 'headless', { 'os.shell': true }, { capacityAvailable: 1 })).status).toBe(200);
+    const [afterRejected] = (await sql`SELECT status, claimed_by FROM runs WHERE id = ${run.id}`) as unknown as Array<Record<string, unknown>>;
+    expect(afterRejected).toEqual({ status: 'pending', claimed_by: null });
+
+    expect((await poll(workerId, undefined, 'headless', { 'os.shell': true }, { capacityAvailable: 1 })).status).toBe(200);
+    const [afterOmitted] = (await sql`SELECT status, claimed_by FROM runs WHERE id = ${run.id}`) as unknown as Array<Record<string, unknown>>;
+    expect(afterOmitted).toEqual({ status: 'pending', claimed_by: null });
+
     const claimingPoll = await poll(
       workerId,
       [HEADLESS_OS_SHELL_MANIFEST],
@@ -1248,7 +1257,7 @@ describe('device connector manifests', () => {
     expect(rows[0]?.connector_manifests).toEqual({});
   });
 
-  it('preserves the last valid inventory when a later manifest payload is rejected', async () => {
+  it('clears current manifest authority when a later payload is rejected', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
@@ -1302,8 +1311,8 @@ describe('device connector manifests', () => {
       FROM device_workers
       WHERE worker_id = ${workerId}
     `) as unknown as Array<{ connector_manifests: Record<string, unknown> }>;
-    expect(Object.keys(devices[0]?.connector_manifests ?? {})).toEqual([CONNECTOR_KEY]);
-    expect(devices[0]?.connector_manifests).toEqual(before[0]?.connector_manifests);
+    expect(devices[0]?.connector_manifests).toEqual({});
+    expect(devices[0]?.connector_manifests).not.toEqual(before[0]?.connector_manifests);
   });
 
   it('registers and reconciles a zero-capacity poll without claiming an eligible run', async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -733,7 +733,6 @@ describe('device connector manifests', () => {
     const body = (await claimResponse.json()) as Record<string, unknown>;
     expect(body.connector_key).toBeUndefined();
     expect(body.execution_backend).toBeUndefined();
-    expect(body.error).toContain('not authorized');
   });
 
   it('reconciles a same-version compiled artifact back to manifest-only poll payload', async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -656,7 +656,7 @@ describe('device connector manifests', () => {
     );
   });
 
-  it('keeps a persisted pre-operations bridge manifest as inventory but not claim authority', async () => {
+  it('fails closed when the current bridge manifest is omitted', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
     const currentManifest = manifest({
@@ -708,12 +708,11 @@ describe('device connector manifests', () => {
     expect(reconcileResponse.status).toBe(200);
 
     const definition = await readDefinition(orgId);
-    expect(definition?.feeds_schema).toEqual(
-      expect.objectContaining({
-        snapshots: expect.objectContaining({ operations: ['sync'] }),
-        live_snapshots: expect.objectContaining({ operations: ['read'] }),
-      }),
-    );
+    // An omitted current advertisement is not authority to create or retain an
+    // active definition. Historical connector_versions, when present, remain
+    // inventory only; this fixture has none because it never advertised a
+    // valid current manifest.
+    expect(definition).toBeNull();
     const feeds = (await sql`
       SELECT f.feed_key, f.next_run_at
       FROM feeds f
@@ -723,10 +722,7 @@ describe('device connector manifests', () => {
         AND f.feed_key IN ('snapshots', 'live_snapshots')
       ORDER BY f.feed_key
     `) as unknown as Array<{ feed_key: string; next_run_at: Date | string | null }>;
-    expect(feeds).toEqual([
-      { feed_key: 'live_snapshots', next_run_at: null },
-      { feed_key: 'snapshots', next_run_at: expect.anything() },
-    ]);
+    expect(feeds).toEqual([]);
 
     const claimResponse = await pollPersistedInventory(1);
     expect(claimResponse.status).toBe(200);

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1193,6 +1193,24 @@ describe('device connector manifests', () => {
       RETURNING id
     `) as unknown as Array<{ id: number }>;
 
+    // A valid retained manifest has exact daemon authorization even when no
+    // exact active definition runtime is available. Authorization alone must
+    // not bypass the daemon backend capacity gate.
+    const noCapacityPoll = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      { capacityAvailable: 0 },
+    );
+    expect(noCapacityPoll.status).toBe(200);
+    const noCapacityBody = (await noCapacityPoll.json()) as Record<string, unknown>;
+    expect(noCapacityBody.run_id).toBeUndefined();
+    const [afterNoCapacity] = (await sql`
+      SELECT status, claimed_by FROM runs WHERE id = ${run.id}
+    `) as unknown as Array<Record<string, unknown>>;
+    expect(afterNoCapacity).toEqual({ status: 'pending', claimed_by: null });
+
     const downgraded = { ...HEADLESS_OS_SHELL_MANIFEST, version: '0.1.0', runtime: { platforms: ['headless'] } };
     expect((await poll(workerId, [downgraded], 'headless', { 'os.shell': true }, { capacityAvailable: 1 })).status).toBe(200);
     const [afterRejected] = (await sql`SELECT status, claimed_by FROM runs WHERE id = ${run.id}`) as unknown as Array<Record<string, unknown>>;

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1193,7 +1193,7 @@ describe('device connector manifests', () => {
         connector_version, action_key, action_input, approval_status, status,
         created_at
       ) VALUES (
-        ${orgId}, 'action', ${connection.id}, 'os.shell', '0.1.0', 'run',
+        ${orgId}, 'action', ${connection.id}, 'os.shell', '0.2.0', 'run',
         ${sql.json({ command: 'hostname' })}, 'auto', 'pending', NOW()
       )
       RETURNING id
@@ -1210,9 +1210,8 @@ describe('device connector manifests', () => {
     const body = (await claimingPoll.json()) as Record<string, unknown>;
     expect(body.run_id).toBe(Number(run.id));
     expect(body.connector_key).toBe('os.shell');
-    expect(body.execution_backend).toBeUndefined();
-    expect(typeof body.compiled_code).toBe('string');
-    expect((body.compiled_code as string).length).toBeGreaterThan(0);
+    expect(body.execution_backend).toBe('daemon_builtin');
+    expect(body.compiled_code).toBeUndefined();
   });
 
   it('drops a manifest that still declares removed entityLinks rules', async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -656,7 +656,7 @@ describe('device connector manifests', () => {
     );
   });
 
-  it('keeps a persisted pre-operations bridge manifest authorized and scheduled', async () => {
+  it('keeps a persisted pre-operations bridge manifest as inventory but not claim authority', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
     const currentManifest = manifest({
@@ -731,10 +731,9 @@ describe('device connector manifests', () => {
     const claimResponse = await pollPersistedInventory(1);
     expect(claimResponse.status).toBe(200);
     const body = (await claimResponse.json()) as Record<string, unknown>;
-    expect(body.connector_key).toBe(CONNECTOR_KEY);
-    expect(body.feed_key).toBe('snapshots');
-    expect(body.execution_backend).toBe('native_bridge');
-    expect(body.connector_manifest_hash).toBe(legacyHash);
+    expect(body.connector_key).toBeUndefined();
+    expect(body.execution_backend).toBeUndefined();
+    expect(body.error).toContain('not authorized');
   });
 
   it('reconciles a same-version compiled artifact back to manifest-only poll payload', async () => {

--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -342,6 +342,7 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [''],
       baseOrgScopeIds: [''],
       workerHardensDbEgress: true,
+      backendCapacity: { compiled_connector: 1 },
     };
     const macContext: DueFeedClaimContext = {
       isUserScopedWorker: true,
@@ -354,6 +355,7 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
+      backendCapacity: { compiled_connector: 1 },
     };
     const chromeContext: DueFeedClaimContext = {
       isUserScopedWorker: true,
@@ -366,6 +368,7 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
+      backendCapacity: { daemon_builtin: 1 },
     };
 
     // Production incident shape: the Mac is recently seen but busy, so it is not

--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -368,7 +368,9 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
-      backendCapacity: { daemon_builtin: 1 },
+      // Chrome is a bridge-only worker in this fixture; it must not advertise
+      // compiled connector capacity merely because it polls successfully.
+      backendCapacity: { compiled_connector: 0 },
     };
 
     // Production incident shape: the Mac is recently seen but busy, so it is not

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -253,6 +253,72 @@ describe("list_feeds health filter and true total", () => {
 		const byKey = new Map(res.feeds.map((feed) => [feed.feed_key, feed]));
 		expect(byKey.get("historical")?.attention).toBe("never_run");
 		expect(byKey.get("active")?.attention).toBe("setup_required");
+		await sql`DELETE FROM feeds WHERE connection_id = ${conn.id}`;
+		await sql`DELETE FROM connections WHERE id = ${conn.id}`;
+		await sql`DELETE FROM device_workers WHERE id = ${device.id}`;
+		await sql`DELETE FROM connector_definitions WHERE organization_id = ${orgId} AND key = ${connectorKey}`;
+	});
+
+	it("reports an online legacy headless backend as unavailable", async () => {
+		const connectorKey = "test.legacy-headless-feed";
+		const version = "1.0.0";
+		const sql = getTestDb();
+		await createTestConnectorDefinition({
+			key: connectorKey,
+			name: "Legacy Headless Feed",
+			version,
+			organization_id: orgId,
+			feeds_schema: { items: {} },
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET runtime = ${sql.json({ platforms: ["headless"] })}, required_capability = 'os.shell'
+			WHERE organization_id = ${orgId} AND key = ${connectorKey}
+		`;
+		const manifest = {
+			key: connectorKey,
+			version,
+			name: "Legacy Headless Feed",
+			required_capability: "os.shell",
+			runtime: { platforms: ["headless"] },
+			feeds_schema: { items: { operations: ["sync"] } },
+		};
+		const [device] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, label, organization_id,
+				connector_manifests, last_seen_at
+			) VALUES (
+				${ctx.userId}, ${`legacy-feed-${Date.now()}`}, 'headless',
+				${sql.json(['os.shell'])}, 'Legacy Headless Feed', ${orgId},
+				${sql.json({
+					[connectorKey]: {
+						manifest,
+						manifest_hash: deviceManifestHash(manifest),
+						received_at: new Date().toISOString(),
+					},
+				})}, NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: connectorKey,
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${device.id}::uuid WHERE id = ${conn.id}`;
+		await sql`
+			INSERT INTO feeds (organization_id, connection_id, feed_key, status, entity_ids, created_at, updated_at)
+			VALUES (${orgId}, ${conn.id}, 'items', 'active', ARRAY[]::bigint[], NOW(), NOW())
+		`;
+
+		const result = await list({ connection_id: conn.id, limit: 10 });
+		expect(result.feeds[0]).toMatchObject({
+			attention: "setup_required",
+		});
+		await sql`DELETE FROM feeds WHERE connection_id = ${conn.id}`;
+		await sql`DELETE FROM connections WHERE id = ${conn.id}`;
+		await sql`DELETE FROM device_workers WHERE id = ${device.id}::uuid`;
+		await sql`DELETE FROM connector_definitions WHERE organization_id = ${orgId} AND key = ${connectorKey}`;
 	});
 
 	it("does not leak the internal count column onto feed rows", async () => {

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -169,6 +169,11 @@ describe("list_feeds health filter and true total", () => {
 		expect(lastPage.has_more).toBe(false);
 	});
 
+	it("executes list_feeds against the connector version artifact projection", async () => {
+		const res = await list({ limit: 1 });
+		expect(res.feeds).toHaveLength(1);
+	});
+
 	it("does not leak the internal count column onto feed rows", async () => {
 		const res = await list({ limit: 10 });
 		for (const feed of res.feeds) {

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -19,6 +19,7 @@ import type { Env } from "../../index";
 import { manageFeeds } from "../../tools/admin/manage_feeds";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
+import { deviceManifestHash } from "../../worker-api/device-manifests";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestConnection,
@@ -169,9 +170,89 @@ describe("list_feeds health filter and true total", () => {
 		expect(lastPage.has_more).toBe(false);
 	});
 
-	it("executes list_feeds against the connector version artifact projection", async () => {
-		const res = await list({ limit: 1 });
-		expect(res.feeds).toHaveLength(1);
+	it("does not derive readiness from a mismatched active connector runtime", async () => {
+		const connectorKey = "test.headless-runtime-regression";
+		const historicalVersion = "1.0.0";
+		const activeVersion = "2.0.0";
+		const sql = getTestDb();
+		await createTestConnectorDefinition({
+			key: connectorKey,
+			name: "Headless Runtime Regression",
+			version: historicalVersion,
+			organization_id: orgId,
+			feeds_schema: { default: {} },
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET status = 'archived'
+			WHERE organization_id = ${orgId} AND key = ${connectorKey}
+			  AND version = ${historicalVersion}
+		`;
+		await createTestConnectorDefinition({
+			key: connectorKey,
+			name: "Headless Runtime Regression",
+			version: activeVersion,
+			organization_id: orgId,
+			feeds_schema: { default: {} },
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET runtime = ${sql.json({
+				platforms: ["headless"],
+				execution: "daemon_builtin",
+			})}
+			WHERE organization_id = ${orgId} AND key = ${connectorKey}
+			  AND version = ${activeVersion}
+		`;
+
+		const manifest = (version: string) => ({
+			key: connectorKey,
+			version,
+			name: "Headless Runtime Regression",
+			required_capability: "test.headless",
+			runtime: { platforms: ["headless"], execution: "daemon_builtin" },
+			feeds_schema: { default: { operations: ["sync"] } },
+		});
+		const storedManifests = Object.fromEntries(
+			[historicalVersion, activeVersion].map((version) => {
+				const value = manifest(version);
+				return [version, {
+					manifest_hash: deviceManifestHash(value),
+					received_at: new Date().toISOString(),
+					manifest: value,
+				}];
+			}),
+		);
+		const [device] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, app_version, capabilities, label,
+				organization_id, connector_manifests, last_seen_at
+			) VALUES (
+				${ctx.userId}, ${`regression-${Date.now()}`}, 'headless', 'test',
+				${sql.json([])}, 'Headless Runtime Regression', ${orgId},
+				${sql.json(storedManifests)}, NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: connectorKey,
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${device.id} WHERE id = ${conn.id}`;
+		await sql`
+			INSERT INTO feeds (
+				organization_id, connection_id, feed_key, status, entity_ids,
+				pinned_version, created_at, updated_at
+			) VALUES
+				(${orgId}, ${conn.id}, 'historical', 'active', ARRAY[]::bigint[], ${historicalVersion}, NOW(), NOW()),
+				(${orgId}, ${conn.id}, 'active', 'active', ARRAY[]::bigint[], NULL, NOW(), NOW())
+		`;
+
+		const res = await list({ connection_id: conn.id, limit: 10 });
+		const byKey = new Map(res.feeds.map((feed) => [feed.feed_key, feed]));
+		expect(byKey.get("historical")?.attention).toBe("never_run");
+		expect(byKey.get("active")?.attention).toBe("setup_required");
 	});
 
 	it("does not leak the internal count column onto feed rows", async () => {

--- a/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
@@ -70,6 +70,7 @@ const KEY_INACTIVE = "demo.ops.inactive";
 const KEY_DEVICE = "demo.ops.device";
 const KEY_DEVICE_SETUP = "chrome.test_readiness";
 const KEY_COMPILED_LEGACY = "whatsapp.local";
+const KEY_HEADLESS_LEGACY = "headless.test_shell";
 
 const ACTIONS_SCHEMA = {
 	create_issue: {
@@ -115,6 +116,7 @@ async function purge(organizationId: string): Promise<void> {
 		KEY_DEVICE,
 		KEY_DEVICE_SETUP,
 		KEY_COMPILED_LEGACY,
+		KEY_HEADLESS_LEGACY,
 	];
 	await sql`DELETE FROM feeds WHERE connection_id IN (SELECT id FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId})`;
 	await sql`DELETE FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
@@ -512,6 +514,72 @@ describe("operations.listAvailable — capability discovery DTO", () => {
 			"https://gateway.test",
 		);
 		expect(JSON.stringify(create)).not.toContain(workerId);
+	});
+
+	it("reports an online legacy headless backend as unavailable until the daemon is updated", async () => {
+		const { org, user } = await setupOwner("Ops Legacy Headless Org");
+		await seedConnector(org.id, KEY_HEADLESS_LEGACY, "Legacy Headless Shell");
+		const sql = getTestDb();
+		await sql`
+			UPDATE connector_definitions
+			SET runtime = ${sql.json({ platforms: ["headless"] })},
+			    required_capability = 'os.shell'
+			WHERE organization_id = ${org.id} AND key = ${KEY_HEADLESS_LEGACY}
+		`;
+		const manifest = {
+			key: KEY_HEADLESS_LEGACY,
+			version: "1.0.0",
+			name: "Legacy Headless Shell",
+			required_capability: "os.shell",
+			runtime: { platforms: ["headless"] },
+			auth_schema: { methods: [{ type: "none" }] },
+			feeds_schema: {},
+			actions_schema: ACTIONS_SCHEMA,
+		};
+		const [device] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, connector_manifests,
+				label, organization_id, last_seen_at
+			) VALUES (
+				${user.id}, ${`headless-${Math.random().toString(36).slice(2, 10)}`},
+				'headless', ${sql.json(["os.shell"])},
+				${sql.json({
+					[KEY_HEADLESS_LEGACY]: {
+						manifest,
+						manifest_hash: deviceManifestHash(
+							manifest as DeviceConnectorManifest,
+						),
+						received_at: new Date().toISOString(),
+					},
+				})},
+				'Legacy Headless', ${org.id}, NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_HEADLESS_LEGACY,
+			status: "active",
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${device.id}::uuid WHERE id = ${conn.id}`;
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_HEADLESS_LEGACY,
+		});
+		const create = getOperation(operations, "create_issue");
+		expect(create).toMatchObject({
+			executable: false,
+			readiness: "backend_unavailable",
+			execution_targets: [
+				{
+					connection_id: conn.id,
+					status: "backend_unavailable",
+					executable: false,
+				},
+			],
+			next_action: { action: "update_device_daemon", manual: true },
+		});
 	});
 
 	it("uses the manifest snapshot to report setup_required for an online device", async () => {

--- a/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
+++ b/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isDelegatedBrowserAffinityConnector,
+  hasHeadlessConnectorPlatform,
   isChromeNamespaceConnectorKey,
   isLegacyNonManifestConnector,
   isLegacyNativeChromeExtensionConnectorKey,
@@ -9,6 +10,13 @@ import {
   LEGACY_NATIVE_CHROME_EXTENSION_CONNECTORS,
   LEGACY_NATIVE_CHROME_EXTENSION_CONNECTOR_KEYS,
 } from '../../utils/connector-execution-placement';
+
+describe('headless connector runtime predicates', () => {
+  it('recognizes a headless platform without requiring an execution mode', () => {
+    expect(hasHeadlessConnectorPlatform({ platforms: ['headless'] })).toBe(true);
+    expect(hasHeadlessConnectorPlatform({ platforms: ['macos'] })).toBe(false);
+  });
+});
 
 describe('Chrome-extension connector execution placement', () => {
   it('keeps the legacy native allowlist exact', () => {

--- a/packages/server/src/__tests__/unit/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/device-feed-read.test.ts
@@ -28,10 +28,11 @@ import { classifyDeviceConnectorReadiness } from '../../worker-api/device-connec
 import { isHeadlessConnectorRuntime } from '../../utils/connector-execution-placement';
 
 describe('headless runtime readiness target selection', () => {
-  it('recognizes only runtimes that advertise the headless platform', () => {
+  it('recognizes only current daemon-built-in headless runtimes', () => {
     expect(isHeadlessConnectorRuntime({ platforms: ['headless'], execution: 'daemon_builtin' })).toBe(true);
     expect(isHeadlessConnectorRuntime({ platforms: ['macos'], execution: 'daemon_builtin' })).toBe(false);
-    expect(isHeadlessConnectorRuntime({ platforms: ['headless'] })).toBe(true);
+    expect(isHeadlessConnectorRuntime({ platforms: ['headless'] })).toBe(false);
+    expect(isHeadlessConnectorRuntime({ platforms: ['headless'], execution: 'bridge' })).toBe(false);
     expect(isHeadlessConnectorRuntime(null)).toBe(false);
   });
 });

--- a/packages/server/src/__tests__/unit/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/device-feed-read.test.ts
@@ -96,6 +96,39 @@ describe('device manifest feed operations', () => {
   });
 });
 
+describe('headless device manifest backend contract', () => {
+  const manifest = {
+    key: 'os.shell',
+    version: '0.2.0',
+    name: 'Shell',
+    required_capability: 'os.shell',
+    runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
+    feeds_schema: {},
+    actions_schema: { run: { key: 'run', name: 'Run' } },
+  };
+
+  it('accepts the explicit daemon built-in backend', () => {
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [manifest],
+    }).accepted).toBe(true);
+  });
+
+  it('rejects legacy or unknown headless execution before advertisement', () => {
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [{ ...manifest, runtime: { platforms: ['headless'] } }],
+    }).accepted).toBe(false);
+    expect(validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [{ ...manifest, runtime: { platforms: ['headless'], execution: 'mystery' } }],
+    }).accepted).toBe(false);
+  });
+});
+
 describe('WhatsApp Browser manifest capability', () => {
   const chromeManifest = {
     key: 'whatsapp.local',
@@ -173,6 +206,24 @@ describe('device connector readiness', () => {
     expect(classifyDeviceConnectorReadiness(source(['device-1'], ['device-1'])).state).toBe(
       'ready'
     );
+  });
+
+  it('does not report a legacy headless manifest ready without an explicit backend', () => {
+    const headless = {
+      ...source(['device-1'], ['device-1']),
+      sourcePath: 'device-manifest://headless/os.shell@0.1.0',
+      metadata: { name: 'Shell', runtime: { platforms: ['headless'] } },
+    } as DeviceConnectorSource;
+    expect(classifyDeviceConnectorReadiness(headless).state).toBe('backend_unavailable');
+    expect(
+      classifyDeviceConnectorReadiness({
+        ...headless,
+        metadata: {
+          name: 'Shell',
+          runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
+        },
+      }).state
+    ).toBe('ready');
   });
 
   it('derives offline when the selected manifest has no online advertiser', () => {

--- a/packages/server/src/__tests__/unit/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/device-feed-read.test.ts
@@ -25,6 +25,16 @@ import {
   validateDeviceConnectorManifests,
 } from '../../worker-api/device-manifests';
 import { classifyDeviceConnectorReadiness } from '../../worker-api/device-connector-readiness';
+import { isHeadlessConnectorRuntime } from '../../utils/connector-execution-placement';
+
+describe('headless runtime readiness target selection', () => {
+  it('recognizes only runtimes that advertise the headless platform', () => {
+    expect(isHeadlessConnectorRuntime({ platforms: ['headless'], execution: 'daemon_builtin' })).toBe(true);
+    expect(isHeadlessConnectorRuntime({ platforms: ['macos'], execution: 'daemon_builtin' })).toBe(false);
+    expect(isHeadlessConnectorRuntime({ platforms: ['headless'] })).toBe(true);
+    expect(isHeadlessConnectorRuntime(null)).toBe(false);
+  });
+});
 
 describe('device feed read — reserved action key', () => {
   it('lives in the gateway-reserved namespace so a manifest can never claim it', () => {

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -103,6 +103,7 @@ interface FeedHealthSemanticsInput {
   device_connector_readiness?:
     | "ready"
     | "setup_required"
+    | "backend_unavailable"
     | "device_offline"
     | null;
 }
@@ -153,7 +154,11 @@ function deviceOffline(input: FeedHealthSemanticsInput): boolean {
 }
 
 function setupRequired(input: FeedHealthSemanticsInput): boolean {
-  return !pinnedDeviceOffline(input) && input.device_connector_readiness === "setup_required";
+  return (
+    !pinnedDeviceOffline(input) &&
+    (input.device_connector_readiness === "setup_required" ||
+      input.device_connector_readiness === "backend_unavailable")
+  );
 }
 
 /** The most recent attempt failed, or a failure episode is underway. */

--- a/packages/server/src/scheduled/refresh-connector-definitions.ts
+++ b/packages/server/src/scheduled/refresh-connector-definitions.ts
@@ -29,6 +29,7 @@ interface DefRow {
   organization_id: string;
   key: string;
   mcp_config: Record<string, unknown> | null;
+  device_manifest_backed: boolean;
 }
 
 export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
@@ -39,6 +40,16 @@ export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
   const rows = (await sql`
     SELECT DISTINCT ON (organization_id, key)
       organization_id, key, mcp_config
+      , COALESCE((
+        SELECT cv.source_path LIKE 'device-manifest://%'
+        FROM connector_versions cv
+        WHERE (cv.organization_id = connector_definitions.organization_id
+           OR cv.organization_id IS NULL)
+          AND cv.connector_key = connector_definitions.key
+          AND cv.version = connector_definitions.version
+        ORDER BY cv.organization_id NULLS LAST, cv.id DESC
+        LIMIT 1
+      ), false) AS device_manifest_backed
     FROM connector_definitions
     WHERE status = 'active'
       AND organization_id IS NOT NULL
@@ -57,6 +68,7 @@ export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
   const noSourceKeys = new Set<string>();
 
   for (const row of rows) {
+    if (row.device_manifest_backed) continue;
     // MCP definitions have no bundled source file. Atlassian Rovo gained its
     // Jira feed after existing installs were already stored, so converge those
     // snapshots here instead of requiring every user to reinstall.

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -88,6 +88,7 @@ async function sleepUnlessAborted(ms: number, abortSignal?: AbortSignal): Promis
 // claimed the run, marking it timeout while the worker was about to
 // pick it up.
 const POST_CLAIM_BUDGET_MS = 95_000; // matches extension's 90s + 5s buffer
+export const DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS = 305_000;
 const POLL_MS = 500;
 
 interface DeviceActionRunOutcome {
@@ -120,11 +121,12 @@ export function waitForDeviceActionRun(
    * On abort we stop polling and finalize the run as `timeout` so the orphaned
    * poll loop and any in-flight device work don't leak past the caller.
    */
-  abortSignal?: AbortSignal
+  abortSignal?: AbortSignal,
+  postClaimMs = POST_CLAIM_BUDGET_MS
 ): Promise<DeviceActionRunOutcome> {
   return waitForDeviceActionRunWithOptions(runId, organizationId, {
     queueMs: DEVICE_ACTION_QUEUE_BUDGET_MS,
-    postClaimMs: POST_CLAIM_BUDGET_MS,
+    postClaimMs,
     pollMs: POLL_MS,
     abortSignal,
   });

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -88,8 +88,9 @@ async function sleepUnlessAborted(ms: number, abortSignal?: AbortSignal): Promis
 // claimed the run, marking it timeout while the worker was about to
 // pick it up.
 const POST_CLAIM_BUDGET_MS = 95_000; // matches extension's 90s + 5s buffer
-// os.shell accepts at most 170s; retain 5s for daemon cleanup and terminal
-// delivery while staying below run_sdk's 180s wall-clock ceiling.
+// os.shell accepts at most 150s. The daemon waiter allows that command budget
+// plus 3s TERM grace, up to 5s reaping, up to 15s terminal delivery, and
+// bounded network/server grace, while staying below run_sdk's 180s ceiling.
 export const DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS = 175_000;
 const POLL_MS = 500;
 

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -88,7 +88,9 @@ async function sleepUnlessAborted(ms: number, abortSignal?: AbortSignal): Promis
 // claimed the run, marking it timeout while the worker was about to
 // pick it up.
 const POST_CLAIM_BUDGET_MS = 95_000; // matches extension's 90s + 5s buffer
-export const DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS = 305_000;
+// os.shell accepts at most 170s; retain 5s for daemon cleanup and terminal
+// delivery while staying below run_sdk's 180s wall-clock ceiling.
+export const DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS = 175_000;
 const POLL_MS = 500;
 
 interface DeviceActionRunOutcome {

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -10,6 +10,11 @@ import {
   describeDeviceLastSeen,
 } from '../../../../utils/device-liveness';
 import {
+  describeDeviceConnectorBackendUnavailable,
+  findDeviceConnectorReadiness,
+  loadDeviceConnectorReadiness,
+} from '../../../../worker-api/device-connector-readiness';
+import {
   getAuthProfileById,
   getBrowserSessionReadiness,
   normalizeAuthValues,
@@ -182,13 +187,15 @@ export async function handleTest(
            c.status,
            c.device_worker_id,
            dw.label AS device_label,
+           dw.user_id AS device_owner_user_id,
            dw.last_seen_at AS device_last_seen_at,
            COALESCE(dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}), false) AS device_online,
-           cd.auth_schema
+           cd.auth_schema,
+           cd.version AS connector_version
     FROM connections c
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     LEFT JOIN LATERAL (
-      SELECT auth_schema
+      SELECT auth_schema, version
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -204,6 +211,29 @@ export async function handleTest(
   }
 
   const conn = rows[0] as any;
+  if (conn.device_worker_id && conn.device_owner_user_id && conn.connector_version) {
+    const readiness = findDeviceConnectorReadiness(
+      await loadDeviceConnectorReadiness({
+        sql,
+        targets: [{
+          ownerUserId: conn.device_owner_user_id,
+          connectorKey: conn.connector_key,
+          connectorVersion: conn.connector_version,
+          deviceWorkerId: conn.device_worker_id,
+        }],
+      }),
+      {
+        ownerUserId: conn.device_owner_user_id,
+        connectorKey: conn.connector_key,
+        connectorVersion: conn.connector_version,
+        deviceWorkerId: conn.device_worker_id,
+      }
+    );
+    if (readiness?.state === 'backend_unavailable') {
+      conn.device_backend_unavailable_reason =
+        describeDeviceConnectorBackendUnavailable(readiness);
+    }
+  }
   const withDeviceHealth = (result: ConnectionTestResult): ConnectionTestResult =>
     applySelectedDeviceHealth(conn, result);
 
@@ -379,6 +409,15 @@ export async function handleTest(
   // mask an offline device behind a generic "requires no auth profile" ok.
   if (conn.device_worker_id) {
     const deviceName = conn.device_label || 'paired device';
+    if (conn.device_backend_unavailable_reason) {
+      return {
+        action: 'test',
+        status: 'warning',
+        message: conn.device_backend_unavailable_reason,
+        device_online: true,
+        ...testErrorFields('UPSTREAM_UNAVAILABLE'),
+      };
+    }
     return conn.device_online
       ? {
           action: 'test',
@@ -433,10 +472,20 @@ function applySelectedDeviceHealth(
     device_online?: unknown;
     device_label?: unknown;
     device_last_seen_at?: Date | string | null;
+    device_backend_unavailable_reason?: unknown;
   },
   result: ConnectionTestResult
 ): ConnectionTestResult {
   if (!conn.device_worker_id) return result;
+  if (typeof conn.device_backend_unavailable_reason === 'string') {
+    return {
+      ...result,
+      status: result.status === 'error' ? 'error' : 'warning',
+      message: `${result.message}; ${conn.device_backend_unavailable_reason}`,
+      device_online: true,
+      ...(result.error_code ? {} : testErrorFields('UPSTREAM_UNAVAILABLE')),
+    };
+  }
   if (conn.device_online === true) {
     return { ...result, device_online: true };
   }

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -64,6 +64,7 @@ import {
 } from '../../utils/connection-config-redaction';
 import {
   isChromeNamespaceConnectorKey,
+  isHeadlessConnectorRuntime,
   selectedConnectorVersionArtifactSql,
 } from '../../utils/connector-execution-placement';
 import {
@@ -386,6 +387,7 @@ async function handleListFeeds(
            COALESCE(p.pinned_version, cd.version) AS connector_version,
            COALESCE(cv.manifest_backed, false) AS connector_manifest_backed,
            cv.artifact_hash AS connector_manifest_hash,
+           cv.artifact_runtime AS connector_runtime,
            ap.profile_kind AS auth_profile_kind,
            ap.status AS auth_profile_status,
            (
@@ -463,7 +465,8 @@ async function handleListFeeds(
       typeof feed.connector_version === 'string' &&
       feed.connector_version.length > 0 &&
       (feed.connector_manifest_backed === true ||
-        isChromeNamespaceConnectorKey(feed.connector_key as string))
+        isChromeNamespaceConnectorKey(feed.connector_key as string) ||
+        isHeadlessConnectorRuntime(feed.connector_runtime))
         ? [{
             ownerUserId: feed.device_owner_user_id as string | null,
             connectorKey: feed.connector_key as string,
@@ -506,6 +509,7 @@ async function handleListFeeds(
       connector_version: _connectorVersion,
       connector_manifest_backed: _connectorManifestBacked,
       connector_manifest_hash: _connectorManifestHash,
+      connector_runtime: _connectorRuntime,
       ...publicFeed
     } = feed;
     return {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -387,7 +387,7 @@ async function handleListFeeds(
            COALESCE(p.pinned_version, cd.version) AS connector_version,
            COALESCE(cv.manifest_backed, false) AS connector_manifest_backed,
            cv.artifact_hash AS connector_manifest_hash,
-           cv.artifact_runtime AS connector_runtime,
+           cd.runtime AS connector_runtime,
            ap.profile_kind AS auth_profile_kind,
            ap.status AS auth_profile_status,
            (
@@ -412,7 +412,7 @@ async function handleListFeeds(
     JOIN "organization" o ON o.id = c.organization_id
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     LEFT JOIN LATERAL (
-      SELECT name, version
+      SELECT name, version, runtime
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -83,6 +83,7 @@ import {
   runStatusLiteral,
 } from '../../utils/run-statuses';
 import {
+  describeDeviceConnectorBackendUnavailable,
   describeDeviceConnectorSetupRequired,
   findDeviceConnectorReadiness,
   loadDeviceConnectorReadiness,
@@ -513,6 +514,8 @@ async function handleListFeeds(
       attention: semantics.attention,
       ...(connectorReadiness?.state === 'setup_required'
         ? { attention_reason: describeDeviceConnectorSetupRequired(connectorReadiness) }
+        : connectorReadiness?.state === 'backend_unavailable'
+          ? { attention_reason: describeDeviceConnectorBackendUnavailable(connectorReadiness) }
         : {}),
     };
   });

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -64,7 +64,7 @@ import {
 } from '../../utils/connection-config-redaction';
 import {
   isChromeNamespaceConnectorKey,
-  isHeadlessConnectorRuntime,
+  hasHeadlessConnectorPlatform,
   selectedConnectorVersionArtifactSql,
 } from '../../utils/connector-execution-placement';
 import {
@@ -469,7 +469,7 @@ async function handleListFeeds(
       feed.connector_version.length > 0 &&
       (feed.connector_manifest_backed === true ||
         isChromeNamespaceConnectorKey(feed.connector_key as string) ||
-        isHeadlessConnectorRuntime(feed.connector_runtime))
+        hasHeadlessConnectorPlatform(feed.connector_runtime))
         ? [{
             ownerUserId: feed.device_owner_user_id as string | null,
             connectorKey: feed.connector_key as string,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -387,7 +387,10 @@ async function handleListFeeds(
            COALESCE(p.pinned_version, cd.version) AS connector_version,
            COALESCE(cv.manifest_backed, false) AS connector_manifest_backed,
            cv.artifact_hash AS connector_manifest_hash,
-           cd.runtime AS connector_runtime,
+           CASE
+             WHEN p.pinned_version IS NULL OR cd.version = p.pinned_version
+             THEN cd.runtime
+           END AS connector_runtime,
            ap.profile_kind AS auth_profile_kind,
            ap.status AS auth_profile_status,
            (

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -54,7 +54,10 @@ import { deriveBrowserActionContext } from "../../../../worker-api/browser-actio
 import { resolveRunInitiator } from "../../../initiator";
 import type { ToolContext } from "../../../registry";
 import { getOrgUrlContext } from "../../../view-urls";
-import { waitForDeviceActionRun } from "../../device-action-wait";
+import {
+	DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS,
+	waitForDeviceActionRun,
+} from "../../device-action-wait";
 import {
 	qualifiedOperationKey,
 	type ConnectionRow,
@@ -914,6 +917,9 @@ export async function handleExecute(
 			runId,
 			ctx.organizationId,
 			ctx.abortSignal,
+			connection.connector_key === "os.shell"
+				? DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS
+				: undefined,
 		);
 		await trackOperationReaction(runId);
 		if (result.status === "completed") {

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -16,6 +16,7 @@ import { getDb } from "../../../../db/client";
 import type { Env } from "../../../../index";
 import {
 	isDelegatedBrowserAffinityConnector,
+	isHeadlessConnectorRuntime,
 	isLegacyNonManifestConnector,
 } from "../../../../utils/connector-execution-placement";
 import { currentMcpActivityAttribution, currentMcpActivityEventMetadata } from "../../../../lobu/stores/mcp-client-conversations";
@@ -917,7 +918,11 @@ export async function handleExecute(
 			runId,
 			ctx.organizationId,
 			ctx.abortSignal,
-			connection.connector_key === "os.shell"
+			// Keyed on the DECLARED execution backend, never on a connector slug:
+			// the longer budget exists because a daemon-builtin action runs
+			// in-process on the device after claim, which is a property of the
+			// backend, not of any one connector.
+			isHeadlessConnectorRuntime(connection.connector_runtime)
 				? DAEMON_BUILTIN_POST_CLAIM_BUDGET_MS
 				: undefined,
 		);

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -29,6 +29,7 @@ import {
 import { buildConnectionsUrl } from "../../../../utils/url-builder";
 import {
 	describeDeviceConnectorSetupRequired,
+	describeDeviceConnectorBackendUnavailable,
 	findDeviceConnectorReadiness,
 	loadDeviceConnectorReadiness,
 	type DeviceConnectorReadiness,
@@ -119,6 +120,14 @@ function executionTargetFromRow(
 			reason: describeDeviceConnectorSetupRequired(deviceReadiness),
 		};
 	}
+	if (deviceReadiness?.state === "backend_unavailable") {
+		return {
+			...base,
+			status: "backend_unavailable",
+			executable: false,
+			reason: describeDeviceConnectorBackendUnavailable(deviceReadiness),
+		};
+	}
 	if (deviceReadiness?.state === "ready") {
 		return {
 			...base,
@@ -197,6 +206,9 @@ function operationReadinessReason(
 	}
 	if (readiness === "setup_required") {
 		return "Connector setup is incomplete on every otherwise-available device.";
+	}
+	if (readiness === "backend_unavailable") {
+		return "Every otherwise-available device is missing the connector's declared execution backend.";
 	}
 	if (readiness === "scope_upgrade_required") {
 		return "This operation needs OAuth scopes the connection has not granted. Reauthorize to grant them.";
@@ -416,7 +428,11 @@ function buildOperationNextAction(args: {
 	}
 	return {
 		action:
-			readiness === "device_offline" ? "bring_device_online" : "open_setup",
+			readiness === "device_offline"
+				? "bring_device_online"
+				: readiness === "backend_unavailable"
+					? "update_device_daemon"
+					: "open_setup",
 		manual: true,
 		...(viewUrl ? { view_url: viewUrl } : {}),
 	};

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -23,7 +23,7 @@ import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-r
 import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
 import {
 	isChromeNamespaceConnectorKey,
-	isHeadlessConnectorRuntime,
+	hasHeadlessConnectorPlatform,
 } from "../../../../utils/connector-execution-placement";
 import {
 	DEVICE_ONLINE_WINDOW_SECONDS,
@@ -707,7 +707,7 @@ export async function handleListAvailable(
 		targets: targetRows.flatMap((row) =>
 			(row.connector_manifest_backed ||
 				isChromeNamespaceConnectorKey(row.connector_key) ||
-				isHeadlessConnectorRuntime(row.connector_runtime))
+				hasHeadlessConnectorPlatform(row.connector_runtime))
 				? [{
 						ownerUserId: row.device_owner_user_id,
 						connectorKey: row.connector_key,

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -1,19 +1,16 @@
-import { ListAvailableAction, type ManageOperationsResult } from "../schemas";
+import {
+	ListAvailableAction,
+	type ManageOperationsResult,
+} from "../schemas";
 import type { Static } from "@sinclair/typebox";
 import {
 	readGrantedScopesFromAuthData,
 	readRequestedScopesFromAuthData,
 } from "../../../../auth/oauth/scopes";
-import {
-	resolveMaxAccessLevel,
-	type ToolAccessLevel,
-} from "../../../../auth/tool-access";
+import { resolveMaxAccessLevel, type ToolAccessLevel } from "../../../../auth/tool-access";
 import { resolveAutomationConnectionVisibilityUserId } from "../../../../authz/automation-connection-visibility";
 import { compileConnectionRowVisibility } from "../../../../authz/connection-visibility";
-import {
-	resolveActingPrincipal,
-	resolveWriteEffects,
-} from "../../../../authz/entity-policy";
+import { resolveActingPrincipal, resolveWriteEffects } from "../../../../authz/entity-policy";
 import { authzScopeFromToolContext } from "../../../../authz/scope";
 import { getDb } from "../../../../db/client";
 import {
@@ -23,10 +20,7 @@ import {
 } from "../../../../operations/action-modes";
 import { listOperations } from "../../../../operations/connector-operations";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
-import type {
-	AvailableOperation,
-	OperationDescriptor,
-} from "../../../../operations/types";
+import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
 import { isChromeNamespaceConnectorKey } from "../../../../utils/connector-execution-placement";
 import {
 	DEVICE_ONLINE_WINDOW_SECONDS,
@@ -148,8 +142,7 @@ function executionTargetFromRow(
 			...base,
 			status: "device_offline",
 			executable: false,
-			reason:
-				"No online device is advertising the connector's selected manifest.",
+			reason: "No online device is advertising the connector's selected manifest.",
 		};
 	}
 	if (row.device_bound && !row.device_online) {
@@ -459,14 +452,7 @@ function buildAvailableOperation(args: {
 	 */
 	callerLacksMembership: boolean;
 }): AvailableOperation & Record<string, unknown> {
-	const {
-		operation,
-		internalTargets,
-		includeInputSchema,
-		viewUrl,
-		callerMax,
-		callerLacksMembership,
-	} = args;
+	const { operation, internalTargets, includeInputSchema, viewUrl, callerMax, callerLacksMembership } = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
 	const requiredScopes = operation.required_scopes ?? [];
@@ -511,11 +497,7 @@ function buildAvailableOperation(args: {
 		operation.backend === "local_action" &&
 		(operation as OperationDescriptor).supports_execute === false;
 	const base = executeUnsupported
-		? {
-				readyTarget: undefined as ExecutionTarget | undefined,
-				executable: false,
-				readiness: "unsupported",
-			}
+		? { readyTarget: undefined as ExecutionTarget | undefined, executable: false, readiness: "unsupported" }
 		: resolveOperationReadiness(targets);
 	// Caller-awareness: readiness answers "is the TARGET ready", but the same
 	// operation must not be advertised as executable to a caller whose session
@@ -529,7 +511,8 @@ function buildAvailableOperation(args: {
 	// MEMBERSHIP (authenticated/anon non-member — routeAction denies with
 	// "requires workspace membership", not a scope message) vs. a member whose
 	// session lacks mcp:write. Emit the right remediation for each.
-	const callerBlockedByMembership = callerLacksMembership && !callerCanExecute;
+	const callerBlockedByMembership =
+		callerLacksMembership && !callerCanExecute;
 	const callerReadiness = callerBlockedByMembership
 		? "membership_required"
 		: "session_scope_required";
@@ -719,41 +702,39 @@ export async function handleListAvailable(
 	const deviceReadiness = await loadDeviceConnectorReadiness({
 		sql: getDb(),
 		targets: targetRows.flatMap((row) =>
-			row.connector_manifest_backed ||
-			isChromeNamespaceConnectorKey(row.connector_key) ||
-			(Array.isArray(row.connector_runtime?.platforms) &&
-				row.connector_runtime.platforms.includes("headless"))
-				? [
-						{
-							ownerUserId: row.device_owner_user_id,
-							connectorKey: row.connector_key,
-							connectorVersion: row.connector_version,
-							manifestHash: row.connector_manifest_hash,
-							deviceWorkerId: row.device_worker_id,
-						},
-					]
+			(row.connector_manifest_backed ||
+				isChromeNamespaceConnectorKey(row.connector_key) ||
+				(Array.isArray(row.connector_runtime?.platforms) &&
+					row.connector_runtime.platforms.includes("headless")))
+				? [{
+						ownerUserId: row.device_owner_user_id,
+						connectorKey: row.connector_key,
+						connectorVersion: row.connector_version,
+						manifestHash: row.connector_manifest_hash,
+						deviceWorkerId: row.device_worker_id,
+					}]
 				: [],
 		),
 	});
 	const targetsByConnector = groupExecutionTargets(targetRows, deviceReadiness);
 
-	// A `disabled` connector_action effect turns an operation OFF for this principal
-	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-	// can disable a single op while the rest stay listed.
-	const actor = await resolveActingPrincipal(getDb(), {
-		organizationId: ctx.organizationId,
-		userId: ctx.userId,
-		agentId: ctx.agentId,
-		sessionAutomationId: ctx.actingAutomationId ?? null,
-	});
-	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-	// its hidden count from the global total gives an inconsistent `total` across pages
-	// and can return a short page while visible ops remain past the offset (a client
-	// treating "short page = end" would silently truncate the catalog). Pagination must
-	// run on the post-filter list.
+  // A `disabled` connector_action effect turns an operation OFF for this principal
+  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+  // can disable a single op while the rest stay listed.
+  const actor = await resolveActingPrincipal(getDb(), {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionAutomationId: ctx.actingAutomationId ?? null,
+  });
+  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+  // its hidden count from the global total gives an inconsistent `total` across pages
+  // and can return a short page while visible ops remain past the offset (a client
+  // treating "short page = end" would silently truncate the catalog). Pagination must
+  // run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -763,25 +744,25 @@ export async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-	const full = await listOperations({
-		organizationId: ctx.organizationId,
+  const full = await listOperations({
+    organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
 		connectionId: args.connection_id,
-		entityId: args.entity_id,
-		kind: args.kind,
-		backend: args.backend,
+    entityId: args.entity_id,
+    kind: args.kind,
+    backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-		includeOutputSchema: args.include_output_schema ?? false,
+    includeOutputSchema: args.include_output_schema ?? false,
 		includeDisabled: true,
-		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-		// would silently drop ops past index 100 and make them unreachable at any
-		// caller offset. We must filter per-op-disabled across the full set BEFORE
-		// slicing, so no internal cap here; the caller's limit/offset apply below.
-		limit: Number.MAX_SAFE_INTEGER,
-		offset: 0,
-	});
+    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+    // would silently drop ops past index 100 and make them unreachable at any
+    // caller offset. We must filter per-op-disabled across the full set BEFORE
+    // slicing, so no internal cap here; the caller's limit/offset apply below.
+    limit: Number.MAX_SAFE_INTEGER,
+    offset: 0,
+  });
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -799,20 +780,20 @@ export async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-	// filtered by agent write-policy. Humans always resolve auto for policy.
+  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+  // filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-		if (op.kind === "read") return "auto" as const;
-		if (blanketDisabled) return "disabled" as const;
-		return (
-			policyEffects.get(
-				qualifiedOperationKey(op.connector_key, op.operation_key),
-			) ?? "auto"
-		);
-	});
+			if (op.kind === "read") return "auto" as const;
+			if (blanketDisabled) return "disabled" as const;
+			return (
+				policyEffects.get(
+					qualifiedOperationKey(op.connector_key, op.operation_key),
+				) ?? "auto"
+  );
+		});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-	);
+  );
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -854,13 +835,13 @@ export async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-	const offset = args.offset ?? 0;
+  const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-	return {
+  return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-		limit,
-		offset,
-	};
+    limit,
+    offset,
+  };
 }

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -1,16 +1,19 @@
-import {
-	ListAvailableAction,
-	type ManageOperationsResult,
-} from "../schemas";
+import { ListAvailableAction, type ManageOperationsResult } from "../schemas";
 import type { Static } from "@sinclair/typebox";
 import {
 	readGrantedScopesFromAuthData,
 	readRequestedScopesFromAuthData,
 } from "../../../../auth/oauth/scopes";
-import { resolveMaxAccessLevel, type ToolAccessLevel } from "../../../../auth/tool-access";
+import {
+	resolveMaxAccessLevel,
+	type ToolAccessLevel,
+} from "../../../../auth/tool-access";
 import { resolveAutomationConnectionVisibilityUserId } from "../../../../authz/automation-connection-visibility";
 import { compileConnectionRowVisibility } from "../../../../authz/connection-visibility";
-import { resolveActingPrincipal, resolveWriteEffects } from "../../../../authz/entity-policy";
+import {
+	resolveActingPrincipal,
+	resolveWriteEffects,
+} from "../../../../authz/entity-policy";
 import { authzScopeFromToolContext } from "../../../../authz/scope";
 import { getDb } from "../../../../db/client";
 import {
@@ -20,7 +23,10 @@ import {
 } from "../../../../operations/action-modes";
 import { listOperations } from "../../../../operations/connector-operations";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
-import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
+import type {
+	AvailableOperation,
+	OperationDescriptor,
+} from "../../../../operations/types";
 import { isChromeNamespaceConnectorKey } from "../../../../utils/connector-execution-placement";
 import {
 	DEVICE_ONLINE_WINDOW_SECONDS,
@@ -73,6 +79,7 @@ type OperationTargetRow = {
 	connector_version: string | null;
 	connector_manifest_backed: boolean;
 	connector_manifest_hash: string | null;
+	connector_runtime: Record<string, unknown> | null;
 	auth_profile_kind: string | null;
 	auth_profile_slug: string | null;
 	auth_data: Record<string, unknown> | null;
@@ -141,7 +148,8 @@ function executionTargetFromRow(
 			...base,
 			status: "device_offline",
 			executable: false,
-			reason: "No online device is advertising the connector's selected manifest.",
+			reason:
+				"No online device is advertising the connector's selected manifest.",
 		};
 	}
 	if (row.device_bound && !row.device_online) {
@@ -451,7 +459,14 @@ function buildAvailableOperation(args: {
 	 */
 	callerLacksMembership: boolean;
 }): AvailableOperation & Record<string, unknown> {
-	const { operation, internalTargets, includeInputSchema, viewUrl, callerMax, callerLacksMembership } = args;
+	const {
+		operation,
+		internalTargets,
+		includeInputSchema,
+		viewUrl,
+		callerMax,
+		callerLacksMembership,
+	} = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
 	const requiredScopes = operation.required_scopes ?? [];
@@ -496,7 +511,11 @@ function buildAvailableOperation(args: {
 		operation.backend === "local_action" &&
 		(operation as OperationDescriptor).supports_execute === false;
 	const base = executeUnsupported
-		? { readyTarget: undefined as ExecutionTarget | undefined, executable: false, readiness: "unsupported" }
+		? {
+				readyTarget: undefined as ExecutionTarget | undefined,
+				executable: false,
+				readiness: "unsupported",
+			}
 		: resolveOperationReadiness(targets);
 	// Caller-awareness: readiness answers "is the TARGET ready", but the same
 	// operation must not be advertised as executable to a caller whose session
@@ -510,8 +529,7 @@ function buildAvailableOperation(args: {
 	// MEMBERSHIP (authenticated/anon non-member — routeAction denies with
 	// "requires workspace membership", not a scope message) vs. a member whose
 	// session lacks mcp:write. Emit the right remediation for each.
-	const callerBlockedByMembership =
-		callerLacksMembership && !callerCanExecute;
+	const callerBlockedByMembership = callerLacksMembership && !callerCanExecute;
 	const callerReadiness = callerBlockedByMembership
 		? "membership_required"
 		: "session_scope_required";
@@ -601,7 +619,8 @@ async function loadVisibleOperationTargets(
 		        c.config,
 		        c.device_worker_id,
 		        COALESCE(dw.user_id, (o.metadata::jsonb)->>'personal_org_for_user_id') AS device_owner_user_id,
-		        latest.version AS connector_version,
+		       latest.version AS connector_version,
+		       latest.runtime AS connector_runtime,
 		        COALESCE(latest.manifest_backed, false) AS connector_manifest_backed,
 		        latest.artifact_hash AS connector_manifest_hash,
 		        ap.profile_kind AS auth_profile_kind,
@@ -700,36 +719,41 @@ export async function handleListAvailable(
 	const deviceReadiness = await loadDeviceConnectorReadiness({
 		sql: getDb(),
 		targets: targetRows.flatMap((row) =>
-			row.connector_manifest_backed || isChromeNamespaceConnectorKey(row.connector_key)
-				? [{
-						ownerUserId: row.device_owner_user_id,
-						connectorKey: row.connector_key,
-						connectorVersion: row.connector_version,
-						manifestHash: row.connector_manifest_hash,
-						deviceWorkerId: row.device_worker_id,
-					}]
+			row.connector_manifest_backed ||
+			isChromeNamespaceConnectorKey(row.connector_key) ||
+			(Array.isArray(row.connector_runtime?.platforms) &&
+				row.connector_runtime.platforms.includes("headless"))
+				? [
+						{
+							ownerUserId: row.device_owner_user_id,
+							connectorKey: row.connector_key,
+							connectorVersion: row.connector_version,
+							manifestHash: row.connector_manifest_hash,
+							deviceWorkerId: row.device_worker_id,
+						},
+					]
 				: [],
 		),
 	});
 	const targetsByConnector = groupExecutionTargets(targetRows, deviceReadiness);
 
-  // A `disabled` connector_action effect turns an operation OFF for this principal
-  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-  // can disable a single op while the rest stay listed.
-  const actor = await resolveActingPrincipal(getDb(), {
-    organizationId: ctx.organizationId,
-    userId: ctx.userId,
-    agentId: ctx.agentId,
-    sessionAutomationId: ctx.actingAutomationId ?? null,
-  });
-  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-  // its hidden count from the global total gives an inconsistent `total` across pages
-  // and can return a short page while visible ops remain past the offset (a client
-  // treating "short page = end" would silently truncate the catalog). Pagination must
-  // run on the post-filter list.
+	// A `disabled` connector_action effect turns an operation OFF for this principal
+	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+	// can disable a single op while the rest stay listed.
+	const actor = await resolveActingPrincipal(getDb(), {
+		organizationId: ctx.organizationId,
+		userId: ctx.userId,
+		agentId: ctx.agentId,
+		sessionAutomationId: ctx.actingAutomationId ?? null,
+	});
+	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+	// its hidden count from the global total gives an inconsistent `total` across pages
+	// and can return a short page while visible ops remain past the offset (a client
+	// treating "short page = end" would silently truncate the catalog). Pagination must
+	// run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -739,25 +763,25 @@ export async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-  const full = await listOperations({
-    organizationId: ctx.organizationId,
+	const full = await listOperations({
+		organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
 		connectionId: args.connection_id,
-    entityId: args.entity_id,
-    kind: args.kind,
-    backend: args.backend,
+		entityId: args.entity_id,
+		kind: args.kind,
+		backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-    includeOutputSchema: args.include_output_schema ?? false,
+		includeOutputSchema: args.include_output_schema ?? false,
 		includeDisabled: true,
-    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-    // would silently drop ops past index 100 and make them unreachable at any
-    // caller offset. We must filter per-op-disabled across the full set BEFORE
-    // slicing, so no internal cap here; the caller's limit/offset apply below.
-    limit: Number.MAX_SAFE_INTEGER,
-    offset: 0,
-  });
+		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+		// would silently drop ops past index 100 and make them unreachable at any
+		// caller offset. We must filter per-op-disabled across the full set BEFORE
+		// slicing, so no internal cap here; the caller's limit/offset apply below.
+		limit: Number.MAX_SAFE_INTEGER,
+		offset: 0,
+	});
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -775,20 +799,20 @@ export async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-  // filtered by agent write-policy. Humans always resolve auto for policy.
+	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+	// filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-			if (op.kind === "read") return "auto" as const;
-			if (blanketDisabled) return "disabled" as const;
-			return (
-				policyEffects.get(
-					qualifiedOperationKey(op.connector_key, op.operation_key),
-				) ?? "auto"
-  );
-		});
+		if (op.kind === "read") return "auto" as const;
+		if (blanketDisabled) return "disabled" as const;
+		return (
+			policyEffects.get(
+				qualifiedOperationKey(op.connector_key, op.operation_key),
+			) ?? "auto"
+		);
+	});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-  );
+	);
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -830,13 +854,13 @@ export async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-  const offset = args.offset ?? 0;
+	const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-  return {
+	return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-    limit,
-    offset,
-  };
+		limit,
+		offset,
+	};
 }

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -21,7 +21,10 @@ import {
 import { listOperations } from "../../../../operations/connector-operations";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
-import { isChromeNamespaceConnectorKey } from "../../../../utils/connector-execution-placement";
+import {
+	isChromeNamespaceConnectorKey,
+	isHeadlessConnectorRuntime,
+} from "../../../../utils/connector-execution-placement";
 import {
 	DEVICE_ONLINE_WINDOW_SECONDS,
 	describeDeviceLastSeen,
@@ -704,8 +707,7 @@ export async function handleListAvailable(
 		targets: targetRows.flatMap((row) =>
 			(row.connector_manifest_backed ||
 				isChromeNamespaceConnectorKey(row.connector_key) ||
-				(Array.isArray(row.connector_runtime?.platforms) &&
-					row.connector_runtime.platforms.includes("headless")))
+				isHeadlessConnectorRuntime(row.connector_runtime))
 				? [{
 						ownerUserId: row.device_owner_user_id,
 						connectorKey: row.connector_key,

--- a/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
+++ b/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
@@ -103,10 +103,13 @@ describe('selected connector execution backend', () => {
     })).toEqual({ manifestBacked: false });
   });
 
-  test('active exact non-bridge definition wins over retained bridge authorization', () => {
+  test('active exact unsupported definition wins over retained bridge authorization', () => {
     expect(classify({
       definition: { ...definition, runtime: { platforms: ['macos'], execution: 'compiled' } },
-    })).toEqual({ manifestBacked: true, inconsistency: 'active exact definition is not bridge execution' });
+    })).toEqual({
+      manifestBacked: true,
+      inconsistency: 'active exact definition declares an unsupported execution backend',
+    });
   });
 
   test('rejects a bridge artifact that is not authorized by the claiming device', () => {
@@ -162,6 +165,8 @@ describe('device manifests served by connector-worker rather than a bridge', () 
     key: headless.key,
     version: headless.version,
     name: headless.name,
+    description: headless.description,
+    faviconDomain: headless.favicon_domain,
     requiredCapability: headless.required_capability,
     runtime: headless.runtime,
     authSchema: headless.auth_schema,
@@ -189,21 +194,26 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         connectorVersion: headless.version,
         manifestHash: headlessHash,
         sourcePath: headlessSourcePath,
+        runtimeExecution: 'daemon_builtin',
       }],
       expectedPlatform: 'headless',
       ...overrides,
     });
   }
 
-  test('the shipped headless os.shell manifest declares no bridge execution', () => {
-    expect(headless.runtime).not.toHaveProperty('execution');
+  test('the shipped headless os.shell manifest declares daemon-owned execution', () => {
+    expect(headless.runtime.execution).toBe('daemon_builtin');
   });
 
-  test('classifies headless os.shell as manifest-backed but not native_bridge', () => {
-    expect(classifyHeadless()).toEqual({ manifestBacked: true });
+  test('classifies headless os.shell as an attested daemon built-in', () => {
+    expect(classifyHeadless()).toEqual({
+      manifestBacked: true,
+      backend: 'daemon_builtin',
+      manifestHash: headlessHash,
+    });
   });
 
-  test('stays non-bridge even when the device authorization claims bridge execution', () => {
+  test('rejects an authorization that claims a different backend', () => {
     expect(classifyHeadless({
       authorizations: [{
         connectorKey: headless.key,
@@ -212,7 +222,7 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         sourcePath: headlessSourcePath,
         runtimeExecution: 'bridge',
       }],
-    })).toEqual({ manifestBacked: true });
+    }).inconsistency).toContain('different execution backend');
   });
 });
 
@@ -221,13 +231,13 @@ describe('deviceExecutesConnectorNatively', () => {
     isUserScopedWorker: true,
     hasStoredCompiledCode: false,
     gatewayHasLocalSource: true,
-    isNativeBridgeRun: false,
+    isDeviceOwnedRun: false,
     manifestBacked: false,
     deviceAdvertisesRequiredCapability: false,
   };
 
   test('a native-bridge run needs no bundle', () => {
-    expect(deviceExecutesConnectorNatively({ ...base, isNativeBridgeRun: true })).toBe(true);
+    expect(deviceExecutesConnectorNatively({ ...base, isDeviceOwnedRun: true })).toBe(true);
   });
 
   test('manifest-backed alone does not mean native execution', () => {
@@ -280,7 +290,7 @@ describe('deviceExecutesConnectorNatively', () => {
     expect(
       deviceExecutesConnectorNatively({
         ...base,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
         hasStoredCompiledCode: true,
       })
     ).toBe(false);
@@ -291,7 +301,7 @@ describe('deviceExecutesConnectorNatively', () => {
       deviceExecutesConnectorNatively({
         ...base,
         isUserScopedWorker: false,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
       })
     ).toBe(false);
   });

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -31,8 +31,10 @@ export interface ConnectorMetadata {
   openapiConfig?: Record<string, unknown> | null;
   requiredCapability?: string | null;
   runtime?: {
-    platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-    execution?: 'bridge';
+    platforms: Array<
+      'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'
+    >;
+    execution?: 'bridge' | 'daemon_builtin';
     scopes?: string[];
   } | null;
   /**

--- a/packages/server/src/utils/connector-execution-backend.ts
+++ b/packages/server/src/utils/connector-execution-backend.ts
@@ -1,6 +1,7 @@
 import { deviceManifestHash, type DeviceConnectorManifest } from '@lobu/connector-sdk';
+import type { ExecutionBackend } from '@lobu/core/contracts/worker/protocol';
 
-export type SelectedConnectorExecutionBackend = 'native_bridge';
+export type SelectedConnectorExecutionBackend = ExecutionBackend;
 
 export interface SelectedConnectorArtifact {
   sourcePath: string | null | undefined;
@@ -41,9 +42,10 @@ export interface SelectedConnectorExecution {
 }
 
 /**
- * Classify the exact artifact selected by the poll query. A bridge marker is
- * emitted only when the selected artifact is hash-attested by this device and
- * its canonical definition is bridge-owned. The artifact source path is part
+ * Classify the exact artifact selected by the poll query. A device-owned
+ * backend marker is emitted only when the selected artifact is hash-attested
+ * by this device and its canonical definition declares that backend. The
+ * artifact source path is part
  * of the authorization, so an organization override cannot silently replace a
  * shared bridge artifact with compiled code or another device's manifest.
  */
@@ -57,7 +59,11 @@ export function classifySelectedConnectorExecution(params: {
 }): SelectedConnectorExecution {
   const manifestBacked = isManifestArtifact(params.artifact);
   const definitionRuntime = asRecord(params.definition?.runtime);
-  const definitionBridge = definitionRuntime?.execution === 'bridge';
+  const definitionExecution = definitionRuntime?.execution;
+  const definitionDeviceExecution =
+    definitionExecution === 'bridge' || definitionExecution === 'daemon_builtin'
+      ? definitionExecution
+      : undefined;
   const definitionExecutionDeclared =
     definitionRuntime !== null && Object.hasOwn(definitionRuntime, 'execution');
   const authorization = params.authorizations.find(
@@ -67,34 +73,37 @@ export function classifySelectedConnectorExecution(params: {
       entry.manifestHash === params.artifact.manifestHash &&
       entry.sourcePath === params.artifact.sourcePath,
   );
-  const authorizedBridge = authorization?.runtimeExecution === 'bridge';
+  const authorizedDeviceExecution = authorization?.runtimeExecution;
   // An active exact definition is authoritative. Retained authorization may
   // only select a historical pinned version when no exact definition exists.
   // Legacy metadata-only definitions remain ordinary manifest-backed device
-  // work; an explicit non-bridge execution value is a contradictory artifact
+  // work; an explicit unsupported execution value is a contradictory artifact
   // selection and must terminalize the already-claimed run.
-  if (params.definition && !definitionBridge) {
+  if (params.definition && !definitionDeviceExecution) {
     return manifestBacked && definitionExecutionDeclared
       ? {
           manifestBacked,
-          inconsistency: 'active exact definition is not bridge execution',
+          inconsistency: 'active exact definition declares an unsupported execution backend',
         }
       : { manifestBacked };
   }
-  const bridgeCandidate = definitionBridge || authorizedBridge;
+  const deviceExecution = definitionDeviceExecution ?? authorizedDeviceExecution;
 
-  if (!bridgeCandidate) return { manifestBacked };
+  if (!deviceExecution) return { manifestBacked };
   if (!params.definition && !authorization) {
-    return { manifestBacked, inconsistency: 'bridge artifact has no canonical definition or manifest authorization' };
+    return { manifestBacked, inconsistency: 'device-owned artifact has no canonical definition or manifest authorization' };
   }
   if (!manifestBacked) {
-    return { manifestBacked, inconsistency: 'bridge-marked definition selected a non-manifest artifact' };
+    return { manifestBacked, inconsistency: 'device-owned definition selected a non-manifest artifact' };
   }
   if (params.artifact.compiledCode || params.artifact.compileConfigHash || params.artifact.hasSourceCode) {
-    return { manifestBacked, inconsistency: 'bridge-marked artifact contains compiled or source code' };
+    return { manifestBacked, inconsistency: 'device-owned artifact contains compiled or source code' };
   }
   if (!authorization) {
-    return { manifestBacked, inconsistency: 'selected bridge artifact is not authorized by the claiming device' };
+    return { manifestBacked, inconsistency: 'selected device-owned artifact is not authorized by the claiming device' };
+  }
+  if (authorization.runtimeExecution !== deviceExecution) {
+    return { manifestBacked, inconsistency: 'claiming device advertised a different execution backend' };
   }
   const parsedSource = parseManifestSourcePath(params.artifact.sourcePath);
   if (!parsedSource) {
@@ -123,7 +132,7 @@ export function classifySelectedConnectorExecution(params: {
   // historical pinned version, the validated device manifest is the canonical
   // definition retained by the authorization and the same hash check has
   // already happened during manifest reconciliation.
-  if (params.definition && definitionBridge) {
+  if (params.definition && definitionDeviceExecution) {
     const hashes = definitionManifestHashes(params.definition, definitionRuntime!);
     if (
       !hashes.has(params.artifact.manifestHash) &&
@@ -134,7 +143,11 @@ export function classifySelectedConnectorExecution(params: {
     }
   }
 
-  return { manifestBacked, backend: 'native_bridge', manifestHash: params.artifact.manifestHash };
+  return {
+    manifestBacked,
+    backend: deviceExecution === 'bridge' ? 'native_bridge' : 'daemon_builtin',
+    manifestHash: params.artifact.manifestHash,
+  };
 }
 
 /**
@@ -151,14 +164,14 @@ export function deviceExecutesConnectorNatively(params: {
   isUserScopedWorker: boolean;
   hasStoredCompiledCode: boolean;
   gatewayHasLocalSource: boolean;
-  isNativeBridgeRun: boolean;
+  isDeviceOwnedRun: boolean;
   manifestBacked: boolean;
   deviceAdvertisesRequiredCapability: boolean;
 }): boolean {
   return (
     params.isUserScopedWorker &&
     !params.hasStoredCompiledCode &&
-    (params.isNativeBridgeRun ||
+    (params.isDeviceOwnedRun ||
       (!params.gatewayHasLocalSource &&
         (params.manifestBacked || params.deviceAdvertisesRequiredCapability)))
   );

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -40,12 +40,13 @@ export function isChromeNamespaceConnectorKey(connectorKey: string): boolean {
 
 export function isHeadlessConnectorRuntime(
   runtime: unknown,
-): runtime is { platforms: string[] } {
+): runtime is { platforms: string[]; execution: 'daemon_builtin' } {
   return (
     typeof runtime === 'object' &&
     runtime !== null &&
     Array.isArray((runtime as { platforms?: unknown }).platforms) &&
-    (runtime as { platforms: unknown[] }).platforms.includes('headless')
+    (runtime as { platforms: unknown[] }).platforms.includes('headless') &&
+    (runtime as { execution?: unknown }).execution === 'daemon_builtin'
   );
 }
 

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -38,6 +38,17 @@ export function isChromeNamespaceConnectorKey(connectorKey: string): boolean {
   return connectorKey === 'chrome' || connectorKey.startsWith('chrome.');
 }
 
+export function isHeadlessConnectorRuntime(
+  runtime: unknown,
+): runtime is { platforms: string[] } {
+  return (
+    typeof runtime === 'object' &&
+    runtime !== null &&
+    Array.isArray((runtime as { platforms?: unknown }).platforms) &&
+    (runtime as { platforms: unknown[] }).platforms.includes('headless')
+  );
+}
+
 export function isLegacyNonManifestConnector(facts: {
   connectorKey: string;
   manifestBacked: boolean;
@@ -158,6 +169,7 @@ export function selectedConnectorVersionArtifactSql<TFragment>(
         AND cv.source_code IS NULL
       ) AS manifest_backed,
       cv.compiled_code_hash AS artifact_hash,
+      cv.runtime AS artifact_runtime,
       cv.source_path AS artifact_source_path,
       cv.compiled_code AS artifact_compiled_code,
       cv.compile_config_hash AS artifact_compile_config_hash,

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -50,6 +50,17 @@ export function isHeadlessConnectorRuntime(
   );
 }
 
+export function hasHeadlessConnectorPlatform(
+  runtime: unknown,
+): runtime is { platforms: string[] } {
+  return (
+    typeof runtime === 'object' &&
+    runtime !== null &&
+    Array.isArray((runtime as { platforms?: unknown }).platforms) &&
+    (runtime as { platforms: unknown[] }).platforms.includes('headless')
+  );
+}
+
 export function isLegacyNonManifestConnector(facts: {
   connectorKey: string;
   manifestBacked: boolean;

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -170,7 +170,6 @@ export function selectedConnectorVersionArtifactSql<TFragment>(
         AND cv.source_code IS NULL
       ) AS manifest_backed,
       cv.compiled_code_hash AS artifact_hash,
-      cv.runtime AS artifact_runtime,
       cv.source_path AS artifact_source_path,
       cv.compiled_code AS artifact_compiled_code,
       cv.compile_config_hash AS artifact_compile_config_hash,

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -24,7 +24,7 @@ export interface ConnectorClaimContext {
   baseOrgScopeIds: string[];
   workerHardensDbEgress: boolean;
   /** Capacity advertised for each execution backend by this worker. */
-  backendCapacity: Record<string, number>;
+  backendCapacity?: Record<string, number>;
 }
 
 interface ConnectorClaimLaneRefs {
@@ -118,7 +118,7 @@ export function connectorClaimLaneSql(
   // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
   // any claim lane unless that backend was explicitly advertised as ready.
   const compiledBackendReady =
-    (context.backendCapacity.compiled_connector ?? 0) > 0;
+    (context.backendCapacity?.compiled_connector ?? 0) > 0;
 
   return sql`
     (

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -5,6 +5,7 @@ import { DB_EGRESS_HARDENED_CONNECTOR_KEYS } from '../utils/connector-cloud-gate
 import {
   delegatedBrowserAffinitySql,
   legacyNonManifestConnectorSql,
+  nativeChromeExtensionConnectorSql,
 } from '../utils/connector-execution-placement';
 import type { ManifestClaimAuthorization } from './device-manifests';
 
@@ -117,17 +118,6 @@ export function connectorClaimLaneSql(
         AND auth_item->>'runtimeExecution' = 'daemon_builtin'
     )
   `;
-  const exactNativeBridgeAuthorization = sql`
-    EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(${sql.json(context.manifestClaimAuthorizations)}::jsonb) auth_item
-      WHERE auth_item->>'connectorKey' = ${refs.connectorKey}
-        AND auth_item->>'connectorVersion' = ${refs.connectorVersion}
-        AND auth_item->>'manifestHash' = ${refs.runManifestHash}
-        AND auth_item->>'sourcePath' = ${refs.runArtifactSourcePath}
-        AND auth_item->>'runtimeExecution' = 'bridge'
-    )
-  `;
   const delegatedBrowserAffinity = delegatedBrowserAffinitySql(sql, {
     platform: refs.pinPlatform,
     connectorKey: refs.connectorKey,
@@ -146,37 +136,41 @@ export function connectorClaimLaneSql(
   });
   // A worker may be able to run the daemon-owned backend while its connector
   // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
-  // any claim lane unless that backend was explicitly advertised as ready.
+  // any claim lane unless that backend was advertised as ready — explicitly
+  // via backend_capacity, or via the poll default in worker-api/poll.ts
+  // (absence of an advertisement means the worker declares no backend
+  // restriction; headless must advertise because its compiler/SDK runtime may
+  // be unavailable).
   const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
   const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
   // Keep this guard outside the individual lanes: every lane must advertise
-  // the backend that the selected artifact actually needs. Historical
-  // manifest artifacts have no run_runtime, so daemon_builtin is derived only
-  // from the exact retained authorization above; unknown headless artifacts
-  // therefore fail closed.
+  // the backend that the selected artifact actually needs. Native
+  // chrome-namespace executions run inside the advertising extension and need
+  // no server-side backend at all. A manifest-backed artifact likewise needs
+  // no server-side backend by itself — the device executes the manifest it
+  // advertised — so only a daemon_builtin execution is backend-restricted
+  // here, and an exact advertisement of that manifest attests the daemon
+  // backend on its own (a headless manifest cannot even validate without
+  // runtime.execution='daemon_builtin'; bridge executions run natively in the
+  // advertising extension).
   const selectedBackendReady = sql`
     (
-      (
+      ${nativeChromeExtensionConnectorSql(sql, {
+        connectorKey: refs.connectorKey,
+        connectorVersion: refs.connectorVersion,
+        manifestBacked: refs.runManifestBacked,
+        artifactSourcePath: refs.runArtifactSourcePath,
+      })}
+      OR (
         NOT COALESCE(${refs.runManifestBacked}, false)
         AND ${compiledBackendReady}
       )
       OR (
         COALESCE(${refs.runManifestBacked}, false)
         AND (
-          (
-            ${refs.runRuntime}->>'execution' = 'daemon_builtin'
-            AND ${daemonBuiltinReady}
-          )
-          OR ${refs.runRuntime}->>'execution' = 'bridge'
-          OR (
-            ${refs.runRuntime} IS NULL
-            AND (${exactDaemonBuiltinAuthorization})
-            AND ${daemonBuiltinReady}
-          )
-          OR (
-            ${refs.runRuntime} IS NULL
-            AND (${exactNativeBridgeAuthorization})
-          )
+          COALESCE(${refs.runRuntime}->>'execution', '') <> 'daemon_builtin'
+          OR ${daemonBuiltinReady}
+          OR (${exactDaemonBuiltinAuthorization})
         )
       )
     )

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -166,7 +166,11 @@ export function connectorClaimLaneSql(
           ${refs.runRuntime}->>'execution' = 'daemon_builtin'
           AND ${daemonBuiltinReady}
           OR ${refs.runRuntime}->>'execution' = 'bridge'
-          OR (${refs.runRuntime} IS NULL AND (${exactDaemonBuiltinAuthorization}))
+          OR (
+            ${refs.runRuntime} IS NULL
+            AND (${exactDaemonBuiltinAuthorization})
+            AND ${daemonBuiltinReady}
+          )
           OR (${refs.runRuntime} IS NULL AND (${exactNativeBridgeAuthorization}))
         )
       )

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -136,42 +136,42 @@ export function connectorClaimLaneSql(
   });
   // A worker may be able to run the daemon-owned backend while its connector
   // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
-  // any claim lane unless that backend was advertised as ready — explicitly
-  // via backend_capacity, or via the poll default in worker-api/poll.ts
-  // (absence of an advertisement means the worker declares no backend
-  // restriction; headless must advertise because its compiler/SDK runtime may
-  // be unavailable).
+  // any claim lane unless that backend was explicitly advertised as ready.
   const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
   const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
+  // A chrome-namespace execution runs inside the advertising extension, so it
+  // needs no server-side backend at all. The helper is narrow by construction:
+  // a reserved chrome key, or a legacy key only while the selected artifact is
+  // exactly its validated Chrome manifest.
+  const nativeChromeExecution = nativeChromeExtensionConnectorSql(sql, {
+    connectorKey: refs.connectorKey,
+    connectorVersion: refs.connectorVersion,
+    manifestBacked: refs.runManifestBacked,
+    artifactSourcePath: refs.runArtifactSourcePath,
+  });
   // Keep this guard outside the individual lanes: every lane must advertise
-  // the backend that the selected artifact actually needs. Native
-  // chrome-namespace executions run inside the advertising extension and need
-  // no server-side backend at all. A manifest-backed artifact likewise needs
-  // no server-side backend by itself — the device executes the manifest it
-  // advertised — so only a daemon_builtin execution is backend-restricted
-  // here, and an exact advertisement of that manifest attests the daemon
-  // backend on its own (a headless manifest cannot even validate without
-  // runtime.execution='daemon_builtin'; bridge executions run natively in the
-  // advertising extension).
+  // the backend that the selected artifact actually needs. A manifest-backed
+  // artifact executes on the device that advertised the manifest, so the only
+  // server-side backend it can need is the daemon-owned one. Historical
+  // manifest artifacts carry no run_runtime, so daemon_builtin is derived from
+  // the exact retained authorization; an unrecognised execution kind fails
+  // closed rather than inheriting the unrestricted branch.
   const selectedBackendReady = sql`
     (
-      ${nativeChromeExtensionConnectorSql(sql, {
-        connectorKey: refs.connectorKey,
-        connectorVersion: refs.connectorVersion,
-        manifestBacked: refs.runManifestBacked,
-        artifactSourcePath: refs.runArtifactSourcePath,
-      })}
+      ${nativeChromeExecution}
       OR (
         NOT COALESCE(${refs.runManifestBacked}, false)
         AND ${compiledBackendReady}
       )
       OR (
         COALESCE(${refs.runManifestBacked}, false)
-        AND (
-          COALESCE(${refs.runRuntime}->>'execution', '') <> 'daemon_builtin'
-          OR ${daemonBuiltinReady}
-          OR (${exactDaemonBuiltinAuthorization})
-        )
+        AND CASE
+          WHEN ${refs.runRuntime}->>'execution' = 'daemon_builtin' THEN ${daemonBuiltinReady}
+          WHEN ${refs.runRuntime}->>'execution' = 'bridge' THEN true
+          WHEN ${refs.runRuntime}->>'execution' IS NULL
+            THEN NOT (${exactDaemonBuiltinAuthorization}) OR ${daemonBuiltinReady}
+          ELSE false
+        END
       )
     )
   `;

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -23,6 +23,8 @@ export interface ConnectorClaimContext {
   orgScopeIds: string[];
   baseOrgScopeIds: string[];
   workerHardensDbEgress: boolean;
+  /** Capacity advertised for each execution backend by this worker. */
+  backendCapacity: Record<string, number>;
 }
 
 interface ConnectorClaimLaneRefs {
@@ -112,9 +114,19 @@ export function connectorClaimLaneSql(
     manifestBacked: refs.runManifestBacked,
     artifactCompiledCode: refs.runArtifactCompiledCode,
   });
+  // A worker may be able to run the daemon-owned backend while its connector
+  // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
+  // any claim lane unless that backend was explicitly advertised as ready.
+  const compiledBackendReady =
+    (context.backendCapacity.compiled_connector ?? 0) > 0;
 
   return sql`
     (
+      (
+        COALESCE(${refs.runManifestBacked}, false)
+        OR ${compiledBackendReady}
+      )
+      AND
       -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
       -- their exact device; browser-affinity parent runs stay on fleet.
       (

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -96,7 +96,7 @@ export function connectorClaimLaneSql(
       NOT COALESCE(${refs.runManifestBacked}, false)
       OR ${refs.runRuntime} IS NOT NULL
     )
-    AND ${context.workerPlatform ?? ''}::text <> 'chrome-extension'
+    AND ${context.workerPlatform ?? ''}::text NOT IN ('headless', 'chrome-extension')
     AND COALESCE(
       ${refs.runRuntime}->'platforms' ? ${context.workerPlatform ?? ''}::text,
       false
@@ -163,15 +163,20 @@ export function connectorClaimLaneSql(
       OR (
         COALESCE(${refs.runManifestBacked}, false)
         AND (
-          ${refs.runRuntime}->>'execution' = 'daemon_builtin'
-          AND ${daemonBuiltinReady}
+          (
+            ${refs.runRuntime}->>'execution' = 'daemon_builtin'
+            AND ${daemonBuiltinReady}
+          )
           OR ${refs.runRuntime}->>'execution' = 'bridge'
           OR (
             ${refs.runRuntime} IS NULL
             AND (${exactDaemonBuiltinAuthorization})
             AND ${daemonBuiltinReady}
           )
-          OR (${refs.runRuntime} IS NULL AND (${exactNativeBridgeAuthorization}))
+          OR (
+            ${refs.runRuntime} IS NULL
+            AND (${exactNativeBridgeAuthorization})
+          )
         )
       )
     )
@@ -180,10 +185,10 @@ export function connectorClaimLaneSql(
   return sql`
     (
       ${selectedBackendReady}
-      AND
-      -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
-      -- their exact device; browser-affinity parent runs stay on fleet.
-      (
+      AND (
+        -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
+        -- their exact device; browser-affinity parent runs stay on fleet.
+        (
         ${!context.isUserScopedWorker}
         AND (
           COALESCE(${refs.runRequiredCapability}, '') = ANY(
@@ -213,10 +218,10 @@ export function connectorClaimLaneSql(
             ${delegatedBrowserAffinity}
           )
         )
-      )
-      -- User-scoped worker claiming an unpinned capability connector in its
-      -- base org scope. Page-activated work is handled by the fleet parent.
-      OR (
+        )
+        -- User-scoped worker claiming an unpinned capability connector in its
+        -- base org scope. Page-activated work is handled by the fleet parent.
+        OR (
         ${context.isUserScopedWorker}
         AND ${refs.connectionDeviceWorkerId} IS NULL
         AND (
@@ -235,11 +240,11 @@ export function connectorClaimLaneSql(
         )
         AND NOT COALESCE(${pageActivated}, false)
         AND ${refs.organizationId} = ANY(${pgTextArray(context.baseOrgScopeIds)}::text[])
-      )
-      -- Exact execution pin. A chrome-extension pin on a connector that does
-      -- not execute natively in the extension is delegated browser affinity,
-      -- so its parent connector work stays on fleet instead.
-      OR (
+        )
+        -- Exact execution pin. A chrome-extension pin on a connector that does
+        -- not execute natively in the extension is delegated browser affinity,
+        -- so its parent connector work stays on fleet instead.
+        OR (
         ${context.isUserScopedWorker}
         AND ${context.deviceWorkerId}::uuid IS NOT NULL
         AND ${refs.connectionDeviceWorkerId} = ${context.deviceWorkerId}::uuid
@@ -256,6 +261,7 @@ export function connectorClaimLaneSql(
         )
         AND ${refs.organizationId} = ANY(${pgTextArray(context.orgScopeIds)}::text[])
         AND NOT (${delegatedBrowserAffinity})
+        )
       )
     )
   `;

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -106,6 +106,28 @@ export function connectorClaimLaneSql(
     (${exactManifestAuthorization})
     OR (${legacyHashlessManifestAuthorization})
   `;
+  const exactDaemonBuiltinAuthorization = sql`
+    EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(${sql.json(context.manifestClaimAuthorizations)}::jsonb) auth_item
+      WHERE auth_item->>'connectorKey' = ${refs.connectorKey}
+        AND auth_item->>'connectorVersion' = ${refs.connectorVersion}
+        AND auth_item->>'manifestHash' = ${refs.runManifestHash}
+        AND auth_item->>'sourcePath' = ${refs.runArtifactSourcePath}
+        AND auth_item->>'runtimeExecution' = 'daemon_builtin'
+    )
+  `;
+  const exactNativeBridgeAuthorization = sql`
+    EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(${sql.json(context.manifestClaimAuthorizations)}::jsonb) auth_item
+      WHERE auth_item->>'connectorKey' = ${refs.connectorKey}
+        AND auth_item->>'connectorVersion' = ${refs.connectorVersion}
+        AND auth_item->>'manifestHash' = ${refs.runManifestHash}
+        AND auth_item->>'sourcePath' = ${refs.runArtifactSourcePath}
+        AND auth_item->>'runtimeExecution' = 'bridge'
+    )
+  `;
   const delegatedBrowserAffinity = delegatedBrowserAffinitySql(sql, {
     platform: refs.pinPlatform,
     connectorKey: refs.connectorKey,
@@ -127,18 +149,33 @@ export function connectorClaimLaneSql(
   // any claim lane unless that backend was explicitly advertised as ready.
   const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
   const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
+  // Keep this guard outside the individual lanes: every lane must advertise
+  // the backend that the selected artifact actually needs. Historical
+  // manifest artifacts have no run_runtime, so daemon_builtin is derived only
+  // from the exact retained authorization above; unknown headless artifacts
+  // therefore fail closed.
+  const selectedBackendReady = sql`
+    (
+      (
+        NOT COALESCE(${refs.runManifestBacked}, false)
+        AND ${compiledBackendReady}
+      )
+      OR (
+        COALESCE(${refs.runManifestBacked}, false)
+        AND (
+          ${refs.runRuntime}->>'execution' = 'daemon_builtin'
+          AND ${daemonBuiltinReady}
+          OR ${refs.runRuntime}->>'execution' = 'bridge'
+          OR (${refs.runRuntime} IS NULL AND (${exactDaemonBuiltinAuthorization}))
+          OR (${refs.runRuntime} IS NULL AND (${exactNativeBridgeAuthorization}))
+        )
+      )
+    )
+  `;
 
   return sql`
     (
-      (
-        COALESCE(${refs.runManifestBacked}, false)
-        OR ${compiledBackendReady}
-      )
-      AND (
-        NOT COALESCE(${refs.runManifestBacked}, false)
-        OR COALESCE(${refs.runRuntime}->>'execution', '') <> 'daemon_builtin'
-        OR ${daemonBuiltinReady}
-      )
+      ${selectedBackendReady}
       AND
       -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
       -- their exact device; browser-affinity parent runs stay on fleet.

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -27,6 +27,14 @@ export interface ConnectorClaimContext {
   backendCapacity?: Record<string, number>;
 }
 
+/** A backend is claimable only when this poll explicitly advertises capacity. */
+export function hasPositiveBackendCapacity(
+  capacity: Record<string, number> | undefined,
+  backend: string
+): boolean {
+  return Number.isFinite(capacity?.[backend]) && (capacity?.[backend] ?? 0) > 0;
+}
+
 interface ConnectorClaimLaneRefs {
   connectorKey: SqlFragment;
   connectorVersion: SqlFragment;
@@ -117,14 +125,19 @@ export function connectorClaimLaneSql(
   // A worker may be able to run the daemon-owned backend while its connector
   // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
   // any claim lane unless that backend was explicitly advertised as ready.
-  const compiledBackendReady =
-    (context.backendCapacity?.compiled_connector ?? 0) > 0;
+  const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
+  const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
 
   return sql`
     (
       (
         COALESCE(${refs.runManifestBacked}, false)
         OR ${compiledBackendReady}
+      )
+      AND (
+        NOT COALESCE(${refs.runManifestBacked}, false)
+        OR COALESCE(${refs.runRuntime}->>'execution', '') <> 'daemon_builtin'
+        OR ${daemonBuiltinReady}
       )
       AND
       -- Trusted/anonymous fleet worker. Execution-pinned connections stay on

--- a/packages/server/src/worker-api/device-connector-readiness.ts
+++ b/packages/server/src/worker-api/device-connector-readiness.ts
@@ -15,6 +15,7 @@ import {
 export type DeviceConnectorReadinessState =
   | 'ready'
   | 'setup_required'
+  | 'backend_unavailable'
   | 'device_offline';
 
 export interface DeviceConnectorReadiness {
@@ -51,9 +52,10 @@ export function classifyDeviceConnectorReadiness(
   source: DeviceConnectorSource,
   deviceWorkerId?: string | null
 ): DeviceConnectorReadiness {
+  const backendReady = deviceManifestBackendReady(source);
   if (deviceWorkerId) {
     if (source.onlineAdvertiserDeviceIds.includes(deviceWorkerId)) {
-      return { state: 'ready', source };
+      return { state: backendReady ? 'ready' : 'backend_unavailable', source };
     }
     if (source.onlineManifestDeviceIds.includes(deviceWorkerId)) {
       return { state: 'setup_required', source };
@@ -61,12 +63,24 @@ export function classifyDeviceConnectorReadiness(
     return { state: 'device_offline', source };
   }
   if (source.onlineAdvertiserDeviceIds.length > 0) {
-    return { state: 'ready', source };
+    return { state: backendReady ? 'ready' : 'backend_unavailable', source };
   }
   if (source.onlineManifestDeviceIds.length > 0) {
     return { state: 'setup_required', source };
   }
   return { state: 'device_offline', source };
+}
+
+/**
+ * Headless manifests execute inside connector-worker, so an online heartbeat
+ * is not sufficient proof. New headless artifacts must name the daemon-owned
+ * backend; legacy metadata-only artifacts are inventory, not executable
+ * readiness. Other platforms retain their compatibility policy while their
+ * bridge/extension clients migrate independently.
+ */
+function deviceManifestBackendReady(source: DeviceConnectorSource): boolean {
+  if (!source.sourcePath?.startsWith('device-manifest://headless/')) return true;
+  return source.metadata.runtime?.execution === 'daemon_builtin';
 }
 
 /** Load each owner's manifest inventory once, then index the requested targets. */
@@ -152,5 +166,14 @@ export function describeDeviceConnectorSetupRequired(
     `${readiness.source.metadata.name} is available on an online device, but setup is incomplete: ` +
     `'${readiness.source.requiredCapability}' has not been granted. ` +
     'Open the paired device app, finish setup, then retry.'
+  );
+}
+
+export function describeDeviceConnectorBackendUnavailable(
+  readiness: DeviceConnectorReadiness,
+): string {
+  return (
+    `${readiness.source.metadata.name} is advertised by an online device, but its exact ` +
+    'manifest does not declare a supported execution backend. Update/restart the device daemon.'
   );
 }

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -376,7 +376,7 @@ export async function getDeviceManifestClaimAuthorizationsForDevice(params: {
         capabilities,
         manifests: [stored.manifest],
       },
-      true
+      false
     );
     const validated = validation.manifests[0];
     if (!validation.accepted || !validated || validated.manifest_hash !== stored.manifest_hash) {

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -153,6 +153,16 @@ function validateDeviceConnectorManifestsInternal(
       if (!manifest.runtime.platforms.includes(platform)) {
         throw new Error(`runtime.platforms must include '${platform}'`);
       }
+      if (
+        manifest.runtime.execution !== undefined &&
+        manifest.runtime.execution !== 'bridge' &&
+        manifest.runtime.execution !== 'daemon_builtin'
+      ) {
+        throw new Error(`unsupported runtime.execution '${String(manifest.runtime.execution)}'`);
+      }
+      if (platform === 'headless' && manifest.runtime.execution !== 'daemon_builtin') {
+        throw new Error("headless device manifests must declare runtime.execution='daemon_builtin'");
+      }
       const capAuth = authorizeCapabilities(platform, [manifest.required_capability]);
       if (!capAuth.authorized.includes(manifest.required_capability)) {
         throw new Error(`required_capability '${manifest.required_capability}' is not allowed for '${platform}'`);

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -1080,21 +1080,14 @@ export async function reconcileDeviceCapabilities(
       (key) => !reconciledAuthorizations.some((authorization) => authorization.connectorKey === key)
     )
   );
-  const validatedReconciledAuthorizations = reconciledAuthorizations.filter((authorization) =>
-    pollingDeviceAuthorizations.some(
-      (validated) =>
-        validated.connectorKey === authorization.connectorKey &&
-        validated.connectorVersion === authorization.connectorVersion &&
-        validated.manifestHash === authorization.manifestHash &&
-        validated.sourcePath === authorization.sourcePath,
-    ),
+  // Built from the polling advertisement alone. Intersecting it with the
+  // reconciled set first added nothing: an entry surviving that intersection
+  // is by definition a reconciled authorization, so its key can never be in
+  // failedCurrentWinnerKeys, so it always reappears below under the same
+  // (key, version, hash) -- and the later entry is the one the Map keeps.
+  const all = pollingDeviceAuthorizations.filter(
+    (authorization) => !failedCurrentWinnerKeys.has(authorization.connectorKey)
   );
-  const all = [
-    ...validatedReconciledAuthorizations,
-    ...pollingDeviceAuthorizations.filter(
-      (authorization) => !failedCurrentWinnerKeys.has(authorization.connectorKey)
-    ),
-  ];
   return [...new Map(
     all.map((authorization) => [
       `${authorization.connectorKey}\u0000${authorization.connectorVersion}\u0000${authorization.manifestHash}`,

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -9,32 +9,41 @@
  * creating runs nothing can claim.
  */
 
-import { parseJsonObject } from '@lobu/core';
-import { getDb, pgTextArray } from '../db/client';
-import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
-import { splitConfigByFeedScope, type FeedDefinition } from '../tools/admin/helpers/feed-helpers';
+import { parseJsonObject } from "@lobu/core";
+import { getDb, pgTextArray } from "../db/client";
+import { findExistingPersonalOrg } from "../auth/personal-org-provisioning";
 import {
-  type BundledDeviceConnector,
-  bundledConnectorSourcePath,
-  compileConnectorFromFile,
-  findBundledConnectorFile,
-  getBundledDeviceConnectors,
-} from '../utils/connector-catalog';
-import { extractConnectorMetadata, type ConnectorMetadata } from '../utils/connector-compiler';
-import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
-import { ensureUniqueConnectionSlug, isConnectionSlugUniqueViolation } from '../utils/connections';
-import { clearDevicePinTombstoneIfPinned } from '../utils/device-pin-tombstones';
-import { DEVICE_AUTOWIRE_SUPPRESSION_KEY } from '../utils/device-autowire-suppression';
-import { errorMessage } from '../utils/errors';
-import logger from '../utils/logger';
+	splitConfigByFeedScope,
+	type FeedDefinition,
+} from "../tools/admin/helpers/feed-helpers";
 import {
-  attestDeviceManifestArtifacts,
-  getDeviceManifestClaimAuthorizationsForDevice,
-  getDeviceManifestSourcesForUser,
-  sortJson,
-  type DeviceConnectorSource,
-  type ManifestClaimAuthorization,
-} from './device-manifests';
+	type BundledDeviceConnector,
+	bundledConnectorSourcePath,
+	compileConnectorFromFile,
+	findBundledConnectorFile,
+	getBundledDeviceConnectors,
+} from "../utils/connector-catalog";
+import {
+	extractConnectorMetadata,
+	type ConnectorMetadata,
+} from "../utils/connector-compiler";
+import { upsertConnectorDefinitionRecords } from "../utils/connector-definition-install";
+import {
+	ensureUniqueConnectionSlug,
+	isConnectionSlugUniqueViolation,
+} from "../utils/connections";
+import { clearDevicePinTombstoneIfPinned } from "../utils/device-pin-tombstones";
+import { DEVICE_AUTOWIRE_SUPPRESSION_KEY } from "../utils/device-autowire-suppression";
+import { errorMessage } from "../utils/errors";
+import logger from "../utils/logger";
+import {
+	attestDeviceManifestArtifacts,
+	getDeviceManifestClaimAuthorizationsForDevice,
+	getDeviceManifestSourcesForUser,
+	sortJson,
+	type DeviceConnectorSource,
+	type ManifestClaimAuthorization,
+} from "./device-manifests";
 
 /**
  * The slice of a manifest `feeds_schema[key]` this module reads. Deliberately
@@ -42,12 +51,12 @@ import {
  * contract, and a manifest is untyped JSON off the wire regardless.
  */
 interface ManifestFeed {
-  name?: string;
-  operations?: Array<'sync' | 'read'>;
+	name?: string;
+	operations?: Array<"sync" | "read">;
 }
 
 /** A device worker counts toward "serves capability X" only if seen this recently. */
-const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
+const DEVICE_WORKER_FRESH_INTERVAL = "7 days";
 
 /**
  * Install + wire a bundled device connector into the user's personal org:
@@ -74,47 +83,50 @@ const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
  * sole remaining fresh device, or NULL) so the connection keeps running.
  */
 async function ensureDeviceConnectorWired(
-  userId: string,
-  organizationId: string,
-  connectorKey: string,
-  declaredFeedKeys: string[],
-  matchingDeviceIds: string[],
-  requiredCapability: string,
-  source?: DeviceConnectorSource,
-  pollingDeviceId?: string | null
+	userId: string,
+	organizationId: string,
+	connectorKey: string,
+	declaredFeedKeys: string[],
+	matchingDeviceIds: string[],
+	requiredCapability: string,
+	source?: DeviceConnectorSource,
+	pollingDeviceId?: string | null,
 ): Promise<ManifestClaimAuthorization | null> {
-  const sql = getDb();
+	const sql = getDb();
 
-  // Self-heal the device pin against the user's current fleet. Cheap, idempotent
-  // (the WHERE matches nothing when the pin is already a valid fresh device), and
-  // runs even on the fast path so a stale pin doesn't silently strand the feeds.
-  const reconcilePin = async (
-    db: typeof sql,
-    connectionId: number,
-    currentMatchingDeviceIds = matchingDeviceIds,
-    currentRequiredCapability = requiredCapability,
-    currentSource = source
-  ) => {
-    let target = currentMatchingDeviceIds.length === 1 ? currentMatchingDeviceIds[0] : null;
-    // `idx_connections_org_connector_device_live` is UNIQUE on
-    // (organization_id, connector_key, device_worker_id) for live rows, and an
-    // org legitimately holds one connection PER DEVICE (same shape as
-    // `idx_connections_org_connector_account_live` for OAuth accounts). So the
-    // row we were handed is not necessarily the one that owns `target`: retiring
-    // a Mac leaves its connection pinned to the stale device while the new Mac's
-    // connection holds the only fresh one, and pinning the former to the latter's
-    // device violates the index, aborts the whole wire transaction, and retries
-    // forever (~8/min in prod for apple.computer_use).
-    //
-    // Never steal a pin another live connection holds — the same guard
-    // `resolveOnlineChromeConnection` already carries for this index (see
-    // `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
-    // dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
-    // clears the dead pin (a connection pinned to a vanished device is claimable
-    // by nobody, while an unpinned one is claimable by any polling device), so
-    // the documented stale-pin repair survives.
-    if (target) {
-      const owner = (await db`
+	// Self-heal the device pin against the user's current fleet. Cheap, idempotent
+	// (the WHERE matches nothing when the pin is already a valid fresh device), and
+	// runs even on the fast path so a stale pin doesn't silently strand the feeds.
+	const reconcilePin = async (
+		db: typeof sql,
+		connectionId: number,
+		currentMatchingDeviceIds = matchingDeviceIds,
+		currentRequiredCapability = requiredCapability,
+		currentSource = source,
+	) => {
+		let target =
+			currentMatchingDeviceIds.length === 1
+				? currentMatchingDeviceIds[0]
+				: null;
+		// `idx_connections_org_connector_device_live` is UNIQUE on
+		// (organization_id, connector_key, device_worker_id) for live rows, and an
+		// org legitimately holds one connection PER DEVICE (same shape as
+		// `idx_connections_org_connector_account_live` for OAuth accounts). So the
+		// row we were handed is not necessarily the one that owns `target`: retiring
+		// a Mac leaves its connection pinned to the stale device while the new Mac's
+		// connection holds the only fresh one, and pinning the former to the latter's
+		// device violates the index, aborts the whole wire transaction, and retries
+		// forever (~8/min in prod for apple.computer_use).
+		//
+		// Never steal a pin another live connection holds — the same guard
+		// `resolveOnlineChromeConnection` already carries for this index (see
+		// `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
+		// dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
+		// clears the dead pin (a connection pinned to a vanished device is claimable
+		// by nobody, while an unpinned one is claimable by any polling device), so
+		// the documented stale-pin repair survives.
+		if (target) {
+			const owner = (await db`
         SELECT id FROM connections
         WHERE organization_id = ${organizationId}
           AND connector_key = ${connectorKey}
@@ -122,55 +134,61 @@ async function ensureDeviceConnectorWired(
           AND deleted_at IS NULL
         LIMIT 1
       `) as unknown as Array<{ id: number }>;
-      const ownerId = owner[0]?.id;
-      if (ownerId != null && Number(ownerId) !== connectionId) {
-        logger.warn(
-          { userId, connectorKey, connectionId, ownerConnectionId: ownerId, deviceWorkerId: target },
-          '[device-connectors] Device already pinned to another connection — unpinning instead'
-        );
-        target = null;
-      }
-    }
-    // Compare via text on both sides — passing a `pgTextArray(...)` literal
-    // through a `::uuid[]` cast trips a postgres "malformed array literal"
-    // failure under the extended-protocol path postgres.js uses (the bound
-    // text parameter never gets re-parsed as an array before the uuid[] cast
-    // runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
-    // entirely; UUIDs are canonical lowercase so text equality matches the
-    // uuid form 1:1.
-    await db`
+			const ownerId = owner[0]?.id;
+			if (ownerId != null && Number(ownerId) !== connectionId) {
+				logger.warn(
+					{
+						userId,
+						connectorKey,
+						connectionId,
+						ownerConnectionId: ownerId,
+						deviceWorkerId: target,
+					},
+					"[device-connectors] Device already pinned to another connection — unpinning instead",
+				);
+				target = null;
+			}
+		}
+		// Compare via text on both sides — passing a `pgTextArray(...)` literal
+		// through a `::uuid[]` cast trips a postgres "malformed array literal"
+		// failure under the extended-protocol path postgres.js uses (the bound
+		// text parameter never gets re-parsed as an array before the uuid[] cast
+		// runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
+		// entirely; UUIDs are canonical lowercase so text equality matches the
+		// uuid form 1:1.
+		await db`
       UPDATE connections
       SET device_worker_id = ${target}::uuid, updated_at = NOW()
       WHERE id = ${connectionId}
         AND device_worker_id IS DISTINCT FROM ${target}::uuid
         AND (device_worker_id IS NULL OR NOT (device_worker_id::text = ANY(${pgTextArray(currentMatchingDeviceIds)}::text[])))
     `;
-    // The statement above repairs only the row we were handed, but an org holds
-    // one connection PER DEVICE and the fast path resolves just one of them
-    // (`GROUP BY … LIMIT 1`, no ORDER BY). When it returns the row that is
-    // already correctly pinned, the UPDATE no-ops — and a sibling left pinned to
-    // a device that has dropped out is never revisited, so it stays bound to a
-    // worker that will never poll again. Sweep every live row instead: a pin
-    // outside the fresh set is stale by definition, and NULL is strictly better
-    // than a dead pin (unpinned is claimable by any polling device; a vanished
-    // device is claimable by nobody).
-    //
-    // Safe for the multi-fresh case — pins INSIDE the fresh set are deliberate
-    // and untouched — and the empty-fleet case never reaches here, because
-    // `reconcileDeviceCapabilities` only calls this connector's wire pass when
-    // `matchingDeviceIds.length > 0` (an offline fleet routes to
-    // `pauseStaleDeviceFeeds`, which must not unpin anything).
-    // Re-check freshness against `device_workers` AT MUTATION TIME rather than
-    // trusting `matchingDeviceIds`, which is snapshotted before the advisory
-    // lock is taken (see `reconcileDeviceCapabilities`). A concurrent poll on
-    // another replica can refresh a device's heartbeat between this pass's
-    // snapshot and its commit; sweeping from the stale list would unpin a
-    // device that is live again. The NOT EXISTS makes the sweep self-verifying:
-    // a row is cleared only if its worker is genuinely absent, stale, or no
-    // longer advertising the implementation as of this statement. Manifest
-    // sources require the exact winning hash as well as their capability;
-    // capability-only bundled sources retain their existing matching semantics.
-    await db`
+		// The statement above repairs only the row we were handed, but an org holds
+		// one connection PER DEVICE and the fast path resolves just one of them
+		// (`GROUP BY … LIMIT 1`, no ORDER BY). When it returns the row that is
+		// already correctly pinned, the UPDATE no-ops — and a sibling left pinned to
+		// a device that has dropped out is never revisited, so it stays bound to a
+		// worker that will never poll again. Sweep every live row instead: a pin
+		// outside the fresh set is stale by definition, and NULL is strictly better
+		// than a dead pin (unpinned is claimable by any polling device; a vanished
+		// device is claimable by nobody).
+		//
+		// Safe for the multi-fresh case — pins INSIDE the fresh set are deliberate
+		// and untouched — and the empty-fleet case never reaches here, because
+		// `reconcileDeviceCapabilities` only calls this connector's wire pass when
+		// `matchingDeviceIds.length > 0` (an offline fleet routes to
+		// `pauseStaleDeviceFeeds`, which must not unpin anything).
+		// Re-check freshness against `device_workers` AT MUTATION TIME rather than
+		// trusting `matchingDeviceIds`, which is snapshotted before the advisory
+		// lock is taken (see `reconcileDeviceCapabilities`). A concurrent poll on
+		// another replica can refresh a device's heartbeat between this pass's
+		// snapshot and its commit; sweeping from the stale list would unpin a
+		// device that is live again. The NOT EXISTS makes the sweep self-verifying:
+		// a row is cleared only if its worker is genuinely absent, stale, or no
+		// longer advertising the implementation as of this statement. Manifest
+		// sources require the exact winning hash as well as their capability;
+		// capability-only bundled sources retain their existing matching semantics.
+		await db`
       UPDATE connections c
       SET device_worker_id = NULL, updated_at = NOW()
       WHERE c.organization_id = ${organizationId}
@@ -196,51 +214,53 @@ async function ensureDeviceConnectorWired(
             ${currentSource ? db`AND (dw.connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${currentSource.manifestHash}` : db``}
         )
     `;
-    // Pin restore (or already-valid pin): drop DELETE/move tombstones so the
-    // connection is not stuck as active + red "Device was removed".
-    await clearDevicePinTombstoneIfPinned(db, {
-      connectionId,
-      matchingDeviceIds: currentMatchingDeviceIds,
-    });
-  };
-  const lockedManifestWinner = async (db: typeof sql): Promise<DeviceConnectorSource | null> => {
-    if (!source) return null;
-    const current = (
-      await getDeviceManifestSourcesForUser({ sql: db, userId, connectorKey })
-    ).find((candidate) => candidate.key === connectorKey);
-    if (
-      !current ||
-      current.metadata.version !== source.metadata.version ||
-      current.manifestHash !== source.manifestHash
-    ) {
-      return null;
-    }
-    return current;
-  };
-  const claimAuthorization = (
-    currentSource: DeviceConnectorSource | null
-  ): ManifestClaimAuthorization | null => {
-    if (
-      !currentSource ||
-      !pollingDeviceId ||
-      !currentSource.advertiserDeviceIds.includes(pollingDeviceId)
-    ) {
-      return null;
-    }
-    return {
-      connectorKey: currentSource.key,
-      connectorVersion: currentSource.metadata.version,
-      manifestHash: currentSource.manifestHash,
-      definitionManifestHash: currentSource.definitionManifestHash,
-      sourcePath: currentSource.sourcePath,
-      runtimeExecution: currentSource.metadata.runtime?.execution,
-    };
-  };
-  const selectedArtifactMatches = async (
-    db: typeof sql,
-    currentSource: DeviceConnectorSource
-  ): Promise<boolean> => {
-    const rows = await db`
+		// Pin restore (or already-valid pin): drop DELETE/move tombstones so the
+		// connection is not stuck as active + red "Device was removed".
+		await clearDevicePinTombstoneIfPinned(db, {
+			connectionId,
+			matchingDeviceIds: currentMatchingDeviceIds,
+		});
+	};
+	const lockedManifestWinner = async (
+		db: typeof sql,
+	): Promise<DeviceConnectorSource | null> => {
+		if (!source) return null;
+		const current = (
+			await getDeviceManifestSourcesForUser({ sql: db, userId, connectorKey })
+		).find((candidate) => candidate.key === connectorKey);
+		if (
+			!current ||
+			current.metadata.version !== source.metadata.version ||
+			current.manifestHash !== source.manifestHash
+		) {
+			return null;
+		}
+		return current;
+	};
+	const claimAuthorization = (
+		currentSource: DeviceConnectorSource | null,
+	): ManifestClaimAuthorization | null => {
+		if (
+			!currentSource ||
+			!pollingDeviceId ||
+			!currentSource.advertiserDeviceIds.includes(pollingDeviceId)
+		) {
+			return null;
+		}
+		return {
+			connectorKey: currentSource.key,
+			connectorVersion: currentSource.metadata.version,
+			manifestHash: currentSource.manifestHash,
+			definitionManifestHash: currentSource.definitionManifestHash,
+			sourcePath: currentSource.sourcePath,
+			runtimeExecution: currentSource.metadata.runtime?.execution,
+		};
+	};
+	const selectedArtifactMatches = async (
+		db: typeof sql,
+		currentSource: DeviceConnectorSource,
+	): Promise<boolean> => {
+		const rows = await db`
       SELECT 1
       FROM connector_definitions cd
       JOIN LATERAL (
@@ -268,15 +288,15 @@ async function ensureDeviceConnectorWired(
         AND cv.source_code IS NULL
       LIMIT 1
     `;
-    return rows.length > 0;
-  };
+		return rows.length > 0;
+	};
 
-  try {
-    // Fast path: definition + version + connection + EVERY declared feed active
-    // → nothing to repair or re-activate. The feed list comes from the bundled
-    // catalog source, not the installed DB row, so adding a new bundled feed
-    // still heals existing installs after deploy.
-    const existingReady = (await sql`
+	try {
+		// Fast path: definition + version + connection + EVERY declared feed active
+		// → nothing to repair or re-activate. The feed list comes from the bundled
+		// catalog source, not the installed DB row, so adding a new bundled feed
+		// still heals existing installs after deploy.
+		const existingReady = (await sql`
       SELECT
         c.id AS connection_id,
         cv.connector_key AS version_key,
@@ -349,173 +369,187 @@ async function ensureDeviceConnectorWired(
         cd.id
       LIMIT 1
     `) as unknown as Array<{
-      connection_id: number | null;
-      version_key: string | null;
-      version_source_path: string | null;
-      version_compiled_code: string | null;
-      version_artifact_hash: string | null;
-      version_compile_config_hash: string | null;
-      version_source_code: string | null;
-      def_name: string | null;
-      def_description: string | null;
-      def_version: string | null;
-      def_auth_schema: unknown;
-      def_feeds_schema: unknown;
-      def_actions_schema: unknown;
-      def_options_schema: unknown;
-      def_favicon_domain: string | null;
-      def_required_capability: string | null;
-      def_runtime: unknown;
-      def_default_config: unknown;
-      conn_config: unknown;
-      active_feed_keys: string[] | null;
-    }>;
-    // Device-manifest connectors carry their full metadata in-hand (`source`),
-    // so a changed manifest MUST break the fast path or the org catalog is
-    // stranded on the old definition forever: the extension re-sends its
-    // manifest on every poll, but nothing else ever re-runs the definition
-    // upsert once everything is wired (this exact staleness shipped
-    // console_capture to device_workers while list_available kept serving the
-    // old 12-action chrome catalog). Compare every field the definition upsert
-    // writes, in the manifest hash's canonical form. Bundled connectors
-    // (`source` undefined) are excluded on purpose — their metadata requires a
-    // compile we can't afford per poll; deploys refresh them via other paths.
-    const definitionMatchesSource = (row: (typeof existingReady)[0]): boolean => {
-      if (!source) return true;
-      const m = source.metadata;
-      const canon = (v: unknown) => JSON.stringify(sortJson(v ?? null));
-      return (
-        row.def_name === m.name &&
-        (row.def_description ?? null) === (m.description ?? null) &&
-        row.def_version === m.version &&
-        row.version_source_path === source.sourcePath &&
-        row.version_compiled_code == null &&
-        row.version_artifact_hash === source.manifestHash &&
-        row.version_compile_config_hash == null &&
-        row.version_source_code == null &&
-        (row.def_favicon_domain ?? null) === (m.faviconDomain ?? null) &&
-        (row.def_required_capability ?? null) === (m.requiredCapability ?? null) &&
-        canon(row.def_auth_schema) === canon(m.authSchema) &&
-        canon(row.def_feeds_schema) === canon(m.feeds) &&
-        canon(row.def_actions_schema) === canon(m.actions) &&
-        canon(row.def_options_schema) === canon(m.optionsSchema) &&
-        canon(row.def_runtime) === canon(m.runtime)
-      );
-    };
-    const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
-    const readyConnectionId = existingReady[0]?.connection_id;
-    // A ready connection whose config is SQL NULL while the org definition
-    // carries a default needs the default seeded — the fast path must not
-    // leave it resolving against raw descriptor fallbacks. `conn_config` is the
-    // raw jsonb value (`null` only when the column is SQL NULL), so an empty
-    // explicit `{}` still counts as configured. Seeded in wireOnce below.
-    // The predicate gates on the CONNECTION-scoped half of the default
-    // (`splitConfigByFeedScope(…).connectionConfig`), the exact value seeding
-    // can write: a wholly feed-scoped default must not keep a NULL-config
-    // connection spinning the wire path forever. `def_feeds_schema` equals the
-    // manifest feeds on this path (definitionMatchesSource above), so the split
-    // here mirrors the one wireOnce performs; don't re-split against a
-    // different feeds schema, or the gate and the seed stop agreeing.
-    const needsDefaultConfigSeed =
-      existingReady[0]?.conn_config == null &&
-      splitConfigByFeedScope(
-        parseJsonObject(existingReady[0]?.def_default_config),
-        (existingReady[0]?.def_feeds_schema as Record<string, FeedDefinition> | null) ?? null,
-      ).connectionConfig != null;
-    const ready =
-      readyConnectionId != null &&
-      existingReady[0]?.version_key != null &&
-      definitionMatchesSource(existingReady[0]) &&
-      !needsDefaultConfigSeed &&
-      // userManaged-only connectors (e.g. local.directory, browser/*) report
-      // declaredFeedKeys=[]. Once the connection + definition are installed,
-      // every subsequent poll has nothing to verify — fast-path out.
-      // Composing primitives still hit /api/workers/me/feeds to mint
-      // explicit per-instance rows; that path is unchanged.
-      (declaredFeedKeys.length === 0 ||
-        declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)));
-    if (ready) {
-      if (source) {
-        return sql.begin(async (tx) => {
-          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-          const currentSource = await lockedManifestWinner(tx);
-          if (!currentSource || !(await selectedArtifactMatches(tx, currentSource))) return null;
-          await reconcilePin(
-            tx,
-            readyConnectionId,
-            currentSource.advertiserDeviceIds,
-            currentSource.requiredCapability,
-            currentSource
-          );
-          return claimAuthorization(currentSource);
-        });
-      } else {
-        // Same advisory lock as the `source` branch above: reconcilePin's owner
-        // check is read-then-write, so two replicas polling concurrently could
-        // both observe "nobody owns this device" and race into the unique index.
-        // (No bundled device connectors ship today, so this branch is currently
-        // unreachable — keep it serialized anyway rather than leave the race
-        // armed for the first one that does.)
-        await sql.begin(async (tx) => {
-          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-          await reconcilePin(tx, readyConnectionId);
-        });
-      }
-      return null;
-    }
+			connection_id: number | null;
+			version_key: string | null;
+			version_source_path: string | null;
+			version_compiled_code: string | null;
+			version_artifact_hash: string | null;
+			version_compile_config_hash: string | null;
+			version_source_code: string | null;
+			def_name: string | null;
+			def_description: string | null;
+			def_version: string | null;
+			def_auth_schema: unknown;
+			def_feeds_schema: unknown;
+			def_actions_schema: unknown;
+			def_options_schema: unknown;
+			def_favicon_domain: string | null;
+			def_required_capability: string | null;
+			def_runtime: unknown;
+			def_default_config: unknown;
+			conn_config: unknown;
+			active_feed_keys: string[] | null;
+		}>;
+		// Device-manifest connectors carry their full metadata in-hand (`source`),
+		// so a changed manifest MUST break the fast path or the org catalog is
+		// stranded on the old definition forever: the extension re-sends its
+		// manifest on every poll, but nothing else ever re-runs the definition
+		// upsert once everything is wired (this exact staleness shipped
+		// console_capture to device_workers while list_available kept serving the
+		// old 12-action chrome catalog). Compare every field the definition upsert
+		// writes, in the manifest hash's canonical form. Bundled connectors
+		// (`source` undefined) are excluded on purpose — their metadata requires a
+		// compile we can't afford per poll; deploys refresh them via other paths.
+		const definitionMatchesSource = (
+			row: (typeof existingReady)[0],
+		): boolean => {
+			if (!source) return true;
+			const m = source.metadata;
+			const canon = (v: unknown) => JSON.stringify(sortJson(v ?? null));
+			return (
+				row.def_name === m.name &&
+				(row.def_description ?? null) === (m.description ?? null) &&
+				row.def_version === m.version &&
+				row.version_source_path === source.sourcePath &&
+				row.version_compiled_code == null &&
+				row.version_artifact_hash === source.manifestHash &&
+				row.version_compile_config_hash == null &&
+				row.version_source_code == null &&
+				(row.def_favicon_domain ?? null) === (m.faviconDomain ?? null) &&
+				(row.def_required_capability ?? null) ===
+					(m.requiredCapability ?? null) &&
+				canon(row.def_auth_schema) === canon(m.authSchema) &&
+				canon(row.def_feeds_schema) === canon(m.feeds) &&
+				canon(row.def_actions_schema) === canon(m.actions) &&
+				canon(row.def_options_schema) === canon(m.optionsSchema) &&
+				canon(row.def_runtime) === canon(m.runtime)
+			);
+		};
+		const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
+		const readyConnectionId = existingReady[0]?.connection_id;
+		// A ready connection whose config is SQL NULL while the org definition
+		// carries a default needs the default seeded — the fast path must not
+		// leave it resolving against raw descriptor fallbacks. `conn_config` is the
+		// raw jsonb value (`null` only when the column is SQL NULL), so an empty
+		// explicit `{}` still counts as configured. Seeded in wireOnce below.
+		// The predicate gates on the CONNECTION-scoped half of the default
+		// (`splitConfigByFeedScope(…).connectionConfig`), the exact value seeding
+		// can write: a wholly feed-scoped default must not keep a NULL-config
+		// connection spinning the wire path forever. `def_feeds_schema` equals the
+		// manifest feeds on this path (definitionMatchesSource above), so the split
+		// here mirrors the one wireOnce performs; don't re-split against a
+		// different feeds schema, or the gate and the seed stop agreeing.
+		const needsDefaultConfigSeed =
+			existingReady[0]?.conn_config == null &&
+			splitConfigByFeedScope(
+				parseJsonObject(existingReady[0]?.def_default_config),
+				(existingReady[0]?.def_feeds_schema as Record<
+					string,
+					FeedDefinition
+				> | null) ?? null,
+			).connectionConfig != null;
+		const ready =
+			readyConnectionId != null &&
+			existingReady[0]?.version_key != null &&
+			definitionMatchesSource(existingReady[0]) &&
+			!needsDefaultConfigSeed &&
+			// userManaged-only connectors (e.g. local.directory, browser/*) report
+			// declaredFeedKeys=[]. Once the connection + definition are installed,
+			// every subsequent poll has nothing to verify — fast-path out.
+			// Composing primitives still hit /api/workers/me/feeds to mint
+			// explicit per-instance rows; that path is unchanged.
+			(declaredFeedKeys.length === 0 ||
+				declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)));
+		if (ready) {
+			if (source) {
+				return sql.begin(async (tx) => {
+					await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+					const currentSource = await lockedManifestWinner(tx);
+					if (
+						!currentSource ||
+						!(await selectedArtifactMatches(tx, currentSource))
+					)
+						return null;
+					await reconcilePin(
+						tx,
+						readyConnectionId,
+						currentSource.advertiserDeviceIds,
+						currentSource.requiredCapability,
+						currentSource,
+					);
+					return claimAuthorization(currentSource);
+				});
+			} else {
+				// Same advisory lock as the `source` branch above: reconcilePin's owner
+				// check is read-then-write, so two replicas polling concurrently could
+				// both observe "nobody owns this device" and race into the unique index.
+				// (No bundled device connectors ship today, so this branch is currently
+				// unreachable — keep it serialized anyway rather than leave the race
+				// armed for the first one that does.)
+				await sql.begin(async (tx) => {
+					await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+					await reconcilePin(tx, readyConnectionId);
+				});
+			}
+			return null;
+		}
 
-    let metadata: ConnectorMetadata;
-    let sourcePath: string;
-    let feedKeys = declaredFeedKeys;
-    if (source) {
-      metadata = source.metadata;
-      sourcePath = source.sourcePath;
-    } else {
-      // Compile metadata outside the lock (pure CPU + a child process — slow).
-      const filePath = findBundledConnectorFile(connectorKey);
-      if (!filePath) {
-        logger.warn({ connectorKey }, '[auto-wire] Bundled connector file not found');
-        return null;
-      }
-      const compiledCode = await compileConnectorFromFile(filePath);
-      metadata = await extractConnectorMetadata(compiledCode);
-      sourcePath = bundledConnectorSourcePath(filePath);
-      if (!metadata.key || !metadata.name || !metadata.version) return null;
-      const feedsSchema = metadata.feeds as Record<
-        string,
-        { configSchema?: unknown; userManaged?: boolean }
-      > | null;
-      // Skip feeds the connector marks `userManaged` — they need per-instance
-      // config (e.g. local.directory.files needs a folder_id per folder) that
-      // auto-wire can't supply. The Mac app creates them explicitly via
-      // /api/workers/me/feeds once it has the folder bookmark.
-      feedKeys = feedsSchema
-        ? Object.keys(feedsSchema).filter((k) => !feedsSchema[k]?.userManaged)
-        : [];
-    }
+		let metadata: ConnectorMetadata;
+		let sourcePath: string;
+		let feedKeys = declaredFeedKeys;
+		if (source) {
+			metadata = source.metadata;
+			sourcePath = source.sourcePath;
+		} else {
+			// Compile metadata outside the lock (pure CPU + a child process — slow).
+			const filePath = findBundledConnectorFile(connectorKey);
+			if (!filePath) {
+				logger.warn(
+					{ connectorKey },
+					"[auto-wire] Bundled connector file not found",
+				);
+				return null;
+			}
+			const compiledCode = await compileConnectorFromFile(filePath);
+			metadata = await extractConnectorMetadata(compiledCode);
+			sourcePath = bundledConnectorSourcePath(filePath);
+			if (!metadata.key || !metadata.name || !metadata.version) return null;
+			const feedsSchema = metadata.feeds as Record<
+				string,
+				{ configSchema?: unknown; userManaged?: boolean }
+			> | null;
+			// Skip feeds the connector marks `userManaged` — they need per-instance
+			// config (e.g. local.directory.files needs a folder_id per folder) that
+			// auto-wire can't supply. The Mac app creates them explicitly via
+			// /api/workers/me/feeds once it has the folder bookmark.
+			feedKeys = feedsSchema
+				? Object.keys(feedsSchema).filter((k) => !feedsSchema[k]?.userManaged)
+				: [];
+		}
 
-    let connectionId: number | undefined;
-    const wireOnce = () => sql.begin(async (tx): Promise<ManifestClaimAuthorization | null> => {
-      // Serialize per (user, connector): two concurrent polls / two devices
-      // both reach here, but only one holds the lock at a time, so the
-      // existence-check-then-insert below is atomic.
-      await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-      // Winner selection before this lock is only a scheduling hint. Recompute
-      // the deterministic winner while serialized so a stale waiter can never
-      // downgrade metadata or repin after a newer manifest has arrived.
-      const currentSource = source ? await lockedManifestWinner(tx) : null;
-      if (source && !currentSource) return null;
+		let connectionId: number | undefined;
+		const wireOnce = () =>
+			sql.begin(async (tx): Promise<ManifestClaimAuthorization | null> => {
+				// Serialize per (user, connector): two concurrent polls / two devices
+				// both reach here, but only one holds the lock at a time, so the
+				// existence-check-then-insert below is atomic.
+				await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+				// Winner selection before this lock is only a scheduling hint. Recompute
+				// the deterministic winner while serialized so a stale waiter can never
+				// downgrade metadata or repin after a newer manifest has arrived.
+				const currentSource = source ? await lockedManifestWinner(tx) : null;
+				if (source && !currentSource) return null;
 
-      // An explicit user delete is durable opt-out for this device connector.
-      // The marker is reserved at every public config-write path and delete
-      // writes it only after proving the connection belongs to this personal
-      // org's active device-connector definition. A device pin is deliberately
-      // not required: multi-device auto-wiring leaves the connection unpinned.
-      // The live-row anti-join makes an explicit reconnect the sole way to
-      // clear the opt-out without mutating the tombstone during heartbeat
-      // reconciliation. Only `handleDelete` writes this reserved marker;
-      // system retirement paths may tombstone rows but never create an opt-out.
-      const suppressed = (await tx`
+				// An explicit user delete is durable opt-out for this device connector.
+				// The marker is reserved at every public config-write path and delete
+				// writes it only after proving the connection belongs to this personal
+				// org's active device-connector definition. A device pin is deliberately
+				// not required: multi-device auto-wiring leaves the connection unpinned.
+				// The live-row anti-join makes an explicit reconnect the sole way to
+				// clear the opt-out without mutating the tombstone during heartbeat
+				// reconciliation. Only `handleDelete` writes this reserved marker;
+				// system retirement paths may tombstone rows but never create an opt-out.
+				const suppressed = (await tx`
         SELECT 1
         FROM connections
         WHERE organization_id = ${organizationId}
@@ -534,40 +568,39 @@ async function ensureDeviceConnectorWired(
               AND live.deleted_at IS NULL
           )
         LIMIT 1
-      `) as unknown as Array<{ '?column?': number }>;
-      if (suppressed.length > 0) return null;
+      `) as unknown as Array<{ "?column?": number }>;
+				if (suppressed.length > 0) return null;
 
-      // 2. Ensure the connector definition + version are installed (idempotent).
-      await upsertConnectorDefinitionRecords({
-        sql: tx,
-        organizationId,
-        metadata,
-        versionRecord: {
-          compiledCode: null,
-          // Device manifests have no compiled bytes, so compiled_code_hash is
-          // the existing durable artifact-hash slot for their validated
-          // manifest identity. Claim authorization compares this exact value.
-          compiledCodeHash: currentSource?.manifestHash ?? null,
-          compileConfigHash: null,
-          sourceCode: null,
-          sourcePath,
-        },
-        // A device-manifest connector's sourcePath is meaningful only to the
-        // owning user's daemon → their org's row. A bundled device connector
-        // points at the shared on-disk catalog → shared row.
-        versionScope: source ? 'organization' : 'shared',
-      });
-      // Seed new/repaired auto-wired connections from the org's definition
-      // default, exactly like manage_connections create/connect merge
-      // `default_connection_config` into the new row's config — auto-wire is
-      // the only creation path that previously skipped this, so a device swap
-      // silently regressed action modes to descriptor fallbacks. Feed-scoped
-      // default keys are dropped here — auto-wired feeds are minted with
-      // `config = NULL` (unchanged from the pre-seed path); the fast-path gate
-      // accounts for this so a wholly feed-scoped default does not re-wire
-      // forever.
-      const defaultConnectionConfig =
-        (await tx`
+				// 2. Ensure the connector definition + version are installed (idempotent).
+				await upsertConnectorDefinitionRecords({
+					sql: tx,
+					organizationId,
+					metadata,
+					versionRecord: {
+						compiledCode: null,
+						// Device manifests have no compiled bytes, so compiled_code_hash is
+						// the existing durable artifact-hash slot for their validated
+						// manifest identity. Claim authorization compares this exact value.
+						compiledCodeHash: currentSource?.manifestHash ?? null,
+						compileConfigHash: null,
+						sourceCode: null,
+						sourcePath,
+					},
+					// A device-manifest connector's sourcePath is meaningful only to the
+					// owning user's daemon → their org's row. A bundled device connector
+					// points at the shared on-disk catalog → shared row.
+					versionScope: source ? "organization" : "shared",
+				});
+				// Seed new/repaired auto-wired connections from the org's definition
+				// default, exactly like manage_connections create/connect merge
+				// `default_connection_config` into the new row's config — auto-wire is
+				// the only creation path that previously skipped this, so a device swap
+				// silently regressed action modes to descriptor fallbacks. Feed-scoped
+				// default keys are dropped here — auto-wired feeds are minted with
+				// `config = NULL` (unchanged from the pre-seed path); the fast-path gate
+				// accounts for this so a wholly feed-scoped default does not re-wire
+				// forever.
+				const defaultConnectionConfig = (await tx`
           SELECT default_connection_config
           FROM connector_definitions
           WHERE organization_id = ${organizationId}
@@ -575,18 +608,20 @@ async function ensureDeviceConnectorWired(
             AND status = 'active'
           LIMIT 1
         `) as unknown as Array<{ default_connection_config: unknown }>;
-      const splitConfig = splitConfigByFeedScope(
-        parseJsonObject(defaultConnectionConfig[0]?.default_connection_config),
-        (metadata.feeds as unknown as Record<string, FeedDefinition>) ?? null,
-      );
-      const seedConfig = splitConfig.connectionConfig;
+				const splitConfig = splitConfigByFeedScope(
+					parseJsonObject(
+						defaultConnectionConfig[0]?.default_connection_config,
+					),
+					(metadata.feeds as unknown as Record<string, FeedDefinition>) ?? null,
+				);
+				const seedConfig = splitConfig.connectionConfig;
 
-      // 3. Reuse or create the connection (no-auth, active, private). Match on
-      //    (org, connector, no auth_profile) — the device-connector identity —
-      //    rather than created_by, so orphan rows (created_by IS NULL, or
-      //    created by a different user/token) get adopted and self-healed
-      //    instead of stranded behind a slug-collision insert.
-      const existingConn = (await tx`
+				// 3. Reuse or create the connection (no-auth, active, private). Match on
+				//    (org, connector, no auth_profile) — the device-connector identity —
+				//    rather than created_by, so orphan rows (created_by IS NULL, or
+				//    created by a different user/token) get adopted and self-healed
+				//    instead of stranded behind a slug-collision insert.
+				const existingConn = (await tx`
         SELECT id, created_by FROM connections
         WHERE organization_id = ${organizationId}
           AND connector_key = ${connectorKey}
@@ -596,53 +631,53 @@ async function ensureDeviceConnectorWired(
         ORDER BY id ASC
         LIMIT 1
       `) as unknown as Array<{ id: number; created_by: string | null }>;
-      connectionId = existingConn[0]?.id;
-      if (connectionId && existingConn[0].created_by == null) {
-        // Backfill ownership so future per-user queries (e.g. /api/me/devices)
-        // attribute the connection to the user whose poll wired it.
-        await tx`
+				connectionId = existingConn[0]?.id;
+				if (connectionId && existingConn[0].created_by == null) {
+					// Backfill ownership so future per-user queries (e.g. /api/me/devices)
+					// attribute the connection to the user whose poll wired it.
+					await tx`
           UPDATE connections
           SET created_by = ${userId}, updated_at = NOW()
           WHERE id = ${connectionId} AND created_by IS NULL
         `;
-      }
-      if (connectionId && seedConfig) {
-        // Heal a surviving connection whose config is still SQL NULL (a row
-        // created before the definition default existed, or by the old
-        // no-seed path): seed the same default now. Guarded by `config IS NULL`
-        // so an explicit per-connection config is never clobbered. Idempotent —
-        // once seeded, this UPDATE stops matching.
-        await tx`
+				}
+				if (connectionId && seedConfig) {
+					// Heal a surviving connection whose config is still SQL NULL (a row
+					// created before the definition default existed, or by the old
+					// no-seed path): seed the same default now. Guarded by `config IS NULL`
+					// so an explicit per-connection config is never clobbered. Idempotent —
+					// once seeded, this UPDATE stops matching.
+					await tx`
           UPDATE connections
           SET config = ${sql.json(seedConfig)}, updated_at = NOW()
           WHERE id = ${connectionId} AND config IS NULL AND deleted_at IS NULL
         `;
-      }
-      if (!connectionId) {
-        // Stable slug for `lobu apply` diffing — same generation path as
-        // manage_connections.
-        //
-        // The advisory lock above does NOT make this race-free, contrary to
-        // what this comment used to claim. The lock is keyed on
-        // (userId, connectorKey), but the slug derives from the connector's
-        // DISPLAY NAME and uniqueness is enforced per-ORG by
-        // `connections_org_slug_unique`. Two different connector keys take two
-        // different locks and run concurrently, so two connectors sharing a
-        // display name compute the same free slug and the loser's INSERT trips
-        // the constraint. Reproduced: see
-        // device-reconcile-slug-race.test.ts. Lock scope and
-        // uniqueness scope simply are not the same scope.
-        //
-        // The retry lives OUTSIDE this transaction (at the wireOnce call
-        // site below), because an aborted transaction cannot be continued —
-        // which is the one thing the old comment got right.
-        const slug = await ensureUniqueConnectionSlug({
-          organizationId,
-          connectorKey,
-          displayName: metadata.name,
-          db: tx,
-        });
-        const inserted = (await tx`
+				}
+				if (!connectionId) {
+					// Stable slug for `lobu apply` diffing — same generation path as
+					// manage_connections.
+					//
+					// The advisory lock above does NOT make this race-free, contrary to
+					// what this comment used to claim. The lock is keyed on
+					// (userId, connectorKey), but the slug derives from the connector's
+					// DISPLAY NAME and uniqueness is enforced per-ORG by
+					// `connections_org_slug_unique`. Two different connector keys take two
+					// different locks and run concurrently, so two connectors sharing a
+					// display name compute the same free slug and the loser's INSERT trips
+					// the constraint. Reproduced: see
+					// device-reconcile-slug-race.test.ts. Lock scope and
+					// uniqueness scope simply are not the same scope.
+					//
+					// The retry lives OUTSIDE this transaction (at the wireOnce call
+					// site below), because an aborted transaction cannot be continued —
+					// which is the one thing the old comment got right.
+					const slug = await ensureUniqueConnectionSlug({
+						organizationId,
+						connectorKey,
+						displayName: metadata.name,
+						db: tx,
+					});
+					const inserted = (await tx`
           INSERT INTO connections (
             organization_id, connector_key, slug, display_name, status,
             auth_profile_id, app_auth_profile_id, config, created_by, visibility
@@ -652,18 +687,21 @@ async function ensureDeviceConnectorWired(
           )
           RETURNING id
         `) as unknown as Array<{ id: number }>;
-        connectionId = inserted[0]?.id;
-      }
-      if (!connectionId) return null;
+					connectionId = inserted[0]?.id;
+				}
+				if (!connectionId) return null;
 
-      // 4. Ensure every connector-declared feed exists and is active. A feed's
-      //    handlers decide its operations; the same row may sync and read.
-      const declaredFeeds = metadata.feeds as Record<string, ManifestFeed> | null;
+				// 4. Ensure every connector-declared feed exists and is active. A feed's
+				//    handlers decide its operations; the same row may sync and read.
+				const declaredFeeds = metadata.feeds as Record<
+					string,
+					ManifestFeed
+				> | null;
 
-      for (const feedKey of feedKeys) {
-        const operations = declaredFeeds?.[feedKey]?.operations ?? [];
-        const canSync = operations.includes('sync');
-        const existingFeed = (await tx`
+				for (const feedKey of feedKeys) {
+					const operations = declaredFeeds?.[feedKey]?.operations ?? [];
+					const canSync = operations.includes("sync");
+					const existingFeed = (await tx`
           SELECT id FROM feeds
           WHERE connection_id = ${connectionId}
             AND feed_key = ${feedKey}
@@ -671,23 +709,23 @@ async function ensureDeviceConnectorWired(
           LIMIT 1
         `) as unknown as Array<{ id: number }>;
 
-        if (existingFeed[0]?.id) {
-          await tx`
+					if (existingFeed[0]?.id) {
+						await tx`
             UPDATE feeds
             SET status = 'active',
                 next_run_at = ${canSync ? tx`COALESCE(next_run_at, NOW())` : tx`NULL::timestamptz`},
                 updated_at = current_timestamp
             WHERE id = ${existingFeed[0].id}
           `;
-        } else {
-          // The manifest's per-feed `name` when it declares one, and only the
-          // connector's own name as the fallback.
-          const declaredName = declaredFeeds?.[feedKey]?.name;
-          const displayName =
-            typeof declaredName === 'string' && declaredName.trim().length > 0
-              ? declaredName.trim()
-              : metadata.name;
-          await tx`
+					} else {
+						// The manifest's per-feed `name` when it declares one, and only the
+						// connector's own name as the fallback.
+						const declaredName = declaredFeeds?.[feedKey]?.name;
+						const displayName =
+							typeof declaredName === "string" && declaredName.trim().length > 0
+								? declaredName.trim()
+								: metadata.name;
+						await tx`
             INSERT INTO feeds (
               organization_id, connection_id, feed_key, display_name, status,
               next_run_at
@@ -697,58 +735,62 @@ async function ensureDeviceConnectorWired(
               ${canSync ? new Date() : null}
             )
           `;
-        }
-      }
+					}
+				}
 
-      // Pin the (possibly just-created) connection to the sole fresh device
-      // serving the capability, or leave it unpinned when several do.
-      await reconcilePin(
-        tx,
-        connectionId,
-        currentSource?.advertiserDeviceIds ?? matchingDeviceIds,
-        currentSource?.requiredCapability ?? requiredCapability,
-        currentSource ?? source
-      );
-      if (currentSource && !(await selectedArtifactMatches(tx, currentSource))) return null;
-      return claimAuthorization(currentSource);
-    });
+				// Pin the (possibly just-created) connection to the sole fresh device
+				// serving the capability, or leave it unpinned when several do.
+				await reconcilePin(
+					tx,
+					connectionId,
+					currentSource?.advertiserDeviceIds ?? matchingDeviceIds,
+					currentSource?.requiredCapability ?? requiredCapability,
+					currentSource ?? source,
+				);
+				if (
+					currentSource &&
+					!(await selectedArtifactMatches(tx, currentSource))
+				)
+					return null;
+				return claimAuthorization(currentSource);
+			});
 
-    let authorization: ManifestClaimAuthorization | null;
-    try {
-      authorization = await wireOnce();
-    } catch (err) {
-      // Retry ONCE, and only for the slug collision described above. The
-      // retry recomputes the slug against a tree that now contains the
-      // winner's committed row, so it converges on `<base>-2` rather than
-      // repeating the same losing bet.
-      //
-      // Bounded at one attempt deliberately. The next poll is the real retry
-      // budget for this reconcile — it already heals the collision — so this
-      // exists to avoid a spurious error-level log and a poll-cycle delay,
-      // not to guarantee convergence here. Anything unbounded would be a
-      // second retry budget layered on the existing one.
-      if (!isConnectionSlugUniqueViolation(err)) throw err;
-      logger.info(
-        { userId, connectorKey, organizationId },
-        '[device-connectors] Connection slug raced a concurrent wire; retrying once'
-      );
-      authorization = await wireOnce();
-    }
+		let authorization: ManifestClaimAuthorization | null;
+		try {
+			authorization = await wireOnce();
+		} catch (err) {
+			// Retry ONCE, and only for the slug collision described above. The
+			// retry recomputes the slug against a tree that now contains the
+			// winner's committed row, so it converges on `<base>-2` rather than
+			// repeating the same losing bet.
+			//
+			// Bounded at one attempt deliberately. The next poll is the real retry
+			// budget for this reconcile — it already heals the collision — so this
+			// exists to avoid a spurious error-level log and a poll-cycle delay,
+			// not to guarantee convergence here. Anything unbounded would be a
+			// second retry budget layered on the existing one.
+			if (!isConnectionSlugUniqueViolation(err)) throw err;
+			logger.info(
+				{ userId, connectorKey, organizationId },
+				"[device-connectors] Connection slug raced a concurrent wire; retrying once",
+			);
+			authorization = await wireOnce();
+		}
 
-    if (connectionId) {
-      logger.info(
-        { userId, connectorKey, organizationId, connectionId },
-        '[device-connectors] Wired device connector'
-      );
-    }
-    return authorization;
-  } catch (err) {
-    logger.error(
-      { userId, connectorKey, err: errorMessage(err) },
-      '[device-connectors] Failed to wire device connector'
-    );
-    return null;
-  }
+		if (connectionId) {
+			logger.info(
+				{ userId, connectorKey, organizationId, connectionId },
+				"[device-connectors] Wired device connector",
+			);
+		}
+		return authorization;
+	} catch (err) {
+		logger.error(
+			{ userId, connectorKey, err: errorMessage(err) },
+			"[device-connectors] Failed to wire device connector",
+		);
+		return null;
+	}
 }
 
 /**
@@ -759,10 +801,14 @@ async function ensureDeviceConnectorWired(
  * in the personal org (exactly what {@link ensureDeviceConnectorWired} creates);
  * that function re-activates them if the capability comes back. Best-effort.
  */
-async function pauseStaleDeviceFeeds(userId: string, organizationId: string, connectorKey: string) {
-  const sql = getDb();
-  try {
-    await sql`
+async function pauseStaleDeviceFeeds(
+	userId: string,
+	organizationId: string,
+	connectorKey: string,
+) {
+	const sql = getDb();
+	try {
+		await sql`
       UPDATE feeds f
       SET status = 'paused', updated_at = current_timestamp
       FROM connections c
@@ -776,12 +822,12 @@ async function pauseStaleDeviceFeeds(userId: string, organizationId: string, con
         AND f.status = 'active'
         AND f.deleted_at IS NULL
     `;
-  } catch (err) {
-    logger.warn(
-      { userId, connectorKey, err: errorMessage(err) },
-      '[device-connectors] Failed to pause stale device feeds'
-    );
-  }
+	} catch (err) {
+		logger.warn(
+			{ userId, connectorKey, err: errorMessage(err) },
+			"[device-connectors] Failed to pause stale device feeds",
+		);
+	}
 }
 
 /**
@@ -795,14 +841,14 @@ async function pauseStaleDeviceFeeds(userId: string, organizationId: string, con
  * and re-check stored manifests so concurrent polls converge. Best-effort.
  */
 async function archiveVanishedDeviceConnectorDefinitions(
-  userId: string,
-  organizationId: string,
-  liveKeys: string[]
+	userId: string,
+	organizationId: string,
+	liveKeys: string[],
 ): Promise<void> {
-  const sql = getDb();
-  try {
-    const archived = await sql.begin(async (tx) => {
-      const candidates = (await tx`
+	const sql = getDb();
+	try {
+		const archived = await sql.begin(async (tx) => {
+			const candidates = (await tx`
         SELECT cd.key
         FROM connector_definitions cd
         WHERE cd.organization_id = ${organizationId}
@@ -832,13 +878,13 @@ async function archiveVanishedDeviceConnectorDefinitions(
           )
         ORDER BY cd.key
       `) as unknown as Array<{ key: string }>;
-      for (const { key } of candidates) {
-        await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
-      }
-      if (candidates.length === 0) return [];
-      const candidateKeys = candidates.map(({ key }) => key);
+			for (const { key } of candidates) {
+				await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
+			}
+			if (candidates.length === 0) return [];
+			const candidateKeys = candidates.map(({ key }) => key);
 
-      const rows = (await tx`
+			const rows = (await tx`
         UPDATE connector_definitions cd
         SET status = 'archived', updated_at = NOW()
         WHERE cd.organization_id = ${organizationId}
@@ -875,21 +921,21 @@ async function archiveVanishedDeviceConnectorDefinitions(
           )
         RETURNING cd.key
       `) as unknown as Array<{ key: string }>;
-      return rows;
-    });
+			return rows;
+		});
 
-    if (archived.length > 0) {
-      logger.info(
-        { userId, organizationId, keys: archived.map((r) => r.key) },
-        '[device-connectors] Archived definitions no longer served by any connector source'
-      );
-    }
-  } catch (err) {
-    logger.warn(
-      { userId, organizationId, err: errorMessage(err) },
-      '[device-connectors] Failed to archive vanished device connector definitions'
-    );
-  }
+		if (archived.length > 0) {
+			logger.info(
+				{ userId, organizationId, keys: archived.map((r) => r.key) },
+				"[device-connectors] Archived definitions no longer served by any connector source",
+			);
+		}
+	} catch (err) {
+		logger.warn(
+			{ userId, organizationId, err: errorMessage(err) },
+			"[device-connectors] Failed to archive vanished device connector definitions",
+		);
+	}
 }
 
 /**
@@ -907,189 +953,209 @@ async function archiveVanishedDeviceConnectorDefinitions(
  * hardcoded — adding a new device connector is just a new file in the catalog.
  */
 export async function reconcileDeviceCapabilities(
-  userId: string,
-  pollingDeviceId?: string | null
+	userId: string,
+	pollingDeviceId?: string | null,
 ): Promise<ManifestClaimAuthorization[]> {
-  const sql = getDb();
+	const sql = getDb();
 
-  let bundledDeviceConnectors: BundledDeviceConnector[];
-  // Both connector sources are fail-soft (empty on error), which makes "no
-  // sources" ambiguous: nothing is served, or we failed to look. Only the
-  // latter must suppress the archive pass below — an empty-but-successful read
-  // is a legitimate "this fleet serves nothing", and is in fact the normal
-  // state for a Chrome-only user (no bundled device connectors exist server
-  // side; every one of them arrives as a device manifest).
-  let sourcesReadable = true;
-  try {
-    bundledDeviceConnectors = await getBundledDeviceConnectors();
-  } catch (err) {
-    logger.warn(
-      { userId, err: errorMessage(err) },
-      '[device-connectors] Failed to read device connector catalog'
-    );
-    bundledDeviceConnectors = [];
-    sourcesReadable = false;
-  }
+	let bundledDeviceConnectors: BundledDeviceConnector[];
+	// Both connector sources are fail-soft (empty on error), which makes "no
+	// sources" ambiguous: nothing is served, or we failed to look. Only the
+	// latter must suppress the archive pass below — an empty-but-successful read
+	// is a legitimate "this fleet serves nothing", and is in fact the normal
+	// state for a Chrome-only user (no bundled device connectors exist server
+	// side; every one of them arrives as a device manifest).
+	let sourcesReadable = true;
+	try {
+		bundledDeviceConnectors = await getBundledDeviceConnectors();
+	} catch (err) {
+		logger.warn(
+			{ userId, err: errorMessage(err) },
+			"[device-connectors] Failed to read device connector catalog",
+		);
+		bundledDeviceConnectors = [];
+		sourcesReadable = false;
+	}
 
-  // Device data ALWAYS lands in the user's personal org — device tokens are
-  // force-bound there (see oauth/device/approve + mint-child-token), and a
-  // team org reaches a device by pinning an automation/connection to it
-  // (resolveDeviceClaimableOrgs), not by re-binding the device. So auto-wire
-  // targets the personal org regardless of where a legacy device_workers row
-  // is still homed (older pairings may still carry a team org_id; they
-  // converge here on the next poll).
-  const personalOrg = await findExistingPersonalOrg(userId, sql);
-  if (!personalOrg) {
-    // No personal org → nothing to auto-wire. Don't touch team-org connectors
-    // a user may have created manually; those survive on their own pins.
-    return [];
-  }
-  const personalOrgId = personalOrg.id;
+	// Device data ALWAYS lands in the user's personal org — device tokens are
+	// force-bound there (see oauth/device/approve + mint-child-token), and a
+	// team org reaches a device by pinning an automation/connection to it
+	// (resolveDeviceClaimableOrgs), not by re-binding the device. So auto-wire
+	// targets the personal org regardless of where a legacy device_workers row
+	// is still homed (older pairings may still carry a team org_id; they
+	// converge here on the next poll).
+	const personalOrg = await findExistingPersonalOrg(userId, sql);
+	if (!personalOrg) {
+		// No personal org → nothing to auto-wire. Don't touch team-org connectors
+		// a user may have created manually; those survive on their own pins.
+		return [];
+	}
+	const personalOrgId = personalOrg.id;
 
-  // deviceId → capabilities it advertises (fresh devices only). We no longer
-  // partition by the device's stored org_id: under the personal-org
-  // invariant every device serves the personal workspace, so the fleet's
-  // combined capabilities decide what gets wired, irrespective of legacy
-  // per-device home rows.
-  const deviceCaps = new Map<string, Set<string>>();
-  try {
-    const rows = (await sql`
+	// deviceId → capabilities it advertises (fresh devices only). We no longer
+	// partition by the device's stored org_id: under the personal-org
+	// invariant every device serves the personal workspace, so the fleet's
+	// combined capabilities decide what gets wired, irrespective of legacy
+	// per-device home rows.
+	const deviceCaps = new Map<string, Set<string>>();
+	try {
+		const rows = (await sql`
       SELECT id, capabilities
       FROM device_workers
       WHERE user_id = ${userId}
         AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
     `) as unknown as Array<{ id: string; capabilities: unknown }>;
-    for (const r of rows) {
-      const caps = Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
-      deviceCaps.set(r.id, new Set(caps));
-    }
-  } catch (err) {
-    logger.warn(
-      { userId, err: errorMessage(err) },
-      '[device-connectors] Failed to read device capabilities'
-    );
-    return [];
-  }
-  if (deviceCaps.size === 0) return [];
-  const devicesWithCapability = (capability: string): string[] =>
-    [...deviceCaps.entries()].
-      filter(([, caps]) => caps.has(capability))
-      .map(([id]) => id);
+		for (const r of rows) {
+			const caps = Array.isArray(r.capabilities)
+				? (r.capabilities as string[])
+				: [];
+			deviceCaps.set(r.id, new Set(caps));
+		}
+	} catch (err) {
+		logger.warn(
+			{ userId, err: errorMessage(err) },
+			"[device-connectors] Failed to read device capabilities",
+		);
+		return [];
+	}
+	if (deviceCaps.size === 0) return [];
+	const devicesWithCapability = (capability: string): string[] =>
+		[...deviceCaps.entries()]
+			.filter(([, caps]) => caps.has(capability))
+			.map(([id]) => id);
 
-  let pollingDeviceAuthorizations: Awaited<
-    ReturnType<typeof getDeviceManifestClaimAuthorizationsForDevice>
-  > = [];
-  let pollingManifestClaimsReadable = true;
-  if (pollingDeviceId) {
-    try {
-      // Attest retained hashless rows before reconciliation's selected-artifact
-      // check. The attestation is still bounded to this validated device's
-      // exact manifest identity and org-scoped artifact row.
-      pollingDeviceAuthorizations = await getDeviceManifestClaimAuthorizationsForDevice({
-        sql,
-        userId,
-        deviceId: pollingDeviceId,
-      });
-      await attestDeviceManifestArtifacts({
-        sql,
-        organizationId: personalOrgId,
-        authorizations: pollingDeviceAuthorizations,
-      });
-    } catch (err) {
-      pollingManifestClaimsReadable = false;
-      logger.warn(
-        { userId, pollingDeviceId, err: errorMessage(err) },
-        '[device-connectors] Failed to read polling device manifest claims'
-      );
-    }
-  }
+	let pollingDeviceAuthorizations: Awaited<
+		ReturnType<typeof getDeviceManifestClaimAuthorizationsForDevice>
+	> = [];
+	let pollingManifestClaimsReadable = true;
+	if (pollingDeviceId) {
+		try {
+			// Attest retained hashless rows before reconciliation's selected-artifact
+			// check. The attestation is still bounded to this validated device's
+			// exact manifest identity and org-scoped artifact row.
+			pollingDeviceAuthorizations =
+				await getDeviceManifestClaimAuthorizationsForDevice({
+					sql,
+					userId,
+					deviceId: pollingDeviceId,
+				});
+			await attestDeviceManifestArtifacts({
+				sql,
+				organizationId: personalOrgId,
+				authorizations: pollingDeviceAuthorizations,
+			});
+		} catch (err) {
+			pollingManifestClaimsReadable = false;
+			logger.warn(
+				{ userId, pollingDeviceId, err: errorMessage(err) },
+				"[device-connectors] Failed to read polling device manifest claims",
+			);
+		}
+	}
 
-  let manifestSources: DeviceConnectorSource[] = [];
-  try {
-    manifestSources = await getDeviceManifestSourcesForUser({
-      sql,
-      userId,
-    });
-  } catch (err) {
-    logger.warn(
-      { userId, err: errorMessage(err) },
-      '[device-connectors] Failed to read device connector manifests'
-    );
-    sourcesReadable = false;
-  }
+	let manifestSources: DeviceConnectorSource[] = [];
+	try {
+		manifestSources = await getDeviceManifestSourcesForUser({
+			sql,
+			userId,
+		});
+	} catch (err) {
+		logger.warn(
+			{ userId, err: errorMessage(err) },
+			"[device-connectors] Failed to read device connector manifests",
+		);
+		sourcesReadable = false;
+	}
 
-  const byKey = new Map<
-    string,
-    | (BundledDeviceConnector & { source?: undefined })
-    | (DeviceConnectorSource & { source: 'device-manifest' })
-  >();
-  for (const dc of bundledDeviceConnectors) byKey.set(dc.key, dc);
-  for (const src of manifestSources) byKey.set(src.key, { ...src, source: 'device-manifest' });
+	const byKey = new Map<
+		string,
+		| (BundledDeviceConnector & { source?: undefined })
+		| (DeviceConnectorSource & { source: "device-manifest" })
+	>();
+	for (const dc of bundledDeviceConnectors) byKey.set(dc.key, dc);
+	for (const src of manifestSources)
+		byKey.set(src.key, { ...src, source: "device-manifest" });
 
-  // Runs BEFORE the early return: a fleet that advertises nothing is precisely
-  // the case where every device definition in the org has gone stale, so
-  // bailing on an empty `byKey` would skip the one pass that can clean it up.
-  // Gated on `sourcesReadable` rather than on `byKey.size` — a transient read
-  // failure must never be read as "the fleet serves nothing" and archive a
-  // user's whole working set.
-  if (sourcesReadable) {
-    await archiveVanishedDeviceConnectorDefinitions(userId, personalOrgId, [...byKey.keys()]);
-  }
-  if (byKey.size === 0) return [];
+	// Runs BEFORE the early return: a fleet that advertises nothing is precisely
+	// the case where every device definition in the org has gone stale, so
+	// bailing on an empty `byKey` would skip the one pass that can clean it up.
+	// Gated on `sourcesReadable` rather than on `byKey.size` — a transient read
+	// failure must never be read as "the fleet serves nothing" and archive a
+	// user's whole working set.
+	if (sourcesReadable) {
+		await archiveVanishedDeviceConnectorDefinitions(userId, personalOrgId, [
+			...byKey.keys(),
+		]);
+	}
+	if (byKey.size === 0) return [];
 
-  const reconciliationResults = await Promise.allSettled(
-    [...byKey.values()].map((dc) => {
-      const matchingDeviceIds =
-        'source' in dc && dc.source === 'device-manifest'
-          ? dc.advertiserDeviceIds
-          : devicesWithCapability(dc.requiredCapability);
-      return matchingDeviceIds.length > 0
-        ? ensureDeviceConnectorWired(
-            userId,
-            personalOrgId,
-            dc.key,
-            dc.feedKeys,
-            matchingDeviceIds,
-            dc.requiredCapability,
-            'source' in dc && dc.source === 'device-manifest'
-              ? dc
-              : undefined,
-            pollingDeviceId
-          )
-        : pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);
-    })
-  );
+	const reconciliationResults = await Promise.allSettled(
+		[...byKey.values()].map((dc) => {
+			const matchingDeviceIds =
+				"source" in dc && dc.source === "device-manifest"
+					? dc.advertiserDeviceIds
+					: devicesWithCapability(dc.requiredCapability);
+			return matchingDeviceIds.length > 0
+				? ensureDeviceConnectorWired(
+						userId,
+						personalOrgId,
+						dc.key,
+						dc.feedKeys,
+						matchingDeviceIds,
+						dc.requiredCapability,
+						"source" in dc && dc.source === "device-manifest" ? dc : undefined,
+						pollingDeviceId,
+					)
+				: pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);
+		}),
+	);
 
-  const reconciledAuthorizations = reconciliationResults.flatMap((result) =>
-    result.status === 'fulfilled' && result.value ? [result.value] : []
-  );
-  if (!pollingDeviceId) return reconciledAuthorizations;
-  if (!pollingManifestClaimsReadable || !sourcesReadable) return [];
+	const reconciledAuthorizations = reconciliationResults.flatMap((result) =>
+		result.status === "fulfilled" && result.value ? [result.value] : [],
+	);
+	if (!pollingDeviceId) return reconciledAuthorizations;
+	if (!pollingManifestClaimsReadable || !sourcesReadable) return [];
 
-  // If the polling device is the current winner for a manifest key, a failed
-  // wire/reconciliation must fail closed for that key. Historical claims are
-  // allowed only for keys where this device advertises a retained version and
-  // winner reconciliation belongs to another device.
-  const currentWinnerKeysForPoller = new Set(
-    manifestSources
-      .filter((source) => source.advertiserDeviceIds.includes(pollingDeviceId))
-      .map((source) => source.key)
-  );
-  const failedCurrentWinnerKeys = new Set(
-    [...currentWinnerKeysForPoller].filter(
-      (key) => !reconciledAuthorizations.some((authorization) => authorization.connectorKey === key)
-    )
-  );
-  const all = [
-    ...reconciledAuthorizations,
-    ...pollingDeviceAuthorizations.filter(
-      (authorization) => !failedCurrentWinnerKeys.has(authorization.connectorKey)
-    ),
-  ];
-  return [...new Map(
-    all.map((authorization) => [
-      `${authorization.connectorKey}\u0000${authorization.connectorVersion}\u0000${authorization.manifestHash}`,
-      authorization,
-    ])
-  ).values()];
+	// If the polling device is the current winner for a manifest key, a failed
+	// wire/reconciliation must fail closed for that key. Historical claims are
+	// allowed only for keys where this device advertises a retained version and
+	// winner reconciliation belongs to another device.
+	const currentWinnerKeysForPoller = new Set(
+		manifestSources
+			.filter((source) => source.advertiserDeviceIds.includes(pollingDeviceId))
+			.map((source) => source.key),
+	);
+	const failedCurrentWinnerKeys = new Set(
+		[...currentWinnerKeysForPoller].filter(
+			(key) =>
+				!reconciledAuthorizations.some(
+					(authorization) => authorization.connectorKey === key,
+				),
+		),
+	);
+	const validatedReconciledAuthorizations = reconciledAuthorizations.filter(
+		(authorization) =>
+			pollingDeviceAuthorizations.some(
+				(validated) =>
+					validated.connectorKey === authorization.connectorKey &&
+					validated.connectorVersion === authorization.connectorVersion &&
+					validated.manifestHash === authorization.manifestHash &&
+					validated.sourcePath === authorization.sourcePath,
+			),
+	);
+	const all = [
+		...validatedReconciledAuthorizations,
+		...pollingDeviceAuthorizations.filter(
+			(authorization) =>
+				!failedCurrentWinnerKeys.has(authorization.connectorKey),
+		),
+	];
+	return [
+		...new Map(
+			all.map((authorization) => [
+				`${authorization.connectorKey}\u0000${authorization.connectorVersion}\u0000${authorization.manifestHash}`,
+				authorization,
+			]),
+		).values(),
+	];
 }

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -9,41 +9,32 @@
  * creating runs nothing can claim.
  */
 
-import { parseJsonObject } from "@lobu/core";
-import { getDb, pgTextArray } from "../db/client";
-import { findExistingPersonalOrg } from "../auth/personal-org-provisioning";
+import { parseJsonObject } from '@lobu/core';
+import { getDb, pgTextArray } from '../db/client';
+import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
+import { splitConfigByFeedScope, type FeedDefinition } from '../tools/admin/helpers/feed-helpers';
 import {
-	splitConfigByFeedScope,
-	type FeedDefinition,
-} from "../tools/admin/helpers/feed-helpers";
+  type BundledDeviceConnector,
+  bundledConnectorSourcePath,
+  compileConnectorFromFile,
+  findBundledConnectorFile,
+  getBundledDeviceConnectors,
+} from '../utils/connector-catalog';
+import { extractConnectorMetadata, type ConnectorMetadata } from '../utils/connector-compiler';
+import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
+import { ensureUniqueConnectionSlug, isConnectionSlugUniqueViolation } from '../utils/connections';
+import { clearDevicePinTombstoneIfPinned } from '../utils/device-pin-tombstones';
+import { DEVICE_AUTOWIRE_SUPPRESSION_KEY } from '../utils/device-autowire-suppression';
+import { errorMessage } from '../utils/errors';
+import logger from '../utils/logger';
 import {
-	type BundledDeviceConnector,
-	bundledConnectorSourcePath,
-	compileConnectorFromFile,
-	findBundledConnectorFile,
-	getBundledDeviceConnectors,
-} from "../utils/connector-catalog";
-import {
-	extractConnectorMetadata,
-	type ConnectorMetadata,
-} from "../utils/connector-compiler";
-import { upsertConnectorDefinitionRecords } from "../utils/connector-definition-install";
-import {
-	ensureUniqueConnectionSlug,
-	isConnectionSlugUniqueViolation,
-} from "../utils/connections";
-import { clearDevicePinTombstoneIfPinned } from "../utils/device-pin-tombstones";
-import { DEVICE_AUTOWIRE_SUPPRESSION_KEY } from "../utils/device-autowire-suppression";
-import { errorMessage } from "../utils/errors";
-import logger from "../utils/logger";
-import {
-	attestDeviceManifestArtifacts,
-	getDeviceManifestClaimAuthorizationsForDevice,
-	getDeviceManifestSourcesForUser,
-	sortJson,
-	type DeviceConnectorSource,
-	type ManifestClaimAuthorization,
-} from "./device-manifests";
+  attestDeviceManifestArtifacts,
+  getDeviceManifestClaimAuthorizationsForDevice,
+  getDeviceManifestSourcesForUser,
+  sortJson,
+  type DeviceConnectorSource,
+  type ManifestClaimAuthorization,
+} from './device-manifests';
 
 /**
  * The slice of a manifest `feeds_schema[key]` this module reads. Deliberately
@@ -51,12 +42,12 @@ import {
  * contract, and a manifest is untyped JSON off the wire regardless.
  */
 interface ManifestFeed {
-	name?: string;
-	operations?: Array<"sync" | "read">;
+  name?: string;
+  operations?: Array<'sync' | 'read'>;
 }
 
 /** A device worker counts toward "serves capability X" only if seen this recently. */
-const DEVICE_WORKER_FRESH_INTERVAL = "7 days";
+const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
 
 /**
  * Install + wire a bundled device connector into the user's personal org:
@@ -83,50 +74,47 @@ const DEVICE_WORKER_FRESH_INTERVAL = "7 days";
  * sole remaining fresh device, or NULL) so the connection keeps running.
  */
 async function ensureDeviceConnectorWired(
-	userId: string,
-	organizationId: string,
-	connectorKey: string,
-	declaredFeedKeys: string[],
-	matchingDeviceIds: string[],
-	requiredCapability: string,
-	source?: DeviceConnectorSource,
-	pollingDeviceId?: string | null,
+  userId: string,
+  organizationId: string,
+  connectorKey: string,
+  declaredFeedKeys: string[],
+  matchingDeviceIds: string[],
+  requiredCapability: string,
+  source?: DeviceConnectorSource,
+  pollingDeviceId?: string | null
 ): Promise<ManifestClaimAuthorization | null> {
-	const sql = getDb();
+  const sql = getDb();
 
-	// Self-heal the device pin against the user's current fleet. Cheap, idempotent
-	// (the WHERE matches nothing when the pin is already a valid fresh device), and
-	// runs even on the fast path so a stale pin doesn't silently strand the feeds.
-	const reconcilePin = async (
-		db: typeof sql,
-		connectionId: number,
-		currentMatchingDeviceIds = matchingDeviceIds,
-		currentRequiredCapability = requiredCapability,
-		currentSource = source,
-	) => {
-		let target =
-			currentMatchingDeviceIds.length === 1
-				? currentMatchingDeviceIds[0]
-				: null;
-		// `idx_connections_org_connector_device_live` is UNIQUE on
-		// (organization_id, connector_key, device_worker_id) for live rows, and an
-		// org legitimately holds one connection PER DEVICE (same shape as
-		// `idx_connections_org_connector_account_live` for OAuth accounts). So the
-		// row we were handed is not necessarily the one that owns `target`: retiring
-		// a Mac leaves its connection pinned to the stale device while the new Mac's
-		// connection holds the only fresh one, and pinning the former to the latter's
-		// device violates the index, aborts the whole wire transaction, and retries
-		// forever (~8/min in prod for apple.computer_use).
-		//
-		// Never steal a pin another live connection holds — the same guard
-		// `resolveOnlineChromeConnection` already carries for this index (see
-		// `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
-		// dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
-		// clears the dead pin (a connection pinned to a vanished device is claimable
-		// by nobody, while an unpinned one is claimable by any polling device), so
-		// the documented stale-pin repair survives.
-		if (target) {
-			const owner = (await db`
+  // Self-heal the device pin against the user's current fleet. Cheap, idempotent
+  // (the WHERE matches nothing when the pin is already a valid fresh device), and
+  // runs even on the fast path so a stale pin doesn't silently strand the feeds.
+  const reconcilePin = async (
+    db: typeof sql,
+    connectionId: number,
+    currentMatchingDeviceIds = matchingDeviceIds,
+    currentRequiredCapability = requiredCapability,
+    currentSource = source
+  ) => {
+    let target = currentMatchingDeviceIds.length === 1 ? currentMatchingDeviceIds[0] : null;
+    // `idx_connections_org_connector_device_live` is UNIQUE on
+    // (organization_id, connector_key, device_worker_id) for live rows, and an
+    // org legitimately holds one connection PER DEVICE (same shape as
+    // `idx_connections_org_connector_account_live` for OAuth accounts). So the
+    // row we were handed is not necessarily the one that owns `target`: retiring
+    // a Mac leaves its connection pinned to the stale device while the new Mac's
+    // connection holds the only fresh one, and pinning the former to the latter's
+    // device violates the index, aborts the whole wire transaction, and retries
+    // forever (~8/min in prod for apple.computer_use).
+    //
+    // Never steal a pin another live connection holds — the same guard
+    // `resolveOnlineChromeConnection` already carries for this index (see
+    // `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
+    // dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
+    // clears the dead pin (a connection pinned to a vanished device is claimable
+    // by nobody, while an unpinned one is claimable by any polling device), so
+    // the documented stale-pin repair survives.
+    if (target) {
+      const owner = (await db`
         SELECT id FROM connections
         WHERE organization_id = ${organizationId}
           AND connector_key = ${connectorKey}
@@ -134,61 +122,55 @@ async function ensureDeviceConnectorWired(
           AND deleted_at IS NULL
         LIMIT 1
       `) as unknown as Array<{ id: number }>;
-			const ownerId = owner[0]?.id;
-			if (ownerId != null && Number(ownerId) !== connectionId) {
-				logger.warn(
-					{
-						userId,
-						connectorKey,
-						connectionId,
-						ownerConnectionId: ownerId,
-						deviceWorkerId: target,
-					},
-					"[device-connectors] Device already pinned to another connection — unpinning instead",
-				);
-				target = null;
-			}
-		}
-		// Compare via text on both sides — passing a `pgTextArray(...)` literal
-		// through a `::uuid[]` cast trips a postgres "malformed array literal"
-		// failure under the extended-protocol path postgres.js uses (the bound
-		// text parameter never gets re-parsed as an array before the uuid[] cast
-		// runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
-		// entirely; UUIDs are canonical lowercase so text equality matches the
-		// uuid form 1:1.
-		await db`
+      const ownerId = owner[0]?.id;
+      if (ownerId != null && Number(ownerId) !== connectionId) {
+        logger.warn(
+          { userId, connectorKey, connectionId, ownerConnectionId: ownerId, deviceWorkerId: target },
+          '[device-connectors] Device already pinned to another connection — unpinning instead'
+        );
+        target = null;
+      }
+    }
+    // Compare via text on both sides — passing a `pgTextArray(...)` literal
+    // through a `::uuid[]` cast trips a postgres "malformed array literal"
+    // failure under the extended-protocol path postgres.js uses (the bound
+    // text parameter never gets re-parsed as an array before the uuid[] cast
+    // runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
+    // entirely; UUIDs are canonical lowercase so text equality matches the
+    // uuid form 1:1.
+    await db`
       UPDATE connections
       SET device_worker_id = ${target}::uuid, updated_at = NOW()
       WHERE id = ${connectionId}
         AND device_worker_id IS DISTINCT FROM ${target}::uuid
         AND (device_worker_id IS NULL OR NOT (device_worker_id::text = ANY(${pgTextArray(currentMatchingDeviceIds)}::text[])))
     `;
-		// The statement above repairs only the row we were handed, but an org holds
-		// one connection PER DEVICE and the fast path resolves just one of them
-		// (`GROUP BY … LIMIT 1`, no ORDER BY). When it returns the row that is
-		// already correctly pinned, the UPDATE no-ops — and a sibling left pinned to
-		// a device that has dropped out is never revisited, so it stays bound to a
-		// worker that will never poll again. Sweep every live row instead: a pin
-		// outside the fresh set is stale by definition, and NULL is strictly better
-		// than a dead pin (unpinned is claimable by any polling device; a vanished
-		// device is claimable by nobody).
-		//
-		// Safe for the multi-fresh case — pins INSIDE the fresh set are deliberate
-		// and untouched — and the empty-fleet case never reaches here, because
-		// `reconcileDeviceCapabilities` only calls this connector's wire pass when
-		// `matchingDeviceIds.length > 0` (an offline fleet routes to
-		// `pauseStaleDeviceFeeds`, which must not unpin anything).
-		// Re-check freshness against `device_workers` AT MUTATION TIME rather than
-		// trusting `matchingDeviceIds`, which is snapshotted before the advisory
-		// lock is taken (see `reconcileDeviceCapabilities`). A concurrent poll on
-		// another replica can refresh a device's heartbeat between this pass's
-		// snapshot and its commit; sweeping from the stale list would unpin a
-		// device that is live again. The NOT EXISTS makes the sweep self-verifying:
-		// a row is cleared only if its worker is genuinely absent, stale, or no
-		// longer advertising the implementation as of this statement. Manifest
-		// sources require the exact winning hash as well as their capability;
-		// capability-only bundled sources retain their existing matching semantics.
-		await db`
+    // The statement above repairs only the row we were handed, but an org holds
+    // one connection PER DEVICE and the fast path resolves just one of them
+    // (`GROUP BY … LIMIT 1`, no ORDER BY). When it returns the row that is
+    // already correctly pinned, the UPDATE no-ops — and a sibling left pinned to
+    // a device that has dropped out is never revisited, so it stays bound to a
+    // worker that will never poll again. Sweep every live row instead: a pin
+    // outside the fresh set is stale by definition, and NULL is strictly better
+    // than a dead pin (unpinned is claimable by any polling device; a vanished
+    // device is claimable by nobody).
+    //
+    // Safe for the multi-fresh case — pins INSIDE the fresh set are deliberate
+    // and untouched — and the empty-fleet case never reaches here, because
+    // `reconcileDeviceCapabilities` only calls this connector's wire pass when
+    // `matchingDeviceIds.length > 0` (an offline fleet routes to
+    // `pauseStaleDeviceFeeds`, which must not unpin anything).
+    // Re-check freshness against `device_workers` AT MUTATION TIME rather than
+    // trusting `matchingDeviceIds`, which is snapshotted before the advisory
+    // lock is taken (see `reconcileDeviceCapabilities`). A concurrent poll on
+    // another replica can refresh a device's heartbeat between this pass's
+    // snapshot and its commit; sweeping from the stale list would unpin a
+    // device that is live again. The NOT EXISTS makes the sweep self-verifying:
+    // a row is cleared only if its worker is genuinely absent, stale, or no
+    // longer advertising the implementation as of this statement. Manifest
+    // sources require the exact winning hash as well as their capability;
+    // capability-only bundled sources retain their existing matching semantics.
+    await db`
       UPDATE connections c
       SET device_worker_id = NULL, updated_at = NOW()
       WHERE c.organization_id = ${organizationId}
@@ -214,53 +196,51 @@ async function ensureDeviceConnectorWired(
             ${currentSource ? db`AND (dw.connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${currentSource.manifestHash}` : db``}
         )
     `;
-		// Pin restore (or already-valid pin): drop DELETE/move tombstones so the
-		// connection is not stuck as active + red "Device was removed".
-		await clearDevicePinTombstoneIfPinned(db, {
-			connectionId,
-			matchingDeviceIds: currentMatchingDeviceIds,
-		});
-	};
-	const lockedManifestWinner = async (
-		db: typeof sql,
-	): Promise<DeviceConnectorSource | null> => {
-		if (!source) return null;
-		const current = (
-			await getDeviceManifestSourcesForUser({ sql: db, userId, connectorKey })
-		).find((candidate) => candidate.key === connectorKey);
-		if (
-			!current ||
-			current.metadata.version !== source.metadata.version ||
-			current.manifestHash !== source.manifestHash
-		) {
-			return null;
-		}
-		return current;
-	};
-	const claimAuthorization = (
-		currentSource: DeviceConnectorSource | null,
-	): ManifestClaimAuthorization | null => {
-		if (
-			!currentSource ||
-			!pollingDeviceId ||
-			!currentSource.advertiserDeviceIds.includes(pollingDeviceId)
-		) {
-			return null;
-		}
-		return {
-			connectorKey: currentSource.key,
-			connectorVersion: currentSource.metadata.version,
-			manifestHash: currentSource.manifestHash,
-			definitionManifestHash: currentSource.definitionManifestHash,
-			sourcePath: currentSource.sourcePath,
-			runtimeExecution: currentSource.metadata.runtime?.execution,
-		};
-	};
-	const selectedArtifactMatches = async (
-		db: typeof sql,
-		currentSource: DeviceConnectorSource,
-	): Promise<boolean> => {
-		const rows = await db`
+    // Pin restore (or already-valid pin): drop DELETE/move tombstones so the
+    // connection is not stuck as active + red "Device was removed".
+    await clearDevicePinTombstoneIfPinned(db, {
+      connectionId,
+      matchingDeviceIds: currentMatchingDeviceIds,
+    });
+  };
+  const lockedManifestWinner = async (db: typeof sql): Promise<DeviceConnectorSource | null> => {
+    if (!source) return null;
+    const current = (
+      await getDeviceManifestSourcesForUser({ sql: db, userId, connectorKey })
+    ).find((candidate) => candidate.key === connectorKey);
+    if (
+      !current ||
+      current.metadata.version !== source.metadata.version ||
+      current.manifestHash !== source.manifestHash
+    ) {
+      return null;
+    }
+    return current;
+  };
+  const claimAuthorization = (
+    currentSource: DeviceConnectorSource | null
+  ): ManifestClaimAuthorization | null => {
+    if (
+      !currentSource ||
+      !pollingDeviceId ||
+      !currentSource.advertiserDeviceIds.includes(pollingDeviceId)
+    ) {
+      return null;
+    }
+    return {
+      connectorKey: currentSource.key,
+      connectorVersion: currentSource.metadata.version,
+      manifestHash: currentSource.manifestHash,
+      definitionManifestHash: currentSource.definitionManifestHash,
+      sourcePath: currentSource.sourcePath,
+      runtimeExecution: currentSource.metadata.runtime?.execution,
+    };
+  };
+  const selectedArtifactMatches = async (
+    db: typeof sql,
+    currentSource: DeviceConnectorSource
+  ): Promise<boolean> => {
+    const rows = await db`
       SELECT 1
       FROM connector_definitions cd
       JOIN LATERAL (
@@ -288,15 +268,15 @@ async function ensureDeviceConnectorWired(
         AND cv.source_code IS NULL
       LIMIT 1
     `;
-		return rows.length > 0;
-	};
+    return rows.length > 0;
+  };
 
-	try {
-		// Fast path: definition + version + connection + EVERY declared feed active
-		// → nothing to repair or re-activate. The feed list comes from the bundled
-		// catalog source, not the installed DB row, so adding a new bundled feed
-		// still heals existing installs after deploy.
-		const existingReady = (await sql`
+  try {
+    // Fast path: definition + version + connection + EVERY declared feed active
+    // → nothing to repair or re-activate. The feed list comes from the bundled
+    // catalog source, not the installed DB row, so adding a new bundled feed
+    // still heals existing installs after deploy.
+    const existingReady = (await sql`
       SELECT
         c.id AS connection_id,
         cv.connector_key AS version_key,
@@ -369,187 +349,173 @@ async function ensureDeviceConnectorWired(
         cd.id
       LIMIT 1
     `) as unknown as Array<{
-			connection_id: number | null;
-			version_key: string | null;
-			version_source_path: string | null;
-			version_compiled_code: string | null;
-			version_artifact_hash: string | null;
-			version_compile_config_hash: string | null;
-			version_source_code: string | null;
-			def_name: string | null;
-			def_description: string | null;
-			def_version: string | null;
-			def_auth_schema: unknown;
-			def_feeds_schema: unknown;
-			def_actions_schema: unknown;
-			def_options_schema: unknown;
-			def_favicon_domain: string | null;
-			def_required_capability: string | null;
-			def_runtime: unknown;
-			def_default_config: unknown;
-			conn_config: unknown;
-			active_feed_keys: string[] | null;
-		}>;
-		// Device-manifest connectors carry their full metadata in-hand (`source`),
-		// so a changed manifest MUST break the fast path or the org catalog is
-		// stranded on the old definition forever: the extension re-sends its
-		// manifest on every poll, but nothing else ever re-runs the definition
-		// upsert once everything is wired (this exact staleness shipped
-		// console_capture to device_workers while list_available kept serving the
-		// old 12-action chrome catalog). Compare every field the definition upsert
-		// writes, in the manifest hash's canonical form. Bundled connectors
-		// (`source` undefined) are excluded on purpose — their metadata requires a
-		// compile we can't afford per poll; deploys refresh them via other paths.
-		const definitionMatchesSource = (
-			row: (typeof existingReady)[0],
-		): boolean => {
-			if (!source) return true;
-			const m = source.metadata;
-			const canon = (v: unknown) => JSON.stringify(sortJson(v ?? null));
-			return (
-				row.def_name === m.name &&
-				(row.def_description ?? null) === (m.description ?? null) &&
-				row.def_version === m.version &&
-				row.version_source_path === source.sourcePath &&
-				row.version_compiled_code == null &&
-				row.version_artifact_hash === source.manifestHash &&
-				row.version_compile_config_hash == null &&
-				row.version_source_code == null &&
-				(row.def_favicon_domain ?? null) === (m.faviconDomain ?? null) &&
-				(row.def_required_capability ?? null) ===
-					(m.requiredCapability ?? null) &&
-				canon(row.def_auth_schema) === canon(m.authSchema) &&
-				canon(row.def_feeds_schema) === canon(m.feeds) &&
-				canon(row.def_actions_schema) === canon(m.actions) &&
-				canon(row.def_options_schema) === canon(m.optionsSchema) &&
-				canon(row.def_runtime) === canon(m.runtime)
-			);
-		};
-		const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
-		const readyConnectionId = existingReady[0]?.connection_id;
-		// A ready connection whose config is SQL NULL while the org definition
-		// carries a default needs the default seeded — the fast path must not
-		// leave it resolving against raw descriptor fallbacks. `conn_config` is the
-		// raw jsonb value (`null` only when the column is SQL NULL), so an empty
-		// explicit `{}` still counts as configured. Seeded in wireOnce below.
-		// The predicate gates on the CONNECTION-scoped half of the default
-		// (`splitConfigByFeedScope(…).connectionConfig`), the exact value seeding
-		// can write: a wholly feed-scoped default must not keep a NULL-config
-		// connection spinning the wire path forever. `def_feeds_schema` equals the
-		// manifest feeds on this path (definitionMatchesSource above), so the split
-		// here mirrors the one wireOnce performs; don't re-split against a
-		// different feeds schema, or the gate and the seed stop agreeing.
-		const needsDefaultConfigSeed =
-			existingReady[0]?.conn_config == null &&
-			splitConfigByFeedScope(
-				parseJsonObject(existingReady[0]?.def_default_config),
-				(existingReady[0]?.def_feeds_schema as Record<
-					string,
-					FeedDefinition
-				> | null) ?? null,
-			).connectionConfig != null;
-		const ready =
-			readyConnectionId != null &&
-			existingReady[0]?.version_key != null &&
-			definitionMatchesSource(existingReady[0]) &&
-			!needsDefaultConfigSeed &&
-			// userManaged-only connectors (e.g. local.directory, browser/*) report
-			// declaredFeedKeys=[]. Once the connection + definition are installed,
-			// every subsequent poll has nothing to verify — fast-path out.
-			// Composing primitives still hit /api/workers/me/feeds to mint
-			// explicit per-instance rows; that path is unchanged.
-			(declaredFeedKeys.length === 0 ||
-				declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)));
-		if (ready) {
-			if (source) {
-				return sql.begin(async (tx) => {
-					await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-					const currentSource = await lockedManifestWinner(tx);
-					if (
-						!currentSource ||
-						!(await selectedArtifactMatches(tx, currentSource))
-					)
-						return null;
-					await reconcilePin(
-						tx,
-						readyConnectionId,
-						currentSource.advertiserDeviceIds,
-						currentSource.requiredCapability,
-						currentSource,
-					);
-					return claimAuthorization(currentSource);
-				});
-			} else {
-				// Same advisory lock as the `source` branch above: reconcilePin's owner
-				// check is read-then-write, so two replicas polling concurrently could
-				// both observe "nobody owns this device" and race into the unique index.
-				// (No bundled device connectors ship today, so this branch is currently
-				// unreachable — keep it serialized anyway rather than leave the race
-				// armed for the first one that does.)
-				await sql.begin(async (tx) => {
-					await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-					await reconcilePin(tx, readyConnectionId);
-				});
-			}
-			return null;
-		}
+      connection_id: number | null;
+      version_key: string | null;
+      version_source_path: string | null;
+      version_compiled_code: string | null;
+      version_artifact_hash: string | null;
+      version_compile_config_hash: string | null;
+      version_source_code: string | null;
+      def_name: string | null;
+      def_description: string | null;
+      def_version: string | null;
+      def_auth_schema: unknown;
+      def_feeds_schema: unknown;
+      def_actions_schema: unknown;
+      def_options_schema: unknown;
+      def_favicon_domain: string | null;
+      def_required_capability: string | null;
+      def_runtime: unknown;
+      def_default_config: unknown;
+      conn_config: unknown;
+      active_feed_keys: string[] | null;
+    }>;
+    // Device-manifest connectors carry their full metadata in-hand (`source`),
+    // so a changed manifest MUST break the fast path or the org catalog is
+    // stranded on the old definition forever: the extension re-sends its
+    // manifest on every poll, but nothing else ever re-runs the definition
+    // upsert once everything is wired (this exact staleness shipped
+    // console_capture to device_workers while list_available kept serving the
+    // old 12-action chrome catalog). Compare every field the definition upsert
+    // writes, in the manifest hash's canonical form. Bundled connectors
+    // (`source` undefined) are excluded on purpose — their metadata requires a
+    // compile we can't afford per poll; deploys refresh them via other paths.
+    const definitionMatchesSource = (row: (typeof existingReady)[0]): boolean => {
+      if (!source) return true;
+      const m = source.metadata;
+      const canon = (v: unknown) => JSON.stringify(sortJson(v ?? null));
+      return (
+        row.def_name === m.name &&
+        (row.def_description ?? null) === (m.description ?? null) &&
+        row.def_version === m.version &&
+        row.version_source_path === source.sourcePath &&
+        row.version_compiled_code == null &&
+        row.version_artifact_hash === source.manifestHash &&
+        row.version_compile_config_hash == null &&
+        row.version_source_code == null &&
+        (row.def_favicon_domain ?? null) === (m.faviconDomain ?? null) &&
+        (row.def_required_capability ?? null) === (m.requiredCapability ?? null) &&
+        canon(row.def_auth_schema) === canon(m.authSchema) &&
+        canon(row.def_feeds_schema) === canon(m.feeds) &&
+        canon(row.def_actions_schema) === canon(m.actions) &&
+        canon(row.def_options_schema) === canon(m.optionsSchema) &&
+        canon(row.def_runtime) === canon(m.runtime)
+      );
+    };
+    const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
+    const readyConnectionId = existingReady[0]?.connection_id;
+    // A ready connection whose config is SQL NULL while the org definition
+    // carries a default needs the default seeded — the fast path must not
+    // leave it resolving against raw descriptor fallbacks. `conn_config` is the
+    // raw jsonb value (`null` only when the column is SQL NULL), so an empty
+    // explicit `{}` still counts as configured. Seeded in wireOnce below.
+    // The predicate gates on the CONNECTION-scoped half of the default
+    // (`splitConfigByFeedScope(…).connectionConfig`), the exact value seeding
+    // can write: a wholly feed-scoped default must not keep a NULL-config
+    // connection spinning the wire path forever. `def_feeds_schema` equals the
+    // manifest feeds on this path (definitionMatchesSource above), so the split
+    // here mirrors the one wireOnce performs; don't re-split against a
+    // different feeds schema, or the gate and the seed stop agreeing.
+    const needsDefaultConfigSeed =
+      existingReady[0]?.conn_config == null &&
+      splitConfigByFeedScope(
+        parseJsonObject(existingReady[0]?.def_default_config),
+        (existingReady[0]?.def_feeds_schema as Record<string, FeedDefinition> | null) ?? null,
+      ).connectionConfig != null;
+    const ready =
+      readyConnectionId != null &&
+      existingReady[0]?.version_key != null &&
+      definitionMatchesSource(existingReady[0]) &&
+      !needsDefaultConfigSeed &&
+      // userManaged-only connectors (e.g. local.directory, browser/*) report
+      // declaredFeedKeys=[]. Once the connection + definition are installed,
+      // every subsequent poll has nothing to verify — fast-path out.
+      // Composing primitives still hit /api/workers/me/feeds to mint
+      // explicit per-instance rows; that path is unchanged.
+      (declaredFeedKeys.length === 0 ||
+        declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)));
+    if (ready) {
+      if (source) {
+        return sql.begin(async (tx) => {
+          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+          const currentSource = await lockedManifestWinner(tx);
+          if (!currentSource || !(await selectedArtifactMatches(tx, currentSource))) return null;
+          await reconcilePin(
+            tx,
+            readyConnectionId,
+            currentSource.advertiserDeviceIds,
+            currentSource.requiredCapability,
+            currentSource
+          );
+          return claimAuthorization(currentSource);
+        });
+      } else {
+        // Same advisory lock as the `source` branch above: reconcilePin's owner
+        // check is read-then-write, so two replicas polling concurrently could
+        // both observe "nobody owns this device" and race into the unique index.
+        // (No bundled device connectors ship today, so this branch is currently
+        // unreachable — keep it serialized anyway rather than leave the race
+        // armed for the first one that does.)
+        await sql.begin(async (tx) => {
+          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+          await reconcilePin(tx, readyConnectionId);
+        });
+      }
+      return null;
+    }
 
-		let metadata: ConnectorMetadata;
-		let sourcePath: string;
-		let feedKeys = declaredFeedKeys;
-		if (source) {
-			metadata = source.metadata;
-			sourcePath = source.sourcePath;
-		} else {
-			// Compile metadata outside the lock (pure CPU + a child process — slow).
-			const filePath = findBundledConnectorFile(connectorKey);
-			if (!filePath) {
-				logger.warn(
-					{ connectorKey },
-					"[auto-wire] Bundled connector file not found",
-				);
-				return null;
-			}
-			const compiledCode = await compileConnectorFromFile(filePath);
-			metadata = await extractConnectorMetadata(compiledCode);
-			sourcePath = bundledConnectorSourcePath(filePath);
-			if (!metadata.key || !metadata.name || !metadata.version) return null;
-			const feedsSchema = metadata.feeds as Record<
-				string,
-				{ configSchema?: unknown; userManaged?: boolean }
-			> | null;
-			// Skip feeds the connector marks `userManaged` — they need per-instance
-			// config (e.g. local.directory.files needs a folder_id per folder) that
-			// auto-wire can't supply. The Mac app creates them explicitly via
-			// /api/workers/me/feeds once it has the folder bookmark.
-			feedKeys = feedsSchema
-				? Object.keys(feedsSchema).filter((k) => !feedsSchema[k]?.userManaged)
-				: [];
-		}
+    let metadata: ConnectorMetadata;
+    let sourcePath: string;
+    let feedKeys = declaredFeedKeys;
+    if (source) {
+      metadata = source.metadata;
+      sourcePath = source.sourcePath;
+    } else {
+      // Compile metadata outside the lock (pure CPU + a child process — slow).
+      const filePath = findBundledConnectorFile(connectorKey);
+      if (!filePath) {
+        logger.warn({ connectorKey }, '[auto-wire] Bundled connector file not found');
+        return null;
+      }
+      const compiledCode = await compileConnectorFromFile(filePath);
+      metadata = await extractConnectorMetadata(compiledCode);
+      sourcePath = bundledConnectorSourcePath(filePath);
+      if (!metadata.key || !metadata.name || !metadata.version) return null;
+      const feedsSchema = metadata.feeds as Record<
+        string,
+        { configSchema?: unknown; userManaged?: boolean }
+      > | null;
+      // Skip feeds the connector marks `userManaged` — they need per-instance
+      // config (e.g. local.directory.files needs a folder_id per folder) that
+      // auto-wire can't supply. The Mac app creates them explicitly via
+      // /api/workers/me/feeds once it has the folder bookmark.
+      feedKeys = feedsSchema
+        ? Object.keys(feedsSchema).filter((k) => !feedsSchema[k]?.userManaged)
+        : [];
+    }
 
-		let connectionId: number | undefined;
-		const wireOnce = () =>
-			sql.begin(async (tx): Promise<ManifestClaimAuthorization | null> => {
-				// Serialize per (user, connector): two concurrent polls / two devices
-				// both reach here, but only one holds the lock at a time, so the
-				// existence-check-then-insert below is atomic.
-				await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-				// Winner selection before this lock is only a scheduling hint. Recompute
-				// the deterministic winner while serialized so a stale waiter can never
-				// downgrade metadata or repin after a newer manifest has arrived.
-				const currentSource = source ? await lockedManifestWinner(tx) : null;
-				if (source && !currentSource) return null;
+    let connectionId: number | undefined;
+    const wireOnce = () => sql.begin(async (tx): Promise<ManifestClaimAuthorization | null> => {
+      // Serialize per (user, connector): two concurrent polls / two devices
+      // both reach here, but only one holds the lock at a time, so the
+      // existence-check-then-insert below is atomic.
+      await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+      // Winner selection before this lock is only a scheduling hint. Recompute
+      // the deterministic winner while serialized so a stale waiter can never
+      // downgrade metadata or repin after a newer manifest has arrived.
+      const currentSource = source ? await lockedManifestWinner(tx) : null;
+      if (source && !currentSource) return null;
 
-				// An explicit user delete is durable opt-out for this device connector.
-				// The marker is reserved at every public config-write path and delete
-				// writes it only after proving the connection belongs to this personal
-				// org's active device-connector definition. A device pin is deliberately
-				// not required: multi-device auto-wiring leaves the connection unpinned.
-				// The live-row anti-join makes an explicit reconnect the sole way to
-				// clear the opt-out without mutating the tombstone during heartbeat
-				// reconciliation. Only `handleDelete` writes this reserved marker;
-				// system retirement paths may tombstone rows but never create an opt-out.
-				const suppressed = (await tx`
+      // An explicit user delete is durable opt-out for this device connector.
+      // The marker is reserved at every public config-write path and delete
+      // writes it only after proving the connection belongs to this personal
+      // org's active device-connector definition. A device pin is deliberately
+      // not required: multi-device auto-wiring leaves the connection unpinned.
+      // The live-row anti-join makes an explicit reconnect the sole way to
+      // clear the opt-out without mutating the tombstone during heartbeat
+      // reconciliation. Only `handleDelete` writes this reserved marker;
+      // system retirement paths may tombstone rows but never create an opt-out.
+      const suppressed = (await tx`
         SELECT 1
         FROM connections
         WHERE organization_id = ${organizationId}
@@ -568,39 +534,40 @@ async function ensureDeviceConnectorWired(
               AND live.deleted_at IS NULL
           )
         LIMIT 1
-      `) as unknown as Array<{ "?column?": number }>;
-				if (suppressed.length > 0) return null;
+      `) as unknown as Array<{ '?column?': number }>;
+      if (suppressed.length > 0) return null;
 
-				// 2. Ensure the connector definition + version are installed (idempotent).
-				await upsertConnectorDefinitionRecords({
-					sql: tx,
-					organizationId,
-					metadata,
-					versionRecord: {
-						compiledCode: null,
-						// Device manifests have no compiled bytes, so compiled_code_hash is
-						// the existing durable artifact-hash slot for their validated
-						// manifest identity. Claim authorization compares this exact value.
-						compiledCodeHash: currentSource?.manifestHash ?? null,
-						compileConfigHash: null,
-						sourceCode: null,
-						sourcePath,
-					},
-					// A device-manifest connector's sourcePath is meaningful only to the
-					// owning user's daemon → their org's row. A bundled device connector
-					// points at the shared on-disk catalog → shared row.
-					versionScope: source ? "organization" : "shared",
-				});
-				// Seed new/repaired auto-wired connections from the org's definition
-				// default, exactly like manage_connections create/connect merge
-				// `default_connection_config` into the new row's config — auto-wire is
-				// the only creation path that previously skipped this, so a device swap
-				// silently regressed action modes to descriptor fallbacks. Feed-scoped
-				// default keys are dropped here — auto-wired feeds are minted with
-				// `config = NULL` (unchanged from the pre-seed path); the fast-path gate
-				// accounts for this so a wholly feed-scoped default does not re-wire
-				// forever.
-				const defaultConnectionConfig = (await tx`
+      // 2. Ensure the connector definition + version are installed (idempotent).
+      await upsertConnectorDefinitionRecords({
+        sql: tx,
+        organizationId,
+        metadata,
+        versionRecord: {
+          compiledCode: null,
+          // Device manifests have no compiled bytes, so compiled_code_hash is
+          // the existing durable artifact-hash slot for their validated
+          // manifest identity. Claim authorization compares this exact value.
+          compiledCodeHash: currentSource?.manifestHash ?? null,
+          compileConfigHash: null,
+          sourceCode: null,
+          sourcePath,
+        },
+        // A device-manifest connector's sourcePath is meaningful only to the
+        // owning user's daemon → their org's row. A bundled device connector
+        // points at the shared on-disk catalog → shared row.
+        versionScope: source ? 'organization' : 'shared',
+      });
+      // Seed new/repaired auto-wired connections from the org's definition
+      // default, exactly like manage_connections create/connect merge
+      // `default_connection_config` into the new row's config — auto-wire is
+      // the only creation path that previously skipped this, so a device swap
+      // silently regressed action modes to descriptor fallbacks. Feed-scoped
+      // default keys are dropped here — auto-wired feeds are minted with
+      // `config = NULL` (unchanged from the pre-seed path); the fast-path gate
+      // accounts for this so a wholly feed-scoped default does not re-wire
+      // forever.
+      const defaultConnectionConfig =
+        (await tx`
           SELECT default_connection_config
           FROM connector_definitions
           WHERE organization_id = ${organizationId}
@@ -608,20 +575,18 @@ async function ensureDeviceConnectorWired(
             AND status = 'active'
           LIMIT 1
         `) as unknown as Array<{ default_connection_config: unknown }>;
-				const splitConfig = splitConfigByFeedScope(
-					parseJsonObject(
-						defaultConnectionConfig[0]?.default_connection_config,
-					),
-					(metadata.feeds as unknown as Record<string, FeedDefinition>) ?? null,
-				);
-				const seedConfig = splitConfig.connectionConfig;
+      const splitConfig = splitConfigByFeedScope(
+        parseJsonObject(defaultConnectionConfig[0]?.default_connection_config),
+        (metadata.feeds as unknown as Record<string, FeedDefinition>) ?? null,
+      );
+      const seedConfig = splitConfig.connectionConfig;
 
-				// 3. Reuse or create the connection (no-auth, active, private). Match on
-				//    (org, connector, no auth_profile) — the device-connector identity —
-				//    rather than created_by, so orphan rows (created_by IS NULL, or
-				//    created by a different user/token) get adopted and self-healed
-				//    instead of stranded behind a slug-collision insert.
-				const existingConn = (await tx`
+      // 3. Reuse or create the connection (no-auth, active, private). Match on
+      //    (org, connector, no auth_profile) — the device-connector identity —
+      //    rather than created_by, so orphan rows (created_by IS NULL, or
+      //    created by a different user/token) get adopted and self-healed
+      //    instead of stranded behind a slug-collision insert.
+      const existingConn = (await tx`
         SELECT id, created_by FROM connections
         WHERE organization_id = ${organizationId}
           AND connector_key = ${connectorKey}
@@ -631,53 +596,53 @@ async function ensureDeviceConnectorWired(
         ORDER BY id ASC
         LIMIT 1
       `) as unknown as Array<{ id: number; created_by: string | null }>;
-				connectionId = existingConn[0]?.id;
-				if (connectionId && existingConn[0].created_by == null) {
-					// Backfill ownership so future per-user queries (e.g. /api/me/devices)
-					// attribute the connection to the user whose poll wired it.
-					await tx`
+      connectionId = existingConn[0]?.id;
+      if (connectionId && existingConn[0].created_by == null) {
+        // Backfill ownership so future per-user queries (e.g. /api/me/devices)
+        // attribute the connection to the user whose poll wired it.
+        await tx`
           UPDATE connections
           SET created_by = ${userId}, updated_at = NOW()
           WHERE id = ${connectionId} AND created_by IS NULL
         `;
-				}
-				if (connectionId && seedConfig) {
-					// Heal a surviving connection whose config is still SQL NULL (a row
-					// created before the definition default existed, or by the old
-					// no-seed path): seed the same default now. Guarded by `config IS NULL`
-					// so an explicit per-connection config is never clobbered. Idempotent —
-					// once seeded, this UPDATE stops matching.
-					await tx`
+      }
+      if (connectionId && seedConfig) {
+        // Heal a surviving connection whose config is still SQL NULL (a row
+        // created before the definition default existed, or by the old
+        // no-seed path): seed the same default now. Guarded by `config IS NULL`
+        // so an explicit per-connection config is never clobbered. Idempotent —
+        // once seeded, this UPDATE stops matching.
+        await tx`
           UPDATE connections
           SET config = ${sql.json(seedConfig)}, updated_at = NOW()
           WHERE id = ${connectionId} AND config IS NULL AND deleted_at IS NULL
         `;
-				}
-				if (!connectionId) {
-					// Stable slug for `lobu apply` diffing — same generation path as
-					// manage_connections.
-					//
-					// The advisory lock above does NOT make this race-free, contrary to
-					// what this comment used to claim. The lock is keyed on
-					// (userId, connectorKey), but the slug derives from the connector's
-					// DISPLAY NAME and uniqueness is enforced per-ORG by
-					// `connections_org_slug_unique`. Two different connector keys take two
-					// different locks and run concurrently, so two connectors sharing a
-					// display name compute the same free slug and the loser's INSERT trips
-					// the constraint. Reproduced: see
-					// device-reconcile-slug-race.test.ts. Lock scope and
-					// uniqueness scope simply are not the same scope.
-					//
-					// The retry lives OUTSIDE this transaction (at the wireOnce call
-					// site below), because an aborted transaction cannot be continued —
-					// which is the one thing the old comment got right.
-					const slug = await ensureUniqueConnectionSlug({
-						organizationId,
-						connectorKey,
-						displayName: metadata.name,
-						db: tx,
-					});
-					const inserted = (await tx`
+      }
+      if (!connectionId) {
+        // Stable slug for `lobu apply` diffing — same generation path as
+        // manage_connections.
+        //
+        // The advisory lock above does NOT make this race-free, contrary to
+        // what this comment used to claim. The lock is keyed on
+        // (userId, connectorKey), but the slug derives from the connector's
+        // DISPLAY NAME and uniqueness is enforced per-ORG by
+        // `connections_org_slug_unique`. Two different connector keys take two
+        // different locks and run concurrently, so two connectors sharing a
+        // display name compute the same free slug and the loser's INSERT trips
+        // the constraint. Reproduced: see
+        // device-reconcile-slug-race.test.ts. Lock scope and
+        // uniqueness scope simply are not the same scope.
+        //
+        // The retry lives OUTSIDE this transaction (at the wireOnce call
+        // site below), because an aborted transaction cannot be continued —
+        // which is the one thing the old comment got right.
+        const slug = await ensureUniqueConnectionSlug({
+          organizationId,
+          connectorKey,
+          displayName: metadata.name,
+          db: tx,
+        });
+        const inserted = (await tx`
           INSERT INTO connections (
             organization_id, connector_key, slug, display_name, status,
             auth_profile_id, app_auth_profile_id, config, created_by, visibility
@@ -687,21 +652,18 @@ async function ensureDeviceConnectorWired(
           )
           RETURNING id
         `) as unknown as Array<{ id: number }>;
-					connectionId = inserted[0]?.id;
-				}
-				if (!connectionId) return null;
+        connectionId = inserted[0]?.id;
+      }
+      if (!connectionId) return null;
 
-				// 4. Ensure every connector-declared feed exists and is active. A feed's
-				//    handlers decide its operations; the same row may sync and read.
-				const declaredFeeds = metadata.feeds as Record<
-					string,
-					ManifestFeed
-				> | null;
+      // 4. Ensure every connector-declared feed exists and is active. A feed's
+      //    handlers decide its operations; the same row may sync and read.
+      const declaredFeeds = metadata.feeds as Record<string, ManifestFeed> | null;
 
-				for (const feedKey of feedKeys) {
-					const operations = declaredFeeds?.[feedKey]?.operations ?? [];
-					const canSync = operations.includes("sync");
-					const existingFeed = (await tx`
+      for (const feedKey of feedKeys) {
+        const operations = declaredFeeds?.[feedKey]?.operations ?? [];
+        const canSync = operations.includes('sync');
+        const existingFeed = (await tx`
           SELECT id FROM feeds
           WHERE connection_id = ${connectionId}
             AND feed_key = ${feedKey}
@@ -709,23 +671,23 @@ async function ensureDeviceConnectorWired(
           LIMIT 1
         `) as unknown as Array<{ id: number }>;
 
-					if (existingFeed[0]?.id) {
-						await tx`
+        if (existingFeed[0]?.id) {
+          await tx`
             UPDATE feeds
             SET status = 'active',
                 next_run_at = ${canSync ? tx`COALESCE(next_run_at, NOW())` : tx`NULL::timestamptz`},
                 updated_at = current_timestamp
             WHERE id = ${existingFeed[0].id}
           `;
-					} else {
-						// The manifest's per-feed `name` when it declares one, and only the
-						// connector's own name as the fallback.
-						const declaredName = declaredFeeds?.[feedKey]?.name;
-						const displayName =
-							typeof declaredName === "string" && declaredName.trim().length > 0
-								? declaredName.trim()
-								: metadata.name;
-						await tx`
+        } else {
+          // The manifest's per-feed `name` when it declares one, and only the
+          // connector's own name as the fallback.
+          const declaredName = declaredFeeds?.[feedKey]?.name;
+          const displayName =
+            typeof declaredName === 'string' && declaredName.trim().length > 0
+              ? declaredName.trim()
+              : metadata.name;
+          await tx`
             INSERT INTO feeds (
               organization_id, connection_id, feed_key, display_name, status,
               next_run_at
@@ -735,62 +697,58 @@ async function ensureDeviceConnectorWired(
               ${canSync ? new Date() : null}
             )
           `;
-					}
-				}
+        }
+      }
 
-				// Pin the (possibly just-created) connection to the sole fresh device
-				// serving the capability, or leave it unpinned when several do.
-				await reconcilePin(
-					tx,
-					connectionId,
-					currentSource?.advertiserDeviceIds ?? matchingDeviceIds,
-					currentSource?.requiredCapability ?? requiredCapability,
-					currentSource ?? source,
-				);
-				if (
-					currentSource &&
-					!(await selectedArtifactMatches(tx, currentSource))
-				)
-					return null;
-				return claimAuthorization(currentSource);
-			});
+      // Pin the (possibly just-created) connection to the sole fresh device
+      // serving the capability, or leave it unpinned when several do.
+      await reconcilePin(
+        tx,
+        connectionId,
+        currentSource?.advertiserDeviceIds ?? matchingDeviceIds,
+        currentSource?.requiredCapability ?? requiredCapability,
+        currentSource ?? source
+      );
+      if (currentSource && !(await selectedArtifactMatches(tx, currentSource))) return null;
+      return claimAuthorization(currentSource);
+    });
 
-		let authorization: ManifestClaimAuthorization | null;
-		try {
-			authorization = await wireOnce();
-		} catch (err) {
-			// Retry ONCE, and only for the slug collision described above. The
-			// retry recomputes the slug against a tree that now contains the
-			// winner's committed row, so it converges on `<base>-2` rather than
-			// repeating the same losing bet.
-			//
-			// Bounded at one attempt deliberately. The next poll is the real retry
-			// budget for this reconcile — it already heals the collision — so this
-			// exists to avoid a spurious error-level log and a poll-cycle delay,
-			// not to guarantee convergence here. Anything unbounded would be a
-			// second retry budget layered on the existing one.
-			if (!isConnectionSlugUniqueViolation(err)) throw err;
-			logger.info(
-				{ userId, connectorKey, organizationId },
-				"[device-connectors] Connection slug raced a concurrent wire; retrying once",
-			);
-			authorization = await wireOnce();
-		}
+    let authorization: ManifestClaimAuthorization | null;
+    try {
+      authorization = await wireOnce();
+    } catch (err) {
+      // Retry ONCE, and only for the slug collision described above. The
+      // retry recomputes the slug against a tree that now contains the
+      // winner's committed row, so it converges on `<base>-2` rather than
+      // repeating the same losing bet.
+      //
+      // Bounded at one attempt deliberately. The next poll is the real retry
+      // budget for this reconcile — it already heals the collision — so this
+      // exists to avoid a spurious error-level log and a poll-cycle delay,
+      // not to guarantee convergence here. Anything unbounded would be a
+      // second retry budget layered on the existing one.
+      if (!isConnectionSlugUniqueViolation(err)) throw err;
+      logger.info(
+        { userId, connectorKey, organizationId },
+        '[device-connectors] Connection slug raced a concurrent wire; retrying once'
+      );
+      authorization = await wireOnce();
+    }
 
-		if (connectionId) {
-			logger.info(
-				{ userId, connectorKey, organizationId, connectionId },
-				"[device-connectors] Wired device connector",
-			);
-		}
-		return authorization;
-	} catch (err) {
-		logger.error(
-			{ userId, connectorKey, err: errorMessage(err) },
-			"[device-connectors] Failed to wire device connector",
-		);
-		return null;
-	}
+    if (connectionId) {
+      logger.info(
+        { userId, connectorKey, organizationId, connectionId },
+        '[device-connectors] Wired device connector'
+      );
+    }
+    return authorization;
+  } catch (err) {
+    logger.error(
+      { userId, connectorKey, err: errorMessage(err) },
+      '[device-connectors] Failed to wire device connector'
+    );
+    return null;
+  }
 }
 
 /**
@@ -801,14 +759,10 @@ async function ensureDeviceConnectorWired(
  * in the personal org (exactly what {@link ensureDeviceConnectorWired} creates);
  * that function re-activates them if the capability comes back. Best-effort.
  */
-async function pauseStaleDeviceFeeds(
-	userId: string,
-	organizationId: string,
-	connectorKey: string,
-) {
-	const sql = getDb();
-	try {
-		await sql`
+async function pauseStaleDeviceFeeds(userId: string, organizationId: string, connectorKey: string) {
+  const sql = getDb();
+  try {
+    await sql`
       UPDATE feeds f
       SET status = 'paused', updated_at = current_timestamp
       FROM connections c
@@ -822,12 +776,12 @@ async function pauseStaleDeviceFeeds(
         AND f.status = 'active'
         AND f.deleted_at IS NULL
     `;
-	} catch (err) {
-		logger.warn(
-			{ userId, connectorKey, err: errorMessage(err) },
-			"[device-connectors] Failed to pause stale device feeds",
-		);
-	}
+  } catch (err) {
+    logger.warn(
+      { userId, connectorKey, err: errorMessage(err) },
+      '[device-connectors] Failed to pause stale device feeds'
+    );
+  }
 }
 
 /**
@@ -841,14 +795,14 @@ async function pauseStaleDeviceFeeds(
  * and re-check stored manifests so concurrent polls converge. Best-effort.
  */
 async function archiveVanishedDeviceConnectorDefinitions(
-	userId: string,
-	organizationId: string,
-	liveKeys: string[],
+  userId: string,
+  organizationId: string,
+  liveKeys: string[]
 ): Promise<void> {
-	const sql = getDb();
-	try {
-		const archived = await sql.begin(async (tx) => {
-			const candidates = (await tx`
+  const sql = getDb();
+  try {
+    const archived = await sql.begin(async (tx) => {
+      const candidates = (await tx`
         SELECT cd.key
         FROM connector_definitions cd
         WHERE cd.organization_id = ${organizationId}
@@ -878,13 +832,13 @@ async function archiveVanishedDeviceConnectorDefinitions(
           )
         ORDER BY cd.key
       `) as unknown as Array<{ key: string }>;
-			for (const { key } of candidates) {
-				await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
-			}
-			if (candidates.length === 0) return [];
-			const candidateKeys = candidates.map(({ key }) => key);
+      for (const { key } of candidates) {
+        await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
+      }
+      if (candidates.length === 0) return [];
+      const candidateKeys = candidates.map(({ key }) => key);
 
-			const rows = (await tx`
+      const rows = (await tx`
         UPDATE connector_definitions cd
         SET status = 'archived', updated_at = NOW()
         WHERE cd.organization_id = ${organizationId}
@@ -921,21 +875,21 @@ async function archiveVanishedDeviceConnectorDefinitions(
           )
         RETURNING cd.key
       `) as unknown as Array<{ key: string }>;
-			return rows;
-		});
+      return rows;
+    });
 
-		if (archived.length > 0) {
-			logger.info(
-				{ userId, organizationId, keys: archived.map((r) => r.key) },
-				"[device-connectors] Archived definitions no longer served by any connector source",
-			);
-		}
-	} catch (err) {
-		logger.warn(
-			{ userId, organizationId, err: errorMessage(err) },
-			"[device-connectors] Failed to archive vanished device connector definitions",
-		);
-	}
+    if (archived.length > 0) {
+      logger.info(
+        { userId, organizationId, keys: archived.map((r) => r.key) },
+        '[device-connectors] Archived definitions no longer served by any connector source'
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      { userId, organizationId, err: errorMessage(err) },
+      '[device-connectors] Failed to archive vanished device connector definitions'
+    );
+  }
 }
 
 /**
@@ -953,209 +907,198 @@ async function archiveVanishedDeviceConnectorDefinitions(
  * hardcoded — adding a new device connector is just a new file in the catalog.
  */
 export async function reconcileDeviceCapabilities(
-	userId: string,
-	pollingDeviceId?: string | null,
+  userId: string,
+  pollingDeviceId?: string | null
 ): Promise<ManifestClaimAuthorization[]> {
-	const sql = getDb();
+  const sql = getDb();
 
-	let bundledDeviceConnectors: BundledDeviceConnector[];
-	// Both connector sources are fail-soft (empty on error), which makes "no
-	// sources" ambiguous: nothing is served, or we failed to look. Only the
-	// latter must suppress the archive pass below — an empty-but-successful read
-	// is a legitimate "this fleet serves nothing", and is in fact the normal
-	// state for a Chrome-only user (no bundled device connectors exist server
-	// side; every one of them arrives as a device manifest).
-	let sourcesReadable = true;
-	try {
-		bundledDeviceConnectors = await getBundledDeviceConnectors();
-	} catch (err) {
-		logger.warn(
-			{ userId, err: errorMessage(err) },
-			"[device-connectors] Failed to read device connector catalog",
-		);
-		bundledDeviceConnectors = [];
-		sourcesReadable = false;
-	}
+  let bundledDeviceConnectors: BundledDeviceConnector[];
+  // Both connector sources are fail-soft (empty on error), which makes "no
+  // sources" ambiguous: nothing is served, or we failed to look. Only the
+  // latter must suppress the archive pass below — an empty-but-successful read
+  // is a legitimate "this fleet serves nothing", and is in fact the normal
+  // state for a Chrome-only user (no bundled device connectors exist server
+  // side; every one of them arrives as a device manifest).
+  let sourcesReadable = true;
+  try {
+    bundledDeviceConnectors = await getBundledDeviceConnectors();
+  } catch (err) {
+    logger.warn(
+      { userId, err: errorMessage(err) },
+      '[device-connectors] Failed to read device connector catalog'
+    );
+    bundledDeviceConnectors = [];
+    sourcesReadable = false;
+  }
 
-	// Device data ALWAYS lands in the user's personal org — device tokens are
-	// force-bound there (see oauth/device/approve + mint-child-token), and a
-	// team org reaches a device by pinning an automation/connection to it
-	// (resolveDeviceClaimableOrgs), not by re-binding the device. So auto-wire
-	// targets the personal org regardless of where a legacy device_workers row
-	// is still homed (older pairings may still carry a team org_id; they
-	// converge here on the next poll).
-	const personalOrg = await findExistingPersonalOrg(userId, sql);
-	if (!personalOrg) {
-		// No personal org → nothing to auto-wire. Don't touch team-org connectors
-		// a user may have created manually; those survive on their own pins.
-		return [];
-	}
-	const personalOrgId = personalOrg.id;
+  // Device data ALWAYS lands in the user's personal org — device tokens are
+  // force-bound there (see oauth/device/approve + mint-child-token), and a
+  // team org reaches a device by pinning an automation/connection to it
+  // (resolveDeviceClaimableOrgs), not by re-binding the device. So auto-wire
+  // targets the personal org regardless of where a legacy device_workers row
+  // is still homed (older pairings may still carry a team org_id; they
+  // converge here on the next poll).
+  const personalOrg = await findExistingPersonalOrg(userId, sql);
+  if (!personalOrg) {
+    // No personal org → nothing to auto-wire. Don't touch team-org connectors
+    // a user may have created manually; those survive on their own pins.
+    return [];
+  }
+  const personalOrgId = personalOrg.id;
 
-	// deviceId → capabilities it advertises (fresh devices only). We no longer
-	// partition by the device's stored org_id: under the personal-org
-	// invariant every device serves the personal workspace, so the fleet's
-	// combined capabilities decide what gets wired, irrespective of legacy
-	// per-device home rows.
-	const deviceCaps = new Map<string, Set<string>>();
-	try {
-		const rows = (await sql`
+  // deviceId → capabilities it advertises (fresh devices only). We no longer
+  // partition by the device's stored org_id: under the personal-org
+  // invariant every device serves the personal workspace, so the fleet's
+  // combined capabilities decide what gets wired, irrespective of legacy
+  // per-device home rows.
+  const deviceCaps = new Map<string, Set<string>>();
+  try {
+    const rows = (await sql`
       SELECT id, capabilities
       FROM device_workers
       WHERE user_id = ${userId}
         AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
     `) as unknown as Array<{ id: string; capabilities: unknown }>;
-		for (const r of rows) {
-			const caps = Array.isArray(r.capabilities)
-				? (r.capabilities as string[])
-				: [];
-			deviceCaps.set(r.id, new Set(caps));
-		}
-	} catch (err) {
-		logger.warn(
-			{ userId, err: errorMessage(err) },
-			"[device-connectors] Failed to read device capabilities",
-		);
-		return [];
-	}
-	if (deviceCaps.size === 0) return [];
-	const devicesWithCapability = (capability: string): string[] =>
-		[...deviceCaps.entries()]
-			.filter(([, caps]) => caps.has(capability))
-			.map(([id]) => id);
+    for (const r of rows) {
+      const caps = Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
+      deviceCaps.set(r.id, new Set(caps));
+    }
+  } catch (err) {
+    logger.warn(
+      { userId, err: errorMessage(err) },
+      '[device-connectors] Failed to read device capabilities'
+    );
+    return [];
+  }
+  if (deviceCaps.size === 0) return [];
+  const devicesWithCapability = (capability: string): string[] =>
+    [...deviceCaps.entries()].
+      filter(([, caps]) => caps.has(capability))
+      .map(([id]) => id);
 
-	let pollingDeviceAuthorizations: Awaited<
-		ReturnType<typeof getDeviceManifestClaimAuthorizationsForDevice>
-	> = [];
-	let pollingManifestClaimsReadable = true;
-	if (pollingDeviceId) {
-		try {
-			// Attest retained hashless rows before reconciliation's selected-artifact
-			// check. The attestation is still bounded to this validated device's
-			// exact manifest identity and org-scoped artifact row.
-			pollingDeviceAuthorizations =
-				await getDeviceManifestClaimAuthorizationsForDevice({
-					sql,
-					userId,
-					deviceId: pollingDeviceId,
-				});
-			await attestDeviceManifestArtifacts({
-				sql,
-				organizationId: personalOrgId,
-				authorizations: pollingDeviceAuthorizations,
-			});
-		} catch (err) {
-			pollingManifestClaimsReadable = false;
-			logger.warn(
-				{ userId, pollingDeviceId, err: errorMessage(err) },
-				"[device-connectors] Failed to read polling device manifest claims",
-			);
-		}
-	}
+  let pollingDeviceAuthorizations: Awaited<
+    ReturnType<typeof getDeviceManifestClaimAuthorizationsForDevice>
+  > = [];
+  let pollingManifestClaimsReadable = true;
+  if (pollingDeviceId) {
+    try {
+      // Attest retained hashless rows before reconciliation's selected-artifact
+      // check. The attestation is still bounded to this validated device's
+      // exact manifest identity and org-scoped artifact row.
+      pollingDeviceAuthorizations = await getDeviceManifestClaimAuthorizationsForDevice({
+        sql,
+        userId,
+        deviceId: pollingDeviceId,
+      });
+      await attestDeviceManifestArtifacts({
+        sql,
+        organizationId: personalOrgId,
+        authorizations: pollingDeviceAuthorizations,
+      });
+    } catch (err) {
+      pollingManifestClaimsReadable = false;
+      logger.warn(
+        { userId, pollingDeviceId, err: errorMessage(err) },
+        '[device-connectors] Failed to read polling device manifest claims'
+      );
+    }
+  }
 
-	let manifestSources: DeviceConnectorSource[] = [];
-	try {
-		manifestSources = await getDeviceManifestSourcesForUser({
-			sql,
-			userId,
-		});
-	} catch (err) {
-		logger.warn(
-			{ userId, err: errorMessage(err) },
-			"[device-connectors] Failed to read device connector manifests",
-		);
-		sourcesReadable = false;
-	}
+  let manifestSources: DeviceConnectorSource[] = [];
+  try {
+    manifestSources = await getDeviceManifestSourcesForUser({
+      sql,
+      userId,
+    });
+  } catch (err) {
+    logger.warn(
+      { userId, err: errorMessage(err) },
+      '[device-connectors] Failed to read device connector manifests'
+    );
+    sourcesReadable = false;
+  }
 
-	const byKey = new Map<
-		string,
-		| (BundledDeviceConnector & { source?: undefined })
-		| (DeviceConnectorSource & { source: "device-manifest" })
-	>();
-	for (const dc of bundledDeviceConnectors) byKey.set(dc.key, dc);
-	for (const src of manifestSources)
-		byKey.set(src.key, { ...src, source: "device-manifest" });
+  const byKey = new Map<
+    string,
+    | (BundledDeviceConnector & { source?: undefined })
+    | (DeviceConnectorSource & { source: 'device-manifest' })
+  >();
+  for (const dc of bundledDeviceConnectors) byKey.set(dc.key, dc);
+  for (const src of manifestSources) byKey.set(src.key, { ...src, source: 'device-manifest' });
 
-	// Runs BEFORE the early return: a fleet that advertises nothing is precisely
-	// the case where every device definition in the org has gone stale, so
-	// bailing on an empty `byKey` would skip the one pass that can clean it up.
-	// Gated on `sourcesReadable` rather than on `byKey.size` — a transient read
-	// failure must never be read as "the fleet serves nothing" and archive a
-	// user's whole working set.
-	if (sourcesReadable) {
-		await archiveVanishedDeviceConnectorDefinitions(userId, personalOrgId, [
-			...byKey.keys(),
-		]);
-	}
-	if (byKey.size === 0) return [];
+  // Runs BEFORE the early return: a fleet that advertises nothing is precisely
+  // the case where every device definition in the org has gone stale, so
+  // bailing on an empty `byKey` would skip the one pass that can clean it up.
+  // Gated on `sourcesReadable` rather than on `byKey.size` — a transient read
+  // failure must never be read as "the fleet serves nothing" and archive a
+  // user's whole working set.
+  if (sourcesReadable) {
+    await archiveVanishedDeviceConnectorDefinitions(userId, personalOrgId, [...byKey.keys()]);
+  }
+  if (byKey.size === 0) return [];
 
-	const reconciliationResults = await Promise.allSettled(
-		[...byKey.values()].map((dc) => {
-			const matchingDeviceIds =
-				"source" in dc && dc.source === "device-manifest"
-					? dc.advertiserDeviceIds
-					: devicesWithCapability(dc.requiredCapability);
-			return matchingDeviceIds.length > 0
-				? ensureDeviceConnectorWired(
-						userId,
-						personalOrgId,
-						dc.key,
-						dc.feedKeys,
-						matchingDeviceIds,
-						dc.requiredCapability,
-						"source" in dc && dc.source === "device-manifest" ? dc : undefined,
-						pollingDeviceId,
-					)
-				: pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);
-		}),
-	);
+  const reconciliationResults = await Promise.allSettled(
+    [...byKey.values()].map((dc) => {
+      const matchingDeviceIds =
+        'source' in dc && dc.source === 'device-manifest'
+          ? dc.advertiserDeviceIds
+          : devicesWithCapability(dc.requiredCapability);
+      return matchingDeviceIds.length > 0
+        ? ensureDeviceConnectorWired(
+            userId,
+            personalOrgId,
+            dc.key,
+            dc.feedKeys,
+            matchingDeviceIds,
+            dc.requiredCapability,
+            'source' in dc && dc.source === 'device-manifest'
+              ? dc
+              : undefined,
+            pollingDeviceId
+          )
+        : pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);
+    })
+  );
 
-	const reconciledAuthorizations = reconciliationResults.flatMap((result) =>
-		result.status === "fulfilled" && result.value ? [result.value] : [],
-	);
-	if (!pollingDeviceId) return reconciledAuthorizations;
-	if (!pollingManifestClaimsReadable || !sourcesReadable) return [];
+  const reconciledAuthorizations = reconciliationResults.flatMap((result) =>
+    result.status === 'fulfilled' && result.value ? [result.value] : []
+  );
+  if (!pollingDeviceId) return reconciledAuthorizations;
+  if (!pollingManifestClaimsReadable || !sourcesReadable) return [];
 
-	// If the polling device is the current winner for a manifest key, a failed
-	// wire/reconciliation must fail closed for that key. Historical claims are
-	// allowed only for keys where this device advertises a retained version and
-	// winner reconciliation belongs to another device.
-	const currentWinnerKeysForPoller = new Set(
-		manifestSources
-			.filter((source) => source.advertiserDeviceIds.includes(pollingDeviceId))
-			.map((source) => source.key),
-	);
-	const failedCurrentWinnerKeys = new Set(
-		[...currentWinnerKeysForPoller].filter(
-			(key) =>
-				!reconciledAuthorizations.some(
-					(authorization) => authorization.connectorKey === key,
-				),
-		),
-	);
-	const validatedReconciledAuthorizations = reconciledAuthorizations.filter(
-		(authorization) =>
-			pollingDeviceAuthorizations.some(
-				(validated) =>
-					validated.connectorKey === authorization.connectorKey &&
-					validated.connectorVersion === authorization.connectorVersion &&
-					validated.manifestHash === authorization.manifestHash &&
-					validated.sourcePath === authorization.sourcePath,
-			),
-	);
-	const all = [
-		...validatedReconciledAuthorizations,
-		...pollingDeviceAuthorizations.filter(
-			(authorization) =>
-				!failedCurrentWinnerKeys.has(authorization.connectorKey),
-		),
-	];
-	return [
-		...new Map(
-			all.map((authorization) => [
-				`${authorization.connectorKey}\u0000${authorization.connectorVersion}\u0000${authorization.manifestHash}`,
-				authorization,
-			]),
-		).values(),
-	];
+  // If the polling device is the current winner for a manifest key, a failed
+  // wire/reconciliation must fail closed for that key. Historical claims are
+  // allowed only for keys where this device advertises a retained version and
+  // winner reconciliation belongs to another device.
+  const currentWinnerKeysForPoller = new Set(
+    manifestSources
+      .filter((source) => source.advertiserDeviceIds.includes(pollingDeviceId))
+      .map((source) => source.key)
+  );
+  const failedCurrentWinnerKeys = new Set(
+    [...currentWinnerKeysForPoller].filter(
+      (key) => !reconciledAuthorizations.some((authorization) => authorization.connectorKey === key)
+    )
+  );
+  const validatedReconciledAuthorizations = reconciledAuthorizations.filter((authorization) =>
+    pollingDeviceAuthorizations.some(
+      (validated) =>
+        validated.connectorKey === authorization.connectorKey &&
+        validated.connectorVersion === authorization.connectorVersion &&
+        validated.manifestHash === authorization.manifestHash &&
+        validated.sourcePath === authorization.sourcePath,
+    ),
+  );
+  const all = [
+    ...validatedReconciledAuthorizations,
+    ...pollingDeviceAuthorizations.filter(
+      (authorization) => !failedCurrentWinnerKeys.has(authorization.connectorKey)
+    ),
+  ];
+  return [...new Map(
+    all.map((authorization) => [
+      `${authorization.connectorKey}\u0000${authorization.connectorVersion}\u0000${authorization.manifestHash}`,
+      authorization,
+    ])
+  ).values()];
 }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -285,6 +285,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   let app_version: string | null = null;
   let label: string | null = null;
   let capacityAvailable: number | null = null;
+  let backendCapacity: Record<string, number> = {};
+  let backendCapacityProvided = false;
   let connectorManifestsProvided = false;
   let connectorManifestsRaw: unknown;
   // Agent CLIs this device can spawn. `null` is NOT the same as `[]`: null means
@@ -313,6 +315,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     app_version = body.app_version ?? null;
     label = body.label ?? null;
     capacityAvailable = body.capacity_available ?? null;
+    backendCapacity = body.backend_capacity ?? {};
+    backendCapacityProvided = Object.hasOwn(body, 'backend_capacity');
     connectorManifestsProvided = Object.hasOwn(body, 'connector_manifests');
     connectorManifestsRaw = body.connector_manifests;
     agentKinds = normalizeAgentKinds(body.agent_kinds);
@@ -367,6 +371,13 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // below, so platform binding / capability authorization / org-scoped claiming
   // all apply exactly as for a signed-in device.
   const isUserScopedWorker = c.var.workerAuthMode === 'user' || anonLocalUserId != null;
+  // Trusted fleet workers predate the per-backend signal and remain compiled
+  // capable unless they explicitly advertise a backend map. Device workers
+  // must opt in because headless recovery intentionally advertises only the
+  // daemon-owned backend when its compiler/SDK runtime is unavailable.
+  if (!backendCapacityProvided && !isUserScopedWorker) {
+    backendCapacity = { compiled_connector: 1 };
+  }
   // Effective device identity: the token's user/org when user-scoped, else the
   // re-anchored local owner.
   const effectiveWorkerUserId = c.var.workerUserId ?? anonLocalUserId;
@@ -478,14 +489,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             manifests: connectorManifestsRaw,
           })
         : null;
-      // An explicitly empty array is an authoritative "this device serves no
-      // connectors". A payload the validator rejected is not: replacing the
-      // last good inventory with {} would make reconcile archive working
-      // definitions because a malformed poll looked like removal.
+      // The manifest field is the current execution attestation, not a
+      // heartbeat cache. Historical connector_versions remain inventory, but
+      // a rejected or omitted current advertisement must remove readiness and
+      // claim authority immediately.
       const connectorManifestsAccepted = manifestValidation?.accepted === true;
       const connectorManifestMap = connectorManifestsAccepted
         ? storedManifestMap(manifestValidation.manifests)
-        : null;
+        : {};
 
       // `xmax = 0` on the RETURNING row distinguishes a brand-new device
       // registration from a routine poll-update so we only emit the
@@ -516,13 +527,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           -- wrote it back would clobber a Devices-page rename on the next poll,
           -- since a headless daemon self-reports its hostname every time.
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
-          connector_manifests = CASE
-            WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests
-            ELSE device_workers.connector_manifests
-          END,
-          -- Only overwrite when the device actually advertised. A client that
-          -- stops sending the field (a downgraded build) must not erase what a
-          -- capable client already told us.
+          connector_manifests = EXCLUDED.connector_manifests,
+          -- A missing field is an explicit loss of current attestation. Do not
+          -- retain a prior manifest merely because the heartbeat is fresh.
           agent_kinds = COALESCE(EXCLUDED.agent_kinds, device_workers.agent_kinds),
           last_seen_at = now()
         RETURNING id, organization_id, (xmax = 0) AS inserted
@@ -647,6 +654,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     orgScopeIds,
     baseOrgScopeIds,
     workerHardensDbEgress,
+    backendCapacity,
   };
   const workerKind = isUserScopedWorker ? 'device' : 'fleet';
   // `platform` is self-reported in the poll body and is only pinned to the

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -371,21 +371,6 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // below, so platform binding / capability authorization / org-scoped claiming
   // all apply exactly as for a signed-in device.
   const isUserScopedWorker = c.var.workerAuthMode === 'user' || anonLocalUserId != null;
-  // A daemon built after the per-backend signal always advertises its own map
-  // (connector-worker/src/daemon/start.ts). An omitted map therefore means a
-  // client that predates the field, or one that never runs the daemon at all
-  // (the Chrome extension and the macOS app poll directly). Mirror what the
-  // daemon would have advertised for that platform rather than inventing a
-  // wider or narrower grant: headless keeps its compiler/SDK runtime gated off
-  // while still owning the daemon backend, and every other platform is
-  // compiled-capable. Keyed on the self-reported platform, not on token scope:
-  // user-scoped device workers are compiled-capable too.
-  if (!backendCapacityProvided) {
-    backendCapacity =
-      platform === 'headless'
-        ? { daemon_builtin: 1, compiled_connector: 0 }
-        : { compiled_connector: 1 };
-  }
   // Effective device identity: the token's user/org when user-scoped, else the
   // re-anchored local owner.
   const effectiveWorkerUserId = c.var.workerUserId ?? anonLocalUserId;
@@ -439,6 +424,26 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       }
       effectivePlatform = existing[0].platform;
     }
+  }
+  // A daemon built after the per-backend signal always advertises its own map
+  // (connector-worker/src/daemon/start.ts). An omitted map therefore means a
+  // client that predates the field, or one that never runs the daemon at all
+  // (the Chrome extension and the macOS app poll directly). Mirror what the
+  // daemon would have advertised for that platform rather than inventing a
+  // wider or narrower grant: headless keeps its compiler/SDK runtime gated off
+  // while still owning the daemon backend, and every other platform is
+  // compiled-capable. Not keyed on token scope: user-scoped device workers are
+  // compiled-capable too.
+  //
+  // Placed AFTER the binding resolution above, and keyed on effectivePlatform,
+  // because the claim lane is: a headless-bound device that omits `platform`
+  // from its body would otherwise default to compiled-only and silently lose
+  // the daemon backend it is the only worker able to run.
+  if (!backendCapacityProvided) {
+    backendCapacity =
+      effectivePlatform === 'headless'
+        ? { daemon_builtin: 1, compiled_connector: 0 }
+        : { compiled_connector: 1 };
   }
   // For user-scoped (device) workers, authorize the advertised capability set
   // against the platform-specific allowlist in @lobu/core. Anything outside

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -371,11 +371,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // below, so platform binding / capability authorization / org-scoped claiming
   // all apply exactly as for a signed-in device.
   const isUserScopedWorker = c.var.workerAuthMode === 'user' || anonLocalUserId != null;
-  // Trusted fleet workers predate the per-backend signal and remain compiled
-  // capable unless they explicitly advertise a backend map. Device workers
-  // must opt in because headless recovery intentionally advertises only the
-  // daemon-owned backend when its compiler/SDK runtime is unavailable.
-  if (!backendCapacityProvided && !isUserScopedWorker) {
+  // Absence of a backend_capacity advertisement means the worker declares no
+  // backend restriction — every claim lane stays open to it. Only the headless
+  // daemon must advertise: its compiler/SDK runtime may be unavailable, so
+  // absent an explicit map it stays compiled-incapable. The headless client is
+  // identified by its self-reported platform, not by token scope — user-scoped
+  // device workers (macOS app, Chrome extension) never send the field and must
+  // stay claimable.
+  if (!backendCapacityProvided && platform !== 'headless') {
     backendCapacity = { compiled_connector: 1 };
   }
   // Effective device identity: the token's user/org when user-scoped, else the

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -371,15 +371,20 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // below, so platform binding / capability authorization / org-scoped claiming
   // all apply exactly as for a signed-in device.
   const isUserScopedWorker = c.var.workerAuthMode === 'user' || anonLocalUserId != null;
-  // Absence of a backend_capacity advertisement means the worker declares no
-  // backend restriction — every claim lane stays open to it. Only the headless
-  // daemon must advertise: its compiler/SDK runtime may be unavailable, so
-  // absent an explicit map it stays compiled-incapable. The headless client is
-  // identified by its self-reported platform, not by token scope — user-scoped
-  // device workers (macOS app, Chrome extension) never send the field and must
-  // stay claimable.
-  if (!backendCapacityProvided && platform !== 'headless') {
-    backendCapacity = { compiled_connector: 1 };
+  // A daemon built after the per-backend signal always advertises its own map
+  // (connector-worker/src/daemon/start.ts). An omitted map therefore means a
+  // client that predates the field, or one that never runs the daemon at all
+  // (the Chrome extension and the macOS app poll directly). Mirror what the
+  // daemon would have advertised for that platform rather than inventing a
+  // wider or narrower grant: headless keeps its compiler/SDK runtime gated off
+  // while still owning the daemon backend, and every other platform is
+  // compiled-capable. Keyed on the self-reported platform, not on token scope:
+  // user-scoped device workers are compiled-capable too.
+  if (!backendCapacityProvided) {
+    backendCapacity =
+      platform === 'headless'
+        ? { daemon_builtin: 1, compiled_connector: 0 }
+        : { compiled_connector: 1 };
   }
   // Effective device identity: the token's user/org when user-scoped, else the
   // re-anchored local owner.

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1191,7 +1191,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     });
     logger.error(
       { run_id: row.run_id, connector_key: row.connector_key, connector_version: row.connector_version },
-      '[poll] rejected inconsistent native bridge artifact'
+      '[poll] rejected inconsistent device-owned artifact'
     );
     return c.json({
       next_poll_seconds: 1,
@@ -1201,6 +1201,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     });
   }
   const isNativeBridgeRun = selectedExecution.backend === 'native_bridge';
+  const isDeviceOwnedRun =
+    isNativeBridgeRun || selectedExecution.backend === 'daemon_builtin';
 
   // Device chat reuses the ordinary messages/chat_message row. The poll
   // response is only an execution envelope: ownership/routing remain on the
@@ -1658,18 +1660,24 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const hasStoredCompiledCode = Boolean(row.compiled_code);
   const workerWillResolveLocally =
     !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
-  // Only a native-bridge run is implemented by the device itself. Manifest
+  // Only an explicitly selected device-owned backend is implemented by the
+  // device itself. Manifest
   // backing and the capability gate do not establish who executes the code.
   const deviceWillExecuteNativeConnector = deviceExecutesConnectorNatively({
     isUserScopedWorker,
     hasStoredCompiledCode,
     gatewayHasLocalSource,
-    isNativeBridgeRun,
+    isDeviceOwnedRun,
     manifestBacked: row.connector_manifest_backed,
     deviceAdvertisesRequiredCapability:
       row.connector_required_capability != null &&
       authorizedCapabilities.includes(row.connector_required_capability),
   });
+  const responseExecutionBackend =
+    selectedExecution.backend ??
+    (row.connector_key && !deviceWillExecuteNativeConnector
+      ? ('compiled_connector' as const)
+      : undefined);
   if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteNativeConnector) {
     try {
       compiledCode = await resolveConnectorCode(row.connector_key, {
@@ -1708,7 +1716,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   //    profile still can't leak secrets to an arbitrary capability-matched device.
   const connectionIsDevicePinned = row.connection_device_worker_id != null;
   const deliverConnectionAuth =
-    !isNativeBridgeRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
+    !isDeviceOwnedRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
   // `user_data_dir` and `cdp_url` for device-bound browser profiles flow to
   // the worker via `sessionState.user_data_dir` / `sessionState.cdp_url`
   // (set inside resolveExecutionAuth). No need to thread them as separate
@@ -1780,10 +1788,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     run_type: row.run_type,
     connector_key: row.connector_key ?? undefined,
     connector_version: row.connector_version ?? undefined,
-    ...(isNativeBridgeRun
+    ...(responseExecutionBackend
       ? {
-          execution_backend: 'native_bridge' as const,
-          connector_manifest_hash: selectedExecution.manifestHash,
+          execution_backend: responseExecutionBackend,
+          ...(selectedExecution.manifestHash
+            ? { connector_manifest_hash: selectedExecution.manifestHash }
+            : {}),
         }
       : {}),
     nix_packages: nixPackages.length > 0 ? nixPackages : undefined,

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -650,7 +650,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     capabilityMatchSet,
     manifestClaimAuthorizations,
     allowLegacyManifestCapabilityClaims:
-      isUserScopedWorker && !connectorManifestsProvided && effectivePlatform !== 'chrome-extension',
+      isUserScopedWorker &&
+      !connectorManifestsProvided &&
+      effectivePlatform !== 'chrome-extension' &&
+      effectivePlatform !== 'headless',
     orgScopeIds,
     baseOrgScopeIds,
     workerHardensDbEgress,

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -320,6 +320,7 @@ gate_connector_parity_smoke() {
   gate_require_docker || return 77
   docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke .
   docker run --rm --network=none lobu-worker:parity-smoke bun src/bin.ts self-check --json
+  ./scripts/test-headless-shell-package.sh || return 1
   node packages/cli/bin/lobu.js connector runtime-self-check --json || return 1
 }
 

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -620,6 +620,8 @@ export { rewriteWorkspaceRefs };
 /** Internals exposed for the guard tests; not part of any published surface. */
 export const __testing = {
   PACKAGES,
+  transformCorePublish,
+  transformWorkerPublish,
   lobuRuntimeDeps,
   markUnavailablePackage,
   packageNameFor,

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -17,6 +17,8 @@ test -f "$package_root/dist/daemon/builtins/index.js" || {
 
 smoke_dir="$(mktemp -d)"
 daemon_cwd="$(mktemp -d)"
+raw_runtime="$smoke_dir/raw-runtime"
+mkdir -p "$raw_runtime"
 trap 'rm -rf "$smoke_dir" "$daemon_cwd"' EXIT
 
 (cd "$package_root" && bun pm pack --destination "$smoke_dir" --quiet) >/dev/null
@@ -25,9 +27,9 @@ test "${#archives[@]}" -eq 1 || {
   echo "expected one connector-worker tarball, found ${#archives[@]}" >&2
   exit 1
 }
-tar -xzf "${archives[0]}" -C "$smoke_dir"
+tar -xzf "${archives[0]}" -C "$raw_runtime"
 
-PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+PACKAGE_ROOT="$raw_runtime/package" node --input-type=module <<'NODE'
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -57,43 +59,73 @@ NODE
 # an empty npm prefix, and invoke the installed `lobu daemon` bin. No workspace
 # node_modules link is present in this phase.
 published_dir="$smoke_dir/published"
-mkdir -p "$published_dir/connector-worker" "$published_dir/cli" "$smoke_dir/prefix"
+mkdir -p "$published_dir/core" "$published_dir/connector-sdk" "$published_dir/embeddings" \
+  "$published_dir/connector-worker" "$published_dir/worker" "$published_dir/cli" "$smoke_dir/prefix"
+cp -R "$repo_root/packages/core/." "$published_dir/core/"
+cp -R "$repo_root/packages/connector-sdk/." "$published_dir/connector-sdk/"
+cp -R "$repo_root/packages/embeddings/." "$published_dir/embeddings/"
 cp -R "$package_root/." "$published_dir/connector-worker/"
+cp -R "$repo_root/packages/agent-worker/." "$published_dir/worker/"
 cp -R "$repo_root/packages/cli/." "$published_dir/cli/"
-PUBLISH_REPO_ROOT="$repo_root" PUBLISH_WORKER_ROOT="$published_dir/connector-worker" PUBLISH_CLI_ROOT="$published_dir/cli" node --input-type=module <<'NODE'
+PUBLISH_REPO_ROOT="$repo_root" PUBLISH_PACKAGE_ROOTS="$published_dir/core:$published_dir/connector-sdk:$published_dir/embeddings:$published_dir/connector-worker:$published_dir/worker:$published_dir/cli" node --input-type=module <<'NODE'
 import { readFile, writeFile } from 'node:fs/promises';
-import { rewriteWorkspaceRefs } from './scripts/publish-packages.mjs';
+import { __testing, rewriteWorkspaceRefs } from './scripts/publish-packages.mjs';
 
-for (const root of [process.env.PUBLISH_WORKER_ROOT, process.env.PUBLISH_CLI_ROOT]) {
+for (const root of process.env.PUBLISH_PACKAGE_ROOTS.split(':')) {
   const path = `${root}/package.json`;
   const pkg = JSON.parse(await readFile(path, 'utf8'));
-  await writeFile(path, `${JSON.stringify(rewriteWorkspaceRefs(pkg), null, 2)}\n`);
+  const transform = root.endsWith('/core')
+    ? __testing.transformCorePublish
+    : root.endsWith('/worker')
+      ? __testing.transformWorkerPublish
+      : rewriteWorkspaceRefs;
+  await writeFile(path, `${JSON.stringify(transform(pkg), null, 2)}\n`);
 }
 NODE
+(cd "$published_dir/core" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
+(cd "$published_dir/connector-sdk" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
+(cd "$published_dir/embeddings" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
 (cd "$published_dir/connector-worker" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
+(cd "$published_dir/worker" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
 (cd "$published_dir/cli" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
 published_archives=("$published_dir"/*.tgz)
-test "${#published_archives[@]}" -eq 2 || {
-  echo "expected transformed CLI and connector-worker tarballs" >&2
+test "${#published_archives[@]}" -eq 6 || {
+  echo "expected six transformed local @lobu tarballs" >&2
   exit 1
 }
 npm install --prefix "$smoke_dir/prefix" --no-audit --no-fund \
-  "${published_archives[0]}" "${published_archives[1]}" >/dev/null
+  "${published_archives[@]}" >/dev/null
 test ! -L "$smoke_dir/prefix/node_modules" || {
   echo "published install unexpectedly uses a node_modules symlink" >&2
   exit 1
 }
 PUBLISHED_PREFIX="$smoke_dir/prefix" node --input-type=module <<'NODE'
 import { access, readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 
 const prefix = process.env.PUBLISHED_PREFIX;
-const bin = resolve(prefix, 'node_modules/@lobu/cli/bin/lobu.js');
+const bin = resolve(prefix, 'node_modules/.bin/lobu');
 await access(bin);
 const workerBuiltins = resolve(prefix, 'node_modules/@lobu/connector-worker/dist/daemon/builtins/index.js');
 await access(workerBuiltins);
+const cliRequire = createRequire(bin);
+const workerRequire = createRequire(workerBuiltins);
+for (const [label, require_] of [['installed CLI', cliRequire], ['installed worker', workerRequire]]) {
+  try {
+    require_.resolve('@lobu/connector-sdk');
+  } catch (error) {
+    throw new Error(`${label} cannot resolve local @lobu/connector-sdk: ${error.message}`);
+  }
+  try {
+    require_.resolve('@lobu/connector-worker/compile');
+    throw new Error(`${label} resolved compiler-only @lobu/connector-worker/compile`);
+  } catch (error) {
+    if (error.message.includes('resolved compiler-only')) throw error;
+  }
+}
 const builtinsSource = await readFile(workerBuiltins, 'utf8');
-for (const forbidden of ['@lobu/connector-sdk', '/compile/index']) {
+for (const forbidden of ['/compile/index']) {
   if (builtinsSource.includes(forbidden)) {
     throw new Error(`published daemon built-ins retain compiler/SDK dependency: ${forbidden}`);
   }
@@ -101,13 +133,11 @@ for (const forbidden of ['@lobu/connector-sdk', '/compile/index']) {
 process.stdout.write('published install dependency boundary: ok\n');
 NODE
 
-# The full daemon has ordinary package dependencies. Reuse the repository's
-# already-installed dependency graph without copying it into the artifact; ESM
-# resolution still starts from the extracted package and the direct check above
-# has already proven the built-in itself is dependency-isolated.
-ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
+# The raw daemon gets the repository dependency graph only in its own isolated
+# sibling. The published CLI's ancestor chain never contains this link.
+ln -s "$repo_root/node_modules" "$raw_runtime/node_modules"
 
-PACKAGE_ROOT="$smoke_dir/package" PUBLISHED_ENTRY="$smoke_dir/prefix/node_modules/@lobu/cli/bin/lobu.js" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
+PACKAGE_ROOT="$raw_runtime/package" PUBLISHED_ENTRY="$smoke_dir/prefix/node_modules/.bin/lobu" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -16,7 +16,8 @@ test -f "$package_root/dist/daemon/builtins/index.js" || {
 }
 
 smoke_dir="$(mktemp -d)"
-trap 'rm -rf "$smoke_dir"' EXIT
+daemon_cwd="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir" "$daemon_cwd"' EXIT
 
 npm pack "$package_root" --pack-destination "$smoke_dir" --silent >/dev/null
 archives=("$smoke_dir"/*.tgz)
@@ -57,12 +58,13 @@ NODE
 # has already proven the built-in itself is dependency-isolated.
 ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
 
-PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+PACKAGE_ROOT="$smoke_dir/package" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import { resolve } from 'node:path';
 
 const packageRoot = process.env.PACKAGE_ROOT;
+const daemonCwd = process.env.DAEMON_CWD;
 const entry = resolve(packageRoot, 'dist/bin.js');
 const token = 'owl_pat_packaged_shell_smoke';
 let activeAttempt = null;
@@ -189,7 +191,7 @@ async function runAttempt(attempt) {
       '--version', 'package-smoke',
     ],
     {
-      cwd: packageRoot,
+      cwd: daemonCwd,
       env: {
         ...process.env,
         WORKER_API_TOKEN: token,

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -99,30 +99,33 @@ test ! -L "$smoke_dir/prefix/node_modules" || {
   echo "published install unexpectedly uses a node_modules symlink" >&2
   exit 1
 }
+find "$smoke_dir/prefix/node_modules" -path '*/@lobu/connector-sdk' -prune -exec rm -rf {} +
+find "$smoke_dir/prefix/node_modules" -name 'connector-sdk' -prune -exec rm -rf {} +
+find "$smoke_dir/prefix/node_modules" -path '*/@lobu/connector-worker/dist/compile' -prune -exec rm -rf {} +
 PUBLISHED_PREFIX="$smoke_dir/prefix" node --input-type=module <<'NODE'
-import { access, readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
+import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const prefix = process.env.PUBLISHED_PREFIX;
 const bin = resolve(prefix, 'node_modules/.bin/lobu');
 await access(bin);
 const workerBuiltins = resolve(prefix, 'node_modules/@lobu/connector-worker/dist/daemon/builtins/index.js');
 await access(workerBuiltins);
-const cliRequire = createRequire(bin);
-const workerRequire = createRequire(workerBuiltins);
-for (const [label, require_] of [['installed CLI', cliRequire], ['installed worker', workerRequire]]) {
+const probe = resolve(prefix, 'dependency-isolation-probe.mjs');
+await writeFile(probe, `for (const specifier of ['@lobu/connector-sdk', '@lobu/connector-worker/compile']) {
   try {
-    require_.resolve('@lobu/connector-sdk');
+    await import(specifier);
+    throw new Error('resolved removed ' + specifier);
   } catch (error) {
-    throw new Error(`${label} cannot resolve local @lobu/connector-sdk: ${error.message}`);
+    if (error.message.includes('resolved removed')) throw error;
   }
-  try {
-    require_.resolve('@lobu/connector-worker/compile');
-    throw new Error(`${label} resolved compiler-only @lobu/connector-worker/compile`);
-  } catch (error) {
-    if (error.message.includes('resolved compiler-only')) throw error;
-  }
+}
+`);
+try {
+  await import(pathToFileURL(probe).href);
+} finally {
+  await rm(probe, { force: true });
 }
 const builtinsSource = await readFile(workerBuiltins, 'utf8');
 for (const forbidden of ['/compile/index']) {

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -59,7 +59,7 @@ NODE
 ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
 
 PACKAGE_ROOT="$smoke_dir/package" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
-import { execFileSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -120,7 +120,7 @@ const server = createServer(async (request, response) => {
           action_input: {
             ...(midCommandPidFile
               ? {
-                  command: `echo $$ > ${JSON.stringify(midCommandPidFile)}; trap '' TERM; sleep 30`,
+                  command: `trap '' TERM; sleep 30 & child_pid=$!; printf '%s\\n' "$PPID" "$$" "$child_pid" > ${JSON.stringify(midCommandPidFile)}; wait "$child_pid"`,
                 }
               : { command: "printf 'lobu-shell-ok\\n'" }),
             cwd: midCommandPidFile ? daemonCwd : process.cwd(),
@@ -243,30 +243,6 @@ async function runAttempt(attempt) {
   process.stdout.write(`packaged queue os.shell attempt ${attempt}: ok\n`);
 }
 
-function processInfo(pid) {
-  let line;
-  try {
-    line = execFileSync('ps', ['-o', 'pid=,ppid=,pgid=', '-p', String(pid)], { encoding: 'utf8' }).trim();
-  } catch (error) {
-    // A PID file can become visible before macOS has published the process in
-    // ps, and a short-lived process can disappear between the probe and ps.
-    // Observation must retry within the bounded wait rather than turn that
-    // race into a false smoke failure.
-    if (error?.status === 1 || error?.code === 'ESRCH') return null;
-    throw error;
-  }
-  if (!line) return null;
-  const [value, parent, group] = line.split(/\s+/).map(Number);
-  return { pid: value, ppid: parent, pgid: group };
-}
-
-function childPids(parentPid) {
-  return execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8' }).trim().split('\n')
-    .map((line) => line.trim().split(/\s+/).map(Number))
-    .filter(([pid, ppid]) => ppid === parentPid && pid > 0)
-    .map(([pid]) => pid);
-}
-
 function isAlive(pid) {
   try { process.kill(pid, 0); return true; } catch (error) {
     return error?.code !== 'ESRCH';
@@ -301,38 +277,44 @@ async function runMidCommandCrashAttempt() {
   daemon.stderr.on('data', (chunk) => { logs += chunk.toString(); });
   const daemonExit = new Promise((resolveExit) => daemon.once('exit', (code, signal) => resolveExit({ code, signal })));
   let supervisorPid = 0;
+  let shellPid = 0;
+  let childPid = 0;
   let groupPid = 0;
-  let descendantPid = 0;
-  const runnerPgid = processInfo(process.pid)?.pgid ?? 0;
   try {
     try {
       await waitUntil(() => {
         if (!isAlive(daemon.pid)) return false;
-        try { descendantPid = Number(readFileSync(pidFile, 'utf8')); } catch { descendantPid = 0; }
-        let current = descendantPid ? processInfo(descendantPid) : null;
-        groupPid = current?.pgid ?? 0;
-        while (current && current.ppid && current.ppid !== 1 && current.ppid !== daemon.pid) current = processInfo(current.ppid);
-        supervisorPid = current?.ppid === daemon.pid ? current.pid : childPids(daemon.pid)[0] ?? 0;
-        if (!descendantPid) {
-          supervisorPid = childPids(daemon.pid)[0] ?? 0;
-          descendantPid = supervisorPid ? childPids(supervisorPid)[0] ?? 0 : 0;
-          if (descendantPid) groupPid = processInfo(supervisorPid).pgid;
+        let recordedPids;
+        try {
+          recordedPids = readFileSync(pidFile, 'utf8').trim().split(/\s+/).map(Number);
+        } catch {
+          return false;
         }
-        return descendantPid > 0 && supervisorPid > 0 && groupPid > 0;
-      }, 'daemon supervisor and descendant PIDs');
+        if (
+          recordedPids.length !== 3 ||
+          recordedPids.some((pid) => !Number.isInteger(pid) || pid <= 0) ||
+          new Set(recordedPids).size !== recordedPids.length ||
+          recordedPids.some((pid) => pid === process.pid || pid === daemon.pid)
+        ) return false;
+        [supervisorPid, shellPid, childPid] = recordedPids;
+        groupPid = supervisorPid;
+        return isAlive(supervisorPid) && isAlive(shellPid) && isAlive(childPid) && groupIsAlive(groupPid);
+      }, 'daemon supervisor, shell target, child, and owned group');
     } catch (error) {
       throw new Error(`${error.message}\n${logs}`);
     }
     daemon.kill('SIGKILL');
     await Promise.race([daemonExit, new Promise((_, reject) => setTimeout(() => reject(new Error(`daemon SIGKILL did not exit\n${logs}`)), 5_000))]);
-    await waitUntil(() => !isAlive(supervisorPid) && !isAlive(descendantPid), 'owned group cleanup after daemon SIGKILL');
-    if (groupIsAlive(groupPid)) throw new Error(`owned process group ${groupPid} survived daemon SIGKILL`);
-    process.stdout.write(`packaged mid-command SIGKILL cleanup: daemon=${daemon.pid} supervisor=${supervisorPid} group=${groupPid} descendant=${descendantPid} ok\n`);
+    await waitUntil(
+      () => !isAlive(supervisorPid) && !isAlive(shellPid) && !isAlive(childPid) && !groupIsAlive(groupPid),
+      'owned supervisor, shell target, child, and group cleanup after daemon SIGKILL',
+    );
+    process.stdout.write(`packaged mid-command SIGKILL cleanup: daemon=${daemon.pid} supervisor=${supervisorPid} shell=${shellPid} child=${childPid} group=${groupPid} ok\n`);
   } finally {
-    for (const pid of [descendantPid, supervisorPid, daemon.pid]) {
+    for (const pid of [childPid, shellPid, supervisorPid, daemon.pid]) {
       if (pid && isAlive(pid)) { try { process.kill(pid, 'SIGKILL'); } catch {} }
     }
-    if (groupPid && groupPid !== runnerPgid && groupIsAlive(groupPid)) {
+    if (groupPid && groupPid !== process.pid && groupIsAlive(groupPid)) {
       try { process.kill(-groupPid, 'SIGKILL'); } catch {}
     }
     midCommandPidFile = null;

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -93,8 +93,35 @@ test "${#published_archives[@]}" -eq 6 || {
   echo "expected six transformed local @lobu tarballs" >&2
   exit 1
 }
-(cd "$smoke_dir/prefix" && bun init -y >/dev/null && bun add --no-save --exact \
-  "${published_archives[@]}" >/dev/null)
+(cd "$smoke_dir/prefix" && bun init -y >/dev/null)
+# Bun otherwise satisfies a workspace-rewritten dependency from the registry
+# and nests it beneath the CLI when the same package is also a direct local
+# archive. Pin the complete @lobu graph to these exact local archives so this
+# proof cannot accidentally exercise a published worker from another build.
+PUBLISHED_PREFIX="$smoke_dir/prefix" PUBLISHED_ARCHIVES="${published_archives[*]}" node --input-type=module <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises';
+
+const prefix = process.env.PUBLISHED_PREFIX;
+const archives = process.env.PUBLISHED_ARCHIVES.split(' ');
+const names = [
+  '@lobu/core',
+  '@lobu/connector-sdk',
+  '@lobu/embeddings',
+  '@lobu/connector-worker',
+  '@lobu/worker',
+  '@lobu/cli',
+];
+const archiveFor = (name) => {
+  const stem = name.slice('@lobu/'.length);
+  const archive = archives.find((candidate) => candidate.includes(`/lobu-${stem}-`));
+  if (!archive) throw new Error(`missing local archive for ${name}`);
+  return archive;
+};
+const packageJson = JSON.parse(await readFile(`${prefix}/package.json`, 'utf8'));
+packageJson.overrides = Object.fromEntries(names.map((name) => [name, `file:${archiveFor(name)}`]));
+await writeFile(`${prefix}/package.json`, `${JSON.stringify(packageJson, null, 2)}\n`);
+NODE
+(cd "$smoke_dir/prefix" && bun add --no-save --exact "${published_archives[@]}" >/dev/null)
 test ! -L "$smoke_dir/prefix/node_modules" || {
   echo "published install unexpectedly uses a node_modules symlink" >&2
   exit 1
@@ -112,6 +139,13 @@ const bin = resolve(prefix, 'node_modules/.bin/lobu');
 await access(bin);
 const workerBuiltins = resolve(prefix, 'node_modules/@lobu/connector-worker/dist/daemon/builtins/index.js');
 await access(workerBuiltins);
+const nestedWorker = resolve(prefix, 'node_modules/@lobu/cli/node_modules/@lobu/connector-worker');
+try {
+  await access(nestedWorker);
+  throw new Error(`published install used a nested connector-worker: ${nestedWorker}`);
+} catch (error) {
+  if (error.message.includes('used a nested')) throw error;
+}
 const probe = resolve(prefix, 'dependency-isolation-probe.mjs');
 await writeFile(probe, `for (const specifier of ['@lobu/connector-sdk', '@lobu/connector-worker/compile']) {
   try {

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -93,8 +93,8 @@ test "${#published_archives[@]}" -eq 6 || {
   echo "expected six transformed local @lobu tarballs" >&2
   exit 1
 }
-npm install --prefix "$smoke_dir/prefix" --no-audit --no-fund \
-  "${published_archives[@]}" >/dev/null
+(cd "$smoke_dir/prefix" && bun init -y >/dev/null && bun add --no-save --exact \
+  "${published_archives[@]}" >/dev/null)
 test ! -L "$smoke_dir/prefix/node_modules" || {
   echo "published install unexpectedly uses a node_modules symlink" >&2
   exit 1

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -52,19 +52,69 @@ if (
 process.stdout.write('packaged os.shell dependency-isolation check: ok\n');
 NODE
 
+# Exercise the customer path too: apply the repository's publish transform to
+# isolated copies, pack the public CLI and its worker dependency, install into
+# an empty npm prefix, and invoke the installed `lobu daemon` bin. No workspace
+# node_modules link is present in this phase.
+published_dir="$smoke_dir/published"
+mkdir -p "$published_dir/connector-worker" "$published_dir/cli" "$smoke_dir/prefix"
+cp -R "$package_root/." "$published_dir/connector-worker/"
+cp -R "$repo_root/packages/cli/." "$published_dir/cli/"
+PUBLISH_REPO_ROOT="$repo_root" PUBLISH_WORKER_ROOT="$published_dir/connector-worker" PUBLISH_CLI_ROOT="$published_dir/cli" node --input-type=module <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises';
+import { rewriteWorkspaceRefs } from './scripts/publish-packages.mjs';
+
+for (const root of [process.env.PUBLISH_WORKER_ROOT, process.env.PUBLISH_CLI_ROOT]) {
+  const path = `${root}/package.json`;
+  const pkg = JSON.parse(await readFile(path, 'utf8'));
+  await writeFile(path, `${JSON.stringify(rewriteWorkspaceRefs(pkg), null, 2)}\n`);
+}
+NODE
+(cd "$published_dir/connector-worker" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
+(cd "$published_dir/cli" && bun pm pack --destination "$published_dir" --quiet) >/dev/null
+published_archives=("$published_dir"/*.tgz)
+test "${#published_archives[@]}" -eq 2 || {
+  echo "expected transformed CLI and connector-worker tarballs" >&2
+  exit 1
+}
+npm install --prefix "$smoke_dir/prefix" --no-audit --no-fund \
+  "${published_archives[0]}" "${published_archives[1]}" >/dev/null
+test ! -L "$smoke_dir/prefix/node_modules" || {
+  echo "published install unexpectedly uses a node_modules symlink" >&2
+  exit 1
+}
+PUBLISHED_PREFIX="$smoke_dir/prefix" node --input-type=module <<'NODE'
+import { access, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const prefix = process.env.PUBLISHED_PREFIX;
+const bin = resolve(prefix, 'node_modules/@lobu/cli/bin/lobu.js');
+await access(bin);
+const workerBuiltins = resolve(prefix, 'node_modules/@lobu/connector-worker/dist/daemon/builtins/index.js');
+await access(workerBuiltins);
+const builtinsSource = await readFile(workerBuiltins, 'utf8');
+for (const forbidden of ['@lobu/connector-sdk', '/compile/index']) {
+  if (builtinsSource.includes(forbidden)) {
+    throw new Error(`published daemon built-ins retain compiler/SDK dependency: ${forbidden}`);
+  }
+}
+process.stdout.write('published install dependency boundary: ok\n');
+NODE
+
 # The full daemon has ordinary package dependencies. Reuse the repository's
 # already-installed dependency graph without copying it into the artifact; ESM
 # resolution still starts from the extracted package and the direct check above
 # has already proven the built-in itself is dependency-isolated.
 ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
 
-PACKAGE_ROOT="$smoke_dir/package" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
+PACKAGE_ROOT="$smoke_dir/package" PUBLISHED_ENTRY="$smoke_dir/prefix/node_modules/@lobu/cli/bin/lobu.js" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const packageRoot = process.env.PACKAGE_ROOT;
+const publishedEntry = process.env.PUBLISHED_ENTRY;
 const daemonCwd = process.env.DAEMON_CWD;
 const entry = resolve(packageRoot, 'dist/bin.js');
 const token = 'owl_pat_packaged_shell_smoke';
@@ -172,7 +222,7 @@ const address = server.address();
 if (!address || typeof address === 'string') throw new Error('mock worker API did not bind TCP');
 const apiUrl = `http://127.0.0.1:${address.port}`;
 
-async function runAttempt(attempt) {
+async function runAttempt(attempt, daemonEntry = entry) {
   const runId = 463 + attempt;
   let resolveCompletion;
   let rejectCompletion;
@@ -189,13 +239,13 @@ async function runAttempt(attempt) {
   const child = spawn(
     process.execPath,
     [
-      entry,
+      daemonEntry,
       'daemon',
       '--api-url', apiUrl,
       '--platform', 'headless',
       '--worker-id', 'headless:package-smoke',
       '--capabilities', 'os.shell',
-      '--version', 'package-smoke',
+      ...(daemonEntry === entry ? ['--version', 'package-smoke'] : []),
     ],
     {
       cwd: daemonCwd,
@@ -326,6 +376,7 @@ try {
   await runAttempt(1);
   await runMidCommandCrashAttempt();
   await runAttempt(2);
+  await runAttempt(3, publishedEntry);
 } finally {
   activeAttempt = null;
   await new Promise((resolveClose) => server.close(resolveClose));

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -19,7 +19,7 @@ smoke_dir="$(mktemp -d)"
 daemon_cwd="$(mktemp -d)"
 trap 'rm -rf "$smoke_dir" "$daemon_cwd"' EXIT
 
-npm pack "$package_root" --pack-destination "$smoke_dir" --silent >/dev/null
+(cd "$package_root" && bun pm pack --destination "$smoke_dir" --quiet) >/dev/null
 archives=("$smoke_dir"/*.tgz)
 test "${#archives[@]}" -eq 1 || {
   echo "expected one connector-worker tarball, found ${#archives[@]}" >&2
@@ -59,8 +59,9 @@ NODE
 ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
 
 PACKAGE_ROOT="$smoke_dir/package" DAEMON_CWD="$daemon_cwd" node --input-type=module <<'NODE'
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const packageRoot = process.env.PACKAGE_ROOT;
@@ -68,6 +69,7 @@ const daemonCwd = process.env.DAEMON_CWD;
 const entry = resolve(packageRoot, 'dist/bin.js');
 const token = 'owl_pat_packaged_shell_smoke';
 let activeAttempt = null;
+let midCommandPidFile = null;
 
 function json(response, status, body) {
   response.writeHead(status, { 'content-type': 'application/json' });
@@ -106,6 +108,7 @@ const server = createServer(async (request, response) => {
       }
       if (activeAttempt && !activeAttempt.claimed) {
         activeAttempt.claimed = true;
+        if (midCommandPidFile) process.stderr.write(`mid-command claimed ${activeAttempt.runId}\n`);
         json(response, 200, {
           run_id: activeAttempt.runId,
           run_type: 'action',
@@ -115,8 +118,12 @@ const server = createServer(async (request, response) => {
           execution_backend: 'daemon_builtin',
           action_key: 'run',
           action_input: {
-            command: "printf 'lobu-shell-ok\\n'",
-            cwd: process.cwd(),
+            ...(midCommandPidFile
+              ? {
+                  command: `echo $$ > ${JSON.stringify(midCommandPidFile)}; trap '' TERM; sleep 30`,
+                }
+              : { command: "printf 'lobu-shell-ok\\n'" }),
+            cwd: midCommandPidFile ? daemonCwd : process.cwd(),
           },
         });
         return;
@@ -223,15 +230,105 @@ async function runAttempt(attempt) {
     clearTimeout(timeoutHandle);
   }
   child.kill('SIGTERM');
-  const exit = await exitResult;
+  const exit = await Promise.race([
+    exitResult,
+    new Promise((_, reject) => setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`packaged daemon shutdown timed out\n${logs}`));
+    }, 5_000)),
+  ]);
   if (exit.code !== 0) {
     throw new Error(`packaged daemon shutdown failed (${exit.code ?? exit.signal})\n${logs}`);
   }
   process.stdout.write(`packaged queue os.shell attempt ${attempt}: ok\n`);
 }
 
+function processInfo(pid) {
+  const line = execFileSync('ps', ['-o', 'pid=,ppid=,pgid=', '-p', String(pid)], { encoding: 'utf8' }).trim();
+  const [value, parent, group] = line.split(/\s+/).map(Number);
+  return { pid: value, ppid: parent, pgid: group };
+}
+
+function childPids(parentPid) {
+  return execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8' }).trim().split('\n')
+    .map((line) => line.trim().split(/\s+/).map(Number))
+    .filter(([pid, ppid]) => ppid === parentPid && pid > 0)
+    .map(([pid]) => pid);
+}
+
+function isAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (error) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+function groupIsAlive(pgid) {
+  try { process.kill(-pgid, 0); return true; } catch (error) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+async function waitUntil(predicate, label, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function runMidCommandCrashAttempt() {
+  const pidFile = resolve(daemonCwd, 'mid-command-descendant.pid');
+  midCommandPidFile = pidFile;
+  activeAttempt = { runId: 466, claimed: false, resolve() {}, reject(error) { throw error; } };
+  const daemon = spawn(process.execPath, [
+    entry, 'daemon', '--api-url', apiUrl, '--platform', 'headless',
+    '--worker-id', 'headless:package-smoke', '--capabilities', 'os.shell', '--version', 'package-smoke',
+  ], { cwd: daemonCwd, env: { ...process.env, WORKER_API_TOKEN: token, WORKER_MAX_CONCURRENT_JOBS: '1' }, stdio: ['ignore', 'pipe', 'pipe'] });
+  let logs = '';
+  daemon.stdout.on('data', (chunk) => { logs += chunk.toString(); });
+  daemon.stderr.on('data', (chunk) => { logs += chunk.toString(); });
+  const daemonExit = new Promise((resolveExit) => daemon.once('exit', (code, signal) => resolveExit({ code, signal })));
+  let supervisorPid = 0;
+  let groupPid = 0;
+  let descendantPid = 0;
+  try {
+    try {
+      await waitUntil(() => {
+        if (!isAlive(daemon.pid)) return false;
+        try { descendantPid = Number(readFileSync(pidFile, 'utf8')); } catch { descendantPid = 0; }
+        let current = descendantPid ? processInfo(descendantPid) : null;
+        groupPid = current?.pgid ?? 0;
+        while (current && current.ppid && current.ppid !== 1 && current.ppid !== daemon.pid) current = processInfo(current.ppid);
+        supervisorPid = current?.ppid === daemon.pid ? current.pid : childPids(daemon.pid)[0] ?? 0;
+        if (!descendantPid) {
+          supervisorPid = childPids(daemon.pid)[0] ?? 0;
+          descendantPid = supervisorPid ? childPids(supervisorPid)[0] ?? 0 : 0;
+          if (descendantPid) groupPid = processInfo(supervisorPid).pgid;
+        }
+        return descendantPid > 0 && supervisorPid > 0 && groupPid > 0;
+      }, 'daemon supervisor and descendant PIDs');
+    } catch (error) {
+      throw new Error(`${error.message}\n${logs}`);
+    }
+    daemon.kill('SIGKILL');
+    await Promise.race([daemonExit, new Promise((_, reject) => setTimeout(() => reject(new Error(`daemon SIGKILL did not exit\n${logs}`)), 5_000))]);
+    await waitUntil(() => !isAlive(supervisorPid) && !isAlive(descendantPid), 'owned group cleanup after daemon SIGKILL');
+    if (groupIsAlive(groupPid)) throw new Error(`owned process group ${groupPid} survived daemon SIGKILL`);
+    process.stdout.write(`packaged mid-command SIGKILL cleanup: daemon=${daemon.pid} supervisor=${supervisorPid} group=${groupPid} descendant=${descendantPid} ok\n`);
+  } finally {
+    for (const pid of [descendantPid, supervisorPid, daemon.pid]) {
+      if (pid && isAlive(pid)) { try { process.kill(pid, 'SIGKILL'); } catch {} }
+    }
+    if (groupPid && groupIsAlive(groupPid)) { try { process.kill(-groupPid, 'SIGKILL'); } catch {} }
+    midCommandPidFile = null;
+    activeAttempt = null;
+  }
+}
+
 try {
   await runAttempt(1);
+  await runMidCommandCrashAttempt();
   await runAttempt(2);
 } finally {
   activeAttempt = null;

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -231,7 +231,7 @@ const server = createServer(async (request, response) => {
       } else {
         activeAttempt.resolve();
       }
-      json(response, 200, {});
+      json(response, 200, { success: true });
       return;
     }
     if (request.url === '/api/workers/heartbeat' && request.method === 'POST') {

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -244,7 +244,18 @@ async function runAttempt(attempt) {
 }
 
 function processInfo(pid) {
-  const line = execFileSync('ps', ['-o', 'pid=,ppid=,pgid=', '-p', String(pid)], { encoding: 'utf8' }).trim();
+  let line;
+  try {
+    line = execFileSync('ps', ['-o', 'pid=,ppid=,pgid=', '-p', String(pid)], { encoding: 'utf8' }).trim();
+  } catch (error) {
+    // A PID file can become visible before macOS has published the process in
+    // ps, and a short-lived process can disappear between the probe and ps.
+    // Observation must retry within the bounded wait rather than turn that
+    // race into a false smoke failure.
+    if (error?.status === 1 || error?.code === 'ESRCH') return null;
+    throw error;
+  }
+  if (!line) return null;
   const [value, parent, group] = line.split(/\s+/).map(Number);
   return { pid: value, ppid: parent, pgid: group };
 }
@@ -292,6 +303,7 @@ async function runMidCommandCrashAttempt() {
   let supervisorPid = 0;
   let groupPid = 0;
   let descendantPid = 0;
+  const runnerPgid = processInfo(process.pid)?.pgid ?? 0;
   try {
     try {
       await waitUntil(() => {
@@ -320,7 +332,9 @@ async function runMidCommandCrashAttempt() {
     for (const pid of [descendantPid, supervisorPid, daemon.pid]) {
       if (pid && isAlive(pid)) { try { process.kill(pid, 'SIGKILL'); } catch {} }
     }
-    if (groupPid && groupIsAlive(groupPid)) { try { process.kill(-groupPid, 'SIGKILL'); } catch {} }
+    if (groupPid && groupPid !== runnerPgid && groupIsAlive(groupPid)) {
+      try { process.kill(-groupPid, 'SIGKILL'); } catch {}
+    }
     midCommandPidFile = null;
     activeAttempt = null;
   }

--- a/scripts/test-headless-shell-package.sh
+++ b/scripts/test-headless-shell-package.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Prove the published connector-worker tarball contains a working daemon-owned
+# os.shell backend, then boot that exact artifact twice against the worker HTTP
+# contract. The direct import deliberately runs before dependencies are made
+# available, so it fails if the built-in grows a runtime dependency on
+# @lobu/connector-sdk or the dynamic compiler. The daemon phase covers poll,
+# manifest advertisement, execution, completion, shutdown, and restart.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_root="$repo_root/packages/connector-worker"
+test -f "$package_root/dist/daemon/builtins/index.js" || {
+  echo "connector-worker dist is missing; build packages before this smoke" >&2
+  exit 1
+}
+
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir"' EXIT
+
+npm pack "$package_root" --pack-destination "$smoke_dir" --silent >/dev/null
+archives=("$smoke_dir"/*.tgz)
+test "${#archives[@]}" -eq 1 || {
+  echo "expected one connector-worker tarball, found ${#archives[@]}" >&2
+  exit 1
+}
+tar -xzf "${archives[0]}" -C "$smoke_dir"
+
+PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const entry = resolve(process.env.PACKAGE_ROOT, 'dist/daemon/builtins/index.js');
+const { executeDaemonBuiltin } = await import(pathToFileURL(entry).href);
+const result = await executeDaemonBuiltin({
+  connectorKey: 'os.shell',
+  actionKey: 'run',
+  input: { command: "printf 'lobu-shell-ok\\n'", cwd: process.cwd() },
+});
+if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+const output = result.output;
+if (
+  output.stdout !== 'lobu-shell-ok\n' ||
+  output.stderr !== '' ||
+  output.exit_code !== 0 ||
+  output.success !== true ||
+  output.timed_out !== false
+) {
+  throw new Error(`unexpected shell result: ${JSON.stringify(output)}`);
+}
+process.stdout.write('packaged os.shell dependency-isolation check: ok\n');
+NODE
+
+# The full daemon has ordinary package dependencies. Reuse the repository's
+# already-installed dependency graph without copying it into the artifact; ESM
+# resolution still starts from the extracted package and the direct check above
+# has already proven the built-in itself is dependency-isolated.
+ln -s "$repo_root/node_modules" "$smoke_dir/node_modules"
+
+PACKAGE_ROOT="$smoke_dir/package" node --input-type=module <<'NODE'
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+
+const packageRoot = process.env.PACKAGE_ROOT;
+const entry = resolve(packageRoot, 'dist/bin.js');
+const token = 'owl_pat_packaged_shell_smoke';
+let activeAttempt = null;
+
+function json(response, status, body) {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+}
+
+const server = createServer(async (request, response) => {
+  try {
+    if (request.url === '/api/health' && request.method === 'GET') {
+      json(response, 200, { ok: true });
+      return;
+    }
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      json(response, 401, { error: 'bad smoke-test authorization' });
+      return;
+    }
+    if (request.url === '/api/workers/poll' && request.method === 'POST') {
+      const body = await readJson(request);
+      const manifest = body.connector_manifests?.find((item) => item.key === 'os.shell');
+      if (
+        body.worker_id !== 'headless:package-smoke' ||
+        body.platform !== 'headless' ||
+        body.capabilities?.['os.shell'] !== true ||
+        body.capacity_available !== 1 ||
+        manifest?.version !== '0.2.0' ||
+        manifest?.runtime?.execution !== 'daemon_builtin'
+      ) {
+        json(response, 400, { error: 'invalid worker advertisement', body });
+        return;
+      }
+      if (activeAttempt && !activeAttempt.claimed) {
+        activeAttempt.claimed = true;
+        json(response, 200, {
+          run_id: activeAttempt.runId,
+          run_type: 'action',
+          connector_key: 'os.shell',
+          connector_version: '0.2.0',
+          connector_manifest_hash: 'package-smoke-manifest',
+          execution_backend: 'daemon_builtin',
+          action_key: 'run',
+          action_input: {
+            command: "printf 'lobu-shell-ok\\n'",
+            cwd: process.cwd(),
+          },
+        });
+        return;
+      }
+      json(response, 200, { next_poll_seconds: 0.05 });
+      return;
+    }
+    if (request.url === '/api/workers/complete-action' && request.method === 'POST') {
+      const body = await readJson(request);
+      if (!activeAttempt || body.run_id !== activeAttempt.runId) {
+        json(response, 409, { error: 'unexpected completion', body });
+        return;
+      }
+      const output = body.action_output;
+      if (
+        body.worker_id !== 'headless:package-smoke' ||
+        body.status !== 'success' ||
+        output?.stdout !== 'lobu-shell-ok\n' ||
+        output?.stderr !== '' ||
+        output?.exit_code !== 0 ||
+        output?.success !== true ||
+        output?.timed_out !== false
+      ) {
+        activeAttempt.reject(new Error(`unexpected completion: ${JSON.stringify(body)}`));
+      } else {
+        activeAttempt.resolve();
+      }
+      json(response, 200, {});
+      return;
+    }
+    if (request.url === '/api/workers/heartbeat' && request.method === 'POST') {
+      json(response, 200, {});
+      return;
+    }
+    json(response, 404, { error: `unexpected route ${request.method} ${request.url}` });
+  } catch (error) {
+    json(response, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+await new Promise((resolveListen, rejectListen) => {
+  server.once('error', rejectListen);
+  server.listen(0, '127.0.0.1', resolveListen);
+});
+const address = server.address();
+if (!address || typeof address === 'string') throw new Error('mock worker API did not bind TCP');
+const apiUrl = `http://127.0.0.1:${address.port}`;
+
+async function runAttempt(attempt) {
+  const runId = 463 + attempt;
+  let resolveCompletion;
+  let rejectCompletion;
+  const completion = new Promise((resolveDone, rejectDone) => {
+    resolveCompletion = resolveDone;
+    rejectCompletion = rejectDone;
+  });
+  activeAttempt = {
+    runId,
+    claimed: false,
+    resolve: resolveCompletion,
+    reject: rejectCompletion,
+  };
+  const child = spawn(
+    process.execPath,
+    [
+      entry,
+      'daemon',
+      '--api-url', apiUrl,
+      '--platform', 'headless',
+      '--worker-id', 'headless:package-smoke',
+      '--capabilities', 'os.shell',
+      '--version', 'package-smoke',
+    ],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        WORKER_API_TOKEN: token,
+        WORKER_MAX_CONCURRENT_JOBS: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let logs = '';
+  child.stdout.on('data', (chunk) => { logs += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { logs += chunk.toString(); });
+  const exitResult = new Promise((resolveExit) => {
+    child.once('exit', (code, signal) => resolveExit({ code, signal }));
+  });
+  const earlyExit = exitResult.then(({ code, signal }) => {
+    throw new Error(`packaged daemon exited before completion (${code ?? signal})\n${logs}`);
+  });
+  let timeoutHandle;
+  const timeout = new Promise((_, rejectTimeout) => {
+    timeoutHandle = setTimeout(
+      () => rejectTimeout(new Error(`packaged daemon timed out\n${logs}`)),
+      15_000,
+    );
+  });
+
+  try {
+    await Promise.race([completion, earlyExit, timeout]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+  child.kill('SIGTERM');
+  const exit = await exitResult;
+  if (exit.code !== 0) {
+    throw new Error(`packaged daemon shutdown failed (${exit.code ?? exit.signal})\n${logs}`);
+  }
+  process.stdout.write(`packaged queue os.shell attempt ${attempt}: ok\n`);
+}
+
+try {
+  await runAttempt(1);
+  await runAttempt(2);
+} finally {
+  activeAttempt = null;
+  await new Promise((resolveClose) => server.close(resolveClose));
+}
+NODE


### PR DESCRIPTION
## Summary
- Clear current device-manifest execution authority on rejected or omitted polls while retaining historical connector-version inventory.
- Preserve active device-manifest-backed connector definitions during bundled catalog refresh.
- Add explicit per-backend poll capacity: headless recovery advertises daemon_builtin capacity and zero compiled_connector capacity; compiled claims require positive advertised capacity.
- Add current-attestation transition coverage and rename the prior same-version retention test to the real rejected-payload behavior.

## Validation
- `bun run --cwd packages/core build` passed.
- `bun run --cwd packages/connector-worker typecheck` passed.
- `bun run --cwd packages/server typecheck` passed.
- Focused core and connector-worker tests: 11 passed.
- `git diff --check` passed; pre-commit Biome and TypeScript checks passed.
- Server Postgres integration tests were attempted but could not start embedded Postgres in this sandbox (`shmget: Operation not permitted`); the DB transition and catalog-refresh regressions therefore still require CI/DB-backed verification.

Exact phase head: `651f2f74a`. Full CI, merge, and deploy are intentionally out of scope for this phase.

## Runtime-safety phase evidence (exact head)

- Added `os.shell` supervision through the existing persistent IPC/process-group anchor; parent/daemon loss uses EOF/disconnect cleanup, and normal settlement kills detached descendants while the anchor is still live.
- Failed builtin shell completions retain bounded `stdout`, `stderr`, `exit_code`, `timed_out`, `duration_ms`, and `success` in `action_output`.
- Terminal action delivery retries one immutable payload within a bounded 15s delivery budget; success delivery uncertainty is never converted into a different failure completion.
- Renamed the environment test to state the actual guarantee (no control-plane environment inheritance) and documented that approved shell runs as the device user with HOME/filesystem access; approval is the trust boundary and auto mode is opt-in.
- Focused tests: 31 passed (`daemon-builtin-os-shell`, `native-bridge`); connector-worker typecheck passed; packaged shell smoke passed for both queue attempts; `git diff --check` passed.
- Full GitHub suite, merge, and deploy were not run in this phase. The packaged crash/restart harness is not expanded here beyond the existing packaged queue/restart smoke; daemon crash coverage remains a follow-up if CI requires a real SIGKILL replacement-daemon scenario.

## Exact-head correction phase (2026-08-31)

- Removed --lobu-target-env JSON argv transport; target environment now comes from supervisor spawn options, with a Bun-only Node-runtime test seam preserving replacement-env semantics.
- completeActionOnce now clears bounded delivery timers; success and failed terminal payloads retry byte-equivalently without contradictory completion.
- Detached new sessions are explicitly outside automatic cleanup; the test asserts bounded settlement and exact-PID/group cleanup in finally.
- Added backend-capacity fixtures and fail-closed omitted-manifest expectations.
- Focused worker tests, connector-worker/server typechecks, build, and diff checks pass.
- Packaged mid-command SIGKILL harness was added but currently fails to observe a child after the mock poll claim on this Mac; no merge, deploy, or full GitHub suite was run. CI must verify/fix that harness before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daemon-managed execution for the headless `os.shell` connector.
  * Headless workers can run shell commands without connector compilation or SDK dependencies.
  * Workers now advertise execution capacity to improve job routing.

* **Bug Fixes**
  * Improved cleanup of timed-out commands and descendant processes.
  * Shell failures preserve structured output and exit details.
  * Unavailable device backends now provide actionable status guidance.
  * Shell timeouts are validated more strictly, with a 150-second maximum.

* **Documentation**
  * Added security guidance for approved device shell access and trust boundaries.

* **Tests**
  * Expanded coverage for packaged execution, recovery, and process safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->\n\n## Final release-path pass (exact head c80c5af63)

- Published-path smoke applies scripts/publish-packages.mjs transforms to isolated CLI/connector-worker copies, packs both tarballs, installs into an empty npm prefix with no workspace symlink, verifies installed daemon built-ins, and runs the public lobu daemon against the mock queue from an unrelated cwd.
- Existing raw packaged queue + SIGKILL/restart proof remains green; published queue execution is also green.
- Feed readiness now uses one shared headless-runtime classifier across manage_feeds and operations.listAvailable; legacy/rejected manifests remain fail closed. Chrome scheduler fixture advertises bridge-only capacity (compiled_connector: 0).
- os.shell timeout is capped and advertised at 170s; server daemon wait budget is 175s, preserving cleanup and terminal-delivery grace within the 180s SDK outer cap.
- Validation: published smoke passed; worker/connector shell tests 27 passed; feed-readiness unit tests 36 passed; fresh package builds, typechecks, knip, naming, funnel gates, pre-commit, and git diff --check passed.
- DB-backed scheduler integration was attempted but remains unavailable here because DATABASE_URL is unset; exact-head CI/DB verification is still required. No merge, deploy, live connection test, or full-CI wait was performed.