### PR TITLE
fix(cloud-gate): admit an image-shipped connector shadowed by an org row

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3405,6 +3405,8 @@ export type ManageFeedsResponses = {
       }
     | {
         action: "trigger_feed";
+        triggered: false;
+        reason: string;
         message: string;
       };
 };

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -275,8 +275,15 @@ export const ManageFeedsResultSchema = Type.Union([
     // the flag and persisting anyway is the one failure mode that matters here.
     dry_run: Type.Optional(Type.Boolean()),
   }),
+  // Nothing was queued. `triggered` discriminates this from the success
+  // variant above: the skip used to carry only `message`, so a caller that
+  // queued no run was shape-indistinguishable from one that did, and no run
+  // row exists to fail or alert on either. `reason` is the machine-readable
+  // cause behind the sentence (`SyncRunSkipReason`).
   Type.Object({
     action: Type.Literal("trigger_feed"),
+    triggered: Type.Literal(false),
+    reason: Type.String(),
     message: Type.String(),
   }),
 ]);

--- a/packages/server/src/__tests__/integration/connectors/custom-connector-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/custom-connector-cloud-gate.test.ts
@@ -11,7 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveAgentToolingDeclaration } from '../../../gateway/agent-tooling/resolver';
 import type { Env } from '../../../index';
