### PR TITLE
test(connectors): pin the child-runner timeout message the media matcher greps

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -495,6 +495,38 @@ describe("media", () => {
    * catch a cap shorter than the delay chosen. Guard the shape instead — no
    * timer may race a dispatch, whatever its constant.
    */
+  it("still matches the child-runner timeout message it depends on", () => {
+    // `whatsapp_web.ts` decides "retryable" vs "this media is gone" by matching
+    // the dispatch backstop's free-text message, which is produced in another
+    // package. Nothing links the two, so a reword there would silently
+    // downgrade every timed-out media item to `unavailable` — permanently
+    // gone, never retried — with all tests still green. Pin the substrings the
+    // connector actually greps for; if this fails, fix the matcher, not this.
+    const producer = readFileSync(
+      new URL(
+        "../../../connector-worker/src/executor/child-runner.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const consumer = readFileSync(
+      new URL("../whatsapp_web.ts", import.meta.url),
+      "utf8",
+    );
+    const matched = [...consumer.matchAll(/text\.includes\("([^"]+)"\)/g)].map(
+      (m) => m[1],
+    );
+    expect(matched).toContain("IPC may be wedged");
+    // Every marker the connector greps for must exist in the producer, except
+    // "timed out", which is the generic phrasing several sources emit.
+    for (const marker of matched.filter((m) => m !== "timed out")) {
+      expect(
+        producer.includes(marker),
+        `child-runner.ts no longer emits "${marker}"; whatsapp_web.ts would downgrade a retryable timeout to unavailable`,
+      ).toBe(true);
+    }
+  });
+
   it("never races an uncancellable dispatch against a local timer", () => {
     const source = readFileSync(
       new URL("../whatsapp_web.ts", import.meta.url),


### PR DESCRIPTION
## What

`packages/connectors/src/whatsapp_web.ts` decides whether a timed-out media item is *retryable* or *permanently gone* by matching the dispatch backstop's free-text error message:

```ts
const timedOut =
  text.includes("timed out") || text.includes("IPC may be wedged");
```

That string is produced in a different package — `packages/connector-worker/src/executor/child-runner.ts:133` — with nothing linking the two. A reword there silently downgrades every timed-out media item to `unavailable`: media marked permanently gone and never retried, with the entire suite still green.

Flagged as a non-blocking finding on #3288 and landed as-is; this closes it with a test rather than a runtime change.

## Red → green

Reworded the producer to `IPC channel may be stalled`:

```
error: child-runner.ts no longer emits "IPC may be wedged"; whatsapp_web.ts would downgrade a retryable timeout to unavailable
(fail) media > still matches the child-runner timeout message it depends on
 32 pass, 1 fail
```

Restored:

```
 33 pass, 0 fail
```

Full connector suite: 507 pass, 0 fail. `make pre-pr` clean.

## Notes

`"timed out"` is excluded from the producer assertion — it is generic phrasing emitted by several sources, not this one backstop. The guard fails with the consequence named so the next engineer fixes the matcher rather than the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that media processing timeouts continue to receive the correct retryable or unavailable classification.
  - Added safeguards against changes to timeout messaging causing timed-out media items to be incorrectly treated as permanently unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->