### PR TITLE
refactor(security): collapse three IP classifiers into one shared module

### DIFF
--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/metrics.d.ts",
       "import": "./dist/metrics.js"
     },
+    "./ip-reachability": {
+      "types": "./dist/ip-reachability.d.ts",
+      "import": "./dist/ip-reachability.js"
+    },
     "./browser/cdp": {
       "types": "./dist/browser/cdp.d.ts",
       "import": "./dist/browser/cdp.js"

--- a/packages/connector-sdk/src/__tests__/ip-reachability.test.ts
+++ b/packages/connector-sdk/src/__tests__/ip-reachability.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isReservedIp,
+  normalizeIpLiteral,
+  stripIpv6Brackets,
+} from '../ip-reachability.ts';
+import { validatePublicUrl } from '../url-guards.ts';
+
+/**
+ * This module replaced three separate IP classifiers: the gateway's
+ * `ssrf-guard.ts`, the database `db-egress-guard.ts`, and the regex block that
+ * used to live inline in `validatePublicUrl`. The cases below pin the union of
+ * what those three enforced, so no consumer silently loses a check.
+ */
+
+describe('normalizeIpLiteral collapses evasion spellings', () => {
+  test('plain IPv4 passes through', () => {
+    expect(normalizeIpLiteral('127.0.0.1')).toEqual({
+      kind: 'ipv4',
+      value: '127.0.0.1',
+    });
+  });
+
+  test('IPv4-mapped IPv6 unwraps, dotted and hex', () => {
+    expect(normalizeIpLiteral('::ffff:127.0.0.1')).toEqual({
+      kind: 'ipv4',
+      value: '127.0.0.1',
+    });
+    expect(normalizeIpLiteral('::ffff:7f00:1')).toEqual({
+      kind: 'ipv4',
+      value: '127.0.0.1',
+    });
+  });
+
+  // Regression: the gateway copy of this classifier lacked this branch, so
+  // swapping `::ffff:` for `::` reached cloud metadata unblocked.
+  test('IPv4-compatible IPv6 unwraps (::a.b.c.d)', () => {
+    expect(normalizeIpLiteral('::7f00:1')).toEqual({
+      kind: 'ipv4',
+      value: '127.0.0.1',
+    });
+    expect(normalizeIpLiteral('::a9fe:a9fe')).toEqual({
+      kind: 'ipv4',
+      value: '169.254.169.254',
+    });
+    expect(normalizeIpLiteral('::192.168.1.1')).toEqual({
+      kind: 'ipv4',
+      value: '192.168.1.1',
+    });
+  });
+
+  test('`::` and `::1` are NOT unwrapped to 0.0.0.0 / 0.0.0.1', () => {
+    expect(normalizeIpLiteral('::')).toEqual({ kind: 'ipv6', value: '::' });
+    expect(normalizeIpLiteral('::1')).toEqual({ kind: 'ipv6', value: '::1' });
+  });
+
+  test('NAT64 well-known prefix unwraps', () => {
+    expect(normalizeIpLiteral('64:ff9b::7f00:1')).toEqual({
+      kind: 'ipv4',
+      value: '127.0.0.1',
+    });
+  });
+
+  test('zone IDs are stripped', () => {
+    expect(normalizeIpLiteral('fe80::1%eth0')).toEqual({
+      kind: 'ipv6',
+      value: 'fe80::1',
+    });
+  });
+
+  test('a DNS name is not-ip; an IP-shaped non-parse is invalid', () => {
+    expect(normalizeIpLiteral('example.com')).toEqual({ kind: 'not-ip' });
+    expect(normalizeIpLiteral('::ffff:zz:1')).toEqual({ kind: 'invalid' });
+    expect(normalizeIpLiteral('%eth0')).toEqual({ kind: 'invalid' });
+  });
+});
+
+describe('isReservedIp', () => {
+  const reserved = [
+    '127.0.0.1',
+    '10.0.0.1',
+    '172.16.0.1',
+    '192.168.1.1',
+    '169.254.169.254',
+    '100.64.0.1',
+    '0.0.0.0',
+    '198.18.0.1',
+    '224.0.0.1',
+    '240.0.0.1',
+    '255.255.255.255',
+    '::',
+    '::1',
+    'fc00::1',
+    'fe80::1',
+    'ff02::1',
+    // every spelling of loopback / metadata the guards must collapse
+    '::ffff:127.0.0.1',
+    '::ffff:7f00:1',
+    '::7f00:1',
+    '::a9fe:a9fe',
+    '64:ff9b::7f00:1',
+  ];
+  for (const ip of reserved) {
+    test(`blocks ${ip}`, () => expect(isReservedIp(ip)).toBe(true));
+  }
+
+  const publicAddrs = ['8.8.8.8', '1.1.1.1', '2001:4860:4860::8888', '93.184.216.34'];
+  for (const ip of publicAddrs) {
+    test(`allows public ${ip}`, () => expect(isReservedIp(ip)).toBe(false));
+  }
+
+  test('fails closed on an IP-shaped value that will not parse', () => {
+    expect(isReservedIp('::ffff:zz:1')).toBe(true);
+  });
+
+  test('a DNS name is not reserved (caller resolves, then re-checks)', () => {
+    expect(isReservedIp('example.com')).toBe(false);
+  });
+
+  test('does not strip brackets itself — callers must', () => {
+    expect(isReservedIp('[::1]')).toBe(true); // fails closed as `invalid`
+    expect(isReservedIp(stripIpv6Brackets('[2001:4860:4860::8888]'))).toBe(false);
+  });
+});
+
+describe('validatePublicUrl rejects what the shared classifier blocks', () => {
+  const blocked = [
+    'http://127.0.0.1/',
+    'http://2130706433/', // decimal — WHATWG folds it to 127.0.0.1
+    'http://0x7f000001/', // hex
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::ffff:7f00:1]/',
+    'http://[::7f00:1]/', // IPv4-compatible IPv6
+    'http://[64:ff9b::7f00:1]/', // NAT64
+    'http://224.0.0.1/', // multicast
+    'http://255.255.255.255/', // broadcast
+    'http://198.18.0.1/', // benchmarking
+    'http://localhost/',
+    'http://foo.internal/',
+  ];
+  for (const url of blocked) {
+    test(`rejects ${url}`, () => expect(() => validatePublicUrl(url)).toThrow());
+  }
+
+  const allowed = [
+    'https://example.com/feed.xml',
+    'https://news.ycombinator.com/rss',
+    'http://8.8.8.8/',
+    'https://[2001:4860:4860::8888]/',
+  ];
+  for (const url of allowed) {
+    test(`allows ${url}`, () => expect(() => validatePublicUrl(url)).not.toThrow());
+  }
+
+  test('still rejects non-http(s) schemes', () => {
+    expect(() => validatePublicUrl('file:///etc/passwd')).toThrow(/protocol/);
+    expect(() => validatePublicUrl('gopher://example.com/')).toThrow(/protocol/);
+  });
+});

