### PR TITLE
fix(gateway): stop a reasoning model's judge verdict being truncated

### DIFF
--- a/packages/server/src/__tests__/unit/gateway-completion.test.ts
+++ b/packages/server/src/__tests__/unit/gateway-completion.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   GatewayCompletionTimeoutError,
+  GatewayCompletionTruncatedError,
   gatewayCompletion,
 } from "../../gateway/inference/gateway-completion";
 
@@ -291,5 +292,114 @@ describe("gatewayCompletion — fail-closed caller options", () => {
 
     expect(err).toBeInstanceOf(GatewayCompletionTimeoutError);
     expect((err as GatewayCompletionTimeoutError).timeoutMs).toBe(10);
+  });
+});
+
+describe("gatewayCompletion — truncated replies", () => {
+  /**
+   * A reasoning model's hidden thinking tokens are charged against
+   * `max_tokens` while being EXCLUDED from `completion_tokens`, so a ceiling
+   * that looks generous next to the visible reply can still cut the answer
+   * off. Measured against gemini-2.5-flash with the judge's production
+   * prompts: `max_tokens: 256` produced `finish_reason: "length"` with
+   * `completion_tokens: 40` but 252 tokens actually generated.
+   *
+   * Returning that truncated body is the dangerous part: the judge's parser
+   * reports it as "no JSON object", which is indistinguishable from a model
+   * that ignored its instructions. A ceiling the operator can raise then looks
+   * like a model that has to be replaced, and the fail-closed deny gets blamed
+   * on the wrong cause.
+   */
+  test("throws rather than returning a body cut off by the token ceiling", async () => {
+    stubFetch({
+      choices: [
+        {
+          message: { content: '```json\n{\n  "verdict": "' },
+          finish_reason: "length",
+        },
+      ],
+    });
+
+    await expect(
+      gatewayCompletion({
+        target: TARGET,
+        systemPrompt: "s",
+        userPrompt: "u",
+        timeoutMs: 1000,
+        maxTokens: 256,
+        maxRetries: 0,
+      })
+    ).rejects.toThrow(GatewayCompletionTruncatedError);
+  });
+
+  test("the error names the ceiling so an operator can act on it", async () => {
+    stubFetch({
+      choices: [{ message: { content: "partial" }, finish_reason: "length" }],
+    });
+
+    const err = await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      timeoutMs: 1000,
+      maxTokens: 256,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(GatewayCompletionTruncatedError);
+    expect(err.maxTokens).toBe(256);
+  });
+
+  /**
+   * Retrying cannot help: the same ceiling truncates the same way, and for a
+   * fail-closed caller each attempt burns the shared deadline before the deny
+   * it was always going to produce.
+   */
+  test("does NOT retry a truncation — the ceiling will not change", async () => {
+    const { calls } = stubFetch({
+      choices: [{ message: { content: "partial" }, finish_reason: "length" }],
+    });
+
+    await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      timeoutMs: 5000,
+      maxTokens: 256,
+    }).catch(() => {});
+
+    expect(calls.length).toBe(1);
+  });
+
+  test("a normal `stop` finish is unaffected", async () => {
+    stubFetch({
+      choices: [{ message: { content: "complete" }, finish_reason: "stop" }],
+    });
+
+    const out = await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      timeoutMs: 1000,
+    });
+
+    expect(out).toBe("complete");
+  });
+
+  /**
+   * Not every provider returns `finish_reason`. Absence must not be read as
+   * truncation, or a conforming provider that simply omits the field would
+   * have every reply rejected.
+   */
+  test("a missing finish_reason is not treated as truncation", async () => {
+    stubFetch(completionBody("no finish reason here"));
+
+    const out = await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      timeoutMs: 1000,
+    });
+
+    expect(out).toBe("no finish reason here");
   });
 });

--- a/packages/server/src/gateway/__tests__/gateway-judge-client.test.ts
+++ b/packages/server/src/gateway/__tests__/gateway-judge-client.test.ts
@@ -42,6 +42,24 @@ function stubFetch(
   return { calls };
 }
 
