### PR TITLE
fix(server): surface an STT provider outage instead of dropping the job

### DIFF
--- a/packages/server/src/gateway/__tests__/transcription-service.test.ts
+++ b/packages/server/src/gateway/__tests__/transcription-service.test.ts
@@ -205,6 +205,9 @@ describe("TranscriptionService provider fallback", () => {
       expect(result).toEqual({
         text: "hello from whatsapp",
         provider: "openai",
+        // The slug that served it — this is what lets a successful
+        // transcription clear a health error the STT path itself set.
+        providerSlug: "openai",
       });
       expect(orgCredentialSource).toHaveBeenCalledWith(
         "agent-buremba",

--- a/packages/server/src/gateway/__tests__/transcription-service.test.ts
+++ b/packages/server/src/gateway/__tests__/transcription-service.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { ProviderConfigEntry } from "@lobu/core";
-import { TranscriptionService } from "../services/transcription-service.js";
+import {
+  ProviderHttpError,
+  TranscriptionService,
+} from "../services/transcription-service.js";
 
 const openAiProviderConfig = (): Record<string, ProviderConfigEntry> => ({
   openai: {
@@ -80,6 +83,65 @@ describe("TranscriptionService provider fallback", () => {
     if ("text" in result) {
       expect(result.text).toBe("hello from groq");
       expect(result.provider).toBe("openai");
+    }
+  });
+
+  test("carries the upstream HTTP status per attempt, not just in the message", async () => {
+    // The status must survive as a FIELD. `provider-health-status.ts` is
+    // status-only precisely because matching provider wording missed OpenAI's
+    // "no credits remaining" in prod — so a caller must never have to parse
+    // the sentence to learn this was a 429.
+    const authProfilesManager = {
+      getBestProfile: mock(async (_agentId: string, providerId: string) =>
+        providerId === "chatgpt" ? { credential: "openai-key" } : null
+      ),
+    } as any;
+    const service = new TranscriptionService(authProfilesManager);
+    (service as any).transcribeWithProvider = mock(async () => {
+      throw new ProviderHttpError(
+        429,
+        'OpenAI API error: 429 - {"code":"credit_balance_exhausted"}'
+      );
+    });
+
+    const result = await service.transcribe(
+      Buffer.from("audio"),
+      "agent-429",
+      "audio/ogg"
+    );
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts?.[0]?.status).toBe(429);
+      expect(result.attempts?.[0]?.providerSlug).toBe("chatgpt");
+    }
+  });
+
+  test("reports no status when the call never reached the provider", async () => {
+    // A DNS failure or timeout is not a health verdict about the account.
+    // Leaving `status` undefined is what keeps it from marking a provider
+    // unhealthy — distinct from a 429, which does.
+    const authProfilesManager = {
+      getBestProfile: mock(async (_agentId: string, providerId: string) =>
+        providerId === "chatgpt" ? { credential: "openai-key" } : null
+      ),
+    } as any;
+    const service = new TranscriptionService(authProfilesManager);
+    (service as any).transcribeWithProvider = mock(async () => {
+      throw new Error("fetch failed");
+    });
+
+    const result = await service.transcribe(
+      Buffer.from("audio"),
+      "agent-net",
+      "audio/ogg"
+    );
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts?.[0]?.status).toBeUndefined();
     }
   });
 

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -61,6 +61,13 @@ interface TranscriptionConfig {
 interface TranscriptionSuccess {
   text: string;
   provider: TranscriptionProvider;
+  /**
+   * `inference_providers.slug` of the row that served this transcription, so
+   * the caller can clear a health error THIS path set. Without it an
+   * STT-only slug marked `error` here could never be cleared: the only other
+   * writer is the LLM proxy, which such a slug never sees.
+   */
+  providerSlug: string;
 }
 
 /**
@@ -215,7 +222,11 @@ export class TranscriptionService {
           profileProviderId: config.profileProviderId,
           textLength: text.length,
         });
-        return { text, provider: config.provider };
+        return {
+          text,
+          provider: config.provider,
+          providerSlug: config.profileProviderId,
+        };
       } catch (error) {
         const errorMessage =
           getErrorMessage(error);

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -63,9 +63,41 @@ interface TranscriptionSuccess {
   provider: TranscriptionProvider;
 }
 
+/**
+ * An upstream provider call that failed with an HTTP status.
+ *
+ * The status is carried as a FIELD, never only in the message. Flattening it
+ * into prose is what made `provider-health-status.ts` status-only in the first
+ * place: OpenAI's "no credits remaining" and Alibaba's "quota has been
+ * exhausted" both went unclassified in prod when the code matched wording.
+ */
+export class ProviderHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "ProviderHttpError";
+  }
+}
+
+/** One provider's failed attempt, with the status a health verdict needs. */
+export interface TranscriptionAttemptFailure {
+  /** `inference_providers.slug` — the row a health writeback targets. */
+  providerSlug: string;
+  /** Upstream HTTP status, absent when the call never reached the provider. */
+  status?: number;
+  message: string;
+}
+
 interface TranscriptionError {
   error: string;
   availableProviders: TranscriptionProvider[];
+  /**
+   * Per-provider failures, so a caller that knows the organization can record
+   * provider health. Absent when no provider was configured at all.
+   */
+  attempts?: TranscriptionAttemptFailure[];
 }
 
 type TranscriptionResult = TranscriptionSuccess | TranscriptionError;
@@ -161,6 +193,7 @@ export class TranscriptionService {
     }
 
     const attemptErrors: string[] = [];
+    const attempts: TranscriptionAttemptFailure[] = [];
     for (const config of configs) {
       logger.info("Transcribing audio", {
         agentId,
@@ -186,19 +219,28 @@ export class TranscriptionService {
       } catch (error) {
         const errorMessage =
           getErrorMessage(error);
+        const status =
+          error instanceof ProviderHttpError ? error.status : undefined;
         logger.error("Transcription failed", {
           agentId,
           provider: config.provider,
           profileProviderId: config.profileProviderId,
+          status,
           error: errorMessage,
         });
         attemptErrors.push(`${config.displayName}: ${errorMessage}`);
+        attempts.push({
+          providerSlug: config.profileProviderId,
+          status,
+          message: errorMessage,
+        });
       }
     }
 
     return {
       error: `Transcription failed with all configured providers: ${attemptErrors.join(" | ")}`,
       availableProviders: [...new Set(configs.map((c) => c.provider))],
+      attempts,
     };
   }
 
@@ -529,7 +571,10 @@ export class TranscriptionService {
 
     if (!resp.ok) {
       const error = await resp.text();
-      throw new Error(`OpenAI API error: ${resp.status} - ${error}`);
+      throw new ProviderHttpError(
+        resp.status,
+        `OpenAI API error: ${resp.status} - ${error}`
+      );
     }
 
     const data = (await resp.json()) as { text: string };

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -6,12 +6,14 @@ import {
   ArtifactStore,
   runArtifactBinding,
 } from '../../gateway/files/artifact-store';
+import * as dbClient from '../../db/client';
 import * as lobuGateway from '../../lobu/gateway';
 import * as providerSecrets from '../../lobu/stores/provider-secrets';
 import {
   deleteMaterializedArtifacts,
   materializeActionOutputAttachments,
   transcribeOne,
+  triggerAudioTranscriptions,
 } from '../inline-attachments';
 
 describe('materializeActionOutputAttachments', () => {
@@ -285,5 +287,76 @@ describe('transcribeOne provider health', () => {
 
     expect(outcome).toBe('failed');
     expect(mark).not.toHaveBeenCalled();
+  });
+});
+
+describe('triggerAudioTranscriptions batch abandon', () => {
+  let artifactsDir: string;
+  let artifactStore: ArtifactStore;
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    artifactsDir = mkdtempSync(join(tmpdir(), 'lobu-stt-batch-'));
+    process.env.ENCRYPTION_KEY = Buffer.from(
+      '12345678901234567890123456789012'
+    ).toString('base64');
+    artifactStore = new ArtifactStore(artifactsDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    rmSync(artifactsDir, { recursive: true, force: true });
+  });
+
+  it('stops after a walled provider instead of burning a call per remaining job', async () => {
+    // The whole point of the outcome: 20 queued voice notes against an
+    // out-of-credit account made 20 doomed upstream calls. One is enough.
+    vi.spyOn(providerSecrets, 'markInferenceProviderUnhealthy').mockResolvedValue(
+      undefined
+    );
+    // `pickTranscriptionAgent` reads the org's agents; this suite has no DB.
+    const sql = (async () => [{ id: 'agent-1' }]) as unknown as ReturnType<
+      typeof dbClient.getDb
+    >;
+    vi.spyOn(dbClient, 'getDb').mockReturnValue(sql);
+    const transcribe = vi.fn(async () => ({
+      error: 'Transcription failed with all configured providers: OpenAI: 429',
+      availableProviders: ['openai'],
+      attempts: [{ providerSlug: 'openai', status: 429, message: 'no credits' }],
+    }));
+    vi.spyOn(lobuGateway, 'getLobuCoreServices').mockReturnValue({
+      getArtifactStore: () => artifactStore,
+      getTranscriptionService: () => ({
+        transcribe,
+        getConfig: async () => ({ profileProviderId: 'openai' }),
+      }),
+    });
+
+    const jobs = [];
+    for (const originId of ['WA-1', 'WA-2', 'WA-3']) {
+      const published = await artifactStore.publish({
+        buffer: Buffer.from('ogg'),
+        filename: 'v.ogg',
+        contentType: 'audio/ogg',
+        publicGatewayUrl: 'https://gw.example',
+      });
+      jobs.push({
+        artifactId: published.artifactId,
+        originId,
+        mimeType: 'audio/ogg',
+        baseEventId: 1,
+        connectionId: 361,
+        title: null,
+      });
+    }
+
+    triggerAudioTranscriptions('org-1', jobs);
+    // Fire-and-forget: let the detached orchestrator settle.
+    await vi.waitFor(() => expect(transcribe).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(transcribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/utils/__tests__/inline-attachments.test.ts
+++ b/packages/server/src/utils/__tests__/inline-attachments.test.ts
@@ -7,9 +7,11 @@ import {
   runArtifactBinding,
 } from '../../gateway/files/artifact-store';
 import * as lobuGateway from '../../lobu/gateway';
+import * as providerSecrets from '../../lobu/stores/provider-secrets';
 import {
   deleteMaterializedArtifacts,
   materializeActionOutputAttachments,
+  transcribeOne,
 } from '../inline-attachments';
 
 describe('materializeActionOutputAttachments', () => {
@@ -163,5 +165,125 @@ describe('materializeActionOutputAttachments', () => {
 
     await deleteMaterializedArtifacts(publishedArtifactIds);
     expect(await artifactStore.read(publishedArtifactIds[0])).toBeNull();
+  });
+});
+
+describe('transcribeOne provider health', () => {
+  let artifactsDir: string;
+  let artifactStore: ArtifactStore;
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+  const publishAudio = async () => {
+    const published = await artifactStore.publish({
+      buffer: Buffer.from('ogg-bytes'),
+      filename: 'voice.ogg',
+      contentType: 'audio/ogg',
+      publicGatewayUrl: 'https://gw.example',
+    });
+    return published.artifactId;
+  };
+
+  const job = (artifactId: string) => ({
+    artifactId,
+    originId: 'WA-ORIGIN-1',
+    mimeType: 'audio/ogg',
+    baseEventId: 1,
+    connectionId: 361,
+    title: null,
+  });
+
+  const withTranscribeResult = (result: unknown) => {
+    vi.spyOn(lobuGateway, 'getLobuCoreServices').mockReturnValue({
+      getArtifactStore: () => artifactStore,
+      getTranscriptionService: () => ({ transcribe: async () => result }),
+    });
+  };
+
+  beforeEach(() => {
+    artifactsDir = mkdtempSync(join(tmpdir(), 'lobu-stt-health-'));
+    process.env.ENCRYPTION_KEY = Buffer.from(
+      '12345678901234567890123456789012'
+    ).toString('base64');
+    artifactStore = new ArtifactStore(artifactsDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    rmSync(artifactsDir, { recursive: true, force: true });
+  });
+
+  it('marks the provider unhealthy and reports the account walled on a 429', async () => {
+    // The prod outage this fixes: OpenAI returned 429
+    // credit_balance_exhausted for weeks while the settings row still read
+    // `active`, because this path reaches the provider directly instead of
+    // through the LLM proxy that records health.
+    const mark = vi
+      .spyOn(providerSecrets, 'markInferenceProviderUnhealthy')
+      .mockResolvedValue(undefined);
+    withTranscribeResult({
+      error: 'Transcription failed with all configured providers: OpenAI: 429',
+      availableProviders: ['openai'],
+      attempts: [{ providerSlug: 'openai', status: 429, message: 'no credits' }],
+    });
+
+    const outcome = await transcribeOne(
+      job(await publishAudio()),
+      'org-1',
+      'agent-1'
+    );
+
+    expect(outcome).toBe('provider-unavailable');
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(mark.mock.calls[0]?.[0]).toBe('org-1');
+    expect(mark.mock.calls[0]?.[1]).toBe('openai');
+    expect(String(mark.mock.calls[0]?.[2])).toContain('429');
+  });
+
+  it('leaves the provider healthy when the file itself is the problem', async () => {
+    // A 400 is the caller's fault — an unsupported codec, say. Marking the
+    // provider unhealthy here would label a working key broken in the UI,
+    // which is why `classifyProviderHealthStatus` is deliberately narrow.
+    const mark = vi
+      .spyOn(providerSecrets, 'markInferenceProviderUnhealthy')
+      .mockResolvedValue(undefined);
+    withTranscribeResult({
+      error: 'Transcription failed with all configured providers: OpenAI: 400',
+      availableProviders: ['openai'],
+      attempts: [
+        { providerSlug: 'openai', status: 400, message: 'unsupported format' },
+      ],
+    });
+
+    const outcome = await transcribeOne(
+      job(await publishAudio()),
+      'org-1',
+      'agent-1'
+    );
+
+    expect(outcome).toBe('failed');
+    expect(mark).not.toHaveBeenCalled();
+  });
+
+  it('does not mark a provider unhealthy when the call never reached it', async () => {
+    // A timeout carries no verdict about the account.
+    const mark = vi
+      .spyOn(providerSecrets, 'markInferenceProviderUnhealthy')
+      .mockResolvedValue(undefined);
+    withTranscribeResult({
+      error: 'Transcription failed with all configured providers: OpenAI: net',
+      availableProviders: ['openai'],
+      attempts: [{ providerSlug: 'openai', message: 'fetch failed' }],
+    });
+
+    const outcome = await transcribeOne(
+      job(await publishAudio()),
+      'org-1',
+      'agent-1'
+    );
+
+    expect(outcome).toBe('failed');
+    expect(mark).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -39,7 +39,10 @@ import { getEnvFromProcess } from "./env";
 import logger from "./logger";
 import { classifyProviderHealthStatus } from "../gateway/proxy/provider-health-status";
 import type { TranscriptionAttemptFailure } from "../gateway/services/transcription-service";
-import { markInferenceProviderUnhealthy } from "../lobu/stores/provider-secrets";
+import {
+  clearInferenceProviderError,
+  markInferenceProviderUnhealthy,
+} from "../lobu/stores/provider-secrets";
 
 /**
  * Hard cap on a single decoded attachment we'll publish. Server-side guard so
@@ -528,6 +531,24 @@ export async function transcribeOne(
     );
     wrote = true;
   });
+  if (wrote) {
+    // A transcription that succeeded is proof the credential works, so clear
+    // an error THIS path may have set. The LLM proxy is the only other
+    // writer, and an STT-only slug never reaches it — without this, the row
+    // would stay `error` forever once credits were restored.
+    //
+    // Best-effort for the same reason the proxy's is: `status` is a display
+    // signal, and failing to clear a label must not fail a transcript that is
+    // already written.
+    try {
+      await clearInferenceProviderError(organizationId, result.providerSlug);
+    } catch (err) {
+      logger.warn(
+        { provider_slug: result.providerSlug, err: String(err) },
+        "[inline-attachments] failed to clear STT provider health"
+      );
+    }
+  }
   return wrote ? "transcribed" : "failed";
 }
 

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -37,6 +37,9 @@ import {
 } from "./embeddings";
 import { getEnvFromProcess } from "./env";
 import logger from "./logger";
+import { classifyProviderHealthStatus } from "../gateway/proxy/provider-health-status";
+import type { TranscriptionAttemptFailure } from "../gateway/services/transcription-service";
+import { markInferenceProviderUnhealthy } from "../lobu/stores/provider-secrets";
 
 /**
  * Hard cap on a single decoded attachment we'll publish. Server-side guard so
@@ -312,9 +315,23 @@ export function triggerAudioTranscriptions(
         return;
       }
 
-      for (const job of pending) {
+      for (const [index, job] of pending.entries()) {
         try {
-          await transcribeOne(job, organizationId, agentId);
+          const outcome = await transcribeOne(job, organizationId, agentId);
+          if (outcome === "provider-unavailable") {
+            // The account is walled, not this file. Transcribing the rest
+            // would produce the same failure per job while burning an
+            // upstream call each; they keep their placeholders instead.
+            logger.warn(
+              {
+                organizationId,
+                abandoned: pending.length - index - 1,
+                pending: pending.length,
+              },
+              "[inline-attachments] STT provider unavailable — abandoning the rest of this batch"
+            );
+            return;
+          }
         } catch (err) {
           logger.warn(
             { origin_id: job.originId, err: String(err) },
@@ -350,15 +367,27 @@ async function pickTranscriptionAgent(
   return null;
 }
 
+/**
+ * Outcome of a single transcription job.
+ *
+ * `provider-unavailable` means the ACCOUNT is walled (quota/credit or auth),
+ * not that this one file failed — every remaining job in the batch would fail
+ * identically, so the caller stops instead of burning the rest against it.
+ */
+export type TranscriptionOutcome =
+  | "transcribed"
+  | "failed"
+  | "provider-unavailable";
+
 export async function transcribeOne(
   job: AudioTranscriptionJob,
   organizationId: string,
   agentId: string
-): Promise<void> {
+): Promise<TranscriptionOutcome> {
   const coreServices = getLobuCoreServices();
   const artifactStore = coreServices!.getArtifactStore();
   const transcriptionService = coreServices!.getTranscriptionService();
-  if (!artifactStore || !transcriptionService) return;
+  if (!artifactStore || !transcriptionService) return "failed";
 
   const stored = await artifactStore.read(job.artifactId, {
     maxBytes: MAX_INLINE_ATTACHMENT_BYTES,
@@ -368,7 +397,7 @@ export async function transcribeOne(
       { artifact_id: job.artifactId },
       "[inline-attachments] artifact missing — cannot transcribe"
     );
-    return;
+    return "failed";
   }
   const result = await transcriptionService.transcribe(
     stored.bytes,
@@ -376,15 +405,29 @@ export async function transcribeOne(
     job.mimeType
   );
   if ("error" in result) {
-    logger.info(
-      { origin_id: job.originId, error: result.error },
-      "[inline-attachments] transcription returned error — keeping placeholder"
+    // Record provider health from the STATUS, never the wording. This path
+    // reaches the provider directly rather than through the LLM proxy, so
+    // without this the settings UI shows a credit-exhausted key as `active`
+    // — which is exactly how a silent multi-week STT outage stayed invisible.
+    const walled = await recordTranscriptionProviderHealth(
+      organizationId,
+      result.attempts
     );
-    return;
+    logger[walled ? "warn" : "info"](
+      {
+        origin_id: job.originId,
+        error: result.error,
+        provider_unavailable: walled,
+      },
+      walled
+        ? "[inline-attachments] transcription provider unavailable — keeping placeholder and stopping this batch"
+        : "[inline-attachments] transcription returned error — keeping placeholder"
+    );
+    return walled ? "provider-unavailable" : "failed";
   }
 
   const transcript = result.text.trim();
-  if (!transcript) return;
+  if (!transcript) return "failed";
 
   let embedding: number[] | undefined;
   let embeddingModel: string | undefined;
@@ -405,6 +448,7 @@ export async function transcribeOne(
   }
 
   const sql = getDb();
+  let wrote = false;
   await sql.begin(async (tx) => {
     // Use the same per-source lock as normal connector resync. The exact event
     // id ties this transcript to the bytes that produced it: if a newer resync
@@ -440,7 +484,12 @@ export async function transcribeOne(
       score: number | null;
     }>;
     const base = baseRows[0];
-    if (!base) return;
+    if (!base) {
+      // Superseded (or resynced) between transcribe and write — the head this
+      // transcript was derived from no longer exists, so there is nothing to
+      // enrich. Not "transcribed": nothing was written.
+      return;
+    }
 
     const meta = { ...(base.metadata ?? {}), transcript_provider: result.provider };
 
@@ -477,5 +526,44 @@ export async function transcribeOne(
         trustedIdentityScopeProjections: true,
       }
     );
+    wrote = true;
   });
+  return wrote ? "transcribed" : "failed";
+}
+
+/**
+ * Write provider health for the failed attempts of one transcription.
+ *
+ * Returns true when the ACCOUNT is walled (quota/credit or auth) rather than
+ * this one file being unsupported — the caller uses that to stop the batch.
+ *
+ * Best-effort, mirroring `secret-proxy`'s `recordProviderHealth`: nothing
+ * routes on `status` today, so failing to write a display label must never
+ * turn into a thrown error on a path that already kept its placeholder.
+ */
+async function recordTranscriptionProviderHealth(
+  organizationId: string,
+  attempts: TranscriptionAttemptFailure[] | undefined
+): Promise<boolean> {
+  if (!attempts?.length) return false;
+  let walled = false;
+  for (const attempt of attempts) {
+    if (attempt.status === undefined) continue;
+    const code = classifyProviderHealthStatus(attempt.status);
+    if (!code) continue;
+    walled = true;
+    try {
+      await markInferenceProviderUnhealthy(
+        organizationId,
+        attempt.providerSlug,
+        `HTTP ${attempt.status} — ${code} (speech-to-text)`
+      );
+    } catch (err) {
+      logger.warn(
+        { provider_slug: attempt.providerSlug, err: String(err) },
+        "[inline-attachments] failed to record STT provider health"
+      );
+    }
+  }
+  return walled;
 }


### PR DESCRIPTION
## Summary
- Speech-to-text reaches the provider **directly**, not through the LLM proxy that records provider health — so a credit-exhausted key kept `inference_providers.status = 'active'` in settings while every voice note silently kept its `[voice note]` placeholder. In prod this hid an STT outage from **2026-08-12** onward: 4 `credit_balance_exhausted` 429s in a 24h window, logged at `INFO`, job dropped.
- `transcribeWithOpenAI` flattened the upstream status into a message string. The status is now carried as a **field** (`ProviderHttpError`) and returned per provider in `attempts`, so the caller classifies with the existing `classifyProviderHealthStatus` and writes health through the existing `markInferenceProviderUnhealthy`.
- A walled account is not a per-file failure: `transcribeOne` returns an outcome and the batch **stops**, instead of burning one upstream call per remaining voice note against the same wall.

Status, never wording — `provider-health-status.ts` is deliberately status-only because a wording list already missed OpenAI's "no credits remaining" in prod. No new table, API, or SDK surface.

## Test plan
- [x] Intended files staged explicitly (4 files); `make pre-pr` clean
- [x] Tests run: `bun test .../transcription-service.test.ts` → 9/9; `bun run test -- run src/utils/__tests__/inline-attachments.test.ts` → 7/7
- [x] Bug fix: red→fix→green pasted below

**RED** — disabled the status capture in `transcribe()`'s catch:
```
error: expect(received).toBe(expected)
Expected: 429
Received: undefined
(fail) carries the upstream HTTP status per attempt, not just in the message
 8 pass, 1 fail
```

**GREEN** — restored:
```
 9 pass, 0 fail, 30 expect() calls
 Test Files  1 passed (1)     Tests  7 passed (7)
```

**Mutation test** — forced `walled = false` in `recordTranscriptionProviderHealth`; killed exactly the intended test and nothing else:
```
× marks the provider unhealthy and reports the account walled on a 429
  → expected 'failed' to be 'provider-unavailable'
✓ leaves the provider healthy when the file itself is the problem
✓ does not mark a provider unhealthy when the call never reached it
```

## Notes
Behaviour covered: a **429/402** marks the provider unhealthy and stops the batch; a **400** (bad codec) leaves it healthy, since labelling a working key broken in the settings UI is the failure mode `classifyProviderHealthStatus` is narrow to avoid; a **transport error with no status** also leaves it healthy.

Also fixed while reviewing the diff: if the base event was superseded between transcribing and writing, the transaction wrote nothing but the function still reported `transcribed`. Now gated on whether the insert ran.

Not in scope — durable retry. Re-driving a dropped job needs persistence, which is new surface and wants its own design pass. This PR stops the silent drop and makes the outage visible; it does not replay the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGVjnekVZtbMaDwdyhR87N
