### PR TITLE
docs(server): document the judged-egress model contract for operators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,16 @@ WORKER_ALLOWED_DOMAINS=api.anthropic.com,.anthropic.com,registry.npmjs.org,.npmj
 # Explicitly blocked domains (optional, use with WORKER_ALLOWED_DOMAINS=*)
 WORKER_DISALLOWED_DOMAINS=
 
+# Default model for the optional LLM egress judge. The judge is a policy
+# control, so it runs on the DEPLOYMENT's credential, never a tenant's:
+# the ref must be `<provider>/<model>` naming a provider whose system key is
+# set in this environment AND that speaks the OpenAI-compatible protocol.
+# A bare model id or an Anthropic-protocol ref (`claude/...`) is not
+# resolvable and the judge FAILS CLOSED — every judged egress is denied.
+# Unset: no default; each judge rule/guardrail must name its own model.
+# Boot logs the resolution outcome; a bad value is loud but non-fatal.
+EGRESS_JUDGE_MODEL=
+
 # Optional remote runtime provider for worker bash commands (deployment-wide
 # default / self-host; per-agent selection comes from its Environment).
 # Default/unset: local per-conversation workspaces with embedded just-bash.


### PR DESCRIPTION
## Summary
- Documents `EGRESS_JUDGE_MODEL` in `.env.example`. #3277 changed the shape of the value this var needs, but it was documented only in the Docker env table — a self-hoster starting from `.env.example` never saw it at all.
- Carries the `BREAKING CHANGE:` footer #3277's squash commit lacks, so the generated 18.0.0 changelog entry ships the repoint guidance rather than just the headline. Release PR #3241 is still open, so this lands inside the window; it does not add a second major bump (18.0.0 is already major).

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [ ] Tests run — n/a, comment-only change to `.env.example`; no code path reads it in a test

Verification of the #3277 paths this note describes, done live in this worktree at `ba6967fdf` (not stubbed):

Boot preflight, good value (`EGRESS_JUDGE_MODEL=gemini/gemini-2.5-flash`), post-listen hook in a real booting server:
```
{"msg":"Lobu running at http://127.0.0.1:9804"}
[info] [system-judge-target] EGRESS_JUDGE_MODEL resolved against an operator-keyed provider
```

Boot preflight, bad value (`EGRESS_JUDGE_MODEL=claude-sonnet-5`) — loud and non-fatal, server keeps serving (`/api/health` = 200):
```
[error] [system-judge-target] EGRESS_JUDGE_MODEL="claude-sonnet-5" cannot be resolved: judge model
"claude-sonnet-5" is not a "<provider>/<model>" ref; an operator-owned judge cannot infer the
provider. Every judged egress request will be DENIED until this is fixed.
```

Live round trip through `gatewayCompletion` from a judge — real HTTPS to `generativelanguage.googleapis.com`, no `fetch` stub, verdict parsed by `parseVerdict`:
```
TextJudge ALLOW case (837ms)  { "allow": true,  "reason": "The text is an ordinary product question about exporting data and does not ask for or reveal any credentials, API keys, or passwords." }
TextJudge DENY  case (982ms)  { "allow": false, "reason": "The text contains and reveals an API key, which is prohibited by the policy." }
```

The break this note documents, exercised for real:
```
resolveSystemJudgeTarget("gpt-4o-mini")        -> unqualified-ref
resolveSystemJudgeTarget("claude/claude-sonnet-5") -> no-system-provider: provider "claude" speaks "anthropic", not the OpenAI-compatible protocol
TextJudge with model "gpt-4o-mini"             -> { allow: false, reason: "Judge not configured; denied" }   # fails closed, does not throw out
```

## Notes
- `EGRESS_JUDGE_MODEL=` is left empty, matching `WORKER_DISALLOWED_DOMAINS=` above it. The reader is `process.env.EGRESS_JUDGE_MODEL?.trim() || undefined`, so an empty value is identical to unset.
- Separately confirmed while verifying: #3277 **is** already in prod. Image builds fire on push to main, not on a release event — build run 2559 (`20260902-121551-002559`) has `headSha = ba6967fdf`, and `git merge-base --is-ancestor` passes against it. Prod has `EGRESS_JUDGE_MODEL` unset and holds no LLM provider system key, so no judged egress is reachable there today; the fail-closed break affects self-hosters, which is why the changelog guidance matters.
