### PR TITLE
fix(server): redact credentials from Sentry events

### DIFF
--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -13,6 +13,10 @@ import dotenv from 'dotenv';
 import * as Sentry from '@sentry/node';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
 import { resolveSentryRuntime } from './utils/runtime-info';
+import {
+  scrubSentryBreadcrumb,
+  scrubSentryErrorEvent,
+} from './utils/sentry-scrubber';
 
 // .env is the single source of truth for secrets. This module reads SENTRY_DSN
 // (and ENVIRONMENT / SENTRY_RELEASE) at load time and is imported before any
@@ -64,6 +68,8 @@ if (dsn) {
     // keeps run/provider/worker errors at 100% and samples only high-volume
     // validation noise.
     sampleRate: 1.0,
+    beforeSend: scrubSentryErrorEvent,
+    beforeBreadcrumb: scrubSentryBreadcrumb,
     // The NodeSystemError integration calls util.getSystemErrorMap(), which
     // some Node builds we run under (notably v24.x in our app image) don't
     // expose. The integration itself then throws inside the event processor

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -16,6 +16,7 @@ import { resolveSentryRuntime } from './utils/runtime-info';
 import {
   scrubSentryBreadcrumb,
   scrubSentryErrorEvent,
+  scrubSentryTransactionEvent,
 } from './utils/sentry-scrubber';
 
 // .env is the single source of truth for secrets. This module reads SENTRY_DSN
@@ -69,6 +70,7 @@ if (dsn) {
     // validation noise.
     sampleRate: 1.0,
     beforeSend: scrubSentryErrorEvent,
+    beforeSendTransaction: scrubSentryTransactionEvent,
     beforeBreadcrumb: scrubSentryBreadcrumb,
     // The NodeSystemError integration calls util.getSystemErrorMap(), which
     // some Node builds we run under (notably v24.x in our app image) don't

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -38,14 +38,18 @@ export function isSentryReported(c: Context): boolean {
 export function captureServerError(
   c: Context,
   error: unknown,
-  source: string
+  source: string,
+  httpStatus: number
 ): void {
   if (error instanceof ToolUserError) return;
   Sentry.captureException(error, {
     tags: {
       source,
       http_method: c.req.method,
-      http_status: String(c.res.status),
+      // Passed in, not read from `c.res`: every caller reports the error before
+      // returning its response, and hono mints a placeholder 200 on that first
+      // `c.res` access — which tagged every 500 in this path as a 200.
+      http_status: String(httpStatus),
       host: c.req.header('host') ?? 'unknown',
     },
     extra: {

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -9,6 +9,7 @@ import type { Context } from 'hono';
 import * as Sentry from '@sentry/node';
 import { ToolUserError } from './utils/errors';
 import { getErrorMessage } from "@lobu/core";
+import { scrubSentryValue } from './utils/sentry-scrubber';
 
 const SENTRY_CAPTURED_FLAG = 'sentryErrorCaptured';
 
@@ -44,10 +45,11 @@ export function captureServerError(
     tags: {
       source,
       http_method: c.req.method,
+      http_status: String(c.res.status),
+      host: c.req.header('host') ?? 'unknown',
     },
     extra: {
       path: c.req.path,
-      url: c.req.url,
     },
   });
   markSentryReported(c);
@@ -78,7 +80,7 @@ export async function trackMCPToolCall<T>(
         // Set success attributes on span
         span?.setAttributes({
           'mcp.tool.status': 'success',
-          'mcp.tool.arguments': JSON.stringify(sanitizeArguments(args)),
+          'mcp.tool.arguments': JSON.stringify(scrubSentryValue(args)),
         });
 
         return result;
@@ -97,7 +99,7 @@ export async function trackMCPToolCall<T>(
               status: 'error',
             },
             extra: {
-              arguments: sanitizeArguments(args),
+              arguments: scrubSentryValue(args),
               error_message: errorMessage,
             },
           });
@@ -112,58 +114,4 @@ export async function trackMCPToolCall<T>(
       }
     }
   );
-}
-
-/**
- * Sanitize arguments to avoid sending sensitive data to Sentry
- * Redacts common sensitive field names
- */
-function sanitizeArguments(args: unknown): unknown {
-  const sensitiveFieldTokens = [
-    'password',
-    'token',
-    'api_key',
-    'apikey',
-    'secret',
-    'authorization',
-    'refresh_token',
-    'access_token',
-    'client_secret',
-    'code_verifier',
-    'session_state',
-    'cookie',
-    'credential',
-  ];
-
-  const seen = new WeakSet<object>();
-
-  function isSensitiveKey(key: string): boolean {
-    const normalized = key.toLowerCase().replace(/[^a-z0-9_]/g, '');
-    return sensitiveFieldTokens.some((token) =>
-      normalized.includes(token.replace(/[^a-z0-9_]/g, ''))
-    );
-  }
-
-  function sanitize(value: unknown): unknown {
-    if (value === null || value === undefined || typeof value !== 'object') {
-      return value;
-    }
-
-    if (seen.has(value as object)) {
-      return '[CIRCULAR]';
-    }
-    seen.add(value as object);
-
-    if (Array.isArray(value)) {
-      return value.map((item) => sanitize(item));
-    }
-
-    const sanitized: Record<string, unknown> = {};
-    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
-      sanitized[key] = isSensitiveKey(key) ? '[REDACTED]' : sanitize(nestedValue);
-    }
-    return sanitized;
-  }
-
-  return sanitize(args);
 }

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -46,9 +46,9 @@ export function captureServerError(
     tags: {
       source,
       http_method: c.req.method,
-      // Passed in, not read from `c.res`: every caller reports the error before
-      // returning its response, and hono mints a placeholder 200 on that first
-      // `c.res` access — which tagged every 500 in this path as a 200.
+      // Passed in, not read from `c.res`: every caller reports the error
+      // before returning its response, and hono mints a placeholder 200 on
+      // that first `c.res` access.
       http_status: String(httpStatus),
     },
     extra: {

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -50,10 +50,13 @@ export function captureServerError(
       // returning its response, and hono mints a placeholder 200 on that first
       // `c.res` access — which tagged every 500 in this path as a 200.
       http_status: String(httpStatus),
-      host: c.req.header('host') ?? 'unknown',
     },
     extra: {
       path: c.req.path,
+      // `extra`, not `tags`: Host is client-supplied, so as an indexed tag its
+      // value cardinality is unbounded by anything we control. Triage still
+      // reads it here; the search index stays bounded.
+      host: c.req.header('host') ?? 'unknown',
     },
   });
   markSentryReported(c);

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -245,10 +245,10 @@ export function buildWrapperApp(
 					source: "http_response",
 					http_method: c.req.method,
 					http_status: String(c.res.status),
+					host: c.req.header("host") ?? "unknown",
 				},
 				extra: {
 					path: c.req.path,
-					url: c.req.url,
 					response_body: body,
 				},
 			});
