### PR TITLE
fix(server): narrow Vite fs.allow to the trees the SPA loads from

### DIFF
--- a/packages/server/src/__tests__/unit/dev-fs-deny.test.ts
+++ b/packages/server/src/__tests__/unit/dev-fs-deny.test.ts
@@ -9,7 +9,7 @@ import {
 	resolveConfig,
 	searchForWorkspaceRoot,
 } from "vite";
-import { devViteFsDeny } from "../../utils/dev-fs-deny";
+import { devViteFsAllow, devViteFsDeny } from "../../utils/dev-fs-deny";
 
 /**
  * `/@fs/` served the embedded Postgres cluster, the agent scratch dir and the
@@ -107,5 +107,87 @@ describe("devViteFsDeny", () => {
 
 	it("still serves ordinary files, so the denials are real and not a dead route", async () => {
 		expect(await status("public-note.txt")).toBe(200);
+	});
+});
+
+/**
+ * `fs.allow` defaulted to the whole workspace root, so `/@fs/` served every
+ * file in the repo. Measured on this checkout before narrowing:
+ * `/@fs/<root>/scripts/sandbox.ts` and `/@fs/<root>/bun.lock` both returned
+ * 200. The allowlist is the first layer and the deny list the second.
+ */
+describe("devViteFsAllow", () => {
+	let servedRoot: string;
+	let webRoot: string;
+	let vite: ViteDevServer;
+	let server: http.Server;
+	let origin: string;
+
+	beforeAll(async () => {
+		servedRoot = mkdtempSync(path.join(tmpdir(), "dev-fs-allow-"));
+		webRoot = path.join(servedRoot, "packages", "web");
+		for (const rel of [
+			"packages/web/index.html",
+			"packages/web/src/main.js",
+			"packages/core/src/refs.js",
+			"node_modules/dep/index.js",
+			"scripts/sandbox.ts",
+			"bun.lock",
+			"deploy/values.yaml",
+		]) {
+			const abs = path.join(servedRoot, rel);
+			mkdirSync(path.dirname(abs), { recursive: true });
+			// Valid JS: an allowed path still has to survive Vite's transform,
+			// and a garbage body would 404 for reasons unrelated to fs.allow.
+			writeFileSync(abs, `export const from = ${JSON.stringify(rel)};`);
+		}
+
+		vite = await createServer({
+			root: webRoot,
+			configFile: false,
+			logLevel: "silent",
+			server: {
+				middlewareMode: true,
+				fs: {
+					allow: devViteFsAllow(servedRoot, webRoot),
+					deny: devViteFsDeny(servedRoot),
+				},
+			},
+			appType: "custom",
+		});
+		server = http.createServer(vite.middlewares);
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const addr = server.address();
+		if (!addr || typeof addr === "string") throw new Error("no port");
+		origin = `http://127.0.0.1:${addr.port}`;
+	});
+
+	afterAll(async () => {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+		await vite.close();
+	});
+
+	const status = async (rel: string) =>
+		(await fetch(`${origin}/@fs${path.join(servedRoot, rel)}`)).status;
+
+	it("refuses repo trees the SPA never loads from", async () => {
+		for (const blocked of ["scripts/sandbox.ts", "bun.lock", "deploy/values.yaml"]) {
+			expect(await status(blocked)).toBe(403);
+		}
+	});
+
+	it("still serves the web root, workspace sources and hoisted deps", async () => {
+		// A crawl of the SPA's module graph (652 modules) reaches exactly three
+		// files outside the web root, all under the hoisted node_modules. The
+		// aliased @lobu/core subpaths are pre-bundled into the web root's own
+		// node_modules/.vite/deps by esbuild, which never goes through fs.allow —
+		// `packages` is allowed so a future direct-source import cannot regress.
+		for (const allowed of [
+			"packages/web/src/main.js",
+			"packages/core/src/refs.js",
+			"node_modules/dep/index.js",
+		]) {
+			expect(await status(allowed)).toBe(200);
+		}
 	});
 });

--- a/packages/server/src/dev-vite.ts
+++ b/packages/server/src/dev-vite.ts
@@ -12,7 +12,7 @@ import type http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setViteDev } from './index';
-import { devViteFsDeny } from './utils/dev-fs-deny';
+import { devViteFsAllow, devViteFsDeny } from './utils/dev-fs-deny';
 import logger from './utils/logger';
 
 // …/packages/server/src/dev-vite.ts → repo root
