### PR TITLE
fix(gateway): prefer a healthy provider over an exhausted one at dispatch

### DIFF
--- a/packages/server/src/gateway/__tests__/model-selection.test.ts
+++ b/packages/server/src/gateway/__tests__/model-selection.test.ts
@@ -134,6 +134,68 @@ describe("enforceModelAllowList (universal dispatch gate — decision A/B)", () 
     expect(r.replaced).toBe(false);
   });
 
+  test("H1: an EXACT-LISTED ROUTABLE but UNHEALTHY request yields to a listed HEALTHY ref", () => {
+    // The live prod shape (community/crm): models=["qwen/…","xai/grok-4"] with
+    // qwen quota-exhausted (429) and xai active. Both are keyed, so both are
+    // ROUTABLE — routability alone cannot tell them apart, and the run picks
+    // the dead head of the list.
+    const r = enforceModelAllowList(
+      "qwen/qwen3.8-max-preview",
+      ["qwen/qwen3.8-max-preview", "xai/grok-4"],
+      () => true,
+      (ref) => ref === "xai/grok-4",
+    );
+    expect(r.model).toBe("xai/grok-4");
+    expect(r.replaced).toBe(true);
+  });
+
+  test("H2: an UNHEALTHY request with NO healthy listed alternate still passes (never strands)", () => {
+    // Health only ever REORDERS routable candidates. A stale or false-positive
+    // unhealthy row must not be able to fail a turn that would otherwise run —
+    // that is what keeps the health column safe to write best-effort.
+    const r = enforceModelAllowList(
+      "qwen/qwen3.8-max",
+      ["qwen/qwen3.8-max"],
+      () => true,
+      () => false,
+    );
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("H3: an out-of-list replacement prefers a HEALTHY ref over an earlier unhealthy one", () => {
+    const r = enforceModelAllowList(
+      "claude/forbidden",
+      ["qwen/qwen3.8-max", "xai/grok-4"],
+      () => true,
+      (ref) => ref === "xai/grok-4",
+    );
+    expect(r.model).toBe("xai/grok-4");
+    expect(r.replaced).toBe(true);
+  });
+
+  test("H4: without a health predicate, routing is unchanged (health-blind)", () => {
+    const r = enforceModelAllowList(
+      "qwen/qwen3.8-max",
+      ["qwen/qwen3.8-max", "xai/grok-4"],
+      () => true,
+    );
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("H5: ROUTABILITY still gates — a healthy but UNROUTABLE ref never wins", () => {
+    // qwen healthy-but-uncredentialed, xai routable-but-unhealthy. Only routable
+    // refs are candidates at all, so the unhealthy-but-routable ref must win.
+    const r = enforceModelAllowList(
+      "claude/forbidden",
+      ["qwen/qwen3.8-max", "xai/grok-4"],
+      (ref) => ref === "xai/grok-4",
+      (ref) => ref === "qwen/qwen3.8-max",
+    );
+    expect(r.model).toBe("xai/grok-4");
+  });
+
   test("R5 #2: DENY-ALL (allowedRefs=[]) drops any requested model (fail closed)", () => {
     const r = enforceModelAllowList("openai/gpt-5", []);
     expect(r.model).toBeUndefined();

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -653,3 +653,108 @@ describe("ProviderCatalogService.getModelPolicy — not-found / orgless are DENY
     expect(allowedRefs).toBeNull(); // allow-all preserved — NOT collapsed to deny
   });
 });
+
+/**
+ * A quota-exhausted provider keeps its API key, so the routability predicate
+ * (`hasSystemKey() || hasCredentials()`) cannot tell it apart from a working
+ * one. Observed live in prod: an agent listing
+ * ["qwen/… (429)", "xai/grok-4 (active)"] routed every turn to the dead head
+ * even though the ordered `models` list already named the healthy alternate.
+ *
+ * `resolveDispatchModel` therefore prefers a healthy sibling — but only as a
+ * PREFERENCE, since `inference_providers.status` is written best-effort from an
+ * upstream response and may be stale.
+ */
+describe("ProviderCatalogService.resolveDispatchModel — provider health", () => {
+  afterEach(() => clearRegistry());
+
+  function healthRow(
+    slug: string,
+    status: "active" | "error"
+  ): InferenceProviderListItem {
+    return {
+      id: 1,
+      slug,
+      kind: slug,
+      displayName: slug,
+      capabilities: { text: { model: "m" } },
+      hasCustomUpstream: false,
+      status,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    } as InferenceProviderListItem;
+  }
+
+  test("an exhausted provider yields to the healthy ref the agent already lists", async () => {
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    registerFakeModule("xai", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max", "xai/grok-4"],
+      orgRows: [healthRow("qwen", "error"), healthRow("xai", "active")],
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("xai/grok-4");
+    expect(r.replaced).toBe(true);
+  });
+
+  test("an exhausted provider with no healthy alternate still dispatches (never strands)", async () => {
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max"],
+      orgRows: [healthRow("qwen", "error")],
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("all-active rows leave the requested ref untouched", async () => {
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    registerFakeModule("xai", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max", "xai/grok-4"],
+      orgRows: [healthRow("qwen", "active"), healthRow("xai", "active")],
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("with no org-provider reader at all, dispatch stays health-blind", async () => {
+    // Health is read from the rows getModelPolicy already loads, so there is no
+    // separate health query that could fail on its own. An orgless caller (no
+    // reader injected) simply gets the pre-existing routability-only ordering.
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    registerFakeModule("xai", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max", "xai/grok-4"],
+      withOrgReader: false,
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -668,9 +668,15 @@ describe("ProviderCatalogService.getModelPolicy — not-found / orgless are DENY
 describe("ProviderCatalogService.resolveDispatchModel — provider health", () => {
   afterEach(() => clearRegistry());
 
+  /**
+   * `ageMs` is how long ago the health row was stamped. `listInferenceProviders`
+   * always returns `updatedAt`, and the routing preference expires with it, so
+   * the fixture must carry it or it would not match the producer's shape.
+   */
   function healthRow(
     slug: string,
-    status: "active" | "error"
+    status: "active" | "error",
+    ageMs = 0
   ): InferenceProviderListItem {
     return {
       id: 1,
@@ -681,6 +687,7 @@ describe("ProviderCatalogService.resolveDispatchModel — provider health", () =
       hasCustomUpstream: false,
       status,
       createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: new Date(Date.now() - ageMs).toISOString(),
     } as InferenceProviderListItem;
   }
 
@@ -725,6 +732,51 @@ describe("ProviderCatalogService.resolveDispatchModel — provider health", () =
     const catalog = makeCatalog({
       models: ["qwen/qwen3.8-max", "xai/grok-4"],
       orgRows: [healthRow("qwen", "active"), healthRow("xai", "active")],
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("a STALE error row stops steering, so traffic drifts back and can recover", async () => {
+    // `error` is cleared only by a proxied 2xx for that slug, so if routing
+    // avoided the provider forever nothing would ever clear it and a transient
+    // 429 would exile it permanently. The preference expires instead.
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    registerFakeModule("xai", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max", "xai/grok-4"],
+      orgRows: [
+        healthRow("qwen", "error", 60 * 60 * 1000),
+        healthRow("xai", "active"),
+      ],
+    });
+
+    const r = await catalog.resolveDispatchModel(
+      "agent-1",
+      "org-1",
+      "qwen/qwen3.8-max"
+    );
+
+    expect(r.model).toBe("qwen/qwen3.8-max");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("a row with no usable updatedAt degrades to health-blind rather than exiling it", async () => {
+    registerFakeModule("qwen", "openai", { hasSystemKey: true });
+    registerFakeModule("xai", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["qwen/qwen3.8-max", "xai/grok-4"],
+      orgRows: [
+        { ...healthRow("qwen", "error"), updatedAt: "not-a-date" },
+        healthRow("xai", "active"),
+      ],
     });
 
     const r = await catalog.resolveDispatchModel(

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -349,6 +349,14 @@ export class ProviderCatalogService {
     modules: ModelProviderModule[];
     /** Ordered exact allow-list, or null when the agent allows all providers. */
     allowedRefs: string[] | null;
+    /**
+     * Org provider slugs currently recorded `error` (quota/credential), taken
+     * from the SAME `inference_providers` read this method already performs to
+     * synthesize org modules. Surfaced so `resolveDispatchModel` can prefer a
+     * healthy sibling without a second query — and so a failing read cannot
+     * introduce a NEW way for dispatch to break: it already fails here.
+     */
+    unhealthyProviderSlugs: Set<string>;
   }> {
     const policy = await resolveAgentModels(
       this.agentSettingsStore,
@@ -361,7 +369,7 @@ export class ProviderCatalogService {
     // modules, so any requested model fails closed. This is the fail-open bug
     // fix — a missing agent must never expose every org/system-key provider.
     if (policy.kind === "not-found") {
-      return { modules: [], allowedRefs: [] };
+      return { modules: [], allowedRefs: [], unhealthyProviderSlugs: new Set() };
     }
 
     const models = policy.kind === "restricted" ? policy.models : [];
@@ -488,7 +496,10 @@ export class ProviderCatalogService {
         if (synthesized) modules.push(synthesized);
       }
     }
-    return { modules, allowedRefs };
+    const unhealthyProviderSlugs = new Set(
+      orgRows.filter((r) => r.status === "error").map((r) => r.slug)
+    );
+    return { modules, allowedRefs, unhealthyProviderSlugs };
   }
 
   /**
@@ -512,6 +523,12 @@ export class ProviderCatalogService {
    * non-sentinel AND ROUTABLE (its provider module is present and keyed) — not
    * merely the first non-sentinel. Returns `{ model, modules, allowedRefs }`;
    * `model` is undefined when nothing routable qualifies (fail closed).
+   *
+   * Among routable refs, a provider recorded `error` (quota/credential, from
+   * `recordProviderHealth`) LOSES to a healthy sibling in the same list —
+   * including when it is the exact request. This is the only place health
+   * influences routing, and it is a preference: it never shrinks the candidate
+   * set, so an agent whose sole provider is unhealthy still dispatches to it.
    */
   async resolveDispatchModel(
     agentId: string,
@@ -524,10 +541,8 @@ export class ProviderCatalogService {
     modules: ModelProviderModule[];
     allowedRefs: string[] | null;
   }> {
-    const { modules, allowedRefs } = await this.getModelPolicy(
-      agentId,
-      organizationId
-    );
+    const { modules, allowedRefs, unhealthyProviderSlugs } =
+      await this.getModelPolicy(agentId, organizationId);
     // A ref is routable when its (non-sentinel) provider module is present in
     // the policy's modules AND has a system key or stored credentials.
     const routableCache = new Map<string, boolean>();
@@ -554,7 +569,29 @@ export class ProviderCatalogService {
         routableCache.set(ref, routable);
       }
     }
-    const gate = enforceModelAllowList(requestedModel, allowedRefs, isRoutable);
+    // Provider HEALTH, as a tie-break among routable refs. A quota-exhausted
+    // provider keeps its key, so `isRoutable` cannot distinguish it from a
+    // working one and the dead head of an ordered `models` list wins every
+    // turn. The slugs come from the `inference_providers` read getModelPolicy
+    // already did, so this adds no query and no new failure mode.
+    //
+    // A Lobu model ref is "<provider-slug>/<model>", and OpenRouter-style refs
+    // keep their own slug first ("openrouter/openai/gpt-4o"), so the leading
+    // segment is the provider — the same prefix `findProviderForModel` falls
+    // back to.
+    const isHealthy = (ref: string): boolean => {
+      const slash = ref.indexOf("/");
+      if (slash <= 0) return true;
+      return !unhealthyProviderSlugs.has(ref.slice(0, slash));
+    };
+    const gate = enforceModelAllowList(
+      requestedModel,
+      allowedRefs,
+      isRoutable,
+      // Omitted when nothing is unhealthy so the predicate cannot perturb the
+      // ordering in the common all-healthy case.
+      unhealthyProviderSlugs.size > 0 ? isHealthy : undefined
+    );
     return { ...gate, modules, allowedRefs };
   }
 

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -19,6 +19,37 @@ import { enforceModelAllowList } from "./settings/model-selection.js";
 
 const logger = createLogger("provider-catalog");
 
+/**
+ * How long a recorded `error` row suppresses its provider in dispatch ordering.
+ *
+ * The status is cleared ONLY by a proxied 2xx for that slug
+ * (`recordProviderHealth` → `clearInferenceProviderError`), so if routing simply
+ * stops sending traffic to an unhealthy provider, nothing ever clears it and a
+ * transient 429 would exile the provider permanently. Expiring the preference
+ * lets traffic drift back: the next turn either succeeds (clearing the row) or
+ * fails again (re-stamping `updated_at`, restarting the window). Recovery is
+ * automatic instead of waiting for a settings-page probe.
+ *
+ * Deliberately a fixed window rather than the provider's own `Retry-After`:
+ * that value survives only as prose inside `error_message`, and parsing it back
+ * out would re-encode a formatted string — the exact fragility
+ * `classifyProviderHealthStatus` avoids by keying on status codes alone.
+ */
+const PROVIDER_HEALTH_PREFERENCE_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * True when an `error` row is recent enough to still steer routing. An absent or
+ * unparseable timestamp returns false — losing the preference degrades to the
+ * pre-existing health-blind ordering, whereas trusting it could exile a provider
+ * forever.
+ */
+function isHealthSignalFresh(updatedAt: string | undefined, now: number): boolean {
+  if (!updatedAt) return false;
+  const t = Date.parse(updatedAt);
+  if (Number.isNaN(t)) return false;
+  return now - t < PROVIDER_HEALTH_PREFERENCE_TTL_MS;
+}
+
 /** Auth mechanism a provider supports. */
 export type ProviderAuthType = "oauth" | "device-code" | "api-key";
 
@@ -350,11 +381,9 @@ export class ProviderCatalogService {
     /** Ordered exact allow-list, or null when the agent allows all providers. */
     allowedRefs: string[] | null;
     /**
-     * Org provider slugs currently recorded `error` (quota/credential), taken
-     * from the SAME `inference_providers` read this method already performs to
-     * synthesize org modules. Surfaced so `resolveDispatchModel` can prefer a
-     * healthy sibling without a second query — and so a failing read cannot
-     * introduce a NEW way for dispatch to break: it already fails here.
+     * Org provider slugs recorded `error` within
+     * `PROVIDER_HEALTH_PREFERENCE_TTL_MS`, from the `inference_providers` read
+     * this method already performs — so no extra query and no new failure mode.
      */
     unhealthyProviderSlugs: Set<string>;
   }> {
@@ -496,8 +525,14 @@ export class ProviderCatalogService {
         if (synthesized) modules.push(synthesized);
       }
     }
+    const healthNow = Date.now();
     const unhealthyProviderSlugs = new Set(
-      orgRows.filter((r) => r.status === "error").map((r) => r.slug)
+      orgRows
+        .filter(
+          (r) =>
+            r.status === "error" && isHealthSignalFresh(r.updatedAt, healthNow)
+        )
+        .map((r) => r.slug)
     );
     return { modules, allowedRefs, unhealthyProviderSlugs };
   }
@@ -569,12 +604,6 @@ export class ProviderCatalogService {
         routableCache.set(ref, routable);
       }
     }
-    // Provider HEALTH, as a tie-break among routable refs. A quota-exhausted
-    // provider keeps its key, so `isRoutable` cannot distinguish it from a
-    // working one and the dead head of an ordered `models` list wins every
-    // turn. The slugs come from the `inference_providers` read getModelPolicy
-    // already did, so this adds no query and no new failure mode.
-    //
     // A Lobu model ref is "<provider-slug>/<model>", and OpenRouter-style refs
     // keep their own slug first ("openrouter/openai/gpt-4o"), so the leading
     // segment is the provider — the same prefix `findProviderForModel` falls

--- a/packages/server/src/gateway/auth/settings/model-selection.ts
+++ b/packages/server/src/gateway/auth/settings/model-selection.ts
@@ -22,6 +22,12 @@ import { isUnresolvedModelRef } from "../model-sentinel.js";
  *     none routable), the model is dropped (undefined) so the run FAILS CLOSED —
  *     it never escalates to an unlisted model.
  *
+ * Provider health (when an `isHealthy` predicate is supplied) is a tie-breaker
+ * layered on top: among refs that are already routable, a healthy provider is
+ * preferred over an unhealthy one, including over an exact-listed request. It
+ * never shrinks the candidate set, so an agent whose only provider is unhealthy
+ * still runs.
+ *
  * Returns the effective model ref, or undefined to run with no model (fail
  * closed / auto-detect for the allow-all case).
  */
@@ -38,6 +44,21 @@ export function enforceModelAllowList(
    * dead xai/grok-4. Omitted ⇒ first non-sentinel (structural check only).
    */
   isRoutable?: (ref: string) => boolean,
+  /**
+   * Optional provider-health predicate. Health only ever REORDERS candidates
+   * that are already routable — it never removes the last one. A quota-exhausted
+   * provider still holds a valid key, so `isRoutable` cannot tell it apart from
+   * a working one; without this, an agent listing
+   * ["qwen/…" (429), "xai/grok-4" (active)] routes every turn to the dead head
+   * even though the ordered list already names the alternate.
+   *
+   * Deliberately a PREFERENCE, not a filter. `inference_providers.status` is
+   * written best-effort off an upstream response, so it can be stale or a false
+   * positive; letting it exclude a candidate would turn a cosmetic mistake into
+   * a stranded workspace. The strongest thing it may do is lose a tie to a
+   * healthy sibling in the same list.
+   */
+  isHealthy?: (ref: string) => boolean,
 ): { model: string | undefined; replaced: boolean } {
   if (!requestedModel) return { model: undefined, replaced: false };
   // The first LISTED ref that is a legal replacement: non-sentinel, and (when a
@@ -45,7 +66,14 @@ export function enforceModelAllowList(
   // for a disallowed/sentinel request; otherwise we fail closed.
   const isReplacement = (r: string): boolean =>
     !isUnresolvedModelRef(r) && (isRoutable ? isRoutable(r) : true);
-  const firstReplacement = allowedRefs?.find(isReplacement) ?? undefined;
+  const replacements = allowedRefs?.filter(isReplacement) ?? [];
+  // Among legal replacements, a healthy provider wins; absent any healthy one we
+  // still take the first legal replacement, so health can never fail a turn that
+  // routability would have allowed.
+  const firstHealthyReplacement = isHealthy
+    ? replacements.find((r) => isHealthy(r))
+    : undefined;
+  const firstReplacement = firstHealthyReplacement ?? replacements[0];
 
   // A sentinel is never a real, routable model. Drop it, but — for a MIXED
   // list like ["x/__unresolved__","openai/gpt-4o"] — replace it with the first
@@ -63,6 +91,17 @@ export function enforceModelAllowList(
     // ref (e.g. requested "xai/grok-4" with xai uncredentialed) would reach the
     // worker and fail at run.
     if (!isRoutable || isRoutable(requestedModel)) {
+      // Routable — but a provider recorded UNHEALTHY yields to a listed healthy
+      // sibling. Only when the list offers no healthy alternate does the
+      // unhealthy pin still run: better a turn that fails at the provider with
+      // its own 429 than one refused on a status column that may be stale.
+      if (
+        isHealthy &&
+        !isHealthy(requestedModel) &&
+        firstHealthyReplacement !== undefined
+      ) {
+        return { model: firstHealthyReplacement, replaced: true };
+      }
       return { model: requestedModel, replaced: false };
     }
     return { model: firstReplacement, replaced: true };

--- a/packages/server/src/gateway/auth/settings/model-selection.ts
+++ b/packages/server/src/gateway/auth/settings/model-selection.ts
@@ -22,11 +22,8 @@ import { isUnresolvedModelRef } from "../model-sentinel.js";
  *     none routable), the model is dropped (undefined) so the run FAILS CLOSED —
  *     it never escalates to an unlisted model.
  *
- * Provider health (when an `isHealthy` predicate is supplied) is a tie-breaker
- * layered on top: among refs that are already routable, a healthy provider is
- * preferred over an unhealthy one, including over an exact-listed request. It
- * never shrinks the candidate set, so an agent whose only provider is unhealthy
- * still runs.
+ * Provider health, when an `isHealthy` predicate is supplied, is a tie-breaker
+ * layered on top (see the parameter doc).
  *
  * Returns the effective model ref, or undefined to run with no model (fail
  * closed / auto-detect for the allow-all case).
@@ -67,9 +64,7 @@ export function enforceModelAllowList(
   const isReplacement = (r: string): boolean =>
     !isUnresolvedModelRef(r) && (isRoutable ? isRoutable(r) : true);
   const replacements = allowedRefs?.filter(isReplacement) ?? [];
-  // Among legal replacements, a healthy provider wins; absent any healthy one we
-  // still take the first legal replacement, so health can never fail a turn that
-  // routability would have allowed.
+  // Among legal replacements, a healthy provider wins.
   const firstHealthyReplacement = isHealthy
     ? replacements.find((r) => isHealthy(r))
     : undefined;
@@ -91,10 +86,7 @@ export function enforceModelAllowList(
     // ref (e.g. requested "xai/grok-4" with xai uncredentialed) would reach the
     // worker and fail at run.
     if (!isRoutable || isRoutable(requestedModel)) {
-      // Routable — but a provider recorded UNHEALTHY yields to a listed healthy
-      // sibling. Only when the list offers no healthy alternate does the
-      // unhealthy pin still run: better a turn that fails at the provider with
-      // its own 429 than one refused on a status column that may be stale.
+      // Routable — but an UNHEALTHY provider yields to a listed healthy sibling.
       if (
         isHealthy &&
         !isHealthy(requestedModel) &&

--- a/packages/server/src/gateway/proxy/provider-health-status.ts
+++ b/packages/server/src/gateway/proxy/provider-health-status.ts
@@ -12,10 +12,12 @@ import { AgentErrorCode } from "@lobu/core";
  * The mapping is intentionally narrow. Only statuses that indicate the
  * CREDENTIAL or the ACCOUNT is at fault mark a provider unhealthy — a 400 (bad
  * request) or 404 (unknown model) is the caller's fault and says nothing about
- * provider health. The row is a display signal (see
+ * provider health. The row drives the settings UI and, via
+ * `resolveDispatchModel`, a routing PREFERENCE for a healthy sibling (see
  * `markInferenceProviderUnhealthy`): a false positive would label a healthy
- * provider broken in the settings UI. `undefined` means "this status carries
- * no health signal", which is distinct from healthy.
+ * provider broken and could move a turn onto another model the agent already
+ * lists, but can never strand it. `undefined` means "this status carries no
+ * health signal", which is distinct from healthy.
  *
  * Lives in its own module so it can be unit-tested without dragging in the
  * proxy's database and secret-store dependencies.

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -1107,11 +1107,13 @@ export class SecretProxy {
    * all, so a 429 on a probe proves the quota wall exactly like one on a
    * completion, and a probe 200 proves the credential works.
    *
-   * Best-effort by design: nothing routes on `status` today (it is a display
-   * signal), so a failure to write must not fail the user's inference call.
-   * That is why this swallows its own errors rather than propagating — the
-   * "fail closed on durable dispatch state" rule governs delivery decisions,
-   * and this is an observation, not a decision.
+   * Best-effort by design: `status` is a display signal plus a routing
+   * PREFERENCE (`resolveDispatchModel` prefers a healthy sibling among the refs
+   * an agent already lists), never a gate — so a failure to write can only cost
+   * that preference, and must not fail the user's inference call. That is why
+   * this swallows its own errors rather than propagating — the "fail closed on
+   * durable dispatch state" rule governs delivery decisions, and this is an
+   * observation, not a decision.
    */
   private async recordProviderHealth(
     organizationId: string | undefined,

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -685,12 +685,16 @@ const PROVIDER_ERROR_MESSAGE_LIMIT = 500;
  * credential error, so the settings page can say WHY a workspace's Automations
  * stopped instead of showing a row that still reads `active`.
  *
- * **Observational only.** Nothing in credential resolution or model routing
- * reads `status` — every reference in this file is a SELECT for display — so a
- * missed, stale or duplicated write can never strand a workspace or reroute a
- * turn. That is exactly why the caller treats a failure here as best-effort:
- * this is not durable dispatch/delivery state, and failing a delivered turn to
- * protect a status label would trade a real outcome for a cosmetic one.
+ * **Never a gate.** Credential resolution ignores `status` entirely. Model
+ * routing reads it in exactly one place — `resolveDispatchModel` prefers a
+ * healthy provider over an `error` one among refs the agent already lists and
+ * that are already routable — and only as a PREFERENCE: it cannot shrink the
+ * candidate set, so a missed, stale or duplicated write here can never strand a
+ * workspace or fail a turn that would otherwise have run. At worst it moves a
+ * turn onto a sibling the agent had already listed. That is why the caller
+ * still treats a failure here as best-effort: this is not durable
+ * dispatch/delivery state, and failing a delivered turn to protect a status
+ * label would trade a real outcome for a cosmetic one.
  *
  * `disabled` is an operator decision and is never overwritten.
  */


### PR DESCRIPTION
## Summary
- An agent's ordered `models` list already expresses a fallback, and `resolveDispatchModel` already replaces a disallowed ref with the first LISTED ref that is ROUTABLE — but routability is `hasSystemKey() || hasCredentials()`, i.e. "is there a key", never "is the provider usable". A quota-exhausted provider keeps its key, so the dead head of the list wins every turn and the listed alternate never runs.
- Health is applied as a **preference, not a filter**: among already-routable refs a provider recorded `error` loses to a healthy sibling in the same list (including when it is the exact request), but is never removed — so an agent whose only provider is unhealthy still dispatches. `inference_providers.status` is written best-effort from an upstream response and can be stale; letting it exclude a candidate would turn a cosmetic mistake into a stranded workspace.
- Slugs come from the `inference_providers` read `getModelPolicy` already performs to synthesize org modules, so this adds **no query and no new failure mode**.

Found while verifying #3297 in prod. Live shape that motivated it: `community/crm` lists `["qwen/qwen3.8-max-preview" (429), "xai/grok-4" (active)]` and routes to qwen. `lobu-team`'s default `qwen` is 429 with `retry-after: 20047`, and its runs emit status updates on exactly that cadence without ever completing.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 5 gates; local fallback — full graph runs here on CI)
- [x] Tests run: targeted `bun test <path>` across all 6 suites touching the resolver
- [x] Bug fix: red→fix→green outputs pasted below

**Red** (before the fix — `bun test packages/server/src/gateway/__tests__/model-selection.test.ts`):
```
Expected: "xai/grok-4"
Received: "qwen/qwen3.8-max-preview"
(fail) … > H1: an EXACT-LISTED ROUTABLE but UNHEALTHY request yields to a listed HEALTHY ref
Expected: "xai/grok-4"
Received: "qwen/qwen3.8-max"
(fail) … > H3: an out-of-list replacement prefers a HEALTHY ref over an earlier unhealthy one
 25 pass
 2 fail
```

**Green** (after):
```
model-selection.test.ts                        27 pass  0 fail
provider-catalog-org-inference.test.ts         29 pass  0 fail
enqueue-model-gate.test.ts                     10 pass  0 fail
worker-session-context-model-fallback.test.ts  12 pass  0 fail
provider-catalog-find-provider.test.ts          6 pass  0 fail
build-provider-catalog.test.ts                  6 pass  0 fail
```

**Mutation-tested** — with the health preference disabled (`firstHealthyReplacement = undefined`), exactly the three behaviour-asserting tests fail and every guard still passes, so the guards are not vacuous:
```
(fail) … > H1: an EXACT-LISTED ROUTABLE but UNHEALTHY request yields to a listed HEALTHY ref
(fail) … > H3: an out-of-list replacement prefers a HEALTHY ref over an earlier unhealthy one
(fail) … > resolveDispatchModel — provider health > an exhausted provider yields to the healthy ref the agent already lists
```
The guards that keep passing under the mutant are the ones that matter for safety: H2 (unhealthy with no healthy alternate still dispatches — never strands), H4 (health-blind without the predicate), H5 (routability still gates), plus "all-active rows leave the requested ref untouched" and "with no org-provider reader at all, dispatch stays health-blind".

## Notes
Three docstrings asserted that nothing routes on `status` (`provider-secrets.ts`, `secret-proxy.ts`, `provider-health-status.ts`). That invariant is now narrower rather than gone, so they are corrected in place instead of left stating a retired rule.

`make review-fix` could not run: codex is at its usage cap until Sep 7 03:26 (`ERROR: You've hit your usage limit`). It made no edits — the diff stat was byte-identical before and after — so the hygiene pass was manual.

**Not in this PR**, deliberately, one branch = one concern:

- **A sole dead-but-keyed pin still times out instead of failing fast.** This change helps only when the agent lists a healthy alternate; when the exhausted provider is the *only* candidate it still dispatches (the deliberate never-strand branch above). Reproducible in prod on demand: an agent pinned solely to the 429'd provider returns `status: "timeout"` with no reason, and `inference_providers.updated_at` is re-stamped at the same second as the run — so the turn reaches the provider, takes its 429, and then hangs rather than surfacing `PROVIDER_QUOTA_EXHAUSTED`. Fixing that means terminating the turn with the provider's recorded reason; it belongs in the worker/dispatch error path, not here.
- **Correction to an earlier reading of this bug:** the 20-second cadence those runs emit is `HEARTBEAT_INTERVAL_MS = 20000` in `agent-worker/src/runtime/session-runner.ts` ("keep connection alive during long API calls"), *not* a retry loop. A provider `retry-after` of 20047 ms landing 47 ms from that hardcoded interval is a coincidence. There is no unbounded 429 retry to bound, so no such guard is included here.
- **The misleading `No model resolved for this run. Set the agent's default model…`** when nothing is *routable* (as opposed to unhealthy) is untouched — that is a routability failure with a different cause, and the server already logs the real reason at `deployment-manager.ts`. Surfacing it to the caller is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
