### PR TITLE
fix(gateway): never grant an allow for a domain the egress judge governs

### DIFF
--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -637,3 +637,172 @@ describe("DeploymentManager.ensureDeployment in-flight coalescing", () => {
     expect(manager.attempts).toBe(2);
   });
 });
+
+/**
+ * A judged domain must never receive a blanket ALLOW grant.
+ *
+ * `checkDomainAccess` consults per-agent allow grants BEFORE the egress judge,
+ * so an allow grant on a judged domain makes that judge permanently inert —
+ * the request succeeds at `source: "grant"` and the policy never runs. PR #3299
+ * rejects the combination when an operator types it into agent config, but the
+ * dispatch path can still produce it without anyone typing it: connector
+ * `agentTooling` contributions are folded into
+ * `payload.networkConfig.allowedDomains` (`foldConnectorTooling`) AFTER that
+ * write-time check, and this reconcile then grants them.
+ *
+ * So the invariant is enforced HERE, where the judged set and the grant
+ * reconcile meet: a domain the judge governs is skipped on the allow side.
+ * Deny still wins — a deny grant outranks the judge by design.
+ */
+describe("syncNetworkConfigGrants — a judged domain gets no allow grant", () => {
+  let grantStore: GrantStore;
+  let policyStore: PolicyStore;
+  let manager: TestDeploymentManager;
+
+  const hasGrant = (pattern: string, organizationId = "test-org") =>
+    grantStore.hasGrant("agent-1", pattern, organizationId);
+  const isDenied = (pattern: string, organizationId = "test-org") =>
+    grantStore.isDenied("agent-1", pattern, organizationId);
+
+  const judgeOn = (...domains: string[]) => [
+    {
+      name: "watchdog",
+      stage: "egress" as const,
+      enabled: true,
+      policy: "Allow read-only GETs.",
+      domains,
+    },
+  ];
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow("agent-1");
+    grantStore = new GrantStore();
+    policyStore = new PolicyStore();
+    manager = new TestDeploymentManager(TEST_CONFIG);
+    manager.setGrantStore(grantStore);
+    manager.setPolicyStore(policyStore);
+  });
+
+  test("skips the allow grant for a domain its own judge governs", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["api.example.com"] },
+        guardrailsInline: judgeOn("api.example.com"),
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(false);
+    // The judge itself must still be registered, or we have just denied it.
+    expect(
+      policyStore.resolve("test-org", "agent-1", "api.example.com")
+    ).toBeDefined();
+  });
+
+  test("still grants an UNJUDGED domain in the same payload", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: {
+          allowedDomains: ["api.example.com", "plain.example.net"],
+        },
+        guardrailsInline: judgeOn("api.example.com"),
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(false);
+    expect(await hasGrant("plain.example.net")).toBe(true);
+  });
+
+  test("skips a connector-folded domain the judge governs", async () => {
+    // The motivating case. This is the shape `foldConnectorTooling` produces:
+    // the domain arrives in `allowedDomains` ON THE PAYLOAD and was never in
+    // the saved agent config, so PR #3299's write-time guard never saw it.
+    // Mechanically identical to a config domain — which is the point: the
+    // reconcile cannot tell them apart, so enforcing here covers both.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["contributed.example.com"] },
+        guardrailsInline: judgeOn("contributed.example.com"),
+      })
+    );
+    expect(await hasGrant("contributed.example.com")).toBe(false);
+  });
+
+  test("skips a Nix cache domain the judge governs, keeps the rest", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        nixConfig: { packages: ["python311"] },
+        guardrailsInline: judgeOn("cache.nixos.org"),
+      })
+    );
+    expect(await hasGrant("cache.nixos.org")).toBe(false);
+    expect(await hasGrant("channels.nixos.org")).toBe(true);
+  });
+
+  test("matches a judged WILDCARD against a specific allowed host", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["api.example.com"] },
+        guardrailsInline: judgeOn("*.example.com"),
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(false);
+  });
+
+  test("normalizes both sides — alias spellings still collapse", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["*.example.com"] },
+        guardrailsInline: judgeOn(".EXAMPLE.com"),
+      })
+    );
+    expect(await hasGrant(".example.com")).toBe(false);
+  });
+
+  test("DENY still wins over the judge", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: {
+          allowedDomains: ["api.example.com"],
+          deniedDomains: ["api.example.com"],
+        },
+        guardrailsInline: judgeOn("api.example.com"),
+      })
+    );
+    expect(await isDenied("api.example.com")).toBe(true);
+  });
+
+  test("HEALS an existing shadowed grant by revoking it", async () => {
+    // First dispatch with no judge: the domain gets a normal allow grant.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["api.example.com"] },
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(true);
+
+    // Adding a judge over it must reconcile the stale grant AWAY, or the
+    // judge stays inert for every agent that was already in this state.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["api.example.com"] },
+        guardrailsInline: judgeOn("api.example.com"),
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(false);
+  });
+
+  test("a DISABLED judge does not suppress the grant", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["api.example.com"] },
+        guardrailsInline: [
+          { ...judgeOn("api.example.com")[0], enabled: false },
+        ],
+      })
+    );
+    expect(await hasGrant("api.example.com")).toBe(true);
+  });
+});

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -18,6 +18,7 @@ import type { ProviderCredentialContext } from "../embedded.js";
 import type { ModelProviderModule } from "../modules/module-system.js";
 import type { GrantStore } from "../permissions/grant-store.js";
 import {
+  allowReachesJudged,
   egressGuardrailsToPolicyBundle,
   type PolicyStore,
 } from "../permissions/policy-store.js";
