### PR TITLE
feat(gateway): warn at boot when an unrestricted allowlist makes every egress judge inert

### DIFF
--- a/packages/server/src/gateway/config/__tests__/judge-allowlist-preflight.test.ts
+++ b/packages/server/src/gateway/config/__tests__/judge-allowlist-preflight.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Boot preflight for the one allowlist state that silently disables EVERY
+ * egress judge.
+ *
+ * `checkDomainAccess` consults the global allowlist (step 3) BEFORE the judge
+ * (step 5), so `WORKER_ALLOWED_DOMAINS=*` returns `allowed: true, source:
+ * "global"` for every host and no judge ever runs. `logAccessDecision`
+ * deliberately drops `allowed && source === "global"` lines, so the suppression
+ * produces no per-request evidence either: the traffic simply flows and the
+ * operator's policy is dead config. One boot line is the only place this can
+ * surface.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { checkJudgeShadowingAllowlist } from "../network-allowlist.js";
+
+const WAD_PRESERVE = process.env.WORKER_ALLOWED_DOMAINS;
+const SENTRY_PRESERVE = process.env.SENTRY_DSN;
+
+beforeEach(() => {
+  delete process.env.WORKER_ALLOWED_DOMAINS;
+  delete process.env.SENTRY_DSN;
+});
+
+afterEach(() => {
+  if (WAD_PRESERVE === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+  else process.env.WORKER_ALLOWED_DOMAINS = WAD_PRESERVE;
+  if (SENTRY_PRESERVE === undefined) delete process.env.SENTRY_DSN;
+  else process.env.SENTRY_DSN = SENTRY_PRESERVE;
+});
+
+describe("checkJudgeShadowingAllowlist", () => {
+  test("unrestricted mode reports the shadowing", () => {
+    process.env.WORKER_ALLOWED_DOMAINS = "*";
+    const detail = checkJudgeShadowingAllowlist();
+    expect(detail).not.toBeNull();
+    // Must name the variable AND the consequence — a warning the operator
+    // cannot act on is worse than none.
+    expect(detail).toContain("WORKER_ALLOWED_DOMAINS");
+    expect(detail?.toLowerCase()).toContain("judge");
+  });
+
+  test("a restricted allowlist reports nothing", () => {
+    process.env.WORKER_ALLOWED_DOMAINS = "github.com,registry.npmjs.org";
+    expect(checkJudgeShadowingAllowlist()).toBeNull();
+  });
+
+  test("complete isolation (unset) reports nothing — it shadows no judge", () => {
+    expect(checkJudgeShadowingAllowlist()).toBeNull();
+  });
+
+  test("a single-entry allowlist is NOT unrestricted", () => {
+    // Guards the `length === 1 && [0] === "*"` shape in isUnrestrictedMode:
+    // a one-domain list must not be mistaken for `*`.
+    process.env.WORKER_ALLOWED_DOMAINS = "github.com";
+    expect(checkJudgeShadowingAllowlist()).toBeNull();
+  });
+
+  test("a list CONTAINING * alongside others is NOT unrestricted mode", () => {
+    // `isUnrestrictedMode` is exact-shape, so "*,github.com" is NOT unrestricted
+    // mode; `matchesDomainPattern` then treats the bare "*" as an exact host
+    // that nothing matches, so only github.com is admitted and judges still
+    // run. Pin the contract so a change to either side is visible here.
+    process.env.WORKER_ALLOWED_DOMAINS = "*,github.com";
+    expect(checkJudgeShadowingAllowlist()).toBeNull();
+  });
+
+  test("whitespace around * still counts as unrestricted", () => {
+    process.env.WORKER_ALLOWED_DOMAINS = "  *  ";
+    expect(checkJudgeShadowingAllowlist()).not.toBeNull();
+  });
+
+  test("SENTRY_DSN does not defeat the unrestricted check", () => {
+    // loadAllowedDomains appends the Sentry host in restricted mode but must
+    // leave `*` alone; if it ever appended, the array would stop being `["*"]`
+    // and this preflight would silently stop firing.
+    process.env.SENTRY_DSN = "https://abc@o1.ingest.sentry.io/2";
+    process.env.WORKER_ALLOWED_DOMAINS = "*";
+    expect(checkJudgeShadowingAllowlist()).not.toBeNull();
+  });
+});

--- a/packages/server/src/gateway/config/network-allowlist.ts
+++ b/packages/server/src/gateway/config/network-allowlist.ts
@@ -110,3 +110,40 @@ export function loadDisallowedDomains(): string[] {
   );
   return parsed;
 }
