### PR TITLE
fix(server): cap the wall-clock budget of a connection pushdown

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/query-sql-pushdown-timeout.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/query-sql-pushdown-timeout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Pushdown wall-clock budget.
+ *
+ * `runConnectorQuery` forks a connector subprocess to run SQL live against a
+ * connection's source. `SubprocessExecutor` defaults to a 600_000ms kill
+ * timeout, so a gateway read path that passes none can hold a subprocess for
+ * ten minutes on one request.
+ *
+ * Deliberately mock-free. `vitest.config.ts` sets `isolate: false` for a true
+ * singleton DB pool, and a per-file `vi.mock` is unreliable once another file
+ * has already loaded the real module — so recording the budget through a mocked
+ * executor would pass alone and go quiet in a shared shard. A real caller
+ * deadline is observable instead: the sleep below can only be cut short if the
+ * resolved budget actually reaches the executor. The cap's own value is pinned
+ * by the unit suite (`__tests__/unit/pushdown-timeout-budget.test.ts`), and the
+ * kill mechanism is connector-worker's contract (`runtime-timeout.test.ts`).
+ *
+ * `pg_sleep` stands in for a slow source: the postgres connector's own
+ * `statement_timeout_ms` (30s default) is connector-owned courtesy, not a
+ * platform guarantee — the next connector need not self-limit at all.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { authzScopeFromToolContext } from '../../../authz/scope';
+import { runConnectorQuery } from '../../../lib/connector-pushdown';
+import { createAuthProfile } from '../../../utils/auth-profiles';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  ownerToolContext,
+} from '../../setup/test-fixtures';
+
+describe('pushdown wall-clock budget', () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Pushdown Budget' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'pushdown-budget@test.example.com' });
+    userId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const db = getTestDb();
+    const profile = await createAuthProfile({
+      organizationId: orgId,
+      connectorKey: 'postgres',
+      displayName: 'slow source',
+      profileKind: 'env',
+      authData: { DATABASE_URL: process.env.DATABASE_URL as string },
+    });
+    await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_by, created_at, updated_at)
+      VALUES
+        (${orgId}, 'postgres', 'slow-source', 'Slow source', 'active', ${profile.id}, 'org', ${user.id}, NOW(), NOW())
+    `;
+  }, 120_000);
+
+  function query(sql: string, deadlineAt?: number) {
+    return runConnectorQuery({
+      scope: authzScopeFromToolContext(ownerToolContext(orgId, userId)),
+      isAdmin: true,
+      connectionSlug: 'slow-source',
+      query: sql,
+      limit: 10,
+      offset: 0,
+      deadlineAt,
+    });
+  }
+
+  it('kills a pushdown that outlives its budget', async () => {
+    const startedAt = Date.now();
+    await expect(query('SELECT pg_sleep(20)', Date.now() + 1_000)).rejects.toThrow(/timed out/);
+    // The point is the budget, not just the rejection: the sleep must not have
+    // been waited out. Pre-fix, this waited it out (twice — the connector also
+    // runs a count query for total_count) and then returned a row.
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+  }, 60_000);
+
+  it('fails an already-expired deadline without forking at all', async () => {
+    const startedAt = Date.now();
+    await expect(query('SELECT 1 AS one', Date.now() - 1)).rejects.toThrow(/deadline expired/);
+    // No connector resolution, no credential read, no fork.
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  }, 60_000);
+
+  it('runs a normal query under the default cap', async () => {
+    const result = await query('SELECT 1 AS one');
+    expect(result.rows).toHaveLength(1);
+    expect(Number(result.rows[0].one)).toBe(1);
+  }, 60_000);
+});

--- a/packages/server/src/__tests__/unit/pushdown-timeout-budget.test.ts
+++ b/packages/server/src/__tests__/unit/pushdown-timeout-budget.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The pushdown budget policy, on its own.
+ *
+ * The wiring (a slow source actually being killed) is covered by the
+ * integration suite; this pins the arithmetic, which is what silently regresses:
+ * a caller deadline may only SHORTEN the budget, never lift the cap, and an
+ * already-expired deadline must fail before anything is forked.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  PUSHDOWN_QUERY_TIMEOUT_MS,
+  resolvePushdownTimeoutMs,
+} from '../../lib/connector-pushdown';
+
+describe('resolvePushdownTimeoutMs', () => {
+  it('caps a pushdown with no caller deadline', () => {
+    expect(resolvePushdownTimeoutMs(undefined)).toBe(PUSHDOWN_QUERY_TIMEOUT_MS);
+  });
+
+  it('shortens to a nearer caller deadline', () => {
+    const budget = resolvePushdownTimeoutMs(Date.now() + 5_000);
+    expect(budget).toBeLessThanOrEqual(5_000);
+    expect(budget).toBeGreaterThan(4_000);
+  });
+
+  it('never lets a distant deadline exceed the cap', () => {
+    expect(resolvePushdownTimeoutMs(Date.now() + 10 * 60_000)).toBe(PUSHDOWN_QUERY_TIMEOUT_MS);
+  });
+
+  it('rejects a deadline that has already passed', () => {
+    expect(() => resolvePushdownTimeoutMs(Date.now() - 1)).toThrow(/deadline expired/);
+  });
+
+  it('stays under the executor default it exists to replace', () => {
+    // SubprocessExecutor defaults to 600_000ms; a cap at or above that is no cap.
+    expect(PUSHDOWN_QUERY_TIMEOUT_MS).toBeLessThan(600_000);
+  });
+});

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -41,6 +41,13 @@ interface ConnectorQueryParams {
   limit?: number;
   offset?: number;
   sort?: { column: string; order: 'asc' | 'desc' };
+  /**
+   * Wall-clock deadline for this pushdown, when the caller has one — the same
+   * shape {@link ReadSourceFeedParams} already exposes on the sibling read path.
+   * It can only SHORTEN the budget: {@link PUSHDOWN_QUERY_TIMEOUT_MS} still caps
+   * it, and a deadline already in the past fails before anything is forked.
+   */
+  deadlineAt?: number;
 }
 
 interface ConnectorQueryResult {
@@ -49,7 +56,39 @@ interface ConnectorQueryResult {
   total?: number;
 }
 
+/**
+ * Hard wall-clock cap on ONE pushdown query. Without it `SubprocessExecutor`'s
+ * 600_000ms default applies, so a slow source could pin a gateway-forked
+ * subprocess for ten minutes per request.
+ *
+ * 30s matches what the request path already promises elsewhere:
+ * `manage_feeds`'s batch read cap and the postgres connector's own
+ * `statement_timeout_ms` default. A connector self-limit is courtesy, though —
+ * the next connector need not have one — so the cap belongs here, on the
+ * platform side. It is deliberately a REQUEST-path budget: a connection tuned
+ * for a long sync statement does not get that long on an interactive read.
+ */
+export const PUSHDOWN_QUERY_TIMEOUT_MS = 30_000;
+
+/**
+ * The budget one pushdown gets: the cap, or whatever is left of the caller's
+ * deadline when that is sooner. Throws when the deadline has already passed, so
+ * an expired request never pays for a fork.
+ */
+export function resolvePushdownTimeoutMs(deadlineAt?: number): number {
+  if (deadlineAt === undefined) return PUSHDOWN_QUERY_TIMEOUT_MS;
+  const remaining = Math.trunc(deadlineAt - Date.now());
+  if (remaining <= 0) {
+    throw Object.assign(new Error('pushdown deadline expired before the query ran'), {
+      exitReason: 'timeout' as const,
+    });
+  }
+  return Math.min(PUSHDOWN_QUERY_TIMEOUT_MS, remaining);
+}
+
 export async function runConnectorQuery(p: ConnectorQueryParams): Promise<ConnectorQueryResult> {
+  // Resolved before any work so an already-expired deadline costs nothing.
+  const timeoutMs = resolvePushdownTimeoutMs(p.deadlineAt);
   const sql = getDb();
   // Resolve org-scoped + active, enforcing the same visibility as manage_connections:
   // owner/admin callers reach every connection; everyone else gets the shared
@@ -126,6 +165,7 @@ export async function runConnectorQuery(p: ConnectorQueryParams): Promise<Connec
       offset: p.offset,
       sort: p.sort,
     },
+    timeoutMs,
   });
 
   if (result.mode !== 'query') {


### PR DESCRIPTION
## Summary
- `runConnectorQuery` forks a connector subprocess to run SQL live against a connection's source and passed **no `timeoutMs`**, so `SubprocessExecutor`'s 600_000ms default applied — one request could pin a gateway-forked subprocess for ten minutes. The sibling read path (`readSourceFeed`) already derives a `timeoutMs` from its deadline; the query path was the only one omitting it.
- A pushdown now gets `PUSHDOWN_QUERY_TIMEOUT_MS` (30s), or whatever is left of the caller's `deadlineAt` when that is sooner. An already-expired deadline throws *before* the connection is resolved, so it pays for no fork, no credential read and no connector resolution.
- **Why 30s:** it's what the request path already promises elsewhere — `manage_feeds`'s batch read cap and the postgres connector's own `statement_timeout_ms` default. That self-limit is connector-owned courtesy, not a platform guarantee (the next connector need not have one), so the cap belongs on the platform side. It is deliberately a REQUEST-path budget: a connection tuned for a long sync statement doesn't get that long on an interactive read.
- **Nothing configured is affected:** no live connection overrides `statement_timeout_ms`, so every existing source already runs under the connector's own 30s.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, per-package typecheck, knip, naming, gateway-LLM + entity-write funnel gates)
- [x] Tests run: `src/__tests__/integration/connectors/` (58 files, 392 tests) and `bun test src/__tests__/unit/pushdown-timeout-budget.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### Red (test present, fix absent)

