### PR TITLE
fix(scripts): sign lobu-device-daemon with JIT entitlements under Hardened Runtime

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -404,7 +404,10 @@ jobs:
           codesign "${OPTS[@]}" \
             --entitlements config/macos/lobu-auth.entitlements \
             "$AUTH_CLI"
-          codesign "${OPTS[@]}" "$DAEMON"
+          codesign "${OPTS[@]}" \
+            --entitlements config/macos/lobu-auth.entitlements \
+            "$DAEMON"
+          scripts/verify-mac-device-daemon.sh "$DAEMON"
 
           # XPC services (each has an inner Mach-O + an outer bundle).
           if [ -d "$SPARKLE/XPCServices/Downloader.xpc" ]; then

--- a/scripts/__tests__/mac-device-daemon-codesign.test.ts
+++ b/scripts/__tests__/mac-device-daemon-codesign.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const BUILD_MAC_SCRIPT = join(REPO_ROOT, "scripts/build-owletto-mac.sh");
+const RELEASE_WORKFLOW = join(REPO_ROOT, ".github/workflows/mac-release.yml");
+const PACKAGE_SMOKE_SCRIPT = join(
+  REPO_ROOT,
+  "scripts/test-mac-device-daemon-package.sh"
+);
+const ENTITLEMENTS_FILE = join(
+  REPO_ROOT,
+  "config/macos/lobu-auth.entitlements"
+);
+
+describe("Mac device daemon codesigning entitlements guard", () => {
+  it("verifies config/macos/lobu-auth.entitlements provides com.apple.security.cs.allow-jit", () => {
+    const entitlements = readFileSync(ENTITLEMENTS_FILE, "utf8");
+    expect(entitlements).toContain("com.apple.security.cs.allow-jit");
+    expect(entitlements).toContain("<true/>");
+  });
+
+  it("ensures build-owletto-mac.sh passes entitlements when codesigning DAEMON with runtime options", () => {
+    const script = readFileSync(BUILD_MAC_SCRIPT, "utf8");
+    expect(script).toMatch(
+      /codesign\s+"\$\{OPTS\[@\]\}"\s+--entitlements\s+"\$AUTH_ENTITLEMENTS"\s+"\$DAEMON"/
+    );
+  });
+
+  it("ensures mac-release.yml passes entitlements when codesigning DAEMON with runtime options", () => {
+    const workflow = readFileSync(RELEASE_WORKFLOW, "utf8");
+    expect(workflow).toMatch(
+      /codesign\s+"(?:\$\{OPTS\[@\]\}|"[^"]+")"\s+\\\s+--entitlements\s+config\/macos\/lobu-auth\.entitlements\s+\\\s+"\$DAEMON"/
+    );
+  });
+
+  it("ensures test-mac-device-daemon-package.sh smokes Hardened Runtime with JIT entitlements", () => {
+    const smoke = readFileSync(PACKAGE_SMOKE_SCRIPT, "utf8");
+    expect(smoke).toContain("--options runtime");
+    expect(smoke).toContain("lobu-auth.entitlements");
+  });
+});

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -76,9 +76,12 @@ SPARKLE="$APP/Contents/Frameworks/Sparkle.framework/Versions/B"
 OPTS=(--force --options runtime --timestamp --sign "$SIGN_ID")
 
 # Xcode treats the daemon as a resource, so seal its Mach-O explicitly before
-# re-signing the umbrella app that records the nested signature.
+# re-signing the umbrella app that records the nested signature. Both CLI and
+# daemon are standalone Bun executables needing MAP_JIT executable memory under
+# Hardened Runtime.
 codesign "${OPTS[@]}" --entitlements "$AUTH_ENTITLEMENTS" "$AUTH_CLI"
-codesign "${OPTS[@]}" "$DAEMON"
+codesign "${OPTS[@]}" --entitlements "$AUTH_ENTITLEMENTS" "$DAEMON"
+"$ROOT/scripts/verify-mac-device-daemon.sh" "$DAEMON" >/dev/null
 
 resign_xpc() {
   local name="$1"

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -55,6 +55,14 @@ grep -q 'owl_pat_' "$WORK/invalid-token.err"
 NO_POLL_JSON="$(run_clean ./lobu-device-daemon --no-poll)"
 [[ "$NO_POLL_JSON" == "$VERSION_JSON" ]]
 
+# Hardened Runtime + JIT entitlement smoke: standalone Bun Mach-Os crash on Apple
+# Silicon under Hardened Runtime ("Ran out of executable memory while allocating 128 bytes")
+# unless signed with com.apple.security.cs.allow-jit.
+codesign --force --options runtime --sign - \
+  --entitlements "$ROOT/config/macos/lobu-auth.entitlements" "$CLEAN/lobu-device-daemon"
+HARDENED_JSON="$(run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-device-daemon)"
+[[ "$HARDENED_JSON" == "$VERSION_JSON" ]]
+
 echo "Mac device-daemon package smoke passed"
 echo "$VERSION_JSON"
 stat -f 'artifact_bytes=%z' "$CLEAN/lobu-device-daemon"


### PR DESCRIPTION
## Summary
- Pass `config/macos/lobu-auth.entitlements` (`com.apple.security.cs.allow-jit`) when codesigning `lobu-device-daemon` under Hardened Runtime (`--options runtime`).
- Without this entitlement, standalone Bun executables (`bun build --compile`) fail on Apple Silicon with `Ran out of executable memory while allocating 128 bytes.`, causing Owletto's `DeviceDaemonSupervisor` to fail `readDaemonBuild()` and drop into passive worker mode.
- Add post-codesign Hardened Runtime verification to `build-owletto-mac.sh`, `mac-release.yml`, and `test-mac-device-daemon-package.sh`, with a structural test guard in `scripts/__tests__/mac-device-daemon-codesign.test.ts`.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun test scripts/__tests__/mac-device-daemon-codesign.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### Red -> Green output:
```bash
# Red (Hardened Runtime without JIT entitlements):
$ codesign --force --options runtime --sign - /tmp/lobu-daemon-test
$ /tmp/lobu-daemon-test --version
Ran out of executable memory while allocating 128 bytes.

# Green (Hardened Runtime with JIT entitlements):
$ codesign --force --options runtime --sign - --entitlements config/macos/lobu-auth.entitlements /tmp/lobu-daemon-test
$ /tmp/lobu-daemon-test --version
{"name":"lobu-device-daemon","version":"17.2.0","protocol":"device-daemon/v2","platform":"macos","artifact":"standalone-bun-macho-arm64"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS device-daemon code signing for release and local build artifacts.
  * Enabled the required Hardened Runtime and JIT entitlements to improve compatibility and validation of signed daemon packages.

* **Tests**
  * Added automated checks to verify signing options, entitlements, package metadata, and release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->