### PR TITLE
fix(mcp): isolate direct client instructions from tenant agent policy

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -276,6 +276,18 @@ describe('MCP Authentication', () => {
 
       const sessionId = initResponse.headers.get('mcp-session-id');
       expect(sessionId).toBeTruthy();
+      const initBody = await initResponse.json();
+      expect(initBody.result?.instructions).toContain(
+        "Use Lobu's tools only when they are relevant to the user's request"
+      );
+      expect(initBody.result?.instructions).toContain('### Writes and approvals');
+      expect(initBody.result?.instructions).toContain('Use it only when the user asks');
+      expect(initBody.result?.instructions).not.toContain(
+        "Use it proactively — don't wait to be asked"
+      );
+      expect(initBody.result?.instructions).not.toContain(
+        '### Saving (do this automatically)'
+      );
 
       await post(`/mcp/${publicOrg.slug}`, {
         body: {
@@ -1284,6 +1296,36 @@ describe('MCP Authentication', () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.error?.message).toContain("Agent 'missing-agent' was not found");
+    });
+
+    it('does not let a client-declared agent binding unlock managed-agent instructions', async () => {
+      const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
+
+      const response = await post('/mcp', {
+        body: {
+          jsonrpc: '2.0',
+          id: '__test_init__',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: {
+              name: 'directory-client-test',
+              version: '1.0',
+              agentId: agent.agentId,
+            },
+          },
+        },
+        token,
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.result?.instructions).toContain('### Writes and approvals');
+      expect(body.result?.instructions).not.toContain(
+        "You have persistent memory. Use it proactively — don't wait to be asked."
+      );
+      expect(body.result?.instructions).not.toContain('### Saving (do this automatically)');
     });
   });
 

--- a/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
@@ -89,11 +89,17 @@ describe('worker MCP session agent identity', () => {
     });
     expect(initResponse.status).toBe(200);
     const sessionId = initResponse.headers.get('mcp-session-id');
+    const initBody = await initResponse.json();
     if (!sessionId) {
       throw new Error(
-        `initialize returned no mcp-session-id: ${JSON.stringify(await initResponse.json())}`
+        `initialize returned no mcp-session-id: ${JSON.stringify(initBody)}`
       );
     }
+    expect(initBody.result?.instructions).toContain(
+      "You have persistent memory. Use it proactively — don't wait to be asked."
+    );
+    expect(initBody.result?.instructions).toContain('### Saving (do this automatically)');
+    expect(initBody.result?.instructions).not.toContain('### Writes and approvals');
     await post(`/mcp/${org.slug}`, {
       body: { jsonrpc: '2.0', method: 'notifications/initialized' },
       token: workerToken,

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -318,6 +318,35 @@ describe('buildWorkspaceInstructions render fixes', () => {
     expect(directiveIdx).toBeGreaterThan(-1);
     expect(directiveIdx).toBeLessThan(toolSurfaceIdx);
   });
+
+  it('keeps direct MCP instructions user-directed and free of automatic personal-data capture', async () => {
+    const directOrg = await createTestOrganization({ name: 'Direct MCP Instructions Org' });
+    const out = await buildWorkspaceInstructions(directOrg.id, { audience: 'direct-mcp' });
+
+    expect(out).toContain(
+      "Use Lobu's tools only when they are relevant to the user's request"
+    );
+    expect(out).toContain('### Writes and approvals');
+    expect(out).toContain('Use it only when the user asks');
+    expect(out).not.toContain("Use it proactively — don't wait to be asked");
+    expect(out).not.toContain('### Saving (do this automatically)');
+    expect(out).not.toContain('Preferences, opinions, or personal details');
+    expect(out).not.toContain('### Schema: Entity Types');
+    expect(out).not.toContain('Direct MCP Instructions Org');
+  });
+
+  it('documents the search_memory workspace narrowing argument to the direct MCP audience', async () => {
+    // The managed-agent text explains the singular `workspace` argument in a
+    // sentence addressed to "a direct bare OAuth connection" — precisely the
+    // audience that now receives DIRECT_MCP_INSTRUCTIONS instead. The static
+    // text is the only capability documentation that audience ever gets, so
+    // the narrowing knob has to be named here or it is discoverable nowhere.
+    const directOrg = await createTestOrganization({ name: 'Narrowing Arg Org' });
+    const out = await buildWorkspaceInstructions(directOrg.id, { audience: 'direct-mcp' });
+
+    expect(out).toContain('`workspace` argument');
+    expect(out).toContain('multi-workspace grant');
+  });
 });
 
 describe('org-wide guidance context', () => {
@@ -382,6 +411,14 @@ describe('org-wide guidance context', () => {
     const schemaIdx = out!.indexOf('### Tool surface');
     expect(ctxIdx).toBeGreaterThan(-1);
     expect(ctxIdx).toBeLessThan(schemaIdx);
+  });
+
+  it('does not expose admin-authored agent guidance to a direct MCP client', async () => {
+    const out = await buildWorkspaceInstructions(org.id, { audience: 'direct-mcp' });
+
+    expect(out).not.toContain('### Organization Context');
+    expect(out).not.toContain('Our fiscal year starts in February.');
+    expect(out).not.toContain('### Schema: Entity Types');
   });
 
   it('backfills `guidance` into a pre-guidance $member registry so authorship still validates (#1913)', async () => {

--- a/packages/server/src/gateway/__tests__/instruction-service.test.ts
+++ b/packages/server/src/gateway/__tests__/instruction-service.test.ts
@@ -128,12 +128,12 @@ describe("InstructionService", () => {
     expect(ctxB.agentLayers.identityMd).not.toContain("I am the ORG-A builder.");
   });
 
-  test("does NOT inject org guidance into the agent layers (delivered via lobu-memory MCP, not duplicated)", async () => {
+  test("does NOT inject org guidance into the agent layers (delivered through managed-agent MCP instructions, not duplicated)", async () => {
     // Single source of truth: guidance reaches the worker prompt through the
-    // lobu-memory MCP server's instructions (buildWorkspaceInstructions renders
-    // the "Organization Context" section). Injecting it into the agent layers
-    // here too — under the same org-scope gate — would duplicate it in the
-    // prompt. This test pins that the session-context path stays out of it.
+    // lobu-memory MCP server's managed-agent instructions
+    // (buildWorkspaceInstructions renders the "Organization Context" section).
+    // Injecting it into the agent layers here too would duplicate it in the
+    // prompt. Direct MCP clients receive a separate directory-safe audience.
     await seedAgentRow("agent-guided", { organizationId: "org-a" });
     await seedGuidanceEvent("org-a", "Fiscal year starts in February.");
 

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -337,13 +337,12 @@ export class InstructionService {
       }
     }
 
-    // NOTE: org-wide `guidance` is NOT injected here. Workers receive it
-    // through the mandatory `lobu-memory` MCP server's instructions
-    // (buildWorkspaceInstructions renders the "Organization Context" section),
-    // which the worker folds into its prompt as MCP server instructions. Both
-    // that server and this injection are gated by the same org-scope condition,
-    // so injecting here too would place identical guidance in the prompt twice.
-    // buildWorkspaceInstructions is the single render site for both surfaces.
+    // NOTE: org-wide `guidance` is NOT injected here. Verified workers receive
+    // it through the mandatory `lobu-memory` MCP server's managed-agent
+    // instructions (buildWorkspaceInstructions renders the "Organization
+    // Context" section), which the worker folds into its prompt. Direct MCP
+    // clients receive the directory-safe audience instead. Injecting here too
+    // would place identical guidance in a managed worker prompt twice.
 
     // Get skills instructions (includes enabled skills from agent settings)
     let skillsInstructions = "";

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -871,8 +871,15 @@ async function resolveMembershipRole(
 }
 
 async function buildSessionInstructions(authCtx: AuthContext): Promise<string | undefined> {
+  // Only verified worker-originated requests carry sourceContext. A client may
+  // request an agent binding in initialize metadata, but that must not grant it
+  // the tenant-authored agent instructions intended for Lobu-managed workers.
+  const audience =
+    authCtx.sourceContext != null || authCtx.actingAutomationId != null
+      ? 'managed-agent'
+      : 'direct-mcp';
   const base = authCtx.organizationId
-    ? ((await buildWorkspaceInstructions(authCtx.organizationId)) ?? '')
+    ? ((await buildWorkspaceInstructions(authCtx.organizationId, { audience })) ?? '')
     : '';
   if (
     authCtx.tokenType !== 'oauth' ||

--- a/packages/server/src/utils/org-guidance.ts
+++ b/packages/server/src/utils/org-guidance.ts
@@ -3,12 +3,12 @@
  *
  * `guidance` is a built-in, code-level event kind (not declared in any
  * entity type's `event_kinds` registry): current, non-superseded `guidance`
- * events for an org render as an "Organization Context" section via the single
- * site `buildWorkspaceInstructions`. That block is the lobu-memory MCP server's
- * instructions, which reach BOTH surfaces from one render: the MCP client
- * directly, and the agent-worker prompt (the worker folds MCP server
- * instructions into its context). It is deliberately NOT re-injected in
- * InstructionService — that would duplicate it in the worker prompt.
+ * events for an org render as an "Organization Context" section through
+ * `buildWorkspaceInstructions` for verified managed-agent sessions. The worker
+ * folds those lobu-memory MCP server instructions into its context. Direct MCP
+ * clients receive capability guidance only and never receive tenant-authored
+ * agent policy. Guidance is deliberately NOT re-injected in InstructionService
+ * because that would duplicate it in the worker prompt.
  *
  * Design notes:
  * - Anchoring: injection selects by organization_id + semantic_type only. A

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -1,9 +1,9 @@
 /**
  * Workspace Instructions Builder
  *
- * Generates MCP instructions with workspace schema (entity types, relationship
- * types) and operating guidance so LLMs act as a proactive memory layer.
- * All entity-level data comes from tool calls at runtime, not from instructions.
+ * Generates managed-agent instructions with workspace schema and operating
+ * guidance, or a static capability description for direct MCP clients. All
+ * entity-level data comes from tool calls at runtime, not from instructions.
  */
 
 import { getDb } from '../db/client';
@@ -55,7 +55,41 @@ function renderSchemaFields(schema: unknown): string {
     .join(', ');
 }
 
-export async function buildWorkspaceInstructions(organizationId: string): Promise<string | null> {
+export type WorkspaceInstructionAudience = 'managed-agent' | 'direct-mcp';
+
+const DIRECT_MCP_INSTRUCTIONS = [
+  '## Lobu — Workspace Memory',
+  '',
+  "Lobu provides access to persistent workspace memory. Use Lobu's tools only when they are relevant to the user's request.",
+  '',
+  '### Read tools',
+  '- `search_memory` searches saved workspace memory.',
+  '- On a multi-workspace grant, `search_memory` accepts a singular `workspace` argument to narrow to one of the granted workspaces; every other tool stays in the current workspace.',
+  '- `search_sdk` discovers documented SDK methods and connector capabilities.',
+  '- `query_sdk` runs capability-scoped, read-only TypeScript.',
+  '- `query_sql` runs member-safe, read-only SQL.',
+  '- Use read tools to discover workspace-specific schema and capabilities instead of assuming they exist.',
+  '',
+  '### Writes and approvals',
+  '- `save_memory` stores a requested fact or note. Use it only when the user asks to remember or save information, or explicitly confirms a proposed save.',
+  '- `run_sdk` can create, update, or delete workspace data and can invoke connector operations. Use it only for a user-requested action; use `query_sdk` for reads and `dry_run=true` to preview supported writes.',
+  '- A policy-gated operation returns `status: "pending_approval"` and a `run_id`. Call `get_approval` with that run id to show the canonical review card. Treat a pending operation as waiting, not failed.',
+  '- Do not infer permission to store conversation details, preferences, personal information, relationships, or files merely because they were mentioned.',
+  '- Do not request, expose, or return authentication secrets.',
+].join('\n');
+
+export async function buildWorkspaceInstructions(
+  organizationId: string,
+  options: { audience?: WorkspaceInstructionAudience } = {}
+): Promise<string | null> {
+  // Preserve the historical managed-agent prompt by default for internal
+  // callers. Direct MCP sessions get an entirely static, directory-safe
+  // capability description. Workspace-authored schema, connector descriptions,
+  // and guidance are discoverable through explicit read tools instead of being
+  // injected into an unrelated host's prompt.
+  const managedAgent = options.audience !== 'direct-mcp';
+  if (!managedAgent) return DIRECT_MCP_INSTRUCTIONS;
+
   const sql = getDb();
 
   try {
@@ -138,8 +172,9 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       "When asked about workspace data — including people, leads, companies, connections, feeds, runs, or counts — query it before answering. On a direct bare OAuth connection, `search_memory` searches every currently accessible workspace the user granted and can be narrowed with its singular `workspace` argument; pinned connections and all other tools stay in the current workspace. Use `query_sdk` or `query_sql` for structured lookups and counts. Do not claim you can see only chat/Slack messages or channel members without querying workspace data first.",
     ];
 
-    // Org-wide admin-authored context goes near the top: it is the governed
-    // "why" that frames everything below (schema, tools, saving rules).
+    // Org-wide admin-authored context is agent policy, not MCP capability
+    // documentation. It belongs in managed-agent prompts only; returning it to
+    // a directory client would let tenant content steer an unrelated host.
     if (orgGuidance) {
       sections.push(
         '',


### PR DESCRIPTION
## Summary

- `buildSessionInstructions` gates the workspace-instructions render on `authCtx.organizationId` **alone** — nothing about token type or worker provenance. So every MCP client that resolves an org receives that org's admin-authored `guidance` verbatim as MCP server instructions, including a client that merely *requests* an agent binding in `initialize` metadata.
- This splits the render into two audiences: verified worker-originated sessions (`sourceContext != null || actingAutomationId != null`) keep the full managed-agent instructions; everything else gets a static, self-contained `DIRECT_MCP_INSTRUCTIONS` capability description.
- **Severity, stated honestly: this is a trust-boundary tightening, not a live data leak.** Only `lobu-team` and `buremba` have `guidance` rows and both are `private`; the 10 public-visibility orgs have zero. No anonymous caller can reach anyone's guidance today. What this closes is the boundary *before* a public org authors guidance, plus it stops spending an org's internal guidance as prompt tokens on clients that have no use for it.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate)
- [x] Tests run: targeted suites, red→green below
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: ran `./scripts/test-bot.sh` or relevant eval — n/a, no bot runtime change

### RED — production files reverted to `origin/main`, branch's tests kept

```
 ❯ src/__tests__/integration/mcp/auth.test.ts (59 tests | 3 failed | 2 skipped)
   × Public Organization MCP > allows anonymous public-read tool calls on public org MCP routes
     → expected '## Lobu — Your Persistent Memory…' to contain 'Use Lobu's tools only when they are …'
   × Public Organization MCP > requires auth for anonymous write attempts on public org MCP routes
     → expected '## Lobu — Your Persistent Memory…' to contain 'Use Lobu's tools only when they are …'
   × OAuth Access Token Authentication > does not let a client-declared agent binding unlock managed-agent instructions
     → expected '## Lobu — Your Persistent Memory…' to contain '### Writes and approvals'
 ❯ src/__tests__/integration/tools/workspace-instructions.test.ts (33 tests | 2 failed)
   × render fixes > keeps direct MCP instructions user-directed and free of automatic personal-data capture
     → expected '## Lobu — Your Persistent Memory…' to contain 'Use Lobu's tools only when they are …'
   × org-wide guidance context > does not expose admin-authored agent guidance to a direct MCP client
     → expected '## Lobu — Your Persistent Memory…' not to contain '### Organization Context'

 Test Files  2 failed | 1 passed (3)
      Tests  5 failed | 90 passed | 2 skipped (97)
```

The decisive failure is the last one: on `main` a direct MCP client's instructions **do** carry `### Organization Context`.

### GREEN — at this branch's HEAD

```
 ✓ src/__tests__/integration/tools/workspace-instructions.test.ts (33 tests) 576ms
 ✓ src/__tests__/integration/mcp/auth.test.ts (59 tests | 2 skipped) 1572ms
 ✓ src/__tests__/integration/mcp/worker-agent-identity.test.ts (5 tests) 203ms
 Test Files  2 passed (2) + 1 passed (1)
      Tests  95 passed | 2 skipped

# gateway suite is bun:test, not Vitest (src/gateway/**/__tests__/** is excluded from the vitest config)
$ bun test src/gateway/__tests__/instruction-service.test.ts --timeout 30000
 4 pass / 0 fail — Ran 4 tests across 1 file

$ make pre-pr
✅ pre-pr gates clean.
```

101 tests green across the four suites.

`worker-agent-identity.test.ts` passes in both directions by design — it is the guard that this change does **not** silently strip guidance from the surface that needs it, asserting a managed worker still receives the full instructions and *not* the direct-MCP block.

## Notes

- `make review-fix` could not run: the codex pool is at its usage limit until Sep 7. I did the diff-hygiene pass by hand instead — the parked version had split one `sections.push(...)` into three contiguous calls with identical content, which builds an identical array; collapsing that removed ~14 lines of no-op churn from the diff.
- Grepping `direct-mcp` on `main` is a false positive — those hits are an unrelated fixture id in `gateway/__tests__/mcp-proxy-edge-cases.test.ts`. Grep `WorkspaceInstructionAudience` to test presence.
- The `org-guidance.ts` hunk is doc-comment only; it restates the two-audience contract and is the clearest statement of intent in the change.
- Unblocks an open item on the Claude Connectors Directory submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bu9fLfHLjgVqsRk8oU6dj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Direct MCP connections now receive streamlined, capability-focused workspace instructions.
  - Direct MCP guidance excludes organization-specific context, administrative guidance, and automatic personal-data or memory-saving instructions.
  - Managed-agent sessions continue receiving organization context and persistent-memory guidance.
  - Session instructions now more clearly distinguish guidance based on connection type and verified session context.
  - Client-declared agent bindings no longer change the guidance provided to authenticated direct MCP sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->