### PR TITLE
fix(gateway): refuse an allow grant for a judged domain at the GrantStore chokepoint

### DIFF
--- a/packages/server/src/gateway/__tests__/grant-store.test.ts
+++ b/packages/server/src/gateway/__tests__/grant-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { GrantStore } from "../permissions/grant-store.js";
 import {
@@ -248,6 +249,149 @@ describe("GrantStore (PG-backed)", () => {
         const patterns = grants.map((g) => g.pattern).sort();
         expect(patterns).toEqual([".github.com", "api.openai.com"]);
       });
+    });
+  });
+});
+
+/**
+ * A judged domain must never receive an ALLOW grant, whoever writes it.
+ *
+ * An allow grant outranks the egress judge in `checkDomainAccess`, so granting
+ * a judged domain makes that judge permanently inert. #3299 refuses the
+ * combination in agent config and #3300 refuses it in the dispatch reconcile,
+ * but the reconcile only governs the rows it can see: the deploy-time
+ * npm-registry grants in `deployment-manager.ts` are exempt from its
+ * revocation, and it skips every row with a non-null `expires_at`. Every domain
+ * writer funnels through `GrantStore.grant()`, so the guard lives here — one
+ * check that covers all present writers and any future one.
+ *
+ * The judged set is read from `agents.guardrails_inline`, NOT from
+ * `PolicyStore`: that store is a per-replica in-memory Map populated only at
+ * dispatch, so a check against it would pass vacuously on any replica that has
+ * not dispatched for the agent.
+ */
+describe("GrantStore.grant — a judged domain gets no allow grant", () => {
+  let store: GrantStore;
+
+  const setJudge = async (domains: string[], enabled = true) => {
+    const sql = getDb();
+    await sql`
+      UPDATE agents SET guardrails_inline = ${sql.json([
+        {
+          name: "watchdog",
+          stage: "egress",
+          enabled,
+          policy: "Allow read-only GETs.",
+          domains,
+        },
+      ])}
+      WHERE organization_id = ${ORG_ID} AND id = 'agent-1'
+    `;
+  };
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 30_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow("agent-1");
+    store = new GrantStore();
+  }, 30_000);
+
+  test("skips the allow grant for a judged domain", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"]);
+      await store.grant("agent-1", "api.example.com", null);
+      expect(await store.hasGrant("agent-1", "api.example.com", ORG_ID)).toBe(
+        false
+      );
+    });
+  });
+
+  test("covers the npm-registry writer (non-expiring, revoke-exempt)", async () => {
+    await withOrg(async () => {
+      await setJudge(["registry.npmjs.org"]);
+      await store.grant("agent-1", "registry.npmjs.org", null);
+      expect(
+        await store.hasGrant("agent-1", "registry.npmjs.org", ORG_ID)
+      ).toBe(false);
+    });
+  });
+
+  test("refuses an EXPIRING allow too (a row the reconcile never sees)", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"]);
+      // The dispatch reconcile skips rows with a non-null expires_at, so an
+      // expiring judged allow could only ever be caught at this chokepoint.
+      await store.grant(
+        "agent-1",
+        "api.example.com",
+        Date.now() + 3_600_000
+      );
+      expect(await store.hasGrant("agent-1", "api.example.com", ORG_ID)).toBe(
+        false
+      );
+    });
+  });
+
+  test("matches a judged WILDCARD against a specific granted host", async () => {
+    await withOrg(async () => {
+      await setJudge(["*.example.com"]);
+      await store.grant("agent-1", "api.example.com", null);
+      expect(await store.hasGrant("agent-1", "api.example.com", ORG_ID)).toBe(
+        false
+      );
+    });
+  });
+
+  // ── negative controls ──────────────────────────────────────────────────
+  test("still grants an UNJUDGED domain", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"]);
+      await store.grant("agent-1", "plain.example.net", null);
+      expect(
+        await store.hasGrant("agent-1", "plain.example.net", ORG_ID)
+      ).toBe(true);
+    });
+  });
+
+  test("a DENY grant on a judged domain still writes (deny outranks the judge)", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"]);
+      await store.grant("agent-1", "api.example.com", null, true);
+      expect(await store.isDenied("agent-1", "api.example.com", ORG_ID)).toBe(
+        true
+      );
+    });
+  });
+
+  test("an MCP TOOL grant is unaffected by a domain judge", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"]);
+      await store.grant("agent-1", "/mcp/gmail/tools/send_email", null);
+      expect(
+        await store.hasGrant("agent-1", "/mcp/gmail/tools/send_email", ORG_ID)
+      ).toBe(true);
+    });
+  });
+
+  test("a DISABLED judge does not suppress the grant", async () => {
+    await withOrg(async () => {
+      await setJudge(["api.example.com"], false);
+      await store.grant("agent-1", "api.example.com", null);
+      expect(await store.hasGrant("agent-1", "api.example.com", ORG_ID)).toBe(
+        true
+      );
+    });
+  });
+
+  test("an agent with NO guardrails grants normally", async () => {
+    await withOrg(async () => {
+      await store.grant("agent-1", "api.example.com", null);
+      expect(await store.hasGrant("agent-1", "api.example.com", ORG_ID)).toBe(
+        true
+      );
     });
   });
 });

