### PR TITLE
fix(connectors): reject a reserved chrome.* connector key that ships its own code

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connector-definition-upsert.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-definition-upsert.test.ts
@@ -117,6 +117,52 @@ describe('upsertConnectorDefinitionRecords', () => {
     ]);
   });
 
+  it('rejects a reserved chrome.* key at the shared writer, and admits its device manifest', async () => {
+    // The guard lives in the shared definition writer rather than on the
+    // compile path, because a device-manifest install skips compilation
+    // entirely. This exercises that wiring — the pure helper's own unit tests
+    // cover the decision, but only this proves the writer actually consults it.
+    const sql = getTestDb();
+    const chromeMetadata: ConnectorMetadata = {
+      ...metadataFor('1.0.0'),
+      key: 'chrome.probe',
+    };
+
+    await expect(
+      upsertConnectorDefinitionRecords({
+        sql,
+        organizationId: orgId,
+        metadata: chromeMetadata,
+        // Ordinary compiled install: exactly what cannot live on a chrome.* key.
+        versionRecord: versionRecordFor('1.0.0'),
+        versionScope: 'organization',
+      })
+    ).rejects.toThrow(/reserved 'chrome\.\*' namespace/);
+
+    // Nothing was persisted — the guard runs before any definition or version
+    // row can become active.
+    const rejected = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM connector_definitions WHERE key = 'chrome.probe'
+    `;
+    expect(rejected[0]?.count).toBe('0');
+
+    // The legitimate path still works: an identity, no payload.
+    const admitted = await upsertConnectorDefinitionRecords({
+      sql,
+      organizationId: orgId,
+      metadata: chromeMetadata,
+      versionRecord: {
+        compiledCode: null,
+        compiledCodeHash: 'manifest-hash-chrome-probe',
+        compileConfigHash: null,
+        sourceCode: null,
+        sourcePath: 'device-manifest://chrome-extension/chrome.probe@1.0.0',
+      },
+      versionScope: 'organization',
+    });
+    expect(admitted.updated).toBe(false);
+  });
+
   it('replaces compiled provenance atomically with a device-manifest artifact', async () => {
     const sql = getTestDb();
     const version = '2.0.0';

--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -31,7 +31,16 @@ vi.mock("@sentry/node", () => ({
 
 // --- heavy collaborators of createServerLifecycle, replaced so the spine
 // --- boots in-process against a real ephemeral HTTP server.
-vi.mock("../db/client", () => ({ closeDbSingleton: vi.fn(async () => {}) }));
+// Spread the real module: this mock leaks into other files sharing the worker,
+// and a hand-listed shape silently drops any export db/client later gains —
+// which surfaces far away as `No "<export>" export is defined on the mock`
+// inside whichever module happens to load under it. db/client has no
+// import-time side effects (the pool is created lazily by getDb), so keeping
+// the real exports costs nothing.
+vi.mock("../db/client", async (importOriginal) => ({
+	...((await importOriginal()) as Record<string, unknown>),
+	closeDbSingleton: vi.fn(async () => {}),
+}));
 vi.mock("../dev-vite", () => ({ mountViteDev: vi.fn(async () => null) }));
 vi.mock("../workspace", () => ({
 	initWorkspaceProvider: vi.fn(async () => undefined),

--- a/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
+++ b/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
@@ -101,13 +101,19 @@ describe('Chrome-extension connector execution placement', () => {
       expect(() =>
         assertChromeNamespaceInstallIsDeviceManifest({
           connectorKey: 'chrome.history',
+          connectorVersion: '1.0.0',
           sourcePath: 'device-manifest://chrome-extension/chrome.history@1.0.0',
+          compiledCode: null,
+          sourceCode: null,
         })
       ).not.toThrow();
       expect(() =>
         assertChromeNamespaceInstallIsDeviceManifest({
           connectorKey: 'chrome',
+          connectorVersion: '1.0.0',
           sourcePath: 'device-manifest://chrome-extension/chrome@1.0.0',
+          compiledCode: null,
+          sourceCode: null,
         })
       ).not.toThrow();
     });
@@ -119,15 +125,69 @@ describe('Chrome-extension connector execution placement', () => {
       expect(() =>
         assertChromeNamespaceInstallIsDeviceManifest({
           connectorKey: 'chrome.whatsapp',
+          connectorVersion: '1.0.0',
           sourcePath: null,
         })
       ).toThrow(/reserved 'chrome\.\*' namespace/);
       expect(() =>
         assertChromeNamespaceInstallIsDeviceManifest({
           connectorKey: 'chrome.whatsapp',
+          connectorVersion: '1.0.0',
           sourcePath: 'connectors/whatsapp-web.ts',
         })
       ).toThrow(/cannot live there/);
+    });
+
+    it('rejects a forged device-manifest path built from a source_url', () => {
+      // resolveConnectorInstallSource derives a source_url install's path as
+      // `url.pathname.replace(/^\//, '')`, so a URL whose pathname is
+      // `/device-manifest://chrome-extension/chrome.whatsapp` yields a
+      // sourcePath that satisfies any PREFIX test — while the very same install
+      // compiles the caller's own source. Only exact `<key>@<version>` identity
+      // closes it.
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.whatsapp',
+          connectorVersion: '1.0.0',
+          sourcePath: 'device-manifest://chrome-extension/chrome.whatsapp',
+          compiledCode: 'export default class {}',
+        })
+      ).toThrow(/reserved 'chrome\.\*' namespace/);
+      // A different key's manifest path must not admit this key either.
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.whatsapp',
+          connectorVersion: '1.0.0',
+          sourcePath: 'device-manifest://chrome-extension/chrome.history@1.0.0',
+        })
+      ).toThrow(/cannot live there/);
+      // Nor may a stale version's path admit a different version.
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.history',
+          connectorVersion: '2.0.0',
+          sourcePath: 'device-manifest://chrome-extension/chrome.history@1.0.0',
+        })
+      ).toThrow(/cannot live there/);
+    });
+
+    it('rejects an exact manifest identity that still carries a payload', () => {
+      // A device manifest carries an identity, never a payload. Checking the
+      // code independently means the guard states the real invariant instead of
+      // trusting the path string to imply it.
+      for (const payload of [
+        { compiledCode: 'export default class {}' },
+        { sourceCode: 'export default class {}' },
+      ]) {
+        expect(() =>
+          assertChromeNamespaceInstallIsDeviceManifest({
+            connectorKey: 'chrome.history',
+            connectorVersion: '1.0.0',
+            sourcePath: 'device-manifest://chrome-extension/chrome.history@1.0.0',
+            ...payload,
+          })
+        ).toThrow(/reserved 'chrome\.\*' namespace/);
+      }
     });
 
     it('leaves keys outside the namespace alone', () => {

--- a/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
+++ b/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
@@ -193,7 +193,11 @@ describe('Chrome-extension connector execution placement', () => {
     it('leaves keys outside the namespace alone', () => {
       for (const connectorKey of ['whatsapp.web', 'chromecast.demo', 'x', 'linkedin']) {
         expect(() =>
-          assertChromeNamespaceInstallIsDeviceManifest({ connectorKey, sourcePath: null })
+          assertChromeNamespaceInstallIsDeviceManifest({
+            connectorKey,
+            connectorVersion: '1.0.0',
+            sourcePath: null,
+          })
         ).not.toThrow();
       }
     });

--- a/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
+++ b/packages/server/src/__tests__/unit/connector-execution-placement.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  assertChromeNamespaceInstallIsDeviceManifest,
   isDelegatedBrowserAffinityConnector,
   isChromeNamespaceConnectorKey,
   isLegacyNonManifestConnector,
@@ -93,5 +94,48 @@ describe('Chrome-extension connector execution placement', () => {
       })
     ).toBe(true);
     expect(isDelegatedBrowserAffinityConnector('macos', facts)).toBe(false);
+  });
+
+  describe('reserved-namespace install guard', () => {
+    it('admits a chrome.* key that arrives as a device manifest', () => {
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.history',
+          sourcePath: 'device-manifest://chrome-extension/chrome.history@1.0.0',
+        })
+      ).not.toThrow();
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome',
+          sourcePath: 'device-manifest://chrome-extension/chrome@1.0.0',
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects a chrome.* key that ships its own code', () => {
+      // The exact shape that killed the chrome.whatsapp migration: the gateway
+      // withholds the bundle from a "native" connector and the extension has no
+      // handler, so the failure only surfaced as `unknown dispatch` at run time.
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.whatsapp',
+          sourcePath: null,
+        })
+      ).toThrow(/reserved 'chrome\.\*' namespace/);
+      expect(() =>
+        assertChromeNamespaceInstallIsDeviceManifest({
+          connectorKey: 'chrome.whatsapp',
+          sourcePath: 'connectors/whatsapp-web.ts',
+        })
+      ).toThrow(/cannot live there/);
+    });
+
+    it('leaves keys outside the namespace alone', () => {
+      for (const connectorKey of ['whatsapp.web', 'chromecast.demo', 'x', 'linkedin']) {
+        expect(() =>
+          assertChromeNamespaceInstallIsDeviceManifest({ connectorKey, sourcePath: null })
+        ).not.toThrow();
+      }
+    });
   });
 });

