### PR TITLE
feat(sandbox): public dev previews with the seat claimed and worker auth closed

### DIFF
--- a/scripts/__tests__/sandbox.test.ts
+++ b/scripts/__tests__/sandbox.test.ts
@@ -13,13 +13,24 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   HOST_ONLY_ENV_KEYS,
+  SANDBOX_CONTROLLED_ENV_KEYS,
   authenticatedUrl,
+  bootEnv,
   buildTarball,
   credentialsFromConfig,
   ExpiredCliTokenError,
+  generateBearerToken,
+  generatePassword,
+  interpretSignUp,
   isAppleDouble,
+  loginLink,
+  previewUrlFor,
+  resolveOwnerEmail,
   sandboxName,
   sanitizedEnv,
+  sessionTokenFrom,
+  signInScript,
+  signUpScript,
 } from "../sandbox";
 
 const temporaryDirectories: string[] = [];
@@ -160,8 +171,202 @@ describe("sanitizedEnv", () => {
     expect(HOST_ONLY_ENV_KEYS).toContain("DATABASE_URL");
   });
 
+  test("drops every sandbox-controlled key", () => {
+    // dev-native.sh preserves only a fixed preset list across `source .env`,
+    // so any of these left in the file would override the boot env and quietly
+    // reopen sign-up or the anonymous worker lane on a public preview.
+    const root = temporaryDirectory("sandbox-env-owned-");
+    writeFileSync(
+      join(root, ".env"),
+      "LOBU_SINGLE_USER=0\nWORKER_API_TOKEN=host-token\nLOBU_DEV_DATA_ROOT=/tmp/elsewhere\nKEEP=yes\n"
+    );
+    const out = sanitizedEnv(root) ?? "";
+    expect(out).toContain("KEEP=yes");
+    for (const key of SANDBOX_CONTROLLED_ENV_KEYS) {
+      expect(out).not.toContain(`${key}=`);
+    }
+  });
+
   test("returns null when the worktree has no .env", () => {
     expect(sanitizedEnv(temporaryDirectory("sandbox-noenv-"))).toBeNull();
+  });
+});
+
+describe("bootEnv", () => {
+  const env = () =>
+    bootEnv({
+      previewUrl: "https://p.example",
+      workerApiToken: "tok-123",
+      embeddingsServiceToken: "emb-456",
+    });
+
+  test("closes sign-up and the anonymous worker lane", () => {
+    expect(env()).toContain("LOBU_SINGLE_USER='1'");
+    expect(env()).toContain("WORKER_API_TOKEN='tok-123'");
+  });
+
+  test("authenticates the embeddings sidecar", () => {
+    // Its bearer check is skipped entirely while the token is unset, and the
+    // preview proxy exposes the sidecar's port too.
+    expect(env()).toContain("EMBEDDINGS_SERVICE_TOKEN='emb-456'");
+  });
+
+  test("points the database at a root outside the Vite serving root", () => {
+    // The dev server serves /@fs/<workspace>/…, and the cluster holds raw
+    // session tokens, so the data root must not sit under the checkout.
+    const value = env().match(/DATABASE_URL='([^']+)'/)?.[1] ?? "";
+    expect(value.startsWith("file:///")).toBe(true);
+    expect(value).not.toContain("/workspace/lobu/");
+  });
+
+  test("binds the gateway to the preview origin", () => {
+    expect(env()).toContain("PUBLIC_GATEWAY_URL='https://p.example/lobu'");
+    expect(env()).toContain("HOST='0.0.0.0'");
+    expect(env()).toContain("PORT='8787'");
+  });
+
+  test("refuses a value that would break out of its shell quotes", () => {
+    expect(() =>
+      bootEnv({
+        previewUrl: "https://p.example",
+        workerApiToken: "a'b",
+        embeddingsServiceToken: "emb",
+      })
+    ).toThrow(/contains a quote/);
+  });
+});
+
+describe("generateBearerToken", () => {
+  test("is url-safe and long enough to be unguessable", () => {
+    const token = generateBearerToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(token).not.toBe(generateBearerToken());
+  });
+});
+
+describe("resolveOwnerEmail", () => {
+  test("prefers the explicit override", () => {
+    expect(resolveOwnerEmail("me@example.com", "git@example.com")).toBe(
+      "me@example.com"
+    );
+  });
+
+  test("falls back to the worktree git identity", () => {
+    expect(resolveOwnerEmail(undefined, " git@example.com ")).toBe(
+      "git@example.com"
+    );
+  });
+
+  test("throws rather than inventing an owner", () => {
+    // A hardcoded address would be personal state in shipping code.
+    expect(() => resolveOwnerEmail(undefined, undefined)).toThrow(
+      /SANDBOX_OWNER_EMAIL/
+    );
+    expect(() => resolveOwnerEmail(undefined, "not-an-email")).toThrow(
+      /SANDBOX_OWNER_EMAIL/
+    );
+  });
+});
+
+describe("generatePassword", () => {
+  test("is url-safe and unique per call", () => {
+    expect(generatePassword()).toMatch(/^[A-Za-z0-9_-]{24}$/);
+    expect(generatePassword()).not.toBe(generatePassword());
+  });
+});
+
+describe("signUpScript", () => {
+  test("never puts the credentials on the shell command line", () => {
+    const script = signUpScript("me@example.com", "p'a\"ss", "Owner");
+    expect(script).not.toContain("me@example.com");
+    expect(script).not.toContain("p'a");
+    expect(script).toContain("base64 -d");
+    expect(script).toContain("/api/auth/sign-up/email");
+  });
+});
+
+describe("signInScript", () => {
+  test("never puts the credentials on the shell command line", () => {
+    const script = signInScript("me@example.com", "p'a\"ss");
+    expect(script).not.toContain("me@example.com");
+    expect(script).not.toContain("p'a");
+    expect(script).toContain("base64 -d");
+    expect(script).toContain("/api/auth/sign-in/email");
+  });
+});
+
+describe("interpretSignUp", () => {
+  test("2xx means the seat was claimed", () => {
+    expect(interpretSignUp('200\n{"token":"t"}')).toEqual({
+      status: "claimed",
+    });
+  });
+
+  test("the hook error code is what proves the seat is taken", () => {
+    expect(
+      interpretSignUp(
+        '403\n{"code":"SIGN_UP_DISABLED_IN_SINGLE_USER_MODE","message":"nope"}'
+      )
+    ).toEqual({ status: "seat_taken" });
+  });
+
+  test("a bare 403 is not proof that sign-up is closed", () => {
+    // Treating any 403 as "closed" would let an unrelated denial authorise
+    // making the preview public.
+    expect(interpretSignUp('403\n{"code":"RATE_LIMITED"}').status).toBe(
+      "error"
+    );
+  });
+
+  test("reports a transport failure rather than guessing", () => {
+    expect(interpretSignUp("").status).toBe("error");
+    expect(interpretSignUp("000\n").status).toBe("error");
+  });
+});
+
+describe("sessionTokenFrom", () => {
+  test("prefers the token in the response body", () => {
+    expect(sessionTokenFrom('{"token":"abc123","user":{}}')).toBe("abc123");
+  });
+
+  test("falls back to the token half of the signed cookie", () => {
+    expect(
+      sessionTokenFrom(
+        "HTTP/1.1 200 OK\nset-cookie: better-auth.session_token=abc123.SIGNATURE; Path=/; HttpOnly\n"
+      )
+    ).toBe("abc123");
+  });
+
+  test("returns undefined when there is no token at all", () => {
+    expect(sessionTokenFrom('{"error":"nope"}')).toBeUndefined();
+  });
+});
+
+describe("loginLink", () => {
+  test("hands the token to the exchange endpoint", () => {
+    expect(loginLink("https://p.example", "tok/en+value")).toBe(
+      "https://p.example/api/exchange-token?token=tok%2Fen%2Bvalue&next=%2F"
+    );
+  });
+
+  test("does not double the slash on a trailing-slash url", () => {
+    expect(loginLink("https://p.example/", "t")).toContain(
+      "https://p.example/api/exchange-token"
+    );
+  });
+});
+
+describe("previewUrlFor", () => {
+  test("a public preview needs no key in the url", () => {
+    expect(previewUrlFor(true, "https://p.example", "tok")).toBe(
+      "https://p.example"
+    );
+  });
+
+  test("a private preview still gets the key", () => {
+    expect(previewUrlFor(false, "https://p.example", "tok")).toBe(
+      "https://p.example?DAYTONA_SANDBOX_AUTH_KEY=tok"
+    );
   });
 });
 

