### PR TITLE
fix(ci): gate releases on image provenance

### DIFF
--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -1,0 +1,61 @@
+name: "Verify release binding"
+description: >
+  Assert that a release tag, the commit it peels to, and the GitHub release
+  itself are one published stable artifact. Fetching the three API documents
+  is identical at every call site, so it lives here rather than being pasted
+  into build-images, release-please and publish-packages; the policy the
+  documents are judged against lives in scripts/release-provenance.mjs, which
+  scripts/__tests__/release-publish-order.test.ts covers.
+
+  Requires the repository to be checked out, for the helper.
+
+inputs:
+  tag:
+    description: "Release tag to verify, e.g. lobu-v17.3.0"
+    required: true
+  expected-sha:
+    description: >
+      Commit the tag must peel to. Omit when the caller is deriving the commit
+      from the tag rather than checking it against one it already trusts.
+    required: false
+    default: ""
+  token:
+    description: "Token with read access to releases and git refs"
+    required: true
+
+outputs:
+  sha:
+    description: "The commit the release tag peels to"
+    value: ${{ steps.verify.outputs.sha }}
+  version:
+    description: "The stable version the tag encodes"
+    value: ${{ steps.verify.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Verify the release binds to an immutable commit
+      id: verify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPOSITORY: ${{ github.repository }}
+        TAG: ${{ inputs.tag }}
+        EXPECTED_SHA: ${{ inputs.expected-sha }}
+      run: |
+        set -euo pipefail
+        release=$(gh api "repos/${REPOSITORY}/releases/tags/${TAG}")
+        tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}")
+        tag_object=null
+        # An annotated tag's ref names the tag object, not the commit, so the
+        # peeled object has to be fetched before anything can be compared.
+        if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
+          tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
+        fi
+        verified=$(jq -n --argjson release "$release" --argjson tagRef "$tag_ref" \
+          --argjson tagObject "$tag_object" --arg tag "$TAG" --arg sha "$EXPECTED_SHA" \
+          '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag}
+           + (if $sha == "" then {} else {expectedSha: $sha} end)' \
+          | node "${GITHUB_WORKSPACE}/scripts/release-provenance.mjs" verify-release)
+        echo "sha=$(jq -r '.sha' <<<"$verified")" >> "$GITHUB_OUTPUT"
+        echo "version=$(jq -r '.version' <<<"$verified")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -106,6 +106,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Verify published release binds to this immutable commit
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          [ "$(jq -r '.draft' <<<"$release")" = false ] && [ "$(jq -r '.prerelease' <<<"$release")" = false ] || { echo "::error::release is not a published stable release"; exit 1; }
+          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
+          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
+          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha'); fi
+          [ "$tag_sha" = "$RELEASE_SHA" ] && [ "$(jq -r '.target_commitish' <<<"$release")" = "$RELEASE_SHA" ] || { echo "::error::release/tag does not bind to workflow SHA"; exit 1; }
+
       # Every tag decision lives in scripts/derive-image-tags.mjs so it is
       # covered by scripts/__tests__/derive-image-tags.test.ts. Computed once
       # here so app/worker/embeddings cannot disagree about the tag,

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -116,11 +116,15 @@ jobs:
         run: |
           set -euo pipefail
           release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
-          [ "$(jq -r '.draft' <<<"$release")" = false ] && [ "$(jq -r '.prerelease' <<<"$release")" = false ] || { echo "::error::release is not a published stable release"; exit 1; }
           tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
-          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
-          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha'); fi
-          [ "$tag_sha" = "$RELEASE_SHA" ] && [ "$(jq -r '.target_commitish' <<<"$release")" = "$RELEASE_SHA" ] || { echo "::error::release/tag does not bind to workflow SHA"; exit 1; }
+          tag_object=null
+          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
+            tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
+          fi
+          jq -n --argjson release "$release" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" \
+            --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
+            '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag, expectedSha: $sha}' \
+            | node scripts/release-provenance.mjs verify-release >/dev/null
 
       # Every tag decision lives in scripts/derive-image-tags.mjs so it is
       # covered by scripts/__tests__/derive-image-tags.test.ts. Computed once

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -342,7 +342,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f release_tag="$RELEASE_TAG" \
-            -f bump=skip \
             -f image_run_id="$GITHUB_RUN_ID"
 
   build-worker:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,7 @@ name: Build and Push Images
 # matching ImagePolicy lives in the owletto submodule and accepts both the old
 # two-segment tags and the new three-segment form.
 concurrency:
-  group: build-images${{ github.event_name == 'release' && '-release' || '' }}
+  group: build-images${{ github.event_name == 'workflow_dispatch' && '-manual' || github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false
 
 on:
@@ -68,8 +68,34 @@ env:
         || 'linux/amd64' }}
 
 jobs:
+  # A manual run is allowed only from the current main tip. This job performs
+  # no checkout, so an old branch cannot execute repository code before the
+  # guard has passed. Manual runs have their own concurrency group above and
+  # therefore cannot evict a pending main push.
+  current-main-guard:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Require manual dispatch from current main
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [ "$REF" = "refs/heads/main" ] || { echo "::error::manual image builds must target main"; exit 1; }
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          [ "$current_sha" = "$DISPATCH_SHA" ] || { echo "::error::manual image build is not at current main"; exit 1; }
+      - name: Allow automated event
+        if: github.event_name != 'workflow_dispatch'
+        run: echo "automated event does not need a manual ref guard"
+
   generate-tag:
     runs-on: ubuntu-24.04
+    needs: [current-main-guard]
     outputs:
       tag: ${{ steps.tags.outputs.tag }}
       semver: ${{ steps.tags.outputs.semver }}
@@ -273,11 +299,9 @@ jobs:
             "${REGISTRY}/${IMAGE_NAME_APP}:${{ needs.generate-tag.outputs.tag }}"
 
   # Package publication belongs after the exact release artifact passes its
-  # runtime smoke. release-please used to dispatch this immediately after
-  # creating the release, while build-images was still queued/in progress;
-  # publish-packages correctly failed closed, leaving 14.9 and 14.10 absent
-  # from npm. Target the release tag and pass this exact run ID so
-  # the downstream guard cannot select a different same-SHA image run.
+  # runtime smoke. Dispatch from current main so the hardened workflow policy
+  # is used; the release tag is data, not the workflow ref. Pass this exact run
+  # ID so the downstream gate cannot select a different producer.
   trigger-package-publish:
     runs-on: ubuntu-24.04
     needs: [generate-tag, app-image-smoke]
@@ -296,7 +320,8 @@ jobs:
           set -euo pipefail
           gh workflow run publish-packages.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$RELEASE_TAG" \
+            --ref main \
+            -f release_tag="$RELEASE_TAG" \
             -f bump=skip \
             -f image_run_id="$GITHUB_RUN_ID"
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -108,23 +108,11 @@ jobs:
 
       - name: Verify published release binds to this immutable commit
         if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
-          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
-          tag_object=null
-          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
-            tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
-          fi
-          jq -n --argjson release "$release" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" \
-            --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
-            '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag, expectedSha: $sha}' \
-            | node scripts/release-provenance.mjs verify-release >/dev/null
+        uses: ./.github/actions/verify-release
+        with:
+          tag: ${{ github.event.release.tag_name }}
+          expected-sha: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Every tag decision lives in scripts/derive-image-tags.mjs so it is
       # covered by scripts/__tests__/derive-image-tags.test.ts. Computed once

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -106,8 +106,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      # Prefix-gated as well as event-gated: derive-image-tags deliberately
+      # returns should_publish=false for another component's release sharing
+      # this event feed (owletto-mac-v*), and verify-release would throw "not a
+      # Lobu release tag" first, turning that graceful skip into a red job.
       - name: Verify published release binds to this immutable commit
-        if: github.event_name == 'release'
+        if: >-
+          github.event_name == 'release' &&
+          startsWith(github.event.release.tag_name, 'lobu-v')
         uses: ./.github/actions/verify-release
         with:
           tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -49,9 +49,12 @@ jobs:
           IMAGE_RUN_ID: ${{ inputs.image_run_id }}
           BUMP: ${{ inputs.bump }}
           WORKFLOW_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::publish policy must run from current main"; exit 1; }
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          [ "$DISPATCH_SHA" = "$current_sha" ] || { echo "::error::publish workflow is not at current main"; exit 1; }
           [ "$BUMP" = skip ] || { echo "::error::hosted arbitrary version bumps are forbidden"; exit 1; }
           [[ "$RELEASE_TAG" =~ ^lobu-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::release_tag must be an exact lobu-vSemVer tag"; exit 1; }
           version="${RELEASE_TAG#lobu-v}"
@@ -67,6 +70,7 @@ jobs:
             tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')
           fi
           [[ "$tag_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::could not peel release tag"; exit 1; }
+          [ "$(jq -r '.target_commitish' <<<"$release")" = "$tag_sha" ] || { echo "::error::release target does not match peeled tag"; exit 1; }
 
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           compare=$(gh api "repos/${REPOSITORY}/compare/${tag_sha}...${current_sha}")
@@ -78,25 +82,26 @@ jobs:
           [ "$(jq -r '.workflow_id' <<<"$build_run")" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
           [ "$(jq -r '.head_repository.full_name // empty' <<<"$build_run")" = "$REPOSITORY" ] || { echo "::error::Build Images repository mismatch"; exit 1; }
           [ "$(jq -r '.event' <<<"$build_run")" = release ] || { echo "::error::Build Images run must be a release event"; exit 1; }
+          [ "$(jq -r '.status' <<<"$build_run")" = completed ] && [ "$(jq -r '.conclusion' <<<"$build_run")" = success ] || { echo "::error::Build Images release run is not completed-success"; exit 1; }
           [ "$(jq -r '.head_sha' <<<"$build_run")" = "$tag_sha" ] || { echo "::error::Build Images SHA does not match peeled tag"; exit 1; }
 
           jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
           selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
             ( $required | split(" ") ) as $required_jobs
-            | [ .[][] | select(.name as $name | ($required_jobs | index($name)) != null) ]
-            | group_by(.name)
-            | if any(.[]; ([ .[] | select(.run_attempt == (max_by(.run_attempt // 1).run_attempt // 1)) ] | length) != 1)
-              then error("duplicate latest-attempt required job") else . end
-            | map(max_by(.run_attempt // 1))
-            | if (map(.name) | sort) == ($required_jobs | sort)
-              and all(.[]; .status == "completed" and .conclusion == "success")
-              then . else error("required release image jobs missing, skipped, failed, or incomplete") end
+            | [ .[] | .jobs[] ] as $jobs
+            | $required_jobs | map(. as $name
+              | [ $jobs[] | select(.name == $name) ] as $matches
+              | if ($matches | length) == 0 then error("missing required job") else . end
+              | ($matches | map(.run_attempt // 1) | max) as $latest
+              | [ $matches[] | select((.run_attempt // 1) == $latest) ] as $chosen
+              | if ($chosen | length) != 1 then error("duplicate latest-attempt required job") else $chosen[0] end)
+            | if all(.[]; .status == "completed" and .conclusion == "success") then . else error("required release image jobs missing, skipped, failed, or incomplete") end
           ' <<<"$jobs") || { echo "::error::release image-job attestation failed"; exit 1; }
           printf '%s\n' "$selected" >/dev/null
 
           ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id')
-          ci_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${tag_sha}&event=push&branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.workflow_id == '"$ci_workflow_id"' and .repository.full_name == "'"$REPOSITORY"'" and .event == "push" and .head_branch == "main" and .head_sha == "'"$tag_sha"'" and .status == "completed" and .conclusion == "success")] | sort_by(.run_attempt // 1) | last.id // empty')
+          ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${tag_sha}&event=push&branch=main&status=completed&per_page=100")
+          ci_run_id=$(jq -r --arg workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$tag_sha" '[.workflow_runs[] | select((.workflow_id|tostring) == $workflow_id and .repository.full_name == $repo and .event == "push" and .head_branch == "main" and .head_sha == $sha and .status == "completed" and .conclusion == "success")] as $runs | if ($runs|length) == 0 then "" else ($runs | map(.run_attempt // 1) | max) as $latest | [$runs[] | select((.run_attempt // 1) == $latest)] as $chosen | if ($chosen|length) == 1 then ($chosen[0].id|tostring) else error("ambiguous CI latest attempt") end end' <<<"$ci_runs")
           [ -n "$ci_run_id" ] || { echo "::error::no exact successful CI push/main run for release SHA"; exit 1; }
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -109,6 +114,9 @@ jobs:
     needs: attest-publish
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    concurrency:
+      group: publish-packages-${{ needs.attest-publish.outputs.version }}
+      cancel-in-progress: false
     environment: production
     env:
       CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
@@ -150,7 +158,15 @@ jobs:
         if: ${{ env.CLAWHUB_TOKEN_SET == 'true' }}
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-        run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
+          run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
+
+      - name: Gate package version monotonicity
+        env:
+          EXPECTED_VERSION: ${{ needs.attest-publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          published=$(npm view @lobu/cli versions --json 2>/dev/null || echo '[]')
+          node --input-type=module -e 'import { compareVersions } from "./scripts/release-provenance.mjs"; const versions = JSON.parse(process.argv[1]); const current = process.argv[2]; const stable = (Array.isArray(versions) ? versions : [versions]).filter(v => /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(v)); if (stable.some(v => compareVersions(v, current) > 0)) throw new Error(`npm already contains a newer stable version than ${current}`);' "$published" "$EXPECTED_VERSION"
 
       - name: Publish packages at exact version
         env:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -11,11 +11,6 @@ on:
         description: "Exact Build and Push Images release run"
         required: true
         type: string
-      bump:
-        description: "Must be skip; versions come from the attested release"
-        required: true
-        default: skip
-        type: string
       provenance:
         description: "Attach npm provenance"
         required: false
@@ -53,12 +48,10 @@ jobs:
       # where main happens to be.
       - name: Verify current-main workflow policy
         env:
-          BUMP: ${{ inputs.bump }}
           WORKFLOW_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::publish policy must run from current main"; exit 1; }
-          [ "$BUMP" = skip ] || { echo "::error::hosted arbitrary version bumps are forbidden"; exit 1; }
 
       - name: Check out current main
         uses: actions/checkout@v7

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -37,8 +37,6 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.version }}
       tag_sha: ${{ steps.release.outputs.tag_sha }}
-      image_run_id: ${{ steps.producer.outputs.image_run_id }}
-      ci_run_id: ${{ steps.producer.outputs.ci_run_id }}
     steps:
       # Deliberately before any checkout: this workflow holds the production
       # environment's publish credentials downstream, so nothing from the
@@ -87,7 +85,6 @@ jobs:
           echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
 
       - name: Attest the producing image run and its exact CI run
-        id: producer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
@@ -114,9 +111,7 @@ jobs:
             '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
               expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
             | node scripts/release-provenance.mjs select-run | jq -r '.id')
-          echo "image_run_id=$IMAGE_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
-
+          echo "attested CI run for ${TAG_SHA}: ${ci_run_id}"
 
   publish-packages:
     name: Publish attested packages

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -95,8 +95,15 @@ jobs:
           [ "$(jq -r '.workflow_id' <<<"$build_run")" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
           [ "$(jq -r '.head_repository.full_name // empty' <<<"$build_run")" = "$REPOSITORY" ] || { echo "::error::Build Images repository mismatch"; exit 1; }
           [ "$(jq -r '.event' <<<"$build_run")" = release ] || { echo "::error::Build Images run must be a release event"; exit 1; }
-          [ "$(jq -r '.status' <<<"$build_run")" = completed ] && [ "$(jq -r '.conclusion' <<<"$build_run")" = success ] || { echo "::error::Build Images release run is not completed-success"; exit 1; }
           [ "$(jq -r '.head_sha' <<<"$build_run")" = "$TAG_SHA" ] || { echo "::error::Build Images SHA does not match peeled tag"; exit 1; }
+          # Deliberately no run-level status/conclusion assertion. This publish
+          # is dispatched by trigger-package-publish, a job *inside* the run it
+          # names, so that run is still in_progress while this gate reads it --
+          # asserting "completed" here strands the release off npm, which is
+          # the defect this workflow exists to prevent. The per-job attestation
+          # below is stronger evidence anyway: it proves all six required image
+          # jobs are completed-success, which an unfinished producer cannot
+          # fake, and none of the six is the job doing the dispatching.
 
           jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
           jq -n --argjson pages "$jobs" --arg required "$REQUIRED_IMAGE_JOBS" \

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,19 +40,24 @@ jobs:
     steps:
       # Deliberately before any checkout: this workflow holds the production
       # environment's publish credentials downstream, so nothing from the
-      # repository runs until the dispatch is shown to be current main.
+      # repository runs until the dispatch is shown to carry main's policy.
+      #
+      # The ref is the whole check. A dispatch resolves refs/heads/main to a
+      # tip nobody can forge, so requiring the workflow to run from main is
+      # what pins the policy. Deliberately NOT also requiring that tip to
+      # still be main's HEAD: this job starts a minute or so after
+      # trigger-package-publish dispatches it, any merge landing in that
+      # window would fail the publish permanently, and a release stranded
+      # off npm by a fail-closed race is the exact defect this workflow
+      # exists to fix. The release itself is bound by its tag below, not by
+      # where main happens to be.
       - name: Verify current-main workflow policy
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
           BUMP: ${{ inputs.bump }}
           WORKFLOW_REF: ${{ github.ref }}
-          DISPATCH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::publish policy must run from current main"; exit 1; }
-          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-          [ "$DISPATCH_SHA" = "$current_sha" ] || { echo "::error::publish workflow is not at current main"; exit 1; }
           [ "$BUMP" = skip ] || { echo "::error::hosted arbitrary version bumps are forbidden"; exit 1; }
 
       - name: Check out current main

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,18 +35,18 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
-      version: ${{ steps.attest.outputs.version }}
-      tag_sha: ${{ steps.attest.outputs.tag_sha }}
-      image_run_id: ${{ steps.attest.outputs.image_run_id }}
-      ci_run_id: ${{ steps.attest.outputs.ci_run_id }}
+      version: ${{ steps.release.outputs.version }}
+      tag_sha: ${{ steps.release.outputs.tag_sha }}
+      image_run_id: ${{ steps.producer.outputs.image_run_id }}
+      ci_run_id: ${{ steps.producer.outputs.ci_run_id }}
     steps:
-      - name: Verify current-main workflow policy and release provenance
-        id: attest
+      # Deliberately before any checkout: this workflow holds the production
+      # environment's publish credentials downstream, so nothing from the
+      # repository runs until the dispatch is shown to be current main.
+      - name: Verify current-main workflow policy
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
           BUMP: ${{ inputs.bump }}
           WORKFLOW_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
@@ -56,58 +56,67 @@ jobs:
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           [ "$DISPATCH_SHA" = "$current_sha" ] || { echo "::error::publish workflow is not at current main"; exit 1; }
           [ "$BUMP" = skip ] || { echo "::error::hosted arbitrary version bumps are forbidden"; exit 1; }
-          [[ "$RELEASE_TAG" =~ ^lobu-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::release_tag must be an exact lobu-vSemVer tag"; exit 1; }
-          version="${RELEASE_TAG#lobu-v}"
 
+      - name: Check out current main
+        uses: actions/checkout@v7
+
+      - name: Attest the release tag binds to an immutable commit
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
           release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
-          [ "$(jq -r '.draft' <<<"$release")" = false ] || { echo "::error::release is a draft"; exit 1; }
-          [ "$(jq -r '.tag_name' <<<"$release")" = "$RELEASE_TAG" ] || { echo "::error::release tag mismatch"; exit 1; }
-
           tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
-          tag_type=$(jq -r '.object.type' <<<"$tag_ref")
-          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
-          if [ "$tag_type" = tag ]; then
-            tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')
+          tag_object=null
+          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
+            tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
           fi
-          [[ "$tag_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::could not peel release tag"; exit 1; }
-          [ "$(jq -r '.target_commitish' <<<"$release")" = "$tag_sha" ] || { echo "::error::release target does not match peeled tag"; exit 1; }
+          verified=$(jq -n --argjson release "$release" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" --arg tag "$RELEASE_TAG" \
+            '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag}' \
+            | node scripts/release-provenance.mjs verify-release)
+          tag_sha=$(jq -r '.sha' <<<"$verified")
 
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-          compare=$(gh api "repos/${REPOSITORY}/compare/${tag_sha}...${current_sha}")
-          compare_status=$(jq -r '.status' <<<"$compare")
+          compare_status=$(gh api "repos/${REPOSITORY}/compare/${tag_sha}...${current_sha}" --jq '.status')
           [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::release tag is not reachable from current main"; exit 1; }
 
+          echo "version=$(jq -r '.version' <<<"$verified")" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Attest the producing image run and its exact CI run
+        id: producer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
+          TAG_SHA: ${{ steps.release.outputs.tag_sha }}
+        run: |
+          set -euo pipefail
           build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')
           build_run=$(gh api "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}")
           [ "$(jq -r '.workflow_id' <<<"$build_run")" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
           [ "$(jq -r '.head_repository.full_name // empty' <<<"$build_run")" = "$REPOSITORY" ] || { echo "::error::Build Images repository mismatch"; exit 1; }
           [ "$(jq -r '.event' <<<"$build_run")" = release ] || { echo "::error::Build Images run must be a release event"; exit 1; }
           [ "$(jq -r '.status' <<<"$build_run")" = completed ] && [ "$(jq -r '.conclusion' <<<"$build_run")" = success ] || { echo "::error::Build Images release run is not completed-success"; exit 1; }
-          [ "$(jq -r '.head_sha' <<<"$build_run")" = "$tag_sha" ] || { echo "::error::Build Images SHA does not match peeled tag"; exit 1; }
+          [ "$(jq -r '.head_sha' <<<"$build_run")" = "$TAG_SHA" ] || { echo "::error::Build Images SHA does not match peeled tag"; exit 1; }
 
           jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
-          selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
-            ( $required | split(" ") ) as $required_jobs
-            | [ .[] | .jobs[] ] as $jobs
-            | $required_jobs | map(. as $name
-              | [ $jobs[] | select(.name == $name) ] as $matches
-              | if ($matches | length) == 0 then error("missing required job") else . end
-              | ($matches | map(.run_attempt // 1) | max) as $latest
-              | [ $matches[] | select((.run_attempt // 1) == $latest) ] as $chosen
-              | if ($chosen | length) != 1 then error("duplicate latest-attempt required job") else $chosen[0] end)
-            | if all(.[]; .status == "completed" and .conclusion == "success") then . else error("required release image jobs missing, skipped, failed, or incomplete") end
-          ' <<<"$jobs") || { echo "::error::release image-job attestation failed"; exit 1; }
-          printf '%s\n' "$selected" >/dev/null
+          jq -n --argjson pages "$jobs" --arg required "$REQUIRED_IMAGE_JOBS" \
+            '{pages: $pages, required: ($required | split(" "))}' \
+            | node scripts/release-provenance.mjs attest-jobs >/dev/null
 
-          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id')
-          ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${tag_sha}&event=push&branch=main&status=completed&per_page=100")
-          ci_run_id=$(jq -r --arg workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$tag_sha" '[.workflow_runs[] | select((.workflow_id|tostring) == $workflow_id and .repository.full_name == $repo and .event == "push" and .head_branch == "main" and .head_sha == $sha and .status == "completed" and .conclusion == "success")] as $runs | if ($runs|length) == 0 then "" else ($runs | map(.run_attempt // 1) | max) as $latest | [$runs[] | select((.run_attempt // 1) == $latest)] as $chosen | if ($chosen|length) == 1 then ($chosen[0].id|tostring) else error("ambiguous CI latest attempt") end end' <<<"$ci_runs")
-          [ -n "$ci_run_id" ] || { echo "::error::no exact successful CI push/main run for release SHA"; exit 1; }
-
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
+          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
+          ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TAG_SHA}&event=push&branch=main&status=completed&per_page=100")
+          ci_run_id=$(jq -n --argjson body "$ci_runs" --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$TAG_SHA" \
+            '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
+              expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
+            | node scripts/release-provenance.mjs select-run | jq -r '.id')
           echo "image_run_id=$IMAGE_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
+
 
   publish-packages:
     name: Publish attested packages
@@ -158,7 +167,7 @@ jobs:
         if: ${{ env.CLAWHUB_TOKEN_SET == 'true' }}
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
+        run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
 
       - name: Gate package version monotonicity
         env:
@@ -166,7 +175,9 @@ jobs:
         run: |
           set -euo pipefail
           published=$(npm view @lobu/cli versions --json 2>/dev/null || echo '[]')
-          node --input-type=module -e 'import { compareVersions } from "./scripts/release-provenance.mjs"; const versions = JSON.parse(process.argv[1]); const current = process.argv[2]; const stable = (Array.isArray(versions) ? versions : [versions]).filter(v => /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(v)); if (stable.some(v => compareVersions(v, current) > 0)) throw new Error(`npm already contains a newer stable version than ${current}`);' "$published" "$EXPECTED_VERSION"
+          jq -n --argjson versions "$published" --arg current "$EXPECTED_VERSION" \
+            '{current: $current, versions: (if ($versions | type) == "array" then $versions else [$versions] end)}' \
+            | node scripts/release-provenance.mjs assert-newer >/dev/null
 
       - name: Publish packages at exact version
         env:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,125 +3,141 @@ name: Publish Packages
 on:
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Exact published lobu-vSemVer release tag"
+        required: true
+        type: string
+      image_run_id:
+        description: "Exact Build and Push Images release run"
+        required: true
+        type: string
       bump:
-        description: "Version bump: patch | minor | major | explicit like 3.1.0 | skip"
-        required: false
-        default: "skip"
+        description: "Must be skip; versions come from the attested release"
+        required: true
+        default: skip
         type: string
       provenance:
-        description: "Attach npm provenance (requires trusted publisher configured on npmjs.com)"
+        description: "Attach npm provenance"
         required: false
         default: false
         type: boolean
-      image_run_id:
-        description: "Exact build-images run whose app-image-smoke must be green (release automation sets this)"
-        required: false
-        type: string
 
 permissions:
   contents: read
-  # The image gate reads workflow/run/job metadata through the Actions API.
   actions: read
-  # Needed for npm trusted publishing (OIDC). Only effective when each
-  # package is registered on npmjs.com → Settings → Publishing access →
-  # Add trusted publisher → Workflow: .github/workflows/publish-packages.yml,
-  # Environment: production.
-  id-token: write
+
+env:
+  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke
 
 jobs:
+  attest-publish:
+    name: Attest release, image, and CI provenance
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.attest.outputs.version }}
+      tag_sha: ${{ steps.attest.outputs.tag_sha }}
+      image_run_id: ${{ steps.attest.outputs.image_run_id }}
+      ci_run_id: ${{ steps.attest.outputs.ci_run_id }}
+    steps:
+      - name: Verify current-main workflow policy and release provenance
+        id: attest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
+          BUMP: ${{ inputs.bump }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::publish policy must run from current main"; exit 1; }
+          [ "$BUMP" = skip ] || { echo "::error::hosted arbitrary version bumps are forbidden"; exit 1; }
+          [[ "$RELEASE_TAG" =~ ^lobu-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::release_tag must be an exact lobu-vSemVer tag"; exit 1; }
+          version="${RELEASE_TAG#lobu-v}"
+
+          release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          [ "$(jq -r '.draft' <<<"$release")" = false ] || { echo "::error::release is a draft"; exit 1; }
+          [ "$(jq -r '.tag_name' <<<"$release")" = "$RELEASE_TAG" ] || { echo "::error::release tag mismatch"; exit 1; }
+
+          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
+          tag_type=$(jq -r '.object.type' <<<"$tag_ref")
+          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
+          if [ "$tag_type" = tag ]; then
+            tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')
+          fi
+          [[ "$tag_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::could not peel release tag"; exit 1; }
+
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          compare=$(gh api "repos/${REPOSITORY}/compare/${tag_sha}...${current_sha}")
+          compare_status=$(jq -r '.status' <<<"$compare")
+          [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::release tag is not reachable from current main"; exit 1; }
+
+          build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')
+          build_run=$(gh api "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}")
+          [ "$(jq -r '.workflow_id' <<<"$build_run")" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
+          [ "$(jq -r '.head_repository.full_name // empty' <<<"$build_run")" = "$REPOSITORY" ] || { echo "::error::Build Images repository mismatch"; exit 1; }
+          [ "$(jq -r '.event' <<<"$build_run")" = release ] || { echo "::error::Build Images run must be a release event"; exit 1; }
+          [ "$(jq -r '.head_sha' <<<"$build_run")" = "$tag_sha" ] || { echo "::error::Build Images SHA does not match peeled tag"; exit 1; }
+
+          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
+          selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
+            ( $required | split(" ") ) as $required_jobs
+            | [ .[][] | select(.name as $name | ($required_jobs | index($name)) != null) ]
+            | group_by(.name)
+            | if any(.[]; ([ .[] | select(.run_attempt == (max_by(.run_attempt // 1).run_attempt // 1)) ] | length) != 1)
+              then error("duplicate latest-attempt required job") else . end
+            | map(max_by(.run_attempt // 1))
+            | if (map(.name) | sort) == ($required_jobs | sort)
+              and all(.[]; .status == "completed" and .conclusion == "success")
+              then . else error("required release image jobs missing, skipped, failed, or incomplete") end
+          ' <<<"$jobs") || { echo "::error::release image-job attestation failed"; exit 1; }
+          printf '%s\n' "$selected" >/dev/null
+
+          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id')
+          ci_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${tag_sha}&event=push&branch=main&status=completed&per_page=100" \
+            --jq '[.workflow_runs[] | select(.workflow_id == '"$ci_workflow_id"' and .repository.full_name == "'"$REPOSITORY"'" and .event == "push" and .head_branch == "main" and .head_sha == "'"$tag_sha"'" and .status == "completed" and .conclusion == "success")] | sort_by(.run_attempt // 1) | last.id // empty')
+          [ -n "$ci_run_id" ] || { echo "::error::no exact successful CI push/main run for release SHA"; exit 1; }
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
+          echo "image_run_id=$IMAGE_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
+
   publish-packages:
+    name: Publish attested packages
+    needs: attest-publish
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: production
+    env:
+      CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       published-version: ${{ steps.published-version.outputs.version }}
-    env:
-      # Step-level env is not visible to the same step's `if:` evaluator.
-      CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
-
-      # Refuse to publish off a commit whose post-merge image smoke is red.
-      #
-      # `app-image-smoke` (in build-images.yml) BOOTS the app image built from
-      # this exact commit. If that is failing, the tree is known-broken at
-      # runtime and a release would ship it — every bug this guards against
-      # (#2231, #2183, __filename, GLIBC_2.38, uid-0) was green on every check
-      # that does not run the artifact.
-      #
-      # Deliberately NOT gated on "Published-artifact smoke": that one installs
-      # `@lobu/cli@latest` from npm, i.e. the PREVIOUS release. It is red
-      # precisely when a fix is waiting to be published, so gating on it would
-      # deadlock the release that repairs it. Its job is to alert on what users
-      # can install right now, and to verify the new version after publishing.
-      - name: Require a green app-image smoke for this commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Read the dispatch input through env, never `${{ }}` inside `run:`.
-          # This job holds `id-token: write` and the production environment's
-          # NPM_TOKEN, so a template-expanded input is a publish-credential
-          # injection, not just a broken script.
-          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
-        run: |
-          set -euo pipefail
-          sha="$(git rev-parse HEAD)"
-          echo "publishing from ${sha}"
-
-          run_id="$IMAGE_RUN_ID"
-          if [ -z "$run_id" ]; then
-            # Manual publishes do not know the producer run ID. Resolve the
-            # newest exact-SHA build server-side rather than scanning a busy
-            # main branch client-side.
-            run_id=$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml/runs?head_sha=${sha}&per_page=1" \
-              --jq '.workflow_runs[0].id // empty')
-          fi
-          if [ -z "$run_id" ]; then
-            echo "::error::No build-images run for ${sha}. The app image for this commit has never been built or smoked; publish would ship an unverified tree."
-            exit 1
-          fi
-
-          expected_workflow_id=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml" \
-            --jq '.id')
-          metadata=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-            --jq '[.workflow_id, .head_sha] | @tsv')
-          IFS=$'\t' read -r workflow_id run_sha <<< "$metadata"
-          if [ "$workflow_id" != "$expected_workflow_id" ]; then
-            echo "::error::Run ${run_id} belongs to workflow ${workflow_id}, not build-images.yml (${expected_workflow_id})."
-            exit 1
-          fi
-          if [ "$run_sha" != "$sha" ]; then
-            echo "::error::Run ${run_id} built ${run_sha}, but publish checked out ${sha}."
-            exit 1
-          fi
-
-          smoke=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
-            --jq '[.jobs[] | select(.name == "app-image-smoke")]
-                  | if length == 0 then "missing"
-                    else "\(.[0].status) \(.[0].conclusion // "none")" end')
-          status="${smoke%% *}"
-          conclusion="${smoke#* }"
-          echo "build-images run ${run_id} app-image-smoke: ${status}, ${conclusion}"
-          if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]; then
-            echo "::error::app-image-smoke for build-images run ${run_id} is not green. Wait for it to complete successfully before publishing."
-            exit 1
-          fi
-          echo "app-image smoke green for ${sha} in run ${run_id} — proceeding."
+        with:
+          ref: ${{ needs.attest-publish.outputs.tag_sha }}
 
       - uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
+      - name: Require exact release version
+        env:
+          EXPECTED_VERSION: ${{ needs.attest-publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          actual=$(node -p "require('./packages/cli/package.json').version")
+          [ "$actual" = "$EXPECTED_VERSION" ] || { echo "::error::package version does not match attested release"; exit 1; }
+
       - uses: actions/setup-node@v7
         with:
-          # Node 24 ships with npm >= 11.5.1 which supports OIDC trusted
-          # publishing. Do NOT downgrade below 24 without re-adding the
-          # npm self-upgrade step (which has a known MODULE_NOT_FOUND bug
-          # on hosted runners).
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
+          registry-url: https://registry.npmjs.org
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -131,45 +147,20 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: ClawHub login
-        # clawhub CLI v0.16 doesn't expose an explicit OIDC flag; use a
-        # long-lived org token stored as a repo + production-environment
-        # secret. Skipped if CLAWHUB_TOKEN is unset (e.g. forks).
         if: ${{ env.CLAWHUB_TOKEN_SET == 'true' }}
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
 
-      - name: Publish packages
+      - name: Publish packages at exact version
         env:
-          # Auth precedence (npm 11+):
-          #   1. OIDC trusted publishing (preferred) — npm CLI exchanges the
-          #      GitHub Actions OIDC token for a short-lived publish token
-          #      automatically when id-token: write is granted AND the package
-          #      is registered as a trusted publisher on npmjs.com.
-          #   2. NODE_AUTH_TOKEN fallback — used for new packages that haven't
-          #      been registered as trusted publishers yet (chicken-and-egg:
-          #      npmjs.com only lets you register packages that already exist).
-          # Once each new package has been registered on npmjs.com → Settings
-          # → Trusted Publishers, OIDC takes over automatically.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # NPM_CONFIG_PROVENANCE enables provenance attestations when the
-          # provenance input is true (requires trusted publisher on npmjs.com).
           NPM_CONFIG_PROVENANCE: "${{ inputs.provenance }}"
-          # Same reason as IMAGE_RUN_ID above: dispatch inputs reach the shell
-          # as env vars, not as `${{ }}` expansions inside the script body.
-          BUMP: ${{ inputs.bump }}
-        run: |
-          if [ "$BUMP" = "skip" ]; then
-            node scripts/publish-packages.mjs --skip-bump
-          else
-            node scripts/publish-packages.mjs "$BUMP"
-          fi
+        run: node scripts/publish-packages.mjs --skip-bump
 
       - name: Record the exact published CLI version
         id: published-version
-        run: |
-          version=$(node -p "require('./packages/cli/package.json').version")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p "require('./packages/cli/package.json').version")" >> "$GITHUB_OUTPUT"
 
   verify-published-artifact:
     needs: publish-packages

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     outputs:
       version: ${{ steps.release.outputs.version }}
-      tag_sha: ${{ steps.release.outputs.tag_sha }}
+      tag_sha: ${{ steps.release.outputs.sha }}
     steps:
       # Deliberately before any checkout: this workflow holds the production
       # environment's publish credentials downstream, so nothing from the
@@ -58,36 +58,28 @@ jobs:
 
       - name: Attest the release tag binds to an immutable commit
         id: release
+        uses: ./.github/actions/verify-release
+        with:
+          tag: ${{ inputs.release_tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Require the release commit to be reachable from main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          TAG_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -euo pipefail
-          release=$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")
-          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
-          tag_object=null
-          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
-            tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
-          fi
-          verified=$(jq -n --argjson release "$release" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" --arg tag "$RELEASE_TAG" \
-            '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag}' \
-            | node scripts/release-provenance.mjs verify-release)
-          tag_sha=$(jq -r '.sha' <<<"$verified")
-
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-          compare_status=$(gh api "repos/${REPOSITORY}/compare/${tag_sha}...${current_sha}" --jq '.status')
+          compare_status=$(gh api "repos/${REPOSITORY}/compare/${TAG_SHA}...${current_sha}" --jq '.status')
           [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::release tag is not reachable from current main"; exit 1; }
-
-          echo "version=$(jq -r '.version' <<<"$verified")" >> "$GITHUB_OUTPUT"
-          echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
 
       - name: Attest the producing image run and its exact CI run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           IMAGE_RUN_ID: ${{ inputs.image_run_id }}
-          TAG_SHA: ${{ steps.release.outputs.tag_sha }}
+          TAG_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -euo pipefail
           build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -167,7 +167,11 @@ jobs:
           EXPECTED_VERSION: ${{ needs.attest-publish.outputs.version }}
         run: |
           set -euo pipefail
-          published=$(npm view @lobu/cli versions --json 2>/dev/null || echo '[]')
+          # npm writes its --json error object to STDOUT, so the exit status is
+          # the only trustworthy signal. Failing closed here is deliberate: an
+          # unreadable registry must not read as "nothing newer is published".
+          published=$(npm view @lobu/cli versions --json 2>/dev/null) || published=""
+          [ -n "$published" ] || { echo "::error::could not read published @lobu/cli versions"; exit 1; }
           jq -n --argjson versions "$published" --arg current "$EXPECTED_VERSION" \
             '{current: $current, versions: (if ($versions | type) == "array" then $versions else [$versions] end)}' \
             | node scripts/release-provenance.mjs assert-newer >/dev/null

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,13 +24,15 @@ jobs:
     name: Attest main image and CI runs
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    # `types: [completed]` also fires for failure and cancellation. Screening
-    # here keeps a red image build from producing a red Release Please run
-    # beside it; the producer's conclusion is re-read from the API below
-    # regardless, so this is noise control, not the gate.
+    # `types: [completed]` also fires for failure and cancellation, and
+    # `branches: [main]` admits a manual Build Images dispatch as readily as a
+    # push. Both would start this job and then hard-fail the API checks below,
+    # so screen them out here. The producer's conclusion and event are re-read
+    # from the API regardless: this is noise control, not the gate.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     outputs:
       sha: ${{ steps.producer.outputs.sha }}
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -208,8 +208,14 @@ jobs:
             exit 0
           fi
 
-          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" || echo "")
-          notes=${notes:0:12000}
+          # This version's changelog entry, not the head of the whole file:
+          # CHANGELOG.md is ~475KB and newest-first, so a plain truncation puts
+          # several past releases in every release body.
+          changelog=$(git show "$ATTESTED_SHA:CHANGELOG.md" || echo "")
+          notes=$(jq -n --arg changelog "$changelog" --arg version "$current_version" \
+            '{changelog: $changelog, version: $version}' \
+            | node scripts/release-provenance.mjs release-notes | jq -r '.notes')
+          notes=${notes:0:60000}
           if ! gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
             gh api --method POST "repos/${REPOSITORY}/git/refs" \
               --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref: $ref, sha: $sha}') >/dev/null

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,8 +33,6 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     outputs:
       sha: ${{ steps.producer.outputs.sha }}
-      image_run_id: ${{ steps.producer.outputs.image_run_id }}
-      ci_run_id: ${{ steps.runs.outputs.ci_run_id }}
     steps:
       # Deliberately before any checkout: no repository code runs until the
       # producing run is known to be a completed-success push to the current
@@ -85,7 +83,6 @@ jobs:
           fetch-depth: 2
 
       - name: Attest required image jobs and the exact CI run
-        id: runs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
@@ -115,7 +112,7 @@ jobs:
             sleep 20
           done
           [ -n "$ci_run_id" ] || { echo "::error::exact successful CI push/main run was not observed within the bounded wait"; exit 1; }
-          echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
+          echo "attested CI run for ${ATTESTED_SHA}: ${ci_run_id}"
 
   release-please-write:
     name: Create release from attested main
@@ -216,14 +213,14 @@ jobs:
               | node scripts/release-provenance.mjs verify-release >/dev/null
           }
 
-          release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}" 2>/dev/null || true)
-          if [ -n "$release" ]; then
+          if release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}" 2>/dev/null); then
             verify_release "$release"
             echo "Immutable release already exists and matches $ATTESTED_SHA."
             exit 0
           fi
 
-          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" | head -c 12000)
+          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md")
+          notes=${notes:0:12000}
           if ! gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
             gh api --method POST "repos/${REPOSITORY}/git/refs" \
               --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref: $ref, sha: $sha}') >/dev/null

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -150,7 +150,6 @@ jobs:
           [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main advanced after attestation"; exit 1; }
 
       - name: Run Release Please against main
-        id: release
         uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -159,18 +158,6 @@ jobs:
           include-component-in-tag: true
           target-branch: main
           skip-github-release: true
-
-      - name: Verify emitted release SHA
-        if: steps.release.outputs.release_created == 'true'
-        env:
-          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
-          RELEASE_SHA: ${{ steps.release.outputs.sha }}
-        run: |
-          set -euo pipefail
-          [ -n "$RELEASE_SHA" ] && [ "$RELEASE_SHA" = "$ATTESTED_SHA" ] || {
-            echo "::error::Release Please emitted a release for an unexpected SHA"
-            exit 1
-          }
 
       # release-please only opens the version-bump PR; the release itself is
       # created here so it is bound to the exact commit that was attested
@@ -219,7 +206,7 @@ jobs:
             exit 0
           fi
 
-          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md")
+          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" || echo "")
           notes=${notes:0:12000}
           if ! gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
             gh api --method POST "repos/${REPOSITORY}/git/refs" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,42 +1,142 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build and Push Images"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
+    inputs:
+      image_run_id:
+        description: "Exact successful main Build and Push Images run"
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  actions: read
+
+env:
+  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke
 
 jobs:
-  release-please:
+  attest:
+    name: Attest main image and CI runs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      sha: ${{ steps.attest.outputs.sha }}
+      image_run_id: ${{ steps.attest.outputs.image_run_id }}
+      ci_run_id: ${{ steps.attest.outputs.ci_run_id }}
+    steps:
+      - name: Fetch and attest immutable producer runs
+        id: attest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_IMAGE_RUN_ID: ${{ inputs.image_run_id }}
+          EVENT_IMAGE_RUN_ID: ${{ github.event.workflow_run.id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          image_run_id="${INPUT_IMAGE_RUN_ID:-${EVENT_IMAGE_RUN_ID:-}}"
+          [ -n "$image_run_id" ] || { echo "::error::image_run_id is required"; exit 1; }
+
+          build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')
+          build_run=$(gh api "repos/${REPOSITORY}/actions/runs/${image_run_id}")
+          workflow_id=$(jq -r '.workflow_id' <<<"$build_run")
+          sha=$(jq -r '.head_sha' <<<"$build_run")
+          head_repo=$(jq -r '.head_repository.full_name // empty' <<<"$build_run")
+          event=$(jq -r '.event' <<<"$build_run")
+          branch=$(jq -r '.head_branch // empty' <<<"$build_run")
+          status=$(jq -r '.status' <<<"$build_run")
+          conclusion=$(jq -r '.conclusion // empty' <<<"$build_run")
+          [ "$workflow_id" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
+          [ "$head_repo" = "$REPOSITORY" ] || { echo "::error::Build Images run repository mismatch"; exit 1; }
+          [ "$event" = push ] && [ "$branch" = main ] || { echo "::error::Build Images run must be a main push"; exit 1; }
+          [ "$status" = completed ] && [ "$conclusion" = success ] || { echo "::error::Build Images run is not completed-success"; exit 1; }
+
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          [ "$current_sha" = "$sha" ] || { echo "::error::main moved while attesting Build Images"; exit 1; }
+
+          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${image_run_id}/jobs?filter=all&per_page=100")
+          selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
+            ( $required | split(" ") ) as $required_jobs
+            | [ .[][] | select(.name as $name | ($required_jobs | index($name)) != null) ]
+            | group_by(.name)
+            | if any(.[]; ([ .[] | select(.run_attempt == (max_by(.run_attempt // 1).run_attempt // 1)) ] | length) != 1)
+              then error("duplicate latest-attempt required job") else . end
+            | map(max_by(.run_attempt // 1))
+            | if (map(.name) | sort) == ($required_jobs | sort)
+              and all(.[]; .status == "completed" and .conclusion == "success")
+              and (map({key: .name, value: .}) | from_entries | length) == ($required_jobs | length)
+              then . else error("required image jobs missing, duplicated, skipped, failed, or incomplete") end
+          ' <<<"$jobs") || { echo "::error::Build Images required-job attestation failed"; exit 1; }
+          printf '%s\n' "$selected" >/dev/null
+
+          ci_run_id=""
+          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id')
+          for attempt in $(seq 1 20); do
+            current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+            [ "$current_sha" = "$sha" ] || { echo "::error::main moved while waiting for exact CI"; exit 1; }
+            ci_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${sha}&event=push&branch=main&status=completed&per_page=100" \
+              --jq '[.workflow_runs[] | select(.workflow_id == '"$ci_workflow_id"' and .repository.full_name == "'"$REPOSITORY"'" and .event == "push" and .head_branch == "main" and .head_sha == "'"$sha"'" and .status == "completed" and .conclusion == "success")] | sort_by(.run_attempt // 1) | last.id // empty')
+            [ -n "$ci_run_id" ] && break
+            sleep 20
+          done
+          [ -n "$ci_run_id" ] || { echo "::error::exact successful CI push/main run was not observed within the bounded wait"; exit 1; }
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "image_run_id=$image_run_id" >> "$GITHUB_OUTPUT"
+          echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
+
+  release-please-write:
+    name: Create release from attested main
+    needs: attest
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    concurrency:
+      group: release-please-write
+      cancel-in-progress: false
     environment: production
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      # Releases created with GITHUB_TOKEN do not trigger release-event
-      # workflows, including build-images and mac-release.
       - name: Require release automation token
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
-            echo "::error::RELEASE_PLEASE_TOKEN is required so release-event workflows can run."
-            exit 1
-          fi
+          set -euo pipefail
+          [ -n "$RELEASE_PLEASE_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required"; exit 1; }
 
-      - uses: googleapis/release-please-action@v5
+      - name: Recheck current main immediately before release action
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main advanced after attestation"; exit 1; }
+
+      - name: Run Release Please against main
+        id: release
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           include-component-in-tag: true
+          target-branch: main
 
-  # build-images.yml triggers publish-packages.yml only after the release's
-  # exact app image has been built and boot-smoked. Keeping that dependency at
-  # the artifact chokepoint prevents release creation from racing image CI.
-
-  # mac-release.yml now auto-fires on `release: types: [published]` directly,
-  # so this job is no longer needed — see mac-release.yml's `on:` block.
+      - name: Verify emitted release SHA
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          [ -n "$RELEASE_SHA" ] && [ "$RELEASE_SHA" = "$ATTESTED_SHA" ] || {
+            echo "::error::Release Please emitted a release for an unexpected SHA"
+            exit 1
+          }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -164,11 +164,15 @@ jobs:
       # release-please only opens the version-bump PR; the release itself is
       # created here so it is bound to the exact commit that was attested
       # above, rather than to whatever the action considered HEAD.
-      - name: Publish only a real immutable manifest bump
+      # Split so the binding check can be the shared composite action rather
+      # than a third copy of the same tag-peeling shell. Creation is
+      # idempotent and verification runs once at the end, which covers the
+      # already-exists case and the just-created case with one assertion
+      # instead of two call sites that could drift apart.
+      - name: Decide whether this attested commit is a release
+        id: bump
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           read_version() { git show "$1:package.json" | node -pe 'JSON.parse(require("fs").readFileSync(0, "utf8")).version'; }
@@ -179,32 +183,31 @@ jobs:
             | node scripts/release-provenance.mjs manifest-bump)
           if [ "$(jq -r '.bumped' <<<"$bump")" != true ]; then
             echo "No release-version manifest bump at attested SHA; release PR only."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          tag=$(jq -n --arg version "$current_version" '{version: $version}' \
-            | node scripts/release-provenance.mjs release-tag | jq -r '.tag')
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "version=$current_version" >> "$GITHUB_OUTPUT"
+          jq -n --arg version "$current_version" '{version: $version}' \
+            | node scripts/release-provenance.mjs release-tag | jq -r '"tag=" + .tag' >> "$GITHUB_OUTPUT"
 
+      - name: Create the tag and release if they are not already there
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
           releases=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100")
-          jq -n --argjson pages "$releases" --arg current "$current_version" \
+          jq -n --argjson pages "$releases" --arg current "$VERSION" \
             '{current: $current, versions: [$pages[][] | select(.prerelease | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
             | node scripts/release-provenance.mjs assert-newer >/dev/null
 
-          verify_release() {
-            local tag_ref tag_object
-            tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}")
-            tag_object=null
-            if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
-              tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
-            fi
-            jq -n --argjson release "$1" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" \
-              --arg tag "$tag" --arg sha "$ATTESTED_SHA" \
-              '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag, expectedSha: $sha}' \
-              | node scripts/release-provenance.mjs verify-release >/dev/null
-          }
-
-          if release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}" 2>/dev/null); then
-            verify_release "$release"
-            echo "Immutable release already exists and matches $ATTESTED_SHA."
+          if gh api "repos/${REPOSITORY}/releases/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; the verification below still has to pass."
             exit 0
           fi
 
@@ -212,16 +215,22 @@ jobs:
           # CHANGELOG.md is ~475KB and newest-first, so a plain truncation puts
           # several past releases in every release body.
           changelog=$(git show "$ATTESTED_SHA:CHANGELOG.md" || echo "")
-          notes=$(jq -n --arg changelog "$changelog" --arg version "$current_version" \
+          notes=$(jq -n --arg changelog "$changelog" --arg version "$VERSION" \
             '{changelog: $changelog, version: $version}' \
             | node scripts/release-provenance.mjs release-notes | jq -r '.notes')
           notes=${notes:0:60000}
-          if ! gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+          if ! gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
             gh api --method POST "repos/${REPOSITORY}/git/refs" \
-              --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref: $ref, sha: $sha}') >/dev/null
+              --input <(jq -n --arg ref "refs/tags/$TAG" --arg sha "$ATTESTED_SHA" '{ref: $ref, sha: $sha}') >/dev/null
           fi
           gh api --method POST "repos/${REPOSITORY}/releases" \
-            --input <(jq -n --arg tag "$tag" --arg sha "$ATTESTED_SHA" --arg body "$notes" \
+            --input <(jq -n --arg tag "$TAG" --arg sha "$ATTESTED_SHA" --arg body "$notes" \
               '{tag_name: $tag, target_commitish: $sha, name: $tag, body: $body, draft: false, prerelease: false, make_latest: "true"}') >/dev/null
 
-          verify_release "$(gh api "repos/${REPOSITORY}/releases/tags/${tag}")"
+      - name: Verify the release binds to the attested commit
+        if: steps.bump.outputs.bumped == 'true'
+        uses: ./.github/actions/verify-release
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          expected-sha: ${{ needs.attest.outputs.sha }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,11 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            [ "$GITHUB_REF" = "refs/heads/main" ] || { echo "::error::workflow dispatch must target main"; exit 1; }
+            current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+            [ "$GITHUB_SHA" = "$current_sha" ] || { echo "::error::workflow dispatch SHA is not live main"; exit 1; }
+          fi
           image_run_id="${INPUT_IMAGE_RUN_ID:-${EVENT_IMAGE_RUN_ID:-}}"
           [ -n "$image_run_id" ] || { echo "::error::image_run_id is required"; exit 1; }
 
@@ -61,15 +66,14 @@ jobs:
           jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${image_run_id}/jobs?filter=all&per_page=100")
           selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
             ( $required | split(" ") ) as $required_jobs
-            | [ .[][] | select(.name as $name | ($required_jobs | index($name)) != null) ]
-            | group_by(.name)
-            | if any(.[]; ([ .[] | select(.run_attempt == (max_by(.run_attempt // 1).run_attempt // 1)) ] | length) != 1)
-              then error("duplicate latest-attempt required job") else . end
-            | map(max_by(.run_attempt // 1))
-            | if (map(.name) | sort) == ($required_jobs | sort)
-              and all(.[]; .status == "completed" and .conclusion == "success")
-              and (map({key: .name, value: .}) | from_entries | length) == ($required_jobs | length)
-              then . else error("required image jobs missing, duplicated, skipped, failed, or incomplete") end
+            | [ .[] | .jobs[] ] as $jobs
+            | $required_jobs | map(. as $name
+              | [ $jobs[] | select(.name == $name) ] as $matches
+              | if ($matches | length) == 0 then error("missing required job") else . end
+              | ($matches | map(.run_attempt // 1) | max) as $latest
+              | [ $matches[] | select((.run_attempt // 1) == $latest) ] as $chosen
+              | if ($chosen | length) != 1 then error("duplicate latest-attempt required job") else $chosen[0] end)
+            | if all(.[]; .status == "completed" and .conclusion == "success") then . else error("required image jobs missing, skipped, failed, or incomplete") end
           ' <<<"$jobs") || { echo "::error::Build Images required-job attestation failed"; exit 1; }
           printf '%s\n' "$selected" >/dev/null
 
@@ -78,8 +82,8 @@ jobs:
           for attempt in $(seq 1 20); do
             current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
             [ "$current_sha" = "$sha" ] || { echo "::error::main moved while waiting for exact CI"; exit 1; }
-            ci_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${sha}&event=push&branch=main&status=completed&per_page=100" \
-              --jq '[.workflow_runs[] | select(.workflow_id == '"$ci_workflow_id"' and .repository.full_name == "'"$REPOSITORY"'" and .event == "push" and .head_branch == "main" and .head_sha == "'"$sha"'" and .status == "completed" and .conclusion == "success")] | sort_by(.run_attempt // 1) | last.id // empty')
+            ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${sha}&event=push&branch=main&status=completed&per_page=100")
+            ci_run_id=$(jq -r --arg workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$sha" '[.workflow_runs[] | select((.workflow_id|tostring) == $workflow_id and .repository.full_name == $repo and .event == "push" and .head_branch == "main" and .head_sha == $sha and .status == "completed" and .conclusion == "success")] as $runs | if ($runs|length) == 0 then "" else ($runs | map(.run_attempt // 1) | max) as $latest | [$runs[] | select((.run_attempt // 1) == $latest)] as $chosen | if ($chosen|length) == 1 then ($chosen[0].id|tostring) else error("ambiguous CI latest attempt") end end' <<<"$ci_runs")
             [ -n "$ci_run_id" ] && break
             sleep 20
           done
@@ -94,9 +98,6 @@ jobs:
     needs: attest
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    concurrency:
-      group: release-please-write
-      cancel-in-progress: false
     environment: production
     permissions:
       contents: write
@@ -109,6 +110,12 @@ jobs:
           set -euo pipefail
           [ -n "$RELEASE_PLEASE_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required"; exit 1; }
 
+      - name: Checkout attested commit for immutable release helper
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.attest.outputs.sha }}
+          fetch-depth: 2
+
       - name: Recheck current main immediately before release action
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,6 +126,13 @@ jobs:
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main advanced after attestation"; exit 1; }
 
+      - name: Require release automation token immediately before write
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "$RELEASE_PLEASE_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required"; exit 1; }
+
       - name: Run Release Please against main
         id: release
         uses: googleapis/release-please-action@v5
@@ -128,6 +142,7 @@ jobs:
           manifest-file: .release-please-manifest.json
           include-component-in-tag: true
           target-branch: main
+          skip-github-release: true
 
       - name: Verify emitted release SHA
         if: steps.release.outputs.release_created == 'true'
@@ -140,3 +155,43 @@ jobs:
             echo "::error::Release Please emitted a release for an unexpected SHA"
             exit 1
           }
+
+      - name: Publish only a real immutable manifest bump
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          parent_sha=$(git rev-parse "$ATTESTED_SHA^1")
+          current_version=$(git show "$ATTESTED_SHA:package.json" | node -e 'let s=""; process.stdin.on("data", c => s += c); process.stdin.on("end", () => process.stdout.write(JSON.parse(s).version))')
+          parent_version=$(git show "$parent_sha:package.json" | node -e 'let s=""; process.stdin.on("data", c => s += c); process.stdin.on("end", () => process.stdout.write(JSON.parse(s).version))')
+          if [ "$current_version" = "$parent_version" ]; then
+            echo "No release-version manifest bump at attested SHA; release PR only."
+            exit 0
+          fi
+          [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "::error::invalid stable release version"; exit 1; }
+          tag="lobu-v${current_version}"
+          releases=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100")
+          node --input-type=module -e 'import { compareVersions } from "./scripts/release-provenance.mjs"; const pages = JSON.parse(process.argv[1]); const current = process.argv[2]; const versions = pages.flatMap(p => p).filter(r => !r.prerelease && /^lobu-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(r.tag_name)).map(r => r.tag_name.slice(6)); if (versions.some(v => compareVersions(current, v) <= 0 && v !== current)) { throw new Error(`release ${current} is not newer than an existing stable release`); }' "$releases" "$current_version"
+          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" | head -c 12000)
+          release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}" 2>/dev/null || true)
+          if [ -n "$release" ]; then
+            [ "$(jq -r '.tag_name' <<<"$release")" = "$tag" ] || { echo "::error::existing release name mismatch"; exit 1; }
+            [ "$(jq -r '.target_commitish' <<<"$release")" = "$ATTESTED_SHA" ] || { echo "::error::existing release target mismatch"; exit 1; }
+            [ "$(jq -r '.prerelease' <<<"$release")" = false ] || { echo "::error::stable release is prerelease"; exit 1; }
+            echo "Immutable release already exists and matches $ATTESTED_SHA."
+            exit 0
+          fi
+          [ -n "$GH_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required before release write"; exit 1; }
+          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" 2>/dev/null || true)
+          if [ -z "$tag_ref" ]; then
+            gh api --method POST "repos/${REPOSITORY}/git/refs" --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref:$ref, sha:$sha}') >/dev/null
+          fi
+          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}")
+          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
+          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
+            tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')
+          fi
+          [ "$tag_sha" = "$ATTESTED_SHA" ] || { echo "::error::tag does not bind to attested commit"; exit 1; }
+          gh api --method POST "repos/${REPOSITORY}/releases" --input <(jq -n --arg tag "$tag" --arg sha "$ATTESTED_SHA" --arg body "$notes" '{tag_name:$tag,target_commitish:$sha,name:$tag,body:$body,draft:false,prerelease:false,make_latest:true}') >/dev/null

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,13 +24,23 @@ jobs:
     name: Attest main image and CI runs
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # `types: [completed]` also fires for failure and cancellation. Screening
+    # here keeps a red image build from producing a red Release Please run
+    # beside it; the producer's conclusion is re-read from the API below
+    # regardless, so this is noise control, not the gate.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     outputs:
-      sha: ${{ steps.attest.outputs.sha }}
-      image_run_id: ${{ steps.attest.outputs.image_run_id }}
-      ci_run_id: ${{ steps.attest.outputs.ci_run_id }}
+      sha: ${{ steps.producer.outputs.sha }}
+      image_run_id: ${{ steps.producer.outputs.image_run_id }}
+      ci_run_id: ${{ steps.runs.outputs.ci_run_id }}
     steps:
-      - name: Fetch and attest immutable producer runs
-        id: attest
+      # Deliberately before any checkout: no repository code runs until the
+      # producing run is known to be a completed-success push to the current
+      # main tip.
+      - name: Attest the producing Build Images run
+        id: producer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_IMAGE_RUN_ID: ${{ inputs.image_run_id }}
@@ -63,34 +73,48 @@ jobs:
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           [ "$current_sha" = "$sha" ] || { echo "::error::main moved while attesting Build Images"; exit 1; }
 
-          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${image_run_id}/jobs?filter=all&per_page=100")
-          selected=$(jq --arg required "$REQUIRED_IMAGE_JOBS" '
-            ( $required | split(" ") ) as $required_jobs
-            | [ .[] | .jobs[] ] as $jobs
-            | $required_jobs | map(. as $name
-              | [ $jobs[] | select(.name == $name) ] as $matches
-              | if ($matches | length) == 0 then error("missing required job") else . end
-              | ($matches | map(.run_attempt // 1) | max) as $latest
-              | [ $matches[] | select((.run_attempt // 1) == $latest) ] as $chosen
-              | if ($chosen | length) != 1 then error("duplicate latest-attempt required job") else $chosen[0] end)
-            | if all(.[]; .status == "completed" and .conclusion == "success") then . else error("required image jobs missing, skipped, failed, or incomplete") end
-          ' <<<"$jobs") || { echo "::error::Build Images required-job attestation failed"; exit 1; }
-          printf '%s\n' "$selected" >/dev/null
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "image_run_id=$image_run_id" >> "$GITHUB_OUTPUT"
 
+      # Pinned to the SHA the step above proved is the current main tip, so the
+      # policy helper cannot come from a ref that moved mid-run.
+      - name: Check out the attested commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.producer.outputs.sha }}
+          fetch-depth: 2
+
+      - name: Attest required image jobs and the exact CI run
+        id: runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ATTESTED_SHA: ${{ steps.producer.outputs.sha }}
+          IMAGE_RUN_ID: ${{ steps.producer.outputs.image_run_id }}
+        run: |
+          set -euo pipefail
+          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
+          jq -n --argjson pages "$jobs" --arg required "$REQUIRED_IMAGE_JOBS" \
+            '{pages: $pages, required: ($required | split(" "))}' \
+            | node scripts/release-provenance.mjs attest-jobs >/dev/null
+
+          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
           ci_run_id=""
-          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id')
-          for attempt in $(seq 1 20); do
+          for _ in $(seq 1 20); do
             current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-            [ "$current_sha" = "$sha" ] || { echo "::error::main moved while waiting for exact CI"; exit 1; }
-            ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${sha}&event=push&branch=main&status=completed&per_page=100")
-            ci_run_id=$(jq -r --arg workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$sha" '[.workflow_runs[] | select((.workflow_id|tostring) == $workflow_id and .repository.full_name == $repo and .event == "push" and .head_branch == "main" and .head_sha == $sha and .status == "completed" and .conclusion == "success")] as $runs | if ($runs|length) == 0 then "" else ($runs | map(.run_attempt // 1) | max) as $latest | [$runs[] | select((.run_attempt // 1) == $latest)] as $chosen | if ($chosen|length) == 1 then ($chosen[0].id|tostring) else error("ambiguous CI latest attempt") end end' <<<"$ci_runs")
-            [ -n "$ci_run_id" ] && break
+            [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main moved while waiting for exact CI"; exit 1; }
+            ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${ATTESTED_SHA}&event=push&branch=main&status=completed&per_page=100")
+            selection=$(jq -n --argjson body "$ci_runs" --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$ATTESTED_SHA" \
+              '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
+                expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
+              | node scripts/release-provenance.mjs select-run) || selection=""
+            if [ -n "$selection" ]; then
+              ci_run_id=$(jq -r '.id' <<<"$selection")
+              break
+            fi
             sleep 20
           done
           [ -n "$ci_run_id" ] || { echo "::error::exact successful CI push/main run was not observed within the bounded wait"; exit 1; }
-
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "image_run_id=$image_run_id" >> "$GITHUB_OUTPUT"
           echo "ci_run_id=$ci_run_id" >> "$GITHUB_OUTPUT"
 
   release-please-write:
@@ -103,6 +127,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Releases created with GITHUB_TOKEN do not trigger release-event
+      # workflows, including build-images and mac-release.
       - name: Require release automation token
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -125,13 +151,6 @@ jobs:
           set -euo pipefail
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main advanced after attestation"; exit 1; }
-
-      - name: Require release automation token immediately before write
-        env:
-          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          set -euo pipefail
-          [ -n "$RELEASE_PLEASE_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required"; exit 1; }
 
       - name: Run Release Please against main
         id: release
@@ -156,6 +175,9 @@ jobs:
             exit 1
           }
 
+      # release-please only opens the version-bump PR; the release itself is
+      # created here so it is bound to the exact commit that was attested
+      # above, rather than to whatever the action considered HEAD.
       - name: Publish only a real immutable manifest bump
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -163,35 +185,51 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          parent_sha=$(git rev-parse "$ATTESTED_SHA^1")
-          current_version=$(git show "$ATTESTED_SHA:package.json" | node -e 'let s=""; process.stdin.on("data", c => s += c); process.stdin.on("end", () => process.stdout.write(JSON.parse(s).version))')
-          parent_version=$(git show "$parent_sha:package.json" | node -e 'let s=""; process.stdin.on("data", c => s += c); process.stdin.on("end", () => process.stdout.write(JSON.parse(s).version))')
-          if [ "$current_version" = "$parent_version" ]; then
+          read_version() { git show "$1:package.json" | node -pe 'JSON.parse(require("fs").readFileSync(0, "utf8")).version'; }
+          current_version=$(read_version "$ATTESTED_SHA")
+          parent_version=$(read_version "$(git rev-parse "${ATTESTED_SHA}^1")")
+          bump=$(jq -n --arg current "$current_version" --arg parent "$parent_version" \
+            '{current: $current, parent: $parent}' \
+            | node scripts/release-provenance.mjs manifest-bump)
+          if [ "$(jq -r '.bumped' <<<"$bump")" != true ]; then
             echo "No release-version manifest bump at attested SHA; release PR only."
             exit 0
           fi
-          [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "::error::invalid stable release version"; exit 1; }
-          tag="lobu-v${current_version}"
+          tag=$(jq -n --arg version "$current_version" '{version: $version}' \
+            | node scripts/release-provenance.mjs release-tag | jq -r '.tag')
+
           releases=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100")
-          node --input-type=module -e 'import { compareVersions } from "./scripts/release-provenance.mjs"; const pages = JSON.parse(process.argv[1]); const current = process.argv[2]; const versions = pages.flatMap(p => p).filter(r => !r.prerelease && /^lobu-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(r.tag_name)).map(r => r.tag_name.slice(6)); if (versions.some(v => compareVersions(current, v) <= 0 && v !== current)) { throw new Error(`release ${current} is not newer than an existing stable release`); }' "$releases" "$current_version"
-          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" | head -c 12000)
+          jq -n --argjson pages "$releases" --arg current "$current_version" \
+            '{current: $current, versions: [$pages[][] | select(.prerelease | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
+            | node scripts/release-provenance.mjs assert-newer >/dev/null
+
+          verify_release() {
+            local tag_ref tag_object
+            tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}")
+            tag_object=null
+            if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
+              tag_object=$(gh api "repos/${REPOSITORY}/git/tags/$(jq -r '.object.sha' <<<"$tag_ref")")
+            fi
+            jq -n --argjson release "$1" --argjson tagRef "$tag_ref" --argjson tagObject "$tag_object" \
+              --arg tag "$tag" --arg sha "$ATTESTED_SHA" \
+              '{release: $release, tagRef: $tagRef, tagObject: $tagObject, expectedTag: $tag, expectedSha: $sha}' \
+              | node scripts/release-provenance.mjs verify-release >/dev/null
+          }
+
           release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}" 2>/dev/null || true)
           if [ -n "$release" ]; then
-            [ "$(jq -r '.tag_name' <<<"$release")" = "$tag" ] || { echo "::error::existing release name mismatch"; exit 1; }
-            [ "$(jq -r '.target_commitish' <<<"$release")" = "$ATTESTED_SHA" ] || { echo "::error::existing release target mismatch"; exit 1; }
-            [ "$(jq -r '.prerelease' <<<"$release")" = false ] || { echo "::error::stable release is prerelease"; exit 1; }
+            verify_release "$release"
             echo "Immutable release already exists and matches $ATTESTED_SHA."
             exit 0
           fi
-          [ -n "$GH_TOKEN" ] || { echo "::error::RELEASE_PLEASE_TOKEN is required before release write"; exit 1; }
-          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" 2>/dev/null || true)
-          if [ -z "$tag_ref" ]; then
-            gh api --method POST "repos/${REPOSITORY}/git/refs" --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref:$ref, sha:$sha}') >/dev/null
+
+          notes=$(git show "$ATTESTED_SHA:CHANGELOG.md" | head -c 12000)
+          if ! gh api "repos/${REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+            gh api --method POST "repos/${REPOSITORY}/git/refs" \
+              --input <(jq -n --arg ref "refs/tags/$tag" --arg sha "$ATTESTED_SHA" '{ref: $ref, sha: $sha}') >/dev/null
           fi
-          tag_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${tag}")
-          tag_sha=$(jq -r '.object.sha' <<<"$tag_ref")
-          if [ "$(jq -r '.object.type' <<<"$tag_ref")" = tag ]; then
-            tag_sha=$(gh api "repos/${REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')
-          fi
-          [ "$tag_sha" = "$ATTESTED_SHA" ] || { echo "::error::tag does not bind to attested commit"; exit 1; }
-          gh api --method POST "repos/${REPOSITORY}/releases" --input <(jq -n --arg tag "$tag" --arg sha "$ATTESTED_SHA" --arg body "$notes" '{tag_name:$tag,target_commitish:$sha,name:$tag,body:$body,draft:false,prerelease:false,make_latest:true}') >/dev/null
+          gh api --method POST "repos/${REPOSITORY}/releases" \
+            --input <(jq -n --arg tag "$tag" --arg sha "$ATTESTED_SHA" --arg body "$notes" \
+              '{tag_name: $tag, target_commitish: $sha, name: $tag, body: $body, draft: false, prerelease: false, make_latest: "true"}') >/dev/null
+
+          verify_release "$(gh api "repos/${REPOSITORY}/releases/tags/${tag}")"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,9 @@ The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`
 
 Every gate in that chain is one subcommand of `scripts/release-provenance.mjs`, covered by `scripts/__tests__/release-publish-order.test.ts`. Change the policy there, not in the workflow YAML.
 
-To force a specific version (for example, `6.2.0-beta.1`), land a commit on `main` whose body contains `Release-As: 6.2.0-beta.1`; release-please then opens or updates the release PR for that version.
+To force a specific version, land a commit on `main` whose body contains `Release-As: 7.2.0`; release-please then opens or updates the release PR for that version.
+
+Only stable `X.Y.Z` versions can be released. The attestation chain rejects anything else — `parseStableVersion` in `scripts/release-provenance.mjs` throws, so a prerelease `Release-As:` fails the release step with `invalid stable Lobu version` rather than shipping. Release a prerelease by publishing from a branch by hand instead.
 
 ## Commit prefixes → version bump
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,9 +5,12 @@ The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`
 ## Flow
 
 1. Merge feature PRs into `main` with conventional commit messages.
-2. release-please opens a `chore(main): release lobu <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`.
-3. Merge the release PR (squash). This creates the `lobu-v<version>` tag + GitHub release, which starts `build-images.yml`.
-4. Once that run's `app-image-smoke` boots the tagged app image, its `trigger-package-publish` job dispatches `publish-packages.yml` against the release tag. Automated npm publication is therefore downstream of a green image smoke — a red or still-queued image build leaves the version unpublished rather than shipping an unverified tree.
+2. The push to `main` starts `build-images.yml`. When it finishes, `release-please.yml` runs on its `workflow_run` and attests the producer before touching anything: the run must be a completed-success push to the current `main` tip, all six required image jobs must be completed-success, and there must be an exact successful `ci.yml` run for the same commit.
+3. Against that attested commit, release-please opens a `chore(main): release lobu <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`. It runs with `skip-github-release: true`, so it never creates the tag or the release itself.
+4. Merging the release PR repeats steps 2–3 for the new commit. This time the manifest version differs from its parent's, so the workflow creates the `lobu-v<version>` tag and GitHub release bound to that exact attested SHA. Publishing the release starts `build-images.yml` again, now on a `release` event.
+5. Once that run's `app-image-smoke` boots the tagged app image, its `trigger-package-publish` job dispatches `publish-packages.yml` from `main` with the release tag and its own run id. Automated npm publication is therefore downstream of a green image smoke — a red or still-queued image build leaves the version unpublished rather than shipping an unverified tree.
+
+Every gate in that chain is one subcommand of `scripts/release-provenance.mjs`, covered by `scripts/__tests__/release-publish-order.test.ts`. Change the policy there, not in the workflow YAML.
 
 To force a specific version (for example, `6.2.0-beta.1`), land a commit on `main` whose body contains `Release-As: 6.2.0-beta.1`; release-please then opens or updates the release PR for that version.
 
@@ -45,7 +48,14 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 **Publish step fails after release PR merge** — re-running `release-please.yml` does NOT re-publish: the release already exists, so no new release event fires and nothing dispatches the publish. Recover from the artifact side instead:
 
 - **`build-images` failed or was evicted** — re-run that run (`gh run rerun <id>`). A green `app-image-smoke` re-fires `trigger-package-publish` on its own.
-- **`build-images` is green but `publish-packages` failed** — re-dispatch it directly against the release tag: `gh workflow run publish-packages.yml --ref lobu-v<version> -f bump=skip`. Omitting `image_run_id` makes the guard resolve the newest build-images run for that exact commit itself.
+- **`build-images` is green but `publish-packages` failed** — re-dispatch it from `main`, naming the release tag and the exact producing run. Both inputs are required and there is no fallback that guesses either one:
+  ```bash
+  gh workflow run publish-packages.yml --ref main \
+    -f release_tag=lobu-v<version> \
+    -f image_run_id=<the build-images run id for the release event>
+  ```
+  The workflow must be dispatched from `main` so it runs main's policy; the release tag is data, not the ref.
+- **`release-please.yml` skipped a push because `main` moved** — the attestation binds to one commit, so a merge landing mid-attestation aborts that run rather than releasing a commit it did not verify. The next push re-attests from scratch; nothing needs unsticking. To release without waiting, dispatch it manually from `main` with the exact producing run: `gh workflow run release-please.yml --ref main -f image_run_id=<build-images run id>`.
 
 `publish-packages.mjs` is idempotent (skips already-published packages), so re-running is safe.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
-  "skip-github-release": true,
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
+  "skip-github-release": true,
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -1,6 +1,14 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
+import {
+  compareVersions,
+  manifestBump,
+  releaseTagForVersion,
+  selectLatestRequiredJobs,
+  selectUniqueLatestRun,
+  verifyImmutableRelease,
+} from "../release-provenance.mjs";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const read = (name: string) =>
@@ -60,7 +68,7 @@ describe("release provenance workflow structure", () => {
     const release = uncommented(read("release-please.yml"));
     expect(release).toContain("filter=all");
     expect(release).toContain("--paginate --slurp");
-    expect(release).toContain("max_by(.run_attempt // 1)");
+    expect(release).toContain("map(.run_attempt // 1) | max");
     expect(release).toContain("head_repository.full_name");
     expect(release).toContain("jq -r '.event' <<<\"$build_run\")");
     expect(release).toContain('[ "$event" = push ] && [ "$branch" = main ]');
@@ -72,10 +80,10 @@ describe("release provenance workflow structure", () => {
     expect(release).toContain("main moved while waiting for exact CI");
   });
 
-  it("keeps release creation privileged and non-cancelling, with a final main recheck", () => {
+  it("keeps release creation privileged without a global evicting queue", () => {
     const release = read("release-please.yml");
     const write = job(release, "release-please-write");
-    expect(write).toContain("cancel-in-progress: false");
+    expect(write).not.toContain("concurrency:");
     expect(write).toContain("contents: write");
     expect(write).toContain("pull-requests: write");
     expect(write).toContain(
@@ -84,6 +92,8 @@ describe("release provenance workflow structure", () => {
     expect(write).toContain("target-branch: main");
     expect(write).toContain("release_created");
     expect(write).toContain("RELEASE_SHA");
+    expect(write).toContain("skip-github-release: true");
+    expect(write).toContain("Publish only a real immutable manifest bump");
   });
 
   it("separates manual image builds and guards before any checkout", () => {
@@ -169,5 +179,140 @@ describe("release provenance workflow structure", () => {
     expect(uncommented(source)).toContain(
       "publish policy must run from current main"
     );
+  });
+});
+
+describe("release provenance helpers execute the attestation policy", () => {
+  const required = ["generate-tag", "build-worker"];
+  const greenPages = [
+    {
+      jobs: [
+        {
+          name: "generate-tag",
+          run_attempt: 1,
+          status: "completed",
+          conclusion: "success",
+        },
+        {
+          name: "build-worker",
+          run_attempt: 1,
+          status: "completed",
+          conclusion: "success",
+        },
+      ],
+    },
+    {
+      jobs: [
+        {
+          name: "build-worker",
+          run_attempt: 2,
+          status: "completed",
+          conclusion: "success",
+        },
+      ],
+    },
+  ];
+
+  it("flattens multi-page jobs and selects exactly the latest attempt", () => {
+    expect(
+      selectLatestRequiredJobs(greenPages, required).map(
+        (job) => job.run_attempt
+      )
+    ).toEqual([1, 2]);
+    expect(() =>
+      selectLatestRequiredJobs(
+        [
+          {
+            jobs: [
+              { name: "generate-tag", run_attempt: 2 },
+              { name: "generate-tag", run_attempt: 2 },
+            ],
+          },
+        ],
+        ["generate-tag"]
+      )
+    ).toThrow("duplicate latest-attempt");
+    expect(() =>
+      selectLatestRequiredJobs(
+        [
+          {
+            jobs: [
+              {
+                name: "generate-tag",
+                status: "completed",
+                conclusion: "skipped",
+              },
+            ],
+          },
+        ],
+        ["generate-tag"]
+      )
+    ).toThrow("completed-success");
+  });
+
+  it("rejects ambiguous, skipped, failed, and missing selected CI runs", () => {
+    const expected = {
+      workflow_id: 7,
+      event: "push",
+      head_branch: "main",
+      head_sha: "a",
+      status: "completed",
+      conclusion: "success",
+    };
+    expect(
+      selectUniqueLatestRun([{ ...expected, id: 1, run_attempt: 1 }], expected)
+        .id
+    ).toBe(1);
+    expect(() =>
+      selectUniqueLatestRun(
+        [
+          { ...expected, id: 1, run_attempt: 2 },
+          { ...expected, id: 2, run_attempt: 2 },
+        ],
+        expected
+      )
+    ).toThrow("ambiguous");
+    expect(() => selectUniqueLatestRun([], expected)).toThrow("no matching");
+  });
+
+  it("binds stable release versions and immutable partial recovery", () => {
+    expect(manifestBump({ current: "17.3.0", parent: "17.2.0" })).toEqual({
+      bumped: true,
+      version: "17.3.0",
+    });
+    expect(manifestBump({ current: "17.2.0", parent: "17.2.0" })).toEqual({
+      bumped: false,
+      version: "17.2.0",
+    });
+    expect(compareVersions("17.10.0", "17.9.0")).toBe(1);
+    expect(releaseTagForVersion("17.3.0")).toBe("lobu-v17.3.0");
+    expect(() => manifestBump({ current: "17.1.0", parent: "17.2.0" })).toThrow(
+      "not newer"
+    );
+    const attested = { name: "lobu-v17.3.0", sha: "a".repeat(40) };
+    expect(
+      verifyImmutableRelease({
+        tag: attested,
+        release: {
+          tag_name: attested.name,
+          target_commitish: attested.sha,
+          prerelease: false,
+        },
+        expectedTag: attested.name,
+        expectedSha: attested.sha,
+      })
+    ).toBe(true);
+    expect(() =>
+      verifyImmutableRelease({
+        tag: attested,
+        release: {
+          tag_name: attested.name,
+          target_commitish: "b".repeat(40),
+          prerelease: false,
+        },
+        expectedTag: attested.name,
+        expectedSha: attested.sha,
+      })
+    ).toThrow("attested commit");
   });
 });

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -309,6 +309,30 @@ describe("publishing requires an attested release", () => {
     );
   });
 
+  it("accepts the producer run that is still dispatching it", () => {
+    // trigger-package-publish lives *inside* the Build Images run and passes
+    // its own $GITHUB_RUN_ID, so that run is necessarily in_progress while
+    // this gate reads it. A run-level "completed" assertion can therefore
+    // never be satisfied, and strands the release off npm.
+    const dispatch = shell("build-images.yml", "trigger-package-publish");
+    expect(dispatch).toContain('-f image_run_id="$GITHUB_RUN_ID"');
+    const gate = shell("publish-packages.yml", "attest-publish");
+    expect(gate).not.toContain("Build Images release run is not completed");
+    expect(gate).not.toMatch(/'\.status'\s*<<<"\$build_run"/);
+    expect(gate).not.toMatch(/'\.conclusion'\s*<<<"\$build_run"/);
+    // Identity still has to hold, and per-job attestation is the evidence.
+    expect(gate).toContain("head_sha");
+    expect(gate).toContain("release-provenance.mjs attest-jobs");
+    // The dispatching job must not be one of the jobs it has to wait for.
+    const required = read("publish-packages.yml").match(
+      /REQUIRED_IMAGE_JOBS: (.+)/
+    )?.[1];
+    expect(required?.split(" ")).not.toContain("trigger-package-publish");
+    expect(required?.split(" ").sort()).toEqual(
+      [...REQUIRED_IMAGE_JOBS].sort()
+    );
+  });
+
   it("treats an unreadable registry as unknown, not as empty", () => {
     // `npm view --json` prints its error object to STDOUT, so `|| echo '[]'`
     // emitted two JSON values and the version gate could not run at all.

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -203,6 +203,21 @@ describe("release provenance workflow structure", () => {
     expect(write).toContain('make_latest: "true"');
   });
 
+  it("does not turn a gh 404 body or a SIGPIPE into a failed release", () => {
+    const write = job(read("release-please.yml"), "release-please-write");
+    // `gh api` prints the 404 body on STDOUT, so `|| true` leaves a
+    // {"message":"Not Found"} document in the variable and the
+    // already-exists branch runs on every first release.
+    expect(write).not.toContain('releases/tags/${tag}" 2>/dev/null || true');
+    expect(write).toContain(
+      'if release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}"'
+    );
+    // CHANGELOG.md is ~475KB: `git show ... | head -c` exits 141 under
+    // pipefail and kills the release step before it creates anything.
+    expect(write).not.toContain("head -c");
+    expect(write).toContain("notes=${notes:0:12000}");
+  });
+
   it("separates manual image builds and guards before any checkout", () => {
     const images = uncommented(read("build-images.yml"));
     expect(images).toContain(
@@ -567,5 +582,20 @@ describe("release provenance helpers execute the attestation policy", () => {
         tagObject: { object: { sha: "d".repeat(40) } },
       })
     ).toThrow("attested commit");
+    // GitHub records a branch name when a release is cut from a branch, and
+    // ignores target_commitish entirely once the tag exists. Only a SHA in
+    // that field carries a binding, so only a SHA is enforced.
+    expect(
+      verifyImmutableRelease({
+        ...stable,
+        release: { ...stable.release, target_commitish: "main" },
+      })
+    ).toMatchObject({ sha });
+    expect(() =>
+      verifyImmutableRelease({
+        ...stable,
+        release: { ...stable.release, target_commitish: "b".repeat(40) },
+      })
+    ).toThrow("does not match peeled tag");
   });
 });

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -193,9 +193,11 @@ describe("release provenance workflow structure", () => {
       "Recheck current main immediately before release action"
     );
     expect(write).toContain("target-branch: main");
-    expect(write).toContain("release_created");
-    expect(write).toContain("RELEASE_SHA");
     expect(write).toContain("skip-github-release: true");
+    // skip-github-release keeps release_created permanently false, and the
+    // step below re-verifies the binding by peeling the tag, so a
+    // release_created guard here would be dead and redundant at once.
+    expect(write).not.toContain("release_created");
     expect(write).toContain("Publish only a real immutable manifest bump");
     expect(write).toContain("release-provenance.mjs manifest-bump");
     expect(write).toContain("release-provenance.mjs verify-release");
@@ -216,6 +218,8 @@ describe("release provenance workflow structure", () => {
     // pipefail and kills the release step before it creates anything.
     expect(write).not.toContain("head -c");
     expect(write).toContain("notes=${notes:0:12000}");
+    // A commit with no CHANGELOG.md costs the release body, not the release.
+    expect(write).toContain('CHANGELOG.md" || echo ""');
   });
 
   it("separates manual image builds and guards before any checkout", () => {
@@ -244,15 +248,17 @@ describe("release provenance workflow structure", () => {
     expect(trigger).toContain("--ref main");
     expect(trigger).not.toContain('--ref "$RELEASE_TAG"');
     expect(trigger).toContain('-f release_tag="$RELEASE_TAG"');
-    expect(trigger).toContain("-f bump=skip");
     expect(trigger).toContain('-f image_run_id="$GITHUB_RUN_ID"');
+    expect(trigger).not.toContain("bump");
   });
 
   it("requires release and producer identifiers and removes fallback and bumps", () => {
     const publish = uncommented(read("publish-packages.yml"));
     expect(publish).toMatch(/release_tag:[\s\S]*required: true/);
     expect(publish).toMatch(/image_run_id:[\s\S]*required: true/);
-    expect(publish).toContain('BUMP" = skip');
+    // `skip` was the only accepted value, so the input was dead surface.
+    expect(publish).not.toContain("BUMP");
+    expect(uncommented(read("build-images.yml"))).not.toContain("-f bump=skip");
     expect(publish).not.toContain("workflow_runs[0]");
     expect(publish).not.toContain('node scripts/publish-packages.mjs "$BUMP"');
     expect(publish).toContain("--skip-bump");
@@ -292,6 +298,7 @@ describe("release provenance workflow structure", () => {
     expect(guard).toContain('"$WORKFLOW_REF" = refs/heads/main');
     expect(guard).not.toContain("git/ref/heads/main");
     expect(guard).not.toContain("DISPATCH_SHA");
+    expect(guard).not.toContain("GH_TOKEN");
   });
 
   it("keeps credentials out of the read-only gate and checks out the attested SHA", () => {

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -1,9 +1,12 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
 import {
+  assertNoNewerStable,
+  COMMAND_NAMES,
   compareVersions,
   manifestBump,
+  peelTag,
   releaseTagForVersion,
   selectLatestRequiredJobs,
   selectUniqueLatestRun,
@@ -11,8 +14,11 @@ import {
 } from "../release-provenance.mjs";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
-const read = (name: string) =>
-  readFileSync(`${root}/.github/workflows/${name}`, "utf8");
+const workflowDir = `${root}/.github/workflows`;
+const read = (name: string) => readFileSync(`${workflowDir}/${name}`, "utf8");
+const workflowNames = readdirSync(workflowDir).filter((name) =>
+  /\.ya?ml$/.test(name)
+);
 const job = (yaml: string, id: string) => {
   const lines = yaml.split("\n");
   const start = lines.indexOf(`  ${id}:`);
@@ -52,6 +58,87 @@ const requiredJobs = [
   "app-image-smoke",
 ];
 
+// Run the helper the way the workflows do, so a subcommand that only works
+// when imported cannot pass. `attest-jobs` on a red producer must exit
+// non-zero: that exit status is the entire gate.
+const helper = (command: string, input: unknown) => {
+  const result = Bun.spawnSync({
+    cmd: ["node", "scripts/release-provenance.mjs", command],
+    cwd: root,
+    stdin: Buffer.from(JSON.stringify(input)),
+  });
+  return {
+    code: result.exitCode,
+    stdout: result.stdout.toString().trim(),
+    stderr: result.stderr.toString(),
+  };
+};
+
+describe("every workflow is parseable and every step is executable", () => {
+  // A `run:` mis-indented one level lands inside the step's `env:` map. The
+  // step then has neither `run` nor `uses`, GitHub rejects the whole file at
+  // parse time, and no amount of string matching against the YAML notices.
+  const stepKeys = new Set([
+    "run",
+    "uses",
+    "with",
+    "if",
+    "name",
+    "env",
+    "id",
+    "shell",
+    "working-directory",
+    "continue-on-error",
+    "timeout-minutes",
+  ]);
+
+  it.each(workflowNames)("%s", (name) => {
+    const doc = Bun.YAML.parse(read(name)) as {
+      jobs?: Record<string, { steps?: Record<string, unknown>[] }>;
+    };
+    for (const [jobId, definition] of Object.entries(doc?.jobs ?? {})) {
+      for (const [index, step] of (definition?.steps ?? []).entries()) {
+        if (!step || typeof step !== "object") continue;
+        const where = `${name} ${jobId} step[${index}] ${step.name ?? ""}`;
+        expect(
+          step.run !== undefined || step.uses !== undefined,
+          `${where} has neither run nor uses`
+        ).toBe(true);
+        for (const key of Object.keys(
+          (step.env as Record<string, unknown>) ?? {}
+        )) {
+          expect(
+            stepKeys.has(key),
+            `${where} smuggles step key "${key}" into env`
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("only invokes release-provenance subcommands that exist", () => {
+    const invoked = workflowNames.flatMap((name) =>
+      Array.from(
+        read(name).matchAll(/release-provenance\.mjs ([a-z-]+)/g),
+        (match) => match[1]
+      )
+    );
+    expect(invoked.length).toBeGreaterThan(0);
+    for (const command of invoked) expect(COMMAND_NAMES).toContain(command);
+  });
+
+  it("keeps the attestation policy out of inline jq", () => {
+    // The rules below used to be copy-pasted jq in two workflows apiece. jq
+    // embedded in YAML is unreachable from this suite, so it must not return.
+    for (const name of ["release-please.yml", "publish-packages.yml"]) {
+      const source = read(name);
+      expect(source).not.toContain("duplicate latest-attempt required job");
+      expect(source).not.toContain("map(.run_attempt // 1) | max");
+      expect(source).not.toContain("--input-type=module");
+    }
+  });
+});
+
 describe("release provenance workflow structure", () => {
   it("uses completed Build Images workflow runs and requires manual image_run_id", () => {
     const release = uncommented(read("release-please.yml"));
@@ -62,22 +149,38 @@ describe("release provenance workflow structure", () => {
     expect(release).toMatch(/image_run_id:[\s\S]*required: true/);
     expect(release).not.toContain("on:\n  push:");
     expect(release).not.toContain("gh workflow run publish-packages.yml");
+    // `types: [completed]` also fires for failure and cancellation.
+    expect(release).toContain(
+      "github.event.workflow_run.conclusion == 'success'"
+    );
   });
 
-  it("attests exact main push metadata, paginates all jobs, and selects attempts", () => {
+  it("attests exact main push metadata and paginates all jobs", () => {
     const release = uncommented(read("release-please.yml"));
     expect(release).toContain("filter=all");
     expect(release).toContain("--paginate --slurp");
-    expect(release).toContain("map(.run_attempt // 1) | max");
     expect(release).toContain("head_repository.full_name");
     expect(release).toContain("jq -r '.event' <<<\"$build_run\")");
     expect(release).toContain('[ "$event" = push ] && [ "$branch" = main ]');
     expect(release).toContain(
       '[ "$status" = completed ] && [ "$conclusion" = success ]'
     );
+    expect(release).toContain("release-provenance.mjs attest-jobs");
+    expect(release).toContain("release-provenance.mjs select-run");
     for (const name of requiredJobs) expect(release).toContain(name);
     expect(release).toContain("sleep 20");
     expect(release).toContain("main moved while waiting for exact CI");
+  });
+
+  it("proves the producer before checking out any repository code", () => {
+    const attest = job(read("release-please.yml"), "attest");
+    expect(
+      attest.indexOf("Attest the producing Build Images run")
+    ).toBeLessThan(attest.indexOf("uses: actions/checkout"));
+    // Pinned, so the helper cannot come from a ref that moved mid-run.
+    expect(attest).toContain("ref: ${{ steps.producer.outputs.sha }}");
+    expect(attest).not.toContain("id-token: write");
+    expect(attest).not.toContain("NPM_TOKEN");
   });
 
   it("keeps release creation privileged without a global evicting queue", () => {
@@ -94,6 +197,10 @@ describe("release provenance workflow structure", () => {
     expect(write).toContain("RELEASE_SHA");
     expect(write).toContain("skip-github-release: true");
     expect(write).toContain("Publish only a real immutable manifest bump");
+    expect(write).toContain("release-provenance.mjs manifest-bump");
+    expect(write).toContain("release-provenance.mjs verify-release");
+    // make_latest is a string enum in the REST API; a boolean is dropped.
+    expect(write).toContain('make_latest: "true"');
   });
 
   it("separates manual image builds and guards before any checkout", () => {
@@ -108,6 +215,7 @@ describe("release provenance workflow structure", () => {
     expect(images.indexOf("current-main-guard:")).toBeLessThan(
       images.indexOf("uses: actions/checkout")
     );
+    expect(images).toContain("release-provenance.mjs verify-release");
     expect(images).toContain("BUILD_PLATFORMS");
     expect(images).toContain("linux/arm64");
     expect(images).toContain("latest");
@@ -136,25 +244,24 @@ describe("release provenance workflow structure", () => {
     expect(publish).toContain("ci_workflow_id");
   });
 
-  it("fail-closes release attestation and allows only green individual producer jobs", () => {
+  it("fail-closes release attestation and allows only green producer jobs", () => {
     const attest = job(
       uncommented(read("publish-packages.yml")),
       "attest-publish"
     );
-    expect(attest).toContain("draft");
     expect(attest).toContain("git/ref/tags");
     expect(attest).toContain("git/tags");
     expect(attest).toContain("compare/");
     expect(attest).toContain("jq -r '.event' <<<\"$build_run\")");
-    expect(attest).toContain("jq -r '.event' <<<\"$build_run\")");
-    expect(attest).toContain('status == "completed"');
-    expect(attest).toContain('conclusion == "success"');
-    expect(attest).toContain("duplicate latest-attempt required job");
-    expect(attest).toContain(
-      'all(.[]; .status == "completed" and .conclusion == "success")'
-    );
+    expect(attest).toContain("release-provenance.mjs verify-release");
+    expect(attest).toContain("release-provenance.mjs attest-jobs");
+    expect(attest).toContain("release-provenance.mjs select-run");
     expect(read("publish-packages.yml")).toContain("actions: read");
-    expect(attest).toContain("exact successful CI push/main run");
+    // The policy guard runs before the checkout that makes the helper
+    // available, so an off-main dispatch never executes repository code.
+    expect(
+      attest.indexOf("publish policy must run from current main")
+    ).toBeLessThan(attest.indexOf("uses: actions/checkout"));
   });
 
   it("keeps credentials out of the read-only gate and checks out the attested SHA", () => {
@@ -169,6 +276,7 @@ describe("release provenance workflow structure", () => {
     );
     expect(privileged).toContain("scripts/publish-packages.mjs --skip-bump");
     expect(privileged).toContain("NODE_AUTH_TOKEN");
+    expect(privileged).toContain("release-provenance.mjs assert-newer");
     expect(runBodies(publish)).not.toContain("${{ inputs.");
     expect(publish).toContain("published-artifact-smoke.yml");
   });
@@ -179,6 +287,97 @@ describe("release provenance workflow structure", () => {
     expect(uncommented(source)).toContain(
       "publish policy must run from current main"
     );
+  });
+});
+
+describe("the helper CLI the workflows actually invoke", () => {
+  const green = {
+    pages: [
+      {
+        jobs: [
+          {
+            name: "generate-tag",
+            run_attempt: 1,
+            status: "completed",
+            conclusion: "success",
+          },
+          {
+            name: "app-image-smoke",
+            run_attempt: 1,
+            status: "completed",
+            conclusion: "failure",
+          },
+          {
+            name: "app-image-smoke",
+            run_attempt: 2,
+            status: "completed",
+            conclusion: "success",
+          },
+        ],
+      },
+    ],
+    required: ["generate-tag", "app-image-smoke"],
+  };
+
+  it("exits zero on a green producer and takes the newest attempt", () => {
+    const ok = helper("attest-jobs", green);
+    expect(ok.code).toBe(0);
+    expect(JSON.parse(ok.stdout)).toEqual({ ok: true, required: 2 });
+  });
+
+  it.each([
+    ["failure", "not completed-success"],
+    ["skipped", "not completed-success"],
+    ["cancelled", "not completed-success"],
+  ])("exits non-zero when a required job is %s", (conclusion, message) => {
+    const red = helper("attest-jobs", {
+      pages: [
+        {
+          jobs: [
+            {
+              name: "generate-tag",
+              status: "completed",
+              conclusion: "success",
+            },
+            { name: "app-image-smoke", status: "completed", conclusion },
+          ],
+        },
+      ],
+      required: green.required,
+    });
+    expect(red.code).not.toBe(0);
+    expect(red.stderr).toContain(message);
+  });
+
+  it("exits non-zero on an unknown subcommand rather than passing silently", () => {
+    const unknown = helper("attest-everything", {});
+    expect(unknown.code).toBe(2);
+    expect(unknown.stderr).toContain("unknown command");
+  });
+
+  it("round-trips each subcommand's shape over stdin", () => {
+    expect(
+      JSON.parse(helper("release-tag", { version: "17.4.0" }).stdout)
+    ).toEqual({ tag: "lobu-v17.4.0" });
+    expect(
+      JSON.parse(
+        helper("manifest-bump", { current: "17.4.0", parent: "17.3.0" }).stdout
+      )
+    ).toEqual({ bumped: true, version: "17.4.0" });
+    expect(
+      JSON.parse(
+        helper("select-run", {
+          runs: [
+            { id: 1, head_sha: "a", run_attempt: 1 },
+            { id: 9, head_sha: "a", run_attempt: 3 },
+          ],
+          expected: { head_sha: "a" },
+        }).stdout
+      )
+    ).toEqual({ id: "9" });
+    expect(
+      helper("assert-newer", { current: "17.3.0", versions: ["17.4.0"] }).code
+    ).not.toBe(0);
   });
 });
 
@@ -248,6 +447,9 @@ describe("release provenance helpers execute the attestation policy", () => {
         ["generate-tag"]
       )
     ).toThrow("completed-success");
+    expect(() => selectLatestRequiredJobs(greenPages, [])).toThrow(
+      "no required job names"
+    );
   });
 
   it("rejects ambiguous, skipped, failed, and missing selected CI runs", () => {
@@ -275,7 +477,7 @@ describe("release provenance helpers execute the attestation policy", () => {
     expect(() => selectUniqueLatestRun([], expected)).toThrow("no matching");
   });
 
-  it("binds stable release versions and immutable partial recovery", () => {
+  it("only lets versions move forward", () => {
     expect(manifestBump({ current: "17.3.0", parent: "17.2.0" })).toEqual({
       bumped: true,
       version: "17.3.0",
@@ -289,29 +491,80 @@ describe("release provenance helpers execute the attestation policy", () => {
     expect(() => manifestBump({ current: "17.1.0", parent: "17.2.0" })).toThrow(
       "not newer"
     );
-    const attested = { name: "lobu-v17.3.0", sha: "a".repeat(40) };
+    expect(() =>
+      assertNoNewerStable({ current: "17.3.0", versions: ["17.4.0"] })
+    ).toThrow("newer stable version");
     expect(
-      verifyImmutableRelease({
-        tag: attested,
-        release: {
-          tag_name: attested.name,
-          target_commitish: attested.sha,
-          prerelease: false,
-        },
-        expectedTag: attested.name,
-        expectedSha: attested.sha,
+      assertNoNewerStable({ current: "17.3.0", versions: ["17.3.0", "16.1.0"] })
+    ).toMatchObject({ ok: true, compared: 2 });
+    // A prerelease string is not a stable version and must not veto a release.
+    expect(
+      assertNoNewerStable({
+        current: "17.3.0",
+        versions: ["17.9.0-beta.1", "17.2.0"],
       })
-    ).toBe(true);
+    ).toMatchObject({ ok: true, compared: 1 });
+  });
+
+  it("peels an annotated tag instead of trusting the ref's own sha", () => {
+    const commit = "a".repeat(40);
+    const tagObjectSha = "c".repeat(40);
+    expect(
+      peelTag({ tagRef: { object: { type: "commit", sha: commit } } })
+    ).toBe(commit);
+    expect(
+      peelTag({
+        tagRef: { object: { type: "tag", sha: tagObjectSha } },
+        tagObject: { object: { sha: commit } },
+      })
+    ).toBe(commit);
+    // Without the peeled object an annotated tag has no commit to bind to.
+    expect(() =>
+      peelTag({ tagRef: { object: { type: "tag", sha: tagObjectSha } } })
+    ).toThrow("could not peel");
+  });
+
+  it("binds stable release versions and immutable partial recovery", () => {
+    const sha = "a".repeat(40);
+    const stable = {
+      release: {
+        tag_name: "lobu-v17.3.0",
+        draft: false,
+        prerelease: false,
+        target_commitish: sha,
+      },
+      tagRef: { object: { type: "commit", sha } },
+      expectedTag: "lobu-v17.3.0",
+      expectedSha: sha,
+    };
+    expect(verifyImmutableRelease(stable)).toEqual({
+      sha,
+      version: "17.3.0",
+    });
+    expect(() =>
+      verifyImmutableRelease({ ...stable, expectedSha: "b".repeat(40) })
+    ).toThrow("attested commit");
     expect(() =>
       verifyImmutableRelease({
-        tag: attested,
-        release: {
-          tag_name: attested.name,
-          target_commitish: "b".repeat(40),
-          prerelease: false,
-        },
-        expectedTag: attested.name,
-        expectedSha: attested.sha,
+        ...stable,
+        release: { ...stable.release, draft: true },
+      })
+    ).toThrow("draft");
+    expect(() =>
+      verifyImmutableRelease({
+        ...stable,
+        release: { ...stable.release, prerelease: true },
+      })
+    ).toThrow("prerelease");
+    expect(() =>
+      verifyImmutableRelease({ ...stable, expectedTag: "lobu-v17.4.0" })
+    ).toThrow("tag/name mismatch");
+    // An annotated tag re-pointed away from the release's own target.
+    expect(() =>
+      verifyImmutableRelease({
+        ...stable,
+        tagRef: { object: { type: "tag", sha: "c".repeat(40) } },
+        tagObject: { object: { sha: "d".repeat(40) } },
       })
     ).toThrow("attested commit");
   });

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -279,6 +279,21 @@ describe("release provenance workflow structure", () => {
     ).toBeLessThan(attest.indexOf("uses: actions/checkout"));
   });
 
+  it("does not fail the publish because main moved after dispatch", () => {
+    // The ref pin is the security property; requiring the dispatched SHA to
+    // still be main's HEAD adds none and strands a release off npm whenever
+    // anything merges between dispatch and this job starting -- the failure
+    // this workflow exists to prevent. The release is bound by its tag.
+    const attest = job(read("publish-packages.yml"), "attest-publish");
+    const guard = attest.slice(
+      attest.indexOf("Verify current-main workflow policy"),
+      attest.indexOf("Check out current main")
+    );
+    expect(guard).toContain('"$WORKFLOW_REF" = refs/heads/main');
+    expect(guard).not.toContain("git/ref/heads/main");
+    expect(guard).not.toContain("DISPATCH_SHA");
+  });
+
   it("keeps credentials out of the read-only gate and checks out the attested SHA", () => {
     const publish = read("publish-packages.yml");
     const attest = job(publish, "attest-publish");

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -2,148 +2,172 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
 
-const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
-const workflow = (name: string) =>
-  readFileSync(`${repoRoot}/.github/workflows/${name}`, "utf8");
-
-/**
- * Slice one top-level job out of a workflow. Scanning to the next job-key line
- * rather than to a named sibling keeps these assertions independent of job
- * order — reordering build-images.yml must not silently empty the haystack.
- */
-function jobBlock(yaml: string, jobId: string): string {
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const read = (name: string) =>
+  readFileSync(`${root}/.github/workflows/${name}`, "utf8");
+const job = (yaml: string, id: string) => {
   const lines = yaml.split("\n");
-  const start = lines.indexOf(`  ${jobId}:`);
-  if (start === -1) throw new Error(`job '${jobId}' not found in workflow`);
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
-    if (/^ {2}[A-Za-z_][\w-]*:/.test(lines[i])) {
-      end = i;
-      break;
-    }
-  }
-  return lines.slice(start, end).join("\n");
-}
+  const start = lines.indexOf(`  ${id}:`);
+  if (start < 0) throw new Error(`missing job ${id}`);
+  const end = lines.findIndex(
+    (line, index) => index > start && /^ {2}[A-Za-z_][\w-]*:/.test(line)
+  );
+  return lines.slice(start, end < 0 ? lines.length : end).join("\n");
+};
+const uncommented = (text: string) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+const runBodies = (text: string) =>
+  text
+    .split("\n")
+    .reduce<{ active: boolean; lines: string[] }>(
+      (state, line) => {
+        if (/^ {8}run: \|/.test(line))
+          return { active: true, lines: state.lines };
+        if (state.active && !/^ {10}/.test(line))
+          return { active: false, lines: state.lines };
+        if (state.active) state.lines.push(line);
+        return state;
+      },
+      { active: false, lines: [] }
+    )
+    .lines.join("\n");
 
-describe("release package publication ordering", () => {
-  it("slices jobs at every valid job ID", () => {
-    const yaml = [
-      "jobs:",
-      "  target:",
-      "    marker: target",
-      "  _next-job:",
-      "    marker: sibling",
-    ].join("\n");
+const requiredJobs = [
+  "generate-tag",
+  "connector-parity-smoke",
+  "build-worker",
+  "build-embeddings-service",
+  "build-app",
+  "app-image-smoke",
+];
 
-    expect(jobBlock(yaml, "target")).not.toContain("sibling");
+describe("release provenance workflow structure", () => {
+  it("uses completed Build Images workflow runs and requires manual image_run_id", () => {
+    const release = uncommented(read("release-please.yml"));
+    expect(release).toContain("workflow_run:");
+    expect(release).toContain('workflows: ["Build and Push Images"]');
+    expect(release).toContain("types: [completed]");
+    expect(release).toContain("workflow_dispatch:");
+    expect(release).toMatch(/image_run_id:[\s\S]*required: true/);
+    expect(release).not.toContain("on:\n  push:");
+    expect(release).not.toContain("gh workflow run publish-packages.yml");
   });
 
-  it("does not dispatch package publication at release creation time", () => {
-    expect(workflow("release-please.yml")).not.toContain(
-      "gh workflow run publish-packages.yml"
+  it("attests exact main push metadata, paginates all jobs, and selects attempts", () => {
+    const release = uncommented(read("release-please.yml"));
+    expect(release).toContain("filter=all");
+    expect(release).toContain("--paginate --slurp");
+    expect(release).toContain("max_by(.run_attempt // 1)");
+    expect(release).toContain("head_repository.full_name");
+    expect(release).toContain("jq -r '.event' <<<\"$build_run\")");
+    expect(release).toContain('[ "$event" = push ] && [ "$branch" = main ]');
+    expect(release).toContain(
+      '[ "$status" = completed ] && [ "$conclusion" = success ]'
     );
+    for (const name of requiredJobs) expect(release).toContain(name);
+    expect(release).toContain("sleep 20");
+    expect(release).toContain("main moved while waiting for exact CI");
   });
 
-  it("dispatches only after app-image-smoke and pins the release tag and run", () => {
-    const job = jobBlock(
-      workflow("build-images.yml"),
+  it("keeps release creation privileged and non-cancelling, with a final main recheck", () => {
+    const release = read("release-please.yml");
+    const write = job(release, "release-please-write");
+    expect(write).toContain("cancel-in-progress: false");
+    expect(write).toContain("contents: write");
+    expect(write).toContain("pull-requests: write");
+    expect(write).toContain(
+      "Recheck current main immediately before release action"
+    );
+    expect(write).toContain("target-branch: main");
+    expect(write).toContain("release_created");
+    expect(write).toContain("RELEASE_SHA");
+  });
+
+  it("separates manual image builds and guards before any checkout", () => {
+    const images = uncommented(read("build-images.yml"));
+    expect(images).toContain(
+      "github.event_name == 'workflow_dispatch' && '-manual'"
+    );
+    const guard = job(images, "current-main-guard");
+    expect(guard).toContain("git/ref/heads/main");
+    expect(guard).toContain("refs/heads/main");
+    expect(guard).toContain("github.sha");
+    expect(images.indexOf("current-main-guard:")).toBeLessThan(
+      images.indexOf("uses: actions/checkout")
+    );
+    expect(images).toContain("BUILD_PLATFORMS");
+    expect(images).toContain("linux/arm64");
+    expect(images).toContain("latest");
+  });
+
+  it("dispatches package publication from main policy with exact inputs", () => {
+    const trigger = job(
+      uncommented(read("build-images.yml")),
       "trigger-package-publish"
     );
-
-    expect(job).toContain("needs: [generate-tag, app-image-smoke]");
-    expect(job).toContain("github.event_name == 'release'");
-    expect(job).toContain('--ref "$RELEASE_TAG"');
-    expect(job).toContain('-f image_run_id="$GITHUB_RUN_ID"');
+    expect(trigger).toContain("--ref main");
+    expect(trigger).not.toContain('--ref "$RELEASE_TAG"');
+    expect(trigger).toContain('-f release_tag="$RELEASE_TAG"');
+    expect(trigger).toContain("-f bump=skip");
+    expect(trigger).toContain('-f image_run_id="$GITHUB_RUN_ID"');
   });
 
-  it("keeps the dispatch skipped when app-image-smoke is not green", () => {
-    // A job whose `if:` carries no status function inherits `success()` over
-    // its `needs`, so a failed or skipped app-image-smoke skips the dispatch.
-    // `always()`/`!cancelled()` would opt out of that and publish anyway.
-    const job = jobBlock(
-      workflow("build-images.yml"),
-      "trigger-package-publish"
-    );
-
-    expect(job).not.toMatch(/always\(\)|cancelled\(\)|failure\(\)/);
+  it("requires release and producer identifiers and removes fallback and bumps", () => {
+    const publish = uncommented(read("publish-packages.yml"));
+    expect(publish).toMatch(/release_tag:[\s\S]*required: true/);
+    expect(publish).toMatch(/image_run_id:[\s\S]*required: true/);
+    expect(publish).toContain('BUMP" = skip');
+    expect(publish).not.toContain("workflow_runs[0]");
+    expect(publish).not.toContain('node scripts/publish-packages.mjs "$BUMP"');
+    expect(publish).toContain("--skip-bump");
+    expect(publish).toContain("ci_workflow_id");
   });
 
-  it("pages when the dispatch itself fails", () => {
-    // build-images is the only thing watching this dispatch; if it drops off
-    // notify-failure's needs, a failed publish trigger goes unnoticed until
-    // someone checks npm.
-    const job = jobBlock(workflow("build-images.yml"), "notify-failure");
-
-    expect(job).toMatch(
-      /^\s+needs:\s*\[[^\]]*\btrigger-package-publish\b[^\]]*\]/m
+  it("fail-closes release attestation and allows only green individual producer jobs", () => {
+    const attest = job(
+      uncommented(read("publish-packages.yml")),
+      "attest-publish"
     );
+    expect(attest).toContain("draft");
+    expect(attest).toContain("git/ref/tags");
+    expect(attest).toContain("git/tags");
+    expect(attest).toContain("compare/");
+    expect(attest).toContain("jq -r '.event' <<<\"$build_run\")");
+    expect(attest).toContain("jq -r '.event' <<<\"$build_run\")");
+    expect(attest).toContain('status == "completed"');
+    expect(attest).toContain('conclusion == "success"');
+    expect(attest).toContain("duplicate latest-attempt required job");
+    expect(attest).toContain(
+      'all(.[]; .status == "completed" and .conclusion == "success")'
+    );
+    expect(read("publish-packages.yml")).toContain("actions: read");
+    expect(attest).toContain("exact successful CI push/main run");
   });
 
-  it("validates the exact producer SHA and green smoke before publishing", () => {
-    const publish = workflow("publish-packages.yml");
-
-    expect(publish).toMatch(/^permissions:\n(?: {2}.*\n)* {2}actions: read$/m);
-    expect(publish).toContain("actions/workflows/build-images.yml");
-    expect(publish).toContain("--jq '.id'");
-    expect(publish).toContain(
-      'if [ "$workflow_id" != "$expected_workflow_id" ]'
+  it("keeps credentials out of the read-only gate and checks out the attested SHA", () => {
+    const publish = read("publish-packages.yml");
+    const attest = job(publish, "attest-publish");
+    const privileged = job(publish, "publish-packages");
+    expect(attest).not.toContain("id-token: write");
+    expect(attest).not.toContain("NPM_TOKEN");
+    expect(privileged).toContain("id-token: write");
+    expect(privileged).toContain(
+      "ref: ${{ needs.attest-publish.outputs.tag_sha }}"
     );
-    expect(publish).not.toContain(
-      'if [ "$workflow_path" != ".github/workflows/build-images.yml" ]'
-    );
-    expect(publish).toContain("--jq '[.workflow_id, .head_sha] | @tsv'");
-    expect(publish).toContain('if [ "$run_sha" != "$sha" ]');
-    expect(publish).toContain('select(.name == "app-image-smoke")');
-    expect(publish).toContain(
-      'if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]'
-    );
+    expect(privileged).toContain("scripts/publish-packages.mjs --skip-bump");
+    expect(privileged).toContain("NODE_AUTH_TOKEN");
+    expect(runBodies(publish)).not.toContain("${{ inputs.");
+    expect(publish).toContain("published-artifact-smoke.yml");
   });
 
-  it("reads dispatch inputs through env, not template expansion", () => {
-    // publish-packages holds `id-token: write` and the production NPM_TOKEN, so
-    // a `${{ inputs.* }}` expanded inside a `run:` body is a publish-credential
-    // injection reachable by anyone who can dispatch the workflow.
-    const publish = workflow("publish-packages.yml");
-    const runBodies = publish
-      .split("\n")
-      .filter((line) => !/^\s{8,}[A-Z_]+:\s/.test(line))
-      .join("\n");
-
-    expect(runBodies).not.toContain("${{ inputs.image_run_id }}");
-    expect(runBodies).not.toContain("${{ inputs.bump }}");
-    expect(publish).toContain('run_id="$IMAGE_RUN_ID"');
-  });
-
-  it("gates a successful publish on the exact npm artifact smoke", () => {
-    const publish = workflow("publish-packages.yml");
-    const artifactSmoke = workflow("published-artifact-smoke.yml");
-    const verify = jobBlock(publish, "verify-published-artifact");
-
-    expect(artifactSmoke).toContain("workflow_call:");
-    expect(artifactSmoke).not.toContain("workflow_run:");
-    expect(verify).toContain("needs: publish-packages");
-    expect(verify).toContain(
-      "uses: ./.github/workflows/published-artifact-smoke.yml"
+  it("does not accept comment-only evidence", () => {
+    const source = read("publish-packages.yml");
+    expect(uncommented(source)).not.toContain("newest exact-SHA");
+    expect(uncommented(source)).toContain(
+      "publish policy must run from current main"
     );
-    expect(verify).toContain(
-      "version: ${{ needs.publish-packages.outputs.published-version }}"
-    );
-    expect(publish).toContain(
-      "published-version: ${{ steps.published-version.outputs.version }}"
-    );
-    expect(publish).toContain("require('./packages/cli/package.json').version");
-  });
-
-  it("fails closed when the published Helm chart is not public", () => {
-    const publish = jobBlock(workflow("helm-chart.yml"), "publish");
-
-    expect(publish).not.toContain("/visibility");
-    expect(publish).not.toContain("|| true");
-    expect(publish).toContain(
-      'gh api "/orgs/${OWNER}/packages/container/charts%2Flobu"'
-    );
-    expect(publish).toContain("--jq '.visibility'");
-    expect(publish).toContain('if [ "$visibility" != "public" ]');
-    expect(publish).toContain("exit 1");
   });
 });

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -133,6 +133,32 @@ describe("every workflow file is well formed", () => {
       expect(read(file)).not.toContain("--input-type=module");
     }
   });
+
+  it("peels release tags in exactly one place", () => {
+    // Fetching the tag ref, peeling an annotated tag and handing all three
+    // documents to the helper was pasted into three workflows. One composite
+    // action owns it now, so the copies cannot drift as the inline jq did.
+    const callers = names.filter((file) =>
+      read(file).includes("./.github/actions/verify-release")
+    );
+    expect(callers.sort()).toEqual([
+      "build-images.yml",
+      "publish-packages.yml",
+      "release-please.yml",
+    ]);
+    for (const file of names) {
+      expect(read(file)).not.toContain("git/tags/");
+    }
+    const action = Bun.YAML.parse(
+      readFileSync(`${root}/.github/actions/verify-release/action.yml`, "utf8")
+    ) as { inputs: Record<string, unknown>; outputs: Record<string, unknown> };
+    expect(Object.keys(action.inputs).sort()).toEqual([
+      "expected-sha",
+      "tag",
+      "token",
+    ]);
+    expect(Object.keys(action.outputs).sort()).toEqual(["sha", "version"]);
+  });
 });
 
 describe("release-please only acts on a green main push", () => {
@@ -202,7 +228,6 @@ describe("the release is created bound to the attested commit", () => {
     // release_created guard would be dead and redundant at once.
     expect(read("release-please.yml")).not.toContain("release_created");
     expect(body()).toContain("release-provenance.mjs manifest-bump");
-    expect(body()).toContain("release-provenance.mjs verify-release");
     expect(body()).toContain("release-provenance.mjs assert-newer");
     // make_latest is a string enum in the REST API; a boolean is dropped.
     expect(body()).toContain('make_latest: "true"');
@@ -227,12 +252,28 @@ describe("the release is created bound to the attested commit", () => {
     });
   });
 
+  it("verifies once, after a creation that tolerates an existing release", () => {
+    const ids = (steps("release-please.yml", id).map((step) => step.name) ??
+      []) as string[];
+    expect(ids).toContain(
+      "Create the tag and release if they are not already there"
+    );
+    expect(ids).toContain("Verify the release binds to the attested commit");
+    // One verification covering both the already-exists and just-created
+    // paths, rather than two call sites that can drift apart.
+    expect(
+      steps("release-please.yml", id).filter((step) =>
+        step.uses?.includes("verify-release")
+      )
+    ).toHaveLength(1);
+    expect(body()).not.toContain("verify_release()");
+  });
+
   it("does not let a 404 body or a large changelog fail the release", () => {
     // `gh api` prints the 404 body on STDOUT, so `|| true` left
     // {"message":"Not Found"} in the variable and the already-exists branch
     // ran on the first release of every version. Branch on exit status.
-    expect(body()).not.toContain('releases/tags/${tag}" 2>/dev/null || true');
-    expect(body()).toContain("if release=$(gh api");
+    expect(body()).not.toContain("2>/dev/null || true");
     // CHANGELOG.md is ~475KB: `git show … | head -c` exits 141 under pipefail
     // and kills the step before it creates anything.
     expect(body()).not.toContain("head -c");
@@ -258,10 +299,12 @@ describe("image builds refuse an off-main manual dispatch", () => {
     );
   });
 
-  it("verifies a release binds to this commit through the helper", () => {
-    expect(shell("build-images.yml", "generate-tag")).toContain(
-      "release-provenance.mjs verify-release"
+  it("verifies a release binds to this commit through the shared action", () => {
+    const verify = steps("build-images.yml", "generate-tag").find((step) =>
+      step.uses?.includes("verify-release")
     );
+    expect(verify?.if).toBe("github.event_name == 'release'");
+    expect(verify?.with?.["expected-sha"]).toBe("${{ github.sha }}");
   });
 
   it("dispatches publication from main policy with exact inputs", () => {

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -13,43 +13,49 @@ import {
   verifyImmutableRelease,
 } from "../release-provenance.mjs";
 
-const root = fileURLToPath(new URL("../..", import.meta.url));
-const workflowDir = `${root}/.github/workflows`;
-const read = (name: string) => readFileSync(`${workflowDir}/${name}`, "utf8");
-const workflowNames = readdirSync(workflowDir).filter((name) =>
-  /\.ya?ml$/.test(name)
-);
-const job = (yaml: string, id: string) => {
-  const lines = yaml.split("\n");
-  const start = lines.indexOf(`  ${id}:`);
-  if (start < 0) throw new Error(`missing job ${id}`);
-  const end = lines.findIndex(
-    (line, index) => index > start && /^ {2}[A-Za-z_][\w-]*:/.test(line)
-  );
-  return lines.slice(start, end < 0 ? lines.length : end).join("\n");
+type Step = {
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, unknown>;
 };
-const uncommented = (text: string) =>
-  text
-    .split("\n")
-    .filter((line) => !/^\s*#/.test(line))
-    .join("\n");
-const runBodies = (text: string) =>
-  text
-    .split("\n")
-    .reduce<{ active: boolean; lines: string[] }>(
-      (state, line) => {
-        if (/^ {8}run: \|/.test(line))
-          return { active: true, lines: state.lines };
-        if (state.active && !/^ {10}/.test(line))
-          return { active: false, lines: state.lines };
-        if (state.active) state.lines.push(line);
-        return state;
-      },
-      { active: false, lines: [] }
-    )
-    .lines.join("\n");
+type Job = {
+  needs?: string | string[];
+  if?: string;
+  permissions?: Record<string, string>;
+  steps?: Step[];
+};
+type Workflow = { on?: Record<string, unknown>; jobs?: Record<string, Job> };
 
-const requiredJobs = [
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const dir = `${root}/.github/workflows`;
+const names = readdirSync(dir).filter((name) => /\.ya?ml$/.test(name));
+const read = (name: string) => readFileSync(`${dir}/${name}`, "utf8");
+const parse = (name: string) => Bun.YAML.parse(read(name)) as Workflow;
+const job = (file: string, id: string) => {
+  const found = parse(file).jobs?.[id];
+  if (!found) throw new Error(`${file} has no job ${id}`);
+  return found;
+};
+const steps = (file: string, id: string) => job(file, id).steps ?? [];
+const stepAt = (file: string, id: string, needle: string) => {
+  const index = steps(file, id).findIndex((step) =>
+    `${step.name ?? ""} ${step.uses ?? ""}`.includes(needle)
+  );
+  if (index < 0)
+    throw new Error(`${file}/${id} has no step matching ${needle}`);
+  return index;
+};
+/** Every shell body in a job, concatenated — what the runner will execute. */
+const shell = (file: string, id: string) =>
+  steps(file, id)
+    .map((step) => step.run ?? "")
+    .join("\n");
+const envOf = (file: string, id: string) =>
+  steps(file, id).flatMap((step) => Object.keys(step.env ?? {}));
+
+const REQUIRED_IMAGE_JOBS = [
   "generate-tag",
   "connector-parity-smoke",
   "build-worker",
@@ -58,10 +64,8 @@ const requiredJobs = [
   "app-image-smoke",
 ];
 
-// Run the helper the way the workflows do, so a subcommand that only works
-// when imported cannot pass. `attest-jobs` on a red producer must exit
-// non-zero: that exit status is the entire gate.
-const helper = (command: string, input: unknown) => {
+/** Run the helper the way the workflows do — over stdin, as a subprocess. */
+const cli = (command: string, input: unknown) => {
   const result = Bun.spawnSync({
     cmd: ["node", "scripts/release-provenance.mjs", command],
     cwd: root,
@@ -74,10 +78,11 @@ const helper = (command: string, input: unknown) => {
   };
 };
 
-describe("every workflow is parseable and every step is executable", () => {
-  // A `run:` mis-indented one level lands inside the step's `env:` map. The
-  // step then has neither `run` nor `uses`, GitHub rejects the whole file at
-  // parse time, and no amount of string matching against the YAML notices.
+describe("every workflow file is well formed", () => {
+  // A `run:` indented one level too far lands inside the step's own `env:`
+  // map. The step then has neither `run` nor `uses`, GitHub rejects the whole
+  // file when it parses it, and no amount of string matching notices — which
+  // is exactly how an unrunnable publish workflow passed 21 green checks.
   const stepKeys = new Set([
     "run",
     "uses",
@@ -92,34 +97,25 @@ describe("every workflow is parseable and every step is executable", () => {
     "timeout-minutes",
   ]);
 
-  it.each(workflowNames)("%s", (name) => {
-    const doc = Bun.YAML.parse(read(name)) as {
-      jobs?: Record<string, { steps?: Record<string, unknown>[] }>;
-    };
-    for (const [jobId, definition] of Object.entries(doc?.jobs ?? {})) {
-      for (const [index, step] of (definition?.steps ?? []).entries()) {
-        if (!step || typeof step !== "object") continue;
-        const where = `${name} ${jobId} step[${index}] ${step.name ?? ""}`;
+  it.each(names)("%s parses and every step is executable", (file) => {
+    for (const [id, definition] of Object.entries(parse(file).jobs ?? {})) {
+      for (const [index, step] of (definition.steps ?? []).entries()) {
+        const where = `${file} ${id} step[${index}] ${step.name ?? ""}`;
         expect(
           step.run !== undefined || step.uses !== undefined,
           `${where} has neither run nor uses`
         ).toBe(true);
-        for (const key of Object.keys(
-          (step.env as Record<string, unknown>) ?? {}
-        )) {
-          expect(
-            stepKeys.has(key),
-            `${where} smuggles step key "${key}" into env`
-          ).toBe(false);
+        for (const key of Object.keys(step.env ?? {})) {
+          expect(stepKeys.has(key), `${where} put "${key}" in env`).toBe(false);
         }
       }
     }
   });
 
-  it("only invokes release-provenance subcommands that exist", () => {
-    const invoked = workflowNames.flatMap((name) =>
+  it("only invokes helper subcommands that exist", () => {
+    const invoked = names.flatMap((file) =>
       Array.from(
-        read(name).matchAll(/release-provenance\.mjs ([a-z-]+)/g),
+        read(file).matchAll(/release-provenance\.mjs ([a-z-]+)/g),
         (match) => match[1]
       )
     );
@@ -127,283 +123,267 @@ describe("every workflow is parseable and every step is executable", () => {
     for (const command of invoked) expect(COMMAND_NAMES).toContain(command);
   });
 
-  it("keeps the attestation policy out of inline jq", () => {
-    // The rules below used to be copy-pasted jq in two workflows apiece. jq
-    // embedded in YAML is unreachable from this suite, so it must not return.
-    for (const name of ["release-please.yml", "publish-packages.yml"]) {
-      const source = read(name);
-      expect(source).not.toContain("duplicate latest-attempt required job");
-      expect(source).not.toContain("map(.run_attempt // 1) | max");
-      expect(source).not.toContain("--input-type=module");
+  it("keeps the attestation policy out of inline jq and inline node", () => {
+    // These rules were copy-pasted jq in two workflows apiece. jq embedded in
+    // YAML is unreachable from this suite, so it must not come back.
+    for (const file of ["release-please.yml", "publish-packages.yml"]) {
+      expect(read(file)).not.toContain("duplicate latest-attempt required job");
+      expect(read(file)).not.toContain("map(.run_attempt // 1) | max");
+      expect(read(file)).not.toContain("--input-type=module");
     }
   });
 });
 
-describe("release provenance workflow structure", () => {
-  it("uses completed Build Images workflow runs and requires manual image_run_id", () => {
-    const release = uncommented(read("release-please.yml"));
-    expect(release).toContain("workflow_run:");
-    expect(release).toContain('workflows: ["Build and Push Images"]');
-    expect(release).toContain("types: [completed]");
-    expect(release).toContain("workflow_dispatch:");
-    expect(release).toMatch(/image_run_id:[\s\S]*required: true/);
-    expect(release).not.toContain("on:\n  push:");
-    expect(release).not.toContain("gh workflow run publish-packages.yml");
-    // `types: [completed]` also fires for failure and cancellation.
-    expect(release).toContain(
-      "github.event.workflow_run.conclusion == 'success'"
-    );
+describe("release-please only acts on a green main push", () => {
+  it("screens the producer's conclusion and its event", () => {
+    const trigger = parse("release-please.yml").on?.workflow_run as Record<
+      string,
+      unknown
+    >;
+    expect(trigger.workflows).toEqual(["Build and Push Images"]);
+    expect(trigger.branches).toEqual(["main"]);
+    // `branches: [main]` admits a manual Build Images dispatch just as
+    // readily as a push, and `types: [completed]` includes failures. Both
+    // would start the job only to hard-fail the API checks below.
+    const guard = job("release-please.yml", "attest").if ?? "";
+    expect(guard).toContain("conclusion == 'success'");
+    expect(guard).toContain("event == 'push'");
   });
 
-  it("attests exact main push metadata and paginates all jobs", () => {
-    const release = uncommented(read("release-please.yml"));
-    expect(release).toContain("filter=all");
-    expect(release).toContain("--paginate --slurp");
-    expect(release).toContain("head_repository.full_name");
-    expect(release).toContain("jq -r '.event' <<<\"$build_run\")");
-    expect(release).toContain('[ "$event" = push ] && [ "$branch" = main ]');
-    expect(release).toContain(
-      '[ "$status" = completed ] && [ "$conclusion" = success ]'
-    );
-    expect(release).toContain("release-provenance.mjs attest-jobs");
-    expect(release).toContain("release-provenance.mjs select-run");
-    for (const name of requiredJobs) expect(release).toContain(name);
-    expect(release).toContain("sleep 20");
-    expect(release).toContain("main moved while waiting for exact CI");
-  });
-
-  it("proves the producer before checking out any repository code", () => {
-    const attest = job(read("release-please.yml"), "attest");
+  it("proves the producer before checking out repository code", () => {
     expect(
-      attest.indexOf("Attest the producing Build Images run")
-    ).toBeLessThan(attest.indexOf("uses: actions/checkout"));
+      stepAt("release-please.yml", "attest", "Build Images run")
+    ).toBeLessThan(stepAt("release-please.yml", "attest", "actions/checkout"));
+    const checkout = steps("release-please.yml", "attest").find((step) =>
+      step.uses?.includes("actions/checkout")
+    );
     // Pinned, so the helper cannot come from a ref that moved mid-run.
-    expect(attest).toContain("ref: ${{ steps.producer.outputs.sha }}");
-    expect(attest).not.toContain("id-token: write");
-    expect(attest).not.toContain("NPM_TOKEN");
+    expect(checkout?.with?.ref).toBe("${{ steps.producer.outputs.sha }}");
+    expect(envOf("release-please.yml", "attest")).not.toContain("NPM_TOKEN");
+    expect(job("release-please.yml", "attest").permissions).toBeUndefined();
   });
 
-  it("keeps release creation privileged without a global evicting queue", () => {
-    const release = read("release-please.yml");
-    const write = job(release, "release-please-write");
-    expect(write).not.toContain("concurrency:");
-    expect(write).toContain("contents: write");
-    expect(write).toContain("pull-requests: write");
-    expect(write).toContain(
-      "Recheck current main immediately before release action"
-    );
-    expect(write).toContain("target-branch: main");
-    expect(write).toContain("skip-github-release: true");
-    // skip-github-release keeps release_created permanently false, and the
-    // step below re-verifies the binding by peeling the tag, so a
-    // release_created guard here would be dead and redundant at once.
-    expect(write).not.toContain("release_created");
-    expect(write).toContain("Publish only a real immutable manifest bump");
-    expect(write).toContain("release-provenance.mjs manifest-bump");
-    expect(write).toContain("release-provenance.mjs verify-release");
-    // make_latest is a string enum in the REST API; a boolean is dropped.
-    expect(write).toContain('make_latest: "true"');
-  });
-
-  it("does not turn a gh 404 body or a SIGPIPE into a failed release", () => {
-    const write = job(read("release-please.yml"), "release-please-write");
-    // `gh api` prints the 404 body on STDOUT, so `|| true` leaves a
-    // {"message":"Not Found"} document in the variable and the
-    // already-exists branch runs on every first release.
-    expect(write).not.toContain('releases/tags/${tag}" 2>/dev/null || true');
-    expect(write).toContain(
-      'if release=$(gh api "repos/${REPOSITORY}/releases/tags/${tag}"'
-    );
-    // CHANGELOG.md is ~475KB: `git show ... | head -c` exits 141 under
-    // pipefail and kills the release step before it creates anything.
-    expect(write).not.toContain("head -c");
-    expect(write).toContain("notes=${notes:0:12000}");
-    // A commit with no CHANGELOG.md costs the release body, not the release.
-    expect(write).toContain('CHANGELOG.md" || echo ""');
-  });
-
-  it("separates manual image builds and guards before any checkout", () => {
-    const images = uncommented(read("build-images.yml"));
-    expect(images).toContain(
-      "github.event_name == 'workflow_dispatch' && '-manual'"
-    );
-    const guard = job(images, "current-main-guard");
-    expect(guard).toContain("git/ref/heads/main");
-    expect(guard).toContain("refs/heads/main");
-    expect(guard).toContain("github.sha");
-    expect(images.indexOf("current-main-guard:")).toBeLessThan(
-      images.indexOf("uses: actions/checkout")
-    );
-    expect(images).toContain("release-provenance.mjs verify-release");
-    expect(images).toContain("BUILD_PLATFORMS");
-    expect(images).toContain("linux/arm64");
-    expect(images).toContain("latest");
-  });
-
-  it("dispatches package publication from main policy with exact inputs", () => {
-    const trigger = job(
-      uncommented(read("build-images.yml")),
-      "trigger-package-publish"
-    );
-    expect(trigger).toContain("--ref main");
-    expect(trigger).not.toContain('--ref "$RELEASE_TAG"');
-    expect(trigger).toContain('-f release_tag="$RELEASE_TAG"');
-    expect(trigger).toContain('-f image_run_id="$GITHUB_RUN_ID"');
-    expect(trigger).not.toContain("bump");
-  });
-
-  it("requires release and producer identifiers and removes fallback and bumps", () => {
-    const publish = uncommented(read("publish-packages.yml"));
-    expect(publish).toMatch(/release_tag:[\s\S]*required: true/);
-    expect(publish).toMatch(/image_run_id:[\s\S]*required: true/);
-    // `skip` was the only accepted value, so the input was dead surface.
-    expect(publish).not.toContain("BUMP");
-    expect(uncommented(read("build-images.yml"))).not.toContain("-f bump=skip");
-    expect(publish).not.toContain("workflow_runs[0]");
-    expect(publish).not.toContain('node scripts/publish-packages.mjs "$BUMP"');
-    expect(publish).toContain("--skip-bump");
-    expect(publish).toContain("ci_workflow_id");
-  });
-
-  it("fail-closes release attestation and allows only green producer jobs", () => {
-    const attest = job(
-      uncommented(read("publish-packages.yml")),
-      "attest-publish"
-    );
-    expect(attest).toContain("git/ref/tags");
-    expect(attest).toContain("git/tags");
-    expect(attest).toContain("compare/");
-    expect(attest).toContain("jq -r '.event' <<<\"$build_run\")");
-    expect(attest).toContain("release-provenance.mjs verify-release");
-    expect(attest).toContain("release-provenance.mjs attest-jobs");
-    expect(attest).toContain("release-provenance.mjs select-run");
-    expect(read("publish-packages.yml")).toContain("actions: read");
-    // The policy guard runs before the checkout that makes the helper
-    // available, so an off-main dispatch never executes repository code.
-    expect(
-      attest.indexOf("publish policy must run from current main")
-    ).toBeLessThan(attest.indexOf("uses: actions/checkout"));
-  });
-
-  it("does not fail the publish because main moved after dispatch", () => {
-    // The ref pin is the security property; requiring the dispatched SHA to
-    // still be main's HEAD adds none and strands a release off npm whenever
-    // anything merges between dispatch and this job starting -- the failure
-    // this workflow exists to prevent. The release is bound by its tag.
-    const attest = job(read("publish-packages.yml"), "attest-publish");
-    const guard = attest.slice(
-      attest.indexOf("Verify current-main workflow policy"),
-      attest.indexOf("Check out current main")
-    );
-    expect(guard).toContain('"$WORKFLOW_REF" = refs/heads/main');
-    expect(guard).not.toContain("git/ref/heads/main");
-    expect(guard).not.toContain("DISPATCH_SHA");
-    expect(guard).not.toContain("GH_TOKEN");
-  });
-
-  it("keeps credentials out of the read-only gate and checks out the attested SHA", () => {
-    const publish = read("publish-packages.yml");
-    const attest = job(publish, "attest-publish");
-    const privileged = job(publish, "publish-packages");
-    expect(attest).not.toContain("id-token: write");
-    expect(attest).not.toContain("NPM_TOKEN");
-    expect(privileged).toContain("id-token: write");
-    expect(privileged).toContain(
-      "ref: ${{ needs.attest-publish.outputs.tag_sha }}"
-    );
-    expect(privileged).toContain("scripts/publish-packages.mjs --skip-bump");
-    expect(privileged).toContain("NODE_AUTH_TOKEN");
-    expect(privileged).toContain("release-provenance.mjs assert-newer");
-    expect(runBodies(publish)).not.toContain("${{ inputs.");
-    expect(publish).toContain("published-artifact-smoke.yml");
-  });
-
-  it("does not accept comment-only evidence", () => {
-    const source = read("publish-packages.yml");
-    expect(uncommented(source)).not.toContain("newest exact-SHA");
-    expect(uncommented(source)).toContain(
-      "publish policy must run from current main"
-    );
+  it("delegates job and run selection to the tested helper", () => {
+    const body = shell("release-please.yml", "attest");
+    expect(body).toContain("release-provenance.mjs attest-jobs");
+    expect(body).toContain("release-provenance.mjs select-run");
+    expect(body).toContain("--paginate --slurp");
+    expect(body).toContain("filter=all");
+    for (const name of REQUIRED_IMAGE_JOBS) {
+      expect(read("release-please.yml")).toContain(name);
+    }
+    // The bounded wait must re-check that main has not moved under it.
+    expect(body).toContain("main moved while waiting for exact CI");
   });
 });
 
-describe("the helper CLI the workflows actually invoke", () => {
-  const green = {
+describe("the release is created bound to the attested commit", () => {
+  const id = "release-please-write";
+  const body = () => shell("release-please.yml", id);
+
+  it("holds the write permissions without a global evicting queue", () => {
+    expect(job("release-please.yml", id).permissions).toEqual({
+      contents: "write",
+      "pull-requests": "write",
+    });
+    expect(read("release-please.yml")).not.toContain("concurrency:");
+    expect(body()).toContain("main advanced after attestation");
+  });
+
+  it("lets release-please open the PR and creates the release itself", () => {
+    const action = steps("release-please.yml", id).find((step) =>
+      step.uses?.includes("release-please-action")
+    );
+    expect(action?.with?.["skip-github-release"]).toBe(true);
+    expect(action?.with?.["target-branch"]).toBe("main");
+    // skip-github-release keeps release_created permanently false, and the
+    // release step re-verifies the binding by peeling the tag, so a
+    // release_created guard would be dead and redundant at once.
+    expect(read("release-please.yml")).not.toContain("release_created");
+    expect(body()).toContain("release-provenance.mjs manifest-bump");
+    expect(body()).toContain("release-provenance.mjs verify-release");
+    expect(body()).toContain("release-provenance.mjs assert-newer");
+    // make_latest is a string enum in the REST API; a boolean is dropped.
+    expect(body()).toContain('make_latest: "true"');
+  });
+
+  it("does not let a 404 body or a large changelog fail the release", () => {
+    // `gh api` prints the 404 body on STDOUT, so `|| true` left
+    // {"message":"Not Found"} in the variable and the already-exists branch
+    // ran on the first release of every version. Branch on exit status.
+    expect(body()).not.toContain('releases/tags/${tag}" 2>/dev/null || true');
+    expect(body()).toContain("if release=$(gh api");
+    // CHANGELOG.md is ~475KB: `git show … | head -c` exits 141 under pipefail
+    // and kills the step before it creates anything.
+    expect(body()).not.toContain("head -c");
+    expect(body()).toContain("notes=${notes:0:12000}");
+    expect(body()).toContain('CHANGELOG.md" || echo ""');
+  });
+});
+
+describe("image builds refuse an off-main manual dispatch", () => {
+  it("guards before any checkout and gates every build behind it", () => {
+    const guard = job("build-images.yml", "current-main-guard");
+    expect(guard.steps?.some((step) => step.uses?.includes("checkout"))).toBe(
+      false
+    );
+    expect(job("build-images.yml", "generate-tag").needs).toContain(
+      "current-main-guard"
+    );
+    expect(shell("build-images.yml", "current-main-guard")).toContain(
+      "git/ref/heads/main"
+    );
+    expect(read("build-images.yml")).toContain(
+      "github.event_name == 'workflow_dispatch' && '-manual'"
+    );
+  });
+
+  it("verifies a release binds to this commit through the helper", () => {
+    expect(shell("build-images.yml", "generate-tag")).toContain(
+      "release-provenance.mjs verify-release"
+    );
+  });
+
+  it("dispatches publication from main policy with exact inputs", () => {
+    const dispatch = shell("build-images.yml", "trigger-package-publish");
+    expect(dispatch).toContain("--ref main");
+    expect(dispatch).not.toContain('--ref "$RELEASE_TAG"');
+    expect(dispatch).toContain('-f release_tag="$RELEASE_TAG"');
+    expect(dispatch).toContain('-f image_run_id="$GITHUB_RUN_ID"');
+    // `skip` was the only accepted value, so the input was dead surface.
+    expect(dispatch).not.toContain("bump");
+  });
+});
+
+describe("publishing requires an attested release", () => {
+  it("requires both producer identifiers and forbids a hosted bump", () => {
+    const inputs = (
+      parse("publish-packages.yml").on?.workflow_dispatch as {
+        inputs: Record<string, { required?: boolean }>;
+      }
+    ).inputs;
+    expect(inputs.release_tag.required).toBe(true);
+    expect(inputs.image_run_id.required).toBe(true);
+    expect(Object.keys(inputs)).not.toContain("bump");
+  });
+
+  it("keeps publish credentials out of the read-only gate", () => {
+    expect(
+      job("publish-packages.yml", "attest-publish").permissions
+    ).toBeUndefined();
+    expect(envOf("publish-packages.yml", "attest-publish")).not.toContain(
+      "NPM_TOKEN"
+    );
+    expect(
+      job("publish-packages.yml", "publish-packages").permissions
+    ).toMatchObject({ "id-token": "write" });
+    const checkout = steps("publish-packages.yml", "publish-packages")[0];
+    expect(checkout.with?.ref).toBe(
+      "${{ needs.attest-publish.outputs.tag_sha }}"
+    );
+    // A dispatch input reaching a shell through `${{ }}` in a job that holds
+    // the production NPM token is credential injection, not a broken script.
+    for (const definition of Object.values(
+      parse("publish-packages.yml").jobs ?? {}
+    )) {
+      for (const step of definition.steps ?? []) {
+        expect(step.run ?? "").not.toContain("${{ inputs.");
+      }
+    }
+  });
+
+  it("does not fail the publish because main moved after dispatch", () => {
+    // The ref pin is the security property: a dispatch resolves
+    // refs/heads/main to a tip nobody can forge. Also requiring that tip to
+    // still be HEAD adds none, and strands a release off npm whenever
+    // anything merges between dispatch and this job starting — the failure
+    // this workflow exists to prevent. The release is bound by its tag.
+    const guard = steps("publish-packages.yml", "attest-publish")[0];
+    expect(guard.run).toContain('"$WORKFLOW_REF" = refs/heads/main');
+    expect(guard.run).not.toContain("git/ref/heads/main");
+    expect(guard.env).not.toHaveProperty("GH_TOKEN");
+    expect(
+      stepAt("publish-packages.yml", "attest-publish", "policy")
+    ).toBeLessThan(
+      stepAt("publish-packages.yml", "attest-publish", "actions/checkout")
+    );
+  });
+
+  it("treats an unreadable registry as unknown, not as empty", () => {
+    // `npm view --json` prints its error object to STDOUT, so `|| echo '[]'`
+    // emitted two JSON values and the version gate could not run at all.
+    const body = shell("publish-packages.yml", "publish-packages");
+    expect(body).not.toContain("--json 2>/dev/null || echo");
+    expect(body).toContain("could not read published @lobu/cli versions");
+    expect(body).toContain("release-provenance.mjs assert-newer");
+  });
+});
+
+describe("the helper CLI the workflows invoke", () => {
+  const required = ["generate-tag", "app-image-smoke"];
+  const page = (conclusion: string, attempt = 1) => ({
     pages: [
       {
         jobs: [
           {
             name: "generate-tag",
-            run_attempt: 1,
             status: "completed",
             conclusion: "success",
+            run_attempt: 1,
           },
           {
             name: "app-image-smoke",
-            run_attempt: 1,
             status: "completed",
-            conclusion: "failure",
-          },
-          {
-            name: "app-image-smoke",
-            run_attempt: 2,
-            status: "completed",
-            conclusion: "success",
+            conclusion,
+            run_attempt: attempt,
           },
         ],
       },
     ],
-    required: ["generate-tag", "app-image-smoke"],
-  };
+    required,
+  });
 
-  it("exits zero on a green producer and takes the newest attempt", () => {
-    const ok = helper("attest-jobs", green);
+  it("exits zero on a green producer, preferring the newest attempt", () => {
+    const green = page("success", 2);
+    green.pages[0].jobs.push({
+      name: "app-image-smoke",
+      status: "completed",
+      conclusion: "failure",
+      run_attempt: 1,
+    });
+    const ok = cli("attest-jobs", green);
     expect(ok.code).toBe(0);
     expect(JSON.parse(ok.stdout)).toEqual({ ok: true, required: 2 });
   });
 
   it.each([
-    ["failure", "not completed-success"],
-    ["skipped", "not completed-success"],
-    ["cancelled", "not completed-success"],
-  ])("exits non-zero when a required job is %s", (conclusion, message) => {
-    const red = helper("attest-jobs", {
-      pages: [
-        {
-          jobs: [
-            {
-              name: "generate-tag",
-              status: "completed",
-              conclusion: "success",
-            },
-            { name: "app-image-smoke", status: "completed", conclusion },
-          ],
-        },
-      ],
-      required: green.required,
-    });
+    "failure",
+    "skipped",
+    "cancelled",
+  ])("exits non-zero when a required job is %s", (conclusion) => {
+    const red = cli("attest-jobs", page(conclusion));
     expect(red.code).not.toBe(0);
-    expect(red.stderr).toContain(message);
+    expect(red.stderr).toContain("not completed-success");
   });
 
-  it("exits non-zero on an unknown subcommand rather than passing silently", () => {
-    const unknown = helper("attest-everything", {});
+  it("exits non-zero on an unknown subcommand rather than passing", () => {
+    const unknown = cli("attest-everything", {});
     expect(unknown.code).toBe(2);
     expect(unknown.stderr).toContain("unknown command");
   });
 
   it("round-trips each subcommand's shape over stdin", () => {
     expect(
-      JSON.parse(helper("release-tag", { version: "17.4.0" }).stdout)
+      JSON.parse(cli("release-tag", { version: "17.4.0" }).stdout)
     ).toEqual({ tag: "lobu-v17.4.0" });
     expect(
       JSON.parse(
-        helper("manifest-bump", { current: "17.4.0", parent: "17.3.0" }).stdout
+        cli("manifest-bump", { current: "17.4.0", parent: "17.3.0" }).stdout
       )
     ).toEqual({ bumped: true, version: "17.4.0" });
     expect(
       JSON.parse(
-        helper("select-run", {
+        cli("select-run", {
           runs: [
             { id: 1, head_sha: "a", run_attempt: 1 },
             { id: 9, head_sha: "a", run_attempt: 3 },
@@ -413,48 +393,41 @@ describe("the helper CLI the workflows actually invoke", () => {
       )
     ).toEqual({ id: "9" });
     expect(
-      helper("assert-newer", { current: "17.3.0", versions: ["17.4.0"] }).code
+      cli("assert-newer", { current: "17.3.0", versions: ["17.4.0"] }).code
     ).not.toBe(0);
   });
 });
 
-describe("release provenance helpers execute the attestation policy", () => {
-  const required = ["generate-tag", "build-worker"];
-  const greenPages = [
-    {
-      jobs: [
-        {
-          name: "generate-tag",
-          run_attempt: 1,
-          status: "completed",
-          conclusion: "success",
-        },
-        {
-          name: "build-worker",
-          run_attempt: 1,
-          status: "completed",
-          conclusion: "success",
-        },
-      ],
-    },
-    {
-      jobs: [
-        {
-          name: "build-worker",
-          run_attempt: 2,
-          status: "completed",
-          conclusion: "success",
-        },
-      ],
-    },
-  ];
-
-  it("flattens multi-page jobs and selects exactly the latest attempt", () => {
+describe("the attestation policy itself", () => {
+  it("flattens paginated jobs and selects exactly the latest attempt", () => {
+    const pages = [
+      {
+        jobs: [
+          {
+            name: "generate-tag",
+            run_attempt: 1,
+            status: "completed",
+            conclusion: "success",
+          },
+        ],
+      },
+      {
+        jobs: [
+          {
+            name: "build-worker",
+            run_attempt: 2,
+            status: "completed",
+            conclusion: "success",
+          },
+        ],
+      },
+    ];
     expect(
-      selectLatestRequiredJobs(greenPages, required).map(
-        (job) => job.run_attempt
+      selectLatestRequiredJobs(pages, ["generate-tag", "build-worker"]).map(
+        (found) => found.run_attempt
       )
     ).toEqual([1, 2]);
+    // Two rows at the same attempt is ambiguous evidence, not a tie to break.
     expect(() =>
       selectLatestRequiredJobs(
         [
@@ -468,36 +441,16 @@ describe("release provenance helpers execute the attestation policy", () => {
         ["generate-tag"]
       )
     ).toThrow("duplicate latest-attempt");
-    expect(() =>
-      selectLatestRequiredJobs(
-        [
-          {
-            jobs: [
-              {
-                name: "generate-tag",
-                status: "completed",
-                conclusion: "skipped",
-              },
-            ],
-          },
-        ],
-        ["generate-tag"]
-      )
-    ).toThrow("completed-success");
-    expect(() => selectLatestRequiredJobs(greenPages, [])).toThrow(
+    expect(() => selectLatestRequiredJobs(pages, ["absent"])).toThrow(
+      "missing required job"
+    );
+    expect(() => selectLatestRequiredJobs(pages, [])).toThrow(
       "no required job names"
     );
   });
 
-  it("rejects ambiguous, skipped, failed, and missing selected CI runs", () => {
-    const expected = {
-      workflow_id: 7,
-      event: "push",
-      head_branch: "main",
-      head_sha: "a",
-      status: "completed",
-      conclusion: "success",
-    };
+  it("rejects ambiguous and missing CI runs", () => {
+    const expected = { head_sha: "a", conclusion: "success" };
     expect(
       selectUniqueLatestRun([{ ...expected, id: 1, run_attempt: 1 }], expected)
         .id
@@ -523,17 +476,14 @@ describe("release provenance helpers execute the attestation policy", () => {
       bumped: false,
       version: "17.2.0",
     });
-    expect(compareVersions("17.10.0", "17.9.0")).toBe(1);
-    expect(releaseTagForVersion("17.3.0")).toBe("lobu-v17.3.0");
     expect(() => manifestBump({ current: "17.1.0", parent: "17.2.0" })).toThrow(
       "not newer"
     );
+    expect(compareVersions("17.10.0", "17.9.0")).toBe(1);
+    expect(releaseTagForVersion("17.3.0")).toBe("lobu-v17.3.0");
     expect(() =>
       assertNoNewerStable({ current: "17.3.0", versions: ["17.4.0"] })
     ).toThrow("newer stable version");
-    expect(
-      assertNoNewerStable({ current: "17.3.0", versions: ["17.3.0", "16.1.0"] })
-    ).toMatchObject({ ok: true, compared: 2 });
     // A prerelease string is not a stable version and must not veto a release.
     expect(
       assertNoNewerStable({
@@ -541,27 +491,32 @@ describe("release provenance helpers execute the attestation policy", () => {
         versions: ["17.9.0-beta.1", "17.2.0"],
       })
     ).toMatchObject({ ok: true, compared: 1 });
+    // An `npm view --json` error object must not read as "nothing published".
+    expect(() =>
+      assertNoNewerStable({
+        current: "17.3.0",
+        versions: [{ error: { code: "E404" } }],
+      })
+    ).toThrow("non-version");
   });
 
   it("peels an annotated tag instead of trusting the ref's own sha", () => {
     const commit = "a".repeat(40);
-    const tagObjectSha = "c".repeat(40);
     expect(
       peelTag({ tagRef: { object: { type: "commit", sha: commit } } })
     ).toBe(commit);
     expect(
       peelTag({
-        tagRef: { object: { type: "tag", sha: tagObjectSha } },
+        tagRef: { object: { type: "tag", sha: "c".repeat(40) } },
         tagObject: { object: { sha: commit } },
       })
     ).toBe(commit);
-    // Without the peeled object an annotated tag has no commit to bind to.
     expect(() =>
-      peelTag({ tagRef: { object: { type: "tag", sha: tagObjectSha } } })
+      peelTag({ tagRef: { object: { type: "tag", sha: "c".repeat(40) } } })
     ).toThrow("could not peel");
   });
 
-  it("binds stable release versions and immutable partial recovery", () => {
+  it("binds a stable release to the commit its tag peels to", () => {
     const sha = "a".repeat(40);
     const stable = {
       release: {
@@ -574,39 +529,27 @@ describe("release provenance helpers execute the attestation policy", () => {
       expectedTag: "lobu-v17.3.0",
       expectedSha: sha,
     };
-    expect(verifyImmutableRelease(stable)).toEqual({
-      sha,
-      version: "17.3.0",
-    });
-    expect(() =>
-      verifyImmutableRelease({ ...stable, expectedSha: "b".repeat(40) })
-    ).toThrow("attested commit");
-    expect(() =>
-      verifyImmutableRelease({
-        ...stable,
-        release: { ...stable.release, draft: true },
-      })
-    ).toThrow("draft");
-    expect(() =>
-      verifyImmutableRelease({
-        ...stable,
-        release: { ...stable.release, prerelease: true },
-      })
-    ).toThrow("prerelease");
-    expect(() =>
-      verifyImmutableRelease({ ...stable, expectedTag: "lobu-v17.4.0" })
-    ).toThrow("tag/name mismatch");
-    // An annotated tag re-pointed away from the release's own target.
-    expect(() =>
-      verifyImmutableRelease({
-        ...stable,
-        tagRef: { object: { type: "tag", sha: "c".repeat(40) } },
-        tagObject: { object: { sha: "d".repeat(40) } },
-      })
-    ).toThrow("attested commit");
-    // GitHub records a branch name when a release is cut from a branch, and
-    // ignores target_commitish entirely once the tag exists. Only a SHA in
-    // that field carries a binding, so only a SHA is enforced.
+    expect(verifyImmutableRelease(stable)).toEqual({ sha, version: "17.3.0" });
+    for (const [patch, message] of [
+      [{ expectedSha: "b".repeat(40) }, "attested commit"],
+      [{ expectedTag: "lobu-v17.4.0" }, "tag/name mismatch"],
+      [{ release: { ...stable.release, draft: true } }, "draft"],
+      [{ release: { ...stable.release, prerelease: true } }, "prerelease"],
+      [
+        {
+          tagRef: { object: { type: "tag", sha: "c".repeat(40) } },
+          tagObject: { object: { sha: "d".repeat(40) } },
+        },
+        "attested commit",
+      ],
+    ] as const) {
+      expect(() => verifyImmutableRelease({ ...stable, ...patch })).toThrow(
+        message
+      );
+    }
+    // GitHub records a branch name when a release is cut from a branch and
+    // ignores target_commitish once the tag exists, so only a SHA there
+    // carries a binding — and a SHA that disagrees is a real mismatch.
     expect(
       verifyImmutableRelease({
         ...stable,

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -303,8 +303,14 @@ describe("image builds refuse an off-main manual dispatch", () => {
     const verify = steps("build-images.yml", "generate-tag").find((step) =>
       step.uses?.includes("verify-release")
     );
-    expect(verify?.if).toBe("github.event_name == 'release'");
     expect(verify?.with?.["expected-sha"]).toBe("${{ github.sha }}");
+    expect(verify?.if).toContain("github.event_name == 'release'");
+    // Another component's release shares this event feed, and
+    // derive-image-tags returns should_publish=false for it rather than
+    // failing. Verifying first would throw before that skip is reached.
+    expect(verify?.if).toContain(
+      "startsWith(github.event.release.tag_name, 'lobu-v')"
+    );
   });
 
   it("dispatches publication from main policy with exact inputs", () => {

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -7,6 +7,7 @@ import {
   compareVersions,
   manifestBump,
   peelTag,
+  releaseNotesFor,
   releaseTagForVersion,
   selectLatestRequiredJobs,
   selectUniqueLatestRun,
@@ -207,6 +208,25 @@ describe("the release is created bound to the attested commit", () => {
     expect(body()).toContain('make_latest: "true"');
   });
 
+  it("posts this version's changelog entry, not the head of the file", () => {
+    // CHANGELOG.md is ~475KB and newest-first, so a plain truncation puts
+    // several past releases into every release body.
+    expect(body()).toContain("release-provenance.mjs release-notes");
+    const changelog = readFileSync(`${root}/CHANGELOG.md`, "utf8");
+    const headings = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\]/gm)];
+    expect(headings.length).toBeGreaterThan(1);
+    const [current, previous] = headings.map((match) => match[1]);
+    const extracted = releaseNotesFor({ changelog, version: current });
+    expect(extracted.found).toBe(true);
+    expect(extracted.notes).not.toContain(`[${previous}]`);
+    expect(extracted.notes.length).toBeLessThan(changelog.length);
+    // A version with no entry still has to produce a release.
+    expect(releaseNotesFor({ changelog, version: "99.0.0" })).toMatchObject({
+      found: false,
+      notes: "",
+    });
+  });
+
   it("does not let a 404 body or a large changelog fail the release", () => {
     // `gh api` prints the 404 body on STDOUT, so `|| true` left
     // {"message":"Not Found"} in the variable and the already-exists branch
@@ -216,7 +236,7 @@ describe("the release is created bound to the attested commit", () => {
     // CHANGELOG.md is ~475KB: `git show … | head -c` exits 141 under pipefail
     // and kills the step before it creates anything.
     expect(body()).not.toContain("head -c");
-    expect(body()).toContain("notes=${notes:0:12000}");
+    expect(body()).toContain("notes=${notes:0:60000}");
     expect(body()).toContain('CHANGELOG.md" || echo ""');
   });
 });

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -195,6 +195,27 @@ export function verifyImmutableRelease({
   return { sha, version: versionForReleaseTag(expectedTag) };
 }
 
+/**
+ * The release body is this version's changelog entry, not the head of the
+ * whole file. release-please writes one `## [<version>](...)` section per
+ * release, newest first, so the entry runs to the next `## ` heading.
+ */
+export function releaseNotesFor({ changelog, version }) {
+  parseStableVersion(version);
+  const lines = String(changelog ?? "").split("\n");
+  const isHeading = (line) => /^## /.test(line);
+  const start = lines.findIndex(
+    (line) => isHeading(line) && line.includes(`[${version}]`)
+  );
+  // A missing entry is not fatal: the release still has to be created, and an
+  // empty body costs a reader one click to the changelog.
+  if (start < 0) return { version, notes: "", found: false };
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex(isHeading);
+  const notes = (end < 0 ? rest : rest.slice(0, end)).join("\n").trim();
+  return { version, notes, found: true };
+}
+
 /** Subcommands the workflows pipe JSON into. Every one is covered by
  * scripts/__tests__/release-publish-order.test.ts, which also asserts that no
  * workflow invokes a name that is missing from this table. */
@@ -210,6 +231,7 @@ const COMMANDS = {
   "manifest-bump": (input) => manifestBump(input),
   "release-tag": (input) => ({ tag: releaseTagForVersion(input.version) }),
   "verify-release": (input) => verifyImmutableRelease(input),
+  "release-notes": (input) => releaseNotesFor(input),
 };
 
 export const COMMAND_NAMES = Object.keys(COMMANDS);

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+const STABLE_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const LOBU_TAG_PREFIX = "lobu-v";
+
+export function parseStableVersion(version) {
+  if (!STABLE_SEMVER.test(version)) {
+    throw new Error(`invalid stable Lobu version: ${version}`);
+  }
+  return version.split(".").map(Number);
+}
+
+export function compareVersions(left, right) {
+  const a = parseStableVersion(left);
+  const b = parseStableVersion(right);
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return a[index] > b[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+export function releaseTagForVersion(version) {
+  parseStableVersion(version);
+  return `${LOBU_TAG_PREFIX}${version}`;
+}
+
+export function manifestBump({ current, parent }) {
+  parseStableVersion(current);
+  parseStableVersion(parent);
+  if (current === parent) return { bumped: false, version: current };
+  if (compareVersions(current, parent) <= 0) {
+    throw new Error(`release version ${current} is not newer than ${parent}`);
+  }
+  return { bumped: true, version: current };
+}
+
+function flattenJobs(pages) {
+  if (!Array.isArray(pages)) throw new Error("jobs response must be paginated");
+  return pages.flatMap((page) => {
+    if (!page || !Array.isArray(page.jobs)) {
+      throw new Error("jobs page has no jobs array");
+    }
+    return page.jobs;
+  });
+}
+
+export function selectLatestRequiredJobs(pages, requiredNames) {
+  const jobs = flattenJobs(pages);
+  return requiredNames.map((name) => {
+    const matches = jobs.filter((job) => job.name === name);
+    if (matches.length === 0) throw new Error(`missing required job: ${name}`);
+    const latestAttempt = Math.max(
+      ...matches.map((job) => job.run_attempt ?? 1)
+    );
+    const latest = matches.filter(
+      (job) => (job.run_attempt ?? 1) === latestAttempt
+    );
+    if (latest.length !== 1) {
+      throw new Error(`duplicate latest-attempt required job: ${name}`);
+    }
+    const job = latest[0];
+    if (job.status !== "completed" || job.conclusion !== "success") {
+      throw new Error(`required job is not completed-success: ${name}`);
+    }
+    return job;
+  });
+}
+
+export function selectUniqueLatestRun(runs, expected) {
+  const candidates = runs.filter((run) =>
+    Object.entries(expected).every(([key, value]) => run[key] === value)
+  );
+  if (candidates.length === 0) throw new Error("no matching successful run");
+  const latestAttempt = Math.max(
+    ...candidates.map((run) => run.run_attempt ?? 1)
+  );
+  const latest = candidates.filter(
+    (run) => (run.run_attempt ?? 1) === latestAttempt
+  );
+  if (latest.length !== 1) throw new Error("ambiguous latest run attempt");
+  return latest[0];
+}
+
+export function verifyImmutableRelease({
+  tag,
+  release,
+  expectedTag,
+  expectedSha,
+}) {
+  if (tag.name !== expectedTag || release.tag_name !== expectedTag) {
+    throw new Error("release tag/name mismatch");
+  }
+  if (tag.sha !== expectedSha || release.target_commitish !== expectedSha) {
+    throw new Error("release does not target attested commit");
+  }
+  if (release.prerelease || release.make_latest === false) {
+    throw new Error(
+      "stable release cannot be prerelease or excluded from latest"
+    );
+  }
+  return true;
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  const input = JSON.parse(
+    await new Promise((resolve, reject) => {
+      let data = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => (data += chunk));
+      process.stdin.on("end", () => resolve(data));
+      process.stdin.on("error", reject);
+    })
+  );
+  const output =
+    input.command === "tag"
+      ? { tag: releaseTagForVersion(input.version) }
+      : input.command === "bump"
+        ? manifestBump({ current: input.current, parent: input.parent })
+        : selectLatestRequiredJobs(input.pages, input.required);
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -64,9 +64,18 @@ export function manifestBump({ current, parent }) {
  */
 export function assertNoNewerStable({ current, versions }) {
   parseStableVersion(current);
-  const stable = (Array.isArray(versions) ? versions : [versions]).filter(
-    (value) => typeof value === "string" && STABLE_SEMVER.test(value)
-  );
+  const listed = Array.isArray(versions) ? versions : [versions];
+  // Fail closed on a shape we do not understand. `npm view --json` prints its
+  // error object to stdout, so a failed probe can reach here looking like data;
+  // silently filtering it out would turn "the registry is unreadable" into
+  // "nothing newer is published", which is exactly backwards for a gate.
+  const unexpected = listed.filter((value) => typeof value !== "string");
+  if (unexpected.length > 0) {
+    throw new Error(
+      `version list holds ${unexpected.length} non-version entr${unexpected.length === 1 ? "y" : "ies"}`
+    );
+  }
+  const stable = listed.filter((value) => STABLE_SEMVER.test(value));
   const newer = stable.filter((value) => compareVersions(value, current) > 0);
   if (newer.length > 0) {
     throw new Error(

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
 
+// The release gate's policy lives here, not in the workflow YAML.
+//
+// Every rule below used to be an inline jq program duplicated across
+// release-please.yml, publish-packages.yml and build-images.yml. Embedded jq
+// is unreachable from the test suite, so the copies drifted and the tests only
+// ever covered a parallel JS transcription of them. Workflows now pipe JSON
+// into the subcommands at the bottom of this file, which makes
+// scripts/__tests__/release-publish-order.test.ts a test of the code that
+// actually decides whether a release ships.
+
 const STABLE_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const LOBU_TAG_PREFIX = "lobu-v";
+const SHA1 = /^[0-9a-f]{40}$/;
 
 export function parseStableVersion(version) {
-  if (!STABLE_SEMVER.test(version)) {
+  if (typeof version !== "string" || !STABLE_SEMVER.test(version)) {
     throw new Error(`invalid stable Lobu version: ${version}`);
   }
   return version.split(".").map(Number);
@@ -24,6 +35,15 @@ export function releaseTagForVersion(version) {
   return `${LOBU_TAG_PREFIX}${version}`;
 }
 
+export function versionForReleaseTag(tag) {
+  if (typeof tag !== "string" || !tag.startsWith(LOBU_TAG_PREFIX)) {
+    throw new Error(`not a Lobu release tag: ${tag}`);
+  }
+  const version = tag.slice(LOBU_TAG_PREFIX.length);
+  parseStableVersion(version);
+  return version;
+}
+
 export function manifestBump({ current, parent }) {
   parseStableVersion(current);
   parseStableVersion(parent);
@@ -32,6 +52,25 @@ export function manifestBump({ current, parent }) {
     throw new Error(`release version ${current} is not newer than ${parent}`);
   }
   return { bumped: true, version: current };
+}
+
+/**
+ * A release may only move versions forward. Both callers -- the GitHub release
+ * list and `npm view @lobu/cli versions` -- reduce to the same question, so
+ * they ask it here instead of each spelling out its own comparison.
+ */
+export function assertNoNewerStable({ current, versions }) {
+  parseStableVersion(current);
+  const stable = (Array.isArray(versions) ? versions : [versions]).filter(
+    (value) => typeof value === "string" && STABLE_SEMVER.test(value)
+  );
+  const newer = stable.filter((value) => compareVersions(value, current) > 0);
+  if (newer.length > 0) {
+    throw new Error(
+      `a newer stable version than ${current} already exists: ${newer.join(", ")}`
+    );
+  }
+  return { ok: true, current, compared: stable.length };
 }
 
 function flattenJobs(pages) {
@@ -44,7 +83,15 @@ function flattenJobs(pages) {
   });
 }
 
+/**
+ * Pick each required job's newest attempt and insist it is completed-success.
+ * A re-run that leaves two rows with the same attempt number is ambiguous
+ * evidence, so it fails closed rather than picking one.
+ */
 export function selectLatestRequiredJobs(pages, requiredNames) {
+  if (!Array.isArray(requiredNames) || requiredNames.length === 0) {
+    throw new Error("no required job names given");
+  }
   const jobs = flattenJobs(pages);
   return requiredNames.map((name) => {
     const matches = jobs.filter((job) => job.name === name);
@@ -67,6 +114,7 @@ export function selectLatestRequiredJobs(pages, requiredNames) {
 }
 
 export function selectUniqueLatestRun(runs, expected) {
+  if (!Array.isArray(runs)) throw new Error("runs must be an array");
   const candidates = runs.filter((run) =>
     Object.entries(expected).every(([key, value]) => run[key] === value)
   );
@@ -81,41 +129,91 @@ export function selectUniqueLatestRun(runs, expected) {
   return latest[0];
 }
 
+/**
+ * Resolve what a release tag actually points at. An annotated tag's ref names
+ * the tag object, not the commit, so a caller that compares `ref.object.sha`
+ * to a commit SHA silently accepts a tag that was re-pointed. `tagObject` is
+ * the peeled `git/tags/<sha>` response, required only for annotated tags.
+ */
+export function peelTag({ tagRef, tagObject }) {
+  const type = tagRef?.object?.type;
+  const sha = tagRef?.object?.sha;
+  if (type !== "commit" && type !== "tag") {
+    throw new Error(`unexpected tag ref object type: ${type}`);
+  }
+  const peeled = type === "tag" ? tagObject?.object?.sha : sha;
+  if (typeof peeled !== "string" || !SHA1.test(peeled)) {
+    throw new Error("could not peel release tag to a commit");
+  }
+  return peeled;
+}
+
+/**
+ * The one binding check shared by release creation, image builds and package
+ * publication: this tag, this release and this commit are the same artifact,
+ * and it is a published stable release.
+ */
 export function verifyImmutableRelease({
-  tag,
   release,
+  tagRef,
+  tagObject,
   expectedTag,
   expectedSha,
 }) {
-  if (tag.name !== expectedTag || release.tag_name !== expectedTag) {
+  if (release?.tag_name !== expectedTag) {
     throw new Error("release tag/name mismatch");
   }
-  if (tag.sha !== expectedSha || release.target_commitish !== expectedSha) {
-    throw new Error("release does not target attested commit");
-  }
-  if (release.prerelease || release.make_latest === false) {
+  if (release.draft === true) throw new Error("release is a draft");
+  if (release.prerelease === true || release.make_latest === false) {
     throw new Error(
       "stable release cannot be prerelease or excluded from latest"
     );
   }
-  return true;
+  versionForReleaseTag(expectedTag);
+  const sha = peelTag({ tagRef, tagObject });
+  if (expectedSha !== undefined && sha !== expectedSha) {
+    throw new Error("release does not target attested commit");
+  }
+  if (release.target_commitish !== sha) {
+    throw new Error("release target does not match peeled tag");
+  }
+  return { sha, version: versionForReleaseTag(expectedTag) };
 }
 
+/** Subcommands the workflows pipe JSON into. Every one is covered by
+ * scripts/__tests__/release-publish-order.test.ts, which also asserts that no
+ * workflow invokes a name that is missing from this table. */
+const COMMANDS = {
+  "attest-jobs": (input) => {
+    selectLatestRequiredJobs(input.pages, input.required);
+    return { ok: true, required: input.required.length };
+  },
+  "select-run": (input) => ({
+    id: String(selectUniqueLatestRun(input.runs, input.expected).id),
+  }),
+  "assert-newer": (input) => assertNoNewerStable(input),
+  "manifest-bump": (input) => manifestBump(input),
+  "release-tag": (input) => ({ tag: releaseTagForVersion(input.version) }),
+  "verify-release": (input) => verifyImmutableRelease(input),
+};
+
+export const COMMAND_NAMES = Object.keys(COMMANDS);
+
 if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
-  const input = JSON.parse(
-    await new Promise((resolve, reject) => {
-      let data = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => (data += chunk));
-      process.stdin.on("end", () => resolve(data));
-      process.stdin.on("error", reject);
-    })
-  );
-  const output =
-    input.command === "tag"
-      ? { tag: releaseTagForVersion(input.version) }
-      : input.command === "bump"
-        ? manifestBump({ current: input.current, parent: input.parent })
-        : selectLatestRequiredJobs(input.pages, input.required);
-  process.stdout.write(`${JSON.stringify(output)}\n`);
+  const command = process.argv[2];
+  const run = COMMANDS[command];
+  if (!run) {
+    process.stderr.write(
+      `unknown command: ${command}\nexpected one of: ${Object.keys(COMMANDS).join(", ")}\n`
+    );
+    process.exit(2);
+  }
+  const raw = await new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+  process.stdout.write(`${JSON.stringify(run(JSON.parse(raw)))}\n`);
 }

--- a/scripts/release-provenance.mjs
+++ b/scripts/release-provenance.mjs
@@ -10,6 +10,9 @@
 // scripts/__tests__/release-publish-order.test.ts a test of the code that
 // actually decides whether a release ships.
 
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 const STABLE_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const LOBU_TAG_PREFIX = "lobu-v";
 const SHA1 = /^[0-9a-f]{40}$/;
@@ -164,17 +167,20 @@ export function verifyImmutableRelease({
     throw new Error("release tag/name mismatch");
   }
   if (release.draft === true) throw new Error("release is a draft");
-  if (release.prerelease === true || release.make_latest === false) {
-    throw new Error(
-      "stable release cannot be prerelease or excluded from latest"
-    );
-  }
+  if (release.prerelease === true) throw new Error("release is a prerelease");
   versionForReleaseTag(expectedTag);
   const sha = peelTag({ tagRef, tagObject });
   if (expectedSha !== undefined && sha !== expectedSha) {
     throw new Error("release does not target attested commit");
   }
-  if (release.target_commitish !== sha) {
+  // `target_commitish` is only a creation hint. GitHub stores a branch name
+  // when a release is cut from a branch and ignores the field entirely when
+  // the tag already exists, so it binds the release to a commit only when it
+  // is itself a commit SHA. The peeled tag above is the authoritative binding.
+  if (
+    SHA1.test(release.target_commitish ?? "") &&
+    release.target_commitish !== sha
+  ) {
     throw new Error("release target does not match peeled tag");
   }
   return { sha, version: versionForReleaseTag(expectedTag) };
@@ -199,7 +205,15 @@ const COMMANDS = {
 
 export const COMMAND_NAMES = Object.keys(COMMANDS);
 
-if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+// Compare real paths: a URL pathname is percent-encoded and neither side is
+// symlink-resolved, so the naive comparison made this file exit 0 printing
+// nothing whenever the checkout path had a space or a symlinked parent -- a
+// release gate that fails open.
+const invokedPath = process.argv[1] ? realpathSync(process.argv[1]) : "";
+if (
+  invokedPath &&
+  realpathSync(fileURLToPath(import.meta.url)) === invokedPath
+) {
   const command = process.argv[2];
   const run = COMMANDS[command];
   if (!run) {


### PR DESCRIPTION
## Summary
- Gate Release Please on completed main Build and Push Images plus exact CI provenance.
- Separate read-only release/package attestations from production publishing and pin package dispatch to current main policy.
- Add manual current-main image guard and fail-closed structural coverage.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` passed.
- [x] Focused tests: 53 passed, 184 assertions (`release-publish-order`, `derive-image-tags`, `publish-packages-guard`).
- [x] Commit hook passed Biome and TypeScript.
- [x] YAML parse, workflow shell `bash -n`, and `git diff --check` passed.

## Notes
- Deliberately not merged, deployed, published, or reviewed by automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Strengthened release validation to ensure artifacts are generated from the current `main` commit.
  * Added provenance checks for release tags, image builds, package versions, and immutable releases.
  * Updated package publishing to use the verified release version and image build run.
  * Improved handling of registry access failures and in-progress or invalid release runs.

* **Documentation**
  * Updated release and recovery procedures for the attested workflow.
  * Added guidance for manually restarting release and package publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->\n\n## Release provenance correction run (2026-08-31)

- Baseline ce9037d4d70b4e6dae0dc6964f13bd79df5a667b: focused suite green 9/9, but only substring-tested the broken `.[][]` paginated jq and chronological CI selection.
- Green b3a52a97d15f53847579c494c74ac69f8e7a1f92: release provenance suite 12/12 (86 assertions), `bun run check`, `bun run typecheck`, pre-commit hook, and `git diff --check`.
- `make pre-pr` reached package/frontend build, then was interrupted after several minutes with no further output; no gate failure was reported.
- Scope is release workflows/config/provenance helper/tests. Release-PR generation is separated from immutable tag/release publication; unchanged manifests publish no release. No merge, live dispatch, package/image publication, or production action was performed.