### PR TITLE
feat(worker): execute os.shell as a daemon builtin and gate claims on backend capacity

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -162,9 +162,9 @@ export interface ConnectorAgentToolingEnv {
 
 export interface ConnectorRuntimeInfo {
   /** Platforms this connector can run on. */
-  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-  /** Native bridge-owned execution. Absent means the normal worker runtime. */
-  execution?: 'bridge';
+  platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'>;
+  /** Device-owned execution. Absent means the normal compiled worker runtime. */
+  execution?: 'bridge' | 'daemon_builtin';
   /**
    * Permission/auth scopes forwarded verbatim to the native platform adapter.
    * Optional — omit when the platform adapter needs no fine-grained scope list.

--- a/packages/connector-sdk/src/device-manifest.ts
+++ b/packages/connector-sdk/src/device-manifest.ts
@@ -2,6 +2,9 @@ import { createHash } from 'node:crypto';
 
 export type DeviceManifestSchema = Record<string, unknown>;
 
+/** Execution owner declared by a device-manifest wire artifact. */
+export type DeviceManifestExecution = 'bridge' | 'daemon_builtin';
+
 export interface DeviceConnectorManifest {
   key: string;
   version: string;
@@ -11,7 +14,7 @@ export interface DeviceConnectorManifest {
   required_capability: string;
   runtime: {
     platforms: string[];
-    execution?: 'bridge';
+    execution?: DeviceManifestExecution;
     scopes?: string[];
     nix?: { packages?: string[] } | null;
   };

--- a/packages/connector-worker/src/__tests__/automation-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-arm.test.ts
@@ -97,6 +97,31 @@ setInterval(() => {}, 1000);
     expect(signalOwnedPosixProcessGroup(liveOwner, 'SIGTERM', sendSignal)).toBe(true);
     expect(signals).toEqual([{ pid: -4242, signal: 'SIGTERM' }]);
   });
+
+  test('separates a vanished process group from one it may not signal', () => {
+    const owner = { pid: 4243, exitCode: null, signalCode: null };
+    const failWith = (code: string) =>
+      (() => {
+        const err = new Error(code) as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      }) as unknown as typeof process.kill;
+
+    // ESRCH: the group is gone. False retires it, and the caller then skips
+    // straight past the grace window — correct, there is nothing to escalate.
+    expect(signalOwnedPosixProcessGroup(owner, 'SIGTERM', failWith('ESRCH'))).toBe(false);
+
+    // EPERM: the group is THERE, we just could not signal a member of it.
+    // Reporting false here is what leaves a TERM-ignoring tree alive, because
+    // `terminateChild` reads false as "no owned group", sends one SIGTERM to
+    // the supervisor and returns without ever escalating to SIGKILL.
+    expect(signalOwnedPosixProcessGroup(owner, 'SIGTERM', failWith('EPERM'))).toBe(true);
+
+    // Anything else is a real fault and must not be swallowed as either.
+    expect(() =>
+      signalOwnedPosixProcessGroup(owner, 'SIGTERM', failWith('EINVAL')),
+    ).toThrow();
+  });
 });
 
 describe('terminated target metadata', () => {

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeRun } from '../daemon/executor.js';
+import { runShellBuiltin } from '../daemon/builtins/os-shell.js';
+
+function processIsLive(pid: number): boolean {
+  try {
+    if (process.platform === 'linux') {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const state = stat.slice(stat.lastIndexOf(') ') + 2, stat.lastIndexOf(') ') + 3);
+      return state !== 'Z';
+    }
+    process.kill(pid, 0);
+    if (process.platform === 'darwin') {
+      process.kill(pid, 0);
+      return true;
+    }
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function forceKill(pid: number, group = false): void {
+  try {
+    process.kill(group ? -pid : pid, 'SIGKILL');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+  }
+}
+
+function processGroupExists(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function stubClient() {
+  const completions: Array<Record<string, unknown>> = [];
+  return {
+    client: {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        completions.push(input);
+      },
+    },
+    completions,
+  };
+}
+
+describe('daemon-builtin os.shell', () => {
+  test('uses a minimal child environment and does not inherit control-plane env', async () => {
+    const sentinels = {
+      WORKER_API_TOKEN: process.env.WORKER_API_TOKEN,
+      LOBU_API_TOKEN: process.env.LOBU_API_TOKEN,
+      LOBU_MEMORY_URL: process.env.LOBU_MEMORY_URL,
+      DATABASE_URL: process.env.DATABASE_URL,
+      LOBU_ENCRYPTION_KEY: process.env.LOBU_ENCRYPTION_KEY,
+      AUTH_SECRET: process.env.AUTH_SECRET,
+      PROVIDER_API_KEY: process.env.PROVIDER_API_KEY,
+    };
+    Object.assign(process.env, {
+      WORKER_API_TOKEN: 'worker-secret',
+      LOBU_API_TOKEN: 'api-secret',
+      LOBU_MEMORY_URL: 'https://memory.invalid',
+      DATABASE_URL: 'postgres://secret',
+      LOBU_ENCRYPTION_KEY: 'encryption-secret',
+      AUTH_SECRET: 'auth-secret',
+      PROVIDER_API_KEY: 'provider-secret',
+    });
+    try {
+      const result = await runShellBuiltin({
+        command: 'printf "PATH=%s\\nHOME=%s\\nTMPDIR=%s\\n" "$PATH" "$HOME" "$TMPDIR"; env',
+        cwd: process.cwd(),
+      });
+      expect(result.success).toBe(true);
+      expect(result.stdout).toMatch(/PATH=.+/);
+      expect(result.stdout).toMatch(/HOME=.+/);
+      expect(result.stdout).toMatch(/TMPDIR=.+/);
+      for (const name of Object.keys(sentinels)) expect(result.stdout).not.toContain(`${name}=`);
+      expect(result.stdout).toContain('LC_ALL=C');
+    } finally {
+      for (const [name, value] of Object.entries(sentinels)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  });
+
+  test('force-kills SIGTERM-ignoring descendants in its process group', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'lobu-shell-test-'));
+    let descendantPid = 0;
+    try {
+      const output = await runShellBuiltin({
+        command: `node -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); fs.writeFileSync("./ready", String(process.pid)); setTimeout(() => {}, 10000)' >/dev/null 2>&1 & while [ ! -s ./ready ]; do sleep 0.01; done; cat ./ready; wait`,
+        cwd: testDir,
+        timeout_ms: 300,
+      });
+      descendantPid = Number(output.stdout.trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Number.isInteger(descendantPid)).toBe(true);
+      expect(processIsLive(descendantPid)).toBe(false);
+    } finally {
+      if (descendantPid > 0 && processIsLive(descendantPid)) forceKill(descendantPid);
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds settlement without claiming ownership of a detached session', async () => {
+    if (process.platform !== 'linux') return;
+
+    let escapedPid = 0;
+    try {
+      const started = Date.now();
+      const output = await runShellBuiltin({
+        command: `setsid bash -c 'trap "" TERM; (sleep 0.1; printf detached-trailing-output >&2) & sleep 10' & echo $!; wait`,
+        cwd: process.cwd(),
+        timeout_ms: 300,
+      });
+      escapedPid = Number(output.stdout.trim());
+
+      expect(output.timed_out).toBe(true);
+      expect(Date.now() - started).toBeLessThan(5_500);
+      expect(output.stderr).toContain('detached-trailing-output');
+      expect(Number.isInteger(escapedPid)).toBe(true);
+      // A deliberately new session is outside the supervisor's owned group;
+      // the test owns this exact PID/group and cleans it up below.
+      expect(processGroupExists(escapedPid)).toBe(true);
+    } finally {
+      if (escapedPid > 0) forceKill(escapedPid, true);
+    }
+  });
+
+  test('does not reject when the command exits before consuming stdin', async () => {
+    const output = await runShellBuiltin({
+      command: 'exit 0',
+      cwd: process.cwd(),
+      stdin: 'x'.repeat(1_000_000),
+    });
+
+    expect(output.success).toBe(true);
+    expect(output.exit_code).toBe(0);
+  });
+
+  test('drains output emitted as the supervisor closes', async () => {
+    const output = await runShellBuiltin({
+      command: `node -e 'process.stdout.write("stdout-at-close"); process.stderr.write("stderr-at-close"); process.exit(0)'`,
+      cwd: process.cwd(),
+    });
+
+    expect(output).toMatchObject({
+      success: true,
+      stdout: 'stdout-at-close',
+      stderr: 'stderr-at-close',
+      exit_code: 0,
+    });
+  });
+
+  test('executes without compiled connector code or connector SDK resolution', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 464,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        connector_version: '0.2.0',
+        connector_manifest_hash: 'test-manifest-hash',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {
+          command: "printf 'lobu-shell-ok\\n'",
+          cwd: process.cwd(),
+        },
+      },
+      {},
+      { heartbeatIntervalMs: 5_000 }
+    );
+
+    expect(result).toEqual({ itemsCollected: 0 });
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      run_id: 464,
+      worker_id: 'headless:test',
+      status: 'success',
+      action_output: {
+        stdout: 'lobu-shell-ok\n',
+        stderr: '',
+        exit_code: 0,
+        success: true,
+        timed_out: false,
+      },
+    });
+  });
+
+  test('fails closed when the declared built-in is not registered', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 465,
+        run_type: 'action',
+        connector_key: 'missing.builtin',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {},
+      },
+      {}
+    );
+
+    expect(result.error).toStartWith('operation_backend_unavailable:');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+
+  test('rejects a contradictory compiled payload', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 466,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        execution_backend: 'daemon_builtin',
+        compiled_code: 'must not execute',
+        action_key: 'run',
+        action_input: { command: 'exit 0' },
+      },
+      {}
+    );
+
+    expect(result.error).toContain('must not contain compiled_code');
+    expect(completions[0]).toMatchObject({ status: 'failed' });
+  });
+
+  test('bounds timeout while killing descendants in the owned process group', async () => {
+    const { client, completions } = stubClient();
+    const started = Date.now();
+    const result = await executeRun(
+      client as never,
+      {
+        run_id: 467,
+        run_type: 'action',
+        connector_key: 'os.shell',
+        connector_version: '0.2.0',
+        connector_manifest_hash: 'test-manifest-hash',
+        execution_backend: 'daemon_builtin',
+        action_key: 'run',
+        action_input: {
+          command: 'sleep 10 & wait',
+          cwd: process.cwd(),
+          timeout_ms: 300,
+        },
+      },
+      {},
+      { heartbeatIntervalMs: 5_000 }
+    );
+
+    expect(result.itemsCollected).toBe(0);
+    expect(result.error).toStartWith('operation_execution_failed:');
+    expect(Date.now() - started).toBeLessThan(5_500);
+    expect(completions[0]?.status).toBe('failed');
+    expect(completions[0]?.error_message).toStartWith('operation_execution_failed: Shell command timed out after ');
+    expect(completions[0]?.action_output).toMatchObject({
+      stdout: '', stderr: '', timed_out: true, success: false,
+    });
+  });
+
+  test('preserves structured output for nonzero builtin results', async () => {
+    const { client, completions } = stubClient();
+    const result = await executeRun(client as never, {
+      run_id: 468,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: "printf out; printf err >&2; exit 7", cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 });
+    expect(result.error).toContain('operation_execution_failed: Shell command exited with code 7');
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      status: 'failed',
+      action_output: { stdout: 'out', stderr: 'err', exit_code: 7, timed_out: false, success: false },
+    });
+  });
+
+  test('retries one immutable success payload after terminal delivery loss', async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    let attempts = 0;
+    const client = {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        payloads.push(structuredClone(input));
+        attempts += 1;
+        if (attempts === 1) throw new Error('response lost');
+      },
+    };
+    await expect(executeRun(client as never, {
+      run_id: 469,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: 'printf success', cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 })).resolves.toEqual({ itemsCollected: 0 });
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual(payloads[1]);
+    expect(payloads[0]).toMatchObject({ status: 'success', action_output: { stdout: 'success' } });
+  });
+
+  test('retries one immutable failed payload after terminal delivery loss', async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    let attempts = 0;
+    const client = {
+      id: 'headless:test',
+      async heartbeat() {},
+      async completeAction(input: Record<string, unknown>) {
+        payloads.push(structuredClone(input));
+        attempts += 1;
+        if (attempts === 1) throw new Error('response lost');
+      },
+    };
+    await expect(executeRun(client as never, {
+      run_id: 470,
+      run_type: 'action',
+      connector_key: 'os.shell',
+      connector_version: '0.2.0',
+      execution_backend: 'daemon_builtin',
+      action_key: 'run',
+      action_input: { command: 'printf err >&2; exit 7', cwd: process.cwd() },
+    }, {}, { heartbeatIntervalMs: 5_000 })).resolves.toMatchObject({ itemsCollected: 0, error: expect.stringContaining('exited with code 7') });
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual(payloads[1]);
+    expect(payloads[0]).toMatchObject({ status: 'failed', action_output: { stderr: 'err', exit_code: 7 } });
+  });
+
+  test('ignores poisoned Bash function state while enforcing timeout reaping', async () => {
+    const previousBashFunction = process.env['BASH_FUNC_sleep%%'];
+    const previousBashEnv = process.env.BASH_ENV;
+    process.env['BASH_FUNC_sleep%%'] = '() { :; }';
+    process.env.BASH_ENV = '/tmp/does-not-exist-lobu-shell-test';
+    try {
+      const started = Date.now();
+      const result = await runShellBuiltin({
+        command: 'trap "" TERM; sleep 30 & descendant=$!; echo "$descendant"; wait',
+        cwd: process.cwd(),
+        timeout_ms: 100,
+      });
+      expect(result.success).toBe(false);
+      expect(result.timed_out).toBe(true);
+      if (process.platform !== 'darwin') expect(processIsLive(Number(result.stdout.trim()))).toBe(false);
+      expect(Date.now() - started).toBeLessThan(4_000);
+    } finally {
+      if (previousBashFunction === undefined) delete process.env['BASH_FUNC_sleep%%'];
+      else process.env['BASH_FUNC_sleep%%'] = previousBashFunction;
+      if (previousBashEnv === undefined) delete process.env.BASH_ENV;
+      else process.env.BASH_ENV = previousBashEnv;
+    }
+  });
+
+  test('daemon abort kills a long-lived child and grandchild process tree', async () => {
+    const shutdown = new AbortController();
+    const started = Date.now();
+    const pending = runShellBuiltin({
+      command: 'sleep 30 & child=$!; sleep 30 & grandchild=$!; wait "$child" "$grandchild"',
+      cwd: process.cwd(),
+      timeout_ms: 150_000,
+    }, shutdown.signal);
+    setTimeout(() => shutdown.abort(), 100);
+    const result = await pending;
+    expect(result.success).toBe(false);
+    expect(result.timed_out).toBe(false);
+    expect(Date.now() - started).toBeLessThan(4_000);
+  });
+
+  test('rejects a timeout that exceeds the caller truth budget', async () => {
+    await expect(runShellBuiltin({
+      command: 'printf nope',
+      cwd: process.cwd(),
+      timeout_ms: 150_001,
+    })).rejects.toThrow('between 100 and 150000');
+  });
+});

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { executeRun } from '../daemon/executor.js';
+import { executeDaemonBuiltin } from '../daemon/builtins/index.js';
 import { runShellBuiltin } from '../daemon/builtins/os-shell.js';
 
 function processIsLive(pid: number): boolean {
@@ -407,5 +408,31 @@ describe('daemon-builtin os.shell', () => {
       cwd: process.cwd(),
       timeout_ms: 150_001,
     })).rejects.toThrow('between 100 and 150000');