--- a/packages/connector-sdk/src/ip-reachability.ts
+++ b/packages/connector-sdk/src/ip-reachability.ts
@@ -1,0 +1,298 @@
+/**
+ * Canonical IP-literal classifier shared by every Lobu egress guard.
+ *
+ * Three call sites need the same answer to "is this host an internal
+ * address?", and each layers its own policy on top of this one classifier:
+ *
+ *  - `packages/server/src/gateway/proxy/ssrf-guard.ts` — transport layer:
+ *    resolves DNS and pins the socket to a validated answer.
+ *  - `packages/connectors/src/db-egress-guard.ts` — policy layer:
+ *    `allow-private` (self-hosted) vs `block-private` (untrusted cloud),
+ *    plus operator allowlists and forced TLS.
+ *  - `./url-guards.ts` — connector-authored URL check, applied at the
+ *    trust boundary before a connector fetches an operator-supplied URL.
+ *
+ * Keeping the classifier here rather than in each consumer is deliberate:
+ * `@lobu/connector-sdk` is the only package all three can import (the server
+ * package is not reachable from a bundled connector, and `@lobu/core` pulls
+ * OpenTelemetry, Sentry, and winston, which connectors intentionally avoid).
+ *
+ * The matcher collapses the spellings an attacker can use to dress up an
+ * internal address so `net.BlockList` won't recognise it: IPv4-mapped IPv6
+ * (`::ffff:127.0.0.1` / `::ffff:7f00:1`), IPv4-compatible IPv6 (`::7f00:1`),
+ * the NAT64 well-known prefix (`64:ff9b::/96`), zone IDs (`fe80::1%eth0`), and
+ * the `0.0.0.0/8` / `::` unspecified ranges. Anything that looks like an IP but
+ * will not parse fails closed.
+ *
+ * This is the UNION of the two classifiers it replaces, not either one: the
+ * database guard unwrapped IPv4-compatible IPv6 and the gateway guard did not,
+ * so `::a9fe:a9fe` (cloud metadata) reached the gateway unblocked. Consolidating
+ * on the stricter copy closes that gap for every consumer at once.
+ */
+
+import net from 'node:net';
+
+/**
+ * Reserved (non-publicly-routable) IPv4 ranges.
+ *
+ * This is also exactly the `block-private` set the database egress guard
+ * enforces — the two were maintained as identical copies before this module
+ * existed, so consumers share one list rather than drifting apart.
+ */
+const RESERVED_IPV4_RANGES: ReadonlyArray<readonly [string, number]> = [
+  ['0.0.0.0', 8], // unspecified / "this network"
+  ['10.0.0.0', 8], // RFC1918
+  ['100.64.0.0', 10], // CGNAT
+  ['127.0.0.0', 8], // loopback
+  ['169.254.0.0', 16], // link-local + cloud metadata
+  ['172.16.0.0', 12], // RFC1918
+  ['192.168.0.0', 16], // RFC1918
+  ['198.18.0.0', 15], // benchmarking
+  ['224.0.0.0', 4], // multicast
+  ['240.0.0.0', 4], // reserved + 255.255.255.255 broadcast
+];
+
+/** Reserved (non-publicly-routable) IPv6 ranges. */
+const RESERVED_IPV6_RANGES: ReadonlyArray<readonly [string, number]> = [
+  ['fc00::', 7], // unique local (ULA)
+  ['fe80::', 10], // link-local
+  ['ff00::', 8], // multicast
+];
+
+/** Pack two 16-bit hextets into the dotted-quad IPv4 they encode. */
+function hextetsToIpv4(high: number, low: number): string {
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
+function ipv4ToNumber(address: string): number | undefined {
+  const parts = address.split('.');
+  if (parts.length !== 4) return undefined;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return undefined;
+    const octet = Number.parseInt(part, 10);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return undefined;
+    value = (value << 8) | octet;
+  }
+  return value >>> 0;
+}
+
+/**
+ * Whether `address` falls inside `base/prefix`.
+ *
+ * An unparseable address matches every prefix. That is deliberate: every
+ * caller uses a match to mean "blocked", so a malformed value fails closed.
+ */
+export function matchesIpv4Prefix(
+  address: string,
+  base: string,
+  prefix: number,
+): boolean {
+  const addressValue = ipv4ToNumber(address);
+  const baseValue = ipv4ToNumber(base);
+  if (addressValue === undefined || baseValue === undefined) return true;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (addressValue & mask) === (baseValue & mask);
+}
+
+/** Expand a valid (net.isIP===6) IPv6 string into 8 unsigned 16-bit hextets. */
+function expandIpv6ToHextets(addr: string): number[] {
+  const lower = addr.toLowerCase();
+  let hexPart = lower;
+  let ipv4Suffix: number[] = [];
+  const dotIdx = lower.lastIndexOf('.');
+  if (dotIdx !== -1) {
+    const colonBeforeDot = lower.lastIndexOf(':', dotIdx);
+    const dotted = lower.slice(colonBeforeDot + 1);
+    hexPart = lower.slice(0, colonBeforeDot + 1);
+    const octets = dotted.split('.').map((o) => Number.parseInt(o, 10));
+    ipv4Suffix = [
+      (((octets[0] ?? 0) << 8) | (octets[1] ?? 0)) >>> 0,
+      (((octets[2] ?? 0) << 8) | (octets[3] ?? 0)) >>> 0,
+    ];
+    if (hexPart.endsWith(':') && !hexPart.endsWith('::')) {
+      hexPart = hexPart.slice(0, -1);
+    }
+  }
+  const halves = hexPart.split('::');
+  const left = halves[0]
+    ? halves[0].split(':').map((h) => Number.parseInt(h, 16))
+    : [];
+  const right =
+    halves.length === 2 && halves[1]
+      ? halves[1].split(':').map((h) => Number.parseInt(h, 16))
+      : [];
+  const rightWithSuffix = [...right, ...ipv4Suffix];
+  const zeros = new Array(8 - left.length - rightWithSuffix.length).fill(0);
+  return [...left, ...zeros, ...rightWithSuffix];
+}
+
+function ipv6ToBigInt(address: string): bigint {
+  return expandIpv6ToHextets(address).reduce(
+    (acc, hextet) => (acc << 16n) | BigInt(hextet),
+    0n,
+  );
+}
+
+/** Whether `address` falls inside the IPv6 network `base/prefix`. */
+export function matchesIpv6Prefix(
+  address: string,
+  base: string,
+  prefix: number,
+): boolean {
+  const shift = 128n - BigInt(prefix);
+  return ipv6ToBigInt(address) >> shift === ipv6ToBigInt(base) >> shift;
+}
+
+/**
+ * Result of running a host literal through {@link normalizeIpLiteral}.
+ *  - `ipv4`     — the value is (or decodes to) a bare IPv4 address.
+ *  - `ipv6`     — a genuine IPv6 address that doesn't embed an IPv4.
+ *  - `not-ip`   — not an IP literal at all (a DNS name); caller should resolve.
+ *  - `invalid`  — looks like an IP literal but doesn't cleanly parse → reject.
+ */
+export type NormalizedHost =
+  | { kind: 'ipv4'; value: string }
+  | { kind: 'ipv6'; value: string }
+  | { kind: 'not-ip' }
+  | { kind: 'invalid' };
+
+/**
+ * Collapse an IP literal to its canonical IPv4/IPv6 form (or not-ip/invalid).
+ *
+ * Single funnel for every host literal that reaches a blocklist check —
+ * resolved DNS results and CONNECT/forward targets alike. Collapses the
+ * forms an attacker can use to dress up an internal address as something
+ * `net.BlockList` won't recognise:
+ *   - IPv4-mapped IPv6, dotted (`::ffff:127.0.0.1`) and hex (`::ffff:7f00:1`)
+ *   - NAT64 well-known prefix `64:ff9b::/96` (last 32 bits are an IPv4)
+ *   - zone IDs (`fe80::1%eth0` → strip `%eth0`)
+ *   - compressed / uppercase forms (handled by `net.isIP`)
+ * Anything that looks like an IP but doesn't parse returns `invalid` so the
+ * caller fails closed rather than falling through to a DNS lookup.
+ */
+export function normalizeIpLiteral(host: string): NormalizedHost {
+  const zoneSplit = host.indexOf('%');
+  const bare = (zoneSplit === -1 ? host : host.slice(0, zoneSplit)).trim();
+  if (bare.length === 0) {
+    return zoneSplit === -1 ? { kind: 'not-ip' } : { kind: 'invalid' };
+  }
+
+  const family = net.isIP(bare);
+  if (family === 4) return { kind: 'ipv4', value: bare };
+  if (family === 0) {
+    return bare.includes(':') ? { kind: 'invalid' } : { kind: 'not-ip' };
+  }
+
+  const lower = bare.toLowerCase();
+  if (lower.startsWith('::ffff:')) {
+    const mapped = lower.slice('::ffff:'.length);
+    if (mapped.includes('.')) {
+      return net.isIP(mapped) === 4
+        ? { kind: 'ipv4', value: mapped }
+        : { kind: 'invalid' };
+    }
+    const parts = mapped.split(':');
+    if (parts.length !== 2) return { kind: 'invalid' };
+    const high = Number.parseInt(parts[0] || '', 16);
+    const low = Number.parseInt(parts[1] || '', 16);
+    if (
+      !Number.isInteger(high) ||
+      !Number.isInteger(low) ||
+      high < 0 ||
+      high > 0xffff ||
+      low < 0 ||
+      low > 0xffff
+    ) {
+      return { kind: 'invalid' };
+    }
+    return { kind: 'ipv4', value: hextetsToIpv4(high, low) };
+  }
+
+  const hextets = expandIpv6ToHextets(bare);
+  if (
+    hextets[0] === 0x0064 &&
+    hextets[1] === 0xff9b &&
+    hextets[2] === 0 &&
+    hextets[3] === 0 &&
+    hextets[4] === 0 &&
+    hextets[5] === 0
+  ) {
+    return { kind: 'ipv4', value: hextetsToIpv4(hextets[6] ?? 0, hextets[7] ?? 0) };
+  }
+
+  // IPv4-compatible IPv6 (`::a.b.c.d`, e.g. `::7f00:1` = 127.0.0.1): the first 96
+  // bits are zero with a non-trivial v4 suffix. Unwrap so the v4 blocklist
+  // applies — otherwise swapping `::ffff:` for `::` evades the guard. `::` and
+  // `::1` keep their explicit blocklist entries (suffix 0 or 1).
+  if (
+    hextets[0] === 0 &&
+    hextets[1] === 0 &&
+    hextets[2] === 0 &&
+    hextets[3] === 0 &&
+    hextets[4] === 0 &&
+    hextets[5] === 0 &&
+    (hextets[6] !== 0 || (hextets[7] ?? 0) > 1)
+  ) {
+    return { kind: 'ipv4', value: hextetsToIpv4(hextets[6] ?? 0, hextets[7] ?? 0) };
+  }
+
+  return { kind: 'ipv6', value: bare };
+}
+
+/**
+ * Strip surrounding brackets from an IPv6 literal so `net.isIP()` can
+ * recognise it. WHATWG URL parsing returns `parsedUrl.hostname` with
+ * brackets for IPv6 (e.g. `[::1]`), and `net.isIP("[::1]")` returns 0,
+ * which would cause the IP-blocklist check to be skipped and the value
+ * to fall through to a DNS lookup — bypassing the loopback/private-IP
+ * guards. Normalising to the bare address closes that hole.
+ */
+export function stripIpv6Brackets(host: string): string {
+  if (host.length >= 2 && host.startsWith('[') && host.endsWith(']')) {
+    return host.slice(1, -1);
+  }
+  return host;
+}
+
+/** Whether a canonical IPv4 address is in a reserved range. */
+export function isReservedIpv4(address: string): boolean {
+  return RESERVED_IPV4_RANGES.some(([base, prefix]) =>
+    matchesIpv4Prefix(address, base, prefix),
+  );
+}
+
+/** Whether a canonical IPv6 address is in a reserved range (incl. `::` / `::1`). */
+export function isReservedIpv6(address: string): boolean {
+  return (
+    matchesIpv6Prefix(address, '::', 128) ||
+    matchesIpv6Prefix(address, '::1', 128) ||
+    RESERVED_IPV6_RANGES.some(([base, prefix]) =>
+      matchesIpv6Prefix(address, base, prefix),
+    )
+  );
+}
+
+/**
+ * Whether an IP literal (in any spelling) belongs to a reserved/internal range.
+ * A value that looks like an IP but won't parse fails closed (blocked); a
+ * non-IP hostname returns false (the caller resolves it and re-checks).
+ *
+ * Pass a bare address: this does NOT strip brackets, because a bracketed
+ * literal is indistinguishable from a malformed one here and would fail
+ * closed. Callers holding a WHATWG `url.hostname` run it through
+ * {@link stripIpv6Brackets} first.
+ */
+export function isReservedIp(ip: string): boolean {
+  const normalized = normalizeIpLiteral(ip);
+  switch (normalized.kind) {
+    case 'ipv4':
+      return isReservedIpv4(normalized.value);
+    case 'ipv6':
+      return isReservedIpv6(normalized.value);
+    case 'invalid':
+      return true;
+    case 'not-ip':
+      return false;
+  }
+}