A **1-second** caller deadline against `SELECT pg_sleep(20)`: the sleep ran to completion and returned a row.

```
 FAIL  pushdown wall-clock budget > kills a pushdown that outlives the caller deadline
       expected [Function] to reject, but it resolved with
       { rows: [ { pg_sleep: "" } ], total: 1 }
 Tests  1 failed | 1 passed (2)
 Duration  55.39s  (tests 40.72s — the full sleep, waited out)
```

### Green

```
[SubprocessExecutor] Killing child process after 1000ms timeout
 ✓ query-sql-pushdown-timeout.test.ts (3 tests) 1438ms
   ✓ kills a pushdown that outlives its budget  1055ms
 Tests  3 passed (3)
```

Neighbouring suite, shared registry: `Test Files 58 passed (58)` · `Tests 392 passed (392)`.
Policy unit suite: `5 pass, 0 fail`. Mutation-checked — flipping `Math.min` to `Math.max` fails two of the five.

## Notes
Tests are mock-free on purpose. `vitest.config.ts` sets `isolate: false` for a true singleton DB pool, and a per-file `vi.mock` is unreliable once another file has already loaded the real module — a mocked executor recording the chosen budget passes alone and goes quiet in a shared shard. A real caller deadline is observable instead: the sleep can only be cut short if the resolved budget actually reaches the executor. The cap's arithmetic is pinned by the unit suite, and the kill mechanism itself is connector-worker's own contract (`runtime-timeout.test.ts`).

Same class, **not** in this PR — each needs its own budget, and one is a behaviour decision rather than a bug fix:
- `connect/webhook-registration.ts` (two call sites) — `webhook_register` on the connect flow, also uncapped at 600s. The read cap is plainly right here.
- `tools/admin/manage_operations/handlers/execute.ts` — connector `action` mode, also uncapped. 30s would be wrong: device and browser actions legitimately run minutes.

`make review-fix` could not be used on this diff — it was killed externally twice (`Terminated: 15`, no summary emitted), the first time after half-applying edits. The diff was hand-reviewed instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pushdown queries now enforce a maximum execution time of 30 seconds.
  * Requests with expired deadlines fail immediately without starting query processing.
  * Caller-provided deadlines are respected when they are sooner than the maximum limit.
  * Queries within the allowed time continue to run normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->