### PR TITLE
fix(authz): stop marking consent-only GitHub connections ACL-failed

### DIFF
--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -17,6 +17,7 @@ import {
 	clearConnectionAclError,
 	formatAclErrorMessage,
 	isAclErrorMessage,
+	markConnectionAclFailed,
 } from "../../../authz/acl-observability";
 import {
 	runGithubAclSyncTick,
@@ -425,6 +426,66 @@ describe("acl observability", () => {
 					"GitHub ACL sync unavailable: no repository feeds configured",
 				),
 			);
+		});
+
+		it("releases ACL residue a consent-only grant-holder can no longer clear", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Residue Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				config: { consent_only: true },
+				createDefaultFeed: false,
+			});
+			// Residue from a tick that ran BEFORE the exclusion existed. The row can
+			// never sync to `fresh`, so `clearConnectionAclError` would never fire —
+			// without an explicit release this is permanent.
+			await markConnectionAclFailed(
+				org.id,
+				String(conn.id),
+				"GitHub ACL sync unavailable: no repository feeds configured",
+			);
+			const [seeded] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(seeded?.error_message).not.toBeNull();
+
+			await runGithubAclSyncTick({
+				getAppInstallationStore: () => ({}),
+			} as unknown as Parameters<typeof runGithubAclSyncTick>[0]);
+
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(row?.error_message).toBeNull();
+			const state = await sql`
+        SELECT 1 FROM authz_source_acl_state
+        WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+      `;
+			expect(state).toHaveLength(0);
+		});
+
+		it("leaves a NON-acl error on a consent-only row untouched", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Residue Foreign Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				config: { consent_only: true },
+				createDefaultFeed: false,
+			});
+			await sql`
+        UPDATE connections SET error_message = 'oauth: token expired' WHERE id = ${conn.id}
+      `;
+
+			await runGithubAclSyncTick({
+				getAppInstallationStore: () => ({}),
+			} as unknown as Parameters<typeof runGithubAclSyncTick>[0]);
+
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(row?.error_message).toBe("oauth: token expired");
 		});
 	});
 

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -15,6 +15,7 @@
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
 	clearConnectionAclError,
+	clearRetainedAclErrorMessage,
 	formatAclErrorMessage,
 	isAclErrorMessage,
 	markConnectionAclFailed,
@@ -458,11 +459,71 @@ describe("acl observability", () => {
         SELECT error_message FROM connections WHERE id = ${conn.id}
       `;
 			expect(row?.error_message).toBeNull();
-			const state = await sql`
-        SELECT 1 FROM authz_source_acl_state
+		});
+
+		it("keeps the enforcement row on a consent-only connection that was graphed", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Residue Graphed Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				config: { consent_only: true },
+				createDefaultFeed: false,
+			});
+			// A connection graphed BEFORE it became consent-only: delete its feeds
+			// and flip the flag and this is the live shape. Its already-synced
+			// events are fenced by this row, and `compileResourceVisibility` treats
+			// a MISSING row as never-graphed passthrough — so dropping it here
+			// would turn fail-closed into readable.
+			await sql`
+        INSERT INTO authz_source_acl_state (organization_id, connection_id, acl_support, freshness_state, last_synced_at)
+        VALUES (${org.id}, ${String(conn.id)}, 'full', 'fresh', now())
+      `;
+			await sql`
+        UPDATE connections SET error_message = ${formatAclErrorMessage("GitHub ACL sync unavailable: no repository feeds configured")} WHERE id = ${conn.id}
+      `;
+
+			await runGithubAclSyncTick({
+				getAppInstallationStore: () => ({}),
+			} as unknown as Parameters<typeof runGithubAclSyncTick>[0]);
+
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(row?.error_message).toBeNull();
+			const [state] = await sql`
+        SELECT freshness_state FROM authz_source_acl_state
         WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
       `;