+/**
+ * Like {@link stubFetch} but takes the whole response body, so a test can set
+ * `finish_reason` — which the content-only helper cannot express.
+ */
+function stubFetchRaw(
+  body: unknown,
+  onRequest?: (parsedBody: Record<string, unknown>) => void
+): void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_url: string, requestInit: RequestInit) => {
+    onRequest?.(JSON.parse(String(requestInit.body)));
+    return new Response(JSON.stringify(body), { status: 200 });
+  }) as unknown as typeof fetch;
+  restore = () => {
+    globalThis.fetch = original;
+  };
+}
+
 describe("GatewayJudgeClient", () => {
   // POSITIVE CONTROL. Every other test here asserts a denial, and a client that
   // denied unconditionally would pass all of them while the feature is dead.
@@ -92,7 +110,11 @@ describe("GatewayJudgeClient", () => {
     // The circuit breaker is the retry policy; retrying inside one judge call
     // only delays the fail-closed deny.
     expect(calls).toHaveLength(1);
-    expect(JSON.parse(String(calls[0]?.init.body)).max_tokens).toBe(256);
+    // Pinned deliberately. This was 256 and had to be raised: a reasoning
+    // model's hidden thinking is charged against `max_tokens`, and 252 tokens
+    // were measured generated against the old 256 ceiling, truncating the
+    // verdict. Do not lower this without reading JUDGE_MAX_TOKENS' comment.
+    expect(JSON.parse(String(calls[0]?.init.body)).max_tokens).toBe(1024);
   });
 
   test("uses the operator credential and target, not a caller-supplied one", async () => {
@@ -356,5 +378,75 @@ describe("resolveSystemJudgeTarget", () => {
     const result = await resolveSystemJudgeTarget("openai/gpt-4o-mini");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("no-system-provider");
+  });
+});
+
+describe("GatewayJudgeClient — ceiling truncation", () => {
+  /**
+   * The regression that motivated raising the ceiling. A reasoning model
+   * spends `max_tokens` on hidden thinking, so the verdict arrives as a
+   * prefix. Before this, `gatewayCompletion` handed the prefix back and the
+   * parser reported "no JSON object" — a budget misconfiguration wearing the
+   * costume of a model that ignored its instructions.
+   */
+  test("a verdict cut off by the ceiling reports the ceiling, not a bad verdict", async () => {
+    stubFetchRaw({
+      choices: [
+        {
+          message: { content: '```json\n{\n  "verdict": "' },
+          finish_reason: "length",
+        },
+      ],
+    });
+
+    const client = new GatewayJudgeClient({
+      resolveTarget: async () => OK_TARGET,
+    });
+
+    const err = await client
+      .judge({
+        model: "gemini/gemini-2.5-flash",
+        systemPrompt: "s",
+        userPrompt: "u",
+      })
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("ceiling");
+    expect((err as Error).message).toContain("gemini/gemini-2.5-flash");
+    // The old failure mode. If this string comes back, a truncation is being
+    // misreported as malformed model output again.
+    expect((err as Error).message).not.toContain("no JSON object");
+  });
+
+  test("the ceiling it sends is large enough for a reasoning model's thinking", async () => {
+    let sentMaxTokens: unknown;
+    stubFetchRaw(
+      {
+        choices: [
+          {
+            message: { content: '{"verdict":"allow","reason":"ok"}' },
+            finish_reason: "stop",
+          },
+        ],
+      },
+      (body) => {
+        sentMaxTokens = body.max_tokens;
+      }
+    );
+
+    const client = new GatewayJudgeClient({
+      resolveTarget: async () => OK_TARGET,
+    });
+    const verdict = await client.judge({
+      model: "p/m",
+      systemPrompt: "s",
+      userPrompt: "u",
+    });
+
+    expect(verdict.verdict).toBe("allow");
+    // 252 tokens were generated under the old 256 ceiling, so anything at or
+    // near 256 reintroduces the coin flip.
+    expect(sentMaxTokens as number).toBeGreaterThanOrEqual(512);
   });
 });

--- a/packages/server/src/gateway/inference/gateway-completion.ts
+++ b/packages/server/src/gateway/inference/gateway-completion.ts
@@ -59,6 +59,11 @@ interface GatewayCompletionRequest {
 interface ChatCompletionResponse {
   choices?: Array<{
     message?: { content?: string | null } | null;
+    /**
+     * `"length"` means the ceiling stopped generation. Absent on providers
+     * that omit it, which must NOT be read as truncation.
+     */
+    finish_reason?: string | null;
   } | null> | null;
 }
 
@@ -197,6 +202,32 @@ export class GatewayCompletionTimeoutError extends Error {
 }
 
 /**
+ * The upstream stopped because it hit the output ceiling, so the body is a
+ * PREFIX of the intended reply rather than the reply.
+ *
+ * This needs its own type because a truncated body is not a malformed one. A
+ * reasoning model's hidden thinking tokens are charged against `max_tokens`
+ * while being excluded from `completion_tokens`, so a ceiling that looks
+ * generous beside the visible reply can still cut the answer off — and every
+ * caller here parses strict JSON, which a prefix never satisfies. Handing that
+ * prefix back makes a budget misconfiguration read as a model that ignored its
+ * instructions, which is the wrong thing to fix.
+ */
+export class GatewayCompletionTruncatedError extends Error {
+  readonly maxTokens: number | undefined;
+
+  constructor(maxTokens: number | undefined) {
+    super(
+      `Gateway completion was truncated by the output ceiling${
+        maxTokens === undefined ? "" : ` (max_tokens: ${maxTokens})`
+      }; the reply is incomplete`
+    );
+    this.name = "GatewayCompletionTruncatedError";
+    this.maxTokens = maxTokens;
+  }
+}
+
+/**
  * An upstream HTTP failure that carries its status so the retry policy can
  * distinguish retryable from terminal responses.
  */
@@ -220,6 +251,10 @@ function isRetryableGatewayCompletionError(error: Error): boolean {
   if (error instanceof GatewayCompletionHttpError) {
     return error.status === 429 || (error.status >= 500 && error.status < 600);
   }
+  // A truncation is terminal by construction: the same ceiling truncates the
+  // same way, and for a fail-closed caller each attempt burns the shared
+  // deadline before the deny it was always going to produce.
+  if (error instanceof GatewayCompletionTruncatedError) return false;
   return /network|fetch|ECONN/i.test(error.message);
 }
 
@@ -259,7 +294,16 @@ async function callCompletionOnce(
   }
 
   const data = (await response.json()) as ChatCompletionResponse;
-  const content = data.choices?.[0]?.message?.content;
+  const choice = data.choices?.[0];
+
+  // Checked BEFORE the empty-content guard: a truncation that left nothing
+  // visible is still a truncation, and "returned no text" would send the
+  // operator looking at the model instead of the ceiling.
+  if (choice?.finish_reason === "length") {
+    throw new GatewayCompletionTruncatedError(request.maxTokens);
+  }
+
+  const content = choice?.message?.content;
   if (!content) throw new Error("Gateway completion returned no text");
   return content;
 }

--- a/packages/server/src/gateway/proxy/egress-judge/gateway-judge-client.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/gateway-judge-client.ts
@@ -21,6 +21,7 @@
 
 import {
   GatewayCompletionTimeoutError,
+  GatewayCompletionTruncatedError,
   gatewayCompletion,
 } from "../../inference/gateway-completion.js";
 import { resolveSystemJudgeTarget } from "../../inference/system-judge-target.js";
@@ -41,12 +42,28 @@ export class JudgeConfigurationError extends Error {
 }
 
 /**
- * Output ceiling for a verdict. A verdict is `{verdict, reason}` with the reason
- * capped at one short sentence by the prompt, so this is a backstop against a
- * model that starts narrating, not a tuning knob. Matches what the Anthropic
- * client sent.
+ * Output ceiling for a verdict. A verdict is `{verdict, reason}` with the
+ * reason capped at one short sentence by the prompt, so this is a backstop
+ * against a model that starts narrating, not a tuning knob.
+ *
+ * It was 256 — what the Anthropic client sent. That did not survive the move
+ * to arbitrary OpenAI-compatible providers, because a REASONING model's hidden
+ * thinking tokens are charged against `max_tokens` while being excluded from
+ * `completion_tokens`. Measured against `gemini/gemini-2.5-flash` with this
+ * judge's own prompts: `finish_reason: "length"`, `completion_tokens: 40`, but
+ * 252 tokens actually generated against the 256 ceiling — so whether a verdict
+ * survived was a coin flip on how much the model thought, and a truncated one
+ * fails closed and DENIES legitimate traffic.
+ *
+ * 1024 clears the observed thinking budget with room to spare while still
+ * bounding a runaway. The judge is asked for one sentence; if a model needs
+ * more than 1024 tokens to produce it, capping is the correct outcome.
+ *
+ * Note this bounds an OUTPUT budget, not billing on thinking — a chatty
+ * reasoning model costs what it costs; the ceiling only decides whether we get
+ * a usable answer for it.
  */
-const JUDGE_MAX_TOKENS = 256;
+const JUDGE_MAX_TOKENS = 1024;
 
 export class GatewayJudgeClient implements JudgeClient {
   private readonly timeoutMs: number;
@@ -88,6 +105,15 @@ export class GatewayJudgeClient implements JudgeClient {
       // aborted here rather than abandoned to finish unobserved.
       if (err instanceof GatewayCompletionTimeoutError) {
         throw new JudgeTimeoutError(err.timeoutMs);
+      }
+      // A truncation is this deployment's ceiling, not the upstream's health,
+      // so it must not read as a provider fault. Rethrown with the model named
+      // because the ceiling only bites for particular (reasoning) models, and
+      // that is the first thing an operator needs in order to act.
+      if (err instanceof GatewayCompletionTruncatedError) {
+        throw new Error(
+          `judge model "${args.model}" did not fit the verdict inside the ${JUDGE_MAX_TOKENS}-token ceiling (${err.message}). A reasoning model spends this budget on hidden thinking; use a smaller-thinking model or raise the ceiling.`
+        );
       }
       throw err;
     }


### PR DESCRIPTION
## Summary
- `JUDGE_MAX_TOKENS` was 256, documented as "what the Anthropic client sent". #3277 moved the judge onto arbitrary OpenAI-compatible providers, where a **reasoning model's hidden thinking tokens are charged against `max_tokens` but excluded from `completion_tokens`** — so the budget is spent before the verdict is written.
- A truncated verdict made `parseVerdict` throw "no JSON object", so the judge **failed closed and denied legitimate traffic**; and since that throw is not a `JudgeConfigurationError`, `judge-runner.ts:250` also counted it toward the circuit breaker, so five of them open the circuit and every later request on that policy is denied, logged as a transient outage that never happened.
- The **deny path was unaffected** (a short "deny" fits), which is why this survived a migration with green tests: any e2e that only checks a bad request gets blocked passes while allow traffic is silently denied.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test src/gateway/__tests__/gateway-judge-client.test.ts src/__tests__/unit/gateway-completion.test.ts` → **37 pass, 0 fail**

### Measured cause

`gemini/gemini-2.5-flash`, the judge's own `buildSystemPrompt()`, raw upstream call at three ceilings:

```
max_tokens=256   finish=length  completion_tokens=40  prompt=241  total=493   → 252 generated, reply cut mid-value
max_tokens=512   finish=stop    completion_tokens=35  → complete JSON
max_tokens=2048  finish=stop    completion_tokens=40  → complete JSON
```

252 generated against a 256 ceiling. Truncation severity varied run to run; one sample came back at 20 chars (``` ```json\n{\n  "verdict": " ```). A one-line system prompt does **not** reproduce it — less thinking, reply fits — so this only shows up through the production composer.

### Red → green, live against the real provider

Same probe, only the ceiling changed:

```
256:   ALLOW-policy  allow=0 deny=0 errors=6      DENY-policy  allow=0 deny=6 errors=0
       judge model "gemini/gemini-2.5-flash" did not fit the verdict inside the 256-token ceiling
1024:  ALLOW-policy  allow=6 deny=0 errors=0      DENY-policy  allow=0 deny=6 errors=0
       {"verdict":"allow","reason":"GET request to an example domain is permitted by policy."}
       {"verdict":"deny","reason":"The policy unconditionally denies all outbound network requests."}
```

12/12 real verdicts after the fix, zero truncation.

### Mutation-verified

Both new guards fail when reverted, so neither is vacuous:

```
ceiling 1024 -> 256                  2 fail  (incl. the pinned-ceiling guard)
drop the finish_reason detection     3 fail
restored                            37 pass
```

## Notes
- The fix is in `gatewayCompletion`, not just the judge, so it covers the class: `suggest-followups`, the memory query rewriter and eval scoring all parse strict JSON that a prefix never satisfies. Truncation is terminal and never retried — the same ceiling truncates the same way, and for a fail-closed caller a retry only burns the shared deadline before the deny it was always going to produce.
- A **missing** `finish_reason` is explicitly not read as truncation (negative-control test), so a provider that omits the field is unaffected.
- One existing test pinned `max_tokens` to 256; updated to 1024 with a comment pointing at the measurement, so the next person to touch the number reads why it is what it is.
- Found while running the prod e2e for #3277. The write-time half of that migration is separately prod-verified; this is the runtime half's first real exercise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gateway completion requests now clearly report when an upstream response is truncated instead of returning incomplete content.
  - Truncated responses are no longer automatically retried.
  - Judge evaluations now distinguish token-limit truncation from malformed responses and provide clearer error details.
  - Increased the token allowance for judge evaluations to reduce incomplete verdicts, particularly for reasoning models.
  - Normal completed responses continue to be handled as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->