--- a/packages/server/src/gateway/permissions/grant-store.ts
+++ b/packages/server/src/gateway/permissions/grant-store.ts
@@ -6,6 +6,10 @@ import {
   type GrantKind,
 } from "@lobu/core";
 import { getDb, pgTextArray } from "../../db/client.js";
+import {
+  allowReachesJudged,
+  egressGuardrailsToPolicyBundle,
+} from "./policy-store.js";
 import { orgScope, requireOrgId } from "../../lobu/stores/org-context.js";
 
 const logger = createLogger("grant-store");
@@ -22,6 +26,38 @@ function getDomainGrantCandidates(pattern: string): string[] {
   }
 
   return [...candidates];
+}
+
+/**
+ * The agent's judged egress domains, read from its DURABLE config.
+ *
+ * Deliberately NOT `PolicyStore`: that is a per-replica in-memory Map populated
+ * only when this replica has dispatched for the agent, so a check against it
+ * would pass vacuously everywhere else — the classic invisible-to-other-replicas
+ * trap. `agents.guardrails_inline` is the one source every replica agrees on.
+ *
+ * Routed through `egressGuardrailsToPolicyBundle`, the same builder the runtime
+ * uses, so the enabled / stage / non-empty-policy filtering and the pattern
+ * normalization match everywhere.
+ *
+ * Errors PROPAGATE. If we cannot tell whether a domain is judged, granting it
+ * risks silently disabling a policy control, while refusing surfaces loudly and
+ * the dispatch reconcile simply retries on the next message.
+ */
+async function readJudgedDomains(
+  agentId: string,
+  organizationId: string
+): Promise<string[]> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT guardrails_inline
+    FROM agents
+    WHERE organization_id = ${organizationId} AND id = ${agentId}
+  `) as Array<{ guardrails_inline: unknown }>;
+  const inline = rows[0]?.guardrails_inline;
+  if (!Array.isArray(inline)) return [];
+  const bundle = egressGuardrailsToPolicyBundle(inline);
+  return bundle ? bundle.judgedDomains.map((r) => r.domain) : [];
 }
 
 /**
@@ -97,6 +133,33 @@ export class GrantStore {
     const kind = inferGrantKind(pattern);
     const expiresAtTs = expiresAt === null ? null : new Date(expiresAt);
     const orgId = requireOrgId(organizationId, "GrantStore.grant");
+
+    // CHOKEPOINT: never write an ALLOW grant for a domain the egress judge
+    // governs. An allow grant outranks the judge in `checkDomainAccess`, so
+    // such a row makes the judge permanently inert — the request succeeds at
+    // `source: "grant"` and the operator's policy never runs.
+    //
+    // Every domain writer funnels through here, which is why the check lives
+    // at this level rather than in each caller. The dispatch reconcile already
+    // skips judged domains (and revokes stale non-expiring rows), but it
+    // cannot heal the deploy-time npm-registry grants — those hosts are exempt
+    // from its revocation — and it never looks at an expiring row at all. A
+    // per-caller fix would have to be repeated for each writer and would
+    // reopen on the next one added.
+    //
+    // Denies are exempt: a deny grant outranks the judge by design. Non-domain
+    // kinds (MCP tool patterns, which is what interactive tool approvals
+    // write) cannot shadow a domain judge at all.
+    if (kind === "domain" && !denied) {
+      const judged = await readJudgedDomains(agentId, orgId);
+      if (judged.some((j) => allowReachesJudged(j, pattern))) {
+        logger.info(
+          "Skipped allow grant — the egress judge governs this domain",
+          { agentId, pattern }
+        );
+        return;
+      }
+    }
 
     const sql = getDb();
     await sql`

