### PR TITLE
fix(queue): keep one worker per queue and fence claims against shutdown

### DIFF
--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -269,6 +269,71 @@ describe("RunsQueue — action_input JSONB shape", () => {
   });
 });
 
+describe("RunsQueue — worker re-registration", () => {
+  /**
+   * The production trigger is `JobRouter.registerWorker`, which re-registers a
+   * deployment's queue every time that worker's SSE connection comes back. The
+   * queue runs one job at a time, and a reconnect arriving mid-job must not
+   * start the next one early or drop the job already in flight.
+   */
+  test("a reconnect mid-job still runs jobs one at a time and loses none", async () => {
+    if (!queue) throw new Error("queue not started");
+    const sql = getDb();
+    await queue.send("test-reconnect", { turn: 1 });
+    await queue.send("test-reconnect", { turn: 2 });
+
+    let releaseFirst: (() => void) | undefined;
+    let firstStarted: (() => void) | undefined;
+    const started = new Promise<void>((r) => { firstStarted = r; });
+    const order: number[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const first = async (job: { data: { turn: number } }) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      order.push(job.data.turn);
+      firstStarted?.();
+      await new Promise<void>((r) => { releaseFirst = r; });
+      active -= 1;
+    };
+    const replacement = async (job: { data: { turn: number } }) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      order.push(job.data.turn);
+      active -= 1;
+    };
+
+    await queue.work("test-reconnect", first);
+    await started;
+
+    // The reconnect.
+    await queue.work("test-reconnect", replacement);
+
+    // Turn 2 must still be waiting on turn 1.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(order).toEqual([1]);
+    expect(maxActive).toBe(1);
+
+    releaseFirst?.();
+
+    const deadline = Date.now() + 10_000;
+    while (order.length < 2 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(order).toEqual([1, 2]);
+    expect(maxActive).toBe(1);
+
+    // Both rows reached a terminal state rather than being stranded as
+    // `claimed` by a worker that got swapped out from under them.
+    const leftover = await sql<{ count: string }>`
+      SELECT count(*)::text AS count FROM runs
+      WHERE queue_name = 'test-reconnect' AND status <> 'completed'
+    `;
+    expect(leftover[0]?.count).toBe("0");
+  });
+});
+
 describe("RunsQueue — graceful shutdown", () => {
   test("stop() releases claimed rows back to pending", async () => {
     if (!queue) throw new Error("queue not started");

--- a/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
+++ b/packages/server/src/gateway/infrastructure/queue/__tests__/runs-queue.test.ts
@@ -6,7 +6,7 @@
  * gated on `DATABASE_URL`.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   backoffSeconds,
   classifyQueue,
@@ -78,6 +78,139 @@ describe("RunsQueue construction", () => {
       expect(() => new RunsQueue()).not.toThrow();
     } finally {
       if (prev !== undefined) process.env.DATABASE_URL = prev;
+      else delete process.env.DATABASE_URL;
+    }
+  });
+});
+
+describe("RunsQueue worker lifecycle", () => {
+  /**
+   * `JobRouter.registerWorker` is documented as safe to call repeatedly, and it
+   * is: a worker's SSE connection dropping and coming back re-registers the
+   * same `thread_message_<deployment>` queue. That must not let a second job
+   * start next to one that is still running.
+   */
+  test("re-registering a queue keeps one worker and does not run two jobs at once", async () => {
+    const prevDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+    const queue = new RunsQueue();
+    const rows = [
+      { runId: 1, payload: { turn: 1 }, attempts: 0, maxAttempts: 3, retryDelaySeconds: null },
+      { runId: 2, payload: { turn: 2 }, attempts: 0, maxAttempts: 3, retryDelaySeconds: null },
+    ];
+    let releaseFirst: (() => void) | undefined;
+    let firstStarted: (() => void) | undefined;
+    let secondStarted: (() => void) | undefined;
+    const started = new Promise<void>((r) => { firstStarted = r; });
+    const secondRan = new Promise<void>((r) => { secondStarted = r; });
+    let active = 0;
+    let maxActive = 0;
+    (queue as any).isConnected = true;
+    (queue as any).ensureChannelListened = async () => undefined;
+    (queue as any).claimOne = async () => rows.shift() ?? null;
+    (queue as any).heartbeatClaim = async () => undefined;
+    (queue as any).markCompleted = async () => undefined;
+
+    const first = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      firstStarted?.();
+      await new Promise<void>((r) => { releaseFirst = r; });
+      active -= 1;
+    };
+    const replacement = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      secondStarted?.();
+      active -= 1;
+    };
+
+    try {
+      await queue.work("same-queue", first);
+      await started;
+      const worker = (queue as any).workers.get("same-queue");
+
+      await queue.work("same-queue", replacement);
+
+      // The symptom first: a replacement that claims alongside `first` shows
+      // up here as maxActive 2, which is the bug. Asserting worker identity
+      // before this would fail on the mechanism instead of the symptom.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(maxActive).toBe(1);
+
+      // Same worker object, so its in-flight accounting survives.
+      expect((queue as any).workers.get("same-queue")).toBe(worker);
+      expect(worker.handler).toBe(replacement);
+      expect((queue as any).workers.size).toBe(1);
+
+      releaseFirst?.();
+      await Promise.race([
+        secondRan,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("second job never ran")), 1000),
+        ),
+      ]);
+      expect(maxActive).toBe(1);
+    } finally {
+      releaseFirst?.();
+      // Halt the poll loops directly rather than via stop(), which would reach
+      // for a database this test deliberately never needs.
+      for (const w of (queue as any).workers.values()) {
+        w.stopped = true;
+        w.wakeup();
+      }
+      if (prevDbUrl !== undefined) process.env.DATABASE_URL = prevDbUrl;
+      else delete process.env.DATABASE_URL;
+    }
+  });
+
+  /**
+   * `stop()` used to drain on `active` alone, so a claim still inside
+   * `claimOne` was invisible: the drain broke, the shutdown release ran, and
+   * the claim then landed and started a handler on a process that was exiting.
+   */
+  test("stop waits for an in-flight claim and releases it instead of running it", async () => {
+    const prevDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+    const queue = new RunsQueue();
+    let finishClaim: (() => void) | undefined;
+    let claimStarted: (() => void) | undefined;
+    const started = new Promise<void>((r) => { claimStarted = r; });
+    const claimMayFinish = new Promise<void>((r) => { finishClaim = r; });
+    const handler = mock(async () => undefined);
+    const release = mock(async () => undefined);
+    (queue as any).isConnected = true;
+    (queue as any).ensureChannelListened = async () => undefined;
+    (queue as any).releaseClaim = release;
+    (queue as any).releaseAllClaims = async () => 0;
+    (queue as any).heartbeatClaim = async () => undefined;
+    (queue as any).markCompleted = async () => undefined;
+    (queue as any).claimOne = async () => {
+      claimStarted?.();
+      await claimMayFinish;
+      return { runId: 41, payload: {}, attempts: 0, maxAttempts: 3, retryDelaySeconds: null };
+    };
+
+    try {
+      await queue.work("shutdown-race", handler);
+      await started;
+
+      const stopping = queue.stop();
+      expect(handler).not.toHaveBeenCalled();
+
+      // The claim lands after stop() has already begun.
+      finishClaim?.();
+      await stopping;
+
+      // Settle past the poll loop's post-claim continuation: without the
+      // fence it starts the handler here, so this assertion is what catches
+      // work beginning on a process that is exiting.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(handler).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledWith(41);
+    } finally {
+      finishClaim?.();
+      if (prevDbUrl !== undefined) process.env.DATABASE_URL = prevDbUrl;
       else delete process.env.DATABASE_URL;
     }
   });

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -102,6 +102,8 @@ interface QueueWorker {
   concurrency: number;
   paused: boolean;
   stopped: boolean;
+  /** Claims issued to `claimOne` that have not returned yet. */
+  claiming: number;
   active: number;
   wakeup: () => void;
   pendingWakeup: boolean;
@@ -226,8 +228,11 @@ export class RunsQueue implements IMessageQueue {
 
     const drainStart = Date.now();
     while (Date.now() - drainStart < SHUTDOWN_DRAIN_MS) {
+      // `claiming` as well as `active`: a claim still inside `claimOne` is
+      // about to become a row this process owns, so breaking the drain before
+      // it lands would leave it claimed by an exiting pod.
       const inFlight = Array.from(this.workers.values()).reduce(
-        (sum, w) => sum + w.active,
+        (sum, w) => sum + w.claiming + w.active,
         0,
       );
       if (inFlight === 0) break;
@@ -239,19 +244,9 @@ export class RunsQueue implements IMessageQueue {
     // sweeper. Filter by our per-process claim identity so a sibling pod's
     // in-flight claims aren't released out from under it.
     try {
-      const sql = getDb();
-      const result = await sql`
-        UPDATE public.runs
-        SET status = 'pending',
-            claimed_at = NULL,
-            claimed_by = NULL
-        WHERE claimed_by = ${this.claimedBy}
-          AND status = 'claimed'
-      `;
-      if (result.count > 0) {
-        logger.info(
-          `Released ${result.count} claimed run(s) on shutdown`,
-        );
+      const released = await this.releaseAllClaims();
+      if (released > 0) {
+        logger.info(`Released ${released} claimed run(s) on shutdown`);
       }
     } catch (err) {
       logger.warn(
@@ -443,13 +438,19 @@ export class RunsQueue implements IMessageQueue {
       throw new Error("RunsQueue is shutting down; refusing new work");
     }
 
-    // Replace any existing worker for this queue.
+    // Re-register in place. The worker object is the concurrency boundary, so
+    // swapping it out on a reconnect published a fresh `active: 0` alongside a
+    // handler the old worker was still running, and the replacement's poll loop
+    // then claimed a second row for a queue meant to run one at a time.
+    // `registerWorker` is documented as safe to call repeatedly, so this ran
+    // every time a worker's SSE connection came back.
     const existing = this.workers.get(queueName);
     if (existing) {
-      existing.stopped = true;
-      this.removeFromChannelIndex(existing);
+      existing.handler = handler as JobHandler<unknown>;
+      existing.paused = options?.startPaused ?? false;
       existing.wakeup();
-      this.workers.delete(queueName);
+      await this.ensureChannelListened(notifyChannelFor(queueName));
+      return;
     }
 
     const runType = classifyQueue(queueName);
@@ -461,6 +462,7 @@ export class RunsQueue implements IMessageQueue {
       concurrency: DEFAULT_WORKER_CONCURRENCY,
       paused: options?.startPaused ?? false,
       stopped: false,
+      claiming: 0,
       active: 0,
       pendingWakeup: false,
       wakeup: () => {
@@ -505,7 +507,21 @@ export class RunsQueue implements IMessageQueue {
           continue;
         }
         try {
-          const claimed = await this.claimOne(worker);
+          worker.claiming += 1;
+          let claimed: Awaited<ReturnType<RunsQueue["claimOne"]>>;
+          try {
+            claimed = await this.claimOne(worker);
+          } finally {
+            worker.claiming -= 1;
+          }
+          // `stop()` can flip these flags while the claim above is in flight.
+          // There is no await between this check and `active += 1`, so a row
+          // claimed by a queue that is going away is handed back rather than
+          // started on a process that is exiting.
+          if (claimed && (worker.stopped || this.shuttingDown)) {
+            await this.releaseClaim(claimed.runId);
+            continue;
+          }
           if (!claimed) {
             await this.sleep(intervals.runsPollIntervalMs, worker, () => {
               resolveWake = null;
@@ -786,12 +802,36 @@ export class RunsQueue implements IMessageQueue {
     });
   }
 
-  private removeFromChannelIndex(worker: QueueWorker): void {
-    const channel = notifyChannelFor(worker.queueName);
-    const set = this.subscribersByChannel.get(channel);
-    if (!set) return;
-    set.delete(worker);
-    if (set.size === 0) this.subscribersByChannel.delete(channel);
+  /** Release every row still claimed by this process. Scoped to our own claim
+   *  identity so a sibling pod's in-flight claims are left alone. */
+  private async releaseAllClaims(): Promise<number> {
+    const sql = getDb();
+    const result = await sql`
+      UPDATE public.runs
+      SET status = 'pending',
+          claimed_at = NULL,
+          claimed_by = NULL
+      WHERE claimed_by = ${this.claimedBy}
+        AND status = 'claimed'
+    `;
+    return result.count;
+  }
+
+  /** Hand a just-claimed row straight back to `pending`. Scoped to this
+   *  process's claim identity for the same reason `scheduleRetry` is: a sibling
+   *  pod that reclaimed the row after a heartbeat gap keeps it. */
+  private async releaseClaim(runId: number): Promise<void> {
+    const sql = getDb();
+    await sql`
+      UPDATE public.runs
+      SET status = 'pending',
+          claimed_at = NULL,
+          claimed_by = NULL
+      WHERE id = ${runId}
+        AND status = 'claimed'
+        AND claimed_by = ${this.claimedBy}
+    `;
+    queueBreadcrumb("release", `Released run ${runId} on shutdown`, { runId });
   }
 
   /**


### PR DESCRIPTION
Reduced to two real races, both reachable from the gateway's normal reconnect and shutdown paths. This used to sit on top of #3244 and #3254; it is now standalone against main and those two are closed.

`work()` replaced an existing worker by marking it stopped and dropping it from the map, then registered a fresh one with `active: 0`. Nothing awaited the old worker's in-flight handler, so the replacement's poll loop claimed a second row and ran it next to a job that was still going, on a queue whose concurrency is 1. `JobRouter.registerWorker` is documented as safe to call repeatedly and does exactly this every time a worker's SSE connection comes back. Re-registering in place keeps the worker object as the concurrency boundary, so the handler swaps but the in-flight accounting survives and no second poll loop starts.

`stop()` drained on `active` alone, which does not count a claim still inside `claimOne`. The drain saw zero in flight, broke, released the process's claimed rows, and only then did the claim land and start a handler on a process that was exiting. Counting in-flight claims makes the drain wait, and a fence after the claim hands the row back to pending instead of running it.

Also removes `removeFromChannelIndex`, whose only caller was the worker-swap path, and lifts the inline shutdown release into `releaseAllClaims` next to the new per-row `releaseClaim`.

What I deliberately dropped from the earlier version of this branch, since none of it was fixing a reproducible failure and one part was a regression:

The `claimed_by` format change from the per-process id to `podId:queueName:generation`. That column is a shared ownership token on `runs` with several writers and readers doing exact equality (`runs/run-lease.ts`, `runs/queue-service.ts`, `automations/automation.ts`, `gateway/permissions/automation-run-intent.ts`, `scheduled/check-stalled-executions.ts`). Changing the format in RunsQueue alone would have broken matching for every row it claimed. It also came with a per-replica in-memory `Set` of issued owners, which is invisible to other replicas and lost on crash.

The `generation` counter and its claim fence. With in-place re-registration the handler is the same logical consumer, so releasing a good claim because the handler reference changed is churn.

Removing `SHUTDOWN_DRAIN_MS`, which turned the drain into `while (true)`. A stuck handler would have hung pod shutdown until SIGKILL.

Tests: two unit tests fence the races deterministically with injected stubs, and one integration test drives the reconnect through real Postgres. All three fail against the previous code. On the old code the integration test's turn 2 ran concurrently with turn 1 instead of queueing behind it, and the unit test showed the handler being invoked once after `stop()` had begun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker reconnection handling during active jobs.
  * Prevented duplicate job processing when a worker reconnects.
  * Ensured queued jobs are preserved and remain processable after reconnects.
  * Improved shutdown behavior so in-progress claims are completed or safely returned to the queue.
  * Prevented jobs from being left in an incomplete state during worker replacement or shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->