### PR TITLE
fix(gateway): stop a provider-failed turn from renewing its own liveness deadline

### DIFF
--- a/packages/server/src/gateway/__tests__/secret-proxy-provider-health.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-provider-health.test.ts
@@ -21,8 +21,11 @@ import {
   spyOn,
   test,
 } from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import * as providerSecrets from "../../lobu/stores/provider-secrets.js";
+import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import { armTurnTimeout } from "../orchestration/turn-liveness.js";
 import type { SecretStore } from "../secrets/index.js";
 import {
   ensureDbForGatewayTests,
@@ -136,6 +139,115 @@ beforeEach(async () => {
 });
 
 describe("secret proxy — inference-provider health writeback", () => {
+  // --- Turn-liveness wiring -------------------------------------------------
+  // A terminal provider answer must ALSO stop the wedged turn from renewing its
+  // own liveness deadline. This half is easy to ship INERT: it only runs when
+  // the SIGNED worker token carries a `deploymentName`, and the other tests in
+  // this file authenticate with an unsigned placeholder bearer, so they would
+  // pass whether or not the wiring exists. These drive a real signed token.
+
+  const TURN_TIMEOUT_QUEUE = "internal:turn_timeout";
+
+  function signedWorkerToken(deploymentName: string, organizationId: string) {
+    return generateWorkerToken("user-1", `conv-${deploymentName}`, deploymentName, {
+      channelId: "chan",
+      agentId: "agent-1",
+      organizationId,
+      platform: "api",
+      responseThreadId: "api:chan:thread-1",
+      runId: 1,
+      messageId: "m-1",
+    });
+  }
+
+  async function armMarker(deploymentName: string): Promise<void> {
+    // `runs` has an FK to `organization`; the marker row needs a real org.
+    await getDb()`
+      INSERT INTO public.organization (id, name, slug)
+      VALUES ('org-1', 'org-1', 'org-1')
+      ON CONFLICT (id) DO NOTHING
+    `;
+    const queue = new RunsQueue();
+    await queue.start();
+    try {
+      await armTurnTimeout(queue, {
+        deploymentName,
+        messageId: "m-1",
+        platform: "api",
+        channelId: "chan",
+        conversationId: `conv-${deploymentName}`,
+        userId: "user-1",
+        organizationId: "org-1",
+      });
+    } finally {
+      await queue.stop();
+    }
+  }
+
+  async function providerFailedFlag(deploymentName: string): Promise<string | null> {
+    const rows = (await getDb()`
+      SELECT action_input->>'providerFailed' AS flag
+      FROM public.runs
+      WHERE queue_name = ${TURN_TIMEOUT_QUEUE}
+        AND action_input->>'deploymentName' = ${deploymentName}
+    `) as Array<{ flag: string | null }>;
+    return rows[0]?.flag ?? null;
+  }
+
+  /** Same as driveProxiedTurn, but authenticating with a real signed token. */
+  async function driveSignedTurn(
+    proxy: InstanceType<typeof SecretProxy>,
+    deploymentName: string
+  ) {
+    return proxy
+      .getApp()
+      .request("/api/proxy/zai/a/agent-1/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${signedWorkerToken(deploymentName, "org-1")}`,
+        },
+        body: JSON.stringify({ model: "zai/glm-5.2", prompt: "hi" }),
+      });
+  }
+
+  test("TL1: a 429 flags the deployment's turn marker so its heartbeat stops extending", async () => {
+    await seedProvider("org-1", "zai");
+    await armMarker("dep-tl1");
+    expect(await providerFailedFlag("dep-tl1")).toBeNull();
+
+    const proxy = makeProxy("org-1");
+    const restore = mockUpstream(429, { "retry-after": "60" });
+    try {
+      expect((await driveSignedTurn(proxy, "dep-tl1")).status).toBe(429);
+    } finally {
+      restore();
+    }
+    expect(await providerFailedFlag("dep-tl1")).toBe("true");
+  });
+
+  test("TL2: a subsequent 2xx clears the flag so an SDK retry that recovers is not swept", async () => {
+    await seedProvider("org-1", "zai");
+    await armMarker("dep-tl2");
+
+    const proxy = makeProxy("org-1");
+    let restore = mockUpstream(429, { "retry-after": "1" });
+    try {
+      await driveSignedTurn(proxy, "dep-tl2");
+    } finally {
+      restore();
+    }
+    expect(await providerFailedFlag("dep-tl2")).toBe("true");
+
+    restore = mockUpstream(200);
+    try {
+      expect((await driveSignedTurn(proxy, "dep-tl2")).status).toBe(200);
+    } finally {
+      restore();
+    }
+    expect(await providerFailedFlag("dep-tl2")).toBeNull();
+  });
+
   test("an upstream quota rejection (429) marks the provider row error", async () => {
     await seedProvider("org-1", "zai");
     const proxy = makeProxy("org-1");

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -23,11 +23,13 @@ import { getDb } from "../../db/client.js";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
   armTurnTimeout,
+  clearTurnProviderFailed,
   commitTerminalReply,
   extendTurnDeadlines,
   failTurnIfPending,
   failTurnsForDeployment,
   hasLiveTurnForMessage,
+  markTurnProviderFailed,
   sweepExpiredTurns,
   type TurnRouting,
 } from "../orchestration/turn-liveness.js";
@@ -393,6 +395,93 @@ describe("turn-liveness", () => {
     expect(await sweepExpiredTurns()).toBe(0);
     expect(await markerCount("dep-7")).toBe(1);
     expect(await errorRowCount()).toBe(0);
+  });
+
+  test("PF1: after a terminal provider answer the heartbeat NO LONGER extends, so the sweep fires", async () => {
+    // The prod hang, in one test. A turn wedged after a 429 keeps emitting its
+    // 20s status_update (an unconditional setInterval — alive, not progressing),
+    // and that heartbeat used to renew the deadline forever, so the backstop for
+    // "alive, never replies" could never fire. Reproduced live: 240s and 12
+    // heartbeats after a single 429, still no terminal event.
+    await armTurnTimeout(queue, routing("dep-pf1", "m"));
+    await markTurnProviderFailed(
+      "dep-pf1",
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      "qwen: HTTP 429 — PROVIDER_QUOTA_EXHAUSTED"
+    );
+    await expireAllMarkers();
+
+    await extendTurnDeadlines("dep-pf1"); // the wedged worker's heartbeat
+
+    // Contrast with "a live worker's heartbeat extends the deadline" above,
+    // which is byte-identical except for the mark — there the sweep returns 0.
+    expect(await sweepExpiredTurns()).toBe(1);
+    expect(await markerCount("dep-pf1")).toBe(0);
+    expect(await errorRowCount()).toBe(1);
+    // And the client is told the PROVIDER failed — not the generic
+    // WORKER_UNRESPONSIVE, which would point the operator at the wrong system.
+    expect(await latestErrorCode()).toBe("PROVIDER_QUOTA_EXHAUSTED");
+  });
+
+  test("PF2: a provider recovery clears the flag and extension resumes", async () => {
+    // Why the fix withdraws the EXTENSION instead of killing the turn: the SDK
+    // retries (maxRetries 2, honouring Retry-After), so a 429 followed by a
+    // successful retry must leave the turn alive.
+    await armTurnTimeout(queue, routing("dep-pf2", "m"));
+    await markTurnProviderFailed(
+      "dep-pf2",
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      "qwen: HTTP 429 — PROVIDER_QUOTA_EXHAUSTED"
+    );
+    await clearTurnProviderFailed("dep-pf2"); // next proxied 2xx
+    await expireAllMarkers();
+
+    await extendTurnDeadlines("dep-pf2");
+
+    expect(await sweepExpiredTurns()).toBe(0);
+    expect(await markerCount("dep-pf2")).toBe(1);
+    expect(await errorRowCount()).toBe(0);
+  });
+
+  test("PF3: the flag is scoped to its own deployment", async () => {
+    await armTurnTimeout(queue, routing("dep-pf3a", "m"));
+    await armTurnTimeout(queue, routing("dep-pf3b", "m"));
+    await markTurnProviderFailed(
+      "dep-pf3a",
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      "qwen: HTTP 429 — PROVIDER_QUOTA_EXHAUSTED"
+    );
+    await expireAllMarkers();
+
+    await extendTurnDeadlines("dep-pf3a");
+    await extendTurnDeadlines("dep-pf3b");
+
+    // Only the flagged deployment lapses; the healthy neighbour keeps running.
+    expect(await sweepExpiredTurns()).toBe(1);
+    expect(await markerCount("dep-pf3a")).toBe(0);
+    expect(await markerCount("dep-pf3b")).toBe(1);
+  });
+
+  test("PF4: the reason is recorded on the marker for diagnosis", async () => {
+    await armTurnTimeout(queue, routing("dep-pf4", "m"));
+    await markTurnProviderFailed(
+      "dep-pf4",
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      "qwen: HTTP 429 — PROVIDER_QUOTA_EXHAUSTED"
+    );
+
+    const rows = (await getDb()`
+      SELECT action_input->>'providerFailedReason' AS reason,
+             action_input->>'providerFailedCode' AS code,
+             action_input->>'providerFailed' AS flag
+      FROM public.runs
+      WHERE queue_name = ${TURN_TIMEOUT_QUEUE}
+        AND action_input->>'deploymentName' = 'dep-pf4'
+    `) as Array<{ reason: string | null; code: string | null; flag: string | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.flag).toBe("true");
+    expect(rows[0]?.code).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(rows[0]?.reason).toBe("qwen: HTTP 429 — PROVIDER_QUOTA_EXHAUSTED");
   });
 
   test("marker key is globally unique: same messageId in two deployments is isolated", async () => {

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -31,6 +31,14 @@
  *    delivery receipts — so a live-but-slow worker is never falsely failed,
  *    while a silent one lapses.
  *
+ *    That status_update proves the process is ALIVE, not that the turn is
+ *    PROGRESSING (it is an unconditional `setInterval` in `session-runner.ts`),
+ *    so on its own it did NOT cover the hung-but-heartbeating worker this
+ *    backstop names: a turn wedged after a terminal provider error renewed its
+ *    own deadline every 20s and hung the client indefinitely. The gap is closed
+ *    by {@link markTurnProviderFailed}, which withdraws the extension once the
+ *    proxy has seen the provider answer that turn terminally.
+ *
  * ## Multi-replica
  * Arming/extending/discharging all happen on the worker's owning pod (worker
  * child, dispatch, and `handleWorkerResponse` are co-located there). The marker
@@ -95,6 +103,27 @@ function asTurnRouting(value: unknown): TurnRouting | null {
   return v as unknown as TurnRouting;
 }
 
+/** The marker's `action_input` as the sweep reads it back. */
+type TurnMarkerInput = unknown;
+
+/**
+ * The provider-failure code recorded on a marker by {@link markTurnProviderFailed},
+ * or null when this turn was not ended by a provider answer.
+ *
+ * Validated against the `AgentErrorCode` enum rather than cast: the value is a
+ * jsonb field on a `runs` row, so it is DATA, and a bad one must degrade to the
+ * caller's default rather than reach `AGENT_ERRORS[code]` and render a broken
+ * (or attacker-chosen) CTA.
+ */
+function providerFailureCode(value: TurnMarkerInput): AgentErrorCode | null {
+  if (typeof value !== "object" || value === null) return null;
+  const raw = (value as Record<string, unknown>).providerFailedCode;
+  if (typeof raw !== "string") return null;
+  return (Object.values(AgentErrorCode) as string[]).includes(raw)
+    ? (raw as AgentErrorCode)
+    : null;
+}
+
 /**
  * Build the marker's globally-unique key. `messageId` alone is NOT global —
  * platform message IDs (e.g. Telegram) are per-chat and API callers can supply
@@ -154,6 +183,13 @@ export async function extendTurnDeadlines(
         AND run_type = 'internal'
         AND queue_name = ${TURN_TIMEOUT_QUEUE}
         AND action_input->>'deploymentName' = ${deploymentName}
+        -- A turn whose provider call terminally failed no longer earns an
+        -- extension. Its worker is still heartbeating (the 20s status_update is
+        -- an unconditional setInterval, not a progress signal), so without this
+        -- predicate the wedged turn renews its own deadline forever and the
+        -- sweep -- the very backstop for "alive, never replies" -- can never
+        -- fire. See markTurnProviderFailed.
+        AND NOT COALESCE((action_input->>'providerFailed')::boolean, false)
     `;
   } catch (err) {
     // Non-throwing by design (a heartbeat ACK must never fail the worker),
@@ -169,6 +205,107 @@ export async function extendTurnDeadlines(
         err: getErrorMessage(err),
       },
       "Failed to extend turn-timeout deadline — in-flight turns for this deployment may be falsely failed by the sweep if extends keep failing"
+    );
+  }
+}
+
+/**
+ * Stop a deployment's in-flight turns from renewing their own deadlines, after
+ * the gateway proxy has seen the provider answer that turn terminally
+ * (quota/auth — see `classifyProviderHealthStatus`).
+ *
+ * **Why this exists.** `pi-ai` collapses a provider failure before the worker
+ * runtime sees a status, and in the wedged case the turn never terminalizes at
+ * all: exactly one upstream request, a 429, and then the session sits emitting
+ * its 20s `status_update` forever. That status_update is an unconditional
+ * `setInterval` in `session-runner.ts` — it means "the process is alive", NOT
+ * "the turn is progressing" — but `extendTurnDeadlines` treated it as liveness,
+ * so the turn pushed its own 60s deadline out indefinitely and the client hung
+ * with no terminal event. Reproduced in prod: 240s and 12 heartbeats after a
+ * single 429, still no answer.
+ *
+ * **Why a flag and not a kill.** The proxy cannot know whether the SDK will
+ * recover: the OpenAI client retries (default `maxRetries: 2`, honouring
+ * `Retry-After`) and a later attempt on the same turn may well succeed. Failing
+ * the turn here would kill turns that were about to work. Instead we only
+ * withdraw the *extension* — the turn keeps whatever deadline it already had
+ * (at most `turnDefaultDeadlineMs` from the last extension), which normally
+ * outlasts the SDK's short `Retry-After` backoff. If a retry succeeds the
+ * worker resumes real progress and {@link clearTurnProviderFailed} re-arms
+ * extension; if none does, the marker lapses and `sweepExpiredTurns` emits a
+ * terminal error carrying `code` — so the client is told the PROVIDER failed
+ * (e.g. `PROVIDER_QUOTA_EXHAUSTED`, which resolves to a real CTA) rather than
+ * the generic `WORKER_UNRESPONSIVE` it would get for a merely silent worker.
+ * `reason` rides along on the marker (`providerFailedReason`) for diagnosis.
+ *
+ * Best-effort and non-throwing, like `extendTurnDeadlines`: this must never fail
+ * a user's inference call. Losing the write costs only the prompt failure — the
+ * turn reverts to the pre-existing hang, never to a wrongly-killed turn.
+ */
+export async function markTurnProviderFailed(
+  deploymentName: string,
+  code: AgentErrorCode,
+  reason: string
+): Promise<void> {
+  try {
+    const sql = getDb();
+    await sql`
+      UPDATE public.runs
+      SET action_input = action_input
+        || jsonb_build_object(
+             'providerFailed', true,
+             'providerFailedCode', ${code}::text,
+             'providerFailedReason', ${reason}::text
+           )
+      WHERE status = 'pending'
+        AND run_type = 'internal'
+        AND queue_name = ${TURN_TIMEOUT_QUEUE}
+        AND action_input->>'deploymentName' = ${deploymentName}
+        AND NOT COALESCE((action_input->>'providerFailed')::boolean, false)
+    `;
+  } catch (err) {
+    logger.error(
+      {
+        deploymentName,
+        reason,
+        queue: TURN_TIMEOUT_QUEUE,
+        err: getErrorMessage(err),
+      },
+      "Failed to mark turn provider-failed — a wedged turn on this deployment may keep extending its own deadline and hang the client"
+    );
+  }
+}
+
+/**
+ * Re-arm deadline extension for a deployment's in-flight turns, called when a
+ * proxied request to the same provider succeeds again. This is what makes
+ * {@link markTurnProviderFailed} safe against the SDK's own retries: a 429
+ * followed by a successful retry clears the flag, so a turn that recovers
+ * before its deadline lapses is not failed for an error it got past.
+ */
+export async function clearTurnProviderFailed(
+  deploymentName: string
+): Promise<void> {
+  try {
+    const sql = getDb();
+    await sql`
+      UPDATE public.runs
+      SET action_input = ((action_input - 'providerFailed')
+        - 'providerFailedCode') - 'providerFailedReason'
+      WHERE status = 'pending'
+        AND run_type = 'internal'
+        AND queue_name = ${TURN_TIMEOUT_QUEUE}
+        AND action_input->>'deploymentName' = ${deploymentName}
+        AND COALESCE((action_input->>'providerFailed')::boolean, false)
+    `;
+  } catch (err) {
+    logger.error(
+      {
+        deploymentName,
+        queue: TURN_TIMEOUT_QUEUE,
+        err: getErrorMessage(err),
+      },
+      "Failed to clear turn provider-failed flag — a recovered turn may be failed by the sweep despite the provider working again"
     );
   }
 }
@@ -350,7 +487,17 @@ export async function failTurnsForDeployment(
           logger.error("Dropping unroutable turn-timeout marker (fast path)");
           continue;
         }
-        await enqueueTerminalError(tx, routing, code);
+        // A marker flagged by the proxy knows WHICH provider failure ended
+        // this turn, so relay that instead of the generic worker verdict —
+        // "quota exhausted on qwen" is actionable, "worker unresponsive" sends
+        // the operator looking at the wrong subsystem. Falls back to `code`
+        // for a genuinely silent/dead worker, and for any unrecognised value
+        // (the column is data, never a code path).
+        await enqueueTerminalError(
+          tx,
+          routing,
+          providerFailureCode(row.action_input) ?? code
+        );
         emitted += 1;
       }
       return emitted;
@@ -384,7 +531,7 @@ export async function sweepExpiredTurns(
   try {
     const sql = getDb();
     const failed = await sql.begin(async (tx: DbClient) => {
-      const rows = await tx.unsafe<{ action_input: unknown }>(
+      const rows = await tx.unsafe<{ action_input: TurnMarkerInput }>(
         // status + run_type match the partial predicate and leading column of
         // `runs_lobu_claim_idx`, so the inner SELECT is an index range scan
         // (run_type, queue_name, …, run_at) — not a full scan of `runs` (which
@@ -410,7 +557,13 @@ export async function sweepExpiredTurns(
           logger.error("Dropping unroutable turn-timeout marker (sweep)");
           continue;
         }
-        await enqueueTerminalError(tx, routing, code);
+        // Same relay as the fast path: a marker the proxy flagged carries the
+        // classified provider failure, which is what actually ended this turn.
+        await enqueueTerminalError(
+          tx,
+          routing,
+          providerFailureCode(row.action_input) ?? code
+        );
         emitted += 1;
       }
       return emitted;

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -12,6 +12,10 @@ import {
   markInferenceProviderUnhealthy,
   readOrgSharedProviderApiKey,
 } from "../../lobu/stores/provider-secrets.js";
+import {
+  clearTurnProviderFailed,
+  markTurnProviderFailed,
+} from "../orchestration/turn-liveness.js";
 import type { SecretStore } from "../secrets/index.js";
 import { getClientIp } from "../utils/rate-limiter.js";
 import { classifyProviderHealthStatus } from "./provider-health-status.js";
@@ -608,6 +612,19 @@ export class SecretProxy {
   }
 
   /**
+   * The `deploymentName` bound into the SIGNED worker token — the key
+   * turn-liveness markers are stored under. Taken from the token rather than the
+   * URL because it decides whether a turn keeps renewing its deadline, and the
+   * URL carries only agent/org/user.
+   */
+  private extractWorkerTokenDeployment(c: Context): string | undefined {
+    for (const data of this.verifiedWorkerClaims(c)) {
+      if (data.deploymentName) return data.deploymentName;
+    }
+    return undefined;
+  }
+
+  /**
    * Extract the bearer/api-key value the caller used to authenticate.
    * Returns the raw token string, or null if no auth header is present.
    */
@@ -1053,7 +1070,8 @@ export class SecretProxy {
     await this.recordProviderHealth(
       expectedOrganizationId,
       resolvedSlug,
-      response
+      response,
+      this.extractWorkerTokenDeployment(c)
     );
 
     // Build response headers (skip hop-by-hop)
@@ -1118,12 +1136,18 @@ export class SecretProxy {
   private async recordProviderHealth(
     organizationId: string | undefined,
     slug: string | undefined,
-    response: Response
+    response: Response,
+    deploymentName?: string
   ): Promise<void> {
     if (!organizationId || !slug) return;
     try {
       if (response.ok) {
         await clearInferenceProviderError(organizationId, slug);
+        // The same success re-arms deadline extension for this deployment's
+        // turns: an SDK retry that recovers must not leave the turn flagged and
+        // waiting to be swept. Keyed on deployment, so it only ever unblocks
+        // turns whose own worker just proved the provider works.
+        if (deploymentName) await clearTurnProviderFailed(deploymentName);
         return;
       }
       const code = classifyProviderHealthStatus(response.status);
@@ -1138,6 +1162,21 @@ export class SecretProxy {
         slug,
         `HTTP ${response.status}${retryAfter ? ` (retry-after: ${retryAfter})` : ""} — ${code}`
       );
+      // Withdraw this deployment's deadline EXTENSION (not the turn itself).
+      // The worker keeps heartbeating after a terminal provider answer even
+      // though the turn will never produce a reply, and that heartbeat was
+      // renewing the turn's own liveness deadline forever. Dropping the
+      // extension lets the existing deadline lapse so the sweep fails the turn
+      // (WORKER_UNRESPONSIVE; the provider reason is kept on the marker for
+      // diagnosis), while the SDK's own retries can still recover and clear the
+      // flag on the next 2xx.
+      if (deploymentName) {
+        await markTurnProviderFailed(
+          deploymentName,
+          code,
+          `${slug}: HTTP ${response.status} — ${code}`
+        );
+      }
     } catch (err) {
       logger.warn(
         `Failed to record provider health for ${slug}: ${err instanceof Error ? err.message : String(err)}`


### PR DESCRIPTION
## What

A turn wedged after a terminal provider answer never terminalized. The worker's
20s `status_update` is an unconditional `setInterval` — it proves the process is
alive, not that the turn is progressing — and `extendTurnDeadlines` treated it as
liveness. So the wedged turn renewed its own 60s deadline forever and
`sweepExpiredTurns`, the backstop whose docstring names *"a hung worker (alive,
never replies)"*, could never fire.

The proxy now withdraws that deployment's deadline **extension** when it sees the
provider answer terminally, so the existing deadline lapses and the existing
sweep terminalizes the turn with the classified code.

## Reproduce red

On the deployed build (`cb74675a7`), pointing `lobu-team/developer` at
quota-exhausted `qwen`:

```
00:30:26  Starting Lobu session: provider=openai, model=qwen3.8-max
00:30:27  proxy/qwen -> 429            (ONE upstream call; not a retry loop)
00:30:46  Still running after 20s - no response from API yet
00:31:06  40s   00:31:26  60s   00:31:46  80s   00:32:06  100s
...
00:34:30  Still running after 240s     (12 heartbeats, no terminal event)
```

Two later sends to that agent (`00:06:41`, `00:09:56` in an earlier run of the
same shape) were enqueued and never started a session at all — one terminal
provider error head-of-line blocks the whole conversation. `manage_conversations`
exposes only `list`/`get`/`send`, so the turn can neither be cancelled nor time
out.

Ruled out on the way, each by reading the code rather than inferring:
- **Not an SDK retry loop** — exactly one proxied request reached the provider.
- **Not a leaked timer** — `runAISession`'s `finally` always clears the heartbeat.
- **Not `turnDone` never resolving** — `pi-agent-core` emits `agent_end` on
  failure (`handleRunFailure`, and `stopReason === "error"` in the agent loop).

## Prove green

`turn-liveness.test.ts` + `secret-proxy-provider-health.test.ts` — 33 pass, 0 fail.
Related suites (7 files incl. all `secret-proxy*`, `provider-health-status`,
`turn-liveness-deployment-probe`) — 99 pass, 0 fail.

`PF1` is the byte-for-byte inversion of the existing
*"a live worker's heartbeat extends the deadline (sweep does not fire)"* test:
same arm, same expire, same heartbeat, differing only by the mark — and the sweep
now fires.

## Mutation testing

| mutation | tests that failed |
|---|---|
| drop the `providerFailed` predicate in `extendTurnDeadlines` | PF1, PF3 |
| no-op `markTurnProviderFailed` | PF1, PF3, PF4 |
| remove the proxy's `mark` call | TL1, TL2 |
| remove the proxy's `clear` call | TL2 |
| `providerFailureCode` always null | PF1 |

TL1/TL2 authenticate with a **real signed worker token**, because the wiring only
runs when the token carries a `deploymentName` — the other tests in that file use
an unsigned placeholder bearer and would pass whether or not the wiring exists.
This subsystem has shipped an inert health path before (#2525 was merged, green,
and dead in prod), so the mutation above is the load-bearing check.

## Why withdraw the extension instead of killing the turn

The proxy cannot know whether the SDK will recover — the OpenAI client retries
(`maxRetries: 2`, honouring `Retry-After`). Failing the turn on the first 429
would kill turns that were about to succeed. Withdrawing only the extension
leaves the turn whatever deadline it already had, which normally outlasts that
backoff; the next proxied 2xx clears the flag and extension resumes (TL2).

## Client-visible change

A turn ended this way now reports the classified provider code
(`PROVIDER_QUOTA_EXHAUSTED` / `PROVIDER_AUTH`), which resolves to a real CTA,
instead of the generic `WORKER_UNRESPONSIVE` that pointed operators at the wrong
subsystem. The code is validated against the `AgentErrorCode` enum rather than
cast — it is a jsonb field on a `runs` row, i.e. data, and must never reach
`AGENT_ERRORS[code]` unchecked.

## Scope / not included

- No schema change: the flag rides in the marker's existing `action_input` jsonb.
- `markTurnProviderFailed` flags every pending marker for the deployment,
  matching how `extendTurnDeadlines` is already deployment-scoped.
- Does not address *why* `pi` leaves the turn open after `agent_end` on a
  provider error. This bounds the blast radius at the gateway; the worker-side
  question is separate and still open.

## Related

Follow-up to #3308 (health-aware dispatch). That one stops a turn being *sent* to
a dead provider when the agent lists a healthy sibling; this one stops a turn
that *did* hit a dead provider from hanging forever. #3308 cannot help an agent
pinned to a single dead provider — that is exactly the case reproduced above.
