### PR TITLE
fix(server): enforce agent admin tool allowlist

### DIFF
--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -612,6 +612,9 @@ describe('checkToolAccess', () => {
       /may not perform admin actions/
     );
     expect(() =>
+      checkToolAccess('manage_agents', { action: 'update' }, { ...agentAuth, adminTools: null })
+    ).toThrow(/may not perform admin actions/);
+    expect(() =>
       checkToolAccess('manage_agents', { action: 'update' }, { ...agentAuth, adminTools: [] })
     ).toThrow(/may not perform admin actions/);
     expect(() =>

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -583,6 +583,7 @@ describe('checkToolAccess', () => {
   it('adminTools allowlist limits ADMIN-tier actions to listed tools only', () => {
     const adminToolsAuth = {
       ...baseAuth,
+      agentId: 'agent_123',
       memberRole: 'owner',
       scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
       adminTools: ['manage_agents'],
@@ -596,6 +597,63 @@ describe('checkToolAccess', () => {
     // Read/write-tier actions on unlisted tools follow the uniform model.
     expect(() =>
       checkToolAccess('manage_classifiers', { action: 'list' }, adminToolsAuth)
+    ).not.toThrow();
+  });
+
+  it('requires a non-empty exact adminTools allowlist for agent identities', () => {
+    const agentAuth = {
+      ...baseAuth,
+      agentId: 'agent_123',
+      memberRole: 'owner',
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    };
+
+    expect(() => checkToolAccess('manage_agents', { action: 'update' }, agentAuth)).toThrow(
+      /may not perform admin actions/
+    );
+    expect(() =>
+      checkToolAccess('manage_agents', { action: 'update' }, { ...agentAuth, adminTools: [] })
+    ).toThrow(/may not perform admin actions/);
+    expect(() =>
+      checkToolAccess('manage_agents', { action: 'update' }, {
+        ...agentAuth,
+        adminTools: ['manage_agents'],
+      })
+    ).not.toThrow();
+    expect(() =>
+      checkToolAccess('manage_classifiers', { action: 'delete' }, {
+        ...agentAuth,
+        adminTools: ['manage_agents'],
+      })
+    ).toThrow(/may not perform admin actions/);
+  });
+
+  it('keeps agent read/write access unchanged and does not let Automation identity bypass the allowlist', () => {
+    const agentAuth = {
+      ...baseAuth,
+      agentId: 'agent_123',
+      memberRole: 'owner',
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    };
+    expect(() => checkToolAccess('manage_entity', { action: 'list' }, agentAuth)).not.toThrow();
+    expect(() => checkToolAccess('manage_entity', { action: 'create' }, agentAuth)).not.toThrow();
+    expect(() =>
+      checkToolAccess('manage_entity', { action: 'delete' }, {
+        ...agentAuth,
+        agentId: null,
+        actingAutomationId: 157,
+      })
+    ).toThrow(/may not perform admin actions/);
+  });
+
+  it('keeps human owner/admin callers without agent identity governed by role and scope', () => {
+    expect(() =>
+      checkToolAccess('manage_entity', { action: 'delete' }, {
+        ...baseAuth,
+        memberRole: 'owner',
+        scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+        adminTools: null,
+      })
     ).not.toThrow();
   });
 

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -93,8 +93,9 @@ export interface AuthContext {
   /**
    * Per-turn LIMIT on which tools may execute admin-tier actions. Carried on
    * the worker token (see
-   * WorkerTokenData.adminTools); empty/null for everyone else (no limit —
-   * role × scope decide). Non-admin-tier actions are unaffected.
+   * WorkerTokenData.adminTools); worker/agent/Automation identities must carry
+   * a non-empty allowlist, while human callers remain governed by role × scope.
+   * Non-admin-tier actions are unaffected.
    */
   adminTools?: string[] | null;
   /**
@@ -250,18 +251,19 @@ export function checkToolAccess(
     : authCtx.memberRole;
   const requiredAccess = getRequiredAccessLevel(toolName, args, isReadOnly);
 
-  // Admin-tools run: the per-turn allowlist is a LIMIT on which
-  // tools may exercise ADMIN-tier actions. Read/write-tier actions follow the
-  // uniform role × scope model like every other caller.
+  // Worker/agent/Automation runs must carry a non-empty signed allowlist for
+  // ADMIN-tier actions. Read/write-tier actions follow the uniform role ×
+  // scope model like every other caller; human callers remain role × scope
+  // governed even when they have no allowlist.
+  const isNonHumanIdentity = Boolean(authCtx.agentId || authCtx.actingAutomationId);
   const adminAllowlist = authCtx.adminTools;
   if (
     requiredAccess === 'admin' &&
-    adminAllowlist &&
-    adminAllowlist.length > 0 &&
-    !adminAllowlist.includes(toolName)
+    isNonHumanIdentity &&
+    (!adminAllowlist || adminAllowlist.length === 0 || !adminAllowlist.includes(toolName))
   ) {
     throw new Error(
-      `This agent run may not perform admin actions with ${toolName}. Allowed admin tools: ${adminAllowlist.join(', ')}.`
+      `This agent run may not perform admin actions with ${toolName}. Allowed admin tools: ${(adminAllowlist ?? []).join(', ')}.`
     );
   }
 


### PR DESCRIPTION
## Summary
- Require signed worker/agent/Automation identities to present a non-empty exact `adminTools` entry for ADMIN-tier tool actions.
- Preserve human role × scope authorization and existing read/write-tier behavior.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean.
- [x] Tests run: `bun run test -- run src/auth/__tests__/tool-access.test.ts` (70/70), `bun test packages/core/src/__tests__/worker-auth.test.ts` (47/47), `bun run build:server` (bundle errors: 0).
- [x] Bug fix: initial focused run was red (3 failures: old test lacked agent identity; null allowlist formatting); corrected implementation and test run is green (70/70).
- [x] `make pre-pr` clean; pre-commit Biome and TypeScript checks passed; `git diff --check` clean.

## Notes
- No table/migration, public API/SDK/wire, token claim, env, package, merge, deploy, or production changes.
- Diff against `origin/main`: 2 files, 69 additions, 9 deletions.