### PR TITLE
feat(sandbox): surface and remove sandboxes that outlived their worktree

### DIFF
--- a/scripts/__tests__/sandbox.test.ts
+++ b/scripts/__tests__/sandbox.test.ts
@@ -24,6 +24,8 @@ import {
   interpretSignUp,
   isAppleDouble,
   loginLink,
+  orphanSandboxNames,
+  parseWorktreeRoots,
   previewUrlFor,
   resolveOwnerEmail,
   sandboxName,
@@ -660,5 +662,62 @@ describe("credentialsFromConfig", () => {
     expect(credentialsFromConfig({})).toBeNull();
     expect(credentialsFromConfig({ profiles: [] })).toBeNull();
     expect(credentialsFromConfig(null)).toBeNull();
+  });
+});
+
+describe("parseWorktreeRoots", () => {
+  test("takes the path off every worktree line and ignores the rest", () => {
+    const porcelain = [
+      "worktree /Users/x/Code/lobu",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /Users/x/Code/lobu/.claude/worktrees/feature",
+      "HEAD def",
+      "branch refs/heads/feat/feature",
+      "",
+    ].join("\n");
+    expect(parseWorktreeRoots(porcelain)).toEqual([
+      "/Users/x/Code/lobu",
+      "/Users/x/Code/lobu/.claude/worktrees/feature",
+    ]);
+  });
+
+  test("a detached worktree still yields its path", () => {
+    expect(
+      parseWorktreeRoots("worktree /tmp/wt\nHEAD abc\ndetached\n")
+    ).toEqual(["/tmp/wt"]);
+  });
+
+  test("empty input is not an empty-string path", () => {
+    expect(parseWorktreeRoots("")).toEqual([]);
+  });
+});
+
+describe("orphanSandboxNames", () => {
+  const live = "/Users/x/Code/lobu/.claude/worktrees/live";
+  const gone = "/Users/x/Code/lobu/.claude/worktrees/gone";
+
+  test("a sandbox whose worktree still exists is not an orphan", () => {
+    expect(orphanSandboxNames([sandboxName(live)], [live])).toEqual([]);
+  });
+
+  test("a sandbox whose worktree is gone is an orphan", () => {
+    expect(
+      orphanSandboxNames([sandboxName(live), sandboxName(gone)], [live])
+    ).toEqual([sandboxName(gone)]);
+  });
+
+  test("only lobu-dev- names are judged; other lobu- sandboxes have no worktree to miss", () => {
+    expect(orphanSandboxNames(["lobu-opencode-test"], [])).toEqual([]);
+  });
+
+  test("same slug at a different path is a different sandbox, so it is an orphan", () => {
+    // sandboxName hashes the absolute path, not the basename: two worktrees
+    // named `gone` under different parents must not alias each other.
+    const elsewhere = "/Users/x/other/gone";
+    expect(orphanSandboxNames([sandboxName(gone)], [elsewhere])).toEqual([
+      sandboxName(gone),
+    ]);
   });
 });

--- a/scripts/land.sh
+++ b/scripts/land.sh
@@ -174,6 +174,14 @@ report_cleanup() {
     | awk -v want="branch refs/heads/$head" \
       '/^worktree /{path = substr($0, 10)} $0 == want {print path; exit}')"
   [ -n "$worktree" ] || return 0