@@ -720,7 +721,7 @@ export class DeploymentManager {
   private syncEgressPolicy(
     messageData: MessagePayload,
     deploymentName?: string
-  ): void {
+  ): string[] {
     const agentId = messageData.agentId;
     const organizationId = messageData.organizationId;
     // PolicyStore is keyed by `(orgId, agentId)` to prevent cross-tenant
@@ -733,7 +734,7 @@ export class DeploymentManager {
           "Skipping egress policy sync — message has no organizationId"
         );
       }
-      return;
+      return [];
     }
 
     const egressGuardrails = (messageData.guardrailsInline ?? []).filter(
@@ -754,9 +755,10 @@ export class DeploymentManager {
           judges: Object.keys(bundle.judges).length,
         });
       }
-    } else {
-      this.policyStore.clear(organizationId, agentId);
+      return bundle.judgedDomains.map((r) => r.domain);
     }
+    this.policyStore.clear(organizationId, agentId);
+    return [];
   }
 
   /**
@@ -784,7 +786,7 @@ export class DeploymentManager {
     const agentId = messageData.agentId;
     if (!agentId) return;
 
-    this.syncEgressPolicy(messageData);
+    const judgedDomains = this.syncEgressPolicy(messageData);
 
     if (!this.grantStore) return;
 
@@ -795,16 +797,31 @@ export class DeploymentManager {
     // ("*.example.com" vs ".example.com") collapse to the single grant row
     // they share. Denies are added last so a domain listed on both sides
     // collapses to deny (matching the proxy's deny precedence).
+    //
+    // A domain the egress judge governs is SKIPPED on the allow side — config
+    // domains and Nix cache domains alike. An allow grant outranks the judge
+    // in `checkDomainAccess`, so granting a judged domain makes its judge
+    // permanently inert — and the dispatch payload can hold such a domain
+    // without anyone having typed it into agent config, because
+    // `foldConnectorTooling` unions connector `agentTooling` domains into
+    // `allowedDomains` AFTER the write-time guard has run. Skipping also
+    // HEALS an agent already in that state: the stale row is absent from
+    // `expectedDomains`, so the reconcile below revokes it. Denies are
+    // unaffected — a deny grant outranks the judge by design.
     const expectedDomains = new Map<string, boolean>();
+    const expectAllowUnlessJudged = (pattern: string) => {
+      if (judgedDomains.some((j) => allowReachesJudged(j, pattern))) return;
+      expectedDomains.set(pattern, false);
+    };
     for (const domain of messageData.networkConfig?.allowedDomains ?? []) {
-      expectedDomains.set(normalizeDomainPattern(domain), false);
+      expectAllowUnlessJudged(normalizeDomainPattern(domain));
     }
     if (
       messageData.nixConfig?.packages?.length ||
       messageData.nixConfig?.flakeUrl
     ) {
       for (const domain of NIX_CACHE_DOMAINS) {
-        expectedDomains.set(domain, false);
+        expectAllowUnlessJudged(domain);
       }
     }
     for (const domain of messageData.networkConfig?.deniedDomains ?? []) {

--- a/packages/server/src/gateway/permissions/policy-store.ts
+++ b/packages/server/src/gateway/permissions/policy-store.ts
@@ -208,16 +208,23 @@ interface SuppressedJudgedDomainOptions {
 /**
  * Whether an allow pattern reaches any host a judged pattern covers.
  *
+ * Two callers, one predicate: {@link findSuppressedJudgedDomains} uses it to
+ * refuse a shadowing agent CONFIG at write time, and the deployment manager's
+ * grant reconcile uses it to refuse the shadowing GRANT at dispatch time (a
+ * connector-contributed domain never passes through agent config). Both default
+ * to grant semantics; only the global-allowlist check passes
+ * `wildcardCoversRoot`.
+ *
  * A judged `.suffix` covers the root and every subdomain — {@link findMatchingRule},
  * which `PolicyStore.resolve` matches with, treats `normalized === suffix` as a
  * hit. Whether the ALLOW side's wildcard covers the root depends on which
  * matcher enforces it (see {@link SuppressedJudgedDomainOptions}). Two
  * wildcards overlap when either suffix sits under the other.
  */
