### PR TITLE
fix(server): name the remedy in Cloud connector denials

### DIFF
--- a/packages/server/src/gateway/__tests__/custom-connector-cloud-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/custom-connector-cloud-gate.test.ts
@@ -206,3 +206,63 @@ describe('Cloud artifact admission', () => {
 		);
 	});
 });
+
+/**
+ * The reason code alone read as an outage inside a run: `not eligible
+ * (organization-supplied)` says which policy fired, not what to do about it.
+ * Each reason names its own remedy, and every remedy names only an action
+ * Cloud actually permits.
+ */
+describe('Cloud denial names the remedy, not only the reason', () => {
+	test('an organization-supplied artifact is pointed at the supported lanes', () => {
+		process.env.LOBU_CLOUD_MODE = 'true';
+		const error = denial(() =>
+			assertCloudConnectorArtifactTrusted({
+				connectorKey: 'github',
+				facts: facts({ organizationId: 'org_1', hasCompiledCode: true }),
+			}),
+		);
+		expect(error.message).toContain('(organization-supplied)');
+		expect(error.message).toMatch(/MCP/);
+		expect(error.message).toMatch(/device connector/);
+		expect(error.message).toMatch(/self-hosted/);
+		// Cloud refuses every source-code install, so an OpenAPI connector —
+		// which is source metadata — must not be offered as a destination.
+		expect(error.message).not.toMatch(/OpenAPI/);
+	});
+
+	test('a shadowed shared row says the copy has to be removed for the tenant', () => {
+		process.env.LOBU_CLOUD_MODE = 'true';
+		const error = denial(() =>
+			assertCloudConnectorArtifactTrusted({
+				connectorKey: 'github',
+				facts: facts({ rowCount: 2 }),
+			}),
+		);
+		expect(error.message).toContain('(ambiguous-artifact-scope)');
+		expect(error.message).toMatch(/organization-scoped copy/);
+		// No Cloud-permitted action deletes a connector_versions row, so the
+		// remedy must not pretend the tenant can self-serve it.
+		expect(error.message).toMatch(/contact support/);
+	});
+
+	test('a missing image file is told apart from a tenant problem', () => {
+		process.env.LOBU_CLOUD_MODE = 'true';
+		const error = denial(() =>
+			assertCloudConnectorArtifactTrusted({
+				connectorKey: 'not_a_bundled_connector',
+				facts: BUNDLED_SHARED_ROW,
+			}),
+		);
+		expect(error.message).toContain('(not-in-image)');
+		expect(error.message).toMatch(/current catalog/);
+		expect(error.message).not.toMatch(/MCP/);
+	});
+
+	test('the install refusal carries the organization-supplied remedy', () => {
+		process.env.LOBU_CLOUD_MODE = 'true';
+		const error = denial(() => assertCustomConnectorInstallAllowed());
+		expect(error.message).toContain('(organization-supplied)');
+		expect(error.message).toMatch(/MCP/);
+	});
+});

--- a/packages/server/src/utils/custom-connector-cloud-gate.ts
+++ b/packages/server/src/utils/custom-connector-cloud-gate.ts
@@ -34,10 +34,32 @@ type CloudDenialReason =
 	| 'ambiguous-artifact-scope'
 	| 'not-in-image';
 
+/**
+ * What the org admin reading the run error can do about each denial.
+ *
+ * The reason code alone read as an outage: a refusal surfaced inside a sync or
+ * reaction run as `not eligible (organization-supplied)` with nothing to say
+ * what the supported path is. The three reasons do not share a remedy — one is
+ * a tenant migration, one needs support to delete a row, one is deploy drift —
+ * so each names its own. Every action named here must be one Cloud actually
+ * permits: source-code installs, updates and rollbacks are all refused by
+ * `assertCustomConnectorInstallAllowed`, so an OpenAPI connector (source
+ * metadata) is not a destination and a tenant cannot remove a shadowing
+ * `connector_versions` row themselves.
+ */
+const CLOUD_DENIAL_REMEDY: Record<CloudDenialReason, string> = {
+	'organization-supplied':
+		'Re-express this connector as an MCP server, ship it as a device connector from a paired device, or run it self-hosted.',
+	'ambiguous-artifact-scope':
+		'An organization-scoped copy of this version shadows the shared connector; contact support to remove the organization-scoped copy so one artifact is selected.',
+	'not-in-image':
+		'The running image ships no source file for this connector key — it was removed or renamed since this version was installed, or the deploy is incomplete. Install its replacement from the current catalog, or contact support.',
+};
+
 function denied(reason: CloudDenialReason): never {
 	throw new ToolError(
 		'PERMISSION',
-		`${CUSTOM_CONNECTOR_CLOUD_DISABLED} Lobu Cloud only runs connector code shipped in its own image; this artifact is not eligible (${reason})`,
+		`${CUSTOM_CONNECTOR_CLOUD_DISABLED} Lobu Cloud only runs connector code shipped in its own image; this artifact is not eligible (${reason}). ${CLOUD_DENIAL_REMEDY[reason]}`,
 	);
 }
 


### PR DESCRIPTION
## Summary
- The Cloud artifact gate refused with a reason code and nothing else, so a denial surfaced inside a sync or reaction run as `not eligible (organization-supplied)` with no indication that a supported path exists. Correct policy, unreadable as a migration.
- Each of the three reasons now names its own remedy, and each names only an action Cloud actually permits.
- Message prefix unchanged, so existing `toStartWith(CUSTOM_CONNECTOR_CLOUD_DISABLED)` and the integration suite's `toContain` assertions still hold.

**Why not OpenAPI in the org-supplied remedy** — worth stating because it is the non-obvious part. `openapiConfig` is declared on a connector *source module* (`connector-sdk/src/define-connector.ts:128` → `utils/connector-compiler.ts:160` → `connector_definitions.openapi_config`), not registered as a spec URL. Installing one therefore travels the `source_code`/`source_url`/`source_uri`/`compiled` branch of `handleInstallConnector`, which calls `assertCustomConnectorInstallAllowed()` and is refused in Cloud. Only `mcp_url` and device-manifest installs are ungated, so MCP, device, and self-host are the three real destinations.

Likewise `ambiguous-artifact-scope` points at support rather than implying a self-serve cleanup — no Cloud-permitted action deletes a `connector_versions` row — and `not-in-image` is operator deploy drift, so its remedy must not send the org down the re-express path.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build + typecheck + knip + naming + funnel gates)
- [x] Tests run: `bun test src/gateway/__tests__/custom-connector-cloud-gate.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

Red — remedies absent before the change (4 new assertions against the reason-code-only message):

```
Expected substring or pattern: /organization-scoped/i
Received: "CUSTOM_CONNECTOR_CLOUD_DISABLED: Lobu Cloud only runs connector code shipped in its own image; this artifact is not eligible (ambiguous-artifact-scope)"
 1 pass
 4 fail
```

Green:

```
bun test v1.3.5 (1e86cebd)
 19 pass
 0 fail
 32 expect() calls
```

Mutation check — with `. ${CLOUD_DENIAL_REMEDY[reason]}` stripped from the thrown message, exactly the 4 remedy tests fail and the other 15 still pass, so they are load-bearing rather than vacuous:

```
 15 pass
 4 fail
```

## Notes
Follow-up left deliberately out of scope: `utils/ensure-connector-installed.ts:84` throws its own defense-in-depth backstop ("Refusing organization-supplied code ... in Lobu Cloud.") with no remedy. The gate should make that path unreachable, so it is not carrying tenant-facing text today, but a reviewer may reasonably ask for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)