--- a/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection-failclosed.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection-failclosed.test.ts
@@ -27,7 +27,11 @@ describe("resolvePinnedSelection — fail closed on total DB failure", () => {
     vi.resetModules();
     // The agents/sandboxes lookup RESOLVES (sbx-b, a repointed provider sandbox),
     // but every conversations query THROWS — codex's exact repro.
-    vi.doMock("../../../db/client.js", () => ({
+    // Spread the real module: vi.doMock is not hoisted or file-scoped, so a
+    // hand-listed shape leaks into later files in the same vitest worker and
+    // surfaces there as `No "<export>" export is defined on the mock`.
+    vi.doMock("../../../db/client.js", async (importOriginal) => ({
+      ...((await importOriginal()) as Record<string, unknown>),
       getDb: () => (strings: TemplateStringsArray, ..._v: unknown[]) => {
         const q = strings.join(" ");
         if (q.includes("FROM agents")) {

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -64,9 +64,16 @@ function mockDeps(opts: MockOpts = {}) {
 	enqueued.length = 0;
 	// The agent-exists probe runs getDb()/createDbClientFromEnv `...` — return a
 	// truthy agent row so assertAgentInOrg passes.
-	vi.doMock("../../db/client.js", () => {
+	// Spread the real module: vi.doMock is not hoisted or file-scoped, so a
+	// hand-listed shape leaks into later files in the same vitest worker and
+	// surfaces there as `No "<export>" export is defined on the mock`.
+	vi.doMock("../../db/client.js", async (importOriginal) => {
 		const tag = () => Promise.resolve([{ ok: 1 }]);
-		return { getDb: () => tag, createDbClientFromEnv: () => tag };
+		return {
+			...((await importOriginal()) as Record<string, unknown>),
+			getDb: () => tag,
+			createDbClientFromEnv: () => tag,
+		};
 	});
 	vi.doMock("../../gateway/services/platform-helpers.js", async () => {
 		const actual = await vi.importActual<

--- a/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
+++ b/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
@@ -65,7 +65,13 @@ beforeEach(() => {
   queries.length = 0;
   storedSourceCode = STORED_SOURCE;
   vi.resetModules();
-  vi.doMock('../../db/client', () => ({ getDb: () => fakeSql }));
+  // Spread the real module: vi.doMock is not hoisted or file-scoped, so a
+  // hand-listed shape leaks into later files in the same vitest worker and
+  // surfaces there as `No "<export>" export is defined on the mock`.
+  vi.doMock('../../db/client', async (importOriginal) => ({
+    ...((await importOriginal()) as Record<string, unknown>),
+    getDb: () => fakeSql,
+  }));
 });
 
 // vitest.config.ts runs this package with `isolate: false` and a single fork,

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -347,7 +347,10 @@ async function upsertConnectorDefinitionRecordsInTransaction(
   // rather than on the compile path a device manifest skips.
   assertChromeNamespaceInstallIsDeviceManifest({
     connectorKey: metadata.key,
+    connectorVersion: metadata.version,
     sourcePath: params.versionRecord.sourcePath,
+    compiledCode: params.versionRecord.compiledCode,
+    sourceCode: params.versionRecord.sourceCode,
   });
 
   await preflightConnectorRelationshipTypes({

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -20,6 +20,7 @@ import {
 } from './connector-compiler';
 import { fetchPublicUrl, isInternalUrl } from '../gateway/proxy/ssrf-guard';
 import type { McpOAuthMetadata } from '../mcp-proxy/types';
+import { assertChromeNamespaceInstallIsDeviceManifest } from './connector-execution-placement';
 import { preflightConnectorRelationshipTypes } from './connector-relationship-declarations';
 import { reconcileConnectorIdentityScopeRegistry } from './connector-identity-scopes';
 import { assertCustomConnectorInstallAllowed } from './custom-connector-cloud-gate';
@@ -341,6 +342,14 @@ async function upsertConnectorDefinitionRecordsInTransaction(
   // on the compile path some of them skip. The preflight validates the local
   // declaration graph and resolves it against the org's own relationship
   // vocabulary before any definition or version row can become active.
+  // The reserved Chrome namespace is an execution declaration, not a name.
+  // Guard it here — the shared writer every install path funnels through —
+  // rather than on the compile path a device manifest skips.
+  assertChromeNamespaceInstallIsDeviceManifest({
+    connectorKey: metadata.key,
+    sourcePath: params.versionRecord.sourcePath,
+  });
+
   await preflightConnectorRelationshipTypes({
     sql,
     organizationId: params.organizationId,

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -39,7 +39,7 @@ export function isChromeNamespaceConnectorKey(connectorKey: string): boolean {
 }
 
 /** Every `chrome.*` artifact identity the extension serves natively. */
-export const DEVICE_MANIFEST_SOURCE_PREFIX = 'device-manifest://chrome-extension/';
+const DEVICE_MANIFEST_SOURCE_PREFIX = 'device-manifest://chrome-extension/';
 
 /**
  * The reserved `chrome.*` namespace declares "the Owletto extension implements
@@ -98,7 +98,7 @@ export function isNativeChromeExtensionConnector(facts: ConnectorExecutionSource
   return (
     facts.manifestBacked &&
     facts.artifactSourcePath ===
-      `device-manifest://chrome-extension/${facts.connectorKey}@${facts.connectorVersion}`
+      `${DEVICE_MANIFEST_SOURCE_PREFIX}${facts.connectorKey}@${facts.connectorVersion}`
   );
 }
 
@@ -130,6 +130,10 @@ export function nativeChromeExtensionConnectorSql<TFragment>(
         )
         AND COALESCE(${refs.manifestBacked}, false)
         AND ${refs.artifactSourcePath} =
+          -- Deliberately a literal, not the DEVICE_MANIFEST_SOURCE_PREFIX constant:
+          -- interpolating here would bind a PARAMETER rather than emit SQL text, and
+          -- concatenating an untyped parameter can fail Postgres type inference. Keep
+          -- it in step with the constant by hand; both sit in this file.
           'device-manifest://chrome-extension/' || ${refs.connectorKey} || '@' || ${refs.connectorVersion}
       )
     )

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -54,13 +54,31 @@ const DEVICE_MANIFEST_SOURCE_PREFIX = 'device-manifest://chrome-extension/';
  * Reject it at install instead of at first run. A connector that needs its own
  * code delivered belongs on an ordinary key with a `chrome-extension` platform
  * pin, which routes it through {@link isDelegatedBrowserAffinityConnector}.
+ *
+ * The admit test is EXACT identity, not a prefix, and it independently requires
+ * that no code was supplied. `resolveConnectorInstallSource` derives a
+ * `source_url` install's path as `url.pathname.replace(/^\//, '')`, so a URL
+ * whose pathname is `/device-manifest://chrome-extension/chrome.x` yields a
+ * sourcePath that satisfies any prefix test — while the same install compiles
+ * the caller's own source. Matching {@link isNativeChromeExtensionConnector}'s
+ * exact `<prefix><key>@<version>` form closes that, and the code check makes
+ * the guard state the real invariant rather than a proxy for it: a device
+ * manifest carries an identity, never a payload.
  */
 export function assertChromeNamespaceInstallIsDeviceManifest(facts: {
   connectorKey: string;
+  connectorVersion: string;
   sourcePath: string | null | undefined;
+  compiledCode?: string | null;
+  sourceCode?: string | null;
 }): void {
   if (!isChromeNamespaceConnectorKey(facts.connectorKey)) return;
-  if (facts.sourcePath?.startsWith(DEVICE_MANIFEST_SOURCE_PREFIX) === true) return;
+  const carriesCode =
+    (facts.compiledCode?.length ?? 0) > 0 || (facts.sourceCode?.length ?? 0) > 0;
+  const isDeviceManifestIdentity =
+    facts.sourcePath ===
+    `${DEVICE_MANIFEST_SOURCE_PREFIX}${facts.connectorKey}@${facts.connectorVersion}`;
+  if (isDeviceManifestIdentity && !carriesCode) return;
   throw new Error(
     `Connector key '${facts.connectorKey}' is in the reserved 'chrome.*' namespace, which is ` +
       'only installable from an Owletto device manifest. A connector that ships its own code ' +

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -38,6 +38,38 @@ export function isChromeNamespaceConnectorKey(connectorKey: string): boolean {
   return connectorKey === 'chrome' || connectorKey.startsWith('chrome.');
 }
 
+/** Every `chrome.*` artifact identity the extension serves natively. */
+export const DEVICE_MANIFEST_SOURCE_PREFIX = 'device-manifest://chrome-extension/';
+
+/**
+ * The reserved `chrome.*` namespace declares "the Owletto extension implements
+ * this natively", and {@link isNativeChromeExtensionConnector} short-circuits
+ * on it. A key installed there with supplied code is therefore unreachable in
+ * both directions: the gateway withholds `compiled_code` from a native
+ * connector, and the extension has no handler for a key it does not implement,
+ * so every run dies with
+ *
+ *   Owletto for Chrome: unknown dispatch (connector='chrome.whatsapp', ...)
+ *
+ * Reject it at install instead of at first run. A connector that needs its own
+ * code delivered belongs on an ordinary key with a `chrome-extension` platform
+ * pin, which routes it through {@link isDelegatedBrowserAffinityConnector}.
+ */
+export function assertChromeNamespaceInstallIsDeviceManifest(facts: {
+  connectorKey: string;
+  sourcePath: string | null | undefined;
+}): void {
+  if (!isChromeNamespaceConnectorKey(facts.connectorKey)) return;
+  if (facts.sourcePath?.startsWith(DEVICE_MANIFEST_SOURCE_PREFIX) === true) return;
+  throw new Error(
+    `Connector key '${facts.connectorKey}' is in the reserved 'chrome.*' namespace, which is ` +
+      'only installable from an Owletto device manifest. A connector that ships its own code ' +
+      'cannot live there: the gateway withholds the bundle from a native connector and the ' +
+      'extension cannot dispatch a key it does not implement. Use a key outside the namespace ' +
+      'and pin the connection to a chrome-extension device for browser access.'
+  );
+}
+
 export function isLegacyNonManifestConnector(facts: {
   connectorKey: string;
   manifestBacked: boolean;


### PR DESCRIPTION
## Summary
- A connector key in the reserved `chrome.*` namespace declares that the Owletto extension implements it natively — `isNativeChromeExtensionConnector` short-circuits on the namespace alone. Installing supplied code there yields a connector unreachable in both directions: the gateway withholds `compiled_code` from a "native" connector, and the extension has no handler for a key it does not implement.
- This is not hypothetical. On 2026-08-21/22 a WhatsApp Web browser integration was spiked end to end — a real E2E, a reload-survival E2E, and repeated message-parity comparisons — and it worked. When it came to shipping, packaging it as a `chrome.whatsapp` connector hit this wall, recorded on the feed as the only feedback the platform gives:

  ```
  Owletto for Chrome: unknown dispatch (connector='chrome.whatsapp',
  feed_key='messages', action_key='undefined'). Known connectors: chrome,
  chrome.history, chrome.bookmarks, chrome.downloads
  ```

  The runtime shipped inside the extension bundle instead. The trap did not kill the work — it silently diverted where the code landed, which is the more expensive failure: 5,463 lines of site-specific code now live in a generic, Web-Store-reviewed extension.

- Guard it at install, in the shared definition writer every path funnels through, with the error naming the correct alternative: an ordinary key plus a `chrome-extension` platform pin, which routes through `isDelegatedBrowserAffinityConnector` and *does* receive its bundle. A `chrome.*` key stays installable from an Owletto device manifest — the only source that legitimately declares native execution.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test packages/server/src/__tests__/unit/connector-execution-placement.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

Red — guard body neutralised (the behaviour before this change):

```
(fail) Chrome-extension connector execution placement > reserved-namespace install guard > rejects a chrome.* key that ships its own code
 7 pass
 1 fail
```

Green — guard restored:

```
 8 pass
 0 fail
 30 expect() calls
```

`make pre-pr`:

```
check-exposed-surface-naming: clean — Automation is canonical across live tracked files.
✓ gateway-llm gate: 743 packages/server/src files contain no unsuppressed one-off LLM client
✓ entity-write funnel gate: 1085 runtime package source files scanned; 0 pinned bypasses
✅ pre-pr gates clean.
```

## Notes
Guard only — no behaviour change for any connector that installs today (no bundled connector uses a `chrome.*` key; every one comes from a device manifest, which the guard admits).

First of three steps in retiring the extension-native WhatsApp runtime. The follow-ups: commit a `whatsapp.web` connector on an ordinary key that drives the generic `chrome` ops, then delete the 5,463 extension lines, the `browser.whatsapp` capability, `LEGACY_NATIVE_CHROME_EXTENSION_CONNECTORS`, and the branching it forces through 7 server files. The mechanism is proven — the extension's 1,444-line MAIN-world adapter installs and answers its own RPC through the generic `evaluate` op with no extension-native code path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved `chrome.*` connector entries are now restricted to valid, metadata-only device-manifest artifacts.
  * Invalid compiled, source, forged, or mismatched artifacts are rejected without being saved.
  * Improved test reliability by preventing database mocks from affecting other tests.

* **Tests**
  * Added coverage for valid device manifests, invalid payloads, identity mismatches, and non-`chrome.*` connector keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->