-function allowReachesJudged(
+export function allowReachesJudged(
   judged: string,
   allow: string,
-  wildcardCoversRoot: boolean
+  wildcardCoversRoot = false
 ): boolean {
   const judgedWild = judged.startsWith(".");
   const allowWild = allow.startsWith(".");


### PR DESCRIPTION
## The hole #3299 could not close

An allow grant outranks the egress judge in `checkDomainAccess` (grants at `http-proxy.ts:205`, judge at `:258`). So a grant on a judged domain makes that judge permanently inert — the request succeeds at `source: "grant"` and the policy never runs.

#3299 refuses that combination when an operator types it into agent config. It cannot see the other way in:

```
foldConnectorTooling (message-consumer.ts:880)
  → unions connector agentTooling domains into payload.networkConfig.allowedDomains
  → AFTER the write-time guard has run
syncNetworkConfigGrants
  → grants them
```

An org-wide connector contributing a judged domain shadows that judge, and no amount of config validation can catch it because nobody typed it into config. Surfaced by the `make review` pass on #3299 as a scope note; I verified it against `origin/main` before acting on it.

## The fix

Enforce the invariant where the judged set and the grant reconcile actually meet — `syncNetworkConfigGrants`, which already calls `syncEgressPolicy` as its first statement. `syncEgressPolicy` now returns the judged patterns, and the allow side skips any domain the judge governs. Config domains and Nix cache domains alike.

Three consequences worth stating plainly:

- **It heals existing state.** A stale shadowing grant is absent from `expectedDomains`, so the reconcile loop below revokes it on the next dispatch. Agents already in this state repair themselves with no operator action.
- **Deny is untouched.** A deny grant outranks the judge by design, and denies are still applied afterwards, so a domain on both sides still collapses to deny.
- **Proxy precedence is unchanged.** Nothing moves on the request hot path — no extra judge calls, no reordered lookups. This was the deciding factor against the alternative of moving the judge ahead of allow grants, which would have put an LLM call on every judged request and made #3299's rejection wrong.

`allowReachesJudged` is now exported and shared, so the write-time guard and the dispatch-time reconcile decide coverage with **one** predicate and cannot drift. It keeps grant semantics by default — `GrantStore.hasGrant` does not let a `.suffix` cover its own two-label root, because `buildGrantCandidates` expands a hostname into its exact form plus its wildcard *parents* and the loop never runs for two labels — and only the global-allowlist check passes `wildcardCoversRoot`.

## Verification

**Red → green.** Neutering the skip predicate turns 7 of the 9 new tests red; all 33 in the file pass with it. The 2 that pass either way are the deny-wins and disabled-judge regression guards, which must.

```
### RED (predicate neutered)     ### GREEN
 26 pass                          33 pass
  7 fail                           0 fail
```

**Mutation-tested**, with one honest caveat:

| Mutation | Result |
| --- | --- |
| string equality instead of the coverage predicate | caught — judged-wildcard test |
| skip the deny side too | caught — deny-wins test |
| drop `enabled` from the outer filter | **survived** |
| drop `enabled` from the bundle builder's filter | **survived** |
| drop `enabled` from **both** | caught — disabled-judge test |

The `enabled` check is genuinely double-guarded (`syncEgressPolicy`'s filter *and* `egressGuardrailsToPolicyBundle`'s own `if (!g.enabled …) continue`), so no single-point mutation can reach it. The test does have teeth; it takes breaking both to show it.

The Nix-cache test is discriminating, not vacuous: `NIX_CACHE_DOMAINS` holds three hosts, the judge covers one, and the test asserts the other two are still granted.

**Suites run** (individually — the gateway tree contends over the shared embedded PG):

```
base-deployment-grants     33 pass   (24 pre-existing + 9 new)
policy-store               29 pass
orchestration-harden       61 pass
agent-tooling-resolver     38 pass
vercel-network-policy      27 pass
enqueue-model-gate         10 pass
http-proxy-judge            7 pass
egress-judge                8 pass
egress-judge-guardrail-audit 2 pass
conversation-pin-enqueue    3 pass
guardrails-runtime         17 pass   (Vitest: bun run test -- run)
```

`make pre-pr`: clean. Pre-commit: biome + `tsc --noEmit` clean.

## Known remaining writers (not this branch's concern)

Two other paths can still write an allow grant that shadows a judge, and this reconcile does not cover them:

- `deployment-manager.ts:1522` — deploy-time npm-registry grants, deliberately exempt from revocation.
- `interaction-bridge.ts:1347` — user-approved domain grants written at runtime.

Both are separate concerns; flagging rather than widening the diff.

## Risk

Behavior change at dispatch. An agent whose connector-contributed domain was silently blanket-allowed now has that traffic judged, and a denying judge will block it — the safe direction, and what the operator's judge rule asked for, but it can break a connector that was working by accident. In prod today zero agents use judge guardrails, so nothing changes there until someone opts in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented blanket allow grants from overriding egress judges for governed domains.
  * Existing conflicting allow grants are now revoked during reconciliation.
  * Unjudged domains continue to receive applicable grants.
  * Deny rules still take precedence, while disabled judges do not block grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Semantics consequence (surfaced by `make review`, verified, accepted)

Judging a **single host** suppresses a whole **wildcard** allow, so its siblings lose the grant too:

```
allowedDomains: ["*.example.com"]   judge on: api.example.com
  → allowReachesJudged("api.example.com", ".example.com") === true
  → the .example.com grant is skipped entirely
  → www.example.com now has no grant AND no judge rule → denied
```

This is inherent to the grant model, not a choice: a grant is a pattern, and there is no pattern-minus-exception form to express "allow `*.example.com` except the judged `api.example.com`". Skipping errs toward **deny**, which is the safe direction — the alternative would leave the judged host allow-granted and its judge inert, which is the whole bug.

Exposure is narrow. #3299 rejects this combination at write time in both directions (adding the judge to a stored wildcard allow, or adding the allow to a stored judge), so an operator cannot reach it through agent config. The only remaining route is a connector contributing a wildcard while a judge covers a host beneath it.

Also noted and accepted: a stale allow on an `NPM_REGISTRY_DOMAINS` host is exempt from revocation by design, so it is not healed if a judge later covers it. That is one of the two known remaining writers listed above.

Not taken: the reviewer suggested trimming the 12-line rationale comment, since the same reasoning appears in the test docblock and the `allowReachesJudged` JSDoc. Fair, but with 0 blockers it is not worth a second review + CI cycle.