+
+/**
+ * Boot preflight: report when the global allowlist makes EVERY egress judge
+ * inert.
+ *
+ * `checkDomainAccess` (proxy/http-proxy.ts) consults the global allowlist at
+ * step 3 and the egress judge only at step 5, so under `WORKER_ALLOWED_DOMAINS=*`
+ * every host returns `allowed: true, source: "global"` and no judge is ever
+ * asked. That is the worst shape of misconfiguration available here: the
+ * request SUCCEEDS, so nothing looks broken, and `logAccessDecision`
+ * deliberately drops `allowed && source === "global"` lines, so there is not
+ * even a per-request trace to grep. A judge policy an operator wrote and
+ * believes is enforcing is silently dead.
+ *
+ * Reports the state itself, NOT "a judge is being shadowed": whether any agent
+ * declares an egress guardrail lives in per-org DB config that changes at
+ * runtime, long after boot, so a boot-time check cannot know. This is
+ * deliberate — one line at startup is cheap, and gating it on a judge existing
+ * would mean the warning never fires for the agent that adds a judge tomorrow.
+ *
+ * Non-fatal, and returned rather than thrown, mirroring
+ * `checkConfiguredJudgeModel`: unrestricted mode is a legitimate deployment
+ * choice (`lobu init --network open`; docs/DOCKER.md documents it), so this
+ * must never turn into a boot failure.
+ */
+export function checkJudgeShadowingAllowlist(): string | null {
+  // Unset = complete isolation, which shadows no judge. Return before
+  // `loadAllowedDomains`, which logs the isolation warning on every call and
+  // the proxy has already logged it once at boot.
+  if (!process.env.WORKER_ALLOWED_DOMAINS) return null;
+  if (!isUnrestrictedMode(loadAllowedDomains())) return null;
+
+  const detail =
+    'WORKER_ALLOWED_DOMAINS="*" (unrestricted): the global allowlist admits every host BEFORE the egress judge runs, so any egress judge guardrail on any agent is inert and its denials will never fire. Set an explicit allowlist to let judged domains reach their judge.';
+  logger.warn(detail);
+  return detail;
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -223,9 +223,16 @@ async function main(): Promise<void> {
 			// misconfigured optional control must not become a gateway outage.
 			async () => {
 				await checkConfiguredJudgeModel();
-				// The other way every judge dies silently: an unrestricted global
-				// allowlist answers before the judge is consulted, and that path
-				// is not audit-logged, so it leaves no per-request trace at all.
+			},
+			// The other way every judge dies silently: an unrestricted global
+			// allowlist answers before the judge is consulted, and that path is
+			// not audit-logged, so it leaves no per-request trace at all.
+			//
+			// Its OWN hook, deliberately: sharing the hook above would put this
+			// call after an `await`, so a rejection there would skip it — and a
+			// preflight that only runs when everything else already worked is
+			// not a preflight. Synchronous, so it cannot reject in turn.
+			() => {
 				checkJudgeShadowingAllowlist();
 			},
 		],

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,6 +22,7 @@ import "./utils/assert-node-version";
 // Sentry must init before any other imports for auto-instrumentation.
 import "./instrument";
 import { checkConfiguredJudgeModel } from "./gateway/inference/system-judge-target";
+import { checkJudgeShadowingAllowlist } from "./gateway/config/network-allowlist";
 
 import dotenv from "dotenv";
 
@@ -222,6 +223,10 @@ async function main(): Promise<void> {
 			// misconfigured optional control must not become a gateway outage.
 			async () => {
 				await checkConfiguredJudgeModel();
+				// The other way every judge dies silently: an unrestricted global
+				// allowlist answers before the judge is consulted, and that path
+				// is not audit-logged, so it leaves no per-request trace at all.
+				checkJudgeShadowingAllowlist();
 			},
 		],
 		extraTeardown,


### PR DESCRIPTION
## Summary

- `checkDomainAccess` consults the global allowlist (step 3) **before** the egress judge (step 5). Under `WORKER_ALLOWED_DOMAINS=*` every host returns `allowed: true, source: "global"` and no judge is ever asked — so every egress judge guardrail on every agent is inert.
- `logAccessDecision` deliberately drops `allowed && source === "global"` records, so this leaves **no per-request trace either**. The traffic flows, nothing looks broken, and the operator's policy is silently dead config. Boot is the only place it can surface.
- Completes the judge-shadowing series (#3299 write-time config, #3300 dispatch reconcile, #3304 GrantStore chokepoint). Those three close the *grant* shadowing paths; this is the remaining *global allowlist* path, which no tenant-facing check can fix because `WORKER_ALLOWED_DOMAINS` is operator config.

Non-fatal by the same reasoning as `checkConfiguredJudgeModel`, which it sits beside: an unrestricted allowlist is a legitimate deployment choice (`lobu init --network open`), so this reports rather than refuses to boot.

Reports the allowlist state rather than a concrete shadowed judge on purpose: whether any agent declares an egress guardrail lives in per-org DB config that changes long after boot, so gating on it would mean the warning never fires for the agent that adds a judge tomorrow.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build + typecheck + knip + naming + gateway-LLM/entity-write gates)
- [x] Tests run: targeted `bun test packages/server/src/gateway/config/__tests__/` — 13 pass, 0 fail across 2 files
- [x] Bug fix: red→green pasted below

### Red (before the implementation)

```
SyntaxError: Export named 'checkJudgeShadowingAllowlist' not found in module
  '.../packages/server/src/gateway/config/network-allowlist.ts'
 0 pass
 1 fail
```

### Green

```
 13 pass
 0 fail
 17 expect() calls
Ran 13 tests across 2 files.
```

### Mutation testing (3/3 killed)

| Mutation | Result |
| --- | --- |
| Invert the guard (`!isUnrestrictedMode` → `isUnrestrictedMode`) | **killed** — 7 fail |
| Always return `null` | **killed** — 3 fail |
| Replace the operator message with a vague string | **killed** — 1 fail |

## Notes

Verified against committed behaviour rather than assumed:

- `isHostnameAllowed` gates unrestricted mode on the same exact-shape `isUnrestrictedMode` the preflight uses, so the two cannot drift. (Its docblock says "contains `*`", which is looser than the code — the code is exact-shape. A test pins `"*,github.com"` → not unrestricted, matching runtime, where a bare `*` is an exact-match pattern that never matches a real hostname.)
- Early-returns on unset `WORKER_ALLOWED_DOMAINS` so the preflight does not re-emit `loadAllowedDomains`' isolation warning, matching the existing request-time check in `agent-routes.ts`.

Follow-up not in scope: SDK-declared agents keep settings in an `InMemoryAgentStore`, so #3304's DB-backed chokepoint read passes vacuously for them. The dispatch reconcile (#3300) still covers them because it reads judged domains from the dispatch payload, leaving only the deploy-time npm-registry grant exposed for that agent shape.