### PR TITLE
fix(core): accept parent Automation run on live worker tokens

### DIFF
--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -222,11 +222,11 @@ describe("worker auth token", () => {
     // unrecognised value reads as LIVE and lets an eval replay perform real
     // side effects. Fail the token instead of defaulting it.
     //
-    // Deliberately minted WITHOUT `automationRunId`: with one present the pair
-    // check rejects the token first and this stays green no matter what the
-    // shape check does. Mutation-verified — dropping the shape check turns
-    // these red only in this shape, which is also the reachable hole: a
-    // garbage mode and no run id is exactly what the pair check waves through.
+    // Nothing else can reject these: the capture check fires only on
+    // `executionMode === "capture"`, so an unrecognised mode never reaches it
+    // and this enum check is the only thing between a garbage mode and a token
+    // that reads as live. Mutation-verified — dropping the enum check turns
+    // these red.
     expect(
       verifyWorkerToken(
         generateWorkerToken("user-1", "conv-1", "deploy-A", {
@@ -251,18 +251,16 @@ describe("worker auth token", () => {
     ).toBe(null);
   });
 
-  test("automationRunId without capture is rejected", () => {
-    // The other direction matters too: a live run addressing an eval row would
-    // let real work stamp a capture record onto a run it never replayed.
-    expect(
-      verifyWorkerToken(
-        generateWorkerToken("user-1", "conv-1", "deploy-A", {
-          channelId: "C1",
-          executionMode: "live",
-          automationRunId: 874626,
-        })
-      )
-    ).toBe(null);
+  test("live Automation provenance round-trips without capture", () => {
+    const verified = verifyWorkerToken(
+      generateWorkerToken("user-1", "conv-1", "deploy-A", {
+        channelId: "C1",
+        executionMode: "live",
+        automationRunId: 874626,
+      })
+    );
+    expect(verified?.executionMode).toBe("live");
+    expect(verified?.automationRunId).toBe(874626);
   });
 
   test("round-trips an admin-tools allowlist with its distinct auth actor", () => {

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -68,10 +68,11 @@ export interface WorkerTokenData {
    */
   executionMode?: "live" | "capture";
   /**
-   * The Automation `runs.id` a capture session records its suppressed side
-   * effects onto. NOT {@link runId} — an Automation execution writes two rows and
-   * that one is the per-turn chat_message run. Set only alongside
-   * `executionMode: 'capture'`.
+   * The parent Automation `runs.id` for this one-shot session. NOT
+   * {@link runId} — an Automation execution writes a parent row and a
+   * per-turn chat_message row. Live sessions use it to stamp trusted causal
+   * provenance on descendant tool runs; capture sessions also use it to
+   * record suppressed side effects.
    */
   automationRunId?: number;
   sessionKey?: string;
@@ -170,7 +171,7 @@ export interface WorkerTokenOptions {
   source?: string;
   /** Side-effect mode — see WorkerTokenData.executionMode. */
   executionMode?: "live" | "capture";
-  /** Automation run this capture session replays — see WorkerTokenData.automationRunId. */
+  /** Parent Automation run for this session — see WorkerTokenData.automationRunId. */
   automationRunId?: number;
   sessionKey?: string;
   traceId?: string;
@@ -416,23 +417,15 @@ function verifyToken(
       );
       return null;
     }
-    // The capture pair is inseparable, for the same reason the admin pair
-    // below is: the mode says the run must not perform side effects and
-    // `automationRunId` says which row records what it tried to do. A capture
-    // run that cannot record is the state evals must never reach — its side
-    // effects are suppressed but nothing says what was suppressed, so the
-    // replay scores as clean. A diverged pair is either a forged token or a
-    // mint-side bug: `buildWorkerTokenClaims` gates both on one verified
-    // intent, but reads the run id back off `platformMetadata.intent`
-    // separately, where a malformed intent yields undefined on its own.
-    // Reject either way — a rejected token fails the run closed, where
-    // honouring the pair would run an eval nothing can score.
+    // A capture token must name the row that records suppressed effects. Live
+    // Automation tokens may also carry automationRunId: that signed parent
+    // identity is how embedded MCP stamps durable descendant lineage.
     if (
-      (data.executionMode === "capture") !==
-      (data.automationRunId !== undefined)
+      data.executionMode === "capture" &&
+      data.automationRunId === undefined
     ) {
       logger.error(
-        "Worker token rejected: executionMode 'capture' and automationRunId must be set together"
+        "Worker token rejected: executionMode 'capture' requires automationRunId"
       );
       return null;
     }

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -70,9 +70,10 @@ export interface WorkerTokenData {
   /**
    * The parent Automation `runs.id` for this one-shot session. NOT
    * {@link runId} — an Automation execution writes a parent row and a
-   * per-turn chat_message row. Live sessions use it to stamp trusted causal
-   * provenance on descendant tool runs; capture sessions also use it to
-   * record suppressed side effects.
+   * per-turn chat_message row. A capture session records its suppressed side
+   * effects onto this row and must carry it. A live session MAY carry it as
+   * signed parent identity; today the mint sets it only for capture, so no
+   * live consumer reads it yet.
    */
   automationRunId?: number;
   sessionKey?: string;
@@ -388,9 +389,9 @@ function verifyToken(
         return null;
       }
     }
-    // Same shape rule for `automationRunId` — it addresses the row the capture
-    // guard writes its record onto, so a non-integer must be rejected here
-    // rather than reaching a query as a coerced value.
+    // Same shape rule for `automationRunId` — it addresses the parent
+    // Automation run row, so a non-integer must be rejected here rather than
+    // reaching a query as a coerced value.
     if (data.automationRunId !== undefined) {
       if (
         typeof data.automationRunId !== "number" ||
@@ -417,9 +418,10 @@ function verifyToken(
       );
       return null;
     }
-    // A capture token must name the row that records suppressed effects. Live
-    // Automation tokens may also carry automationRunId: that signed parent
-    // identity is how embedded MCP stamps durable descendant lineage.
+    // A capture token must name the row that records suppressed effects. The
+    // reverse is deliberately NOT enforced: a live token carrying a parent
+    // Automation run id is a valid shape, so the two are checked in one
+    // direction only.
     if (
       data.executionMode === "capture" &&
       data.automationRunId === undefined

--- a/packages/server/src/gateway/worker-dispatch/worker-gateway.ts
+++ b/packages/server/src/gateway/worker-dispatch/worker-gateway.ts
@@ -983,8 +983,9 @@ export class WorkerGateway {
         // Preserve the capture pair, or a long eval replay silently becomes a
         // LIVE run the moment its token rotates: absent `executionMode` reads
         // as live, so every guarded route would start performing real side
-        // effects against the org being scored. Both travel together because
-        // `verifyWorkerToken` rejects one without the other.
+        // effects against the org being scored. `verifyWorkerToken` rejects a
+        // capture claim with no `automationRunId`; a live token may carry the
+        // parent run id on its own, so carry both through explicitly.
         executionMode: tokenData.executionMode,
         automationRunId: tokenData.automationRunId,
       }


### PR DESCRIPTION
**PR A of the D4 split of #3244.** Deploy-order-critical: this must be fully rolled out to every replica **before** #3244's remainder (PR B) lands.

## What this changes

`verifyWorkerToken` enforced a biconditional — `executionMode === "capture"` had to agree exactly with the presence of `automationRunId`. A live (non-capture) Automation token carrying its parent run id was therefore rejected outright.

This relaxes the check to the only half that protects an eval replay:

```ts
if (data.executionMode === "capture" && data.automationRunId === undefined) { ... reject }
```

A `capture` token must still name the row that records its suppressed side effects. A live token may now carry the signed parent Automation run id, and it round-trips intact. Doc comments on `WorkerTokenData.automationRunId` and `WorkerTokenOptions.automationRunId` are updated to the new meaning: parent Automation run for this session, used by live sessions to stamp trusted causal provenance on descendant tool runs.

Scope is `packages/core/src/worker/auth.ts` plus its test. **Nothing mints the new shape here** — no preflight, no lock ordering, no lifecycle fencing, no `runs-queue.ts` / `run-lifecycle.ts` / `automation.ts`. All of that stays in PR B.

## Why split

#3244 both relaxes this validator and starts minting live tokens that carry `automationRunId` (in `buildWorkerTokenClaims`). If both land together, during a rolling deploy a token minted by a new pod is rejected by an old pod's validator and Automation runs fail for the whole rollout window. Landing the permissive validator alone, deploying it everywhere, then landing the minting closes that window.

`packages/core/src/worker/wire.ts`'s internal-only `parentRunId?: number` from #3244 is **not** included: it is purely a minting/queue-payload field, and core + server both typecheck clean without it. It stays in PR B.

## Tests

`packages/core/src/__tests__/worker-auth.test.ts` now covers both directions explicitly:

- `live Automation provenance round-trips without capture` — a live token with `automationRunId: 874626` is **accepted** and both claims survive verification (replaces #3244's now-invalid `automationRunId without capture is rejected`).
- `capture without automationRunId is rejected` — unchanged, still red-on-regression.
- The `executionMode=%p is rejected` table's comment was corrected: it justified itself by "the pair check rejects the token first", which is no longer how a garbage mode is caught. The enum check is now the only thing standing between an unrecognised mode and a token that reads as live.

## Gates run

| Gate | Result |
|---|---|
| `bun test packages/core/src/__tests__/worker-auth.test.ts` | **47 pass / 0 fail**, 95 assertions |
| `packages/core` whole-package `tsc --noEmit` | **clean** |
| `packages/server` whole-package `tsc --noEmit` | **clean** |
| `make pre-pr` (build-packages, per-package strict typecheck, knip, exposed-surface naming, gateway-LLM + entity-write funnel gates) | **clean, exit 0** |
| `git diff --check` | **clean** |
| husky pre-commit (root `tsc --noEmit` + `biome check`) | **clean** |
| `packages/server/.../durable-replay-claim-parity.test.ts` | 2/2 pass (capture-pair fixture still valid) |
| `packages/server/.../worker-token-refresh-route.test.ts` | 8/8 pass |

**Not run / blocked:**

- `packages/server/src/__tests__/unit/eval-capture-mode.test.ts` — fails locally with `ReferenceError: Cannot access 'QuerySchema' before initialization` at `packages/server/src/tools/registry.ts:308`. Verified **pre-existing**: identical failure on an unmodified `origin/main` tree in the same worktree. Not caused by this PR; CI is the reference for it.
- No DB-backed integration suite was run — this change touches no query, no schema, and no route. Per the batch audit there are no migrations anywhere in this queue.
- `make review` not run (settled-HEAD reviewer pass still owed).

Closes nothing. #3244 stays open for PR B.

## CI (canonical gate) — green on `2c158343e`

All 8 required checks pass: `base-branch-guard`, `check-drift`, `format-lint`, `frontend`, `integration`, `migrations`, `typecheck`, `unit`. 29 checks pass total (incl. `integration-bun`, `integration-vitest` 1–3/3, `connector-parity-smoke`, `sdk-cli-e2e`, `sdk-lifecycle-e2e`, `sdk-error-taxonomy-e2e`, `mac-build-smoke`, CodeQL ×3). Nothing red.

`unit` passing on CI also confirms the locally-failing `eval-capture-mode.test.ts` is a local-environment module-init artifact, not a real failure.

`make review` (LLM reviewer / `pi-review`) has **not** been run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live-mode worker tokens can now include and preserve automation run information during verification and refresh.
  * Capture-mode tokens continue to require an associated automation run.
* **Documentation**
  * Clarified how execution mode and automation run details are retained when worker tokens are refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->