### PR TITLE
fix(agent-worker): preserve durable turn delivery

### DIFF
--- a/packages/agent-worker/src/__tests__/message-batcher.test.ts
+++ b/packages/agent-worker/src/__tests__/message-batcher.test.ts
@@ -244,6 +244,44 @@ describe("MessageBatcher — error resilience", () => {
     // After any error path, isProcessing must be false
     expect(batcher.isCurrentlyProcessing()).toBe(false);
   });
+
+  test("messages queued during a failed batch are still processed", async () => {
+    const processed: string[] = [];
+    let releaseFirst: (() => void) | null = null;
+    let signalFirstStarted: (() => void) | null = null;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+
+    const batcher = new MessageBatcher({
+      batchWindowMs: 10,
+      onBatchReady: async (messages) => {
+        const id = messages[0]?.payload.messageId;
+        if (id === "fails") {
+          signalFirstStarted?.();
+          await new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+          throw new Error("turn failed");
+        }
+        if (id) processed.push(id);
+      },
+    });
+
+    const failedBatch = batcher.addMessage(makeMsg("fails", "first", 1));
+    await firstStarted;
+    await batcher.addMessage(makeMsg("must-survive", "second", 2));
+    releaseFirst?.();
+    await failedBatch.catch(() => undefined);
+
+    const deadline = Date.now() + 500;
+    while (processed.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(processed).toEqual(["must-survive"]);
+    batcher.stop();
+  });
 });
 
 describe("MessageBatcher — addPriorityMessage (`!`-bash)", () => {

--- a/packages/agent-worker/src/__tests__/message-batcher.test.ts
+++ b/packages/agent-worker/src/__tests__/message-batcher.test.ts
@@ -188,6 +188,59 @@ describe("MessageBatcher — stop()", () => {
     // The timer was cleared; the queued message is still in the queue
     expect(batcher.getPendingCount()).toBe(1);
   });
+
+  test("stop during a failed batch leaves the queued suffix pending", async () => {
+    const processed: string[] = [];
+    let releaseFirst: (() => void) | null = null;
+    let firstStarted: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    const batcher = new MessageBatcher({
+      batchWindowMs: 10,
+      onBatchReady: async (messages) => {
+        if (messages[0]?.payload.messageId === "fails") {
+          firstStarted?.();
+          await new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+          throw new Error("turn failed");
+        }
+        processed.push(...messages.map((message) => message.payload.messageId));
+      },
+    });
+
+    const failed = batcher.addMessage(makeMsg("fails", "first", 1));
+    await started;
+    await batcher.addMessage(makeMsg("suffix", "second", 2));
+    batcher.stop();
+    releaseFirst?.();
+    await failed.catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(processed).toEqual([]);
+    expect(batcher.getPendingCount()).toBe(1);
+  });
+
+  test("idle direct requeue and priority delivery cannot drain after stop", async () => {
+    const processed: string[] = [];
+    const batcher = new MessageBatcher({
+      batchWindowMs: 10,
+      onBatchReady: async (messages) => {
+        processed.push(...messages.map((message) => message.payload.messageId));
+      },
+    });
+
+    await batcher.addMessage(makeMsg("warm", "warmup", 1));
+    batcher.stop();
+    batcher.requeueClaimedMessages([makeMsg("suffix", "suffix", 2)]);
+    await batcher.addPriorityMessage(makeMsg("priority", "priority", 3));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(processed).toEqual(["warm"]);
+    expect(batcher.getPendingCount()).toBe(2);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -612,6 +612,22 @@ describe("stop() mid-run cleanup", () => {
     const client = makeClient();
     await expect(client.stop()).resolves.toBeUndefined();
   });
+
+  test("does not recreate a worker when a queued drain runs after stop", async () => {
+    const client = makeClient();
+    await client.stop();
+
+    const workerConstructor = (client as any).currentWorker;
+    await (client as any).processSingleMessage({
+      payload: {
+        ...JSON.parse(makeJobEvent()).payload,
+        messageId: "after-stop",
+      },
+      timestamp: 1,
+    });
+
+    expect((client as any).currentWorker).toBe(workerConstructor);
+  });
 });
 
 describe("live steering classification", () => {

--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -853,6 +853,48 @@ describe("live steering classification", () => {
     expect(processSingleMessage).toHaveBeenNthCalledWith(2, second, ["second"]);
   });
 
+  test("continues an unattempted batch suffix exactly once after an earlier item fails", async () => {
+    const client = makeClient();
+    const attempts: string[] = [];
+    (client as any).processSingleMessage = mock(async (message: any) => {
+      const messageId = message.payload.messageId as string;
+      attempts.push(messageId);
+      if (messageId === "first-fails") throw new Error("turn failed");
+    });
+
+    const batcher = (client as any).messageBatcher;
+    batcher.batchWindowMs = 5;
+    await batcher.addMessage({
+      payload: { ...payload, messageId: "warmup" },
+      timestamp: 0,
+    });
+    await batcher.addMessage({
+      payload: {
+        ...payload,
+        messageId: "first-fails",
+        userId: "first-user",
+      },
+      timestamp: 1,
+    });
+    await batcher.addMessage({
+      payload: {
+        ...payload,
+        messageId: "suffix-must-run",
+        userId: "second-user",
+      },
+      timestamp: 2,
+    });
+
+    const deadline = Date.now() + 500;
+    while (!attempts.includes("suffix-must-run") && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(attempts).toEqual(["warmup", "first-fails", "suffix-must-run"]);
+    batcher.stop();
+  });
+
   test("keeps queue-policy Automation events as one turn per delivery", async () => {
     const client = makeClient();
     const processSingleMessage = mock(async () => undefined);

--- a/packages/agent-worker/src/gateway/message-batcher.ts
+++ b/packages/agent-worker/src/gateway/message-batcher.ts
@@ -124,6 +124,29 @@ export class MessageBatcher {
     }
   }
 
+  /**
+   * Restore the never-attempted suffix of a batch whose callback failed.
+   * These IDs were reserved before the original batch was captured, so this
+   * deliberately bypasses claimMessageId(). Prepend them ahead of messages
+   * that arrived while the failed callback was running to preserve delivery
+   * order without replaying the already-attempted prefix.
+   */
+  requeueClaimedMessages(messages: QueuedMessage[]): void {
+    if (messages.length === 0) return;
+    this.messageQueue = [...messages, ...this.messageQueue];
+
+    // Production calls this from onBatchReady while isProcessing is true, and
+    // processBatch() schedules the restored suffix in its finally block. Keep
+    // the method safe for direct callers too.
+    if (!this.isProcessing && !this.batchTimer) {
+      this.batchTimer = setTimeout(() => {
+        void this.processBatch().catch((error) => {
+          logger.error("Error during requeued batch processing:", error);
+        });
+      }, this.batchWindowMs);
+    }
+  }
+
   private async processBatch(): Promise<void> {
     if (this.batchTimer) {
       clearTimeout(this.batchTimer);
@@ -146,10 +169,15 @@ export class MessageBatcher {
       if (this.onBatchReady) {
         await this.onBatchReady(messagesToProcess);
       }
+    } finally {
+      this.isProcessing = false;
 
-      // If more messages arrived during processing, start new batch.
-      // `batchTimer` is always null here — it was cleared at the top of
-      // processBatch() and addMessage() can't set it while isProcessing.
+      // Always schedule messages that arrived during this batch, including
+      // when onBatchReady failed. The queue job was already acknowledged on
+      // SSE receipt, so leaving these messages only in memory until a third
+      // message happened to arrive stranded a durable user turn indefinitely.
+      // `batchTimer` is null here: processBatch cleared it before setting
+      // isProcessing, and addMessage never starts one while a batch is active.
       if (this.messageQueue.length > 0) {
         logger.info(
           `Starting new batch window for ${this.messageQueue.length} queued messages`
@@ -160,8 +188,6 @@ export class MessageBatcher {
           });
         }, this.batchWindowMs);
       }
-    } finally {
-      this.isProcessing = false;
     }
   }
 

--- a/packages/agent-worker/src/gateway/message-batcher.ts
+++ b/packages/agent-worker/src/gateway/message-batcher.ts
@@ -23,6 +23,7 @@ export class MessageBatcher {
   private readonly batchWindowMs: number;
   private readonly onBatchReady?: (messages: QueuedMessage[]) => Promise<void>;
   private hasProcessedInitialBatch = false;
+  private stopped = false;
 
   constructor(config: BatcherConfig = {}) {
     this.batchWindowMs = config.batchWindowMs ?? 2000; // 2 second window by default
@@ -67,6 +68,8 @@ export class MessageBatcher {
   async addPriorityMessage(message: QueuedMessage): Promise<void> {
     this.messageQueue.push(message);
 
+    if (this.stopped) return;
+
     // A turn is in flight: queue only. processBatch()'s tail picks it up when
     // the active turn finishes, so we never start a second concurrent turn.
     if (this.isProcessing) {
@@ -89,6 +92,8 @@ export class MessageBatcher {
   /** Queue a message whose ID was already reserved by claimMessageId(). */
   async addClaimedMessage(message: QueuedMessage): Promise<void> {
     this.messageQueue.push(message);
+
+    if (this.stopped) return;
 
     // If already processing, message will be picked up in next batch
     if (this.isProcessing) {
@@ -135,6 +140,8 @@ export class MessageBatcher {
     if (messages.length === 0) return;
     this.messageQueue = [...messages, ...this.messageQueue];
 
+    if (this.stopped) return;
+
     // Production calls this from onBatchReady while isProcessing is true, and
     // processBatch() schedules the restored suffix in its finally block. Keep
     // the method safe for direct callers too.
@@ -148,6 +155,8 @@ export class MessageBatcher {
   }
 
   private async processBatch(): Promise<void> {
+    if (this.stopped) return;
+
     if (this.batchTimer) {
       clearTimeout(this.batchTimer);
       this.batchTimer = null;
@@ -178,7 +187,7 @@ export class MessageBatcher {
       // message happened to arrive stranded a durable user turn indefinitely.
       // `batchTimer` is null here: processBatch cleared it before setting
       // isProcessing, and addMessage never starts one while a batch is active.
-      if (this.messageQueue.length > 0) {
+      if (!this.stopped && this.messageQueue.length > 0) {
         logger.info(
           `Starting new batch window for ${this.messageQueue.length} queued messages`
         );
@@ -192,6 +201,8 @@ export class MessageBatcher {
   }
 
   stop(): void {
+    this.stopped = true;
+
     if (this.batchTimer) {
       clearTimeout(this.batchTimer);
       this.batchTimer = null;

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -895,6 +895,8 @@ export class GatewayClient {
     message: QueuedMessage,
     processedIds?: string[]
   ): Promise<void> {
+    if (!this.isRunning) return;
+
     // Get traceparent for distributed tracing
     const traceparent =
       (message.payload.platformMetadata?.traceparent as string) ||

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -802,9 +802,7 @@ export class GatewayClient {
     // into one prompt under the first message's token; preserve arrival order
     // and execute each subject with its own token instead.
     if (new Set(messages.map((message) => message.payload.userId)).size > 1) {
-      for (const message of messages) {
-        await this.processSingleMessage(message, [message.payload.messageId]);
-      }
+      await this.processMessagesIndividually(messages);
       return;
     }
 
@@ -829,9 +827,7 @@ export class GatewayClient {
         (message) => message.payload.platformMetadata?.bangBash !== undefined
       )
     ) {
-      for (const message of messages) {
-        await this.processSingleMessage(message, [message.payload.messageId]);
-      }
+      await this.processMessagesIndividually(messages);
       return;
     }
 
@@ -874,6 +870,25 @@ export class GatewayClient {
       .map((m) => m.payload.messageId)
       .filter(Boolean);
     await this.processSingleMessage(batchedMessage, processedIds);
+  }
+
+  private async processMessagesIndividually(
+    messages: QueuedMessage[]
+  ): Promise<void> {
+    for (let index = 0; index < messages.length; index += 1) {
+      const message = messages[index];
+      if (!message) continue;
+      try {
+        await this.processSingleMessage(message, [message.payload.messageId]);
+      } catch (error) {
+        // The failing item was attempted and processSingleMessage already
+        // reported its terminal error. Only restore the untouched suffix: all
+        // of its IDs were reserved before batching, so routing it back through
+        // claimMessageId would incorrectly discard it as duplicate delivery.
+        this.messageBatcher.requeueClaimedMessages(messages.slice(index + 1));
+        throw error;
+      }
+    }
   }
 
   private async processSingleMessage(


### PR DESCRIPTION
## Summary

Successor slice extracted from #3230 for the independent agent-worker P0 half.

- Always schedules a follow-up drain for arrivals during `onBatchReady`, including callback rejection/throw.
- Sequential preclaimed batches restore only the untouched suffix, ahead of later arrivals, without replaying the attempted prefix.
- Preserves message-ID dedupe and serialized per-conversation processing while retaining existing error logging and bounded batch-window scheduling.
- Adds a sticky `MessageBatcher.stop()` fence across enqueue, direct requeue, timer, callback-finally, and drain paths; queued suffixes remain pending.
- Prevents `GatewayClient.processSingleMessage` from recreating a worker after shutdown.

## Tests and verification

- `bun test packages/agent-worker/src/__tests__/message-batcher.test.ts packages/agent-worker/src/__tests__/sse-client-harden.test.ts` — 64/64
- `make clean-workers`
- `make pre-pr` — clean (fresh builds, strict typecheck, knip, naming, and funnel gates)
- pre-commit Biome + TypeScript — clean
- `git diff --check` — clean

## Deferred RunsQueue half

This PR intentionally does not touch server RunsQueue reconnect, active-count, claim, or shutdown files. That is PR B, dependent on corrected #3244, as required by #3230's split.

Reviewer note: `make review-fix` was not run for this correction because the Automation explicitly prohibited nested review/review-fix.