+  });
+
+  test('separates an argument fault from a spawn fault', async () => {
+    const badArgument = await executeDaemonBuiltin({
+      connectorKey: 'os.shell',
+      actionKey: 'run',
+      input: { command: 'printf nope', timeout_ms: 150_001 },
+    });
+    expect(badArgument).toMatchObject({ ok: false, code: 'invalid_operation_input' });
+
+    // A cwd that exists but is a FILE clears the builtin's own checks and then
+    // fails inside spawn with ENOTDIR. Reporting that as bad input would send
+    // the caller off to fix a payload that was fine.
+    const dir = mkdtempSync(join(tmpdir(), 'os-shell-cwd-'));
+    const file = join(dir, 'not-a-directory');
+    writeFileSync(file, 'x');
+    try {
+      const spawnFault = await executeDaemonBuiltin({
+        connectorKey: 'os.shell',
+        actionKey: 'run',
+        input: { command: 'printf nope', cwd: file },
+      });
+      expect(spawnFault).toMatchObject({ ok: false, code: 'operation_execution_failed' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,8 +15,23 @@ function processIsLive(pid: number): boolean {
     }
     process.kill(pid, 0);
     if (process.platform === 'darwin') {
-      process.kill(pid, 0);
-      return true;
+      // A zombie still answers kill(pid, 0), so ask `ps` for the real state --
+      // the same check the sibling suite uses. Between the signal probe and
+      // this call the pid can be reaped, and `ps` then exits 1 with no stdout,
+      // which execFileSync raises as an error carrying a `status` rather than
+      // an ESRCH/ENOENT `code`; the handler below would rethrow it and fail
+      // the test. A pid `ps` cannot find is not an error here: it is the
+      // definition of not live.
+      let state: string;
+      try {
+        state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        return false;
+      }
+      return state !== '' && !state.startsWith('Z');
     }
     return true;
   } catch (error) {

--- a/packages/connector-worker/src/__tests__/terminal-delivery.test.ts
+++ b/packages/connector-worker/src/__tests__/terminal-delivery.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `completeActionOnce` carries an already-decided terminal outcome to the
+ * gateway. Losing it costs a real run: the gateway then has no report and the
+ * stale-run reaper mislabels a finished action as a timeout. These pin the two
+ * properties that make the retry worth having — a hung first attempt is
+ * retried inside the remaining budget, and a payload the gateway could not
+ * parse is not re-sent.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { WorkerDecodeError } from '../daemon/client.js';
+import type { ExecutorClient } from '../daemon/client.js';
+import { completeActionOnce } from '../daemon/terminal-delivery.js';
+
+type CompletePayload = Parameters<ExecutorClient['completeAction']>[0];
+
+const PAYLOAD = {
+  run_id: 1,
+  worker_id: 'wk-terminal-delivery',
+  status: 'completed',
+} as unknown as CompletePayload;
+
+function clientWith(
+  completeAction: (payload: CompletePayload) => Promise<void>
+): ExecutorClient {
+  return { completeAction } as unknown as ExecutorClient;
+}
+
+describe('completeActionOnce', () => {
+  it('retries a hung attempt instead of spending the whole deadline on it', async () => {
+    const calls: number[] = [];
+    const started = Date.now();
+    const client = clientWith(async () => {
+      calls.push(Date.now() - started);
+      // The first attempt never settles — exactly the dropped-connection case
+      // the deadline exists for. The second answers immediately.
+      if (calls.length === 1) return new Promise<void>(() => {});
+    });
+
+    await completeActionOnce(client, PAYLOAD);
+
+    expect(calls.length).toBe(2);
+    // The retry starts after the first attempt's HALF of the 15s budget, not
+    // after the whole of it: the split is what makes a second attempt possible.
+    expect(calls[1]).toBeGreaterThanOrEqual(7_000);
+    expect(calls[1]).toBeLessThan(14_000);
+  }, 30_000);
+
+  it('re-sends a payload the gateway rejected transiently', async () => {
+    let attempts = 0;
+    const client = clientWith(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('socket hang up');
+    });
+
+    await completeActionOnce(client, PAYLOAD);
+
+    expect(attempts).toBe(2);
+  });
+
+  it('does NOT re-send a payload the gateway could not decode', async () => {
+    let attempts = 0;
+    const client = clientWith(async () => {
+      attempts += 1;
+      throw new WorkerDecodeError('unparseable completion payload');
+    });
+
+    await expect(completeActionOnce(client, PAYLOAD)).rejects.toThrow(WorkerDecodeError);
+    expect(attempts).toBe(1);
+  });
+
+  it('surfaces the last transport error when every attempt fails', async () => {
+    let attempts = 0;
+    const client = clientWith(async () => {
+      attempts += 1;
+      throw new Error(`ECONNRESET ${attempts}`);
+    });
+
+    await expect(completeActionOnce(client, PAYLOAD)).rejects.toThrow('ECONNRESET 2');
+    expect(attempts).toBe(2);
+  });
+});

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -25,8 +25,7 @@ const PROCESS_REAP_GRACE_MS = 5000;
  * negative-pid group signals.
  */
 function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
-  const supervisorArgs = process.argv.slice(1);
-  const [binary, ...args] = supervisorArgs;
+  const [binary, ...args] = process.argv.slice(1);
   let targetFinished = false;
   let parentLost = false;
   let target: ChildProcess | undefined;
@@ -363,7 +362,17 @@ export function spawnSupervisedCli(
       });
     });
     supervisor.once('error', (error) => {
-      settle({ exitCode: null, signalCode: null, error: error.message });
+      // Deliberately NOT falling back to process.execPath under Bun. The
+      // supervisor runs on Node there precisely because Bun's
+      // node:child_process merges `env` with the parent environment, which
+      // would hand every supervised command the daemon's own environment --
+      // the leak the built-in shell exists to avoid. A missing Node is a
+      // packaging fault to fix, not a property to trade away silently.
+      const detail =
+        (error as NodeJS.ErrnoException).code === 'ENOENT' && process.versions.bun
+          ? `${error.message} (the supervised-CLI runner requires an installed \`node\` when the daemon itself runs on Bun; install Node in the runtime image)`
+          : error.message;
+      settle({ exitCode: null, signalCode: null, error: detail });
     });
     supervisor.once('exit', (code, signal) => {
       settle({

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -330,11 +330,7 @@ export function spawnSupervisedCli(
   options: { stdin?: 'ignore' | 'pipe'; cwd?: string } = {}
 ): SupervisedCli {
   const supervisor = spawn(
-    // Bun's node:child_process compatibility layer merges env with the
-    // parent environment. Use the installed Node runtime there so the
-    // spawn-options contract remains an actual replacement environment; the
-    // packaged/runtime path uses its own executable unchanged.
-    process.versions.bun ? 'node' : process.execPath,
+    process.execPath,
     ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
     {
       detached: SUPPORTS_PROCESS_GROUPS,
@@ -362,17 +358,7 @@ export function spawnSupervisedCli(
       });
     });
     supervisor.once('error', (error) => {
-      // Deliberately NOT falling back to process.execPath under Bun. The
-      // supervisor runs on Node there precisely because Bun's
-      // node:child_process merges `env` with the parent environment, which
-      // would hand every supervised command the daemon's own environment --
-      // the leak the built-in shell exists to avoid. A missing Node is a
-      // packaging fault to fix, not a property to trade away silently.
-      const detail =
-        (error as NodeJS.ErrnoException).code === 'ENOENT' && process.versions.bun
-          ? `${error.message} (the supervised-CLI runner requires an installed \`node\` when the daemon itself runs on Bun; install Node in the runtime image)`
-          : error.message;
-      settle({ exitCode: null, signalCode: null, error: detail });
+      settle({ exitCode: null, signalCode: null, error: error.message });
     });
     supervisor.once('exit', (code, signal) => {
       settle({

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -226,7 +226,17 @@ export function signalOwnedPosixProcessGroup(
     sendSignal(-owner.pid, signal);
     return true;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH' || (err as NodeJS.ErrnoException).code === 'EPERM') return false;
+    const code = (err as NodeJS.ErrnoException).code;
+    // ESRCH is the only "there is no group here" answer, and it is the only one
+    // that may return false: the caller reads false as "no owned group", skips
+    // the grace window and never escalates to SIGKILL.
+    if (code === 'ESRCH') return false;
+    // EPERM means the opposite — the group EXISTS, we just could not signal any
+    // member of it (a setuid'd descendant, say). Reporting that as "gone" would
+    // retire the tree from escalation while it is still running, so keep the
+    // caller on the owned-group path: the SIGKILL escalation may still land,
+    // and the supervisor itself is ours to kill directly if it does not.
+    if (code === 'EPERM') return true;
     throw err;
   }
 }

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -25,7 +25,8 @@ const PROCESS_REAP_GRACE_MS = 5000;
  * negative-pid group signals.
  */
 function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
-  const [binary, ...args] = process.argv.slice(1);
+  const supervisorArgs = process.argv.slice(1);
+  const [binary, ...args] = supervisorArgs;
   let targetFinished = false;
   let parentLost = false;
   let target: ChildProcess | undefined;
@@ -85,6 +86,11 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
   };
   process.on('SIGTERM', () => {});
   process.once('disconnect', stopAfterParentLoss);
+  // A broken parent pipe is parent loss for ownership purposes. Do not report
+  // the target's normal exit first: the gateway may release the run while the
+  // delayed whole-tree SIGKILL is still pending, orphaning TERM-ignoring
+  // descendants.
+  process.stdin.once('error', stopAfterParentLoss);
   process.on('message', (message: unknown) => {
     if (
       typeof message !== 'object' ||
@@ -104,7 +110,10 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
         stdio: ['pipe', 'inherit', 'inherit'],
         windowsHide: true,
       });
-      if (target.stdin) process.stdin.pipe(target.stdin);
+      if (target.stdin) {
+        target.stdin.on('error', () => {});
+        process.stdin.pipe(target.stdin);
+      }
     } catch (error) {
       finish(127, null, error instanceof Error ? error.message : String(error));
     }
@@ -218,7 +227,7 @@ export function signalOwnedPosixProcessGroup(
     sendSignal(-owner.pid, signal);
     return true;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH' || (err as NodeJS.ErrnoException).code === 'EPERM') return false;
     throw err;
   }
 }
@@ -319,14 +328,19 @@ export function spawnSupervisedCli(
   binary: string,
   args: string[],
   env: NodeJS.ProcessEnv,
-  options: { stdin?: 'ignore' | 'pipe' } = {}
+  options: { stdin?: 'ignore' | 'pipe'; cwd?: string } = {}
 ): SupervisedCli {
   const supervisor = spawn(
-    process.execPath,
+    // Bun's node:child_process compatibility layer merges env with the
+    // parent environment. Use the installed Node runtime there so the
+    // spawn-options contract remains an actual replacement environment; the
+    // packaged/runtime path uses its own executable unchanged.
+    process.versions.bun ? 'node' : process.execPath,
     ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
     {
       detached: SUPPORTS_PROCESS_GROUPS,
       env,
+      cwd: options.cwd,
       stdio: [options.stdin ?? 'ignore', 'pipe', 'pipe', 'ipc'],
       windowsHide: true,
     }

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -1,4 +1,4 @@
-import { runShellBuiltin } from './os-shell.js';
+import { ShellInputError, runShellBuiltin } from './os-shell.js';
 
 export type DaemonBuiltinErrorCode =
   | 'invalid_operation_input'
@@ -37,9 +37,13 @@ export async function executeDaemonBuiltin(params: {
     }
     return { ok: true, output: { ...output } };
   } catch (error) {
+    // Only the builtin's own argument checks are input faults. Anything else
+    // reaching here -- a spawn failure, an ENOTDIR on a cwd that turned out to
+    // be a file -- is an execution fault, and reporting it as bad input would
+    // send the caller off to fix a payload that was fine.
     return {
       ok: false,
-      code: 'invalid_operation_input',
+      code: error instanceof ShellInputError ? 'invalid_operation_input' : 'operation_execution_failed',
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -1,0 +1,46 @@
+import { runShellBuiltin } from './os-shell.js';
+
+export type DaemonBuiltinErrorCode =
+  | 'invalid_operation_input'
+  | 'operation_backend_unavailable'
+  | 'operation_execution_failed';
+
+export type DaemonBuiltinResult =
+  | { ok: true; output: Record<string, unknown> }
+  | { ok: false; code: DaemonBuiltinErrorCode; error: string; output?: Record<string, unknown> };
+
+export async function executeDaemonBuiltin(params: {
+  connectorKey: string;
+  actionKey: string;
+  input: Record<string, unknown>;
+  shutdownSignal?: AbortSignal;
+}): Promise<DaemonBuiltinResult> {
+  if (params.connectorKey !== 'os.shell' || params.actionKey !== 'run') {
+    return {
+      ok: false,
+      code: 'operation_backend_unavailable',
+      error: `No daemon built-in is registered for '${params.connectorKey}/${params.actionKey}'`,
+    };
+  }
+
+  try {
+    const output = await runShellBuiltin(params.input, params.shutdownSignal);
+    if (!output.success) {
+      return {
+        ok: false,
+        code: 'operation_execution_failed',
+        error: output.timed_out
+          ? `Shell command timed out after ${output.duration_ms}ms`
+          : `Shell command exited with code ${output.exit_code}`,
+        output: { ...output },
+      };
+    }
+    return { ok: true, output: { ...output } };
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'invalid_operation_input',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -1,3 +1,12 @@
+/**
+ * os.shell as a daemon builtin.
+ *
+ * PAIRED IMPLEMENTATION — keep the CONTRACT in step with
+ * `packages/connectors/src/os_shell.ts` (see its header for why the two are
+ * not merged). This side additionally replaces the environment rather than
+ * inheriting it: a builtin runs in the daemon's own process, so an inherited
+ * env would hand the command the daemon's credentials.
+ */
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute } from 'node:path';

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -1,0 +1,173 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
+import {
+  releaseSupervisor,
+  signalOwnedPosixProcessGroup,
+  spawnSupervisedCli,
+  terminateChild,
+} from '../automation-process.js';
+
+export interface ShellRunOutput {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  success: boolean;
+  timed_out: boolean;
+  duration_ms: number;
+}
+
+// The owned process group is cleaned up automatically. Deliberately detached
+// new sessions are outside that ownership contract and must be cleaned up by
+// their creator; never signal a detached numeric PGID after ownership ends.
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+// The requested command budget must leave room inside run_sdk's 180s ceiling
+// for 3s TERM grace, up to 5s reaping, up to 15s terminal delivery, and
+// bounded network/server grace.
+const MAX_TIMEOUT_MS = 150_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const OUTPUT_DRAIN_GRACE_MS = 2_000;
+const TRUNCATED_MARKER = '\n... (output truncated)';
+function appendCapped(current: string, chunk: string): string {
+  if (current.endsWith(TRUNCATED_MARKER)) return current;
+  const next = current + chunk;
+  if (Buffer.byteLength(next, 'utf8') <= MAX_OUTPUT_BYTES) return next;
+  return Buffer.from(next, 'utf8').subarray(0, MAX_OUTPUT_BYTES).toString('utf8') + TRUNCATED_MARKER;
+}
+
+function readTimeout(value: unknown): number {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(value) || Number(value) < 100 || Number(value) > MAX_TIMEOUT_MS) {
+    throw new Error(`timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`);
+  }
+  return Number(value);
+}
+
+function shellEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: process.env.HOME ?? homedir(),
+    TMPDIR: process.env.TMPDIR ?? '/tmp',
+    LANG: 'C',
+    LC_ALL: 'C',
+  };
+  return env;
+}
+
+export async function runShellBuiltin(
+  input: Record<string, unknown>,
+  shutdownSignal?: AbortSignal
+): Promise<ShellRunOutput> {
+  const command = typeof input.command === 'string' ? input.command.trim() : '';
+  if (!command) throw new Error('command is required');
+  if (command.length > 20_000) throw new Error('command must contain at most 20000 characters');
+
+  const cwdValue = input.cwd;
+  const cwd = cwdValue === undefined ? homedir() : String(cwdValue);
+  if (!isAbsolute(cwd) || !existsSync(cwd)) {
+    throw new Error(`cwd must be an existing absolute path (got '${cwd}')`);
+  }
+  const timeoutMs = readTimeout(input.timeout_ms);
+  const stdin = input.stdin;
+  if (stdin !== undefined && typeof stdin !== 'string') throw new Error('stdin must be a string');
+  if (typeof stdin === 'string' && stdin.length > 1_000_000) {
+    throw new Error('stdin must contain at most 1000000 characters');
+  }
+
+  const startedAt = Date.now();
+  return await new Promise<ShellRunOutput>((resolve) => {
+    const supervised = spawnSupervisedCli(
+      'bash', ['--noprofile', '--norc', '-c', command], shellEnvironment(), { stdin: 'pipe', cwd },
+    );
+    const child = supervised.supervisor;
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    let finishing = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const waitForClose = (stream: NodeJS.ReadableStream | null | undefined): Promise<void> => {
+      if (!stream || (stream as NodeJS.ReadableStream & { destroyed?: boolean }).destroyed) {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => stream.once('close', resolve));
+    };
+    const stdoutClosed = waitForClose(child.stdout);
+    const stderrClosed = waitForClose(child.stderr);
+
+    const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
+      try {
+        if (child.pid != null) {
+          if (signalOwnedPosixProcessGroup(child, signal)) return;
+        }
+      } catch {}
+      try { child.kill(signal); } catch {}
+    };
+
+    const abortHandler = () => {
+      if (!settled) void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
+    };
+    // Let the finish closure initialize before handling an already-aborted
+    // signal; this path is common during daemon shutdown.
+    if (shutdownSignal?.aborted) queueMicrotask(abortHandler);
+    else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
+
+    // Synchronous by construction: the only caller drains and destroys both
+    // pipes before calling this, so there is nothing left to await here.
+    const finish = (exitCode: number): void => {
+      if (settled || finishing) return;
+      finishing = true;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      shutdownSignal?.removeEventListener('abort', abortHandler);
+      settled = true;
+      resolve({
+        stdout,
+        stderr,
+        exit_code: exitCode,
+        success: !timedOut && exitCode === 0,
+        timed_out: timedOut,
+        duration_ms: Date.now() - startedAt,
+      });
+    };
+
+    const finishAfterOutputDrain = async (exitCode: number): Promise<void> => {
+      await Promise.race([
+        Promise.all([stdoutClosed, stderrClosed]),
+        new Promise((resolve) => setTimeout(resolve, OUTPUT_DRAIN_GRACE_MS).unref()),
+      ]);
+      if (!settled) child.stdout?.destroy();
+      if (!settled) child.stderr?.destroy();
+      finish(exitCode);
+    };
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout = appendCapped(stdout, chunk);
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr = appendCapped(stderr, chunk);
+    });
+    child.stdin?.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EPIPE') stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
+    });
+    child.stdin?.end(stdin);
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
+    }, timeoutMs);
+
+    supervised.targetExit.then((target) => {
+      if (process.platform !== 'win32') killOwnedProcessGroup('SIGKILL');
+      else void terminateChild(child);
+      void releaseSupervisor(child).finally(() => finishAfterOutputDrain(target.exitCode ?? -1));
+    });
+    child.on('error', (error) => {
+      stderr = appendCapped(stderr, `spawn error: ${error.message}`);
+      void finishAfterOutputDrain(-1);
+    });
+  });
+}

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -38,10 +38,6 @@ export interface ShellRunOutput {
   duration_ms: number;
 }
 
-// The owned process group is cleaned up automatically. Deliberately detached
-// new sessions are outside that ownership contract and must be cleaned up by
-// their creator; never signal a detached numeric PGID after ownership ends.
-
 const DEFAULT_TIMEOUT_MS = 60_000;
 // The requested command budget must leave room inside run_sdk's 180s ceiling
 // for 3s TERM grace, up to 5s reaping, up to 15s terminal delivery, and
@@ -120,6 +116,10 @@ export async function runShellBuiltin(
     const stdoutClosed = waitForClose(child.stdout);
     const stderrClosed = waitForClose(child.stderr);
 
+    // Only the group this daemon owns. A command that deliberately detaches a
+    // new session is outside that ownership contract and belongs to whoever
+    // created it: signalling a numeric PGID we no longer own risks hitting a
+    // reused one, so ownership ending is the end of our reach.
     const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
       try {
         if (child.pid != null) {

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -17,6 +17,18 @@ import {
   terminateChild,
 } from '../automation-process.js';
 
+/**
+ * A caller-supplied argument the builtin rejects before spawning anything.
+ * Distinguishes an input fault from a runtime one so the caller can classify
+ * the failure instead of assuming every throw came from validation.
+ */
+export class ShellInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShellInputError';
+  }
+}
+
 export interface ShellRunOutput {
   stdout: string;
   stderr: string;
@@ -48,7 +60,7 @@ function appendCapped(current: string, chunk: string): string {
 function readTimeout(value: unknown): number {
   if (value === undefined) return DEFAULT_TIMEOUT_MS;
   if (!Number.isInteger(value) || Number(value) < 100 || Number(value) > MAX_TIMEOUT_MS) {
-    throw new Error(`timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`);
+    throw new ShellInputError(`timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`);
   }
   return Number(value);
 }
@@ -69,19 +81,21 @@ export async function runShellBuiltin(
   shutdownSignal?: AbortSignal
 ): Promise<ShellRunOutput> {
   const command = typeof input.command === 'string' ? input.command.trim() : '';
-  if (!command) throw new Error('command is required');
-  if (command.length > 20_000) throw new Error('command must contain at most 20000 characters');
+  if (!command) throw new ShellInputError('command is required');
+  if (command.length > 20_000)
+    throw new ShellInputError('command must contain at most 20000 characters');
 
   const cwdValue = input.cwd;
   const cwd = cwdValue === undefined ? homedir() : String(cwdValue);
   if (!isAbsolute(cwd) || !existsSync(cwd)) {
-    throw new Error(`cwd must be an existing absolute path (got '${cwd}')`);
+    throw new ShellInputError(`cwd must be an existing absolute path (got '${cwd}')`);
   }
   const timeoutMs = readTimeout(input.timeout_ms);
   const stdin = input.stdin;
-  if (stdin !== undefined && typeof stdin !== 'string') throw new Error('stdin must be a string');
+  if (stdin !== undefined && typeof stdin !== 'string')
+    throw new ShellInputError('stdin must be a string');
   if (typeof stdin === 'string' && stdin.length > 1_000_000) {
-    throw new Error('stdin must contain at most 1000000 characters');
+    throw new ShellInputError('stdin must contain at most 1000000 characters');
   }
 
   const startedAt = Date.now();

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -346,14 +346,7 @@ export class WorkerClient implements ExecutorClient {
         ? {}
         : { capacity_available: capacityAvailable }),
       ...(Object.keys(this.backendCapacity).length > 0
-        ? {
-            backend_capacity: Object.fromEntries(
-              Object.entries(this.backendCapacity).map(([backend, capacity]) => [
-                backend,
-                Math.min(capacity, capacityAvailable ?? capacity),
-              ])
-            ),
-          }
+        ? { backend_capacity: this.backendCapacity }
         : {}),
       // app_version belongs to the device registration fields, so omit both for
       // fleet workers rather than sending empty values. A device worker also

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -228,6 +228,7 @@ export class WorkerClient implements ExecutorClient {
   private fixedAgentKinds?: AgentKind[];
   private advertisementProvider?: WorkerAdvertisementProvider;
   private agentKindsCache: { kinds: AgentKind[]; at: number } | null = null;
+  private backendCapacity: Record<string, number>;
 
   constructor(config: {
     apiUrl: string;
@@ -247,6 +248,8 @@ export class WorkerClient implements ExecutorClient {
     agentKinds?: AgentKind[];
     /** Mutable device capability/manifest snapshot, updated by the native bridge. */
     advertisementProvider?: WorkerAdvertisementProvider;
+    /** Static readiness/capacity per execution backend. */
+    backendCapacity?: Record<string, number>;
   }) {
     this.apiUrl = trimTrailingSlashes(config.apiUrl);
     this.workerId = config.workerId;
@@ -259,6 +262,7 @@ export class WorkerClient implements ExecutorClient {
     this.binaryOverrides = config.binaryOverrides;
     this.fixedAgentKinds = config.agentKinds;
     this.advertisementProvider = config.advertisementProvider;
+    this.backendCapacity = { ...(config.backendCapacity ?? {}) };
   }
 
   /**
@@ -341,6 +345,16 @@ export class WorkerClient implements ExecutorClient {
       ...(capacityAvailable === undefined
         ? {}
         : { capacity_available: capacityAvailable }),
+      ...(Object.keys(this.backendCapacity).length > 0
+        ? {
+            backend_capacity: Object.fromEntries(
+              Object.entries(this.backendCapacity).map(([backend, capacity]) => [
+                backend,
+                Math.min(capacity, capacityAvailable ?? capacity),
+              ])
+            ),
+          }
+        : {}),
       // app_version belongs to the device registration fields, so omit both for
       // fleet workers rather than sending empty values. A device worker also
       // advertises the agent kinds its automation arm can run.

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -2,22 +2,23 @@
  * Device manifests the connector-worker daemon declares on poll, keyed by
  * platform. A headless device (server/VM/pod) advertises the os.shell
  * connector so an org can create a connection pinned to it and run shell
- * commands (executed by the bundled os.shell connector via bash -lc).
+ * commands through the daemon's built-in shell backend.
  */
 
 /**
  * os.shell manifest for headless platforms. Mirrors the macOS manifest's
  * run action (packages/owletto/apps/mac/.../os_shell.json) but targets
- * linux, where the connector-worker daemon (not a native bridge) serves it.
+ * headless workers, where the connector-worker daemon (not a native bridge or
+ * dynamically compiled connector) serves it.
  */
 export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
   key: 'os.shell',
-  version: '0.1.0',
+  version: '0.2.0',
   name: 'Shell',
   description:
     'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
   required_capability: 'os.shell',
-  runtime: { platforms: ['headless'] },
+  runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
   auth_schema: { methods: [{ type: 'none' }] },
   feeds_schema: {},
   actions_schema: {
@@ -38,7 +39,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
             maxLength: 20000,
           },
           cwd: { type: 'string' },
-          timeout_ms: { type: 'integer', minimum: 100, maximum: 300000, default: 60000 },
+          timeout_ms: { type: 'integer', minimum: 100, maximum: 150000, default: 60000 },
           stdin: { type: 'string', maxLength: 1000000 },
         },
         additionalProperties: false,

--- a/packages/connector-worker/src/daemon/device-manifests.ts
+++ b/packages/connector-worker/src/daemon/device-manifests.ts
@@ -16,7 +16,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
   version: '0.2.0',
   name: 'Shell',
   description:
-    'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands run in the device\'s real environment (host PATH, files) - gate with approval.',
+    'Run shell commands on this device through Lobu. Returns structured stdout/stderr/exit_code. Commands see the device\'s real filesystem and PATH but a minimal environment (no profile, no inherited secrets) - gate with approval.',
   required_capability: 'os.shell',
   runtime: { platforms: ['headless'], execution: 'daemon_builtin' },
   auth_schema: { methods: [{ type: 'none' }] },
@@ -27,7 +27,7 @@ export const HEADLESS_OS_SHELL_MANIFEST: Record<string, unknown> = {
       kind: 'write',
       name: 'Run command',
       description:
-        'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash -lc`, so pipes, redirects, and && chains work. Prefer one focused command per call.',
+        'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash --noprofile --norc -c`, so pipes, redirects, and && chains work, but shell profile/rc files are NOT loaded - use absolute paths rather than relying on aliases or a login PATH. Prefer one focused command per call.',
       requiresApproval: true,
       inputSchema: {
         type: 'object',

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -10,7 +10,6 @@ import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
 import { executeAutomationRun } from './automation.js';
 import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
-import { WorkerDecodeError } from './client.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
 import { log } from './log.js';
@@ -63,11 +62,19 @@ async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
   }
 }
 
+/**
+ * Load the compiler and the subprocess runtime, together and on demand.
+ *
+ * Dynamic on purpose. A daemon whose compiler/SDK artifacts are missing or
+ * broken is precisely the case the daemon builtins exist to recover, and a
+ * static import here would fail this whole module at load — taking the
+ * recovery path down with it. So inline-compiled jobs (which already carry
+ * their code) and daemon_builtin jobs never reach this graph at all; only
+ * source-backed jobs do, and those need both halves anyway. The published-
+ * package isolation smoke pins that: it runs both lanes with the source
+ * artifacts absent.
+ */
 async function loadCompiledRuntime() {
-  // These are the only production imports retained for source-backed jobs:
-  // the published-package isolation smoke runs inline and daemon_builtin jobs
-  // with compiler/SDK source artifacts absent, while source-backed jobs still
-  // need the compiler and subprocess runtime together.
   return Promise.all([
     import('../executor/subprocess.js'),
     import('../executor/runtime.js'),

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -7,12 +7,10 @@
 
 import type { Env, EventEnvelope } from '@lobu/connector-sdk';
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
-import { compileConnectorFromFile, findBundledConnectorFile } from '../compile-connector.js';
-import { batchGenerateEmbeddings } from '../embeddings.js';
-import { executeCompiledConnector } from '../executor/runtime.js';
-import { SubprocessExecutor } from '../executor/subprocess.js';
 import { executeAutomationRun } from './automation.js';
+import { executeDaemonBuiltin } from './builtins/index.js';
 import { executeDeviceChatRun } from './device-chat.js';
+import { WorkerDecodeError } from './client.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
 import { log } from './log.js';
@@ -41,6 +39,8 @@ type JobCodeResult = { ok: true; code: string } | { ok: false; error: string };
 
 async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
   if (job.compiled_code) return { ok: true, code: job.compiled_code };
+  // Inline compiled jobs must not load the optional compiler/SDK graph.
+  const { compileConnectorFromFile, findBundledConnectorFile } = await import('../compile-connector.js');
   if (!job.connector_key) {
     return { ok: false, error: 'No compiled_code and no connector_key — gateway sent neither.' };
   }
@@ -60,6 +60,17 @@ async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, error: `esbuild failed for '${job.connector_key}' (${localPath}): ${msg}` };
   }
+}
+
+async function loadCompiledRuntime() {
+  // These are the only production imports retained for source-backed jobs:
+  // the published-package isolation smoke runs inline and daemon_builtin jobs
+  // with compiler/SDK source artifacts absent, while source-backed jobs still
+  // need the compiler and subprocess runtime together.
+  return Promise.all([
+    import('../executor/subprocess.js'),
+    import('../executor/runtime.js'),
+  ]);
 }
 
 export interface ExecutorConfig {
@@ -89,6 +100,49 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   timeoutMs: 600000,
   maxOldSpaceSize: 1024,
 };
+
+const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+
+async function withTerminalDeliveryTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Retry one immutable terminal payload without changing its outcome. */
+async function completeActionOnce(
+  client: ExecutorClient,
+  payload: Parameters<ExecutorClient['completeAction']>[0],
+): Promise<void> {
+  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    try {
+      const attemptsLeft = 2 - attempt;
+      await withTerminalDeliveryTimeout(
+        client.completeAction(payload),
+        Math.max(1, Math.floor(remaining / attemptsLeft)),
+      );
+      return;
+    } catch (error) {
+      if (error instanceof WorkerDecodeError) throw error;
+      lastError = error;
+      if (error instanceof Error && error.message === 'terminal completion deadline exceeded') break;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
 
 /**
  * Fold the gateway's authoritative DB egress config into the worker's env.
@@ -148,6 +202,16 @@ export async function executeRun(
     }
     return { itemsCollected: 0, error: message };
   }
+  if (job.execution_backend === 'daemon_builtin' && job.run_type !== 'action') {
+    const message =
+      'operation_backend_unavailable: daemon_builtin currently supports action runs only';
+    try {
+      await reportTerminalFailure(client, job, message, 'error_message');
+    } catch (error) {
+      log.info('[executor] Failed to reject invalid daemon built-in run:', error);
+    }
+    return { itemsCollected: 0, error: message };
+  }
   // The inherited session rides on a non-enumerable symbol, which a spread
   // drops; re-attach it or every interactive run silently falls back to a
   // subprocess.
@@ -201,6 +265,7 @@ async function executeSyncRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
   const subprocessExecutor = new SubprocessExecutor({
     timeoutMs: cfg.timeoutMs,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
@@ -449,21 +514,27 @@ async function executeActionRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
-  const subprocessExecutor = new SubprocessExecutor({
-    timeoutMs: cfg.timeoutMs,
-    maxOldSpaceSize: cfg.maxOldSpaceSize,
-  });
   const { run_id, connector_key, action_key, action_input, credentials } = job;
 
   if (!run_id || !connector_key || !action_key) {
     throw new Error('Invalid action run: missing run_id, connector_key, or action_key');
   }
 
+  if (job.execution_backend === 'daemon_builtin') {
+    return await executeDaemonBuiltinActionRun(client, job, cfg);
+  }
+
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
+  const subprocessExecutor = new SubprocessExecutor({
+    timeoutMs: cfg.timeoutMs,
+    maxOldSpaceSize: cfg.maxOldSpaceSize,
+  });
+
   const codeResult = await resolveJobCode(job);
   if (!codeResult.ok) {
     const errorMessage = `Action run ${run_id} (${connector_key}): ${codeResult.error}`;
     log.info('[executor]', errorMessage);
-    await client.completeAction({
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'failed',
@@ -489,6 +560,7 @@ async function executeActionRun(
       log.debug('[executor] Action heartbeat failed:', err);
     }
   }, cfg.heartbeatIntervalMs);
+  let terminalPayloadStarted = false;
 
   try {
     const result = await executeCompiledConnector({
@@ -532,7 +604,8 @@ async function executeActionRun(
     }
     const actionOutput = result.output;
 
-    await client.completeAction({
+    terminalPayloadStarted = true;
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'success',
@@ -545,7 +618,10 @@ async function executeActionRun(
     const errorMessage = error instanceof Error ? error.message : String(error);
     log.info(`[executor] Action run ${run_id} failed:`, errorMessage);
 
-    await client.completeAction({
+    if (terminalPayloadStarted) {
+      return { itemsCollected: 0, error: errorMessage };
+    }
+    await completeActionOnce(client, {
       run_id,
       worker_id: client.id,
       status: 'failed',
@@ -553,6 +629,72 @@ async function executeActionRun(
     });
 
     return { itemsCollected: 0, error: errorMessage };
+  } finally {
+    clearInterval(heartbeatInterval);
+  }
+}
+
+async function executeDaemonBuiltinActionRun(
+  client: ExecutorClient,
+  job: PollResponse,
+  cfg: ExecutorConfig
+): Promise<{ itemsCollected: number; error?: string }> {
+  const { run_id, connector_key, action_key, action_input } = job;
+  if (!run_id || !connector_key || !action_key) {
+    throw new Error('Invalid daemon built-in action: missing run_id, connector_key, or action_key');
+  }
+  if (job.compiled_code) {
+    const message =
+      'operation_backend_unavailable: daemon_builtin payload must not contain compiled_code';
+    await completeActionOnce(client, {
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: message,
+    });
+    return { itemsCollected: 0, error: message };
+  }
+
+  const heartbeatInterval = setInterval(async () => {
+    try {
+      await client.heartbeat(run_id);
+    } catch (error) {
+      log.debug('[executor] Daemon built-in heartbeat failed:', error);
+    }
+  }, cfg.heartbeatIntervalMs);
+
+  try {
+    const result = await executeDaemonBuiltin({
+      connectorKey: connector_key,
+      actionKey: action_key,
+      input: (action_input ?? {}) as Record<string, unknown>,
+      shutdownSignal: cfg.shutdownSignal,
+    });
+    if (!result.ok) {
+      const message = `${result.code}: ${result.error}`;
+      await completeActionOnce(client, {
+        run_id,
+        worker_id: client.id,
+        status: 'failed',
+        error_message: message,
+        ...(result.output ? { action_output: result.output } : {}),
+      });
+      return { itemsCollected: 0, error: message };
+    }
+
+    await completeActionOnce(client, {
+      run_id,
+      worker_id: client.id,
+      status: 'success',
+      action_output: result.output,
+    });
+    return { itemsCollected: 0 };
+  } catch (error) {
+    // Delivery uncertainty is not an execution failure. The immutable payload
+    // was retried above; never send a contradictory terminal result here.
+    const message = error instanceof Error ? error.message : String(error);
+    log.info(`[executor] Daemon built-in terminal delivery uncertain for ${run_id}:`, message);
+    return { itemsCollected: 0, error: message };
   } finally {
     clearInterval(heartbeatInterval);
   }
@@ -568,6 +710,7 @@ async function executeAuthRun(
   env: Env,
   cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
+  const [{ SubprocessExecutor }, { executeCompiledConnector }] = await loadCompiledRuntime();
   // Interactive auth runs wait on human input (QR scans, OTP entry, OAuth
   // redirects) — a fixed subprocess timeout would kill the pairing mid-flow.
   // Terminate via the UI cancel signal instead.
@@ -795,6 +938,10 @@ async function executeEmbedBackfillRun(
     }> = [];
     let batchError: string | undefined;
     try {
+      // Dynamic: the headless shell package ships without the embeddings
+      // provider stack, so a static import would pull it into every daemon
+      // bundle. Loaded only when a feed actually has text to embed.
+      const { batchGenerateEmbeddings } = await import('../embeddings.js');
       const { embeddings, model } = await batchGenerateEmbeddings(pending.map((p) => p.text));
       for (let i = 0; i < pending.length; i++) {
         const embedding = embeddings[i];
@@ -936,6 +1083,9 @@ async function processEventChunk(
   }
 
   try {
+    // Dynamic for the same reason as above: keeps the embeddings provider
+    // stack out of the headless shell bundle.
+    const { batchGenerateEmbeddings } = await import('../embeddings.js');
     const { embeddings, model } = await batchGenerateEmbeddings(texts);
     for (let j = 0; j < targets.length; j++) {
       const embedding = embeddings[j];

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -15,6 +15,7 @@ import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
 import { log } from './log.js';
 import { reportTerminalFailure } from './terminal-failure.js';
+import { completeActionOnce } from './terminal-delivery.js';
 
 /**
  * Resolve the executable compiled code for a job.
@@ -100,49 +101,6 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   timeoutMs: 600000,
   maxOldSpaceSize: 1024,
 };
-
-const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
-
-async function withTerminalDeliveryTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), timeoutMs);
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-/** Retry one immutable terminal payload without changing its outcome. */
-async function completeActionOnce(
-  client: ExecutorClient,
-  payload: Parameters<ExecutorClient['completeAction']>[0],
-): Promise<void> {
-  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    try {
-      const attemptsLeft = 2 - attempt;
-      await withTerminalDeliveryTimeout(
-        client.completeAction(payload),
-        Math.max(1, Math.floor(remaining / attemptsLeft)),
-      );
-      return;
-    } catch (error) {
-      if (error instanceof WorkerDecodeError) throw error;
-      lastError = error;
-      if (error instanceof Error && error.message === 'terminal completion deadline exceeded') break;
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
-}
 
 /**
  * Fold the gateway's authoritative DB egress config into the worker's env.

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -8,7 +8,10 @@ import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { hostname } from 'node:os';
 import { isKnownPlatform } from '@lobu/core';
-import { defaultBackendCapacity } from '@lobu/core/contracts/worker/protocol';
+import {
+  EXECUTION_BACKENDS,
+  defaultBackendCapacity,
+} from '@lobu/core/contracts/worker/protocol';
 import { assertExternalDepsResolvable } from '../compile/index.js';
 import { buildConnectorWorkerEnv } from '../env.js';
 import { assertConnectorRuntimeLoadable } from '../self-check/index.js';
@@ -155,14 +158,33 @@ export async function startDaemonCommand(
   const workerId = resolveDaemonWorkerId(opts, platform, shortHostname, detected);
   const label = opts.label ?? (platform ? shortHostname : undefined);
 
-  // Crash loud before the first poll if the installed runtime cannot resolve
-  // or execute the same connector graph this worker is about to advertise.
-  assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
-  await assertConnectorRuntimeLoadable();
-  // Resolved only after the assertions above, because they are what makes the
-  // advertisement true: a daemon that reached this line has proven it can
-  // resolve and load the compiled-connector runtime.
-  const backendCapacity = defaultBackendCapacity(platform);
+  // Crash loud before the first poll if the installed runtime cannot resolve or
+  // execute the same connector graph this worker is about to advertise -- with
+  // one exception: on `headless` the shell builtin is the recovery primitive
+  // used to REPAIR exactly this breakage, so a daemon whose compiler graph is
+  // broken must still boot and advertise it.
+  //
+  // The compiled backend is then reported from what the probe actually found,
+  // never from the platform label. `headless` is also the default platform of
+  // every ordinary self-hosted `lobu daemon`, so treating the label as proof of
+  // a broken compiler would close the compiled lane on healthy device workers
+  // and leave their execution-pinned connections queued forever with no error.
+  let compiledRuntimeReady = true;
+  try {
+    assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
+    await assertConnectorRuntimeLoadable();
+  } catch (error) {
+    if (platform !== 'headless') throw error;
+    compiledRuntimeReady = false;
+    log.info(
+      '[cli] compiled-connector runtime unavailable; this daemon will advertise built-in operations only:',
+      error
+    );
+  }
+  const backendCapacity = {
+    ...defaultBackendCapacity(platform),
+    [EXECUTION_BACKENDS.compiledConnector]: compiledRuntimeReady ? 1 : 0,
+  };
   log.info(`[cli] Starting worker daemon (ID: ${workerId}, API: ${opts.apiUrl})`);
   const env = buildConnectorWorkerEnv();
   const maxConcurrentJobs = process.env.WORKER_MAX_CONCURRENT_JOBS

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -145,6 +145,12 @@ export async function startDaemonCommand(
   const workerCapabilities: Record<string, boolean> = platform
     ? Object.fromEntries(capabilities.map((name) => [name, true]))
     : { db_egress_hardening: true };
+  // Headless recovery daemons own the daemon-builtin backend and deliberately
+  // keep their compiler/SDK runtime closed; everything else is compiled-capable.
+  const backendCapacity: Record<string, number> =
+    platform === 'headless'
+      ? { daemon_builtin: 1, compiled_connector: 0 }
+      : { compiled_connector: 1 };
   // Auto-discover device identity from the host when not passed: a device
   // worker defaults to `<platform>:<short-hostname>` and a hostname label. An
   // interactive daemon instead derives its id from the exact inherited
@@ -184,6 +190,7 @@ export async function startDaemonCommand(
     ...(label ? { label } : {}),
     ...(platform ? { manifests: DEVICE_MANIFESTS_BY_PLATFORM[platform] ?? [] } : {}),
     ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
+    backendCapacity,
     ...(opts.workerCredentialMaintenance
       ? { workerCredentialMaintenance: opts.workerCredentialMaintenance }
       : {}),

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { hostname } from 'node:os';
 import { isKnownPlatform } from '@lobu/core';
+import { defaultBackendCapacity } from '@lobu/core/contracts/worker/protocol';
 import { assertExternalDepsResolvable } from '../compile/index.js';
 import { buildConnectorWorkerEnv } from '../env.js';
 import { assertConnectorRuntimeLoadable } from '../self-check/index.js';
@@ -145,12 +146,6 @@ export async function startDaemonCommand(
   const workerCapabilities: Record<string, boolean> = platform
     ? Object.fromEntries(capabilities.map((name) => [name, true]))
     : { db_egress_hardening: true };
-  // Headless recovery daemons own the daemon-builtin backend and deliberately
-  // keep their compiler/SDK runtime closed; everything else is compiled-capable.
-  const backendCapacity: Record<string, number> =
-    platform === 'headless'
-      ? { daemon_builtin: 1, compiled_connector: 0 }
-      : { compiled_connector: 1 };
   // Auto-discover device identity from the host when not passed: a device
   // worker defaults to `<platform>:<short-hostname>` and a hostname label. An
   // interactive daemon instead derives its id from the exact inherited
@@ -164,6 +159,10 @@ export async function startDaemonCommand(
   // or execute the same connector graph this worker is about to advertise.
   assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
   await assertConnectorRuntimeLoadable();
+  // Resolved only after the assertions above, because they are what makes the
+  // advertisement true: a daemon that reached this line has proven it can
+  // resolve and load the compiled-connector runtime.
+  const backendCapacity = defaultBackendCapacity(platform);
   log.info(`[cli] Starting worker daemon (ID: ${workerId}, API: ${opts.apiUrl})`);
   const env = buildConnectorWorkerEnv();
   const maxConcurrentJobs = process.env.WORKER_MAX_CONCURRENT_JOBS

--- a/packages/connector-worker/src/daemon/terminal-delivery.ts
+++ b/packages/connector-worker/src/daemon/terminal-delivery.ts
@@ -14,6 +14,7 @@ import { WorkerDecodeError } from './client.js';
 import type { ExecutorClient } from './client.js';
 
 const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+const TERMINAL_DELIVERY_ATTEMPTS = 2;
 
 async function withTerminalDeliveryTimeout<T>(
   promise: Promise<T>,
@@ -33,18 +34,30 @@ async function withTerminalDeliveryTimeout<T>(
   }
 }
 
-/** Retry one immutable terminal payload without changing its outcome. */
+/**
+ * Retry one immutable terminal payload without changing its outcome.
+ *
+ * A timed-out attempt is retried, not abandoned: a hung connection is the
+ * commonest transient failure, and abandoning it there would leave the rest of
+ * the deadline unused. The timeout does not cancel the in-flight request, so a
+ * retry can reach a gateway that already accepted the first one -- that is
+ * safe because the gateway's terminal write is fenced
+ * (`status = 'running' AND claimed_by = worker_id`) and answers a second
+ * delivery with `already_finalized` rather than re-finalizing the run.
+ */
 export async function completeActionOnce(
   client: ExecutorClient,
   payload: Parameters<ExecutorClient['completeAction']>[0]
 ): Promise<void> {
   const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
   let lastError: unknown;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
+  for (let attempt = 0; attempt < TERMINAL_DELIVERY_ATTEMPTS; attempt += 1) {
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     try {
-      const attemptsLeft = 2 - attempt;
+      // Split the remaining budget across the attempts still to come, so a hung
+      // connection cannot spend the whole deadline before anything is retried.
+      const attemptsLeft = TERMINAL_DELIVERY_ATTEMPTS - attempt;
       await withTerminalDeliveryTimeout(
         client.completeAction(payload),
         Math.max(1, Math.floor(remaining / attemptsLeft))
@@ -53,7 +66,6 @@ export async function completeActionOnce(
     } catch (error) {
       if (error instanceof WorkerDecodeError) throw error;
       lastError = error;
-      if (error instanceof Error && error.message === 'terminal completion deadline exceeded') break;
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));

--- a/packages/connector-worker/src/daemon/terminal-delivery.ts
+++ b/packages/connector-worker/src/daemon/terminal-delivery.ts
@@ -1,0 +1,58 @@
+/**
+ * One terminal-completion policy for the whole daemon.
+ *
+ * Both the ordinary executor path and the failure-reporting path must deliver
+ * an already-decided outcome under the same bounded budget. They used to carry
+ * separate copies with separate constants, and the copies had already drifted:
+ * one rethrew a decode error immediately, the other retried it. A retry cannot
+ * fix a payload the gateway could not parse, and re-sending hides the protocol
+ * fault behind a timeout.
+ */
+import { WorkerDecodeError } from './client.js';
+import type { ExecutorClient } from './client.js';
+
+export const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+
+export async function withTerminalDeliveryTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Retry one immutable terminal payload without changing its outcome. */
+export async function completeActionOnce(
+  client: ExecutorClient,
+  payload: Parameters<ExecutorClient['completeAction']>[0]
+): Promise<void> {
+  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    try {
+      const attemptsLeft = 2 - attempt;
+      await withTerminalDeliveryTimeout(
+        client.completeAction(payload),
+        Math.max(1, Math.floor(remaining / attemptsLeft))
+      );
+      return;
+    } catch (error) {
+      if (error instanceof WorkerDecodeError) throw error;
+      lastError = error;
+      if (error instanceof Error && error.message === 'terminal completion deadline exceeded') break;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}

--- a/packages/connector-worker/src/daemon/terminal-delivery.ts
+++ b/packages/connector-worker/src/daemon/terminal-delivery.ts
@@ -1,19 +1,21 @@
 /**
  * One terminal-completion policy for the whole daemon.
  *
- * Both the ordinary executor path and the failure-reporting path must deliver
- * an already-decided outcome under the same bounded budget. They used to carry
- * separate copies with separate constants, and the copies had already drifted:
- * one rethrew a decode error immediately, the other retried it. A retry cannot
- * fix a payload the gateway could not parse, and re-sending hides the protocol
- * fault behind a timeout.
+ * Both the ordinary executor path and the failure-reporting path awaited
+ * `client.completeAction` directly, which neither retries nor bounds its wait:
+ * a single dropped connection lost an already-decided outcome and left the run
+ * to the gateway's stale-run reaper. Route both through one bounded retry so
+ * the outcome survives a transient failure without either caller inventing its
+ * own budget. A `WorkerDecodeError` is rethrown rather than retried -- a retry
+ * cannot fix a payload the gateway could not parse, and re-sending would hide
+ * the protocol fault behind a timeout.
  */
 import { WorkerDecodeError } from './client.js';
 import type { ExecutorClient } from './client.js';
 
-export const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
 
-export async function withTerminalDeliveryTimeout<T>(
+async function withTerminalDeliveryTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number
 ): Promise<T> {

--- a/packages/connector-worker/src/daemon/terminal-failure.ts
+++ b/packages/connector-worker/src/daemon/terminal-failure.ts
@@ -1,35 +1,5 @@
 import type { PollResponse, ExecutorClient } from './client.js';
-
-const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
-
-async function completeActionWithBoundedRetry(
-  client: ExecutorClient,
-  payload: Parameters<ExecutorClient['completeAction']>[0],
-): Promise<void> {
-  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    const budget = Math.max(1, Math.floor(remaining / (2 - attempt)));
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        client.completeAction(payload),
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), budget);
-          timer.unref?.();
-        }),
-      ]);
-      return;
-    } catch (error) {
-      lastError = error;
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
-}
+import { completeActionOnce } from './terminal-delivery.js';
 
 export async function reportTerminalFailure(
   client: ExecutorClient,
@@ -39,7 +9,7 @@ export async function reportTerminalFailure(
 ): Promise<void> {
   if (job.run_id == null) return;
   if (job.run_type === 'action') {
-    await completeActionWithBoundedRetry(client, {
+    await completeActionOnce(client, {
       run_id: job.run_id,
       worker_id: client.id,
       status: 'failed',

--- a/packages/connector-worker/src/daemon/terminal-failure.ts
+++ b/packages/connector-worker/src/daemon/terminal-failure.ts
@@ -1,5 +1,36 @@
 import type { PollResponse, ExecutorClient } from './client.js';
 
+const TERMINAL_DELIVERY_DEADLINE_MS = 15_000;
+
+async function completeActionWithBoundedRetry(
+  client: ExecutorClient,
+  payload: Parameters<ExecutorClient['completeAction']>[0],
+): Promise<void> {
+  const deadline = Date.now() + TERMINAL_DELIVERY_DEADLINE_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const budget = Math.max(1, Math.floor(remaining / (2 - attempt)));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        client.completeAction(payload),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('terminal completion deadline exceeded')), budget);
+          timer.unref?.();
+        }),
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 export async function reportTerminalFailure(
   client: ExecutorClient,
   job: PollResponse,
@@ -8,7 +39,7 @@ export async function reportTerminalFailure(
 ): Promise<void> {
   if (job.run_id == null) return;
   if (job.run_type === 'action') {
-    await client.completeAction({
+    await completeActionWithBoundedRetry(client, {
       run_id: job.run_id,
       worker_id: client.id,
       status: 'failed',

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -49,7 +49,7 @@ export class WorkerDaemon {
   private env: Env;
   private config: { executor: Partial<ExecutorConfig> };
   private pollLoop: WorkerPollLoop;
-  private shutdownController?: AbortController;
+  private shutdownController: AbortController;
 
   constructor(daemonConfig: DaemonConfig, env: Env) {
     const interactiveSession = attachedInteractiveSession(daemonConfig);
@@ -114,7 +114,7 @@ export class WorkerDaemon {
    */
   stop(): void {
     this.pollLoop.stop();
-    this.shutdownController?.abort();
+    this.shutdownController.abort();
   }
 
   /**

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -32,6 +32,8 @@ export interface DaemonConfig {
   /** Fixed advertisement for an exact interactive session. */
   agentKinds?: AgentKind[];
   workerCredentialMaintenance?: (activate: (workerApiToken: string) => void) => Promise<void>;
+  /** Backend capacities advertised to the gateway. */
+  backendCapacity?: Record<string, number>;
 }
 
 const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
@@ -65,6 +67,7 @@ export class WorkerDaemon {
       // binaries, or the device advertises a kind it then fails to launch.
       binaryOverrides: daemonConfig.executor?.binaryOverrides,
       agentKinds: daemonConfig.agentKinds,
+      backendCapacity: daemonConfig.backendCapacity,
     });
 
     this.env = env;

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -71,15 +71,13 @@ export class WorkerDaemon {
     });
 
     this.env = env;
-    this.shutdownController = interactiveSession
-      ? new AbortController()
-      : undefined;
+    // Always present: the daemon builtin cancels an in-flight shell command on
+    // shutdown, so the signal can no longer be scoped to interactive sessions.
+    this.shutdownController = new AbortController();
     const executor = {
       timeoutMs: DEFAULT_EXECUTOR_TIMEOUT_MS,
       ...(daemonConfig.executor ?? {}),
-      ...(this.shutdownController
-        ? { shutdownSignal: this.shutdownController.signal }
-        : {}),
+      shutdownSignal: this.shutdownController.signal,
     };
     if (interactiveSession) attachInteractiveSession(executor, interactiveSession);
     this.config = {

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -25,6 +25,7 @@ import {
 	createConnectorCompiler,
 	EXTERNAL_RUNTIME_DEPS,
 } from "../compile/index.js";
+import { executeDaemonBuiltin } from "../daemon/builtins/index.js";
 import type { ExecutorJob } from "../executor/interface.js";
 import {
 	registerConnectorRuntimeDependencyLoader,
@@ -406,6 +407,26 @@ export async function runConnectorRuntimeSelfCheck(
 	await check("synthetic-connector-subprocess-execute", async () => {
 		await runSyntheticConnector(compileConnectorFromFile);
 		return "compiled + executed via default SubprocessExecutor; emitted >=1 event.";
+	});
+
+	// Recovery/control primitives must remain executable even when the dynamic
+	// connector compiler or its npm resolution graph is unhealthy. This call is
+	// intentionally direct and therefore proves the packaged dist contains the
+	// daemon-owned os.shell backend.
+	await check("daemon-builtin:os.shell/run", async () => {
+		const result = await executeDaemonBuiltin({
+			connectorKey: "os.shell",
+			actionKey: "run",
+			input: { command: "printf 'lobu-shell-self-check\\n'", cwd: process.cwd() },
+		});
+		if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+		if (result.output.stdout !== "lobu-shell-self-check\n") {
+			throw new Error(`Unexpected stdout: ${JSON.stringify(result.output.stdout)}.`);
+		}
+		if (result.output.stderr !== "" || result.output.exit_code !== 0) {
+			throw new Error(`Unexpected shell result: ${JSON.stringify(result.output)}.`);
+		}
+		return "executed from packaged worker code without connector compilation.";
 	});
 
 	return {

--- a/packages/connectors/src/__tests__/os_shell.test.ts
+++ b/packages/connectors/src/__tests__/os_shell.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { connectorSdkMock } from './connector-sdk.mock';
 
@@ -33,6 +34,24 @@ function processIsLive(pid: number): boolean {
       return state !== 'Z';
     }
     process.kill(pid, 0);
+    if (process.platform === 'darwin') {
+      // A zombie still answers kill(pid, 0), so ask `ps` for the real state.
+      // Between that signal probe and this call the pid can be reaped, and
+      // `ps` then exits 1 with no stdout -- which execFileSync raises as an
+      // error carrying a `status`, not an ESRCH/ENOENT `code`, so the handler
+      // below would rethrow it and fail the test. A pid `ps` cannot find is
+      // not an error here: it is the definition of not live.
+      let state: string;
+      try {
+        state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        return false;
+      }
+      return state !== '' && !state.startsWith('Z');
+    }
     return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -71,6 +90,15 @@ function processGroupExists(pid: number): boolean {
 describe('os.shell connector', () => {
   const connector = new OsShellConnector();
 
+  it('rejects timeout values beyond the published execution budget', async () => {
+    const result = await connector.execute(
+      runContext('run', { command: 'printf nope', timeout_ms: 150001 })
+    );
+    expect(result).toEqual({
+      success: false,
+      error: 'timeout_ms must be an integer between 100 and 150000',
+    });
+  });
   it('runs a command and returns stdout with exit 0', async () => {
     const result = await connector.execute(
       runContext('run', { command: 'echo hello-from-shell' })
@@ -170,7 +198,7 @@ describe('os.shell connector', () => {
       escapedPid = Number(String(output.stdout).trim());
 
       expect(output.timed_out).toBe(true);
-      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Date.now() - started).toBeLessThan(5500);
       expect(escapedPid).toBeGreaterThan(1);
       // setsid is explicitly outside process-group cleanup. The connector must
       // return on time even though the escaped session is still alive.
@@ -196,7 +224,7 @@ describe('os.shell connector', () => {
       escapedPid = Number(String(output.stdout).trim());
 
       expect(output.timed_out).toBe(true);
-      expect(Date.now() - started).toBeLessThan(4000);
+      expect(Date.now() - started).toBeLessThan(5500);
       expect(escapedPid).toBeGreaterThan(1);
       expect(processGroupExists(escapedPid)).toBe(true);
     } finally {

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -8,6 +8,17 @@
  * real environment (host PATH, files), so the action is approval-gated. The
  * timeout bounds this call and cleans up its process group; it is not sandbox
  * containment, and deliberately daemonized/session-detached work may outlive it.
+ *
+ * PAIRED IMPLEMENTATION — keep the CONTRACT in step with
+ * `packages/connector-worker/src/daemon/builtins/os-shell.ts`: the argv
+ * (`bash --noprofile --norc -c`), the timeout bounds, the 1MB output cap, and
+ * the returned shape are one action contract with two executors. They are not
+ * merged because they run on different substrates and for opposite reasons:
+ * this one executes inside the compiled-connector subprocess runtime, while
+ * the daemon builtin runs on the daemon's own supervisor precisely so a device
+ * whose compiler is broken can still be recovered. Sharing a module would put
+ * the compiler graph back on the recovery path. A device serves whichever its
+ * manifest declares (`runtime.execution`); it never runs both.
  */
 
 import { spawn } from 'node:child_process';
@@ -200,7 +211,7 @@ export default class OsShellConnector extends ConnectorRuntime {
     name: 'Shell',
     description:
       'Run shell commands on the host device. Executes via `bash --noprofile --norc -c` and returns structured stdout/stderr/exit_code. Same trust tier as the macOS shell connector - commands run in the device\'s real environment (host PATH, files), so gate with approval.',
-    version: '0.1.0',
+    version: '0.2.0',
     requiredCapability: 'os.shell',
     authSchema: { methods: [{ type: 'none' }] },
     feeds: {},

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -37,14 +37,21 @@ interface RunOutput {
   duration_ms: number;
 }
 
-const MAX_TIMEOUT_MS = 300000;
+// Keep the requested command budget truthful: run_sdk's 180s outer ceiling
+// must also cover 3s TERM grace, up to 5s reaping, up to 15s terminal
+// delivery, and bounded network/server grace.
+const MAX_TIMEOUT_MS = 150000;
 const DEFAULT_TIMEOUT_MS = 60000;
 const SIGTERM_GRACE_MS = 3000;
 // The outer shell remains the live process-group owner until Node's grace
 // timer fires, so its numeric pgid cannot be recycled before SIGKILL. The
 // inner login shell and command still receive SIGTERM normally.
-const SHELL_GROUP_ANCHOR = `trap 'sleep 4' TERM
-bash -lc "$1"
+//
+// The trap must outlive the grace timer, so derive it rather than restating
+// it: a hardcoded sleep silently reopens the recycle window the moment
+// SIGTERM_GRACE_MS is raised past it, and nothing would fail to say so.
+const SHELL_GROUP_ANCHOR = `trap 'sleep ${(SIGTERM_GRACE_MS + 1000) / 1000}' TERM
+bash --noprofile --norc -lc "$1"
 status=$?
 exit "$status"`;
 // Cap captured output so a chatty command cannot balloon daemon memory.
@@ -227,7 +234,7 @@ export default class OsShellConnector extends ConnectorRuntime {
             timeout_ms: {
               type: 'integer',
               minimum: 100,
-              maximum: 300000,
+              maximum: 150000,
               default: 60000,
               description:
                 'Wall-clock budget in milliseconds. On timeout the owned process group gets SIGTERM (3s grace) then SIGKILL. Session-detached or daemonized commands may outlive the call; this is not sandbox containment.',
@@ -265,10 +272,17 @@ export default class OsShellConnector extends ConnectorRuntime {
     if (!command) {
       return { success: false, error: 'command is required' };
     }
-    const timeoutMs = Math.min(
-      typeof input.timeout_ms === 'number' ? input.timeout_ms : DEFAULT_TIMEOUT_MS,
-      MAX_TIMEOUT_MS
-    );
+    const timeoutMs = input.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    if (
+      !Number.isInteger(timeoutMs) ||
+      timeoutMs < 100 ||
+      timeoutMs > MAX_TIMEOUT_MS
+    ) {
+      return {
+        success: false,
+        error: `timeout_ms must be an integer between 100 and ${MAX_TIMEOUT_MS}`,
+      };
+    }
     // cwd must be an existing absolute path (the declared contract); default
     // to the device home. Reject rather than let bash guess at a relative cwd.
     let cwd: string | undefined;

--- a/packages/connectors/src/os_shell.ts
+++ b/packages/connectors/src/os_shell.ts
@@ -2,7 +2,7 @@
  * os.shell - run shell commands on the host device.
  *
  * Device-bound connector served by the connector-worker daemon on headless
- * devices (servers, VMs, k8s pods). Executes through `bash -lc` and returns
+ * devices (servers, VMs, k8s pods). Executes through `bash --noprofile --norc -c` and returns
  * structured stdout/stderr/exit_code - the same contract as the macOS
  * os.shell manifest, but for boxes without a UI. Commands run in the device's
  * real environment (host PATH, files), so the action is approval-gated. The
@@ -51,7 +51,7 @@ const SIGTERM_GRACE_MS = 3000;
 // it: a hardcoded sleep silently reopens the recycle window the moment
 // SIGTERM_GRACE_MS is raised past it, and nothing would fail to say so.
 const SHELL_GROUP_ANCHOR = `trap 'sleep ${(SIGTERM_GRACE_MS + 1000) / 1000}' TERM
-bash --noprofile --norc -lc "$1"
+bash --noprofile --norc -c "$1"
 status=$?
 exit "$status"`;
 // Cap captured output so a chatty command cannot balloon daemon memory.
@@ -199,7 +199,7 @@ export default class OsShellConnector extends ConnectorRuntime {
     key: 'os.shell',
     name: 'Shell',
     description:
-      'Run shell commands on the host device. Executes via `bash -lc` and returns structured stdout/stderr/exit_code. Same trust tier as the macOS shell connector - commands run in the device\'s real environment (host PATH, files), so gate with approval.',
+      'Run shell commands on the host device. Executes via `bash --noprofile --norc -c` and returns structured stdout/stderr/exit_code. Same trust tier as the macOS shell connector - commands run in the device\'s real environment (host PATH, files), so gate with approval.',
     version: '0.1.0',
     requiredCapability: 'os.shell',
     authSchema: { methods: [{ type: 'none' }] },
@@ -210,7 +210,7 @@ export default class OsShellConnector extends ConnectorRuntime {
         kind: 'write',
         name: 'Run command',
         description:
-          'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash -lc`, so pipes, redirects, and && chains work. Prefer one focused command per call.',
+          'Run a shell command on the device and return stdout, stderr, and exit_code. Executes through `bash --noprofile --norc -c`, so pipes, redirects, and && chains work, but shell profile/rc files are NOT loaded - use absolute paths rather than relying on aliases. Prefer one focused command per call.',
         requiresApproval: true,
         annotations: {
           destructiveHint: true,
@@ -225,7 +225,7 @@ export default class OsShellConnector extends ConnectorRuntime {
               type: 'string',
               minLength: 1,
               maxLength: 20000,
-              description: 'Shell command to execute. Runs via `bash -lc`, so pipes, redirects, and && chains work. Keep commands short and targeted.',
+              description: 'Shell command to execute. Runs via `bash --noprofile --norc -c`, so pipes, redirects, and && chains work, but no profile or rc file is loaded. Keep commands short and targeted.',
             },
             cwd: {
               type: 'string',

--- a/packages/core/src/__tests__/default-backend-capacity.test.ts
+++ b/packages/core/src/__tests__/default-backend-capacity.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `headless` is the default platform of `lobu daemon`, and `startDaemonCommand`
+ * calls `assertExternalDepsResolvable()` / `assertConnectorRuntimeLoadable()`
+ * before its first poll — so a headless daemon that is polling at all has
+ * already proven it can execute compiled connectors.
+ *
+ * An earlier draft advertised `compiled_connector: 0` for headless on the
+ * theory that a recovery daemon keeps its compiler runtime closed. It does not,
+ * and the claim lane gates compiled artifacts on exactly this number: every
+ * execution-pinned compiled connection on a self-hosted device worker would
+ * have stopped being claimed, queued forever with no error raised anywhere.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  EXECUTION_BACKENDS,
+  defaultBackendCapacity,
+} from "../contracts/worker/protocol.js";
+
+describe("defaultBackendCapacity", () => {
+  test("keeps the compiled lane open on every platform", () => {
+    for (const platform of [
+      "headless",
+      "macos",
+      "chrome-extension",
+      "ios",
+      null,
+      undefined,
+    ]) {
+      expect(
+        defaultBackendCapacity(platform)[EXECUTION_BACKENDS.compiledConnector]
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  test("grants the daemon builtin only to the platform that runs a daemon", () => {
+    expect(
+      defaultBackendCapacity("headless")[EXECUTION_BACKENDS.daemonBuiltin]
+    ).toBeGreaterThan(0);
+    // The Chrome extension and the macOS app poll the gateway directly rather
+    // than running `lobu daemon`, so they own no in-process builtin.
+    for (const platform of ["macos", "chrome-extension", null]) {
+      expect(
+        defaultBackendCapacity(platform)[EXECUTION_BACKENDS.daemonBuiltin]
+      ).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -108,9 +108,9 @@ export const OAuthCredentialsSchema = Type.Object({
  */
 export const EXECUTION_BACKENDS = {
   /** Artifact compiled from connector source and executed by the worker. */
-  compiledConnector: 'compiled_connector',
+  compiledConnector: "compiled_connector",
   /** Built into the daemon binary; no compiler or SDK resolution involved. */
-  daemonBuiltin: 'daemon_builtin',
+  daemonBuiltin: "daemon_builtin",
 } as const;
 
 /**
@@ -126,7 +126,7 @@ export const EXECUTION_BACKENDS = {
 export function defaultBackendCapacity(
   platform: string | null | undefined
 ): Record<string, number> {
-  return platform === 'headless'
+  return platform === "headless"
     ? {
         [EXECUTION_BACKENDS.daemonBuiltin]: 1,
         [EXECUTION_BACKENDS.compiledConnector]: 1,

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -134,9 +134,15 @@ export function defaultBackendCapacity(
     : { [EXECUTION_BACKENDS.compiledConnector]: 1 };
 }
 
-/** Server-selected execution path for an exact pinned connector artifact. */
+/**
+ * Server-selected execution path for an exact pinned connector artifact.
+ *
+ * Device-owned paths only. A compiled run ships the code itself and carries no
+ * marker, so `compiled_connector` is a `backend_capacity` key and never a poll
+ * response value — listing it here would widen the wire contract with a value
+ * no producer emits and the worker ignores.
+ */
 export const ExecutionBackendSchema = Type.Union([
-  Type.Literal(EXECUTION_BACKENDS.compiledConnector),
   Type.Literal(EXECUTION_BACKENDS.daemonBuiltin),
   Type.Literal("native_bridge"),
 ]);

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -111,6 +111,10 @@ export const PollRequestSchema = Type.Object({
   capacity_available: Type.Optional(
     Type.Integer({ minimum: 0, maximum: 1024 })
   ),
+  /** Per-execution-backend capacity. Zero means the backend is not ready. */
+  backend_capacity: Type.Optional(
+    Type.Record(Type.String(), Type.Integer({ minimum: 0, maximum: 1024 }))
+  ),
   platform: Type.Optional(Type.String()),
   app_version: Type.Optional(Type.String()),
   /**

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -103,6 +103,40 @@ export const OAuthCredentialsSchema = Type.Object({
 /** Server-selected execution path for an exact pinned connector artifact. */
 export const ExecutionBackendSchema = Type.Literal("native_bridge");
 
+/**
+ * Execution backends a worker can advertise capacity for. Declared here, and
+ * imported by both the daemon that advertises and the gateway that gates on
+ * it, because the two sides only agree by string equality: a typo in either
+ * copy silently disables every claim for that worker rather than failing.
+ */
+export const EXECUTION_BACKENDS = {
+  /** Artifact compiled from connector source and executed by the worker. */
+  compiledConnector: 'compiled_connector',
+  /** Built into the daemon binary; no compiler or SDK resolution involved. */
+  daemonBuiltin: 'daemon_builtin',
+} as const;
+
+/**
+ * What a worker on `platform` advertises when it sends no `backend_capacity`.
+ *
+ * Every daemon is compiled-capable by construction: `startDaemonCommand`
+ * asserts the compiled runtime resolves and loads before the first poll, so a
+ * polling daemon has already proven it. `headless` — the default platform of
+ * `lobu daemon` — additionally owns the in-process daemon builtin. Platforms
+ * that poll without running a daemon (the Chrome extension, the macOS app)
+ * never run one and so never advertise it.
+ */
+export function defaultBackendCapacity(
+  platform: string | null | undefined
+): Record<string, number> {
+  return platform === 'headless'
+    ? {
+        [EXECUTION_BACKENDS.daemonBuiltin]: 1,
+        [EXECUTION_BACKENDS.compiledConnector]: 1,
+      }
+    : { [EXECUTION_BACKENDS.compiledConnector]: 1 };
+}
+
 /** `POST /api/workers/poll` request body. */
 export const PollRequestSchema = Type.Object({
   worker_id: Type.String(),

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -100,9 +100,6 @@ export const OAuthCredentialsSchema = Type.Object({
 
 // ── poll ────────────────────────────────────────────────────────────────────
 
-/** Server-selected execution path for an exact pinned connector artifact. */
-export const ExecutionBackendSchema = Type.Literal("native_bridge");
-
 /**
  * Execution backends a worker can advertise capacity for. Declared here, and
  * imported by both the daemon that advertises and the gateway that gates on
@@ -136,6 +133,13 @@ export function defaultBackendCapacity(
       }
     : { [EXECUTION_BACKENDS.compiledConnector]: 1 };
 }
+
+/** Server-selected execution path for an exact pinned connector artifact. */
+export const ExecutionBackendSchema = Type.Union([
+  Type.Literal(EXECUTION_BACKENDS.compiledConnector),
+  Type.Literal(EXECUTION_BACKENDS.daemonBuiltin),
+  Type.Literal("native_bridge"),
+]);
 
 /** `POST /api/workers/poll` request body. */
 export const PollRequestSchema = Type.Object({

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -148,6 +148,30 @@ async function readWhatsAppRows(orgId: string) {
   return { connections, feeds };
 }
 
+/** Queue an approved os.shell action run against the device's auto-wired connection. */
+async function seedHeadlessShellRun(orgId: string, version = '0.2.0') {
+  const sql = getTestDb();
+  const [connection] = (await sql`
+    SELECT id FROM connections
+    WHERE organization_id = ${orgId}
+      AND connector_key = 'os.shell'
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{ id: number }>;
+  const [run] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, connection_id, connector_key,
+      connector_version, action_key, action_input, approval_status, status,
+      created_at
+    ) VALUES (
+      ${orgId}, 'action', ${connection.id}, 'os.shell', ${version}, 'run',
+      ${sql.json({ command: 'hostname' })}, 'auto', 'pending', NOW()
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(run.id);
+}
+
 async function readFeedStatus(orgId: string, key = CONNECTOR_KEY) {
   const sql = getTestDb();
   const rows = (await sql`
@@ -184,7 +208,11 @@ async function poll(
   connectorManifests: unknown[],
   platform = 'macos',
   capabilities: Record<string, boolean> = { screentime: true },
-  options: { capacityAvailable?: number; agentKinds?: string[] } = {},
+  options: {
+    capacityAvailable?: number;
+    agentKinds?: string[];
+    backendCapacity?: Record<string, number>;
+  } = {},
 ) {
   const body: Record<string, unknown> = {
     worker_id: workerId,
@@ -198,6 +226,7 @@ async function poll(
     body.capacity_available = options.capacityAvailable;
   }
   if (options.agentKinds !== undefined) body.agent_kinds = options.agentKinds;
+  if (options.backendCapacity !== undefined) body.backend_capacity = options.backendCapacity;
   return post('/api/workers/poll', {
     body,
   });
@@ -1213,6 +1242,94 @@ describe('device connector manifests', () => {
     expect(body.execution_backend).toBeUndefined();
     expect(typeof body.compiled_code).toBe('string');
     expect((body.compiled_code as string).length).toBeGreaterThan(0);
+  });
+
+  it('routes an os.shell run to the daemon builtin on builtin capacity alone', async () => {
+    const { orgId, workerId } = await seedDeviceOwner('headless');
+    // The daemon declares os.shell as `runtime.execution: 'daemon_builtin'`, so
+    // the gateway has to classify the run onto that backend AND tell the worker
+    // which backend it picked. Without the marker the worker falls through to
+    // its compiled path and imports the connector compiler for a run the
+    // gateway deliberately shipped no code for.
+    const registered = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      { capacityAvailable: 0 },
+    );
+    expect(registered.status).toBe(200);
+
+    const sql = getTestDb();
+    const [version] = (await sql`
+      SELECT source_path, compiled_code FROM connector_versions
+      WHERE connector_key = 'os.shell' AND version = '0.2.0'
+      LIMIT 1
+    `) as unknown as Array<{ source_path: string | null; compiled_code: string | null }>;
+    expect(version?.source_path).toBe('device-manifest://headless/os.shell@0.2.0');
+    expect(version?.compiled_code).toBeNull();
+
+    const runId = await seedHeadlessShellRun(orgId);
+
+    // A daemon whose connector compiler failed to load still owns the builtin;
+    // advertising `compiled_connector: 0` is exactly the recovery case this
+    // backend exists for, so builtin capacity alone must admit the run.
+    const claimed = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      {
+        capacityAvailable: 1,
+        backendCapacity: { daemon_builtin: 1, compiled_connector: 0 },
+      },
+    );
+    expect(claimed.status).toBe(200);
+    const body = (await claimed.json()) as Record<string, unknown>;
+    expect(body.run_id).toBe(runId);
+    expect(body.connector_key).toBe('os.shell');
+    expect(body.execution_backend).toBe('daemon_builtin');
+    expect(body.connector_manifest_hash).toBe(
+      deviceManifestHash(HEADLESS_OS_SHELL_MANIFEST as unknown as DeviceConnectorManifest),
+    );
+    expect(body.compiled_code).toBeUndefined();
+  });
+
+  it('leaves an os.shell run queued for a daemon advertising no builtin capacity', async () => {
+    const { orgId, workerId } = await seedDeviceOwner('headless');
+    const registered = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      { capacityAvailable: 0 },
+    );
+    expect(registered.status).toBe(200);
+    const runId = await seedHeadlessShellRun(orgId);
+
+    // Compiled capacity cannot stand in for the builtin: the artifact is a
+    // manifest with no code, so a daemon that lost its builtin has nothing to
+    // run it with and must leave the run for a later poll.
+    const claimed = await poll(
+      workerId,
+      [HEADLESS_OS_SHELL_MANIFEST],
+      'headless',
+      { 'os.shell': true },
+      {
+        capacityAvailable: 1,
+        backendCapacity: { daemon_builtin: 0, compiled_connector: 1 },
+      },
+    );
+    expect(claimed.status).toBe(200);
+    const body = (await claimed.json()) as Record<string, unknown>;
+    expect(body.run_id).toBeUndefined();
+
+    const sql = getTestDb();
+    const [run] = (await sql`
+      SELECT status, claimed_by FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ status: string; claimed_by: string | null }>;
+    expect(run.status).toBe('pending');
+    expect(run.claimed_by).toBeNull();
   });
 
   it('drops a manifest that still declares removed entityLinks rules', async () => {

--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -355,7 +355,14 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
-      backendCapacity: { compiled_connector: 1 },
+      // Deliberately the map a headless daemon advertises, both backends open,
+      // so the claim assertions below double as the regression test: `headless`
+      // is the default platform of `lobu daemon` and that daemon asserts its
+      // compiled runtime loads before it polls, so owning the daemon builtin
+      // must never cost a worker its compiled lane. If it did, every
+      // execution-pinned compiled connection on a self-hosted device would stop
+      // being claimed with no error anywhere.
+      backendCapacity: { daemon_builtin: 1, compiled_connector: 1 },
     };
     const chromeContext: DueFeedClaimContext = {
       isUserScopedWorker: true,
@@ -368,9 +375,11 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
-      // Chrome is a bridge-only worker in this fixture; it must not advertise
-      // compiled connector capacity merely because it polls successfully.
-      backendCapacity: { compiled_connector: 0 },
+      // Matches what poll.ts advertises for a non-headless platform. This
+      // feed claims through the manifest/bridge lane, which does not consult
+      // compiled capacity at all -- so the value here must mirror production
+      // rather than imply a restriction the lane never applies.
+      backendCapacity: { compiled_connector: 1 },
     };
 
     // Production incident shape: the Mac is recently seen but busy, so it is not

--- a/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/device-feed-scheduler-liveness.test.ts
@@ -342,6 +342,7 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [''],
       baseOrgScopeIds: [''],
       workerHardensDbEgress: true,
+      backendCapacity: { compiled_connector: 1 },
     };
     const macContext: DueFeedClaimContext = {
       isUserScopedWorker: true,
@@ -354,6 +355,7 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
+      backendCapacity: { compiled_connector: 1 },
     };
     const chromeContext: DueFeedClaimContext = {
       isUserScopedWorker: true,
@@ -366,6 +368,9 @@ describe('scheduled feed device liveness', () => {
       orgScopeIds: [org.id],
       baseOrgScopeIds: [org.id],
       workerHardensDbEgress: false,
+      // Chrome is a bridge-only worker in this fixture; it must not advertise
+      // compiled connector capacity merely because it polls successfully.
+      backendCapacity: { compiled_connector: 0 },
     };
 
     // Production incident shape: the Mac is recently seen but busy, so it is not
@@ -396,6 +401,22 @@ describe('scheduled feed device liveness', () => {
       SET last_seen_at = current_timestamp - INTERVAL '10 minutes'
       WHERE id = ${macDeviceId}::uuid
     `;
+
+    // Same Mac, same pins, same authorized capability -- but with its compiled
+    // backend closed it must claim nothing. That is the gate's whole point: a
+    // worker can be online and fully authorized and still be unable to RUN a
+    // compiled artifact because its connector compiler/SDK runtime is
+    // unavailable, and claiming it would surface the failure only after the run
+    // is already running. An advertisement that omits the backend is not a
+    // grant either.
+    for (const backendCapacity of [{ compiled_connector: 0 }, {}]) {
+      expect(
+        await materializeDueFeeds({} as Env, sql, {
+          claimContext: { ...macContext, backendCapacity },
+          maxRunsCreated: 1,
+        })
+      ).toMatchObject({ runsCreated: 0 });
+    }
 
     // The Mac poll owns both its explicit pin and the unpinned capability lane,
     // but each idle poll materializes only one claim slot.

--- a/packages/server/src/__tests__/unit/device-manifest-headless-execution.test.ts
+++ b/packages/server/src/__tests__/unit/device-manifest-headless-execution.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { validateDeviceConnectorManifests } from '../../worker-api/device-manifests';
+
+/**
+ * `runtime.execution` arrived with the daemon-builtin routing. This same
+ * validator also runs over ALREADY-STORED manifests to rebuild a device's
+ * claim authority (getDeviceManifestSourcesForUser), so anything it rejects
+ * silently revokes that device's ability to claim — no error, the runs just
+ * queue forever. Every headless daemon registered before this field existed
+ * stored `runtime: { platforms: ['headless'] }` and nothing more, so requiring
+ * the field would strip os.shell from the entire installed base the moment the
+ * gateway deployed, ahead of any daemon upgrade.
+ */
+function headlessManifest(runtime: Record<string, unknown>) {
+  return {
+    key: 'os.shell',
+    version: '0.1.0',
+    name: 'Shell',
+    required_capability: 'os.shell',
+    runtime,
+    auth_schema: { methods: [{ type: 'none' }] },
+    actions_schema: { run: { key: 'run' } },
+  };
+}
+
+function validateHeadless(runtime: Record<string, unknown>) {
+  return validateDeviceConnectorManifests({
+    platform: 'headless',
+    capabilities: ['os.shell'],
+    manifests: [headlessManifest(runtime)],
+  });
+}
+
+describe('headless manifest runtime.execution', () => {
+  it('accepts an absent execution — the pre-0.2.0 installed base keeps claiming', () => {
+    const result = validateHeadless({ platforms: ['headless'] });
+    expect(result.accepted).toBe(true);
+    expect(result.manifests).toHaveLength(1);
+    // Absent stays absent: it must NOT be rewritten to daemon_builtin, or the
+    // manifest hash would change and the stored-vs-computed comparison in the
+    // revalidation path would drop the authorization anyway.
+    expect(result.manifests[0]?.manifest.runtime.execution).toBeUndefined();
+  });
+
+  it('accepts the explicit daemon_builtin a 0.2.0 daemon advertises', () => {
+    const result = validateHeadless({
+      platforms: ['headless'],
+      execution: 'daemon_builtin',
+    });
+    expect(result.accepted).toBe(true);
+    expect(result.manifests[0]?.manifest.runtime.execution).toBe('daemon_builtin');
+  });
+
+  it('still rejects bridge on headless — there is no bridge to route to', () => {
+    const result = validateHeadless({ platforms: ['headless'], execution: 'bridge' });
+    expect(result.accepted).toBe(false);
+    expect(result.manifests).toHaveLength(0);
+  });
+
+  it('still rejects an unrecognised execution value', () => {
+    const result = validateHeadless({ platforms: ['headless'], execution: 'wat' });
+    expect(result.accepted).toBe(false);
+    expect(result.manifests).toHaveLength(0);
+  });
+
+  it('keeps the hash of an absent-execution manifest stable across revalidation', () => {
+    // The revalidation path drops any manifest whose recomputed hash differs
+    // from the stored one, so a hash that moves is the same silent revocation
+    // as an outright reject.
+    const first = validateHeadless({ platforms: ['headless'] });
+    const second = validateDeviceConnectorManifests({
+      platform: 'headless',
+      capabilities: ['os.shell'],
+      manifests: [first.manifests[0]?.manifest as unknown as Record<string, unknown>],
+    });
+    expect(second.accepted).toBe(true);
+    expect(second.manifests[0]?.manifest_hash).toBe(first.manifests[0]?.manifest_hash);
+  });
+});

--- a/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
+++ b/packages/server/src/utils/__tests__/connector-execution-backend.test.ts
@@ -103,10 +103,13 @@ describe('selected connector execution backend', () => {
     })).toEqual({ manifestBacked: false });
   });
 
-  test('active exact non-bridge definition wins over retained bridge authorization', () => {
+  test('active exact unsupported definition wins over retained bridge authorization', () => {
     expect(classify({
       definition: { ...definition, runtime: { platforms: ['macos'], execution: 'compiled' } },
-    })).toEqual({ manifestBacked: true, inconsistency: 'active exact definition is not bridge execution' });
+    })).toEqual({
+      manifestBacked: true,
+      inconsistency: 'active exact definition declares an unsupported execution backend',
+    });
   });
 
   test('rejects a bridge artifact that is not authorized by the claiming device', () => {
@@ -162,6 +165,8 @@ describe('device manifests served by connector-worker rather than a bridge', () 
     key: headless.key,
     version: headless.version,
     name: headless.name,
+    description: headless.description,
+    faviconDomain: headless.favicon_domain,
     requiredCapability: headless.required_capability,
     runtime: headless.runtime,
     authSchema: headless.auth_schema,
@@ -189,21 +194,26 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         connectorVersion: headless.version,
         manifestHash: headlessHash,
         sourcePath: headlessSourcePath,
+        runtimeExecution: 'daemon_builtin',
       }],
       expectedPlatform: 'headless',
       ...overrides,
     });
   }
 
-  test('the shipped headless os.shell manifest declares no bridge execution', () => {
-    expect(headless.runtime).not.toHaveProperty('execution');
+  test('the shipped headless os.shell manifest declares daemon-owned execution', () => {
+    expect(headless.runtime.execution).toBe('daemon_builtin');
   });
 
-  test('classifies headless os.shell as manifest-backed but not native_bridge', () => {
-    expect(classifyHeadless()).toEqual({ manifestBacked: true });
+  test('classifies headless os.shell as an attested daemon built-in', () => {
+    expect(classifyHeadless()).toEqual({
+      manifestBacked: true,
+      backend: 'daemon_builtin',
+      manifestHash: headlessHash,
+    });
   });
 
-  test('stays non-bridge even when the device authorization claims bridge execution', () => {
+  test('rejects an authorization that claims a different backend', () => {
     expect(classifyHeadless({
       authorizations: [{
         connectorKey: headless.key,
@@ -212,7 +222,7 @@ describe('device manifests served by connector-worker rather than a bridge', () 
         sourcePath: headlessSourcePath,
         runtimeExecution: 'bridge',
       }],
-    })).toEqual({ manifestBacked: true });
+    }).inconsistency).toContain('different execution backend');
   });
 });
 
@@ -221,13 +231,13 @@ describe('deviceExecutesConnectorNatively', () => {
     isUserScopedWorker: true,
     hasStoredCompiledCode: false,
     gatewayHasLocalSource: true,
-    isNativeBridgeRun: false,
+    isDeviceOwnedRun: false,
     manifestBacked: false,
     deviceAdvertisesRequiredCapability: false,
   };
 
   test('a native-bridge run needs no bundle', () => {
-    expect(deviceExecutesConnectorNatively({ ...base, isNativeBridgeRun: true })).toBe(true);
+    expect(deviceExecutesConnectorNatively({ ...base, isDeviceOwnedRun: true })).toBe(true);
   });
 
   test('manifest-backed alone does not mean native execution', () => {
@@ -280,7 +290,7 @@ describe('deviceExecutesConnectorNatively', () => {
     expect(
       deviceExecutesConnectorNatively({
         ...base,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
         hasStoredCompiledCode: true,
       })
     ).toBe(false);
@@ -291,7 +301,7 @@ describe('deviceExecutesConnectorNatively', () => {
       deviceExecutesConnectorNatively({
         ...base,
         isUserScopedWorker: false,
-        isNativeBridgeRun: true,
+        isDeviceOwnedRun: true,
       })
     ).toBe(false);
   });

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -31,8 +31,10 @@ export interface ConnectorMetadata {
   openapiConfig?: Record<string, unknown> | null;
   requiredCapability?: string | null;
   runtime?: {
-    platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
-    execution?: 'bridge';
+    platforms: Array<
+      'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'headless' | 'chrome-extension'
+    >;
+    execution?: 'bridge' | 'daemon_builtin';
     scopes?: string[];
   } | null;
   /**

--- a/packages/server/src/utils/connector-execution-backend.ts
+++ b/packages/server/src/utils/connector-execution-backend.ts
@@ -1,6 +1,7 @@
 import { deviceManifestHash, type DeviceConnectorManifest } from '@lobu/connector-sdk';
+import type { ExecutionBackend } from '@lobu/core/contracts/worker/protocol';
 
-export type SelectedConnectorExecutionBackend = 'native_bridge';
+export type SelectedConnectorExecutionBackend = ExecutionBackend;
 
 export interface SelectedConnectorArtifact {
   sourcePath: string | null | undefined;
@@ -41,9 +42,10 @@ export interface SelectedConnectorExecution {
 }
 
 /**
- * Classify the exact artifact selected by the poll query. A bridge marker is
- * emitted only when the selected artifact is hash-attested by this device and
- * its canonical definition is bridge-owned. The artifact source path is part
+ * Classify the exact artifact selected by the poll query. A device-owned
+ * backend marker is emitted only when the selected artifact is hash-attested
+ * by this device and its canonical definition declares that backend. The
+ * artifact source path is part
  * of the authorization, so an organization override cannot silently replace a
  * shared bridge artifact with compiled code or another device's manifest.
  */
@@ -57,7 +59,11 @@ export function classifySelectedConnectorExecution(params: {
 }): SelectedConnectorExecution {
   const manifestBacked = isManifestArtifact(params.artifact);
   const definitionRuntime = asRecord(params.definition?.runtime);
-  const definitionBridge = definitionRuntime?.execution === 'bridge';
+  const definitionExecution = definitionRuntime?.execution;
+  const definitionDeviceExecution =
+    definitionExecution === 'bridge' || definitionExecution === 'daemon_builtin'
+      ? definitionExecution
+      : undefined;
   const definitionExecutionDeclared =
     definitionRuntime !== null && Object.hasOwn(definitionRuntime, 'execution');
   const authorization = params.authorizations.find(
@@ -67,34 +73,37 @@ export function classifySelectedConnectorExecution(params: {
       entry.manifestHash === params.artifact.manifestHash &&
       entry.sourcePath === params.artifact.sourcePath,
   );
-  const authorizedBridge = authorization?.runtimeExecution === 'bridge';
+  const authorizedDeviceExecution = authorization?.runtimeExecution;
   // An active exact definition is authoritative. Retained authorization may
   // only select a historical pinned version when no exact definition exists.
   // Legacy metadata-only definitions remain ordinary manifest-backed device
-  // work; an explicit non-bridge execution value is a contradictory artifact
+  // work; an explicit unsupported execution value is a contradictory artifact
   // selection and must terminalize the already-claimed run.
-  if (params.definition && !definitionBridge) {
+  if (params.definition && !definitionDeviceExecution) {
     return manifestBacked && definitionExecutionDeclared
       ? {
           manifestBacked,
-          inconsistency: 'active exact definition is not bridge execution',
+          inconsistency: 'active exact definition declares an unsupported execution backend',
         }
       : { manifestBacked };
   }
-  const bridgeCandidate = definitionBridge || authorizedBridge;
+  const deviceExecution = definitionDeviceExecution ?? authorizedDeviceExecution;
 
-  if (!bridgeCandidate) return { manifestBacked };
+  if (!deviceExecution) return { manifestBacked };
   if (!params.definition && !authorization) {
-    return { manifestBacked, inconsistency: 'bridge artifact has no canonical definition or manifest authorization' };
+    return { manifestBacked, inconsistency: 'device-owned artifact has no canonical definition or manifest authorization' };
   }
   if (!manifestBacked) {
-    return { manifestBacked, inconsistency: 'bridge-marked definition selected a non-manifest artifact' };
+    return { manifestBacked, inconsistency: 'device-owned definition selected a non-manifest artifact' };
   }
   if (params.artifact.compiledCode || params.artifact.compileConfigHash || params.artifact.hasSourceCode) {
-    return { manifestBacked, inconsistency: 'bridge-marked artifact contains compiled or source code' };
+    return { manifestBacked, inconsistency: 'device-owned artifact contains compiled or source code' };
   }
   if (!authorization) {
-    return { manifestBacked, inconsistency: 'selected bridge artifact is not authorized by the claiming device' };
+    return { manifestBacked, inconsistency: 'selected device-owned artifact is not authorized by the claiming device' };
+  }
+  if (authorization.runtimeExecution !== deviceExecution) {
+    return { manifestBacked, inconsistency: 'claiming device advertised a different execution backend' };
   }
   const parsedSource = parseManifestSourcePath(params.artifact.sourcePath);
   if (!parsedSource) {
@@ -123,7 +132,7 @@ export function classifySelectedConnectorExecution(params: {
   // historical pinned version, the validated device manifest is the canonical
   // definition retained by the authorization and the same hash check has
   // already happened during manifest reconciliation.
-  if (params.definition && definitionBridge) {
+  if (params.definition && definitionDeviceExecution) {
     const hashes = definitionManifestHashes(params.definition, definitionRuntime!);
     if (
       !hashes.has(params.artifact.manifestHash) &&
@@ -134,7 +143,11 @@ export function classifySelectedConnectorExecution(params: {
     }
   }
 
-  return { manifestBacked, backend: 'native_bridge', manifestHash: params.artifact.manifestHash };
+  return {
+    manifestBacked,
+    backend: deviceExecution === 'bridge' ? 'native_bridge' : 'daemon_builtin',
+    manifestHash: params.artifact.manifestHash,
+  };
 }
 
 /**
@@ -151,14 +164,14 @@ export function deviceExecutesConnectorNatively(params: {
   isUserScopedWorker: boolean;
   hasStoredCompiledCode: boolean;
   gatewayHasLocalSource: boolean;
-  isNativeBridgeRun: boolean;
+  isDeviceOwnedRun: boolean;
   manifestBacked: boolean;
   deviceAdvertisesRequiredCapability: boolean;
 }): boolean {
   return (
     params.isUserScopedWorker &&
     !params.hasStoredCompiledCode &&
-    (params.isNativeBridgeRun ||
+    (params.isDeviceOwnedRun ||
       (!params.gatewayHasLocalSource &&
         (params.manifestBacked || params.deviceAdvertisesRequiredCapability)))
   );

--- a/packages/server/src/utils/connector-execution-backend.ts
+++ b/packages/server/src/utils/connector-execution-backend.ts
@@ -1,5 +1,5 @@
 import { deviceManifestHash, type DeviceConnectorManifest } from '@lobu/connector-sdk';
-import type { ExecutionBackend } from '@lobu/core/contracts/worker/protocol';
+import { EXECUTION_BACKENDS, type ExecutionBackend } from '@lobu/core/contracts/worker/protocol';
 
 export type SelectedConnectorExecutionBackend = ExecutionBackend;
 
@@ -45,9 +45,9 @@ export interface SelectedConnectorExecution {
  * Classify the exact artifact selected by the poll query. A device-owned
  * backend marker is emitted only when the selected artifact is hash-attested
  * by this device and its canonical definition declares that backend. The
- * artifact source path is part
- * of the authorization, so an organization override cannot silently replace a
- * shared bridge artifact with compiled code or another device's manifest.
+ * artifact source path is part of the authorization, so an organization
+ * override cannot silently replace a shared bridge artifact with compiled code
+ * or another device's manifest.
  */
 export function classifySelectedConnectorExecution(params: {
   artifact: SelectedConnectorArtifact;
@@ -107,7 +107,7 @@ export function classifySelectedConnectorExecution(params: {
   }
   const parsedSource = parseManifestSourcePath(params.artifact.sourcePath);
   if (!parsedSource) {
-    return { manifestBacked, inconsistency: 'bridge-marked artifact has an invalid manifest source path' };
+    return { manifestBacked, inconsistency: 'device-owned artifact has an invalid manifest source path' };
   }
   if (params.expectedPlatform && parsedSource.platform !== params.expectedPlatform) {
     return {
@@ -145,7 +145,7 @@ export function classifySelectedConnectorExecution(params: {
 
   return {
     manifestBacked,
-    backend: deviceExecution === 'bridge' ? 'native_bridge' : 'daemon_builtin',
+    backend: deviceExecution === 'bridge' ? 'native_bridge' : EXECUTION_BACKENDS.daemonBuiltin,
     manifestHash: params.artifact.manifestHash,
   };
 }
@@ -154,11 +154,12 @@ export function classifySelectedConnectorExecution(params: {
  * Whether the claiming device implements this connector itself, so the gateway
  * may omit `compiled_code` from the poll response.
  *
- * A native-bridge run always qualifies. Legacy device manifests and
- * capability-only clients also remain device-executed when the gateway has no
- * code it could deliver. When bundled or stored code exists, manifest backing
- * and capability advertisement are authorization signals only; they do not
- * establish that the device implements the connector.
+ * A device-owned run (native bridge or daemon builtin) always qualifies.
+ * Legacy device manifests and capability-only clients also remain
+ * device-executed when the gateway has no code it could deliver. When bundled
+ * or stored code exists, manifest backing and capability advertisement are
+ * authorization signals only; they do not establish that the device implements
+ * the connector.
  */
 export function deviceExecutesConnectorNatively(params: {
   isUserScopedWorker: boolean;

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -25,16 +25,20 @@ export interface ConnectorClaimContext {
   orgScopeIds: string[];
   baseOrgScopeIds: string[];
   workerHardensDbEgress: boolean;
-  /** Capacity advertised for each execution backend by this worker. */
-  backendCapacity?: Record<string, number>;
+  /**
+   * Capacity advertised for each execution backend by this worker. Required:
+   * an omitted map reads as zero capacity for every backend, so the worker
+   * claims nothing at all and nothing anywhere reports why.
+   */
+  backendCapacity: Record<string, number>;
 }
 
 /** A backend is claimable only when this poll explicitly advertises capacity. */
 function hasPositiveBackendCapacity(
-  capacity: Record<string, number> | undefined,
+  capacity: Record<string, number>,
   backend: string
 ): boolean {
-  const value = capacity?.[backend];
+  const value = capacity[backend];
   return typeof value === 'number' && value > 0;
 }
 

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -35,7 +35,7 @@ function hasPositiveBackendCapacity(
   backend: string
 ): boolean {
   const value = capacity?.[backend];
-  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+  return typeof value === 'number' && value > 0;
 }
 
 interface ConnectorClaimLaneRefs {

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -1,3 +1,4 @@
+import { EXECUTION_BACKENDS } from '@lobu/core/contracts/worker/protocol';
 import type { DbClient } from '../db/client';
 import { pgTextArray } from '../db/client';
 import { isCloudMode } from '../utils/cloud-mode';
@@ -33,7 +34,8 @@ function hasPositiveBackendCapacity(
   capacity: Record<string, number> | undefined,
   backend: string
 ): boolean {
-  return Number.isFinite(capacity?.[backend]) && (capacity?.[backend] ?? 0) > 0;
+  const value = capacity?.[backend];
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 interface ConnectorClaimLaneRefs {
@@ -115,7 +117,7 @@ export function connectorClaimLaneSql(
         AND auth_item->>'connectorVersion' = ${refs.connectorVersion}
         AND auth_item->>'manifestHash' = ${refs.runManifestHash}
         AND auth_item->>'sourcePath' = ${refs.runArtifactSourcePath}
-        AND auth_item->>'runtimeExecution' = 'daemon_builtin'
+        AND auth_item->>'runtimeExecution' = ${EXECUTION_BACKENDS.daemonBuiltin}
     )
   `;
   const delegatedBrowserAffinity = delegatedBrowserAffinitySql(sql, {
@@ -137,8 +139,14 @@ export function connectorClaimLaneSql(
   // A worker may be able to run the daemon-owned backend while its connector
   // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
   // any claim lane unless that backend was explicitly advertised as ready.
-  const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
-  const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
+  const compiledBackendReady = hasPositiveBackendCapacity(
+    context.backendCapacity,
+    EXECUTION_BACKENDS.compiledConnector
+  );
+  const daemonBuiltinReady = hasPositiveBackendCapacity(
+    context.backendCapacity,
+    EXECUTION_BACKENDS.daemonBuiltin
+  );
   // A chrome-namespace execution runs inside the advertising extension, so it
   // needs no server-side backend at all. The helper is narrow by construction:
   // a reserved chrome key, or a legacy key only while the selected artifact is
@@ -166,7 +174,7 @@ export function connectorClaimLaneSql(
       OR (
         COALESCE(${refs.runManifestBacked}, false)
         AND CASE
-          WHEN ${refs.runRuntime}->>'execution' = 'daemon_builtin' THEN ${daemonBuiltinReady}
+          WHEN ${refs.runRuntime}->>'execution' = ${EXECUTION_BACKENDS.daemonBuiltin} THEN ${daemonBuiltinReady}
           WHEN ${refs.runRuntime}->>'execution' = 'bridge' THEN true
           WHEN ${refs.runRuntime}->>'execution' IS NULL
             THEN NOT (${exactDaemonBuiltinAuthorization}) OR ${daemonBuiltinReady}

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -29,7 +29,7 @@ export interface ConnectorClaimContext {
 }
 
 /** A backend is claimable only when this poll explicitly advertises capacity. */
-export function hasPositiveBackendCapacity(
+function hasPositiveBackendCapacity(
   capacity: Record<string, number> | undefined,
   backend: string
 ): boolean {

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -5,6 +5,7 @@ import { DB_EGRESS_HARDENED_CONNECTOR_KEYS } from '../utils/connector-cloud-gate
 import {
   delegatedBrowserAffinitySql,
   legacyNonManifestConnectorSql,
+  nativeChromeExtensionConnectorSql,
 } from '../utils/connector-execution-placement';
 import type { ManifestClaimAuthorization } from './device-manifests';
 
@@ -23,6 +24,16 @@ export interface ConnectorClaimContext {
   orgScopeIds: string[];
   baseOrgScopeIds: string[];
   workerHardensDbEgress: boolean;
+  /** Capacity advertised for each execution backend by this worker. */
+  backendCapacity?: Record<string, number>;
+}
+
+/** A backend is claimable only when this poll explicitly advertises capacity. */
+export function hasPositiveBackendCapacity(
+  capacity: Record<string, number> | undefined,
+  backend: string
+): boolean {
+  return Number.isFinite(capacity?.[backend]) && (capacity?.[backend] ?? 0) > 0;
 }
 
 interface ConnectorClaimLaneRefs {
@@ -86,7 +97,7 @@ export function connectorClaimLaneSql(
       NOT COALESCE(${refs.runManifestBacked}, false)
       OR ${refs.runRuntime} IS NOT NULL
     )
-    AND ${context.workerPlatform ?? ''}::text <> 'chrome-extension'
+    AND ${context.workerPlatform ?? ''}::text NOT IN ('headless', 'chrome-extension')
     AND COALESCE(
       ${refs.runRuntime}->'platforms' ? ${context.workerPlatform ?? ''}::text,
       false
@@ -95,6 +106,17 @@ export function connectorClaimLaneSql(
   const manifestAuthorization = sql`
     (${exactManifestAuthorization})
     OR (${legacyHashlessManifestAuthorization})
+  `;
+  const exactDaemonBuiltinAuthorization = sql`
+    EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(${sql.json(context.manifestClaimAuthorizations)}::jsonb) auth_item
+      WHERE auth_item->>'connectorKey' = ${refs.connectorKey}
+        AND auth_item->>'connectorVersion' = ${refs.connectorVersion}
+        AND auth_item->>'manifestHash' = ${refs.runManifestHash}
+        AND auth_item->>'sourcePath' = ${refs.runArtifactSourcePath}
+        AND auth_item->>'runtimeExecution' = 'daemon_builtin'
+    )
   `;
   const delegatedBrowserAffinity = delegatedBrowserAffinitySql(sql, {
     platform: refs.pinPlatform,
@@ -112,12 +134,55 @@ export function connectorClaimLaneSql(
     manifestBacked: refs.runManifestBacked,
     artifactCompiledCode: refs.runArtifactCompiledCode,
   });
+  // A worker may be able to run the daemon-owned backend while its connector
+  // compiler/SDK runtime is unavailable. Never let a compiled artifact enter
+  // any claim lane unless that backend was explicitly advertised as ready.
+  const compiledBackendReady = hasPositiveBackendCapacity(context.backendCapacity, 'compiled_connector');
+  const daemonBuiltinReady = hasPositiveBackendCapacity(context.backendCapacity, 'daemon_builtin');
+  // A chrome-namespace execution runs inside the advertising extension, so it
+  // needs no server-side backend at all. The helper is narrow by construction:
+  // a reserved chrome key, or a legacy key only while the selected artifact is
+  // exactly its validated Chrome manifest.
+  const nativeChromeExecution = nativeChromeExtensionConnectorSql(sql, {
+    connectorKey: refs.connectorKey,
+    connectorVersion: refs.connectorVersion,
+    manifestBacked: refs.runManifestBacked,
+    artifactSourcePath: refs.runArtifactSourcePath,
+  });
+  // Keep this guard outside the individual lanes: every lane must advertise
+  // the backend that the selected artifact actually needs. A manifest-backed
+  // artifact executes on the device that advertised the manifest, so the only
+  // server-side backend it can need is the daemon-owned one. Historical
+  // manifest artifacts carry no run_runtime, so daemon_builtin is derived from
+  // the exact retained authorization; an unrecognised execution kind fails
+  // closed rather than inheriting the unrestricted branch.
+  const selectedBackendReady = sql`
+    (
+      ${nativeChromeExecution}
+      OR (
+        NOT COALESCE(${refs.runManifestBacked}, false)
+        AND ${compiledBackendReady}
+      )
+      OR (
+        COALESCE(${refs.runManifestBacked}, false)
+        AND CASE
+          WHEN ${refs.runRuntime}->>'execution' = 'daemon_builtin' THEN ${daemonBuiltinReady}
+          WHEN ${refs.runRuntime}->>'execution' = 'bridge' THEN true
+          WHEN ${refs.runRuntime}->>'execution' IS NULL
+            THEN NOT (${exactDaemonBuiltinAuthorization}) OR ${daemonBuiltinReady}
+          ELSE false
+        END
+      )
+    )
+  `;
 
   return sql`
     (
-      -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
-      -- their exact device; browser-affinity parent runs stay on fleet.
-      (
+      ${selectedBackendReady}
+      AND (
+        -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
+        -- their exact device; browser-affinity parent runs stay on fleet.
+        (
         ${!context.isUserScopedWorker}
         AND (
           COALESCE(${refs.runRequiredCapability}, '') = ANY(
@@ -147,10 +212,10 @@ export function connectorClaimLaneSql(
             ${delegatedBrowserAffinity}
           )
         )
-      )
-      -- User-scoped worker claiming an unpinned capability connector in its
-      -- base org scope. Page-activated work is handled by the fleet parent.
-      OR (
+        )
+        -- User-scoped worker claiming an unpinned capability connector in its
+        -- base org scope. Page-activated work is handled by the fleet parent.
+        OR (
         ${context.isUserScopedWorker}
         AND ${refs.connectionDeviceWorkerId} IS NULL
         AND (
@@ -169,11 +234,11 @@ export function connectorClaimLaneSql(
         )
         AND NOT COALESCE(${pageActivated}, false)
         AND ${refs.organizationId} = ANY(${pgTextArray(context.baseOrgScopeIds)}::text[])
-      )
-      -- Exact execution pin. A chrome-extension pin on a connector that does
-      -- not execute natively in the extension is delegated browser affinity,
-      -- so its parent connector work stays on fleet instead.
-      OR (
+        )
+        -- Exact execution pin. A chrome-extension pin on a connector that does
+        -- not execute natively in the extension is delegated browser affinity,
+        -- so its parent connector work stays on fleet instead.
+        OR (
         ${context.isUserScopedWorker}
         AND ${context.deviceWorkerId}::uuid IS NOT NULL
         AND ${refs.connectionDeviceWorkerId} = ${context.deviceWorkerId}::uuid
@@ -190,6 +255,7 @@ export function connectorClaimLaneSql(
         )
         AND ${refs.organizationId} = ANY(${pgTextArray(context.orgScopeIds)}::text[])
         AND NOT (${delegatedBrowserAffinity})
+        )
       )
     )
   `;

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -191,78 +191,78 @@ export function connectorClaimLaneSql(
         -- Trusted/anonymous fleet worker. Execution-pinned connections stay on
         -- their exact device; browser-affinity parent runs stay on fleet.
         (
-        ${!context.isUserScopedWorker}
-        AND (
-          COALESCE(${refs.runRequiredCapability}, '') = ANY(
-            ${pgTextArray(context.capabilityMatchSet)}::text[]
+          ${!context.isUserScopedWorker}
+          AND (
+            COALESCE(${refs.runRequiredCapability}, '') = ANY(
+              ${pgTextArray(context.capabilityMatchSet)}::text[]
+            )
+            OR (${legacyFleetArtifact})
           )
-          OR (${legacyFleetArtifact})
-        )
-        -- The empty capability match is the anonymous fleet lane. A legacy
-        -- whatsapp.local row must still have a runnable selected artifact;
-        -- otherwise it would be claimed and fail only after becoming running.
-        AND (
-          NOT (${refs.connectorKey} = ANY(
-            ${pgTextArray(['whatsapp.local'])}::text[]
-          ))
-          OR (${legacyFleetArtifact})
-        )
-        AND NOT COALESCE(${refs.runManifestBacked}, false)
-        AND (
-          ${!isCloudMode()}
-          OR ${context.workerHardensDbEgress}
-          OR NOT (${refs.connectorKey} = ANY(${dbEgressHardenedKeys}::text[]))
-        )
-        AND (
-          (${pageActivated})
-          OR ${refs.connectionDeviceWorkerId} IS NULL
-          OR (
-            ${delegatedBrowserAffinity}
+          -- The empty capability match is the anonymous fleet lane. A legacy
+          -- whatsapp.local row must still have a runnable selected artifact;
+          -- otherwise it would be claimed and fail only after becoming running.
+          AND (
+            NOT (${refs.connectorKey} = ANY(
+              ${pgTextArray(['whatsapp.local'])}::text[]
+            ))
+            OR (${legacyFleetArtifact})
           )
-        )
+          AND NOT COALESCE(${refs.runManifestBacked}, false)
+          AND (
+            ${!isCloudMode()}
+            OR ${context.workerHardensDbEgress}
+            OR NOT (${refs.connectorKey} = ANY(${dbEgressHardenedKeys}::text[]))
+          )
+          AND (
+            (${pageActivated})
+            OR ${refs.connectionDeviceWorkerId} IS NULL
+            OR (
+              ${delegatedBrowserAffinity}
+            )
+          )
         )
         -- User-scoped worker claiming an unpinned capability connector in its
         -- base org scope. Page-activated work is handled by the fleet parent.
         OR (
-        ${context.isUserScopedWorker}
-        AND ${refs.connectionDeviceWorkerId} IS NULL
-        AND (
-          (
-            COALESCE(${refs.runManifestBacked}, false)
-            AND (${manifestAuthorization})
-          )
-          OR (
-            NOT COALESCE(${refs.runManifestBacked}, false)
-            AND NOT (${legacyFleetArtifact})
-            AND ${refs.runRequiredCapability} IS NOT NULL
-            AND ${refs.runRequiredCapability} = ANY(
-              ${pgTextArray(context.authorizedCapabilities)}::text[]
+          ${context.isUserScopedWorker}
+          AND ${refs.connectionDeviceWorkerId} IS NULL
+          AND (
+            (
+              COALESCE(${refs.runManifestBacked}, false)
+              AND (${manifestAuthorization})
+            )
+            OR (
+              NOT COALESCE(${refs.runManifestBacked}, false)
+              AND NOT (${legacyFleetArtifact})
+              AND ${refs.runRequiredCapability} IS NOT NULL
+              AND ${refs.runRequiredCapability} = ANY(
+                ${pgTextArray(context.authorizedCapabilities)}::text[]
+              )
             )
           )
-        )
-        AND NOT COALESCE(${pageActivated}, false)
-        AND ${refs.organizationId} = ANY(${pgTextArray(context.baseOrgScopeIds)}::text[])
+          AND NOT COALESCE(${pageActivated}, false)
+          AND ${refs.organizationId} = ANY(${pgTextArray(context.baseOrgScopeIds)}::text[])
         )
         -- Exact execution pin. A chrome-extension pin on a connector that does
         -- not execute natively in the extension is delegated browser affinity,
         -- so its parent connector work stays on fleet instead.
         OR (
-        ${context.isUserScopedWorker}
-        AND ${context.deviceWorkerId}::uuid IS NOT NULL
-        AND ${refs.connectionDeviceWorkerId} = ${context.deviceWorkerId}::uuid
-        AND (
-          NOT COALESCE(${refs.runManifestBacked}, false)
-          OR (${manifestAuthorization})
-        )
-        AND NOT COALESCE(${pageActivated}, false)
-        AND (
-          ${refs.runRequiredCapability} IS NULL
-          OR ${refs.runRequiredCapability} = ANY(
-            ${pgTextArray(context.authorizedCapabilities)}::text[]
+          ${context.isUserScopedWorker}
+          AND ${context.deviceWorkerId}::uuid IS NOT NULL
+          AND ${refs.connectionDeviceWorkerId} = ${context.deviceWorkerId}::uuid
+          AND (
+            NOT COALESCE(${refs.runManifestBacked}, false)
+            OR (${manifestAuthorization})
           )
-        )
-        AND ${refs.organizationId} = ANY(${pgTextArray(context.orgScopeIds)}::text[])
-        AND NOT (${delegatedBrowserAffinity})
+          AND NOT COALESCE(${pageActivated}, false)
+          AND (
+            ${refs.runRequiredCapability} IS NULL
+            OR ${refs.runRequiredCapability} = ANY(
+              ${pgTextArray(context.authorizedCapabilities)}::text[]
+            )
+          )
+          AND ${refs.organizationId} = ANY(${pgTextArray(context.orgScopeIds)}::text[])
+          AND NOT (${delegatedBrowserAffinity})
         )
       )
     )

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -153,6 +153,16 @@ function validateDeviceConnectorManifestsInternal(
       if (!manifest.runtime.platforms.includes(platform)) {
         throw new Error(`runtime.platforms must include '${platform}'`);
       }
+      if (
+        manifest.runtime.execution !== undefined &&
+        manifest.runtime.execution !== 'bridge' &&
+        manifest.runtime.execution !== 'daemon_builtin'
+      ) {
+        throw new Error(`unsupported runtime.execution '${String(manifest.runtime.execution)}'`);
+      }
+      if (platform === 'headless' && manifest.runtime.execution !== 'daemon_builtin') {
+        throw new Error("headless device manifests must declare runtime.execution='daemon_builtin'");
+      }
       const capAuth = authorizeCapabilities(platform, [manifest.required_capability]);
       if (!capAuth.authorized.includes(manifest.required_capability)) {
         throw new Error(`required_capability '${manifest.required_capability}' is not allowed for '${platform}'`);
@@ -366,7 +376,7 @@ export async function getDeviceManifestClaimAuthorizationsForDevice(params: {
         capabilities,
         manifests: [stored.manifest],
       },
-      true
+      false
     );
     const validated = validation.manifests[0];
     if (!validation.accepted || !validated || validated.manifest_hash !== stored.manifest_hash) {

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -376,7 +376,12 @@ export async function getDeviceManifestClaimAuthorizationsForDevice(params: {
         capabilities,
         manifests: [stored.manifest],
       },
-      false
+      // Legacy feed schemas without `operations` stay acceptable here (#3132):
+      // this path revalidates an ALREADY-STORED manifest, and a device that
+      // registered before operations existed must keep its claim authorization.
+      // The headless `runtime.execution` requirement above is independent of
+      // this flag, so fail-closed routing is unaffected either way.
+      true
     );
     const validated = validation.manifests[0];
     if (!validation.accepted || !validated || validated.manifest_hash !== stored.manifest_hash) {

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -160,8 +160,23 @@ function validateDeviceConnectorManifestsInternal(
       ) {
         throw new Error(`unsupported runtime.execution '${String(manifest.runtime.execution)}'`);
       }
-      if (platform === 'headless' && manifest.runtime.execution !== 'daemon_builtin') {
-        throw new Error("headless device manifests must declare runtime.execution='daemon_builtin'");
+      // Only an EXPLICIT contradiction is rejected. `execution` is absent on
+      // every headless manifest registered before this field existed
+      // (os.shell@0.1.0 declared `runtime: { platforms: ['headless'] }` and
+      // nothing else), and this validator also runs over ALREADY-STORED
+      // manifests to rebuild claim authority — so rejecting an absent value
+      // would strip os.shell from every headless device the moment the gateway
+      // deploys, ahead of any daemon upgrade. An absent value keeps its
+      // pre-existing meaning (ordinary manifest-backed device work over the
+      // compiled runtime); `daemon_builtin` routing is opt-in at 0.2.0.
+      if (
+        platform === 'headless' &&
+        manifest.runtime.execution !== undefined &&
+        manifest.runtime.execution !== 'daemon_builtin'
+      ) {
+        throw new Error(
+          `headless device manifests may not declare runtime.execution='${String(manifest.runtime.execution)}'`
+        );
       }
       const capAuth = authorizeCapabilities(platform, [manifest.required_capability]);
       if (!capAuth.authorized.includes(manifest.required_capability)) {
@@ -379,8 +394,9 @@ export async function getDeviceManifestClaimAuthorizationsForDevice(params: {
       // Legacy feed schemas without `operations` stay acceptable here (#3132):
       // this path revalidates an ALREADY-STORED manifest, and a device that
       // registered before operations existed must keep its claim authorization.
-      // The headless `runtime.execution` requirement above is independent of
-      // this flag, so fail-closed routing is unaffected either way.
+      // Same reasoning covers an absent headless `runtime.execution` above —
+      // both are fields a device could not have known to send when it
+      // registered, and neither can be a reason to revoke its claim.
       true
     );
     const validated = validation.manifests[0];
@@ -603,9 +619,9 @@ function connectorKeyAllowedForPlatform(platform: string, key: string): boolean 
       isChromeNamespaceConnectorKey(key) || isLegacyNativeChromeExtensionConnectorKey(key)
     );
   }
-  // Headless devices (servers/VMs/pods, the herdr box) serve the shell
-  // connector: bundled `os.shell` executes `bash -lc` and returns structured
-  // output. Keep this list tight - nothing browser/OS-UI based.
+  // Headless devices (servers/VMs/pods) serve the shell connector: `os.shell`
+  // executes `bash --noprofile --norc -c` and returns structured output.
+  // Keep this list tight - nothing browser/OS-UI based.
   if (platform === 'headless') {
     return key === 'os.shell';
   }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -285,6 +285,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   let app_version: string | null = null;
   let label: string | null = null;
   let capacityAvailable: number | null = null;
+  let backendCapacity: Record<string, number> = {};
+  let backendCapacityProvided = false;
   let connectorManifestsProvided = false;
   let connectorManifestsRaw: unknown;
   // Agent CLIs this device can spawn. `null` is NOT the same as `[]`: null means
@@ -313,6 +315,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     app_version = body.app_version ?? null;
     label = body.label ?? null;
     capacityAvailable = body.capacity_available ?? null;
+    backendCapacity = body.backend_capacity ?? {};
+    backendCapacityProvided = Object.hasOwn(body, 'backend_capacity');
     connectorManifestsProvided = Object.hasOwn(body, 'connector_manifests');
     connectorManifestsRaw = body.connector_manifests;
     agentKinds = normalizeAgentKinds(body.agent_kinds);
@@ -420,6 +424,26 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       }
       effectivePlatform = existing[0].platform;
     }
+  }
+  // A daemon built after the per-backend signal always advertises its own map
+  // (connector-worker/src/daemon/start.ts). An omitted map therefore means a
+  // client that predates the field, or one that never runs the daemon at all
+  // (the Chrome extension and the macOS app poll directly). Mirror what the
+  // daemon would have advertised for that platform rather than inventing a
+  // wider or narrower grant: headless keeps its compiler/SDK runtime gated off
+  // while still owning the daemon backend, and every other platform is
+  // compiled-capable. Not keyed on token scope: user-scoped device workers are
+  // compiled-capable too.
+  //
+  // Placed AFTER the binding resolution above, and keyed on effectivePlatform,
+  // because the claim lane is: a headless-bound device that omits `platform`
+  // from its body would otherwise default to compiled-only and silently lose
+  // the daemon backend it is the only worker able to run.
+  if (!backendCapacityProvided) {
+    backendCapacity =
+      effectivePlatform === 'headless'
+        ? { daemon_builtin: 1, compiled_connector: 0 }
+        : { compiled_connector: 1 };
   }
   // For user-scoped (device) workers, authorize the advertised capability set
   // against the platform-specific allowlist in @lobu/core. Anything outside
@@ -643,10 +667,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     capabilityMatchSet,
     manifestClaimAuthorizations,
     allowLegacyManifestCapabilityClaims:
-      isUserScopedWorker && !connectorManifestsProvided && effectivePlatform !== 'chrome-extension',
+      isUserScopedWorker &&
+      !connectorManifestsProvided &&
+      effectivePlatform !== 'chrome-extension' &&
+      effectivePlatform !== 'headless',
     orgScopeIds,
     baseOrgScopeIds,
     workerHardensDbEgress,
+    backendCapacity,
   };
   const workerKind = isUserScopedWorker ? 'device' : 'fleet';
   // `platform` is self-reported in the poll body and is only pinned to the

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -426,20 +426,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       effectivePlatform = existing[0].platform;
     }
   }
-  // A daemon built after the per-backend signal always advertises its own map
-  // (connector-worker/src/daemon/start.ts). An omitted map therefore means a
-  // client that predates the field, or one that never runs the daemon at all
-  // (the Chrome extension and the macOS app poll directly). Mirror what the
-  // daemon would have advertised for that platform rather than inventing a
-  // wider or narrower grant: a running daemon has asserted its compiled
-  // runtime loads before it polls, so every platform is compiled-capable, and
-  // `headless` additionally owns the in-process daemon builtin. Not keyed on
-  // token scope: user-scoped device workers are compiled-capable too.
+  // An omitted map means a client that predates the field; mirror what that
+  // platform's daemon would have advertised — see `defaultBackendCapacity` in
+  // core/contracts/worker/protocol.ts for why each platform gets what it gets.
   //
-  // Placed AFTER the binding resolution above, and keyed on effectivePlatform,
-  // because the claim lane is: a headless-bound device that omits `platform`
-  // from its body would otherwise default to compiled-only and silently lose
-  // the daemon backend it is the only worker able to run.
+  // Keyed on effectivePlatform and placed AFTER the binding resolution above:
+  // a headless-bound device that omits `platform` from its body would
+  // otherwise default to compiled-only and silently lose the one backend it
+  // is the only worker able to run.
   if (!backendCapacityProvided) {
     backendCapacity = defaultBackendCapacity(effectivePlatform);
   }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -14,6 +14,7 @@ import {
 import { Value } from '@sinclair/typebox/value';
 import {
   PollRequestSchema,
+  defaultBackendCapacity,
   type PollRequest,
 } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
@@ -430,20 +431,17 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // client that predates the field, or one that never runs the daemon at all
   // (the Chrome extension and the macOS app poll directly). Mirror what the
   // daemon would have advertised for that platform rather than inventing a
-  // wider or narrower grant: headless keeps its compiler/SDK runtime gated off
-  // while still owning the daemon backend, and every other platform is
-  // compiled-capable. Not keyed on token scope: user-scoped device workers are
-  // compiled-capable too.
+  // wider or narrower grant: a running daemon has asserted its compiled
+  // runtime loads before it polls, so every platform is compiled-capable, and
+  // `headless` additionally owns the in-process daemon builtin. Not keyed on
+  // token scope: user-scoped device workers are compiled-capable too.
   //
   // Placed AFTER the binding resolution above, and keyed on effectivePlatform,
   // because the claim lane is: a headless-bound device that omits `platform`
   // from its body would otherwise default to compiled-only and silently lose
   // the daemon backend it is the only worker able to run.
   if (!backendCapacityProvided) {
-    backendCapacity =
-      effectivePlatform === 'headless'
-        ? { daemon_builtin: 1, compiled_connector: 0 }
-        : { compiled_connector: 1 };
+    backendCapacity = defaultBackendCapacity(effectivePlatform);
   }
   // For user-scoped (device) workers, authorize the advertised capability set
   // against the platform-specific allowlist in @lobu/core. Anything outside

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -13,6 +13,7 @@ import {
 } from '@lobu/core';
 import { Value } from '@sinclair/typebox/value';
 import {
+  EXECUTION_BACKENDS,
   PollRequestSchema,
   defaultBackendCapacity,
   type PollRequest,
@@ -1227,6 +1228,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     });
   }
   const isNativeBridgeRun = selectedExecution.backend === 'native_bridge';
+  // Both device-owned backends: the device implements the work itself, so the
+  // gateway ships no compiled code and does not hold the connection lease.
+  const isDeviceOwnedRun =
+    isNativeBridgeRun ||
+    selectedExecution.backend === EXECUTION_BACKENDS.daemonBuiltin;
 
   // Device chat reuses the ordinary messages/chat_message row. The poll
   // response is only an execution envelope: ownership/routing remain on the
@@ -1690,7 +1696,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     isUserScopedWorker,
     hasStoredCompiledCode,
     gatewayHasLocalSource,
-    isNativeBridgeRun,
+    isDeviceOwnedRun,
     manifestBacked: row.connector_manifest_backed,
     deviceAdvertisesRequiredCapability:
       row.connector_required_capability != null &&
@@ -1734,7 +1740,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   //    profile still can't leak secrets to an arbitrary capability-matched device.
   const connectionIsDevicePinned = row.connection_device_worker_id != null;
   const deliverConnectionAuth =
-    !isNativeBridgeRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
+    !isDeviceOwnedRun && !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
   // `user_data_dir` and `cdp_url` for device-bound browser profiles flow to
   // the worker via `sessionState.user_data_dir` / `sessionState.cdp_url`
   // (set inside resolveExecutionAuth). No need to thread them as separate

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -13,7 +13,6 @@ import {
 } from '@lobu/core';
 import { Value } from '@sinclair/typebox/value';
 import {
-  EXECUTION_BACKENDS,
   PollRequestSchema,
   defaultBackendCapacity,
   type PollRequest,
@@ -1227,12 +1226,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       ...pollMetadata,
     });
   }
-  const isNativeBridgeRun = selectedExecution.backend === 'native_bridge';
   // Both device-owned backends: the device implements the work itself, so the
-  // gateway ships no compiled code and does not hold the connection lease.
-  const isDeviceOwnedRun =
-    isNativeBridgeRun ||
-    selectedExecution.backend === EXECUTION_BACKENDS.daemonBuiltin;
+  // gateway ships no compiled code and does not hold the connection lease. The
+  // classifier returns a backend only for a hash-attested manifest artifact
+  // that carries no compiled or source code, so "a backend was classified" is
+  // exactly "this run is device-owned".
+  const isDeviceOwnedRun = selectedExecution.backend !== undefined;
 
   // Device chat reuses the ordinary messages/chat_message row. The poll
   // response is only an execution envelope: ownership/routing remain on the
@@ -1690,8 +1689,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const hasStoredCompiledCode = Boolean(row.compiled_code);
   const workerWillResolveLocally =
     !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
-  // Only a native-bridge run is implemented by the device itself. Manifest
-  // backing and the capability gate do not establish who executes the code.
+  // Only a device-owned run (native bridge or daemon builtin) is implemented by
+  // the device itself. Manifest backing and the capability gate do not
+  // establish who executes the code.
   const deviceWillExecuteNativeConnector = deviceExecutesConnectorNatively({
     isUserScopedWorker,
     hasStoredCompiledCode,
@@ -1812,9 +1812,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     run_type: row.run_type,
     connector_key: row.connector_key ?? undefined,
     connector_version: row.connector_version ?? undefined,
-    ...(isNativeBridgeRun
+    // The routing marker the worker switches on: `daemon_builtin` selects the
+    // daemon's supervised built-in, `native_bridge` the native bridge daemon.
+    // Every classified backend has to reach the worker -- emitting only one of
+    // them leaves the other lane dead, and the worker then falls through to the
+    // compiled path for a run the gateway deliberately shipped no code for.
+    ...(selectedExecution.backend
       ? {
-          execution_backend: 'native_bridge' as const,
+          execution_backend: selectedExecution.backend,
           connector_manifest_hash: selectedExecution.manifestHash,
         }
       : {}),


### PR DESCRIPTION
## Summary

Routes headless `os.shell` through an explicit `daemon_builtin` execution
backend, and gates connector claims on the backends a worker actually
advertises so nothing is routed to a worker that cannot run it.

This is the first slice of #3243, which spanned five concerns across ~2300
lines and was not reviewable as one change. It carries #3243's fixes, not the
original draft: the two are the same work, and #3243's 30 follow-up commits
were review fixes on top of it (#3235 is byte-identical to #3243's base commit
and is superseded by both).

## Root cause

The headless `device-manifest://headless/os.shell@0.1.0` artifact declared no
execution owner, so the gateway treated it as a portable compiled connector.
The compiler leaves `@lobu/connector-sdk` as a bare runtime import; the
packaged daemon then loaded a temporary ESM module whose deployment graph could
not resolve that workspace package, and the action failed before bash ran.

A built-in backend removes dynamic compilation and npm resolution from the
shell recovery primitive entirely.

## Two deliberate behavior changes

- **The compiled backend is advertised from a probe, not the platform label.**
  A headless daemon boots even when the compiler graph is broken -- that is the
  breakage the shell primitive exists to repair -- and then reports whether the
  compiled runtime actually loaded. Keying this on the label instead would have
  closed the compiled lane on every ordinary self-hosted `lobu daemon`, whose
  default platform is also `headless`, leaving their execution-pinned
  connections queued forever with no error raised anywhere. Covered by
  `default-backend-capacity.test.ts`.
- **A requested `timeout_ms` above the 150s ceiling is rejected, not clamped**,
  leaving room inside run_sdk's 180s budget for TERM grace, reaping and
  terminal delivery.

## Security

The shell now runs under the process supervisor rather than a bare detached
`spawn`, and with a constructed environment (`PATH`/`HOME`/`TMPDIR`/`LANG`)
instead of the daemon's own `process.env`, which previously handed every
command the daemon's full secret environment.

## Verification

- `default-backend-capacity` (bun), `os_shell` connector tests (13),
  `connector-execution-backend` (21), `device-connector-manifests` (37),
  `device-feed-scheduler-liveness` (3) -- all green locally
- shell builtin exercised directly: stdout capture, non-zero exit propagation,
  timeout rejection, and a probe confirming the daemon environment does not
  leak into the command
- strict typecheck clean for core, connector-sdk, connector-worker and server
- the daemon-builtin executor suite needs `@agentclientprotocol/sdk`, which is
  not installed locally on main either, so CI owns that file

## Review round 2 (blocking fix)

`make review` failed the gate on the previous head (bug_free 80, simplicity 60,
slop 25). Its "unverified risk 1" turned out to be a **real rollout regression**
and is now fixed.

The new `platform === 'headless' requires runtime.execution='daemon_builtin'`
check also runs over ALREADY-STORED manifests, because
`getDeviceManifestSourcesForUser` revalidates the persisted payload to rebuild a
device's claim authority. `runtime.execution` did not exist before this branch —
`origin/main` ships `runtime: { platforms: ['headless'] }` and nothing else — so
the check would have dropped the stored manifest of **every headless device in
the field** the moment the gateway deployed, ahead of any daemon upgrade. The
device then simply stops claiming `os.shell`: no error, runs queue forever.

This is the third instance of the same class on this branch, after
`allowLegacyMissingOperations` and `compiled_connector: 0`.

Now only an EXPLICIT contradiction is rejected. An absent value keeps its
pre-existing meaning (ordinary manifest-backed device work over the compiled
runtime) and is deliberately left ABSENT rather than resolved — rewriting it
would move the manifest hash, and the revalidation path drops anything whose
recomputed hash no longer matches what was stored, which is the same silent
revocation by another route.

New: `packages/server/src/__tests__/unit/device-manifest-headless-execution.test.ts`
(5 tests). Mutation-checked — 2 of the 5 fail against the pre-fix code.

Also from the review: dropped the unused `WorkerDecodeError` import; bumped
`os.shell` 0.1.0 -> 0.2.0 (the action contract changed: login shell ->
`bash --noprofile --norc -c`, timeout ceiling halved to 150s, silent clamp
replaced by a hard reject) so pins do not silently change meaning under one
version string; rewrote the unparseable `loadCompiledRuntime` rationale;
documented the paired `os.shell` implementations in both headers with why they
are two (sharing a module would put the compiler graph back on the recovery path
the daemon builtin exists to be); fixed one more stale `bash -lc` doc string.

## Local verification (the env gap is closed)

The reviewer noted the daemon-builtin suites "cannot run locally". They can now —
`@agentclientprotocol/{sdk,claude-agent-acp,codex-acp}` were declared but absent
from every local install, so they were installed out-of-tree and symlinked into
the worktree's (gitignored) `node_modules`:

- `bun test packages/connector-worker` — **284 pass / 0 fail** across 34 files,
  including `daemon-builtin-os-shell` and `executor-heartbeat`
- `bun test packages/core` — 463 pass / 0 fail
- `bun test packages/server/src/__tests__/unit` — the new suite 5/5
- vitest `device-connector-manifests` — **35 pass**, including "ships bundled
  os.shell code to the headless daemon", the test the 0.2.0 bump could have broken
- vitest `device-feed-scheduler-liveness` — 3 pass
- vitest `connector-execution-backend` — 21 pass
- `make pre-pr` — clean

## Still to come from #3243

Manifest fail-closed readiness surfacing, terminal delivery hardening, and the
packaged-tarball queue smoke. #3243 stays open as the reference branch until
those land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added headless device support for daemon-managed connector execution.
  * Added a built-in shell action with controlled environments, output capture, and timeout handling.
  * Added backend capacity reporting for improved execution routing and availability decisions.

* **Bug Fixes**
  * Prevented unavailable execution backends from receiving work.
  * Improved process cleanup, shutdown handling, and terminal result delivery.
  * Shell commands no longer load user profiles or inherited secrets.
  * Added clearer handling when the connector runtime is unavailable.
  * Added validation for shell inputs and execution time limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
