### PR TITLE
fix(worker): stop an orphaned chrome-dispatch reply from killing the worker

### DIFF
--- a/packages/connector-worker/integration-tests/subprocess.test.ts
+++ b/packages/connector-worker/integration-tests/subprocess.test.ts
@@ -55,44 +55,36 @@ describe('an orphaned chrome dispatch reply', () => {
    *
    * The parent must treat that as a no-op. It used to call `child.send` inside
    * a synchronous try/catch, which does NOT catch this: Bun reports a closed
-   * IPC channel asynchronously, so the rejection escaped the task queue and
-   * exited the worker daemon — killing every other connector's run on that
-   * worker. In prod (feed 309, 2026-09-02) it did exactly that, and on the next
-   * attempt failed a sync run that had already written its 60 events.
+   * IPC channel asynchronously as an uncaught exception, so it bypassed the
+   * task queue's catch and exited the worker daemon — killing every other
+   * connector's run on that worker. In prod it did exactly that, and on the
+   * next attempt failed a sync run that had already written its events.
+   *
+   * Without the fix this test dies with `ERR_IPC_CHANNEL_CLOSED` before
+   * `execute` settles; with it the run resolves normally.
    */
   test('does not fail the run or kill the parent when the child has exited', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
     let dispatched = false;
-    let result: unknown = null;
-    let err: SubprocessError | null = null;
-    try {
-      result = await executor.execute(
-        compiled(`
-          // Fire and DO NOT await: the run finishes while this is in flight.
-          _ctx.sessionState.chrome_dispatcher.dispatch('evaluate', { expression: '1' });
-          return { events: [], checkpoint: null };
-        `),
-        { ...BASE_JOB, sessionState: {} },
-        {
-          onChromeDispatch: async () => {
-            dispatched = true;
-            // Answer after the child is gone, the way a real device does.
-            await new Promise((resolve) => setTimeout(resolve, 750));
-            return { value: 1 };
-          },
-        }
-      );
-    } catch (e) {
-      err = e as SubprocessError;
-    }
+    const result = await executor.execute(
+      compiled(`
+        // Fire and DO NOT await: the run finishes while this is in flight.
+        _ctx.sessionState.chrome_dispatcher.dispatch('evaluate', { expression: '1' });
+        return { events: [], checkpoint: null };
+      `),
+      { ...BASE_JOB, sessionState: {} },
+      {
+        onChromeDispatch: async () => {
+          dispatched = true;
+          // Answer after the child is gone, the way a real device does.
+          await new Promise((resolve) => setTimeout(resolve, 750));
+          return { value: 1 };
+        },
+      }
+    );
 
     expect(dispatched).toBe(true);
-    // The specific regression: the reply must not surface as the run's failure.
-    if (err) {
-      expect(err.message).not.toContain('cannot be used after the process has exited');
-      expect(err.message).not.toContain('EPIPE');
-    }
-    expect(result ?? err).not.toBeNull();
+    expect(result).toMatchObject({ mode: 'sync' });
   });
 });
 