-import { createSyncRun } from '../../../runs/queue-service';
+import { createSyncRun, describeSyncRunSkip } from '../../../runs/queue-service';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { post } from '../../setup/test-helpers';
 import {
@@ -112,6 +112,16 @@ describe('organization-supplied connector code under LOBU_CLOUD_MODE', () => {
 
     expect(created.ok).toBe(false);
     expect(created.ok ? null : created.reason).toBe('cloud_restricted');
+    // The reason code alone reads as an outage. `cloud_restricted` collapses
+    // two unrelated causes, and the sentence it maps to ("cannot run on Lobu
+    // Cloud yet") gave an operator nowhere to go — verified against prod,
+    // where that string is all a denied trigger_feed returns. The gate's own
+    // message names the provenance AND the supported path, so it rides along
+    // and wins in `describeSyncRunSkip`.
+    const detail = created.ok ? null : created.detail;
+    expect(detail).toContain('organization-supplied');
+    expect(detail).toMatch(/MCP/);
+    expect(describeSyncRunSkip('cloud_restricted', detail ?? undefined)).toBe(detail);
     const runs = await sql`SELECT id FROM runs WHERE feed_id = ${feedId}`;
     expect(runs.length).toBe(0);
   });

--- a/packages/server/src/__tests__/integration/connectors/custom-connector-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/custom-connector-cloud-gate.test.ts
@@ -22,20 +22,34 @@ import {
 
 /** `postgres` ships in the image, so the key itself is always attested. */
 const CONNECTOR_KEY = 'postgres';
+/**
+ * A key the running image ships no source file for — the genuinely
+ * organization-authored shape.
+ *
+ * Provenance and in-image status used to be independently testable, so these
+ * suites pinned `organization` denial against an attested key. They are no
+ * longer independent: an org-scoped row is refused only when the image cannot
+ * supply the code, because otherwise the image file is what executes and
+ * denying just takes the connector offline. Asserting the policy therefore
+ * requires a key the image genuinely lacks.
+ */
+const UNATTESTED_KEY = 'custom_test_connector';
 const CONNECTOR_VERSION = '1.0.0';
 
-async function setupFeed(): Promise<{ feedId: number; connId: number; orgId: string }> {
+async function setupFeed(
+  connectorKey: string = CONNECTOR_KEY,
+): Promise<{ feedId: number; connId: number; orgId: string }> {
   const sql = getTestDb();
   const org = await createTestOrganization();
   await createTestConnectorDefinition({
-    key: CONNECTOR_KEY,
-    name: 'PostgreSQL',
+    key: connectorKey,
+    name: connectorKey === CONNECTOR_KEY ? 'PostgreSQL' : 'Custom Test Connector',
     version: CONNECTOR_VERSION,
     organization_id: org.id,
   });
   const conn = await createTestConnection({
     organization_id: org.id,
-    connector_key: CONNECTOR_KEY,
+    connector_key: connectorKey,
   });
   const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${conn.id}`;
   return { feedId: Number((feed as { id: number }).id), connId: conn.id, orgId: org.id };
@@ -46,13 +60,16 @@ async function setupFeed(): Promise<{ feedId: number; connId: number; orgId: str
  * bytes — the shape `install_connector` used to produce before the install
  * gate closed, and the one Cloud must never execute.
  */
-async function makeArtifactOrgSupplied(orgId: string): Promise<void> {
+async function makeArtifactOrgSupplied(
+  orgId: string,
+  connectorKey: string = CONNECTOR_KEY
+): Promise<void> {
   const sql = getTestDb();
   await sql`
     UPDATE connector_versions
     SET organization_id = ${orgId},
         source_code = ${'export default { sync: async () => ({ items: [] }) }'}
-    WHERE connector_key = ${CONNECTOR_KEY} AND version = ${CONNECTOR_VERSION}
+    WHERE connector_key = ${connectorKey} AND version = ${CONNECTOR_VERSION}
   `;
 }
 
@@ -60,7 +77,8 @@ async function makeArtifactOrgSupplied(orgId: string): Promise<void> {
 async function insertPendingRun(
   orgId: string,
   feedId: number,
-  connId: number
+  connId: number,
+  connectorKey: string = CONNECTOR_KEY
 ): Promise<number> {
   const sql = getTestDb();
   const [run] = await sql`
@@ -68,7 +86,7 @@ async function insertPendingRun(
       organization_id, run_type, feed_id, connection_id, connector_key, connector_version,
       status, approval_status, created_at
     ) VALUES (
-      ${orgId}, 'sync', ${feedId}, ${connId}, ${CONNECTOR_KEY}, ${CONNECTOR_VERSION},
+      ${orgId}, 'sync', ${feedId}, ${connId}, ${connectorKey}, ${CONNECTOR_VERSION},
       'pending', 'auto', current_timestamp
     )
     RETURNING id
@@ -86,8 +104,8 @@ describe('organization-supplied connector code under LOBU_CLOUD_MODE', () => {
 
   it('queue admission refuses to create a sync run for org-supplied code', async () => {
     const sql = getTestDb();
-    const { feedId, orgId } = await setupFeed();
-    await makeArtifactOrgSupplied(orgId);
+    const { feedId, orgId } = await setupFeed(UNATTESTED_KEY);
+    await makeArtifactOrgSupplied(orgId, UNATTESTED_KEY);
 
     process.env.LOBU_CLOUD_MODE = '1';
     const created = await createSyncRun(feedId, {} as Env, sql);
@@ -113,9 +131,9 @@ describe('organization-supplied connector code under LOBU_CLOUD_MODE', () => {
 
   it('worker dispatch fails an already-claimed run rather than shipping org code', async () => {
     const sql = getTestDb();
-    const { feedId, connId, orgId } = await setupFeed();
-    const runId = await insertPendingRun(orgId, feedId, connId);
-    await makeArtifactOrgSupplied(orgId);
+    const { feedId, connId, orgId } = await setupFeed(UNATTESTED_KEY);
+    const runId = await insertPendingRun(orgId, feedId, connId, UNATTESTED_KEY);
+    await makeArtifactOrgSupplied(orgId, UNATTESTED_KEY);
 
     process.env.LOBU_CLOUD_MODE = '1';
     const res = await post('/api/workers/poll', {
@@ -185,6 +203,71 @@ describe('organization-supplied connector code under LOBU_CLOUD_MODE', () => {
   });
 
   /**
+   * The shadow shape, end to end — the state that took ~160 active feeds dark.
+   *
+   * A long-lived workspace has BOTH a shared row and an org-scoped copy for an
+   * image-shipped key, because `apply` wrote org copies for years before the
+   * shared-row convention. Readers select `ORDER BY organization_id NULLS
+   * LAST`, so the org row wins and the artifact classified `organization`.
+   *
+   * Three fences had to move together, which is why this is an integration
+   * test rather than three unit assertions: queue admission denied it,
+   * `resolveConnectorCode` refused an org-scoped row before consulting the
+   * image, and poll's stored-bytes suppression was scoped to shared rows only.
+   * Fixing admission alone would have converted a clean queue-time skip into a
+   * FAILED already-claimed run — strictly worse than the bug.
+   *
+   * The planted bytes assertion is the safety half: admitting the row must not
+   * put organization-supplied code on a worker.
+   */
+  it('admits an image-shipped key shadowed by an org row, without shipping its bytes', async () => {
+    const sql = getTestDb();
+    const planted = 'PLANTED_ORG_SHADOW_BYTES_MUST_NEVER_REACH_A_WORKER';
+    const { feedId, orgId } = await setupFeed();
+
+    // The org-scoped copy that shadows the fixture's shared row.
+    await sql`
+      INSERT INTO connector_versions (
+        connector_key, version, organization_id, compiled_code, compile_config_hash, created_at
+      ) VALUES (
+        ${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, ${orgId},
+        ${`export default class P { m(){ return '${planted}'; } }`},
+        (SELECT compile_config_hash FROM connector_versions
+          WHERE connector_key = ${CONNECTOR_KEY} AND organization_id IS NULL LIMIT 1),
+        NOW()
+      )
+    `;
+    const rows = await sql`
+      SELECT organization_id FROM connector_versions
+      WHERE connector_key = ${CONNECTOR_KEY} AND version = ${CONNECTOR_VERSION}
+    `;
+    // Guard the fixture itself: without both rows this test proves nothing.
+    expect(rows.length).toBe(2);
+
+    process.env.LOBU_CLOUD_MODE = '1';
+    const created = await createSyncRun(feedId, {} as Env, sql);
+    expect(created.ok).toBe(true);
+
+    const runId = created.ok ? created.runId : -1;
+    const res = await post('/api/workers/poll', {
+      body: { worker_id: 'cloud-shadow-worker', capabilities: { db_egress_hardening: true } },
+      token: 'test-fleet-token',
+      env: { WORKER_API_TOKEN: 'test-fleet-token' },
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // Dispatched, not skipped or failed.
+    expect(text).not.toContain('CUSTOM_CONNECTOR_CLOUD_DISABLED');
+    expect(text).not.toContain('Refusing organization-supplied code');
+    expect(JSON.parse(text).run_id).toBe(runId);
+    // And the org bytes stayed on the gateway.
+    expect(text).not.toContain(planted);
+
+    const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect((row as { status: string }).status).toBe('running');
+  });
+
+  /**
    * The availability half. Both layers must still admit the row every Cloud
    * connector actually has — shared scope, pointing at the image source.
    */
@@ -243,12 +326,14 @@ describe('Cloud agent tooling comes from the image, not the stored declaration',
   const PLANTED_PACKAGE = 'curl';
   const PLANTED_DOMAIN = 'planted.example.com';
 
-  async function setupToolingConnection(): Promise<string> {
+  async function setupToolingConnection(
+    connectorKey: string = TOOLING_KEY
+  ): Promise<string> {
     const sql = getTestDb();
     const org = await createTestOrganization();
     await createTestConnectorDefinition({
-      key: TOOLING_KEY,
-      name: 'GitHub',
+      key: connectorKey,
+      name: connectorKey === TOOLING_KEY ? 'GitHub' : 'Custom Test Connector',
       version: TOOLING_VERSION,
       organization_id: org.id,
     });
@@ -258,11 +343,11 @@ describe('Cloud agent tooling comes from the image, not the stored declaration',
         nix: { packages: [PLANTED_PACKAGE] },
         domains: [PLANTED_DOMAIN],
       })}
-      WHERE key = ${TOOLING_KEY} AND organization_id = ${org.id}
+      WHERE key = ${connectorKey} AND organization_id = ${org.id}
     `;
     await createTestConnection({
       organization_id: org.id,
-      connector_key: TOOLING_KEY,
+      connector_key: connectorKey,
     });
     return org.id;
   }
@@ -297,7 +382,14 @@ describe('Cloud agent tooling comes from the image, not the stored declaration',
     expect(declared.domains).toContain(IMAGE_DOMAIN);
   });
 
-  it('Cloud contributes nothing for an org-scoped artifact', async () => {
+  /**
+   * An org-scoped row over an image-shipped key is attestable, so the image's
+   * own declaration is what builds the worker. The planted org declaration is
+   * still dropped — that, not the emptiness, is the security property. Before
+   * the shadow-row fix this returned nothing and took the connector's tooling
+   * offline along with its runs.
+   */
+  it('Cloud uses the image declaration for an org-scoped row over a shipped key', async () => {
     const sql = getTestDb();
     const orgId = await setupToolingConnection();
     await sql`
@@ -310,8 +402,30 @@ describe('Cloud agent tooling comes from the image, not the stored declaration',
     process.env.LOBU_CLOUD_MODE = '1';
     const declared = await resolveAgentToolingDeclaration({ organizationId: orgId });
 
-    // Not the planted declaration, and not the image's either — an artifact
-    // Cloud cannot attest gets no tooling at all.
+    expect(declared.packages).not.toContain(PLANTED_PACKAGE);
+    expect(declared.domains).not.toContain(PLANTED_DOMAIN);
+    expect(declared.packages).toContain(IMAGE_PACKAGE);
+    expect(declared.domains).toContain(IMAGE_DOMAIN);
+  });
+
+  /**
+   * The unattestable case the assertion above used to stand for: an org-scoped
+   * row for a key the image does not ship contributes nothing at all, so a
+   * tenant cannot widen a worker's deny-by-default egress allowlist.
+   */
+  it('Cloud contributes nothing for an org-scoped artifact it cannot attest', async () => {
+    const sql = getTestDb();
+    const orgId = await setupToolingConnection(UNATTESTED_KEY);
+    await sql`
+      UPDATE connector_versions
+      SET organization_id = ${orgId},
+          source_code = ${'export default { sync: async () => ({ items: [] }) }'}
+      WHERE connector_key = ${UNATTESTED_KEY} AND version = ${TOOLING_VERSION}
+    `;
+
+    process.env.LOBU_CLOUD_MODE = '1';
+    const declared = await resolveAgentToolingDeclaration({ organizationId: orgId });
+
     expect(declared.packages).toEqual([]);
     expect(declared.domains).toEqual([]);
   });

--- a/packages/server/src/__tests__/integration/trigger-feed-skip-reason.test.ts
+++ b/packages/server/src/__tests__/integration/trigger-feed-skip-reason.test.ts
@@ -79,9 +79,14 @@ describe('trigger_feed skip reasons', () => {
       { action: 'trigger_feed', feed_id: feedId },
       {} as Env,
       ctx,
-    )) as { action?: string; message?: string; triggered?: boolean };
+    )) as { action?: string; message?: string; triggered?: boolean; reason?: string };
 
-    expect(res.triggered).toBeUndefined();
+    // `false`, not absent: the skip has to be readable as a skip WITHOUT
+    // parsing the sentence. `toBeUndefined()` here was the old shape, in
+    // which a caller that queued nothing was indistinguishable from one that
+    // did — and no run row is written either, so nothing failed or alerted.
+    expect(res.triggered).toBe(false);
+    expect(res.reason).toBeTruthy();
     // The actionable part: name the real cause.
     expect(res.message).toContain('no longer installed');
     // And explicitly NOT the old catch-all, which sent operators off to wait
@@ -105,9 +110,10 @@ describe('trigger_feed skip reasons', () => {
       { action: 'trigger_feed', feed_id: feedId },
       {} as Env,
       ctx,
-    )) as { message?: string; triggered?: boolean };
+    )) as { message?: string; triggered?: boolean; reason?: string };
 
-    expect(second.triggered).toBeUndefined();
+    expect(second.triggered).toBe(false);
+    expect(second.reason).toBeTruthy();
     expect(second.message).toContain('already pending or running');
   });
 
@@ -123,6 +129,8 @@ describe('trigger_feed skip reasons', () => {
       ctx,
     )) as { error?: string; triggered?: boolean };
 
+    // The ERROR variant, not the skip variant — it carries no `triggered` at
+    // all, which is why this assertion stays `toBeUndefined()`.
     expect(res.triggered).toBeUndefined();
     expect(res.error).toContain('does not support sync');
 

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -341,7 +341,10 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
   const feedId = Number(feed.id);
   const created = await createSyncRun(feedId, c.env as unknown as Env);
   if (!created.ok) {
-    return c.json({ error: describeSyncRunSkip(created.reason) }, 409);
+    return c.json(
+      { error: describeSyncRunSkip(created.reason, created.detail) },
+      409
+    );
   }
   const runId = created.runId;
 

--- a/packages/server/src/gateway/__tests__/custom-connector-cloud-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/custom-connector-cloud-gate.test.ts
@@ -148,24 +148,70 @@ describe('Cloud artifact admission', () => {
 		expect(error.message.startsWith(CUSTOM_CONNECTOR_CLOUD_DISABLED)).toBe(true);
 	});
 
-	test('Cloud denies organization-supplied bytes even for a shipped key', () => {
+	/**
+	 * INVERTED from "deny org bytes even for a shipped key".
+	 *
+	 * That assertion was the defect: readers select `ORDER BY organization_id
+	 * NULLS LAST`, so an org-scoped copy of an image-shipped key wins the
+	 * selection, classifies `organization`, and returned before the image check
+	 * ever ran. `apply` wrote org copies for years before the shared-row
+	 * convention, so this is the ordinary state of a long-lived workspace, not
+	 * an exotic one — it took ~160 active feeds across several orgs dark.
+	 *
+	 * Admitting costs nothing because the org bytes still never execute:
+	 * `resolveConnectorCode` compiles the image file in Cloud. It is the same
+	 * reasoning already applied to version drift and to a shared row holding
+	 * non-image bytes, two tests below — this key's provenance was the only
+	 * shape the argument had not been extended to.
+	 */
+	test('Cloud admits an org-scoped row for a key the image ships', () => {
 		process.env.LOBU_CLOUD_MODE = 'true';
-		denial(() =>
-			assertCloudConnectorArtifactTrusted({
-				connectorKey: 'github',
-				facts: facts({ organizationId: 'org_1', hasSourceCode: true }),
-			}),
-		);
+		assertCloudConnectorArtifactTrusted({
+			connectorKey: 'github',
+			facts: facts({ organizationId: 'org_1', hasSourceCode: true }),
+		});
 	});
 
-	test('Cloud denies an org row shadowing the shared row', () => {
+	/**
+	 * The exact production shape, pinned because every other fixture holds one
+	 * row in isolation: an image-shipped key whose shared row is shadowed by an
+	 * org-scoped row carrying bytes. `rowCount` is what the reader's own scope
+	 * query saw — both rows — and the selected row is the org one.
+	 */
+	test('Cloud admits an image-shipped key whose shared row an org row shadows', () => {
 		process.env.LOBU_CLOUD_MODE = 'true';
-		denial(() =>
+		for (const connectorKey of ['github', 'hackernews', 'google.gmail']) {
 			assertCloudConnectorArtifactTrusted({
-				connectorKey: 'github',
-				facts: facts({ rowCount: 2 }),
+				connectorKey,
+				facts: facts({
+					organizationId: 'org_1',
+					rowCount: 2,
+					hasCompiledCode: true,
+					sourcePath: null,
+				}),
+			});
+		}
+	});
+
+	/**
+	 * The policy half, and the reason the fix is a key check rather than a
+	 * blanket allow. A genuinely org-authored connector has no image file, so
+	 * it stays denied on exactly the same code path.
+	 */
+	test('Cloud still denies an org-scoped row for a key the image does not ship', () => {
+		process.env.LOBU_CLOUD_MODE = 'true';
+		const error = denial(() =>
+			assertCloudConnectorArtifactTrusted({
+				connectorKey: 'not_a_bundled_connector',
+				facts: facts({
+					organizationId: 'org_1',
+					rowCount: 2,
+					hasCompiledCode: true,
+					sourcePath: null,
+				}),
 			}),
 		);
+		expect(error.message).toContain('organization-supplied');
 	});
 
 	/**
@@ -216,9 +262,11 @@ describe('Cloud artifact admission', () => {
 describe('Cloud denial names the remedy, not only the reason', () => {
 	test('an organization-supplied artifact is pointed at the supported lanes', () => {
 		process.env.LOBU_CLOUD_MODE = 'true';
+		// A key the image does not ship: the genuinely organization-authored
+		// case, and now the only one that reaches this denial.
 		const error = denial(() =>
 			assertCloudConnectorArtifactTrusted({
-				connectorKey: 'github',
+				connectorKey: 'not_a_bundled_connector',
 				facts: facts({ organizationId: 'org_1', hasCompiledCode: true }),
 			}),
 		);
@@ -229,21 +277,6 @@ describe('Cloud denial names the remedy, not only the reason', () => {
 		// Cloud refuses every source-code install, so an OpenAPI connector —
 		// which is source metadata — must not be offered as a destination.
 		expect(error.message).not.toMatch(/OpenAPI/);
-	});
-
-	test('a shadowed shared row says the copy has to be removed for the tenant', () => {
-		process.env.LOBU_CLOUD_MODE = 'true';
-		const error = denial(() =>
-			assertCloudConnectorArtifactTrusted({
-				connectorKey: 'github',
-				facts: facts({ rowCount: 2 }),
-			}),
-		);
-		expect(error.message).toContain('(ambiguous-artifact-scope)');
-		expect(error.message).toMatch(/organization-scoped copy/);
-		// No Cloud-permitted action deletes a connector_versions row, so the
-		// remedy must not pretend the tenant can self-serve it.
-		expect(error.message).toMatch(/contact support/);
 	});
 
 	test('a missing image file is told apart from a tenant problem', () => {

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -347,11 +347,31 @@ export type SyncRunSkipReason =
 
 export type CreateSyncRunResult =
   | { ok: true; runId: number }
-  | { ok: false; reason: SyncRunSkipReason };
+  | {
+      ok: false;
+      reason: SyncRunSkipReason;
+      /**
+       * The denial sentence, when the cause produced one. `cloud_restricted`
+       * collapses two very different causes, and the artifact gate's own
+       * message already names the reason AND the remedy — discarding it left
+       * the operator with "cannot run on Lobu Cloud yet" and nowhere to go.
+       */
+      detail?: string;
+    };
 
-/** Operator-facing sentence per cause. Kept beside the reasons so a new reason
- *  cannot be added without deciding what a human should be told. */
-export function describeSyncRunSkip(reason: SyncRunSkipReason): string {
+/**
+ * Operator-facing sentence per cause. Kept beside the reasons so a new reason
+ * cannot be added without deciding what a human should be told.
+ *
+ * `detail` wins when the cause carried its own sentence: the Cloud artifact
+ * gate names the specific provenance and the supported path out of it, which
+ * is strictly more than the reason code can say.
+ */
+export function describeSyncRunSkip(
+  reason: SyncRunSkipReason,
+  detail?: string
+): string {
+  if (detail) return detail;
   switch (reason) {
     case 'already_active':
       return 'Sync already pending or running for this feed';
@@ -519,7 +539,7 @@ async function createSyncRunWithClient(
       { feedId, connector_key: feed.connector_key, error: errorMessage(error) },
       '[queue] Skipping sync run for custom executable connector under LOBU_CLOUD_MODE'
     );
-    return { ok: false, reason: 'cloud_restricted' };
+    return { ok: false, reason: 'cloud_restricted', detail: errorMessage(error) };
   }
 
   // Manual feeds (schedule null) keep next_run_at null after enqueue so they

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -1339,8 +1339,15 @@ async function handleTriggerFeed(
     if (created.reason === 'sync_unsupported') {
       return { error: 'Feed does not support sync' };
     }
+    // `triggered: false` mirrors the success shape below, because the message
+    // alone was indistinguishable from success: the skip result carried no
+    // error and no flag, so a caller that queued nothing read as one that had.
+    // No run row is written for a skip either, so there is no failed run to
+    // alert on — a Cloud denial sat unnoticed behind this shape.
     return {
       action: 'trigger_feed',
+      triggered: false,
+      reason: created.reason,
       message: describeSyncRunSkip(created.reason),
     };
   }

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -1348,7 +1348,7 @@ async function handleTriggerFeed(
       action: 'trigger_feed',
       triggered: false,
       reason: created.reason,
-      message: describeSyncRunSkip(created.reason),
+      message: describeSyncRunSkip(created.reason, created.detail),
     };
   }
   const runId = created.runId;

--- a/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
+++ b/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
@@ -81,6 +81,9 @@ beforeEach(() => {
 // sql object with no `.begin`, failing far from the cause.
 afterEach(() => {
   vi.doUnmock('../../db/client');
+  // The logger mock is set inside a single test, but `isolate: false` shares
+  // the registry across files — retract it here for the same reason.
+  vi.doUnmock('../logger');
   vi.resetModules();
 });
 
@@ -286,12 +289,68 @@ describe('Cloud executes image bytes, never the stored row', () => {
     expect(code.length).toBeGreaterThan(PLANTED_BUNDLE.length);
   });
 
-  test('Cloud refuses outright when the row is organization-scoped', async () => {
+  /**
+   * INVERTED from "Cloud refuses outright when the row is organization-scoped".
+   *
+   * Refusing here is what turned an admitted run into a failed CLAIMED run:
+   * readers select `ORDER BY organization_id NULLS LAST`, so an org-scoped
+   * copy of an image-shipped key wins the selection, and the whole default
+   * catalog went dark for any workspace old enough to have one. Compiling the
+   * image file honours the identical invariant the refusal did — the planted
+   * bytes still never execute, asserted below — while keeping it online.
+   */
+  test('Cloud compiles the image for an org-scoped row, and its bytes never execute', async () => {
+    process.env.LOBU_CLOUD_MODE = 'true';
+    const { resolveConnectorCode } = await import('../ensure-connector-installed');
+
+    const code = await resolveConnectorCode('github', {
+      ...sharedRow,
+      organization_id: 'org_planted',
+    });
+
+    expect(code).not.toContain(PLANTED_MARKER);
+    expect(code).not.toBe(PLANTED_BUNDLE);
+    expect(code).toContain('github');
+  });
+
+  /**
+   * The substitution above is invisible from the run: the org's bytes are
+   * discarded and the image runs instead. An org that deliberately overrode a
+   * catalog key would otherwise see a connector that "works" while executing
+   * code it did not install, so the resolver is the one place that can say so.
+   * The line's volume is also how the shadow-row cleanup gets measured.
+   */
+  test('Cloud logs the substitution, and stays quiet for a shared row', async () => {
+    process.env.LOBU_CLOUD_MODE = 'true';
+    const warn = vi.fn();
+    vi.doMock('../logger', () => ({
+      default: { warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    }));
+    const { resolveConnectorCode } = await import('../ensure-connector-installed');
+
+    await resolveConnectorCode('github', { ...sharedRow, organization_id: 'org_planted' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatchObject({
+      connector_key: 'github',
+      organization_id: 'org_planted',
+    });
+
+    // A shared row is the ordinary Cloud shape — every connector would log.
+    warn.mockClear();
+    await resolveConnectorCode('github', sharedRow);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('Cloud still refuses an org-scoped row for a key the image does not ship', async () => {
     process.env.LOBU_CLOUD_MODE = 'true';
     const { resolveConnectorCode } = await import('../ensure-connector-installed');
 
     await expect(
-      resolveConnectorCode('github', { ...sharedRow, organization_id: 'org_planted' })
+      resolveConnectorCode('zz.staleprobe', {
+        ...sharedRow,
+        organization_id: 'org_planted',
+        version: '1.0.0',
+      })
     ).rejects.toThrow(/organization-supplied/i);
   });
 

--- a/packages/server/src/utils/custom-connector-cloud-gate.ts
+++ b/packages/server/src/utils/custom-connector-cloud-gate.ts
@@ -17,8 +17,8 @@ export type ConnectorArtifactProvenance =
  * `rowCount` is how many rows the reader's own scope query saw for the
  * selected (connector_key, version) — 0 when no stored row exists at all, and
  * >1 when an org-scoped copy shadows the shared row. Readers select the same
- * ORDER BY organization_id NULLS LAST row, so the count is what distinguishes
- * "the shared row" from "the shared row plus an org override".
+ * ORDER BY organization_id NULLS LAST row, so a shadowed selection always
+ * surfaces as the org-scoped row itself; only 0 changes the verdict.
  */
 export interface ConnectorArtifactFacts {
 	organizationId: string | null;
@@ -29,29 +29,22 @@ export interface ConnectorArtifactFacts {
 }
 
 /** Why Cloud will not run an artifact. Surfaced to operators in the error. */
-type CloudDenialReason =
-	| 'organization-supplied'
-	| 'ambiguous-artifact-scope'
-	| 'not-in-image';
+type CloudDenialReason = 'organization-supplied' | 'not-in-image';
 
 /**
  * What the org admin reading the run error can do about each denial.
  *
  * The reason code alone read as an outage: a refusal surfaced inside a sync or
  * reaction run as `not eligible (organization-supplied)` with nothing to say
- * what the supported path is. The three reasons do not share a remedy — one is
- * a tenant migration, one needs support to delete a row, one is deploy drift —
- * so each names its own. Every action named here must be one Cloud actually
- * permits: source-code installs, updates and rollbacks are all refused by
- * `assertCustomConnectorInstallAllowed`, so an OpenAPI connector (source
- * metadata) is not a destination and a tenant cannot remove a shadowing
- * `connector_versions` row themselves.
+ * what the supported path is. The two reasons do not share a remedy — one is
+ * a tenant migration, one is deploy drift — so each names its own. Every
+ * action named here must be one Cloud actually permits: source-code installs,
+ * updates and rollbacks are all refused by `assertCustomConnectorInstallAllowed`,
+ * so an OpenAPI connector (source metadata) is not a destination.
  */
 const CLOUD_DENIAL_REMEDY: Record<CloudDenialReason, string> = {
 	'organization-supplied':
 		'Re-express this connector as an MCP server, ship it as a device connector from a paired device, or run it self-hosted.',
-	'ambiguous-artifact-scope':
-		'An organization-scoped copy of this version shadows the shared connector; contact support to remove the organization-scoped copy so one artifact is selected.',
 	'not-in-image':
 		'The running image ships no source file for this connector key — it was removed or renamed since this version was installed, or the deploy is incomplete. Install its replacement from the current catalog, or contact support.',
 };
@@ -125,10 +118,25 @@ function cloudDenialReason(params: {
 	// in connector_versions to refuse, and demanding an image file here would
 	// take every device-executed connector offline in Cloud.
 	if (provenance === 'bundled') return null;
-	if (provenance === 'organization') return 'organization-supplied';
-	// An org-scoped copy shadowing the shared row makes the selection ambiguous
-	// across readers; fail closed rather than pick a winner here.
-	if (params.facts.rowCount > 1) return 'ambiguous-artifact-scope';
+	// An org-scoped row for a key the image ships is admitted, because the org
+	// bytes still never execute: `resolveConnectorCode` compiles the image file
+	// in Cloud whatever the stored row's scope. Denying took the connector
+	// offline and prevented nothing — the same argument already applied to
+	// version drift and to a shared row holding non-image bytes.
+	//
+	// This is the ordinary state of a long-lived workspace, not an exotic one:
+	// readers select `ORDER BY organization_id NULLS LAST`, so an org copy wins
+	// the selection over the shared row, and `apply` wrote org copies for years
+	// before the shared-row convention. A key the image does NOT ship is the
+	// genuinely organization-authored case and stays denied.
+	if (provenance === 'organization') {
+		return findBundledConnectorFile(params.connectorKey) === null
+			? 'organization-supplied'
+			: null;
+	}
+	// A selected shared row is the only row in scope: readers order org rows
+	// first and the two partial unique indexes allow one row per scope, so
+	// there is no second candidate left to disambiguate.
 	if (findBundledConnectorFile(params.connectorKey) === null) return 'not-in-image';
 	return null;
 }

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -79,16 +79,20 @@ export async function resolveConnectorCode(
   // refuses every stored-byte fallback below, so an admission gap can still
   // never put organization-supplied code on a runtime.
   if (isCloudMode()) {
+    // Image first, whatever the stored row's scope. An org-scoped row for a key
+    // the image ships is the common shadow shape (readers select ORDER BY
+    // organization_id NULLS LAST), and refusing it here turned an admitted run
+    // into a failed claimed run. Compiling the image file honours the same
+    // invariant the refusal did — organization-supplied bytes never execute —
+    // while keeping the connector online.
+    const imagePath = findBundledConnectorFile(connectorKey);
+    if (imagePath) return compileConnectorFromFile(imagePath);
     if (stored?.organization_id != null) {
       throw new Error(
         `Refusing organization-supplied code for '${connectorKey}' in Lobu Cloud.`
       );
     }
-    const imagePath = findBundledConnectorFile(connectorKey);
-    if (!imagePath) {
-      throw new Error(`No bundled source for '${connectorKey}' in Lobu Cloud.`);
-    }
-    return compileConnectorFromFile(imagePath);
+    throw new Error(`No bundled source for '${connectorKey}' in Lobu Cloud.`);
   }
   if (stored?.compiled_code) {
     if (stored.compile_config_hash === COMPILE_CONFIG_HASH) return stored.compiled_code;

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -86,7 +86,31 @@ export async function resolveConnectorCode(
     // invariant the refusal did — organization-supplied bytes never execute —
     // while keeping the connector online.
     const imagePath = findBundledConnectorFile(connectorKey);
-    if (imagePath) return compileConnectorFromFile(imagePath);
+    if (imagePath) {
+      // The substitution is otherwise invisible: the org's stored bytes are
+      // discarded and the image file runs instead, with nothing in the run to
+      // say so. This is the only place that knows it happened, so an org that
+      // deliberately overrode a catalog key would see a connector that "works"
+      // while executing code it did not install. The volume of this line is
+      // also the measure of the shadow-row cleanup — it goes quiet when the
+      // org-scoped rows for image-shipped keys are retired.
+      //
+      // `StoredConnectorVersion` carries no `source_code`, so a source-only
+      // org row is superseded without a line here; every prod shadow row for
+      // an image-shipped key carries `compiled_code`.
+      if (stored?.organization_id != null && stored.compiled_code != null) {
+        logger.warn(
+          {
+            connector_key: connectorKey,
+            organization_id: stored.organization_id,
+            version: stored.version,
+            row_id: stored.id,
+          },
+          'Cloud superseded an organization-scoped connector artifact with the image file'
+        );
+      }
+      return compileConnectorFromFile(imagePath);
+    }
     if (stored?.organization_id != null) {
       throw new Error(
         `Refusing organization-supplied code for '${connectorKey}' in Lobu Cloud.`

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1712,10 +1712,17 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // compiled_code on the version row. Fleet workers normally compile bundled
   // sources locally, but an explicit override must still ship inline so prod
   // picks up connector code before the next image deploy. In Cloud the image
-  // is the trust root, so stored bytes on a shared row are ignored whenever
-  // the image carries the source — the worker compiles from its own image.
+  // is the trust root, so stored bytes are ignored whenever the image carries
+  // the source — the worker compiles from its own image.
+  //
+  // Deliberately NOT restricted to shared rows. Scoping the suppression to
+  // `artifact_organization_id === null` left the shadow shape — an org-scoped
+  // copy of an image-shipped key — routing into `resolveConnectorCode` with a
+  // row it then refused, failing an already-claimed run. Suppressing on the
+  // image alone is also the stricter half of the pair: org bytes now never
+  // reach a worker for a key the image ships.
   const hasStoredCompiledCode = Boolean(row.compiled_code) &&
-    !(isCloudMode() && row.artifact_organization_id === null && gatewayHasLocalSource);
+    !(isCloudMode() && gatewayHasLocalSource);
   const workerWillResolveLocally =
     !isUserScopedWorker && gatewayHasLocalSource && !hasStoredCompiledCode;
   // Only a device-owned run (native bridge or daemon builtin) is implemented by


### PR DESCRIPTION
## Summary

- The Cloud artifact gate denied connectors the running image **does** ship. Readers select `ORDER BY organization_id NULLS LAST`, so an org-scoped copy of an image-shipped key wins the selection, classifies `organization`, and returned a denial before the image check ever ran. `apply` wrote org copies for years before the shared-row convention. Measured on prod (read-only): **106 org-scoped rows carrying bytes sit on image-shipped keys** (`x` 42, `github` 18, `reddit` 9, `hackernews` 6, `youtube`/`google.gmail`/`rss`/`slack` 4 each, `market.quotes` 2, …), and **30 active feeds** (`github` 10, `reddit` 8, `slack` 7, `hackernews` 3, `rss` 1, `x` 1) plus **15 active connections** were dark on keys the image ships.
- Admitting costs nothing: the org bytes still never execute, because in Cloud `resolveConnectorCode` compiles the image file whatever the stored row's scope. This is the same argument #3246 already applied to version drift and to a shared row holding non-image bytes — this provenance was the only shape it had not been extended to. **A key the image does not ship stays denied on the same code path.** The same audit confirms the policy half holds: the other 50 dark feeds (`website` 41, `spotify` 4, `revolut` 2, `midas` 1, `loki.activity` 1, `linkedin` 1) are genuinely absent from the image and stay refused.
- `trigger_feed` returned success-shaped JSON on a skip: nothing queued, no run row, so nothing to fail or alert on. That is how the denial sat unnoticed. The skip variant now carries `triggered: false` + machine-readable `reason`.

## The defect is three fences wide

Fixing only admission is **strictly worse** than the bug — an admitted run then dies at compile as a failed claimed run:

1. `cloudDenialReason` — consult the image before refusing org scope.
2. `worker-api/poll` — suppress stored bytes on the image alone, not only for shared rows. Also the stricter half: org bytes now never reach a worker for a key the image ships.
3. `resolveConnectorCode` — image first, then the org refusal.

`ambiguous-artifact-scope` is removed as unreachable: the two partial unique indexes on `connector_versions` (`connector_versions_org_key_version`, `connector_versions_shared_unique`) plus the `organization_id = $org OR IS NULL` scope filter bound the lookup to two candidates, and `NULLS LAST` always selects the org one — so a *selected shared* row is the only row in its scope.

## Test plan

- [x] Intended files staged explicitly, `make pre-pr` clean
- [x] Tests run: `bun test packages/server/src/gateway/__tests__/custom-connector-cloud-gate.test.ts`; `cd packages/server && bun run test -- run src/__tests__/integration/connectors/custom-connector-cloud-gate.test.ts`
- [x] Bug fix: red→green pasted below

### Red (before the fix)

```
 19 pass
  2 fail
```
Integration: `2 failed | 8 passed` — the new shadow-row test failed at admission with `CUSTOM_CONNECTOR_CLOUD_DISABLED`.

### Green

```
$ bun test .../gateway/__tests__/custom-connector-cloud-gate.test.ts
 19 pass
 0 fail

$ cd packages/server && bun run test -- run .../integration/connectors/custom-connector-cloud-gate.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Mutation check

| reverted fence | caught? |
|---|---|
| 1 — `cloudDenialReason` | ✅ 2 unit + 2 integration failures |
| 2 — `poll.ts` alone | ❌ |
| 3 — `resolveConnectorCode` alone | ❌ |
| 2 **and** 3 together | ✅ `expected … not to contain 'Refusing organization-supplied code'` |

Fences 2 and 3 are mutually masking: with either in place the run still resolves image bytes, so only the pair is observable. Recorded rather than papered over — the same scope note the existing suite already carries for a sibling test.

## Notes

The new integration test plants `PLANTED_ORG_SHADOW_BYTES_MUST_NEVER_REACH_A_WORKER` in the org row and asserts it is absent from the poll response, so the test proves both halves: the run is admitted **and** the org bytes are not shipped. It guards `expect(rows.length).toBe(2)` so the fixture itself cannot go vacuous.

Three pre-existing integration tests used in-image keys (`postgres`, `github`) to assert the `organization` denial; they now use a synthetic `custom_test_connector`, which is what they always meant.

Follow-ups, not in this PR: a cleanup migration retiring org-scoped `connector_versions` rows for keys the image ships (the shadow rows are historical debris — `connector-definition-install.ts` writes `versionScope: 'shared'` today), and an observable signal when an org override is silently superseded by the image version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Surface sweep (second commit)

Every executing path routes through the one `resolveConnectorCode` chokepoint (`feed-sync`, `connector-pushdown` ×2, `webhook-registration` ×2, `manage_operations/execute`, `catalog/connector-definitions`, `worker-api/poll`), so fence 3 covers them all. Admission has four callers, not three — `queue-service` ×3, `poll`, and `agent-tooling/resolver` via the non-throwing `isCloudConnectorArtifactTrusted`; that last one silently contributed **no agent tooling at all** for a shadowed connection (no egress allowlist, no auth schema) and is fixed by the same predicate.

The sweep also found a fourth surface the first commit missed: `connector-stale-artifact.test.ts` pinned `resolveConnectorCode` to refuse an org-scoped `github` row — the fence-3 bug stated as a contract. Inverted, with the refusal re-pointed at a key the image does not ship.

`resolveConnectorCode` now warns once per resolution when it supersedes an org-scoped artifact with the image file, so an org that deliberately overrode a catalog key is no longer silently switched. Test asserts it fires for the org row and stays quiet for the ordinary shared row.

Suites: `integration/connectors` + `utils` + `catalog` — **111 files, 1523 tests passed**; `worker-api`/`gateway`/`runs`/`tools` — 7 files, 38 passed; bun gate suite — 19 pass.

## Known, out of scope

The audit found 4 active device-connector definitions (`google.takeout`, `instagram.takeout`, `twitter.takeout`, `whatsapp.local`) whose selected row is org-scoped **with bytes**. `IS_DEVICE_CONNECTOR_SQL` requires `source_path LIKE 'device-manifest://%'` on the org branch, so those are not recognized as device connectors by the autowire-suppression fragment or the two copies of that test in `device-reconcile.ts`. Same shadow-row debris class, different subsystem, untouched by this PR — filed rather than fixed blind.


## Verified live against prod

#3281's remedy work is already deployed (image `20260902-033615-002552` → build run 2552 → `9606ce1f`, which contains squash `630dd21a`). Reproducing the original report on prod showed the remedies never reach the surface it was reported from:

```
POST /api/<org>/manage_feeds {"action":"trigger_feed","feed_id":550}
→ {"action":"trigger_feed","message":"This connector cannot run on Lobu Cloud yet, so no sync was queued"}
```

`createSyncRun` catches the gate's denial, discards the message and returns the reason code `cloud_restricted`. That code collapses two unrelated causes (the key-based `CLOUD_RESTRICTED_CONNECTOR_KEYS` restriction and the artifact gate), so the sentence it maps to cannot say which fired or what to do. The skip now carries the denial sentence as `detail` and `describeSyncRunSkip` prefers it, at both readers (`manage_feeds`, the connect route's 409). No contract change — `message` was already a string. Mutation-checked: dropping `detail` fails the admission test.

Feed 550 is `hackernews` in the reporter's org — image-shipped, and one of the 30 feeds this branch brings back.

`make ui-review`: not applicable (`packages/owletto` unchanged at `c2ce1b6d`).

## Toolchain note (not this PR)

`scripts/dev-native.sh` refuses Node 25+ because "isolated-vm has no Node 25+ build", but `sandbox/run-script.ts` already resolves `isolated-vm-next` (isolated-vm@7) on Node 26+. The server boots and serves the OpenAPI document fine on Node 26 — the guard is stale. (Regenerating the client needed a booted server, and this machine's `node@22` keg is separately broken: missing `libsimdutf.34.dylib`.)