+  # task-clean.sh:44 resolves NAME to "$repo/.claude/worktrees/$NAME", so the
+  # command below is only actionable for a worktree that actually lives there.
+  # Landing from the main checkout or an ad-hoc worktree (~/Code/lobu-pr3173-exact)
+  # would otherwise print a command that exits "no worktree at ...".
+  case "$worktree" in
+    */.claude/worktrees/*) ;;
+    *) return 0 ;;
+  esac
   slug="$(basename "$worktree")"
   echo
   echo "Cleanup: this merge does not retire the worktree or its dev sandbox."

--- a/scripts/land.sh
+++ b/scripts/land.sh
@@ -158,6 +158,29 @@ gh pr merge "$PR" --squash --admin || exit $?
 
 merge_sha="$(gh pr view "$PR" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null)"
 echo "merged. squash commit: ${merge_sha:-unknown}"
+
+# Merging is the only event that retires a task worktree, and nothing is wired
+# to it: `task-clean` exists but only ever runs when someone types it, so a
+# merged branch leaves a multi-GB worktree and a Daytona sandbox that keeps
+# billing for disk against the org ceiling until the next `make sandbox` fails
+# on quota. Deliberately a hint and not an action — the worktree is often still
+# needed after the merge to verify the rollout, and this may be running from
+# inside the very directory it would remove.
+report_cleanup() {
+  local head worktree slug
+  head="$(gh pr view "$PR" --json headRefName --jq .headRefName 2>/dev/null)" || return 0
+  [ -n "$head" ] || return 0
+  worktree="$(git worktree list --porcelain \
+    | awk -v want="branch refs/heads/$head" \
+      '/^worktree /{path = substr($0, 10)} $0 == want {print path; exit}')"
+  [ -n "$worktree" ] || return 0
+  slug="$(basename "$worktree")"
+  echo
+  echo "Cleanup: this merge does not retire the worktree or its dev sandbox."
+  echo "Once you no longer need it for verification:"
+  echo "  make task-clean NAME=$slug"
+}
+report_cleanup
 echo
 echo "Prod-visible? Gate rollout on the SQUASH commit, not your branch head:"
 echo "  git merge-base --is-ancestor ${merge_sha:-<sha>} \"\$DEPLOYED_SHA\""

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -118,6 +118,41 @@ export function sandboxName(root: string): string {
   return `lobu-dev-${slug}-${pathHash}`;
 }
 
+/** Absolute worktree paths from `git worktree list --porcelain`. */
+export function parseWorktreeRoots(porcelain: string): string[] {
+  const marker = "worktree ";
+  return porcelain
+    .split("\n")
+    .filter((line) => line.startsWith(marker))
+    .map((line) => line.slice(marker.length).trim())
+    .filter(Boolean);
+}
+
+/**
+ * Sandboxes this tool created whose worktree no longer exists.
+ *
+ * `sandboxName` hashes the ABSOLUTE worktree path, so the set of live
+ * worktrees regenerates exactly the set of names that still have an owner —
+ * no network call and no PR lookup. Anything else under `lobu-dev-` outlived
+ * the directory it was derived from.
+ *
+ * That happens because `task-clean` deletes the sandbox BEFORE the worktree,
+ * so an interruption between the two steps (a killed run, a hand-removed
+ * directory) strands one — and once the path is gone the name cannot be
+ * re-derived, so nothing else will ever reclaim it. A stopped sandbox still
+ * bills for disk against the org ceiling, which is why this is worth surfacing
+ * rather than leaving to be noticed when the next `up` fails on quota.
+ *
+ * Only `lobu-dev-` names are judged: `ls` shows every `lobu-` sandbox, but the
+ * others were never derived from a worktree and so have no owner to be missing.
+ */
+export function orphanSandboxNames(names: string[], roots: string[]): string[] {
+  const owned = new Set(roots.map(sandboxName));
+  return names.filter(
+    (name) => name.startsWith("lobu-dev-") && !owned.has(name)
+  );
+}
+
 /**
  * Tar the working tree as the sandbox should see it: tracked files plus
  * untracked-but-not-ignored, which is exactly what `-z -co --exclude-standard`
@@ -906,28 +941,54 @@ async function main() {
   }
   const root = repoRoot();
   const name = sandboxName(root);
+  // `rm` takes an optional sandbox name so an ORPHAN can be removed at all:
+  // its worktree is gone, so there is no directory to run the bare form from
+  // and the name cannot be re-derived from a path that no longer exists.
+  // Guarded to the `lobu-` prefix `ls` prints, so a typo cannot reach an
+  // unrelated sandbox in the org.
+  const explicitTarget = cmd === "rm" ? process.argv[3] : undefined;
+  if (explicitTarget !== undefined && !explicitTarget.startsWith("lobu-")) {
+    console.error(
+      `refusing to remove '${explicitTarget}': not a lobu- sandbox (see: make sandbox-ls)`
+    );
+    process.exit(1);
+  }
+  const target = explicitTarget ?? name;
   const daytona = await client();
 
   if (cmd === "ls") {
     const all = await listAll(daytona);
     const { used, running } = memoryOfRunning(all);
+    const orphans = orphanSandboxNames(
+      all.map((s) => s.name),
+      parseWorktreeRoots(sh("git", ["worktree", "list", "--porcelain"], root))
+    );
     for (const s of all) {
       const n = s.name;
       if (!n.startsWith("lobu-")) continue;
-      console.log(`${n.padEnd(34)} ${stateOf(s).padEnd(10)} ${s.memory}GB`);
+      const tag = orphans.includes(n) ? "  orphan (no worktree)" : "";
+      console.log(
+        `${n.padEnd(34)} ${stateOf(s).padEnd(10)} ${s.memory}GB${tag}`
+      );
     }
     console.log(
       `\nrunning: ${used}GB / ${TOTAL_MEMORY_CAP_GB}GB cap (${running.length} started)`
     );
+    if (orphans.length > 0) {
+      console.log(
+        `\n${orphans.length} sandbox(es) outlived their worktree and still bill for disk:`
+      );
+      for (const n of orphans) console.log(`  bun scripts/sandbox.ts rm ${n}`);
+    }
     return;
   }
 
-  let sandbox = await findSandbox(daytona, name);
+  let sandbox = await findSandbox(daytona, target);
 
   if (cmd === "rm") {
-    if (!sandbox) return console.log(`no sandbox ${name}`);
+    if (!sandbox) return console.log(`no sandbox ${target}`);
     await sandbox.delete();
-    return console.log(`deleted ${name}`);
+    return console.log(`deleted ${target}`);
   }
   if (cmd === "stop") {
     if (!sandbox) return console.log(`no sandbox ${name}`);

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -18,8 +18,11 @@
  *   bun scripts/sandbox.ts sync   re-upload the tree without restarting the app
  *   bun scripts/sandbox.ts url    print the preview URL
  *   bun scripts/sandbox.ts stop   stop it (frees quota; disk and DB survive)
- *   bun scripts/sandbox.ts rm     delete it permanently
- *   bun scripts/sandbox.ts ls     every lobu sandbox + quota headroom
+ *   bun scripts/sandbox.ts rm     delete it permanently; `rm <name>` targets
+ *                                 another lobu- sandbox, which is the only way
+ *                                 to reclaim one whose worktree is already gone
+ *   bun scripts/sandbox.ts ls     every lobu sandbox + quota headroom, with the
+ *                                 ones that outlived their worktree flagged
  */
 import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";


