### PR TITLE
test(gateway): stop the Slack activation assertion racing its write

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -441,16 +441,21 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
         { platform_message_id: linkedDmTs, team_id: WORKSPACE_TEAM_ID },
       ]);
     });
-    const [dmAutomation] = await sql<
-      { id: number; last_event_activation_at: Date | null }[]
-    >`
-      SELECT id, last_event_activation_at
-      FROM automations
-      WHERE organization_id = 'org-slack-grid-e2e'
-        AND triggers->0->'match'->>'channel_id' = ${DM_ID}
-      LIMIT 1
-    `;
-    expect(dmAutomation?.last_event_activation_at).not.toBeNull();
+    // The activation stamp lands in a different statement from the `runs` and
+    // `channel_messages` rows polled above, so a bare read here races it: the
+    // rows can be present while `last_event_activation_at` is still null.
+    await waitFor(async () => {
+      const [dmAutomation] = await sql<
+        { id: number; last_event_activation_at: Date | null }[]
+      >`
+        SELECT id, last_event_activation_at
+        FROM automations
+        WHERE organization_id = 'org-slack-grid-e2e'
+          AND triggers->0->'match'->>'channel_id' = ${DM_ID}
+        LIMIT 1
+      `;
+      expect(dmAutomation?.last_event_activation_at).not.toBeNull();
+    });
     const activationTimesBeforeBots = new Map(
       (
         await sql<{ id: number; last_event_activation_at: Date | null }[]>`


### PR DESCRIPTION
## What

`slack-automation-message-e2e.test.ts` asserted `last_event_activation_at` with a bare read. That column is stamped by a different statement from the `runs` and `channel_messages` rows the two `waitFor` blocks above it poll for, so the read can land while it is still null. Every neighbouring assertion in the test polls; this one did not.

It failed exactly that way on an unrelated PR's CI run (#3279, `integration-bun` gateway lane 1) and passed on rerun:

```
(fail) Slack Enterprise Grid event -> chat Automation -> Slack reply >
       workspace-stamped channel and DM events persist, activate once, and reply
453 |     expect(dmAutomation?.last_event_activation_at).not.toBeNull();
error: expect(received).not.toBeNull()
Received: null
```

## Red

The flake is timing-dependent and won't reproduce on demand, so I isolated the mechanism instead: drop the two preceding `waitFor` blocks so the read *always* races the write, then vary only the assertion form.

```
A) bare read (before this change)
   error: expect(received).not.toBeNull()
   Received: null
   (fail) ... persist, activate once, and reply
   1 pass, 1 fail

B) waitFor read (this change), identical racing conditions
   2 pass, 0 fail        ← and 3 further runs, all 2 pass / 0 fail
```

Variant A's failure signature matches the CI failure exactly, down to the assertion.

## Green

Full suite on the real code path, unmodified:

```
2 pass
0 fail
35 expect() calls
Ran 2 tests across 1 file. [10.63s]
```

`make pre-pr` clean.

## Note

This changes only the assertion's shape, not what it asserts — the column must still be non-null, it is just polled for like its neighbours. The 5s `waitFor` timeout is the file's existing default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)