-			expect(state).toHaveLength(0);
+			expect(state?.freshness_state).toBe("fresh");
+		});
+
+		it("clears only acl-prefixed text when called directly", async () => {
+			// The tick's selection predicate already filters on the prefix, so the
+			// guard inside the clear cannot be reached through it. Exercise the
+			// function's own contract: `connections.error_message` is shared, and
+			// this must never blank another subsystem's message.
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Clear Guard Org" });
+			const conn = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				config: { consent_only: true },
+				createDefaultFeed: false,
+			});
+			await sql`
+        UPDATE connections SET error_message = 'oauth: token expired' WHERE id = ${conn.id}
+      `;
+
+			await clearRetainedAclErrorMessage(sql, {
+				organizationId: org.id,
+				connectionId: String(conn.id),
+			});
+
+			const [row] = await sql`
+        SELECT error_message FROM connections WHERE id = ${conn.id}
+      `;
+			expect(row?.error_message).toBe("oauth: token expired");
 		});
 
 		it("leaves a NON-acl error on a consent-only row untouched", async () => {

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -574,6 +574,40 @@ describe("acl observability", () => {
 			expect(row?.unhealthy_alerted_at).not.toBeNull();
 		});
 
+		it("suppresses the alert for a consent-only github row but not a slack one", async () => {
+			// The retained `failed` row is deliberate — it keeps already-synced
+			// events fenced — but the github tick no longer sweeps consent-only
+			// connections, so it can never clear and alerting on it would be
+			// permanent noise. The slack tick DOES still sweep them, so a failure
+			// it records is live and must still alert.
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Consent Alert Org" });
+			const gh = await seedAclFailedConnection({
+				orgId: org.id,
+				errorMessage: formatAclErrorMessage("GitHub ACL sync failed: 401"),
+			});
+			const slack = await seedAclFailedConnection({
+				orgId: org.id,
+				errorMessage: formatAclErrorMessage("Slack ACL sync failed: 401"),
+			});
+			await sql`
+        UPDATE connections
+        SET config = jsonb_set(COALESCE(config, '{}'::jsonb), '{consent_only}', 'true')
+        WHERE id IN (${gh.id}, ${slack.id})
+      `;
+			await sql`
+        UPDATE connections SET connector_key = 'slack' WHERE id = ${slack.id}
+      `;
+
+			const result = await runConnectorHealthCheck();
+			expect(
+				result.details.find((d) => d.connectionId === gh.id)?.reason,
+			).toBeUndefined();
+			expect(result.details.find((d) => d.connectionId === slack.id)?.reason).toBe(
+				"acl_failed",
+			);
+		});
+
 		it("does not attribute a chat runtime ACL failure to a colliding data slug", async () => {
 			const sql = getTestDb();
 			const org = await createTestOrganization({

--- a/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
+++ b/packages/server/src/__tests__/integration/authz/acl-observability.test.ts
@@ -18,7 +18,10 @@ import {
 	formatAclErrorMessage,
 	isAclErrorMessage,
 } from "../../../authz/acl-observability";
-import { syncGithubConnectionAcl } from "../../../authz/github-acl-sync";
+import {
+	runGithubAclSyncTick,
+	syncGithubConnectionAcl,
+} from "../../../authz/github-acl-sync";
 import { runConnectorHealthCheck } from "../../../connectors/connector-health";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -383,6 +386,45 @@ describe("acl observability", () => {
 			// module exists to remove, so the reason must survive the losing clear.
 			expect(state?.freshness_state).toBe("failed");
 			expect(row?.error_message).toBe(formatAclErrorMessage("newer failure"));
+		});
+
+		it("skips a consent-only grant-holder instead of marking it ACL-failed", async () => {
+			const sql = getTestDb();
+			const org = await createTestOrganization({ name: "Acl Consent Only Org" });
+			// A consent-only grant-holder holds an OAuth grant for delegation and
+			// `manage_feeds` refuses feeds on it BY CONSTRUCTION, so a feedless sweep
+			// is its steady state — not an outage to downgrade the graph over.
+			const consentOnly = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				config: { consent_only: true },
+				createDefaultFeed: false,
+			});
+			// A NORMAL connection that has no feeds must still fail closed; the skip
+			// is scoped to consent-only, never a blanket "empty means fine".
+			const regular = await createTestConnection({
+				organization_id: org.id,
+				connector_key: "github",
+				createDefaultFeed: false,
+			});
+
+			await runGithubAclSyncTick({
+				getAppInstallationStore: () => ({}),
+			} as unknown as Parameters<typeof runGithubAclSyncTick>[0]);
+
+			const [consentRow] = await sql`
+        SELECT error_message FROM connections WHERE id = ${consentOnly.id}
+      `;
+			expect(consentRow?.error_message).toBeNull();
+
+			const [regularRow] = await sql`
+        SELECT error_message FROM connections WHERE id = ${regular.id}
+      `;
+			expect(regularRow?.error_message).toBe(
+				formatAclErrorMessage(
+					"GitHub ACL sync unavailable: no repository feeds configured",
+				),
+			);
 		});
 	});
 

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -8,7 +8,7 @@
 import { type DbClient, getDb } from "../db/client.js";
 import { bumpAclGeneration } from "./acl-generation.js";
 
-const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
+export const ACL_ERROR_MESSAGE_PREFIX = "acl: ";
 
 /** Maximum length of the complete persisted message, including its prefix. */
 const ACL_ERROR_MESSAGE_MAX_LENGTH = 500;
@@ -174,5 +174,37 @@ export async function deleteConnectionAclRow(
       AND c.organization_id = ${params.organizationId}
       AND a.organization_id = c.organization_id
       AND a.connection_id = ${sql.unsafe(aclConnectionIdSql("c"))}
+  `;
+}
+
+
+/**
+ * Release a connection's ACL materialization and its ACL-owned error text.
+ *
+ * For a connection a source deliberately EXCLUDES from its sweep (a
+ * consent-only grant-holder), {@link clearConnectionAclError} can never fire:
+ * it only clears behind a `fresh` state, and an excluded connection never syncs
+ * to reach one. Without this, a failure recorded by an earlier tick — or by any
+ * tick before the exclusion existed — stays on a healthy row forever.
+ *
+ * The state row is a pure materialization with no FK dependents (same rationale
+ * as {@link deleteConnectionAclRow}), and only `acl:`-prefixed text is cleared,
+ * so another subsystem's error message survives untouched.
+ */
+export async function releaseConnectionAclState(
+	sql: DbClient,
+	params: {
+		organizationId: string;
+		connectionId: string | number;
+	},
+): Promise<void> {
+	await deleteConnectionAclRow(sql, params);
+	await sql`
+    UPDATE connections
+    SET error_message = NULL, updated_at = current_timestamp
+    WHERE id = ${params.connectionId}
+      AND organization_id = ${params.organizationId}
+      AND deleted_at IS NULL
+      AND left(error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
   `;
 }

--- a/packages/server/src/authz/acl-observability.ts
+++ b/packages/server/src/authz/acl-observability.ts
@@ -177,28 +177,35 @@ export async function deleteConnectionAclRow(
   `;
 }
 
-
 /**
- * Release a connection's ACL materialization and its ACL-owned error text.
+ * Clear the ACL-owned error text on a connection, leaving every other piece
+ * of ACL state alone.
  *
  * For a connection a source deliberately EXCLUDES from its sweep (a
  * consent-only grant-holder), {@link clearConnectionAclError} can never fire:
  * it only clears behind a `fresh` state, and an excluded connection never syncs
- * to reach one. Without this, a failure recorded by an earlier tick — or by any
- * tick before the exclusion existed — stays on a healthy row forever.
+ * to reach one. Without this, a failure message recorded by an earlier tick —
+ * or by any tick before the exclusion existed — stays on a healthy row forever.
  *
- * The state row is a pure materialization with no FK dependents (same rationale
- * as {@link deleteConnectionAclRow}), and only `acl:`-prefixed text is cleared,
- * so another subsystem's error message survives untouched.
+ * Deliberately does NOT touch `authz_source_acl_state`. Dropping that row moves
+ * a graphed connection to `not-graphed`, which is the PASSTHROUGH branch of
+ * `compileResourceVisibility` — so its already-synced resource-linked events
+ * would go from fail-closed to readable. `resource-visibility.ts` states the
+ * invariant directly: once a connection is graphed it never falls back to the
+ * legacy per-connection fence, because a stalled sync must hide data rather
+ * than leak it. Retaining a `failed` row keeps exactly that fail-closed
+ * posture; only the operator-facing message is stale, and only it is cleared.
+ *
+ * Only `acl:`-prefixed text is cleared, so another subsystem's error message
+ * survives untouched.
  */
-export async function releaseConnectionAclState(
+export async function clearRetainedAclErrorMessage(
 	sql: DbClient,
 	params: {
 		organizationId: string;
 		connectionId: string | number;
 	},
 ): Promise<void> {
-	await deleteConnectionAclRow(sql, params);
 	await sql`
     UPDATE connections
     SET error_message = NULL, updated_at = current_timestamp

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -25,8 +25,11 @@ import {
   githubReposToResources,
 } from '@lobu/connectors/github-identity';
 import {
+  ACL_ERROR_MESSAGE_PREFIX,
+  aclConnectionIdSql,
   clearConnectionAclError,
   markConnectionAclFailed,
+  releaseConnectionAclState,
 } from './acl-observability.js';
 import { buildAccessGraph } from './access-graph.js';
 import { captureAclSyncFence } from './acl-generation.js';
@@ -202,6 +205,34 @@ async function fetchRepoCollaborators(
  */
 export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<void> {
   const sql = getDb();
+  // Residue release, BEFORE the sweep below. The exclusion stops NEW failures but
+  // cannot undo old ones: `clearConnectionAclError` only clears behind a
+  // `fresh` state, which an excluded row can never reach, so a failure written
+  // by an earlier tick (or by any tick before this exclusion existed) would sit
+  // on a healthy connection forever. Matches only rows that actually carry
+  // residue, so the steady state does no work.
+  const stale = await sql<{ id: string; organization_id: string }>`
+		SELECT c.id::text AS id, c.organization_id
+		FROM connections c
+		WHERE c.connector_key = 'github'
+		  AND c.deleted_at IS NULL
+		  AND c.config->>'consent_only' = 'true'
+		  AND (
+		    left(c.error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
+		    OR EXISTS (
+		      SELECT 1 FROM authz_source_acl_state a
+		      WHERE a.organization_id = c.organization_id
+		        AND a.connection_id = ${sql.unsafe(aclConnectionIdSql('c'))}
+		    )
+		  )
+	`;
+  for (const row of stale) {
+    await releaseConnectionAclState(sql, {
+      organizationId: row.organization_id,
+      connectionId: row.id,
+    });
+  }
+
   // Consent-only grant-holders are EXCLUDED, not swept and failed: they exist
   // solely to hold an OAuth grant for delegation, and `manage_feeds` refuses
   // feeds on them by construction, so `listRepos` is empty for them on every

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -26,10 +26,9 @@ import {
 } from '@lobu/connectors/github-identity';
 import {
   ACL_ERROR_MESSAGE_PREFIX,
-  aclConnectionIdSql,
   clearConnectionAclError,
+  clearRetainedAclErrorMessage,
   markConnectionAclFailed,
-  releaseConnectionAclState,
 } from './acl-observability.js';
 import { buildAccessGraph } from './access-graph.js';
 import { captureAclSyncFence } from './acl-generation.js';
@@ -209,7 +208,10 @@ export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<
   // cannot undo old ones: `clearConnectionAclError` only clears behind a
   // `fresh` state, which an excluded row can never reach, so a failure written
   // by an earlier tick (or by any tick before this exclusion existed) would sit
-  // on a healthy connection forever. Matches only rows that actually carry
+  // on a healthy connection forever. Keyed on the residue itself, not on "an
+  // ACL state row exists": a consent-only connection can legitimately hold a
+  // `fresh` or `stale` enforcement row, and that row is what keeps its
+  // already-synced events fenced. Matches only rows that actually carry
   // residue, so the steady state does no work.
   const stale = await sql<{ id: string; organization_id: string }>`
 		SELECT c.id::text AS id, c.organization_id
@@ -217,17 +219,10 @@ export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<
 		WHERE c.connector_key = 'github'
 		  AND c.deleted_at IS NULL
 		  AND c.config->>'consent_only' = 'true'
-		  AND (
-		    left(c.error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
-		    OR EXISTS (
-		      SELECT 1 FROM authz_source_acl_state a
-		      WHERE a.organization_id = c.organization_id
-		        AND a.connection_id = ${sql.unsafe(aclConnectionIdSql('c'))}
-		    )
-		  )
+		  AND left(c.error_message, ${ACL_ERROR_MESSAGE_PREFIX.length}) = ${ACL_ERROR_MESSAGE_PREFIX}
 	`;
   for (const row of stale) {
-    await releaseConnectionAclState(sql, {
+    await clearRetainedAclErrorMessage(sql, {
       organizationId: row.organization_id,
       connectionId: row.id,
     });

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -202,10 +202,18 @@ async function fetchRepoCollaborators(
  */
 export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<void> {
   const sql = getDb();
+  // Consent-only grant-holders are EXCLUDED, not swept and failed: they exist
+  // solely to hold an OAuth grant for delegation, and `manage_feeds` refuses
+  // feeds on them by construction, so `listRepos` is empty for them on every
+  // tick. Sweeping them would mark a healthy row `failed` forever (the reason
+  // only clears on a successful sync, which can never happen), turning the
+  // ACL-failure signal into permanent noise. A NORMAL connection that has no
+  // feeds still fails closed below — the skip is scoped to consent-only.
   const connections = await sql<{ id: string; organization_id: string }>`
 		SELECT id::text AS id, organization_id
 		FROM connections
 		WHERE connector_key = 'github' AND status = 'active' AND deleted_at IS NULL
+		  AND config->>'consent_only' IS DISTINCT FROM 'true'
 	`;
   if (connections.length === 0) return;
 

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -333,7 +333,14 @@ async function loadConnectionHealthRows(
       -- failure mode with no feed symptom. Select the connection's actual ACL
       -- id shape so a data slug cannot collide with a chat runtime id. The
       -- cleanup migration mirrors this predicate.
-      EXISTS (
+      -- Consent-only grant-holders are excluded: runGithubAclSyncTick does not
+      -- sweep them, so a retained failed row is frozen history, not a live
+      -- refresh failure. The row is deliberately kept -- it is what keeps any
+      -- already-synced events fenced -- but it can never clear, so alerting on
+      -- it would mark a healthy connection unhealthy forever with nothing an
+      -- operator could do about it.
+      c.config ->> 'consent_only' IS DISTINCT FROM 'true'
+      AND EXISTS (
         SELECT 1
         FROM public.authz_source_acl_state a
         WHERE a.organization_id = c.organization_id

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -333,13 +333,21 @@ async function loadConnectionHealthRows(
       -- failure mode with no feed symptom. Select the connection's actual ACL
       -- id shape so a data slug cannot collide with a chat runtime id. The
       -- cleanup migration mirrors this predicate.
-      -- Consent-only grant-holders are excluded: runGithubAclSyncTick does not
-      -- sweep them, so a retained failed row is frozen history, not a live
-      -- refresh failure. The row is deliberately kept -- it is what keeps any
-      -- already-synced events fenced -- but it can never clear, so alerting on
-      -- it would mark a healthy connection unhealthy forever with nothing an
-      -- operator could do about it.
-      c.config ->> 'consent_only' IS DISTINCT FROM 'true'
+      -- Consent-only GITHUB grant-holders are excluded: runGithubAclSyncTick
+      -- does not sweep them, so a retained failed row there is frozen history,
+      -- not a live refresh failure. The row is deliberately kept -- it is what
+      -- keeps any already-synced events fenced -- but it can never clear, so
+      -- alerting on it would mark a healthy connection unhealthy forever with
+      -- nothing an operator could do about it. Scoped to the one sweep that
+      -- actually skips these rows: the Slack tick still sweeps consent-only
+      -- connections, so a failure it records IS live and must still alert.
+      -- Written as OR/IS DISTINCT FROM rather than NOT(... AND ...): config is
+      -- nullable, and NOT (true AND NULL) evaluates to NULL, which would have
+      -- dropped the alert for every connection whose config is unset.
+      (
+        c.connector_key <> 'github'
+        OR c.config ->> 'consent_only' IS DISTINCT FROM 'true'
+      )
       AND EXISTS (
         SELECT 1
         FROM public.authz_source_acl_state a


### PR DESCRIPTION
## Summary
- `runGithubAclSyncTick` swept every active GitHub connection, including consent-only grant-holders. Those hold an OAuth grant for delegation and `manage_feeds.ts:828` refuses feeds on them **by construction**, so `listRepos` is empty on every tick.
- Result: `markConnectionAclFailed` writes `acl: GitHub ACL sync unavailable: no repository feeds configured` onto a healthy row, and it never clears — `clearConnectionAclError` only runs on the success path, which can never be reached. Plus an ERROR log every tick.
- Fix excludes consent-only rows from the enumeration. A normal connection with no feeds **still fails closed** — the skip is scoped to consent-only, so the fail-closed contract is unchanged.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, typecheck, knip, naming, gateway/entity gates)
- [x] Tests run: targeted `bun run test -- run src/__tests__/integration/authz/ src/__tests__/integration/connectors/managed-connect-consent-only.test.ts` → **27 files, 260 tests passed**
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before fix)
```
× acl observability > failure reason persistence > skips a consent-only grant-holder instead of marking it ACL-failed
  → expected 'acl: GitHub ACL sync unavailable: no …' to be null
- Expected: null
+ Received: "acl: GitHub ACL sync unavailable: no repository feeds configured"
Test Files  1 failed (1)
```

### Green (after fix)
```
✓ src/__tests__/integration/authz/acl-observability.test.ts (13 tests) 3122ms
Test Files  1 passed (1)
     Tests  13 passed (13)
```

Tick log confirms the enumeration change (1 connection swept, not 2 — the consent-only one is excluded, the regular feedless one still fails closed):
```
[github-acl-sync] GitHub ACL sync tick complete {"connections":1,"ok":0,"failed":1,"skipped":0}
```

### Regression
```
Test Files  27 passed (27)
     Tests  260 passed (260)
```

## Notes
Verified against real production rows — the predicate excludes exactly the right set:

| connection | org | `config.consent_only` | new predicate |
|---|---|---|---|
| 575, 574 | lobu-cloud | `true` | excluded (these carry the stale message today) |
| 385 | lobu-team | absent → NULL | retained |
| 233 | community | absent → NULL | retained |

`IS DISTINCT FROM` is deliberate so a NULL `config` (or absent key) still enumerates.

Slack's tick is incidentally protected by its own `credential_mode IS NOT NULL` filter, so it does not have this gap; no change needed there.

⚠️ `make review-fix` could not run — the Codex backend returned `You've hit your usage limit … try again at Sep 7th, 2026`. Not a clean-pass, an environmental block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consent-only GitHub connections no longer retain stale ACL failure messages or trigger incorrect connector-health alerts.
  * Existing ACL state is preserved while stale errors are cleared.
  * Standard connections without configured repository feeds continue to fail safely with a clear configuration error.
* **Tests**
  * Added integration coverage for ACL cleanup, state retention, error handling, and connector-health alerting across GitHub and Slack connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->