### PR DESCRIPTION
## Summary

- `make land` merges and stops. Nothing is wired to "PR merged", so `task-clean` — which removes the worktree, the dev database and the Daytona sandbox — only runs when someone remembers to type it. A merged branch leaves a multi-GB worktree and a sandbox still billing for disk, and the first symptom is the *next* `make sandbox` failing on quota. That is what happened while shipping #3284: the second sandbox could not be created and the e2e had to be reworked around it.
- Once the worktree is gone the sandbox becomes **unreachable by the tool that created it**. `sandboxName` hashes the absolute worktree path and `rm` only ever removed the current root's sandbox, so an orphan could not be named. Reclaiming one after this session required hand-rolling a Daytona SDK call.
- Dev tooling only — `scripts/` and its bun:test suite. No runtime, server, API, SDK or DB surface.

**What changes**

- `orphanSandboxNames` treats the live worktree set as the authority: hashing each root regenerates exactly the names that still have an owner, so orphans are detectable with no network call and no PR lookup. Only `lobu-dev-` names are judged.
- `sandbox.ts ls` tags those rows `orphan (no worktree)` and prints the exact removal command for each.
- `sandbox.ts rm [name]` accepts an explicit name, guarded to the `lobu-` prefix `ls` prints, so an orphan can actually be removed.
- `land.sh` reports the worktree the merge just retired plus its `task-clean` command. Deliberately a hint and not an action: the worktree is usually still needed to verify the rollout, and `land` may be running from inside the very directory it would delete.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; `make pr-full` not run)
- [x] Tests run: `bun test scripts/__tests__/sandbox.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

**Red** (tests written first, before the exports existed):

```
SyntaxError: Export named 'parseWorktreeRoots' not found in module '.../scripts/sandbox.ts'
 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [161.00ms]