--- a/packages/server/src/gateway/permissions/policy-store.ts
+++ b/packages/server/src/gateway/permissions/policy-store.ts
@@ -208,11 +208,12 @@ interface SuppressedJudgedDomainOptions {
 /**
  * Whether an allow pattern reaches any host a judged pattern covers.
  *
- * Two callers, one predicate: {@link findSuppressedJudgedDomains} uses it to
- * refuse a shadowing agent CONFIG at write time, and the deployment manager's
+ * Three callers, one predicate: {@link findSuppressedJudgedDomains} uses it to
+ * refuse a shadowing agent CONFIG at write time, the deployment manager's
  * grant reconcile uses it to refuse the shadowing GRANT at dispatch time (a
- * connector-contributed domain never passes through agent config). Both default
- * to grant semantics; only the global-allowlist check passes
+ * connector-contributed domain never passes through agent config), and
+ * `GrantStore.grant` uses it to refuse the row itself, whichever writer asks.
+ * All default to grant semantics; only the global-allowlist check passes
  * `wildcardCoversRoot`.
  *
  * A judged `.suffix` covers the root and every subdomain — {@link findMatchingRule},


### PR DESCRIPTION
## Why a third PR on this

Because the first two were instance fixes. Owner pushed back on exactly that, so I audited every writer of an allow grant instead of waiting for a reviewer to find the next one.

All eight call sites funnel through `GrantStore.grant()`:

| Writer | Kind | Can shadow a domain judge? | Covered before this PR |
| --- | --- | --- | --- |
| `deployment-manager.ts:848/864` dispatch reconcile | domain allow + deny | yes | **yes — #3300** |
| `deployment-manager.ts:1523` deploy-time npm-registry | domain allow | yes | **no** |
| `interaction-bridge.ts:1323/1347` interactive approval | `mcp_tool` (`pattern = /mcp/${mcpId}/tools/${toolName}`, `:1265`) | no | n/a |
| `gateway.ts:342/350` CLI approval | `mcp_tool` | no | n/a |

So one genuinely uncovered writer, and it is one the reconcile **structurally cannot heal**: npm-registry hosts are exempt from its revocation (`NPM_REGISTRY_DOMAINS.includes(pattern)` → `continue`, `deployment-manager.ts:843`), and it skips every row with a non-null `expires_at` (`:833`).

## The fix

One guard in `GrantStore.grant()` — the single funnel — instead of a third per-caller patch that reopens on the next writer added.

The judged set is read from **`agents.guardrails_inline`**, not from `PolicyStore`. That store is `private readonly policies = new Map()`: per-replica, in-memory, populated only at dispatch. A check against it would pass vacuously on any replica that had not dispatched for the agent — correct in dev, broken in prod. Resolution routes through `egressGuardrailsToPolicyBundle` and `allowReachesJudged`, so all three checks now share one predicate and one notion of "judged".

Two deliberate exemptions:

- **Denies still write.** A deny grant outranks the judge by design.
- **Non-domain kinds skip the lookup.** An MCP tool pattern cannot shadow a domain judge, and tool approvals are frequent enough that the extra read is worth avoiding.

Errors propagate. If we cannot tell whether a domain is judged, granting it risks silently disabling a policy control; refusing surfaces loudly and the reconcile retries on the next message.

`deployment-manager.ts`'s own skip stays and is still load-bearing: without it the judged domain lands in `expectedDomains` and a stale row would never be revoked. The chokepoint stops new rows; the reconcile heals old ones.

## Verification

**Red → green.** Short-circuiting the guard fails exactly the 4 positive tests; all 5 negative controls pass in both states.

```
### RED (guard short-circuited)     ### GREEN
 31 pass                             35 pass
  4 fail                              0 fail
```

**Mutation-tested — 2 of 3, and the third is inert by construction:**

| Mutation | Result |
| --- | --- |
| string equality instead of `allowReachesJudged` | caught — judged-wildcard test |
| drop the deny exemption | caught — deny-still-writes test |
| drop the `kind === "domain"` restriction | **survived** |

The third cannot be caught: a judged domain never string-matches an `/mcp/...` pattern (and `normalizeDomainPattern` leaves `/`-prefixed patterns alone), so that clause is a cost short-circuit plus protection against a pathological `domains` value, not a correctness guard. Saying so rather than reporting a clean sweep.

**Suites run** (individually — the gateway tree contends over the shared embedded PG):

```
grant-store                        35 pass   (25 pre-existing + 10 new)
base-deployment-grants             33 pass
policy-store                       29 pass
orchestration-harden               61 pass
mcp-proxy-edge-cases               41 pass
agent-tooling-resolver             38 pass
vercel-network-policy              27 pass
interaction-bridge-action-handlers 26 pass
guardrails-runtime                 17 pass   (Vitest)
enqueue-model-gate                 10 pass
http-proxy-judge                    7 pass
interaction-bridge-slack-webhook    6 pass
agent-config-org-scope              4 pass
conversation-pin-enqueue            3 pass
egress-judge                        8 pass
```

`src/__tests__/integration/grant-store-org-scope.test.ts` throws at import without a provisioned `DATABASE_URL` (`test-db.ts:96`), before any code in this diff runs. CI covers it.

`make pre-pr`: clean. Pre-commit: biome + `tsc --noEmit` clean.

## Known limitation

SDK-declared agents keep settings in an `InMemoryAgentStore` (`core-services.ts:915`, `populateStoreFromAgentConfigs`), so there is no durable `guardrails_inline` for this guard to read and it passes vacuously for them. #3300's payload-based reconcile still covers their dispatch path. Additive, not a regression — closing it would mean either persisting declared settings or reading SDK config from a store that should not know about it, both bigger than this diff.

## Risk

One extra indexed `SELECT` per **domain** `grant()` call. The reconcile only calls `grant()` when a domain's state actually changes, so steady state is zero extra reads; npm-registry grants happen at deploy. Not measured under load.

Behaviorally: an npm-registry host that an operator has judged is no longer blanket-allowed, so package installs on that host become judged and a denying judge will block them. That is what writing the judge rule asked for, and it matches the Nix-cache decision in #3300, but it can break a build that was working by accident.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented domain allow grants from being created when those domains are governed by judged egress policies.
  * Preserved deny grants and non-domain grants, including MCP tool permissions and unaffected domains.
  * Ensured policy and database errors are surfaced instead of silently creating grants.

* **Documentation**
  * Updated permission behavior documentation to reflect grant validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->