### PR TITLE
feat(chart): alert on terminal chat run failures

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -123,6 +123,9 @@ jobs:
             exit 1
           fi
 
+      - name: Chat run failure alert stays wired
+        run: bash charts/lobu/tests/chat-run-failure-alert.sh
+
       - name: Exercise migration failure recovery
         run: sh charts/lobu/tests/migrate-upgrade-recovery.sh
 

--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 17.2.0
-appVersion: 17.2.0
+version: 17.2.1
+appVersion: 17.2.1
 keywords:
   - lobu
   - content

--- a/charts/lobu/templates/prometheusrule.yaml
+++ b/charts/lobu/templates/prometheusrule.yaml
@@ -38,6 +38,22 @@ spec:
             description: "{{ include "lobu.fullname" . }}-app dropped to 0 available replicas, so the ingress served 503 for that window. Deploy-related unless a node was lost: check whether the pre-upgrade migration hook quiesced (kubectl logs job/{{ include "lobu.fullname" . }}-migrate) and whether it should have — it only quiesces when an incompatible migration is pending (or the check cannot answer)."
     - name: lobu-automations
       rules:
+        # A terminal chat run failure means the user-facing reply was dropped.
+        # `increase` handles counter resets and returns no series value for an
+        # absent metric; summing across queue avoids high-cardinality alerts.
+        # There is no established runbook annotation convention in this chart.
+        # The warning/15m/one-failure defaults are intentionally conservative;
+        # threshold and severity are the only ops decisions before merge.
+        - alert: LobuChatRunFailure
+          expr: |
+            sum(increase(lobu_runs_failed_total{run_type="chat_message"}[15m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+            service: lobu
+          annotations:
+            summary: "Lobu chat run failed terminally"
+            description: "A chat-message run exhausted retries and its user-facing reply was dropped in the last 15m. Inspect the failed runs table and worker logs. Ops decision before merge: confirm the one-failure threshold and warning severity."
         # Heartbeat / dead-man's-switch. The 12-day outage (lobu#1046) was a
         # SILENT one: the app was healthy but the automation scheduler produced
         # zero successful ticks. Alert on the ABSENCE of success, not just on

--- a/charts/lobu/tests/chat-run-failure-alert.sh
+++ b/charts/lobu/tests/chat-run-failure-alert.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT
+
+helm template lobu charts/lobu --namespace lobu \
+  --set metrics.prometheusRule.enabled=true >"$rendered"
+
+rule="$(awk '/^        - alert: LobuChatRunFailure$/{found=1} found{print} found && /^        - alert: / && $0 !~ /LobuChatRunFailure/{exit}' "$rendered")"
+test -n "$rule"
+
+# No failures: the strict > 0 predicate is false for increase == 0.
+grep -q 'sum(increase(lobu_runs_failed_total{run_type="chat_message"}\[15m\])) > 0' <<<"$rule"
+# One/sustained increase: increase is positive and the 15m `for` avoids a
+# short scrape blip while retaining the repository's low-noise warning style.
+grep -q '^          for: 15m$' <<<"$rule"
+# Counter reset: increase(), rather than raw counter comparison, is required.
+! grep -q 'lobu_runs_failed_total{run_type="chat_message"}[[:space:]]*>' <<<"$rule"
+# Other run types excluded: selector is exact and has no regex/wildcard.
+grep -q 'run_type="chat_message"' <<<"$rule"
+! grep -q 'run_type=~' <<<"$rule"
+# No high-cardinality queue grouping or duplicate per-queue alerts.
+! grep -q 'by (.*queue' <<<"$rule"
+test "$(grep -c '^        - alert: LobuChatRunFailure$' "$rendered")" -eq 1
+# Exact labels and annotations.
+grep -q '^            severity: warning$' <<<"$rule"
+grep -q '^            service: lobu$' <<<"$rule"
+grep -q '^            summary: "Lobu chat run failed terminally"$' <<<"$rule"
+grep -q '^            description: ' <<<"$rule"
+
+echo "chat-run-failure-alert: rendered rule checks passed"


### PR DESCRIPTION
## Summary
- add `LobuChatRunFailure` to the chart PrometheusRule
- select the exact emitted `run_type="chat_message"` label and aggregate across `queue`
- use `sum(increase(...[15m])) > 0` with `for: 15m`, warning severity, and `service: lobu`
- bump chart/app version to 17.2.1
- add rendered-rule assertions and wire them into the Helm workflow

## Threshold and severity rationale
The repository has no established PrometheusRule runbook annotation/link convention. This draft uses the conservative low-noise existing convention: a 15-minute `increase` window and `for: 15m`, with `severity: warning` and no queue grouping. It alerts on one or more terminal chat failures while avoiding duplicate per-queue alerts. The one-failure threshold and warning severity are the only ops decisions to confirm before merge.

## Evidence
- `bash charts/lobu/tests/chat-run-failure-alert.sh` ✅
- `helm lint charts/lobu` ✅ (icon recommendation only)
- default chart render omits `LobuChatRunFailure` ✅
- `--set metrics.prometheusRule.enabled=false` omits `LobuChatRunFailure` ✅
- enabled render includes `LobuChatRunFailure` ✅
- `bun test packages/server/src/gateway/__tests__/runs-failed-metric.test.ts` ✅ (1 pass)
- `make pre-pr` ✅
- `git diff --check` ✅
- commit pre-commit Biome and TypeScript checks ✅

The rule uses Prometheus `increase`, so counter resets do not become positive failure events; absent/no-increase series evaluate to zero and do not alert. The exact selector excludes other run types.

`make review-fix` was attempted with both the default Claude reviewer and `REVIEWER_CLI=codex`; Claude reported expired OAuth and Codex exited without a verdict. Neither changed the tree.

## Scope
No DB/schema, runtime API, SDK/wire contract, product behavior, merge, deploy, or production access changes.