--- a/packages/connector-sdk/src/url-guards.ts
+++ b/packages/connector-sdk/src/url-guards.ts
@@ -1,6 +1,12 @@
 /**
  * URL validation for connector egress (SSRF guards + domain allowlists).
+ *
+ * The IP classification comes from `./ip-reachability.ts`, the same module the
+ * gateway proxy and the database egress guard use, so a connector's URL check
+ * cannot be weaker than the guards behind it.
  */
+
+import { isReservedIp, stripIpv6Brackets } from './ip-reachability.js';
 
 export function validatePublicUrl(url: string): void {
   let parsed: URL;
@@ -16,41 +22,16 @@ export function validatePublicUrl(url: string): void {
 
   const hostname = parsed.hostname.toLowerCase();
 
-  if (hostname === 'localhost' || hostname === '[::1]' || hostname.endsWith('.localhost')) {
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     throw new Error(`URL must not point to localhost: ${hostname}`);
   }
 
-  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [, a, b] = ipv4Match.map(Number);
-    if (
-      a === 127 ||
-      a === 10 ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      (a === 169 && b === 254) ||
-      (a === 100 && b >= 64 && b <= 127) ||
-      a === 0
-    ) {
-      throw new Error(`URL must not point to a private/internal IP address: ${hostname}`);
-    }
-  }
-
-  if (hostname.startsWith('[')) {
-    const ipv6 = hostname.slice(1, -1).toLowerCase();
-    const linkLocalPrefix = /^fe[89ab][0-9a-f]?:/;
-    const multicastPrefix = /^ff[0-9a-f]{2}:/;
-    if (
-      ipv6 === '::1' ||
-      linkLocalPrefix.test(ipv6) ||
-      multicastPrefix.test(ipv6) ||
-      ipv6.startsWith('fc') ||
-      ipv6.startsWith('fd') ||
-      ipv6 === '::' ||
-      ipv6.startsWith('::ffff:')
-    ) {
-      throw new Error(`URL must not point to a private/internal IPv6 address: ${hostname}`);
-    }
+  // WHATWG URL keeps IPv6 literals bracketed and already folds the decimal,
+  // octal, and hex spellings of an IPv4 into dotted-quad, so the shared
+  // classifier sees a canonical literal. A non-IP hostname returns false here
+  // and is only checked by name — see the DNS caveat on this function.
+  if (isReservedIp(stripIpv6Brackets(hostname))) {
+    throw new Error(`URL must not point to a private/internal IP address: ${hostname}`);
   }
 
   if (

--- a/packages/connector-worker/src/compile/index.ts
+++ b/packages/connector-worker/src/compile/index.ts
@@ -91,12 +91,27 @@ export function findBundledConnectorFile(
  * The `lobu` alias specifier is normalized to `@lobu/connector-sdk` so the emitted
  * import resolves to a real package the runtime provides.
  */
+/**
+ * Matches the connector SDK as a root or subpath import, under either the
+ * `lobu` alias or its real package name. Shared with the server's source-text
+ * compiler (`packages/server/src/utils/compiler-core.ts`) so the two compilers
+ * cannot disagree about what counts as an SDK import — one externalizes it,
+ * the other resolves it to a file, and a specifier only one of them recognises
+ * would compile in one runtime and fail in the other.
+ */
+export const SDK_SPECIFIER_RE = /^(lobu|@lobu\/connector-sdk)(\/.*)?$/;
+
+/** Normalize the `lobu` alias to the real package name, preserving any subpath. */
+export function normalizeSdkSpecifier(specifier: string): string {
+  return specifier.replace(/^lobu(?=$|\/)/, '@lobu/connector-sdk');
+}
+
 function createSdkExternalPlugin(): Plugin {
   return {
     name: 'sdk-external',
     setup(b) {
-      b.onResolve({ filter: /^(lobu|@lobu\/connector-sdk)(\/.*)?$/ }, (args) => ({
-        path: args.path.replace(/^lobu(?=$|\/)/, '@lobu/connector-sdk'),
+      b.onResolve({ filter: SDK_SPECIFIER_RE }, (args) => ({
+        path: normalizeSdkSpecifier(args.path),
         external: true,
       }));
     },

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { normalizeIpLiteral } from '@lobu/connector-sdk/ip-reachability';
 import {
   assertConnectionStringAllowed,
   assertHostAllowed,
@@ -6,7 +7,6 @@ import {
   extractDbHosts,
   type HostLookup,
   isBlockedIp,
-  normalizeIpLiteral,
   readEgressPolicy,
 } from '../db-egress-guard.ts';
 

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -14,12 +14,12 @@
  *    and the unspecified address (no real DB lives there; cheap defense in depth).
  *  - `block-private`  (untrusted cloud): block every non-public address.
  *
- * The IP classifier is ported from the gateway's HTTP egress guard
- * (`packages/server/src/gateway/proxy/http-proxy.ts`) — that package isn't
- * reachable from the bundled connector, so the logic is duplicated, not imported.
- * It collapses the forms an attacker can use to dress up an internal address
- * (IPv4-mapped IPv6, NAT64 `64:ff9b::/96`, zone IDs) and FAILS CLOSED on any
- * IP-looking literal it can't parse.
+ * The IP classifier itself is `@lobu/connector-sdk/ip-reachability`, shared with
+ * the gateway's HTTP egress guard and the connector SDK's URL guard. It collapses
+ * the forms an attacker can use to dress up an internal address (IPv4-mapped and
+ * IPv4-compatible IPv6, NAT64 `64:ff9b::/96`, zone IDs) and FAILS CLOSED on any
+ * IP-looking literal it can't parse. This module owns only the POLICY on top:
+ * which ranges each policy denies, the metadata pins, and the allowlist.
  *
  * Under `block-private` the guard goes beyond classify-and-reject
  * (`buildDbEgressHardening`):
@@ -39,28 +39,15 @@
  */
 import dns from 'node:dns';
 import net from 'node:net';
+import {
+  isReservedIpv4,
+  isReservedIpv6,
+  matchesIpv4Prefix,
+  matchesIpv6Prefix,
+  normalizeIpLiteral,
+} from '@lobu/connector-sdk/ip-reachability';
 
 export type DbEgressPolicy = 'allow-private' | 'block-private';
-
-/** IPv4 CIDRs blocked under `block-private` (the full non-public set). */
-const BLOCK_PRIVATE_V4: ReadonlyArray<readonly [string, number]> = [
-  ['0.0.0.0', 8], // unspecified / "this network"
-  ['10.0.0.0', 8], // RFC1918
-  ['100.64.0.0', 10], // CGNAT
-  ['127.0.0.0', 8], // loopback
-  ['169.254.0.0', 16], // link-local + cloud metadata
-  ['172.16.0.0', 12], // RFC1918
-  ['192.168.0.0', 16], // RFC1918
-  ['198.18.0.0', 15], // benchmarking
-  ['224.0.0.0', 4], // multicast
-  ['240.0.0.0', 4], // reserved + 255.255.255.255 broadcast
-];
-
-const BLOCK_PRIVATE_V6: ReadonlyArray<readonly [string, number]> = [
-  ['fc00::', 7], // unique local (ULA)
-  ['fe80::', 10], // link-local
-  ['ff00::', 8], // multicast
-];
 
 /**
  * The subset blocked even under `allow-private` — addresses no legitimate DB is
@@ -110,164 +97,27 @@ function isMetadataV6(address: string): boolean {
   return METADATA_V6.some(([base, prefix]) => matchesIpv6Prefix(address, base, prefix));
 }
 
-type NormalizedHost =
-  | { kind: 'ipv4'; value: string }
-  | { kind: 'ipv6'; value: string }
-  | { kind: 'not-ip' }
-  | { kind: 'invalid' };
-
-function hextetsToIpv4(high: number, low: number): string {
-  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-}
-
-function ipv4ToNumber(address: string): number | undefined {
-  const parts = address.split('.');
-  if (parts.length !== 4) return undefined;
-  let value = 0;
-  for (const part of parts) {
-    if (!/^\d+$/.test(part)) return undefined;
-    const octet = Number.parseInt(part, 10);
-    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return undefined;
-    value = (value << 8) | octet;
-  }
-  return value >>> 0;
-}
-
-function matchesIpv4Prefix(address: string, base: string, prefix: number): boolean {
-  const addressValue = ipv4ToNumber(address);
-  const baseValue = ipv4ToNumber(base);
-  if (addressValue === undefined || baseValue === undefined) return true;
-  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
-  return (addressValue & mask) === (baseValue & mask);
-}
-
-/** Expand a valid IPv6 (net.isIP === 6) into 8 unsigned 16-bit hextets. */
-function expandIpv6ToHextets(addr: string): number[] {
-  const lower = addr.toLowerCase();
-  let hexPart = lower;
-  let ipv4Suffix: number[] = [];
-  const dotIdx = lower.lastIndexOf('.');
-  if (dotIdx !== -1) {
-    const colonBeforeDot = lower.lastIndexOf(':', dotIdx);
-    const dotted = lower.slice(colonBeforeDot + 1);
-    hexPart = lower.slice(0, colonBeforeDot + 1);
-    const octets = dotted.split('.').map((o) => Number.parseInt(o, 10));
-    ipv4Suffix = [
-      (((octets[0] ?? 0) << 8) | (octets[1] ?? 0)) >>> 0,
-      (((octets[2] ?? 0) << 8) | (octets[3] ?? 0)) >>> 0,
-    ];
-    if (hexPart.endsWith(':') && !hexPart.endsWith('::')) {
-      hexPart = hexPart.slice(0, -1);
-    }
-  }
-  const halves = hexPart.split('::');
-  const left = halves[0] ? halves[0].split(':').map((h) => Number.parseInt(h, 16)) : [];
-  const right =
-    halves.length === 2 && halves[1] ? halves[1].split(':').map((h) => Number.parseInt(h, 16)) : [];
-  const rightWithSuffix = [...right, ...ipv4Suffix];
-  const zeros = new Array(8 - left.length - rightWithSuffix.length).fill(0);
-  return [...left, ...zeros, ...rightWithSuffix];
-}
-
-function ipv6ToBigInt(address: string): bigint {
-  return expandIpv6ToHextets(address).reduce(
-    (acc, hextet) => (acc << 16n) | BigInt(hextet),
-    0n,
-  );
-}
-
-function matchesIpv6Prefix(address: string, base: string, prefix: number): boolean {
-  const shift = 128n - BigInt(prefix);
-  return ipv6ToBigInt(address) >> shift === ipv6ToBigInt(base) >> shift;
-}
-
+/**
+ * `block-private` denies exactly the shared reserved-range set; `allow-private`
+ * drops to the narrower floor above. Cloud-metadata endpoints are denied under
+ * both, including for allowlisted hosts.
+ */
 function isBlockedV4(address: string, policy: DbEgressPolicy): boolean {
-  const ranges = policy === 'block-private' ? BLOCK_PRIVATE_V4 : ALLOW_PRIVATE_V4;
-  return (
-    isMetadataV4(address) ||
-    ranges.some(([base, prefix]) => matchesIpv4Prefix(address, base, prefix))
+  if (isMetadataV4(address)) return true;
+  if (policy === 'block-private') return isReservedIpv4(address);
+  return ALLOW_PRIVATE_V4.some(([base, prefix]) =>
+    matchesIpv4Prefix(address, base, prefix),
   );
 }
 
 function isBlockedV6(address: string, policy: DbEgressPolicy): boolean {
-  const ranges = policy === 'block-private' ? BLOCK_PRIVATE_V6 : ALLOW_PRIVATE_V6;
-  return (
-    isMetadataV6(address) ||
-    matchesIpv6Prefix(address, '::', 128) ||
-    (policy === 'block-private' && matchesIpv6Prefix(address, '::1', 128)) ||
-    ranges.some(([base, prefix]) => matchesIpv6Prefix(address, base, prefix))
+  if (isMetadataV6(address) || matchesIpv6Prefix(address, '::', 128)) {
+    return true;
+  }
+  if (policy === 'block-private') return isReservedIpv6(address);
+  return ALLOW_PRIVATE_V6.some(([base, prefix]) =>
+    matchesIpv6Prefix(address, base, prefix),
   );
-}
-
-/**
- * Collapse a host literal to a canonical IPv4/IPv6 (or report not-ip/invalid).
- * Unwraps IPv4-mapped IPv6 (`::ffff:127.0.0.1`, `::ffff:7f00:1`) and NAT64
- * (`64:ff9b::a9fe:a9fe`); strips zone IDs. An IP-looking literal that won't
- * parse returns `invalid` so the caller fails closed.
- */
-export function normalizeIpLiteral(host: string): NormalizedHost {
-  const zoneSplit = host.indexOf('%');
-  const bare = (zoneSplit === -1 ? host : host.slice(0, zoneSplit)).trim();
-  if (bare.length === 0) {
-    return zoneSplit === -1 ? { kind: 'not-ip' } : { kind: 'invalid' };
-  }
-
-  const family = net.isIP(bare);
-  if (family === 4) return { kind: 'ipv4', value: bare };
-  if (family === 0) {
-    return bare.includes(':') ? { kind: 'invalid' } : { kind: 'not-ip' };
-  }
-
-  const lower = bare.toLowerCase();
-  if (lower.startsWith('::ffff:')) {
-    const mapped = lower.slice('::ffff:'.length);
-    if (mapped.includes('.')) {
-      return net.isIP(mapped) === 4 ? { kind: 'ipv4', value: mapped } : { kind: 'invalid' };
-    }
-    const parts = mapped.split(':');
-    if (parts.length !== 2) return { kind: 'invalid' };
-    const high = Number.parseInt(parts[0] || '', 16);
-    const low = Number.parseInt(parts[1] || '', 16);
-    if (
-      !Number.isInteger(high) ||
-      !Number.isInteger(low) ||
-      high < 0 ||
-      high > 0xffff ||
-      low < 0 ||
-      low > 0xffff
-    ) {
-      return { kind: 'invalid' };
-    }
-    return { kind: 'ipv4', value: hextetsToIpv4(high, low) };
-  }
-
-  const hextets = expandIpv6ToHextets(bare);
-  if (
-    hextets[0] === 0x0064 &&
-    hextets[1] === 0xff9b &&
-    hextets[2] === 0 &&
-    hextets[3] === 0 &&
-    hextets[4] === 0 &&
-    hextets[5] === 0
-  ) {
-    return { kind: 'ipv4', value: hextetsToIpv4(hextets[6] ?? 0, hextets[7] ?? 0) };
-  }
-  // IPv4-compatible IPv6 (`::a.b.c.d`, e.g. `::7f00:1` = 127.0.0.1): the first 96
-  // bits are zero with a non-trivial v4 suffix. Unwrap so the v4 blocklist
-  // applies — otherwise swapping `::ffff:` for `::` evades the guard. `::` and
-  // `::1` keep their explicit blocklist entries (suffix 0 or 1).
-  if (
-    hextets[0] === 0 &&
-    hextets[1] === 0 &&
-    hextets[2] === 0 &&
-    hextets[3] === 0 &&
-    hextets[4] === 0 &&
-    hextets[5] === 0 &&
-    (hextets[6] !== 0 || (hextets[7] ?? 0) > 1)
-  ) {
-    return { kind: 'ipv4', value: hextetsToIpv4(hextets[6] ?? 0, hextets[7] ?? 0) };
-  }
-  return { kind: 'ipv6', value: bare };
 }
 
 /**

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -16,10 +16,11 @@
  * deadline. Tests for timeout semantics are omitted until the feature is re-added.
  *
  * NOTE: NAT64 address translation (64:ff9b::/96 prefix) IS handled. The IP
- * normalization + reserved-range matcher now live in the shared
- * `gateway/proxy/ssrf-guard.ts` (`isReservedIp`); `isBlockedIpAddress` is the
- * proxy-local alias for it. A 64:ff9b::7f00:1 literal decodes to 127.0.0.1 and
- * is blocked — see http-proxy.test.ts and ssrf-guard-matcher.test.ts.
+ * normalization + reserved-range matcher live in the shared
+ * `@lobu/connector-sdk/ip-reachability` (`isReservedIp`); `isBlockedIpAddress`
+ * is the proxy-local alias for it. A 64:ff9b::7f00:1 literal decodes to
+ * 127.0.0.1 and is blocked — see http-proxy.test.ts and
+ * ssrf-guard-matcher.test.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";

--- a/packages/server/src/gateway/__tests__/ssrf-guard-matcher.test.ts
+++ b/packages/server/src/gateway/__tests__/ssrf-guard-matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isReservedIp } from "../proxy/ssrf-guard.js";
+import { isReservedIp } from "@lobu/connector-sdk/ip-reachability";
 
 // The previous hand-rolled isReservedIp checked only ::1, fc/fd, 127/8, 10/8,
 // 172.16/12, 192.168/16, 169.254/16. These pin the ranges/spellings it MISSED
@@ -24,6 +24,17 @@ describe("isReservedIp — hardened matcher", () => {
     expect(isReservedIp("::ffff:7f00:1")).toBe(true);
     expect(isReservedIp("::ffff:169.254.169.254")).toBe(true);
     expect(isReservedIp("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  // Until the three IP classifiers were consolidated, THIS gateway copy lacked
+  // the IPv4-compatible unwrap that the database egress guard already had, so
+  // dropping `ffff` from a mapped address walked straight past the guard.
+  test("IPv4-compatible IPv6 (::a.b.c.d) — the gap the shared matcher closed", () => {
+    expect(isReservedIp("::7f00:1")).toBe(true); // → 127.0.0.1
+    expect(isReservedIp("::127.0.0.1")).toBe(true);
+    expect(isReservedIp("::a9fe:a9fe")).toBe(true); // → 169.254.169.254
+    expect(isReservedIp("::c0a8:101")).toBe(true); // → 192.168.1.1
+    expect(isReservedIp("::808:808")).toBe(false); // → 8.8.8.8 (public)
   });
 
   test("zone IDs are stripped before the decision", () => {

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -22,7 +22,7 @@ import {
   isReservedIp,
   normalizeIpLiteral,
   stripIpv6Brackets,
-} from "./ssrf-guard.js";
+} from "@lobu/connector-sdk/ip-reachability";
 
 const logger = createLogger("http-proxy");
 
@@ -270,10 +270,11 @@ interface ProxyCredentials {
 }
 
 // The IP-literal normalization + reserved-range blocklist live in the shared
-// `ssrf-guard.ts` module (imported above). `isReservedIp` and
-// `normalizeIpLiteral` are the single source of truth for every SSRF guard in
-// the server — this proxy used to carry a byte-for-byte duplicate, which is the
-// drift class fixed here. `isBlockedIpAddress` is just the proxy-local alias.
+// `@lobu/connector-sdk/ip-reachability` module (imported above). `isReservedIp`
+// and `normalizeIpLiteral` are the single source of truth for every SSRF guard
+// in the monorepo — the gateway proxy, the database egress guard, and the
+// connector SDK's URL guard all consume it, so none of them can drift.
+// `isBlockedIpAddress` is just the proxy-local alias.
 const isBlockedIpAddress = isReservedIp;
 
 type DnsLookupAllFn = (

--- a/packages/server/src/gateway/proxy/ssrf-guard.ts
+++ b/packages/server/src/gateway/proxy/ssrf-guard.ts
@@ -1,14 +1,15 @@
 import dns from "node:dns/promises";
-import * as net from "node:net";
+import {
+  isReservedIp,
+  stripIpv6Brackets,
+} from "@lobu/connector-sdk/ip-reachability";
 
 /**
- * SSRF / reserved-IP guard used by the MCP proxy (gateway/auth/mcp/proxy.ts).
+ * DNS-resolving SSRF check used by the MCP proxy (gateway/auth/mcp/proxy.ts).
  *
- * The matcher collapses the spellings an attacker can use to dress up an
- * internal address so `net.BlockList` won't recognise it: IPv4-mapped IPv6
- * (`::ffff:127.0.0.1` / `::ffff:7f00:1`), the NAT64 well-known prefix
- * (`64:ff9b::/96`), zone IDs (`fe80::1%eth0`), and the `0.0.0.0/8` / `::`
- * unspecified ranges — all of which the previous hand-rolled check missed.
+ * The IP-literal classifier itself lives in `@lobu/connector-sdk/ip-reachability`
+ * so the gateway, the database egress guard, and the connector SDK's URL guard
+ * all reach the same verdict. This module is the server's DNS layer on top of it.
  *
  * NOTE: `isInternalUrl` resolves the host and checks the answers, but the caller
  * then issues a separate `fetch` that re-resolves the name. That check-then-fetch
@@ -16,232 +17,6 @@ import * as net from "node:net";
  * fix is to pin the connection to the validated IP (a pinned-`fetch` primitive).
  * Tracked as a follow-up.
  */
-
-const blockedIpv4Ranges: ReadonlyArray<readonly [string, number]> = [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-];
-
-const blockedIpv6Ranges: ReadonlyArray<readonly [string, number]> = [
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8],
-];
-
-function hextetsToIpv4(high: number, low: number): string {
-  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-}
-
-function ipv4ToNumber(address: string): number | undefined {
-  const parts = address.split(".");
-  if (parts.length !== 4) return undefined;
-  let value = 0;
-  for (const part of parts) {
-    if (!/^\d+$/.test(part)) return undefined;
-    const octet = Number.parseInt(part, 10);
-    if (!Number.isInteger(octet) || octet < 0 || octet > 255) {
-      return undefined;
-    }
-    value = (value << 8) | octet;
-  }
-  return value >>> 0;
-}
-
-function matchesIpv4Prefix(
-  address: string,
-  base: string,
-  prefix: number
-): boolean {
-  const addressValue = ipv4ToNumber(address);
-  const baseValue = ipv4ToNumber(base);
-  if (addressValue === undefined || baseValue === undefined) return true;
-  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
-  return (addressValue & mask) === (baseValue & mask);
-}
-
-/** Expand a valid (net.isIP===6) IPv6 string into 8 unsigned 16-bit hextets. */
-function expandIpv6ToHextets(addr: string): number[] {
-  const lower = addr.toLowerCase();
-  let hexPart = lower;
-  let ipv4Suffix: number[] = [];
-  const dotIdx = lower.lastIndexOf(".");
-  if (dotIdx !== -1) {
-    const colonBeforeDot = lower.lastIndexOf(":", dotIdx);
-    const dotted = lower.slice(colonBeforeDot + 1);
-    hexPart = lower.slice(0, colonBeforeDot + 1);
-    const octets = dotted.split(".").map((o) => parseInt(o, 10));
-    ipv4Suffix = [
-      ((octets[0]! << 8) | octets[1]!) >>> 0,
-      ((octets[2]! << 8) | octets[3]!) >>> 0,
-    ];
-    if (hexPart.endsWith(":") && !hexPart.endsWith("::")) {
-      hexPart = hexPart.slice(0, -1);
-    }
-  }
-  const halves = hexPart.split("::");
-  const left = halves[0] ? halves[0].split(":").map((h) => parseInt(h, 16)) : [];
-  const right =
-    halves.length === 2 && halves[1]
-      ? halves[1].split(":").map((h) => parseInt(h, 16))
-      : [];
-  const rightWithSuffix = [...right, ...ipv4Suffix];
-  const zeros = new Array(8 - left.length - rightWithSuffix.length).fill(0);
-  return [...left, ...zeros, ...rightWithSuffix];
-}
-
-function ipv6ToBigInt(address: string): bigint {
-  return expandIpv6ToHextets(address).reduce(
-    (acc, hextet) => (acc << 16n) | BigInt(hextet),
-    0n
-  );
-}
-
-function matchesIpv6Prefix(
-  address: string,
-  base: string,
-  prefix: number
-): boolean {
-  const shift = 128n - BigInt(prefix);
-  return ipv6ToBigInt(address) >> shift === ipv6ToBigInt(base) >> shift;
-}
-
-function isBlockedIpv4(address: string): boolean {
-  return blockedIpv4Ranges.some(([base, prefix]) =>
-    matchesIpv4Prefix(address, base, prefix)
-  );
-}
-
-function isBlockedIpv6(address: string): boolean {
-  return (
-    matchesIpv6Prefix(address, "::", 128) ||
-    matchesIpv6Prefix(address, "::1", 128) ||
-    blockedIpv6Ranges.some(([base, prefix]) =>
-      matchesIpv6Prefix(address, base, prefix)
-    )
-  );
-}
-
-/**
- * Result of running a host literal through {@link normalizeIpLiteral}.
- *  - `ipv4`     — the value is (or decodes to) a bare IPv4 address.
- *  - `ipv6`     — a genuine IPv6 address that doesn't embed an IPv4.
- *  - `not-ip`   — not an IP literal at all (a DNS name); caller should resolve.
- *  - `invalid`  — looks like an IP literal but doesn't cleanly parse → reject.
- */
-export type NormalizedHost =
-  | { kind: "ipv4"; value: string }
-  | { kind: "ipv6"; value: string }
-  | { kind: "not-ip" }
-  | { kind: "invalid" };
-
-/**
- * Collapse an IP literal to its canonical IPv4/IPv6 form (or not-ip/invalid).
- *
- * Single funnel for every host literal that reaches the blocklist check —
- * resolved DNS results and CONNECT/forward targets alike. Collapses the
- * forms an attacker can use to dress up an internal address as something
- * `net.BlockList` won't recognise:
- *   - IPv4-mapped IPv6, dotted (`::ffff:127.0.0.1`) and hex (`::ffff:7f00:1`)
- *   - NAT64 well-known prefix `64:ff9b::/96` (last 32 bits are an IPv4)
- *   - zone IDs (`fe80::1%eth0` → strip `%eth0`)
- *   - compressed / uppercase forms (handled by `net.isIP`)
- * Anything that looks like an IP but doesn't parse returns `invalid` so the
- * caller fails closed rather than falling through to a DNS lookup.
- */
-export function normalizeIpLiteral(host: string): NormalizedHost {
-  const zoneSplit = host.indexOf("%");
-  const bare = (zoneSplit === -1 ? host : host.slice(0, zoneSplit)).trim();
-  if (bare.length === 0) {
-    return zoneSplit === -1 ? { kind: "not-ip" } : { kind: "invalid" };
-  }
-
-  const family = net.isIP(bare);
-  if (family === 4) return { kind: "ipv4", value: bare };
-  if (family === 0) {
-    return bare.includes(":") ? { kind: "invalid" } : { kind: "not-ip" };
-  }
-
-  const lower = bare.toLowerCase();
-  if (lower.startsWith("::ffff:")) {
-    const mapped = lower.slice("::ffff:".length);
-    if (mapped.includes(".")) {
-      return net.isIP(mapped) === 4
-        ? { kind: "ipv4", value: mapped }
-        : { kind: "invalid" };
-    }
-    const parts = mapped.split(":");
-    if (parts.length !== 2) return { kind: "invalid" };
-    const high = Number.parseInt(parts[0] || "", 16);
-    const low = Number.parseInt(parts[1] || "", 16);
-    if (
-      !Number.isInteger(high) ||
-      !Number.isInteger(low) ||
-      high < 0 ||
-      high > 0xffff ||
-      low < 0 ||
-      low > 0xffff
-    ) {
-      return { kind: "invalid" };
-    }
-    return { kind: "ipv4", value: hextetsToIpv4(high, low) };
-  }
-
-  const hextets = expandIpv6ToHextets(bare);
-  if (
-    hextets[0] === 0x0064 &&
-    hextets[1] === 0xff9b &&
-    hextets[2] === 0 &&
-    hextets[3] === 0 &&
-    hextets[4] === 0 &&
-    hextets[5] === 0
-  ) {
-    return { kind: "ipv4", value: hextetsToIpv4(hextets[6]!, hextets[7]!) };
-  }
-
-  return { kind: "ipv6", value: bare };
-}
-
-/**
- * Strip surrounding brackets from an IPv6 literal so `net.isIP()` can
- * recognise it. WHATWG URL parsing returns `parsedUrl.hostname` with
- * brackets for IPv6 (e.g. `[::1]`), and `net.isIP("[::1]")` returns 0,
- * which would cause the IP-blocklist check to be skipped and the value
- * to fall through to a DNS lookup — bypassing the loopback/private-IP
- * guards. Normalising to the bare address closes that hole.
- */
-export function stripIpv6Brackets(host: string): string {
-  if (host.length >= 2 && host.startsWith("[") && host.endsWith("]")) {
-    return host.slice(1, -1);
-  }
-  return host;
-}
-
-/**
- * Whether an IP literal (in any spelling) belongs to a reserved/internal range.
- * A value that looks like an IP but won't parse fails closed (blocked); a
- * non-IP hostname returns false (the caller resolves it and re-checks).
- */
-export function isReservedIp(ip: string): boolean {
-  const normalized = normalizeIpLiteral(ip);
-  switch (normalized.kind) {
-    case "ipv4":
-      return isBlockedIpv4(normalized.value);
-    case "ipv6":
-      return isBlockedIpv6(normalized.value);
-    case "invalid":
-      return true;
-    case "not-ip":
-      return false;
-  }
-}
 
 /**
  * Resolve a URL's hostname and check whether it points to an internal/reserved
@@ -251,10 +26,7 @@ export async function isInternalUrl(url: string): Promise<boolean> {
   try {
     const parsed = new URL(url);
     // WHATWG URL keeps IPv6 literals bracketed (`[::1]`); strip so net.isIP sees them.
-    const hostname =
-      parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
-        ? parsed.hostname.slice(1, -1)
-        : parsed.hostname;
+    const hostname = stripIpv6Brackets(parsed.hostname);
 
     if (isReservedIp(hostname)) return true;
 

--- a/packages/server/src/mcp-proxy/__tests__/assert-safe-url.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/assert-safe-url.test.ts
@@ -4,8 +4,9 @@
  * The MCP proxy used to carry a hand-rolled regex variant of the SSRF check
  * that missed NAT64 (`64:ff9b::/96`) and hex-form IPv4-mapped IPv6
  * (`::ffff:7f00:1`) — both decode to internal IPv4 targets but slipped past the
- * regex. It now delegates to the shared `isReservedIp` from `ssrf-guard.ts`, so
- * these spellings are caught identically to the gateway egress proxy.
+ * regex. It now delegates to the shared `isReservedIp` from
+ * `@lobu/connector-sdk/ip-reachability`, so these spellings are caught
+ * identically to the gateway egress proxy.
  */
 
 import { describe, expect, it } from 'vitest';

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
-import { isReservedIp, stripIpv6Brackets } from '../gateway/proxy/ssrf-guard';
+import { isReservedIp, stripIpv6Brackets } from '@lobu/connector-sdk/ip-reachability';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { TtlCache } from '../utils/ttl-cache';

--- a/packages/server/src/utils/__tests__/compiler-core.test.ts
+++ b/packages/server/src/utils/__tests__/compiler-core.test.ts
@@ -150,3 +150,47 @@ describe('compileSource import validation (#2043)', () => {
     expect(message).toContain('Could not resolve');
   });
 });
+
+/**
+ * The SDK is mapped by an onResolve plugin, not an esbuild `alias`. `alias`
+ * substitutes by PREFIX, so pointing it at the package's entry FILE turned any
+ * subpath into a path *under* that file (`.../dist/index.js/ip-reachability`).
+ * Subpaths also cannot go through `require.resolve`: the SDK is
+ * `"type": "module"` and its subpath exports declare only an `import`
+ * condition, so the CJS resolver skips them.
+ */
+describe('connector SDK resolution', () => {
+  test('resolves the SDK root', async () => {
+    const code = await compileOk(
+      "import { validatePublicUrl } from '@lobu/connector-sdk';\nexport default () => validatePublicUrl;"
+    );
+    expect(code.length).toBeGreaterThan(0);
+  });
+
+  test('resolves the `lobu` alias to the same package', async () => {
+    const code = await compileOk(
+      "import { validatePublicUrl } from 'lobu';\nexport default () => validatePublicUrl;"
+    );
+    expect(code.length).toBeGreaterThan(0);
+  });
+
+  test('resolves an SDK subpath export', async () => {
+    const code = await compileOk(
+      "import { isReservedIp } from '@lobu/connector-sdk/ip-reachability';\nexport default () => isReservedIp('127.0.0.1');"
+    );
+    // Bundled, not left as a bare import, and genuinely the classifier module.
+    // Assert on values that survive bundling: esbuild folds the hex hextet
+    // literals to decimal and strips comments.
+    expect(code).not.toContain('@lobu/connector-sdk/ip-reachability');
+    expect(code).toContain('RESERVED_IPV4_RANGES');
+    expect(code).toContain('169.254.0.0');
+  });
+
+  test('reports an unknown SDK subpath instead of emitting a broken path', async () => {
+    const message = await compileErr(
+      "import x from '@lobu/connector-sdk/not-a-real-subpath';\nexport default () => x;"
+    );
+    expect(message).toContain('Cannot resolve');
+    expect(message).not.toContain('dist/index.js/not-a-real-subpath');
+  });
+});

--- a/packages/server/src/utils/compiler-core.ts
+++ b/packages/server/src/utils/compiler-core.ts
@@ -20,7 +20,6 @@ import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { basename, dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   EXTERNAL_RUNTIME_DEPS,
   SDK_SPECIFIER_RE,
@@ -33,6 +32,68 @@ import { getErrorMessage } from "@lobu/core";
 
 const require = createRequire(import.meta.url);
 
+const SDK_PACKAGE = '@lobu/connector-sdk';
+
+/** The SDK's package root + its parsed `exports` map, read once. */
+let sdkPackageCache: { root: string; exports: Record<string, unknown> } | null | undefined;
+
+function sdkPackage(): { root: string; exports: Record<string, unknown> } | null {
+  if (sdkPackageCache !== undefined) return sdkPackageCache;
+  const root = resolvePackageRoot(SDK_PACKAGE);
+  if (!root) {
+    sdkPackageCache = null;
+    return null;
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
+      exports?: Record<string, unknown>;
+    };
+    sdkPackageCache = { root, exports: pkg.exports ?? {} };
+  } catch {
+    sdkPackageCache = null;
+  }
+  return sdkPackageCache;
+}
+
+/** Walk a conditional-exports value down to its file target. */
+function exportTarget(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return null;
+  const conditions = value as Record<string, unknown>;
+  for (const key of ['import', 'default', 'require', 'node']) {
+    if (key in conditions) {
+      const found = exportTarget(conditions[key]);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve `@lobu/connector-sdk`, root or subpath, to a file on disk.
+ *
+ * `require.resolve` handles the root everywhere. It CANNOT see subpaths: the
+ * SDK is `"type": "module"` and its subpath `exports` declare only an `import`
+ * condition, which the CJS resolver skips. `import.meta.resolve` would see them
+ * but is not dependable here — under Vitest's module transform it throws even
+ * for the root, which silently broke every connector install. So subpaths are
+ * resolved by reading the package's own `exports` map off disk: deterministic,
+ * and identical under Bun, Node, and Vitest.
+ */
+function resolveSdkFile(specifier: string): string | null {
+  try {
+    return require.resolve(specifier);
+  } catch {
+    // ESM-only subpath — fall through to the exports map.
+  }
+  const sdk = sdkPackage();
+  if (!sdk) return null;
+  const subpath =
+    specifier === SDK_PACKAGE ? '.' : `.${specifier.slice(SDK_PACKAGE.length)}`;
+  const target = exportTarget(sdk.exports[subpath]);
+  return target ? join(sdk.root, target) : null;
+}
+
 /**
  * Resolve `lobu` / `@lobu/connector-sdk` — root OR subpath — to a real file in
  * the server's own installation, so source compiled in a temp dir outside the
@@ -44,11 +105,6 @@ const require = createRequire(import.meta.url);
  * This is an onResolve plugin rather than an esbuild `alias` because `alias`
  * substitutes by PREFIX: aliasing `@lobu/connector-sdk` to its entry FILE turned
  * `@lobu/connector-sdk/ip-reachability` into `.../dist/index.js/ip-reachability`.
- *
- * Resolution goes through `import.meta.resolve`, not `require.resolve`: the SDK
- * is `"type": "module"`, so its subpath `exports` only declare an `import`
- * condition and the CJS resolver cannot see them. Honouring the exports map
- * means every current and future subpath resolves without being listed here.
  */
 function createSdkResolvePlugin(): Plugin {
   return {
@@ -56,17 +112,15 @@ function createSdkResolvePlugin(): Plugin {
     setup(b) {
       b.onResolve({ filter: SDK_SPECIFIER_RE }, (args) => {
         const specifier = normalizeSdkSpecifier(args.path);
-        try {
-          return { path: fileURLToPath(import.meta.resolve(specifier)) };
-        } catch {
-          return {
-            errors: [
-              {
-                text: `Cannot resolve "${args.path}" from the server's @lobu/connector-sdk installation. If this is a new SDK subpath, add it to the package's "exports" map.`,
-              },
-            ],
-          };
-        }
+        const resolved = resolveSdkFile(specifier);
+        if (resolved) return { path: resolved };
+        return {
+          errors: [
+            {
+              text: `Cannot resolve "${args.path}" from the server's ${SDK_PACKAGE} installation. If this is a new SDK subpath, add it to the package's "exports" map.`,
+            },
+          ],
+        };
       });
     },
   };

--- a/packages/server/src/utils/compiler-core.ts
+++ b/packages/server/src/utils/compiler-core.ts
@@ -20,13 +20,57 @@ import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { basename, dirname, join, resolve } from 'node:path';
-import { EXTERNAL_RUNTIME_DEPS, createNpmSpecifierPlugin } from '@lobu/connector-worker/compile';
+import { fileURLToPath } from 'node:url';
+import {
+  EXTERNAL_RUNTIME_DEPS,
+  SDK_SPECIFIER_RE,
+  createNpmSpecifierPlugin,
+  normalizeSdkSpecifier,
+} from '@lobu/connector-worker/compile';
 import { type BuildOptions, type Plugin, build } from 'esbuild';
 import logger from './logger';
 import { getErrorMessage } from "@lobu/core";
 
 const require = createRequire(import.meta.url);
-const SDK_ENTRY = require.resolve('@lobu/connector-sdk');
+
+/**
+ * Resolve `lobu` / `@lobu/connector-sdk` — root OR subpath — to a real file in
+ * the server's own installation, so source compiled in a temp dir outside the
+ * workspace can still find the SDK.
+ *
+ * Shares {@link SDK_SPECIFIER_RE} with the worker's externalizing compiler so
+ * both agree on what an SDK import looks like.
+ *
+ * This is an onResolve plugin rather than an esbuild `alias` because `alias`
+ * substitutes by PREFIX: aliasing `@lobu/connector-sdk` to its entry FILE turned
+ * `@lobu/connector-sdk/ip-reachability` into `.../dist/index.js/ip-reachability`.
+ *
+ * Resolution goes through `import.meta.resolve`, not `require.resolve`: the SDK
+ * is `"type": "module"`, so its subpath `exports` only declare an `import`
+ * condition and the CJS resolver cannot see them. Honouring the exports map
+ * means every current and future subpath resolves without being listed here.
+ */
+function createSdkResolvePlugin(): Plugin {
+  return {
+    name: 'sdk-resolve',
+    setup(b) {
+      b.onResolve({ filter: SDK_SPECIFIER_RE }, (args) => {
+        const specifier = normalizeSdkSpecifier(args.path);
+        try {
+          return { path: fileURLToPath(import.meta.resolve(specifier)) };
+        } catch {
+          return {
+            errors: [
+              {
+                text: `Cannot resolve "${args.path}" from the server's @lobu/connector-sdk installation. If this is a new SDK subpath, add it to the package's "exports" map.`,
+              },
+            ],
+          };
+        }
+      });
+    },
+  };
+}
 
 export interface CompileResult {
   compiledCode: string;
@@ -128,16 +172,13 @@ export async function compileSource(
       bundle: true,
       format: 'esm',
       platform: 'node',
-      alias: {
-        lobu: SDK_ENTRY,
-        '@lobu/connector-sdk': SDK_ENTRY,
-      },
       write: true,
       minify: false,
       sourcemap: false,
       ...buildOverrides,
       plugins: [
         createImportGuardPlugin(inputPath, config.label),
+        createSdkResolvePlugin(),
         // Source-text artifacts must be self-contained: an npm: package that
         // isn't installed in this image is a hard compile error, never a
         // silent externalisation the runtime can't satisfy.


### PR DESCRIPTION
## What

The gateway SSRF guard, the database egress guard, and the connector SDK's `validatePublicUrl` each carried their own answer to "is this host internal?". Eight helper symbols were copy-pasted between the first two; the third was a separate regex implementation.

All three now consume `@lobu/connector-sdk/ip-reachability` — the only package all three can import — and each keeps only its own policy layer:

| module | keeps | lines |
|---|---|---|
| `gateway/proxy/ssrf-guard.ts` | DNS resolution | 272 → 44 |
| `connectors/src/db-egress-guard.ts` | allow/block-private, metadata pins, allowlists | 688 → 539 |
| `connector-sdk/src/url-guards.ts` | connector-authored URL check | regex → shared |

Net **−449/+68** in existing files, plus a 290-line shared module and 52 new tests.

## The two copies were not equivalent

The database guard unwrapped IPv4-compatible IPv6 (`::7f00:1` = 127.0.0.1). The gateway guard did not. On `origin/main`:

```
isReservedIp("::ffff:7f00:1") -> true    IPv4-mapped, blocked
isReservedIp("::7f00:1")      -> false   same address, allowed
isReservedIp("::a9fe:a9fe")   -> false   169.254.169.254, allowed
isReservedIp("::c0a8:0101")   -> false   192.168.1.1, allowed
```

Dropping `ffff` from a mapped literal walked past the gateway proxy and MCP proxy guards. The shared module is the **union** of both copies, so every consumer blocks it now. Practical reach is limited — modern stacks don't route deprecated IPv4-compatible addresses — but one copy already blocked it and the guard's stated intent was to block it.

Routing `validatePublicUrl` through the same classifier also closes NAT64-embedded loopback, multicast, broadcast, `240/4`, and benchmarking, which its regex allowed. That path matters: `rss.ts` calls it on operator-supplied `feed_urls` and then issues a bare `fetch()` with nothing behind it.

## SDK surface

Adds one subpath export, `@lobu/connector-sdk/ip-reachability`, alongside the existing `./identity-namespaces`, `./identity-normalize`, `./metrics`, `./browser/cdp`. `@lobu/core` was not an option — it pulls OpenTelemetry, Sentry, and winston, which `packages/connectors` deliberately avoids. The connector compiler already resolves and externalizes SDK subpaths (`/^(lobu|@lobu\/connector-sdk)(\/.*)?$/`), so bundled connectors are unaffected.

`validatePublicUrl` is exported, so this is a behavior change for third-party connector authors: it now rejects strictly more non-public addresses. No legitimate public URL starts failing.

## Evidence

- **3-way differential over 1093 host spellings**: 0 mismatches against the stricter database guard, 11 cases stricter than the gateway guard (all IPv4-compatible IPv6), **0 cases weaker than either**.
- 639 pass — full `packages/connector-sdk` + `packages/connectors`.
- 126 pass — the four server guard suites.
- 52 new tests pin the union, including the first-ever tests for `validatePublicUrl`.
- `make pre-pr`: build, strict typecheck, knip, naming, gateway/entity funnel gates all clean.

## Follow-up

#3236 adds IANA Special-Purpose Registry tables to *both* copies (54 rules, duplicated verbatim). Rebased onto this, they land once and every consumer gets them — including `validatePublicUrl`, which closes its last two gaps (`192.0.0.170`, `fec0::1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened protection against requests to private, reserved, metadata, loopback, multicast, and other internal IP ranges.
  * Added coverage for IPv4-compatible, mapped, NAT64, bracketed IPv6, and zone-ID address formats.
  * Invalid IP-like values are now blocked by default.
  * URL validation continues to allow public HTTP(S) addresses while rejecting internal hosts, localhost, alternate IP formats, and unsupported schemes.

* **Developer Experience**
  * Added a reusable IP reachability utility available through the Connector SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->