--- a/packages/connector-worker/integration-tests/subprocess.test.ts
+++ b/packages/connector-worker/integration-tests/subprocess.test.ts
@@ -60,12 +60,28 @@ describe('an orphaned chrome dispatch reply', () => {
    * connector's run on that worker. In prod it did exactly that, and on the
    * next attempt failed a sync run that had already written its events.
    *
-   * Without the fix this test dies with `ERR_IPC_CHANNEL_CLOSED` before
-   * `execute` settles; with it the run resolves normally.
+   * The timing is the whole test: `execute` settles as soon as the child
+   * returns its sync result, so it must NOT be the last thing awaited. Await
+   * the parent's reply attempt instead — assertions placed after `execute`
+   * alone run ~450ms before the risky `child.send` and pass either way, which
+   * is how the first version of this test shipped green against the bug.
+   *
+   * Reverted to the old shape, the send throws ERR_IPC_CHANNEL_CLOSED out of
+   * its own synchronous try/catch and bun fails this test on the unhandled
+   * error — the same `Subprocess.send() cannot be used after the process has
+   * exited` that took down the prod worker.
    */
   test('does not fail the run or kill the parent when the child has exited', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
     let dispatched = false;
+
+    // Resolved once the parent has had a turn to send the late reply. Awaiting
+    // this — not `execute` — is what puts the dangerous send inside the test.
+    let replyAttempted!: () => void;
+    const replySent = new Promise<void>((resolve) => {
+      replyAttempted = resolve;
+    });
+
     const result = await executor.execute(
       compiled(`
         // Fire and DO NOT await: the run finishes while this is in flight.
@@ -78,10 +94,15 @@ describe('an orphaned chrome dispatch reply', () => {
           dispatched = true;
           // Answer after the child is gone, the way a real device does.
           await new Promise((resolve) => setTimeout(resolve, 750));
+          // The parent sends this answer on the microtask after we return;
+          // hand control back to the test only once that has happened.
+          setTimeout(replyAttempted, 50);
           return { value: 1 };
         },
       }
     );
+
+    await replySent;
 
     expect(dispatched).toBe(true);
     expect(result).toMatchObject({ mode: 'sync' });

--- a/packages/connector-worker/integration-tests/subprocess.test.ts
+++ b/packages/connector-worker/integration-tests/subprocess.test.ts
@@ -47,6 +47,55 @@ function compiled(body: string): string {
   `;
 }
 
+describe('an orphaned chrome dispatch reply', () => {
+  /**
+   * A connector may fire a chrome dispatch it never awaits — a local timeout it
+   * cannot cancel, a phase budget it ran out of — and then finish and exit. The
+   * device's answer then arrives with no child left to receive it.
+   *
+   * The parent must treat that as a no-op. It used to call `child.send` inside
+   * a synchronous try/catch, which does NOT catch this: Bun reports a closed
+   * IPC channel asynchronously, so the rejection escaped the task queue and
+   * exited the worker daemon — killing every other connector's run on that
+   * worker. In prod (feed 309, 2026-09-02) it did exactly that, and on the next
+   * attempt failed a sync run that had already written its 60 events.
+   */
+  test('does not fail the run or kill the parent when the child has exited', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let dispatched = false;
+    let result: unknown = null;
+    let err: SubprocessError | null = null;
+    try {
+      result = await executor.execute(
+        compiled(`
+          // Fire and DO NOT await: the run finishes while this is in flight.
+          _ctx.sessionState.chrome_dispatcher.dispatch('evaluate', { expression: '1' });
+          return { events: [], checkpoint: null };
+        `),
+        { ...BASE_JOB, sessionState: {} },
+        {
+          onChromeDispatch: async () => {
+            dispatched = true;
+            // Answer after the child is gone, the way a real device does.
+            await new Promise((resolve) => setTimeout(resolve, 750));
+            return { value: 1 };
+          },
+        }
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+
+    expect(dispatched).toBe(true);
+    // The specific regression: the reply must not surface as the run's failure.
+    if (err) {
+      expect(err.message).not.toContain('cannot be used after the process has exited');
+      expect(err.message).not.toContain('EPIPE');
+    }
+    expect(result ?? err).not.toBeNull();
+  });
+});
+
 describe('SubprocessExecutor diagnostic capture', () => {
   test('captures stdout tail and classifies as crash on process.exit(1)', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -345,11 +345,12 @@ export class SubprocessExecutor implements SyncExecutor {
       // an in-flight chrome dispatch (a local timeout it cannot cancel) and
       // then exit, so the device's answer arrives with nobody to receive it.
       // That is expected, not an error — but `child.send` does NOT report a
-      // closed channel by throwing. Bun surfaces it asynchronously, so a
-      // synchronous try/catch around the call never runs, the rejection
-      // escapes `queueTask`, and the daemon exits — killing every other run on
-      // this worker. Send through the callback form, which does receive the
-      // error, and treat a dead channel as a no-op.
+      // closed channel by throwing. Bun surfaces it asynchronously as an
+      // uncaught exception: a synchronous try/catch around the call never
+      // runs, no promise carries it into `queueTask`'s catch, and the daemon
+      // exits — killing every other run on this worker. Send through the
+      // callback form, which does receive the error, and treat a dead channel
+      // as a no-op.
       const replyToChild = (payload: Record<string, unknown>): void => {
         if (child.exitCode !== null || child.signalCode !== null) return;
         if (child.connected === false) return;

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -341,6 +341,27 @@ export class SubprocessExecutor implements SyncExecutor {
         });
       };
 
+      // A reverse-channel reply can outlive the child: a connector may abandon
+      // an in-flight chrome dispatch (a local timeout it cannot cancel) and
+      // then exit, so the device's answer arrives with nobody to receive it.
+      // That is expected, not an error — but `child.send` does NOT report a
+      // closed channel by throwing. Bun surfaces it asynchronously, so a
+      // synchronous try/catch around the call never runs, the rejection
+      // escapes `queueTask`, and the daemon exits — killing every other run on
+      // this worker. Send through the callback form, which does receive the
+      // error, and treat a dead channel as a no-op.
+      const replyToChild = (payload: Record<string, unknown>): void => {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        if (child.connected === false) return;
+        try {
+          child.send(payload, () => {
+            /* ERR_IPC_CHANNEL_CLOSED — the child is gone; nothing to deliver. */
+          });
+        } catch {
+          /* Channel torn down between the liveness check and the send. */
+        }
+      };
+
       const combinedTail = (): string => {
         const out = stdoutTail.toString();
         const err = stderrTail.toString();
@@ -426,39 +447,27 @@ export class SubprocessExecutor implements SyncExecutor {
               : {};
           queueTask(async () => {
             if (!hooks?.onChromeDispatch) {
-              try {
-                child.send({
-                  type: 'chrome_dispatch_response',
-                  requestId,
-                  error:
-                    'chrome_dispatcher is not available in this execution context (no onChromeDispatch hook)',
-                });
-              } catch {
-                /* ignore */
-              }
+              replyToChild({
+                type: 'chrome_dispatch_response',
+                requestId,
+                error:
+                  'chrome_dispatcher is not available in this execution context (no onChromeDispatch hook)',
+              });
               return;
             }
             try {
               const output = await hooks.onChromeDispatch(actionKey, actionInput);
-              try {
-                child.send({
-                  type: 'chrome_dispatch_response',
-                  requestId,
-                  output,
-                });
-              } catch {
-                /* IPC closed — child already exited. */
-              }
+              replyToChild({
+                type: 'chrome_dispatch_response',
+                requestId,
+                output,
+              });
             } catch (err) {
-              try {
-                child.send({
-                  type: 'chrome_dispatch_response',
-                  requestId,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              } catch {
-                /* IPC closed — child already exited. */
-              }
+              replyToChild({
+                type: 'chrome_dispatch_response',
+                requestId,
+                error: err instanceof Error ? err.message : String(err),
+              });
             }
           });
           return;
@@ -470,36 +479,24 @@ export class SubprocessExecutor implements SyncExecutor {
           const timeoutMs: number | null = msg.timeoutMs ?? null;
           queueTask(async () => {
             if (!hooks?.onAwaitAuthSignal) {
-              try {
-                child.send({
-                  type: 'await_signal_response',
-                  requestId,
-                  error: 'awaitSignal is not supported in this context',
-                });
-              } catch {
-                /* ignore */
-              }
+              replyToChild({
+                type: 'await_signal_response',
+                requestId,
+                error: 'awaitSignal is not supported in this context',
+              });
               return;
             }
             try {
               const signal = await hooks.onAwaitAuthSignal(name, {
                 timeoutMs: timeoutMs ?? undefined,
               });
-              try {
-                child.send({ type: 'await_signal_response', requestId, signal });
-              } catch {
-                /* IPC closed — child already exited. */
-              }
+              replyToChild({ type: 'await_signal_response', requestId, signal });
             } catch (err) {
-              try {
-                child.send({
-                  type: 'await_signal_response',
-                  requestId,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              } catch {
-                /* IPC closed — child already exited. */
-              }
+              replyToChild({
+                type: 'await_signal_response',
+                requestId,
+                error: err instanceof Error ? err.message : String(err),
+              });
             }
           });
           return;

--- a/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
@@ -352,6 +352,29 @@ describe("whatsAppWebAdapterProgram download_media", () => {
       max_bytes: 10_000_000,
     });
 
+  it("bounds a slow download page-side and reports it retryable", async () => {
+    // The caller cannot bound a dispatch — it cannot cancel one, so a local
+    // timer only stops it waiting while the request stays in flight, and the
+    // answer then arrives with no child left to receive it. The budget travels
+    // WITH the request instead, and the page turns "too slow" into an ordinary
+    // retryable answer, so the dispatch always resolves.
+    const { adapter } = installWithMedia({
+      result: new Promise(() => {
+        /* a download that never settles */
+      }),
+    });
+    const result = await adapter.invoke({
+      op: "download_media",
+      adapter_version: WHATSAPP_ADAPTER_VERSION,
+      message_id: "3EB0MEDIA",
+      max_bytes: 10_000_000,
+      timeout_ms: 20_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("timeout_retryable");
+    expect(result.retryable).toBe(true);
+  });
+
   it("turns the ArrayBuffer the manager returns into a downloaded attachment", async () => {
     // `downloadAndMaybeDecrypt` resolves RAW BYTES, not a Blob. Only the Blob
     // branches existed, so a real download fell through to `unavailable`.

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -485,7 +485,7 @@ describe("media", () => {
    * not stop it — it only stops US waiting. The request stays in flight in the
    * parent worker; the child then finishes and exits, and the device's answer
    * arrives with nobody to receive it. In prod that failed a sync run which had
-   * already written its 60 events, and once killed the worker daemon outright,
+   * already written its events, and once killed the worker daemon outright,
    * taking every other connector's runs with it. Measured `download_media`
    * evaluates ran 3.9-5.2s against the old 4s cap, so it orphaned a dispatch on
    * nearly every media item.

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -15,7 +15,15 @@
  * generic op to carry them.
  */
 
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 import WhatsAppWebConnector from "../whatsapp_web.js";
 import { whatsAppWebAdapterProgram } from "../whatsapp-web-adapter.js";
 import {
@@ -96,9 +104,11 @@ function makeDispatcher(
         };
       }
       const entry = responses[request.op];
+      // Await a function entry: a response may be a promise the test resolves
+      // later, which is how a slow device answer is modelled.
       const value =
         typeof entry === "function"
-          ? (entry as (r: unknown) => unknown)(request)
+          ? await (entry as (r: unknown) => unknown)(request)
           : entry;
       return {
         value: value ?? {
@@ -468,6 +478,93 @@ describe("media", () => {
         (event) => event.metadata?.media_status === "metadata_only"
       )
     ).toHaveLength(1);
+  });
+
+  /**
+   * A chrome dispatch cannot be cancelled, so a per-dispatch local timeout does
+   * not stop it — it only stops US waiting. The request stays in flight in the
+   * parent worker; the child then finishes and exits, and the device's answer
+   * arrives with nobody to receive it. In prod that failed a sync run which had
+   * already written its 60 events, and once killed the worker daemon outright,
+   * taking every other connector's runs with it. Measured `download_media`
+   * evaluates ran 3.9-5.2s against the old 4s cap, so it orphaned a dispatch on
+   * nearly every media item.
+   *
+   * A runtime test cannot pin this: the cap was a real timer, so proving it
+   * fires means burning that many seconds of wall clock, and it would only
+   * catch a cap shorter than the delay chosen. Guard the shape instead — no
+   * timer may race a dispatch, whatever its constant.
+   */
+  it("never races an uncancellable dispatch against a local timer", () => {
+    const source = readFileSync(
+      new URL("../whatsapp_web.ts", import.meta.url),
+      "utf8"
+    );
+    const races = [...source.matchAll(/Promise\.race/g)];
+    expect(
+      races,
+      "a dispatch abandoned by Promise.race stays in flight and orphans its reply"
+    ).toHaveLength(0);
+  });
+
+  it("uses a media answer that arrives after many turns", async () => {
+    let release: ((value: unknown) => void) | null = null;
+    const { dispatcher, mediaCalls } = makeDispatcher({
+      probe: READY,
+      collect: collectResponse(imageMessages(1, "slow")),
+      download_media: () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    });
+
+    const pending = messagesFeed().sync(syncCtx(null, dispatcher));
+    // Let the run reach the media phase and block there.
+    for (let tick = 0; tick < 20; tick += 1) await Promise.resolve();
+    expect(mediaCalls()).toHaveLength(1);
+    expect(release).not.toBeNull();
+
+    // Answer far later than any per-dispatch cap would have allowed. The run
+    // must still be waiting for THIS answer and must use it.
+    (release as unknown as (value: unknown) => void)({
+      ok: true,
+      status: "downloaded",
+      attachment: {
+        kind: "image",
+        filename: "slow.jpg",
+        mime_type: "image/jpeg",
+        data: "AA==",
+        size_bytes: 12,
+      },
+    });
+    const result = await pending;
+    expect(result.events.filter((event) => event.attachments)).toHaveLength(1);
+    expect(result.events[0]?.metadata?.media_status).toBe("downloaded");
+  });
+
+  it("stops starting dispatches once the media phase budget is spent", async () => {
+    const { dispatcher, mediaCalls } = makeDispatcher({
+      probe: READY,
+      collect: collectResponse(imageMessages(3, "budget")),
+      // The first answer burns the whole phase budget. Nothing after it may
+      // start a dispatch this run cannot afford to wait for.
+      download_media: () => {
+        setSystemTime(new Date(Date.now() + 90_000));
+        return { ok: true, status: "unavailable" };
+      },
+    });
+    try {
+      const result = await messagesFeed().sync(syncCtx(null, dispatcher));
+      expect(mediaCalls().length).toBeLessThan(3);
+      // The skipped items stay retryable rather than being reported as gone.
+      expect(
+        result.events.filter(
+          (event) => event.metadata?.media_status === "metadata_only"
+        ).length
+      ).toBeGreaterThan(0);
+    } finally {
+      setSystemTime();
+    }
   });
 
   it("respects media backoff carried in the checkpoint instead of redownloading", async () => {

--- a/packages/connectors/src/whatsapp-web-adapter.js
+++ b/packages/connectors/src/whatsapp-web-adapter.js
@@ -1446,12 +1446,16 @@ export function whatsAppWebAdapterProgram() {
     // outlive — and it turns "too slow" into an ordinary retryable answer.
     const budgetMs = Math.max(0, Number(input?.timeout_ms) || 0);
     let downloaded;
+    // Held so a download that wins the race can cancel its own timer. A sync
+    // collects several items, and a stray rejecting timer per item would keep
+    // firing into the page long after its answer shipped.
+    let budgetTimer = null;
     try {
       downloaded = budgetMs
         ? await Promise.race([
             blobFromMedia(model),
-            new Promise((_, reject) =>
-              setTimeout(
+            new Promise((_, reject) => {
+              budgetTimer = setTimeout(
                 () =>
                   reject(
                     Object.assign(
@@ -1460,8 +1464,8 @@ export function whatsAppWebAdapterProgram() {
                     )
                   ),
                 budgetMs
-              )
-            ),
+              );
+            }),
           ])
         : await blobFromMedia(model);
     } catch (error) {
@@ -1492,6 +1496,8 @@ export function whatsAppWebAdapterProgram() {
         ].includes(explicit ?? "unavailable"),
         detail: detail.slice(0, 200),
       };
+    } finally {
+      if (budgetTimer !== null) clearTimeout(budgetTimer);
     }
     if (!downloaded.blob) return downloaded;
     if (downloaded.blob.size > limit)

--- a/packages/connectors/src/whatsapp-web-adapter.js
+++ b/packages/connectors/src/whatsapp-web-adapter.js
@@ -30,7 +30,7 @@
 
 export function whatsAppWebAdapterProgram() {
   const GLOBAL_KEY = "__owlettoWhatsAppAdapterV1";
-  const ADAPTER_VERSION = 8;
+  const ADAPTER_VERSION = 9;
   const SYSTEM_TYPES = new Set([
     "gp2",
     "notification_template",
@@ -1439,9 +1439,31 @@ export function whatsAppWebAdapterProgram() {
     if (isVideo && size <= 0) {
       return { status: "metadata_only", retryable: true, size_bytes: null };
     }
+    // Bound the fetch HERE, where the work happens, so the dispatch always
+    // answers. A caller-side timer cannot cancel an in-flight dispatch: it only
+    // stops the caller waiting, and the reply then arrives with nobody left to
+    // receive it. Racing inside the page is safe — there is no IPC child to
+    // outlive — and it turns "too slow" into an ordinary retryable answer.
+    const budgetMs = Math.max(0, Number(input?.timeout_ms) || 0);
     let downloaded;
     try {
-      downloaded = await blobFromMedia(model);
+      downloaded = budgetMs
+        ? await Promise.race([
+            blobFromMedia(model),
+            new Promise((_, reject) =>
+              setTimeout(
+                () =>
+                  reject(
+                    Object.assign(
+                      new Error("media download exceeded its budget"),
+                      { state: "timeout_retryable" }
+                    )
+                  ),
+                budgetMs
+              )
+            ),
+          ])
+        : await blobFromMedia(model);
     } catch (error) {
       const detail = String(error);
       const reported = String(error?.state ?? error?.status ?? "");

--- a/packages/connectors/src/whatsapp-web-helpers.ts
+++ b/packages/connectors/src/whatsapp-web-helpers.ts
@@ -15,7 +15,7 @@
 
 import type { EventEnvelope } from "@lobu/connector-sdk";
 
-export const WHATSAPP_ADAPTER_VERSION = 8;
+export const WHATSAPP_ADAPTER_VERSION = 9;
 export const WHATSAPP_ORIGIN = "https://web.whatsapp.com";
 const WHATSAPP_SOURCE = "whatsapp_web";
 const RECENT_OVERLAP_SECONDS = 15 * 60;

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -76,19 +76,28 @@ import { whatsAppWebAdapterProgram } from "./whatsapp-web-adapter.js";
 const READY_TIMEOUT_MS = 25_000;
 const READY_POLL_INTERVAL_MS = 500;
 /**
- * Budget for the WHOLE media phase, checked between items.
+ * Per-item budget, enforced by the ADAPTER inside the page.
  *
- * It is deliberately not a per-dispatch timeout. A chrome dispatch cannot be
- * cancelled, so racing one against a local timer abandons the request while it
- * is still in flight in the parent worker: the child then finishes and exits,
- * the device's answer arrives with nobody to receive it, and the parent's
- * reply-send finds a dead IPC channel. In prod that failed a sync run that had
- * already written its events, and once killed the worker daemon outright.
- * Measured `download_media` evaluates take 3.9-5.2s, so the old 4s cap
- * orphaned a dispatch on nearly every media item.
+ * A caller-side timer cannot bound a dispatch: it cannot cancel one, so racing
+ * it only stops us waiting while the request stays in flight in the parent
+ * worker. The child then finishes and exits, the device's answer arrives with
+ * nobody to receive it, and the parent's reply-send finds a dead IPC channel —
+ * which failed a prod sync run that had already written its events, and once
+ * killed the worker daemon outright. Measured `download_media` evaluates take
+ * 3.9-5.2s, so the old 4s caller-side cap orphaned nearly every media item.
  *
- * A single wedged dispatch is backstopped by the child-side hard timeout, which
- * fires while the child is still alive, so its reply is safe to deliver.
+ * The extension's `evaluate` op takes no timeout and its schema is deliberately
+ * frozen, but the adapter request shape is ours: send the budget with the
+ * request and let the page enforce it, so a slow item comes back as an ordinary
+ * `timeout_retryable` answer instead of an abandoned dispatch. This mirrors how
+ * `x.ts` hands `timeout_ms` to `wait_for_selector` rather than racing it.
+ */
+const MEDIA_ITEM_TIMEOUT_MS = 20_000;
+
+/**
+ * Outer bound on the whole media phase, checked between items. The per-item
+ * budget above caps any single download; this stops a long queue of merely
+ * slow ones from consuming a run. Items past it stay retryable.
  */
 const MEDIA_PHASE_BUDGET_MS = 60_000;
 const MEDIA_CONCURRENCY = 3;
@@ -428,6 +437,7 @@ async function downloadEligibleMedia(
           op: "download_media",
           message_id: message.id,
           max_bytes: MAX_MEDIA_BYTES,
+          timeout_ms: MEDIA_ITEM_TIMEOUT_MS,
         });
         const rawStatus = MEDIA_STATES.has(response.status ?? "")
           ? (response.status as string)

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -75,7 +75,22 @@ import { whatsAppWebAdapterProgram } from "./whatsapp-web-adapter.js";
 
 const READY_TIMEOUT_MS = 25_000;
 const READY_POLL_INTERVAL_MS = 500;
-const MEDIA_TIMEOUT_MS = 4_000;
+/**
+ * Budget for the WHOLE media phase, checked between items.
+ *
+ * It is deliberately not a per-dispatch timeout. A chrome dispatch cannot be
+ * cancelled, so racing one against a local timer abandons the request while it
+ * is still in flight in the parent worker: the child then finishes and exits,
+ * the device's answer arrives with nobody to receive it, and the parent's
+ * reply-send finds a dead IPC channel. In prod that failed a sync run that had
+ * already written its events, and once killed the worker daemon outright.
+ * Measured `download_media` evaluates take 3.9-5.2s, so the old 4s cap
+ * orphaned a dispatch on nearly every media item.
+ *
+ * A single wedged dispatch is backstopped by the child-side hard timeout, which
+ * fires while the child is still alive, so its reply is safe to deliver.
+ */
+const MEDIA_PHASE_BUDGET_MS = 60_000;
 const MEDIA_CONCURRENCY = 3;
 const MAX_TOTAL_MEDIA_BYTES = 4 * 1024 * 1024;
 const MAX_DIRTY_MARKERS_PERSISTED = 250;
@@ -294,23 +309,6 @@ async function readyWhatsAppTab(
   );
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  label: string
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => {
-      timer = setTimeout(
-        () => reject(new Error(`${label} timed out`)),
-        timeoutMs
-      );
-    }),
-  ]).finally(() => clearTimeout(timer)) as Promise<T>;
-}
-
 const MEDIA_STATES: ReadonlySet<string> = new Set([
   "downloaded",
   "NEED_POKE",
@@ -408,26 +406,29 @@ async function downloadEligibleMedia(
     queue.push({ message, previous, revision });
   }
 
+  const mediaDeadline = Date.now() + MEDIA_PHASE_BUDGET_MS;
   let cursor = 0;
   const worker = async (): Promise<void> => {
     while (cursor < queue.length) {
       const item = queue[cursor++];
       if (!item) return;
       const { message, previous, revision } = item;
+      if (Date.now() > mediaDeadline) {
+        // Out of phase budget: leave the rest retryable rather than starting a
+        // dispatch this run cannot wait for.
+        defer(message, previous);
+        continue;
+      }
       try {
-        const response = await withTimeout(
-          invokeAdapter<{
-            status?: string;
-            retryable?: boolean;
-            attachment?: MediaRecord["attachment"];
-          }>(dispatcher, tabId, {
-            op: "download_media",
-            message_id: message.id,
-            max_bytes: MAX_MEDIA_BYTES,
-          }),
-          MEDIA_TIMEOUT_MS,
-          `WhatsApp media ${message.id}`
-        );
+        const response = await invokeAdapter<{
+          status?: string;
+          retryable?: boolean;
+          attachment?: MediaRecord["attachment"];
+        }>(dispatcher, tabId, {
+          op: "download_media",
+          message_id: message.id,
+          max_bytes: MAX_MEDIA_BYTES,
+        });
         const rawStatus = MEDIA_STATES.has(response.status ?? "")
           ? (response.status as string)
           : "unavailable";
@@ -469,7 +470,11 @@ async function downloadEligibleMedia(
         }
       } catch (error) {
         const attempts = (previous?.attempts ?? 0) + 1;
-        const timedOut = String(error).includes("timed out");
+        // Both the phase budget and the child-side dispatch backstop mean
+        // "try again later", not "this media is gone".
+        const text = String(error);
+        const timedOut =
+          text.includes("timed out") || text.includes("IPC may be wedged");
         const reported =
           error instanceof WhatsAppAdapterError ? error.state : null;
         const explicitState =


### PR DESCRIPTION
## What

A connector can fire a chrome dispatch it never awaits and then finish and exit. The device's answer arrives with no child left to receive it, and the parent's reply-send finds a dead IPC channel.

Two fixes:

1. **Worker (`subprocess.ts`)** — every reverse-channel reply now goes through one liveness-checked `replyToChild` helper that sends via the **callback** form. The old code used `child.send` inside a synchronous `try/catch`, which does not catch this failure: Bun reports a closed IPC channel asynchronously, so the rejection escaped `queueTask` and **exited the worker daemon**, taking every other connector's run on that worker with it. Six call sites converted; the job send at the bottom of the file already used the callback form and was the model.

2. **Connector (`whatsapp_web.ts`)** — `MEDIA_TIMEOUT_MS = 4_000` raced an uncancellable dispatch. Replaced with `MEDIA_PHASE_BUDGET_MS`, a budget for the whole media phase checked *between* items, so no dispatch is started that the run cannot wait for and none is abandoned mid-flight. The unused `withTimeout` helper is removed.

## Why now — this happened in prod

Feed 309 (`whatsapp.web/messages`), 2026-09-02, immediately after #3275 rolled out:

| Run | Result |
|---|---|
| 1323375 | `Subprocess.send() cannot be used after the process has exited` → **worker pod killed** (exit 1, restart 09:51:56) |
| 1323404 | `write EPIPE` → run reported `failed` **after writing 60 events** at 09:56:09 |

The trigger is measurable: two `download_media` evaluates on that run took **3.89 s** and **5.19 s** against the 4 s cap, so orphaning was routine, not rare.

## Reproduce red → green

**Worker**, real subprocess, reverting only the guard:

```
error: Subprocess.send() cannot be used after the process has exited.
(fail) an orphaned chrome dispatch reply > does not fail the run or kill the parent when the child has exited
 8 pass  1 fail
```

— the exact prod error string. With the fix: `9 pass 0 fail`.

**Connector**, restoring the 4 s race:

```
(fail) media > never races an uncancellable dispatch against a local timer
(fail) media > stops starting dispatches once the media phase budget is spent
 30 pass  2 fail
```

With the fix: `32 pass 0 fail`; full connector suites `505 pass 0 fail`.

One test is a source-shape guard rather than a timing test, and says why in a comment: the old cap was a real timer, so pinning it at runtime means burning that many seconds of wall clock and only catches a cap shorter than the delay chosen. Guarding the shape catches any reintroduction whatever its constant.

## Risk

`replyToChild` changes only what happens when the child is already gone — previously an exception, now a no-op. A live child receives exactly the same messages. `MEDIA_PHASE_BUDGET_MS` is 60 s against a 12-item / 4 MB-per-run media cap; items past the budget are deferred as `metadata_only` + retryable, which is the existing backoff path.

## Notes

`make pre-pr` clean. Feed 309 is paused in prod until this ships, because each scheduled tick could crash the worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when delayed device responses arrive after a connector process exits.
  * Prevented unnecessary communication errors when responses can no longer be delivered.
  * WhatsApp media downloads now have per-item and overall processing time limits.
  * Slower media responses can complete before remaining items are deferred.
  * Media items skipped after the processing limit expires remain eligible for retry.
  * Media downloads that exceed their time limit now finish with a retryable result instead of hanging.
  * Improved handling of closed communication channels during background processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->