### PR TITLE
chore(review): default reviewer models to fable and gpt-5.6-sol xhigh, drop the pi reviewer

### DIFF
--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -11,13 +11,11 @@ nothing runs locally besides the reviewer, reviews of different commits
 execute concurrently with no host-wide lock; a duplicate run of the same
 commit is refused so the `pi-review` status has exactly one owner per sha. Codex harnesses use Claude; other
 environments, including Claude Code, use Codex. Set
-`REVIEWER_CLI=codex|claude|pi` to override automatic selection (`pi` is
-never chosen by `auto`; it is the explicit third reviewer for when the
-codex/claude CLIs are out of quota or unauthenticated). The script
-also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`,
-`CODEX_REVIEW_MODEL`, `PI_REVIEW_MODEL` (default `gpt-5.6-terra`; the
-ChatGPT account backend rejects `gpt-5.6-sol`), and
-`PI_REVIEW_PROVIDER` overrides. Claude reviews fail closed unless
+`REVIEWER_CLI=codex|claude` to override automatic selection. The script
+also accepts `CLAUDE_REVIEW_MODEL` (default `fable`),
+`CLAUDE_REVIEW_EFFORT` (default `high`), and `CODEX_REVIEW_MODEL`
+(default `gpt-5.6-sol` at `model_reasoning_effort=xhigh`). Claude reviews
+fail closed unless
 `CLAUDE_REVIEW_MODEL` is `fable`, `opus`, or a full `claude-opus-*` model ID;
 Sonnet, Haiku, empty, and arbitrary model values are rejected before the
 review starts. It posts a `pi-review` commit status

--- a/scripts/lib/__tests__/review-cache.test.sh
+++ b/scripts/lib/__tests__/review-cache.test.sh
@@ -17,8 +17,7 @@ trap 'rm -rf "$cache_root"' EXIT
 export REVIEW_CACHE_ROOT_FOR_TESTS="$cache_root"
 export REVIEWER_CLI_SELECTED=codex
 export CLAUDE_REVIEW_MODEL=fable CLAUDE_REVIEW_EFFORT=high
-export CODEX_REVIEW_MODEL=""
-export PI_REVIEW_MODEL=gpt-5.6-terra PI_REVIEW_PROVIDER=openai-codex
+export CODEX_REVIEW_MODEL=gpt-5.6-sol CODEX_REVIEW_EFFORT=xhigh
 
 sig="$(review_reviewer_signature)"
 [ -n "$sig" ] || fail "empty reviewer signature"
@@ -33,7 +32,7 @@ hit="$(review_cache_lookup "hash-a" "$sig")"
 [ "$(jq -r .diff_hash "$hit")" = "hash-a" ] || fail "cached diff_hash not stored"
 
 # different reviewer signature → miss (stale verdict under a new reviewer)
-if review_cache_lookup "hash-a" "claude|fable|low||gpt-5.6-terra|openai-codex" >/dev/null 2>&1; then
+if review_cache_lookup "hash-a" "claude|fable|low|gpt-5.6-sol|xhigh" >/dev/null 2>&1; then
   fail "different reviewer signature unexpectedly hit"
 fi
 
@@ -42,10 +41,20 @@ if review_cache_lookup "hash-b" "$sig" >/dev/null 2>&1; then
   fail "different diff hash unexpectedly hit"
 fi
 
-# a changed signature must invalidate: same verdict under pi vs codex
+# a changed signature must invalidate: same verdict under claude vs codex
 review_cache_store "hash-c" "$sig" "origin/main" "cafe" "$verdict"
-if review_cache_lookup "hash-c" "pi|fable|high||gpt-5.6-terra|openai-codex" >/dev/null 2>&1; then
+if review_cache_lookup "hash-c" "claude|fable|high|gpt-5.6-sol|xhigh" >/dev/null 2>&1; then
   fail "cross-reviewer verdict reused"
+fi
+
+# a changed codex effort must invalidate: effort is part of the signature
+sig_low_effort="$(CODEX_REVIEW_EFFORT=high review_reviewer_signature)"
+if [ "$sig_low_effort" = "$sig" ]; then
+  fail "codex effort not included in the reviewer signature"
+fi
+review_cache_store "hash-d" "$sig_low_effort" "origin/main" "cafe" "$verdict"
+if review_cache_lookup "hash-d" "$sig" >/dev/null 2>&1; then
+  fail "verdict cached under a different codex effort was reused"
 fi
 
 # review_diff_hash is stable for identical content and differs on change

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -37,8 +37,10 @@ assert_auto_selected codex CODEX_CI=0
   fail "codex override was not honored"
 [ "$(review_select_reviewer claude)" = "claude" ] ||
   fail "claude override was not honored"
-[ "$(review_select_reviewer pi)" = "pi" ] ||
-  fail "pi override was not honored"
+
+if review_select_reviewer pi >/dev/null 2>&1; then
+  fail "pi reviewer must not be selectable for the review gate"
+fi
 
 if review_select_reviewer invalid >/dev/null 2>&1; then
   fail "invalid reviewer override unexpectedly succeeded"
@@ -74,13 +76,19 @@ case "$failure_message" in
   *) fail "fail-closed message does not explain fallback policy" ;;
 esac
 case "$failure_message" in
-  *"REVIEWER_CLI=claude|codex|pi"*) ;;
+  *"REVIEWER_CLI=claude|codex"*) ;;
   *) fail "fail-closed message does not explain the explicit override" ;;
 esac
 
 review_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/review.sh"
-grep -Fq 'CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"' "$review_script" ||
-  fail "Claude reviewer must default to the Opus model"
+grep -Fq 'CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"' "$review_script" ||
+  fail "Claude reviewer must default to the Fable model"
+
+grep -Fq 'CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-sol}"' "$review_script" ||
+  fail "Codex reviewer must default to the gpt-5.6-sol model"
+
+grep -Fq 'CODEX_REVIEW_EFFORT="${CODEX_REVIEW_EFFORT:-xhigh}"' "$review_script" ||
+  fail "Codex reviewer must default to xhigh reasoning effort"
 
 grep -Fq 'review_validate_claude_model "$CLAUDE_REVIEW_MODEL"' "$review_script" ||
   fail "review.sh must fail closed on disallowed Claude reviewer models"
@@ -92,20 +100,11 @@ schema_arg_count="$(grep -F -- '--json-schema "$(cat "$SCHEMA_FILE")"' "$review_
 grep -Fq '2> "$diagnostic_file"' "$review_script" ||
   fail "inline Codex reviewer stderr must be retained for fail-closed diagnostics"
 
-# pi reviewer arm contract: explicit opt-in invocation, ephemeral session, and a
-# read-only-shaped tool allowlist (read,bash — no edit/write). The allowlist is
-# not an OS sandbox; that trust parity with the claude arm is documented in
-# review.sh itself.
-grep -Fq 'PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"' "$review_script" ||
-  fail "pi reviewer must default to the gpt-5.6-terra model"
-grep -Fq 'pi -p' "$review_script" ||
-  fail "review.sh must keep its pi invocation arm"
-grep -Fq -- '--no-session' "$review_script" ||
-  fail "pi reviewer arm must run an ephemeral session"
-grep -Fq -- '--tools "read,bash"' "$review_script" ||
-  fail "pi reviewer arm must keep its read-only-shaped tool allowlist"
-if grep -E -- 'pi[^|]*--tools [^[:space:]]*(edit|write)' "$review_script"; then
-  fail "pi reviewer arm must not carry edit/write tools"
+# pi was removed from the review gate: no pi invocation or pi-specific model
+# knobs may reappear in review.sh. The `pi-review` STATUS CONTEXT name is
+# unrelated — branch protection requires that exact status label.
+if grep -Eq 'pi -p|PI_REVIEW_MODEL|PI_REVIEW_PROVIDER' "$review_script"; then
+  fail "pi reviewer must not reappear in review.sh"
 fi
 
 if grep -Eiq 'herdr|CLAUDE_REVIEW_HERDR' "$review_script"; then
@@ -136,8 +135,9 @@ grep -Fq 'claude -p' "$review_fix_script" ||
   fail "review-fix.sh must keep its claude invocation arm"
 grep -Eq -- '--tools [^[:space:]]*Edit[^[:space:]]*Write' "$review_fix_script" ||
   fail "review-fix.sh claude arm must carry the Edit/Write tools that make it a fixer"
-grep -Fq -- '--tools "read,bash,edit,write"' "$review_fix_script" ||
-  fail "review-fix.sh pi arm must carry the edit/write tools that make it a fixer"
+if grep -Eq 'pi -p|PI_REVIEW_MODEL|PI_REVIEW_PROVIDER' "$review_fix_script"; then
+  fail "pi reviewer must not reappear in review-fix.sh"
+fi
 if grep -Fq 'command -v codex >/dev/null' "$review_fix_script"; then
   fail "review-fix.sh must not gate every run on codex being installed"
 fi

--- a/scripts/lib/review-cache.sh
+++ b/scripts/lib/review-cache.sh
@@ -34,13 +34,12 @@ review_diff_hash() {
 # A verdict is only reusable for the same reviewer identity. Any knob that can
 # change the verdict — CLI, model, effort, provider — must be in the signature.
 review_reviewer_signature() {
-  printf '%s|%s|%s|%s|%s|%s\n' \
+  printf '%s|%s|%s|%s|%s\n' \
     "${REVIEWER_CLI_SELECTED:-}" \
     "${CLAUDE_REVIEW_MODEL:-}" \
     "${CLAUDE_REVIEW_EFFORT:-}" \
     "${CODEX_REVIEW_MODEL:-}" \
-    "${PI_REVIEW_MODEL:-}" \
-    "${PI_REVIEW_PROVIDER:-}"
+    "${CODEX_REVIEW_EFFORT:-}"
 }
 
 # review_cache_lookup <hash> <signature>

--- a/scripts/lib/review-reviewer.sh
+++ b/scripts/lib/review-reviewer.sh
@@ -15,11 +15,11 @@ review_select_reviewer() {
         printf 'codex\n'
       fi
       ;;
-    codex|claude|pi)
+    codex|claude)
       printf '%s\n' "$1"
       ;;
     *)
-      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, claude, or pi)" >&2
+      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, or claude)" >&2
       return 2
       ;;
   esac
@@ -43,6 +43,6 @@ review_should_retry_inline() {
 review_fail_closed_message() {
   local reviewer="$1"
   local detail="$2"
-  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex|pi only to explicitly select the intended independent reviewer.\n" \
+  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex only to explicitly select the intended independent reviewer.\n" \
     "$reviewer" "$detail"
 }

--- a/scripts/review-fix.sh
+++ b/scripts/review-fix.sh
@@ -5,7 +5,7 @@
 # nothing. The driving agent inspects the edits (shown at the end), commits,
 # then runs `make review` once on the settled HEAD.
 #
-# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude|pi. This
+# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude. This
 # step is mandated by AGENTS.md but is not a gate: unlike review.sh it posts no
 # status, so a reviewer outage here silently skips the fixer instead of failing
 # a check. Being hard-wired to one CLI therefore costs a whole quality pass
@@ -69,10 +69,10 @@ if [ "$REVIEWER_MODE" != "full" ] \
 fi
 
 FIXER_CLI="$(review_select_reviewer "${REVIEWER_CLI:-auto}")"
-CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
-PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
-PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-sol}"
+CODEX_REVIEW_EFFORT="${CODEX_REVIEW_EFFORT:-xhigh}"
 if [ "$FIXER_CLI" = "claude" ]; then
   review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
 fi
@@ -92,6 +92,10 @@ case "$FIXER_CLI" in
     if [ -n "${CODEX_REVIEW_MODEL:-}" ]; then
       CODEX_ARGS+=(--model "$CODEX_REVIEW_MODEL")
     fi
+    if [ -n "${CODEX_REVIEW_EFFORT:-}" ]; then
+      # codex -c values are TOML, so the string needs embedded quotes.
+      CODEX_ARGS+=(-c "model_reasoning_effort=\"$CODEX_REVIEW_EFFORT\"")
+    fi
     env BASE_BRANCH="$BASE_BRANCH" "${CODEX_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > /dev/null 2> "$LAST_MSG_FILE.stderr"
     FIXER_EXIT=$?
     ;;
@@ -108,20 +112,6 @@ case "$FIXER_CLI" in
         --no-session-persistence \
         --tools Bash,Read,Grep,LS,Edit,Write \
         --permission-mode bypassPermissions < /dev/null > "$LAST_MSG_FILE"
-    FIXER_EXIT=$?
-    ;;
-  pi)
-    # Same shape as the claude arm: stdout is the summary, and edit/write are
-    # the point of the fixer pass.
-    PI_ARGS=(pi -p --no-session --tools "read,bash,edit,write")
-    if [ -n "${PI_REVIEW_PROVIDER:-}" ]; then
-      PI_ARGS+=(--provider "$PI_REVIEW_PROVIDER")
-    fi
-    if [ -n "${PI_REVIEW_MODEL:-}" ]; then
-      PI_ARGS+=(--model "$PI_REVIEW_MODEL")
-    fi
-    env BASE_BRANCH="$BASE_BRANCH" \
-      "${PI_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > "$LAST_MSG_FILE"
     FIXER_EXIT=$?
     ;;
 esac

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -79,19 +79,13 @@ elif git show-ref --verify --quiet refs/remotes/origin/main; then
 else
   BASE_BRANCH="main"
 fi
-CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
-CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
-# `pi` is the explicit third reviewer (never chosen by `auto`): useful when the
-# codex/claude CLIs are out of quota or unauthenticated. Auth comes from the
-# operator's pi provider accounts; PI_REVIEW_PROVIDER defaults to the
-# operator's ChatGPT-backed openai-codex accounts. Without an explicit
-# provider, pi's own model-pattern resolution can land on a provider that has
-# no credentials. Model note: the ChatGPT account backend rejects gpt-5.6-sol
-# ("not supported when using Codex with a ChatGPT account") while it accepts
-# gpt-5.6-terra, so terra is the default; override with PI_REVIEW_MODEL.
-PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
-PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
+# Codex defaults assume API-key auth: the ChatGPT account backend rejects
+# gpt-5.6-sol ("not supported when using Codex with a ChatGPT account"), so
+# ChatGPT-backed operators must override CODEX_REVIEW_MODEL.
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-sol}"
+CODEX_REVIEW_EFFORT="${CODEX_REVIEW_EFFORT:-xhigh}"
 REVIEWER_CLI="${REVIEWER_CLI:-auto}"
 # light (default): skip the cross-harness reviewer for small safe-class diffs
 # (docs/renames/generated/root bun.lock/snapshots/additive-tests, exact model
@@ -267,38 +261,15 @@ run_reviewer_inline() {
       if [ -n "$CODEX_REVIEW_MODEL" ]; then
         codex_args+=(--model "$CODEX_REVIEW_MODEL")
       fi
+      if [ -n "$CODEX_REVIEW_EFFORT" ]; then
+        # codex -c values are TOML, so the string needs embedded quotes.
+        codex_args+=(-c "model_reasoning_effort=\"$CODEX_REVIEW_EFFORT\"")
+      fi
       run_review_child env \
         BASE_BRANCH="$BASE_BRANCH" \
         HEAD_SHA="$HEAD_SHA" \
         CI_CHECKS_FILE="$CI_CHECKS_FILE" \
         "${codex_args[@]}" "$(cat "$prompt_file")" < /dev/null > /dev/null 2> "$diagnostic_file"
-      ;;
-    pi)
-      # Read-only exploratory parity with the codex arm: read+bash let the
-      # reviewer inspect the tree and run targeted suites, with no edit tools.
-      # NOTE: pi's tool allowlist is not an OS-enforced sandbox — bash can
-      # still mutate the worktree. That is the same trust model as the claude
-      # arm above (Bash without Edit/Write); the verdict's value (running the
-      # changed-path suites) requires shell access, and the commit lock plus
-      # HEAD-is-current re-assertions contain a bad actor's blast radius to
-      # this worktree's status posts.
-      # --no-session keeps an ephemeral verdict run out of session history.
-      local pi_args=(
-        pi -p
-        --no-session
-        --tools "read,bash"
-      )
-      if [ -n "$PI_REVIEW_PROVIDER" ]; then
-        pi_args+=(--provider "$PI_REVIEW_PROVIDER")
-      fi
-      if [ -n "$PI_REVIEW_MODEL" ]; then
-        pi_args+=(--model "$PI_REVIEW_MODEL")
-      fi
-      run_review_child env \
-        BASE_BRANCH="$BASE_BRANCH" \
-        HEAD_SHA="$HEAD_SHA" \
-        CI_CHECKS_FILE="$CI_CHECKS_FILE" \
-        "${pi_args[@]}" "$(cat "$prompt_file")" < /dev/null > "$raw_file" 2> "$diagnostic_file"
       ;;
   esac
   REVIEWER_EXIT=$?

--- a/scripts/ui-review-agent.sh
+++ b/scripts/ui-review-agent.sh
@@ -25,9 +25,10 @@ CONTEXT_FILE="${1:?usage: ui-review-agent.sh <context-file> <out-file>}"
 OUT_FILE="${2:?usage: ui-review-agent.sh <context-file> <out-file>}"
 
 REVIEWER_CLI="${REVIEWER_CLI:-auto}"
-CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
-CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-sol}"
+CODEX_REVIEW_EFFORT="${CODEX_REVIEW_EFFORT:-xhigh}"
 SCHEMA_FILE="$SCRIPT_DIR/../prompts/ui-review-agent-output-schema.json"
 PROMPT_FILE="$SCRIPT_DIR/../prompts/ui-review-agent-prompt.md"
 SCHEMA_JQ='(.has_ui_surface | type == "boolean") and (.reasoning | type == "string" and length > 0) and (.verification_summary | type == "string" and length > 0)'
@@ -68,13 +69,8 @@ case "$REVIEWER_CLI_SELECTED" in
   codex)
     codex_args=(codex exec --sandbox read-only --output-schema "$SCHEMA_FILE" --output-last-message "$RAW_FILE" --ephemeral)
     [ -n "$CODEX_REVIEW_MODEL" ] && codex_args+=(--model "$CODEX_REVIEW_MODEL")
+    [ -n "$CODEX_REVIEW_EFFORT" ] && codex_args+=(-c "model_reasoning_effort=\"$CODEX_REVIEW_EFFORT\"")
     "${codex_args[@]}" "$(cat "$FULL_PROMPT_FILE")" < /dev/null > /dev/null 2> "$DIAGNOSTIC_FILE"
-    ;;
-  pi)
-    pi_args=(pi -p --no-session --tools "read")
-    [ -n "${PI_REVIEW_PROVIDER:-}" ] && pi_args+=(--provider "$PI_REVIEW_PROVIDER")
-    [ -n "${PI_REVIEW_MODEL:-}" ] && pi_args+=(--model "$PI_REVIEW_MODEL")
-    "${pi_args[@]}" "$(cat "$FULL_PROMPT_FILE")" < /dev/null > "$RAW_FILE" 2> "$DIAGNOSTIC_FILE"
     ;;
 esac
 REVIEWER_EXIT=$?


### PR DESCRIPTION
## Summary
- Reviewer model defaults are now fable (claude arm, effort high) and gpt-5.6-sol at model_reasoning_effort=xhigh (codex arm), applied consistently across review.sh, review-fix.sh, and ui-review-agent.sh
- The pi CLI is removed from the review gate entirely: review_select_reviewer accepts only auto|codex|claude, and the pi invocation arms + PI_REVIEW_MODEL/PI_REVIEW_PROVIDER knobs are deleted from all three scripts
- The required `pi-review` commit-status label, PI_REVIEW_STATUS_CONTEXT, and the PI_REVIEW_MIN_BUG_FREE/MAX_SLOP/MIN_SIMPLICITY verdict gates are unchanged (branch protection requires the exact status name)
- review-cache reviewer signature now includes the codex effort, so cached verdicts invalidate on an effort change

## Test plan
- [x] Tests run: `bash scripts/lib/__tests__/review-reviewer.test.sh` and `bash scripts/lib/__tests__/review-cache.test.sh` — both green; `bun test scripts/__tests__/review-output-schema.test.ts scripts/__tests__/review-prompt-env-blockers.test.ts` — 20 pass
- [x] `make pre-pr` clean (build, typecheck, knip, biome, naming gates)
- New test coverage: selector rejects `REVIEWER_CLI=pi`; absence assertions keep pi out of review.sh/review-fix.sh; cache signature invalidates on codex effort change

## Notes
- Live codex check of `-m gpt-5.6-sol -c model_reasoning_effort="xhigh"` was blocked by account usage limit (resets Sep 7); the flag quoting follows codex's documented TOML `(key="value")` style
- Intended file list = `git diff --name-only origin/main...HEAD` (8 files, verified)