### PR TITLE
fix(server): stop /@fs/ serving live state from the dev server

### DIFF
--- a/packages/server/src/__tests__/unit/dev-fs-deny.test.ts
+++ b/packages/server/src/__tests__/unit/dev-fs-deny.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	type ViteDevServer,
+	createServer,
+	resolveConfig,
+	searchForWorkspaceRoot,
+} from "vite";
+import { devViteFsDeny } from "../../utils/dev-fs-deny";
+
+/**
+ * `/@fs/` served the embedded Postgres cluster, the agent scratch dir and the
+ * per-agent worker tree to anyone who could reach the dev server — which a
+ * public Daytona preview now lets be the whole internet. Proven on a real
+ * sandbox before this fix: an anonymous GET of
+ * `/@fs/workspace/lobu/.lobu/probe.json` returned 200 with the file body.
+ *
+ * This boots a real Vite dev server over real HTTP rather than asserting
+ * against a local reimplementation of Vite's glob matching, so it stays honest
+ * if Vite changes how `fs.deny` is interpreted.
+ */
+describe("devViteFsDeny", () => {
+	let root: string;
+	let deny: string[];
+	let vite: ViteDevServer;
+	let server: http.Server;
+	let origin: string;
+
+	beforeAll(async () => {
+		// The checkout sits under a directory named `workspaces` and its own name
+		// carries glob metacharacters: an unanchored `**\/workspaces/**` or an
+		// unescaped root would 403 every ordinary file below.
+		root = path.join(
+			mkdtempSync(path.join(tmpdir(), "dev-fs-deny-")),
+			"workspaces",
+			"lobu (dev)",
+		);
+		for (const rel of [
+			".lobu-dev/postgresql.conf",
+			".lobu-dev/.lobu/pgdata/PG_VERSION",
+			".lobu/session.jsonl",
+			"packages/server/workspaces/agent-1/session.jsonl",
+			".env",
+			"index.html",
+			"public-note.txt",
+		]) {
+			const abs = path.join(root, rel);
+			mkdirSync(path.dirname(abs), { recursive: true });
+			writeFileSync(abs, `contents of ${rel}`);
+		}
+
+		// Same call dev-vite.ts makes: anchor to the tree Vite's `fs.allow` opens.
+		deny = devViteFsDeny(searchForWorkspaceRoot(root));
+		vite = await createServer({
+			root,
+			configFile: false,
+			logLevel: "silent",
+			server: {
+				middlewareMode: true,
+				fs: { deny },
+			},
+			appType: "custom",
+		});
+		server = http.createServer(vite.middlewares);
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const addr = server.address();
+		if (!addr || typeof addr === "string") throw new Error("no port");
+		origin = `http://127.0.0.1:${addr.port}`;
+	});
+
+	afterAll(async () => {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+		await vite.close();
+	});
+
+	const status = async (rel: string) =>
+		(await fetch(`${origin}/@fs${path.join(root, rel)}`)).status;
+
+	it("keeps covering every one of Vite's own defaults", async () => {
+		// Setting fs.deny REPLACES Vite's default array instead of merging with
+		// it, so a well-meaning trim here would quietly start serving .env. Read
+		// the defaults from Vite itself so a Vite upgrade that adds one fails here.
+		const defaults = (
+			await resolveConfig({ root, configFile: false, logLevel: "silent" }, "serve")
+		).server.fs.deny;
+		expect(defaults.length).toBeGreaterThan(0);
+		for (const pattern of defaults) {
+			expect(deny).toContain(pattern);
+		}
+	});
+
+	it("refuses the Postgres cluster, agent scratch and worker tree over /@fs/", async () => {
+		for (const denied of [
+			// directly under .lobu-dev, so only the .lobu-dev pattern can deny it
+			".lobu-dev/postgresql.conf",
+			".lobu-dev/.lobu/pgdata/PG_VERSION",
+			".lobu/session.jsonl",
+			"packages/server/workspaces/agent-1/session.jsonl",
+			".env",
+		]) {
+			expect(await status(denied)).toBe(403);
+		}
+	});
+
+	it("still serves ordinary files, so the denials are real and not a dead route", async () => {
+		expect(await status("public-note.txt")).toBe(200);
+	});
+});

--- a/packages/server/src/dev-vite.ts
+++ b/packages/server/src/dev-vite.ts
@@ -12,6 +12,7 @@ import type http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setViteDev } from './index';
+import { devViteFsDeny } from './utils/dev-fs-deny';
 import logger from './utils/logger';
 
 // …/packages/server/src/dev-vite.ts → repo root