@@ -264,10 +264,10 @@ export function buildWrapperApp(
 				tags: {
 					source: "app_onError",
 					http_method: c.req.method,
+					host: c.req.header("host") ?? "unknown",
 				},
 				extra: {
 					path: c.req.path,
-					url: c.req.url,
 				},
 			});
 			markSentryReported(c);

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -245,10 +245,12 @@ export function buildWrapperApp(
 					source: "http_response",
 					http_method: c.req.method,
 					http_status: String(c.res.status),
-					host: c.req.header("host") ?? "unknown",
 				},
 				extra: {
 					path: c.req.path,
+					// `extra`, not `tags`: Host is client-supplied, so as an indexed
+					// tag its value cardinality is unbounded by anything we control.
+					host: c.req.header("host") ?? "unknown",
 					response_body: body,
 				},
 			});
@@ -264,10 +266,11 @@ export function buildWrapperApp(
 				tags: {
 					source: "app_onError",
 					http_method: c.req.method,
-					host: c.req.header("host") ?? "unknown",
 				},
 				extra: {
 					path: c.req.path,
+					// See above: client-supplied, so never an indexed tag.
+					host: c.req.header("host") ?? "unknown",
 				},
 			});
 			markSentryReported(c);

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -126,6 +126,31 @@ describe('Sentry credential scrubber', () => {
 		expect(result).toContain('db.internal:5432/lobu');
 	});
 
