### PR TITLE
fix(naming): stop the canonical-vocabulary gate from renaming Chrome APIs

### DIFF
--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -116,6 +116,25 @@ describe("check-exposed-surface-naming", () => {
     expect(runGuard()).toBe(0);
   });
 
+  it("allows the exact Chrome sidePanel identifiers", () => {
+    // The extension calls these as members and stubs them as bare property
+    // keys, so both spellings have to survive the gate. Without this, keeping
+    // the calling file scanned means renaming a Chrome API — which is how #863
+    // broke the toolbar icon.
+    create(
+      GENERIC_BEHAVIOR_PROBE_FILE,
+      "chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })\n" +
+        "await chrome.sidePanel.getPanelBehavior()\n" +
+        "const stub = { setPanelBehavior: fake }\n"
+    );
+    expect(runGuard()).toBe(0);
+  });
+
+  it("does not exempt an owned key that merely resembles the Chrome name", () => {
+    create(GENERIC_BEHAVIOR_PROBE_FILE, '{"panelBehavior":"owned"}\n');
+    expect(runGuard()).toBe(1);
+  });
+
   it("does not exempt an owned AppKit-shaped behavior key", () => {
     create(GENERIC_BEHAVIOR_PROBE_FILE, '{"collectionBehavior":"owned"}\n');
     expect(runGuard()).toBe(1);

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -572,6 +572,16 @@ function scanCanonicalVocabulary(violations: Violation[]): void {
           // spellings. Match member access only, so an owned key or prose using
           // the same words still fails the canonical vocabulary gate.
           .replace(/\.(?:collectionBehavior|animationBehavior)\b/gi, "")
+          // Chrome owns these exact `chrome.sidePanel` identifiers. Unlike the
+          // AppKit names this matches the bare token, not just member access:
+          // the extension stubs the setter as a bare object key in tests, and
+          // no owned surface is spelled exactly this. Banning them is what
+          // made #863 rename `setPanelBehavior` to `setPanelAutomation` — a
+          // name no Chrome build ships — which left the Owletto toolbar icon
+          // silently unable to open the side panel
+          // (packages/owletto/apps/chrome/side-panel-action-click.js).
+          // A retired term is ours to retire; a platform's identifier is not.
+          .replace(/\b(?:setPanelBehavior|getPanelBehavior)\b/g, "")
           .replace(/\bscroll-behavior\b/g, "");
         if (RETIRED_CANONICAL_VOCABULARY.test(canonicalLine)) {
           violations.push({


### PR DESCRIPTION
## Summary

- The canonical-vocabulary gate bans `/watcher|behaviou?r/i` across every tracked file in both repos. Chrome's side panel API is named `chrome.sidePanel.setPanelBehavior`, so #863 satisfied the ban by renaming it to `setPanelAutomation` — a name no Chrome build ships — and #882 wrapped the call in an always-false `typeof` guard. The Owletto toolbar icon has silently been unable to open the side panel since 2026-08-15.
- The gate already has this exemption class (`behavior: "smooth"`, `.collectionBehavior`, `scroll-behavior`); Chrome's side panel names were never added. Added, matching the bare token rather than member access only, because the extension stubs them by name in tests. An owned lookalike (`panelBehavior`) still fails.
- Bumps `packages/owletto` to `0f2e7272` (lobu-ai/owletto#984), which fixes the call site and adds a Chrome API allowlist + digest so a repo-wide rename can never silently retarget a platform identifier again.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (build + typecheck + knip + biome + naming)
- [x] Tests run: `bun test scripts/__tests__/check-exposed-surface-naming.test.ts` → 20 pass / 0 fail; `bun run test -- --project chrome-ext` in `packages/owletto` → 28 files, 473 pass
- [x] Bug fix: red→fix→green outputs pasted below

### Red → green

The gate exemption is load-bearing, not decorative. Remove the one added line and the gate fails on the clean tree, because the extension now legitimately calls Chrome's real API:

```
--- exemption removed ---
(fail) check-exposed-surface-naming > passes on the clean tree
(fail) check-exposed-surface-naming > allows an exact external platform behavior option
(fail) check-exposed-surface-naming > allows exact AppKit behavior property and type spellings
(fail) check-exposed-surface-naming > allows the exact Chrome sidePanel identifiers
 16 pass / 4 fail
--- restored ---
check-exposed-surface-naming: clean — Automation is canonical across live tracked files.
 20 pass / 0 fail
```

Live behavior, two identical fresh Chrome 152 profiles, `getPanelBehavior()` evaluated in the extension's service worker over CDP:

```
origin/main   {"openPanelOnActionClick":false}   ← toolbar icon inert
this branch   {"openPanelOnActionClick":true}
```

Both runs also confirm the API surface directly — `typeof setPanelBehavior` is `"function"`, `typeof setPanelAutomation` is `"undefined"`. Chrome 152's framework binary agrees: 4 hits each for `setPanelBehavior`/`getPanelBehavior`/`openPanelOnActionClick`, **0** for `setPanelAutomation`.

## Notes

The submodule PR carries the tests that make this class of regression fail loudly, each mutation-verified:

| mutation | unit test | `chrome-api-surface.test.js` |
| --- | --- | --- |
| rename at one call site | RED | RED |
| **blanket `sed` over source + tests** (#863 as it happened) | **green** | **RED (pinned digest)** |
| delete the call from `background.js` | RED (wiring test) | green |

The middle row is why the digest exists: a find-and-replace rewrites a unit test's expectations in the same pass, so the unit test alone could never have caught #863.

Follow-ups, not in this PR:
- Extension `0.5.7` → `0.5.8`. Web Store installs carry the same dead icon and need a publish.
- Anyone who removed and re-added the unpacked extension while debugging lost `chrome.storage.local` (Chrome clears it on uninstall) and has to re-pair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored reliable opening of the Chrome side panel from the toolbar.
  - Prevented valid Chrome side-panel controls from being incorrectly blocked by naming checks.

- **Tests**
  - Added regression coverage confirming supported Chrome identifiers are accepted while similar unsupported names remain rejected.

- **Maintenance**
  - Updated the integrated Owletto component with the latest fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->