@@ -68,12 +69,16 @@ export async function mountViteDev(
     return null;
   }
   try {
-    const { createServer } = await import('vite');
+    const { createServer, searchForWorkspaceRoot } = await import('vite');
+    const webRoot = resolveWebSourceRoot();
     const vite = await createServer({
-      root: resolveWebSourceRoot(),
+      root: webRoot,
       server: {
         middlewareMode: true,
         hmr: { server: httpServer },
+        // searchForWorkspaceRoot(webRoot) is what Vite defaults `fs.allow` to,
+        // i.e. the tree `/@fs/` can reach — the denials are anchored to it.
+        fs: { deny: devViteFsDeny(searchForWorkspaceRoot(webRoot)) },
         // The worker scratch dir (packages/server/workspaces/<agent>/.lobu/*)
         // is written constantly while an agent runs; without this Vite triggers
         // a full browser page reload on every session.jsonl write, which kills

--- a/packages/server/src/utils/dev-fs-deny.ts
+++ b/packages/server/src/utils/dev-fs-deny.ts
@@ -1,0 +1,36 @@
+/**
+ * Paths `/@fs/` must never serve from the Vite dev server.
+ *
+ * `server.fs.allow` defaults to the workspace root, so anything inside the repo
+ * is fetchable over `/@fs/<abs path>` by whoever can reach the dev server —
+ * which now includes a public Daytona preview. Three trees hold live state:
+ * `.lobu-dev` is the embedded Postgres cluster (a local `make dev` keeps it in
+ * the repo root), `.lobu` is the agent scratch dir holding session transcripts,
+ * and `workspaces` is the per-agent worker tree.
+ *
+ * Vite matches `fs.deny` globs against the ABSOLUTE file path, so the three
+ * are anchored to `servedRoot` rather than written as `**\/workspaces/**`: the
+ * unanchored form also matched a checkout that merely lives under a directory
+ * named `workspaces` (`~/workspaces/lobu`) and 403'd every SPA file.
+ *
+ * The first four entries are Vite's own defaults. Setting `fs.deny` REPLACES
+ * that default array rather than merging with it, so dropping them here would
+ * silently start serving `.env` — the one file that must never leave the host.
+ */
+export function devViteFsDeny(servedRoot: string): string[] {
+	const root = escapeGlob(servedRoot.replace(/\/+$/, ""));
+	return [
+		".env",
+		".env.*",
+		"*.{crt,pem}",
+		"**/.git/**",
+		`${root}/.lobu-dev/**`,
+		`${root}/**/.lobu/**`,
+		`${root}/**/workspaces/**`,
+	];
+}
+
+/** picomatch treats these as glob syntax; a repo path such as `my (repo)` must match literally. */
+function escapeGlob(p: string): string {
+	return p.replace(/[\\*?[\]{}()!+@]/g, "\\$&");
+}


### PR DESCRIPTION
## What

Vite's `server.fs.allow` defaults to the workspace root, so anything inside the repo was fetchable over `/@fs/<abs path>` by whoever could reach the dev server. That used to mean localhost. Since #3279 made Daytona dev previews public, it means the internet.

This denies the three trees that hold live state: `.lobu-dev` (embedded Postgres cluster, where a local `make dev` keeps it), `.lobu` (agent scratch dir with session transcripts), and `workspaces` (per-agent worker tree).

## Red

Anonymous GET against the live public sandbox running #3279's code, before this change:

```
$ curl -s -o /dev/null -w "%{http_code}" \
    https://8787-<sandbox>.daytonaproxy01.net/@fs/workspace/lobu/.lobu/probe.json
200
$ curl -s https://8787-<sandbox>.daytonaproxy01.net/@fs/workspace/lobu/.lobu/probe.json | head -c 60
{
  "name": "lobu-monorepo",
  "version": "17.2.0",
  "descr
```

## Green

Real Vite dev server, real HTTP, this change applied:

```
/@fs/<root>/.lobu-dev/postgresql.conf              -> 403
/@fs/<root>/.lobu-dev/.lobu/pgdata/PG_VERSION      -> 403
/@fs/<root>/.lobu/session.jsonl                    -> 403
/@fs/<root>/packages/server/workspaces/agent-1/... -> 403
/@fs/<root>/.env                                   -> 403
/@fs/<root>/public-note.txt                        -> 200   (control)

3 pass, 0 fail, 11 expect() calls
```

## Two traps

**Vite matches `fs.deny` against the absolute path.** The obvious `**/workspaces/**` 403s *every* file in a checkout that merely lives under a directory named `workspaces`. Measured directly:

```
UNANCHORED (**/workspaces/**):     ordinary app.js -> 403
ANCHORED  (<root>/**/workspaces/**): ordinary app.js -> 200
```

So the patterns are anchored to the served root, and a root containing glob metacharacters (`my (repo)`) is escaped.

**Setting `fs.deny` replaces Vite's default array instead of merging.** Omitting the four defaults would have silently started serving `.env`. The test reads them back from Vite itself, so a Vite upgrade that adds a default fails here rather than quietly losing it.

## Testing

The test boots a real Vite dev server and probes over HTTP instead of reimplementing Vite's glob matching, so it stays honest if Vite changes how `fs.deny` is interpreted.

Mutation-tested individually — each drop fails only its own assertion:

| mutation | result |
|---|---|
| drop `<root>/.lobu-dev/**` | 1 fail |
| drop `<root>/**/.lobu/**` | 1 fail |
| drop `<root>/**/workspaces/**` | 1 fail |
| drop the glob escaping | 1 fail |

`make pre-pr` clean.

## Note on shape

This is a denylist, and `fs.allow` remains the whole workspace root. Narrowing `fs.allow` instead would be the stronger fix but is a bigger design call — flagging it rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)