+	it('redacts signature headers whose squashed form no exact set can hold', () => {
+		// `X-Hub-Signature-256` squashes to `xhubsignature256`; matching the whole
+		// key against a set silently missed every real signature header.
+		const result = scrubSentryValue({
+			'X-Hub-Signature-256': SECRET,
+			'X-Amz-Signature': SECRET,
+			'x-slack-signature': SECRET,
+			design: 'kept',
+		}) as Record<string, string>;
+		expect(result['X-Hub-Signature-256']).toBe('[REDACTED]');
+		expect(result['X-Amz-Signature']).toBe('[REDACTED]');
+		expect(result['x-slack-signature']).toBe('[REDACTED]');
+		expect(result.design).toBe('kept');
+		expect(scrubSentryValue(`X-Amz-Signature=${SECRET}&limit=1`)).toBe(
+			'X-Amz-Signature=[REDACTED]&limit=1',
+		);
+	});
+
+	it('keeps trailing sentence punctuation outside the URL it strips', () => {
+		const result = scrubSentryValue(
+			`see https://example.test/a?token=${SECRET}, then retry.`,
+		) as string;
+		expect(result).toBe('see https://example.test/a, then retry.');
+	});
+
 	it('summarizes built-ins that a plain walk would flatten or explode', () => {
 		const result = scrubSentryValue({
 			at: new Date('2026-08-31T12:00:00.000Z'),

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { scrubSentryEvent, scrubSentryValue } from '../sentry-scrubber';
+
+const SECRET = 'SENTRY_SECRET_SENTINEL';
+
+describe('Sentry credential scrubber', () => {
+	it('removes URL queries and fragments while preserving route paths', () => {
+		const value = scrubSentryValue(
+			`GET https://example.test/api/v1/files/a?token=${SECRET}&state=x#fragment`,
+		);
+		expect(value).toBe('GET https://example.test/api/v1/files/a');
+	});
+
+	it('removes every query value, including duplicate, encoded, and mixed-case credentials', () => {
+		const event = scrubSentryEvent({
+			request: {
+				url: `https://example.test/api/v1/files/artifact?ToKeN=${SECRET}&token=${SECRET}&sigNature=${SECRET}&x%2Dapi%2Dkey=${SECRET}#${SECRET}`,
+			},
+			message: `signed download failed: https://example.test/api/v1/files/artifact?token=${SECRET}`,
+		});
+		const serialized = JSON.stringify(event);
+		expect(serialized).not.toContain(SECRET);
+		expect(serialized).toContain('https://example.test/api/v1/files/artifact');
+		expect(serialized).not.toContain('?');
+		expect(serialized).not.toContain('#');
+	});
+
+	it('redacts mixed-case secret keys through nested arrays and objects', () => {
+		const nested: Record<string, unknown> = {
+			Authorization: `Bearer ${SECRET}`,
+			'X-API-Key': SECRET,
+			CoOkIe: SECRET,
+			items: [{ signature: SECRET, safeRoute: '/api/v1/files/a' }],
+		};
+		const result = scrubSentryValue(nested) as Record<string, unknown>;
+		expect(JSON.stringify(result)).not.toContain(SECRET);
+		expect((result.items as Array<Record<string, unknown>>)[0]?.safeRoute).toBe(
+			'/api/v1/files/a',
+		);
+	});
+
+	it('handles errors, causes, breadcrumbs, and circular values', () => {
+		const cause = new Error(`download failed at https://example.test/file?code=${SECRET}`);
+		const error = new Error('outer', { cause });
+		(error as Error & { extras?: unknown }).extras = { state: SECRET };
+		const circular: Record<string, unknown> = { error, breadcrumb: { data: { token: SECRET } } };
+		circular.self = circular;
+
+		const event = scrubSentryEvent({
+			message: error.message,
+			extra: circular,
+			breadcrumbs: [{ message: `failed https://example.test/file?token=${SECRET}`, data: circular }],
+			exception: { values: [{ type: 'Error', value: error.message, mechanism: { data: circular } }] },
+		});
+		const serialized = JSON.stringify(event);
+		expect(serialized).not.toContain(SECRET);
+		expect(serialized).toContain('https://example.test/file');
+		expect(serialized).toContain('[REDACTED]');
+	});
+});

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -144,6 +144,40 @@ describe('Sentry credential scrubber', () => {
 		);
 	});
 
+	it('keeps the code_verifier and session_state coverage of the sanitizer it replaced', () => {
+		// The shared denylist classifies neither: `verifier` and `state` are not
+		// suffixes it knows, and both are far too broad to add as segments.
+		const result = scrubSentryValue({
+			code_verifier: SECRET,
+			session_state: SECRET,
+			codeVerifier: SECRET,
+			freshness_state: 'fresh',
+			url: `/cb?code_verifier=${SECRET}`,
+		}) as Record<string, string>;
+		expect(result.code_verifier).toBe('[REDACTED]');
+		expect(result.session_state).toBe('[REDACTED]');
+		expect(result.codeVerifier).toBe('[REDACTED]');
+		expect(result.freshness_state).toBe('fresh');
+		expect(result.url).not.toContain(SECRET);
+	});
+
+	it('does not report a shared sibling reference as circular', () => {
+		// `seen` tracks the current path; a repeated non-ancestor reference is
+		// ordinary structure sharing, not a cycle.
+		const shared = { api_key: SECRET, note: 'kept' };
+		const result = scrubSentryValue({ x: shared, y: shared }) as Record<
+			string,
+			Record<string, string>
+		>;
+		expect(result.y).not.toBe('[CIRCULAR]');
+		expect(result.y.note).toBe('kept');
+		expect(result.y.api_key).toBe('[REDACTED]');
+
+		const cycle: Record<string, unknown> = { name: 'root' };
+		cycle.self = cycle;
+		expect((scrubSentryValue(cycle) as Record<string, unknown>).self).toBe('[CIRCULAR]');
+	});
+
 	it('keeps trailing sentence punctuation outside the URL it strips', () => {
 		const result = scrubSentryValue(
 			`see https://example.test/a?token=${SECRET}, then retry.`,

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -42,7 +42,7 @@ describe('Sentry credential scrubber', () => {
 	it('handles errors, causes, breadcrumbs, and circular values', () => {
 		const cause = new Error(`download failed at https://example.test/file?code=${SECRET}`);
 		const error = new Error('outer', { cause });
-		(error as Error & { extras?: unknown }).extras = { state: SECRET };
+		(error as Error & { extras?: unknown }).extras = { api_key: SECRET };
 		const circular: Record<string, unknown> = { error, breadcrumb: { data: { token: SECRET } } };
 		circular.self = circular;
 
@@ -80,14 +80,63 @@ describe('Sentry credential scrubber', () => {
 			status_code: 500,
 			error_code: 'E_TIMEOUT',
 			stack_key: 'abc',
-			code: SECRET,
-			state: SECRET,
 		}) as Record<string, unknown>;
 		expect(result.status_code).toBe(500);
 		expect(result.error_code).toBe('E_TIMEOUT');
 		expect(result.stack_key).toBe('abc');
-		expect(result.code).toBe('[REDACTED]');
-		expect(result.state).toBe('[REDACTED]');
+	});
+
+	it('keeps error codes as object keys but redacts them as query parameters', () => {
+		// `code`/`state`/`key` are credentials in `?code=…` and diagnostics as
+		// object keys. Redacting the key form blanks the Node errno and the
+		// Postgres SQLSTATE, which are the first things read during triage.
+		const result = scrubSentryValue({
+			code: 'ECONNREFUSED',
+			state: 'running',
+			pgCode: '23505',
+			url: `/oauth/callback?code=${SECRET}&state=${SECRET}`,
+		}) as Record<string, string>;
+		expect(result.code).toBe('ECONNREFUSED');
+		expect(result.state).toBe('running');
+		expect(result.pgCode).toBe('23505');
+		expect(result.url).not.toContain(SECRET);
+		expect(result.url).toContain('/oauth/callback');
+	});
+
+	it('uses the shared secret-key denylist rather than a private copy', () => {
+		// These are all classified by @lobu/core's isSecretKey; a hand-rolled
+		// local pattern silently missed every one of them.
+		const result = scrubSentryValue({
+			auth: SECRET,
+			dsn: SECRET,
+			private_key: SECRET,
+			database_url: SECRET,
+			session_id: SECRET,
+		}) as Record<string, string>;
+		for (const field of ['auth', 'dsn', 'private_key', 'database_url', 'session_id']) {
+			expect(result[field]).toBe('[REDACTED]');
+		}
+	});
+
+	it('redacts URI userinfo credentials that carry no query string at all', () => {
+		const result = scrubSentryValue(
+			`connect failed: postgres://lobu:${SECRET}@db.internal:5432/lobu`,
+		) as string;
+		expect(result).not.toContain(SECRET);
+		expect(result).toContain('db.internal:5432/lobu');
+	});
+
+	it('summarizes built-ins that a plain walk would flatten or explode', () => {
+		const result = scrubSentryValue({
+			at: new Date('2026-08-31T12:00:00.000Z'),
+			buf: Buffer.from('abcd'),
+			seen: new Set([1, 2]),
+			byKey: new Map([['a', 1]]),
+		}) as Record<string, unknown>;
+		expect(result.at).toBe('2026-08-31T12:00:00.000Z');
+		expect(result.buf).toBe('[Buffer 4 bytes]');
+		expect(result.seen).toBe('[Set 2 items]');
+		expect(result.byKey).toBe('[Map 1 entries]');
 	});
 
 	it('preserves an Error instead of flattening it to an empty object', () => {

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scrubSentryEvent, scrubSentryValue } from '../sentry-scrubber';
+import { scrubSentryErrorEvent, scrubSentryValue } from '../sentry-scrubber';
 
 const SECRET = 'SENTRY_SECRET_SENTINEL';
 
@@ -12,7 +12,7 @@ describe('Sentry credential scrubber', () => {
 	});
 
 	it('removes every query value, including duplicate, encoded, and mixed-case credentials', () => {
-		const event = scrubSentryEvent({
+		const event = scrubSentryErrorEvent({
 			request: {
 				url: `https://example.test/api/v1/files/artifact?ToKeN=${SECRET}&token=${SECRET}&sigNature=${SECRET}&x%2Dapi%2Dkey=${SECRET}#${SECRET}`,
 			},
@@ -46,7 +46,7 @@ describe('Sentry credential scrubber', () => {
 		const circular: Record<string, unknown> = { error, breadcrumb: { data: { token: SECRET } } };
 		circular.self = circular;
 
-		const event = scrubSentryEvent({
+		const event = scrubSentryErrorEvent({
 			message: error.message,
 			extra: circular,
 			breadcrumbs: [{ message: `failed https://example.test/file?token=${SECRET}`, data: circular }],
@@ -56,5 +56,50 @@ describe('Sentry credential scrubber', () => {
 		expect(serialized).not.toContain(SECRET);
 		expect(serialized).toContain('https://example.test/file');
 		expect(serialized).toContain('[REDACTED]');
+	});
+
+	it('redacts credentials in relative URLs and bare query strings', () => {
+		// Neither has a scheme, so a URL-only scrub never sees them. This is the
+		// signed-download-token vector the scrubber exists to close.
+		const relative = scrubSentryValue(
+			`GET /api/v1/files/a?token=${SECRET}&page=2`,
+		) as string;
+		expect(relative).not.toContain(SECRET);
+		expect(relative).toContain('/api/v1/files/a');
+		expect(relative).toContain('page=2');
+
+		const queryString = scrubSentryValue({
+			request: { query_string: `signature=${SECRET}&limit=10` },
+		}) as { request: { query_string: string } };
+		expect(queryString.request.query_string).not.toContain(SECRET);
+		expect(queryString.request.query_string).toContain('limit=10');
+	});
+
+	it('keeps triage fields whose names merely contain a secret word', () => {
+		const result = scrubSentryValue({
+			status_code: 500,
+			error_code: 'E_TIMEOUT',
+			stack_key: 'abc',
+			code: SECRET,
+			state: SECRET,
+		}) as Record<string, unknown>;
+		expect(result.status_code).toBe(500);
+		expect(result.error_code).toBe('E_TIMEOUT');
+		expect(result.stack_key).toBe('abc');
+		expect(result.code).toBe('[REDACTED]');
+		expect(result.state).toBe('[REDACTED]');
+	});
+
+	it('preserves an Error instead of flattening it to an empty object', () => {
+		// name/message/stack live on the prototype, so Object.keys sees none of
+		// them and a plain walk would discard the whole error.
+		const error = new Error(`boom at https://example.test/f?token=${SECRET}`);
+		const result = scrubSentryValue({ cause: error }) as {
+			cause: { name: string; message: string; stack?: string };
+		};
+		expect(result.cause.name).toBe('Error');
+		expect(result.cause.message).toContain('boom at');
+		expect(result.cause.message).not.toContain(SECRET);
+		expect(result.cause.stack).toBeDefined();
 	});
 });

--- a/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
+++ b/packages/server/src/utils/__tests__/sentry-scrubber.test.ts
@@ -75,6 +75,18 @@ describe('Sentry credential scrubber', () => {
 		expect(queryString.request.query_string).toContain('limit=10');
 	});
 
+	it('redacts cookie pairs written with a space after the separator', () => {
+		// Cookie serialization is `a=b; c=d`. Without whitespace in the
+		// separator, only the first pair anchors and every later credential
+		// survives in a raw string headed for Sentry.
+		const scrubbed = scrubSentryValue(
+			`set-cookie rejected: theme=dark; token=${SECRET}; limit=10`,
+		) as string;
+		expect(scrubbed).not.toContain(SECRET);
+		expect(scrubbed).toContain('theme=dark');
+		expect(scrubbed).toContain('limit=10');
+	});
+
 	it('keeps triage fields whose names merely contain a secret word', () => {
 		const result = scrubSentryValue({
 			status_code: 500,

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -1,6 +1,9 @@
 import * as Sentry from '@sentry/node';
 import { isSecretKey } from '@lobu/core';
+import { scrubSentryValue } from './sentry-scrubber';
 import pino from 'pino';
+
+type SentryExtras = Record<string, unknown>;
 
 /**
  * Logger utility using Pino for structured logging
@@ -144,13 +147,13 @@ function fingerprintAndCapture(parsed: Record<string, unknown>): void {
       const reconstructed = new Error(errObj.message);
       if (errObj.stack) reconstructed.stack = errObj.stack;
       Sentry.captureException(reconstructed, {
-        extra: parsed,
+        extra: scrubSentryValue(parsed) as SentryExtras,
         tags: { source: 'pino', level: String(level) },
       });
     } else {
       Sentry.captureMessage(msg, {
         level: level === 'fatal' ? 'fatal' : 'error',
-        extra: parsed,
+        extra: scrubSentryValue(parsed) as SentryExtras,
         tags: { source: 'pino' },
       });
     }

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -16,7 +16,14 @@ const SECRET_QUERY_PARAMS = new Set(['state', 'code', 'key']);
  * never appear in connector config, and that denylist also feeds the CLI's
  * deployment manifest hash — widening it there would change hashes.
  */
-const EXTRA_SECRET_KEYS = new Set(['signature', 'sig']);
+const SECRET_KEY_SEGMENTS = new Set(['signature', 'sig']);
+/**
+ * Whole (squashed) key names the shared denylist does not classify. Carried
+ * over from the bespoke sanitizer this module replaced: `verifier` and `state`
+ * are far too broad as segments (`freshness_state`, `run_state`), so these two
+ * are matched only as complete names.
+ */
+const SECRET_KEY_EXACT = new Set(['codeverifier', 'sessionstate']);
 
 /** Deep enough to outlive Sentry's own normalize(); short of unbounded work. */
 const MAX_DEPTH = 8;
@@ -38,11 +45,12 @@ function isSecretObjectKey(key: string): boolean {
 	// Matched per separated segment, not against the squashed whole:
 	// `X-Hub-Signature-256` squashes to `xhubsignature256`, which no exact set
 	// can ever hold, so every real signature header would slip through.
+	if (SECRET_KEY_EXACT.has(squashKey(key))) return true;
 	return key
 		.replace(/[^a-z0-9]+/gi, '_')
 		.toLowerCase()
 		.split('_')
-		.some((segment) => EXTRA_SECRET_KEYS.has(segment));
+		.some((segment) => SECRET_KEY_SEGMENTS.has(segment));
 }
 const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
 /**
@@ -104,8 +112,18 @@ export function scrubSentryValue(value: unknown): unknown {
 		// a single console breadcrumb carrying a huge or deeply nested object is
 		// fully deep-cloned on the hot path only to be truncated moments later.
 		if (depth >= MAX_DEPTH) return '[TRUNCATED]';
+		// Tracks the current PATH, not every node ever visited. Two siblings may
+		// legitimately hold the same reference, and reporting the second one as
+		// [CIRCULAR] would corrupt the event; only an ancestor is a real cycle.
 		seen.add(current);
+		try {
+			return walk(current, depth);
+		} finally {
+			seen.delete(current);
+		}
+	}
 
+	function walk(current: object, depth: number): unknown {
 		// An Error carries name/message/stack on its prototype, so Object.keys
 		// returns nothing and a plain walk would flatten it to `{}` — discarding
 		// the only part of the event worth reading.

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -1,0 +1,71 @@
+import type { Breadcrumb, ErrorEvent, Event } from '@sentry/node';
+
+const SECRET_KEY_PATTERN = /(?:authorization|api[-_ ]?key|apikey|bearer|cookie|credential|password|secret|signature|state|token|code|key)/i;
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
+
+function scrubString(value: string): string {
+	return value.replace(URL_PATTERN, (candidate) => {
+		try {
+			const url = new URL(candidate.replace(/[),.;]+$/, ''));
+			return `${url.origin}${url.pathname}`;
+		} catch {
+			return candidate;
+		}
+	});
+}
+
+function isSecretKey(key: string): boolean {
+	return SECRET_KEY_PATTERN.test(key.replace(/[^a-z0-9]/gi, ''));
+}
+
+/**
+ * Recursively remove credential material from values headed for Sentry.
+ * This is deliberately defensive: telemetry must never make an unusual
+ * application value or a circular error object throw another error.
+ */
+export function scrubSentryValue(value: unknown): unknown {
+	const seen = new WeakSet<object>();
+
+	function scrub(current: unknown): unknown {
+		if (typeof current === 'string') return scrubString(current);
+		if (current === null || typeof current !== 'object') return current;
+		if (seen.has(current)) return '[CIRCULAR]';
+		seen.add(current);
+
+		if (Array.isArray(current)) return current.map((item) => scrub(item));
+
+		const result: Record<string, unknown> = {};
+		try {
+			for (const key of Object.keys(current)) {
+				if (isSecretKey(key)) {
+					result[key] = '[REDACTED]';
+					continue;
+				}
+				try {
+					result[key] = scrub((current as Record<string, unknown>)[key]);
+				} catch {
+					result[key] = '[UNREADABLE]';
+				}
+			}
+		} catch {
+			return '[UNREADABLE]';
+		}
+		return result;
+	}
+
+	return scrub(value);
+}
+
+export function scrubSentryEvent(event: Event): Event {
+	return scrubSentryValue(event) as Event;
+}
+
+export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
+	return scrubSentryValue(event) as ErrorEvent;
+}
+
+export function scrubSentryBreadcrumb(
+	breadcrumb: Breadcrumb,
+): Breadcrumb | null {
+	return scrubSentryValue(breadcrumb) as Breadcrumb;
+}

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -16,7 +16,11 @@ const SECRET_QUERY_PARAMS = new Set(['state', 'code', 'key']);
  * never appear in connector config, and that denylist also feeds the CLI's
  * deployment manifest hash — widening it there would change hashes.
  */
-const EXTRA_SECRET_KEYS = new Set(['signature', 'sig', 'xhubsignature']);
+const EXTRA_SECRET_KEYS = new Set(['signature', 'sig']);
+
+/** Deep enough to outlive Sentry's own normalize(); short of unbounded work. */
+const MAX_DEPTH = 8;
+const MAX_ENTRIES = 1000;
 
 /** Separator/case-squashed form, for keys core's camel-case split can't read. */
 function squashKey(key: string): string {
@@ -30,8 +34,15 @@ function squashKey(key: string): string {
  */
 function isSecretObjectKey(key: string): boolean {
 	if (isSecretKey(key)) return true;
-	const squashed = squashKey(key);
-	return isSecretKey(squashed) || EXTRA_SECRET_KEYS.has(squashed);
+	if (isSecretKey(squashKey(key))) return true;
+	// Matched per separated segment, not against the squashed whole:
+	// `X-Hub-Signature-256` squashes to `xhubsignature256`, which no exact set
+	// can ever hold, so every real signature header would slip through.
+	return key
+		.replace(/[^a-z0-9]+/gi, '_')
+		.toLowerCase()
+		.split('_')
+		.some((segment) => EXTRA_SECRET_KEYS.has(segment));
 }
 const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
 /**
@@ -59,9 +70,13 @@ function scrubString(value: string): string {
 	// in a query pair or a secret-named key, so neither pass below would see it.
 	const withoutUriCredentials = redactUriCredentials(value);
 	const withoutUrlQueries = withoutUriCredentials.replace(URL_PATTERN, (candidate) => {
+		// Trailing sentence punctuation is not part of the URL, but it is part of
+		// the message: strip it to parse, then put it back.
+		const trailing = candidate.match(/[),.;]+$/)?.[0] ?? '';
+		const bare = trailing ? candidate.slice(0, -trailing.length) : candidate;
 		try {
-			const url = new URL(candidate.replace(/[),.;]+$/, ''));
-			return `${url.origin}${url.pathname}`;
+			const url = new URL(bare);
+			return `${url.origin}${url.pathname}${trailing}`;
 		} catch {
 			return candidate;
 		}
@@ -81,10 +96,14 @@ function scrubString(value: string): string {
 export function scrubSentryValue(value: unknown): unknown {
 	const seen = new WeakSet<object>();
 
-	function scrub(current: unknown): unknown {
+	function scrub(current: unknown, depth = 0): unknown {
 		if (typeof current === 'string') return scrubString(current);
 		if (current === null || typeof current !== 'object') return current;
 		if (seen.has(current)) return '[CIRCULAR]';
+		// beforeBreadcrumb runs BEFORE Sentry's own normalize(), so without a cap
+		// a single console breadcrumb carrying a huge or deeply nested object is
+		// fully deep-cloned on the hot path only to be truncated moments later.
+		if (depth >= MAX_DEPTH) return '[TRUNCATED]';
 		seen.add(current);
 
 		// An Error carries name/message/stack on its prototype, so Object.keys
@@ -96,11 +115,11 @@ export function scrubSentryValue(value: unknown): unknown {
 				message: scrubString(current.message),
 			};
 			if (current.stack) serialized.stack = scrubString(current.stack);
-			if (current.cause !== undefined) serialized.cause = scrub(current.cause);
+			if (current.cause !== undefined) serialized.cause = scrub(current.cause, depth + 1);
 			for (const key of Object.keys(current)) {
 				serialized[key] = isSecretObjectKey(key)
 					? '[REDACTED]'
-					: scrub((current as unknown as Record<string, unknown>)[key]);
+					: scrub((current as unknown as Record<string, unknown>)[key], depth + 1);
 			}
 			return serialized;
 		}
@@ -116,17 +135,19 @@ export function scrubSentryValue(value: unknown): unknown {
 		if (current instanceof Map) return `[Map ${current.size} entries]`;
 		if (current instanceof Set) return `[Set ${current.size} items]`;
 
-		if (Array.isArray(current)) return current.map((item) => scrub(item));
+		if (Array.isArray(current)) {
+			return current.slice(0, MAX_ENTRIES).map((item) => scrub(item, depth + 1));
+		}
 
 		const result: Record<string, unknown> = {};
 		try {
-			for (const key of Object.keys(current)) {
+			for (const key of Object.keys(current).slice(0, MAX_ENTRIES)) {
 				if (isSecretObjectKey(key)) {
 					result[key] = '[REDACTED]';
 					continue;
 				}
 				try {
-					result[key] = scrub((current as Record<string, unknown>)[key]);
+					result[key] = scrub((current as Record<string, unknown>)[key], depth + 1);
 				} catch {
 					result[key] = '[UNREADABLE]';
 				}
@@ -140,8 +161,27 @@ export function scrubSentryValue(value: unknown): unknown {
 	return scrub(value);
 }
 
+/**
+ * `sdkProcessingMetadata` holds the live Scope -> Client -> options graph, and
+ * @sentry/core deletes the field outright in createEventEnvelope. Deep-walking
+ * it is therefore pure per-event work on a structure that never ships, and it
+ * is the only part of a prepared event holding class instances. Detach it for
+ * the walk and put the original reference back.
+ */
+function scrubEvent<T extends Event>(event: T): T {
+	const { sdkProcessingMetadata } = event;
+	const scrubbed = scrubSentryValue({
+		...event,
+		sdkProcessingMetadata: undefined,
+	}) as T;
+	if (sdkProcessingMetadata !== undefined) {
+		scrubbed.sdkProcessingMetadata = sdkProcessingMetadata;
+	}
+	return scrubbed;
+}
+
 export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
-	return scrubSentryValue(event) as ErrorEvent;
+	return scrubEvent(event);
 }
 
 /**
@@ -153,7 +193,7 @@ export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
 // not re-export that type, and @sentry/core is not a direct dependency here.
 // Inference recovers it exactly at the beforeSendTransaction call site.
 export function scrubSentryTransactionEvent<T extends Event>(event: T): T {
-	return scrubSentryValue(event) as T;
+	return scrubEvent(event);
 }
 
 /** Never drops a breadcrumb; it only rewrites credential material in place. */

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -1,10 +1,35 @@
-import type { Breadcrumb, ErrorEvent, Event } from '@sentry/node';
+import type { Breadcrumb, ErrorEvent } from '@sentry/node';
 
-const SECRET_KEY_PATTERN = /(?:authorization|api[-_ ]?key|apikey|bearer|cookie|credential|password|secret|signature|state|token|code|key)/i;
+/**
+ * Secret only as a whole key name. As substrings these match `status_code`,
+ * `error_code`, and `stack_key` — the fields triage actually needs.
+ */
+const EXACT_SECRET_KEYS = new Set(['state', 'code', 'key']);
+const SECRET_KEY_PATTERN =
+	/(?:authorization|apikey|bearer|cookie|credential|password|secret|signature|token)/i;
 const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
+/**
+ * A relative URL (`/api/v1/files/a?token=…`) and Sentry's own
+ * `request.query_string` (`token=…`, no scheme and no path) never match
+ * URL_PATTERN, so the signed-download token would survive a URL-only scrub.
+ */
+const QUERY_PAIR_PATTERN = /([?&;]|^)([A-Za-z0-9_.\-%[\]]+)=([^&;\s"'<>]*)/g;
+
+function decodeKey(raw: string): string {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		return raw;
+	}
+}
+
+function isSecretKey(key: string): boolean {
+	const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+	return EXACT_SECRET_KEYS.has(normalized) || SECRET_KEY_PATTERN.test(normalized);
+}
 
 function scrubString(value: string): string {
-	return value.replace(URL_PATTERN, (candidate) => {
+	const withoutUrlQueries = value.replace(URL_PATTERN, (candidate) => {
 		try {
 			const url = new URL(candidate.replace(/[),.;]+$/, ''));
 			return `${url.origin}${url.pathname}`;
@@ -12,10 +37,11 @@ function scrubString(value: string): string {
 			return candidate;
 		}
 	});
-}
-
-function isSecretKey(key: string): boolean {
-	return SECRET_KEY_PATTERN.test(key.replace(/[^a-z0-9]/gi, ''));
+	return withoutUrlQueries.replace(
+		QUERY_PAIR_PATTERN,
+		(match, lead: string, name: string) =>
+			isSecretKey(decodeKey(name)) ? `${lead}${name}=[REDACTED]` : match
+	);
 }
 
 /**
@@ -31,6 +57,24 @@ export function scrubSentryValue(value: unknown): unknown {
 		if (current === null || typeof current !== 'object') return current;
 		if (seen.has(current)) return '[CIRCULAR]';
 		seen.add(current);
+
+		// An Error carries name/message/stack on its prototype, so Object.keys
+		// returns nothing and a plain walk would flatten it to `{}` — discarding
+		// the only part of the event worth reading.
+		if (current instanceof Error) {
+			const serialized: Record<string, unknown> = {
+				name: current.name,
+				message: scrubString(current.message),
+			};
+			if (current.stack) serialized.stack = scrubString(current.stack);
+			if (current.cause !== undefined) serialized.cause = scrub(current.cause);
+			for (const key of Object.keys(current)) {
+				serialized[key] = isSecretKey(key)
+					? '[REDACTED]'
+					: scrub((current as unknown as Record<string, unknown>)[key]);
+			}
+			return serialized;
+		}
 
 		if (Array.isArray(current)) return current.map((item) => scrub(item));
 
@@ -56,16 +100,11 @@ export function scrubSentryValue(value: unknown): unknown {
 	return scrub(value);
 }
 
-export function scrubSentryEvent(event: Event): Event {
-	return scrubSentryValue(event) as Event;
-}
-
 export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
 	return scrubSentryValue(event) as ErrorEvent;
 }
 
-export function scrubSentryBreadcrumb(
-	breadcrumb: Breadcrumb,
-): Breadcrumb | null {
+/** Never drops a breadcrumb; it only rewrites credential material in place. */
+export function scrubSentryBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
 	return scrubSentryValue(breadcrumb) as Breadcrumb;
 }

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -1,12 +1,38 @@
-import type { Breadcrumb, ErrorEvent } from '@sentry/node';
+import { isSecretKey, redactUriCredentials } from '@lobu/core';
+import type { Breadcrumb, ErrorEvent, TransactionEvent } from '@sentry/node';
 
 /**
- * Secret only as a whole key name. As substrings these match `status_code`,
- * `error_code`, and `stack_key` — the fields triage actually needs.
+ * Secret as a QUERY PARAMETER name, and only there. `code` is an OAuth
+ * authorization code in `?code=…` but a Node/Postgres error code
+ * (`ECONNREFUSED`, `23505`) as an object key; `state` and `key` are the same
+ * story. Context decides, so this stays separate from the shared key denylist
+ * rather than widening it — redacting these as object keys would blank the
+ * fields triage actually reads.
  */
-const EXACT_SECRET_KEYS = new Set(['state', 'code', 'key']);
-const SECRET_KEY_PATTERN =
-	/(?:authorization|apikey|bearer|cookie|credential|password|secret|signature|token)/i;
+const SECRET_QUERY_PARAMS = new Set(['state', 'code', 'key']);
+/**
+ * Credential key names the shared config denylist has no reason to carry:
+ * request signatures reach telemetry (webhook headers, presigned URLs) but
+ * never appear in connector config, and that denylist also feeds the CLI's
+ * deployment manifest hash — widening it there would change hashes.
+ */
+const EXTRA_SECRET_KEYS = new Set(['signature', 'sig', 'xhubsignature']);
+
+/** Separator/case-squashed form, for keys core's camel-case split can't read. */
+function squashKey(key: string): string {
+	return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+/**
+ * Object and header keys. Core's normalizer splits on case boundaries, so an
+ * arbitrarily-cased header (`CoOkIe`) normalizes to `co_ok_ie` and misses;
+ * test the squashed form too.
+ */
+function isSecretObjectKey(key: string): boolean {
+	if (isSecretKey(key)) return true;
+	const squashed = squashKey(key);
+	return isSecretKey(squashed) || EXTRA_SECRET_KEYS.has(squashed);
+}
 const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
 /**
  * A relative URL (`/api/v1/files/a?token=…`) and Sentry's own
@@ -23,13 +49,16 @@ function decodeKey(raw: string): string {
 	}
 }
 
-function isSecretKey(key: string): boolean {
-	const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
-	return EXACT_SECRET_KEYS.has(normalized) || SECRET_KEY_PATTERN.test(normalized);
+function isSecretQueryParam(name: string): boolean {
+	const key = decodeKey(name);
+	return isSecretObjectKey(key) || SECRET_QUERY_PARAMS.has(squashKey(key));
 }
 
 function scrubString(value: string): string {
-	const withoutUrlQueries = value.replace(URL_PATTERN, (candidate) => {
+	// `postgres://user:pa55@host/db` carries its credential in the userinfo, not
+	// in a query pair or a secret-named key, so neither pass below would see it.
+	const withoutUriCredentials = redactUriCredentials(value);
+	const withoutUrlQueries = withoutUriCredentials.replace(URL_PATTERN, (candidate) => {
 		try {
 			const url = new URL(candidate.replace(/[),.;]+$/, ''));
 			return `${url.origin}${url.pathname}`;
@@ -40,7 +69,7 @@ function scrubString(value: string): string {
 	return withoutUrlQueries.replace(
 		QUERY_PAIR_PATTERN,
 		(match, lead: string, name: string) =>
-			isSecretKey(decodeKey(name)) ? `${lead}${name}=[REDACTED]` : match
+			isSecretQueryParam(name) ? `${lead}${name}=[REDACTED]` : match
 	);
 }
 
@@ -69,19 +98,30 @@ export function scrubSentryValue(value: unknown): unknown {
 			if (current.stack) serialized.stack = scrubString(current.stack);
 			if (current.cause !== undefined) serialized.cause = scrub(current.cause);
 			for (const key of Object.keys(current)) {
-				serialized[key] = isSecretKey(key)
+				serialized[key] = isSecretObjectKey(key)
 					? '[REDACTED]'
 					: scrub((current as unknown as Record<string, unknown>)[key]);
 			}
 			return serialized;
 		}
 
+		// Built-ins whose state is not enumerable: walking them as plain objects
+		// yields `{}` (Date, Map, Set, RegExp) or one key per byte (Buffer). A
+		// readable summary costs less payload and tells triage strictly more.
+		if (current instanceof Date) return current.toISOString();
+		if (current instanceof RegExp) return String(current);
+		if (ArrayBuffer.isView(current)) {
+			return `[${current.constructor.name} ${current.byteLength} bytes]`;
+		}
+		if (current instanceof Map) return `[Map ${current.size} entries]`;
+		if (current instanceof Set) return `[Set ${current.size} items]`;
+
 		if (Array.isArray(current)) return current.map((item) => scrub(item));
 
 		const result: Record<string, unknown> = {};
 		try {
 			for (const key of Object.keys(current)) {
-				if (isSecretKey(key)) {
+				if (isSecretObjectKey(key)) {
 					result[key] = '[REDACTED]';
 					continue;
 				}
@@ -102,6 +142,15 @@ export function scrubSentryValue(value: unknown): unknown {
 
 export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
 	return scrubSentryValue(event) as ErrorEvent;
+}
+
+/**
+ * Transactions are sampled (0.02 prod, 1.0 dev) but not exempt: a span's
+ * attributes carry the request URL, which is the very `?token=` vector the
+ * error path scrubs. Without this they reach Sentry unscrubbed.
+ */
+export function scrubSentryTransactionEvent(event: TransactionEvent): TransactionEvent {
+	return scrubSentryValue(event) as TransactionEvent;
 }
 
 /** Never drops a breadcrumb; it only rewrites credential material in place. */

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -42,10 +42,10 @@ function squashKey(key: string): string {
 function isSecretObjectKey(key: string): boolean {
 	if (isSecretKey(key)) return true;
 	if (isSecretKey(squashKey(key))) return true;
+	if (SECRET_KEY_EXACT.has(squashKey(key))) return true;
 	// Matched per separated segment, not against the squashed whole:
 	// `X-Hub-Signature-256` squashes to `xhubsignature256`, which no exact set
 	// can ever hold, so every real signature header would slip through.
-	if (SECRET_KEY_EXACT.has(squashKey(key))) return true;
 	return key
 		.replace(/[^a-z0-9]+/gi, '_')
 		.toLowerCase()
@@ -57,8 +57,10 @@ const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
  * A relative URL (`/api/v1/files/a?token=…`) and Sentry's own
  * `request.query_string` (`token=…`, no scheme and no path) never match
  * URL_PATTERN, so the signed-download token would survive a URL-only scrub.
+ * The separator absorbs trailing whitespace because cookie serialization is
+ * `a=b; c=d`: without it every pair after the first space goes unredacted.
  */
-const QUERY_PAIR_PATTERN = /([?&;]|^)([A-Za-z0-9_.\-%[\]]+)=([^&;\s"'<>]*)/g;
+const QUERY_PAIR_PATTERN = /([?&;]\s*|^)([A-Za-z0-9_.\-%[\]]+)=([^&;\s"'<>]*)/g;
 
 function decodeKey(raw: string): string {
 	try {

--- a/packages/server/src/utils/sentry-scrubber.ts
+++ b/packages/server/src/utils/sentry-scrubber.ts
@@ -1,5 +1,5 @@
 import { isSecretKey, redactUriCredentials } from '@lobu/core';
-import type { Breadcrumb, ErrorEvent, TransactionEvent } from '@sentry/node';
+import type { Breadcrumb, ErrorEvent, Event } from '@sentry/node';
 
 /**
  * Secret as a QUERY PARAMETER name, and only there. `code` is an OAuth
@@ -149,8 +149,11 @@ export function scrubSentryErrorEvent(event: ErrorEvent): ErrorEvent {
  * attributes carry the request URL, which is the very `?token=` vector the
  * error path scrubs. Without this they reach Sentry unscrubbed.
  */
-export function scrubSentryTransactionEvent(event: TransactionEvent): TransactionEvent {
-	return scrubSentryValue(event) as TransactionEvent;
+// Generic over Event rather than naming TransactionEvent: @sentry/node does
+// not re-export that type, and @sentry/core is not a direct dependency here.
+// Inference recovers it exactly at the beforeSendTransaction call site.
+export function scrubSentryTransactionEvent<T extends Event>(event: T): T {
+	return scrubSentryValue(event) as T;
 }
 
 /** Never drops a breadcrumb; it only rewrites credential material in place. */

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -162,7 +162,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
     return c.json({ devices: await queryDeviceWorkers(userId) });
   } catch (err: unknown) {
     logger.error({ error: errorMessage(err) }, '[listDeviceWorkers] Error');
-    captureServerError(c, err, 'listDeviceWorkers');
+    captureServerError(c, err, 'listDeviceWorkers', 500);
     return c.json({ error: errorMessage(err) }, 500);
   }
 }
@@ -502,7 +502,7 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     });
   } catch (err) {
     logger.error({ err: errorMessage(err) }, '[mintDeviceChildToken] failed');
-    captureServerError(c, err, 'mintDeviceChildToken');
+    captureServerError(c, err, 'mintDeviceChildToken', 500);
     return c.json({ error: errorMessage(err) }, 500);
   }
 }


### PR DESCRIPTION
## Summary
<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->

## Test plan
<!-- Check only what you actually ran. See AGENTS.md → "Ship a change". -->
- [ ] Intended files staged explicitly, then `make pr-full` clean (full Linux CI graph; `make pre-pr` only as local fallback)
- [ ] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval

## Notes
<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive credentials, signatures, query parameters, and URL metadata are now redacted from error reports, transactions, breadcrumbs, and logged details.
  * Improved protection for nested values, URLs, cookies, and error metadata.

* **Bug Fixes**
  * Server error reports now include the relevant HTTP status and request host for clearer diagnostics.
  * Sensitive URL metadata is no longer exposed in error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->