### PR TITLE
fix(gateway): reject an egress guardrail whose judged domain an allow grant shadows

### DIFF
--- a/packages/server/src/gateway/__tests__/policy-store.test.ts
+++ b/packages/server/src/gateway/__tests__/policy-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AgentInlineGuardrail } from "@lobu/core";
 import {
   egressGuardrailsToPolicyBundle,
+  findSuppressedJudgedDomains,
   PolicyStore,
 } from "../permissions/policy-store.js";
 
@@ -167,5 +168,156 @@ describe("egressGuardrailsToPolicyBundle", () => {
       guardrail({ name: "default", domains: ["*.Example.COM"] }),
     ]);
     expect(bundle?.judgedDomains[0]?.domain).toBe(".example.com");
+  });
+});
+
+describe("findSuppressedJudgedDomains", () => {
+  const judge = (
+    over: Partial<AgentInlineGuardrail> = {}
+  ): AgentInlineGuardrail =>
+    ({
+      name: "watchdog",
+      stage: "egress",
+      enabled: true,
+      policy: "Allow read-only GETs.",
+      domains: ["example.com"],
+      ...over,
+    }) as AgentInlineGuardrail;
+
+  test("reports an exact judged domain shadowed by an exact grant", () => {
+    const found = findSuppressedJudgedDomains([judge()], ["example.com"]);
+    expect(found).toEqual([
+      { domain: "example.com", judge: "watchdog", grant: "example.com" },
+    ]);
+  });
+
+  test("reports a judged domain shadowed by a WILDCARD grant", () => {
+    // The whole point of reusing the runtime matcher: string equality would
+    // miss this, and the judge would silently never run.
+    const found = findSuppressedJudgedDomains(
+      [judge({ domains: ["api.example.com"] })],
+      ["*.example.com"]
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]?.grant).toBe(".example.com");
+  });
+
+  test("reports PARTIAL shadowing: exact grant against a wildcard judge", () => {
+    // `example.com` itself becomes grant-allowed while subdomains stay judged.
+    // A narrower hole is still a hole.
+    const found = findSuppressedJudgedDomains(
+      [judge({ domains: ["*.example.com"] })],
+      ["example.com"]
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]?.domain).toBe(".example.com");
+  });
+
+  test("reports a grant NARROWER than the judged wildcard — one host carved out", () => {
+    // `api.example.com` is granted, so its judge never runs, while the rest of
+    // `*.example.com` stays judged. Testing only the judged root would miss it.
+    const found = findSuppressedJudgedDomains(
+      [judge({ domains: ["*.example.com"] })],
+      ["api.example.com"]
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]?.grant).toBe("api.example.com");
+  });
+
+  test("reports two wildcards whose subdomain sets intersect", () => {
+    expect(
+      findSuppressedJudgedDomains(
+        [judge({ domains: ["*.example.com"] })],
+        ["*.api.example.com"]
+      )
+    ).toHaveLength(1);
+    expect(
+      findSuppressedJudgedDomains(
+        [judge({ domains: ["*.api.example.com"] })],
+        ["*.example.com"]
+      )
+    ).toHaveLength(1);
+  });
+
+  test("normalizes both sides, so spelling variants still collide", () => {
+    const found = findSuppressedJudgedDomains(
+      [judge({ domains: [".EXAMPLE.com"] })],
+      ["*.example.com"]
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  // ── negative controls: the guard must not fire on a healthy config ──
+  test("returns [] when the grant names an unrelated domain", () => {
+    expect(findSuppressedJudgedDomains([judge()], ["example.org"])).toEqual([]);
+  });
+
+  test("returns [] when a narrower grant does not cover the judged domain", () => {
+    // Grant is a strict subdomain of the judged host — it cannot shadow it.
+    expect(
+      findSuppressedJudgedDomains([judge()], ["api.example.com"])
+    ).toEqual([]);
+  });
+
+  test("returns [] for an exact judged ROOT beside a wildcard grant of the same suffix", () => {
+    // `GrantStore.hasGrant` expands a host into its wildcard PARENTS only, so a
+    // `*.example.com` grant never covers `example.com` itself — the judge still
+    // runs for the root. Rejecting this would be a false positive.
+    expect(
+      findSuppressedJudgedDomains([judge()], ["*.example.com"])
+    ).toEqual([]);
+  });
+
+  test("wildcardCoversRoot: the GLOBAL allowlist's `.suffix` DOES cover the root", () => {
+    // `matchesDomainPattern` in the proxy treats `.example.com` as matching
+    // `example.com` too, so for WORKER_ALLOWED_DOMAINS the same pair is a hit.
+    expect(
+      findSuppressedJudgedDomains([judge()], ["*.example.com"], {
+        wildcardCoversRoot: true,
+      })
+    ).toHaveLength(1);
+  });
+
+  test("returns [] when there is no allow list at all", () => {
+    expect(findSuppressedJudgedDomains([judge()], [])).toEqual([]);
+    expect(findSuppressedJudgedDomains([judge()], undefined)).toEqual([]);
+  });
+
+  test("ignores a DISABLED guardrail — it has no judge to suppress", () => {
+    expect(
+      findSuppressedJudgedDomains([judge({ enabled: false })], ["example.com"])
+    ).toEqual([]);
+  });
+
+  test("ignores a non-egress guardrail", () => {
+    expect(
+      findSuppressedJudgedDomains(
+        [judge({ stage: "ingress" } as Partial<AgentInlineGuardrail>)],
+        ["example.com"]
+      )
+    ).toEqual([]);
+  });
+
+  test("ignores blank and non-string allow entries", () => {
+    expect(
+      findSuppressedJudgedDomains([judge()], [
+        "",
+        "   ",
+        null as unknown as string,
+      ])
+    ).toEqual([]);
+  });
+
+  test("attributes each hit to the guardrail that owns the domain", () => {
+    const found = findSuppressedJudgedDomains(
+      [
+        judge({ name: "a", domains: ["a.test"] }),
+        judge({ name: "b", domains: ["b.test"] }),
+      ],
+      ["b.test"]
+    );
+    expect(found).toEqual([
+      { domain: "b.test", judge: "b", grant: "b.test" },
+    ]);
   });
 });

--- a/packages/server/src/gateway/permissions/policy-store.ts
+++ b/packages/server/src/gateway/permissions/policy-store.ts
@@ -175,6 +175,104 @@ export function egressGuardrailsToPolicyBundle(
   };
 }
 