--- a/scripts/__tests__/sandbox.test.ts
+++ b/scripts/__tests__/sandbox.test.ts
@@ -171,14 +171,28 @@ describe("sanitizedEnv", () => {
     expect(HOST_ONLY_ENV_KEYS).toContain("DATABASE_URL");
   });
 
+  test("names every key the boot env owns", () => {
+    // The generated fixture below proves each listed key is stripped, but it
+    // shrinks with the list, so it cannot notice a key going missing. These
+    // four are what keep a public preview shut, so name them outright.
+    expect([...SANDBOX_CONTROLLED_ENV_KEYS].sort()).toEqual([
+      "EMBEDDINGS_SERVICE_TOKEN",
+      "LOBU_DEV_DATA_ROOT",
+      "LOBU_SINGLE_USER",
+      "WORKER_API_TOKEN",
+    ]);
+  });
+
   test("drops every sandbox-controlled key", () => {
     // dev-native.sh preserves only a fixed preset list across `source .env`,
     // so any of these left in the file would override the boot env and quietly
     // reopen sign-up or the anonymous worker lane on a public preview.
     const root = temporaryDirectory("sandbox-env-owned-");
+    // Planted from the constant itself so a key added to the strip list can
+    // never sit unexercised here and pass the loop below vacuously.
     writeFileSync(
       join(root, ".env"),
-      "LOBU_SINGLE_USER=0\nWORKER_API_TOKEN=host-token\nLOBU_DEV_DATA_ROOT=/tmp/elsewhere\nKEEP=yes\n"
+      `${SANDBOX_CONTROLLED_ENV_KEYS.map((k) => `${k}=host-value`).join("\n")}\nKEEP=yes\n`
     );
     const out = sanitizedEnv(root) ?? "";
     expect(out).toContain("KEEP=yes");

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -171,7 +171,7 @@ if [ "$_LOBU_EMBEDDED" = 1 ]; then
   echo "→ embedded Postgres   cluster: $DEV_DATA_ROOT/.lobu/pgdata"
   echo "→ server on http://${HOST}:${PORT}   (Vite HMR in-process)"
   lobu_dev_print_app_url
-  echo "→ first run seeds a web login: dev@lobu.local / lobudev123   (org 'dev')"
+  echo "→ first run: sign up in the app to claim its single account (LOBU_SINGLE_USER=1)"
   echo "→ then run \`lobu apply\` from a project dir to sync its lobu.config.ts"
   echo ""
   if [[ "${OPEN:-}" == "1" || "${OPEN:-}" == "true" ]]; then

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -782,12 +782,12 @@ async function claimSeat(sandbox: Sandbox, root: string): Promise<ClaimedSeat> {
     created_at: new Date().toISOString(),
   };
   await writeSeat(sandbox, seat);
-  // codeql[js/clear-text-logging]: printing the generated seat password once to
-  // the operator's own terminal is the point — it is the only moment the value
-  // is shown, it was minted here rather than taken from a store, and the same
-  // value is written to SEAT_FILE inside the developer's own sandbox anyway.
-  console.log(`\n  seat:  ${email} / ${password}`);
-  console.log(`         (shown once; kept in the sandbox at ${SEAT_FILE})`);
+  // The password is deliberately not printed. The login link below signs the
+  // operator in without it, and keeping it out of terminal scrollback means the
+  // only copy lives in SEAT_FILE inside the sandbox (`cat` it if you ever need
+  // to type the password by hand).
+  console.log(`\n  seat:  ${email}`);
+  console.log(`         (password kept in the sandbox at ${SEAT_FILE})`);
   return { seat, sessionToken: await signIn(sandbox, seat) };
 }
 

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -22,7 +22,7 @@
  *   bun scripts/sandbox.ts ls     every lobu sandbox + quota headroom
  */
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdtempSync,
@@ -45,6 +45,17 @@ const DISK_GB = Number(process.env.SANDBOX_DISK_GB ?? 10);
 const TOTAL_MEMORY_CAP_GB = 10; // org tier limit; the API enforces it too
 const APP_PORT = 8787; // fixed: a sandbox has no neighbours to collide with
 const WORKSPACE = "/workspace/lobu";
+/**
+ * The embedded Postgres data root sits deliberately OUTSIDE the checkout. The
+ * dev server runs Vite in middleware mode, and Vite's `server.fs.allow` spans
+ * the whole workspace root, so anything under WORKSPACE is reachable as
+ * `/@fs/<path>` — and the cluster's `session` heap holds raw session tokens.
+ * Keeping the cluster a sibling of the checkout is what makes a public preview
+ * safe to hand out.
+ */
+const DATA_ROOT = "/workspace/lobu-data";
+/** The seat credentials live outside the served tree for the same reason. */
+const SEAT_FILE = "/workspace/.lobu-sandbox-seat";
 
 function sh(
   cmd: string,
@@ -69,14 +80,29 @@ function repoRoot(): string {
 }
 
 /**
- * A private sandbox's preview host rejects an unauthenticated request. The
+ * A PRIVATE sandbox's preview host rejects an unauthenticated request. The
  * `x-daytona-preview-token` header is the API form; a browser cannot set one,
  * so the query parameter is what makes the printed link actually clickable.
+ *
+ * `up` makes the sandbox public once the seat is claimed, so this is the
+ * fallback for a sandbox that is not public (yet) — see previewUrlFor.
  */
 export function authenticatedUrl(url: string, token?: string): string {
   if (!token) return url;
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}DAYTONA_SANDBOX_AUTH_KEY=${encodeURIComponent(token)}`;
+}
+
+/**
+ * A public preview needs no key in the URL, and a key in a link that gets
+ * pasted around is a liability, so it is only added when it is actually needed.
+ */
+export function previewUrlFor(
+  isPublic: boolean,
+  url: string,
+  token?: string
+): string {
+  return isPublic ? url : authenticatedUrl(url, token);
 }
 
 /** Include the absolute path hash to avoid collisions between checkouts. */
@@ -287,6 +313,22 @@ export const HOST_ONLY_ENV_KEYS = [
   "LOBU_EMBEDDED",
 ];
 
+/**
+ * Keys the sandbox decides for itself. dev-native.sh preserves only a fixed
+ * preset list across `source .env`, and none of these is on it, so any left in
+ * the uploaded .env would silently OVERRIDE the boot environment — reopening
+ * sign-up or dropping /api/workers/* back to its anonymous fallback on a public
+ * preview. LOBU_DEV_DATA_ROOT is the same decision one level down: it names the
+ * cluster directory whenever DATABASE_URL is absent, so a host value there
+ * would put the database back inside the served tree.
+ */
+export const SANDBOX_CONTROLLED_ENV_KEYS = [
+  "LOBU_SINGLE_USER",
+  "WORKER_API_TOKEN",
+  "EMBEDDINGS_SERVICE_TOKEN",
+  "LOBU_DEV_DATA_ROOT",
+];
+
 export function sanitizedEnv(root: string): string | null {
   const src = join(root, ".env");
   if (!existsSync(src)) return null;
@@ -298,7 +340,9 @@ export function sanitizedEnv(root: string): string | null {
       )?.[1];
       return (
         !key ||
-        (!HOST_ONLY_ENV_KEYS.includes(key) && !key.startsWith("DAYTONA_"))
+        (!HOST_ONLY_ENV_KEYS.includes(key) &&
+          !SANDBOX_CONTROLLED_ENV_KEYS.includes(key) &&
+          !key.startsWith("DAYTONA_"))
       );
     })
     .join("\n");
@@ -409,8 +453,9 @@ async function syncTree(sandbox: Sandbox, root: string) {
       );
     }
     // Delete only files sent by the previous sync. Ignored runtime state
-    // (node_modules, dist, workspaces, and .lobu-dev) is never in this manifest,
-    // so source deletions propagate without erasing the warm install or database.
+    // (node_modules, dist, workspaces) is never in this manifest, so source
+    // deletions propagate without erasing the warm install. The database is
+    // not even in the tree: it lives at DATA_ROOT, beside the checkout.
     await exec(
       sandbox,
       `mkdir -p ${WORKSPACE} && ` +
@@ -438,22 +483,125 @@ async function syncTree(sandbox: Sandbox, root: string) {
   }
 }
 
-async function bootApp(sandbox: Sandbox, previewUrl: string) {
-  // PUBLIC_GATEWAY_URL must be the preview URL before boot: the server hands
-  // the SPA absolute sse/messages URLs, and a wrong origin breaks chat and
-  // stamps MCP asset URLs the host sandbox then rejects.
-  // No DATABASE_URL in the env or the sanitized .env, so dev-native.sh runs
-  // its embedded Postgres (backend choice keys on the DATABASE_URL scheme).
-  const env = [
-    `PORT=${APP_PORT}`,
-    "HOST=0.0.0.0",
-    `PUBLIC_GATEWAY_URL=${previewUrl}/lobu`,
-  ].join(" ");
+/** Both bearers below only have to be unguessable; each is compared verbatim. */
+export function generateBearerToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * The boot environment, as `env K='V'` words. Every value here is a security
+ * decision for a preview that is handed out publicly, so they live in one
+ * exported, tested place rather than inline at the call site.
+ */
+export function bootEnv(options: {
+  previewUrl: string;
+  workerApiToken: string;
+  embeddingsServiceToken: string;
+}): string {
+  const values: Array<[string, string]> = [
+    ["PORT", String(APP_PORT)],
+    ["HOST", "0.0.0.0"],
+    // PUBLIC_GATEWAY_URL must be the preview URL before boot: the server hands
+    // the SPA absolute sse/messages URLs, a wrong origin breaks chat and stamps
+    // MCP asset URLs the host sandbox then rejects, and Better Auth derives its
+    // baseURL and trustedOrigins from this origin.
+    ["PUBLIC_GATEWAY_URL", `${options.previewUrl}/lobu`],
+    // dev-native.sh picks its backend from the DATABASE_URL *scheme*, so a
+    // file:// path is what keeps embedded Postgres — here, out of the Vite root.
+    ["DATABASE_URL", `file://${DATA_ROOT}`],
+    // A public preview must accept exactly one account: the owner's.
+    ["LOBU_SINGLE_USER", "1"],
+    // …and must not leave /api/workers/* on its unauthenticated fallback,
+    // which only applies while WORKER_API_TOKEN is unset.
+    ["WORKER_API_TOKEN", options.workerApiToken],
+    // The embeddings sidecar is a second listener the preview proxy exposes,
+    // and its bearer check is skipped entirely while this is unset. Server and
+    // sidecar both read this one variable, so injecting it authenticates the
+    // caller and closes the endpoint in the same step.
+    ["EMBEDDINGS_SERVICE_TOKEN", options.embeddingsServiceToken],
+  ];
+  return values
+    .map(([key, value]) => {
+      if (value.includes("'")) {
+        throw new Error(`refusing to pass ${key}: the value contains a quote`);
+      }
+      return `${key}='${value}'`;
+    })
+    .join(" ");
+}
+
+/**
+ * Stopping the old server is load-bearing, not hygiene. dev-native.sh `exec`s
+ * into `bun run --filter @lobu/server dev:local`, so once it is up NO process
+ * cmdline contains "dev-native.sh" any more: the old single pattern matched
+ * nothing, the replacement boot died on EADDRINUSE, and waitReady then passed
+ * against the STALE process — which still had the previous environment. A boot
+ * env that silently does not apply is exactly the failure this file must not
+ * have, so a port that stays busy is a hard error.
+ */
+async function stopApp(sandbox: Sandbox) {
   await exec(
     sandbox,
-    "pkill -f '[d]ev-native.sh' || true; pkill -f '[l]obu run' || true",
+    "pkill -f '[d]ev-native.sh' || true; " +
+      "pkill -f '[@]lobu/server' || true; " +
+      "pkill -f '[s]rc/server.ts' || true; " +
+      "pkill -f '[l]obu run' || true",
     120
   );
+  // The image ships no ss/netstat/lsof, so the listen socket is read straight
+  // from /proc — and an unreadable /proc is a hard error rather than a silent
+  // "the port looks free", which is how this check would fail open.
+  const portHex = APP_PORT.toString(16).toUpperCase().padStart(4, "0");
+  const portState = await exec(
+    sandbox,
+    `[ -r /proc/net/tcp ] || { echo 'cannot read /proc/net/tcp' >&2; exit 1; }; ` +
+      "for _ in $(seq 1 30); do " +
+      `if ! cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qE ':${portHex} [0-9A-F]{8,32}:[0-9A-F]{4} 0A'; then echo free; exit 0; fi; ` +
+      "sleep 1; done; echo busy",
+    120
+  );
+  if (!portState.includes("free")) {
+    throw new Error(
+      `port ${APP_PORT} is still held after stopping the app; refusing to boot a second server over it`
+    );
+  }
+  // The cluster has to be down before its data root can move underneath it.
+  const pgState = await exec(
+    sandbox,
+    "pkill -f '[p]ostgres -D' || true; " +
+      "for _ in $(seq 1 30); do " +
+      "if ! pgrep -f '[p]ostgres -D' > /dev/null; then echo stopped; exit 0; fi; " +
+      "sleep 1; done; echo running",
+    120
+  );
+  if (!pgState.includes("stopped")) {
+    throw new Error(
+      "embedded Postgres is still running; refusing to move its data root underneath it"
+    );
+  }
+}
+
+async function bootApp(
+  sandbox: Sandbox,
+  previewUrl: string,
+  tokens: { workerApiToken: string; embeddingsServiceToken: string }
+) {
+  await stopApp(sandbox);
+  // One-time relocation for sandboxes created before the cluster moved out of
+  // the served tree. An EMPTY destination is just the leftover of a boot that
+  // failed after mkdir, so it is replaced; two non-empty clusters is a real
+  // conflict this script must not resolve by guessing which one to delete.
+  await exec(
+    sandbox,
+    `if [ -d ${WORKSPACE}/.lobu-dev ]; then ` +
+      `if [ -n "$(ls -A ${DATA_ROOT} 2>/dev/null)" ]; then ` +
+      `echo "both ${WORKSPACE}/.lobu-dev and ${DATA_ROOT} hold data; move or delete one" >&2; exit 1; fi; ` +
+      `rmdir ${DATA_ROOT} 2>/dev/null || true; ` +
+      `mv ${WORKSPACE}/.lobu-dev ${DATA_ROOT}; fi; ` +
+      `mkdir -p ${DATA_ROOT}`,
+    300
+  );
+  const env = bootEnv({ previewUrl, ...tokens });
   // `cmd &` alone is not enough: executeCommand waits on the whole process
   // group, so a bare background job hangs until the app exits. The subshell
   // plus closed stdin detaches it and lets exec return immediately.
@@ -462,6 +610,253 @@ async function bootApp(sandbox: Sandbox, previewUrl: string) {
     `cd ${WORKSPACE} && ( env ${env} nohup ./scripts/dev-native.sh > /workspace/dev.log 2>&1 </dev/null & ) ; echo started`,
     120
   );
+}
+
+/**
+ * The single seat this install allows, kept inside the sandbox so a re-run does
+ * not mint a second password and `url` can hand out a fresh login link.
+ */
+export type Seat = { email: string; password: string; created_at: string };
+
+/** The session token is absent only when a freshly claimed seat cannot sign in. */
+type ClaimedSeat = { seat: Seat; sessionToken?: string };
+
+/**
+ * Never a hardcoded address: the repo forbids personal state in shipping code,
+ * and the sandbox owner is whoever is driving this checkout.
+ */
+export function resolveOwnerEmail(
+  configuredEmail: string | undefined,
+  gitEmail: string | undefined
+): string {
+  const email = (configuredEmail ?? gitEmail ?? "").trim();
+  if (!/^[^\s@]+@[^\s@]+$/.test(email)) {
+    throw new Error(
+      "No owner email for the sandbox seat. Set SANDBOX_OWNER_EMAIL, or configure git user.email in this worktree."
+    );
+  }
+  return email;
+}
+
+/** 24 base64url characters — well inside Better Auth's 128-character ceiling. */
+export function generatePassword(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+/**
+ * The credentials reach the remote shell base64-encoded so that no part of an
+ * email or a generated password is ever shell-quoted.
+ */
+function jsonPostScript(path: string, body: unknown, curlFlags = ""): string {
+  const encoded = Buffer.from(JSON.stringify(body), "utf8").toString("base64");
+  return (
+    `printf %s '${encoded}' | base64 -d | ` +
+    `curl -s ${curlFlags} -H 'Content-Type: application/json' --data-binary @- ` +
+    `http://127.0.0.1:${APP_PORT}${path}`
+  );
+}
+
+export function signInScript(email: string, password: string): string {
+  return `${jsonPostScript("/api/auth/sign-in/email", { email, password }, "-D /tmp/lobu-signin.h")}; echo; cat /tmp/lobu-signin.h; rm -f /tmp/lobu-signin.h`;
+}
+
+export function signUpScript(
+  email: string,
+  password: string,
+  name: string
+): string {
+  return `${jsonPostScript("/api/auth/sign-up/email", { email, password, name }, "-o /tmp/lobu-seat.json -w '%{http_code}'")}; echo; cat /tmp/lobu-seat.json; rm -f /tmp/lobu-seat.json`;
+}
+
+export type SignUpOutcome =
+  | { status: "claimed" }
+  | { status: "seat_taken" }
+  | { status: "error"; detail: string };
+
+/**
+ * Reads `<http status>\n<body>`. "seat_taken" is recognised by the hook's own
+ * error code rather than a bare 403, so an unrelated 403 can never be mistaken
+ * for proof that the seat is closed.
+ */
+export function interpretSignUp(output: string): SignUpOutcome {
+  const newline = output.indexOf("\n");
+  const code = (newline === -1 ? output : output.slice(0, newline)).trim();
+  const body = newline === -1 ? "" : output.slice(newline + 1).trim();
+  if (/^2\d\d$/.test(code)) return { status: "claimed" };
+  if (code === "403" && body.includes("SIGN_UP_DISABLED_IN_SINGLE_USER_MODE")) {
+    return { status: "seat_taken" };
+  }
+  return {
+    status: "error",
+    detail: `HTTP ${code || "(none)"}: ${body.slice(0, 400)}`,
+  };
+}
+
+/**
+ * Better Auth returns the raw session token in the sign-in body; if a build
+ * ever stops doing that, the cookie carries `<token>.<base64 HMAC>` and the
+ * exchange endpoint wants the token half alone.
+ */
+export function sessionTokenFrom(output: string): string | undefined {
+  const fromBody = output.match(/"token"\s*:\s*"([^"]+)"/)?.[1];
+  if (fromBody) return fromBody;
+  const cookie = output.match(/better-auth\.session_token=([^;\s]+)/i)?.[1];
+  if (!cookie) return undefined;
+  return decodeURIComponent(cookie).split(".")[0] || undefined;
+}
+
+/**
+ * A link, not just a password, because the preview origin is long and the
+ * exchange endpoint sets a first-party session cookie and redirects to the SPA.
+ */
+export function loginLink(previewUrl: string, sessionToken: string): string {
+  const base = previewUrl.replace(/\/+$/, "");
+  return `${base}/api/exchange-token?token=${encodeURIComponent(sessionToken)}&next=%2F`;
+}
+
+async function readSeat(sandbox: Sandbox): Promise<Seat | undefined> {
+  const raw = await exec(
+    sandbox,
+    `cat ${SEAT_FILE} 2>/dev/null || true`,
+    60
+  ).catch(() => "");
+  const text = raw.trim();
+  if (!text) return undefined;
+  try {
+    const seat = JSON.parse(text) as Seat;
+    return seat?.email && seat?.password ? seat : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeSeat(sandbox: Sandbox, seat: Seat) {
+  const encoded = Buffer.from(JSON.stringify(seat), "utf8").toString("base64");
+  await exec(
+    sandbox,
+    `umask 077 && printf %s '${encoded}' | base64 -d > ${SEAT_FILE} && chmod 600 ${SEAT_FILE}`,
+    60
+  );
+}
+
+/**
+ * Claims the one seat single-user mode allows, so that making the preview
+ * public cannot hand the install to whoever opens the URL first.
+ */
+async function claimSeat(sandbox: Sandbox, root: string): Promise<ClaimedSeat> {
+  const existing = await readSeat(sandbox);
+  if (existing) {
+    // A seat file that no longer signs in means the database was replaced
+    // underneath it. The seat is then unclaimed again and the next visitor's
+    // sign-up would take the install, so this must never reach setPublic.
+    const sessionToken = await signIn(sandbox, existing);
+    if (!sessionToken) {
+      throw new Error(
+        `the seat recorded at ${SEAT_FILE} no longer signs in, so the account that owns this install is unknown. ` +
+          "Refusing to make it public; delete the sandbox (make sandbox-rm) and run up again."
+      );
+    }
+    return { seat: existing, sessionToken };
+  }
+
+  const gitEmail = spawnSync("git", ["-C", root, "config", "user.email"], {
+    encoding: "utf8",
+  }).stdout?.trim();
+  const email = resolveOwnerEmail(process.env.SANDBOX_OWNER_EMAIL, gitEmail);
+  const password = generatePassword();
+  const outcome = interpretSignUp(
+    await exec(sandbox, signUpScript(email, password, "Sandbox Owner"), 120)
+  );
+  if (outcome.status === "error") {
+    throw new Error(`could not claim the sandbox seat — ${outcome.detail}`);
+  }
+  if (outcome.status === "seat_taken") {
+    throw new Error(
+      `this sandbox already has an account but no seat record at ${SEAT_FILE}, so its login is unknown. ` +
+        "Refusing to make it public; delete the sandbox (make sandbox-rm) and run up again."
+    );
+  }
+  const seat: Seat = {
+    email,
+    password,
+    created_at: new Date().toISOString(),
+  };
+  await writeSeat(sandbox, seat);
+  console.log(`\n  seat:  ${email} / ${password}`);
+  console.log(`         (shown once; kept in the sandbox at ${SEAT_FILE})`);
+  return { seat, sessionToken: await signIn(sandbox, seat) };
+}
+
+/**
+ * Proves the door is shut BEFORE it is opened. A boot env that failed to apply
+ * would leave sign-up wide open, and every other check here would still pass.
+ */
+async function assertSignUpClosed(sandbox: Sandbox) {
+  const probeEmail = `probe-${randomBytes(6).toString("hex")}@example.com`;
+  const probe = interpretSignUp(
+    await exec(
+      sandbox,
+      signUpScript(probeEmail, generatePassword(), "probe"),
+      120
+    )
+  );
+  if (probe.status === "seat_taken") return;
+  throw new Error(
+    probe.status === "claimed"
+      ? `sign-up is still OPEN (${probeEmail} was created); refusing to make the sandbox public`
+      : `could not prove sign-up is closed — ${probe.detail}; refusing to make the sandbox public`
+  );
+}
+
+type PublicToggleApi = {
+  updatePublicStatus?: (id: string, isPublic: boolean) => Promise<unknown>;
+};
+
+/**
+ * `public` is also a create-time option, but flipping it AFTER the seat is
+ * claimed is what removes the first-visitor race, and it gives sandboxes that
+ * already exist the same code path. The SDK keeps its generated client private,
+ * and reaching through it is narrower than depending on @daytona/api-client
+ * directly (a transitive package under a different org name).
+ */
+async function setPublic(sandbox: Sandbox, isPublic: boolean) {
+  const api = (sandbox as unknown as { sandboxApi?: PublicToggleApi })
+    .sandboxApi;
+  if (typeof api?.updatePublicStatus !== "function") {
+    throw new Error(
+      "this Daytona SDK no longer exposes sandboxApi.updatePublicStatus; the preview cannot be made public"
+    );
+  }
+  await api.updatePublicStatus(sandbox.id, isPublic);
+  await sandbox.refreshData();
+  if (sandbox.public !== isPublic) {
+    throw new Error(
+      `the sandbox public flag did not change (still ${String(sandbox.public)})`
+    );
+  }
+}
+
+/** The raw session token, or undefined when the credentials no longer work. */
+async function signIn(
+  sandbox: Sandbox,
+  seat: Seat
+): Promise<string | undefined> {
+  const out = await exec(
+    sandbox,
+    signInScript(seat.email, seat.password),
+    120
+  ).catch(() => "");
+  return sessionTokenFrom(out);
+}
+
+/** Re-mintable, so a lost password is inconvenient rather than fatal. */
+async function mintLoginLink(
+  sandbox: Sandbox,
+  previewUrl: string,
+  seat: Seat
+): Promise<string | undefined> {
+  const token = await signIn(sandbox, seat);
+  return token ? loginLink(previewUrl, token) : undefined;
 }
 
 /**
@@ -575,7 +970,16 @@ async function main() {
       process.exit(1);
     }
     const link = await sandbox.getPreviewLink(APP_PORT);
-    console.log(authenticatedUrl(String(link?.url ?? link), link?.token));
+    const previewUrl = String(link?.url ?? link);
+    await sandbox.refreshData();
+    console.log(previewUrlFor(sandbox.public, previewUrl, link?.token));
+    // A stopped sandbox can still report its URL, but nothing inside it can
+    // sign in, so the link is only minted when the app is actually up.
+    if (/start|running/i.test(stateOf(sandbox))) {
+      const seat = await readSeat(sandbox);
+      const login = seat && (await mintLoginLink(sandbox, previewUrl, seat));
+      if (login) console.log(login);
+    }
     return;
   }
 
@@ -642,7 +1046,10 @@ async function main() {
   const link = await sandbox.getPreviewLink(APP_PORT);
   const url: string = link?.url ?? String(link);
   console.log(">> booting app (first boot builds every workspace package)");
-  await bootApp(sandbox, url);
+  await bootApp(sandbox, url, {
+    workerApiToken: generateBearerToken(),
+    embeddingsServiceToken: generateBearerToken(),
+  });
   const ready = await waitReady(sandbox);
 
   if (!ready) {
@@ -654,10 +1061,22 @@ async function main() {
     );
     process.exit(1);
   }
+  // The order is the whole point: take the one seat single-user mode allows,
+  // PROVE that sign-up is shut, and only then drop the preview key.
+  const { seat, sessionToken } = await claimSeat(sandbox, root);
+  await assertSignUpClosed(sandbox);
+  await setPublic(sandbox, true);
+  const login = sessionToken ? loginLink(url, sessionToken) : undefined;
+
   console.log(`\n  ${name} ready`);
-  console.log(`  app:  ${authenticatedUrl(url, link?.token)}`);
-  console.log(`  logs: make sandbox-logs`);
-  console.log(`  stop: make sandbox-stop   (frees quota; DB survives)\n`);
+  console.log(`  app:   ${previewUrlFor(sandbox.public, url, link?.token)}`);
+  console.log(
+    login
+      ? `  login: ${login}`
+      : `  login: sign in as ${seat.email} (could not mint a link; see ${SEAT_FILE})`
+  );
+  console.log("  logs:  make sandbox-logs");
+  console.log("  stop:  make sandbox-stop   (frees quota; DB survives)\n");
 }
 
 // Importing this module (the tests do) must not launch a sandbox.

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -1049,6 +1049,10 @@ async function main() {
 
   const link = await sandbox.getPreviewLink(APP_PORT);
   const url: string = link?.url ?? String(link);
+  // Shut the door before the app comes up. On a re-run the sandbox is already
+  // public from the last `up`, so without this the whole build-and-wait window
+  // serves on a public URL before claimSeat and assertSignUpClosed have run.
+  await setPublic(sandbox, false);
   console.log(">> booting app (first boot builds every workspace package)");
   await bootApp(sandbox, url, {
     workerApiToken: generateBearerToken(),
@@ -1065,8 +1069,9 @@ async function main() {
     );
     process.exit(1);
   }
-  // The order is the whole point: take the one seat single-user mode allows,
-  // PROVE that sign-up is shut, and only then drop the preview key.
+  // The order is the whole point: the preview is private above, so we take the
+  // one seat single-user mode allows, PROVE that sign-up is shut, and only then
+  // drop the preview key.
   const { seat, sessionToken } = await claimSeat(sandbox, root);
   await assertSignUpClosed(sandbox);
   await setPublic(sandbox, true);

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -782,6 +782,10 @@ async function claimSeat(sandbox: Sandbox, root: string): Promise<ClaimedSeat> {
     created_at: new Date().toISOString(),
   };
   await writeSeat(sandbox, seat);
+  // codeql[js/clear-text-logging]: printing the generated seat password once to
+  // the operator's own terminal is the point — it is the only moment the value
+  // is shown, it was minted here rather than taken from a store, and the same
+  // value is written to SEAT_FILE inside the developer's own sandbox anyway.
   console.log(`\n  seat:  ${email} / ${password}`);
   console.log(`         (shown once; kept in the sandbox at ${SEAT_FILE})`);
   return { seat, sessionToken: await signIn(sandbox, seat) };


### PR DESCRIPTION
## Summary

- Daytona dev previews are now public by default, and the flip happens after the single seat is claimed, so there is no window where the first visitor can take the install. `up` claims the seat over loopback, proves sign-up is shut, and only then drops the `DAYTONA_SANDBOX_AUTH_KEY` from the printed URL. A login link is minted on every `up` and `url`, so a lost password is not fatal.
- Closes the auth gaps that made a public preview unsafe. `LOBU_SINGLE_USER`, `WORKER_API_TOKEN` and `EMBEDDINGS_SERVICE_TOKEN` were all unset, so `/api/workers/*` sat on its anonymous fallback and the embeddings sidecar skipped its bearer check entirely. All three are now injected at boot and stripped from the uploaded `.env`. The embedded Postgres data root also moves out of the Vite serving root, where its `session` heap was reachable as `/@fs/…`.
- Fixes a pre-existing restart bug. `bootApp` killed `dev-native.sh`, but that script `exec`s into `bun run --filter @lobu/server`, so after boot no process cmdline matches. Verified live: `pgrep -af '[d]ev-native.sh'` returns `NO MATCH`. The old server survived every `up`, the new boot lost the port, and `waitReady` passed against the stale process carrying the previous environment. Without this fix none of the env above would ever have applied.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate)
- [x] Tests run: `bun test scripts/__tests__/sandbox.test.ts`, 51 pass (was 28)
- [x] Bug fix: red→green outputs pasted below
- [ ] Bot runtime unchanged

### red → green: the restart bug

Before, inside a running sandbox, the pattern `bootApp` relied on:

```
$ pgrep -af "[d]ev-native.sh"
NO MATCH for dev-native.sh

$ ps -eo pid,args | grep -E "server.ts|lobu/server"
  913 bun run --filter @lobu/server dev:local
 2104 node .../tsx watch ... src/server.ts

$ tr '\0' '\n' < /proc/<server>/environ | grep -E '^(LOBU_SINGLE_USER|WORKER_API_TOKEN)='
(nothing: the boot env never reached the process)
```

After, across an `up` on the same running sandbox:

```
PIDS_BEFORE server=6796,6807  emb=6839
PIDS_AFTER  server=11493,11504  emb=11536      # the old server really died

$ tr '\0' '\n' < /proc/<server>/environ | grep -E '^(LOBU_SINGLE_USER|WORKER_API_TOKEN|EMBEDDINGS_SERVICE_TOKEN|DATABASE_URL)='
LOBU_SINGLE_USER=1
WORKER_API_TOKEN=<set>
EMBEDDINGS_SERVICE_TOKEN=<set>
DATABASE_URL=file:///workspace/lobu-data
```

### e2e against the live public preview

```
$ curl -H 'Accept: text/html' $URL/
200   (SPA shell: id="root", /@vite/client, and no auth key in the URL)

$ curl -X POST $URL/api/auth/sign-up/email -d '{"email":"x@example.com",...}'
403  {"code":"SIGN_UP_DISABLED_IN_SINGLE_USER_MODE","message":"This install allows exactly one user; …"}

$ curl -X POST $URL/api/workers/poll -d '{}'
401  {"error":"Unauthorized"}

$ curl -X POST https://<emb-port>-<id>…/api/embeddings -d '{"texts":["hello"]}'
401  {"error":"Unauthorized"}          # was 400 "texts must be an array", i.e. auth was being skipped

$ curl $URL/@fs/<path>                 # Vite serving root = /workspace/lobu
  /workspace/lobu-data/.lobu/pgdata/PG_VERSION   403
  /workspace/.lobu-sandbox-seat                  403
  /workspace/lobu/.env                           403
  /workspace/lobu/package.json                   200   (control)
```

Login works through the preview origin. That path was never exercised before, since the SPA could not boot behind the per-request preview key:

```
$ curl -L "$URL/api/exchange-token?token=…&next=%2F"  → 302 → / , session cookie set
$ curl -b jar $URL/api/auth/get-session              → {"session":{…},"user":{…}}
$ curl    $URL/api/auth/get-session                  → null            (anonymous control)
$ curl -X POST $URL/api/auth/sign-in/email -d '{email,password}'  → ok, token present
```

Idempotent re-run on the running sandbox: seat reused, no second password printed, still public, fresh login link. `sandbox.ts url` prints the bare URL plus a newly minted link.

A stored seat is only trusted if it still signs in. If the database is replaced underneath the seat file the seat is unclaimed again, and the next visitor's sign-up would take the install, so that case must never reach the public flip. Exercised by writing a wrong password into `/workspace/.lobu-sandbox-seat` and running `up`:

```
the seat recorded at /workspace/.lobu-sandbox-seat no longer signs in, so the account
that owns this install is unknown. Refusing to make it public; delete the sandbox
(make sandbox-rm) and run up again.
```

`up` exits there, before `setPublic`. Restoring the real seat and re-running gives the normal ready/app/login output again.

### Listening ports on a public sandbox (enumerated from `/proc/net/tcp`)

| port | owner | unauthenticated over the preview proxy |
|---|---|---|
| 8787 | the app | intended: SPA + API, now behind the single seat |
| `<random>` | embeddings sidecar | **401** after this PR (was open) |
| `<random>` | embedded Postgres | 502, the preview proxy is HTTP-only so there is no pg wire |
| 8118 | egress proxy | 400/404, it rejects the absolute-URI form and is not drivable |
| 2280 / 22222 / 33333 | Daytona daemon | 401 from Daytona's own proxy |

## Notes

Deliberately **not** fixed here, so this stays one concern:

- `packages/server/src/dev-vite.ts` has no `server.fs.deny` for `**/.lobu-dev/**`, `**/.lobu/**`, `**/workspaces/**`. The data-root move closes the pgdata exposure for sandboxes, but the agent scratch dir (`packages/server/workspaces`, not env-configurable) and `HOST=0.0.0.0 make dev` on a LAN still want the chokepoint fix. Follow-up PR.
- `GET /api/organizations` still lists anonymously, and the install-operator password is `ENCRYPTION_KEY`.
- `scripts/sandbox.ts` does not exit after printing, because the Daytona SDK keeps the event loop alive. Pre-existing and unrelated to this change.

Also drops a stale `dev-native.sh` line advertising a `dev@lobu.local / lobudev123` seed login; nothing on `origin/main` creates that account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnDtUBpnS38WwsGsPVrAmU