@@ -77,8 +77,12 @@ export async function mountViteDev(
         middlewareMode: true,
         hmr: { server: httpServer },
         // searchForWorkspaceRoot(webRoot) is what Vite defaults `fs.allow` to,
-        // i.e. the tree `/@fs/` can reach — the denials are anchored to it.
-        fs: { deny: devViteFsDeny(searchForWorkspaceRoot(webRoot)) },
+        // i.e. the tree `/@fs/` would otherwise reach. Narrow it to the trees
+        // the SPA actually loads from, and anchor the denials to the same root.
+        fs: {
+          allow: devViteFsAllow(searchForWorkspaceRoot(webRoot), webRoot),
+          deny: devViteFsDeny(searchForWorkspaceRoot(webRoot)),
+        },
         // The worker scratch dir (packages/server/workspaces/<agent>/.lobu/*)
         // is written constantly while an agent runs; without this Vite triggers
         // a full browser page reload on every session.jsonl write, which kills

--- a/packages/server/src/utils/dev-fs-deny.ts
+++ b/packages/server/src/utils/dev-fs-deny.ts
@@ -34,3 +34,29 @@ export function devViteFsDeny(servedRoot: string): string[] {
 function escapeGlob(p: string): string {
 	return p.replace(/[\\*?[\]{}()!+@]/g, "\\$&");
 }
+
+/**
+ * The only trees `/@fs/` may reach, replacing Vite's default of the whole
+ * workspace root. The deny list below is the second layer; this is the first,
+ * and it is what keeps `scripts/`, `deploy/`, `charts/`, `docs/`, the Makefile
+ * and (in the main checkout) every sibling worktree under `.claude/` out of
+ * reach entirely rather than merely denied by pattern.
+ *
+ * Measured, not guessed: crawling the SPA's module graph — its entry plus every
+ * module under `src/`, 652 modules — turns up exactly three files outside the
+ * web root, all in the hoisted root `node_modules`. The aliased `@lobu/core/*`
+ * subpaths never appear because Vite's dep optimizer pre-bundles them into
+ * `<webRoot>/node_modules/.vite/deps/`, which esbuild reads straight off disk,
+ * so `fs.allow` never applies to them.
+ *
+ * `packages` is allowed anyway. Nothing in the crawl needs it today, but
+ * `vite.config.ts` aliases `@lobu/core/*` at `../core/src/*.ts`, and its own
+ * comment records that a miss there "is invisible to every gate ... Only the
+ * dev server breaks". Allowing the tree costs nothing — the state dirs inside
+ * it (`workspaces`, `.lobu`) are denied below — and spares the next person a
+ * dev-only breakage no CI job would catch.
+ */
+export function devViteFsAllow(servedRoot: string, webRoot: string): string[] {
+	const root = servedRoot.replace(/\/+$/, "");
+	return [webRoot, `${root}/node_modules`, `${root}/packages`];
+}


### PR DESCRIPTION
## What

#3282 denied the three trees holding live state, but `server.fs.allow` still defaulted to the whole workspace root, so `/@fs/` served every *other* file in the repo. A denylist only stops the trees someone thought of; an allowlist stops everything nobody listed.

## Red

Measured on a checkout before the change:

```
BASELINE 200  /@fs/<root>/scripts/sandbox.ts     ← the whole orchestration script
BASELINE 200  /@fs/<root>/bun.lock
```

## Green — live, on the public sandbox preview

Same public URL #3279 created, running this build:

```
must be BLOCKED
  scripts/sandbox.ts                                 -> 403
  bun.lock                                           -> 403
  Makefile                                           -> 403
  AGENTS.md                                          -> 403
  .env                                               -> 403
  .lobu/probe.json                                   -> 403   (200 before #3282)

must still be SERVED
  packages/core/src/refs.ts                          -> 200
  node_modules/vite/dist/client/env.mjs              -> 200
  packages/owletto/src/main.tsx                      -> 200
```

And the SPA itself, crawled through the real server over the public URL:

```
modules fetched: 616
statuses: 200:616
403s: 0
/@fs/ served: 3   (all under the hoisted node_modules)
```

## The allowlist is measured, not guessed

Crawling the SPA's module graph locally — entry plus every module under `src/`, 646 modules — reaches exactly three files outside the web root, all in the hoisted `node_modules`.

The aliased `@lobu/core/*` subpaths look like they must be reachable, and they are not: Vite's dep optimizer pre-bundles them into `<webRoot>/node_modules/.vite/deps/`, which esbuild reads straight off disk, so `fs.allow` never applies. `packages` is allowed regardless — `vite.config.ts` records that a missed alias there is "invisible to every gate ... Only the dev server breaks", and allowing the tree costs nothing when its state dirs are already denied.

Baseline vs narrowed on the same local crawl is identical:

```
[baseline] modules=646 statuses=200:641 504:5   /@fs/ served: 3   403s: 0
[narrowed] modules=646 statuses=200:641 504:5   /@fs/ served: 3   403s: 0
```

The five 504s are a pre-existing dep-optimizer failure on `msw`, a test-only dep — identical in both runs, not introduced here.

## Testing

Mutation-tested, each caught by the right test:

| mutation | fails |
|---|---|
| revert to whole-root allow | `refuses repo trees the SPA never loads from` |
| drop `packages` | `still serves the web root, workspace sources and hoisted deps` |
| drop `node_modules` | `still serves the web root, workspace sources and hoisted deps` |

5/5 tests pass, `make pre-pr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted development server file access to resources required by the application.
  * Continued blocking sensitive workspace files and directories from browser access.
  * Preserved access to web assets, workspace sources, and required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->