```

**Green** (after implementing, and again after `biome check --write`):

```
bun test v1.3.5 (1e86cebd)
 60 pass
 0 fail
 101 expect() calls
Ran 60 tests across 1 file. [966.00ms]
```

**Live, against the real Daytona API and real git state** — not just unit tests:

```
$ bun scripts/sandbox.ts rm production-database
refusing to remove 'production-database': not a lobu- sandbox (see: make sandbox-ls)
exit=1

$ bun scripts/sandbox.ts ls
lobu-opencode-test                 stopped    1GB
running: 0GB / 10GB cap (0 started)

$ git worktree list --porcelain | awk -v want="branch refs/heads/feat/land-cleanup-surface" \
    '/^worktree /{path = substr($0, 10)} $0 == want {print path; exit}'
/Users/burakemre/Code/lobu/.claude/worktrees/land-cleanup-surface
```

The `land.sh` hint, run verbatim against real PRs (both branches):

```
--- #3287, whose branch HAS a worktree ---
Cleanup: this merge does not retire the worktree or its dev sandbox.
Once you no longer need it for verification:
  make task-clean NAME=land-cleanup-surface

--- #3241 (release-please), whose branch has no local worktree ---
(silent, as intended)
```

`make pre-pr`: all 5 gates clean (build, per-package typecheck, knip, exposed-surface naming, gateway-LLM + entity-write funnel).

## Notes

- **`make review-fix` could not run**: the codex backend returned `ERROR: You've hit your usage limit ... try again at Sep 7th, 2026`. It made no working-tree changes (`git status` clean afterwards). Flagging rather than silently skipping.
- **Review round 1 (Fable) found a real defect in the first commit, fixed in `8c6aa8d1`.** The `land.sh` hint fired for any worktree matching the PR head, but `task-clean.sh:44` resolves NAME to `$repo/.claude/worktrees/$NAME` — so landing from the main checkout or an ad-hoc worktree printed a command that exits `no worktree at ...`. Now guarded, and verified against every worktree on this machine: `/Users/burakemre/Code/lobu` and `/Users/burakemre/Code/lobu-pr3173-exact` go silent, task worktrees still print. The second suggestion (document `rm [name]` in the usage header) is in the same commit.
- **Residual risk Fable flagged, chased down**: orphan detection assumes `git worktree list --porcelain` and `rev-parse --show-toplevel` yield byte-identical path strings — if they diverged, every sandbox would be mis-flagged. Checked all 34 worktrees here: all identical, and this worktree's `repoRoot()`-derived name is present in the owned set built from `worktree list`. Blast radius if it ever diverges is a wrong hint only; `rm` requires an explicit name.
- **Honest coverage gap**: the `orphan (no worktree)` tag itself is proven by unit test, not live — there is currently no `lobu-dev-` sandbox in the org without a worktree to display it against (the one that existed, `lobu-dev-fix-tool-page-size-limit-8eb6c954` from merged #3267, was removed as part of the cleanup that motivated this PR). The `lobu-opencode-test` row above does exercise the live "not a `lobu-dev-` name, so not judged" branch.
- Follow-up worth considering separately: `task-clean` bails with `error: no worktree at <path>` when the directory is already gone, which strands the branch, dev DB and Lobu-context steps that come after it. That is how this session ended up finishing a half-run cleanup by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaHrPhnYi3UP79SZBCHSMi
