### PR TITLE
fix(server): fence inline operation run leases

### DIFF
--- a/packages/server/src/__tests__/integration/approval-lease-guard.test.ts
+++ b/packages/server/src/__tests__/integration/approval-lease-guard.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Approval-run lease guards.
+ *
+ * A builder approval claims the run, then runs the family's `apply` OUTSIDE
+ * that transaction — a slow, network-bound call. Until now the claim flipped
+ * the run to `running` without taking a lease, so across the whole of that
+ * call the run sat approved, running and UNOWNED: exactly the row the
+ * stale-run reaper terminalizes and a second approve re-approves. Whichever
+ * write landed last won, and an already-applied mutation could be relabelled.
+ *
+ * Two guards close it, and both are pinned here:
+ *
+ *  - `claimBuilderRun` takes the lease in the statement that approves the run,
+ *    so there is no unowned window to lose it in.
+ *  - `terminalizeApprovalRunCompleted` fences on an owner the caller must
+ *    supply. Its two RECOVERY callers — `tryReconcileTerminalization` and the
+ *    stalled-execution reaper — finalize runs they did not claim, so they pass
+ *    the owner they READ off the row; a re-claim between that read and the
+ *    write makes the write lose instead of overwriting the new owner.
+ *
+ * `null` is a real assertion here, not an escape hatch: it means "this run is
+ * still unowned", which is what a row claimed before the gateway took leases
+ * looks like. It is NOT "skip the check".
+ */
+
+import type { Context } from "hono";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import { terminalizeApprovalRunCompleted } from "../../tools/admin/approval-events";
+import type { ToolContext } from "../../tools/registry";
+import { insertEvent } from "../../utils/insert-event";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { ownerToolContext, seedOwnerContext } from "../setup/test-fixtures";
+
+const THIEF = "some-other-replica";
+const CARD = { title: "t — completed", content: "c" };
+
+/** A pending agent_ask run + its pending card, the shape `queueAgentAsk` makes. */
+async function seedAgentAskRun(
+	organizationId: string,
+	userId: string,
+): Promise<number> {
+	const sql = getTestDb();
+	const [run] = await sql`
+		INSERT INTO runs (
+			organization_id, run_type, action_key, action_input,
+			created_by_user_id, approval_status, status, created_at
+		) VALUES (
+			${organizationId}, 'internal', 'agent_ask',
+			${sql.json({ question: "Ship it?", input_schema: { type: "object" } })},
+			${userId}, 'pending', 'pending', NOW()
+		)
+		RETURNING id
+	`;
+	const runId = Number(run.id);
+	await insertEvent({
+		entityIds: [],
+		organizationId,
+		originId: `run_${runId}_pending`,
+		title: "Ship it?",
+		content: null,
+		semanticType: "operation",
+		runId,
+		interactionType: "approval",
+		interactionStatus: "pending",
+		interactionInputSchema: { type: "object" },
+		metadata: { tool: "notify", action_key: "agent_ask", run_id: runId },
+		authorName: "agent",
+	});
+	return runId;
+}
+
+/** A run already claimed and mid-apply, the state a terminal write lands on. */
+async function seedClaimedRun(
+	organizationId: string,
+	claimedBy: string | null,
+): Promise<number> {
+	const sql = getTestDb();
+	const [run] = await sql`
+		INSERT INTO runs (
+			organization_id, run_type, action_key, approval_status, status,
+			claimed_by, claimed_at, created_at
+		) VALUES (
+			${organizationId}, 'action', 'demo.op', 'approved', 'running',
+			${claimedBy}, NOW(), NOW()
+		)
+		RETURNING id
+	`;
+	const runId = Number(run.id);
+	await insertEvent({
+		entityIds: [],
+		organizationId,
+		originId: `run_${runId}_confirmed`,
+		title: "demo.op — executing",
+		content: null,
+		semanticType: "operation",
+		runId,
+		interactionType: "approval",
+		// The card's persisted status for a 'confirmed' transition; 'confirmed'
+		// itself is not one of the five the events check constraint allows.
+		interactionStatus: "approved",
+		metadata: { action_key: "demo.op", run_id: runId },
+		authorName: "agent",
+	});
+	return runId;
+}
+
+async function readRun(runId: number) {
+	const [row] = await getTestDb()<{
+		status: string;
+		claimed_by: string | null;
+		action_output: Record<string, unknown> | null;
+	}>`SELECT status, claimed_by, action_output FROM runs WHERE id = ${runId}`;
+	return row;
+}
+
+describe("approval lease guards", () => {
+	let orgId: string;
+	let userId: string;
+	let humanCtx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user } = await seedOwnerContext({ orgName: "Approval Lease Org" });
+		orgId = org.id;
+		userId = user.id;
+		humanCtx = ownerToolContext(orgId, userId);
+		humanCtx.baseUrl = "https://gateway.test/lobu";
+	});
+
+	it("approving a builder run takes the lease in the same statement", async () => {
+		const runId = await seedAgentAskRun(orgId, userId);
+		const approved = (await manageOperations(
+			{ action: "approve", run_id: runId, input: { answer: "yes" } },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+		expect(approved.error).toBeUndefined();
+		expect(approved.approved).toBe(true);
+
+		// The lease outlives the run: it is what every terminal write for this
+		// decision fences on, so it must be the gateway's own owner and never null.
+		const run = await readRun(runId);
+		expect(run.claimed_by).toMatch(/^gateway-inline-/);
+		expect(String(run.status)).toBe("completed");
+	});
+
+	it("does NOT terminalize a run whose lease moved since it was read", async () => {
+		const owner = "gateway-inline-original";
+		const runId = await seedClaimedRun(orgId, owner);
+		// The recovery caller read `owner`; the run is re-claimed before its write.
+		await getTestDb()`UPDATE runs SET claimed_by = ${THIEF} WHERE id = ${runId}`;
+
+		const eventId = await terminalizeApprovalRunCompleted(
+			runId,
+			orgId,
+			{ recovered: true },
+			CARD,
+			null,
+			owner,
+		);
+
+		expect(eventId).toBeNull();
+		const run = await readRun(runId);
+		expect(run.claimed_by).toBe(THIEF);
+		expect(String(run.status)).toBe("running");
+		expect(run.action_output).toBeNull();
+	});
+
+	it("terminalizes a run still held by the owner the caller read", async () => {
+		const owner = "gateway-inline-original";
+		const runId = await seedClaimedRun(orgId, owner);
+
+		const eventId = await terminalizeApprovalRunCompleted(
+			runId,
+			orgId,
+			{ recovered: true },
+			CARD,
+			null,
+			owner,
+		);
+
+		expect(eventId).not.toBeNull();
+		const run = await readRun(runId);
+		expect(String(run.status)).toBe("completed");
+		expect(run.action_output).toEqual({ recovered: true });
+	});
+
+	it("treats a null owner as 'still unowned', not as 'skip the check'", async () => {
+		// A row claimed before the gateway took leases: the recovery caller reads
+		// null and must still finalize it.
+		const legacyRunId = await seedClaimedRun(orgId, null);
+		expect(
+			await terminalizeApprovalRunCompleted(
+				legacyRunId,
+				orgId,
+				{ recovered: true },
+				CARD,
+				null,
+				null,
+			),
+		).not.toBeNull();
+		expect(String((await readRun(legacyRunId)).status)).toBe("completed");
+
+		// The same null must NOT wave through a run someone now owns.
+		const ownedRunId = await seedClaimedRun(orgId, THIEF);
+		expect(
+			await terminalizeApprovalRunCompleted(
+				ownedRunId,
+				orgId,
+				{ recovered: true },
+				CARD,
+				null,
+				null,
+			),
+		).toBeNull();
+		const owned = await readRun(ownedRunId);
+		expect(String(owned.status)).toBe("running");
+		expect(owned.action_output).toBeNull();
+	});
+});