+/**
+ * One judged domain whose judge can never run because an allow grant covers it.
+ *
+ * `checkDomainAccess` (proxy/http-proxy.ts) consults per-agent allow grants
+ * BEFORE the egress judge, so a domain that is both judged and allow-granted
+ * returns `allowed: true, source: "grant"` and its judge policy is dead config.
+ * The request looks permitted for a reason that has nothing to do with the
+ * policy the operator wrote, which is exactly the shape of failure the operator
+ * will not notice: the traffic flows.
+ */
+interface SuppressedJudgedDomain {
+  /** Normalized judged pattern from the guardrail's `domains` selector. */
+  domain: string;
+  /** The guardrail whose judge is suppressed. */
+  judge: string;
+  /** The normalized allow pattern that shadows it. */
+  grant: string;
+}
+
+interface SuppressedJudgedDomainOptions {
+  /**
+   * Whether a `.suffix` allow pattern also covers its root host. The proxy's
+   * global allowlist matcher does (`matchesDomainPattern`); the per-agent
+   * `GrantStore.hasGrant` does not — it expands a hostname into its exact form
+   * plus its wildcard PARENTS, so the root never sees its own wildcard row.
+   * Defaults to grant semantics.
+   */
+  wildcardCoversRoot?: boolean;
+}
+
+/**
+ * Whether an allow pattern reaches any host a judged pattern covers.
+ *
+ * A judged `.suffix` covers the root and every subdomain — {@link findMatchingRule},
+ * which `PolicyStore.resolve` matches with, treats `normalized === suffix` as a
+ * hit. Whether the ALLOW side's wildcard covers the root depends on which
+ * matcher enforces it (see {@link SuppressedJudgedDomainOptions}). Two
+ * wildcards overlap when either suffix sits under the other.
+ */
+function allowReachesJudged(
+  judged: string,
+  allow: string,
+  wildcardCoversRoot: boolean
+): boolean {
+  const judgedWild = judged.startsWith(".");
+  const allowWild = allow.startsWith(".");
+  const j = judgedWild ? judged.slice(1) : judged;
+  const a = allowWild ? allow.slice(1) : allow;
+  const under = (host: string, suffix: string) => host.endsWith(`.${suffix}`);
+  if (!judgedWild && !allowWild) return j === a;
+  if (!judgedWild) return (wildcardCoversRoot && j === a) || under(j, a);
+  if (!allowWild) return a === j || under(a, j);
+  return j === a || under(j, a) || under(a, j);
+}
+
+/**
+ * Find judged domains that an allow list shadows.
+ *
+ * Derives the judged set through {@link egressGuardrailsToPolicyBundle} — the
+ * same builder the runtime uses — so write-time validation and runtime
+ * enforcement cannot disagree about which domains are judged (the enabled /
+ * stage / non-empty-policy filtering and the normalization both come along).
+ *
+ * Reports PARTIAL shadowing too: an exact allow for `example.com` against a
+ * judged `.example.com` leaves the root ungoverned while subdomains stay
+ * judged, and an allow for `api.example.com` under that same judge carves one
+ * host out of it. Each is a narrower hole, but still a hole.
+ */
+export function findSuppressedJudgedDomains(
+  guardrails: AgentInlineGuardrail[],
+  allowedDomains: string[] | undefined,
+  options: SuppressedJudgedDomainOptions = {}
+): SuppressedJudgedDomain[] {
+  const bundle = egressGuardrailsToPolicyBundle(guardrails);
+  if (!bundle) return [];
+
+  const allowPatterns = (allowedDomains ?? [])
+    .filter((d): d is string => typeof d === "string" && d.trim() !== "")
+    .map((d) => normalizeDomainPattern(d));
+  if (allowPatterns.length === 0) return [];
+
+  const wildcardCoversRoot = options.wildcardCoversRoot ?? false;
+  const suppressed: SuppressedJudgedDomain[] = [];
+  for (const rule of bundle.judgedDomains) {
+    const covering = allowPatterns.find((allow) =>
+      allowReachesJudged(rule.domain, allow, wildcardCoversRoot)
+    );
+    if (covering) {
+      suppressed.push({
+        domain: rule.domain,
+        judge: rule.judge ?? "default",
+        grant: covering,
+      });
+    }
+  }
+  return suppressed;
+}
+
 function prepareBundle(
   organizationId: string,
   agentId: string,

--- a/packages/server/src/lobu/__tests__/agent-routes-judge-grant-shadow.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-judge-grant-shadow.test.ts
@@ -1,0 +1,207 @@
+/**
+ * An allow grant BEATS the egress judge. `checkDomainAccess` (gateway/proxy/
+ * http-proxy.ts) consults per-agent allow grants BEFORE the judge, so a domain
+ * that is both judged and allow-granted returns `source: "grant"` and its judge
+ * policy never runs. The request still succeeds, which is why nobody notices.
+ *
+ * PATCH `/:agentId/config` rejects that combination (400
+ * `guardrail_domain_shadowed_by_grant`). These tests drive the real `agentRoutes`
+ * Hono app over the embedded-PG harness, because the part that cannot be
+ * covered by a pure unit test is the MERGE: a PATCH may carry `guardrailsInline`
+ * alone, `networkConfig` alone, or both, and the hole only exists in the
+ * combination of the patch with what is already stored.
+ *
+ * Pure matching/normalization coverage for `findSuppressedJudgedDomains` lives
+ * in `gateway/__tests__/policy-store.test.ts`.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import {
+  authStash,
+  coreServicesStash,
+  installRouteTestMocks,
+} from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const ORG = "org-judge-shadow";
+const AGENT = "judge-shadow-agent";
+
+const JUDGE = {
+  name: "watchdog",
+  stage: "egress",
+  enabled: true,
+  policy: "Allow read-only GETs.",
+  domains: ["example.com"],
+  // Named explicitly so the route's judge-model check cannot be what rejects.
+  model: "openai/gpt-4o-mini",
+};
+
+async function seedOrgAndAgent(): Promise<void> {
+  const { getDb } = await import("../../db/client.js");
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG}) ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agents (id, organization_id, name)
+    VALUES (${AGENT}, ${ORG}, 'Judge Shadow Agent')
+    ON CONFLICT (organization_id, id) DO NOTHING
+  `;
+}
+
+/** Write settings straight to the row, bypassing the route's validation. */
+async function storeSettings(settings: Record<string, unknown>): Promise<void> {
+  const { getDb } = await import("../../db/client.js");
+  const sql = getDb();
+  for (const [column, value] of Object.entries({
+    guardrails_inline: settings.guardrailsInline ?? [],
+    network_config: settings.networkConfig ?? {},
+  })) {
+    await sql`
+      UPDATE agents SET ${sql(column)} = ${sql.json(value as object)}
+      WHERE organization_id = ${ORG} AND id = ${AGENT}
+    `;
+  }
+}
+
+async function patchConfig(body: unknown) {
+  const { agentRoutes } = await import("../agent-routes.js");
+  return agentRoutes.request(`/${AGENT}/config`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  // The route resolves every NEW judge model against the provider registry
+  // before it reaches the shadowing check, so `JUDGE.model` needs a registry
+  // and a system key or `guardrail_model_unresolvable` is the rejection.
+  process.env.LOBU_PROVIDER_REGISTRY_PATH = new URL(
+    "../../../../../config/providers.json",
+    import.meta.url
+  ).pathname;
+  process.env.OPENAI_API_KEY ||= "sk-test-deployment-owned";
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  await seedOrgAndAgent();
+  authStash.user = {
+    id: "u1",
+    name: "Test",
+    email: "u1@test",
+    emailVerified: true,
+  };
+  authStash.organizationId = ORG;
+  authStash.authSource = "session";
+  authStash.mcpAuthInfo = null;
+  coreServicesStash.services = null;
+}, 30_000);
+
+describe("PATCH /config — a judged domain must not be allow-granted", () => {
+  test("rejects when ONE patch carries both sides", async () => {
+    const res = await patchConfig({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: ["example.com"] },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: string;
+      error_description?: string;
+    };
+    expect(body.error).toBe("guardrail_domain_shadowed_by_grant");
+    // The message must name all three parties or the operator cannot act on it.
+    expect(body.error_description).toContain("watchdog");
+    expect(body.error_description).toContain("example.com");
+  });
+
+  test("rejects a guardrail patch that collides with the STORED allow list", async () => {
+    await storeSettings({ networkConfig: { allowedDomains: ["example.com"] } });
+    const res = await patchConfig({ guardrailsInline: [JUDGE] });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "guardrail_domain_shadowed_by_grant"
+    );
+  });
+
+  test("rejects a networkConfig patch that collides with the STORED guardrail", async () => {
+    await storeSettings({ guardrailsInline: [JUDGE] });
+    const res = await patchConfig({
+      networkConfig: { allowedDomains: ["example.com"] },
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "guardrail_domain_shadowed_by_grant"
+    );
+  });
+
+  test("rejects when a stored WILDCARD grant covers a newly judged subdomain", async () => {
+    await storeSettings({
+      networkConfig: { allowedDomains: ["*.example.com"] },
+    });
+    const res = await patchConfig({
+      guardrailsInline: [{ ...JUDGE, domains: ["api.example.com"] }],
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "guardrail_domain_shadowed_by_grant"
+    );
+  });
+
+  // ── the config must still be repairable, and healthy configs must save ──
+  test("accepts a judged domain with NO grant (the correct shape)", async () => {
+    const res = await patchConfig({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: [] },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("accepts a grant for an UNRELATED domain alongside a judge", async () => {
+    const res = await patchConfig({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: ["example.org"] },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("REPAIR: removing the grant saves, even from a shadowed stored state", async () => {
+    await storeSettings({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: ["example.com"] },
+    });
+    const res = await patchConfig({ networkConfig: { allowedDomains: [] } });
+    expect(res.status).toBe(200);
+  });
+
+  test("REPAIR: dropping the guardrail saves, even from a shadowed stored state", async () => {
+    await storeSettings({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: ["example.com"] },
+    });
+    const res = await patchConfig({ guardrailsInline: [] });
+    expect(res.status).toBe(200);
+  });
+
+  test("an UNRELATED patch is not blocked by a pre-existing shadowed state", async () => {
+    // Rejecting here would lock the agent out of edits it cannot use to repair
+    // the overlap — the same reasoning that grandfathers stored judge models.
+    await storeSettings({
+      guardrailsInline: [JUDGE],
+      networkConfig: { allowedDomains: ["example.com"] },
+    });
+    const res = await patchConfig({ skillsConfig: { skills: [] } });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -4,7 +4,11 @@
  * All routes are org-scoped via mcpAuth middleware and orgContext.
  */
 
-import { type AuthProfile, isSdkCompat } from "@lobu/core";
+import {
+	type AgentInlineGuardrail,
+	type AuthProfile,
+	isSdkCompat,
+} from "@lobu/core";
 import { SkillsConfigSchema } from "@lobu/core/contracts/agent-settings";
 import {
 	type ManageAutomationsArgs,
@@ -24,6 +28,14 @@ import {
 } from "../gateway/auth/oauth/providers";
 import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
 import { resolveSystemJudgeTarget } from "../gateway/inference/system-judge-target";
+import {
+	egressGuardrailsToPolicyBundle,
+	findSuppressedJudgedDomains,
+} from "../gateway/permissions/policy-store";
+import {
+	isUnrestrictedMode,
+	loadAllowedDomains,
+} from "../gateway/config/network-allowlist";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
 import { validateModelRefsAgainstOrg } from "./model-config";
@@ -2008,6 +2020,11 @@ routes.patch("/:agentId/config", async (c) => {
 		);
 	}
 
+	// Read once and reuse: both the judge-model grandfathering below and the
+	// grant-shadowing check after it need the CURRENT settings, because a PATCH
+	// may carry only one of `guardrailsInline` / `networkConfig`.
+	const storedSettings = await configStore.getSettings(agentId);
+
 	// Judge-kind custom guardrails need a model. With no gateway default
 	// (`EGRESS_JUDGE_MODEL` unset), every judge entry must carry its own
 	// `model` — otherwise it would fail closed at runtime with no model to call.
@@ -2055,11 +2072,9 @@ routes.patch("/:agentId/config", async (c) => {
 		// the offending guardrail. Grandfathering the stored value keeps the
 		// repair path open while still refusing to accept a new bad one.
 		const storedModels = new Map<string, string>();
-		const storedInline = (
-			(await configStore.getSettings(agentId)) as {
-				guardrailsInline?: Array<{ name?: string; model?: string }>;
-			} | null
-		)?.guardrailsInline;
+		const storedInline = (storedSettings as {
+			guardrailsInline?: Array<{ name?: string; model?: string }>;
+		} | null)?.guardrailsInline;
 		if (Array.isArray(storedInline)) {
 			for (const g of storedInline) {
 				if (g?.name && typeof g.model === "string") {
@@ -2081,6 +2096,81 @@ routes.patch("/:agentId/config", async (c) => {
 						error_description: `Custom guardrail "${g?.name ?? "(unnamed)"}" names judge model "${model}", which this deployment cannot run: ${resolved.detail}. Use a "<provider>/<model>" ref whose provider has a system key and speaks the OpenAI-compatible protocol.`,
 					},
 					400
+				);
+			}
+		}
+	}
+
+	// An allow grant BEATS the egress judge. `checkDomainAccess` (proxy/
+	// http-proxy.ts) checks per-agent allow grants (step 4) before consulting
+	// the judge (step 5), so a domain that is both judged and allow-granted
+	// returns `source: "grant"` and its judge never runs. That failure is
+	// invisible from the outside — the request succeeds, just for the wrong
+	// reason — so refuse the config instead of saving a control that cannot fire.
+	//
+	// Validate the MERGE, not the patch: a PATCH may carry `guardrailsInline`
+	// alone, `networkConfig` alone, or both, and the hole only exists in the
+	// combination. Only run when the patch actually touches one of them, so an
+	// unrelated edit to an agent that is already in this state still saves (and
+	// so removing either side is always a valid repair).
+	const touchesGuardrails = "guardrailsInline" in (updates as object);
+	const touchesNetwork = "networkConfig" in (updates as object);
+	if (touchesGuardrails || touchesNetwork) {
+		const stored = storedSettings as {
+			guardrailsInline?: AgentInlineGuardrail[];
+			networkConfig?: { allowedDomains?: string[] };
+		} | null;
+		const effectiveGuardrails = touchesGuardrails
+			? ((updates as { guardrailsInline?: AgentInlineGuardrail[] })
+					.guardrailsInline ?? [])
+			: (stored?.guardrailsInline ?? []);
+		const effectiveAllowed = touchesNetwork
+			? ((updates as { networkConfig?: { allowedDomains?: string[] } })
+					.networkConfig?.allowedDomains ?? [])
+			: (stored?.networkConfig?.allowedDomains ?? []);
+
+		const shadowed = findSuppressedJudgedDomains(
+			effectiveGuardrails,
+			effectiveAllowed
+		);
+		if (shadowed[0]) {
+			const { domain, judge, grant } = shadowed[0];
+			return c.json(
+				{
+					error: "guardrail_domain_shadowed_by_grant",
+					error_description: `Guardrail "${judge}" judges "${domain}", but this agent's networkConfig.allowedDomains grants "${grant}", which the proxy matches FIRST — the judge would never run. A judged domain must not be allow-listed: remove "${grant}" from allowedDomains (a judged domain is reachable through its judge, so it needs no grant), or drop "${domain}" from the guardrail.`,
+				},
+				400
+			);
+		}
+
+		// The GLOBAL allowlist shadows judges the same way (`checkDomainAccess`
+		// step 3), but it is `WORKER_ALLOWED_DOMAINS` — operator config the
+		// tenant editing this agent cannot fix. Warn rather than reject, so
+		// the signal reaches whoever can act on it without blocking a save
+		// nobody in this request can make valid. Only consult the allowlist
+		// when there is a judge to shadow: `loadAllowedDomains` logs on every
+		// call in isolation mode.
+		const judgedCount =
+			egressGuardrailsToPolicyBundle(effectiveGuardrails)?.judgedDomains
+				.length ?? 0;
+		if (judgedCount > 0) {
+			const globalAllowed = loadAllowedDomains();
+			const unrestricted = isUnrestrictedMode(globalAllowed);
+			// Unrestricted mode allows every host, so it shadows every judged
+			// domain without any of them appearing in a list to match against.
+			// The global matcher's `.suffix` also covers the root host, unlike a
+			// per-agent grant.
+			if (
+				unrestricted ||
+				findSuppressedJudgedDomains(effectiveGuardrails, globalAllowed, {
+					wildcardCoversRoot: true,
+				}).length > 0
+			) {
+				logger.warn(
+					`[agent-config] agent "${agentId}" has egress judge guardrails whose domains are covered by WORKER_ALLOWED_DOMAINS${
+						unrestricted ? " (unrestricted, '*')" : ""
+					}. The global allowlist is matched before the judge, so those judges will not run.`
 				);
 			}
 		}


### PR DESCRIPTION
## The bug

`checkDomainAccess` (`gateway/proxy/http-proxy.ts`) resolves in a fixed order:

1. global denylist
2. per-agent **deny** grant (authoritative — beats the judge, by design)
3. global allowlist
4. per-agent **allow** grant
5. **egress judge**

So a domain in BOTH an egress guardrail's `domains` and the agent's `networkConfig.allowedDomains` returns `allowed: true, source: "grant"` at step 4 and its judge policy is dead config. The request succeeds — just for a reason unrelated to the policy the operator wrote. That is the shape of failure nobody notices: the traffic flows.

This cost a full prod round trip while verifying #3277. I added the two test domains to `allowedDomains` so the agent could reach them, which is precisely what suppressed the judge under test. Both requests came back 200 and read as a working allow. Only `source: "grant"` in the audit line gave it away.

## The fix

`PATCH /:agentId/config` rejects the combination with `guardrail_domain_shadowed_by_grant` (400), naming the guardrail, the judged pattern, the shadowing grant, and both repairs. It joins the two guardrail checks already in that handler (`guardrail_model_required`, `guardrail_model_unresolvable`), which is the established chokepoint for "this guardrail would not work at runtime".

Shape notes:

- **Validates the merge, not the patch.** A PATCH may carry `guardrailsInline` alone, `networkConfig` alone, or both, and the hole only exists in the combination — so the check reads stored settings and merges. It only runs when the patch touches one of those fields, so an unrelated edit to an already-shadowed agent still saves, and removing either side is always a valid repair. Same reasoning that grandfathers stored judge models a few lines above.
- **The judged set comes from `egressGuardrailsToPolicyBundle`**, the same builder the runtime uses, so write-time validation and runtime enforcement cannot drift about which domains are judged (enabled/stage/non-empty-policy filtering and normalization all come along).
- **The two enforcement matchers genuinely disagree** about whether a `.suffix` pattern covers its own root. `matchesDomainPattern` (global allowlist) treats `.example.com` as matching `example.com`. `GrantStore.hasGrant` does not: `buildGrantCandidates` expands a hostname into its exact form plus its wildcard PARENTS, and for a two-label host the loop `for (let i = 1; i < parts.length - 1; i++)` never runs, so `example.com` never sees an `.example.com` row. A single predicate with a `wildcardCoversRoot` option serves both call sites rather than assuming one semantics for both.
- **Partial shadowing is reported too** — an exact grant against a judged wildcard leaves the root ungoverned; a grant for `api.example.com` under a judged `.example.com` carves one host out. Narrower holes, still holes.
- **The global allowlist warns rather than rejects.** `WORKER_ALLOWED_DOMAINS` shadows judges identically (step 3), but it is operator config the tenant editing this agent cannot fix, so a rejection would block a save nobody in that request can make valid. The signal goes to the operator log instead. On an unrestricted (`*`) deployment every judge is inert, and that now says so.

## Verification

**Red → green.** With the guard disabled, 4 of the 9 route tests fail; with it enabled all 9 pass. The 5 passing either way are the negative controls and the two repair paths — they must pass in both states.

```
### RED (guard disabled)          ### GREEN
 5 pass                            9 pass
 4 fail                            0 fail
```

**Mutation-tested** (`policy-store.test.ts`), each mutation caught by the test that claims to cover it:

| Mutation | Failing test |
| --- | --- |
| don't strip the judged pattern's leading dot | partial-shadowing case |
| skip `normalizeDomainPattern` on allow patterns | wildcard-grant + spelling-variant cases |
| drop the enabled/stage filtering | disabled-guardrail + non-egress cases |

**Suites run** (individually — the gateway tree contends over the shared embedded PG):

```
policy-store                        29 pass
agent-routes-judge-grant-shadow      9 pass
agent-routes-guardrail-validation   25 pass
agent-routes-models-config           5 pass
agent-routes-models-validation       7 pass
agent-routes-guardrail-trips        17 pass
http-proxy-judge                     7 pass
egress-judge                         8 pass
egress-judge-guardrail-audit         2 pass
policy-composer-sanitisation         3 pass
vercel-network-policy               27 pass
```

The route suite is **key-independent**: it pins `LOBU_PROVIDER_REGISTRY_PATH` and synthesizes `OPENAI_API_KEY` if absent, because the route resolves a new judge model against the registry before reaching this check. Verified passing with the ambient key scrubbed. (`review-fix` caught this — the first version passed only because my worktree `.env` happened to hold a real key, so it would have failed in CI.)

`make pre-pr`: clean. Pre-commit: biome + `tsc --noEmit` clean.

## Risk

Behavior change on one write path: a config that previously saved and silently disabled its own judge is now a 400. Existing agents are unaffected until someone edits `guardrailsInline` or `networkConfig`, and both repairs (drop the grant, drop the judged domain) always save. In prod today zero agents use judge guardrails, so the blast radius is nil.

The alternative — flipping the proxy so the judge outranks an allow grant — would make the config do what it looks like it does, but that is a semantics change to a live enforcement path and a much bigger swing. Worth considering separately; this PR takes the conservative side and fails loud at save time.