### PR TITLE
fix(server): claim connectorless embedding backfills

### DIFF
--- a/packages/server/src/__tests__/integration/embed-backfill-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/embed-backfill-poll-claim.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { PollResponseSchema } from '@lobu/core/contracts/worker/protocol';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestPAT,
+  createTestUser,
+} from '../setup/test-fixtures';
+import { post } from '../setup/test-helpers';
+
+async function insertEmbedRun(organizationId: string, older = false) {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    INSERT INTO runs (organization_id, run_type, status, approval_status, created_at)
+    VALUES (
+      ${organizationId}, 'embed_backfill', 'pending', 'auto',
+      ${older ? sql`current_timestamp - interval '1 minute'` : sql`current_timestamp`}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function runStatus(runId: number) {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT status, claimed_by FROM runs WHERE id = ${runId}
+  `) as unknown as Array<{ status: string; claimed_by: string | null }>;
+  return row;
+}
+
+async function pollFleet(workerId: string) {
+  return post('/api/workers/poll', {
+    body: { worker_id: workerId, capabilities: {} },
+    token: 'test-fleet-token',
+    env: { WORKER_API_TOKEN: 'test-fleet-token' },
+  });
+}
+
+describe('embed_backfill worker poll claim lane', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.WORKER_API_TOKEN;
+  });
+
+  it('trusted fleet claims a connectorless embed_backfill and emits a schema-valid response without connector_key', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertEmbedRun(org.id);
+
+    const response = await pollFleet('fleet-embed-response');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Value.Check(PollResponseSchema, body)).toBe(true);
+    expect(body.run_id).toBe(runId);
+    expect(body.run_type).toBe('embed_backfill');
+    expect(Object.hasOwn(body, 'connector_key')).toBe(false);
+    expect(await runStatus(runId)).toEqual({
+      status: 'running',
+      claimed_by: 'fleet-embed-response',
+    });
+  });
+
+  it('two concurrent fleet polls claim one embed_backfill exactly once', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertEmbedRun(org.id);
+
+    const responses = await Promise.all([
+      pollFleet('fleet-embed-race-a'),
+      pollFleet('fleet-embed-race-b'),
+    ]);
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    expect(bodies.filter((body) => body.run_id === runId)).toHaveLength(1);
+    expect(await runStatus(runId)).toMatchObject({ status: 'running' });
+    expect(['fleet-embed-race-a', 'fleet-embed-race-b']).toContain(
+      (await runStatus(runId)).claimed_by
+    );
+  });
+
+  it('a user/device poll cannot claim a connectorless embed_backfill', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const workerId = 'device-embed-not-allowed';
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, organization_id)
+      VALUES (${user.id}, ${workerId}, 'macos', ${sql.json([])}, ${org.id})
+    `;
+    const pat = await createTestPAT(user.id, org.id, { scope: 'device_worker:run' });
+    const runId = await insertEmbedRun(org.id);
+
+    const response = await post('/api/workers/poll', {
+      token: pat.token,
+      body: { worker_id: workerId, platform: 'macos', capabilities: {} },
+    });
+    expect(response.status).toBe(200);
+    expect((await response.json()).run_id).toBeUndefined();
+    expect(await runStatus(runId)).toEqual({ status: 'pending', claimed_by: null });
+  });
+
+  it('does not let an older embed_backfill block a later eligible device connector run', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const workerId = 'device-embed-hol';
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, organization_id)
+      VALUES (${user.id}, ${workerId}, 'macos', ${sql.json([])}, ${org.id})
+    `;
+    const pat = await createTestPAT(user.id, org.id, { scope: 'device_worker:run' });
+    const embedId = await insertEmbedRun(org.id, true);
+    const connectorKey = 'test.embed-hol';
+    await createTestConnectorDefinition({
+      key: connectorKey,
+      name: 'Embed HOL Test',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: connectorKey,
+    });
+    const deviceId = (await sql`
+      SELECT id FROM device_workers WHERE worker_id = ${workerId}
+    `)[0].id;
+    await sql`UPDATE connections SET device_worker_id = ${deviceId}::uuid WHERE id = ${connection.id}`;
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key, connector_version,
+        approval_status, status, created_at
+      )
+      VALUES (${org.id}, 'sync', ${connection.id}, ${connectorKey}, '1.0.0', 'auto', 'pending', current_timestamp)
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const deviceResponse = await post('/api/workers/poll', {
+      token: pat.token,
+      body: { worker_id: workerId, platform: 'macos', capabilities: {} },
+    });
+    expect(deviceResponse.status).toBe(200);
+    expect((await deviceResponse.json()).run_id).toBe(Number(run.id));
+    expect(await runStatus(embedId)).toEqual({ status: 'pending', claimed_by: null });
+
+    const fleetResponse = await pollFleet('fleet-embed-after-device');
+    expect(fleetResponse.status).toBe(200);
+    expect((await fleetResponse.json()).run_id).toBe(embedId);
+    expect(await runStatus(embedId)).toEqual({
+      status: 'running',
+      claimed_by: 'fleet-embed-after-device',
+    });
+  });
+});

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -752,9 +752,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           )
           AND (r.approval_status = 'auto' OR r.approval_status = 'approved')
           AND (
-            -- (1) Connector-worker lanes: sync / action / embed_backfill / auth.
+            -- (1) Connector-worker lanes: sync / action / auth.
             (
-              r.run_type IN ('sync', 'action', 'embed_backfill', 'auth')
+              r.run_type IN ('sync', 'action', 'auth')
               AND ${connectorClaimLaneSql(tx, connectorClaimContext, {
                 connectorKey: tx`r.connector_key`,
                 connectorVersion: tx`r.connector_version`,
@@ -770,6 +770,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                 runArtifactCompiledCode: tx`run_cv.artifact_compiled_code`,
                 runRuntime: tx`cd.run_runtime`,
               })}
+            )
+            -- (1b) Embedding backfills have no connector identity. They are
+            -- server-side work and may only be claimed by the trusted fleet.
+            OR (
+              ${!isUserScopedWorker}
+              AND r.run_type = 'embed_backfill'
             )
             -- (2) Automation lane: an automation run with approved_input.device_worker_id
             --     matching this device. Automations don't carry a connection_id and
@@ -1089,7 +1095,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     run_type: string;
     feed_id: number | null;
     connection_id: number | null;
-    connector_key: string;
+    connector_key: string | null;
     connector_version: string | null;
     action_key: string | null;
     action_input: Record<string, unknown> | null;
@@ -1759,7 +1765,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const selectedActionInput = row.approved_input ?? row.action_input ?? undefined;
   const isChromeAction =
     row.run_type === 'action' &&
-    (row.connector_key === 'chrome' || row.connector_key.startsWith('chrome.'));
+    (row.connector_key === 'chrome' || row.connector_key?.startsWith('chrome.'));
   const actionInput = isChromeAction
     ? trustedChromeActionInput(
         selectedActionInput ?? {},
@@ -1772,7 +1778,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     ...pollMetadata,
     run_id: row.run_id,
     run_type: row.run_type,
-    connector_key: row.connector_key,
+    connector_key: row.connector_key ?? undefined,
     connector_version: row.connector_version ?? undefined,
     ...(isNativeBridgeRun
       ? {


### PR DESCRIPTION
## Summary

The live worker queue has an embedding-backfill `worker_claim_timeout` incident. `trigger-embed-backfill.ts` creates runs with NULL `connector_key`, `connector_version`, and `connection_id`; the shared connector claim predicates therefore evaluate to SQL UNKNOWN and trusted fleet workers never claim them.

This patch gives `embed_backfill` its own trusted-fleet-only claim lane, keeps connector predicates limited to `sync`, `action`, and `auth`, and makes the connectorless response truthful (`connector_key` omitted). No shared placement or connector identity fallback was changed.

## Tests

- Pre-fix regression: restored the original combined lane; 3/4 focused cases failed, including fleet claim and device head-of-line behavior.
- Post-fix focused integration suite: `embed-backfill-poll-claim.test.ts` passed 4/4.
- Neighbor suite: `embed-backfill-poll-claim.test.ts browser-affinity-poll-claim.test.ts` passed 15/15.
- Covers trusted-fleet claim, concurrent exactly-once claim, device rejection, device-vs-fleet head-of-line behavior, final `status`/`claimed_by`, and `PollResponseSchema` with omitted `connector_key`.
- `make pre-pr` passed.
- Normal pre-commit passed Biome and TypeScript checks.
- `git diff --check` passed.

## Rollout / rollback

Roll out as a fleet-only canary: observe embed-backfill claim latency and `worker_claim_timeout` counts on trusted fleet workers before widening. Device workers cannot claim this lane by construction. Rollback is server-only: revert the poll-lane change and redeploy the server; no database migration or connector rollout is required.

## Scope

- Server poll claim SQL and connectorless poll wire handling.
- One focused server integration test file.
- No merge or deployment performed in this phase.