--- a/packages/server/src/__tests__/integration/heartbeat-lease-guard.test.ts
+++ b/packages/server/src/__tests__/integration/heartbeat-lease-guard.test.ts
@@ -1,0 +1,156 @@
+/**
+ * heartbeat lease-guard reproducer.
+ *
+ * Bug: `heartbeat` stamped `last_heartbeat_at` — and, when the worker reports
+ * an `agent_session`, the `run_metadata.device_agent_session` checkpoint —
+ * with a bare `WHERE id = run_id`. So a worker reporting in AFTER the gateway
+ * reaped the run, or after another device re-claimed it, would:
+ *   1. resurrect the run's liveness clock, keeping a dead run off the reaper's
+ *      next sweep, and
+ *   2. pin ITS OWN `device_agent_session` onto a run it no longer owns —
+ *      which is what a later poll reads to decide where to resume the agent
+ *      session, so the resume lands on the wrong machine.
+ *
+ * The fix mirrors completeWorkerJob and completeAuthRun: the UPDATE carries
+ * `AND status = 'running' AND claimed_by = worker_id` + RETURNING, and a
+ * 0-row match answers 409 without writing.
+ *
+ * `authorizeRunForWorker` checks the same two things, but only in
+ * `workerAuthMode === 'user'` — it returns null immediately for every other
+ * mode. A token-auth cloud worker therefore reaches the UPDATE with NO prior
+ * ownership check at all, and the guard on the statement is the only one. It
+ * also closes the TOCTOU window for user-mode workers, where the status flips
+ * between authorizeRunForWorker's read and the UPDATE.
+ *
+ * Drives the REAL exported `heartbeat` handler against the embedded DB via a
+ * minimal Hono Context, the same approach as
+ * complete-worker-job-status-guard.test.ts: the mock context has no
+ * workerAuthMode, so authorizeRunForWorker is a no-op and the guard under test
+ * is isolated — exactly the shared-token cloud worker's path in production.
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { heartbeat } from '../../worker-api/run-lifecycle';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const CLAIMANT = 'worker-legit';
+const OTHER = 'worker-other';
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (b: unknown, status?: number) => {
+      captured = { body: b, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
+
+async function insertRun(
+  organizationId: string,
+  status: string,
+  claimedBy: string | null
+): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, status, claimed_by, claimed_at,
+       last_heartbeat_at, created_at)
+    VALUES
+      (${organizationId}, 'automation', ${status}, ${claimedBy}, NOW(),
+       NULL, NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+async function readRun(runId: number) {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT status, claimed_by, last_heartbeat_at, run_metadata
+    FROM runs WHERE id = ${runId}
+  `) as Array<{
+    status: string;
+    claimed_by: string | null;
+    last_heartbeat_at: Date | null;
+    run_metadata: { device_agent_session?: { worker_id?: string } } | null;
+  }>;
+  return rows[0];
+}
+
+const AGENT_SESSION = {
+  protocol: 'acp',
+  agent_kind: 'opencode',
+  session_id: 'session-from-the-wrong-device',
+};
+
+describe('heartbeat lease guard', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('does NOT let a reaped run be resurrected by its own late worker', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertRun(org.id, 'timeout', CLAIMANT);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: CLAIMANT,
+      agent_session: AGENT_SESSION,
+    });
+    await heartbeat(ctx);
+
+    expect(result().status).toBe(409);
+    const run = await readRun(runId);
+    expect(String(run.status)).toBe('timeout');
+    expect(run.last_heartbeat_at).toBeNull();
+    expect(run.run_metadata?.device_agent_session).toBeUndefined();
+  });
+
+  it('does NOT let a non-claimant pin its agent session onto a running run', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertRun(org.id, 'running', CLAIMANT);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: OTHER,
+      agent_session: AGENT_SESSION,
+    });
+    await heartbeat(ctx);
+
+    expect(result().status).toBe(409);
+    const run = await readRun(runId);
+    // The rightful claimant keeps the run, and poll will not be told to resume
+    // the session on `OTHER`'s machine.
+    expect(run.claimed_by).toBe(CLAIMANT);
+    expect(run.last_heartbeat_at).toBeNull();
+    expect(run.run_metadata?.device_agent_session).toBeUndefined();
+  });
+
+  it('still checkpoints the claimant of a running run', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertRun(org.id, 'running', CLAIMANT);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: CLAIMANT,
+      agent_session: AGENT_SESSION,
+    });
+    await heartbeat(ctx);
+
+    expect(result().status).toBe(200);
+    expect(result().body).toEqual({ continue: true });
+    const run = await readRun(runId);
+    expect(run.last_heartbeat_at).not.toBeNull();
+    expect(run.run_metadata?.device_agent_session?.worker_id).toBe(CLAIMANT);
+  });
+});

--- a/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
@@ -119,6 +119,19 @@ async function operationReadiness(connectionId: number, ctx: ToolContext) {
 	return result.operations.find((operation) => operation.operation_key === ACTION_KEY);
 }
 
+/**
+ * An inline run is owned by the gateway request that executed it
+ * (`gateway-inline-<uuid>`), so "no device claimed this" is no longer
+ * `claimed_by IS NULL` — it is "the owner is the gateway, not a device".
+ */
+function expectInlineCompleted(run: {
+	status: string;
+	claimed_by: string | null;
+}): void {
+	expect(run.status).toBe("completed");
+	expect(run.claimed_by).toMatch(/^gateway-inline-/);
+}
+
 describe("connection-to-device operation routing lifecycle", () => {
 	beforeAll(async () => {
 		await initWorkspaceProvider();
@@ -315,7 +328,7 @@ describe("connection-to-device operation routing lifecycle", () => {
 			WHERE connection_id = ${chromeAffinityConnection.id}
 			  AND action_idempotency_key = 'device-routing:chrome-affinity'
 		`) as unknown as Array<{ status: string; claimed_by: string | null }>;
-		expect(chromeRun).toEqual({ status: "completed", claimed_by: null });
+		expectInlineCompleted(chromeRun);
 
 		// A connector whose key merely starts with "chrome" is still non-Chrome.
 		// A chrome-extension pin therefore remains delegated browser affinity: the
@@ -388,7 +401,7 @@ describe("connection-to-device operation routing lifecycle", () => {
 			WHERE connection_id = ${chromePrefixConnection.id}
 			  AND action_idempotency_key = ${chromePrefixIdempotencyKey}
 		`) as unknown as Array<{ status: string; claimed_by: string | null }>;
-		expect(chromePrefixRun).toEqual({ status: "completed", claimed_by: null });
+		expectInlineCompleted(chromePrefixRun);
 
 		// The legacy WhatsApp key is native Chrome execution only for a clean,
 		// metadata-only Chrome manifest artifact. Compiled bytes stay delegated even
@@ -467,7 +480,7 @@ describe("connection-to-device operation routing lifecycle", () => {
 			WHERE connection_id = ${compiledWhatsappConnection.id}
 			  AND action_idempotency_key = 'device-routing:compiled-whatsapp-affinity'
 		`) as unknown as Array<{ status: string; claimed_by: string | null }>;
-		expect(compiledWhatsappRun).toEqual({ status: "completed", claimed_by: null });
+		expectInlineCompleted(compiledWhatsappRun);
 
 		await sql`
 			UPDATE connections SET device_worker_id = NULL

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -37,6 +37,16 @@ import {
 // retry that re-executes the mutation is detectable (it must run exactly once).
 let postItemsCalls = 0;
 
+/**
+ * Runs once, inside the external POST — exactly the window between the gateway
+ * taking a run's lease and writing the outcome back. A stale-run reaper, a
+ * cancel, or another replica re-claiming all land in this window in
+ * production, and it is the only place to hit it deterministically: the
+ * gateway holds the lease across the whole call.
+ */
+let duringExternalCall: (() => Promise<void>) | null = null;
+const THIEF = "some-other-replica";
+
 const CONNECTOR = "demo.ops.transition.atomic";
 
 // Force a REAL failure of ONLY the terminal 'completed' card INSERT. The
@@ -185,6 +195,9 @@ describe("approval-run transition atomicity", () => {
 	let userId: string;
 	let humanCtx: ToolContext;
 	let connectionId: number;
+	// Same connector, `create_item` set to `auto`: `execute` runs the operation
+	// inline with no approval round-trip, the other path that takes a lease.
+	let autoConnectionId: number;
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -249,6 +262,20 @@ describe("approval-run transition atomicity", () => {
 			WHERE id = ${connectionId}
 		`;
 
+		const autoConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR,
+			created_by: userId,
+			visibility: "private",
+			config: { action_modes: { create_item: "auto" } },
+		});
+		autoConnectionId = autoConn.id;
+		await sql`
+			UPDATE connections
+			SET auth_profile_id = ${profile.id}
+			WHERE id = ${autoConnectionId}
+		`;
+
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(
@@ -283,6 +310,11 @@ describe("approval-run transition atomicity", () => {
 					}
 					if (url === "https://api.example.test/items") {
 						postItemsCalls += 1;
+						if (duringExternalCall) {
+							const hook = duringExternalCall;
+							duringExternalCall = null;
+							await hook();
+						}
 						return new Response(JSON.stringify({ created: true }), {
 							status: 200,
 							headers: { "content-type": "application/json" },
@@ -295,6 +327,7 @@ describe("approval-run transition atomicity", () => {
 	});
 
 	afterEach(async () => {
+		duringExternalCall = null;
 		// Always drop the failure triggers so they can't leak into other tests
 		// that share this DB under the suite's single-fork registry.
 		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
@@ -502,6 +535,93 @@ describe("approval-run transition atomicity", () => {
 		expect(run.action_output).toEqual({ body: { created: true } });
 		expect((await currentApprovalCard(queued.run_id, orgId))?.interaction_status).toBe(
 			"completed",
+		);
+	});
+
+	it("auto-mode execute reports the lost lease instead of overwriting the run", async () => {
+		const sql = getTestDb();
+		const postItemsBefore = postItemsCalls;
+		// An auto-mode `execute` claims the run in the same INSERT that sets it
+		// `running`, so the lease is already held when the external call goes
+		// out. The run id is not knowable before that INSERT, so the thief
+		// targets the connection's one running run.
+		duringExternalCall = async () => {
+			await sql`
+				UPDATE runs SET claimed_by = ${THIEF}
+				WHERE connection_id = ${autoConnectionId}
+					AND run_type = 'action'
+					AND status = 'running'
+			`;
+		};
+		const result = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: autoConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "auto-stolen-lease" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number; status: string; error_message?: string };
+
+		expect(postItemsCalls).toBe(postItemsBefore + 1);
+		expect(result.status).toBe("failed");
+		expect(result.error_message).toMatch(/lost its run lease/i);
+
+		const [run] = await sql`
+			SELECT status, claimed_by, action_output, completed_at
+			FROM runs WHERE id = ${result.run_id}
+		`;
+		expect(run.claimed_by).toBe(THIEF);
+		expect(run.status).toBe("running");
+		expect(run.action_output).toBeNull();
+		expect(run.completed_at).toBeNull();
+	});
+
+	it("approve does not overwrite a run whose lease was stolen mid-execution", async () => {
+		const sql = getTestDb();
+		const postItemsBefore = postItemsCalls;
+		const queued = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: connectionId,
+				operation_key: "create_item",
+				input: { body: { value: "stolen-lease" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number };
+		expect(queued.status).toBe("pending_approval");
+
+		// Approve claims the run under a `gateway-inline-<uuid>` owner. The POST
+		// then hands it to another owner before the terminal write lands.
+		duringExternalCall = async () => {
+			await sql`UPDATE runs SET claimed_by = ${THIEF} WHERE id = ${queued.run_id}`;
+		};
+		const approved = (await manageOperations(
+			{ action: "approve", run_id: queued.run_id },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+
+		// The external mutation still ran exactly once — the fence guards the
+		// WRITE-BACK, not the call.
+		expect(postItemsCalls).toBe(postItemsBefore + 1);
+		expect(approved.approved).toBeUndefined();
+		expect(approved.error).toMatch(/already decided while this request was in flight/i);
+
+		const [run] = await sql`
+			SELECT status, claimed_by, action_output, completed_at
+			FROM runs WHERE id = ${queued.run_id}
+		`;
+		// Neither phase wrote: the durable output stays untouched and the run is
+		// left to whoever holds it now.
+		expect(run.claimed_by).toBe(THIEF);
+		expect(run.status).toBe("running");
+		expect(run.action_output).toBeNull();
+		expect(run.completed_at).toBeNull();
+		expect((await currentApprovalCard(queued.run_id, orgId))?.interaction_status).toBe(
+			"approved",
 		);
 	});
 

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -45,6 +45,12 @@ let postItemsCalls = 0;
  * gateway holds the lease across the whole call.
  */
 let duringExternalCall: (() => Promise<void>) | null = null;
+/**
+ * Make the external POST THROW rather than answer. A thrown request is the one
+ * path that reaches `executeHttpOperation`'s `failRun`; a non-2xx response is
+ * handled by the already-fenced error lane instead.
+ */
+let throwOnPostItems = false;
 const THIEF = "some-other-replica";
 
 const CONNECTOR = "demo.ops.transition.atomic";
@@ -110,6 +116,30 @@ DROP TRIGGER IF EXISTS test_fail_pending_approval_event_trg ON events;
 DROP FUNCTION IF EXISTS test_fail_pending_approval_event();
 `;
 
+// Hand a builder run's lease to another owner at the exact instant the claim
+// commits. `claimBuilderRun` and the 'confirmed' card INSERT share one
+// transaction, so a trigger on that INSERT fires INSIDE it and commits with
+// it — reproducing "the reaper took this run while `apply` was in flight"
+// without a module mock, which this suite's shared registry cannot isolate.
+const STEAL_ON_CONFIRMED_TRIGGER = `
+CREATE OR REPLACE FUNCTION test_steal_lease_on_confirmed() RETURNS trigger AS $fn$
+BEGIN
+  IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'approved'
+     AND NEW.run_id IS NOT NULL THEN
+    UPDATE runs SET claimed_by = 'some-other-replica' WHERE id = NEW.run_id;
+  END IF;
+  RETURN NEW;
+END;
+$fn$ LANGUAGE plpgsql;
+CREATE TRIGGER test_steal_lease_on_confirmed_trg
+  AFTER INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION test_steal_lease_on_confirmed();
+`;
+const DROP_STEAL_ON_CONFIRMED_TRIGGER = `
+DROP TRIGGER IF EXISTS test_steal_lease_on_confirmed_trg ON events;
+DROP FUNCTION IF EXISTS test_steal_lease_on_confirmed();
+`;
+
 /**
  * Seed a pending agent-ask run + its pending approval card, exactly the shape
  * `queueAgentAsk` produces (legacy ask: no input_schema_validation_version, so
@@ -153,6 +183,45 @@ async function seedAgentAskRun(
 			status: "pending_approval",
 			run_id: runId,
 		},
+		authorName: "agent",
+	});
+	return runId;
+}
+
+/**
+ * A pending `manage_agents` builder run whose apply is guaranteed to THROW:
+ * `applyDelete` requires `agent_id`, and the family's `isValidProposal` only
+ * checks the proposal is non-null, so the run claims cleanly and then fails in
+ * the out-of-transaction apply — the window `failBuilderRun` writes back into.
+ */
+async function seedThrowingBuilderRun(
+	organizationId: string,
+	userId: string,
+): Promise<number> {
+	const sql = getTestDb();
+	const [run] = await sql`
+		INSERT INTO runs (
+			organization_id, run_type, action_key, action_input,
+			created_by_user_id, approval_status, status, created_at
+		) VALUES (
+			${organizationId}, 'internal', 'manage_agents',
+			${sql.json({ action: "delete" })},
+			${userId}, 'pending', 'pending', NOW()
+		)
+		RETURNING id
+	`;
+	const runId = Number(run.id);
+	await insertEvent({
+		entityIds: [],
+		organizationId,
+		originId: `run_${runId}_pending`,
+		title: "Agent: delete undefined — pending",
+		content: null,
+		semanticType: "operation",
+		runId,
+		interactionType: "approval",
+		interactionStatus: "pending",
+		metadata: { action_key: "manage_agents", run_id: runId },
 		authorName: "agent",
 	});
 	return runId;
@@ -315,6 +384,10 @@ describe("approval-run transition atomicity", () => {
 							duringExternalCall = null;
 							await hook();
 						}
+						if (throwOnPostItems) {
+							throwOnPostItems = false;
+							throw new Error("upstream socket hang up");
+						}
 						return new Response(JSON.stringify({ created: true }), {
 							status: 200,
 							headers: { "content-type": "application/json" },
@@ -328,6 +401,8 @@ describe("approval-run transition atomicity", () => {
 
 	afterEach(async () => {
 		duringExternalCall = null;
+		throwOnPostItems = false;
+		await getTestDb().unsafe(DROP_STEAL_ON_CONFIRMED_TRIGGER);
 		// Always drop the failure triggers so they can't leak into other tests
 		// that share this DB under the suite's single-fork registry.
 		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
@@ -622,6 +697,163 @@ describe("approval-run transition atomicity", () => {
 		expect(run.completed_at).toBeNull();
 		expect((await currentApprovalCard(queued.run_id, orgId))?.interaction_status).toBe(
 			"approved",
+		);
+	});
+
+	it("a THROWN external call does not overwrite a run whose lease moved", async () => {
+		const sql = getTestDb();
+		// A thrown request terminalizes through `failRun`, the last unfenced
+		// terminal write on the inline path: it fired on id + organization_id
+		// alone, so it relabelled whatever the new owner had already recorded.
+		throwOnPostItems = true;
+		duringExternalCall = async () => {
+			await sql`
+				UPDATE runs SET claimed_by = ${THIEF}
+				WHERE connection_id = ${autoConnectionId}
+					AND run_type = 'action'
+					AND status = 'running'
+			`;
+		};
+		const result = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: autoConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "auto-thrown-stolen" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number; status: string; error_message?: string };
+
+		expect(result.status).toBe("failed");
+		expect(result.error_message).toMatch(/lost its run lease/i);
+		const [run] = await sql`
+			SELECT status, claimed_by, error_message, completed_at
+			FROM runs WHERE id = ${result.run_id}
+		`;
+		expect(run.claimed_by).toBe(THIEF);
+		expect(run.status).toBe("running");
+		expect(run.error_message).toBeNull();
+		expect(run.completed_at).toBeNull();
+	});
+
+	it("a THROWN external call still terminalizes a run its owner still holds", async () => {
+		const sql = getTestDb();
+		throwOnPostItems = true;
+		const result = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: autoConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "auto-thrown-kept" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number; status: string; error_message?: string };
+
+		// The fence blocks a LOST lease, never the ordinary failure path.
+		expect(result.status).toBe("failed");
+		expect(result.error_message).toMatch(/socket hang up/i);
+		const [run] = await sql`
+			SELECT status, error_message FROM runs WHERE id = ${result.run_id}
+		`;
+		expect(run.status).toBe("failed");
+		expect(String(run.error_message)).toMatch(/socket hang up/i);
+	});
+
+	it("approve does not record a FAILURE on a run whose lease was stolen", async () => {
+		const sql = getTestDb();
+		const queued = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: connectionId,
+				operation_key: "create_item",
+				input: { body: { value: "approve-fail-stolen" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number; status: string };
+		expect(queued.status).toBe("pending_approval");
+
+		// deferTerminalWrite means the inline execution wrote nothing, so
+		// handleApprove's failure lane is the ONLY terminal write for this run.
+		throwOnPostItems = true;
+		duringExternalCall = async () => {
+			await sql`UPDATE runs SET claimed_by = ${THIEF} WHERE id = ${queued.run_id}`;
+		};
+		const approved = (await manageOperations(
+			{ action: "approve", run_id: queued.run_id },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+
+		expect(approved.approved).toBeUndefined();
+		expect(approved.error).toMatch(
+			/already decided while this request was in flight/i,
+		);
+		const [run] = await sql`
+			SELECT status, claimed_by, error_message, completed_at
+			FROM runs WHERE id = ${queued.run_id}
+		`;
+		expect(run.claimed_by).toBe(THIEF);
+		expect(run.status).toBe("running");
+		expect(run.error_message).toBeNull();
+		expect(run.completed_at).toBeNull();
+		// The card must NOT be superseded to 'failed' on a run we no longer own.
+		expect(
+			(await currentApprovalCard(queued.run_id, orgId))?.interaction_status,
+		).toBe("approved");
+	});
+
+	it("a failed builder apply does not overwrite a run whose lease was stolen", async () => {
+		const sql = getTestDb();
+		const runId = await seedThrowingBuilderRun(orgId, userId);
+		await sql.unsafe(STEAL_ON_CONFIRMED_TRIGGER);
+
+		const result = (await manageOperations(
+			{ action: "approve", run_id: runId },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+
+		expect(result.approved).toBeUndefined();
+		expect(result.error).toMatch(
+			/already decided while this request was in flight/i,
+		);
+		const [run] = await sql`
+			SELECT status, claimed_by, error_message, completed_at
+			FROM runs WHERE id = ${runId}
+		`;
+		expect(run.claimed_by).toBe(THIEF);
+		expect(run.status).toBe("running");
+		expect(run.error_message).toBeNull();
+		expect(run.completed_at).toBeNull();
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"approved",
+		);
+	});
+
+	it("a failed builder apply terminalizes a run its owner still holds", async () => {
+		const sql = getTestDb();
+		const runId = await seedThrowingBuilderRun(orgId, userId);
+
+		const result = (await manageOperations(
+			{ action: "approve", run_id: runId },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; message?: string; error?: string };
+
+		expect(result.error).toBeUndefined();
+		expect(result.approved).toBe(true);
+		expect(result.message).toMatch(/approved but failed/i);
+		const [run] = await sql`
+			SELECT status, claimed_by, error_message FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("failed");
+		expect(String(run.claimed_by)).toMatch(/^gateway-inline-/);
+		expect(String(run.error_message)).toMatch(/agent_id is required/i);
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"failed",
 		);
 	});
 

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -1,35 +1,11 @@
 import { getErrorMessage } from "@lobu/core";
-import { type DbClient, getDb } from "../db/client";
+import { getDb } from "../db/client";
+import { LOST_LEASE_MESSAGE, inlineLeaseFence } from "../runs/inline-lease";
 import { resolveCredentialsByConnectionId } from "../mcp-proxy/credential-resolver";
 import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import type { OperationDescriptor } from "./types";
 
 const DEFAULT_HTTP_OPERATION_FETCH_TIMEOUT_MS = 120_000;
-
-/**
- * Reported when a fenced terminal write matches no row: the run was cancelled,
- * reaped, or re-claimed while this request was still executing. The external
- * call may well have succeeded, but this request no longer owns the run, so it
- * must not overwrite whoever does — the durable row is the answer.
- */
-export const LOST_LEASE_MESSAGE =
-	"Inline execution lost its run lease; the durable run state is authoritative.";
-
-/**
- * The guard every inline terminal write shares: land the outcome only while
- * this request still owns the run it claimed and nothing has terminalized it
- * (a cancel, the stale-run reaper, a second approve). One definition, because
- * four hand-written copies drift and a fence that silently matches no row is
- * indistinguishable from one that worked.
- *
- * A caller that took no lease passes `null` and keeps the unfenced semantics:
- * it has no owner to lose, and `claimed_by = NULL` is never true, so spelling
- * the fence unconditionally would strand the run.
- */
-export function inlineLeaseFence(sql: DbClient, claimedBy: string | null) {
-	return sql`AND status = 'running'
-		AND (${claimedBy}::text IS NULL OR claimed_by = ${claimedBy})`;
-}
 
 export type HttpOperationExecutionResult =
 	| {
@@ -151,9 +127,9 @@ export async function executeHttpOperation(
 	connection: HttpOperationConnection,
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
-	abortSignal?: AbortSignal,
-	deferTerminalWrite = false,
-	claimedBy?: string | null,
+	abortSignal: AbortSignal | undefined,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<HttpOperationExecutionResult> {
 	const sql = getDb();
 	if (operation.backend_config.backend !== "http_operation") {
@@ -265,7 +241,7 @@ export async function executeHttpOperation(
 			const errorText =
 				typeof parsedBody === "string" ? parsedBody : `HTTP ${response.status}`;
 			if (!deferTerminalWrite) {
-				const updated = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+				const updated = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy)} RETURNING id`;
 				if (updated.length === 0)
 					return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 			}
@@ -273,7 +249,7 @@ export async function executeHttpOperation(
 		}
 
 		if (!deferTerminalWrite) {
-			const updated = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+			const updated = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy)} RETURNING id`;
 			if (updated.length === 0)
 				return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 		}

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -128,6 +128,7 @@ export async function executeHttpOperation(
 	actionInput: Record<string, unknown>,
 	abortSignal?: AbortSignal,
 	deferTerminalWrite = false,
+	claimedBy?: string | null,
 ): Promise<HttpOperationExecutionResult> {
 	const sql = getDb();
 	if (operation.backend_config.backend !== "http_operation") {
@@ -239,13 +240,14 @@ export async function executeHttpOperation(
 			const errorText =
 				typeof parsedBody === "string" ? parsedBody : `HTTP ${response.status}`;
 			if (!deferTerminalWrite) {
-				await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+				await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
 			}
 			return { status: "failed", error_message: errorText, output };
 		}
 
 		if (!deferTerminalWrite) {
-			await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+			const updated = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
+			if (updated.length === 0) return { status: 'failed', error_message: 'Inline execution lost its run lease; the durable run state is authoritative.' };
 		}
 		return { status: "completed", output, metadata };
 	} catch (error) {

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -74,13 +74,20 @@ async function failRun(
 	runId: number,
 	organizationId: string,
 	errorMessage: string,
-	deferTerminalWrite = false,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<HttpOperationExecutionResult> {
 	// Upstream response text reaches here through getErrorMessage, so the
 	// message can carry NUL (0x00) that Postgres rejects (see streamContent).
 	const message = stripNul(errorMessage);
 	if (!deferTerminalWrite) {
-		await getDb()`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		// Same lease fence as the completed/failed lanes below: a config refusal
+		// or a thrown request still terminalizes the run, and must not overwrite
+		// an outcome the reaper or a re-claim already recorded.
+		const sql = getDb();
+		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy)} RETURNING id`;
+		if (rows.length === 0)
+			return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 	}
 	return { status: "failed", error_message: message };
 }
@@ -138,6 +145,7 @@ export async function executeHttpOperation(
 			organizationId,
 			"Invalid HTTP operation backend config",
 			deferTerminalWrite,
+			claimedBy,
 		);
 	}
 
@@ -152,6 +160,7 @@ export async function executeHttpOperation(
 				organizationId,
 				`No active OAuth credentials found for '${connection.connector_key}'.`,
 				deferTerminalWrite,
+				claimedBy,
 			);
 		}
 
@@ -260,6 +269,7 @@ export async function executeHttpOperation(
 			organizationId,
 			getErrorMessage(error),
 			deferTerminalWrite,
+			claimedBy,
 		);
 	}
 }

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -1,10 +1,35 @@
 import { getErrorMessage } from "@lobu/core";
-import { getDb } from "../db/client";
+import { type DbClient, getDb } from "../db/client";
 import { resolveCredentialsByConnectionId } from "../mcp-proxy/credential-resolver";
 import { stripNul, stripNulDeep } from "../utils/strip-nul";
 import type { OperationDescriptor } from "./types";
 
 const DEFAULT_HTTP_OPERATION_FETCH_TIMEOUT_MS = 120_000;
+
+/**
+ * Reported when a fenced terminal write matches no row: the run was cancelled,
+ * reaped, or re-claimed while this request was still executing. The external
+ * call may well have succeeded, but this request no longer owns the run, so it
+ * must not overwrite whoever does — the durable row is the answer.
+ */
+export const LOST_LEASE_MESSAGE =
+	"Inline execution lost its run lease; the durable run state is authoritative.";
+
+/**
+ * The guard every inline terminal write shares: land the outcome only while
+ * this request still owns the run it claimed and nothing has terminalized it
+ * (a cancel, the stale-run reaper, a second approve). One definition, because
+ * four hand-written copies drift and a fence that silently matches no row is
+ * indistinguishable from one that worked.
+ *
+ * A caller that took no lease passes `null` and keeps the unfenced semantics:
+ * it has no owner to lose, and `claimed_by = NULL` is never true, so spelling
+ * the fence unconditionally would strand the run.
+ */
+export function inlineLeaseFence(sql: DbClient, claimedBy: string | null) {
+	return sql`AND status = 'running'
+		AND (${claimedBy}::text IS NULL OR claimed_by = ${claimedBy})`;
+}
 
 export type HttpOperationExecutionResult =
 	| {
@@ -240,14 +265,17 @@ export async function executeHttpOperation(
 			const errorText =
 				typeof parsedBody === "string" ? parsedBody : `HTTP ${response.status}`;
 			if (!deferTerminalWrite) {
-				await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
+				const updated = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+				if (updated.length === 0)
+					return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 			}
 			return { status: "failed", error_message: errorText, output };
 		}
 
 		if (!deferTerminalWrite) {
-			const updated = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
-			if (updated.length === 0) return { status: 'failed', error_message: 'Inline execution lost its run lease; the durable run state is authoritative.' };
+			const updated = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+			if (updated.length === 0)
+				return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 		}
 		return { status: "completed", output, metadata };
 	} catch (error) {

--- a/packages/server/src/runs/inline-lease.ts
+++ b/packages/server/src/runs/inline-lease.ts
@@ -1,0 +1,49 @@
+/**
+ * The run-lease vocabulary shared by every write that finalizes a run the
+ * gateway itself is executing.
+ *
+ * A gateway request that executes a run inline claims it first
+ * (`gateway-inline-<uuid>`) and holds that lease across the external call. The
+ * writes below can therefore land long after the claim, by which time a
+ * cancel, the stale-run reaper, or a second approve may have handed the run to
+ * someone else. Every one of them fences on the owner so a late write cannot
+ * overwrite whoever holds the run now.
+ *
+ * The fence values are REQUIRED parameters. An "omit it to skip the fence"
+ * escape hatch is a fail-open guard dressed as a guard: the one caller that
+ * forgets is exactly the one that clobbers another owner's run.
+ */
+
+import type { DbClient } from "../db/client";
+
+/**
+ * Reported when a fenced terminal write matches no row: the run was cancelled,
+ * reaped, or re-claimed while this request was still executing. The external
+ * call may well have succeeded, but this request no longer owns the run, so it
+ * must not overwrite whoever does — the durable row is the answer.
+ */
+export const LOST_LEASE_MESSAGE =
+	"Inline execution lost its run lease; the durable run state is authoritative.";
+
+/**
+ * The guard every inline terminal write shares: land the outcome only while
+ * this request still owns the run it claimed and nothing has terminalized it.
+ * One definition, because hand-written copies drift and a fence that silently
+ * matches no row looks exactly like one that worked.
+ */
+export function inlineLeaseFence(sql: DbClient, claimedBy: string) {
+	return sql`AND status = 'running' AND claimed_by = ${claimedBy}`;
+}
+
+/**
+ * Fence a terminal write on the owner the caller READ, for recovery paths that
+ * finalize a run they did not claim themselves. `null` is not "no fence": it
+ * asserts the run is still unowned, which is what a run claimed before the
+ * gateway took leases looks like. Either way the write loses to a concurrent
+ * re-claim instead of overwriting it.
+ */
+export function runOwnerFence(sql: DbClient, expectedOwner: string | null) {
+	return expectedOwner === null
+		? sql`AND claimed_by IS NULL`
+		: sql`AND claimed_by = ${expectedOwner}`;
+}

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -42,6 +42,7 @@ import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { AUTOMATION_RUN_TYPES_PG } from "./run-types.js";
+import { randomUUID } from 'node:crypto';
 
 type AutomationDispatchSource = 'scheduled' | 'manual' | 'event';
 export type AutomationActivationTrigger =
@@ -1174,6 +1175,7 @@ export async function createConnectorOperationRun(params: {
   approvalStatus: string;
   actionOutput: unknown;
   errorMessage: string | null;
+  claimedBy: string | null;
 }> {
   const sql = params.db ?? getDb();
   if (params.activation && params.approvalMode !== 'inline') {
@@ -1185,6 +1187,10 @@ export async function createConnectorOperationRun(params: {
   const approvalStatus = params.approvalMode === 'queued' ? 'pending' : 'auto';
   const status =
     params.activation || params.approvalMode !== 'inline' ? 'pending' : 'running';
+  const inlineOwner =
+    params.approvalMode === 'inline' && !params.activation
+      ? `gateway-inline-${randomUUID()}`
+      : null;
 
   // Ephemeral device/browser/shell action runs get a bounded claim horizon:
   // a `device` run waits for a device worker to claim it via /poll, and an
@@ -1231,13 +1237,14 @@ export async function createConnectorOperationRun(params: {
     approval_status: string;
     action_output: unknown;
     error_message: string | null;
+    claimed_by: string | null;
   }>`
     INSERT INTO runs (
       organization_id, run_type, connection_id, connector_key, connector_version,
       action_key, action_input, approval_status, status,
       automation_id, parent_run_id,
       policy_principal_kind, policy_principal_id, created_by_user_id,
-      action_idempotency_key, expires_at,
+      action_idempotency_key, expires_at, claimed_at, last_heartbeat_at, claimed_by,
       activation_kind, activation_target_urls,
       run_metadata,
       created_at
@@ -1256,12 +1263,15 @@ export async function createConnectorOperationRun(params: {
       ${params.activation?.kind ?? null},
       ${params.activation ? pgTextArray(params.activation.urls) : null}::text[],
       ${params.runMetadata == null ? null : sql.json(params.runMetadata)},
+      ${inlineOwner ? sql`current_timestamp` : sql`NULL`},
+      ${inlineOwner ? sql`current_timestamp` : sql`NULL`},
+      ${inlineOwner},
       current_timestamp
     )
     ON CONFLICT (organization_id, action_idempotency_key)
       WHERE run_type = 'action' AND action_idempotency_key IS NOT NULL
     DO NOTHING
-    RETURNING id, status, approval_status, action_output, error_message
+    RETURNING id, status, approval_status, action_output, error_message, claimed_by
   `;
 
   if (inserted.length === 0) {
@@ -1286,12 +1296,13 @@ export async function createConnectorOperationRun(params: {
       approval_status: string;
       action_output: unknown;
       error_message: string | null;
+      claimed_by: string | null;
     }>`
       SELECT id, connection_id, connector_key, action_key, action_input,
              policy_principal_kind, policy_principal_id, created_by_user_id,
              automation_id, parent_run_id, run_metadata,
              activation_kind, activation_target_urls,
-             status, approval_status, action_output, error_message
+             status, approval_status, action_output, error_message, claimed_by
       FROM runs
       WHERE organization_id = ${params.organizationId}
         AND run_type = 'action'
@@ -1389,6 +1400,7 @@ export async function createConnectorOperationRun(params: {
       approvalStatus: prior.approval_status,
       actionOutput: prior.action_output,
       errorMessage: prior.error_message,
+      claimedBy: prior.claimed_by,
     };
   }
 
@@ -1404,5 +1416,6 @@ export async function createConnectorOperationRun(params: {
     approvalStatus: row.approval_status,
     actionOutput: row.action_output,
     errorMessage: row.error_message,
+    claimedBy: row.claimed_by,
   };
 }

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -7,6 +7,8 @@
  * - JSON utilities for duplicate detection
  */
 
+import { randomUUID } from 'node:crypto';
+
 import { type DbClient, parsePgTextArray, pgTextArray } from '../db/client';
 import {
   resolvedEventExecution,
@@ -42,7 +44,6 @@ import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { AUTOMATION_RUN_TYPES_PG } from "./run-types.js";
-import { randomUUID } from 'node:crypto';
 
 type AutomationDispatchSource = 'scheduled' | 'manual' | 'event';
 export type AutomationActivationTrigger =
@@ -1260,12 +1261,12 @@ export async function createConnectorOperationRun(params: {
       ${expiresAtSeconds == null
         ? null
         : sql`current_timestamp + (${expiresAtSeconds}::int * interval '1 second')`},
+      ${inlineOwner === null ? null : sql`current_timestamp`},
+      ${inlineOwner === null ? null : sql`current_timestamp`},
+      ${inlineOwner},
       ${params.activation?.kind ?? null},
       ${params.activation ? pgTextArray(params.activation.urls) : null}::text[],
       ${params.runMetadata == null ? null : sql.json(params.runMetadata)},
-      ${inlineOwner ? sql`current_timestamp` : sql`NULL`},
-      ${inlineOwner ? sql`current_timestamp` : sql`NULL`},
-      ${inlineOwner},
       current_timestamp
     )
     ON CONFLICT (organization_id, action_idempotency_key)

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -268,7 +268,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       // staleness predicate, so a worker heartbeat/completion that wins after
       // the candidate read makes this a no-op rather than being overwritten.
       const approvedActionCandidates = (await reserved`
-        SELECT id, organization_id, action_key, action_output
+        SELECT id, organization_id, action_key, action_output, claimed_by
         FROM public.runs
         WHERE ${reserved.unsafe(staleWhereSql)}
           AND run_type = 'action'
@@ -279,6 +279,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
         organization_id: string;
         action_key: string | null;
         action_output: Record<string, unknown> | null;
+        claimed_by: string | null;
       }>;
       let approvalActionsReaped = 0;
       for (const candidate of approvedActionCandidates) {
@@ -304,6 +305,10 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
                 content: `Operation completed: ${actionKey}`,
               },
               null,
+              // Finalize the run exactly as read: if the gateway or another
+              // pod re-claims it between this candidate read and the write,
+              // the write loses instead of overwriting the new owner.
+              candidate.claimed_by,
               sql
             );
             if (eventId !== null) approvalActionsReaped += 1;

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -1,5 +1,5 @@
-import type { DbClient } from "../../db/client";
-import { getDb } from "../../db/client";
+import { type DbClient, getDb } from "../../db/client";
+import { runOwnerFence } from "../../runs/inline-lease";
 import { insertEvent } from "../../utils/insert-event";
 
 /**
@@ -42,6 +42,11 @@ export function requireApprovalCard(
  * the loser matches zero rows and writes no card. The card guard runs INSIDE
  * the tx, so a missing card rolls the completed write back (fail-closed).
  *
+ * `expectedOwner` is the lease this write is allowed to finalize under: the
+ * owner the caller claimed, or the one it read off the row when recovering a
+ * run someone else claimed. It is required, because a terminalization that
+ * skips the owner check is exactly the one that overwrites a re-claim.
+ *
  * Returns the completed card event id, or null when the run was no longer in
  * the claimed state (already terminalized concurrently) — the caller returns a
  * "decided concurrently" outcome instead of writing anything.
@@ -52,8 +57,8 @@ export async function terminalizeApprovalRunCompleted(
 	output: Record<string, unknown>,
 	card: { title: string; content: string },
 	reviewer: ApprovalReviewer | null,
+	expectedOwner: string | null,
 	db: DbClient = getDb(),
-	options?: { expectedOwner?: string | null },
 ): Promise<number | null> {
 	return db.begin(async (tx) => {
 		const rows = await tx`
@@ -64,7 +69,7 @@ export async function terminalizeApprovalRunCompleted(
 				AND organization_id = ${organizationId}
 				AND status = 'running'
 				AND approval_status = 'approved'
-				AND (${options?.expectedOwner ?? null}::text IS NULL OR claimed_by = ${options?.expectedOwner ?? null})
+				${runOwnerFence(tx, expectedOwner)}
 			RETURNING id
 		`;
 		if (rows.length === 0) return null;

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -53,6 +53,7 @@ export async function terminalizeApprovalRunCompleted(
 	card: { title: string; content: string },
 	reviewer: ApprovalReviewer | null,
 	db: DbClient = getDb(),
+	options?: { expectedOwner?: string | null },
 ): Promise<number | null> {
 	return db.begin(async (tx) => {
 		const rows = await tx`
@@ -63,6 +64,7 @@ export async function terminalizeApprovalRunCompleted(
 				AND organization_id = ${organizationId}
 				AND status = 'running'
 				AND approval_status = 'approved'
+				AND (${options?.expectedOwner ?? null}::text IS NULL OR claimed_by = ${options?.expectedOwner ?? null})
 			RETURNING id
 		`;
 		if (rows.length === 0) return null;

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -63,6 +63,7 @@ import {
 } from "../../manage_entity_schema";
 import { executeOperationInline } from "./execute";
 import { qualifiedOperationKey } from "./shared";
+import { randomUUID } from "node:crypto";
 /**
  * Durably persist a claimed run's apply/execution output in its OWN
  * transaction, BEFORE the terminalization attempt. If the terminal card write
@@ -78,6 +79,7 @@ async function persistDurableApplyOutput(
 	runId: number,
 	organizationId: string,
 	output: Record<string, unknown>,
+	claimedBy?: string | null,
 ): Promise<void> {
 	const sql = getDb();
 	await sql`
@@ -86,6 +88,7 @@ async function persistDurableApplyOutput(
 			AND organization_id = ${organizationId}
 			AND status = 'running'
 			AND approval_status = 'approved'
+			AND (${claimedBy ?? null}::text IS NULL OR claimed_by = ${claimedBy ?? null})
 	`;
 }
 
@@ -1611,18 +1614,21 @@ export async function handleApprove(
 	// same transaction as the claim + confirmed card — there is no separate
 	// post-claim status write to race with the card.
 	const setRunning = resolved.operation.backend !== "local_action";
+	const inlineOwner = setRunning ? `gateway-inline-${randomUUID()}` : null;
 	const claimed = await sql.begin(async (tx) => {
 		const statusSet = setRunning ? tx`, status = 'running'` : tx``;
+		const ownerSet = setRunning ? tx`, claimed_by = ${inlineOwner}, claimed_at = current_timestamp, last_heartbeat_at = current_timestamp` : tx``;
 		const rows = await tx`
 			UPDATE runs
 			SET approval_status = 'approved'
 				${statusSet},
+				${ownerSet},
 				action_input = ${args.input ? tx.json(args.input) : tx`action_input`}
 			WHERE id = ${args.run_id}
 				AND organization_id = ${ctx.organizationId}
 				AND approval_status = 'pending'
 				AND run_type = 'action'
-			RETURNING id, connection_id, action_key, action_input, created_by_user_id
+			RETURNING id, connection_id, action_key, action_input, created_by_user_id, claimed_by
 		`;
 		if (rows.length === 0) return null;
 		// The confirmed card's event id is the run's approval identity for this
@@ -1673,14 +1679,14 @@ export async function handleApprove(
 		run.created_by_user_id,
 		env,
 		undefined,
-		{ deferTerminalWrite: true },
+		{ deferTerminalWrite: true, claimedBy: inlineOwner },
 	);
 
 	if (result.status === "completed") {
 		// Phase 2a (durable): persist the execution output BEFORE the
 		// terminalization attempt so a failed completed-card write cannot lose
 		// the only durable record of an already-successful external mutation.
-		await persistDurableApplyOutput(args.run_id, ctx.organizationId, result.output);
+		await persistDurableApplyOutput(args.run_id, ctx.organizationId, result.output, inlineOwner);
 
 		// Phase 2b (atomic): terminal completed runs write + 'completed' card.
 		// The card guard runs INSIDE the tx so a missing card rolls the
@@ -1694,6 +1700,8 @@ export async function handleApprove(
 				content: `Operation completed: ${run.action_key}`,
 			},
 			reviewer,
+			getDb(),
+			{ expectedOwner: inlineOwner },
 		);
 		if (terminalCardId === null) {
 			return {

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
 	ApproveAction,
 	ApproveBatchAction,
@@ -61,9 +63,9 @@ import {
 	MANAGE_ENTITY_SCHEMA_ACTION_KEY,
 	type StoredManageEntitySchemaProposal,
 } from "../../manage_entity_schema";
+import { inlineLeaseFence } from "../../../../operations/execute-http-operation";
 import { executeOperationInline } from "./execute";
 import { qualifiedOperationKey } from "./shared";
-import { randomUUID } from "node:crypto";
 /**
  * Durably persist a claimed run's apply/execution output in its OWN
  * transaction, BEFORE the terminalization attempt. If the terminal card write
@@ -86,9 +88,8 @@ async function persistDurableApplyOutput(
 		UPDATE runs SET action_output = ${sql.json(output)}
 		WHERE id = ${runId}
 			AND organization_id = ${organizationId}
-			AND status = 'running'
 			AND approval_status = 'approved'
-			AND (${claimedBy ?? null}::text IS NULL OR claimed_by = ${claimedBy ?? null})
+			${inlineLeaseFence(sql, claimedBy ?? null)}
 	`;
 }
 
@@ -1616,13 +1617,16 @@ export async function handleApprove(
 	const setRunning = resolved.operation.backend !== "local_action";
 	const inlineOwner = setRunning ? `gateway-inline-${randomUUID()}` : null;
 	const claimed = await sql.begin(async (tx) => {
-		const statusSet = setRunning ? tx`, status = 'running'` : tx``;
-		const ownerSet = setRunning ? tx`, claimed_by = ${inlineOwner}, claimed_at = current_timestamp, last_heartbeat_at = current_timestamp` : tx``;
+		// The lease is taken in the same statement that flips the run to
+		// `running`: an approved, running, unowned row is exactly the window the
+		// stale-run reaper and a second approve would both grab.
+		const runningSet = setRunning
+			? tx`, status = 'running', claimed_by = ${inlineOwner}, claimed_at = current_timestamp, last_heartbeat_at = current_timestamp`
+			: tx``;
 		const rows = await tx`
 			UPDATE runs
 			SET approval_status = 'approved'
-				${statusSet},
-				${ownerSet},
+				${runningSet},
 				action_input = ${args.input ? tx.json(args.input) : tx`action_input`}
 			WHERE id = ${args.run_id}
 				AND organization_id = ${ctx.organizationId}

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -63,7 +63,7 @@ import {
 	MANAGE_ENTITY_SCHEMA_ACTION_KEY,
 	type StoredManageEntitySchemaProposal,
 } from "../../manage_entity_schema";
-import { inlineLeaseFence } from "../../../../operations/execute-http-operation";
+import { inlineLeaseFence } from "../../../../runs/inline-lease";
 import { executeOperationInline } from "./execute";
 import { qualifiedOperationKey } from "./shared";
 /**
@@ -81,7 +81,7 @@ async function persistDurableApplyOutput(
 	runId: number,
 	organizationId: string,
 	output: Record<string, unknown>,
-	claimedBy?: string | null,
+	claimedBy: string,
 ): Promise<void> {
 	const sql = getDb();
 	await sql`
@@ -89,7 +89,7 @@ async function persistDurableApplyOutput(
 		WHERE id = ${runId}
 			AND organization_id = ${organizationId}
 			AND approval_status = 'approved'
-			${inlineLeaseFence(sql, claimedBy ?? null)}
+			${inlineLeaseFence(sql, claimedBy)}
 	`;
 }
 
@@ -111,7 +111,7 @@ async function tryReconcileTerminalization(
 ): Promise<ManageOperationsResult | null> {
 	const sql = getDb();
 	const rows = await sql`
-		SELECT run_type, action_key, action_input, action_output
+		SELECT run_type, action_key, action_input, action_output, claimed_by
 		FROM runs
 		WHERE id = ${args.run_id}
 			AND organization_id = ${ctx.organizationId}
@@ -127,6 +127,7 @@ async function tryReconcileTerminalization(
 		action_key: string;
 		action_input: unknown;
 		action_output: Record<string, unknown>;
+		claimed_by: string | null;
 	};
 	const output = row.action_output;
 	let title: string;
@@ -152,6 +153,10 @@ async function tryReconcileTerminalization(
 		output,
 		{ title, content },
 		reviewer,
+		// This request did not claim the run — it is recovering one whose
+		// terminal write failed. Fence on the owner as read so a concurrent
+		// re-claim wins instead of being overwritten.
+		row.claimed_by,
 	);
 	if (eventId === null) {
 		return {
@@ -388,15 +393,24 @@ async function claimBuilderRun(
 	handler: BuilderApprovalHandler;
 	proposal: unknown;
 	requesterUserId: string | null;
+	claimedBy: string;
 } | null> {
 	const sql = db;
 	const handlers = getBuilderApprovalHandlers();
 	const actionKeys = pgTextArray(handlers.map((h) => h.actionKey));
+	// The approve branch runs the handler's apply OUTSIDE this transaction, so
+	// the run sits `running` across a slow external call. Take the lease in the
+	// same statement that approves it — an approved, running, unowned row is
+	// what the reaper and a second approve both grab. The reject branch is
+	// terminal in one statement and has no such window.
+	const claimedBy = `gateway-inline-${randomUUID()}`;
 	const rows =
 		decision === "approved"
 			? await sql`
           UPDATE runs
-          SET approval_status = 'approved', status = 'running'
+          SET approval_status = 'approved', status = 'running',
+              claimed_by = ${claimedBy}, claimed_at = current_timestamp,
+              last_heartbeat_at = current_timestamp
           WHERE id = ${runId}
             AND organization_id = ${organizationId}
             AND approval_status = 'pending'
@@ -427,6 +441,7 @@ async function claimBuilderRun(
 		handler,
 		proposal: row.action_input,
 		requesterUserId: row.created_by_user_id,
+		claimedBy,
 	};
 }
 
@@ -643,7 +658,7 @@ async function tryApproveBuilderRun(
 	if (!phaseOne) return null;
 	if (phaseOne.kind === "completed") return phaseOne.result;
 
-	const { handler, apply, proposal, requesterUserId, desc } = phaseOne;
+	const { handler, apply, proposal, requesterUserId, desc, claimedBy } = phaseOne;
 
 	// Apply runs OUTSIDE any transaction — the family's write can be
 	// slow/network-bound and must not hold a DB transaction open. The catch
@@ -695,6 +710,7 @@ async function tryApproveBuilderRun(
 		args.run_id,
 		ctx.organizationId,
 		output as unknown as Record<string, unknown>,
+		claimedBy,
 	);
 
 	// Phase 2b (atomic): the terminal completed runs write + the 'completed'
@@ -711,6 +727,7 @@ async function tryApproveBuilderRun(
 			content: `Builder action completed: ${desc}`,
 		},
 		reviewer,
+		claimedBy,
 	);
 	if (eventId === null) {
 		return {
@@ -1615,7 +1632,10 @@ export async function handleApprove(
 	// same transaction as the claim + confirmed card — there is no separate
 	// post-claim status write to race with the card.
 	const setRunning = resolved.operation.backend !== "local_action";
-	const inlineOwner = setRunning ? `gateway-inline-${randomUUID()}` : null;
+	// Minted unconditionally so the fence value is never nullable. Only a run
+	// that actually flips to `running` records it as its owner; a `local_action`
+	// run stays unclaimed and returns before any fenced write.
+	const inlineOwner = `gateway-inline-${randomUUID()}`;
 	const claimed = await sql.begin(async (tx) => {
 		// The lease is taken in the same statement that flips the run to
 		// `running`: an approved, running, unowned row is exactly the window the
@@ -1704,8 +1724,7 @@ export async function handleApprove(
 				content: `Operation completed: ${run.action_key}`,
 			},
 			reviewer,
-			getDb(),
-			{ expectedOwner: inlineOwner },
+			inlineOwner,
 		);
 		if (terminalCardId === null) {
 			return {

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -453,16 +453,25 @@ async function failBuilderRun(
 	desc: string,
 	errorMessage: string,
 	reviewer: ApprovalReviewer | null,
+	claimedBy: string,
 ): Promise<ManageOperationsResult> {
 	// Atomic: the failed runs write and the 'failed' card supersede commit
 	// together. The card guard runs INSIDE the transaction, so a missing card
 	// throws while the tx is open and rolls the runs write back — the run must
 	// never land terminal with no card.
+	//
+	// Fenced: apply() ran OUTSIDE any transaction, so the reaper or a second
+	// approve can have taken the lease while it was in flight. Without the fence
+	// this write clobbers whatever they recorded and supersedes the card to
+	// 'failed' on a run that is no longer ours.
 	const eventId = await getDb().begin(async (tx) => {
-		await tx`
+		const rows = await tx`
 			UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
 			WHERE id = ${runId} AND organization_id = ${organizationId}
+			${inlineLeaseFence(tx, claimedBy)}
+			RETURNING id
 		`;
+		if (rows.length === 0) return null;
 		const cardId = await supersedeActionEvent(
 			runId,
 			organizationId,
@@ -476,6 +485,12 @@ async function failBuilderRun(
 		requireApprovalCard(runId, cardId, "failed");
 		return cardId;
 	});
+	if (eventId === null) {
+		return {
+			error:
+				"The approval was already decided while this request was in flight. Refresh before acting.",
+		};
+	}
 	return {
 		action: "approve",
 		approved: true,
@@ -687,6 +702,7 @@ async function tryApproveBuilderRun(
 				desc,
 				softFailure,
 				reviewer,
+				claimedBy,
 			);
 		}
 	} catch (error) {
@@ -698,6 +714,7 @@ async function tryApproveBuilderRun(
 			desc,
 			errorMessage,
 			reviewer,
+			claimedBy,
 		);
 	}
 
@@ -1744,13 +1761,21 @@ export async function handleApprove(
 	// Phase 2 (atomic): terminal failed runs write + 'failed' card. The card
 	// guard runs INSIDE the tx so a missing card rolls the failed runs write
 	// back.
-	await sql.begin(async (tx) => {
-		await tx`
+	//
+	// Fenced on the same lease as the completed lane above: with
+	// deferTerminalWrite the inline execution wrote nothing, so this is the ONLY
+	// terminal write for a failed inline apply. Unfenced it would overwrite a
+	// reaper's or a re-claim's outcome and supersede the card to 'failed'.
+	const failed = await sql.begin(async (tx) => {
+		const rows = await tx`
 			UPDATE runs SET status = 'failed', completed_at = NOW(),
 				action_output = ${result.output ? tx.json(result.output) : null},
 				error_message = ${result.error_message}
 			WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+			${inlineLeaseFence(tx, inlineOwner)}
+			RETURNING id
 		`;
+		if (rows.length === 0) return false;
 		const cardId = await supersedeActionEvent(
 			args.run_id,
 			ctx.organizationId,
@@ -1762,8 +1787,14 @@ export async function handleApprove(
 			tx,
 		);
 		requireApprovalCard(args.run_id, cardId, "failed");
-		return cardId;
+		return true;
 	});
+	if (!failed) {
+		return {
+			error:
+				"The approval was already decided while this request was in flight. Refresh before acting.",
+		};
+	}
 	return {
 		action: "approve",
 		approved: true,

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -25,7 +25,11 @@ import { notifyActionApprovalNeeded } from "../../../../notifications/triggers";
 import { resolveApprovalChatOrigin } from "../../approval-delivery";
 import { resolveActionMode } from "../../../../operations/action-modes";
 import { getOperationForConnection } from "../../../../operations/connector-operations";
-import { executeHttpOperation } from "../../../../operations/execute-http-operation";
+import {
+	LOST_LEASE_MESSAGE,
+	inlineLeaseFence,
+	executeHttpOperation,
+} from "../../../../operations/execute-http-operation";
 import { validateOperationInput } from "../../../../operations/input-validation";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { OperationDescriptor } from "../../../../operations/types";
@@ -78,8 +82,9 @@ async function failRunInline(
 	const message = stripNul(errorMsg);
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
-		if (rows.length === 0) return { status: 'failed', error_message: message };
+		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+		if (rows.length === 0)
+			return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 	}
 	return { status: "failed", error_message: message };
 }
@@ -98,8 +103,9 @@ async function completeRunInline(
 	const sanitized = stripNulDeep(output) as Record<string, unknown>;
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		const rows = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
-		if (rows.length === 0) return { status: 'failed', error_message: 'Inline execution lost its run lease; the durable run state is authoritative.' };
+		const rows = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+		if (rows.length === 0)
+			return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 	}
 	return { status: "completed", output: sanitized };
 }
@@ -321,10 +327,10 @@ async function executeMcpToolInline(
     return failRunInline(
       runId,
       organizationId,
-	      errorText,
-	      deferTerminalWrite,
-	      claimedBy,
-	    );
+      errorText,
+      deferTerminalWrite,
+      claimedBy,
+    );
   }
 
 	return completeRunInline(
@@ -964,8 +970,8 @@ export async function handleExecute(
 		input,
 		visibilityUserId,
 		env,
-	ctx.abortSignal,
-	{ claimedBy: claim.claimedBy },
+		ctx.abortSignal,
+		{ claimedBy: claim.claimedBy },
 	);
 	await trackOperationReaction(runId);
 	if (result.status === "completed") {

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -69,6 +69,7 @@ async function failRunInline(
 	organizationId: string,
 	errorMsg: string,
 	deferTerminalWrite = false,
+	claimedBy?: string | null,
 ): Promise<InlineExecutionResult> {
 	// Connector code, scraped pages and upstream MCP servers all reach here as
 	// raw text, so the message can carry NUL (0x00) that Postgres rejects (see
@@ -77,7 +78,8 @@ async function failRunInline(
 	const message = stripNul(errorMsg);
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
+		if (rows.length === 0) return { status: 'failed', error_message: message };
 	}
 	return { status: "failed", error_message: message };
 }
@@ -88,6 +90,7 @@ async function completeRunInline(
 	organizationId: string,
 	output: Record<string, unknown>,
 	deferTerminalWrite = false,
+	claimedBy?: string | null,
 ): Promise<InlineExecutionResult> {
 	// Same NUL strip as failRunInline — `output` is connector- or upstream-MCP-
 	// produced and lands in the jsonb `action_output` column. Sanitize before
@@ -95,7 +98,8 @@ async function completeRunInline(
 	const sanitized = stripNulDeep(output) as Record<string, unknown>;
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		const rows = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId} AND status = 'running' AND claimed_by = ${claimedBy ?? null} RETURNING id`;
+		if (rows.length === 0) return { status: 'failed', error_message: 'Inline execution lost its run lease; the durable run state is authoritative.' };
 	}
 	return { status: "completed", output: sanitized };
 }
@@ -155,6 +159,7 @@ async function executeLocalActionInline(
 	env: Env,
 	abortSignal?: AbortSignal,
 	deferTerminalWrite = false,
+	claimedBy?: string | null,
 ): Promise<InlineExecutionResult> {
 	const sql = getDb();
 
@@ -177,6 +182,7 @@ async function executeLocalActionInline(
 			organizationId,
 			getErrorMessage(err),
 			deferTerminalWrite,
+			claimedBy,
 		);
 	}
 
@@ -255,6 +261,7 @@ async function executeLocalActionInline(
 			organizationId,
 			result.output,
 			deferTerminalWrite,
+			claimedBy,
 		);
 	} catch (error) {
 		return failRunInline(
@@ -262,6 +269,7 @@ async function executeLocalActionInline(
 			organizationId,
 			getErrorMessage(error),
 			deferTerminalWrite,
+			claimedBy,
 		);
 	}
 }
@@ -273,6 +281,7 @@ async function executeMcpToolInline(
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
 	deferTerminalWrite = false,
+	claimedBy?: string | null,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend_config.backend !== "mcp_tool") {
 		return {
@@ -300,6 +309,7 @@ async function executeMcpToolInline(
 			organizationId,
 			getErrorMessage(error),
 			deferTerminalWrite,
+			claimedBy,
 		);
 	}
 
@@ -311,9 +321,10 @@ async function executeMcpToolInline(
     return failRunInline(
       runId,
       organizationId,
-      errorText,
-      deferTerminalWrite,
-    );
+	      errorText,
+	      deferTerminalWrite,
+	      claimedBy,
+	    );
   }
 
 	return completeRunInline(
@@ -323,6 +334,7 @@ async function executeMcpToolInline(
 			content: result.content,
 		} as Record<string, unknown>,
 		deferTerminalWrite,
+		claimedBy,
 	);
 }
 
@@ -337,6 +349,7 @@ interface InlineExecutionOptions {
 	 * would leave a terminal run with no card when the card INSERT fails).
 	 */
 	deferTerminalWrite?: boolean;
+	claimedBy?: string | null;
 }
 
 export async function executeOperationInline(
@@ -362,6 +375,7 @@ export async function executeOperationInline(
 			env,
 			abortSignal,
 			deferTerminalWrite,
+			options?.claimedBy,
 		);
 	}
 	if (operation.backend === "mcp_tool") {
@@ -372,6 +386,7 @@ export async function executeOperationInline(
 			operation,
 			actionInput,
 			deferTerminalWrite,
+			options?.claimedBy,
 		);
 	}
 	return executeHttpOperation(
@@ -382,6 +397,7 @@ export async function executeOperationInline(
 		actionInput,
 		abortSignal,
 		deferTerminalWrite,
+		options?.claimedBy,
 	);
 }
 /** Return the durable outcome of a run claimed by an earlier request. */
@@ -948,7 +964,8 @@ export async function handleExecute(
 		input,
 		visibilityUserId,
 		env,
-		ctx.abortSignal,
+	ctx.abortSignal,
+	{ claimedBy: claim.claimedBy },
 	);
 	await trackOperationReaction(runId);
 	if (result.status === "completed") {

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -25,11 +25,8 @@ import { notifyActionApprovalNeeded } from "../../../../notifications/triggers";
 import { resolveApprovalChatOrigin } from "../../approval-delivery";
 import { resolveActionMode } from "../../../../operations/action-modes";
 import { getOperationForConnection } from "../../../../operations/connector-operations";
-import {
-	LOST_LEASE_MESSAGE,
-	inlineLeaseFence,
-	executeHttpOperation,
-} from "../../../../operations/execute-http-operation";
+import { LOST_LEASE_MESSAGE, inlineLeaseFence } from "../../../../runs/inline-lease";
+import { executeHttpOperation } from "../../../../operations/execute-http-operation";
 import { validateOperationInput } from "../../../../operations/input-validation";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { OperationDescriptor } from "../../../../operations/types";
@@ -72,8 +69,8 @@ async function failRunInline(
 	runId: number,
 	organizationId: string,
 	errorMsg: string,
-	deferTerminalWrite = false,
-	claimedBy?: string | null,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<InlineExecutionResult> {
 	// Connector code, scraped pages and upstream MCP servers all reach here as
 	// raw text, so the message can carry NUL (0x00) that Postgres rejects (see
@@ -82,7 +79,7 @@ async function failRunInline(
 	const message = stripNul(errorMsg);
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+		const rows = await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${message} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy)} RETURNING id`;
 		if (rows.length === 0)
 			return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 	}
@@ -94,8 +91,8 @@ async function completeRunInline(
 	runId: number,
 	organizationId: string,
 	output: Record<string, unknown>,
-	deferTerminalWrite = false,
-	claimedBy?: string | null,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<InlineExecutionResult> {
 	// Same NUL strip as failRunInline — `output` is connector- or upstream-MCP-
 	// produced and lands in the jsonb `action_output` column. Sanitize before
@@ -103,7 +100,7 @@ async function completeRunInline(
 	const sanitized = stripNulDeep(output) as Record<string, unknown>;
 	if (!deferTerminalWrite) {
 		const sql = getDb();
-		const rows = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy ?? null)} RETURNING id`;
+		const rows = await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(sanitized)} WHERE id = ${runId} AND organization_id = ${organizationId} ${inlineLeaseFence(sql, claimedBy)} RETURNING id`;
 		if (rows.length === 0)
 			return { status: "failed", error_message: LOST_LEASE_MESSAGE };
 	}
@@ -163,9 +160,9 @@ async function executeLocalActionInline(
 	actionInput: Record<string, unknown>,
 	requesterUserId: string | null,
 	env: Env,
-	abortSignal?: AbortSignal,
-	deferTerminalWrite = false,
-	claimedBy?: string | null,
+	abortSignal: AbortSignal | undefined,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<InlineExecutionResult> {
 	const sql = getDb();
 
@@ -286,8 +283,8 @@ async function executeMcpToolInline(
 	connection: ConnectionRow,
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
-	deferTerminalWrite = false,
-	claimedBy?: string | null,
+	deferTerminalWrite: boolean,
+	claimedBy: string,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend_config.backend !== "mcp_tool") {
 		return {
@@ -355,7 +352,12 @@ interface InlineExecutionOptions {
 	 * would leave a terminal run with no card when the card INSERT fails).
 	 */
 	deferTerminalWrite?: boolean;
-	claimedBy?: string | null;
+	/**
+	 * The owner this request claimed the run under. Required: every inline
+	 * terminal write fences on it, and an optional fence value is a fence the
+	 * next caller can forget.
+	 */
+	claimedBy: string;
 }
 
 export async function executeOperationInline(
@@ -366,10 +368,10 @@ export async function executeOperationInline(
 	actionInput: Record<string, unknown>,
 	requesterUserId: string | null,
 	env: Env,
-	abortSignal?: AbortSignal,
-	options?: InlineExecutionOptions,
+	abortSignal: AbortSignal | undefined,
+	options: InlineExecutionOptions,
 ): Promise<InlineExecutionResult> {
-	const deferTerminalWrite = options?.deferTerminalWrite ?? false;
+	const deferTerminalWrite = options.deferTerminalWrite ?? false;
 	if (operation.backend === "local_action") {
 		return executeLocalActionInline(
 			runId,
@@ -381,7 +383,7 @@ export async function executeOperationInline(
 			env,
 			abortSignal,
 			deferTerminalWrite,
-			options?.claimedBy,
+			options.claimedBy,
 		);
 	}
 	if (operation.backend === "mcp_tool") {
@@ -392,7 +394,7 @@ export async function executeOperationInline(
 			operation,
 			actionInput,
 			deferTerminalWrite,
-			options?.claimedBy,
+			options.claimedBy,
 		);
 	}
 	return executeHttpOperation(
@@ -403,7 +405,7 @@ export async function executeOperationInline(
 		actionInput,
 		abortSignal,
 		deferTerminalWrite,
-		options?.claimedBy,
+		options.claimedBy,
 	);
 }
 /** Return the durable outcome of a run claimed by an earlier request. */
@@ -962,6 +964,17 @@ export async function handleExecute(
 		};
 	}
 
+	if (claim.claimedBy === null) {
+		// Every inline run is claimed in the INSERT that creates it. A null owner
+		// means this row was not created for inline execution, and running it
+		// would write the outcome back with no lease to fence against.
+		return {
+			action: "execute",
+			run_id: runId,
+			status: "failed",
+			error_message: "Inline execution requires a claimed run.",
+		};
+	}
 	const result = await executeOperationInline(
 		runId,
 		ctx.organizationId,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -237,6 +237,14 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
             )`
 			: sql``;
 
+		// `authorizeRunForWorker` already checked both of these, but it read the
+		// row in a separate statement. This write is not idempotent — it stamps
+		// `device_agent_session` with the reporting worker — so a run cancelled or
+		// re-claimed in the gap would get another device's session pinned onto it
+		// and poll would resume it on the wrong machine. Re-assert the lease in
+		// the UPDATE itself; the 409 below is the same body and status
+		// `authorizeRunForWorker` returns for the same condition, so it is not a
+		// new outcome for the worker to handle.
 		const updated = await sql`
       UPDATE runs
       SET last_heartbeat_at = current_timestamp,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -237,12 +237,18 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
             )`
 			: sql``;
 
-		await sql`
+		const updated = await sql`
       UPDATE runs
       SET last_heartbeat_at = current_timestamp,
           items_collected = COALESCE(${progress?.items_collected_so_far ?? null}, items_collected)${agentSessionCheckpoint}
       WHERE id = ${run_id}
+        AND status = 'running'
+        AND claimed_by = ${worker_id}
+      RETURNING id
     `;
+		if (updated.length === 0) {
+			return c.json({ error: 'Run is not in progress' }, 409);
+		}
 
 		return c.json({ continue: true });
 	} catch (err: unknown) {


### PR DESCRIPTION
## Summary
- assign private `gateway-inline-<uuid>` ownership only to immediately executing gateway inline action runs
- require running + exact owner for inline completion/failure writes and guarded worker heartbeats
- stamp approved inline HTTP/MCP runs with the same owner and guard durable/terminal approval writes

## Evidence
- `make pre-pr` ✅
- pre-commit Biome + TypeScript ✅
- `bun test packages/connector-worker/src/__tests__/automation-arm-e2e.test.ts` ✅ 20 pass
- server integration tests ⚠️ blocked: `DATABASE_URL` is not configured in this environment
- `make review-fix` ⚠️ blocked: Claude OAuth session expired
- `git diff --check` ✅

## Scope / exclusions
No DB schema or migrations, public REST/MCP/worker protocol, core contract, generated client, connector SDK, UI, cancellation schema/state, deploy, or merge changes.

PR #3244 overlaps queue/approval/run-lifecycle surfaces and should be rebased if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent workers from overwriting run results after ownership changes.
  * Added safeguards so heartbeats from expired, cancelled, or non-owning workers are rejected.
  * Ensured approval and execution outcomes are recorded only by the current run owner.
  * Improved handling of failed external operations and stale runs.
* **Reliability**
  * Inline executions now track ownership consistently, improving lease recovery and preventing conflicting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->